### PR TITLE
Add #[instrument_request] proc-macro and re-export from tailscope-tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,10 +50,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "pin-project-lite"
@@ -117,10 +150,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "syn"
@@ -151,10 +199,111 @@ dependencies = [
 ]
 
 [[package]]
+name = "tailscope-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tailscope-tokio"
 version = "0.1.0"
 dependencies = [
  "tailscope-core",
+ "tailscope-macros",
+ "tracing",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -162,6 +311,27 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "tailscope-core",
   "tailscope-tokio",
   "tailscope-cli",
+  "tailscope-macros",
 ]
 resolver = "2"
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,8 @@ Current repository state:
 - Cargo workspace compiles
 - CI runs format, clippy, and tests
 - `tailscope-core` includes run schema, local JSON sink, and initial `Config`/`Tailscope::init` plus request, in-flight, stage, and queue timing primitives
-- `tailscope-tokio` and `tailscope-cli` remain bootstrap placeholders
+- `tailscope-tokio` now exports `#[instrument_request(...)]` for async request entrypoints and still has placeholder runtime sampling
+- `tailscope-cli` remains a bootstrap placeholder
 
 ## Development philosophy
 - small PRs

--- a/tailscope-macros/Cargo.toml
+++ b/tailscope-macros/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "tailscope-macros"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full", "parsing"] }
+
+[lints]
+workspace = true
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"

--- a/tailscope-macros/src/lib.rs
+++ b/tailscope-macros/src/lib.rs
@@ -1,0 +1,212 @@
+use proc_macro::TokenStream;
+
+use quote::quote;
+use syn::parse::{Parse, ParseStream, Parser};
+use syn::{
+    parse_macro_input, punctuated::Punctuated, Error, Expr, ExprLit, FnArg, ItemFn, Lit, Meta,
+    MetaList, MetaNameValue, Result as SynResult, Token,
+};
+
+#[derive(Default)]
+struct InstrumentArgs {
+    route: Option<Expr>,
+    kind: Option<Expr>,
+    skip: Option<Punctuated<syn::Ident, Token![,]>>,
+}
+
+impl Parse for InstrumentArgs {
+    fn parse(input: ParseStream<'_>) -> SynResult<Self> {
+        let metas = Punctuated::<Meta, Token![,]>::parse_terminated(input)?;
+        let mut args = InstrumentArgs::default();
+
+        for meta in metas {
+            match meta {
+                Meta::NameValue(MetaNameValue { path, value, .. }) if path.is_ident("route") => {
+                    args.route = Some(value);
+                }
+                Meta::NameValue(MetaNameValue { path, value, .. }) if path.is_ident("kind") => {
+                    args.kind = Some(value);
+                }
+                Meta::List(MetaList { path, tokens, .. }) if path.is_ident("skip") => {
+                    if args.skip.is_some() {
+                        return Err(Error::new_spanned(path, "duplicate skip argument"));
+                    }
+
+                    let parsed =
+                        Punctuated::<syn::Ident, Token![,]>::parse_terminated.parse2(tokens)?;
+                    args.skip = Some(parsed);
+                }
+                _ => {
+                    return Err(Error::new_spanned(
+                        meta,
+                        "unsupported argument; expected route = <expr>, kind = <expr>, or skip(...)",
+                    ));
+                }
+            }
+        }
+
+        Ok(args)
+    }
+}
+
+#[proc_macro_attribute]
+pub fn instrument_request(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(attr as InstrumentArgs);
+    let input_fn = parse_macro_input!(item as ItemFn);
+
+    match expand_instrument_request(args, input_fn) {
+        Ok(expanded) => expanded.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+fn expand_instrument_request(
+    args: InstrumentArgs,
+    mut input_fn: ItemFn,
+) -> SynResult<proc_macro2::TokenStream> {
+    if input_fn.sig.asyncness.is_none() {
+        return Err(Error::new_spanned(
+            input_fn.sig.fn_token,
+            "#[instrument_request] only supports async functions",
+        ));
+    }
+
+    let skip_names = args.skip.unwrap_or_default();
+    validate_skipped_args(&skip_names, &input_fn)?;
+
+    let route_expr = args
+        .route
+        .unwrap_or_else(|| default_route_expr(&input_fn.sig.ident));
+    let kind_expr = args
+        .kind
+        .unwrap_or_else(|| default_kind_expr(&input_fn.sig.ident));
+
+    let route_field = make_field_expr("route", route_expr);
+    let kind_field = make_field_expr("kind", kind_expr);
+
+    let skip_attr = if skip_names.is_empty() {
+        quote! {}
+    } else {
+        quote! { skip(#skip_names), }
+    };
+
+    let body = input_fn.block;
+    let returns_result = returns_result(&input_fn.sig.output);
+    let tail_event = if returns_result {
+        quote! {
+            match &__tailscope_result {
+                Ok(_) => ::tracing::info!(
+                    target: "tailscope::request",
+                    route = __tailscope_route,
+                    kind = __tailscope_kind,
+                    outcome = "ok",
+                    duration_us = __tailscope_duration_us,
+                    "request completed"
+                ),
+                Err(_) => ::tracing::warn!(
+                    target: "tailscope::request",
+                    route = __tailscope_route,
+                    kind = __tailscope_kind,
+                    outcome = "error",
+                    duration_us = __tailscope_duration_us,
+                    "request completed"
+                ),
+            }
+        }
+    } else {
+        quote! {
+            ::tracing::info!(
+                target: "tailscope::request",
+                route = __tailscope_route,
+                kind = __tailscope_kind,
+                outcome = "ok",
+                duration_us = __tailscope_duration_us,
+                "request completed"
+            );
+        }
+    };
+
+    input_fn.block = Box::new(syn::parse_quote!({
+        let __tailscope_route = #route_field;
+        let __tailscope_kind = #kind_field;
+        let __tailscope_started = ::std::time::Instant::now();
+        let __tailscope_result = (async move #body).await;
+        let __tailscope_duration_us =
+            ::std::convert::TryFrom::try_from(__tailscope_started.elapsed().as_micros())
+                .unwrap_or(u64::MAX);
+        #tail_event
+        __tailscope_result
+    }));
+
+    input_fn.attrs.push(syn::parse_quote!(
+        #[::tracing::instrument(
+            name = "tailscope.request",
+            target = "tailscope::request",
+            #skip_attr
+            fields(
+                route = ::tracing::field::display(&#route_field),
+                kind = ::tracing::field::display(&#kind_field)
+            )
+        )]
+    ));
+
+    Ok(quote!(#input_fn))
+}
+
+fn make_field_expr(_name: &str, expr: Expr) -> proc_macro2::TokenStream {
+    match expr {
+        Expr::Lit(ExprLit {
+            lit: Lit::Str(value),
+            ..
+        }) => quote!(#value),
+        other => quote!((#other)),
+    }
+}
+
+fn default_route_expr(name: &syn::Ident) -> Expr {
+    syn::parse_quote!(concat!(module_path!(), "::", stringify!(#name)))
+}
+
+fn default_kind_expr(name: &syn::Ident) -> Expr {
+    syn::parse_quote!(stringify!(#name))
+}
+
+fn validate_skipped_args(
+    skip_names: &Punctuated<syn::Ident, Token![,]>,
+    func: &ItemFn,
+) -> SynResult<()> {
+    for ident in skip_names {
+        let found = func.sig.inputs.iter().any(|arg| match arg {
+            FnArg::Receiver(_) => ident == "self",
+            FnArg::Typed(pat_type) => match pat_type.pat.as_ref() {
+                syn::Pat::Ident(pat_ident) => pat_ident.ident == *ident,
+                _ => false,
+            },
+        });
+
+        if !found {
+            return Err(Error::new_spanned(
+                ident,
+                format!("skip argument `{ident}` does not match any function parameter"),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn returns_result(output: &syn::ReturnType) -> bool {
+    let syn::ReturnType::Type(_, ty) = output else {
+        return false;
+    };
+
+    let syn::Type::Path(type_path) = ty.as_ref() else {
+        return false;
+    };
+
+    type_path
+        .path
+        .segments
+        .last()
+        .is_some_and(|segment| segment.ident == "Result")
+}

--- a/tailscope-macros/tests/instrument_request.rs
+++ b/tailscope-macros/tests/instrument_request.rs
@@ -1,0 +1,97 @@
+use std::sync::{Arc, Mutex};
+
+use tailscope_macros::instrument_request;
+use tracing::{Event, Subscriber};
+use tracing_subscriber::layer::{Context, Layer};
+use tracing_subscriber::prelude::*;
+
+#[derive(Default, Clone)]
+struct RecordedEvents {
+    lines: Arc<Mutex<Vec<String>>>,
+}
+
+impl RecordedEvents {
+    fn push(&self, value: String) {
+        self.lines.lock().expect("event mutex poisoned").push(value);
+    }
+
+    fn snapshot(&self) -> Vec<String> {
+        self.lines.lock().expect("event mutex poisoned").clone()
+    }
+}
+
+#[derive(Clone)]
+struct CaptureLayer {
+    events: RecordedEvents,
+}
+
+impl<S> Layer<S> for CaptureLayer
+where
+    S: Subscriber,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        struct Visit {
+            parts: Vec<String>,
+        }
+
+        impl tracing::field::Visit for Visit {
+            fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+                self.parts.push(format!("{}={value:?}", field.name()));
+            }
+        }
+
+        let mut visitor = Visit { parts: Vec::new() };
+        event.record(&mut visitor);
+        self.events.push(visitor.parts.join(" "));
+    }
+}
+
+#[instrument_request(route = "/invoice", kind = "create_invoice", skip(state))]
+async fn ok_handler(state: u32) -> Result<u32, &'static str> {
+    let _ = state;
+    Ok(42)
+}
+
+#[instrument_request(route = "/invoice", kind = "create_invoice", skip(state))]
+async fn err_handler(state: u32) -> Result<u32, &'static str> {
+    let _ = state;
+    Err("boom")
+}
+
+#[tokio::test]
+async fn records_ok_and_error_outcomes() {
+    let recorded = RecordedEvents::default();
+    let layer = CaptureLayer {
+        events: recorded.clone(),
+    };
+
+    let subscriber = tracing_subscriber::registry().with(layer);
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let value = ok_handler(1).await.expect("ok handler should succeed");
+    assert_eq!(value, 42);
+    let err = err_handler(2).await.expect_err("err handler should fail");
+    assert_eq!(err, "boom");
+
+    let events = recorded.snapshot();
+    let tail_events: Vec<_> = events
+        .iter()
+        .filter(|line| line.contains("outcome"))
+        .cloned()
+        .collect();
+
+    assert_eq!(tail_events.len(), 2, "expected two completion events");
+    assert!(tail_events
+        .iter()
+        .any(|line| line.contains("outcome=\"ok\"")));
+    assert!(tail_events
+        .iter()
+        .any(|line| line.contains("outcome=\"error\"")));
+    assert!(tail_events.iter().all(|line| line.contains("duration_us=")));
+    assert!(tail_events
+        .iter()
+        .all(|line| line.contains("route=\"/invoice\"")));
+    assert!(tail_events
+        .iter()
+        .all(|line| line.contains("kind=\"create_invoice\"")));
+}

--- a/tailscope-tokio/Cargo.toml
+++ b/tailscope-tokio/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 
 [dependencies]
 tailscope-core = { path = "../tailscope-core" }
+tailscope-macros = { path = "../tailscope-macros" }
+tracing = "0.1"
 
 [lints]
 workspace = true

--- a/tailscope-tokio/src/lib.rs
+++ b/tailscope-tokio/src/lib.rs
@@ -1,4 +1,6 @@
-//! Tokio runtime integration for tailscope (placeholder).
+//! Tokio runtime integration for tailscope.
+
+pub use tailscope_macros::instrument_request;
 
 /// Returns the crate name for smoke-testing workspace wiring.
 #[must_use]


### PR DESCRIPTION
### Motivation
- Provide a zero-friction integration for request-level instrumentation so a developer can add one attribute to async handlers and get total request timing, metadata, and outcome recording.
- Keep the macro simple, explicit, and easy to consume from the Tokio integration crate.

### Description
- Add a new `tailscope-macros` proc-macro crate implementing `#[instrument_request(...)]` for `async fn` handlers with `route = ...`, `kind = ...`, and `skip(...)` support.
- Macro wraps the function body to measure total duration (`duration_us`), emit a `tailscope::request` tracing event, and automatically record `ok`/`error` outcomes for `Result` return types while providing sensible route/kind defaults.
- Validate usage at compile time (rejects non-async functions and invalid `skip` parameters) and attach a `tracing::instrument` span with the route/kind fields.
- Re-export the macro from `tailscope-tokio` and add the new crate to the workspace, update `Cargo.toml` and `README.md` to reflect availability.
- Add an integration test that exercises both success and error outcomes and asserts emitted tracing fields.

### Testing
- Ran `cargo fmt --check` and formatting check passed.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and clippy passed with no warnings.
- Ran `cargo test --workspace` and all workspace unit and integration tests (including the `instrument_request` test) passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bba206694483308b83241214ed4724)