### PR TITLE
Remove unused tailscope-tokio dependency from tailscope-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tailscope-core",
- "tailscope-tokio",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -104,3 +104,4 @@ async fn handle_demo(tailscope: &tailscope_core::Tailscope) {
 - [Diagnostics guide](docs/diagnostics.md)
 - [Getting started demos](docs/getting-started-demo.md)
 - [Runtime cost measurement](docs/runtime-cost.md)
+- [Changelog](docs/changelog.md)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+### Changed
+
+- Simplified `tailscope-cli` dependencies by removing a direct `tailscope-tokio` dependency; the CLI only consumes `tailscope-core` analyzer APIs.

--- a/tailscope-cli/Cargo.toml
+++ b/tailscope-cli/Cargo.toml
@@ -13,7 +13,6 @@ clap = { version = "4.5.40", features = ["derive"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 tailscope-core = { path = "../tailscope-core" }
-tailscope-tokio = { path = "../tailscope-tokio" }
 
 [lints]
 workspace = true


### PR DESCRIPTION
### Motivation
- Simplify the CLI crate graph by removing an unused direct dependency on `tailscope-tokio` because the CLI only consumes analyzer APIs from `tailscope-core`.

### Description
- Removed the `tailscope-tokio` entry from `tailscope-cli/Cargo.toml`, updated `Cargo.lock` to reflect the resolved dependency set, added `docs/changelog.md` with an Unreleased note about the dependency simplification, and linked the changelog from `README.md`.

### Testing
- Verified no CLI code or tests reference `tailscope-tokio` with `rg`, then ran `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc60419904833098e71027d584a9af)