### PR TITLE
Follow-up: add reproducible blocking contamination demo and validator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "blocking-service-demo"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "tailscope-core",
+ "tokio",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "tailscope-cli",
   "tailscope-macros",
   "demos/queue_service",
+  "demos/blocking_service",
 ]
 resolver = "2"
 

--- a/README.md
+++ b/README.md
@@ -240,3 +240,33 @@ Artifacts are written to:
 
 A sample analyzer output fixture is stored at:
 - `demos/queue_service/fixtures/sample-analysis.json`
+
+## Blocking contamination demo
+
+A reproducible blocking-pressure proof case is provided in `demos/blocking_service`.
+
+What it does:
+- launches a Tokio runtime with a small blocking thread pool (`max_blocking_threads = 2`)
+- pushes high request concurrency through a `spawn_blocking` hot path
+- records request and stage timing with `tailscope-core`
+- records blocking backlog samples as runtime snapshots
+- produces a run artifact and analyzer report
+
+Run the demo and produce analysis:
+
+```bash
+scripts/run_blocking_demo.sh
+```
+
+Validate that the analyzer flags blocking-pool pressure as the primary suspect:
+
+```bash
+scripts/validate_blocking_demo.sh
+```
+
+Artifacts are written to:
+- `demos/blocking_service/artifacts/blocking-run.json`
+- `demos/blocking_service/artifacts/blocking-analysis.json`
+
+A sample analyzer output fixture is stored at:
+- `demos/blocking_service/fixtures/sample-analysis.json`

--- a/demos/blocking_service/Cargo.toml
+++ b/demos/blocking_service/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "blocking-service-demo"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = "1"
+tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }
+tailscope-core = { path = "../../tailscope-core" }

--- a/demos/blocking_service/fixtures/sample-analysis.json
+++ b/demos/blocking_service/fixtures/sample-analysis.json
@@ -1,0 +1,33 @@
+{
+  "request_count": 250,
+  "p50_latency_us": 1881608,
+  "p95_latency_us": 3545649,
+  "p99_latency_us": 3695811,
+  "primary_suspect": {
+    "kind": "BlockingPoolPressure",
+    "score": 80,
+    "confidence": "medium",
+    "evidence": [
+      "Blocking queue depth p95 is 244, indicating sustained spawn_blocking backlog."
+    ],
+    "next_checks": [
+      "Audit blocking sections and move avoidable synchronous work out of hot paths.",
+      "Inspect spawn_blocking callsites for long-running CPU or I/O work."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "DownstreamStageDominates",
+      "score": 60,
+      "confidence": "low",
+      "evidence": [
+        "Stage 'spawn_blocking_path' has p95 latency 3544453 us across 250 samples.",
+        "Stage 'spawn_blocking_path' cumulative latency is 469122763 us."
+      ],
+      "next_checks": [
+        "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
+        "Collect downstream service timings and retry behavior during tail windows."
+      ]
+    }
+  ]
+}

--- a/demos/blocking_service/src/main.rs
+++ b/demos/blocking_service/src/main.rs
@@ -1,0 +1,121 @@
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::Context;
+use tailscope_core::{Config, RequestMeta, RuntimeSnapshot, Tailscope};
+
+fn main() -> anyhow::Result<()> {
+    let output_path = std::env::args()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("demos/blocking_service/artifacts/blocking-run.json"));
+
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create artifact directory {}", parent.display()))?;
+    }
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .max_blocking_threads(2)
+        .enable_time()
+        .build()
+        .context("failed to build Tokio runtime")?;
+
+    runtime.block_on(run_demo(output_path))
+}
+
+async fn run_demo(output_path: PathBuf) -> anyhow::Result<()> {
+    let mut config = Config::new("blocking_service_demo");
+    config.output_path = output_path.clone();
+    let tailscope = Arc::new(Tailscope::init(config)?);
+
+    let offered_requests: u64 = 250;
+    let blocking_work = Duration::from_millis(30);
+
+    let pending_blocking = Arc::new(AtomicU64::new(0));
+
+    let sampler = {
+        let tailscope = Arc::clone(&tailscope);
+        let pending_blocking = Arc::clone(&pending_blocking);
+
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(Duration::from_millis(5));
+            for _ in 0..200 {
+                ticker.tick().await;
+                let pending = pending_blocking.load(Ordering::SeqCst);
+                tailscope.record_runtime_snapshot(RuntimeSnapshot {
+                    at_unix_ms: unix_time_ms(),
+                    alive_tasks: None,
+                    global_queue_depth: Some(0),
+                    local_queue_depth: None,
+                    blocking_queue_depth: Some(pending),
+                    remote_schedule_count: None,
+                });
+            }
+        })
+    };
+
+    let mut tasks = Vec::with_capacity(offered_requests as usize);
+
+    for request_number in 0..offered_requests {
+        let tailscope = Arc::clone(&tailscope);
+        let pending_blocking = Arc::clone(&pending_blocking);
+
+        tasks.push(tokio::spawn(async move {
+            let request_id = format!("request-{request_number}");
+            let meta = RequestMeta::new(request_id.clone(), "/blocking-demo");
+
+            tailscope
+                .request(meta, "ok", async {
+                    let _inflight = tailscope.inflight("blocking_service_inflight");
+                    let _wait = tailscope
+                        .queue(request_id.clone(), "dispatch_overhead")
+                        .await_on(tokio::time::sleep(Duration::from_micros(10)))
+                        .await;
+
+                    pending_blocking.fetch_add(1, Ordering::SeqCst);
+                    let handle = tokio::task::spawn_blocking(move || {
+                        std::thread::sleep(blocking_work);
+                    });
+
+                    tailscope
+                        .stage(request_id, "spawn_blocking_path")
+                        .await_on(async {
+                            handle
+                                .await
+                                .expect("spawn_blocking workload should complete")
+                        })
+                        .await;
+                    pending_blocking.fetch_sub(1, Ordering::SeqCst);
+                })
+                .await;
+        }));
+
+        if request_number % 8 == 0 {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    }
+
+    for task in tasks {
+        task.await.context("request task panicked")?;
+    }
+
+    sampler.await.context("sampler task panicked")?;
+
+    tailscope.flush()?;
+    println!("wrote {}", output_path.display());
+
+    Ok(())
+}
+
+fn unix_time_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time before UNIX_EPOCH")
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
+}

--- a/scripts/run_blocking_demo.sh
+++ b/scripts/run_blocking_demo.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ARTIFACT_PATH="${1:-$ROOT_DIR/demos/blocking_service/artifacts/blocking-run.json}"
+ANALYSIS_PATH="$ROOT_DIR/demos/blocking_service/artifacts/blocking-analysis.json"
+
+mkdir -p "$(dirname "$ARTIFACT_PATH")"
+
+cargo run --quiet --manifest-path "$ROOT_DIR/demos/blocking_service/Cargo.toml" -- "$ARTIFACT_PATH"
+
+cargo run --quiet --manifest-path "$ROOT_DIR/tailscope-cli/Cargo.toml" -- analyze "$ARTIFACT_PATH" --format json \
+  > "$ANALYSIS_PATH"
+
+printf 'run artifact: %s\n' "$ARTIFACT_PATH"
+printf 'analysis: %s\n' "$ANALYSIS_PATH"

--- a/scripts/validate_blocking_demo.sh
+++ b/scripts/validate_blocking_demo.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ANALYSIS_PATH="$ROOT_DIR/demos/blocking_service/artifacts/blocking-analysis.json"
+
+"$ROOT_DIR/scripts/run_blocking_demo.sh"
+
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+analysis_path = Path("demos/blocking_service/artifacts/blocking-analysis.json")
+report = json.loads(analysis_path.read_text())
+
+kind = report["primary_suspect"]["kind"]
+expected = {"blocking_pool_pressure", "BlockingPoolPressure"}
+if kind not in expected:
+    raise SystemExit(f"expected blocking pool pressure suspect, got {kind}")
+
+print(f"validation passed: primary suspect is {kind}")
+PY
+
+echo "validated analysis file: $ANALYSIS_PATH"


### PR DESCRIPTION
### Motivation

- Provide a reproducible proof case that demonstrates `tailscope` can detect blocking-pool pressure caused by `spawn_blocking` misuse under load.
- Ensure the analyzer has a stable, observable signal (blocking backlog snapshots) so the diagnosis ranks `BlockingPoolPressure` as the primary suspect.
- Make the demo runnable and automatically validated so reviewers and CI can reproduce the behavior easily.

### Description

- Add a new workspace demo `demos/blocking_service` with `Cargo.toml` and `src/main.rs` that constrains the Tokio blocking pool (`max_blocking_threads = 2`), drives many `spawn_blocking` requests, and records `RuntimeSnapshot` entries with `blocking_queue_depth` samples.
- Add runnable scripts `scripts/run_blocking_demo.sh` and `scripts/validate_blocking_demo.sh` to produce the run artifact, run the analyzer (`tailscope-cli analyze`), and assert the primary suspect is blocking-pool pressure; include a captured fixture at `demos/blocking_service/fixtures/sample-analysis.json`.
- Update the workspace `Cargo.toml` to include the new demo and append documentation to `README.md` describing how to run and validate the blocking contamination demo.

### Testing

- Ran the demo and analyzer via `scripts/run_blocking_demo.sh` and validated the analyzer output with `scripts/validate_blocking_demo.sh`, which passed and confirmed the primary suspect is `BlockingPoolPressure`.
- Ran full workspace checks: `cargo fmt --check` succeeded, `cargo clippy --workspace --all-targets -- -D warnings` succeeded, and `cargo test --workspace` succeeded.
- Generated and committed a sample analysis fixture `demos/blocking_service/fixtures/sample-analysis.json` that shows `BlockingPoolPressure` as the primary suspect for the demo run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbb438cf408330ac57d7f5011dd5f1)