### PR TITLE
Add queue-saturation demo, run/validate scripts, and workspace updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ target
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Demo run artifacts
+demos/queue_service/artifacts/*.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +215,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "queue-service-demo"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "tailscope-core",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "tailscope-tokio",
   "tailscope-cli",
   "tailscope-macros",
+  "demos/queue_service",
 ]
 resolver = "2"
 

--- a/README.md
+++ b/README.md
@@ -211,3 +211,32 @@ tailscope analyze tailscope-run.json --format json
 - document every public API
 - keep the MVP tight
 - do not expand scope casually
+
+## Queue and backpressure demo
+
+A reproducible queue-saturation proof case is provided in `demos/queue_service`.
+
+What it does:
+- launches a Tokio runtime with low worker-permit capacity
+- drives offered load above service capacity
+- records queue wait and stage timing with `tailscope-core`
+- produces a run artifact and analyzer report
+
+Run the demo and produce analysis:
+
+```bash
+scripts/run_queue_demo.sh
+```
+
+Validate that the analyzer flags application queue saturation as the primary suspect:
+
+```bash
+scripts/validate_queue_demo.sh
+```
+
+Artifacts are written to:
+- `demos/queue_service/artifacts/queue-run.json`
+- `demos/queue_service/artifacts/queue-analysis.json`
+
+A sample analyzer output fixture is stored at:
+- `demos/queue_service/fixtures/sample-analysis.json`

--- a/demos/queue_service/Cargo.toml
+++ b/demos/queue_service/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "queue-service-demo"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
+tailscope-core = { path = "../../tailscope-core" }

--- a/demos/queue_service/fixtures/sample-analysis.json
+++ b/demos/queue_service/fixtures/sample-analysis.json
@@ -1,0 +1,34 @@
+{
+  "request_count": 250,
+  "p50_latency_us": 913603,
+  "p95_latency_us": 1729997,
+  "p99_latency_us": 1807406,
+  "primary_suspect": {
+    "kind": "ApplicationQueueSaturation",
+    "score": 90,
+    "confidence": "high",
+    "evidence": [
+      "Queue wait at p95 consumes 98.4% of request time.",
+      "Observed queue depth sample up to 230."
+    ],
+    "next_checks": [
+      "Inspect queue admission limits and producer burst patterns.",
+      "Compare queue wait distribution before and after increasing worker parallelism."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "DownstreamStageDominates",
+      "score": 60,
+      "confidence": "low",
+      "evidence": [
+        "Stage 'simulated_work' has p95 latency 39564 us across 250 samples.",
+        "Stage 'simulated_work' cumulative latency is 7664590 us."
+      ],
+      "next_checks": [
+        "Inspect downstream dependency behind stage 'simulated_work'.",
+        "Collect downstream service timings and retry behavior during tail windows."
+      ]
+    }
+  ]
+}

--- a/demos/queue_service/src/main.rs
+++ b/demos/queue_service/src/main.rs
@@ -1,0 +1,79 @@
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use tailscope_core::{Config, RequestMeta, Tailscope};
+use tokio::sync::Semaphore;
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 2)]
+async fn main() -> anyhow::Result<()> {
+    let output_path = std::env::args()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("demos/queue_service/artifacts/queue-run.json"));
+
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create artifact directory {}", parent.display()))?;
+    }
+
+    let mut config = Config::new("queue_service_demo");
+    config.output_path = output_path.clone();
+    let tailscope = Arc::new(Tailscope::init(config)?);
+
+    let service_capacity = 4;
+    let offered_requests = 250_u64;
+    let work_duration = Duration::from_millis(25);
+
+    let semaphore = Arc::new(Semaphore::new(service_capacity));
+    let waiting_depth = Arc::new(AtomicU64::new(0));
+
+    let mut tasks = Vec::with_capacity(offered_requests as usize);
+
+    for request_number in 0..offered_requests {
+        let tailscope = Arc::clone(&tailscope);
+        let semaphore = Arc::clone(&semaphore);
+        let waiting_depth = Arc::clone(&waiting_depth);
+
+        tasks.push(tokio::spawn(async move {
+            let request_id = format!("request-{request_number}");
+            let meta = RequestMeta::new(request_id.clone(), "/queue-demo");
+
+            tailscope
+                .request(meta, "ok", async {
+                    let _inflight = tailscope.inflight("queue_service_inflight");
+
+                    let depth = waiting_depth.fetch_add(1, Ordering::SeqCst) + 1;
+                    let permit = tailscope
+                        .queue(request_id.clone(), "worker_permit")
+                        .with_depth_at_start(depth)
+                        .await_on(semaphore.acquire())
+                        .await
+                        .expect("semaphore should remain open");
+                    waiting_depth.fetch_sub(1, Ordering::SeqCst);
+
+                    let _permit = permit;
+                    tailscope
+                        .stage(request_id, "simulated_work")
+                        .await_on(tokio::time::sleep(work_duration))
+                        .await;
+                })
+                .await;
+        }));
+
+        if request_number % 5 == 0 {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    }
+
+    for task in tasks {
+        task.await.context("request task panicked")?;
+    }
+
+    tailscope.flush()?;
+    println!("wrote {}", output_path.display());
+
+    Ok(())
+}

--- a/scripts/run_queue_demo.sh
+++ b/scripts/run_queue_demo.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ARTIFACT_PATH="${1:-$ROOT_DIR/demos/queue_service/artifacts/queue-run.json}"
+
+mkdir -p "$(dirname "$ARTIFACT_PATH")"
+
+cargo run --quiet --manifest-path "$ROOT_DIR/demos/queue_service/Cargo.toml" -- "$ARTIFACT_PATH"
+
+cargo run --quiet --manifest-path "$ROOT_DIR/tailscope-cli/Cargo.toml" -- analyze "$ARTIFACT_PATH" --format json \
+  > "$ROOT_DIR/demos/queue_service/artifacts/queue-analysis.json"
+
+printf 'run artifact: %s\n' "$ARTIFACT_PATH"
+printf 'analysis: %s\n' "$ROOT_DIR/demos/queue_service/artifacts/queue-analysis.json"

--- a/scripts/validate_queue_demo.sh
+++ b/scripts/validate_queue_demo.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ANALYSIS_PATH="$ROOT_DIR/demos/queue_service/artifacts/queue-analysis.json"
+
+"$ROOT_DIR/scripts/run_queue_demo.sh"
+
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+analysis_path = Path("demos/queue_service/artifacts/queue-analysis.json")
+report = json.loads(analysis_path.read_text())
+
+kind = report["primary_suspect"]["kind"]
+expected = {"application_queue_saturation", "ApplicationQueueSaturation"}
+if kind not in expected:
+    raise SystemExit(f"expected queue saturation suspect, got {kind}")
+
+print(f"validation passed: primary suspect is {kind}")
+PY
+
+echo "validated analysis file: $ANALYSIS_PATH"

--- a/tailscope-tokio/Cargo.toml
+++ b/tailscope-tokio/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 [dependencies]
 tailscope-core = { path = "../tailscope-core" }
 tailscope-macros = { path = "../tailscope-macros" }
-tokio = { version = "1", features = ["rt", "sync", "time"] }
+tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 tracing = "0.1"
 
 [lints]


### PR DESCRIPTION
### Motivation

- Provide a reproducible proof case so `tailscope` can demonstrate detection of application-level queue saturation and satisfy the demo/validation acceptance criteria. 

### Description

- Add a new demo crate `demos/queue_service` containing a Tokio binary that overloads a bounded semaphore while recording request, queue, stage, and inflight signals via `tailscope-core` (`demos/queue_service/Cargo.toml`, `demos/queue_service/src/main.rs`).
- Add `scripts/run_queue_demo.sh` to produce the run artifact and run the analyzer to emit `queue-run.json` and `queue-analysis.json` and add `scripts/validate_queue_demo.sh` to assert the analyzer’s primary suspect is queue saturation.
- Commit a sample analysis fixture at `demos/queue_service/fixtures/sample-analysis.json` and ignore generated demo artifacts via `.gitignore`.
- Update workspace `Cargo.toml` to include the demo crate and enable Tokio `macros` in `tailscope-tokio/Cargo.toml` so workspace builds cleanly.
- Apply a small formatting adjustment in the demo code to satisfy `cargo fmt`.

### Testing

- Ran the demo runner `scripts/run_queue_demo.sh` which produced `demos/queue_service/artifacts/queue-run.json` and `demos/queue_service/artifacts/queue-analysis.json` (success).
- Ran the validation script `scripts/validate_queue_demo.sh` which asserts the analyzer primary suspect is queue saturation (success).
- Ran workspace checks `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, and all completed successfully (tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbb0472cec8330a2808c00fa9404eb)