### PR TITLE
Clarify README value proposition and fix runnable snippet guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,25 @@ This repository is an MVP release candidate with three workspace crates:
 - a GUI observability product
 - a claim of root-cause certainty
 
+## Why teams would adopt tailscope (MVP value proposition)
+
+`tailscope` is designed for teams that already have logs/metrics/traces, but still lose time deciding
+*which latency lane to investigate first*.
+
+- **Clear first diagnosis lane**: ranked suspects with explicit evidence and confidence.
+- **Low integration friction**: one init call, request wrapper, and a few await wrappers.
+- **Useful with partial coverage**: still emits a report when instrumentation is incomplete.
+- **Action-oriented output**: each suspect includes concrete next checks to run.
+
+If your team does **not** use `tailscope`, common alternatives are:
+
+- ad-hoc log and trace spelunking across many dashboards,
+- custom one-off timing probes per service,
+- runtime-local profiling sessions (e.g., tokio-console) without durable diagnosis artifacts.
+
+Those approaches can work, but are usually slower to repeat and compare across runs than
+`tailscope` JSON artifacts plus analyzer output.
+
 ## 5-minute quickstart (end to end)
 
 ### 1) Add dependencies
@@ -104,15 +123,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ### 3) Run and analyze
 
+From the repository root:
+
 ```bash
-cargo run
 cargo run --manifest-path tailscope-cli/Cargo.toml -- analyze tailscope-run.json
 cargo run --manifest-path tailscope-cli/Cargo.toml -- analyze tailscope-run.json --format json
 ```
 
-If you used the `/tmp/tailscope-quickstart` verification path above, run analyzer with:
+If you used the `/tmp/tailscope-quickstart` verification path above, run the app and analyzer with:
 
 ```bash
+cargo run
 cargo run --manifest-path "$TAILSCOPE_REPO/tailscope-cli/Cargo.toml" -- analyze tailscope-run.json
 cargo run --manifest-path "$TAILSCOPE_REPO/tailscope-cli/Cargo.toml" -- analyze tailscope-run.json --format json
 ```
@@ -212,8 +233,14 @@ cargo run --manifest-path tailscope-cli/Cargo.toml -- analyze tailscope-run.json
 
 ### 3) Macro-based request entry point
 
+When using the `#[instrument_request(...)]` macro, include `tracing` in your app dependencies:
+
+```toml
+[dependencies]
+tracing = "0.1"
+```
+
 ```rust
-use std::sync::Arc;
 use tailscope_core::Tailscope;
 use tailscope_tokio::instrument_request;
 
@@ -225,7 +252,7 @@ use tailscope_tokio::instrument_request;
     skip(tailscope)
 )]
 async fn create_invoice(
-    tailscope: Arc<Tailscope>,
+    tailscope: &Tailscope,
     request_id: String,
 ) -> Result<(), &'static str> {
     let _inflight = tailscope.inflight("invoice_inflight");


### PR DESCRIPTION
### Motivation

- Make the README explicitly state the MVP value proposition and adoption rationale so teams understand why to integrate `tailscope` and what alternatives they would use without it. 
- Remove ambiguity in the quickstart instructions so copy/paste verification flows run as intended. 
- Ensure the macro-based example in the README compiles as shown and documents required dependencies. 

### Description

- Added a new section "Why teams would adopt tailscope (MVP value proposition)" that lists the core benefits and common alternatives. 
- Clarified the quickstart run/analyze instructions to distinguish invoking the analyzer from the repository root vs the temporary verification flow. 
- Documented the `tracing = "0.1"` dependency required when using `#[instrument_request(...)]` and updated the example to use `&Tailscope` (instead of `Arc<Tailscope>`) so the snippet compiles. 

### Testing

- Ran repository checks: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, all succeeded. 
- Verified README examples end-to-end by creating fresh temporary crates and running the quickstart and full-integration flows with the CLI analyzer, which produced text and JSON analyzer output successfully. 
- Validated macro example compiles after adding `tracing = "0.1"`, and executed demo/validation scripts: `python3 scripts/run_*_demo.py` and corresponding `validate_*_demo.py` as well as `python3 scripts/measure_runtime_cost.py`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc44f50a0c8330a4d87f5452546189)