### PR TITLE
Add mixed_contention_service demo and baseline/mitigation validator checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "mixed_contention_service"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "tailtriage-core",
+ "tokio",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "demos/queue_service",
   "demos/blocking_service",
   "demos/downstream_service",
+  "demos/mixed_contention_service",
   "demos/runtime_cost",
 ]
 resolver = "2"

--- a/SPEC.md
+++ b/SPEC.md
@@ -213,6 +213,7 @@ Validation scripts in `scripts/` must pass for both demos.
 ### 9.1 Additional runnable proof case
 
 - `demos/downstream_service`: deterministic downstream-stage dominance scenario that should rank `DownstreamStageDominates` as the primary suspect.
+- `demos/mixed_contention_service`: deterministic mixed queue + downstream contention scenario where both suspects should be present in ranked evidence and mitigation should shift rank and/or score when one bottleneck is reduced.
 
 This demo is intentionally small and single-purpose; it extends storytelling trust without expanding MVP scope.
 

--- a/demos/mixed_contention_service/Cargo.toml
+++ b/demos/mixed_contention_service/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "mixed_contention_service"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
+tailtriage-core = { path = "../../tailtriage-core" }

--- a/demos/mixed_contention_service/fixtures/baseline-analysis.json
+++ b/demos/mixed_contention_service/fixtures/baseline-analysis.json
@@ -1,0 +1,44 @@
+{
+  "request_count": 220,
+  "p50_latency_us": 397747,
+  "p95_latency_us": 744661,
+  "p99_latency_us": 775005,
+  "p95_queue_share_permille": 980,
+  "p95_service_share_permille": 390,
+  "inflight_trend": {
+    "gauge": "mixed_contention_inflight",
+    "sample_count": 440,
+    "peak_count": 202,
+    "p95_count": 191,
+    "growth_delta": -1,
+    "growth_per_sec_milli": -1157
+  },
+  "primary_suspect": {
+    "kind": "ApplicationQueueSaturation",
+    "score": 90,
+    "confidence": "high",
+    "evidence": [
+      "Queue wait at p95 consumes 98.0% of request time.",
+      "Observed queue depth sample up to 197."
+    ],
+    "next_checks": [
+      "Inspect queue admission limits and producer burst patterns.",
+      "Compare queue wait distribution before and after increasing worker parallelism."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "DownstreamStageDominates",
+      "score": 60,
+      "confidence": "low",
+      "evidence": [
+        "Stage 'downstream_call' has p95 latency 32680 us across 220 samples.",
+        "Stage 'downstream_call' cumulative latency is 3785567 us."
+      ],
+      "next_checks": [
+        "Inspect downstream dependency behind stage 'downstream_call'.",
+        "Collect downstream service timings and retry behavior during tail windows."
+      ]
+    }
+  ]
+}

--- a/demos/mixed_contention_service/fixtures/before-after-comparison.json
+++ b/demos/mixed_contention_service/fixtures/before-after-comparison.json
@@ -1,0 +1,20 @@
+{
+  "before": {
+    "primary_suspect_kind": "ApplicationQueueSaturation",
+    "primary_suspect_score": 90,
+    "p95_latency_us": 744661,
+    "p95_queue_share_permille": 980
+  },
+  "after": {
+    "primary_suspect_kind": "DownstreamStageDominates",
+    "primary_suspect_score": 60,
+    "p95_latency_us": 34718,
+    "p95_queue_share_permille": 0
+  },
+  "delta": {
+    "primary_suspect_kind": null,
+    "primary_suspect_score": -30,
+    "p95_latency_us": -709943,
+    "p95_queue_share_permille": -980
+  }
+}

--- a/demos/mixed_contention_service/fixtures/mitigated-analysis.json
+++ b/demos/mixed_contention_service/fixtures/mitigated-analysis.json
@@ -1,0 +1,30 @@
+{
+  "request_count": 220,
+  "p50_latency_us": 14372,
+  "p95_latency_us": 34718,
+  "p99_latency_us": 34955,
+  "p95_queue_share_permille": 0,
+  "p95_service_share_permille": 1000,
+  "inflight_trend": {
+    "gauge": "mixed_contention_inflight",
+    "sample_count": 440,
+    "peak_count": 14,
+    "p95_count": 13,
+    "growth_delta": -1,
+    "growth_per_sec_milli": -2631
+  },
+  "primary_suspect": {
+    "kind": "DownstreamStageDominates",
+    "score": 60,
+    "confidence": "low",
+    "evidence": [
+      "Stage 'downstream_call' has p95 latency 32449 us across 220 samples.",
+      "Stage 'downstream_call' cumulative latency is 3769992 us."
+    ],
+    "next_checks": [
+      "Inspect downstream dependency behind stage 'downstream_call'.",
+      "Collect downstream service timings and retry behavior during tail windows."
+    ]
+  },
+  "secondary_suspects": []
+}

--- a/demos/mixed_contention_service/src/main.rs
+++ b/demos/mixed_contention_service/src/main.rs
@@ -1,0 +1,143 @@
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use tailtriage_core::{Config, RequestMeta, Tailtriage};
+use tokio::sync::Semaphore;
+
+#[derive(Clone, Copy)]
+enum DemoMode {
+    Baseline,
+    Mitigated,
+}
+
+impl DemoMode {
+    fn from_arg(value: Option<String>) -> anyhow::Result<Self> {
+        match value.as_deref() {
+            None | Some("baseline") | Some("before") => Ok(Self::Baseline),
+            Some("mitigated") | Some("after") => Ok(Self::Mitigated),
+            Some(other) => anyhow::bail!(
+                "unsupported mode '{other}', expected one of: baseline, before, mitigated, after"
+            ),
+        }
+    }
+}
+
+struct ModeSettings {
+    service_capacity: usize,
+    offered_requests: u64,
+    inter_arrival_pause_every: u64,
+    inter_arrival_delay: Duration,
+    app_stage_delay: Duration,
+    downstream_base_delay: Duration,
+    downstream_slow_delay: Duration,
+}
+
+impl ModeSettings {
+    fn for_mode(mode: DemoMode) -> Self {
+        match mode {
+            DemoMode::Baseline => Self {
+                service_capacity: 5,
+                offered_requests: 220,
+                inter_arrival_pause_every: 6,
+                inter_arrival_delay: Duration::from_millis(1),
+                app_stage_delay: Duration::from_millis(1),
+                downstream_base_delay: Duration::from_millis(11),
+                downstream_slow_delay: Duration::from_millis(20),
+            },
+            DemoMode::Mitigated => Self {
+                service_capacity: 14,
+                offered_requests: 220,
+                inter_arrival_pause_every: 2,
+                inter_arrival_delay: Duration::from_millis(2),
+                app_stage_delay: Duration::from_millis(1),
+                downstream_base_delay: Duration::from_millis(11),
+                downstream_slow_delay: Duration::from_millis(20),
+            },
+        }
+    }
+}
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 2)]
+async fn main() -> anyhow::Result<()> {
+    let mut args = std::env::args().skip(1);
+    let output_path = args.next().map(PathBuf::from).unwrap_or_else(|| {
+        PathBuf::from("demos/mixed_contention_service/artifacts/mixed-contention-run.json")
+    });
+    let mode = DemoMode::from_arg(args.next())?;
+    let settings = ModeSettings::for_mode(mode);
+
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create artifact directory {}", parent.display()))?;
+    }
+
+    let mut config = Config::new("mixed_contention_service_demo");
+    config.output_path = output_path.clone();
+    let tailtriage = Arc::new(Tailtriage::init(config)?);
+
+    let semaphore = Arc::new(Semaphore::new(settings.service_capacity));
+    let waiting_depth = Arc::new(AtomicU64::new(0));
+
+    let mut tasks = Vec::with_capacity(settings.offered_requests as usize);
+
+    for request_number in 0..settings.offered_requests {
+        let tailtriage = Arc::clone(&tailtriage);
+        let semaphore = Arc::clone(&semaphore);
+        let waiting_depth = Arc::clone(&waiting_depth);
+
+        tasks.push(tokio::spawn(async move {
+            let request_id = format!("request-{request_number}");
+            let meta = RequestMeta::new(request_id.clone(), "/mixed-contention-demo");
+
+            tailtriage
+                .request(meta, "ok", async {
+                    let _inflight = tailtriage.inflight("mixed_contention_inflight");
+
+                    let depth = waiting_depth.fetch_add(1, Ordering::SeqCst) + 1;
+                    let permit = tailtriage
+                        .queue(request_id.clone(), "worker_permit")
+                        .with_depth_at_start(depth)
+                        .await_on(semaphore.acquire())
+                        .await
+                        .expect("semaphore should remain open");
+                    waiting_depth.fetch_sub(1, Ordering::SeqCst);
+
+                    let _permit = permit;
+
+                    tailtriage
+                        .stage(request_id.clone(), "app_prepare")
+                        .await_value(tokio::time::sleep(settings.app_stage_delay))
+                        .await;
+
+                    let extra_downstream = if request_number % 4 == 0 {
+                        settings.downstream_slow_delay
+                    } else {
+                        Duration::ZERO
+                    };
+                    tailtriage
+                        .stage(request_id, "downstream_call")
+                        .await_value(tokio::time::sleep(
+                            settings.downstream_base_delay + extra_downstream,
+                        ))
+                        .await;
+                })
+                .await;
+        }));
+
+        if request_number % settings.inter_arrival_pause_every == 0 {
+            tokio::time::sleep(settings.inter_arrival_delay).await;
+        }
+    }
+
+    for task in tasks {
+        task.await.context("request task panicked")?;
+    }
+
+    tailtriage.flush()?;
+    println!("wrote {}", output_path.display());
+
+    Ok(())
+}

--- a/docs/getting-started-demo.md
+++ b/docs/getting-started-demo.md
@@ -18,6 +18,9 @@ python3 scripts/demo_tool.py validate blocking
 
 python3 scripts/demo_tool.py run downstream
 python3 scripts/demo_tool.py validate downstream
+
+python3 scripts/demo_tool.py run mixed
+python3 scripts/demo_tool.py validate mixed
 ```
 
 ## What each demo demonstrates
@@ -27,6 +30,15 @@ python3 scripts/demo_tool.py validate downstream
 | `queue_service` | application queueing pressure | `primary_suspect.kind`, `p95_queue_share_permille`, suspect evidence |
 | `blocking_service` | blocking-pool pressure | `primary_suspect.kind`, blocking-related evidence, p95 shares |
 | `downstream_service` | downstream-stage dominance | `primary_suspect.kind`, `p95_service_share_permille`, suspect evidence |
+| `mixed_contention_service` | queue + downstream contention together | baseline includes both suspects; mitigation should shift rank and/or score |
+
+## Mixed-contention expected rank behavior
+
+- Baseline profile intentionally keeps both contention sources visible in report evidence:
+  - application queue saturation from semaphore worker limits
+  - downstream-stage latency from a deterministic slow-stage ratio
+- One of these is expected to be the primary suspect, and the other should appear in the ranked suspects list.
+- Mitigation profile reduces one bottleneck (worker-limit queueing), and validation expects a rank/score shift in the primary suspect.
 
 ## If local results differ from fixtures
 

--- a/scripts/demo_tool.py
+++ b/scripts/demo_tool.py
@@ -319,6 +319,16 @@ def validate_mixed(root_dir: Path) -> None:
         "baseline score={} mitigated score={}".format(
             baseline_primary,
             after_primary,
+            before_score,
+            after_score,
+        )
+    )
+    print(
+        "validated analysis files: "
+        f"{artifact_dir / 'before-analysis.json'}, {artifact_dir / 'after-analysis.json'}"
+    )
+
+
 def _contains_blocking_depth_evidence(report: dict) -> bool:
     suspect = report.get("primary_suspect") or {}
     evidence = suspect.get("evidence") or []
@@ -401,7 +411,7 @@ def main(argv: list[str] | None = None) -> None:
         elif args.scenario == "blocking":
             run_scenario_blocking(root_dir, args.mode)
         elif args.scenario == "downstream":
-          if args.mode != "both":
+            if args.mode != "both":
                 raise SystemExit("downstream scenario does not accept mode; use --artifact-path if needed")
             run_scenario_downstream(root_dir, args.artifact_path)
         elif args.scenario == "executor":
@@ -415,9 +425,9 @@ def main(argv: list[str] | None = None) -> None:
     elif args.scenario == "blocking":
         validate_blocking(root_dir)
     elif args.scenario == "downstream":
-        validate_downstream(root_dir)  
+        validate_downstream(root_dir)
     elif args.scenario == "executor":
-        validate_executor(root_dir)        
+        validate_executor(root_dir)
     else:
         validate_mixed(root_dir)
 

--- a/scripts/demo_tool.py
+++ b/scripts/demo_tool.py
@@ -19,6 +19,7 @@ from _demo_runner import (
 EXPECTED_QUEUE_KIND = {"application_queue_saturation", "ApplicationQueueSaturation"}
 EXPECTED_BLOCKING_KIND = {"blocking_pool_pressure", "BlockingPoolPressure"}
 EXPECTED_DOWNSTREAM_KIND = {"downstream_stage_dominates", "DownstreamStageDominates"}
+EXPECTED_MIXED_PRIMARY_KINDS = EXPECTED_QUEUE_KIND | EXPECTED_DOWNSTREAM_KIND
 MODE_CHOICES = ["before", "after", "both", "baseline", "mitigated"]
 
 
@@ -126,6 +127,21 @@ def run_scenario_downstream(root_dir: Path, artifact_path: str | None) -> None:
     )
     print(f"run artifact: {run_path}")
     print(f"analysis: {analysis_path}")
+
+
+def run_scenario_mixed(root_dir: Path, mode: str) -> None:
+    run_before_after_scenario(
+        root_dir,
+        root_dir / "demos/mixed_contention_service/Cargo.toml",
+        root_dir / "demos/mixed_contention_service/artifacts",
+        mode,
+        snapshot_queue,
+    )
+
+
+def has_suspect_kind(report: dict, expected_kinds: set[str]) -> bool:
+    all_suspects = [report["primary_suspect"], *(report.get("secondary_suspects") or [])]
+    return any(suspect.get("kind") in expected_kinds for suspect in all_suspects)
 
 
 def validate_queue(root_dir: Path) -> None:
@@ -251,12 +267,62 @@ def validate_downstream(root_dir: Path) -> None:
     print(f"validated analysis file: {analysis_path}")
 
 
+def validate_mixed(root_dir: Path) -> None:
+    run_scenario_mixed(root_dir, "both")
+    artifact_dir = root_dir / "demos/mixed_contention_service/artifacts"
+    before = load_report_json(artifact_dir / "before-analysis.json")
+    after = load_report_json(artifact_dir / "after-analysis.json")
+
+    baseline_primary = before["primary_suspect"]["kind"]
+    if baseline_primary not in EXPECTED_MIXED_PRIMARY_KINDS:
+        raise SystemExit(
+            "expected baseline primary suspect to be queue or downstream, "
+            f"got {baseline_primary}"
+        )
+
+    if baseline_primary in EXPECTED_QUEUE_KIND:
+        expected_secondary = EXPECTED_DOWNSTREAM_KIND
+    else:
+        expected_secondary = EXPECTED_QUEUE_KIND
+
+    if not has_suspect_kind(before, expected_secondary):
+        raise SystemExit(
+            "expected baseline report to include secondary contention source, "
+            f"missing one of {sorted(expected_secondary)}"
+        )
+
+    after_primary = after["primary_suspect"]["kind"]
+    before_score = before["primary_suspect"]["score"]
+    after_score = after["primary_suspect"]["score"]
+    rank_shifted = after_primary != baseline_primary
+    score_shifted = after_score != before_score
+    if not (rank_shifted or score_shifted):
+        raise SystemExit(
+            "expected mitigation to shift rank or score for the primary suspect, "
+            f"got kind {baseline_primary}->{after_primary}, score {before_score}->{after_score}"
+        )
+
+    print(
+        "validation passed: baseline primary={}, mitigated primary={}, "
+        "baseline score={} mitigated score={}".format(
+            baseline_primary,
+            after_primary,
+            before_score,
+            after_score,
+        )
+    )
+    print(
+        "validated analysis files: "
+        f"{artifact_dir / 'before-analysis.json'}, {artifact_dir / 'after-analysis.json'}"
+    )
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Unified tailtriage demo run/validate tool.")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     run_parser = subparsers.add_parser("run", help="Run demo scenario and produce analysis artifacts")
-    run_parser.add_argument("scenario", choices=["queue", "blocking", "downstream"])
+    run_parser.add_argument("scenario", choices=["queue", "blocking", "downstream", "mixed"])
     run_parser.add_argument(
         "mode",
         nargs="?",
@@ -270,7 +336,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
 
     validate_parser = subparsers.add_parser("validate", help="Run scenario validation contract checks")
-    validate_parser.add_argument("scenario", choices=["queue", "blocking", "downstream"])
+    validate_parser.add_argument("scenario", choices=["queue", "blocking", "downstream", "mixed"])
 
     return parser.parse_args(argv)
 
@@ -284,18 +350,22 @@ def main(argv: list[str] | None = None) -> None:
             run_scenario_queue(root_dir, args.mode)
         elif args.scenario == "blocking":
             run_scenario_blocking(root_dir, args.mode)
-        else:
+        elif args.scenario == "downstream":
             if args.mode != "both":
                 raise SystemExit("downstream scenario does not accept mode; use --artifact-path if needed")
             run_scenario_downstream(root_dir, args.artifact_path)
+        else:
+            run_scenario_mixed(root_dir, args.mode)
         return
 
     if args.scenario == "queue":
         validate_queue(root_dir)
     elif args.scenario == "blocking":
         validate_blocking(root_dir)
-    else:
+    elif args.scenario == "downstream":
         validate_downstream(root_dir)
+    else:
+        validate_mixed(root_dir)
 
 
 if __name__ == "__main__":

--- a/scripts/demo_tool.py
+++ b/scripts/demo_tool.py
@@ -140,8 +140,9 @@ def run_scenario_mixed(root_dir: Path, mode: str) -> None:
 
 
 def has_suspect_kind(report: dict, expected_kinds: set[str]) -> bool:
-    all_suspects = [report["primary_suspect"], *(report.get("secondary_suspects") or [])]
-    return any(suspect.get("kind") in expected_kinds for suspect in all_suspects)
+    primary = report.get("primary_suspect") or {}
+    all_suspects = [primary, *(report.get("secondary_suspects") or [])]
+    return any((suspect or {}).get("kind") in expected_kinds for suspect in all_suspects)
 
 
 def validate_queue(root_dir: Path) -> None:

--- a/scripts/tests/test_demo_scripts.py
+++ b/scripts/tests/test_demo_scripts.py
@@ -55,6 +55,14 @@ class DemoWrapperTests(unittest.TestCase):
         self.assertEqual(args.scenario, "mixed")
         self.assertEqual(args.mode, "baseline")
 
+    def test_has_suspect_kind_handles_missing_primary(self) -> None:
+        report = {
+            "secondary_suspects": [{"kind": "downstream_stage_dominates"}],
+        }
+
+        self.assertTrue(has_suspect_kind(report, {"downstream_stage_dominates"}))
+        self.assertFalse(has_suspect_kind(report, {"application_queue_saturation"}))
+
     def test_has_suspect_kind_checks_primary_and_secondary(self) -> None:
         report = {
             "primary_suspect": {"kind": "application_queue_saturation"},

--- a/scripts/tests/test_demo_scripts.py
+++ b/scripts/tests/test_demo_scripts.py
@@ -13,7 +13,7 @@ SCRIPTS_DIR = REPO_ROOT / "scripts"
 
 sys.path.insert(0, str(SCRIPTS_DIR))
 
-from demo_tool import parse_args  # noqa: E402
+from demo_tool import has_suspect_kind, parse_args  # noqa: E402
 from run_downstream_demo import build_argv  # noqa: E402
 
 
@@ -48,6 +48,22 @@ class DemoWrapperTests(unittest.TestCase):
         self.assertEqual(args.command, "run")
         self.assertEqual(args.scenario, "downstream")
         self.assertEqual(args.artifact_path, "custom-run.json")
+
+    def test_parse_args_accepts_mixed_scenario(self) -> None:
+        args = parse_args(["run", "mixed", "baseline"])
+        self.assertEqual(args.command, "run")
+        self.assertEqual(args.scenario, "mixed")
+        self.assertEqual(args.mode, "baseline")
+
+    def test_has_suspect_kind_checks_primary_and_secondary(self) -> None:
+        report = {
+            "primary_suspect": {"kind": "application_queue_saturation"},
+            "secondary_suspects": [{"kind": "downstream_stage_dominates"}],
+        }
+
+        self.assertTrue(has_suspect_kind(report, {"application_queue_saturation"}))
+        self.assertTrue(has_suspect_kind(report, {"downstream_stage_dominates"}))
+        self.assertFalse(has_suspect_kind(report, {"blocking_pool_pressure"}))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Provide a deterministic demo that combines application queue contention and downstream-stage latency so both suspects appear in analysis evidence while one is primary.
- Enable an automated validation that checks mitigation changes rank/score to demonstrate reproducible before/after diagnosis behavior.

### Description
- Add a new demo crate at `demos/mixed_contention_service` that uses a semaphore-limited worker pool plus a downstream-stage delay ratio and exposes `baseline`/`mitigated` modes via `src/main.rs` and `Cargo.toml`.
- Commit representative fixture analyses under `demos/mixed_contention_service/fixtures` (`baseline-analysis.json`, `mitigated-analysis.json`, `before-after-comparison.json`) capturing expected primary/secondary suspects.
- Extend `scripts/demo_tool.py` to support `run mixed` and `validate mixed`, add `has_suspect_kind` helper, and implement mixed-demo validator logic that asserts the baseline primary is queue or downstream, the other source appears as a secondary suspect, and mitigation changes primary `score` or rank.
- Add Python unit tests in `scripts/tests/test_demo_scripts.py` for mixed scenario arg parsing and the suspect-kind helper, and update `docs/getting-started-demo.md` and `SPEC.md` to document the new demo and expected rank-shift behavior, and register the demo in the workspace `Cargo.toml`.

### Testing
- Ran `cargo fmt --check` (passed).
- Ran `cargo clippy --workspace --all-targets -- -D warnings` (passed).
- Ran `cargo test --workspace` (all Rust tests passed).
- Ran Python unit tests `python3 -m unittest scripts/tests/test_demo_scripts.py` (passed).
- Executed `python3 scripts/demo_tool.py validate mixed` which runs the demo variants, analyzes artifacts, and the mixed-demo validator passed (baseline primary was queue, mitigated primary switched to downstream and score changed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd1132cae48330a924effee083c644)