### PR TITLE
Refactor queue/blocking demo scripts to use shared runner utilities

### DIFF
--- a/scripts/_demo_runner.py
+++ b/scripts/_demo_runner.py
@@ -1,10 +1,17 @@
 #!/usr/bin/env python3
-"""Shared helpers for demo runners."""
+"""Shared helpers for demo run scripts.
+
+This module holds common subprocess and artifact-writing utilities used by
+multiple demos. Per-demo scripts should keep only mode selection,
+demo-specific metric extraction, and validation semantics.
+"""
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
+from typing import Any
 
 
 def run_demo_binary(manifest_path: Path, artifact_path: Path, *demo_args: str) -> None:
@@ -43,3 +50,33 @@ def run_cli_analysis_json(cli_manifest_path: Path, artifact_path: Path, analysis
             check=True,
             stdout=analysis_file,
         )
+
+
+def nullable_delta(before_value: Any, after_value: Any) -> Any:
+    """Return ``after - before`` when both values are present, otherwise ``None``."""
+    if before_value is None or after_value is None:
+        return None
+    return after_value - before_value
+
+
+def write_before_after_comparison(
+    artifact_dir: Path,
+    before_snapshot: dict[str, Any],
+    after_snapshot: dict[str, Any],
+) -> Path:
+    """Write a standard before/after comparison file with automatic deltas."""
+    delta = {
+        key: nullable_delta(before_snapshot[key], after_snapshot[key])
+        for key in before_snapshot
+        if key in after_snapshot
+    }
+
+    comparison = {
+        "before": before_snapshot,
+        "after": after_snapshot,
+        "delta": delta,
+    }
+
+    comparison_path = artifact_dir / "before-after-comparison.json"
+    comparison_path.write_text(json.dumps(comparison, indent=2) + "\n", encoding="utf-8")
+    return comparison_path

--- a/scripts/run_blocking_demo.py
+++ b/scripts/run_blocking_demo.py
@@ -8,7 +8,7 @@ import json
 import re
 from pathlib import Path
 
-from _demo_runner import run_cli_analysis_json, run_demo_binary
+from _demo_runner import run_cli_analysis_json, run_demo_binary, write_before_after_comparison
 
 
 def extract_blocking_queue_depth_p95(report: dict) -> int | None:
@@ -43,49 +43,25 @@ def run_variant(root_dir: Path, artifact_dir: Path, variant: str) -> None:
     print(f"analysis ({variant}): {analysis_path}")
 
 
+def snapshot(report: dict) -> dict[str, int | str | None]:
+    return {
+        "primary_suspect_kind": report["primary_suspect"]["kind"],
+        "primary_suspect_score": report["primary_suspect"]["score"],
+        "p95_latency_us": report["p95_latency_us"],
+        "p95_service_share_permille": report.get("p95_service_share_permille"),
+        "blocking_queue_depth_p95": extract_blocking_queue_depth_p95(report),
+    }
+
+
 def write_comparison(artifact_dir: Path) -> None:
     before = json.loads((artifact_dir / "before-analysis.json").read_text())
     after = json.loads((artifact_dir / "after-analysis.json").read_text())
 
-    comparison = {
-        "before": {
-            "primary_suspect_kind": before["primary_suspect"]["kind"],
-            "primary_suspect_score": before["primary_suspect"]["score"],
-            "p95_latency_us": before["p95_latency_us"],
-            "p95_service_share_permille": before.get("p95_service_share_permille"),
-            "blocking_queue_depth_p95": extract_blocking_queue_depth_p95(before),
-        },
-        "after": {
-            "primary_suspect_kind": after["primary_suspect"]["kind"],
-            "primary_suspect_score": after["primary_suspect"]["score"],
-            "p95_latency_us": after["p95_latency_us"],
-            "p95_service_share_permille": after.get("p95_service_share_permille"),
-            "blocking_queue_depth_p95": extract_blocking_queue_depth_p95(after),
-        },
-    }
-
-    before_snapshot = comparison["before"]
-    after_snapshot = comparison["after"]
-    comparison["delta"] = {
-        "p95_latency_us": after_snapshot["p95_latency_us"] - before_snapshot["p95_latency_us"],
-        "primary_suspect_score": after_snapshot["primary_suspect_score"]
-        - before_snapshot["primary_suspect_score"],
-        "p95_service_share_permille": (
-            None
-            if before_snapshot["p95_service_share_permille"] is None
-            or after_snapshot["p95_service_share_permille"] is None
-            else after_snapshot["p95_service_share_permille"] - before_snapshot["p95_service_share_permille"]
-        ),
-        "blocking_queue_depth_p95": (
-            None
-            if before_snapshot["blocking_queue_depth_p95"] is None
-            or after_snapshot["blocking_queue_depth_p95"] is None
-            else after_snapshot["blocking_queue_depth_p95"] - before_snapshot["blocking_queue_depth_p95"]
-        ),
-    }
-
-    comparison_path = artifact_dir / "before-after-comparison.json"
-    comparison_path.write_text(json.dumps(comparison, indent=2) + "\n", encoding="utf-8")
+    comparison_path = write_before_after_comparison(
+        artifact_dir,
+        snapshot(before),
+        snapshot(after),
+    )
     print(f"comparison: {comparison_path}")
 
 

--- a/scripts/run_queue_demo.py
+++ b/scripts/run_queue_demo.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 
 import argparse
 import json
-import subprocess
 from pathlib import Path
+
+from _demo_runner import run_cli_analysis_json, run_demo_binary, write_before_after_comparison
 
 
 def run_variant(root_dir: Path, artifact_dir: Path, variant: str) -> None:
@@ -16,76 +17,39 @@ def run_variant(root_dir: Path, artifact_dir: Path, variant: str) -> None:
 
     artifact_dir.mkdir(parents=True, exist_ok=True)
 
-    subprocess.run(
-        [
-            "cargo",
-            "run",
-            "--quiet",
-            "--manifest-path",
-            str(root_dir / "demos/queue_service/Cargo.toml"),
-            "--",
-            str(run_path),
-            mode_arg,
-        ],
-        check=True,
+    run_demo_binary(
+        root_dir / "demos/queue_service/Cargo.toml",
+        run_path,
+        mode_arg,
     )
-    with analysis_path.open("w", encoding="utf-8") as analysis_file:
-        subprocess.run(
-            [
-                "cargo",
-                "run",
-                "--quiet",
-                "--manifest-path",
-                str(root_dir / "tailscope-cli/Cargo.toml"),
-                "--",
-                "analyze",
-                str(run_path),
-                "--format",
-                "json",
-            ],
-            check=True,
-            stdout=analysis_file,
-        )
+    run_cli_analysis_json(
+        root_dir / "tailscope-cli/Cargo.toml",
+        run_path,
+        analysis_path,
+    )
 
     print(f"run artifact ({variant}): {run_path}")
     print(f"analysis ({variant}): {analysis_path}")
+
+
+def snapshot(report: dict) -> dict[str, int | str | None]:
+    return {
+        "primary_suspect_kind": report["primary_suspect"]["kind"],
+        "primary_suspect_score": report["primary_suspect"]["score"],
+        "p95_latency_us": report["p95_latency_us"],
+        "p95_queue_share_permille": report.get("p95_queue_share_permille"),
+    }
 
 
 def write_comparison(artifact_dir: Path) -> None:
     before = json.loads((artifact_dir / "before-analysis.json").read_text())
     after = json.loads((artifact_dir / "after-analysis.json").read_text())
 
-    comparison = {
-        "before": {
-            "primary_suspect_kind": before["primary_suspect"]["kind"],
-            "primary_suspect_score": before["primary_suspect"]["score"],
-            "p95_latency_us": before["p95_latency_us"],
-            "p95_queue_share_permille": before.get("p95_queue_share_permille"),
-        },
-        "after": {
-            "primary_suspect_kind": after["primary_suspect"]["kind"],
-            "primary_suspect_score": after["primary_suspect"]["score"],
-            "p95_latency_us": after["p95_latency_us"],
-            "p95_queue_share_permille": after.get("p95_queue_share_permille"),
-        },
-    }
-
-    before_snapshot = comparison["before"]
-    after_snapshot = comparison["after"]
-    comparison["delta"] = {
-        "p95_latency_us": after_snapshot["p95_latency_us"] - before_snapshot["p95_latency_us"],
-        "primary_suspect_score": after_snapshot["primary_suspect_score"]
-        - before_snapshot["primary_suspect_score"],
-        "p95_queue_share_permille": (
-            None
-            if before_snapshot["p95_queue_share_permille"] is None
-            or after_snapshot["p95_queue_share_permille"] is None
-            else after_snapshot["p95_queue_share_permille"] - before_snapshot["p95_queue_share_permille"]
-        ),
-    }
-
-    comparison_path = artifact_dir / "before-after-comparison.json"
-    comparison_path.write_text(json.dumps(comparison, indent=2) + "\n", encoding="utf-8")
+    comparison_path = write_before_after_comparison(
+        artifact_dir,
+        snapshot(before),
+        snapshot(after),
+    )
     print(f"comparison: {comparison_path}")
 
 


### PR DESCRIPTION
### Motivation
- Reduce duplicated subprocess and delta-calculation logic across demo scripts by centralizing common run/analysis/comparison helpers while keeping per-demo files focused on mode selection and metric extraction.

### Description
- Add a clearer module docstring to `scripts/_demo_runner.py` describing that shared subprocess and artifact-writing helpers belong there and per-demo scripts should keep mode selection, metric extraction, and validation semantics.
- Add `nullable_delta` and `write_before_after_comparison` to `scripts/_demo_runner.py` and keep existing `run_demo_binary` and `run_cli_analysis_json` helpers for demo execution and analysis output writing.
- Refactor `scripts/run_queue_demo.py` to use the shared helpers and introduce a small `snapshot` function to capture queue-specific fields while removing inline `subprocess` and delta-building code.
- Refactor `scripts/run_blocking_demo.py` to use the shared helpers and introduce a `snapshot` function while preserving blocking-specific extraction logic (`extract_blocking_queue_depth_p95`).

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it passed.
- Ran `cargo test --workspace` and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc5aa9a76c833089fd0d5f2e33f4c0)