### PR TITLE
ci: validate all documented deterministic demo scenarios in Python Demo Checks

### DIFF
--- a/.github/workflows/python-demos.yml
+++ b/.github/workflows/python-demos.yml
@@ -32,5 +32,21 @@ jobs:
       - name: Validate blocking demo
         run: python3 scripts/demo_tool.py validate blocking
 
+      - name: Validate executor demo
+        run: python3 scripts/demo_tool.py validate executor
+
       - name: Validate downstream demo
         run: python3 scripts/demo_tool.py validate downstream
+
+      - name: Validate mixed demo
+        run: python3 scripts/demo_tool.py validate mixed
+
+      - name: Validate cold-start demo
+        run: python3 scripts/demo_tool.py validate cold-start
+
+      - name: Validate db-pool demo
+        run: python3 scripts/demo_tool.py validate db-pool
+
+      - name: Measure runtime cost (non-blocking)
+        continue-on-error: true
+        run: python3 scripts/measure_runtime_cost.py

--- a/docs/public-readiness-checklist.md
+++ b/docs/public-readiness-checklist.md
@@ -8,7 +8,9 @@ Use this checklist before switching repository visibility from private to public
 - [ ] Topics are intentional (for example: `rust`, `tokio`, `performance`, `latency`, `diagnostics`).
 - [ ] Default branch is correct and protected.
 - [ ] Branch protection requires passing CI and blocks force-pushes/deletions.
-- [ ] Required status checks reference current workflow names (`CI`, `Python Demo Checks`).
+- [ ] Required status checks reference current workflow names (`CI`, `Python Demo Checks`) and avoid transient job-level names.
+- [ ] Required checks include Rust quality gates (`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`) and deterministic triage validations for: `queue`, `blocking`, `executor`, `downstream`, `mixed`, `cold-start`, and `db-pool`.
+- [ ] Runtime-cost measurement remains informational/non-blocking (it should not gate merges).
 - [ ] Tag and release policy is intentional (no accidental internal tags).
 
 ## 2) CI log and artifact hygiene
@@ -40,6 +42,19 @@ Run locally before the visibility flip:
 cargo fmt --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
+python3 scripts/demo_tool.py validate queue
+python3 scripts/demo_tool.py validate blocking
+python3 scripts/demo_tool.py validate executor
+python3 scripts/demo_tool.py validate downstream
+python3 scripts/demo_tool.py validate mixed
+python3 scripts/demo_tool.py validate cold-start
+python3 scripts/demo_tool.py validate db-pool
+```
+
+Optional/non-blocking measurement:
+
+```bash
+python3 scripts/measure_runtime_cost.py
 ```
 
 Definition of ready:


### PR DESCRIPTION
### Motivation

- The documented demos include deterministic scenarios beyond the existing checks, so CI should validate all documented triage fixtures to keep demo regressions from slipping in.
- Runtime-cost measurement is useful but slow and should remain informational and non-blocking to avoid gating merges.

### Description

- Added `executor`, `mixed`, `cold-start`, and `db-pool` `python3 scripts/demo_tool.py validate` steps to the existing `Python Demo Checks` workflow while keeping the workflow and job names stable for branch protection.
- Added a separate `Measure runtime cost (non-blocking)` step that runs `python3 scripts/measure_runtime_cost.py` with `continue-on-error: true` so it is clearly optional.
- Updated `docs/public-readiness-checklist.md` to list the full deterministic validation set and to mark the runtime-cost measurement as optional/non-blocking, and to note required workflow-level names (`CI`, `Python Demo Checks`).

### Testing

- Ran `cargo fmt --check` and it succeeded.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it succeeded.
- Ran `cargo test --workspace` and it succeeded.
- Ran Python unit tests `python3 -m unittest -v scripts/tests/test_demo_scripts.py` and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bda40ad8088330be7a2e04c1f6c0f9)