### PR TITLE
docs: add runtime-cost demo guidance

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -163,3 +163,22 @@ python3 scripts/demo_tool.py validate blocking
 ```
 
 Repeat for the remaining demos (`executor`, `downstream`, `mixed`, `cold-start`, `db-pool`, `shared-lock`, `retry-storm`).
+
+For runtime-cost overhead measurement (separate from suspect-ranking triage), run `python3 scripts/measure_runtime_cost.py` and see `docs/runtime-cost.md` for usage details and interpretation guidance.
+
+## `runtime_cost`
+
+**Purpose**
+
+- Measures instrumentation overhead across `baseline`, `light`, and `investigation` modes.
+- This is a runtime-cost measurement path, not a suspect-ranking triage scenario.
+
+**Canonical command**
+
+```bash
+python3 scripts/measure_runtime_cost.py
+```
+
+**Output artifacts**
+
+- `demos/runtime_cost/artifacts/`

--- a/docs/getting-started-demo.md
+++ b/docs/getting-started-demo.md
@@ -46,6 +46,19 @@ python3 scripts/demo_tool.py validate db-pool
 | `mixed_contention_service` | queue + downstream contention together | baseline includes both suspects; mitigation should shift rank and/or score |
 | `cold_start_burst_service` | cold-start cohort causes warmup drag and burst queueing | baseline evidence references `cold_start_stage` and/or queue pressure; mitigation lowers p95 and primary suspect score |
 | `db_pool_saturation_service` | DB pool admission + slow DB stage contention | baseline suspect includes queue saturation and/or downstream dominance; mitigation improves p95 and/or score |
+| `runtime_cost` | instrumentation overhead measurement (not suspect-ranking triage) | run via `python3 scripts/measure_runtime_cost.py`; writes `demos/runtime_cost/artifacts/` |
+
+## Runtime-cost demo path (separate from triage scenarios)
+
+`runtime_cost` is a measurement demo that uses a separate script entrypoint rather than `scripts/demo_tool.py`.
+
+Use:
+
+```bash
+python3 scripts/measure_runtime_cost.py
+```
+
+For mode definitions, metrics, and interpretation details, see **[`docs/runtime-cost.md`](./runtime-cost.md)**.
 
 ## Mixed-contention expected rank behavior
 


### PR DESCRIPTION
### Motivation

- Clarify that `runtime_cost` is an instrumentation-overhead measurement path distinct from the suspect-ranking demo scenarios. 
- Make it easier for contributors and first-time users to find the canonical command and artifact location for reproducible overhead measurements.

### Description

- Added a short note to the `Typical local workflow` section in `demos/README.md` pointing to the runtime-cost command and `docs/runtime-cost.md` for usage and interpretation. 
- Added a new `runtime_cost` section to `demos/README.md` documenting purpose, canonical command (`python3 scripts/measure_runtime_cost.py`), and output artifacts path (`demos/runtime_cost/artifacts/`). 
- Updated `docs/getting-started-demo.md` to include a `runtime_cost` row in the demo table and a dedicated section explaining it uses a separate script entrypoint and pointing to `docs/runtime-cost.md`.

### Testing

- Ran `cargo fmt --check` which passed. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` which passed. 
- Ran `cargo test --workspace` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd8c4aac788330b5b268a8fdc5be85)