### PR TITLE
Canonicalize manual request instrumentation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,16 +69,28 @@ JSON output fields to start with:
 - `p95_service_share_permille`
 - `primary_suspect.evidence[]`
 
+### Optional macro path (`tailscope-tokio`)
+
+```rust
+use tailscope_tokio::instrument_request;
+
+#[instrument_request(route = "/demo", kind = "quickstart", tailscope = tailscope)]
+async fn handle_demo(tailscope: &tailscope_core::Tailscope) {
+    // handler logic...
+}
+```
+
 ## Canonical integration path
 
 > Script workflows are Python-first and canonical.
 
 1. Initialize one collector: `Tailscope::init(Config::new("service-name"))`.
-2. Wrap request entry points with `request(...)` (or the macro path from `tailscope-tokio`).
-3. Add `queue(...).await_on(...)` around known wait points.
-4. Add `stage(...).await_on(...)` around key downstream awaits.
-5. Optionally add `inflight(...)` guards and `RuntimeSampler::start(...)` when diagnosis evidence is insufficient.
-6. Flush and analyze: `tailscope.flush()?` then `tailscope analyze <run.json>`.
+2. Manual path: wrap request entry points with `request(RequestMeta::for_route(...).with_kind(...), ...)`.
+3. Macro path: use `#[instrument_request(...)]` from `tailscope-tokio` when you want attribute-based request instrumentation.
+4. Add `queue(...).await_on(...)` around known wait points.
+5. Add `stage(...).await_on(...)` around key downstream awaits.
+6. Optionally add `inflight(...)` guards and `RuntimeSampler::start(...)` when diagnosis evidence is insufficient.
+7. Flush and analyze: `tailscope.flush()?` then `tailscope analyze <run.json>`.
 
 ## MVP limitations
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -59,28 +59,17 @@ let tailscope = Tailscope::init(config)?;
 ```rust
 use tailscope_core::RequestMeta;
 
-tailscope
-    .request(
-        RequestMeta::new("req-1", "/invoice"),
-        "ok",
-        async { /* request body */ },
-    )
-    .await;
-```
-
-Ergonomic helper path (auto request ID + builder-style kind):
-
-```rust
 let meta = RequestMeta::for_route("/invoice").with_kind("create_invoice");
 let request_id = meta.request_id.clone();
 
-tailscope.request(meta, "ok", async move {
-    tailscope
-        .queue(request_id.clone(), "invoice_worker")
-        .await_on(semaphore.acquire())
-        .await;
-})
-.await;
+tailscope
+    .request(meta, "ok", async move {
+        tailscope
+            .queue(request_id.clone(), "invoice_worker")
+            .await_on(semaphore.acquire())
+            .await;
+    })
+    .await;
 ```
 
 ### 5.3 In-flight tracking

--- a/tailscope-core/src/collector.rs
+++ b/tailscope-core/src/collector.rs
@@ -78,35 +78,6 @@ impl Tailscope {
         value
     }
 
-    /// Times one request future with an auto-generated request ID for `route`.
-    pub async fn request_for_route<Fut, T>(
-        &self,
-        route: impl Into<String>,
-        outcome: impl Into<String>,
-        fut: Fut,
-    ) -> T
-    where
-        Fut: std::future::Future<Output = T>,
-    {
-        self.request(RequestMeta::for_route(route), outcome, fut)
-            .await
-    }
-
-    /// Times one request future with an auto-generated request ID and explicit `kind`.
-    pub async fn request_with_kind<Fut, T>(
-        &self,
-        route: impl Into<String>,
-        kind: impl Into<String>,
-        outcome: impl Into<String>,
-        fut: Fut,
-    ) -> T
-    where
-        Fut: std::future::Future<Output = T>,
-    {
-        self.request(RequestMeta::for_route(route).with_kind(kind), outcome, fut)
-            .await
-    }
-
     /// Returns a clone of the current in-memory run state.
     #[must_use]
     pub fn snapshot(&self) -> Run {

--- a/tailscope-core/src/tests.rs
+++ b/tailscope-core/src/tests.rs
@@ -151,7 +151,7 @@ fn request_meta_for_route_generates_traceable_unique_ids() {
 }
 
 #[test]
-fn request_with_kind_records_helper_fields() {
+fn request_with_for_route_and_kind_records_expected_fields() {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("system time before epoch")
@@ -161,12 +161,8 @@ fn request_with_kind_records_helper_fields() {
     config.output_path = std::env::temp_dir().join(format!("tailscope_core_helper_{nanos}.json"));
 
     let tailscope = Tailscope::init(config).expect("init should succeed");
-    let result = futures_executor::block_on(tailscope.request_with_kind(
-        "/invoice",
-        "create_invoice",
-        "ok",
-        ready(9_u32),
-    ));
+    let meta = RequestMeta::for_route("/invoice").with_kind("create_invoice");
+    let result = futures_executor::block_on(tailscope.request(meta, "ok", ready(9_u32)));
     assert_eq!(result, 9);
 
     let snapshot = tailscope.snapshot();
@@ -175,6 +171,34 @@ fn request_with_kind_records_helper_fields() {
     assert_eq!(event.route, "/invoice");
     assert_eq!(event.kind.as_deref(), Some("create_invoice"));
     assert_eq!(event.outcome, "ok");
+    assert!(event.request_id.starts_with("_invoice-"));
+}
+
+#[test]
+fn request_with_for_route_records_route_and_outcome_without_kind() {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time before epoch")
+        .as_nanos();
+
+    let mut config = Config::new("payments");
+    config.output_path =
+        std::env::temp_dir().join(format!("tailscope_core_route_only_{nanos}.json"));
+
+    let tailscope = Tailscope::init(config).expect("init should succeed");
+    let result = futures_executor::block_on(tailscope.request(
+        RequestMeta::for_route("/invoice"),
+        "error",
+        ready(13_u32),
+    ));
+    assert_eq!(result, 13);
+
+    let snapshot = tailscope.snapshot();
+    assert_eq!(snapshot.requests.len(), 1);
+    let event = &snapshot.requests[0];
+    assert_eq!(event.route, "/invoice");
+    assert_eq!(event.kind, None);
+    assert_eq!(event.outcome, "error");
     assert!(event.request_id.starts_with("_invoice-"));
 }
 


### PR DESCRIPTION
### Motivation

- Provide a single, explicit manual integration API to simplify instrumentation and avoid API surface churn during pre-release.
- Ensure tests and docs exercise and recommend the canonical manual path so users and examples are consistent.

### Description

- Removed the non-canonical helper methods `Tailscope::request_for_route` and `Tailscope::request_with_kind` so `Tailscope::request(RequestMeta, ...)` is the single manual entrypoint.  
- Updated core tests to call `request(RequestMeta::for_route(...).with_kind(...), ...)` and added a route-only test to validate `kind == None` and outcome recording.  
- Aligned `README.md` and `SPEC.md` to document one manual path (`request(RequestMeta::for_route(...).with_kind(...), ...)`) plus an explicit macro path example using `#[instrument_request(...)]`.  

### Testing

- Ran `cargo fmt --check` and formatting passed after minor adjustments.  
- Ran `cargo clippy --workspace --all-targets -- -D warnings` with no warnings.  
- Ran `cargo test --workspace` and all unit tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc5c42a3f48330a31d8f68c1d74f1e)