### PR TITLE
Fix downstream demo wrapper, add Python demo tests and CI

### DIFF
--- a/.github/workflows/python-demos.yml
+++ b/.github/workflows/python-demos.yml
@@ -1,0 +1,30 @@
+name: Python Demo Checks
+
+on:
+  pull_request:
+    paths:
+      - '**/*.py'
+      - '.github/workflows/python-demos.yml'
+
+jobs:
+  demo-python-checks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Verify Python demo wrapper tests
+        run: python3 -m unittest -v scripts/tests/test_demo_scripts.py
+
+      - name: Validate queue demo
+        run: python3 scripts/validate_queue_demo.py
+
+      - name: Validate blocking demo
+        run: python3 scripts/validate_blocking_demo.py
+
+      - name: Validate downstream demo
+        run: python3 scripts/validate_downstream_demo.py

--- a/scripts/run_downstream_demo.py
+++ b/scripts/run_downstream_demo.py
@@ -8,8 +8,22 @@ import sys
 from demo_tool import main
 
 
+def build_argv(raw_args: list[str]) -> list[str]:
+    """Translate wrapper args into ``demo_tool run downstream`` args.
+
+    Backward compatibility:
+    - ``run_downstream_demo.py`` runs the default downstream scenario.
+    - ``run_downstream_demo.py <path>`` treats ``<path>`` as ``--artifact-path``.
+    - Explicit flags are passed through unchanged.
+    """
+    if not raw_args:
+        return ["run", "downstream"]
+
+    if raw_args[0].startswith("-"):
+        return ["run", "downstream", *raw_args]
+
+    return ["run", "downstream", "--artifact-path", raw_args[0], *raw_args[1:]]
+
+
 if __name__ == "__main__":
-    argv = ["run", "downstream"]
-    if len(sys.argv) > 1:
-        argv.extend(["--artifact-path", *sys.argv[1:2]])
-    main(argv)
+    main(build_argv(sys.argv[1:]))

--- a/scripts/tests/test_demo_scripts.py
+++ b/scripts/tests/test_demo_scripts.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Lightweight tests for Python demo wrappers and argument parsing."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from demo_tool import parse_args  # noqa: E402
+from run_downstream_demo import build_argv  # noqa: E402
+
+
+class DemoWrapperTests(unittest.TestCase):
+    def test_help_runs_for_all_demo_wrappers(self) -> None:
+        wrappers = [
+            "run_queue_demo.py",
+            "run_blocking_demo.py",
+            "run_downstream_demo.py",
+        ]
+
+        for wrapper in wrappers:
+            with self.subTest(wrapper=wrapper):
+                completed = subprocess.run(
+                    [sys.executable, str(SCRIPTS_DIR / wrapper), "--help"],
+                    cwd=REPO_ROOT,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                self.assertEqual(
+                    completed.returncode,
+                    0,
+                    msg=f"{wrapper} help failed: {completed.stderr}",
+                )
+                self.assertIn("usage:", completed.stdout)
+
+    def test_downstream_positional_artifact_path_is_mapped_to_flag(self) -> None:
+        argv = build_argv(["custom-run.json"])
+        args = parse_args(argv)
+
+        self.assertEqual(args.command, "run")
+        self.assertEqual(args.scenario, "downstream")
+        self.assertEqual(args.artifact_path, "custom-run.json")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- `run_downstream_demo.py` treated any argument as a positional artifact path which caused flag invocations like `--help` to be mis-parsed and demos to fail.
- Add lightweight Python tests and a focused CI workflow to catch regressions in demo wrappers and keep demo validation runnable after refactors.

### Description
- Update `scripts/run_downstream_demo.py` to introduce `build_argv()` that preserves flag-style args, maps a single positional path to `--artifact-path`, and keeps the no-arg default behavior for the downstream demo.
- Add `scripts/tests/test_demo_scripts.py`, a small `unittest` suite that checks `--help` works for all three wrapper scripts and that downstream positional artifact-path mapping is translated correctly.
- Add a dedicated GitHub Actions workflow `.github/workflows/python-demos.yml` that triggers on Python file changes and runs the Python tests plus the three demo validation scripts.

### Testing
- Ran the new Python unit tests with `python3 -m unittest -v scripts/tests/test_demo_scripts.py` and they passed.
- Ran demo validations with `python3 scripts/validate_queue_demo.py`, `python3 scripts/validate_blocking_demo.py`, and `python3 scripts/validate_downstream_demo.py`, all of which succeeded.
- Verified repository checks: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcdf201a6883308edf066437b9ad17)