### PR TITLE
Refactor demos to use shared demo_support crate and add explicit demo triage guide

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,7 @@ name = "blocking-service-demo"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "demo-support",
  "tailtriage-core",
  "tokio",
 ]
@@ -118,6 +119,7 @@ name = "cold-start-burst-service-demo"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "demo-support",
  "tailtriage-core",
  "tokio",
 ]
@@ -129,10 +131,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "demo-support"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "tailtriage-core",
+]
+
+[[package]]
 name = "downstream_service"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "demo-support",
  "tailtriage-core",
  "tokio",
 ]
@@ -142,6 +153,7 @@ name = "executor-pressure-service-demo"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "demo-support",
  "tailtriage-core",
  "tokio",
 ]
@@ -222,6 +234,7 @@ name = "mixed_contention_service"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "demo-support",
  "tailtriage-core",
  "tokio",
 ]
@@ -267,6 +280,7 @@ name = "queue-service-demo"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "demo-support",
  "tailtriage-core",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "tailtriage-tokio",
   "tailtriage-cli",
   "tailtriage-macros",
+  "demos/demo_support",
   "demos/queue_service",
   "demos/blocking_service",
   "demos/executor_pressure_service",

--- a/README.md
+++ b/README.md
@@ -136,3 +136,5 @@ Start with:
 ## Documentation
 
 For concise docs by audience, start at **[docs/README.md](docs/README.md)**.
+
+For demo-specific behavior and triage expectations, see **[demos/README.md](demos/README.md)**.

--- a/demos/README.md
+++ b/demos/README.md
@@ -1,0 +1,120 @@
+# Demo guide: what each demo does and what triage it exercises
+
+The demos are intentionally small synthetic services for Tokio tail-latency triage.
+
+Each one answers a specific triage question by producing an artifact that should drive the analyzer toward evidence-ranked suspects. Suspects are leads, not proof.
+
+## Shared ideas across all demos
+
+All service demos follow the same pattern:
+
+1. Parse output path and optional mode (`baseline`/`before`, `mitigated`/`after`).
+2. Create artifact output directory.
+3. Initialize one `Tailtriage` collector.
+4. Generate a deterministic request burst.
+5. Wrap requests with `tailtriage.request(...)`.
+6. Instrument admission queue and/or stages.
+7. Flush to JSON and run CLI analysis.
+
+Shared helper code for this setup lives in `demos/demo_support`:
+
+- `DemoMode` and mode parsing
+- common CLI argument parsing
+- artifact directory creation
+- collector initialization
+
+This keeps demo binaries focused on the triage scenario rather than boilerplate.
+
+## Demo catalog
+
+### `queue_service`
+
+**What happens**
+
+- Requests compete for a limited semaphore (`worker_permit`).
+- Baseline has tighter capacity and slower work; mitigated raises capacity and shortens work.
+
+**Triage being exercised**
+
+- Primary suspect should emphasize application queueing.
+- Evidence should reference queue depth and queue share.
+- Mitigation should reduce queue-dominant evidence and suspect score.
+
+### `blocking_service`
+
+**What happens**
+
+- Requests dispatch to `spawn_blocking` workloads.
+- Baseline constrains `max_blocking_threads` and uses longer blocking work.
+- Runtime snapshots include a synthetic `blocking_queue_depth` signal.
+
+**Triage being exercised**
+
+- Primary suspect should emphasize blocking-pool pressure.
+- Evidence should point at elevated blocking queue depth alongside request timing impact.
+- Mitigation should reduce blocking pressure evidence.
+
+### `executor_pressure_service`
+
+**What happens**
+
+- Each request fans out many hot subtasks and does repeated CPU turns with frequent scheduling.
+- Baseline uses fewer worker threads and heavier fanout.
+- Runtime snapshots capture global/local runnable depth signals.
+
+**Triage being exercised**
+
+- Primary suspect should emphasize executor pressure/runnable backlog.
+- Evidence should reference runtime queue depth and scheduling saturation patterns.
+- Mitigation should reduce runnable backlog evidence and score.
+
+### `downstream_service`
+
+**What happens**
+
+- Request flow has a tiny local precheck and a consistently slower downstream stage.
+- No intentional queue bottleneck is introduced.
+
+**Triage being exercised**
+
+- Primary suspect should emphasize downstream stage dominance.
+- Evidence should highlight stage service share (`downstream_call`) rather than admission queueing.
+
+### `mixed_contention_service`
+
+**What happens**
+
+- Requests first queue for worker admission and then call a downstream stage with periodic slow outliers.
+- Baseline keeps both contention sources visible.
+- Mitigated mode reduces admission queueing while keeping downstream behavior comparable.
+
+**Triage being exercised**
+
+- Ranked suspects should keep both queueing and downstream leads visible.
+- Primary suspect can vary by machine, but evidence should justify the rank.
+- Mitigation should shift score/rank toward the remaining bottleneck.
+
+### `cold_start_burst_service`
+
+**What happens**
+
+- Early requests pay extra warmup delay in `cold_start_stage` while a burst competes for admission.
+- Baseline has larger cold-start cohort and tighter capacity.
+- Mitigated mode reduces warmup cohort and increases admission capacity.
+
+**Triage being exercised**
+
+- Analyzer should surface queueing and/or downstream-stage warmup leads with explicit evidence.
+- Mitigation should lower p95 and reduce primary suspect score.
+
+## Typical local workflow
+
+```bash
+python3 scripts/demo_tool.py run queue
+python3 scripts/demo_tool.py validate queue
+
+python3 scripts/demo_tool.py run blocking
+python3 scripts/demo_tool.py validate blocking
+```
+
+Repeat for the remaining demos (`executor`, `downstream`, `mixed`, `cold-start`).

--- a/demos/blocking_service/Cargo.toml
+++ b/demos/blocking_service/Cargo.toml
@@ -8,3 +8,4 @@ publish = false
 anyhow = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }
 tailtriage-core = { path = "../../tailtriage-core" }
+demo-support = { path = "../demo_support" }

--- a/demos/blocking_service/src/main.rs
+++ b/demos/blocking_service/src/main.rs
@@ -4,25 +4,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context;
-use tailtriage_core::{unix_time_ms, Config, RequestMeta, RuntimeSnapshot, Tailtriage};
-
-#[derive(Clone, Copy)]
-enum DemoMode {
-    Baseline,
-    Mitigated,
-}
-
-impl DemoMode {
-    fn from_arg(value: Option<String>) -> anyhow::Result<Self> {
-        match value.as_deref() {
-            None | Some("baseline") | Some("before") => Ok(Self::Baseline),
-            Some("mitigated") | Some("after") => Ok(Self::Mitigated),
-            Some(other) => anyhow::bail!(
-                "unsupported mode '{other}', expected one of: baseline, before, mitigated, after"
-            ),
-        }
-    }
-}
+use demo_support::{init_collector, parse_demo_args, DemoMode};
+use tailtriage_core::{unix_time_ms, RequestMeta, RuntimeSnapshot};
 
 struct ModeSettings {
     offered_requests: u64,
@@ -54,18 +37,8 @@ impl ModeSettings {
 }
 
 fn main() -> anyhow::Result<()> {
-    let mut args = std::env::args().skip(1);
-    let output_path = args
-        .next()
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("demos/blocking_service/artifacts/blocking-run.json"));
-    let mode = DemoMode::from_arg(args.next())?;
-    let settings = ModeSettings::for_mode(mode);
-
-    if let Some(parent) = output_path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create artifact directory {}", parent.display()))?;
-    }
+    let args = parse_demo_args("demos/blocking_service/artifacts/blocking-run.json")?;
+    let settings = ModeSettings::for_mode(args.mode);
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(2)
@@ -74,13 +47,11 @@ fn main() -> anyhow::Result<()> {
         .build()
         .context("failed to build Tokio runtime")?;
 
-    runtime.block_on(run_demo(output_path, settings))
+    runtime.block_on(run_demo(args.output_path, settings))
 }
 
 async fn run_demo(output_path: PathBuf, settings: ModeSettings) -> anyhow::Result<()> {
-    let mut config = Config::new("blocking_service_demo");
-    config.output_path = output_path.clone();
-    let tailtriage = Arc::new(Tailtriage::init(config)?);
+    let tailtriage = init_collector("blocking_service_demo", &output_path)?;
 
     let pending_blocking = Arc::new(AtomicU64::new(0));
 

--- a/demos/cold_start_burst_service/Cargo.toml
+++ b/demos/cold_start_burst_service/Cargo.toml
@@ -8,3 +8,4 @@ publish = false
 anyhow = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
 tailtriage-core = { path = "../../tailtriage-core" }
+demo-support = { path = "../demo_support" }

--- a/demos/cold_start_burst_service/src/main.rs
+++ b/demos/cold_start_burst_service/src/main.rs
@@ -1,29 +1,11 @@
-use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context;
-use tailtriage_core::{Config, RequestMeta, Tailtriage};
+use demo_support::{init_collector, parse_demo_args, DemoMode};
+use tailtriage_core::RequestMeta;
 use tokio::sync::Semaphore;
-
-#[derive(Clone, Copy)]
-enum DemoMode {
-    Baseline,
-    Mitigated,
-}
-
-impl DemoMode {
-    fn from_arg(value: Option<String>) -> anyhow::Result<Self> {
-        match value.as_deref() {
-            None | Some("baseline") | Some("before") => Ok(Self::Baseline),
-            Some("mitigated") | Some("after") => Ok(Self::Mitigated),
-            Some(other) => anyhow::bail!(
-                "unsupported mode '{other}', expected one of: baseline, before, mitigated, after"
-            ),
-        }
-    }
-}
 
 struct ModeSettings {
     service_capacity: usize,
@@ -70,21 +52,11 @@ impl ModeSettings {
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 2)]
 async fn main() -> anyhow::Result<()> {
-    let mut args = std::env::args().skip(1);
-    let output_path = args.next().map(PathBuf::from).unwrap_or_else(|| {
-        PathBuf::from("demos/cold_start_burst_service/artifacts/cold-start-burst-run.json")
-    });
-    let mode = DemoMode::from_arg(args.next())?;
-    let settings = ModeSettings::for_mode(mode);
+    let args =
+        parse_demo_args("demos/cold_start_burst_service/artifacts/cold-start-burst-run.json")?;
+    let settings = ModeSettings::for_mode(args.mode);
 
-    if let Some(parent) = output_path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create artifact directory {}", parent.display()))?;
-    }
-
-    let mut config = Config::new("cold_start_burst_service_demo");
-    config.output_path = output_path.clone();
-    let tailtriage = Arc::new(Tailtriage::init(config)?);
+    let tailtriage = init_collector("cold_start_burst_service_demo", &args.output_path)?;
 
     let semaphore = Arc::new(Semaphore::new(settings.service_capacity));
     let waiting_depth = Arc::new(AtomicU64::new(0));
@@ -134,7 +106,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     tailtriage.flush()?;
-    println!("wrote {}", output_path.display());
+    println!("wrote {}", args.output_path.display());
 
     Ok(())
 }

--- a/demos/demo_support/Cargo.toml
+++ b/demos/demo_support/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "demo-support"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = "1"
+tailtriage-core = { path = "../../tailtriage-core" }

--- a/demos/demo_support/src/lib.rs
+++ b/demos/demo_support/src/lib.rs
@@ -1,0 +1,75 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::Context;
+use tailtriage_core::{Config, Tailtriage};
+
+/// Demo profile selector used by before/after style demo binaries.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DemoMode {
+    Baseline,
+    Mitigated,
+}
+
+impl DemoMode {
+    /// Parse a mode argument.
+    ///
+    /// Accepted values:
+    /// - `baseline` or `before`
+    /// - `mitigated` or `after`
+    ///
+    /// If omitted, defaults to `baseline`.
+    pub fn from_arg(value: Option<String>) -> anyhow::Result<Self> {
+        match value.as_deref() {
+            None | Some("baseline") | Some("before") => Ok(Self::Baseline),
+            Some("mitigated") | Some("after") => Ok(Self::Mitigated),
+            Some(other) => anyhow::bail!(
+                "unsupported mode '{other}', expected one of: baseline, before, mitigated, after"
+            ),
+        }
+    }
+}
+
+pub struct DemoArgs {
+    pub output_path: PathBuf,
+    pub mode: DemoMode,
+}
+
+/// Parse common `<output_path> [mode]` demo arguments.
+pub fn parse_demo_args(default_output_path: &str) -> anyhow::Result<DemoArgs> {
+    let mut args = std::env::args().skip(1);
+    let output_path = args
+        .next()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(default_output_path));
+    let mode = DemoMode::from_arg(args.next())?;
+    ensure_parent_dir(&output_path)?;
+
+    Ok(DemoArgs { output_path, mode })
+}
+
+/// Parse common `<output_path>` demo arguments.
+pub fn parse_output_arg(default_output_path: &str) -> anyhow::Result<PathBuf> {
+    let output_path = std::env::args()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(default_output_path));
+    ensure_parent_dir(&output_path)?;
+    Ok(output_path)
+}
+
+fn ensure_parent_dir(output_path: &Path) -> anyhow::Result<()> {
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create artifact directory {}", parent.display()))?;
+    }
+    Ok(())
+}
+
+/// Build a Tailtriage collector for a demo service name and output artifact path.
+pub fn init_collector(service_name: &str, output_path: &Path) -> anyhow::Result<Arc<Tailtriage>> {
+    let mut config = Config::new(service_name);
+    config.output_path = output_path.to_path_buf();
+    let collector = Tailtriage::init(config)?;
+    Ok(Arc::new(collector))
+}

--- a/demos/downstream_service/Cargo.toml
+++ b/demos/downstream_service/Cargo.toml
@@ -8,3 +8,4 @@ publish = false
 anyhow = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 tailtriage-core = { path = "../../tailtriage-core" }
+demo-support = { path = "../demo_support" }

--- a/demos/downstream_service/src/main.rs
+++ b/demos/downstream_service/src/main.rs
@@ -1,25 +1,15 @@
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context;
-use tailtriage_core::{Config, RequestMeta, Tailtriage};
+use demo_support::{init_collector, parse_output_arg};
+use tailtriage_core::RequestMeta;
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 2)]
 async fn main() -> anyhow::Result<()> {
-    let output_path = std::env::args()
-        .nth(1)
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("demos/downstream_service/artifacts/downstream-run.json"));
+    let output_path = parse_output_arg("demos/downstream_service/artifacts/downstream-run.json")?;
 
-    if let Some(parent) = output_path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create artifact directory {}", parent.display()))?;
-    }
-
-    let mut config = Config::new("downstream_service_demo");
-    config.output_path = output_path.clone();
-    let tailtriage = Arc::new(Tailtriage::init(config)?);
+    let tailtriage = init_collector("downstream_service_demo", &output_path)?;
 
     let offered_requests = 80_u64;
     let mut tasks = Vec::with_capacity(offered_requests as usize);

--- a/demos/executor_pressure_service/Cargo.toml
+++ b/demos/executor_pressure_service/Cargo.toml
@@ -8,3 +8,4 @@ publish = false
 anyhow = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }
 tailtriage-core = { path = "../../tailtriage-core" }
+demo-support = { path = "../demo_support" }

--- a/demos/executor_pressure_service/src/main.rs
+++ b/demos/executor_pressure_service/src/main.rs
@@ -4,25 +4,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context;
-use tailtriage_core::{unix_time_ms, Config, RequestMeta, RuntimeSnapshot, Tailtriage};
-
-#[derive(Clone, Copy)]
-enum DemoMode {
-    Baseline,
-    Mitigated,
-}
-
-impl DemoMode {
-    fn from_arg(value: Option<String>) -> anyhow::Result<Self> {
-        match value.as_deref() {
-            None | Some("baseline") | Some("before") => Ok(Self::Baseline),
-            Some("mitigated") | Some("after") => Ok(Self::Mitigated),
-            Some(other) => anyhow::bail!(
-                "unsupported mode '{other}', expected one of: baseline, before, mitigated, after"
-            ),
-        }
-    }
-}
+use demo_support::{init_collector, parse_demo_args, DemoMode};
+use tailtriage_core::{unix_time_ms, RequestMeta, RuntimeSnapshot};
 
 struct ModeSettings {
     worker_threads: usize,
@@ -57,17 +40,9 @@ impl ModeSettings {
 }
 
 fn main() -> anyhow::Result<()> {
-    let mut args = std::env::args().skip(1);
-    let output_path = args.next().map(PathBuf::from).unwrap_or_else(|| {
-        PathBuf::from("demos/executor_pressure_service/artifacts/executor-pressure-run.json")
-    });
-    let mode = DemoMode::from_arg(args.next())?;
-    let settings = ModeSettings::for_mode(mode);
-
-    if let Some(parent) = output_path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create artifact directory {}", parent.display()))?;
-    }
+    let args =
+        parse_demo_args("demos/executor_pressure_service/artifacts/executor-pressure-run.json")?;
+    let settings = ModeSettings::for_mode(args.mode);
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(settings.worker_threads)
@@ -76,13 +51,11 @@ fn main() -> anyhow::Result<()> {
         .build()
         .context("failed to build Tokio runtime")?;
 
-    runtime.block_on(run_demo(output_path, settings))
+    runtime.block_on(run_demo(args.output_path, settings))
 }
 
 async fn run_demo(output_path: PathBuf, settings: ModeSettings) -> anyhow::Result<()> {
-    let mut config = Config::new("executor_pressure_demo");
-    config.output_path = output_path.clone();
-    let tailtriage = Arc::new(Tailtriage::init(config)?);
+    let tailtriage = init_collector("executor_pressure_demo", &output_path)?;
 
     let runnable_backlog = Arc::new(AtomicU64::new(0));
     let hot_slice_local_depth = Arc::new(AtomicU64::new(0));

--- a/demos/mixed_contention_service/Cargo.toml
+++ b/demos/mixed_contention_service/Cargo.toml
@@ -8,3 +8,4 @@ publish = false
 anyhow = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
 tailtriage-core = { path = "../../tailtriage-core" }
+demo-support = { path = "../demo_support" }

--- a/demos/mixed_contention_service/src/main.rs
+++ b/demos/mixed_contention_service/src/main.rs
@@ -1,29 +1,11 @@
-use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context;
-use tailtriage_core::{Config, RequestMeta, Tailtriage};
+use demo_support::{init_collector, parse_demo_args, DemoMode};
+use tailtriage_core::RequestMeta;
 use tokio::sync::Semaphore;
-
-#[derive(Clone, Copy)]
-enum DemoMode {
-    Baseline,
-    Mitigated,
-}
-
-impl DemoMode {
-    fn from_arg(value: Option<String>) -> anyhow::Result<Self> {
-        match value.as_deref() {
-            None | Some("baseline") | Some("before") => Ok(Self::Baseline),
-            Some("mitigated") | Some("after") => Ok(Self::Mitigated),
-            Some(other) => anyhow::bail!(
-                "unsupported mode '{other}', expected one of: baseline, before, mitigated, after"
-            ),
-        }
-    }
-}
 
 struct ModeSettings {
     service_capacity: usize,
@@ -62,21 +44,11 @@ impl ModeSettings {
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 2)]
 async fn main() -> anyhow::Result<()> {
-    let mut args = std::env::args().skip(1);
-    let output_path = args.next().map(PathBuf::from).unwrap_or_else(|| {
-        PathBuf::from("demos/mixed_contention_service/artifacts/mixed-contention-run.json")
-    });
-    let mode = DemoMode::from_arg(args.next())?;
-    let settings = ModeSettings::for_mode(mode);
+    let args =
+        parse_demo_args("demos/mixed_contention_service/artifacts/mixed-contention-run.json")?;
+    let settings = ModeSettings::for_mode(args.mode);
 
-    if let Some(parent) = output_path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create artifact directory {}", parent.display()))?;
-    }
-
-    let mut config = Config::new("mixed_contention_service_demo");
-    config.output_path = output_path.clone();
-    let tailtriage = Arc::new(Tailtriage::init(config)?);
+    let tailtriage = init_collector("mixed_contention_service_demo", &args.output_path)?;
 
     let semaphore = Arc::new(Semaphore::new(settings.service_capacity));
     let waiting_depth = Arc::new(AtomicU64::new(0));
@@ -137,7 +109,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     tailtriage.flush()?;
-    println!("wrote {}", output_path.display());
+    println!("wrote {}", args.output_path.display());
 
     Ok(())
 }

--- a/demos/queue_service/Cargo.toml
+++ b/demos/queue_service/Cargo.toml
@@ -8,3 +8,4 @@ publish = false
 anyhow = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
 tailtriage-core = { path = "../../tailtriage-core" }
+demo-support = { path = "../demo_support" }

--- a/demos/queue_service/src/main.rs
+++ b/demos/queue_service/src/main.rs
@@ -1,47 +1,17 @@
-use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context;
-use tailtriage_core::{Config, RequestMeta, Tailtriage};
+use demo_support::{init_collector, parse_demo_args, DemoMode};
+use tailtriage_core::RequestMeta;
 use tokio::sync::Semaphore;
-
-#[derive(Clone, Copy)]
-enum DemoMode {
-    Baseline,
-    Mitigated,
-}
-
-impl DemoMode {
-    fn from_arg(value: Option<String>) -> anyhow::Result<Self> {
-        match value.as_deref() {
-            None | Some("baseline") | Some("before") => Ok(Self::Baseline),
-            Some("mitigated") | Some("after") => Ok(Self::Mitigated),
-            Some(other) => anyhow::bail!(
-                "unsupported mode '{other}', expected one of: baseline, before, mitigated, after"
-            ),
-        }
-    }
-}
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 2)]
 async fn main() -> anyhow::Result<()> {
-    let mut args = std::env::args().skip(1);
-    let output_path = args
-        .next()
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("demos/queue_service/artifacts/queue-run.json"));
-    let mode = DemoMode::from_arg(args.next())?;
+    let args = parse_demo_args("demos/queue_service/artifacts/queue-run.json")?;
 
-    if let Some(parent) = output_path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create artifact directory {}", parent.display()))?;
-    }
-
-    let mut config = Config::new("queue_service_demo");
-    config.output_path = output_path.clone();
-    let tailtriage = Arc::new(Tailtriage::init(config)?);
+    let tailtriage = init_collector("queue_service_demo", &args.output_path)?;
 
     let (
         service_capacity,
@@ -49,7 +19,7 @@ async fn main() -> anyhow::Result<()> {
         work_duration,
         inter_arrival_pause_every,
         inter_arrival_delay,
-    ) = match mode {
+    ) = match args.mode {
         DemoMode::Baseline => (
             4,
             250_u64,
@@ -112,7 +82,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     tailtriage.flush()?;
-    println!("wrote {}", output_path.display());
+    println!("wrote {}", args.output_path.display());
 
     Ok(())
 }

--- a/docs/getting-started-demo.md
+++ b/docs/getting-started-demo.md
@@ -2,6 +2,8 @@
 
 Use demos to validate diagnosis behavior with deterministic fixtures.
 
+For a scenario-by-scenario explanation of what each demo simulates, what triage it is intended to exercise, and what setup is shared, see **[`demos/README.md`](../demos/README.md)**.
+
 ## Artifact policy
 
 - `demos/*/artifacts/`: generated, untracked local outputs.


### PR DESCRIPTION
### Motivation

- Reduce repeated boilerplate across demo binaries and make demo intent explicit by centralizing common setup code. 
- Improve discoverability of what each demo simulates and which triage question it exercises. 
- Keep individual demo binaries focused on scenario payloads while preserving existing behavior.

### Description

- Add a new helper crate `demos/demo_support` providing `DemoMode`, `parse_demo_args`, `parse_output_arg`, and `init_collector` to centralize argument parsing, artifact directory creation, and collector initialization (`demos/demo_support/src/lib.rs`).
- Refactor all runnable demo binaries (`demos/queue_service`, `demos/blocking_service`, `demos/executor_pressure_service`, `demos/downstream_service`, `demos/mixed_contention_service`, `demos/cold_start_burst_service`) to use the shared helpers and remove duplicated CLI/setup boilerplate while keeping each scenario's logic unchanged (`demos/*/src/main.rs`).
- Register `demos/demo_support` in the workspace `Cargo.toml` and add it as a dependency to the demo crates, and add a demo-focused guide `demos/README.md` with per-demo descriptions and triage expectations; also link this guide from `docs/getting-started-demo.md` and the top-level `README.md`.

### Testing

- Ran `cargo fmt --check` and formatted fixes were applied where needed, resulting in a passing check after formatting. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` which completed with no warnings. 
- Ran `cargo test --workspace` and all workspace tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd5d18239883308fff9687175a878f)