### PR TITLE
Add downstream-stage runnable demo, validator, and fixture coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "downstream_service"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "tailscope-core",
+ "tokio",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "tailscope-macros",
   "demos/queue_service",
   "demos/blocking_service",
+  "demos/downstream_service",
   "demos/runtime_cost",
 ]
 resolver = "2"

--- a/README.md
+++ b/README.md
@@ -187,6 +187,31 @@ Artifacts:
 - `demos/blocking_service/artifacts/blocking-run.json`
 - `demos/blocking_service/artifacts/blocking-analysis.json`
 
+### Downstream-stage dominance demo
+
+Canonical (Python-first):
+
+```bash
+python3 scripts/run_downstream_demo.py
+python3 scripts/validate_downstream_demo.py
+```
+
+Compatibility wrappers:
+
+```bash
+scripts/run_downstream_demo.sh
+scripts/validate_downstream_demo.sh
+```
+
+Artifacts:
+
+- `demos/downstream_service/artifacts/downstream-run.json`
+- `demos/downstream_service/artifacts/downstream-analysis.json`
+
+Fixture snapshot:
+
+- `demos/downstream_service/fixtures/sample-analysis.json`
+
 ## Runtime cost measurement
 
 Use the reproducible harness (canonical Python-first invocation):
@@ -229,7 +254,7 @@ This keeps one implementation path while still supporting existing shell-based i
 - `tailscope-core/`: instrumentation and run schema
 - `tailscope-tokio/`: runtime sampler and macro integration
 - `tailscope-cli/`: analyzer and report rendering
-- `demos/`: queue and blocking proof cases
+- `demos/`: queue, blocking, and downstream-stage proof cases
 - `scripts/`: reproducible demo + validation + runtime-cost scripts
 - `docs/`: architecture, diagnostics, and runtime-cost docs
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -204,6 +204,12 @@ Important: these are evidence-ranked suspects, **not** proof of root cause.
 
 Validation scripts in `scripts/` must pass for both demos.
 
+### 9.1 Additional runnable proof case
+
+- `demos/downstream_service`: deterministic downstream-stage dominance scenario that should rank `DownstreamStageDominates` as the primary suspect.
+
+This demo is intentionally small and single-purpose; it extends storytelling trust without expanding MVP scope.
+
 ## 10. Runtime-cost measurement
 
 Repro harness:

--- a/demos/downstream_service/Cargo.toml
+++ b/demos/downstream_service/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "downstream_service"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = "1"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+tailscope-core = { path = "../../tailscope-core" }

--- a/demos/downstream_service/fixtures/sample-analysis.json
+++ b/demos/downstream_service/fixtures/sample-analysis.json
@@ -1,0 +1,30 @@
+{
+  "request_count": 80,
+  "p50_latency_us": 24618,
+  "p95_latency_us": 25920,
+  "p99_latency_us": 26706,
+  "p95_queue_share_permille": 0,
+  "p95_service_share_permille": 1000,
+  "inflight_trend": {
+    "gauge": "downstream_service_inflight",
+    "sample_count": 160,
+    "peak_count": 56,
+    "p95_count": 55,
+    "growth_delta": 5,
+    "growth_per_sec_milli": 76923
+  },
+  "primary_suspect": {
+    "kind": "DownstreamStageDominates",
+    "score": 60,
+    "confidence": "low",
+    "evidence": [
+      "Stage 'downstream_call' has p95 latency 22680 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 1718786 us."
+    ],
+    "next_checks": [
+      "Inspect downstream dependency behind stage 'downstream_call'.",
+      "Collect downstream service timings and retry behavior during tail windows."
+    ]
+  },
+  "secondary_suspects": []
+}

--- a/demos/downstream_service/src/main.rs
+++ b/demos/downstream_service/src/main.rs
@@ -1,0 +1,64 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use tailscope_core::{Config, RequestMeta, Tailscope};
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 2)]
+async fn main() -> anyhow::Result<()> {
+    let output_path = std::env::args()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("demos/downstream_service/artifacts/downstream-run.json"));
+
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create artifact directory {}", parent.display()))?;
+    }
+
+    let mut config = Config::new("downstream_service_demo");
+    config.output_path = output_path.clone();
+    let tailscope = Arc::new(Tailscope::init(config)?);
+
+    let offered_requests = 80_u64;
+    let mut tasks = Vec::with_capacity(offered_requests as usize);
+
+    for request_number in 0..offered_requests {
+        let tailscope = Arc::clone(&tailscope);
+
+        tasks.push(tokio::spawn(async move {
+            let request_id = format!("request-{request_number}");
+            let meta = RequestMeta::new(request_id.clone(), "/downstream-demo");
+
+            tailscope
+                .request(meta, "ok", async {
+                    let _inflight = tailscope.inflight("downstream_service_inflight");
+
+                    tailscope
+                        .stage(request_id.clone(), "app_precheck")
+                        .await_on(tokio::time::sleep(Duration::from_millis(1)))
+                        .await;
+
+                    tailscope
+                        .stage(request_id, "downstream_call")
+                        .await_on(tokio::time::sleep(Duration::from_millis(20)))
+                        .await;
+                })
+                .await;
+        }));
+
+        if request_number % 8 == 0 {
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+    }
+
+    for task in tasks {
+        task.await.context("request task panicked")?;
+    }
+
+    tailscope.flush()?;
+    println!("wrote {}", output_path.display());
+
+    Ok(())
+}

--- a/scripts/run_downstream_demo.py
+++ b/scripts/run_downstream_demo.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Run downstream-stage demo and generate analysis artifact."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run downstream demo and analyze output.")
+    parser.add_argument(
+        "artifact_path",
+        nargs="?",
+        help="Optional path to write the run JSON artifact.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    root_dir = Path(__file__).resolve().parent.parent
+    artifact_path = (
+        Path(args.artifact_path)
+        if args.artifact_path
+        else root_dir / "demos/downstream_service/artifacts/downstream-run.json"
+    )
+    analysis_path = root_dir / "demos/downstream_service/artifacts/downstream-analysis.json"
+
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+
+    subprocess.run(
+        [
+            "cargo",
+            "run",
+            "--quiet",
+            "--manifest-path",
+            str(root_dir / "demos/downstream_service/Cargo.toml"),
+            "--",
+            str(artifact_path),
+        ],
+        check=True,
+    )
+
+    with analysis_path.open("w", encoding="utf-8") as analysis_file:
+        subprocess.run(
+            [
+                "cargo",
+                "run",
+                "--quiet",
+                "--manifest-path",
+                str(root_dir / "tailscope-cli/Cargo.toml"),
+                "--",
+                "analyze",
+                str(artifact_path),
+                "--format",
+                "json",
+            ],
+            check=True,
+            stdout=analysis_file,
+        )
+
+    print(f"run artifact: {artifact_path}")
+    print(f"analysis: {analysis_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_downstream_demo.sh
+++ b/scripts/run_downstream_demo.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+python3 "$SCRIPT_DIR/run_downstream_demo.py" "$@"

--- a/scripts/validate_downstream_demo.py
+++ b/scripts/validate_downstream_demo.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Validate downstream demo output contract."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+
+def main() -> None:
+    root_dir = Path(__file__).resolve().parent.parent
+    analysis_path = root_dir / "demos/downstream_service/artifacts/downstream-analysis.json"
+
+    subprocess.run(["python3", str(root_dir / "scripts/run_downstream_demo.py")], check=True)
+
+    report = json.loads(analysis_path.read_text(encoding="utf-8"))
+    kind = report["primary_suspect"]["kind"]
+    expected = {"downstream_stage_dominates", "DownstreamStageDominates"}
+    if kind not in expected:
+        raise SystemExit(f"expected downstream stage suspect, got {kind}")
+
+    print(f"validation passed: primary suspect is {kind}")
+    print(f"validated analysis file: {analysis_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_downstream_demo.sh
+++ b/scripts/validate_downstream_demo.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+python3 "$SCRIPT_DIR/validate_downstream_demo.py" "$@"

--- a/tailscope-cli/tests/demo_smoke_fixtures.rs
+++ b/tailscope-cli/tests/demo_smoke_fixtures.rs
@@ -43,3 +43,20 @@ fn blocking_demo_fixture_reports_blocking_pool_pressure() {
         "blocking demo should strongly prioritize blocking pressure"
     );
 }
+
+#[test]
+fn downstream_demo_fixture_reports_downstream_stage_dominance() {
+    let report = load_demo_analysis("demos/downstream_service/fixtures/sample-analysis.json");
+
+    assert_eq!(
+        report["primary_suspect"]["kind"],
+        Value::String("DownstreamStageDominates".to_string())
+    );
+    assert!(
+        report["primary_suspect"]["score"]
+            .as_u64()
+            .unwrap_or_default()
+            >= 60,
+        "downstream demo should prioritize downstream stage dominance"
+    );
+}


### PR DESCRIPTION
### Motivation
- Provide a small deterministic runnable proof case for the `DownstreamStageDominates` diagnosis to improve demo coverage beyond existing queue/blocking fixtures.

### Description
- Add a new demo crate `demos/downstream_service` with a simple binary that emits request/stage events where a single downstream stage (`downstream_call`) dominates latency.
- Add canonical Python run/validate scripts and Unix wrappers: `scripts/run_downstream_demo.py`, `scripts/validate_downstream_demo.py`, `scripts/run_downstream_demo.sh`, and `scripts/validate_downstream_demo.sh`.
- Check in a sample analysis fixture `demos/downstream_service/fixtures/sample-analysis.json` and expand `tailscope-cli` smoke tests to assert the downstream demo reports `DownstreamStageDominates` as primary.
- Update workspace membership and documentation (`Cargo.toml`, `README.md`, `SPEC.md`) so the demo is discoverable and the spec notes the additional runnable proof case.

### Testing
- Ran the demo validator with `python3 scripts/validate_downstream_demo.py`, which completed and validated the primary suspect as `DownstreamStageDominates`.
- Ran repository checks `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, all of which completed successfully.
- Added a unit test in `tailscope-cli/tests/demo_smoke_fixtures.rs` that passes under the existing test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc1ba5b5fc83309a87375c9967e054)