### PR TITLE
Add explicit request-time share metrics to tailscope analyze output

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -8,6 +8,8 @@ This document explains what the analyzer currently reports and how to interpret 
 
 - request count
 - request p50/p95/p99 latency
+- p95 request-time share for queue wait (permille)
+- p95 request-time share for service time (permille)
 - one primary suspect
 - zero or more secondary suspects
 
@@ -18,6 +20,24 @@ Each suspect includes:
 - confidence
 - evidence (human-readable)
 - recommended next checks
+
+## Request-time share metrics
+
+The report includes two explicit request-time share fields:
+
+- `p95_queue_share_permille`
+- `p95_service_share_permille`
+
+Both are measured in permille (0-1000) across requests, where:
+
+- `1000` = 100.0% of request time
+- `500` = 50.0% of request time
+
+Interpretation guidance:
+
+- high `p95_queue_share_permille` (for example 300+ = 30%+) points to application-level queueing pressure
+- high `p95_service_share_permille` with a dominant stage points to downstream/service-time bottlenecks
+- queue + service shares are complementary at request level in current MVP heuristics (queue wait is clamped to request latency)
 
 ## Suspect kinds
 

--- a/tailscope-cli/src/analyze.rs
+++ b/tailscope-cli/src/analyze.rs
@@ -77,6 +77,8 @@ pub struct Report {
     pub p50_latency_us: Option<u64>,
     pub p95_latency_us: Option<u64>,
     pub p99_latency_us: Option<u64>,
+    pub p95_queue_share_permille: Option<u64>,
+    pub p95_service_share_permille: Option<u64>,
     pub primary_suspect: Suspect,
     pub secondary_suspects: Vec<Suspect>,
 }
@@ -92,6 +94,9 @@ pub fn analyze_run(run: &Run) -> Report {
     let p50_latency_us = percentile(&request_latencies, 50, 100);
     let p95_latency_us = percentile(&request_latencies, 95, 100);
     let p99_latency_us = percentile(&request_latencies, 99, 100);
+    let (queue_shares, service_shares) = request_time_shares(run);
+    let p95_queue_share_permille = percentile(&queue_shares, 95, 100);
+    let p95_service_share_permille = percentile(&service_shares, 95, 100);
 
     let mut suspects = Vec::new();
 
@@ -145,13 +150,15 @@ pub fn analyze_run(run: &Run) -> Report {
         p50_latency_us,
         p95_latency_us,
         p99_latency_us,
+        p95_queue_share_permille,
+        p95_service_share_permille,
         primary_suspect,
         secondary_suspects: ranked.collect(),
     }
 }
 
 fn queue_saturation_suspect(run: &Run) -> Option<Suspect> {
-    let queue_shares = request_queue_shares(run);
+    let (queue_shares, _) = request_time_shares(run);
     let p95_queue_share_permille = percentile(&queue_shares, 95, 100)?;
     let max_depth = run
         .queues
@@ -280,7 +287,7 @@ fn downstream_stage_suspect(run: &Run) -> Option<Suspect> {
     ))
 }
 
-fn request_queue_shares(run: &Run) -> Vec<u64> {
+fn request_time_shares(run: &Run) -> (Vec<u64>, Vec<u64>) {
     let mut total_queue_wait_by_request = HashMap::<&str, u64>::new();
     for queue in &run.queues {
         *total_queue_wait_by_request
@@ -292,20 +299,26 @@ fn request_queue_shares(run: &Run) -> Vec<u64> {
             .saturating_add(queue.wait_us);
     }
 
-    run.requests
-        .iter()
-        .filter_map(|request| {
-            if request.latency_us == 0 {
-                return None;
-            }
+    let mut queue_shares = Vec::new();
+    let mut service_shares = Vec::new();
 
-            let queue_wait = total_queue_wait_by_request
-                .get(request.request_id.as_str())
-                .copied()
-                .unwrap_or_default();
-            Some(queue_wait.saturating_mul(1_000) / request.latency_us)
-        })
-        .collect()
+    for request in &run.requests {
+        if request.latency_us == 0 {
+            continue;
+        }
+
+        let queue_wait = total_queue_wait_by_request
+            .get(request.request_id.as_str())
+            .copied()
+            .unwrap_or_default()
+            .min(request.latency_us);
+        let service_time = request.latency_us.saturating_sub(queue_wait);
+
+        queue_shares.push(queue_wait.saturating_mul(1_000) / request.latency_us);
+        service_shares.push(service_time.saturating_mul(1_000) / request.latency_us);
+    }
+
+    (queue_shares, service_shares)
 }
 
 fn runtime_metric_series(
@@ -350,6 +363,10 @@ pub fn render_text(report: &Report) -> String {
         format!(
             "latency_us p50={:?} p95={:?} p99={:?}",
             report.p50_latency_us, report.p95_latency_us, report.p99_latency_us
+        ),
+        format!(
+            "request_time_share_permille p95 queue={:?} service={:?}",
+            report.p95_queue_share_permille, report.p95_service_share_permille
         ),
         format!(
             "primary: {} (confidence={:?}, score={})",

--- a/tailscope-cli/tests/analyzer_fixtures.rs
+++ b/tailscope-cli/tests/analyzer_fixtures.rs
@@ -56,9 +56,25 @@ fn fixture_reports_render_to_text_and_json() {
 
     let text = render_text(&report);
     assert!(text.contains("primary:"));
+    assert!(text.contains("request_time_share_permille"));
     assert!(text.contains("secondary suspects") || report.secondary_suspects.is_empty());
 
     let json = serde_json::to_string_pretty(&report).expect("json rendering should work");
     assert!(json.contains("primary_suspect"));
     assert!(json.contains("confidence"));
+    assert!(json.contains("p95_queue_share_permille"));
+    assert!(json.contains("p95_service_share_permille"));
+}
+
+#[test]
+fn fixture_reports_include_expected_request_time_shares() {
+    let queue_run = load_fixture("queue_saturation.json");
+    let queue_report = analyze_run(&queue_run);
+    assert_eq!(queue_report.p95_queue_share_permille, Some(666));
+    assert_eq!(queue_report.p95_service_share_permille, Some(500));
+
+    let downstream_run = load_fixture("downstream_stage.json");
+    let downstream_report = analyze_run(&downstream_run);
+    assert_eq!(downstream_report.p95_queue_share_permille, Some(0));
+    assert_eq!(downstream_report.p95_service_share_permille, Some(1000));
 }


### PR DESCRIPTION
### Motivation

- Align the CLI analyzer with the M4 deliverable to surface explicit request-time share metrics (queue vs service) instead of leaving them implicit in heuristics. 
- Provide concrete, machine-readable fields and readable text output so downstream tooling and fixture tests can validate queue/service attribution.

### Description

- Added `p95_queue_share_permille` and `p95_service_share_permille` to the `Report` struct and included them in JSON and text rendering via `render_text`.
- Implemented a helper `request_time_shares(run: &Run) -> (Vec<u64>, Vec<u64>)` that computes per-request queue and service time shares (permille) and clamps queue wait to request latency.
- Wired the queue-saturation rule to use the computed queue-share series and compute p95 for ranking, and preserved existing diagnosis heuristics and evidence strings.
- Added fixture tests in `tailscope-cli/tests/analyzer_fixtures.rs` asserting expected p95 share values and updated `docs/diagnostics.md` with interpretation guidance for the new fields.

### Testing

- Ran `cargo fmt --check` which completed successfully.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` which completed successfully.
- Ran `cargo test --workspace` and all workspace tests passed, including the new fixture tests validating `p95_queue_share_permille` and `p95_service_share_permille`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbc23e175c83308bbc9901b89e3d13)