### PR TITLE
docs: add March 20 MVP audit snapshot and update docs index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ Use this page as the single entry point for project documentation.
 
 ## Historical snapshot
 
+- **MVP audit (2026-03-20):** [mvp-audit-2026-03-20.md](mvp-audit-2026-03-20.md)
 - **MVP audit (2026-03-19):** [mvp-audit-2026-03-19.md](mvp-audit-2026-03-19.md)
 
 ## Documentation conventions

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Added a fresh dated MVP audit snapshot (`docs/mvp-audit-2026-03-20.md`) with current acceptance/milestone/scope verification results.
 - Consolidated documentation structure around `docs/README.md` as the canonical docs index.
 - Reduced duplication across README/user guide/diagnostics/demo docs while keeping MVP integration and diagnosis guidance intact.
 - Simplified the historical MVP audit doc and removed stale cross-document references.

--- a/docs/mvp-audit-2026-03-20.md
+++ b/docs/mvp-audit-2026-03-20.md
@@ -1,0 +1,91 @@
+# MVP audit (2026-03-20)
+
+Current snapshot of repository status on March 20, 2026.
+
+## Scope used for this audit
+
+- `SPEC.md`
+- `IMPLEMENTATION_PLAN.md`
+- runnable checks and demo/runtime scripts
+
+## Commands executed
+
+- `cargo fmt --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo test --workspace`
+- `python3 scripts/demo_tool.py run queue`
+- `python3 scripts/demo_tool.py validate queue`
+- `python3 scripts/demo_tool.py run blocking`
+- `python3 scripts/demo_tool.py validate blocking`
+- `python3 scripts/demo_tool.py run downstream`
+- `python3 scripts/demo_tool.py validate downstream`
+- `python3 scripts/measure_runtime_cost.py`
+
+All commands completed successfully in this environment.
+
+## Acceptance criteria status (MVP minimum acceptance)
+
+From `IMPLEMENTATION_PLAN.md`, MVP minimum acceptance requires six outcomes:
+
+1. quick integration for a small Tokio service
+2. queue/backpressure demo correctly diagnosed
+3. blocking contamination demo correctly diagnosed
+4. report readable and useful
+5. light mode overhead measured and acceptable
+6. docs clearly explain integration and limits
+
+Current status: all six are satisfied.
+
+## Milestone status
+
+Milestones in `IMPLEMENTATION_PLAN.md`:
+
+- M0 repository bootstrap: met
+- M1 `tailscope-core`: met
+- M2 request macro: met
+- M3 `tailscope-tokio`: met
+- M4 `tailscope-cli`: met
+- M5 demo services: met (queue + blocking), plus downstream proof case in scope extension
+- M6 runtime cost + polish: met
+
+## In-scope completeness
+
+No missing required MVP scope items were found relative to `SPEC.md` and the milestone plan.
+
+## Scope drift check
+
+No prohibited non-goal features were found (no GUI, tracing backend, Prometheus/OpenTelemetry exporter, eBPF, ML/auto-remediation, multi-service diagnosis, or non-Tokio runtime support).
+
+Observed extension beyond the earliest minimum milestone wording:
+
+- `tailscope-macros` exists as a dedicated proc-macro crate to support `#[instrument_request]`
+- a deterministic downstream-dominance demo is included
+
+Both are explicitly reflected in current docs/spec and remain aligned with project intent.
+
+## Docs truthfulness and freshness
+
+Documentation is largely truthful and aligned to current behavior:
+
+- README and docs index point to the intended integration and diagnosis paths
+- diagnostics language is explicit that suspects are evidence-ranked leads, not proof
+- runtime-cost docs avoid hard-coded stale machine-specific numbers
+
+Minor caveat:
+
+- this audit only validates behavior in the current local environment and date; performance numbers remain machine dependent.
+
+## Practical usefulness and adoption outlook
+
+Assessment:
+
+- usefulness: strong for single-service Tokio latency triage
+- adoption chance: realistic for Rust/Tokio teams needing low-friction local diagnosis, especially when they can add a few wrappers/macros
+- onboarding clarity: good (quickstart + user guide + demo scripts)
+- value proposition clarity: good (specific suspect ranking and next checks)
+
+Primary adoption constraints:
+
+- currently Tokio-only
+- single-process, run-artifact-based workflow (not a live/centralized observability system)
+- diagnosis quality still depends on instrumentation coverage


### PR DESCRIPTION
### Motivation
- Add a fresh, date-stamped MVP audit to record current acceptance/milestone status and make the repo health snapshot discoverable from the docs index.

### Description
- Added `docs/mvp-audit-2026-03-20.md`, updated `docs/README.md` to reference the new audit, and recorded the addition in `docs/changelog.md`.

### Testing
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, the demo run/validate scripts (`python3 scripts/demo_tool.py run/validate queue|blocking|downstream`), and `python3 scripts/measure_runtime_cost.py`, all of which completed successfully in the validation environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bceec6fc508330b623d8630ed9e2c6)