### PR TITLE
Add shared unix-ms conversion utility and dedupe time conversions

### DIFF
--- a/demos/blocking_service/src/main.rs
+++ b/demos/blocking_service/src/main.rs
@@ -1,10 +1,10 @@
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use anyhow::Context;
-use tailscope_core::{Config, RequestMeta, RuntimeSnapshot, Tailscope};
+use tailscope_core::{unix_time_ms, Config, RequestMeta, RuntimeSnapshot, Tailscope};
 
 #[derive(Clone, Copy)]
 enum DemoMode {
@@ -157,13 +157,4 @@ async fn run_demo(output_path: PathBuf, settings: ModeSettings) -> anyhow::Resul
     println!("wrote {}", output_path.display());
 
     Ok(())
-}
-
-fn unix_time_ms() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system time before UNIX_EPOCH")
-        .as_millis()
-        .try_into()
-        .unwrap_or(u64::MAX)
 }

--- a/tailscope-core/src/collector.rs
+++ b/tailscope-core/src/collector.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Mutex;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant};
 
 use crate::InflightGuard;
 use crate::RunSink;
 use crate::{
-    Config, InFlightSnapshot, InitError, LocalJsonSink, QueueTimer, RequestEvent, RequestMeta, Run,
-    RunMetadata, RuntimeSnapshot, SinkError, StageTimer,
+    unix_time_ms, Config, InFlightSnapshot, InitError, LocalJsonSink, QueueTimer, RequestEvent,
+    RequestMeta, Run, RunMetadata, RuntimeSnapshot, SinkError, StageTimer,
 };
 
 /// Per-run collector that records request events and writes the final artifact.
@@ -223,15 +223,6 @@ pub(crate) fn lock_map(
 
 pub(crate) fn duration_to_us(duration: Duration) -> u64 {
     duration.as_micros().try_into().unwrap_or(u64::MAX)
-}
-
-pub(crate) fn unix_time_ms() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system time before UNIX_EPOCH")
-        .as_millis()
-        .try_into()
-        .unwrap_or(u64::MAX)
 }
 
 fn generate_run_id() -> String {

--- a/tailscope-core/src/config.rs
+++ b/tailscope-core/src/config.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::unix_time_ms;
 use serde::{Deserialize, Serialize};
 
 /// Capture mode used during a run.
@@ -112,12 +112,3 @@ impl std::fmt::Display for InitError {
 impl std::error::Error for InitError {}
 
 static REQUEST_META_SEQUENCE: AtomicU64 = AtomicU64::new(0);
-
-fn unix_time_ms() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system time before UNIX_EPOCH")
-        .as_millis()
-        .try_into()
-        .unwrap_or(u64::MAX)
-}

--- a/tailscope-core/src/lib.rs
+++ b/tailscope-core/src/lib.rs
@@ -4,6 +4,7 @@ mod collector;
 mod config;
 mod events;
 mod sink;
+mod time;
 mod timers;
 
 pub use collector::Tailscope;
@@ -12,6 +13,7 @@ pub use events::{
     InFlightSnapshot, QueueEvent, RequestEvent, Run, RunMetadata, RuntimeSnapshot, StageEvent,
 };
 pub use sink::{LocalJsonSink, RunSink, SinkError};
+pub use time::{system_time_to_unix_ms, unix_time_ms};
 pub use timers::{InflightGuard, QueueTimer, StageTimer};
 
 #[cfg(test)]

--- a/tailscope-core/src/time.rs
+++ b/tailscope-core/src/time.rs
@@ -1,0 +1,51 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Converts a [`SystemTime`] to unix epoch milliseconds.
+///
+/// Values before [`UNIX_EPOCH`] are clamped to `0`. Values larger than
+/// [`u64::MAX`] milliseconds are saturated at `u64::MAX`.
+#[must_use]
+pub fn system_time_to_unix_ms(time: SystemTime) -> u64 {
+    match time.duration_since(UNIX_EPOCH) {
+        Ok(duration) => duration.as_millis().try_into().unwrap_or(u64::MAX),
+        Err(_) => 0,
+    }
+}
+
+/// Returns the current unix epoch timestamp in milliseconds.
+#[must_use]
+pub fn unix_time_ms() -> u64 {
+    system_time_to_unix_ms(SystemTime::now())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::system_time_to_unix_ms;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn system_time_to_unix_ms_clamps_epoch_and_overflow() {
+        let before_epoch = UNIX_EPOCH
+            .checked_sub(Duration::from_millis(1))
+            .expect("one millisecond before epoch should be representable");
+        assert_eq!(system_time_to_unix_ms(before_epoch), 0);
+
+        let overflow_duration = Duration::from_millis(u64::MAX)
+            .checked_add(Duration::from_millis(1))
+            .expect("overflow test duration should be representable");
+        let overflow = UNIX_EPOCH
+            .checked_add(overflow_duration)
+            .expect("overflow test timestamp should be representable");
+        assert_eq!(system_time_to_unix_ms(overflow), u64::MAX);
+
+        assert_eq!(system_time_to_unix_ms(UNIX_EPOCH), 0);
+        assert_eq!(
+            system_time_to_unix_ms(UNIX_EPOCH + Duration::from_millis(123)),
+            123
+        );
+        assert_eq!(
+            system_time_to_unix_ms(SystemTime::UNIX_EPOCH + Duration::from_secs(1)),
+            1_000
+        );
+    }
+}

--- a/tailscope-core/src/timers.rs
+++ b/tailscope-core/src/timers.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
-use crate::collector::{duration_to_us, lock_map, lock_run, unix_time_ms};
-use crate::{InFlightSnapshot, QueueEvent, StageEvent, Tailscope};
+use crate::collector::{duration_to_us, lock_map, lock_run};
+use crate::{unix_time_ms, InFlightSnapshot, QueueEvent, StageEvent, Tailscope};
 
 /// RAII guard tracking one in-flight unit for a named gauge.
 #[derive(Debug)]

--- a/tailscope-macros/src/lib.rs
+++ b/tailscope-macros/src/lib.rs
@@ -106,6 +106,7 @@ fn expand_instrument_request(
     };
 
     let body = input_fn.block;
+    let unix_time_ms_expr = unix_time_ms_expr();
     let returns_result = returns_result(&input_fn.sig.output);
     let (outcome_expr, tail_event) = if returns_result {
         (
@@ -173,21 +174,12 @@ fn expand_instrument_request(
     input_fn.block = Box::new(syn::parse_quote!({
         let __tailscope_route = ::std::string::ToString::to_string(&#route_field);
         let __tailscope_kind = ::std::string::ToString::to_string(&#kind_field);
-        let __tailscope_started_at_unix_ms = ::std::time::SystemTime::now()
-            .duration_since(::std::time::UNIX_EPOCH)
-            .expect("system time before UNIX_EPOCH")
-            .as_millis()
-            .try_into()
-            .unwrap_or(u64::MAX);
+        let __tailscope_unix_time_ms = #unix_time_ms_expr;
+        let __tailscope_started_at_unix_ms = __tailscope_unix_time_ms();
         let __tailscope_started = ::std::time::Instant::now();
         let __tailscope_result = (async move #body).await;
         #outcome_expr
-        let __tailscope_finished_at_unix_ms = ::std::time::SystemTime::now()
-            .duration_since(::std::time::UNIX_EPOCH)
-            .expect("system time before UNIX_EPOCH")
-            .as_millis()
-            .try_into()
-            .unwrap_or(u64::MAX);
+        let __tailscope_finished_at_unix_ms = __tailscope_unix_time_ms();
         let __tailscope_duration_us =
             ::std::convert::TryFrom::try_from(__tailscope_started.elapsed().as_micros())
                 .unwrap_or(u64::MAX);
@@ -234,6 +226,17 @@ fn default_request_id_expr() -> Expr {
         "{}-{}",
         __tailscope_route, __tailscope_started_at_unix_ms
     ))
+}
+
+fn unix_time_ms_expr() -> proc_macro2::TokenStream {
+    quote!(|| -> u64 {
+        match ::std::time::SystemTime::now().duration_since(::std::time::UNIX_EPOCH) {
+            Ok(duration) => {
+                ::std::convert::TryInto::try_into(duration.as_millis()).unwrap_or(u64::MAX)
+            }
+            Err(_) => 0,
+        }
+    })
 }
 
 fn validate_skipped_args(

--- a/tailscope-tokio/src/lib.rs
+++ b/tailscope-tokio/src/lib.rs
@@ -28,7 +28,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use tailscope_core::{RuntimeSnapshot, Tailscope};
+use tailscope_core::{unix_time_ms, RuntimeSnapshot, Tailscope};
 use tokio::runtime::Handle;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
@@ -143,17 +143,6 @@ pub fn capture_runtime_snapshot(handle: &Handle) -> RuntimeSnapshot {
         blocking_queue_depth,
         remote_schedule_count,
     }
-}
-
-fn unix_time_ms() -> u64 {
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system time before UNIX_EPOCH")
-        .as_millis()
-        .try_into()
-        .unwrap_or(u64::MAX)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation
- Reduce duplicated `SystemTime -> unix ms` conversion logic across crates and ensure consistent, safe behavior for pre-epoch values and overflow cases.
- Provide a single, small public helper in `tailscope-core` so runtime crates and demos can call a vetted implementation instead of inlining conversions.
- Keep macro-generated instrumentation compact and consistent by emitting a reusable local helper expression instead of repeating the same conversion snippet.

### Description
- Add `tailscope-core/src/time.rs` with `system_time_to_unix_ms(SystemTime) -> u64` and `unix_time_ms() -> u64`, clamping pre-epoch to `0` and saturating overflow to `u64::MAX`, and include a focused unit test for epoch/overflow behavior.
- Export the helpers from `tailscope-core::time` and replace duplicated implementations in `tailscope-core` (collector/config/timers), `tailscope-tokio` (runtime snapshot), and `demos/blocking_service` to use `tailscope_core::unix_time_ms`.
- Update `tailscope-macros` to generate a single local closure expression `__tailscope_unix_time_ms` and call it for start/finish timestamps to keep generated code small and consistent.
- Adjust imports and small callsites (e.g., `generate_run_id`, runtime sampling) to use the new shared helpers and remove prior inline conversions.

### Testing
- Ran `cargo fmt --check` which passed after formatting changes.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` which completed with no warnings.
- Ran `cargo test --workspace` and all automated tests succeeded (all unit and integration tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc2792809c833089f4f03345deb836)