### PR TITLE
Remove shell wrapper scripts and make Python workflows canonical

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ JSON output fields to start with:
 
 ## Canonical integration path
 
+> Script workflows are Python-first and canonical.
+
 1. Initialize one collector: `Tailscope::init(Config::new("service-name"))`.
 2. Wrap request entry points with `request(...)` (or the macro path from `tailscope-tokio`).
 3. Add `queue(...).await_on(...)` around known wait points.

--- a/SPEC.md
+++ b/SPEC.md
@@ -182,7 +182,6 @@ The report includes:
 Canonical invocation for demo validation and runtime-cost measurement is **Python-first** (`python3 scripts/*.py`).
 
 - `scripts/*.py` are the source-of-truth implementations.
-- `scripts/*.sh` remain thin compatibility wrappers for Unix workflows.
 - Required runtime dependencies for script workflows: `python3` and `cargo`.
 
 ## 8. Diagnosis categories
@@ -216,7 +215,6 @@ Repro harness:
 
 - binary: `demos/runtime_cost`
 - canonical script: `python3 scripts/measure_runtime_cost.py`
-- compatibility wrapper: `scripts/measure_runtime_cost.sh`
 
 Modes measured:
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -158,7 +158,7 @@ Confidence is an internal ranking confidence, not a statistical confidence inter
 
 ### Queue demo before/after example
 
-`scripts/run_queue_demo.sh` now emits `before` (pathological baseline) and `after` (mitigated) analyses, plus a machine-readable comparison JSON at `demos/queue_service/artifacts/before-after-comparison.json`.
+`python3 scripts/run_queue_demo.py` now emits `before` (pathological baseline) and `after` (mitigated) analyses, plus a machine-readable comparison JSON at `demos/queue_service/artifacts/before-after-comparison.json`.
 
 In the current checked-in fixtures:
 
@@ -169,7 +169,7 @@ Use this pattern for diagnosis validation: keep load shape constant, adjust one 
 
 ### Blocking demo before/after example
 
-`scripts/run_blocking_demo.sh` now emits `before` (blocking-pool-constrained baseline) and `after` (mitigated) analyses, plus a machine-readable comparison JSON at `demos/blocking_service/artifacts/before-after-comparison.json`.
+`python3 scripts/run_blocking_demo.py` now emits `before` (blocking-pool-constrained baseline) and `after` (mitigated) analyses, plus a machine-readable comparison JSON at `demos/blocking_service/artifacts/before-after-comparison.json`.
 
 In the current checked-in fixtures:
 

--- a/docs/mvp-audit-2026-03-19.md
+++ b/docs/mvp-audit-2026-03-19.md
@@ -94,11 +94,10 @@ Rationale:
 Not yet "staff/principal" polish in all areas because:
 
 - Some planning-doc aspirations (for example PR-history coherence) are process-level and not demonstrably enforced by repository tooling.
-- There is still minor command-wrapper duplication (Python canonical scripts + shell wrappers), though this is intentional for compatibility.
+- Demo workflow scripts still share some orchestration patterns; further centralization in `scripts/_demo_runner.py` could reduce repeated glue code.
 
 ## Duplication and simplification opportunities
 
-- Shell wrappers duplicate Python entry points at a thin level; acceptable but could be auto-generated or standardized through one launcher to reduce maintenance.
 - Demo workflow scripts share orchestration patterns; further centralization in `scripts/_demo_runner.py` could reduce repeated glue code.
 - Otherwise, Rust crate boundaries are already straightforward and reasonably small.
 

--- a/docs/runtime-cost.md
+++ b/docs/runtime-cost.md
@@ -17,7 +17,6 @@ The summary also computes relative overhead for `light` and `investigation` vs `
 
 - Binary: `demos/runtime_cost`
 - Canonical script: `python3 scripts/measure_runtime_cost.py`
-- Compatibility wrapper: `scripts/measure_runtime_cost.sh`
 
 The harness runs a queueing workload with bounded concurrency and fixed simulated work per request.
 

--- a/scripts/measure_runtime_cost.sh
+++ b/scripts/measure_runtime_cost.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-python3 "$ROOT_DIR/scripts/measure_runtime_cost.py" "$@"

--- a/scripts/run_blocking_demo.sh
+++ b/scripts/run_blocking_demo.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-python3 "$ROOT_DIR/scripts/run_blocking_demo.py" "$@"

--- a/scripts/run_downstream_demo.sh
+++ b/scripts/run_downstream_demo.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-python3 "$SCRIPT_DIR/run_downstream_demo.py" "$@"

--- a/scripts/run_queue_demo.sh
+++ b/scripts/run_queue_demo.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-python3 "$ROOT_DIR/scripts/run_queue_demo.py" "$@"

--- a/scripts/validate_blocking_demo.sh
+++ b/scripts/validate_blocking_demo.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-python3 "$ROOT_DIR/scripts/validate_blocking_demo.py" "$@"

--- a/scripts/validate_downstream_demo.sh
+++ b/scripts/validate_downstream_demo.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-python3 "$SCRIPT_DIR/validate_downstream_demo.py" "$@"

--- a/scripts/validate_queue_demo.sh
+++ b/scripts/validate_queue_demo.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-python3 "$ROOT_DIR/scripts/validate_queue_demo.py" "$@"


### PR DESCRIPTION
### Motivation

- Remove thin shell wrappers that only proxied to the Python demo and measurement scripts to reduce duplication and maintenance surface.
- Make the Python scripts the canonical, documented entrypoints for demos and runtime-cost measurement to clarify portability and tooling requirements.

### Description

- Deleted the thin shell wrapper scripts in `scripts/`: `run_queue_demo.sh`, `run_blocking_demo.sh`, `run_downstream_demo.sh`, `validate_queue_demo.sh`, `validate_blocking_demo.sh`, `validate_downstream_demo.sh`, and `measure_runtime_cost.sh`.
- Updated `README.md` to add the note `> Script workflows are Python-first and canonical.` in the canonical integration section.
- Updated `SPEC.md`, `docs/diagnostics.md`, `docs/runtime-cost.md`, and `docs/mvp-audit-2026-03-19.md` to reference `python3 scripts/*.py` invocations and to remove references to `.sh` compatibility wrappers.

### Testing

- Ran `cargo fmt --check` and it completed successfully.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it completed successfully.
- Ran `cargo test --workspace` and the test suite completed with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc587e458883309c3076c05d23b5f4)