### PR TITLE
docs: add 5-minute end-to-end quickstart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,71 @@ This repository is an MVP release candidate with three workspace crates:
 
 ## Quick start
 
+## 5-minute quickstart (end to end)
+
+### 1) Add dependencies
+
+In your `Cargo.toml`:
+
+```toml
+[dependencies]
+tailscope-core = { path = "../tailscope-core" }
+tailscope-tokio = { path = "../tailscope-tokio" }
+tokio = { version = "1", features = ["macros", "rt", "time"] }
+```
+
+### 2) Minimal runnable `main.rs`
+
+```rust
+use std::time::Duration;
+
+use tailscope_core::{Config, RequestMeta, Tailscope};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut config = Config::new("quickstart-service");
+    config.output_path = "tailscope-run.json".into();
+
+    let tailscope = Tailscope::init(config)?;
+
+    let request = RequestMeta::for_route("/demo").with_kind("quickstart");
+    let request_id = request.request_id.clone();
+
+    tailscope
+        .request(request, "ok", async {
+            tailscope
+                .queue(request_id.clone(), "ingress_queue")
+                .await_on(tokio::time::sleep(Duration::from_millis(5)))
+                .await;
+
+            tailscope
+                .stage(request_id, "db_call")
+                .await_on(tokio::time::sleep(Duration::from_millis(12)))
+                .await;
+        })
+        .await;
+
+    tailscope.flush()?;
+    Ok(())
+}
+```
+
+### 3) Run and analyze
+
+```bash
+cargo run
+cargo run --manifest-path tailscope-cli/Cargo.toml -- analyze tailscope-run.json
+cargo run --manifest-path tailscope-cli/Cargo.toml -- analyze tailscope-run.json --format json
+```
+
+### 4) What to look for
+
+- `Primary suspect`: the top-ranked bottleneck category for this run.
+- `Score`: higher score means stronger evidence for that suspect in this run.
+- `Queue/service share`: request time split (queue time share vs service/stage time share) to tell whether waiting or work dominates p95 latency.
+
+For more diagnosis detail, see [`docs/diagnostics.md`](docs/diagnostics.md).
+
 ### 1) Collect a run artifact
 
 ```rust


### PR DESCRIPTION
### Motivation

- Provide a tiny end-to-end integration example that demonstrates how to collect a `tailscope` run and analyze it with `tailscope-cli` in under five minutes.
- Make it easy for users to copy-paste exact `Cargo.toml` dependency lines and a minimal `main.rs` that exercises one request, one queue wait, and one stage.
- Give clear, actionable next steps and a short checklist of what to look for in the analyzer output so newcomers can interpret results quickly.

### Description

- Adds a new top-level `## 5-minute quickstart (end to end)` section in `README.md` that includes exact dependency lines for `tailscope-core`, `tailscope-tokio`, and `tokio` to paste into `Cargo.toml`.
- Adds a minimal, runnable `main.rs` example (well under ~60 lines) that initializes `Tailscope`, wraps a single request via `tailscope.request(...)`, instruments one queue wait and one stage with `await_on(...)`, and calls `tailscope.flush()` to write `tailscope-run.json`.
- Documents exact shell commands to run the example and analyze the produced `tailscope-run.json` with `tailscope-cli`, including `--format json` usage.
- Adds a short “what to look for” interpretation bullet list covering `Primary suspect`, `Score`, and `Queue/service share`, and includes a cross-link to `docs/diagnostics.md` for more detail.

### Testing

- Ran `cargo fmt --check` and it completed successfully.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it completed successfully.
- Ran `cargo test --workspace` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc352ee7c483309712f67d22fb8b27)