### PR TITLE
docs: simplify and verify README quickstart flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ This repository is an MVP release candidate with three workspace crates:
 - a GUI observability product
 - a claim of root-cause certainty
 
-## Quick start
-
 ## 5-minute quickstart (end to end)
 
 ### 1) Add dependencies
@@ -43,7 +41,25 @@ In your `Cargo.toml`:
 [dependencies]
 tailscope-core = { path = "../tailscope-core" }
 tailscope-tokio = { path = "../tailscope-tokio" }
-tokio = { version = "1", features = ["macros", "rt", "time"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
+```
+
+
+If you want a **copy/paste verification path** from a blank app, run this sequence:
+
+```bash
+export TAILSCOPE_REPO="/path/to/this/repo"
+mkdir -p /tmp/tailscope-quickstart && cd /tmp/tailscope-quickstart
+cargo new quickstart --bin && cd quickstart
+```
+
+Then use this `Cargo.toml` dependency block (replace the placeholder path):
+
+```toml
+[dependencies]
+tailscope-core = { path = "/absolute/path/to/tailscope/tailscope-core" }
+tailscope-tokio = { path = "/absolute/path/to/tailscope/tailscope-tokio" }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 ```
 
 ### 2) Minimal runnable `main.rs`
@@ -55,14 +71,17 @@ use tailscope_core::{Config, RequestMeta, Tailscope};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // tailscope boilerplate: init + output path
     let mut config = Config::new("quickstart-service");
     config.output_path = "tailscope-run.json".into();
 
     let tailscope = Tailscope::init(config)?;
 
+    // tailscope boilerplate: request metadata + id
     let request = RequestMeta::for_route("/demo").with_kind("quickstart");
     let request_id = request.request_id.clone();
 
+    // tailscope boilerplate: request wrapper + queue/stage wrappers
     tailscope
         .request(request, "ok", async {
             tailscope
@@ -77,6 +96,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         })
         .await;
 
+    // tailscope boilerplate: ensure run artifact is written
     tailscope.flush()?;
     Ok(())
 }
@@ -90,9 +110,16 @@ cargo run --manifest-path tailscope-cli/Cargo.toml -- analyze tailscope-run.json
 cargo run --manifest-path tailscope-cli/Cargo.toml -- analyze tailscope-run.json --format json
 ```
 
+If you used the `/tmp/tailscope-quickstart` verification path above, run analyzer with:
+
+```bash
+cargo run --manifest-path "$TAILSCOPE_REPO/tailscope-cli/Cargo.toml" -- analyze tailscope-run.json
+cargo run --manifest-path "$TAILSCOPE_REPO/tailscope-cli/Cargo.toml" -- analyze tailscope-run.json --format json
+```
+
 ### Example output (text + JSON)
 
-Text-mode snippet (from committed queue-service fixture style):
+Text-mode snippet (sample from a successful local quickstart analysis run):
 
 ```text
 Primary suspect: ApplicationQueueSaturation
@@ -130,6 +157,8 @@ How this guides next action:
 
 For more diagnosis detail, see [`docs/diagnostics.md`](docs/diagnostics.md).
 
+## Full integration example (runtime sampler + macro path)
+
 ### 1) Collect a run artifact
 
 ```rust
@@ -140,7 +169,7 @@ use tailscope_core::{Config, RequestMeta, Tailscope};
 use tailscope_tokio::RuntimeSampler;
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut config = Config::new("invoice-api");
     config.output_path = "tailscope-run.json".into();
 
@@ -150,6 +179,7 @@ async fn main() -> anyhow::Result<()> {
     let request = RequestMeta::for_route("/invoice").with_kind("create_invoice");
     let request_id = request.request_id.clone();
 
+    // tailscope boilerplate: request wrapper + queue/stage wrappers
     tailscope
         .request(request, "ok", async {
             let _inflight = tailscope.inflight("invoice_inflight");
@@ -167,6 +197,7 @@ async fn main() -> anyhow::Result<()> {
         .await;
 
     sampler.shutdown().await;
+    // tailscope boilerplate: ensure run artifact is written
     tailscope.flush()?;
     Ok(())
 }
@@ -203,7 +234,7 @@ async fn create_invoice(
 ```
 
 ```bash
-tailscope analyze tailscope-run.json
+cargo run --manifest-path tailscope-cli/Cargo.toml -- analyze tailscope-run.json
 ```
 
 ## Integration cost and boilerplate


### PR DESCRIPTION
### Motivation

- Improve first-run onboarding by removing friction in the quickstart flow and making the provided examples copy/paste runnable. 
- Fix a `tokio` feature mismatch that prevented the `#[tokio::main]` examples from compiling as written. 
- Make it clearer which lines are minimal `tailscope` integration boilerplate versus optional richer instrumentation so newcomers can evaluate adoption cost quickly.

### Description

- Update `README.md` to use `tokio` features `rt-multi-thread` so the sample `#[tokio::main]` snippets compile as-is. 
- Add a copy/paste "blank app verification path" that shows how to create a temp `cargo` app and wire `tailscope` dependencies with explicit path placeholders. 
- Annotate the sample code with `// tailscope boilerplate:` markers to highlight the minimal integration lines and add a separate "Full integration example (runtime sampler + macro path)" section. 
- Clarify analyzer invocation examples and make the full integration sample return type use `Result<(), Box<dyn std::error::Error>>` to avoid requiring undeclared `anyhow`.

### Testing

- Verified the quickstart sample by creating a fresh temporary app, running `cargo run`, and running the CLI analysis with `cargo run --manifest-path tailscope-cli/Cargo.toml -- analyze tailscope-run.json`, and the run/analysis succeeded. 
- Validated the full integration sample by creating a fresh app that uses `RuntimeSampler`, running `cargo run`, and producing JSON analysis with `--format json`, which succeeded. 
- Ran the demo validation scripts `python3 scripts/run_queue_demo.py && python3 scripts/validate_queue_demo.py`, `python3 scripts/run_blocking_demo.py && python3 scripts/validate_blocking_demo.py`, and `python3 scripts/run_downstream_demo.py && python3 scripts/validate_downstream_demo.py`, and all demo validations passed. 
- Ran repository checks `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, and they all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc419a50e48330858708b052391ce2)