### PR TITLE
Add db_pool_saturation_service demo with before/after validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "db-pool-saturation-service-demo"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "demo-support",
+ "tailtriage-core",
+ "tokio",
+]
+
+[[package]]
 name = "demo-support"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
   "demos/downstream_service",
   "demos/mixed_contention_service",
   "demos/cold_start_burst_service",
+  "demos/db_pool_saturation_service",
   "demos/runtime_cost",
 ]
 resolver = "2"

--- a/demos/README.md
+++ b/demos/README.md
@@ -94,6 +94,21 @@ This keeps demo binaries focused on the triage scenario rather than boilerplate.
 - Primary suspect can vary by machine, but evidence should justify the rank.
 - Mitigation should shift score/rank toward the remaining bottleneck.
 
+
+### `db_pool_saturation_service`
+
+**What happens**
+
+- Requests do a tiny `app_precheck` and then queue for a bounded semaphore that represents DB connections.
+- Baseline uses a smaller DB pool and slower `db_query` stage.
+- Mitigated mode increases pool capacity and shortens the `db_query` stage.
+
+**Triage being exercised**
+
+- Ranked suspects should include application queue saturation and/or downstream stage dominance.
+- Evidence should reference `queue(..., "db_pool")` wait behavior and `stage(..., "db_query")` service share.
+- Mitigation should improve p95 latency and/or primary suspect score.
+
 ### `cold_start_burst_service`
 
 **What happens**
@@ -117,4 +132,4 @@ python3 scripts/demo_tool.py run blocking
 python3 scripts/demo_tool.py validate blocking
 ```
 
-Repeat for the remaining demos (`executor`, `downstream`, `mixed`, `cold-start`).
+Repeat for the remaining demos (`executor`, `downstream`, `mixed`, `cold-start`, `db-pool`).

--- a/demos/db_pool_saturation_service/Cargo.toml
+++ b/demos/db_pool_saturation_service/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "db-pool-saturation-service-demo"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
+tailtriage-core = { path = "../../tailtriage-core" }
+demo-support = { path = "../demo_support" }

--- a/demos/db_pool_saturation_service/artifacts/.gitignore
+++ b/demos/db_pool_saturation_service/artifacts/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/demos/db_pool_saturation_service/fixtures/after-analysis.json
+++ b/demos/db_pool_saturation_service/fixtures/after-analysis.json
@@ -1,0 +1,30 @@
+{
+  "request_count": 220,
+  "p50_latency_us": 14465,
+  "p95_latency_us": 23631,
+  "p99_latency_us": 102348,
+  "p95_queue_share_permille": 1,
+  "p95_service_share_permille": 1000,
+  "inflight_trend": {
+    "gauge": "db_pool_saturation_inflight",
+    "sample_count": 440,
+    "peak_count": 10,
+    "p95_count": 10,
+    "growth_delta": -1,
+    "growth_per_sec_milli": -1872
+  },
+  "primary_suspect": {
+    "kind": "DownstreamStageDominates",
+    "score": 60,
+    "confidence": "low",
+    "evidence": [
+      "Stage 'db_query' has p95 latency 18218 us across 220 samples.",
+      "Stage 'db_query' cumulative latency is 3100313 us."
+    ],
+    "next_checks": [
+      "Inspect downstream dependency behind stage 'db_query'.",
+      "Collect downstream service timings and retry behavior during tail windows."
+    ]
+  },
+  "secondary_suspects": []
+}

--- a/demos/db_pool_saturation_service/fixtures/before-after-comparison.json
+++ b/demos/db_pool_saturation_service/fixtures/before-after-comparison.json
@@ -1,0 +1,20 @@
+{
+  "before": {
+    "primary_suspect_kind": "ApplicationQueueSaturation",
+    "primary_suspect_score": 90,
+    "p95_latency_us": 1000477,
+    "p95_queue_share_permille": 977
+  },
+  "after": {
+    "primary_suspect_kind": "DownstreamStageDominates",
+    "primary_suspect_score": 60,
+    "p95_latency_us": 23631,
+    "p95_queue_share_permille": 1
+  },
+  "delta": {
+    "primary_suspect_kind": null,
+    "primary_suspect_score": -30,
+    "p95_latency_us": -976846,
+    "p95_queue_share_permille": -976
+  }
+}

--- a/demos/db_pool_saturation_service/fixtures/before-analysis.json
+++ b/demos/db_pool_saturation_service/fixtures/before-analysis.json
@@ -1,0 +1,44 @@
+{
+  "request_count": 220,
+  "p50_latency_us": 572910,
+  "p95_latency_us": 1000477,
+  "p99_latency_us": 1064713,
+  "p95_queue_share_permille": 977,
+  "p95_service_share_permille": 377,
+  "inflight_trend": {
+    "gauge": "db_pool_saturation_inflight",
+    "sample_count": 440,
+    "peak_count": 195,
+    "p95_count": 185,
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
+  },
+  "primary_suspect": {
+    "kind": "ApplicationQueueSaturation",
+    "score": 90,
+    "confidence": "high",
+    "evidence": [
+      "Queue wait at p95 consumes 97.7% of request time.",
+      "Observed queue depth sample up to 190."
+    ],
+    "next_checks": [
+      "Inspect queue admission limits and producer burst patterns.",
+      "Compare queue wait distribution before and after increasing worker parallelism."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "DownstreamStageDominates",
+      "score": 60,
+      "confidence": "low",
+      "evidence": [
+        "Stage 'db_query' has p95 latency 22329 us across 220 samples.",
+        "Stage 'db_query' cumulative latency is 4665893 us."
+      ],
+      "next_checks": [
+        "Inspect downstream dependency behind stage 'db_query'.",
+        "Collect downstream service timings and retry behavior during tail windows."
+      ]
+    }
+  ]
+}

--- a/demos/db_pool_saturation_service/src/main.rs
+++ b/demos/db_pool_saturation_service/src/main.rs
@@ -1,0 +1,105 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use demo_support::{init_collector, parse_demo_args, DemoMode};
+use tailtriage_core::RequestMeta;
+use tokio::sync::Semaphore;
+
+struct ModeSettings {
+    db_pool_size: usize,
+    offered_requests: u64,
+    inter_arrival_pause_every: u64,
+    inter_arrival_delay: Duration,
+    app_precheck_delay: Duration,
+    db_query_delay: Duration,
+}
+
+impl ModeSettings {
+    fn for_mode(mode: DemoMode) -> Self {
+        match mode {
+            DemoMode::Baseline => Self {
+                db_pool_size: 4,
+                offered_requests: 220,
+                inter_arrival_pause_every: 5,
+                inter_arrival_delay: Duration::from_millis(1),
+                app_precheck_delay: Duration::from_millis(1),
+                db_query_delay: Duration::from_millis(18),
+            },
+            DemoMode::Mitigated => Self {
+                db_pool_size: 12,
+                offered_requests: 220,
+                inter_arrival_pause_every: 2,
+                inter_arrival_delay: Duration::from_millis(2),
+                app_precheck_delay: Duration::from_millis(1),
+                db_query_delay: Duration::from_millis(10),
+            },
+        }
+    }
+}
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 2)]
+async fn main() -> anyhow::Result<()> {
+    let args =
+        parse_demo_args("demos/db_pool_saturation_service/artifacts/db-pool-saturation-run.json")?;
+    let settings = ModeSettings::for_mode(args.mode);
+
+    let tailtriage = init_collector("db_pool_saturation_service_demo", &args.output_path)?;
+
+    let db_pool = Arc::new(Semaphore::new(settings.db_pool_size));
+    let waiting_depth = Arc::new(AtomicU64::new(0));
+
+    let mut tasks = Vec::with_capacity(settings.offered_requests as usize);
+
+    for request_number in 0..settings.offered_requests {
+        let tailtriage = Arc::clone(&tailtriage);
+        let db_pool = Arc::clone(&db_pool);
+        let waiting_depth = Arc::clone(&waiting_depth);
+
+        tasks.push(tokio::spawn(async move {
+            let request_id = format!("request-{request_number}");
+            let meta = RequestMeta::new(request_id.clone(), "/db-pool-saturation-demo");
+
+            tailtriage
+                .request(meta, "ok", async {
+                    let _inflight = tailtriage.inflight("db_pool_saturation_inflight");
+
+                    tailtriage
+                        .stage(request_id.clone(), "app_precheck")
+                        .await_value(tokio::time::sleep(settings.app_precheck_delay))
+                        .await;
+
+                    let depth = waiting_depth.fetch_add(1, Ordering::SeqCst) + 1;
+                    let permit = tailtriage
+                        .queue(request_id.clone(), "db_pool")
+                        .with_depth_at_start(depth)
+                        .await_on(db_pool.acquire())
+                        .await
+                        .expect("db pool semaphore should remain open");
+                    waiting_depth.fetch_sub(1, Ordering::SeqCst);
+
+                    let _permit = permit;
+
+                    tailtriage
+                        .stage(request_id, "db_query")
+                        .await_value(tokio::time::sleep(settings.db_query_delay))
+                        .await;
+                })
+                .await;
+        }));
+
+        if request_number % settings.inter_arrival_pause_every == 0 {
+            tokio::time::sleep(settings.inter_arrival_delay).await;
+        }
+    }
+
+    for task in tasks {
+        task.await.context("request task panicked")?;
+    }
+
+    tailtriage.flush()?;
+    println!("wrote {}", args.output_path.display());
+
+    Ok(())
+}

--- a/docs/getting-started-demo.md
+++ b/docs/getting-started-demo.md
@@ -29,6 +29,10 @@ python3 scripts/demo_tool.py validate mixed
 
 python3 scripts/demo_tool.py run cold-start
 python3 scripts/demo_tool.py validate cold-start
+
+python3 scripts/demo_tool.py run db-pool
+python3 scripts/demo_tool.py validate db-pool
+
 ```
 
 ## What each demo demonstrates
@@ -41,6 +45,7 @@ python3 scripts/demo_tool.py validate cold-start
 | `downstream_service` | downstream-stage dominance | `primary_suspect.kind`, `p95_service_share_permille`, suspect evidence |
 | `mixed_contention_service` | queue + downstream contention together | baseline includes both suspects; mitigation should shift rank and/or score |
 | `cold_start_burst_service` | cold-start cohort causes warmup drag and burst queueing | baseline evidence references `cold_start_stage` and/or queue pressure; mitigation lowers p95 and primary suspect score |
+| `db_pool_saturation_service` | DB pool admission + slow DB stage contention | baseline suspect includes queue saturation and/or downstream dominance; mitigation improves p95 and/or score |
 
 ## Mixed-contention expected rank behavior
 

--- a/scripts/demo_tool.py
+++ b/scripts/demo_tool.py
@@ -22,8 +22,8 @@ EXPECTED_EXECUTOR_KIND = {"executor_pressure_suspected", "ExecutorPressureSuspec
 EXPECTED_DOWNSTREAM_KIND = {"downstream_stage_dominates", "DownstreamStageDominates"}
 EXPECTED_MIXED_PRIMARY_KINDS = EXPECTED_QUEUE_KIND | EXPECTED_DOWNSTREAM_KIND
 EXPECTED_COLD_START_PRIMARY_KINDS = EXPECTED_QUEUE_KIND | EXPECTED_DOWNSTREAM_KIND
+EXPECTED_DB_POOL_PRIMARY_KINDS = EXPECTED_QUEUE_KIND | EXPECTED_DOWNSTREAM_KIND
 MODE_CHOICES = ["before", "after", "both", "baseline", "mitigated"]
-
 
 def extract_blocking_queue_depth_p95(report: dict) -> int | None:
     suspect = report.get("primary_suspect") or {}
@@ -33,14 +33,12 @@ def extract_blocking_queue_depth_p95(report: dict) -> int | None:
             return int(match.group(1))
     return None
 
-
 def normalize_mode(mode: str) -> str:
     if mode in {"baseline", "before"}:
         return "before"
     if mode in {"mitigated", "after"}:
         return "after"
     return mode
-
 
 def snapshot_queue(report: dict) -> dict[str, int | str | None]:
     return {
@@ -50,7 +48,6 @@ def snapshot_queue(report: dict) -> dict[str, int | str | None]:
         "p95_queue_share_permille": report.get("p95_queue_share_permille"),
     }
 
-
 def snapshot_blocking(report: dict) -> dict[str, int | str | None]:
     return {
         "primary_suspect_kind": report["primary_suspect"]["kind"],
@@ -59,7 +56,6 @@ def snapshot_blocking(report: dict) -> dict[str, int | str | None]:
         "p95_service_share_permille": report.get("p95_service_share_permille"),
         "blocking_queue_depth_p95": extract_blocking_queue_depth_p95(report),
     }
-
 
 def run_before_after_scenario(
     root_dir: Path,
@@ -93,7 +89,6 @@ def run_before_after_scenario(
     )
     print(f"comparison: {comparison_path}")
 
-
 def run_scenario_queue(root_dir: Path, mode: str) -> None:
     run_before_after_scenario(
         root_dir,
@@ -102,7 +97,6 @@ def run_scenario_queue(root_dir: Path, mode: str) -> None:
         mode,
         snapshot_queue,
     )
-
 
 def run_scenario_blocking(root_dir: Path, mode: str) -> None:
     run_before_after_scenario(
@@ -113,7 +107,6 @@ def run_scenario_blocking(root_dir: Path, mode: str) -> None:
         snapshot_blocking,
     )
 
-
 def run_scenario_executor(root_dir: Path, mode: str) -> None:
     run_before_after_scenario(
         root_dir,
@@ -122,7 +115,6 @@ def run_scenario_executor(root_dir: Path, mode: str) -> None:
         mode,
         snapshot_queue,
     )
-
 
 def run_scenario_downstream(root_dir: Path, artifact_path: str | None) -> None:
     run_path = (
@@ -140,7 +132,6 @@ def run_scenario_downstream(root_dir: Path, artifact_path: str | None) -> None:
     print(f"run artifact: {run_path}")
     print(f"analysis: {analysis_path}")
 
-
 def run_scenario_mixed(root_dir: Path, mode: str) -> None:
     run_before_after_scenario(
         root_dir,
@@ -149,7 +140,6 @@ def run_scenario_mixed(root_dir: Path, mode: str) -> None:
         mode,
         snapshot_queue,
     )
-
 
 def run_scenario_cold_start(root_dir: Path, mode: str) -> None:
     run_before_after_scenario(
@@ -160,12 +150,19 @@ def run_scenario_cold_start(root_dir: Path, mode: str) -> None:
         snapshot_queue,
     )
 
+def run_scenario_db_pool(root_dir: Path, mode: str) -> None:
+    run_before_after_scenario(
+        root_dir,
+        root_dir / "demos/db_pool_saturation_service/Cargo.toml",
+        root_dir / "demos/db_pool_saturation_service/artifacts",
+        mode,
+        snapshot_queue,
+    )
 
 def has_suspect_kind(report: dict, expected_kinds: set[str]) -> bool:
     primary = report.get("primary_suspect") or {}
     all_suspects = [primary, *(report.get("secondary_suspects") or [])]
     return any((suspect or {}).get("kind") in expected_kinds for suspect in all_suspects)
-
 
 def validate_queue(root_dir: Path) -> None:
     run_scenario_queue(root_dir, "both")
@@ -205,7 +202,6 @@ def validate_queue(root_dir: Path) -> None:
         "validated analysis files: "
         f"{artifact_dir / 'before-analysis.json'}, {artifact_dir / 'after-analysis.json'}"
     )
-
 
 def validate_blocking(root_dir: Path) -> None:
     run_scenario_blocking(root_dir, "both")
@@ -276,7 +272,6 @@ def validate_blocking(root_dir: Path) -> None:
         f"{artifact_dir / 'before-analysis.json'}, {artifact_dir / 'after-analysis.json'}"
     )
 
-
 def validate_downstream(root_dir: Path) -> None:
     run_scenario_downstream(root_dir, None)
     analysis_path = root_dir / "demos/downstream_service/artifacts/downstream-analysis.json"
@@ -288,7 +283,6 @@ def validate_downstream(root_dir: Path) -> None:
 
     print(f"validation passed: primary suspect is {kind}")
     print(f"validated analysis file: {analysis_path}")
-
 
 def validate_mixed(root_dir: Path) -> None:
     run_scenario_mixed(root_dir, "both")
@@ -339,12 +333,10 @@ def validate_mixed(root_dir: Path) -> None:
         f"{artifact_dir / 'before-analysis.json'}, {artifact_dir / 'after-analysis.json'}"
     )
 
-
 def _contains_blocking_depth_evidence(report: dict) -> bool:
     suspect = report.get("primary_suspect") or {}
     evidence = suspect.get("evidence") or []
     return any("blocking queue depth" in str(item).lower() for item in evidence)
-
 
 def validate_executor(root_dir: Path) -> None:
     run_scenario_executor(root_dir, "both")
@@ -387,7 +379,6 @@ def validate_executor(root_dir: Path) -> None:
         f"{artifact_dir / 'before-analysis.json'}, {artifact_dir / 'after-analysis.json'}"
     )
 
-
 def _report_mentions_cold_start_or_queue(report: dict) -> bool:
     suspects = [report.get("primary_suspect") or {}, *(report.get("secondary_suspects") or [])]
     evidence_items = [
@@ -401,7 +392,6 @@ def _report_mentions_cold_start_or_queue(report: dict) -> bool:
         or "queue depth sample" in item
         for item in evidence_items
     )
-
 
 def validate_cold_start(root_dir: Path) -> None:
     run_scenario_cold_start(root_dir, "both")
@@ -449,6 +439,43 @@ def validate_cold_start(root_dir: Path) -> None:
         f"{artifact_dir / 'before-analysis.json'}, {artifact_dir / 'after-analysis.json'}"
     )
 
+def validate_db_pool(root_dir: Path) -> None:
+    run_scenario_db_pool(root_dir, "both")
+    artifact_dir = root_dir / "demos/db_pool_saturation_service/artifacts"
+    before = load_report_json(artifact_dir / "before-analysis.json")
+    after = load_report_json(artifact_dir / "after-analysis.json")
+
+    before_kind = before["primary_suspect"]["kind"]
+    if before_kind not in EXPECTED_DB_POOL_PRIMARY_KINDS:
+        raise SystemExit(
+            "expected baseline primary suspect to indicate queue or downstream pressure, "
+            f"got {before_kind}"
+        )
+
+    before_p95 = before["p95_latency_us"]
+    after_p95 = after["p95_latency_us"]
+    before_score = before["primary_suspect"]["score"]
+    after_score = after["primary_suspect"]["score"]
+
+    if after_p95 >= before_p95 and after_score >= before_score:
+        raise SystemExit(
+            "expected mitigation to improve p95 and/or primary suspect score, "
+            f"got p95 {before_p95}->{after_p95} and score {before_score}->{after_score}"
+        )
+
+    print(
+        "validation passed: baseline suspect kind={}, p95 {}us -> {}us, score {} -> {}".format(
+            before_kind,
+            before_p95,
+            after_p95,
+            before_score,
+            after_score,
+        )
+    )
+    print(
+        "validated analysis files: "
+        f"{artifact_dir / 'before-analysis.json'}, {artifact_dir / 'after-analysis.json'}"
+    )
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Unified tailtriage demo run/validate tool.")
@@ -457,7 +484,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     run_parser = subparsers.add_parser("run", help="Run demo scenario and produce analysis artifacts")
     run_parser.add_argument(
         "scenario",
-        choices=["queue", "blocking", "executor", "downstream", "mixed", "cold-start"],
+        choices=["queue", "blocking", "executor", "downstream", "mixed", "cold-start", "db-pool"],
     )
     run_parser.add_argument(
         "mode",
@@ -474,11 +501,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     validate_parser = subparsers.add_parser("validate", help="Run scenario validation contract checks")
     validate_parser.add_argument(
         "scenario",
-        choices=["queue", "blocking", "executor", "downstream", "mixed", "cold-start"],
+        choices=["queue", "blocking", "executor", "downstream", "mixed", "cold-start", "db-pool"],
     )
 
     return parser.parse_args(argv)
-
 
 def main(argv: list[str] | None = None) -> None:
     args = parse_args(argv)
@@ -497,6 +523,8 @@ def main(argv: list[str] | None = None) -> None:
             run_scenario_executor(root_dir, args.mode)
         elif args.scenario == "cold-start":
             run_scenario_cold_start(root_dir, args.mode)
+        elif args.scenario == "db-pool":
+            run_scenario_db_pool(root_dir, args.mode)
         else:
             run_scenario_mixed(root_dir, args.mode)
         return
@@ -511,9 +539,10 @@ def main(argv: list[str] | None = None) -> None:
         validate_executor(root_dir)
     elif args.scenario == "cold-start":
         validate_cold_start(root_dir)
+    elif args.scenario == "db-pool":
+        validate_db_pool(root_dir)
     else:
         validate_mixed(root_dir)
-
 
 if __name__ == "__main__":
     main()

--- a/scripts/tests/test_demo_scripts.py
+++ b/scripts/tests/test_demo_scripts.py
@@ -43,6 +43,13 @@ class DemoWrapperTests(unittest.TestCase):
         self.assertEqual(args.command, "validate")
         self.assertEqual(args.scenario, "cold-start")
 
+
+    def test_parse_args_accepts_db_pool_scenario(self) -> None:
+        args = parse_args(["run", "db-pool", "mitigated"])
+        self.assertEqual(args.command, "run")
+        self.assertEqual(args.scenario, "db-pool")
+        self.assertEqual(args.mode, "mitigated")
+
     def test_parse_args_accepts_downstream_artifact_flag(self) -> None:
         args = parse_args(["run", "downstream", "--artifact-path", "custom-run.json"])
         self.assertEqual(args.command, "run")


### PR DESCRIPTION
### Motivation

- Add a deterministic demo that models DB-connection-pool admission pressure so the analyzer can triage whether tail latency is caused by application queueing vs a slow DB stage. 

### Description

- Add a new demo crate at `demos/db_pool_saturation_service` (and register it in the workspace `Cargo.toml`) that uses a bounded `tokio::sync::Semaphore` to represent a DB pool and exposes `baseline`/`mitigated` modes via `ModeSettings`.
- Instrument the flow with an admission queue and a downstream stage by calling `queue(..., "db_pool")` (with depth samples) and `stage(..., "db_query")` so analyzer evidence includes queue wait and service-share info.
- Commit deterministic fixtures under `demos/db_pool_saturation_service/fixtures/` (before/after analysis and comparison) and add an `artifacts/.gitignore` to keep generated run outputs untracked.
- Wire the scenario into the unified demo tool `scripts/demo_tool.py` (`run_scenario_db_pool` + `validate_db_pool`) with validation checks that baseline primary suspect is queue or downstream and that mitigated mode improves `p95` and/or the primary suspect score, and extend `scripts/tests/test_demo_scripts.py` to cover parsing of the new `db-pool` scenario.
- Update `demos/README.md` and `docs/getting-started-demo.md` to list the new `db_pool_saturation_service` demo and its expected triage behavior.

### Testing

- Ran the scenario end-to-end with `python3 scripts/demo_tool.py run db-pool` and validated with `python3 scripts/demo_tool.py validate db-pool`, both succeeded and produced expected fixtures.
- Ran the Python unit tests `python3 -m unittest scripts/tests/test_demo_scripts.py`, which passed.
- Ensured code hygiene by running `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd787e5c4c8330bd0b95e5f35be68f)