### PR TITLE
Make downstream-stage diagnosis tie-breaking deterministic

### DIFF
--- a/tailscope-cli/src/analyze.rs
+++ b/tailscope-cli/src/analyze.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use serde::Serialize;
 use tailscope_core::{Run, RuntimeSnapshot};
@@ -233,7 +233,7 @@ fn executor_pressure_suspect(run: &Run) -> Option<Suspect> {
 }
 
 fn downstream_stage_suspect(run: &Run) -> Option<Suspect> {
-    let mut stage_totals: HashMap<&str, u64> = HashMap::new();
+    let mut stage_totals: BTreeMap<&str, u64> = BTreeMap::new();
     for stage in &run.stages {
         *stage_totals.entry(stage.stage.as_str()).or_default() = stage_totals
             .get(stage.stage.as_str())
@@ -244,7 +244,7 @@ fn downstream_stage_suspect(run: &Run) -> Option<Suspect> {
 
     let (dominant_stage, total_latency) = stage_totals
         .iter()
-        .max_by(|left, right| left.1.cmp(right.1))
+        .max_by(|left, right| left.1.cmp(right.1).then_with(|| right.0.cmp(left.0)))
         .map(|(stage, latency)| (*stage, *latency))?;
 
     let stage_count = run
@@ -380,4 +380,125 @@ pub fn render_text(report: &Report) -> String {
     }
 
     lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use tailscope_core::{CaptureMode, RequestEvent, Run, RunMetadata, StageEvent};
+
+    use crate::analyze::{analyze_run, DiagnosisKind};
+
+    fn test_run() -> Run {
+        Run {
+            metadata: RunMetadata {
+                run_id: "run-1".to_owned(),
+                service_name: "svc".to_owned(),
+                service_version: None,
+                started_at_unix_ms: 1,
+                finished_at_unix_ms: 2,
+                mode: CaptureMode::Light,
+                host: None,
+                pid: Some(1),
+            },
+            requests: vec![
+                RequestEvent {
+                    request_id: "req-1".to_owned(),
+                    route: "/test".to_owned(),
+                    kind: None,
+                    started_at_unix_ms: 1,
+                    finished_at_unix_ms: 2,
+                    latency_us: 1_000,
+                    outcome: "ok".to_owned(),
+                },
+                RequestEvent {
+                    request_id: "req-2".to_owned(),
+                    route: "/test".to_owned(),
+                    kind: None,
+                    started_at_unix_ms: 2,
+                    finished_at_unix_ms: 3,
+                    latency_us: 1_000,
+                    outcome: "ok".to_owned(),
+                },
+                RequestEvent {
+                    request_id: "req-3".to_owned(),
+                    route: "/test".to_owned(),
+                    kind: None,
+                    started_at_unix_ms: 3,
+                    finished_at_unix_ms: 4,
+                    latency_us: 1_000,
+                    outcome: "ok".to_owned(),
+                },
+            ],
+            stages: Vec::new(),
+            queues: Vec::new(),
+            inflight: Vec::new(),
+            runtime_snapshots: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn downstream_stage_tie_break_is_deterministic() {
+        let mut run = test_run();
+        run.stages = vec![
+            StageEvent {
+                request_id: "req-1".to_owned(),
+                stage: "stage_a".to_owned(),
+                started_at_unix_ms: 1,
+                finished_at_unix_ms: 2,
+                latency_us: 300,
+                success: true,
+            },
+            StageEvent {
+                request_id: "req-2".to_owned(),
+                stage: "stage_a".to_owned(),
+                started_at_unix_ms: 2,
+                finished_at_unix_ms: 3,
+                latency_us: 300,
+                success: true,
+            },
+            StageEvent {
+                request_id: "req-3".to_owned(),
+                stage: "stage_a".to_owned(),
+                started_at_unix_ms: 3,
+                finished_at_unix_ms: 4,
+                latency_us: 300,
+                success: true,
+            },
+            StageEvent {
+                request_id: "req-1".to_owned(),
+                stage: "stage_b".to_owned(),
+                started_at_unix_ms: 1,
+                finished_at_unix_ms: 2,
+                latency_us: 300,
+                success: true,
+            },
+            StageEvent {
+                request_id: "req-2".to_owned(),
+                stage: "stage_b".to_owned(),
+                started_at_unix_ms: 2,
+                finished_at_unix_ms: 3,
+                latency_us: 300,
+                success: true,
+            },
+            StageEvent {
+                request_id: "req-3".to_owned(),
+                stage: "stage_b".to_owned(),
+                started_at_unix_ms: 3,
+                finished_at_unix_ms: 4,
+                latency_us: 300,
+                success: true,
+            },
+        ];
+
+        let report = analyze_run(&run);
+        assert_eq!(
+            report.primary_suspect.kind,
+            DiagnosisKind::DownstreamStageDominates
+        );
+        assert!(
+            report.primary_suspect.evidence[0].contains("stage_a"),
+            "expected deterministic stage tie-breaker to choose stage_a, got {:?}",
+            report.primary_suspect.evidence
+        );
+    }
 }


### PR DESCRIPTION
### Motivation
- The downstream-stage selection could vary across runs when multiple stages had equal cumulative latency due to `HashMap` iteration order, causing unstable reports and flaky behavior in tests.

### Description
- Switched downstream stage aggregation from `HashMap` to `BTreeMap` in `tailscope-cli/src/analyze.rs` to provide a stable key order.
- Added an explicit tie-break when selecting the max cumulative latency using `.then_with(|| right.0.cmp(left.0))` so equal totals deterministically prefer the lexicographically smaller stage name.
- Imported `BTreeMap` and kept the existing diagnosis logic and output format unchanged aside from determinism.
- Added a unit test `downstream_stage_tie_break_is_deterministic` in `tailscope-cli/src/analyze.rs` that builds a tied-stage fixture and asserts deterministic selection of the primary downstream-stage suspect.

### Testing
- Ran `cargo fmt --check` which succeeded. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` which completed without warnings. 
- Ran `cargo test --workspace` and all tests passed, including the new `downstream_stage_tie_break_is_deterministic` unit test and existing analyzer fixture tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbaea28b548330be364932998543d5)