### PR TITLE
Run deterministic Python demo validations for Rust PRs and expand demo workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,30 @@ jobs:
 
       - name: Cargo test
         run: cargo test --workspace
+
+  demo-validation:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo target
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-target-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-target-
+
+      - name: Validate queue demo
+        run: python3 scripts/demo_tool.py validate queue
+
+      - name: Validate blocking demo
+        run: python3 scripts/demo_tool.py validate blocking
+
+      - name: Validate downstream demo
+        run: python3 scripts/demo_tool.py validate downstream

--- a/.github/workflows/python-demos.yml
+++ b/.github/workflows/python-demos.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     paths:
       - '**/*.py'
+      - 'demos/**'
+      - 'tailtriage-cli/**'
+      - 'tailtriage-core/**'
+      - 'tailtriage-tokio/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
       - '.github/workflows/python-demos.yml'
 
 jobs:


### PR DESCRIPTION
### Motivation

- Ensure demo validations run for relevant Rust changes and demo edits so regressions in demos or crates are caught by PR checks.
- Keep demo validation runtime manageable by running deterministic Python validations instead of full interactive demos.

### Description

- Expanded `on.pull_request.paths` in `.github/workflows/python-demos.yml` to include `demos/**`, `tailtriage-cli/**`, `tailtriage-core/**`, `tailtriage-tokio/**`, and top-level `Cargo.toml`/`Cargo.lock` in addition to Python files and the workflow itself.
- Added a new `demo-validation` job to `.github/workflows/ci.yml` that runs the deterministic demo validations via `python3 scripts/demo_tool.py validate <scenario>` for `queue`, `blocking`, and `downstream`.
- Added a Cargo target cache in the new CI job using `actions/cache@v4` keyed by `**/Cargo.lock` to reduce repeated compile time and keep runtime reasonable.
- Kept Python demo checks in `python-demos.yml` for Python-focused changes while ensuring Rust PRs also exercise the demo validations via the CI job.

### Testing

- Ran the Python unit tests with `python3 -m unittest -v scripts/tests/test_demo_scripts.py` and they passed.
- Executed `python3 scripts/demo_tool.py validate queue` and validation passed.
- Executed `python3 scripts/demo_tool.py validate blocking` and validation passed.
- Executed `python3 scripts/demo_tool.py validate downstream` and validation passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd69144c2c83309e49290e0654b858)