### PR TITLE
docs: add README example output section for text + JSON analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,38 @@ cargo run --manifest-path tailscope-cli/Cargo.toml -- analyze tailscope-run.json
 cargo run --manifest-path tailscope-cli/Cargo.toml -- analyze tailscope-run.json --format json
 ```
 
+### Example output (text + JSON)
+
+Text-mode snippet (from committed queue-service fixture style):
+
+```text
+Primary suspect: ApplicationQueueSaturation
+Score/confidence: 90 (high)
+Key evidence: Queue wait at p95 consumes 98.4% of request time.
+```
+
+JSON snippet (from committed blocking-service fixture fields):
+
+```json
+{
+  "primary_suspect": {
+    "kind": "BlockingPoolPressure",
+    "score": 80,
+    "confidence": "medium"
+  },
+  "p95_queue_share_permille": 6,
+  "recommendations": [
+    "Audit blocking sections and move avoidable synchronous work out of hot paths."
+  ]
+}
+```
+
+How this guides next action:
+
+- Start with the top suspect and confidence to choose your first investigation lane (queueing vs blocking vs downstream).
+- Use `p95_queue_share_permille` to decide whether to focus on admission/backpressure mechanics (high queue share) or execution-time work (low queue share).
+- Execute the first recommendation as a concrete next check, then re-run analysis and compare suspect score/confidence movement.
+
 ### 4) What to look for
 
 - `Primary suspect`: the top-ranked bottleneck category for this run.


### PR DESCRIPTION
### Motivation
- Provide a short, stable example of analyzer output immediately after the quickstart analysis commands so users can quickly understand the text and JSON report shape and what to act on, using committed fixtures to avoid churn.

### Description
- Add an `Example output (text + JSON)` section to `README.md` (after the run/analyze commands) containing a compact text-mode snippet (primary suspect, score/confidence, key evidence), a short JSON snippet with `primary_suspect`, `p95_queue_share_permille`, and one recommendation, and a 3-bullet guidance on next actions; snippets were sourced from `demos/queue_service/fixtures/sample-analysis.json` and `demos/blocking_service/fixtures/sample-analysis.json`.

### Testing
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, and all checks/tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc38f327bc83308b57357e089d56ad)