### PR TITLE
docs: consolidate docs and simplify navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 # tailscope
 
-[**Start here: first-use user guide**](docs/user-guide.md)
-
 `tailscope` is a Rust toolkit for diagnosing **tail latency**, **queueing**, and **backpressure** in Tokio services.
 
-## What tailscope does
+It answers one practical question:
 
-- Produces one local JSON run artifact from lightweight request/queue/stage instrumentation.
-- Analyzes a run and ranks likely bottleneck suspects (queue saturation, blocking pressure, executor pressure, downstream stage dominance).
-- Includes supporting evidence and recommended next checks for each suspect.
-- Works with partial instrumentation and can optionally include Tokio runtime sampling for stronger attribution.
+> Is this service slow because of application queueing, executor pressure, blocking-pool pressure, or a slow downstream stage?
 
-## 2-minute quickstart
+## Why it is useful
+
+- Produces one local JSON run artifact from lightweight instrumentation.
+- Ranks likely bottleneck suspects with evidence and recommended next checks.
+- Works with partial instrumentation (you can start small and improve coverage over time).
+- Keeps diagnosis reproducible: capture run -> analyze with CLI -> compare before/after.
+
+## Quickstart
 
 ### 1) Add dependencies
 
@@ -22,25 +24,23 @@ tailscope-tokio = { path = "../tailscope-tokio" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 ```
 
-### 2) Minimal code (`src/main.rs`)
+### 2) Instrument one request path
 
 ```rust
 use std::time::Duration;
-
 use tailscope_core::{Config, RequestMeta, Tailscope};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut config = Config::new("quickstart-service");
+    let mut config = Config::new("checkout-service");
     config.output_path = "tailscope-run.json".into();
-
     let tailscope = Tailscope::init(config)?;
 
-    let request = RequestMeta::for_route("/demo").with_kind("quickstart");
-    let request_id = request.request_id.clone();
+    let meta = RequestMeta::for_route("/checkout").with_kind("http");
+    let request_id = meta.request_id.clone();
 
     tailscope
-        .request(request, "ok", async {
+        .request(meta, "ok", async {
             tailscope
                 .queue(request_id.clone(), "ingress_queue")
                 .await_on(tokio::time::sleep(Duration::from_millis(5)))
@@ -61,67 +61,31 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### 3) Analyze
 
 ```bash
-cargo run --manifest-path tailscope-cli/Cargo.toml -- analyze tailscope-run.json
+cargo run --manifest-path tailscope-cli/Cargo.toml -- analyze tailscope-run.json --format json
 ```
 
-JSON output fields to start with:
+Start with:
 
 - `primary_suspect.kind`
+- `primary_suspect.evidence[]`
 - `p95_queue_share_permille`
 - `p95_service_share_permille`
-- `primary_suspect.evidence[]`
-
-### Optional macro path (`tailscope-tokio`)
-
-```rust
-use tailscope_tokio::instrument_request;
-
-#[instrument_request(route = "/demo", kind = "quickstart", tailscope = tailscope)]
-async fn handle_demo(tailscope: &tailscope_core::Tailscope) {
-    // handler logic...
-}
-```
 
 ## Canonical integration path
 
-> Rust API integration (`tailscope-core` + `tailscope-tokio`) is the canonical product path.
+1. Initialize one collector (`Tailscope::init`).
+2. Wrap request entry points (`request(...)` or `#[instrument_request(...)]`).
+3. Add a few high-impact `queue(...).await_on(...)` wrappers.
+4. Add key downstream `stage(...).await_on(...)` / `await_value(...)` wrappers.
+5. Optionally enable `RuntimeSampler::start(...)` for stronger runtime attribution.
+6. Flush and analyze.
 
-1. Initialize one collector: `Tailscope::init(Config::new("service-name"))`.
-2. Manual path: wrap request entry points with `request(RequestMeta::for_route(...).with_kind(...), ...)`.
-3. Macro path: use `#[instrument_request(...)]` from `tailscope-tokio` when you want attribute-based request instrumentation.
-4. Add `queue(...).await_on(...)` around known wait points.
-5. Add `stage(...).await_on(...)` around key downstream awaits that return `Result`, or `stage(...).await_value(...)` for infallible futures.
-6. Optionally add `inflight(...)` guards and `RuntimeSampler::start(...)` when diagnosis evidence is insufficient.
-7. Flush and analyze: `tailscope.flush()?` then `tailscope analyze <run.json>`.
-
-### Demo and reproducibility workflows
-
-Python scripts are for deterministic demos, fixtures, and reproducibility workflows, not for primary product integration.
-
-Typical user workflow: instrument a Rust service and run the CLI analyzer; maintainer/demo workflow: run `scripts/*.py` to validate scenarios deterministically.
-
-## MVP limitations
+## Scope and limitations (MVP)
 
 - Tokio-only runtime support.
-- Single-process diagnosis (no multi-service correlation).
-- Rule-based, evidence-ranked diagnosis (not proof of root cause).
+- Single-process diagnosis (no distributed correlation).
+- Rule-based suspect ranking with evidence (not proof of root cause).
 
-## Docs index
+## Documentation
 
-- [User guide](docs/user-guide.md)
-- [Architecture](docs/architecture.md)
-- [Diagnostics guide](docs/diagnostics.md)
-- [Mental model for newcomers](docs/mental-model.md)
-- [Getting started demos](docs/getting-started-demo.md)
-- [Runtime cost measurement](docs/runtime-cost.md)
-- [Changelog](docs/changelog.md)
-
-## Repository planning and instruction docs
-
-These files intentionally serve different audiences and levels of detail:
-
-- `AGENTS.md`: contribution and coding-agent operating instructions (scope guardrails, workflow, required checks, and definition of done for implementation tasks).
-- `SPEC.md`: MVP product contract (goals/non-goals, public API surface, run artifact model, CLI/report requirements, and required demos).
-- `IMPLEMENTATION_PLAN.md`: consolidated roadmap + execution detail (milestones, phase tasks, estimates, risks, and success criteria).
-- `README.md` (this file): onboarding and practical integration path for users and maintainers.
-
+For concise docs by audience, start at **[docs/README.md](docs/README.md)**.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,30 @@
+# Documentation map
+
+Use this page as the single entry point for project documentation.
+
+## Start here
+
+- **First use / integration:** [user-guide.md](user-guide.md)
+- **How diagnosis works:** [diagnostics.md](diagnostics.md)
+
+## Core references
+
+- **Architecture and crate responsibilities:** [architecture.md](architecture.md)
+- **MVP product contract:** [../SPEC.md](../SPEC.md)
+- **Implementation roadmap:** [../IMPLEMENTATION_PLAN.md](../IMPLEMENTATION_PLAN.md)
+
+## Reproducibility and operations
+
+- **Demos and fixture workflow:** [getting-started-demo.md](getting-started-demo.md)
+- **Runtime cost measurement:** [runtime-cost.md](runtime-cost.md)
+- **Project changelog:** [changelog.md](changelog.md)
+
+## Historical snapshot
+
+- **MVP audit (2026-03-19):** [mvp-audit-2026-03-19.md](mvp-audit-2026-03-19.md)
+
+## Documentation conventions
+
+- `demos/*/artifacts/` = generated, untracked outputs.
+- `demos/*/fixtures/` = committed reference snapshots used for deterministic validation.
+- Suspects are evidence-ranked leads, not causal proof.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,85 +1,49 @@
-# tailscope architecture (MVP)
+# Architecture (MVP)
 
-This document describes how the current MVP implementation is structured.
+`tailscope` is a file-based diagnosis pipeline over one instrumented run.
 
-## High-level flow
+## Flow
 
-1. Application code records request/queue/stage/in-flight signals through `tailscope-core`.
-2. Optional Tokio runtime sampling records runtime snapshots through `tailscope-tokio`.
-3. `tailscope-core` writes one run artifact (`Run`) as JSON.
-4. `tailscope-cli` reads the artifact and ranks diagnosis suspects.
+1. Service code records request/queue/stage/in-flight signals via `tailscope-core`.
+2. Optional runtime snapshots are collected by `tailscope-tokio`.
+3. `tailscope-core` writes one JSON run artifact (`Run`).
+4. `tailscope-cli` ranks suspects from that artifact.
 
 ## Crate responsibilities
 
-## `tailscope-core`
+### `tailscope-core`
 
-Responsibilities:
-
-- run schema (`Run`, metadata, event/snapshot structs)
+- run schema (`Run`, metadata, events, snapshots)
 - collection lifecycle (`Tailscope::init`, `flush`, `snapshot`)
-- request wrapper (`request`)
-- queue/stage wrappers (`queue(...).await_on(...)`, `stage(...).await_on(...)` for `Result`, `stage(...).await_value(...)` for infallible futures)
-- in-flight RAII tracking (`inflight`)
+- instrumentation wrappers (`request`, `queue`, `stage`, `inflight`)
 - local JSON sink (`LocalJsonSink`)
 
-Design intent:
+### `tailscope-tokio`
 
-- explicit instrumentation boundaries
-- low implementation complexity
-- deterministic local artifact output
+- runtime sampling (`RuntimeSampler`)
+- runtime snapshot capture (`capture_runtime_snapshot`)
+- macro re-export: `#[instrument_request]`
 
-## `tailscope-tokio`
+Note: some runtime metrics require `tokio_unstable`; unavailable fields are recorded as `None`.
 
-Responsibilities:
-
-- runtime sampling loop (`RuntimeSampler`)
-- runtime metric snapshot extraction (`capture_runtime_snapshot`)
-- `#[instrument_request]` macro re-export
-
-Notes:
-
-- Some runtime metrics are unavailable without `tokio_unstable` and are recorded as `None`.
-- Sampling is periodic and intentionally lightweight in normal use.
-
-## `tailscope-cli`
-
-Responsibilities:
+### `tailscope-cli`
 
 - parse run JSON
 - compute request percentiles
-- apply diagnosis rules
-- output text or JSON report
+- apply rule-based diagnosis ranking
+- render text or JSON report
 
-The analyzer is intentionally rule-based for clarity and debuggability.
+## Contract boundary
 
-## Data contract
+- Input: one local `Run` JSON artifact.
+- Output: ranked suspects with evidence and next checks.
+- Non-claim: proven root cause.
 
-All analysis is derived from one `Run` artifact containing:
+## Recommended integration sequence
 
-- metadata
-- request events
-- stage events
-- queue events
-- in-flight snapshots
-- runtime snapshots
-
-This keeps the diagnosis pipeline reproducible and file-based.
-
-## Diagnostics boundary
-
-`tailscope` diagnoses based on captured evidence; it does not claim causal certainty.
-
-It answers “most likely suspects with supporting signals,” not “proven root cause.”
-
-## Integration pattern
-
-Recommended integration order:
-
-1. initialize one `Tailscope` collector
-2. wrap request handlers with `request(...)` (or macro path)
-3. instrument high-impact queue waits
-4. instrument critical downstream stages
-5. optionally start runtime sampling
-6. flush run output and analyze with CLI
-
-This keeps instrumentation incremental and practical for existing services.
+1. init one collector
+2. wrap request handlers
+3. instrument key queue waits
+4. instrument key downstream stages
+5. optionally enable runtime sampler
+6. flush and analyze

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,4 +4,7 @@
 
 ### Changed
 
+- Consolidated documentation structure around `docs/README.md` as the canonical docs index.
+- Reduced duplication across README/user guide/diagnostics/demo docs while keeping MVP integration and diagnosis guidance intact.
+- Simplified the historical MVP audit doc and removed stale cross-document references.
 - Simplified `tailscope-cli` dependencies by removing a direct `tailscope-tokio` dependency; the CLI only consumes `tailscope-core` analyzer APIs.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,186 +1,79 @@
-# tailscope diagnostics guide (MVP)
+# Diagnostics guide
 
-This document explains what the analyzer currently reports and how to interpret it.
+This document explains what `tailscope analyze` reports and how to use it.
 
-## Report shape
+## Report contents
 
-`tailscope analyze <run.json>` returns:
+`tailscope analyze <run.json>` outputs:
 
 - request count
-- request p50/p95/p99 latency
-- p95 request-time share for queue wait (permille)
-- p95 request-time share for service time (permille)
-- optional dominant in-flight trend summary (`inflight_trend`)
-- one primary suspect
-- zero or more secondary suspects
+- request latency percentiles (p50/p95/p99)
+- p95 request-time shares:
+  - `p95_queue_share_permille`
+  - `p95_service_share_permille`
+- optional in-flight trend summary
+- ranked suspects (one primary, zero or more secondary)
 
 Each suspect includes:
 
-- kind
-- score
-- confidence
-- evidence (human-readable)
-- recommended next checks
+- `kind`
+- `score`
+- `confidence`
+- `evidence[]`
+- `next_checks[]`
 
-## JSON report schema (MVP)
+## JSON fields (stable MVP shape)
 
-Top-level JSON object fields currently emitted by `tailscope-cli`:
-
-| Field | Type | Notes |
+| Field | Type | Meaning |
 | --- | --- | --- |
-| `request_count` | `number` (`usize`) | Total requests seen in the run. |
-| `p50_latency_us` | `number \| null` (`Option<u64>`) | Request p50 latency in microseconds. |
-| `p95_latency_us` | `number \| null` (`Option<u64>`) | Request p95 latency in microseconds. |
-| `p99_latency_us` | `number \| null` (`Option<u64>`) | Request p99 latency in microseconds. |
-| `p95_queue_share_permille` | `number \| null` (`Option<u64>`) | p95 queue-time share of request latency, permille (0-1000). |
-| `p95_service_share_permille` | `number \| null` (`Option<u64>`) | p95 service-time share of request latency, permille (0-1000). |
-| `inflight_trend` | `object \| null` (`Option<InflightTrend>`) | Dominant in-flight gauge trend summary when snapshots are available. |
-| `primary_suspect` | `object` (`Suspect`) | Highest-ranked suspect; includes `kind`, `score`, `confidence`, `evidence`, `next_checks`. |
-| `secondary_suspects` | `array` of `Suspect` | Remaining ranked suspects, possibly empty. |
+| `request_count` | `usize` | Requests observed in the run. |
+| `p50_latency_us` / `p95_latency_us` / `p99_latency_us` | `Option<u64>` | Request latency percentiles (microseconds). |
+| `p95_queue_share_permille` | `Option<u64>` | Queue-time share of p95 request latency (0-1000). |
+| `p95_service_share_permille` | `Option<u64>` | Service/stage share of p95 request latency (0-1000). |
+| `inflight_trend` | `Option<InflightTrend>` | Dominant in-flight gauge trend when snapshots exist. |
+| `primary_suspect` | `Suspect` | Highest-ranked suspect. |
+| `secondary_suspects` | `Vec<Suspect>` | Remaining ranked suspects. |
 
-## Request-time share metrics
+## Interpreting shares quickly
 
-The report includes two explicit request-time share fields:
+- `1000` permille = 100%
+- `500` permille = 50%
 
-- `p95_queue_share_permille`
-- `p95_service_share_permille`
+Rules of thumb:
 
-Both are measured in permille (0-1000) across requests, where:
-
-- `1000` = 100.0% of request time
-- `500` = 50.0% of request time
-
-Interpretation guidance:
-
-- high `p95_queue_share_permille` (for example 300+ = 30%+) points to application-level queueing pressure
-- high `p95_service_share_permille` with a dominant stage points to downstream/service-time bottlenecks
-- queue + service shares are complementary at request level in current MVP heuristics (queue wait is clamped to request latency)
-
-## In-flight trend metrics
-
-When in-flight snapshots are present, the report emits a dominant gauge summary:
-
-- `inflight_trend.gauge`
-- `inflight_trend.sample_count`
-- `inflight_trend.peak_count`
-- `inflight_trend.p95_count`
-- `inflight_trend.growth_delta`
-- `inflight_trend.growth_per_sec_milli` (count/sec in milli-units)
-
-In text output, this summary is rendered on one explicit line:
-
-- `inflight_trend gauge=<name> samples=<n> peak=<count> p95=<count> growth_delta=<delta> growth_per_sec_milli=<value>`
-
-Interpretation guidance:
-
-- positive `growth_delta` means in-flight work accumulated over the run window
-- high `peak_count`/`p95_count` plus high queue share strengthens queue saturation suspicion
-- positive growth plus elevated runtime global queue depth can reinforce executor pressure signals
+- high queue share suggests queue saturation
+- high service share plus dominant stage suggests downstream latency dominance
+- use suspect evidence and next checks to choose one follow-up experiment
 
 ## Suspect kinds
 
-## `ApplicationQueueSaturation`
+- `ApplicationQueueSaturation`
+- `BlockingPoolPressure`
+- `ExecutorPressureSuspected`
+- `DownstreamStageDominates`
+- `InsufficientEvidence`
 
-Typical evidence:
+These are **evidence-ranked leads**, not causal proof.
 
-- queue wait consumes large request share (p95 queue share high)
-- queue depth samples rise
+## In-flight trend fields
 
-What to check next:
+When present:
 
-- admission limits, producer burstiness
-- worker parallelism and queue policies
+- `gauge`
+- `sample_count`
+- `peak_count`
+- `p95_count`
+- `growth_delta`
+- `growth_per_sec_milli`
 
-## `BlockingPoolPressure`
-
-Typical evidence:
-
-- blocking queue depth p95 above zero/sustained
-- tails align with `spawn_blocking` backlog
-
-What to check next:
-
-- blocking callsites and workload duration
-- synchronous CPU or blocking I/O in hot paths
-
-## `ExecutorPressureSuspected`
-
-Typical evidence:
-
-- runtime global queue depth p95 elevated
-- broad scheduler pressure signal
-
-What to check next:
-
-- long-running polls and missing yields
-- uneven fan-out / task scheduling behavior
-
-## `DownstreamStageDominates`
-
-Typical evidence:
-
-- one stage dominates p95 and cumulative latency
-
-What to check next:
-
-- dependency behind that stage
-- retries/timeouts/circuit behavior under load
-
-## `InsufficientEvidence`
-
-Typical evidence:
-
-- sparse queue/stage/runtime signals
-- weak or conflicting attribution data
-
-What to check next:
-
-- add targeted queue/stage instrumentation
-- capture runtime snapshots during the workload window
-
-## Confidence model
-
-Current confidence mapping is score-based:
-
-- `high` for strong scores
-- `medium` for moderate scores
-- `low` otherwise
-
-Confidence is an internal ranking confidence, not a statistical confidence interval.
+Positive growth means in-flight work accumulated during the run.
 
 ## Practical workflow
 
-1. Run workload and capture one run JSON.
-2. Analyze with CLI (`text` and `json` when needed).
-3. Start from the primary suspect evidence.
-4. Validate suspect with one targeted experiment.
-5. Re-run and compare before/after output.
+1. Capture one run.
+2. Analyze and inspect primary suspect evidence.
+3. Change one thing.
+4. Re-run under comparable load.
+5. Compare p95 shares and suspect evidence.
 
-### Queue demo before/after example
-
-`python3 scripts/demo_tool.py run queue` now emits `before` (pathological baseline) and `after` (mitigated) analyses, plus a machine-readable comparison JSON at `demos/queue_service/artifacts/before-after-comparison.json`.
-
-In the current checked-in fixtures:
-
-- `before-analysis.json` reports `ApplicationQueueSaturation` with score `90` and p95 latency `1,682,454us`
-- `after-analysis.json` reports p95 latency `24,745us` with queue share reduced from `981` to `5` permille
-
-Use this pattern for diagnosis validation: keep load shape constant, adjust one mitigation lever, and compare suspect ranking plus p95-level shares.
-
-### Blocking demo before/after example
-
-`python3 scripts/demo_tool.py run blocking` now emits `before` (blocking-pool-constrained baseline) and `after` (mitigated) analyses, plus a machine-readable comparison JSON at `demos/blocking_service/artifacts/before-after-comparison.json`.
-
-In the current checked-in fixtures:
-
-- `before-analysis.json` reports `BlockingPoolPressure` with score `80`, p95 latency `3,524,739us`, and blocking queue depth p95 of `244`
-- `after-analysis.json` reports p95 latency `82,559us` with the same suspect score but lower blocking queue depth p95 (`39`)
-
-This demo validates mitigation by comparing both latency and at least one pressure signal (`blocking_queue_depth_p95`, suspect score, or p95 share) instead of relying on suspect kind changes alone.
-
-## Limitations
-
-- No cross-service correlation.
-- Rule-based heuristics may miss mixed-cause incidents.
-- Quality depends on instrumentation coverage.
-- Runtime metrics are partially constrained on stable Tokio without `tokio_unstable`.
+For reproducible before/after demo workflows, see [getting-started-demo.md](getting-started-demo.md).

--- a/docs/getting-started-demo.md
+++ b/docs/getting-started-demo.md
@@ -1,105 +1,35 @@
 # Getting started with demos
 
-Use this guide to run the MVP demos and compare generated outputs against tracked fixtures.
+Use demos to validate diagnosis behavior with deterministic fixtures.
 
-## Demo artifact policy
+## Artifact policy
 
-`tailscope` demo outputs are intentionally split into two classes:
+- `demos/*/artifacts/`: generated, untracked local outputs.
+- `demos/*/fixtures/`: committed reference snapshots.
 
-- **Generated outputs (untracked):** `demos/*/artifacts/`.
-  - These are local run results produced by scripts.
-  - Regenerate any time; do not treat as repository source-of-truth.
-- **Reference fixtures (tracked):** `demos/*/fixtures/`.
-  - These are committed snapshots used for deterministic validation and documentation.
-  - Use these when asserting expected behavior in docs/tests.
-
-## Queue service demo (`demos/queue_service`)
-
-**Scenario:** heavy application queueing before mitigation, reduced queue pressure after mitigation.
-
-**Run:**
+## Run + validate commands
 
 ```bash
 python3 scripts/demo_tool.py run queue
 python3 scripts/demo_tool.py validate queue
-```
 
-**Key generated artifacts (`artifacts/`):**
-
-- `before-run.json`, `before-analysis.json`
-- `after-run.json`, `after-analysis.json`
-- `before-after-comparison.json`
-
-**Reference fixtures (`fixtures/`):**
-
-- `before-analysis.json`
-- `after-analysis.json`
-
-**Interpretation focus:**
-
-- `primary_suspect.kind`
-- `p95_queue_share_permille`
-- `p95_service_share_permille`
-- `primary_suspect.evidence[]`
-
-## Blocking service demo (`demos/blocking_service`)
-
-**Scenario:** blocking-pool contention before mitigation, lower blocking pressure after mitigation.
-
-**Run:**
-
-```bash
 python3 scripts/demo_tool.py run blocking
 python3 scripts/demo_tool.py validate blocking
-```
 
-**Key generated artifacts (`artifacts/`):**
-
-- `before-run.json`, `before-analysis.json`
-- `after-run.json`, `after-analysis.json`
-- `before-after-comparison.json`
-
-**Reference fixtures (`fixtures/`):**
-
-- `before-analysis.json`
-- `after-analysis.json`
-
-**Interpretation focus:**
-
-- `primary_suspect.kind`
-- `p95_queue_share_permille`
-- `p95_service_share_permille`
-- `primary_suspect.evidence[]`
-
-## Downstream service demo (`demos/downstream_service`)
-
-**Scenario:** latency dominated by a downstream stage.
-
-**Run:**
-
-```bash
 python3 scripts/demo_tool.py run downstream
 python3 scripts/demo_tool.py validate downstream
 ```
 
-**Key generated artifacts (`artifacts/`):**
+## What each demo demonstrates
 
-- `downstream-run.json`
-- `downstream-analysis.json`
+| Demo | Expected emphasis | Key fields |
+| --- | --- | --- |
+| `queue_service` | application queueing pressure | `primary_suspect.kind`, `p95_queue_share_permille`, suspect evidence |
+| `blocking_service` | blocking-pool pressure | `primary_suspect.kind`, blocking-related evidence, p95 shares |
+| `downstream_service` | downstream-stage dominance | `primary_suspect.kind`, `p95_service_share_permille`, suspect evidence |
 
-**Reference fixtures (`fixtures/`):**
+## If local results differ from fixtures
 
-- `sample-analysis.json`
-
-**Interpretation focus:**
-
-- `primary_suspect.kind`
-- `p95_service_share_permille`
-- `p95_queue_share_permille`
-- `primary_suspect.evidence[]`
-
-## If your local output differs
-
-- Re-run on an otherwise idle machine.
-- Confirm demo script success before comparing fields.
-- Compare against `fixtures/` first, then inspect local `artifacts/` deltas.
+1. rerun on an otherwise idle machine
+2. confirm script success first
+3. compare fixture JSONs before interpreting local artifact drift

--- a/docs/mental-model.md
+++ b/docs/mental-model.md
@@ -1,123 +1,24 @@
-# tailscope mental model for newcomers
+# Mental model
 
-This guide is for Rust developers who use Tokio but may not be deep performance engineers.
+`tailscope` gives a ranked answer to: *what most likely drives tail latency in this run?*
 
-`tailscope` helps answer one practical question:
+## Four bottleneck families
 
-> Is tail latency mainly driven by queueing, executor pressure, blocking-pool pressure, or a slow downstream stage?
+1. **Application queueing**: work waits before execution.
+2. **Blocking-pool pressure**: `spawn_blocking` backlog inflates tails.
+3. **Executor pressure**: scheduler contention delays runnable work.
+4. **Downstream stage latency**: a dependency dominates request time.
 
-Use this document as a quick interpretation layer on top of `README.md` quickstart and `docs/diagnostics.md`.
+## How to read results
 
-## Who this guide is for
+- Treat `primary_suspect` as the best lead, not proof.
+- Use `evidence[]` to choose one targeted experiment.
+- Re-run and compare p95 shares plus suspect evidence.
 
-- You can read and write async Rust service code.
-- You can add small instrumentation wrappers around important awaits.
-- You want clear diagnosis direction without claiming root-cause certainty.
+## Confidence boundaries
 
-## Core concepts in plain language
-
-### Tail latency
-
-"Tail" latency means the slow end of requests (for example p95/p99), not the average.
-A service can have good average latency while still having painful tails.
-
-### Queueing
-
-Time spent waiting to be worked on.
-Examples: waiting on a semaphore permit, waiting for a worker queue slot, or waiting behind backlog.
-
-In `tailscope`, queueing often shows up as higher `p95_queue_share_permille`.
-
-### Service time / stage latency
-
-Time spent actively doing work once admitted.
-Often represented by stage wrappers around downstream awaits (DB, cache, RPC, etc.).
-
-In `tailscope`, service-heavy paths often show up in `p95_service_share_permille` and stage evidence.
-
-### Executor pressure (Tokio scheduler pressure)
-
-A signal that runnable task load is high enough that scheduling delay may contribute to tails.
-This is not a proof by itself; it is an evidence-ranked suspect.
-
-### Blocking-pool pressure
-
-A signal that `spawn_blocking` style work is queued or saturated.
-If blocking queue depth remains elevated, tail latency can increase even if async code looks normal.
-
-## How to read a diagnosis report
-
-Start with these fields:
-
-1. `primary_suspect.kind`
-2. `primary_suspect.evidence[]`
-3. `primary_suspect.next_checks[]`
-4. `p95_queue_share_permille` and `p95_service_share_permille`
-
-Interpretation pattern:
-
-- Treat `primary_suspect` as "best current lead," not proven root cause.
-- Use evidence lines to pick one focused experiment.
-- Re-run workload after one change and compare p95-level fields.
-
-## First checks by suspect kind
-
-### `ApplicationQueueSaturation`
-
-Try first:
-
-- verify admission limits and queue policies
-- reduce producer burstiness or cap concurrency at ingress
-- add queue depth samples at major wait points
-
-### `BlockingPoolPressure`
-
-Try first:
-
-- audit `spawn_blocking` callsites for long-running work
-- move synchronous hot-path work off critical request path
-- check whether blocking queue depth trends down after mitigation
-
-### `ExecutorPressureSuspected`
-
-Try first:
-
-- look for long-running polls or missing cooperative yields
-- reduce overly broad fan-out that creates scheduler churn
-- compare runtime snapshots before/after one targeted change
-
-### `DownstreamStageDominates`
-
-Try first:
-
-- inspect the dominant stage dependency (DB/RPC/cache)
-- check timeout/retry behavior under load
-- isolate with one synthetic test to verify downstream contribution
-
-### `InsufficientEvidence`
-
-Try first:
-
-- instrument 1-3 important queues and stages
-- capture runtime snapshots during the same load window
-- rerun with equivalent load shape
-
-## Confidence and limits (important)
-
-`tailscope` provides evidence-ranked suspects, not causal proof.
-
-Keep in mind:
-
-- Partial instrumentation is supported, but confidence can be lower.
+- Partial instrumentation can still be useful.
 - Mixed-cause incidents can produce overlapping signals.
-- One run is a starting point; confidence improves with targeted reruns.
+- Confidence improves through iterative, controlled reruns.
 
-## Suggested workflow for newcomers
-
-1. Integrate quickly using one request wrapper (or macro) and a few stage/queue wrappers.
-2. Run representative load and export one run JSON.
-3. Analyze and read primary suspect evidence.
-4. Make one mitigation change only.
-5. Re-run, compare p95 metrics and suspect evidence, then iterate.
-
-This keeps diagnosis practical and avoids overfitting conclusions to a single run.
+For field-level details, see [diagnostics.md](diagnostics.md).

--- a/docs/mvp-audit-2026-03-19.md
+++ b/docs/mvp-audit-2026-03-19.md
@@ -1,13 +1,14 @@
 # MVP audit (2026-03-19)
 
-This audit evaluates repository status against:
+Historical snapshot of repository status on March 19, 2026.
 
-- `PLANS.md`
-- `IMPLEMENTATION_PLAN.md`
+## Scope used for audit
+
 - `SPEC.md`
-- current runnable checks and scripts
+- `IMPLEMENTATION_PLAN.md`
+- runnable checks and demo/runtime scripts
 
-## Commands executed
+## Commands executed in the audit run
 
 - `cargo fmt --check`
 - `cargo clippy --workspace --all-targets -- -D warnings`
@@ -20,93 +21,18 @@ This audit evaluates repository status against:
 - `python3 scripts/demo_tool.py validate downstream`
 - `python3 scripts/measure_runtime_cost.py`
 
-All commands completed successfully in this environment.
+All commands completed successfully in that environment.
 
-## Acceptance criteria status (PLANS minimum acceptance)
+## Outcome at that date
 
-From `PLANS.md`, MVP minimum acceptance requires:
+The audit concluded the repository met MVP acceptance intent:
 
-1. quick integration in a small Tokio service
-2. queue/backpressure demo correctly diagnosed
-3. blocking contamination demo correctly diagnosed
-4. readable/useful report
-5. light mode overhead measured
-6. docs clarify integration and limits
+- practical Rust integration path existed
+- queue and blocking demos validated expected suspects
+- analyzer produced readable ranked reports
+- runtime-cost workflow was reproducible
+- docs covered integration boundaries and limitations
 
-Assessment:
+## Caveat
 
-- **Met (1)**: integration path exists via `request`, `queue`, `stage`, `inflight`, and macro path examples in README/SPEC.
-- **Met (2)**: queue validation script passes and reports expected suspect kind.
-- **Met (3)**: blocking validation script passes and reports expected suspect kind.
-- **Met (4)**: analyzer emits both text and JSON reports with suspect ranking, evidence, and next checks.
-- **Met (5)**: runtime cost script runs and writes machine-readable summary artifacts.
-- **Met (6)**: README/SPEC/docs describe API, limits, and non-goals.
-
-Conclusion: **the repository currently satisfies the stated MVP acceptance criteria**.
-
-## Alignment with PLANS.md and IMPLEMENTATION_PLAN.md
-
-### Milestone/phase coverage
-
-- **M0 / Phase 0 (bootstrap)**: workspace, CI checks, and core docs exist.
-- **M1 / Phase 1-2 (`tailscope-core`)**: config/init, request/queue/stage/inflight instrumentation, JSON sink, and tests exist.
-- **M2 / Phase 3 (request macro)**: `#[instrument_request]` exists via `tailscope-macros` and is re-exported from `tailscope-tokio`.
-- **M3 / Phase 4 (`tailscope-tokio`)**: runtime sampler and snapshot capture are implemented and tested.
-- **M4 / Phase 5 (`tailscope-cli`)**: analyze command, percentile calculations, diagnosis rules, text/JSON output, fixture tests exist.
-- **M5 / Phase 6 (demos)**: queue + blocking demos and validation scripts exist and pass; downstream demo also exists.
-- **M6 / Phase 7 (runtime cost)**: reproducible runtime-cost harness/script and docs are present.
-- **Phase 8 (polish/docs)**: substantial docs present (README, SPEC, architecture, diagnostics, runtime-cost).
-
-### Items that appear partially unverified from repository state alone
-
-- `IMPLEMENTATION_PLAN.md` Phase 8 task "ensure issue/PR history is coherent" cannot be proven from code contents alone.
-
-## Scope adherence
-
-### In scope and done
-
-- Tokio-only implementation.
-- Local JSON run artifact workflow.
-- Instrumentation primitives and request macro.
-- Runtime sampling.
-- Analyzer CLI with ranked suspects.
-- Required demos and validation scripts.
-- Runtime-cost measurement scripts/docs.
-
-### Above/outside original PLANS minimum scope
-
-- Workspace includes an explicit **fourth** crate `tailscope-macros` in addition to the three expected top-level crates.
-- A third demo (`downstream_service`) is included beyond the original two required demos.
-
-These are additive and still consistent with `SPEC.md` as currently written.
-
-## Code quality/readability assessment
-
-Overall rating: **senior**.
-
-Rationale:
-
-- Clear crate/module split (`core`/`tokio`/`cli`/`macros`).
-- Deterministic fixture-driven tests for diagnosis behavior.
-- Scripted reproducibility for demos and runtime cost.
-- Good documentation density and candid limitation statements.
-
-Not yet "staff/principal" polish in all areas because:
-
-- Some planning-doc aspirations (for example PR-history coherence) are process-level and not demonstrably enforced by repository tooling.
-- Demo workflow scripts still share some orchestration patterns; further centralization in `scripts/_demo_runner.py` could reduce repeated glue code.
-
-## Duplication and simplification opportunities
-
-- Demo workflow scripts share orchestration patterns; further centralization in `scripts/_demo_runner.py` could reduce repeated glue code.
-- Otherwise, Rust crate boundaries are already straightforward and reasonably small.
-
-## Documentation freshness
-
-Documentation appears up to date with implemented behavior and artifact policy:
-
-- README reflects current crates, demos, and script usage.
-- SPEC includes macro support, downstream demo, and runtime-cost path.
-- docs/* aligns with current CLI outputs and instrumentation philosophy.
-
-No obvious stale claims were detected in this audit run.
+This file is intentionally time-bound. Treat it as historical context, not as current project status.

--- a/docs/runtime-cost.md
+++ b/docs/runtime-cost.md
@@ -1,78 +1,41 @@
 # Runtime cost measurement
 
-This document defines the reproducible runtime-cost measurement path for `tailscope` MVP modes.
+This is the reproducible overhead measurement path for MVP modes.
 
-## What is measured
-
-For each mode (`baseline`, `light`, `investigation`) the harness reports:
-
-- throughput (requests/second)
-- end-to-end latency p50
-- end-to-end latency p95
-- end-to-end latency p99
-
-The summary also computes relative overhead for `light` and `investigation` vs `baseline`.
-
-## Harness
-
-- Binary: `demos/runtime_cost`
-- Canonical script: `python3 scripts/measure_runtime_cost.py`
-
-The harness runs a queueing workload with bounded concurrency and fixed simulated work per request.
-
-Mode behavior:
+## Modes
 
 - `baseline`: no `tailscope` instrumentation
 - `light`: request + queue + stage + inflight instrumentation
-- `investigation`: same as light, plus an additional stage marker and dense Tokio runtime sampling
+- `investigation`: light mode + extra stage marker + dense runtime sampling
 
-## Reproduce
+## Metrics reported
 
-From repo root:
+- throughput (req/s)
+- latency p50/p95/p99
+- relative overhead vs baseline (for `light` and `investigation`)
+
+## Canonical command
 
 ```bash
 python3 scripts/measure_runtime_cost.py
 ```
 
-Optional tuning via environment variables:
+Optional environment overrides:
 
 - `REQUESTS` (default `1200`)
 - `CONCURRENCY` (default `48`)
 - `WORK_MS` (default `3`)
 - `ITERATIONS` (default `5`)
 
-Artifacts written to `demos/runtime_cost/artifacts/`:
+## Outputs
+
+Written to `demos/runtime_cost/artifacts/`:
 
 - `runtime-cost-raw.jsonl`
 - `runtime-cost-summary.json`
 - per-mode run JSON files for instrumented modes
 
-## Regenerating current numbers
+## Policy
 
-This document intentionally does **not** pin “latest local run” numeric claims, because runtime-cost values are machine- and workload-dependent.
-
-To generate fresh summary values on your machine, run:
-
-```bash
-python3 scripts/measure_runtime_cost.py
-```
-
-Then inspect:
-
-- `demos/runtime_cost/artifacts/runtime-cost-summary.json`
-
-If you need to compare runs over time, archive selected summaries under a tracked fixtures path (for example, `demos/runtime_cost/fixtures/`) and cite those committed files in docs/PRs.
-
-## Artifact policy
-
-- `demos/runtime_cost/artifacts/` is **generated at runtime** and intentionally untracked.
-- `demos/*/fixtures/` is the **tracked snapshot** area for reproducible, reviewable fixtures.
-
-Use `artifacts/` for local/regenerated outputs and `fixtures/` for intentionally versioned reference snapshots.
-
-## Notes and limits
-
-- Results are workload- and machine-specific.
-- Runtime-cost claims should cite either:
-  - fresh output generated via `python3 scripts/measure_runtime_cost.py`, or
-  - a committed fixture snapshot under `demos/*/fixtures/`.
+- Do not hardcode machine-specific “latest numbers” in docs.
+- Cite either fresh script output or committed fixture snapshots when making overhead claims.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,98 +1,68 @@
 # User guide (first use)
 
-This page is intentionally scoped to the **first-use flow**: get one run artifact, analyze it, and interpret the top diagnosis fields.
+This guide covers the shortest path to a useful diagnosis.
 
-## When to use tailscope
-
-Use `tailscope` when you need to quickly determine whether tail latency in a Tokio service is most likely caused by:
-
-- **Application-level queueing** (work sitting in queues before execution).
-- **Executor or blocking-pool pressure** (runtime contention that inflates wait/dispatch time).
-- **A slow downstream stage** (for example a DB/cache/RPC call dominating request time).
-
-## Minimal integration
-
-Start with one collector and only a few wrappers.
-
-1. **Initialize once** near service startup.
+## 1) Instrument one request flow
 
 ```rust
-use tailscope_core::{Config, Tailscope};
+use tailscope_core::{Config, RequestMeta, Tailscope};
 
 let tailscope = Tailscope::init(Config::new("my-service"))?;
-```
 
-2. **Wrap one request entry point**.
-
-```rust
-use tailscope_core::RequestMeta;
+let meta = RequestMeta::for_route("/checkout").with_kind("http");
+let request_id = meta.request_id.clone();
 
 tailscope
-    .request(
-        RequestMeta::for_route("/checkout").with_kind("http"),
-        "ok",
-        async {
-            // request body
-        },
-    )
-    .await;
-```
+    .request(meta, "ok", async {
+        tailscope
+            .queue(request_id.clone(), "ingress_queue")
+            .await_on(async_work_that_waits())
+            .await;
 
-3. **Wrap one queue wait and one stage await** inside that request flow.
-
-```rust
-// queue wait
-let request_id = RequestMeta::for_route("/checkout").with_kind("http").request_id;
-tailscope
-    .queue(request_id.clone(), "ingress_queue")
-    .await_on(async_work_that_waits())
+        tailscope
+            .stage(request_id, "db_call")
+            .await_value(async_downstream_call())
+            .await;
+    })
     .await;
 
-// downstream stage
-tailscope
-    .stage(request_id, "db_call")
-    .await_value(async_downstream_call())
-    .await;
-```
-
-After collecting data, flush once before process exit:
-
-```rust
 tailscope.flush()?;
 ```
 
-## Analyze one run
-
-Use the CLI analysis command:
+## 2) Analyze the run
 
 ```bash
 tailscope analyze <run.json> --format json
 ```
 
-## Read the key output fields
+Read these fields first:
 
-Focus on these fields first:
+- `primary_suspect.kind`
+- `primary_suspect.evidence[]`
+- `primary_suspect.next_checks[]`
+- `p95_queue_share_permille`
+- `p95_service_share_permille`
 
-- **`primary_suspect`**: the top-ranked diagnosis candidate.
-  - Start with `primary_suspect.kind` to see the likely bottleneck category.
-- **`p95_queue_share_permille`**: how much of p95 latency is attributable to queue time, in permille (per-thousand).
-  - Example: `420` means ~42.0% of p95 latency.
-- **`evidence`** (under the suspect): concrete signals that supported ranking.
-  - Treat this as the “why” behind the suspect selection and as guidance for where to inspect next.
+## 3) If result is `InsufficientEvidence`
 
-## If result is `InsufficientEvidence`
+Add one more queue wrapper and one more stage wrapper around the most likely missing wait points, then rerun with comparable load.
 
-Take two concrete instrumentation actions next:
+## 4) Optional stronger attribution
 
-1. **Add one more `queue(...).await_on(...)` wrapper** around the most likely uninstrumented wait point in the request path.
-2. **Add one more `stage(...).await_on(...)` or `stage(...).await_value(...)` wrapper** around the slowest suspected downstream await.
+Enable runtime snapshots when queue/stage instrumentation is still ambiguous:
 
-Then run again and re-analyze.
+```rust
+use std::sync::Arc;
+use std::time::Duration;
+use tailscope_tokio::RuntimeSampler;
+
+let sampler = RuntimeSampler::start(Arc::clone(&tailscope), Duration::from_millis(200))?;
+// run workload
+sampler.shutdown().await;
+```
 
 ## Next docs
 
-For details beyond first use, see:
-
-- [Architecture](architecture.md)
 - [Diagnostics guide](diagnostics.md)
-- [Getting started demos](getting-started-demo.md)
+- [Architecture](architecture.md)
+- [Demo workflow](getting-started-demo.md)


### PR DESCRIPTION
### Motivation
- Streamline and de-duplicate project documentation so the top-level README stays crisp and readers have a single entry point for deeper detail.
- Preserve all essential quickstart, integration, and diagnosis guidance while removing repetitive or stale cross-references.

### Description
- Rewrote the top-level `README.md` to focus on value, a short quickstart, and the canonical integration path while linking to `docs/README.md` for more detail.
- Added `docs/README.md` as a single docs index and simplified the core docs pages (`docs/user-guide.md`, `docs/diagnostics.md`, `docs/architecture.md`, `docs/getting-started-demo.md`, `docs/runtime-cost.md`, `docs/mental-model.md`, `docs/mvp-audit-2026-03-19.md`) to remove duplication and improve clarity.
- Updated `docs/changelog.md` to record the documentation consolidation and clarified the historical MVP audit as time-bound context.
- This PR is documentation-only and does not change runtime behavior, public APIs, or demos.

### Testing
- Ran `cargo fmt --check` which succeeded.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` which completed without warnings.
- Ran `cargo test --workspace` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bce5c9aebc8330865711bb11300ba5)