### PR TITLE
Integrate request macro with tailscope run artifact recording

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,7 +363,9 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
+ "serde_json",
  "syn",
+ "tailscope-core",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/README.md
+++ b/README.md
@@ -82,6 +82,33 @@ cargo run --manifest-path tailscope-cli/Cargo.toml -- analyze tailscope-run.json
 cargo run --manifest-path tailscope-cli/Cargo.toml -- analyze tailscope-run.json --format json
 ```
 
+### 3) Macro-based request entry point
+
+```rust
+use std::sync::Arc;
+use tailscope_core::Tailscope;
+use tailscope_tokio::instrument_request;
+
+#[instrument_request(
+    route = "/invoice",
+    kind = "create_invoice",
+    tailscope = tailscope,
+    request_id = request_id.clone(),
+    skip(tailscope)
+)]
+async fn create_invoice(
+    tailscope: Arc<Tailscope>,
+    request_id: String,
+) -> Result<(), &'static str> {
+    let _inflight = tailscope.inflight("invoice_inflight");
+    Ok(())
+}
+```
+
+```bash
+tailscope analyze tailscope-run.json
+```
+
 ## Diagnosis categories (MVP)
 
 The analyzer ranks suspects from run evidence:

--- a/SPEC.md
+++ b/SPEC.md
@@ -118,6 +118,16 @@ sampler.shutdown().await;
 
 `tailscope-tokio` re-exports `#[instrument_request]` from `tailscope-macros` for request entry-point ergonomics.
 
+The macro always emits tracing request events. When `tailscope = <expr>` is provided,
+it also records `RequestEvent` entries directly into the active run artifact.
+
+Supported arguments:
+- `route = <expr>` (optional; defaults to `module_path!()::fn_name`)
+- `kind = <expr>` (optional; defaults to `fn_name`)
+- `tailscope = <expr>` (optional; enables run-artifact request recording)
+- `request_id = <expr>` (optional; defaults to a route+timestamp id when `tailscope` is set)
+- `skip(...)` (optional; passed through to `tracing::instrument`)
+
 ## 6. Run data model
 
 `tailscope-core` emits one JSON run artifact with:

--- a/tailscope-core/src/lib.rs
+++ b/tailscope-core/src/lib.rs
@@ -278,17 +278,14 @@ impl Tailscope {
         let value = fut.await;
         let finished_at_unix_ms = unix_time_ms();
 
-        let event = RequestEvent {
-            request_id: meta.request_id,
-            route: meta.route,
-            kind: meta.kind,
-            started_at_unix_ms,
-            finished_at_unix_ms,
-            latency_us: duration_to_us(started.elapsed()),
-            outcome: outcome.into(),
-        };
-
-        lock_run(&self.run).requests.push(event);
+        self.record_request_fields(
+            meta.request_id,
+            meta.route,
+            meta.kind,
+            (started_at_unix_ms, finished_at_unix_ms),
+            duration_to_us(started.elapsed()),
+            outcome,
+        );
 
         value
     }
@@ -297,6 +294,28 @@ impl Tailscope {
     #[must_use]
     pub fn snapshot(&self) -> Run {
         lock_run(&self.run).clone()
+    }
+
+    /// Records one request event using pre-computed timing and outcome fields.
+    pub fn record_request_fields(
+        &self,
+        request_id: impl Into<String>,
+        route: impl Into<String>,
+        kind: Option<String>,
+        time_window_unix_ms: (u64, u64),
+        latency_us: u64,
+        outcome: impl Into<String>,
+    ) {
+        let (started_at_unix_ms, finished_at_unix_ms) = time_window_unix_ms;
+        lock_run(&self.run).requests.push(RequestEvent {
+            request_id: request_id.into(),
+            route: route.into(),
+            kind,
+            started_at_unix_ms,
+            finished_at_unix_ms,
+            latency_us,
+            outcome: outcome.into(),
+        });
     }
 
     /// Writes the current run to the configured sink.

--- a/tailscope-macros/Cargo.toml
+++ b/tailscope-macros/Cargo.toml
@@ -16,6 +16,8 @@ syn = { version = "2", features = ["full", "parsing"] }
 workspace = true
 
 [dev-dependencies]
+serde_json = "1"
+tailscope-core = { path = "../tailscope-core" }
 tokio = { version = "1", features = ["macros", "rt"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/tailscope-macros/src/lib.rs
+++ b/tailscope-macros/src/lib.rs
@@ -11,6 +11,8 @@ use syn::{
 struct InstrumentArgs {
     route: Option<Expr>,
     kind: Option<Expr>,
+    tailscope: Option<Expr>,
+    request_id: Option<Expr>,
     skip: Option<Punctuated<syn::Ident, Token![,]>>,
 }
 
@@ -27,6 +29,16 @@ impl Parse for InstrumentArgs {
                 Meta::NameValue(MetaNameValue { path, value, .. }) if path.is_ident("kind") => {
                     args.kind = Some(value);
                 }
+                Meta::NameValue(MetaNameValue { path, value, .. })
+                    if path.is_ident("tailscope") =>
+                {
+                    args.tailscope = Some(value);
+                }
+                Meta::NameValue(MetaNameValue { path, value, .. })
+                    if path.is_ident("request_id") =>
+                {
+                    args.request_id = Some(value);
+                }
                 Meta::List(MetaList { path, tokens, .. }) if path.is_ident("skip") => {
                     if args.skip.is_some() {
                         return Err(Error::new_spanned(path, "duplicate skip argument"));
@@ -39,7 +51,7 @@ impl Parse for InstrumentArgs {
                 _ => {
                     return Err(Error::new_spanned(
                         meta,
-                        "unsupported argument; expected route = <expr>, kind = <expr>, or skip(...)",
+                        "unsupported argument; expected route = <expr>, kind = <expr>, tailscope = <expr>, request_id = <expr>, or skip(...)",
                     ));
                 }
             }
@@ -60,6 +72,7 @@ pub fn instrument_request(attr: TokenStream, item: TokenStream) -> TokenStream {
     }
 }
 
+#[allow(clippy::too_many_lines)]
 fn expand_instrument_request(
     args: InstrumentArgs,
     mut input_fn: ItemFn,
@@ -80,6 +93,8 @@ fn expand_instrument_request(
     let kind_expr = args
         .kind
         .unwrap_or_else(|| default_kind_expr(&input_fn.sig.ident));
+    let tailscope_expr = args.tailscope;
+    let request_id_expr = args.request_id;
 
     let route_field = make_field_expr("route", route_expr);
     let kind_field = make_field_expr("kind", kind_expr);
@@ -92,48 +107,91 @@ fn expand_instrument_request(
 
     let body = input_fn.block;
     let returns_result = returns_result(&input_fn.sig.output);
-    let tail_event = if returns_result {
-        quote! {
-            match &__tailscope_result {
-                Ok(_) => ::tracing::info!(
-                    target: "tailscope::request",
-                    route = __tailscope_route,
-                    kind = __tailscope_kind,
-                    outcome = "ok",
-                    duration_us = __tailscope_duration_us,
-                    "request completed"
-                ),
-                Err(_) => ::tracing::warn!(
-                    target: "tailscope::request",
-                    route = __tailscope_route,
-                    kind = __tailscope_kind,
-                    outcome = "error",
-                    duration_us = __tailscope_duration_us,
-                    "request completed"
-                ),
-            }
-        }
+    let (outcome_expr, tail_event) = if returns_result {
+        (
+            quote! {
+                let __tailscope_outcome = match &__tailscope_result {
+                    Ok(_) => "ok",
+                    Err(_) => "error",
+                };
+            },
+            quote! {
+                if __tailscope_outcome == "ok" {
+                    ::tracing::info!(
+                        target: "tailscope::request",
+                        route = __tailscope_route,
+                        kind = __tailscope_kind,
+                        outcome = __tailscope_outcome,
+                        duration_us = __tailscope_duration_us,
+                        "request completed"
+                    );
+                } else {
+                    ::tracing::warn!(
+                        target: "tailscope::request",
+                        route = __tailscope_route,
+                        kind = __tailscope_kind,
+                        outcome = __tailscope_outcome,
+                        duration_us = __tailscope_duration_us,
+                        "request completed"
+                    );
+                }
+            },
+        )
     } else {
+        (
+            quote! {
+                let __tailscope_outcome = "ok";
+            },
+            quote! {
+                ::tracing::info!(
+                    target: "tailscope::request",
+                    route = __tailscope_route,
+                    kind = __tailscope_kind,
+                    outcome = __tailscope_outcome,
+                    duration_us = __tailscope_duration_us,
+                    "request completed"
+                );
+            },
+        )
+    };
+    let record_request = if let Some(tailscope) = tailscope_expr {
+        let request_id = request_id_expr.unwrap_or_else(default_request_id_expr);
         quote! {
-            ::tracing::info!(
-                target: "tailscope::request",
-                route = __tailscope_route,
-                kind = __tailscope_kind,
-                outcome = "ok",
-                duration_us = __tailscope_duration_us,
-                "request completed"
+            (#tailscope).record_request_fields(
+                #request_id,
+                __tailscope_route.clone(),
+                Some(__tailscope_kind.clone()),
+                (__tailscope_started_at_unix_ms, __tailscope_finished_at_unix_ms),
+                __tailscope_duration_us,
+                __tailscope_outcome,
             );
         }
+    } else {
+        quote! {}
     };
 
     input_fn.block = Box::new(syn::parse_quote!({
-        let __tailscope_route = #route_field;
-        let __tailscope_kind = #kind_field;
+        let __tailscope_route = ::std::string::ToString::to_string(&#route_field);
+        let __tailscope_kind = ::std::string::ToString::to_string(&#kind_field);
+        let __tailscope_started_at_unix_ms = ::std::time::SystemTime::now()
+            .duration_since(::std::time::UNIX_EPOCH)
+            .expect("system time before UNIX_EPOCH")
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX);
         let __tailscope_started = ::std::time::Instant::now();
         let __tailscope_result = (async move #body).await;
+        #outcome_expr
+        let __tailscope_finished_at_unix_ms = ::std::time::SystemTime::now()
+            .duration_since(::std::time::UNIX_EPOCH)
+            .expect("system time before UNIX_EPOCH")
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX);
         let __tailscope_duration_us =
             ::std::convert::TryFrom::try_from(__tailscope_started.elapsed().as_micros())
                 .unwrap_or(u64::MAX);
+        #record_request
         #tail_event
         __tailscope_result
     }));
@@ -169,6 +227,13 @@ fn default_route_expr(name: &syn::Ident) -> Expr {
 
 fn default_kind_expr(name: &syn::Ident) -> Expr {
     syn::parse_quote!(stringify!(#name))
+}
+
+fn default_request_id_expr() -> Expr {
+    syn::parse_quote!(format!(
+        "{}-{}",
+        __tailscope_route, __tailscope_started_at_unix_ms
+    ))
 }
 
 fn validate_skipped_args(

--- a/tailscope-macros/tests/instrument_request.rs
+++ b/tailscope-macros/tests/instrument_request.rs
@@ -1,5 +1,7 @@
 use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
 
+use tailscope_core::{Config, Tailscope};
 use tailscope_macros::instrument_request;
 use tracing::{Event, Subscriber};
 use tracing_subscriber::layer::{Context, Layer};
@@ -58,6 +60,25 @@ async fn err_handler(state: u32) -> Result<u32, &'static str> {
     Err("boom")
 }
 
+#[instrument_request(
+    route = "/macro",
+    kind = "macro_collector",
+    tailscope = tailscope,
+    request_id = request_id.clone(),
+    skip(tailscope)
+)]
+async fn collector_handler(
+    tailscope: &Tailscope,
+    request_id: String,
+    succeed: bool,
+) -> Result<&'static str, &'static str> {
+    if succeed {
+        Ok("ok")
+    } else {
+        Err("boom")
+    }
+}
+
 #[tokio::test]
 async fn records_ok_and_error_outcomes() {
     let recorded = RecordedEvents::default();
@@ -94,4 +115,45 @@ async fn records_ok_and_error_outcomes() {
     assert!(tail_events
         .iter()
         .all(|line| line.contains("kind=\"create_invoice\"")));
+}
+
+#[tokio::test]
+async fn writes_request_events_to_run_json_when_tailscope_is_provided() {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time before epoch")
+        .as_nanos();
+    let output_path = std::env::temp_dir().join(format!("tailscope_macro_run_{nanos}.json"));
+
+    let mut config = Config::new("macro-test");
+    config.output_path = output_path.clone();
+
+    let tailscope = Tailscope::init(config).expect("init should succeed");
+
+    let ok = collector_handler(&tailscope, "req-ok".to_string(), true)
+        .await
+        .expect("ok request should succeed");
+    assert_eq!(ok, "ok");
+
+    let err = collector_handler(&tailscope, "req-err".to_string(), false)
+        .await
+        .expect_err("error request should fail");
+    assert_eq!(err, "boom");
+
+    tailscope.flush().expect("flush should succeed");
+
+    let run_json = std::fs::read_to_string(&output_path).expect("run artifact should be readable");
+    let run_value: serde_json::Value =
+        serde_json::from_str(&run_json).expect("run artifact should be valid json");
+    let requests = run_value["requests"]
+        .as_array()
+        .expect("run artifact requests should be an array");
+
+    assert_eq!(requests.len(), 2);
+    assert!(requests.iter().any(|event| event["request_id"] == "req-ok"));
+    assert!(requests
+        .iter()
+        .any(|event| event["request_id"] == "req-err"));
+    assert!(requests.iter().any(|event| event["outcome"] == "ok"));
+    assert!(requests.iter().any(|event| event["outcome"] == "error"));
 }

--- a/tailscope-tokio/src/lib.rs
+++ b/tailscope-tokio/src/lib.rs
@@ -1,4 +1,29 @@
 //! Tokio runtime integration for tailscope.
+//!
+//! This crate provides:
+//! - [`RuntimeSampler`] for periodic Tokio runtime metrics snapshots.
+//! - [`instrument_request`] for request entry-point tracing and optional
+//!   request-event recording into a [`tailscope_core::Tailscope`] collector.
+//!
+//! Macro example:
+//! ```ignore
+//! use tailscope_core::Tailscope;
+//! use tailscope_tokio::instrument_request;
+//!
+//! #[instrument_request(
+//!     route = "/invoice",
+//!     kind = "create_invoice",
+//!     tailscope = tailscope,
+//!     request_id = request_id.clone(),
+//!     skip(tailscope)
+//! )]
+//! async fn handle_invoice(
+//!     tailscope: &Tailscope,
+//!     request_id: String,
+//! ) -> Result<(), &'static str> {
+//!     Ok(())
+//! }
+//! ```
 
 use std::sync::Arc;
 use std::time::Duration;


### PR DESCRIPTION
### Motivation
- Enable the `#[instrument_request]` macro to optionally write request timing/outcome directly into the `tailscope-core::Tailscope` run artifact so macro-instrumented handlers can be used as collectors as well as tracers.
- Preserve existing tracing output and semantics while providing a clear, low-friction integration path into the collector for the MVP.

### Description
- Extended `#[instrument_request]` (in `tailscope-macros`) with optional `tailscope = <expr>` and `request_id = <expr>` arguments so the macro can obtain a `Tailscope` and write `RequestEvent` records when provided, while still emitting tracing events as before.
- Added `Tailscope::record_request_fields(...)` in `tailscope-core` to accept pre-computed start/finish/latency/outcome fields and append a `RequestEvent` to the in-memory run.
- Macro now computes start/finish timestamps, duration, and outcome and, when `tailscope` is present, calls `record_request_fields` to persist the request into the run; tracing instrumentation and outcome-level logging are unchanged.
- Added an integration test in `tailscope-macros/tests/` that instruments a handler with `tailscope = tailscope` and `request_id`, flushes the run JSON, and asserts both `ok` and `error` request events are present; updated `tailscope-macros` dev-dependencies (`serde_json`, `tailscope-core`) and updated `README.md`, `SPEC.md`, and `tailscope-tokio` crate docs with macro usage and semantics.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it passed with no warnings.
- Ran `cargo test --workspace` and all tests (including the new macro integration tests) passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbbfdf83d08330aa472b883fd1516b)