### PR TITLE
Add ergonomic RequestMeta helpers and Tailscope convenience wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ async fn main() -> anyhow::Result<()> {
     let tailscope = Arc::new(Tailscope::init(config)?);
     let sampler = RuntimeSampler::start(Arc::clone(&tailscope), Duration::from_millis(200))?;
 
-    let request_id = "req-42".to_string();
-    let meta = RequestMeta::new(request_id.clone(), "/invoice");
+    let request = RequestMeta::for_route("/invoice").with_kind("create_invoice");
+    let request_id = request.request_id.clone();
 
     tailscope
-        .request(meta, "ok", async {
+        .request(request, "ok", async {
             let _inflight = tailscope.inflight("invoice_inflight");
 
             tailscope

--- a/SPEC.md
+++ b/SPEC.md
@@ -68,6 +68,21 @@ tailscope
     .await;
 ```
 
+Ergonomic helper path (auto request ID + builder-style kind):
+
+```rust
+let meta = RequestMeta::for_route("/invoice").with_kind("create_invoice");
+let request_id = meta.request_id.clone();
+
+tailscope.request(meta, "ok", async move {
+    tailscope
+        .queue(request_id.clone(), "invoice_worker")
+        .await_on(semaphore.acquire())
+        .await;
+})
+.await;
+```
+
 ### 5.3 In-flight tracking
 
 ```rust

--- a/tailscope-core/src/collector.rs
+++ b/tailscope-core/src/collector.rs
@@ -78,6 +78,35 @@ impl Tailscope {
         value
     }
 
+    /// Times one request future with an auto-generated request ID for `route`.
+    pub async fn request_for_route<Fut, T>(
+        &self,
+        route: impl Into<String>,
+        outcome: impl Into<String>,
+        fut: Fut,
+    ) -> T
+    where
+        Fut: std::future::Future<Output = T>,
+    {
+        self.request(RequestMeta::for_route(route), outcome, fut)
+            .await
+    }
+
+    /// Times one request future with an auto-generated request ID and explicit `kind`.
+    pub async fn request_with_kind<Fut, T>(
+        &self,
+        route: impl Into<String>,
+        kind: impl Into<String>,
+        outcome: impl Into<String>,
+        fut: Fut,
+    ) -> T
+    where
+        Fut: std::future::Future<Output = T>,
+    {
+        self.request(RequestMeta::for_route(route).with_kind(kind), outcome, fut)
+            .await
+    }
+
     /// Returns a clone of the current in-memory run state.
     #[must_use]
     pub fn snapshot(&self) -> Run {

--- a/tailscope-core/src/config.rs
+++ b/tailscope-core/src/config.rs
@@ -1,4 +1,6 @@
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
@@ -62,6 +64,34 @@ impl RequestMeta {
             kind: None,
         }
     }
+
+    /// Creates metadata with an auto-generated request ID for `route`.
+    ///
+    /// The generated ID keeps a readable route prefix and appends the current
+    /// unix timestamp with a process-local sequence number.
+    #[must_use]
+    pub fn for_route(route: impl Into<String>) -> Self {
+        let route = route.into();
+        let route_prefix = route
+            .chars()
+            .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
+            .collect::<String>();
+        let sequence = REQUEST_META_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let request_id = format!("{route_prefix}-{}-{sequence}", unix_time_ms());
+
+        Self {
+            request_id,
+            route,
+            kind: None,
+        }
+    }
+
+    /// Sets a semantic request kind for this request metadata.
+    #[must_use]
+    pub fn with_kind(mut self, kind: impl Into<String>) -> Self {
+        self.kind = Some(kind.into());
+        self
+    }
 }
 
 /// Errors emitted while initializing tailscope capture.
@@ -80,3 +110,14 @@ impl std::fmt::Display for InitError {
 }
 
 impl std::error::Error for InitError {}
+
+static REQUEST_META_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+fn unix_time_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time before UNIX_EPOCH")
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
+}

--- a/tailscope-core/src/tests.rs
+++ b/tailscope-core/src/tests.rs
@@ -139,6 +139,46 @@ fn request_records_timing_and_outcome() {
 }
 
 #[test]
+fn request_meta_for_route_generates_traceable_unique_ids() {
+    let first = RequestMeta::for_route("/invoice");
+    let second = RequestMeta::for_route("/invoice");
+
+    assert_eq!(first.route, "/invoice");
+    assert_eq!(second.route, "/invoice");
+    assert_ne!(first.request_id, second.request_id);
+    assert!(first.request_id.starts_with("_invoice-"));
+    assert!(second.request_id.starts_with("_invoice-"));
+}
+
+#[test]
+fn request_with_kind_records_helper_fields() {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time before epoch")
+        .as_nanos();
+
+    let mut config = Config::new("payments");
+    config.output_path = std::env::temp_dir().join(format!("tailscope_core_helper_{nanos}.json"));
+
+    let tailscope = Tailscope::init(config).expect("init should succeed");
+    let result = futures_executor::block_on(tailscope.request_with_kind(
+        "/invoice",
+        "create_invoice",
+        "ok",
+        ready(9_u32),
+    ));
+    assert_eq!(result, 9);
+
+    let snapshot = tailscope.snapshot();
+    assert_eq!(snapshot.requests.len(), 1);
+    let event = &snapshot.requests[0];
+    assert_eq!(event.route, "/invoice");
+    assert_eq!(event.kind.as_deref(), Some("create_invoice"));
+    assert_eq!(event.outcome, "ok");
+    assert!(event.request_id.starts_with("_invoice-"));
+}
+
+#[test]
 fn flush_writes_current_snapshot() {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)


### PR DESCRIPTION
### Motivation
- Reduce common instrumentation boilerplate by providing a simple, ergonomic path for creating request metadata and timing requests without forcing callers to manually generate stable request IDs. 
- Preserve existing explicit APIs while offering small helpers that fit the one-init / one-guard / thin-wrapper integration style targeted by the project.

### Description
- Add `RequestMeta::for_route(route)` which auto-generates a traceable request ID using a sanitized route prefix + unix timestamp + process-local sequence number implemented with `AtomicU64` and `unix_time_ms()` in `tailscope-core::config`.  
- Add `RequestMeta::with_kind(kind)` for builder-style kind assignment to avoid mutable setup ceremony.  
- Add `Tailscope::request_for_route(...)` and `Tailscope::request_with_kind(...)` convenience wrappers that call the existing `request(...)` path with the new helpers in `tailscope-core::collector`.  
- Update docs/examples in `README.md` and `SPEC.md` to show the ergonomic quick-start path, and add unit tests in `tailscope-core::tests` validating generated IDs and helper-recorded event fields.

### Testing
- Ran `cargo fmt --check` and formatting check passed.  
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and the workspace lints passed.  
- Ran `cargo test --workspace` and the full test suite passed (all unit tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc1068e7308330befccff5960eb762)