### PR TITLE
Refocus docs: position project as Tokio tail-latency triage for non-experts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file tells coding agents how to work in this repository.
 
 ## Mission
 
-Build `tailtriage`, a small, useful Rust toolkit for diagnosing tail-latency, queueing, and backpressure problems in Tokio services.
+Build `tailtriage`, a small, useful Rust toolkit for **Tokio tail-latency triage** in real services.
 
 The repository exists to produce a **real developer tool**, not a toy lab and not a generic observability platform.
 
@@ -18,7 +18,31 @@ The tool should:
 - be easy to integrate
 - be useful with partial instrumentation
 - be low-overhead in light mode
-- produce a clear diagnosis report
+- produce a clear triage report with evidence-ranked suspects and next checks
+
+## Product language and positioning guardrails
+
+When editing docs, prefer language that reinforces the MVP category:
+- use **triage** for product/category language
+- use **diagnosis** for analyzer/report actions where natural
+- describe output as **evidence-ranked suspects** and **next checks**
+
+Always preserve the distinction:
+- suspects are leads
+- suspects are **not** proof of root cause
+
+Avoid wording drift toward:
+- vague “observability platform” framing
+- broad automated-causality claims
+- comparisons that imply `tailtriage` replaces tokio-console, tokio-metrics, or telemetry stacks
+
+Optimize docs for:
+- first-time users
+- non-expert readers
+- concrete workflows
+- short examples
+- direct statements of fit and non-fit
+- narrow, honest claims over ambitious language
 
 ## What this repository is NOT building
 
@@ -139,7 +163,7 @@ Assume the following are existing building blocks:
 - tokio-console is a local debugging/profiling tool
 - tokio-metrics is a runtime/task metrics source
 
-`tailtriage` is the diagnosis layer above these, not a replacement for them.
+`tailtriage` is the triage/diagnosis layer above these, not a replacement for them.
 
 ## File hygiene
 

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,652 +1,122 @@
 # IMPLEMENTATION_PLAN.md
 
-This file is the consolidated execution and implementation plan for the `tailtriage` MVP.
+Release/polish plan for shipping the `tailtriage` MVP clearly.
+
+The MVP feature set is implemented. Remaining work focuses on positioning, onboarding, demo storytelling, and publishability without expanding scope.
 
 ## Summary
 
-Estimated effort:
-- focused full-time: 9–15 working days
-- realistic remote GitHub/Codex workflow: 3–6 calendar weeks part-time
+Goal: make a new reader understand in under 30 seconds that this project is **Tokio tail-latency triage** for ordinary developers.
 
-The project should be built as a sequence of small, reviewable milestones.
+This plan prioritizes:
+- consistent product/category language
+- shortest path to first value
+- modest, evidence-based comparisons with adjacent tools
+- narrow, honest scope and uncertainty statements
 
-## Phase 0 — bootstrap
-
-### Goals
-- create workspace
-- define docs
-- set up CI
-- make first trivial green build
-
-### Tasks
-1. create Cargo workspace
-2. add crates:
-   - `tailtriage-core`
-   - `tailtriage-tokio`
-   - `tailtriage-cli`
-3. add GitHub Actions:
-   - fmt
-   - clippy
-   - test
-4. add placeholder docs
-5. add one smoke test
-
-### Deliverables
-- working workspace
-- passing CI
-- docs in place
-
-### Estimated effort
-0.5–1 day
-
----
-
-## Phase 1 — core data model and collection
+## Phase 1 — positioning and terminology alignment
 
 ### Goals
-Define the internal event model and local collection strategy.
-
-### Design choices
-Use a local in-process collector with JSON output for v1.
-
-Avoid:
-- network exporters
-- external metrics backends
-- complex aggregation layers
-
-### Proposed internal concepts
-- request start/end records
-- stage timing records
-- queue timing records
-- in-flight gauge updates
-- runtime snapshots
-- run metadata
+- align product language across all top-level docs
+- preserve distinction between evidence-ranked suspects and causal proof
 
 ### Tasks
-1. define event/data structs
-2. define run metadata format
-3. define collector trait or internal sink abstraction
-4. implement local JSON sink
-5. add serialization tests
+1. ensure README/SPEC/docs map use triage-first wording
+2. keep “diagnosis” mainly for analyzer/report actions
+3. standardize “evidence-ranked suspect” and “next checks” language
+4. remove observability-platform phrasing that implies broader scope
 
 ### Deliverables
-- stable internal JSON schema for v1
-- unit tests for serialization
-
-### Estimated effort
-1–2 days
+- consistent, non-contradictory product positioning
+- explicit non-goals preserved across docs
 
 ---
 
-## Phase 2 — `tailtriage-core`
+## Phase 2 — onboarding and quickstart ergonomics
 
 ### Goals
-Implement the user-facing instrumentation primitives.
-
-### Public API to implement
-- `Tailtriage::init`
-- `Config`
-- `request(...)`
-- `inflight(...)`
-- `queue(...).await_on(...)`
-- `stage(...).await_on(...)`
-
-### Important design decisions
-- prefer RAII guards
-- wrappers should be thin and readable
-- avoid forcing users into a custom framework
-- support partial instrumentation
-
-### Suggested modules
-- `config`
-- `collector`
-- `request`
-- `inflight`
-- `stage`
-- `queue`
-- `events`
-- `output`
+- reduce friction for first-time users
+- tighten quickstart around shortest path to value
 
 ### Tasks
-1. implement config and init guard
-2. implement request scope object
-3. implement in-flight guard
-4. implement stage wrapper
-5. implement queue wrapper
-6. connect all primitives to collector
-7. add example-based unit tests
+1. trim quickstart to one request path + one analyze command
+2. ensure canonical workflow is capture -> analyze -> next check -> re-run
+3. keep examples short and directly tied to suspect ranking
+4. fix one or two high-impact adoption-friction issues only (no feature expansion)
 
 ### Deliverables
-- core instrumentation works
-- docs examples compile
-- unit tests pass
-
-### Estimated effort
-2–3 days
+- faster time-to-first-triage for new users
+- concise examples optimized for non-experts
 
 ---
 
-## Phase 3 — request macro
+## Phase 3 — ecosystem framing and comparisons
 
 ### Goals
-Provide the easiest possible integration path.
-
-### API
-- `#[instrument_request(...)]`
-
-### Approach
-Start with a simple proc macro crate only if necessary.
-If proc-macro complexity becomes a time sink, consider a first version built on top of `tracing` + explicit request scope helpers, but the end goal remains the request macro.
-
-### Macro responsibilities
-- create request scope/span
-- record top-level metadata
-- measure total function duration
-- record result status
-- honor skipped parameters
-
-### Non-responsibilities
-- infer queue semantics
-- infer stage meanings
-- instrument every await automatically
+- clarify fit alongside existing Tokio tooling
+- keep comparisons grounded and modest
 
 ### Tasks
-1. choose proc-macro crate layout
-2. parse simple attribute arguments
-3. wrap async fn body
-4. connect to core collector
-5. test with async examples
+1. document “why not just tokio-console / tokio-metrics” in product docs
+2. distinguish live debugging, raw metrics, and triage interpretation use-cases
+3. avoid disparaging adjacent tools; emphasize complementarity
 
 ### Deliverables
-- one realistic handler instrumented by macro
-- docs example passes
-
-### Estimated effort
-1–2 days
+- clear product boundary in README/docs
+- improved newcomer understanding of when to use `tailtriage`
 
 ---
 
-## Phase 4 — `tailtriage-tokio`
+## Phase 4 — demo storytelling polish
 
 ### Goals
-Add runtime-level context.
-
-### Runtime signals to capture
-Target the stable, useful subset first:
-- alive tasks
-- global queue depth
-- local queue depth if available
-- blocking queue depth if available
-- remote scheduling count if available
-
-### Design choices
-- sample periodically
-- write snapshots into the same run output
-- do not try to capture every poll event
-- keep collection cheap in light mode
-
-### Suggested modules
-- `sampler`
-- `snapshot`
-- `runtime_metrics`
-- `serialization`
+- make demo outputs clearly support the product promise
+- preserve reproducible before/after triage loops
 
 ### Tasks
-1. implement sampler loop
-2. capture runtime snapshots
-3. integrate with config and collector
-4. test snapshot collection
-5. document platform/runtime caveats if needed
+1. tighten demo docs around suspect ranking and evidence
+2. keep fixtures deterministic and easy to re-run
+3. ensure each demo links to practical next checks
+4. add at most one adoption-oriented example if it improves clarity
 
 ### Deliverables
-- periodic runtime snapshots in run output
-- sampler start/stop lifecycle works
-
-### Estimated effort
-2–3 days
+- demos that teach triage workflow, not platform ambitions
+- reproducible storytelling artifacts for reviewers/users
 
 ---
 
-## Phase 5 — `tailtriage-cli`
+## Phase 5 — release packaging and discoverability
 
 ### Goals
-Turn one run into a diagnosis report.
-
-### Commands for MVP
-- `tailtriage analyze <run.json>`
-
-Optional later:
-- `tailtriage summarize`
-- `tailtriage explain`
-
-### Core report calculations
-- per-stage count
-- p50/p95/p99 by stage
-- queue wait share vs total time
-- service time share vs total time
-- in-flight trends
-- runtime metrics trends
-
-### Diagnosis rules for MVP
-
-#### Rule A — application queue saturation
-Conditions:
-- queue wait dominates service time
-- queue-related timing rises strongly under load
-- app in-flight rises
-- runtime global queue pressure is not the primary mover
-
-#### Rule B — blocking-pool pressure
-Conditions:
-- blocking queue depth elevated
-- long tails correlate with blocking pressure
-- async stage timings alone do not explain the tail fully
-
-#### Rule C — executor pressure suspected
-Conditions:
-- runtime/global scheduling pressure elevated
-- no single app-level queue dominates
-- broad latency inflation across stages
-
-#### Rule D — downstream stage dominates
-Conditions:
-- one stage dominates p95/p99
-- queue wait is secondary
-- tails correlate with that stage
-
-#### Rule E — insufficient evidence
-Conditions:
-- data too sparse
-- instrumentation too incomplete
-- conflicting signals
-
-### Output formats
-- human-readable text
-- structured JSON
+- improve publishability and discoverability without adding major features
 
 ### Tasks
-1. define report structs
-2. implement percentile computations
-3. implement diagnosis rules
-4. implement text renderer
-5. implement JSON renderer
-6. add fixture tests
+1. confirm crate metadata/docs links are consistent
+2. align repository/doc entry points for first-time readers
+3. ensure changelog and docs map support release readability
+4. verify rustdoc/README language coherence for crate consumers
 
 ### Deliverables
-- diagnosis output from fixture data
-- tested rule ranking
-
-### Estimated effort
-2–4 days
+- release-ready docs surface
+- coherent external-facing project story
 
 ---
 
-## Phase 6 — demo services
+## Explicit anti-goals for this plan
 
-### Demo A — queue/backpressure service
-Purpose:
-- prove queue diagnosis works
-
-Behavior:
-- bounded concurrency
-- queue/permit acquisition
-- downstream async work with controllable latency
-
-Expected diagnosis:
-- application-level queue saturation
-
-Possible fix:
-- reduce queue growth
-- tune concurrency
-- add shedding / timeout
-
-### Demo B — blocking contamination service
-Purpose:
-- prove blocking diagnosis works
-
-Behavior:
-- too much work on blocking pool or equivalent bad pattern
-
-Expected diagnosis:
-- blocking-pool pressure
-
-Possible fix:
-- remove or reduce blocking work
-- isolate blocking work
-- change concurrency policy
-
-### Tasks
-1. build minimal services
-2. add simple load generators or scripts
-3. capture run artifacts
-4. validate analyzer output
-5. implement one fix per demo
-
-### Deliverables
-- reproducible demo scripts
-- sample before/after outputs
-
-### Estimated effort
-2–3 days
-
----
-
-## Phase 7 — runtime cost evaluation
-
-### Goals
-Measure and document overhead honestly.
-
-### Modes to measure
-- off
-- light
-- investigation
-
-### Metrics
-- throughput
-- p50/p95/p99 latency
-- CPU time if feasible
-- relative overhead vs baseline
-
-### Design target
-- light mode should be low single-digit overhead if practical
-- investigation mode may cost more and that is acceptable
-
-### Tasks
-1. define benchmark scenario
-2. run baseline
-3. run light mode
-4. run investigation mode
-5. summarize results in docs
-
-### Deliverables
-- measured overhead section
-- benchmark script outputs
-
-### Estimated effort
-1–2 days
-
----
-
-## Phase 8 — polish and sample-quality documentation
-
-### Goals
-Make the repository strong enough to function as:
-- a work sample
-- an analysis sample
-- a writing sample
-
-### Tasks
-1. improve README
-2. refine examples
-3. document limitations honestly
-4. add architecture docs
-5. write a memo-style narrative
-6. ensure issue/PR history is coherent
-
-### Deliverables
-- polished docs
-- coherent repo story
-
-### Estimated effort
-1–2 days
-
----
-
-## Recommended issue breakdown
-
-Suggested first 12 issues:
-
-1. bootstrap workspace and CI
-2. define run/event JSON schema
-3. implement config + init
-4. implement request scope
-5. implement in-flight guard
-6. implement stage wrapper
-7. implement queue wrapper
-8. add request macro
-9. add Tokio runtime sampler
-10. build CLI report skeleton
-11. implement queue saturation diagnosis rule
-12. implement blocking pressure diagnosis rule
-
-Then:
-13. queue demo
-14. blocking demo
-15. overhead measurement
-16. docs polish
-
----
-
-## Risk management
-
-### Biggest risks
-1. macro complexity grows too much
-2. runtime metrics API differences complicate sampler
-3. analyzer becomes vague instead of useful
-4. scope creep into a full observability platform
-
-### Responses
-- keep macro MVP simple
-- start with minimal stable runtime signals
-- prefer few explicit rules over a grand diagnosis engine
-- enforce non-goals aggressively
-
----
+Do not use this phase to:
+- add major diagnosis categories
+- build exporters/backends
+- build a live UI
+- add distributed-system features
+- shift into a general observability platform
 
 ## Success criteria
 
-The implementation is successful if:
-- the API is easy to integrate
-- the demos are correctly diagnosed
-- the CLI output is useful to a developer
-- the overhead is measured
-- the repository reads like a coherent product, not a pile of experiments
+This release plan succeeds when:
 
----
-
-## Consolidated milestone roadmap (from former `PLANS.md`)
-
-This section preserves the milestone-oriented roadmap that previously lived in `PLANS.md` so planning context remains in one file.
-
-# PLANS.md
-
-This file defines the execution plan for the `tailtriage` MVP.
-
-## Objective
-
-Deliver a working MVP of `tailtriage` that can:
-1. instrument a Tokio service with low effort
-2. collect request/stage/queue timings
-3. sample Tokio runtime metrics
-4. analyze one run and emit a ranked diagnosis
-5. prove usefulness on two small demo services
-
-## Core product promise
-
-> Add one macro for request-level visibility. Wrap a few important awaits. Get a report telling you whether your tails are dominated by queueing, blocking, executor pressure, or a slow downstream stage.
-
-## MVP scope
-
-### In scope
-- Tokio-only
-- local JSON run output
-- request macro
-- stage and queue wrappers
-- in-flight guard
-- runtime sampler
-- analyzer CLI
-- two demo services
-- benchmark scripts
-- docs
-
-### Out of scope
-- tracing backend
-- metrics backend
-- distributed tracing
-- live UI
-- OpenTelemetry
-- Prometheus
-- eBPF
-- auto-remediation
-- ML diagnosis
-- multi-service diagnosis
-
-## Milestones
-
-## M0 — Repository bootstrap
-Goal:
-- workspace exists
-- CI exists
-- docs define the product clearly
-
-Deliverables:
-- workspace skeleton
-- fmt/clippy/test GitHub Actions
-- README
-- AGENTS
-- plans/spec docs
-
-Exit criteria:
-- repo builds
-- CI passes
-- docs are coherent
-
-## M1 — `tailtriage-core`
-Goal:
-- core instrumentation primitives exist
-
-Deliverables:
-- `Tailtriage::init`
-- `Config`
-- `request(...)`
-- `inflight(...)`
-- `queue(...).await_on(...)`
-- `stage(...).await_on(...)`
-- local JSON sink/collector
-
-Exit criteria:
-- example code compiles
-- unit tests pass
-- basic event aggregation works
-
-## M2 — request macro
-Goal:
-- easiest integration path exists
-
-Deliverables:
-- `#[instrument_request(...)]`
-- minimal metadata support
-- skip fields support or equivalent
-- docs/examples
-
-Exit criteria:
-- one handler can be instrumented with macro only
-- request timing appears in output
-
-## M3 — `tailtriage-tokio`
-Goal:
-- runtime context is available
-
-Deliverables:
-- Tokio runtime sampler
-- periodic snapshots
-- queue depth / alive tasks / blocking metrics where available
-- JSON export integration
-
-Exit criteria:
-- runtime snapshots collected during a run
-- tests validate snapshot serialization and shape
-
-## M4 — `tailtriage-cli`
-Goal:
-- turn collected data into a diagnosis report
-
-Deliverables:
-- `tailtriage analyze`
-- p50/p95/p99 computation
-- queue/service share computation
-- initial diagnosis rules
-- text + JSON output
-
-Initial diagnosis families:
-- application-level queue saturation
-- blocking-pool pressure
-- executor pressure suspected
-- downstream stage dominates
-- insufficient evidence
-
-Exit criteria:
-- CLI works on fixture data
-- diagnosis tests pass
-
-## M5 — demo services
-Goal:
-- prove the tool finds real pathologies
-
-Deliverables:
-- queue/backpressure demo
-- blocking contamination demo
-- load scripts
-- sample outputs
-
-Exit criteria:
-- each demo produces a useful diagnosis
-- at least one fix improves behavior
-
-## M6 — runtime cost and polish
-Goal:
-- make the MVP presentable and honest
-
-Deliverables:
-- light mode overhead measurements
-- investigation mode overhead measurements
-- docs on cost and trade-offs
-- cleaned README/examples
-
-Exit criteria:
-- runtime cost documented with measured evidence
-- docs ready for external readers
-
-## Guiding constraints
-
-- Small PRs
-- No casual scope expansion
-- Keep the integration ergonomic
-- Prefer explicitness over magic
-- Use existing ecosystem primitives where sensible
-- Measure before making performance claims
-
-## Diagnosis philosophy
-
-The analyzer should output:
-- one primary suspect
-- optional secondary suspects
-- supporting evidence
-- recommended next checks
-
-The analyzer should not output:
-- fake certainty
-- causal claims
-- overconfident root-cause declarations
-
-## Minimum acceptance for MVP
-
-The MVP is successful if:
-
-1. a developer can integrate it into a small Tokio service quickly
-2. the queue/backpressure demo is correctly diagnosed
-3. the blocking contamination demo is correctly diagnosed
-4. the report is readable and useful
-5. light mode has acceptable measured overhead
-6. the docs make the integration and limits clear
-
-## Stretch goals after MVP
-
-Only after MVP is solid:
-- HTTP layer integration helpers
-- richer labels/fields
-- optional sampled tracing mode
-- nicer report formatting
-- improved rule ranking
-- additional demo scenarios
-
+1. product category is obvious quickly: Tokio tail-latency triage
+2. target user is explicit: ordinary Rust/Tokio developers
+3. docs clearly explain complementarity with tokio-console/tokio-metrics style tools
+4. wording consistently states suspects are evidence-ranked leads, not proof
+5. no scope expansion beyond the current MVP

--- a/README.md
+++ b/README.md
@@ -1,45 +1,51 @@
 # tailtriage
 
-`tailtriage` is a Rust toolkit for **tail-latency triage** in Tokio services.
+`tailtriage` is a Rust toolkit for **Tokio tail-latency triage**.
 
-It is built for one practical question:
+It is built for ordinary Rust/Tokio developers who need a useful first answer without being expert performance engineers.
+
+Core question:
 
 > Is this request path slow because of **application queueing**, **executor pressure**, **blocking-pool pressure**, or a **slow downstream stage**?
 
 ## What it is
 
-`tailtriage` helps ordinary Rust developers get a useful first diagnosis without having to read raw runtime metrics or think like a performance engineer.
+`tailtriage` is an interpretation-first diagnosis layer:
 
-It does this by:
+- capture one local run artifact from lightweight request, queue, stage, and runtime instrumentation
+- analyze it into evidence-ranked suspects
+- get concrete next checks for the highest-ranked suspect
+- compare before/after runs to keep diagnosis reproducible
 
-- capturing one local run artifact from lightweight request, queue, stage, and runtime instrumentation
-- ranking likely bottleneck suspects
-- showing evidence for that ranking
-- suggesting the next checks to run
-- keeping diagnosis reproducible: capture -> analyze -> compare before/after
+Workflow in one line: **capture -> analyze -> choose next check -> re-run**.
+
+## Who it is for
+
+- developers shipping Tokio services
+- teams with latency/backpressure incidents but limited perf-engineering bandwidth
+- people who want a fast local triage loop before adopting heavier observability workflows
+
+## Why not just use tokio-console or tokio-metrics?
+
+Those tools are valuable and complementary:
+
+- **Live debugger/console tools** (for example `tokio-console`) are great for interactive inspection and runtime/task debugging.
+- **Raw metrics libraries** (for example `tokio-metrics`) are great for exposing runtime/task measurements.
+- **General observability stacks** are great when you need broad telemetry storage, querying, and cross-service operations.
+
+`tailtriage` is different: it focuses on a first useful **triage** answer from a small, local run artifact by ranking suspects and recommending next checks. It is not trying to replace those tools.
 
 ## What it is not
 
-`tailtriage` is **not** a live debugger, metrics backend, or general observability stack.
+`tailtriage` is intentionally **not**:
 
-If you want raw runtime/task data or an interactive debugging UI, tools like `tokio-console`, `tokio-metrics`, and `dial9-tokio-telemetry` already cover those areas well. `tailtriage` is the interpretation layer on top: a focused tool for turning a small amount of instrumentation into an actionable bottleneck hypothesis. :contentReference[oaicite:0]{index=0}
+- a live debugging console
+- a generalized telemetry/export platform
+- an observability backend
+- a distributed tracing system
+- an automated root-cause proof engine
 
-## Why it is useful
-
-- **Focused on triage:** ranks likely suspects instead of just surfacing telemetry
-- **Usable with partial instrumentation:** start with a few key waits/stages and improve coverage over time
-- **Low-friction workflow:** one run artifact, one CLI analysis step
-- **Honest output:** suspects are evidence-ranked leads, not proof of root cause
-- **Made for non-experts:** useful hints first, deeper investigation second
-
-## Best fit
-
-`tailtriage` is a good fit when:
-
-- you run a Tokio service
-- you have a tail-latency or backpressure problem
-- you want a fast, local, reproducible answer
-- you do **not** want to start with a full observability platform
+Outputs are evidence-ranked leads, not proof of causality.
 
 ## Current scope
 
@@ -108,6 +114,7 @@ Start with:
 
 - `primary_suspect.kind`
 - `primary_suspect.evidence[]`
+- `primary_suspect.next_checks[]`
 - `p95_queue_share_permille`
 - `p95_service_share_permille`
 
@@ -123,7 +130,7 @@ Start with:
 ## Scope and limitations (MVP)
 
 - Tokio-only runtime support.
-- Single-process diagnosis (no distributed correlation).
+- Single-process triage (no distributed correlation).
 - Rule-based suspect ranking with evidence (not proof of root cause).
 
 ## Documentation

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,30 +1,36 @@
 # SPEC.md
 
-Implementation contract for the `tailtriage` MVP.
+Product contract for the `tailtriage` triage MVP.
 
 ## 1. Product summary
 
-`tailtriage` is a Rust toolkit for diagnosing tail-latency, queueing, and backpressure problems in Tokio services.
+`tailtriage` is a Rust toolkit for **Tokio tail-latency triage**.
 
 Primary question:
 
-> Given one instrumented run, what is the strongest suspect: application queueing, executor pressure, blocking-pool pressure, or downstream stage latency?
+> Given one instrumented run, what is the strongest evidence-ranked bottleneck suspect (application queueing, executor pressure, blocking-pool pressure, or downstream stage latency), and what should we check next?
 
-## 2. Goals
+This product is interpretation-first: provide a useful first answer for ordinary developers, then guide deeper investigation.
+
+## 2. Product goals
 
 The MVP must:
 
-1. be easy to integrate
-2. remain useful with partial instrumentation
-3. produce a clear diagnosis report
-4. be honest about uncertainty
-5. measure runtime cost with reproducible scripts
+1. be easy to integrate into existing Tokio services
+2. produce useful output for non-experts with partial instrumentation
+3. emit ranked suspects with supporting evidence and actionable next checks
+4. stay explicit that suspects are leads, not root-cause proof
+5. support reproducible before/after diagnosis from comparable runs
+6. measure runtime cost with reproducible scripts
 
 ## 3. Non-goals
 
 MVP does **not** include:
 
-- distributed tracing backend
+- live debugging console
+- generalized telemetry/export platform
+- observability backend
+- distributed tracing system
 - metrics backend/exporter
 - GUI/web UI
 - OpenTelemetry exporter
@@ -32,6 +38,7 @@ MVP does **not** include:
 - eBPF integration
 - non-Tokio runtime support
 - auto-remediation or ML root-cause engine
+- automated proof claims of causality
 
 ## 4. Workspace layout
 
@@ -154,7 +161,7 @@ Supported arguments:
 - `inflight`
 - `runtime_snapshots`
 
-Each section captures timestamped events/snapshots used by the CLI diagnosis rules.
+Each section captures timestamped events/snapshots used by the CLI triage rules.
 
 ## 7. Analyzer CLI (`tailtriage-cli`)
 
@@ -184,7 +191,7 @@ Canonical invocation for demo validation and runtime-cost measurement is **Pytho
 - `scripts/*.py` are the source-of-truth implementations.
 - Required runtime dependencies for script workflows: `python3` and `cargo`.
 
-## 8. Diagnosis categories
+## 8. Suspect categories
 
 MVP categories:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,13 +5,13 @@ Use this page as the single entry point for project documentation.
 ## Start here
 
 - **First use / integration:** [user-guide.md](user-guide.md)
-- **How diagnosis works:** [diagnostics.md](diagnostics.md)
+- **How triage analysis works:** [diagnostics.md](diagnostics.md)
 
 ## Core references
 
 - **Architecture and crate responsibilities:** [architecture.md](architecture.md)
-- **MVP product contract:** [../SPEC.md](../SPEC.md)
-- **Implementation roadmap:** [../IMPLEMENTATION_PLAN.md](../IMPLEMENTATION_PLAN.md)
+- **MVP product contract (Tokio tail-latency triage):** [../SPEC.md](../SPEC.md)
+- **Release/polish plan:** [../IMPLEMENTATION_PLAN.md](../IMPLEMENTATION_PLAN.md)
 
 ## Reproducibility and operations
 
@@ -29,3 +29,4 @@ Use this page as the single entry point for project documentation.
 - `demos/*/artifacts/` = generated, untracked outputs.
 - `demos/*/fixtures/` = committed reference snapshots used for deterministic validation.
 - Suspects are evidence-ranked leads, not causal proof.
+- Prefer triage language for product/category descriptions.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,6 +1,6 @@
 # Diagnostics guide
 
-This document explains what `tailtriage analyze` reports and how to use it.
+This document explains how `tailtriage analyze` produces a triage report and how to use it.
 
 ## Report contents
 
@@ -68,12 +68,13 @@ When present:
 
 Positive growth means in-flight work accumulated during the run.
 
-## Practical workflow
+## Practical triage workflow
 
 1. Capture one run.
 2. Analyze and inspect primary suspect evidence.
-3. Change one thing.
-4. Re-run under comparable load.
-5. Compare p95 shares and suspect evidence.
+3. Run the suggested next check for that suspect.
+4. Change one thing.
+5. Re-run under comparable load.
+6. Compare p95 shares and suspect evidence.
 
 For reproducible before/after demo workflows, see [getting-started-demo.md](getting-started-demo.md).


### PR DESCRIPTION
### Motivation

- The repository read like a generic instrumentation/runtime project; the intent is to present a focused product: Tokio tail-latency triage for ordinary developers. 
- Docs and agent guidance needed consistent language to emphasize interpretation-first outputs (evidence-ranked suspects + next checks) and to avoid implying full observability/trace/back-end scope. 

### Description

- Reworked top-level product docs to a triage-first framing by updating `README.md` and making the core workflow and target user explicit. 
- Converted `SPEC.md` from an implementation contract to a product contract that emphasizes non-expert usability, ranked suspects with evidence, actionable next checks, and reproducible before/after diagnosis. 
- Replaced the build-roadmap tone in `IMPLEMENTATION_PLAN.md` with a release/polish plan focused on positioning, onboarding ergonomics, demo storytelling, and publishability while listing anti-goals. 
- Updated `AGENTS.md`, `docs/README.md`, and `docs/diagnostics.md` to enforce triage-first terminology and guardrails (suspects-as-leads, avoid platform-scope drift). 

### Testing

- Ran formatting, lints, and tests: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`.
- All checks passed: format check succeeded, clippy finished without warnings, and the full workspace test run completed with all unit and fixture tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd0daed9d083309f620b7ecb8ab7ff)