### PR TITLE
Add shared-state lock contention demo and validator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,6 +369,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared-state-lock-service-demo"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "demo-support",
+ "tailtriage-core",
+ "tokio",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "demos/mixed_contention_service",
   "demos/cold_start_burst_service",
   "demos/db_pool_saturation_service",
+  "demos/shared_state_lock_service",
   "demos/runtime_cost",
 ]
 resolver = "2"

--- a/SPEC.md
+++ b/SPEC.md
@@ -215,6 +215,7 @@ Validation scripts in `scripts/` must pass for these demos.
 
 - `demos/downstream_service`: deterministic downstream-stage dominance scenario that should rank `DownstreamStageDominates` as the primary suspect.
 - `demos/mixed_contention_service`: deterministic mixed queue + downstream contention scenario where both suspects should be present in ranked evidence and mitigation should shift rank and/or score when one bottleneck is reduced.
+- `demos/shared_state_lock_service`: deterministic shared-state lock contention scenario where lock wait is modeled as queue-like wait and lock-protected work is modeled as a service stage; mitigation should reduce queueing/serialization signals.
 
 This demo is intentionally small and single-purpose; it extends storytelling trust without expanding MVP scope.
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -109,6 +109,20 @@ This keeps demo binaries focused on the triage scenario rather than boilerplate.
 - Evidence should reference `queue(..., "db_pool")` wait behavior and `stage(..., "db_query")` service share.
 - Mitigation should improve p95 latency and/or primary suspect score.
 
+### `shared_state_lock_service`
+
+**What happens**
+
+- Requests do small pre-lock work, then contend on a shared `tokio::sync::RwLock` write lock.
+- Baseline keeps a long lock-protected critical section, which serializes many requests.
+- Mitigated mode shortens critical section hold time to reduce lock wait buildup.
+
+**Triage being exercised**
+
+- Lock wait is instrumented as a queue-like wait (`queue(..., "shared_state_write_lock")`), so lock contention can appear as application queueing pressure.
+- Critical section execution is instrumented as a service stage (`stage(..., "shared_state_critical_section")`).
+- Mitigation should lower p95 latency and/or reduce primary suspect score.
+
 ### `cold_start_burst_service`
 
 **What happens**
@@ -132,4 +146,4 @@ python3 scripts/demo_tool.py run blocking
 python3 scripts/demo_tool.py validate blocking
 ```
 
-Repeat for the remaining demos (`executor`, `downstream`, `mixed`, `cold-start`, `db-pool`).
+Repeat for the remaining demos (`executor`, `downstream`, `mixed`, `cold-start`, `db-pool`, `shared-lock`).

--- a/demos/shared_state_lock_service/Cargo.toml
+++ b/demos/shared_state_lock_service/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "shared-state-lock-service-demo"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
+tailtriage-core = { path = "../../tailtriage-core" }
+demo-support = { path = "../demo_support" }

--- a/demos/shared_state_lock_service/artifacts/.gitignore
+++ b/demos/shared_state_lock_service/artifacts/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/demos/shared_state_lock_service/fixtures/after-analysis.json
+++ b/demos/shared_state_lock_service/fixtures/after-analysis.json
@@ -1,0 +1,44 @@
+{
+  "request_count": 220,
+  "p50_latency_us": 944016,
+  "p95_latency_us": 1820403,
+  "p99_latency_us": 1879203,
+  "p95_queue_share_permille": 993,
+  "p95_service_share_permille": 153,
+  "inflight_trend": {
+    "gauge": "shared_state_lock_inflight",
+    "sample_count": 440,
+    "peak_count": 199,
+    "p95_count": 189,
+    "growth_delta": -1,
+    "growth_per_sec_milli": -481
+  },
+  "primary_suspect": {
+    "kind": "ApplicationQueueSaturation",
+    "score": 90,
+    "confidence": "high",
+    "evidence": [
+      "Queue wait at p95 consumes 99.3% of request time.",
+      "Observed queue depth sample up to 198."
+    ],
+    "next_checks": [
+      "Inspect queue admission limits and producer burst patterns.",
+      "Compare queue wait distribution before and after increasing worker parallelism."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "DownstreamStageDominates",
+      "score": 60,
+      "confidence": "low",
+      "evidence": [
+        "Stage 'shared_state_critical_section' has p95 latency 9650 us across 220 samples.",
+        "Stage 'shared_state_critical_section' cumulative latency is 2038815 us."
+      ],
+      "next_checks": [
+        "Inspect downstream dependency behind stage 'shared_state_critical_section'.",
+        "Collect downstream service timings and retry behavior during tail windows."
+      ]
+    }
+  ]
+}

--- a/demos/shared_state_lock_service/fixtures/before-after-comparison.json
+++ b/demos/shared_state_lock_service/fixtures/before-after-comparison.json
@@ -1,0 +1,20 @@
+{
+  "before": {
+    "primary_suspect_kind": "ApplicationQueueSaturation",
+    "primary_suspect_score": 90,
+    "p95_latency_us": 5270251,
+    "p95_queue_share_permille": 995
+  },
+  "after": {
+    "primary_suspect_kind": "ApplicationQueueSaturation",
+    "primary_suspect_score": 90,
+    "p95_latency_us": 1820403,
+    "p95_queue_share_permille": 993
+  },
+  "delta": {
+    "primary_suspect_kind": null,
+    "primary_suspect_score": 0,
+    "p95_latency_us": -3449848,
+    "p95_queue_share_permille": -2
+  }
+}

--- a/demos/shared_state_lock_service/fixtures/before-analysis.json
+++ b/demos/shared_state_lock_service/fixtures/before-analysis.json
@@ -1,0 +1,44 @@
+{
+  "request_count": 220,
+  "p50_latency_us": 2739217,
+  "p95_latency_us": 5270251,
+  "p99_latency_us": 5459301,
+  "p95_queue_share_permille": 995,
+  "p95_service_share_permille": 119,
+  "inflight_trend": {
+    "gauge": "shared_state_lock_inflight",
+    "sample_count": 440,
+    "peak_count": 217,
+    "p95_count": 206,
+    "growth_delta": -1,
+    "growth_per_sec_milli": -178
+  },
+  "primary_suspect": {
+    "kind": "ApplicationQueueSaturation",
+    "score": 90,
+    "confidence": "high",
+    "evidence": [
+      "Queue wait at p95 consumes 99.5% of request time.",
+      "Observed queue depth sample up to 215."
+    ],
+    "next_checks": [
+      "Inspect queue admission limits and producer burst patterns.",
+      "Compare queue wait distribution before and after increasing worker parallelism."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "DownstreamStageDominates",
+      "score": 60,
+      "confidence": "low",
+      "evidence": [
+        "Stage 'shared_state_critical_section' has p95 latency 24765 us across 220 samples.",
+        "Stage 'shared_state_critical_section' cumulative latency is 5530991 us."
+      ],
+      "next_checks": [
+        "Inspect downstream dependency behind stage 'shared_state_critical_section'.",
+        "Collect downstream service timings and retry behavior during tail windows."
+      ]
+    }
+  ]
+}

--- a/demos/shared_state_lock_service/src/main.rs
+++ b/demos/shared_state_lock_service/src/main.rs
@@ -1,0 +1,103 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use demo_support::{init_collector, parse_demo_args, DemoMode};
+use tailtriage_core::RequestMeta;
+use tokio::sync::RwLock;
+
+struct ModeSettings {
+    offered_requests: u64,
+    inter_arrival_pause_every: u64,
+    inter_arrival_delay: Duration,
+    pre_lock_stage_delay: Duration,
+    critical_section_delay: Duration,
+}
+
+impl ModeSettings {
+    fn for_mode(mode: DemoMode) -> Self {
+        match mode {
+            DemoMode::Baseline => Self {
+                offered_requests: 220,
+                inter_arrival_pause_every: 6,
+                inter_arrival_delay: Duration::from_millis(1),
+                pre_lock_stage_delay: Duration::from_millis(1),
+                critical_section_delay: Duration::from_millis(22),
+            },
+            DemoMode::Mitigated => Self {
+                offered_requests: 220,
+                inter_arrival_pause_every: 3,
+                inter_arrival_delay: Duration::from_millis(1),
+                pre_lock_stage_delay: Duration::from_millis(1),
+                critical_section_delay: Duration::from_millis(7),
+            },
+        }
+    }
+}
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 2)]
+async fn main() -> anyhow::Result<()> {
+    let args =
+        parse_demo_args("demos/shared_state_lock_service/artifacts/shared-state-lock-run.json")?;
+    let settings = ModeSettings::for_mode(args.mode);
+
+    let tailtriage = init_collector("shared_state_lock_service_demo", &args.output_path)?;
+
+    let shared_state = Arc::new(RwLock::new(0_u64));
+    let waiting_writers = Arc::new(AtomicU64::new(0));
+
+    let mut tasks = Vec::with_capacity(settings.offered_requests as usize);
+
+    for request_number in 0..settings.offered_requests {
+        let tailtriage = Arc::clone(&tailtriage);
+        let shared_state = Arc::clone(&shared_state);
+        let waiting_writers = Arc::clone(&waiting_writers);
+
+        tasks.push(tokio::spawn(async move {
+            let request_id = format!("request-{request_number}");
+            let meta = RequestMeta::new(request_id.clone(), "/shared-state-lock-demo");
+
+            tailtriage
+                .request(meta, "ok", async {
+                    let _inflight = tailtriage.inflight("shared_state_lock_inflight");
+
+                    tailtriage
+                        .stage(request_id.clone(), "pre_lock_work")
+                        .await_value(tokio::time::sleep(settings.pre_lock_stage_delay))
+                        .await;
+
+                    let waiting_depth = waiting_writers.fetch_add(1, Ordering::SeqCst) + 1;
+                    let guard = tailtriage
+                        .queue(request_id.clone(), "shared_state_write_lock")
+                        .with_depth_at_start(waiting_depth)
+                        .await_on(shared_state.write())
+                        .await;
+                    waiting_writers.fetch_sub(1, Ordering::SeqCst);
+
+                    let mut guard = guard;
+                    tailtriage
+                        .stage(request_id, "shared_state_critical_section")
+                        .await_value(async {
+                            *guard += 1;
+                            tokio::time::sleep(settings.critical_section_delay).await;
+                        })
+                        .await;
+                })
+                .await;
+        }));
+
+        if request_number % settings.inter_arrival_pause_every == 0 {
+            tokio::time::sleep(settings.inter_arrival_delay).await;
+        }
+    }
+
+    for task in tasks {
+        task.await.context("request task panicked")?;
+    }
+
+    tailtriage.flush()?;
+    println!("wrote {}", args.output_path.display());
+
+    Ok(())
+}

--- a/scripts/demo_tool.py
+++ b/scripts/demo_tool.py
@@ -23,6 +23,7 @@ EXPECTED_DOWNSTREAM_KIND = {"downstream_stage_dominates", "DownstreamStageDomina
 EXPECTED_MIXED_PRIMARY_KINDS = EXPECTED_QUEUE_KIND | EXPECTED_DOWNSTREAM_KIND
 EXPECTED_COLD_START_PRIMARY_KINDS = EXPECTED_QUEUE_KIND | EXPECTED_DOWNSTREAM_KIND
 EXPECTED_DB_POOL_PRIMARY_KINDS = EXPECTED_QUEUE_KIND | EXPECTED_DOWNSTREAM_KIND
+EXPECTED_SHARED_LOCK_PRIMARY_KINDS = EXPECTED_QUEUE_KIND | EXPECTED_DOWNSTREAM_KIND
 MODE_CHOICES = ["before", "after", "both", "baseline", "mitigated"]
 
 def extract_blocking_queue_depth_p95(report: dict) -> int | None:
@@ -155,6 +156,15 @@ def run_scenario_db_pool(root_dir: Path, mode: str) -> None:
         root_dir,
         root_dir / "demos/db_pool_saturation_service/Cargo.toml",
         root_dir / "demos/db_pool_saturation_service/artifacts",
+        mode,
+        snapshot_queue,
+    )
+
+def run_scenario_shared_lock(root_dir: Path, mode: str) -> None:
+    run_before_after_scenario(
+        root_dir,
+        root_dir / "demos/shared_state_lock_service/Cargo.toml",
+        root_dir / "demos/shared_state_lock_service/artifacts",
         mode,
         snapshot_queue,
     )
@@ -477,6 +487,52 @@ def validate_db_pool(root_dir: Path) -> None:
         f"{artifact_dir / 'before-analysis.json'}, {artifact_dir / 'after-analysis.json'}"
     )
 
+def validate_shared_lock(root_dir: Path) -> None:
+    run_scenario_shared_lock(root_dir, "both")
+    artifact_dir = root_dir / "demos/shared_state_lock_service/artifacts"
+    before = load_report_json(artifact_dir / "before-analysis.json")
+    after = load_report_json(artifact_dir / "after-analysis.json")
+
+    before_kind = before["primary_suspect"]["kind"]
+    if before_kind not in EXPECTED_SHARED_LOCK_PRIMARY_KINDS:
+        raise SystemExit(
+            "expected baseline primary suspect to indicate queue or downstream pressure, "
+            f"got {before_kind}"
+        )
+
+    evidence_text = " ".join(
+        str(item).lower()
+        for suspect in [before.get("primary_suspect") or {}, *(before.get("secondary_suspects") or [])]
+        for item in (suspect.get("evidence") or [])
+    )
+    if "queue wait at p95" not in evidence_text and "queue depth sample" not in evidence_text:
+        raise SystemExit("expected baseline evidence to mention queue wait/depth from lock contention")
+
+    before_p95 = before["p95_latency_us"]
+    after_p95 = after["p95_latency_us"]
+    before_score = before["primary_suspect"]["score"]
+    after_score = after["primary_suspect"]["score"]
+
+    if after_p95 >= before_p95 and after_score >= before_score:
+        raise SystemExit(
+            "expected mitigation to improve p95 and/or primary suspect score, "
+            f"got p95 {before_p95}->{after_p95} and score {before_score}->{after_score}"
+        )
+
+    print(
+        "validation passed: baseline suspect kind={}, p95 {}us -> {}us, score {} -> {}".format(
+            before_kind,
+            before_p95,
+            after_p95,
+            before_score,
+            after_score,
+        )
+    )
+    print(
+        "validated analysis files: "
+        f"{artifact_dir / 'before-analysis.json'}, {artifact_dir / 'after-analysis.json'}"
+    )
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Unified tailtriage demo run/validate tool.")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -484,7 +540,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     run_parser = subparsers.add_parser("run", help="Run demo scenario and produce analysis artifacts")
     run_parser.add_argument(
         "scenario",
-        choices=["queue", "blocking", "executor", "downstream", "mixed", "cold-start", "db-pool"],
+        choices=[
+            "queue",
+            "blocking",
+            "executor",
+            "downstream",
+            "mixed",
+            "cold-start",
+            "db-pool",
+            "shared-lock",
+        ],
     )
     run_parser.add_argument(
         "mode",
@@ -501,7 +566,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     validate_parser = subparsers.add_parser("validate", help="Run scenario validation contract checks")
     validate_parser.add_argument(
         "scenario",
-        choices=["queue", "blocking", "executor", "downstream", "mixed", "cold-start", "db-pool"],
+        choices=[
+            "queue",
+            "blocking",
+            "executor",
+            "downstream",
+            "mixed",
+            "cold-start",
+            "db-pool",
+            "shared-lock",
+        ],
     )
 
     return parser.parse_args(argv)
@@ -525,6 +599,8 @@ def main(argv: list[str] | None = None) -> None:
             run_scenario_cold_start(root_dir, args.mode)
         elif args.scenario == "db-pool":
             run_scenario_db_pool(root_dir, args.mode)
+        elif args.scenario == "shared-lock":
+            run_scenario_shared_lock(root_dir, args.mode)
         else:
             run_scenario_mixed(root_dir, args.mode)
         return
@@ -541,6 +617,8 @@ def main(argv: list[str] | None = None) -> None:
         validate_cold_start(root_dir)
     elif args.scenario == "db-pool":
         validate_db_pool(root_dir)
+    elif args.scenario == "shared-lock":
+        validate_shared_lock(root_dir)
     else:
         validate_mixed(root_dir)
 


### PR DESCRIPTION
### Motivation
- Provide a focused, reproducible demo that shows how shared lock contention can manifest as application-level queueing in triage output. 
- Offer a before/after mitigation case (long critical section vs reduced lock hold time) to exercise ranking and evidence shifts in the analyzer. 
- Surface this scenario in docs and the test harness so reviewers and users can validate that lock waits are captured as queue-like waits and critical sections as service stages.

### Description
- Add a new demo crate `demos/shared_state_lock_service` that models high-contention write access protected by `tokio::sync::RwLock`, where the lock wait is instrumented via `queue(..., "shared_state_write_lock")` and the protected work is instrumented via `stage(..., "shared_state_critical_section")`. 
- Add deterministic before/after fixtures under `demos/shared_state_lock_service/fixtures/` and an artifacts directory to hold run outputs. 
- Extend `scripts/demo_tool.py` with `run`/`validate` support for the `shared-lock` scenario and validator rules that assert baseline shows queue-like evidence and that mitigation improves p95 and/or suspect score. 
- Update `demos/README.md` and `SPEC.md` to document the new demo and include the demo in the workspace members so it builds with the repo.

### Testing
- Ran the demo validator with `python3 scripts/demo_tool.py validate shared-lock`, which produced before/after artifacts and passed the validation checks. 
- Ran formatting and linting checks with `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings`, which succeeded. 
- Ran the full test suite with `cargo test --workspace`, which completed and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd7dabd39883309f0f14f8f06a72bb)