### PR TITLE
Add MVP run schema and local JSON sink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,90 @@
 version = 4
 
 [[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tailscope-cli"
 version = "0.1.0"
 dependencies = [
@@ -13,6 +97,10 @@ dependencies = [
 [[package]]
 name = "tailscope-core"
 version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "tailscope-tokio"
@@ -20,3 +108,15 @@ version = "0.1.0"
 dependencies = [
  "tailscope-core",
 ]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/tailscope-core/Cargo.toml
+++ b/tailscope-core/Cargo.toml
@@ -5,6 +5,8 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [lints]
 workspace = true

--- a/tailscope-core/src/lib.rs
+++ b/tailscope-core/src/lib.rs
@@ -151,6 +151,11 @@ pub struct RuntimeSnapshot {
 /// A sink that can persist a run artifact.
 pub trait RunSink {
     /// Persists a run.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SinkError`] if the sink cannot write the run output, such as
+    /// when file I/O fails or serialization cannot complete.
     fn write(&self, run: &Run) -> Result<(), SinkError>;
 }
 

--- a/tailscope-core/src/lib.rs
+++ b/tailscope-core/src/lib.rs
@@ -1,17 +1,319 @@
-//! Core primitives for tailscope (placeholder).
+//! Core run schema and local JSON sink for tailscope.
 
-/// Returns the crate name for smoke-testing workspace wiring.
-#[must_use]
-pub const fn crate_name() -> &'static str {
-    "tailscope-core"
+use std::fs::File;
+use std::io::{BufWriter, Error as IoError};
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// A full output artifact for one tailscope capture run.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Run {
+    /// Metadata for the capture session.
+    pub metadata: RunMetadata,
+    /// Request timing events.
+    pub requests: Vec<RequestEvent>,
+    /// Stage timing events.
+    pub stages: Vec<StageEvent>,
+    /// Queue wait timing events.
+    pub queues: Vec<QueueEvent>,
+    /// In-flight gauge changes over time.
+    pub inflight: Vec<InFlightSnapshot>,
+    /// Tokio runtime metrics snapshots.
+    pub runtime_snapshots: Vec<RuntimeSnapshot>,
+}
+
+impl Run {
+    /// Creates an empty run with the provided metadata.
+    #[must_use]
+    pub fn new(metadata: RunMetadata) -> Self {
+        Self {
+            metadata,
+            requests: Vec::new(),
+            stages: Vec::new(),
+            queues: Vec::new(),
+            inflight: Vec::new(),
+            runtime_snapshots: Vec::new(),
+        }
+    }
+}
+
+/// Top-level metadata for one capture run.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunMetadata {
+    /// A unique identifier for the run.
+    pub run_id: String,
+    /// Service/application name.
+    pub service_name: String,
+    /// Optional service version.
+    pub service_version: Option<String>,
+    /// Timestamp (milliseconds since epoch UTC) when collection started.
+    pub started_at_unix_ms: u64,
+    /// Timestamp (milliseconds since epoch UTC) when collection ended.
+    pub finished_at_unix_ms: u64,
+    /// Capture mode, such as "light" or "investigation".
+    pub mode: CaptureMode,
+    /// Hostname if available.
+    pub host: Option<String>,
+    /// Process identifier if available.
+    pub pid: Option<u32>,
+}
+
+/// Capture mode used during a run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CaptureMode {
+    /// Low-overhead mode.
+    Light,
+    /// Higher-detail mode for incident investigation.
+    Investigation,
+}
+
+/// Per-request timing and status.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RequestEvent {
+    /// Correlation ID for the request.
+    pub request_id: String,
+    /// Route name, operation, or endpoint.
+    pub route: String,
+    /// Semantic request kind.
+    pub kind: Option<String>,
+    /// Request start timestamp (milliseconds since epoch UTC).
+    pub started_at_unix_ms: u64,
+    /// Request completion timestamp (milliseconds since epoch UTC).
+    pub finished_at_unix_ms: u64,
+    /// Total request latency in microseconds.
+    pub latency_us: u64,
+    /// Logical outcome such as "ok", "error", or "timeout".
+    pub outcome: String,
+}
+
+/// Timing record for one named stage.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StageEvent {
+    /// Parent request ID.
+    pub request_id: String,
+    /// Stage identifier.
+    pub stage: String,
+    /// Stage start timestamp (milliseconds since epoch UTC).
+    pub started_at_unix_ms: u64,
+    /// Stage completion timestamp (milliseconds since epoch UTC).
+    pub finished_at_unix_ms: u64,
+    /// Stage latency in microseconds.
+    pub latency_us: u64,
+    /// Whether the stage returned a successful result.
+    pub success: bool,
+}
+
+/// Queue wait measurement for a request waiting on a queue/permit.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QueueEvent {
+    /// Parent request ID.
+    pub request_id: String,
+    /// Queue identifier.
+    pub queue: String,
+    /// Queue wait start timestamp (milliseconds since epoch UTC).
+    pub waited_from_unix_ms: u64,
+    /// Queue wait end timestamp (milliseconds since epoch UTC).
+    pub waited_until_unix_ms: u64,
+    /// Total wait time in microseconds.
+    pub wait_us: u64,
+    /// Queue depth sample captured at wait start, if known.
+    pub depth_at_start: Option<u64>,
+}
+
+/// Point-in-time in-flight gauge reading.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InFlightSnapshot {
+    /// Gauge name.
+    pub gauge: String,
+    /// Timestamp (milliseconds since epoch UTC).
+    pub at_unix_ms: u64,
+    /// Number of in-flight units.
+    pub count: u64,
+}
+
+/// Point-in-time runtime metrics sample.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeSnapshot {
+    /// Timestamp (milliseconds since epoch UTC).
+    pub at_unix_ms: u64,
+    /// Number of alive tasks.
+    pub alive_tasks: Option<u64>,
+    /// Runtime global queue depth.
+    pub global_queue_depth: Option<u64>,
+    /// Runtime blocking pool queue depth.
+    pub blocking_queue_depth: Option<u64>,
+    /// Runtime worker thread count.
+    pub worker_threads: Option<u64>,
+}
+
+/// A sink that can persist a run artifact.
+pub trait RunSink {
+    /// Persists a run.
+    fn write(&self, run: &Run) -> Result<(), SinkError>;
+}
+
+/// Local file sink that writes one JSON document per run.
+#[derive(Debug, Clone)]
+pub struct LocalJsonSink {
+    path: PathBuf,
+}
+
+impl LocalJsonSink {
+    /// Creates a local JSON sink for `path`.
+    #[must_use]
+    pub fn new(path: impl AsRef<Path>) -> Self {
+        Self {
+            path: path.as_ref().to_path_buf(),
+        }
+    }
+
+    /// Returns the target file path used by this sink.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl RunSink for LocalJsonSink {
+    fn write(&self, run: &Run) -> Result<(), SinkError> {
+        let file = File::create(&self.path).map_err(SinkError::Io)?;
+        let mut writer = BufWriter::new(file);
+        serde_json::to_writer_pretty(&mut writer, run).map_err(SinkError::Serialize)?;
+        Ok(())
+    }
+}
+
+/// Errors emitted while writing run artifacts.
+#[derive(Debug)]
+pub enum SinkError {
+    /// Underlying I/O failure.
+    Io(IoError),
+    /// Serialization failure.
+    Serialize(serde_json::Error),
+}
+
+impl std::fmt::Display for SinkError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(err) => write!(f, "I/O error while writing run output: {err}"),
+            Self::Serialize(err) => {
+                write!(f, "serialization error while writing run output: {err}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SinkError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(err) => Some(err),
+            Self::Serialize(err) => Some(err),
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::crate_name;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::{
+        CaptureMode, InFlightSnapshot, LocalJsonSink, QueueEvent, RequestEvent, Run, RunMetadata,
+        RunSink, RuntimeSnapshot, StageEvent,
+    };
+
+    fn sample_run() -> Run {
+        let metadata = RunMetadata {
+            run_id: "run_123".to_owned(),
+            service_name: "payments".to_owned(),
+            service_version: Some("1.2.3".to_owned()),
+            started_at_unix_ms: 1_000,
+            finished_at_unix_ms: 3_000,
+            mode: CaptureMode::Light,
+            host: Some("devbox".to_owned()),
+            pid: Some(4242),
+        };
+
+        let mut run = Run::new(metadata);
+
+        run.requests.push(RequestEvent {
+            request_id: "req-1".to_owned(),
+            route: "/invoice".to_owned(),
+            kind: Some("create_invoice".to_owned()),
+            started_at_unix_ms: 1_100,
+            finished_at_unix_ms: 1_400,
+            latency_us: 300_000,
+            outcome: "ok".to_owned(),
+        });
+
+        run.stages.push(StageEvent {
+            request_id: "req-1".to_owned(),
+            stage: "persist_invoice".to_owned(),
+            started_at_unix_ms: 1_220,
+            finished_at_unix_ms: 1_350,
+            latency_us: 130_000,
+            success: true,
+        });
+
+        run.queues.push(QueueEvent {
+            request_id: "req-1".to_owned(),
+            queue: "invoice_worker".to_owned(),
+            waited_from_unix_ms: 1_110,
+            waited_until_unix_ms: 1_200,
+            wait_us: 90_000,
+            depth_at_start: Some(8),
+        });
+
+        run.inflight.push(InFlightSnapshot {
+            gauge: "invoice_requests".to_owned(),
+            at_unix_ms: 1_300,
+            count: 12,
+        });
+
+        run.runtime_snapshots.push(RuntimeSnapshot {
+            at_unix_ms: 1_350,
+            alive_tasks: Some(240),
+            global_queue_depth: Some(45),
+            blocking_queue_depth: Some(6),
+            worker_threads: Some(8),
+        });
+
+        run
+    }
 
     #[test]
-    fn crate_name_is_stable() {
-        assert_eq!(crate_name(), "tailscope-core");
+    fn run_serializes_all_mvp_sections() {
+        let run = sample_run();
+        let value = serde_json::to_value(&run).expect("run should serialize");
+
+        assert!(value.get("metadata").is_some());
+        assert!(value.get("requests").is_some());
+        assert!(value.get("stages").is_some());
+        assert!(value.get("queues").is_some());
+        assert!(value.get("inflight").is_some());
+        assert!(value.get("runtime_snapshots").is_some());
+        assert_eq!(value["metadata"]["mode"], "light");
+        assert_eq!(value["requests"][0]["route"], "/invoice");
+    }
+
+    #[test]
+    fn local_json_sink_writes_valid_json_file() {
+        let run = sample_run();
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after UNIX_EPOCH")
+            .as_nanos();
+        let output_path = std::env::temp_dir().join(format!("tailscope-run-{unique}.json"));
+
+        let sink = LocalJsonSink::new(&output_path);
+        sink.write(&run).expect("sink write should succeed");
+
+        let saved = std::fs::read_to_string(&output_path).expect("json file should exist");
+        let round_trip: Run = serde_json::from_str(&saved).expect("json should deserialize");
+
+        assert_eq!(round_trip, run);
+
+        std::fs::remove_file(&output_path).expect("temporary file should be removable");
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a concrete, stable JSON schema for a single capture `Run` so downstream instrumentation, the CLI analyzer, and demos can write and consume a consistent artifact.
- Offer a simple local persistence sink so runs can be recorded to disk for offline analysis and CI/fixtures.

### Description
- Add `Run`, `RunMetadata`, `RequestEvent`, `StageEvent`, `QueueEvent`, `InFlightSnapshot`, and `RuntimeSnapshot` structs with `serde` (de)serialization in `tailscope-core` (`tailscope-core/src/lib.rs`).
- Add `CaptureMode` enum serialized as `snake_case` for stable JSON shape.
- Introduce a `RunSink` trait and a `LocalJsonSink` implementation that writes pretty JSON to a local file path.
- Add `SinkError` with `Display` and `Error` implementations to surface I/O and serialization failures.
- Add unit tests that construct a sample `Run`, verify JSON serialization shape, and validate that `LocalJsonSink` round-trips a file to `Run` via `serde_json`.
- Add `serde` and `serde_json` dependencies to `tailscope-core/Cargo.toml`.

### Testing
- Ran `cargo fmt` and `cargo fmt --check` successfully in this environment.
- Attempted `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace` but dependency resolution was blocked by network/registry access (crates.io index fetch returned HTTP 403), so full linting and tests could not complete here; the included serialization unit tests are present and will run in CI or a network-enabled dev environment.
- The change set is limited to `tailscope-core` and includes focused serialization tests that validate JSON shape and file round-trip behavior using `serde_json`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb1aa1491483309ec2b12efeec8d4c)