### PR TITLE
docs: clarify canonical Rust integration and move Python scripts to demo section

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ async fn handle_demo(tailscope: &tailscope_core::Tailscope) {
 
 ## Canonical integration path
 
-> Script workflows are Python-first and canonical.
+> Rust API integration (`tailscope-core` + `tailscope-tokio`) is the canonical product path.
 
 1. Initialize one collector: `Tailscope::init(Config::new("service-name"))`.
 2. Manual path: wrap request entry points with `request(RequestMeta::for_route(...).with_kind(...), ...)`.
@@ -92,6 +92,12 @@ async fn handle_demo(tailscope: &tailscope_core::Tailscope) {
 6. Optionally add `inflight(...)` guards and `RuntimeSampler::start(...)` when diagnosis evidence is insufficient.
 7. Flush and analyze: `tailscope.flush()?` then `tailscope analyze <run.json>`.
 
+### Demo and reproducibility workflows
+
+Python scripts are for deterministic demos, fixtures, and reproducibility workflows, not for primary product integration.
+
+Typical user workflow: instrument a Rust service and run the CLI analyzer; maintainer/demo workflow: run `scripts/*.py` to validate scenarios deterministically.
+
 ## MVP limitations
 
 - Tokio-only runtime support.
@@ -100,6 +106,7 @@ async fn handle_demo(tailscope: &tailscope_core::Tailscope) {
 
 ## Docs index
 
+- [User guide](docs/user-guide.md)
 - [Architecture](docs/architecture.md)
 - [Diagnostics guide](docs/diagnostics.md)
 - [Getting started demos](docs/getting-started-demo.md)


### PR DESCRIPTION
### Motivation
- Make README guidance explicit that the primary product integration path is the Rust API (`tailscope-core` + `tailscope-tokio`) and that Python scripts are intended for demos and reproducibility rather than primary integration.

### Description
- Replace the previous “Script workflows are Python-first and canonical” wording with a statement that `Rust API integration (tailscope-core + tailscope-tokio)` is the canonical product path.
- Add a new `Demo and reproducibility workflows` subsection that explains Python scripts are for deterministic demos, fixtures, and reproducibility workflows and not for primary product integration.
- Add a single-sentence distinction between user workflow (instrument a Rust service and run the CLI analyzer) and maintainer/demo workflow (run `scripts/*.py` for deterministic validation) and insert `docs/user-guide.md` as the first link in the docs index.

### Testing
- No automated tests were run because this is a docs-only change; the README was updated and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc651739508330abedb28055f19148)