### PR TITLE
Follow-up: public launch readiness docs, templates, and minimal example

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Report incorrect triage output, crashes, or integration issues.
+title: "bug: "
+labels: ["bug"]
+assignees: []
+---
+
+## Summary
+
+Describe the bug clearly.
+
+## Environment
+
+- Rust toolchain:
+- Tokio version:
+- OS:
+
+## Reproduction
+
+Provide minimal reproduction steps.
+
+## Expected behavior
+
+What did you expect to happen?
+
+## Actual behavior
+
+What happened instead?
+
+## Artifact / logs
+
+If possible, attach a small run artifact or anonymized output.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Propose an MVP-aligned improvement.
+title: "feature: "
+labels: ["enhancement"]
+assignees: []
+---
+
+## Problem statement
+
+What triage workflow problem are you trying to solve?
+
+## Proposed change
+
+Describe the smallest useful change.
+
+## Why this belongs in MVP
+
+Explain why this improves Tokio tail-latency triage without broadening into a general observability platform.
+
+## Alternatives considered
+
+What else did you consider?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+
+-
+
+## Why this change
+
+-
+
+## Validation
+
+- [ ] `cargo fmt --check`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo test --workspace`
+
+## Scope check
+
+- [ ] This PR stays within MVP triage scope.
+- [ ] If behavior changed, docs were updated.
+- [ ] Suspects are still described as evidence-ranked leads, not causal proof.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing to tailtriage
+
+Thanks for helping improve `tailtriage`.
+
+## What this project is
+
+`tailtriage` is a Rust toolkit for **Tokio tail-latency triage**.
+
+The project focuses on producing **evidence-ranked suspects** and **next checks** from one run artifact. Suspects are leads, not proof of root cause.
+
+## Fast contributor workflow
+
+1. Open an issue (or comment on an existing one) before large changes.
+2. Keep PRs scoped to one problem.
+3. Add or update tests with behavior changes.
+4. Run local checks before pushing:
+
+```bash
+cargo fmt --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+## Scope guardrails
+
+Please do not expand MVP scope in drive-by PRs. In particular, avoid adding:
+
+- observability backends/exporters
+- distributed tracing backends
+- non-Tokio runtime support
+- GUI/web UI
+- ML/statistical auto-diagnosis systems
+
+## Docs updates expected
+
+If behavior or user workflows change, update:
+
+- `README.md`
+- `SPEC.md`
+- `IMPLEMENTATION_PLAN.md` (if roadmap/milestone expectations shift)
+
+## Pull request checklist
+
+- [ ] Change is scoped and explained.
+- [ ] Tests updated/added where needed.
+- [ ] `cargo fmt`, `cargo clippy`, and `cargo test` pass.
+- [ ] Public docs reflect behavior changes.
+- [ ] Claims remain evidence-based and within MVP scope.

--- a/README.md
+++ b/README.md
@@ -65,10 +65,12 @@ MVP scope is intentionally narrow:
 
 ```toml
 [dependencies]
-tailtriage-core = { path = "../tailtriage-core" }
-tailtriage-tokio = { path = "../tailtriage-tokio" }
+tailtriage-core = "0.1"
+tailtriage-tokio = "0.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 ```
+
+For local workspace development, swap the version entries for path dependencies in your own repository checkout.
 
 ### 2) Instrument one request path
 
@@ -118,6 +120,18 @@ Start with:
 - `p95_queue_share_permille`
 - `p95_service_share_permille`
 
+## Minimal runnable example
+
+A minimal end-to-end example is available at:
+
+- [`tailtriage-tokio/examples/minimal_checkout.rs`](tailtriage-tokio/examples/minimal_checkout.rs)
+
+Run it with:
+
+```bash
+cargo run -p tailtriage-tokio --example minimal_checkout
+```
+
 ## Canonical integration path
 
 1. Initialize one collector (`Tailtriage::init`).
@@ -138,3 +152,5 @@ Start with:
 For concise docs by audience, start at **[docs/README.md](docs/README.md)**.
 
 For demo-specific behavior and triage expectations, see **[demos/README.md](demos/README.md)**.
+
+For a concrete before/after workflow, see **[demos/retry_storm_service/fixtures/before-after-comparison.json](demos/retry_storm_service/fixtures/before-after-comparison.json)**.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Use this page as the single entry point for project documentation.
 - **MVP product contract (Tokio tail-latency triage):** [../SPEC.md](../SPEC.md)
 - **Release/polish plan:** [../IMPLEMENTATION_PLAN.md](../IMPLEMENTATION_PLAN.md)
 - **v0.1 release decision gates and launch order:** [release-gates-v0.1.md](release-gates-v0.1.md)
+- **Public visibility readiness checklist:** [public-readiness-checklist.md](public-readiness-checklist.md)
 
 ## Reproducibility and operations
 

--- a/docs/public-readiness-checklist.md
+++ b/docs/public-readiness-checklist.md
@@ -1,0 +1,50 @@
+# Public readiness checklist
+
+Use this checklist before switching repository visibility from private to public.
+
+## 1) Repository metadata and settings
+
+- [ ] Repository description clearly says: "Rust toolkit for Tokio tail-latency triage".
+- [ ] Topics are intentional (for example: `rust`, `tokio`, `performance`, `latency`, `diagnostics`).
+- [ ] Default branch is correct and protected.
+- [ ] Branch protection requires passing CI and blocks force-pushes/deletions.
+- [ ] Required status checks reference current workflow names (`CI`, `Python Demo Checks`).
+- [ ] Tag and release policy is intentional (no accidental internal tags).
+
+## 2) CI log and artifact hygiene
+
+- [ ] Review recent GitHub Actions logs for secrets, internal hostnames, and private paths.
+- [ ] Confirm Actions artifacts do not contain sensitive internals.
+- [ ] Confirm workflow output is reproducible and intentionally public-facing.
+
+## 3) Public docs and front page quality
+
+- [ ] README opening clearly states category and target user.
+- [ ] README quickstart avoids internal-only path assumptions.
+- [ ] README links to at least one concrete before/after workflow artifact.
+- [ ] Docs index (`docs/README.md`) points first-time users to an obvious start path.
+- [ ] Language keeps suspects as evidence-ranked leads, not proof of root cause.
+
+## 4) Community and contribution surface
+
+- [ ] `LICENSE` is present and intentional.
+- [ ] `CONTRIBUTING.md` is present and aligned with MVP scope.
+- [ ] Issue templates and PR template are present and intentional.
+- [ ] Labels are curated for public use (bug, enhancement, docs, triage, good first issue).
+
+## 5) Launch readiness checks
+
+Run locally before the visibility flip:
+
+```bash
+cargo fmt --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+Definition of ready:
+
+- main branch green
+- no obvious internal-only assumptions in public docs
+- no known sensitive exposure in Actions logs/artifacts
+- first-time visitor can understand product category and workflow from repository front page

--- a/tailtriage-tokio/examples/minimal_checkout.rs
+++ b/tailtriage-tokio/examples/minimal_checkout.rs
@@ -1,0 +1,34 @@
+use std::time::Duration;
+use tailtriage_core::{Config, RequestMeta, Tailtriage};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut config = Config::new("minimal-checkout");
+    config.output_path = "tailtriage-run.json".into();
+
+    let tailtriage = Tailtriage::init(config)?;
+
+    let meta = RequestMeta::for_route("/checkout").with_kind("http");
+    let request_id = meta.request_id.clone();
+
+    tailtriage
+        .request(meta, "ok", async {
+            tailtriage
+                .queue(request_id.clone(), "ingress_queue")
+                .await_on(tokio::time::sleep(Duration::from_millis(3)))
+                .await;
+
+            tailtriage
+                .stage(request_id, "db_call")
+                .await_value(tokio::time::sleep(Duration::from_millis(8)))
+                .await;
+        })
+        .await;
+
+    tailtriage.flush()?;
+
+    println!("wrote tailtriage-run.json");
+    println!("next: cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json");
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Prepare the repository for public visibility by removing internal assumptions from the front page and adding contributor and launch-readiness scaffolding. 
- Make it easy for a first-time visitor to run a minimal end-to-end capture + analyze workflow and find a concrete before/after artifact. 
- Provide a concise checklist and templates so maintainers can verify CI/artifact hygiene and community surfaces before flipping visibility. 

### Description

- Replace local-path-only quickstart snippets in `README.md` with public-facing versioned dependencies and add a note for local workspace development. 
- Add a minimal runnable example at `tailtriage-tokio/examples/minimal_checkout.rs` and link it from the README. 
- Add contributor and collaboration scaffolding: `CONTRIBUTING.md`, issue templates (`.github/ISSUE_TEMPLATE/`), and a pull request template (`.github/pull_request_template.md`). 
- Add a new `docs/public-readiness-checklist.md` and link it from `docs/README.md` to document the repository visibility and CI/artifact hygiene checks. 

### Testing

- Ran `cargo fmt --check` which completed successfully. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` which completed successfully. 
- Ran `cargo test --workspace` and all unit and fixture tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd9eae067083309fcdded5690a9e15)