### PR TITLE
Add ranked diagnosis report with primary/secondary suspects and fixture-based analyzer tests

### DIFF
--- a/tailscope-cli/src/analyze.rs
+++ b/tailscope-cli/src/analyze.rs
@@ -25,12 +25,50 @@ impl DiagnosisKind {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Confidence {
+    Low,
+    Medium,
+    High,
+}
+
+impl Confidence {
+    fn from_score(score: u8) -> Self {
+        if score >= 85 {
+            Self::High
+        } else if score >= 65 {
+            Self::Medium
+        } else {
+            Self::Low
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Suspect {
     pub kind: DiagnosisKind,
     pub score: u8,
+    pub confidence: Confidence,
     pub evidence: Vec<String>,
     pub next_checks: Vec<String>,
+}
+
+impl Suspect {
+    fn new(
+        kind: DiagnosisKind,
+        score: u8,
+        evidence: Vec<String>,
+        next_checks: Vec<String>,
+    ) -> Self {
+        Self {
+            kind,
+            score,
+            confidence: Confidence::from_score(score),
+            evidence,
+            next_checks,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -39,7 +77,8 @@ pub struct Report {
     pub p50_latency_us: Option<u64>,
     pub p95_latency_us: Option<u64>,
     pub p99_latency_us: Option<u64>,
-    pub suspects: Vec<Suspect>,
+    pub primary_suspect: Suspect,
+    pub secondary_suspects: Vec<Suspect>,
 }
 
 #[must_use]
@@ -73,30 +112,41 @@ pub fn analyze_run(run: &Run) -> Report {
     }
 
     if suspects.is_empty() {
-        suspects.push(Suspect {
-            kind: DiagnosisKind::InsufficientEvidence,
-            score: 100,
-            evidence: vec![
+        suspects.push(Suspect::new(
+            DiagnosisKind::InsufficientEvidence,
+            50,
+            vec![
                 "Not enough queue, stage, or runtime signals to rank a stronger suspect."
                     .to_string(),
             ],
-            next_checks: vec![
+            vec![
                 "Wrap critical awaits with queue(...).await_on(...) and stage(...).await_on(...)."
                     .to_string(),
                 "Enable RuntimeSampler during the run to capture runtime pressure signals."
                     .to_string(),
             ],
-        });
+        ));
     }
 
     suspects.sort_by(|left, right| right.score.cmp(&left.score));
+
+    let mut ranked = suspects.into_iter();
+    let primary_suspect = ranked.next().unwrap_or_else(|| {
+        Suspect::new(
+            DiagnosisKind::InsufficientEvidence,
+            50,
+            vec!["No diagnosis signals were captured for this run.".to_string()],
+            vec!["Verify that request, queue, or stage instrumentation is enabled.".to_string()],
+        )
+    });
 
     Report {
         request_count: run.requests.len(),
         p50_latency_us,
         p95_latency_us,
         p99_latency_us,
-        suspects,
+        primary_suspect,
+        secondary_suspects: ranked.collect(),
     }
 }
 
@@ -123,16 +173,16 @@ fn queue_saturation_suspect(run: &Run) -> Option<Suspect> {
         evidence.push(format!("Observed queue depth sample up to {depth}."));
     }
 
-    Some(Suspect {
-        kind: DiagnosisKind::ApplicationQueueSaturation,
-        score: 90,
+    Some(Suspect::new(
+        DiagnosisKind::ApplicationQueueSaturation,
+        90,
         evidence,
-        next_checks: vec![
+        vec![
             "Inspect queue admission limits and producer burst patterns.".to_string(),
             "Compare queue wait distribution before and after increasing worker parallelism."
                 .to_string(),
         ],
-    })
+    ))
 }
 
 fn blocking_pressure_suspect(run: &Run) -> Option<Suspect> {
@@ -145,17 +195,18 @@ fn blocking_pressure_suspect(run: &Run) -> Option<Suspect> {
         return None;
     }
 
-    Some(Suspect {
-        kind: DiagnosisKind::BlockingPoolPressure,
-        score: 80,
-        evidence: vec![format!(
+    Some(Suspect::new(
+        DiagnosisKind::BlockingPoolPressure,
+        80,
+        vec![format!(
             "Blocking queue depth p95 is {p95_blocking_depth}, indicating sustained spawn_blocking backlog."
         )],
-        next_checks: vec![
-            "Audit blocking sections and move avoidable synchronous work out of hot paths.".to_string(),
+        vec![
+            "Audit blocking sections and move avoidable synchronous work out of hot paths."
+                .to_string(),
             "Inspect spawn_blocking callsites for long-running CPU or I/O work.".to_string(),
         ],
-    })
+    ))
 }
 
 fn executor_pressure_suspect(run: &Run) -> Option<Suspect> {
@@ -168,17 +219,17 @@ fn executor_pressure_suspect(run: &Run) -> Option<Suspect> {
         return None;
     }
 
-    Some(Suspect {
-        kind: DiagnosisKind::ExecutorPressureSuspected,
-        score: 65,
-        evidence: vec![format!(
+    Some(Suspect::new(
+        DiagnosisKind::ExecutorPressureSuspected,
+        65,
+        vec![format!(
             "Runtime global queue depth p95 is {p95_global_depth}, suggesting scheduler contention."
         )],
-        next_checks: vec![
+        vec![
             "Check for long polls without yielding and uneven task fan-out.".to_string(),
             "Compare with per-stage timings to isolate overloaded async stages.".to_string(),
         ],
-    })
+    ))
 }
 
 fn downstream_stage_suspect(run: &Run) -> Option<Suspect> {
@@ -213,20 +264,20 @@ fn downstream_stage_suspect(run: &Run) -> Option<Suspect> {
         return None;
     }
 
-    Some(Suspect {
-        kind: DiagnosisKind::DownstreamStageDominates,
-        score: 60,
-        evidence: vec![
+    Some(Suspect::new(
+        DiagnosisKind::DownstreamStageDominates,
+        60,
+        vec![
             format!(
                 "Stage '{dominant_stage}' has p95 latency {stage_p95} us across {stage_count} samples."
             ),
             format!("Stage '{dominant_stage}' cumulative latency is {total_latency} us."),
         ],
-        next_checks: vec![
+        vec![
             format!("Inspect downstream dependency behind stage '{dominant_stage}'."),
             "Collect downstream service timings and retry behavior during tail windows.".to_string(),
         ],
-    })
+    ))
 }
 
 fn request_queue_shares(run: &Run) -> Vec<u64> {
@@ -300,192 +351,33 @@ pub fn render_text(report: &Report) -> String {
             "latency_us p50={:?} p95={:?} p99={:?}",
             report.p50_latency_us, report.p95_latency_us, report.p99_latency_us
         ),
+        format!(
+            "primary: {} (confidence={:?}, score={})",
+            report.primary_suspect.kind.as_str(),
+            report.primary_suspect.confidence,
+            report.primary_suspect.score
+        ),
     ];
 
-    for (index, suspect) in report.suspects.iter().enumerate() {
-        lines.push(format!(
-            "{}. {} (score={})",
-            index + 1,
-            suspect.kind.as_str(),
-            suspect.score
-        ));
+    for evidence in &report.primary_suspect.evidence {
+        lines.push(format!("  evidence: {evidence}"));
+    }
 
-        for evidence in &suspect.evidence {
-            lines.push(format!("   evidence: {evidence}"));
-        }
+    for next_check in &report.primary_suspect.next_checks {
+        lines.push(format!("  next: {next_check}"));
+    }
 
-        for next_check in &suspect.next_checks {
-            lines.push(format!("   next: {next_check}"));
+    if !report.secondary_suspects.is_empty() {
+        lines.push("secondary suspects:".to_string());
+        for suspect in &report.secondary_suspects {
+            lines.push(format!(
+                "  - {} (confidence={:?}, score={})",
+                suspect.kind.as_str(),
+                suspect.confidence,
+                suspect.score
+            ));
         }
     }
 
     lines.join("\n")
-}
-
-#[cfg(test)]
-mod tests {
-    use tailscope_core::{
-        CaptureMode, QueueEvent, RequestEvent, Run, RunMetadata, RuntimeSnapshot, StageEvent,
-    };
-
-    use super::{analyze_run, DiagnosisKind};
-
-    fn fixture_run() -> Run {
-        let mut run = Run::new(RunMetadata {
-            run_id: "run-test".to_string(),
-            service_name: "svc".to_string(),
-            service_version: None,
-            started_at_unix_ms: 1,
-            finished_at_unix_ms: 2,
-            mode: CaptureMode::Light,
-            host: None,
-            pid: Some(42),
-        });
-
-        run.requests = vec![
-            RequestEvent {
-                request_id: "r1".to_string(),
-                route: "/a".to_string(),
-                kind: None,
-                started_at_unix_ms: 1,
-                finished_at_unix_ms: 2,
-                latency_us: 100,
-                outcome: "ok".to_string(),
-            },
-            RequestEvent {
-                request_id: "r2".to_string(),
-                route: "/a".to_string(),
-                kind: None,
-                started_at_unix_ms: 1,
-                finished_at_unix_ms: 2,
-                latency_us: 200,
-                outcome: "ok".to_string(),
-            },
-            RequestEvent {
-                request_id: "r3".to_string(),
-                route: "/a".to_string(),
-                kind: None,
-                started_at_unix_ms: 1,
-                finished_at_unix_ms: 2,
-                latency_us: 300,
-                outcome: "ok".to_string(),
-            },
-        ];
-
-        run
-    }
-
-    #[test]
-    fn prioritizes_queue_saturation_when_queue_share_is_high() {
-        let mut run = fixture_run();
-        run.queues = vec![
-            QueueEvent {
-                request_id: "r1".to_string(),
-                queue: "q".to_string(),
-                waited_from_unix_ms: 1,
-                waited_until_unix_ms: 2,
-                wait_us: 80,
-                depth_at_start: Some(3),
-            },
-            QueueEvent {
-                request_id: "r2".to_string(),
-                queue: "q".to_string(),
-                waited_from_unix_ms: 1,
-                waited_until_unix_ms: 2,
-                wait_us: 150,
-                depth_at_start: Some(4),
-            },
-            QueueEvent {
-                request_id: "r3".to_string(),
-                queue: "q".to_string(),
-                waited_from_unix_ms: 1,
-                waited_until_unix_ms: 2,
-                wait_us: 220,
-                depth_at_start: Some(5),
-            },
-        ];
-
-        let report = analyze_run(&run);
-        assert_eq!(
-            report.suspects.first().map(|suspect| &suspect.kind),
-            Some(&DiagnosisKind::ApplicationQueueSaturation)
-        );
-    }
-
-    #[test]
-    fn detects_blocking_pool_pressure_from_runtime_snapshots() {
-        let mut run = fixture_run();
-        run.runtime_snapshots = vec![
-            RuntimeSnapshot {
-                at_unix_ms: 1,
-                alive_tasks: Some(10),
-                global_queue_depth: Some(0),
-                local_queue_depth: None,
-                blocking_queue_depth: Some(2),
-                remote_schedule_count: None,
-            },
-            RuntimeSnapshot {
-                at_unix_ms: 2,
-                alive_tasks: Some(11),
-                global_queue_depth: Some(0),
-                local_queue_depth: None,
-                blocking_queue_depth: Some(3),
-                remote_schedule_count: None,
-            },
-        ];
-
-        let report = analyze_run(&run);
-        assert!(report
-            .suspects
-            .iter()
-            .any(|suspect| suspect.kind == DiagnosisKind::BlockingPoolPressure));
-    }
-
-    #[test]
-    fn falls_back_to_insufficient_evidence_without_signals() {
-        let run = fixture_run();
-
-        let report = analyze_run(&run);
-        assert_eq!(
-            report.suspects.first().map(|suspect| &suspect.kind),
-            Some(&DiagnosisKind::InsufficientEvidence)
-        );
-    }
-
-    #[test]
-    fn can_identify_dominant_stage() {
-        let mut run = fixture_run();
-        run.stages = vec![
-            StageEvent {
-                request_id: "r1".to_string(),
-                stage: "db".to_string(),
-                started_at_unix_ms: 1,
-                finished_at_unix_ms: 2,
-                latency_us: 70,
-                success: true,
-            },
-            StageEvent {
-                request_id: "r2".to_string(),
-                stage: "db".to_string(),
-                started_at_unix_ms: 1,
-                finished_at_unix_ms: 2,
-                latency_us: 90,
-                success: true,
-            },
-            StageEvent {
-                request_id: "r3".to_string(),
-                stage: "db".to_string(),
-                started_at_unix_ms: 1,
-                finished_at_unix_ms: 2,
-                latency_us: 120,
-                success: true,
-            },
-        ];
-
-        let report = analyze_run(&run);
-        assert!(report
-            .suspects
-            .iter()
-            .any(|suspect| suspect.kind == DiagnosisKind::DownstreamStageDominates));
-    }
 }

--- a/tailscope-cli/src/lib.rs
+++ b/tailscope-cli/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod analyze;

--- a/tailscope-cli/src/main.rs
+++ b/tailscope-cli/src/main.rs
@@ -1,9 +1,7 @@
-mod analyze;
-
 use std::path::PathBuf;
 
-use analyze::{analyze_run, render_text};
 use clap::{Parser, ValueEnum};
+use tailscope_cli::analyze::{analyze_run, render_text};
 use tailscope_core::Run;
 
 #[derive(Debug, Parser)]

--- a/tailscope-cli/tests/analyzer_fixtures.rs
+++ b/tailscope-cli/tests/analyzer_fixtures.rs
@@ -1,0 +1,64 @@
+use std::path::Path;
+
+use tailscope_cli::analyze::{analyze_run, render_text, DiagnosisKind};
+use tailscope_core::Run;
+
+fn load_fixture(name: &str) -> Run {
+    let path = Path::new("tests/fixtures").join(name);
+    let content = std::fs::read_to_string(path).expect("fixture should exist");
+    serde_json::from_str(&content).expect("fixture should deserialize")
+}
+
+#[test]
+fn fixture_categories_produce_expected_primary_suspect() {
+    let cases = [
+        (
+            "queue_saturation.json",
+            DiagnosisKind::ApplicationQueueSaturation,
+        ),
+        (
+            "blocking_pressure.json",
+            DiagnosisKind::BlockingPoolPressure,
+        ),
+        (
+            "executor_pressure.json",
+            DiagnosisKind::ExecutorPressureSuspected,
+        ),
+        (
+            "downstream_stage.json",
+            DiagnosisKind::DownstreamStageDominates,
+        ),
+        (
+            "insufficient_evidence.json",
+            DiagnosisKind::InsufficientEvidence,
+        ),
+    ];
+
+    for (fixture, expected) in cases {
+        let run = load_fixture(fixture);
+        let report = analyze_run(&run);
+        assert_eq!(report.primary_suspect.kind, expected, "fixture={fixture}");
+        assert!(
+            !report.primary_suspect.evidence.is_empty(),
+            "fixture={fixture} should include evidence"
+        );
+        assert!(
+            !report.primary_suspect.next_checks.is_empty(),
+            "fixture={fixture} should include next checks"
+        );
+    }
+}
+
+#[test]
+fn fixture_reports_render_to_text_and_json() {
+    let run = load_fixture("queue_saturation.json");
+    let report = analyze_run(&run);
+
+    let text = render_text(&report);
+    assert!(text.contains("primary:"));
+    assert!(text.contains("secondary suspects") || report.secondary_suspects.is_empty());
+
+    let json = serde_json::to_string_pretty(&report).expect("json rendering should work");
+    assert!(json.contains("primary_suspect"));
+    assert!(json.contains("confidence"));
+}

--- a/tailscope-cli/tests/fixtures/blocking_pressure.json
+++ b/tailscope-cli/tests/fixtures/blocking_pressure.json
@@ -1,0 +1,25 @@
+{
+  "metadata": {
+    "run_id": "blocking-run",
+    "service_name": "svc",
+    "service_version": null,
+    "started_at_unix_ms": 1,
+    "finished_at_unix_ms": 2,
+    "mode": "light",
+    "host": null,
+    "pid": 7
+  },
+  "requests": [
+    {"request_id":"r1","route":"/a","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":200,"outcome":"ok"},
+    {"request_id":"r2","route":"/a","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":210,"outcome":"ok"},
+    {"request_id":"r3","route":"/a","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":190,"outcome":"ok"}
+  ],
+  "stages": [],
+  "queues": [],
+  "inflight": [],
+  "runtime_snapshots": [
+    {"at_unix_ms":1,"alive_tasks":10,"global_queue_depth":0,"local_queue_depth":null,"blocking_queue_depth":3,"remote_schedule_count":null},
+    {"at_unix_ms":2,"alive_tasks":11,"global_queue_depth":0,"local_queue_depth":null,"blocking_queue_depth":4,"remote_schedule_count":null},
+    {"at_unix_ms":3,"alive_tasks":11,"global_queue_depth":0,"local_queue_depth":null,"blocking_queue_depth":2,"remote_schedule_count":null}
+  ]
+}

--- a/tailscope-cli/tests/fixtures/downstream_stage.json
+++ b/tailscope-cli/tests/fixtures/downstream_stage.json
@@ -1,0 +1,28 @@
+{
+  "metadata": {
+    "run_id": "stage-run",
+    "service_name": "svc",
+    "service_version": null,
+    "started_at_unix_ms": 1,
+    "finished_at_unix_ms": 2,
+    "mode": "light",
+    "host": null,
+    "pid": 7
+  },
+  "requests": [
+    {"request_id":"r1","route":"/a","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":300,"outcome":"ok"},
+    {"request_id":"r2","route":"/a","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":320,"outcome":"ok"},
+    {"request_id":"r3","route":"/a","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":310,"outcome":"ok"}
+  ],
+  "stages": [
+    {"request_id":"r1","stage":"db","started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":180,"success":true},
+    {"request_id":"r2","stage":"db","started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":200,"success":true},
+    {"request_id":"r3","stage":"db","started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":190,"success":true},
+    {"request_id":"r1","stage":"cache","started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":20,"success":true},
+    {"request_id":"r2","stage":"cache","started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":30,"success":true},
+    {"request_id":"r3","stage":"cache","started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":25,"success":true}
+  ],
+  "queues": [],
+  "inflight": [],
+  "runtime_snapshots": []
+}

--- a/tailscope-cli/tests/fixtures/executor_pressure.json
+++ b/tailscope-cli/tests/fixtures/executor_pressure.json
@@ -1,0 +1,25 @@
+{
+  "metadata": {
+    "run_id": "executor-run",
+    "service_name": "svc",
+    "service_version": null,
+    "started_at_unix_ms": 1,
+    "finished_at_unix_ms": 2,
+    "mode": "light",
+    "host": null,
+    "pid": 7
+  },
+  "requests": [
+    {"request_id":"r1","route":"/a","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":100,"outcome":"ok"},
+    {"request_id":"r2","route":"/a","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":120,"outcome":"ok"},
+    {"request_id":"r3","route":"/a","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":110,"outcome":"ok"}
+  ],
+  "stages": [],
+  "queues": [],
+  "inflight": [],
+  "runtime_snapshots": [
+    {"at_unix_ms":1,"alive_tasks":20,"global_queue_depth":7,"local_queue_depth":null,"blocking_queue_depth":0,"remote_schedule_count":null},
+    {"at_unix_ms":2,"alive_tasks":22,"global_queue_depth":6,"local_queue_depth":null,"blocking_queue_depth":0,"remote_schedule_count":null},
+    {"at_unix_ms":3,"alive_tasks":21,"global_queue_depth":8,"local_queue_depth":null,"blocking_queue_depth":0,"remote_schedule_count":null}
+  ]
+}

--- a/tailscope-cli/tests/fixtures/insufficient_evidence.json
+++ b/tailscope-cli/tests/fixtures/insufficient_evidence.json
@@ -1,0 +1,21 @@
+{
+  "metadata": {
+    "run_id": "insufficient-run",
+    "service_name": "svc",
+    "service_version": null,
+    "started_at_unix_ms": 1,
+    "finished_at_unix_ms": 2,
+    "mode": "light",
+    "host": null,
+    "pid": 7
+  },
+  "requests": [
+    {"request_id":"r1","route":"/a","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":100,"outcome":"ok"},
+    {"request_id":"r2","route":"/a","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":120,"outcome":"ok"},
+    {"request_id":"r3","route":"/a","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":130,"outcome":"ok"}
+  ],
+  "stages": [],
+  "queues": [],
+  "inflight": [],
+  "runtime_snapshots": []
+}

--- a/tailscope-cli/tests/fixtures/queue_saturation.json
+++ b/tailscope-cli/tests/fixtures/queue_saturation.json
@@ -1,0 +1,25 @@
+{
+  "metadata": {
+    "run_id": "queue-run",
+    "service_name": "svc",
+    "service_version": null,
+    "started_at_unix_ms": 1,
+    "finished_at_unix_ms": 2,
+    "mode": "light",
+    "host": null,
+    "pid": 7
+  },
+  "requests": [
+    {"request_id":"r1","route":"/a","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":100,"outcome":"ok"},
+    {"request_id":"r2","route":"/a","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":120,"outcome":"ok"},
+    {"request_id":"r3","route":"/a","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":150,"outcome":"ok"}
+  ],
+  "stages": [],
+  "queues": [
+    {"request_id":"r1","queue":"worker","waited_from_unix_ms":1,"waited_until_unix_ms":2,"wait_us":50,"depth_at_start":4},
+    {"request_id":"r2","queue":"worker","waited_from_unix_ms":1,"waited_until_unix_ms":2,"wait_us":75,"depth_at_start":5},
+    {"request_id":"r3","queue":"worker","waited_from_unix_ms":1,"waited_until_unix_ms":2,"wait_us":100,"depth_at_start":6}
+  ],
+  "inflight": [],
+  "runtime_snapshots": []
+}


### PR DESCRIPTION
### Motivation

- Fulfill the MVP analyzer requirements to emit a single primary suspect, optional secondary suspects, confidence, evidence, and recommended next checks from one run. 
- Make the diagnosis output easier to consume programmatically (JSON) and readable for humans (text) while keeping rule logic explicit and conservative. 
- Add deterministic fixture coverage so analyzer logic is validated against representative run artifacts for each diagnosis category.

### Description

- Change the analyzer report shape to produce `primary_suspect` plus `secondary_suspects` instead of a flat suspects list and add a per-suspect `Confidence` derived from numeric `score`.
- Keep rule-based suspect generation for the five MVP categories: application queue saturation, blocking-pool pressure, executor pressure suspected, downstream stage dominates, and insufficient evidence fallback, while preserving evidence bullets and `next_checks` for each suspect in `tailscope-cli/src/analyze.rs`.
- Update text rendering via `render_text` to emphasize the primary suspect and list secondary suspects, and wire analyzer code into the CLI by adding `tailscope-cli/src/lib.rs` and updating `main.rs` to use the library entrypoint.
- Add fixture JSONs under `tailscope-cli/tests/fixtures/` and an integration test `tailscope-cli/tests/analyzer_fixtures.rs` that verifies the expected primary suspect, evidence presence, next checks, and both text and JSON rendering.

### Testing

- Ran `cargo fmt --check` and `cargo fmt` to ensure formatting (succeeded).
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and fixed lints (succeeded).
- Ran `cargo test --workspace` and all unit and integration tests passed, including the new fixture-based analyzer tests (all tests green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbab7a0cc48330a38eb03d4cca3ec4)