### PR TITLE
Unify demo run/validate scripts under a single `demo_tool.py` entry point

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -158,7 +158,7 @@ Confidence is an internal ranking confidence, not a statistical confidence inter
 
 ### Queue demo before/after example
 
-`python3 scripts/run_queue_demo.py` now emits `before` (pathological baseline) and `after` (mitigated) analyses, plus a machine-readable comparison JSON at `demos/queue_service/artifacts/before-after-comparison.json`.
+`python3 scripts/demo_tool.py run queue` now emits `before` (pathological baseline) and `after` (mitigated) analyses, plus a machine-readable comparison JSON at `demos/queue_service/artifacts/before-after-comparison.json`.
 
 In the current checked-in fixtures:
 
@@ -169,7 +169,7 @@ Use this pattern for diagnosis validation: keep load shape constant, adjust one 
 
 ### Blocking demo before/after example
 
-`python3 scripts/run_blocking_demo.py` now emits `before` (blocking-pool-constrained baseline) and `after` (mitigated) analyses, plus a machine-readable comparison JSON at `demos/blocking_service/artifacts/before-after-comparison.json`.
+`python3 scripts/demo_tool.py run blocking` now emits `before` (blocking-pool-constrained baseline) and `after` (mitigated) analyses, plus a machine-readable comparison JSON at `demos/blocking_service/artifacts/before-after-comparison.json`.
 
 In the current checked-in fixtures:
 

--- a/docs/getting-started-demo.md
+++ b/docs/getting-started-demo.md
@@ -20,8 +20,8 @@ Use this guide to run the MVP demos and compare generated outputs against tracke
 **Run:**
 
 ```bash
-python3 scripts/run_queue_demo.py
-python3 scripts/validate_queue_demo.py
+python3 scripts/demo_tool.py run queue
+python3 scripts/demo_tool.py validate queue
 ```
 
 **Key generated artifacts (`artifacts/`):**
@@ -49,8 +49,8 @@ python3 scripts/validate_queue_demo.py
 **Run:**
 
 ```bash
-python3 scripts/run_blocking_demo.py
-python3 scripts/validate_blocking_demo.py
+python3 scripts/demo_tool.py run blocking
+python3 scripts/demo_tool.py validate blocking
 ```
 
 **Key generated artifacts (`artifacts/`):**
@@ -78,8 +78,8 @@ python3 scripts/validate_blocking_demo.py
 **Run:**
 
 ```bash
-python3 scripts/run_downstream_demo.py
-python3 scripts/validate_downstream_demo.py
+python3 scripts/demo_tool.py run downstream
+python3 scripts/demo_tool.py validate downstream
 ```
 
 **Key generated artifacts (`artifacts/`):**

--- a/docs/mvp-audit-2026-03-19.md
+++ b/docs/mvp-audit-2026-03-19.md
@@ -12,12 +12,12 @@ This audit evaluates repository status against:
 - `cargo fmt --check`
 - `cargo clippy --workspace --all-targets -- -D warnings`
 - `cargo test --workspace`
-- `python3 scripts/run_queue_demo.py`
-- `python3 scripts/validate_queue_demo.py`
-- `python3 scripts/run_blocking_demo.py`
-- `python3 scripts/validate_blocking_demo.py`
-- `python3 scripts/run_downstream_demo.py`
-- `python3 scripts/validate_downstream_demo.py`
+- `python3 scripts/demo_tool.py run queue`
+- `python3 scripts/demo_tool.py validate queue`
+- `python3 scripts/demo_tool.py run blocking`
+- `python3 scripts/demo_tool.py validate blocking`
+- `python3 scripts/demo_tool.py run downstream`
+- `python3 scripts/demo_tool.py validate downstream`
 - `python3 scripts/measure_runtime_cost.py`
 
 All commands completed successfully in this environment.

--- a/scripts/_demo_runner.py
+++ b/scripts/_demo_runner.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Shared helpers for demo run scripts.
+"""Shared helpers for demo run/validation scripts.
 
 This module holds common subprocess and artifact-writing utilities used by
 multiple demos. Per-demo scripts should keep only mode selection,
@@ -12,6 +12,11 @@ import json
 import subprocess
 from pathlib import Path
 from typing import Any
+
+
+def repo_root(from_file: str) -> Path:
+    """Return repository root for a script file path under ``scripts/``."""
+    return Path(from_file).resolve().parent.parent
 
 
 def run_demo_binary(manifest_path: Path, artifact_path: Path, *demo_args: str) -> None:
@@ -52,11 +57,37 @@ def run_cli_analysis_json(cli_manifest_path: Path, artifact_path: Path, analysis
         )
 
 
+def run_and_analyze(
+    demo_manifest_path: Path,
+    cli_manifest_path: Path,
+    artifact_path: Path,
+    analysis_path: Path,
+    *demo_args: str,
+) -> None:
+    """Run demo and analyze the resulting artifact into ``analysis_path``."""
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+    run_demo_binary(demo_manifest_path, artifact_path, *demo_args)
+    run_cli_analysis_json(cli_manifest_path, artifact_path, analysis_path)
+
+
+def variant_paths(artifact_dir: Path, variant: str) -> tuple[Path, Path]:
+    """Return ``(run_path, analysis_path)`` for a before/after variant."""
+    return artifact_dir / f"{variant}-run.json", artifact_dir / f"{variant}-analysis.json"
+
+
+def load_report_json(path: Path) -> dict[str, Any]:
+    """Load a JSON report file into a dictionary."""
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
 def nullable_delta(before_value: Any, after_value: Any) -> Any:
     """Return ``after - before`` when both values are present, otherwise ``None``."""
     if before_value is None or after_value is None:
         return None
-    return after_value - before_value
+    try:
+        return after_value - before_value
+    except TypeError:
+        return None
 
 
 def write_before_after_comparison(

--- a/scripts/demo_tool.py
+++ b/scripts/demo_tool.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Unified runner/validator for tailscope demo scenarios."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from typing import Callable
+
+from _demo_runner import (
+    load_report_json,
+    repo_root,
+    run_and_analyze,
+    variant_paths,
+    write_before_after_comparison,
+)
+
+EXPECTED_QUEUE_KIND = {"application_queue_saturation", "ApplicationQueueSaturation"}
+EXPECTED_BLOCKING_KIND = {"blocking_pool_pressure", "BlockingPoolPressure"}
+EXPECTED_DOWNSTREAM_KIND = {"downstream_stage_dominates", "DownstreamStageDominates"}
+MODE_CHOICES = ["before", "after", "both", "baseline", "mitigated"]
+
+
+def extract_blocking_queue_depth_p95(report: dict) -> int | None:
+    suspect = report.get("primary_suspect") or {}
+    for evidence in suspect.get("evidence") or []:
+        match = re.search(r"Blocking queue depth p95 is (\d+)", evidence)
+        if match:
+            return int(match.group(1))
+    return None
+
+
+def normalize_mode(mode: str) -> str:
+    if mode in {"baseline", "before"}:
+        return "before"
+    if mode in {"mitigated", "after"}:
+        return "after"
+    return mode
+
+
+def snapshot_queue(report: dict) -> dict[str, int | str | None]:
+    return {
+        "primary_suspect_kind": report["primary_suspect"]["kind"],
+        "primary_suspect_score": report["primary_suspect"]["score"],
+        "p95_latency_us": report["p95_latency_us"],
+        "p95_queue_share_permille": report.get("p95_queue_share_permille"),
+    }
+
+
+def snapshot_blocking(report: dict) -> dict[str, int | str | None]:
+    return {
+        "primary_suspect_kind": report["primary_suspect"]["kind"],
+        "primary_suspect_score": report["primary_suspect"]["score"],
+        "p95_latency_us": report["p95_latency_us"],
+        "p95_service_share_permille": report.get("p95_service_share_permille"),
+        "blocking_queue_depth_p95": extract_blocking_queue_depth_p95(report),
+    }
+
+
+def run_before_after_scenario(
+    root_dir: Path,
+    demo_manifest: Path,
+    artifact_dir: Path,
+    mode: str,
+    snapshot_fn: Callable[[dict], dict[str, int | str | None]],
+) -> None:
+    cli_manifest = root_dir / "tailscope-cli/Cargo.toml"
+
+    def run_variant(variant: str) -> None:
+        run_path, analysis_path = variant_paths(artifact_dir, variant)
+        mode_arg = "baseline" if variant == "before" else "mitigated"
+        run_and_analyze(demo_manifest, cli_manifest, run_path, analysis_path, mode_arg)
+        print(f"run artifact ({variant}): {run_path}")
+        print(f"analysis ({variant}): {analysis_path}")
+
+    normalized = normalize_mode(mode)
+    if normalized in {"before", "after"}:
+        run_variant(normalized)
+        return
+
+    run_variant("before")
+    run_variant("after")
+    before = load_report_json(artifact_dir / "before-analysis.json")
+    after = load_report_json(artifact_dir / "after-analysis.json")
+    comparison_path = write_before_after_comparison(
+        artifact_dir,
+        snapshot_fn(before),
+        snapshot_fn(after),
+    )
+    print(f"comparison: {comparison_path}")
+
+
+def run_scenario_queue(root_dir: Path, mode: str) -> None:
+    run_before_after_scenario(
+        root_dir,
+        root_dir / "demos/queue_service/Cargo.toml",
+        root_dir / "demos/queue_service/artifacts",
+        mode,
+        snapshot_queue,
+    )
+
+
+def run_scenario_blocking(root_dir: Path, mode: str) -> None:
+    run_before_after_scenario(
+        root_dir,
+        root_dir / "demos/blocking_service/Cargo.toml",
+        root_dir / "demos/blocking_service/artifacts",
+        mode,
+        snapshot_blocking,
+    )
+
+
+def run_scenario_downstream(root_dir: Path, artifact_path: str | None) -> None:
+    run_path = (
+        Path(artifact_path)
+        if artifact_path
+        else root_dir / "demos/downstream_service/artifacts/downstream-run.json"
+    )
+    analysis_path = root_dir / "demos/downstream_service/artifacts/downstream-analysis.json"
+    run_and_analyze(
+        root_dir / "demos/downstream_service/Cargo.toml",
+        root_dir / "tailscope-cli/Cargo.toml",
+        run_path,
+        analysis_path,
+    )
+    print(f"run artifact: {run_path}")
+    print(f"analysis: {analysis_path}")
+
+
+def validate_queue(root_dir: Path) -> None:
+    run_scenario_queue(root_dir, "both")
+    artifact_dir = root_dir / "demos/queue_service/artifacts"
+    before = load_report_json(artifact_dir / "before-analysis.json")
+    after = load_report_json(artifact_dir / "after-analysis.json")
+
+    kind = before["primary_suspect"]["kind"]
+    if kind not in EXPECTED_QUEUE_KIND:
+        raise SystemExit(f"expected queue saturation suspect in baseline, got {kind}")
+
+    before_p95 = before["p95_latency_us"]
+    after_p95 = after["p95_latency_us"]
+    before_score = before["primary_suspect"]["score"]
+    after_score = after["primary_suspect"]["score"]
+
+    if after_p95 >= before_p95:
+        raise SystemExit(
+            f"expected mitigated p95 to drop, got before={before_p95}us after={after_p95}us"
+        )
+
+    if after_score >= before_score:
+        raise SystemExit(
+            f"expected mitigated suspect score to drop, got before={before_score} after={after_score}"
+        )
+
+    print(
+        "validation passed: baseline suspect kind={}, p95 {}us -> {}us, score {} -> {}".format(
+            kind,
+            before_p95,
+            after_p95,
+            before_score,
+            after_score,
+        )
+    )
+    print(
+        "validated analysis files: "
+        f"{artifact_dir / 'before-analysis.json'}, {artifact_dir / 'after-analysis.json'}"
+    )
+
+
+def validate_blocking(root_dir: Path) -> None:
+    run_scenario_blocking(root_dir, "both")
+    artifact_dir = root_dir / "demos/blocking_service/artifacts"
+    before = load_report_json(artifact_dir / "before-analysis.json")
+    after = load_report_json(artifact_dir / "after-analysis.json")
+
+    before_kind = before["primary_suspect"]["kind"]
+    if before_kind not in EXPECTED_BLOCKING_KIND:
+        raise SystemExit(f"expected blocking pool pressure suspect in baseline, got {before_kind}")
+
+    before_p95 = before["p95_latency_us"]
+    after_p95 = after["p95_latency_us"]
+    if after_p95 >= before_p95:
+        raise SystemExit(
+            f"expected mitigated p95 to drop, got before={before_p95}us after={after_p95}us"
+        )
+
+    before_score = before["primary_suspect"]["score"]
+    after_score = after["primary_suspect"]["score"]
+
+    before_service_share = before.get("p95_service_share_permille")
+    after_service_share = after.get("p95_service_share_permille")
+    before_blocking_depth = extract_blocking_queue_depth_p95(before)
+    after_blocking_depth = extract_blocking_queue_depth_p95(after)
+
+    improvement_signals = []
+    if after_score < before_score:
+        improvement_signals.append("score")
+    if (
+        before_service_share is not None
+        and after_service_share is not None
+        and after_service_share < before_service_share
+    ):
+        improvement_signals.append("service_share")
+    if (
+        before_blocking_depth is not None
+        and after_blocking_depth is not None
+        and after_blocking_depth < before_blocking_depth
+    ):
+        improvement_signals.append("blocking_queue_depth")
+
+    if not improvement_signals:
+        raise SystemExit(
+            "expected at least one non-latency improvement signal (score/share/blocking depth), "
+            f"got score {before_score}->{after_score}, "
+            f"service_share {before_service_share}->{after_service_share}, "
+            f"blocking_queue_depth {before_blocking_depth}->{after_blocking_depth}"
+        )
+
+    print(
+        "validation passed: baseline suspect kind={}, p95 {}us -> {}us, score {} -> {}, "
+        "service-share {} -> {}, blocking-depth {} -> {} (signals: {})".format(
+            before_kind,
+            before_p95,
+            after_p95,
+            before_score,
+            after_score,
+            before_service_share,
+            after_service_share,
+            before_blocking_depth,
+            after_blocking_depth,
+            ", ".join(improvement_signals),
+        )
+    )
+    print(
+        "validated analysis files: "
+        f"{artifact_dir / 'before-analysis.json'}, {artifact_dir / 'after-analysis.json'}"
+    )
+
+
+def validate_downstream(root_dir: Path) -> None:
+    run_scenario_downstream(root_dir, None)
+    analysis_path = root_dir / "demos/downstream_service/artifacts/downstream-analysis.json"
+
+    report = load_report_json(analysis_path)
+    kind = report["primary_suspect"]["kind"]
+    if kind not in EXPECTED_DOWNSTREAM_KIND:
+        raise SystemExit(f"expected downstream stage suspect, got {kind}")
+
+    print(f"validation passed: primary suspect is {kind}")
+    print(f"validated analysis file: {analysis_path}")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Unified tailscope demo run/validate tool.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = subparsers.add_parser("run", help="Run demo scenario and produce analysis artifacts")
+    run_parser.add_argument("scenario", choices=["queue", "blocking", "downstream"])
+    run_parser.add_argument(
+        "mode",
+        nargs="?",
+        default="both",
+        choices=MODE_CHOICES,
+        help="Queue/blocking mode (before/after/both + baseline/mitigated aliases).",
+    )
+    run_parser.add_argument(
+        "--artifact-path",
+        help="Downstream only: custom run artifact path.",
+    )
+
+    validate_parser = subparsers.add_parser("validate", help="Run scenario validation contract checks")
+    validate_parser.add_argument("scenario", choices=["queue", "blocking", "downstream"])
+
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    root_dir = repo_root(__file__)
+
+    if args.command == "run":
+        if args.scenario == "queue":
+            run_scenario_queue(root_dir, args.mode)
+        elif args.scenario == "blocking":
+            run_scenario_blocking(root_dir, args.mode)
+        else:
+            if args.mode != "both":
+                raise SystemExit("downstream scenario does not accept mode; use --artifact-path if needed")
+            run_scenario_downstream(root_dir, args.artifact_path)
+        return
+
+    if args.scenario == "queue":
+        validate_queue(root_dir)
+    elif args.scenario == "blocking":
+        validate_blocking(root_dir)
+    else:
+        validate_downstream(root_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_blocking_demo.py
+++ b/scripts/run_blocking_demo.py
@@ -1,97 +1,12 @@
 #!/usr/bin/env python3
-"""Run blocking demo variants and emit analysis artifacts."""
+"""Compatibility wrapper for blocking demo runs."""
 
 from __future__ import annotations
 
-import argparse
-import json
-import re
-from pathlib import Path
+import sys
 
-from _demo_runner import run_cli_analysis_json, run_demo_binary, write_before_after_comparison
-
-
-def extract_blocking_queue_depth_p95(report: dict) -> int | None:
-    suspect = report.get("primary_suspect") or {}
-    for evidence in suspect.get("evidence") or []:
-        match = re.search(r"Blocking queue depth p95 is (\d+)", evidence)
-        if match:
-            return int(match.group(1))
-    return None
-
-
-def run_variant(root_dir: Path, artifact_dir: Path, variant: str) -> None:
-    # Canonical cargo run + analysis helpers live in scripts/_demo_runner.py.
-    run_path = artifact_dir / f"{variant}-run.json"
-    analysis_path = artifact_dir / f"{variant}-analysis.json"
-    mode_arg = "baseline" if variant == "before" else "mitigated"
-
-    artifact_dir.mkdir(parents=True, exist_ok=True)
-
-    run_demo_binary(
-        root_dir / "demos/blocking_service/Cargo.toml",
-        run_path,
-        mode_arg,
-    )
-    run_cli_analysis_json(
-        root_dir / "tailscope-cli/Cargo.toml",
-        run_path,
-        analysis_path,
-    )
-
-    print(f"run artifact ({variant}): {run_path}")
-    print(f"analysis ({variant}): {analysis_path}")
-
-
-def snapshot(report: dict) -> dict[str, int | str | None]:
-    return {
-        "primary_suspect_kind": report["primary_suspect"]["kind"],
-        "primary_suspect_score": report["primary_suspect"]["score"],
-        "p95_latency_us": report["p95_latency_us"],
-        "p95_service_share_permille": report.get("p95_service_share_permille"),
-        "blocking_queue_depth_p95": extract_blocking_queue_depth_p95(report),
-    }
-
-
-def write_comparison(artifact_dir: Path) -> None:
-    before = json.loads((artifact_dir / "before-analysis.json").read_text())
-    after = json.loads((artifact_dir / "after-analysis.json").read_text())
-
-    comparison_path = write_before_after_comparison(
-        artifact_dir,
-        snapshot(before),
-        snapshot(after),
-    )
-    print(f"comparison: {comparison_path}")
-
-
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run blocking demo and analyze outputs.")
-    parser.add_argument(
-        "mode",
-        nargs="?",
-        default="both",
-        choices=["before", "after", "both", "baseline", "mitigated"],
-        help="Variant to run.",
-    )
-    return parser.parse_args()
-
-
-def main() -> None:
-    args = parse_args()
-    root_dir = Path(__file__).resolve().parent.parent
-    artifact_dir = root_dir / "demos/blocking_service/artifacts"
-
-    mode = args.mode
-    if mode in {"before", "baseline"}:
-        run_variant(root_dir, artifact_dir, "before")
-    elif mode in {"after", "mitigated"}:
-        run_variant(root_dir, artifact_dir, "after")
-    else:
-        run_variant(root_dir, artifact_dir, "before")
-        run_variant(root_dir, artifact_dir, "after")
-        write_comparison(artifact_dir)
+from demo_tool import main
 
 
 if __name__ == "__main__":
-    main()
+    main(["run", "blocking", *sys.argv[1:]])

--- a/scripts/run_downstream_demo.py
+++ b/scripts/run_downstream_demo.py
@@ -1,50 +1,15 @@
 #!/usr/bin/env python3
-"""Run downstream-stage demo and generate analysis artifact."""
+"""Compatibility wrapper for downstream demo runs."""
 
 from __future__ import annotations
 
-import argparse
-from pathlib import Path
+import sys
 
-from _demo_runner import run_cli_analysis_json, run_demo_binary
-
-
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run downstream demo and analyze output.")
-    parser.add_argument(
-        "artifact_path",
-        nargs="?",
-        help="Optional path to write the run JSON artifact.",
-    )
-    return parser.parse_args()
-
-
-def main() -> None:
-    # Canonical cargo run + analysis helpers live in scripts/_demo_runner.py.
-    args = parse_args()
-    root_dir = Path(__file__).resolve().parent.parent
-    artifact_path = (
-        Path(args.artifact_path)
-        if args.artifact_path
-        else root_dir / "demos/downstream_service/artifacts/downstream-run.json"
-    )
-    analysis_path = root_dir / "demos/downstream_service/artifacts/downstream-analysis.json"
-
-    artifact_path.parent.mkdir(parents=True, exist_ok=True)
-
-    run_demo_binary(
-        root_dir / "demos/downstream_service/Cargo.toml",
-        artifact_path,
-    )
-    run_cli_analysis_json(
-        root_dir / "tailscope-cli/Cargo.toml",
-        artifact_path,
-        analysis_path,
-    )
-
-    print(f"run artifact: {artifact_path}")
-    print(f"analysis: {analysis_path}")
+from demo_tool import main
 
 
 if __name__ == "__main__":
-    main()
+    argv = ["run", "downstream"]
+    if len(sys.argv) > 1:
+        argv.extend(["--artifact-path", *sys.argv[1:2]])
+    main(argv)

--- a/scripts/run_queue_demo.py
+++ b/scripts/run_queue_demo.py
@@ -1,85 +1,12 @@
 #!/usr/bin/env python3
-"""Run queue demo variants and emit analysis artifacts."""
+"""Compatibility wrapper for queue demo runs."""
 
 from __future__ import annotations
 
-import argparse
-import json
-from pathlib import Path
+import sys
 
-from _demo_runner import run_cli_analysis_json, run_demo_binary, write_before_after_comparison
-
-
-def run_variant(root_dir: Path, artifact_dir: Path, variant: str) -> None:
-    run_path = artifact_dir / f"{variant}-run.json"
-    analysis_path = artifact_dir / f"{variant}-analysis.json"
-    mode_arg = "baseline" if variant == "before" else "mitigated"
-
-    artifact_dir.mkdir(parents=True, exist_ok=True)
-
-    run_demo_binary(
-        root_dir / "demos/queue_service/Cargo.toml",
-        run_path,
-        mode_arg,
-    )
-    run_cli_analysis_json(
-        root_dir / "tailscope-cli/Cargo.toml",
-        run_path,
-        analysis_path,
-    )
-
-    print(f"run artifact ({variant}): {run_path}")
-    print(f"analysis ({variant}): {analysis_path}")
-
-
-def snapshot(report: dict) -> dict[str, int | str | None]:
-    return {
-        "primary_suspect_kind": report["primary_suspect"]["kind"],
-        "primary_suspect_score": report["primary_suspect"]["score"],
-        "p95_latency_us": report["p95_latency_us"],
-        "p95_queue_share_permille": report.get("p95_queue_share_permille"),
-    }
-
-
-def write_comparison(artifact_dir: Path) -> None:
-    before = json.loads((artifact_dir / "before-analysis.json").read_text())
-    after = json.loads((artifact_dir / "after-analysis.json").read_text())
-
-    comparison_path = write_before_after_comparison(
-        artifact_dir,
-        snapshot(before),
-        snapshot(after),
-    )
-    print(f"comparison: {comparison_path}")
-
-
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run queue demo and analyze outputs.")
-    parser.add_argument(
-        "mode",
-        nargs="?",
-        default="both",
-        choices=["before", "after", "both", "baseline", "mitigated"],
-        help="Variant to run.",
-    )
-    return parser.parse_args()
-
-
-def main() -> None:
-    args = parse_args()
-    root_dir = Path(__file__).resolve().parent.parent
-    artifact_dir = root_dir / "demos/queue_service/artifacts"
-
-    mode = args.mode
-    if mode in {"before", "baseline"}:
-        run_variant(root_dir, artifact_dir, "before")
-    elif mode in {"after", "mitigated"}:
-        run_variant(root_dir, artifact_dir, "after")
-    else:
-        run_variant(root_dir, artifact_dir, "before")
-        run_variant(root_dir, artifact_dir, "after")
-        write_comparison(artifact_dir)
+from demo_tool import main
 
 
 if __name__ == "__main__":
-    main()
+    main(["run", "queue", *sys.argv[1:]])

--- a/scripts/validate_blocking_demo.py
+++ b/scripts/validate_blocking_demo.py
@@ -1,100 +1,10 @@
 #!/usr/bin/env python3
-"""Validate blocking demo output contract."""
+"""Compatibility wrapper for blocking demo validation."""
 
 from __future__ import annotations
 
-import json
-import re
-import subprocess
-from pathlib import Path
-
-
-EXPECTED_BLOCKING_KIND = {"blocking_pool_pressure", "BlockingPoolPressure"}
-
-
-def extract_blocking_queue_depth_p95(report: dict) -> int | None:
-    suspect = report.get("primary_suspect") or {}
-    for evidence in suspect.get("evidence") or []:
-        match = re.search(r"Blocking queue depth p95 is (\d+)", evidence)
-        if match:
-            return int(match.group(1))
-    return None
-
-
-def main() -> None:
-    root_dir = Path(__file__).resolve().parent.parent
-    artifact_dir = root_dir / "demos/blocking_service/artifacts"
-    before_analysis_path = artifact_dir / "before-analysis.json"
-    after_analysis_path = artifact_dir / "after-analysis.json"
-
-    subprocess.run(["python3", str(root_dir / "scripts/run_blocking_demo.py")], check=True)
-
-    before = json.loads(before_analysis_path.read_text())
-    after = json.loads(after_analysis_path.read_text())
-
-    before_kind = before["primary_suspect"]["kind"]
-    if before_kind not in EXPECTED_BLOCKING_KIND:
-        raise SystemExit(f"expected blocking pool pressure suspect in baseline, got {before_kind}")
-
-    before_p95 = before["p95_latency_us"]
-    after_p95 = after["p95_latency_us"]
-    if after_p95 >= before_p95:
-        raise SystemExit(
-            f"expected mitigated p95 to drop, got before={before_p95}us after={after_p95}us"
-        )
-
-    before_score = before["primary_suspect"]["score"]
-    after_score = after["primary_suspect"]["score"]
-
-    before_service_share = before.get("p95_service_share_permille")
-    after_service_share = after.get("p95_service_share_permille")
-
-    before_blocking_depth = extract_blocking_queue_depth_p95(before)
-    after_blocking_depth = extract_blocking_queue_depth_p95(after)
-
-    improvement_signals = []
-    if after_score < before_score:
-        improvement_signals.append("score")
-
-    if (
-        before_service_share is not None
-        and after_service_share is not None
-        and after_service_share < before_service_share
-    ):
-        improvement_signals.append("service_share")
-
-    if (
-        before_blocking_depth is not None
-        and after_blocking_depth is not None
-        and after_blocking_depth < before_blocking_depth
-    ):
-        improvement_signals.append("blocking_queue_depth")
-
-    if not improvement_signals:
-        raise SystemExit(
-            "expected at least one non-latency improvement signal (score/share/blocking depth), "
-            f"got score {before_score}->{after_score}, "
-            f"service_share {before_service_share}->{after_service_share}, "
-            f"blocking_queue_depth {before_blocking_depth}->{after_blocking_depth}"
-        )
-
-    print(
-        "validation passed: baseline suspect kind={}, p95 {}us -> {}us, score {} -> {}, "
-        "service-share {} -> {}, blocking-depth {} -> {} (signals: {})".format(
-            before_kind,
-            before_p95,
-            after_p95,
-            before_score,
-            after_score,
-            before_service_share,
-            after_service_share,
-            before_blocking_depth,
-            after_blocking_depth,
-            ", ".join(improvement_signals),
-        )
-    )
-    print(f"validated analysis files: {before_analysis_path}, {after_analysis_path}")
+from demo_tool import main
 
 
 if __name__ == "__main__":
-    main()
+    main(["validate", "blocking"])

--- a/scripts/validate_downstream_demo.py
+++ b/scripts/validate_downstream_demo.py
@@ -1,28 +1,10 @@
 #!/usr/bin/env python3
-"""Validate downstream demo output contract."""
+"""Compatibility wrapper for downstream demo validation."""
 
 from __future__ import annotations
 
-import json
-import subprocess
-from pathlib import Path
-
-
-def main() -> None:
-    root_dir = Path(__file__).resolve().parent.parent
-    analysis_path = root_dir / "demos/downstream_service/artifacts/downstream-analysis.json"
-
-    subprocess.run(["python3", str(root_dir / "scripts/run_downstream_demo.py")], check=True)
-
-    report = json.loads(analysis_path.read_text(encoding="utf-8"))
-    kind = report["primary_suspect"]["kind"]
-    expected = {"downstream_stage_dominates", "DownstreamStageDominates"}
-    if kind not in expected:
-        raise SystemExit(f"expected downstream stage suspect, got {kind}")
-
-    print(f"validation passed: primary suspect is {kind}")
-    print(f"validated analysis file: {analysis_path}")
+from demo_tool import main
 
 
 if __name__ == "__main__":
-    main()
+    main(["validate", "downstream"])

--- a/scripts/validate_queue_demo.py
+++ b/scripts/validate_queue_demo.py
@@ -1,54 +1,10 @@
 #!/usr/bin/env python3
-"""Validate queue demo output contract."""
+"""Compatibility wrapper for queue demo validation."""
 
 from __future__ import annotations
 
-import json
-import subprocess
-from pathlib import Path
-
-
-def main() -> None:
-    root_dir = Path(__file__).resolve().parent.parent
-    before_analysis_path = root_dir / "demos/queue_service/artifacts/before-analysis.json"
-    after_analysis_path = root_dir / "demos/queue_service/artifacts/after-analysis.json"
-
-    subprocess.run(["python3", str(root_dir / "scripts/run_queue_demo.py")], check=True)
-
-    before = json.loads(before_analysis_path.read_text())
-    after = json.loads(after_analysis_path.read_text())
-
-    kind = before["primary_suspect"]["kind"]
-    expected = {"application_queue_saturation", "ApplicationQueueSaturation"}
-    if kind not in expected:
-        raise SystemExit(f"expected queue saturation suspect in baseline, got {kind}")
-
-    before_p95 = before["p95_latency_us"]
-    after_p95 = after["p95_latency_us"]
-    before_score = before["primary_suspect"]["score"]
-    after_score = after["primary_suspect"]["score"]
-
-    if after_p95 >= before_p95:
-        raise SystemExit(
-            f"expected mitigated p95 to drop, got before={before_p95}us after={after_p95}us"
-        )
-
-    if after_score >= before_score:
-        raise SystemExit(
-            f"expected mitigated suspect score to drop, got before={before_score} after={after_score}"
-        )
-
-    print(
-        "validation passed: baseline suspect kind={}, p95 {}us -> {}us, score {} -> {}".format(
-            kind,
-            before_p95,
-            after_p95,
-            before_score,
-            after_score,
-        )
-    )
-    print(f"validated analysis files: {before_analysis_path}, {after_analysis_path}")
+from demo_tool import main
 
 
 if __name__ == "__main__":
-    main()
+    main(["validate", "queue"])


### PR DESCRIPTION
### Motivation

- Reduce duplication across per-demo run/validate scripts by centralizing shared behavior for running demos, invoking the CLI analyzer, loading JSON reports, and producing before/after comparisons.
- Keep scenario-specific validation logic small and readable while preserving existing CLI compatibility and documented workflows.

### Description

- Add `scripts/demo_tool.py` which implements a unified CLI with `run <scenario>` and `validate <scenario>` subcommands for `queue`, `blocking`, and `downstream`, preserving `before/after/both` and `baseline/mitigated` aliases and `--artifact-path` for downstream runs.
- Extend `scripts/_demo_runner.py` with `repo_root`, `run_and_analyze`, `variant_paths`, and `load_report_json` helpers and make `write_before_after_comparison` tolerate non-numeric fields by returning `null` for non-numeric deltas.
- Replace the original per-demo implementations with thin compatibility wrappers in `scripts/run_*.py` and `scripts/validate_*.py` that forward to `demo_tool.py` so existing automation remains functional.
- Update demo documentation (`docs/getting-started-demo.md`, `docs/diagnostics.md`, `docs/mvp-audit-2026-03-19.md`) to recommend the new unified entry point while keeping backwards-compatible wrappers available.

### Testing

- Ran `python3 scripts/demo_tool.py --help` and exercised `run` flows including `python3 scripts/demo_tool.py run queue before`, `python3 scripts/demo_tool.py run blocking after`, and `python3 scripts/demo_tool.py run downstream --artifact-path ...` which produced expected artifact and analysis files.
- Ran end-to-end validations with `python3 scripts/demo_tool.py validate queue`, `python3 scripts/demo_tool.py validate blocking`, and `python3 scripts/demo_tool.py validate downstream`, and each validation completed successfully.
- Project linters and tests all passed: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` (all green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc64b54220833092d117ab9f14a8ee)