### PR TITLE
Add reproducible runtime-cost measurement harness and docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,6 +245,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "runtime_cost"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
+ "tailscope-core",
+ "tailscope-tokio",
+ "tokio",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "tailscope-macros",
   "demos/queue_service",
   "demos/blocking_service",
+  "demos/runtime_cost",
 ]
 resolver = "2"
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ tailscope should support three practical modes:
 
 The repository should measure these costs rather than assert them.
 
+See `docs/runtime-cost.md` and `scripts/measure_runtime_cost.sh` for the reproducible measurement path and the latest local sample output.
+
 ## Non-goals for MVP
 
 We do not aim for:

--- a/demos/runtime_cost/Cargo.toml
+++ b/demos/runtime_cost/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "runtime_cost"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+anyhow = "1"
+tailscope-core = { path = "../../tailscope-core" }
+tailscope-tokio = { path = "../../tailscope-tokio" }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/demos/runtime_cost/src/main.rs
+++ b/demos/runtime_cost/src/main.rs
@@ -1,0 +1,259 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::{bail, Context};
+use serde::Serialize;
+use tailscope_core::{CaptureMode, Config, RequestMeta, Tailscope};
+use tailscope_tokio::RuntimeSampler;
+use tokio::sync::{Mutex, Semaphore};
+
+const DEFAULT_REQUESTS: usize = 800;
+const DEFAULT_CONCURRENCY: usize = 32;
+const DEFAULT_WORK_MS: u64 = 3;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum Mode {
+    Baseline,
+    Light,
+    Investigation,
+}
+
+impl Mode {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "baseline" => Some(Self::Baseline),
+            "light" => Some(Self::Light),
+            "investigation" => Some(Self::Investigation),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Cli {
+    mode: Mode,
+    requests: usize,
+    concurrency: usize,
+    work_ms: u64,
+    output_dir: PathBuf,
+}
+
+#[derive(Debug, Serialize)]
+struct Measurement {
+    mode: Mode,
+    requests: usize,
+    concurrency: usize,
+    work_ms: u64,
+    throughput_rps: f64,
+    latency_p50_ms: f64,
+    latency_p95_ms: f64,
+    latency_p99_ms: f64,
+}
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 4)]
+async fn main() -> anyhow::Result<()> {
+    let cli = parse_cli()?;
+    std::fs::create_dir_all(&cli.output_dir)
+        .with_context(|| format!("failed to create {}", cli.output_dir.display()))?;
+
+    let mut tailscope = None;
+    let mut sampler = None;
+
+    if cli.mode != Mode::Baseline {
+        let mut config = Config::new("runtime_cost_demo");
+        config.mode = match cli.mode {
+            Mode::Light => CaptureMode::Light,
+            Mode::Investigation => CaptureMode::Investigation,
+            Mode::Baseline => CaptureMode::Light,
+        };
+        config.output_path = cli
+            .output_dir
+            .join(format!("run-{:?}.json", cli.mode).to_lowercase());
+
+        let instance = Arc::new(Tailscope::init(config)?);
+
+        if cli.mode == Mode::Investigation {
+            sampler = Some(RuntimeSampler::start(
+                Arc::clone(&instance),
+                Duration::from_millis(2),
+            )?);
+        }
+
+        tailscope = Some(instance);
+    }
+
+    let latencies_us = Arc::new(Mutex::new(Vec::<u64>::with_capacity(cli.requests)));
+    let semaphore = Arc::new(Semaphore::new(cli.concurrency));
+
+    let wall_start = Instant::now();
+    let mut tasks = Vec::with_capacity(cli.requests);
+
+    for idx in 0..cli.requests {
+        let sem = Arc::clone(&semaphore);
+        let latencies = Arc::clone(&latencies_us);
+        let mode = cli.mode;
+        let work_duration = Duration::from_millis(cli.work_ms);
+        let tailscope = tailscope.as_ref().map(Arc::clone);
+
+        tasks.push(tokio::spawn(async move {
+            let start = Instant::now();
+
+            match (mode, tailscope) {
+                (Mode::Baseline, _) => {
+                    let permit = sem.acquire().await.expect("semaphore closed");
+                    tokio::time::sleep(work_duration).await;
+                    drop(permit);
+                }
+                (_, Some(ts)) => {
+                    let request_id = format!("request-{idx}");
+                    let meta = RequestMeta::new(request_id.clone(), "/runtime-cost");
+
+                    ts.request(meta, "ok", async {
+                        let _inflight = ts.inflight("runtime_cost_requests");
+                        let permit = ts
+                            .queue(request_id.clone(), "worker_semaphore")
+                            .await_on(sem.acquire())
+                            .await
+                            .expect("semaphore closed");
+
+                        if mode == Mode::Investigation {
+                            ts.stage(request_id.clone(), "pre_work_marker")
+                                .await_on(tokio::time::sleep(Duration::from_micros(300)))
+                                .await;
+                        }
+
+                        ts.stage(request_id, "simulated_work")
+                            .await_on(tokio::time::sleep(work_duration))
+                            .await;
+
+                        drop(permit);
+                    })
+                    .await;
+                }
+                (_, None) => unreachable!("instrumented modes require a collector"),
+            }
+
+            let elapsed_us = u64::try_from(start.elapsed().as_micros()).unwrap_or(u64::MAX);
+            latencies.lock().await.push(elapsed_us);
+        }));
+    }
+
+    for task in tasks {
+        task.await.context("request task panicked")?;
+    }
+
+    let elapsed = wall_start.elapsed();
+
+    if let Some(sampler) = sampler {
+        sampler.shutdown().await;
+    }
+
+    if let Some(ts) = tailscope {
+        ts.flush()?;
+    }
+
+    let mut latencies = Arc::into_inner(latencies_us)
+        .expect("all task refs dropped")
+        .into_inner();
+    latencies.sort_unstable();
+
+    let measurement = Measurement {
+        mode: cli.mode,
+        requests: cli.requests,
+        concurrency: cli.concurrency,
+        work_ms: cli.work_ms,
+        throughput_rps: cli.requests as f64 / elapsed.as_secs_f64(),
+        latency_p50_ms: percentile_ms(&latencies, 0.50),
+        latency_p95_ms: percentile_ms(&latencies, 0.95),
+        latency_p99_ms: percentile_ms(&latencies, 0.99),
+    };
+
+    println!("{}", serde_json::to_string(&measurement)?);
+
+    Ok(())
+}
+
+fn parse_cli() -> anyhow::Result<Cli> {
+    let mut mode = None;
+    let mut requests = DEFAULT_REQUESTS;
+    let mut concurrency = DEFAULT_CONCURRENCY;
+    let mut work_ms = DEFAULT_WORK_MS;
+    let mut output_dir = PathBuf::from("demos/runtime_cost/artifacts");
+
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--mode" => {
+                let value = args.next().context("missing value for --mode")?;
+                mode = Mode::parse(&value);
+                if mode.is_none() {
+                    bail!("invalid --mode {value}; expected baseline|light|investigation");
+                }
+            }
+            "--requests" => {
+                requests = args
+                    .next()
+                    .context("missing value for --requests")?
+                    .parse()
+                    .context("invalid integer for --requests")?;
+            }
+            "--concurrency" => {
+                concurrency = args
+                    .next()
+                    .context("missing value for --concurrency")?
+                    .parse()
+                    .context("invalid integer for --concurrency")?;
+            }
+            "--work-ms" => {
+                work_ms = args
+                    .next()
+                    .context("missing value for --work-ms")?
+                    .parse()
+                    .context("invalid integer for --work-ms")?;
+            }
+            "--output-dir" => {
+                output_dir = PathBuf::from(args.next().context("missing value for --output-dir")?);
+            }
+            "--help" | "-h" => {
+                print_help();
+                std::process::exit(0);
+            }
+            _ => bail!("unknown arg: {arg}"),
+        }
+    }
+
+    let mode = mode.context("--mode is required")?;
+
+    if requests == 0 || concurrency == 0 || work_ms == 0 {
+        bail!("--requests, --concurrency, and --work-ms must be > 0");
+    }
+
+    Ok(Cli {
+        mode,
+        requests,
+        concurrency,
+        work_ms,
+        output_dir,
+    })
+}
+
+fn print_help() {
+    eprintln!(
+        "runtime_cost --mode <baseline|light|investigation> [--requests N] [--concurrency N] [--work-ms N] [--output-dir DIR]"
+    );
+}
+
+fn percentile_ms(sorted_us: &[u64], percentile: f64) -> f64 {
+    let len = sorted_us.len();
+    if len == 0 {
+        return 0.0;
+    }
+
+    let max_index = len - 1;
+    let target = (max_index as f64 * percentile).round();
+    let index = target.clamp(0.0, max_index as f64) as usize;
+
+    sorted_us[index] as f64 / 1_000.0
+}

--- a/docs/runtime-cost.md
+++ b/docs/runtime-cost.md
@@ -1,0 +1,69 @@
+# Runtime cost measurement
+
+This document defines the reproducible runtime-cost measurement path for `tailscope` MVP modes.
+
+## What is measured
+
+For each mode (`baseline`, `light`, `investigation`) the harness reports:
+
+- throughput (requests/second)
+- end-to-end latency p50
+- end-to-end latency p95
+- end-to-end latency p99
+
+The summary also computes relative overhead for `light` and `investigation` vs `baseline`.
+
+## Harness
+
+- Binary: `demos/runtime_cost`
+- Script: `scripts/measure_runtime_cost.sh`
+
+The harness runs a queueing workload with bounded concurrency and fixed simulated work per request.
+
+Mode behavior:
+
+- `baseline`: no `tailscope` instrumentation
+- `light`: request + queue + stage + inflight instrumentation
+- `investigation`: same as light, plus an additional stage marker and dense Tokio runtime sampling
+
+## Reproduce
+
+From repo root:
+
+```bash
+scripts/measure_runtime_cost.sh
+```
+
+Optional tuning via environment variables:
+
+- `REQUESTS` (default `1200`)
+- `CONCURRENCY` (default `48`)
+- `WORK_MS` (default `3`)
+- `ITERATIONS` (default `5`)
+
+Artifacts written to `demos/runtime_cost/artifacts/`:
+
+- `runtime-cost-raw.jsonl`
+- `runtime-cost-summary.json`
+- per-mode run JSON files for instrumented modes
+
+## Latest local run (2026-03-19)
+
+The following values come from `demos/runtime_cost/artifacts/runtime-cost-summary.json` generated in this repository on **2026-03-19**:
+
+| mode | throughput (req/s) | p50 (ms) | p95 (ms) | p99 (ms) |
+|---|---:|---:|---:|---:|
+| baseline | 10859.91 | 50.21 | 92.71 | 96.27 |
+| light | 10607.71 | 52.23 | 97.41 | 101.07 |
+| investigation | 7958.86 | 72.07 | 132.07 | 137.31 |
+
+Relative overhead vs baseline:
+
+- `light`: throughput **-2.32%**, p50 **+4.02%**, p95 **+5.08%**, p99 **+4.98%**
+- `investigation`: throughput **-26.71%**, p50 **+43.54%**, p95 **+42.47%**, p99 **+42.64%**
+
+## Notes and limits
+
+- Results are workload- and machine-specific.
+- These numbers are provided as an honest sample from one reproducible run path, not as universal guarantees.
+- Future runtime-cost claims should cite fresh output from this script/harness.

--- a/scripts/measure_runtime_cost.sh
+++ b/scripts/measure_runtime_cost.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ARTIFACT_DIR="${1:-$ROOT_DIR/demos/runtime_cost/artifacts}"
+REQUESTS="${REQUESTS:-1200}"
+CONCURRENCY="${CONCURRENCY:-48}"
+WORK_MS="${WORK_MS:-3}"
+ITERATIONS="${ITERATIONS:-5}"
+
+mkdir -p "$ARTIFACT_DIR"
+RAW_PATH="$ARTIFACT_DIR/runtime-cost-raw.jsonl"
+SUMMARY_PATH="$ARTIFACT_DIR/runtime-cost-summary.json"
+: > "$RAW_PATH"
+
+for mode in baseline light investigation; do
+  for ((i=1; i<=ITERATIONS; i++)); do
+    cargo run --quiet --manifest-path "$ROOT_DIR/demos/runtime_cost/Cargo.toml" -- \
+      --mode "$mode" \
+      --requests "$REQUESTS" \
+      --concurrency "$CONCURRENCY" \
+      --work-ms "$WORK_MS" \
+      --output-dir "$ARTIFACT_DIR" >> "$RAW_PATH"
+  done
+done
+
+python3 - "$RAW_PATH" "$SUMMARY_PATH" <<'PY'
+import json
+import statistics
+import sys
+
+raw_path = sys.argv[1]
+out_path = sys.argv[2]
+
+rows = [json.loads(line) for line in open(raw_path, encoding='utf-8') if line.strip()]
+by_mode = {}
+for row in rows:
+    by_mode.setdefault(row["mode"], []).append(row)
+
+required = ["baseline", "light", "investigation"]
+for mode in required:
+    if mode not in by_mode:
+        raise SystemExit(f"missing mode: {mode}")
+
+summary = {
+    "requests": by_mode["baseline"][0]["requests"],
+    "concurrency": by_mode["baseline"][0]["concurrency"],
+    "work_ms": by_mode["baseline"][0]["work_ms"],
+    "iterations_per_mode": len(by_mode["baseline"]),
+    "modes": {},
+}
+
+for mode, values in by_mode.items():
+    metrics = {k: [row[k] for row in values] for k in ["throughput_rps", "latency_p50_ms", "latency_p95_ms", "latency_p99_ms"]}
+    summary["modes"][mode] = {
+        "throughput_rps_mean": statistics.fmean(metrics["throughput_rps"]),
+        "latency_p50_ms_mean": statistics.fmean(metrics["latency_p50_ms"]),
+        "latency_p95_ms_mean": statistics.fmean(metrics["latency_p95_ms"]),
+        "latency_p99_ms_mean": statistics.fmean(metrics["latency_p99_ms"]),
+    }
+
+baseline = summary["modes"]["baseline"]
+for mode in ["light", "investigation"]:
+    m = summary["modes"][mode]
+    m["throughput_overhead_pct_vs_baseline"] = ((baseline["throughput_rps_mean"] - m["throughput_rps_mean"]) / baseline["throughput_rps_mean"]) * 100.0
+    m["p50_overhead_pct_vs_baseline"] = ((m["latency_p50_ms_mean"] - baseline["latency_p50_ms_mean"]) / baseline["latency_p50_ms_mean"]) * 100.0
+    m["p95_overhead_pct_vs_baseline"] = ((m["latency_p95_ms_mean"] - baseline["latency_p95_ms_mean"]) / baseline["latency_p95_ms_mean"]) * 100.0
+    m["p99_overhead_pct_vs_baseline"] = ((m["latency_p99_ms_mean"] - baseline["latency_p99_ms_mean"]) / baseline["latency_p99_ms_mean"]) * 100.0
+
+with open(out_path, "w", encoding="utf-8") as f:
+    json.dump(summary, f, indent=2)
+
+print(json.dumps(summary, indent=2))
+PY
+
+echo "raw results: $RAW_PATH"
+echo "summary: $SUMMARY_PATH"


### PR DESCRIPTION
### Motivation

- The project required concrete, reproducible measurements for `baseline`, `light`, and `investigation` modes instead of unmeasured runtime-cost claims. 
- Provide a minimal, easy-to-run harness so maintainers and reviewers can reproduce overhead numbers and tune workloads for future claims. 

### Description

- Add a new measurement harness crate at `demos/runtime_cost` that runs a bounded-concurrency workload and emits per-run JSON measurements for throughput and p50/p95/p99 latency. 
- Add `scripts/measure_runtime_cost.sh` to run repeated trials across `baseline`, `light`, and `investigation` modes, aggregate means, and produce a machine-readable summary `runtime-cost-summary.json`. 
- Add documentation at `docs/runtime-cost.md` describing the harness, reproduction steps, artifact locations, tuning knobs, and a dated local sample run. 
- Update `README.md` and the workspace `Cargo.toml` to include the new demo and point to the reproducible measurement path. 

### Testing

- Ran the measurement script `scripts/measure_runtime_cost.sh` which completed and produced `demos/runtime_cost/artifacts/runtime-cost-summary.json` and `runtime-cost-raw.jsonl`. 
- Ran formatting check with `cargo fmt --check` which succeeded. 
- Ran lints with `cargo clippy --workspace --all-targets -- -D warnings` which succeeded. 
- Ran the full test suite with `cargo test --workspace` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbb7f4f77c8330a6c43366870c619c)