### PR TITLE
Make stage success semantics truthful; add `await_value` for infallible stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             tailscope
                 .stage(request_id, "db_call")
-                .await_on(tokio::time::sleep(Duration::from_millis(12)))
+                .await_value(tokio::time::sleep(Duration::from_millis(12)))
                 .await;
         })
         .await;
@@ -88,7 +88,7 @@ async fn handle_demo(tailscope: &tailscope_core::Tailscope) {
 2. Manual path: wrap request entry points with `request(RequestMeta::for_route(...).with_kind(...), ...)`.
 3. Macro path: use `#[instrument_request(...)]` from `tailscope-tokio` when you want attribute-based request instrumentation.
 4. Add `queue(...).await_on(...)` around known wait points.
-5. Add `stage(...).await_on(...)` around key downstream awaits.
+5. Add `stage(...).await_on(...)` around key downstream awaits that return `Result`, or `stage(...).await_value(...)` for infallible futures.
 6. Optionally add `inflight(...)` guards and `RuntimeSampler::start(...)` when diagnosis evidence is insufficient.
 7. Flush and analyze: `tailscope.flush()?` then `tailscope analyze <run.json>`.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -99,10 +99,21 @@ tailscope
 
 ### 5.5 Stage timing wrapper
 
+For fallible stages (`Result` output):
+
 ```rust
 tailscope
-    .stage(request_id, "fetch_customer")
+    .stage(request_id.clone(), "fetch_customer")
     .await_on(customer_api.fetch())
+    .await;
+```
+
+For infallible stages:
+
+```rust
+tailscope
+    .stage(request_id, "cache_lookup")
+    .await_value(cache.refresh())
     .await;
 ```
 

--- a/demos/blocking_service/src/main.rs
+++ b/demos/blocking_service/src/main.rs
@@ -131,7 +131,7 @@ async fn run_demo(output_path: PathBuf, settings: ModeSettings) -> anyhow::Resul
 
                     tailscope
                         .stage(request_id, "spawn_blocking_path")
-                        .await_on(async {
+                        .await_value(async {
                             handle
                                 .await
                                 .expect("spawn_blocking workload should complete")

--- a/demos/downstream_service/src/main.rs
+++ b/demos/downstream_service/src/main.rs
@@ -37,12 +37,12 @@ async fn main() -> anyhow::Result<()> {
 
                     tailscope
                         .stage(request_id.clone(), "app_precheck")
-                        .await_on(tokio::time::sleep(Duration::from_millis(1)))
+                        .await_value(tokio::time::sleep(Duration::from_millis(1)))
                         .await;
 
                     tailscope
                         .stage(request_id, "downstream_call")
-                        .await_on(tokio::time::sleep(Duration::from_millis(20)))
+                        .await_value(tokio::time::sleep(Duration::from_millis(20)))
                         .await;
                 })
                 .await;

--- a/demos/queue_service/src/main.rs
+++ b/demos/queue_service/src/main.rs
@@ -96,7 +96,7 @@ async fn main() -> anyhow::Result<()> {
                     let _permit = permit;
                     tailscope
                         .stage(request_id, "simulated_work")
-                        .await_on(tokio::time::sleep(work_duration))
+                        .await_value(tokio::time::sleep(work_duration))
                         .await;
                 })
                 .await;

--- a/demos/runtime_cost/src/main.rs
+++ b/demos/runtime_cost/src/main.rs
@@ -120,12 +120,12 @@ async fn main() -> anyhow::Result<()> {
 
                         if mode == Mode::Investigation {
                             ts.stage(request_id.clone(), "pre_work_marker")
-                                .await_on(tokio::time::sleep(Duration::from_micros(300)))
+                                .await_value(tokio::time::sleep(Duration::from_micros(300)))
                                 .await;
                         }
 
                         ts.stage(request_id, "simulated_work")
-                            .await_on(tokio::time::sleep(work_duration))
+                            .await_value(tokio::time::sleep(work_duration))
                             .await;
 
                         drop(permit);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@ Responsibilities:
 - run schema (`Run`, metadata, event/snapshot structs)
 - collection lifecycle (`Tailscope::init`, `flush`, `snapshot`)
 - request wrapper (`request`)
-- queue/stage wrappers (`queue(...).await_on(...)`, `stage(...).await_on(...)`)
+- queue/stage wrappers (`queue(...).await_on(...)`, `stage(...).await_on(...)` for `Result`, `stage(...).await_value(...)` for infallible futures)
 - in-flight RAII tracking (`inflight`)
 - local JSON sink (`LocalJsonSink`)
 

--- a/tailscope-cli/src/analyze.rs
+++ b/tailscope-cli/src/analyze.rs
@@ -137,8 +137,7 @@ pub fn analyze_run(run: &Run) -> Report {
                     .to_string(),
             ],
             vec![
-                "Wrap critical awaits with queue(...).await_on(...) and stage(...).await_on(...)."
-                    .to_string(),
+                "Wrap critical awaits with queue(...).await_on(...), and use stage(...).await_on(...) for Result-returning work or stage(...).await_value(...) for infallible work.".to_string(),
                 "Enable RuntimeSampler during the run to capture runtime pressure signals."
                     .to_string(),
             ],

--- a/tailscope-core/src/events.rs
+++ b/tailscope-core/src/events.rs
@@ -87,7 +87,8 @@ pub struct StageEvent {
     pub finished_at_unix_ms: u64,
     /// Stage latency in microseconds.
     pub latency_us: u64,
-    /// Whether the stage returned a successful result.
+    /// Whether the stage completed successfully (`Result::is_ok()` for
+    /// `StageTimer::await_on`, always `true` for `StageTimer::await_value`).
     pub success: bool,
 }
 

--- a/tailscope-core/src/tests.rs
+++ b/tailscope-core/src/tests.rs
@@ -255,7 +255,7 @@ fn stage_wrapper_records_stage_event() {
     let result = futures_executor::block_on(
         tailscope
             .stage("req-22", "fetch_customer")
-            .await_on(ready(11_u32)),
+            .await_value(ready(11_u32)),
     );
     assert_eq!(result, 11);
 
@@ -264,7 +264,52 @@ fn stage_wrapper_records_stage_event() {
     let event = &snapshot.stages[0];
     assert_eq!(event.request_id, "req-22");
     assert_eq!(event.stage, "fetch_customer");
+    assert!(event.success);
     assert!(event.finished_at_unix_ms >= event.started_at_unix_ms);
+}
+
+#[test]
+fn stage_wrapper_records_success_for_ok_result() {
+    let mut config = Config::new("payments");
+    config.output_path = std::env::temp_dir().join("tailscope_core_stage_ok_test.json");
+
+    let tailscope = Tailscope::init(config).expect("init should succeed");
+
+    let result = futures_executor::block_on(
+        tailscope
+            .stage("req-33", "persist_invoice")
+            .await_on(ready::<Result<u32, &'static str>>(Ok(17_u32))),
+    );
+    assert_eq!(result, Ok(17));
+
+    let snapshot = tailscope.snapshot();
+    assert_eq!(snapshot.stages.len(), 1);
+    let event = &snapshot.stages[0];
+    assert_eq!(event.request_id, "req-33");
+    assert_eq!(event.stage, "persist_invoice");
+    assert!(event.success);
+}
+
+#[test]
+fn stage_wrapper_records_failure_for_err_result() {
+    let mut config = Config::new("payments");
+    config.output_path = std::env::temp_dir().join("tailscope_core_stage_err_test.json");
+
+    let tailscope = Tailscope::init(config).expect("init should succeed");
+
+    let result = futures_executor::block_on(
+        tailscope
+            .stage("req-34", "persist_invoice")
+            .await_on(ready::<Result<u32, &'static str>>(Err("boom"))),
+    );
+    assert_eq!(result, Err("boom"));
+
+    let snapshot = tailscope.snapshot();
+    assert_eq!(snapshot.stages.len(), 1);
+    let event = &snapshot.stages[0];
+    assert_eq!(event.request_id, "req-34");
+    assert_eq!(event.stage, "persist_invoice");
+    assert!(!event.success);
 }
 
 #[test]

--- a/tailscope-core/src/timers.rs
+++ b/tailscope-core/src/timers.rs
@@ -41,7 +41,38 @@ pub struct StageTimer<'a> {
 
 impl StageTimer<'_> {
     /// Awaits `fut`, records stage duration, and returns the original output.
-    pub async fn await_on<Fut, T>(self, fut: Fut) -> T
+    ///
+    /// This helper is intended for fallible stage work where success can be
+    /// derived from `Result::is_ok`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same error value produced by `fut` after recording the
+    /// stage event with `success = false`.
+    pub async fn await_on<Fut, T, E>(self, fut: Fut) -> Result<T, E>
+    where
+        Fut: std::future::Future<Output = Result<T, E>>,
+    {
+        let started_at_unix_ms = unix_time_ms();
+        let started = Instant::now();
+        let value = fut.await;
+        let finished_at_unix_ms = unix_time_ms();
+        let success = value.is_ok();
+
+        lock_run(&self.tailscope.run).stages.push(StageEvent {
+            request_id: self.request_id,
+            stage: self.stage,
+            started_at_unix_ms,
+            finished_at_unix_ms,
+            latency_us: duration_to_us(started.elapsed()),
+            success,
+        });
+
+        value
+    }
+
+    /// Awaits an infallible stage future and records a successful stage event.
+    pub async fn await_value<Fut, T>(self, fut: Fut) -> T
     where
         Fut: std::future::Future<Output = T>,
     {


### PR DESCRIPTION
### Motivation
- Ensure `StageEvent.success` reflects actual stage outcome instead of always `true` by tying success to `Result` outputs where available.
- Preserve ergonomics for existing infallible awaits by providing a dedicated API rather than breaking callers that await `()` or other non-`Result` futures.

### Description
- Constrain `StageTimer::await_on` to `Future<Output = Result<T, E>>` and record `StageEvent.success` from `Result::is_ok()` so recorded success is truthful; see `tailscope-core/src/timers.rs`.
- Add `StageTimer::await_value` for infallible futures which records `success = true` and preserves the previous ergonomic pattern for non-`Result` awaits; see `tailscope-core/src/timers.rs`.
- Update the `StageEvent` doc comment to explain the `success` contract and update user-facing docs and examples in `README.md`, `SPEC.md`, and `docs/architecture.md` to show when to use `await_on` vs `await_value`.
- Update demos and analyzer guidance to use `await_value` for infallible awaits and add unit tests in `tailscope-core/src/tests.rs` that verify both `Ok` and `Err` stage outcomes are recorded correctly.

### Testing
- Ran `cargo fmt --check` which completed successfully.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` which completed successfully.
- Ran `cargo test --workspace` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc5e3a0f608330adb38d6bd076d949)