### PR TITLE
Add fixture-backed smoke coverage for queue and blocking demos

### DIFF
--- a/tailscope-cli/tests/demo_smoke_fixtures.rs
+++ b/tailscope-cli/tests/demo_smoke_fixtures.rs
@@ -1,0 +1,45 @@
+use std::path::Path;
+
+use serde_json::Value;
+
+fn load_demo_analysis(path: &str) -> Value {
+    let path = Path::new("..").join(path);
+    let content = std::fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("failed reading fixture {}: {err}", path.display()));
+    serde_json::from_str(&content)
+        .unwrap_or_else(|err| panic!("failed parsing fixture {}: {err}", path.display()))
+}
+
+#[test]
+fn queue_demo_fixture_reports_application_queue_saturation() {
+    let report = load_demo_analysis("demos/queue_service/fixtures/sample-analysis.json");
+
+    assert_eq!(
+        report["primary_suspect"]["kind"],
+        Value::String("ApplicationQueueSaturation".to_string())
+    );
+    assert!(
+        report["primary_suspect"]["score"]
+            .as_u64()
+            .unwrap_or_default()
+            >= 70,
+        "queue demo should strongly prioritize queue saturation"
+    );
+}
+
+#[test]
+fn blocking_demo_fixture_reports_blocking_pool_pressure() {
+    let report = load_demo_analysis("demos/blocking_service/fixtures/sample-analysis.json");
+
+    assert_eq!(
+        report["primary_suspect"]["kind"],
+        Value::String("BlockingPoolPressure".to_string())
+    );
+    assert!(
+        report["primary_suspect"]["score"]
+            .as_u64()
+            .unwrap_or_default()
+            >= 70,
+        "blocking demo should strongly prioritize blocking pressure"
+    );
+}


### PR DESCRIPTION
### Motivation
- Provide deterministic CI coverage that detects regressions in the two MVP demos without relying on timing-sensitive runtime runs, using fixture-backed checks instead.

### Description
- Add `tailscope-cli/tests/demo_smoke_fixtures.rs` which loads demo analysis fixtures (`demos/queue_service/fixtures/sample-analysis.json` and `demos/blocking_service/fixtures/sample-analysis.json`) and asserts the `primary_suspect.kind` and a score floor (`>= 70`) for each demo.

### Testing
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, and all checks and tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbb68355ac8330a372cea8fe154177)