### PR TITLE
Align docs with analyzer JSON fields and add JSON-report contract test

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 cargo run --manifest-path tailscope-cli/Cargo.toml -- analyze tailscope-run.json
 ```
 
+JSON output fields to start with:
+
+- `primary_suspect.kind`
+- `p95_queue_share_permille`
+- `p95_service_share_permille`
+- `primary_suspect.evidence[]`
+
 ## Canonical integration path
 
 1. Initialize one collector: `Tailscope::init(Config::new("service-name"))`.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -22,6 +22,22 @@ Each suspect includes:
 - evidence (human-readable)
 - recommended next checks
 
+## JSON report schema (MVP)
+
+Top-level JSON object fields currently emitted by `tailscope-cli`:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `request_count` | `number` (`usize`) | Total requests seen in the run. |
+| `p50_latency_us` | `number \| null` (`Option<u64>`) | Request p50 latency in microseconds. |
+| `p95_latency_us` | `number \| null` (`Option<u64>`) | Request p95 latency in microseconds. |
+| `p99_latency_us` | `number \| null` (`Option<u64>`) | Request p99 latency in microseconds. |
+| `p95_queue_share_permille` | `number \| null` (`Option<u64>`) | p95 queue-time share of request latency, permille (0-1000). |
+| `p95_service_share_permille` | `number \| null` (`Option<u64>`) | p95 service-time share of request latency, permille (0-1000). |
+| `inflight_trend` | `object \| null` (`Option<InflightTrend>`) | Dominant in-flight gauge trend summary when snapshots are available. |
+| `primary_suspect` | `object` (`Suspect`) | Highest-ranked suspect; includes `kind`, `score`, `confidence`, `evidence`, `next_checks`. |
+| `secondary_suspects` | `array` of `Suspect` | Remaining ranked suspects, possibly empty. |
+
 ## Request-time share metrics
 
 The report includes two explicit request-time share fields:

--- a/docs/getting-started-demo.md
+++ b/docs/getting-started-demo.md
@@ -38,8 +38,9 @@ python3 scripts/validate_queue_demo.py
 **Interpretation focus:**
 
 - `primary_suspect.kind`
-- `request_latency_us.p95`
 - `p95_queue_share_permille`
+- `p95_service_share_permille`
+- `primary_suspect.evidence[]`
 
 ## Blocking service demo (`demos/blocking_service`)
 
@@ -66,8 +67,9 @@ python3 scripts/validate_blocking_demo.py
 **Interpretation focus:**
 
 - `primary_suspect.kind`
-- `runtime_pressure.blocking_queue_depth.p95`
-- `request_latency_us.p95`
+- `p95_queue_share_permille`
+- `p95_service_share_permille`
+- `primary_suspect.evidence[]`
 
 ## Downstream service demo (`demos/downstream_service`)
 
@@ -92,8 +94,9 @@ python3 scripts/validate_downstream_demo.py
 **Interpretation focus:**
 
 - `primary_suspect.kind`
-- `dominant_stage.name`
-- `dominant_stage.p95_share_permille`
+- `p95_service_share_permille`
+- `p95_queue_share_permille`
+- `primary_suspect.evidence[]`
 
 ## If your local output differs
 

--- a/tailscope-cli/tests/report_schema_contract.rs
+++ b/tailscope-cli/tests/report_schema_contract.rs
@@ -1,0 +1,52 @@
+use std::path::Path;
+
+use serde_json::Value;
+use tailscope_cli::analyze::analyze_run;
+use tailscope_core::Run;
+
+fn load_fixture(name: &str) -> Run {
+    let path = Path::new("tests/fixtures").join(name);
+    let content = std::fs::read_to_string(path).expect("fixture should exist");
+    serde_json::from_str(&content).expect("fixture should deserialize")
+}
+
+#[test]
+fn documented_report_keys_exist_in_json_output() {
+    let run = load_fixture("queue_saturation.json");
+    let report = analyze_run(&run);
+    let json = serde_json::to_value(&report).expect("report should serialize");
+
+    for key in [
+        "request_count",
+        "p50_latency_us",
+        "p95_latency_us",
+        "p99_latency_us",
+        "p95_queue_share_permille",
+        "p95_service_share_permille",
+        "inflight_trend",
+        "primary_suspect",
+        "secondary_suspects",
+    ] {
+        assert!(
+            json.get(key).is_some(),
+            "expected top-level documented key '{key}'"
+        );
+    }
+
+    let primary_suspect = json
+        .get("primary_suspect")
+        .and_then(Value::as_object)
+        .expect("primary_suspect should be an object");
+
+    assert!(primary_suspect.contains_key("kind"));
+    assert!(primary_suspect.contains_key("evidence"));
+
+    let evidence = primary_suspect
+        .get("evidence")
+        .and_then(Value::as_array)
+        .expect("primary_suspect.evidence should be an array");
+    assert!(
+        evidence.iter().all(Value::is_string),
+        "primary_suspect.evidence should contain strings"
+    );
+}


### PR DESCRIPTION
### Motivation

- Prevent documentation drift by using `tailscope-cli` `Report`/`Suspect` field names as the canonical JSON contract. 
- Make it easy for users and automated checks to find the key fields to inspect when analyzing demo outputs.

### Description

- Updated `docs/getting-started-demo.md` to reference the actual analyzer fields `primary_suspect.kind`, `p95_queue_share_permille`, `p95_service_share_permille`, and `primary_suspect.evidence[]` in all demo interpretation sections. 
- Added a "JSON report schema (MVP)" table to `docs/diagnostics.md` enumerating every top-level `Report` field and its type. 
- Added a short README snippet under the Analyze section highlighting the primary JSON fields to inspect. 
- Added a regression/contract smoke test `tailscope-cli/tests/report_schema_contract.rs` that serializes `analyze_run` output from a fixture and asserts the documented top-level keys exist and that `primary_suspect.evidence` is an array of strings.

### Testing

- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` and all checks completed successfully. 
- The new test `documented_report_keys_exist_in_json_output` passed along with the existing analyzer and core unit tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc52e069ec8330bcfc669a40262190)