### PR TITLE
Refactor demo scripts to use shared cargo runner helpers

### DIFF
--- a/scripts/_demo_runner.py
+++ b/scripts/_demo_runner.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Shared helpers for demo runners."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def run_demo_binary(manifest_path: Path, artifact_path: Path, *demo_args: str) -> None:
+    """Run a demo binary via ``cargo run --manifest-path ...``."""
+    subprocess.run(
+        [
+            "cargo",
+            "run",
+            "--quiet",
+            "--manifest-path",
+            str(manifest_path),
+            "--",
+            str(artifact_path),
+            *demo_args,
+        ],
+        check=True,
+    )
+
+
+def run_cli_analysis_json(cli_manifest_path: Path, artifact_path: Path, analysis_path: Path) -> None:
+    """Analyze an artifact and write JSON output to ``analysis_path``."""
+    with analysis_path.open("w", encoding="utf-8") as analysis_file:
+        subprocess.run(
+            [
+                "cargo",
+                "run",
+                "--quiet",
+                "--manifest-path",
+                str(cli_manifest_path),
+                "--",
+                "analyze",
+                str(artifact_path),
+                "--format",
+                "json",
+            ],
+            check=True,
+            stdout=analysis_file,
+        )

--- a/scripts/run_blocking_demo.py
+++ b/scripts/run_blocking_demo.py
@@ -6,8 +6,9 @@ from __future__ import annotations
 import argparse
 import json
 import re
-import subprocess
 from pathlib import Path
+
+from _demo_runner import run_cli_analysis_json, run_demo_binary
 
 
 def extract_blocking_queue_depth_p95(report: dict) -> int | None:
@@ -20,43 +21,23 @@ def extract_blocking_queue_depth_p95(report: dict) -> int | None:
 
 
 def run_variant(root_dir: Path, artifact_dir: Path, variant: str) -> None:
+    # Canonical cargo run + analysis helpers live in scripts/_demo_runner.py.
     run_path = artifact_dir / f"{variant}-run.json"
     analysis_path = artifact_dir / f"{variant}-analysis.json"
     mode_arg = "baseline" if variant == "before" else "mitigated"
 
     artifact_dir.mkdir(parents=True, exist_ok=True)
 
-    subprocess.run(
-        [
-            "cargo",
-            "run",
-            "--quiet",
-            "--manifest-path",
-            str(root_dir / "demos/blocking_service/Cargo.toml"),
-            "--",
-            str(run_path),
-            mode_arg,
-        ],
-        check=True,
+    run_demo_binary(
+        root_dir / "demos/blocking_service/Cargo.toml",
+        run_path,
+        mode_arg,
     )
-
-    with analysis_path.open("w", encoding="utf-8") as analysis_file:
-        subprocess.run(
-            [
-                "cargo",
-                "run",
-                "--quiet",
-                "--manifest-path",
-                str(root_dir / "tailscope-cli/Cargo.toml"),
-                "--",
-                "analyze",
-                str(run_path),
-                "--format",
-                "json",
-            ],
-            check=True,
-            stdout=analysis_file,
-        )
+    run_cli_analysis_json(
+        root_dir / "tailscope-cli/Cargo.toml",
+        run_path,
+        analysis_path,
+    )
 
     print(f"run artifact ({variant}): {run_path}")
     print(f"analysis ({variant}): {analysis_path}")

--- a/scripts/run_downstream_demo.py
+++ b/scripts/run_downstream_demo.py
@@ -4,8 +4,9 @@
 from __future__ import annotations
 
 import argparse
-import subprocess
 from pathlib import Path
+
+from _demo_runner import run_cli_analysis_json, run_demo_binary
 
 
 def parse_args() -> argparse.Namespace:
@@ -19,6 +20,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> None:
+    # Canonical cargo run + analysis helpers live in scripts/_demo_runner.py.
     args = parse_args()
     root_dir = Path(__file__).resolve().parent.parent
     artifact_path = (
@@ -30,36 +32,15 @@ def main() -> None:
 
     artifact_path.parent.mkdir(parents=True, exist_ok=True)
 
-    subprocess.run(
-        [
-            "cargo",
-            "run",
-            "--quiet",
-            "--manifest-path",
-            str(root_dir / "demos/downstream_service/Cargo.toml"),
-            "--",
-            str(artifact_path),
-        ],
-        check=True,
+    run_demo_binary(
+        root_dir / "demos/downstream_service/Cargo.toml",
+        artifact_path,
     )
-
-    with analysis_path.open("w", encoding="utf-8") as analysis_file:
-        subprocess.run(
-            [
-                "cargo",
-                "run",
-                "--quiet",
-                "--manifest-path",
-                str(root_dir / "tailscope-cli/Cargo.toml"),
-                "--",
-                "analyze",
-                str(artifact_path),
-                "--format",
-                "json",
-            ],
-            check=True,
-            stdout=analysis_file,
-        )
+    run_cli_analysis_json(
+        root_dir / "tailscope-cli/Cargo.toml",
+        artifact_path,
+        analysis_path,
+    )
 
     print(f"run artifact: {artifact_path}")
     print(f"analysis: {analysis_path}")


### PR DESCRIPTION
### Motivation
- Consolidate duplicated `cargo run` and CLI analysis subprocess logic used by demo runners into a single helper module to reduce maintenance surface and make demos easier to update.
- Preserve existing demo script CLIs and behavior so existing invocation patterns remain compatible.

### Description
- Add `scripts/_demo_runner.py` with `run_demo_binary(manifest_path, artifact_path, *demo_args)` and `run_cli_analysis_json(cli_manifest_path, artifact_path, analysis_path)` helpers that wrap `cargo run` and `tailscope-cli analyze --format json` respectively.
- Refactor `scripts/run_blocking_demo.py` to import and use `run_demo_binary` and `run_cli_analysis_json` while keeping the `mode` argument interface unchanged and adding a short comment pointing to the canonical helper.
- Refactor `scripts/run_downstream_demo.py` to import and use the same helpers while keeping the optional `artifact_path` positional argument unchanged and adding the same canonical-helper comment.
- No changes to demo CLI semantics or artifact layout were made; only the subprocess invocation code was consolidated.

### Testing
- Ran `python -m py_compile scripts/_demo_runner.py scripts/run_blocking_demo.py scripts/run_downstream_demo.py` and it succeeded.
- Ran `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings` and both checks passed.
- Ran `cargo test --workspace` and the full test suite completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc27929b248330bcd96e6ed7433fe6)