### PR TITLE
Add reproducible before/after queue demo with comparative analysis outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,22 @@ scripts/validate_queue_demo.sh
 
 Artifacts:
 
-- `demos/queue_service/artifacts/queue-run.json`
-- `demos/queue_service/artifacts/queue-analysis.json`
+- `demos/queue_service/artifacts/before-run.json`
+- `demos/queue_service/artifacts/before-analysis.json`
+- `demos/queue_service/artifacts/after-run.json`
+- `demos/queue_service/artifacts/after-analysis.json`
+- `demos/queue_service/artifacts/before-after-comparison.json`
+
+Fixture snapshots:
+
+- `demos/queue_service/fixtures/before-analysis.json`
+- `demos/queue_service/fixtures/after-analysis.json`
+
+Observed signal in the checked-in queue demo fixtures:
+
+- p95 latency drops from ~1,682,454us (before) to ~24,745us (after)
+- primary suspect score drops from 90 to 60
+- p95 queue share drops from 981 permille to 5 permille
 
 ### Blocking-pool pressure demo
 

--- a/demos/queue_service/fixtures/after-analysis.json
+++ b/demos/queue_service/fixtures/after-analysis.json
@@ -1,0 +1,22 @@
+{
+  "request_count": 250,
+  "p50_latency_us": 17043,
+  "p95_latency_us": 24745,
+  "p99_latency_us": 26891,
+  "p95_queue_share_permille": 5,
+  "p95_service_share_permille": 1000,
+  "primary_suspect": {
+    "kind": "DownstreamStageDominates",
+    "score": 60,
+    "confidence": "low",
+    "evidence": [
+      "Stage 'simulated_work' has p95 latency 24066 us across 250 samples.",
+      "Stage 'simulated_work' cumulative latency is 4468249 us."
+    ],
+    "next_checks": [
+      "Inspect downstream dependency behind stage 'simulated_work'.",
+      "Collect downstream service timings and retry behavior during tail windows."
+    ]
+  },
+  "secondary_suspects": []
+}

--- a/demos/queue_service/fixtures/before-analysis.json
+++ b/demos/queue_service/fixtures/before-analysis.json
@@ -1,0 +1,36 @@
+{
+  "request_count": 250,
+  "p50_latency_us": 892107,
+  "p95_latency_us": 1682454,
+  "p99_latency_us": 1753285,
+  "p95_queue_share_permille": 981,
+  "p95_service_share_permille": 263,
+  "primary_suspect": {
+    "kind": "ApplicationQueueSaturation",
+    "score": 90,
+    "confidence": "high",
+    "evidence": [
+      "Queue wait at p95 consumes 98.1% of request time.",
+      "Observed queue depth sample up to 223."
+    ],
+    "next_checks": [
+      "Inspect queue admission limits and producer burst patterns.",
+      "Compare queue wait distribution before and after increasing worker parallelism."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "DownstreamStageDominates",
+      "score": 60,
+      "confidence": "low",
+      "evidence": [
+        "Stage 'simulated_work' has p95 latency 36111 us across 250 samples.",
+        "Stage 'simulated_work' cumulative latency is 7566556 us."
+      ],
+      "next_checks": [
+        "Inspect downstream dependency behind stage 'simulated_work'.",
+        "Collect downstream service timings and retry behavior during tail windows."
+      ]
+    }
+  ]
+}

--- a/demos/queue_service/src/main.rs
+++ b/demos/queue_service/src/main.rs
@@ -7,12 +7,32 @@ use anyhow::Context;
 use tailscope_core::{Config, RequestMeta, Tailscope};
 use tokio::sync::Semaphore;
 
+#[derive(Clone, Copy)]
+enum DemoMode {
+    Baseline,
+    Mitigated,
+}
+
+impl DemoMode {
+    fn from_arg(value: Option<String>) -> anyhow::Result<Self> {
+        match value.as_deref() {
+            None | Some("baseline") | Some("before") => Ok(Self::Baseline),
+            Some("mitigated") | Some("after") => Ok(Self::Mitigated),
+            Some(other) => anyhow::bail!(
+                "unsupported mode '{other}', expected one of: baseline, before, mitigated, after"
+            ),
+        }
+    }
+}
+
 #[tokio::main(flavor = "multi_thread", worker_threads = 2)]
 async fn main() -> anyhow::Result<()> {
-    let output_path = std::env::args()
-        .nth(1)
+    let mut args = std::env::args().skip(1);
+    let output_path = args
+        .next()
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("demos/queue_service/artifacts/queue-run.json"));
+    let mode = DemoMode::from_arg(args.next())?;
 
     if let Some(parent) = output_path.parent() {
         std::fs::create_dir_all(parent)
@@ -23,9 +43,28 @@ async fn main() -> anyhow::Result<()> {
     config.output_path = output_path.clone();
     let tailscope = Arc::new(Tailscope::init(config)?);
 
-    let service_capacity = 4;
-    let offered_requests = 250_u64;
-    let work_duration = Duration::from_millis(25);
+    let (
+        service_capacity,
+        offered_requests,
+        work_duration,
+        inter_arrival_pause_every,
+        inter_arrival_delay,
+    ) = match mode {
+        DemoMode::Baseline => (
+            4,
+            250_u64,
+            Duration::from_millis(25),
+            5,
+            Duration::from_millis(1),
+        ),
+        DemoMode::Mitigated => (
+            12,
+            250_u64,
+            Duration::from_millis(15),
+            2,
+            Duration::from_millis(2),
+        ),
+    };
 
     let semaphore = Arc::new(Semaphore::new(service_capacity));
     let waiting_depth = Arc::new(AtomicU64::new(0));
@@ -63,8 +102,8 @@ async fn main() -> anyhow::Result<()> {
                 .await;
         }));
 
-        if request_number % 5 == 0 {
-            tokio::time::sleep(Duration::from_millis(1)).await;
+        if request_number % inter_arrival_pause_every == 0 {
+            tokio::time::sleep(inter_arrival_delay).await;
         }
     }
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -118,6 +118,17 @@ Confidence is an internal ranking confidence, not a statistical confidence inter
 4. Validate suspect with one targeted experiment.
 5. Re-run and compare before/after output.
 
+### Queue demo before/after example
+
+`scripts/run_queue_demo.sh` now emits `before` (pathological baseline) and `after` (mitigated) analyses, plus a machine-readable comparison JSON at `demos/queue_service/artifacts/before-after-comparison.json`.
+
+In the current checked-in fixtures:
+
+- `before-analysis.json` reports `ApplicationQueueSaturation` with score `90` and p95 latency `1,682,454us`
+- `after-analysis.json` reports p95 latency `24,745us` with queue share reduced from `981` to `5` permille
+
+Use this pattern for diagnosis validation: keep load shape constant, adjust one mitigation lever, and compare suspect ranking plus p95-level shares.
+
 ## Limitations
 
 - No cross-service correlation.

--- a/scripts/run_queue_demo.sh
+++ b/scripts/run_queue_demo.sh
@@ -2,14 +2,87 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-ARTIFACT_PATH="${1:-$ROOT_DIR/demos/queue_service/artifacts/queue-run.json}"
+ARTIFACT_DIR="$ROOT_DIR/demos/queue_service/artifacts"
+MODE="${1:-both}"
 
-mkdir -p "$(dirname "$ARTIFACT_PATH")"
+run_variant() {
+  local variant="$1"
+  local run_path="$ARTIFACT_DIR/${variant}-run.json"
+  local analysis_path="$ARTIFACT_DIR/${variant}-analysis.json"
+  local mode_arg="$variant"
 
-cargo run --quiet --manifest-path "$ROOT_DIR/demos/queue_service/Cargo.toml" -- "$ARTIFACT_PATH"
+  if [[ "$variant" == "before" ]]; then
+    mode_arg="baseline"
+  else
+    mode_arg="mitigated"
+  fi
 
-cargo run --quiet --manifest-path "$ROOT_DIR/tailscope-cli/Cargo.toml" -- analyze "$ARTIFACT_PATH" --format json \
-  > "$ROOT_DIR/demos/queue_service/artifacts/queue-analysis.json"
+  mkdir -p "$ARTIFACT_DIR"
 
-printf 'run artifact: %s\n' "$ARTIFACT_PATH"
-printf 'analysis: %s\n' "$ROOT_DIR/demos/queue_service/artifacts/queue-analysis.json"
+  cargo run --quiet --manifest-path "$ROOT_DIR/demos/queue_service/Cargo.toml" -- "$run_path" "$mode_arg"
+  cargo run --quiet --manifest-path "$ROOT_DIR/tailscope-cli/Cargo.toml" -- analyze "$run_path" --format json \
+    > "$analysis_path"
+
+  printf 'run artifact (%s): %s\n' "$variant" "$run_path"
+  printf 'analysis (%s): %s\n' "$variant" "$analysis_path"
+}
+
+case "$MODE" in
+  before|baseline)
+    run_variant before
+    ;;
+  after|mitigated)
+    run_variant after
+    ;;
+  both)
+    run_variant before
+    run_variant after
+    ;;
+  *)
+    echo "unsupported mode '$MODE'; expected one of: before, after, both, baseline, mitigated" >&2
+    exit 1
+    ;;
+esac
+
+if [[ "$MODE" == "both" ]]; then
+  python3 - <<'PY'
+import json
+from pathlib import Path
+
+artifacts = Path("demos/queue_service/artifacts")
+before = json.loads((artifacts / "before-analysis.json").read_text())
+after = json.loads((artifacts / "after-analysis.json").read_text())
+
+comparison = {
+    "before": {
+        "primary_suspect_kind": before["primary_suspect"]["kind"],
+        "primary_suspect_score": before["primary_suspect"]["score"],
+        "p95_latency_us": before["p95_latency_us"],
+        "p95_queue_share_permille": before.get("p95_queue_share_permille"),
+    },
+    "after": {
+        "primary_suspect_kind": after["primary_suspect"]["kind"],
+        "primary_suspect_score": after["primary_suspect"]["score"],
+        "p95_latency_us": after["p95_latency_us"],
+        "p95_queue_share_permille": after.get("p95_queue_share_permille"),
+    },
+}
+
+comparison["delta"] = {
+    "p95_latency_us": comparison["after"]["p95_latency_us"] - comparison["before"]["p95_latency_us"],
+    "primary_suspect_score": comparison["after"]["primary_suspect_score"]
+    - comparison["before"]["primary_suspect_score"],
+    "p95_queue_share_permille": (
+        None
+        if comparison["before"]["p95_queue_share_permille"] is None
+        or comparison["after"]["p95_queue_share_permille"] is None
+        else comparison["after"]["p95_queue_share_permille"]
+        - comparison["before"]["p95_queue_share_permille"]
+    ),
+}
+
+comparison_path = artifacts / "before-after-comparison.json"
+comparison_path.write_text(json.dumps(comparison, indent=2) + "\n")
+print(f"comparison: {comparison_path}")
+PY
+fi

--- a/scripts/validate_queue_demo.sh
+++ b/scripts/validate_queue_demo.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-ANALYSIS_PATH="$ROOT_DIR/demos/queue_service/artifacts/queue-analysis.json"
+BEFORE_ANALYSIS_PATH="$ROOT_DIR/demos/queue_service/artifacts/before-analysis.json"
+AFTER_ANALYSIS_PATH="$ROOT_DIR/demos/queue_service/artifacts/after-analysis.json"
 
 "$ROOT_DIR/scripts/run_queue_demo.sh"
 
@@ -10,15 +11,36 @@ python3 - <<'PY'
 import json
 from pathlib import Path
 
-analysis_path = Path("demos/queue_service/artifacts/queue-analysis.json")
-report = json.loads(analysis_path.read_text())
+before_analysis_path = Path("demos/queue_service/artifacts/before-analysis.json")
+after_analysis_path = Path("demos/queue_service/artifacts/after-analysis.json")
 
-kind = report["primary_suspect"]["kind"]
+before = json.loads(before_analysis_path.read_text())
+after = json.loads(after_analysis_path.read_text())
+
+kind = before["primary_suspect"]["kind"]
 expected = {"application_queue_saturation", "ApplicationQueueSaturation"}
 if kind not in expected:
-    raise SystemExit(f"expected queue saturation suspect, got {kind}")
+    raise SystemExit(f"expected queue saturation suspect in baseline, got {kind}")
 
-print(f"validation passed: primary suspect is {kind}")
+before_p95 = before["p95_latency_us"]
+after_p95 = after["p95_latency_us"]
+before_score = before["primary_suspect"]["score"]
+after_score = after["primary_suspect"]["score"]
+
+if after_p95 >= before_p95:
+    raise SystemExit(
+        f"expected mitigated p95 to drop, got before={before_p95}us after={after_p95}us"
+    )
+
+if after_score >= before_score:
+    raise SystemExit(
+        f"expected mitigated suspect score to drop, got before={before_score} after={after_score}"
+    )
+
+print(
+    "validation passed: baseline suspect kind={}, p95 {}us -> {}us, "
+    "score {} -> {}".format(kind, before_p95, after_p95, before_score, after_score)
+)
 PY
 
-echo "validated analysis file: $ANALYSIS_PATH"
+echo "validated analysis files: $BEFORE_ANALYSIS_PATH, $AFTER_ANALYSIS_PATH"


### PR DESCRIPTION
### Motivation

- Provide a reproducible baseline (pathological) and mitigated variant for the queue demo so diagnosis changes can be validated automatically and machine-readably.
- Make it simple to run both variants and compare analyzer outputs (p95, suspect score, queue-share) without manual editing.

### Description

- Add mode parsing and two demo modes to `demos/queue_service/src/main.rs` (`baseline`/`mitigated`) that change capacity, work duration, and arrival pacing to produce pathological and mitigated runs.
- Extend `scripts/run_queue_demo.sh` to run `before`/`after`/`both` variants, emit per-variant run and analysis JSON files, and write a `before-after-comparison.json` summarizing deltas.
- Update `scripts/validate_queue_demo.sh` to validate both analyses and assert an improvement in p95 latency and primary suspect score between baseline and mitigated runs.
- Add fixture snapshots under `demos/queue_service/fixtures/` named `before-analysis.json` and `after-analysis.json` and document the observed signal in `README.md` and `docs/diagnostics.md` (p95 drop, suspect score drop, queue-share reduction).

### Testing

- Ran formatting check with `cargo fmt --check` which passed.
- Ran linting with `cargo clippy --workspace --all-targets -- -D warnings` which passed.
- Ran the full test suite with `cargo test --workspace` which passed.
- Executed the demo validation `scripts/validate_queue_demo.sh` which generated `before`/`after` artifacts, produced a `before-after-comparison.json`, and confirmed p95 and suspect-score improvements (validation passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbc49b2b0c8330bcc7b285c0a7bbe2)