### PR TITLE
Add cold-start burst demo with before/after validation flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ target
 # Demo run artifacts
 demos/queue_service/artifacts/*.json
 demos/blocking_service/artifacts/*.json
+demos/cold_start_burst_service/artifacts/*.json
 demos/runtime_cost/artifacts/*.json
 demos/runtime_cost/artifacts/*.jsonl

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cold-start-burst-service-demo"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "tailtriage-core",
+ "tokio",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "demos/queue_service",
   "demos/blocking_service",
   "demos/downstream_service",
+  "demos/cold_start_burst_service",
   "demos/runtime_cost",
 ]
 resolver = "2"

--- a/demos/cold_start_burst_service/Cargo.toml
+++ b/demos/cold_start_burst_service/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "cold-start-burst-service-demo"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
+tailtriage-core = { path = "../../tailtriage-core" }

--- a/demos/cold_start_burst_service/fixtures/after-analysis.json
+++ b/demos/cold_start_burst_service/fixtures/after-analysis.json
@@ -1,0 +1,30 @@
+{
+  "request_count": 220,
+  "p50_latency_us": 9319,
+  "p95_latency_us": 10009,
+  "p99_latency_us": 10431,
+  "p95_queue_share_permille": 0,
+  "p95_service_share_permille": 999,
+  "inflight_trend": {
+    "gauge": "cold_start_inflight",
+    "sample_count": 440,
+    "peak_count": 8,
+    "p95_count": 6,
+    "growth_delta": -1,
+    "growth_per_sec_milli": -2481
+  },
+  "primary_suspect": {
+    "kind": "DownstreamStageDominates",
+    "score": 60,
+    "confidence": "low",
+    "evidence": [
+      "Stage 'dependency_call' has p95 latency 9983 us across 220 samples.",
+      "Stage 'dependency_call' cumulative latency is 2043309 us."
+    ],
+    "next_checks": [
+      "Inspect downstream dependency behind stage 'dependency_call'.",
+      "Collect downstream service timings and retry behavior during tail windows."
+    ]
+  },
+  "secondary_suspects": []
+}

--- a/demos/cold_start_burst_service/fixtures/before-analysis.json
+++ b/demos/cold_start_burst_service/fixtures/before-analysis.json
@@ -1,0 +1,44 @@
+{
+  "request_count": 220,
+  "p50_latency_us": 679893,
+  "p95_latency_us": 796339,
+  "p99_latency_us": 804466,
+  "p95_queue_share_permille": 988,
+  "p95_service_share_permille": 503,
+  "inflight_trend": {
+    "gauge": "cold_start_inflight",
+    "sample_count": 440,
+    "peak_count": 220,
+    "p95_count": 209,
+    "growth_delta": -1,
+    "growth_per_sec_milli": -1114
+  },
+  "primary_suspect": {
+    "kind": "ApplicationQueueSaturation",
+    "score": 90,
+    "confidence": "high",
+    "evidence": [
+      "Queue wait at p95 consumes 98.8% of request time.",
+      "Observed queue depth sample up to 214."
+    ],
+    "next_checks": [
+      "Inspect queue admission limits and producer burst patterns.",
+      "Compare queue wait distribution before and after increasing worker parallelism."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "DownstreamStageDominates",
+      "score": 60,
+      "confidence": "low",
+      "evidence": [
+        "Stage 'dependency_call' has p95 latency 91453 us across 220 samples.",
+        "Stage 'dependency_call' cumulative latency is 5327927 us."
+      ],
+      "next_checks": [
+        "Inspect downstream dependency behind stage 'dependency_call'.",
+        "Collect downstream service timings and retry behavior during tail windows."
+      ]
+    }
+  ]
+}

--- a/demos/cold_start_burst_service/fixtures/sample-analysis.json
+++ b/demos/cold_start_burst_service/fixtures/sample-analysis.json
@@ -1,0 +1,44 @@
+{
+  "request_count": 220,
+  "p50_latency_us": 679893,
+  "p95_latency_us": 796339,
+  "p99_latency_us": 804466,
+  "p95_queue_share_permille": 988,
+  "p95_service_share_permille": 503,
+  "inflight_trend": {
+    "gauge": "cold_start_inflight",
+    "sample_count": 440,
+    "peak_count": 220,
+    "p95_count": 209,
+    "growth_delta": -1,
+    "growth_per_sec_milli": -1114
+  },
+  "primary_suspect": {
+    "kind": "ApplicationQueueSaturation",
+    "score": 90,
+    "confidence": "high",
+    "evidence": [
+      "Queue wait at p95 consumes 98.8% of request time.",
+      "Observed queue depth sample up to 214."
+    ],
+    "next_checks": [
+      "Inspect queue admission limits and producer burst patterns.",
+      "Compare queue wait distribution before and after increasing worker parallelism."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "DownstreamStageDominates",
+      "score": 60,
+      "confidence": "low",
+      "evidence": [
+        "Stage 'dependency_call' has p95 latency 91453 us across 220 samples.",
+        "Stage 'dependency_call' cumulative latency is 5327927 us."
+      ],
+      "next_checks": [
+        "Inspect downstream dependency behind stage 'dependency_call'.",
+        "Collect downstream service timings and retry behavior during tail windows."
+      ]
+    }
+  ]
+}

--- a/demos/cold_start_burst_service/src/main.rs
+++ b/demos/cold_start_burst_service/src/main.rs
@@ -1,0 +1,139 @@
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use tailtriage_core::{Config, RequestMeta, Tailtriage};
+use tokio::sync::Semaphore;
+
+#[derive(Clone, Copy)]
+enum DemoMode {
+    Baseline,
+    Mitigated,
+}
+
+impl DemoMode {
+    fn from_arg(value: Option<String>) -> anyhow::Result<Self> {
+        match value.as_deref() {
+            None | Some("baseline") | Some("before") => Ok(Self::Baseline),
+            Some("mitigated") | Some("after") => Ok(Self::Mitigated),
+            Some(other) => anyhow::bail!(
+                "unsupported mode '{other}', expected one of: baseline, before, mitigated, after"
+            ),
+        }
+    }
+}
+
+struct ModeSettings {
+    offered_requests: u64,
+    service_capacity: usize,
+    warmup_cohort: u64,
+    warmup_stage_delay: Duration,
+    steady_stage_delay: Duration,
+    inter_arrival_pause_every: u64,
+    inter_arrival_delay: Duration,
+}
+
+impl ModeSettings {
+    fn for_mode(mode: DemoMode) -> Self {
+        match mode {
+            DemoMode::Baseline => Self {
+                offered_requests: 220,
+                service_capacity: 6,
+                warmup_cohort: 40,
+                warmup_stage_delay: Duration::from_millis(90),
+                steady_stage_delay: Duration::from_millis(8),
+                inter_arrival_pause_every: 6,
+                inter_arrival_delay: Duration::from_millis(1),
+            },
+            DemoMode::Mitigated => Self {
+                offered_requests: 220,
+                service_capacity: 6,
+                warmup_cohort: 0,
+                warmup_stage_delay: Duration::from_millis(8),
+                steady_stage_delay: Duration::from_millis(8),
+                inter_arrival_pause_every: 2,
+                inter_arrival_delay: Duration::from_millis(2),
+            },
+        }
+    }
+
+    fn stage_delay_for(&self, request_number: u64) -> Duration {
+        if request_number < self.warmup_cohort {
+            self.warmup_stage_delay
+        } else {
+            self.steady_stage_delay
+        }
+    }
+}
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 2)]
+async fn main() -> anyhow::Result<()> {
+    let mut args = std::env::args().skip(1);
+    let output_path = args.next().map(PathBuf::from).unwrap_or_else(|| {
+        PathBuf::from("demos/cold_start_burst_service/artifacts/cold-start-run.json")
+    });
+    let mode = DemoMode::from_arg(args.next())?;
+    let settings = ModeSettings::for_mode(mode);
+
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create artifact directory {}", parent.display()))?;
+    }
+
+    let mut config = Config::new("cold_start_burst_service_demo");
+    config.output_path = output_path.clone();
+    let tailtriage = Arc::new(Tailtriage::init(config)?);
+
+    let semaphore = Arc::new(Semaphore::new(settings.service_capacity));
+    let waiting_depth = Arc::new(AtomicU64::new(0));
+
+    let mut tasks = Vec::with_capacity(settings.offered_requests as usize);
+
+    for request_number in 0..settings.offered_requests {
+        let tailtriage = Arc::clone(&tailtriage);
+        let semaphore = Arc::clone(&semaphore);
+        let waiting_depth = Arc::clone(&waiting_depth);
+        let stage_delay = settings.stage_delay_for(request_number);
+
+        tasks.push(tokio::spawn(async move {
+            let request_id = format!("request-{request_number}");
+            let meta = RequestMeta::new(request_id.clone(), "/cold-start-demo");
+
+            tailtriage
+                .request(meta, "ok", async {
+                    let _inflight = tailtriage.inflight("cold_start_inflight");
+
+                    let depth = waiting_depth.fetch_add(1, Ordering::SeqCst) + 1;
+                    let permit = tailtriage
+                        .queue(request_id.clone(), "admission_permit")
+                        .with_depth_at_start(depth)
+                        .await_on(semaphore.acquire())
+                        .await
+                        .expect("semaphore should remain open");
+                    waiting_depth.fetch_sub(1, Ordering::SeqCst);
+
+                    let _permit = permit;
+                    tailtriage
+                        .stage(request_id, "dependency_call")
+                        .await_value(tokio::time::sleep(stage_delay))
+                        .await;
+                })
+                .await;
+        }));
+
+        if request_number % settings.inter_arrival_pause_every == 0 {
+            tokio::time::sleep(settings.inter_arrival_delay).await;
+        }
+    }
+
+    for task in tasks {
+        task.await.context("request task panicked")?;
+    }
+
+    tailtriage.flush()?;
+    println!("wrote {}", output_path.display());
+
+    Ok(())
+}

--- a/docs/getting-started-demo.md
+++ b/docs/getting-started-demo.md
@@ -18,6 +18,9 @@ python3 scripts/demo_tool.py validate blocking
 
 python3 scripts/demo_tool.py run downstream
 python3 scripts/demo_tool.py validate downstream
+
+python3 scripts/demo_tool.py run cold-start
+python3 scripts/demo_tool.py validate cold-start
 ```
 
 ## What each demo demonstrates
@@ -27,6 +30,20 @@ python3 scripts/demo_tool.py validate downstream
 | `queue_service` | application queueing pressure | `primary_suspect.kind`, `p95_queue_share_permille`, suspect evidence |
 | `blocking_service` | blocking-pool pressure | `primary_suspect.kind`, blocking-related evidence, p95 shares |
 | `downstream_service` | downstream-stage dominance | `primary_suspect.kind`, `p95_service_share_permille`, suspect evidence |
+| `cold_start_burst_service` | cold-start burst triage (warmup + admission queueing) | `primary_suspect.kind`, `p95_*_share_permille`, warmup-stage suspect evidence |
+
+## Cold-start demo interpretation
+
+`cold_start_burst_service` includes two modes to compare diagnosis behavior:
+
+- `before` / `baseline`: the first cohort of requests has a much slower `dependency_call` stage to simulate warmup under burst load.
+- `after` / `mitigated`: warmup is pre-completed (no slow first cohort) and arrivals are more staggered.
+
+Expected interpretation:
+
+1. baseline report should rank either queue impact or warmup-driven service dominance as the leading suspect.
+2. mitigated report should show lower p95 latency and a lower primary suspect score.
+3. this is triage evidence: the suspect indicates likely pressure points, not proven root cause.
 
 ## If local results differ from fixtures
 

--- a/scripts/demo_tool.py
+++ b/scripts/demo_tool.py
@@ -19,6 +19,12 @@ from _demo_runner import (
 EXPECTED_QUEUE_KIND = {"application_queue_saturation", "ApplicationQueueSaturation"}
 EXPECTED_BLOCKING_KIND = {"blocking_pool_pressure", "BlockingPoolPressure"}
 EXPECTED_DOWNSTREAM_KIND = {"downstream_stage_dominates", "DownstreamStageDominates"}
+EXPECTED_COLD_START_KIND = {
+    "application_queue_saturation",
+    "ApplicationQueueSaturation",
+    "downstream_stage_dominates",
+    "DownstreamStageDominates",
+}
 MODE_CHOICES = ["before", "after", "both", "baseline", "mitigated"]
 
 
@@ -55,6 +61,16 @@ def snapshot_blocking(report: dict) -> dict[str, int | str | None]:
         "p95_latency_us": report["p95_latency_us"],
         "p95_service_share_permille": report.get("p95_service_share_permille"),
         "blocking_queue_depth_p95": extract_blocking_queue_depth_p95(report),
+    }
+
+
+def snapshot_cold_start(report: dict) -> dict[str, int | str | None]:
+    return {
+        "primary_suspect_kind": report["primary_suspect"]["kind"],
+        "primary_suspect_score": report["primary_suspect"]["score"],
+        "p95_latency_us": report["p95_latency_us"],
+        "p95_queue_share_permille": report.get("p95_queue_share_permille"),
+        "p95_service_share_permille": report.get("p95_service_share_permille"),
     }
 
 
@@ -126,6 +142,16 @@ def run_scenario_downstream(root_dir: Path, artifact_path: str | None) -> None:
     )
     print(f"run artifact: {run_path}")
     print(f"analysis: {analysis_path}")
+
+
+def run_scenario_cold_start(root_dir: Path, mode: str) -> None:
+    run_before_after_scenario(
+        root_dir,
+        root_dir / "demos/cold_start_burst_service/Cargo.toml",
+        root_dir / "demos/cold_start_burst_service/artifacts",
+        mode,
+        snapshot_cold_start,
+    )
 
 
 def validate_queue(root_dir: Path) -> None:
@@ -251,12 +277,74 @@ def validate_downstream(root_dir: Path) -> None:
     print(f"validated analysis file: {analysis_path}")
 
 
+def validate_cold_start(root_dir: Path) -> None:
+    run_scenario_cold_start(root_dir, "both")
+    artifact_dir = root_dir / "demos/cold_start_burst_service/artifacts"
+    before = load_report_json(artifact_dir / "before-analysis.json")
+    after = load_report_json(artifact_dir / "after-analysis.json")
+
+    kind = before["primary_suspect"]["kind"]
+    if kind not in EXPECTED_COLD_START_KIND:
+        raise SystemExit(f"expected queue/downstream suspect in baseline, got {kind}")
+
+    before_p95 = before["p95_latency_us"]
+    after_p95 = after["p95_latency_us"]
+    before_score = before["primary_suspect"]["score"]
+    after_score = after["primary_suspect"]["score"]
+
+    if after_p95 >= before_p95:
+        raise SystemExit(
+            f"expected mitigated p95 to drop, got before={before_p95}us after={after_p95}us"
+        )
+
+    if after_score >= before_score:
+        raise SystemExit(
+            f"expected mitigated suspect score to drop, got before={before_score} after={after_score}"
+        )
+
+    before_evidence = " ".join(before["primary_suspect"].get("evidence") or []).lower()
+    queue_share = before.get("p95_queue_share_permille") or 0
+    service_share = before.get("p95_service_share_permille") or 0
+    has_warmup_stage_signal = "dependency_call" in before_evidence
+    has_queue_signal = queue_share >= 200
+    has_service_signal = service_share >= 700
+
+    if not (has_warmup_stage_signal or has_queue_signal or has_service_signal):
+        raise SystemExit(
+            "expected baseline warmup-driven service/queue signal, got evidence={!r}, "
+            "p95_queue_share_permille={}, p95_service_share_permille={}".format(
+                before["primary_suspect"].get("evidence") or [],
+                before.get("p95_queue_share_permille"),
+                before.get("p95_service_share_permille"),
+            )
+        )
+
+    print(
+        "validation passed: baseline suspect kind={}, p95 {}us -> {}us, score {} -> {}, "
+        "queue-share {} -> {}, service-share {} -> {}".format(
+            kind,
+            before_p95,
+            after_p95,
+            before_score,
+            after_score,
+            before.get("p95_queue_share_permille"),
+            after.get("p95_queue_share_permille"),
+            before.get("p95_service_share_permille"),
+            after.get("p95_service_share_permille"),
+        )
+    )
+    print(
+        "validated analysis files: "
+        f"{artifact_dir / 'before-analysis.json'}, {artifact_dir / 'after-analysis.json'}"
+    )
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Unified tailtriage demo run/validate tool.")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     run_parser = subparsers.add_parser("run", help="Run demo scenario and produce analysis artifacts")
-    run_parser.add_argument("scenario", choices=["queue", "blocking", "downstream"])
+    run_parser.add_argument("scenario", choices=["queue", "blocking", "downstream", "cold-start"])
     run_parser.add_argument(
         "mode",
         nargs="?",
@@ -270,7 +358,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
 
     validate_parser = subparsers.add_parser("validate", help="Run scenario validation contract checks")
-    validate_parser.add_argument("scenario", choices=["queue", "blocking", "downstream"])
+    validate_parser.add_argument("scenario", choices=["queue", "blocking", "downstream", "cold-start"])
 
     return parser.parse_args(argv)
 
@@ -284,6 +372,8 @@ def main(argv: list[str] | None = None) -> None:
             run_scenario_queue(root_dir, args.mode)
         elif args.scenario == "blocking":
             run_scenario_blocking(root_dir, args.mode)
+        elif args.scenario == "cold-start":
+            run_scenario_cold_start(root_dir, args.mode)
         else:
             if args.mode != "both":
                 raise SystemExit("downstream scenario does not accept mode; use --artifact-path if needed")
@@ -294,6 +384,8 @@ def main(argv: list[str] | None = None) -> None:
         validate_queue(root_dir)
     elif args.scenario == "blocking":
         validate_blocking(root_dir)
+    elif args.scenario == "cold-start":
+        validate_cold_start(root_dir)
     else:
         validate_downstream(root_dir)
 

--- a/scripts/run_cold_start_demo.py
+++ b/scripts/run_cold_start_demo.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""Compatibility wrapper for cold-start demo runs."""
+
+from __future__ import annotations
+
+import sys
+
+from demo_tool import main
+
+
+if __name__ == "__main__":
+    main(["run", "cold-start", *sys.argv[1:]])

--- a/scripts/tests/test_demo_scripts.py
+++ b/scripts/tests/test_demo_scripts.py
@@ -49,6 +49,12 @@ class DemoWrapperTests(unittest.TestCase):
         self.assertEqual(args.scenario, "downstream")
         self.assertEqual(args.artifact_path, "custom-run.json")
 
+    def test_cold_start_scenario_accepts_mode_aliases(self) -> None:
+        args = parse_args(["run", "cold-start", "baseline"])
+        self.assertEqual(args.command, "run")
+        self.assertEqual(args.scenario, "cold-start")
+        self.assertEqual(args.mode, "baseline")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_demo_scripts.py
+++ b/scripts/tests/test_demo_scripts.py
@@ -23,6 +23,7 @@ class DemoWrapperTests(unittest.TestCase):
             "run_queue_demo.py",
             "run_blocking_demo.py",
             "run_downstream_demo.py",
+            "run_cold_start_demo.py",
         ]
 
         for wrapper in wrappers:

--- a/scripts/tests/test_demo_scripts.py
+++ b/scripts/tests/test_demo_scripts.py
@@ -21,9 +21,13 @@ class DemoWrapperTests(unittest.TestCase):
     def test_help_runs_for_all_demo_wrappers(self) -> None:
         wrappers = [
             "run_queue_demo.py",
+            "validate_queue_demo.py",
             "run_blocking_demo.py",
+            "validate_blocking_demo.py",
             "run_downstream_demo.py",
+            "validate_downstream_demo.py",
             "run_cold_start_demo.py",
+            "validate_cold_start_demo.py",
         ]
 
         for wrapper in wrappers:

--- a/scripts/validate_blocking_demo.py
+++ b/scripts/validate_blocking_demo.py
@@ -3,8 +3,10 @@
 
 from __future__ import annotations
 
+import sys
+
 from demo_tool import main
 
 
 if __name__ == "__main__":
-    main(["validate", "blocking"])
+    main(["validate", "blocking", *sys.argv[1:]])

--- a/scripts/validate_cold_start_demo.py
+++ b/scripts/validate_cold_start_demo.py
@@ -3,8 +3,10 @@
 
 from __future__ import annotations
 
+import sys
+
 from demo_tool import main
 
 
 if __name__ == "__main__":
-    main(["validate", "cold-start"])
+    main(["validate", "cold-start", *sys.argv[1:]])

--- a/scripts/validate_cold_start_demo.py
+++ b/scripts/validate_cold_start_demo.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""Compatibility wrapper for cold-start demo validation."""
+
+from __future__ import annotations
+
+from demo_tool import main
+
+
+if __name__ == "__main__":
+    main(["validate", "cold-start"])

--- a/scripts/validate_downstream_demo.py
+++ b/scripts/validate_downstream_demo.py
@@ -3,8 +3,10 @@
 
 from __future__ import annotations
 
+import sys
+
 from demo_tool import main
 
 
 if __name__ == "__main__":
-    main(["validate", "downstream"])
+    main(["validate", "downstream", *sys.argv[1:]])

--- a/scripts/validate_queue_demo.py
+++ b/scripts/validate_queue_demo.py
@@ -3,8 +3,10 @@
 
 from __future__ import annotations
 
+import sys
+
 from demo_tool import main
 
 
 if __name__ == "__main__":
-    main(["validate", "queue"])
+    main(["validate", "queue", *sys.argv[1:]])

--- a/tailtriage-cli/tests/demo_smoke_fixtures.rs
+++ b/tailtriage-cli/tests/demo_smoke_fixtures.rs
@@ -60,3 +60,23 @@ fn downstream_demo_fixture_reports_downstream_stage_dominance() {
         "downstream demo should prioritize downstream stage dominance"
     );
 }
+
+#[test]
+fn cold_start_demo_fixture_reports_warmup_or_queue_pressure() {
+    let report = load_demo_analysis("demos/cold_start_burst_service/fixtures/sample-analysis.json");
+    let kind = report["primary_suspect"]["kind"]
+        .as_str()
+        .unwrap_or_default();
+
+    assert!(
+        kind == "ApplicationQueueSaturation" || kind == "DownstreamStageDominates",
+        "cold-start demo should prioritize queue saturation or downstream stage dominance, got {kind}"
+    );
+    assert!(
+        report["primary_suspect"]["score"]
+            .as_u64()
+            .unwrap_or_default()
+            >= 60,
+        "cold-start demo should surface a meaningful suspect score"
+    );
+}


### PR DESCRIPTION
### Motivation
- Provide a deterministic demo that reproduces a cold-start burst pattern (slow initial cohort + steady-state) so triage behavior for warmup-driven latency can be exercised and compared against a mitigated mode. 
- Make the demo easy to run and assertable so regression checks can ensure analysis produces evidence-ranked suspects for queue vs. downstream warmup signals.

### Description
- Add a new Rust demo crate at `demos/cold_start_burst_service/` that instruments requests with a request wrapper, a queue wait around admission (`admission_permit`), and a single downstream stage `dependency_call`, with `before/baseline` (warmup cohort) and `after/mitigated` modes. 
- Wire the demo into the workspace (`Cargo.toml`) and add committed fixture snapshots under `demos/cold_start_burst_service/fixtures/` for deterministic expectations. 
- Extend `scripts/demo_tool.py` to support `run cold-start` and `validate cold-start`, including snapshotting and contract checks that baseline reports a warmup/queue signal and mitigated mode reduces p95 and the primary suspect score. 
- Add small test and docs updates: a Python unit test for CLI parsing (`scripts/tests/test_demo_scripts.py`), a CLI smoke test asserting fixture expectations (`tailtriage-cli/tests/demo_smoke_fixtures.rs`), and updated demo guidance in `docs/getting-started-demo.md`; also ignore generated cold-start artifacts in `.gitignore`.

### Testing
- Ran `python3 scripts/demo_tool.py validate cold-start` which executed both before/after runs, produced artifacts, and passed the validation checks (baseline showed queue warmup signals and after lowered p95 and suspect score). 
- Ran formatting and linting: `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings`, both completed successfully. 
- Ran the full test suite with `cargo test --workspace`, which completed with all tests passing. 
- Ran Python unit tests `python3 -m unittest scripts/tests/test_demo_scripts.py`, which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd1130056083308ce615a40fe9efe4)