### PR TITLE
Add crates.io metadata to publishable crates and add dry-run publish checklist

### DIFF
--- a/docs/launch-checklist-issue-v0.1.md
+++ b/docs/launch-checklist-issue-v0.1.md
@@ -1,0 +1,90 @@
+# Launch checklist issue: crates metadata and dry-run publish status (v0.1)
+
+Date: 2026-03-20
+
+## Scope
+
+- Added public-facing crates.io metadata to publishable crates:
+  - `tailtriage-core`
+  - `tailtriage-macros`
+  - `tailtriage-tokio`
+  - `tailtriage-cli`
+- Ran `cargo publish --dry-run` for each publishable crate.
+
+## Metadata checklist
+
+- [x] `description` added and aligned with Tokio tail-latency triage positioning.
+- [x] `repository` added (`https://github.com/tailtriage/tailtriage`).
+- [x] `documentation` added (docs.rs URL per crate).
+- [x] `readme` added (`../README.md`).
+- [x] `keywords` added for crates.io discovery.
+- [x] `categories` added for crates.io discovery.
+
+## Dry-run outcomes
+
+### 1) `tailtriage-core`
+
+Command:
+
+```bash
+cargo publish -p tailtriage-core --dry-run --allow-dirty
+```
+
+Outcome: ✅ Success (packaging + verification completed; upload aborted due to dry-run).
+
+### 2) `tailtriage-macros`
+
+Command:
+
+```bash
+cargo publish -p tailtriage-macros --dry-run --allow-dirty
+```
+
+Outcome: ⚠️ Blocked in pre-publish sequence because `tailtriage-core` is not yet available on crates.io in this local dry-run context.
+
+Error excerpt:
+
+```text
+no matching package named `tailtriage-core` found
+location searched: crates.io index
+```
+
+### 3) `tailtriage-tokio`
+
+Command:
+
+```bash
+cargo publish -p tailtriage-tokio --dry-run --allow-dirty
+```
+
+Outcome: ⚠️ Blocked in pre-publish sequence because `tailtriage-core` is not yet available on crates.io in this local dry-run context.
+
+Error excerpt:
+
+```text
+no matching package named `tailtriage-core` found
+location searched: crates.io index
+```
+
+### 4) `tailtriage-cli`
+
+Command:
+
+```bash
+cargo publish -p tailtriage-cli --dry-run --allow-dirty
+```
+
+Outcome: ⚠️ Blocked in pre-publish sequence because `tailtriage-core` is not yet available on crates.io in this local dry-run context.
+
+Error excerpt:
+
+```text
+no matching package named `tailtriage-core` found
+location searched: crates.io index
+```
+
+## Next checks
+
+1. Publish `tailtriage-core` first.
+2. Re-run dry-runs for `tailtriage-macros`, `tailtriage-tokio`, and `tailtriage-cli` after `tailtriage-core` is available on crates.io.
+3. Publish remaining crates in dependency order and confirm docs.rs pages resolve.

--- a/tailtriage-cli/Cargo.toml
+++ b/tailtriage-cli/Cargo.toml
@@ -3,6 +3,12 @@ name = "tailtriage-cli"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+description = "CLI for Tokio tail-latency triage reports with evidence-ranked suspects and next checks"
+repository = "https://github.com/tailtriage/tailtriage"
+documentation = "https://docs.rs/tailtriage-cli"
+readme = "../README.md"
+keywords = ["tokio", "latency", "cli", "diagnostics", "triage"]
+categories = ["command-line-utilities", "development-tools::profiling", "development-tools::debugging"]
 
 [[bin]]
 name = "tailtriage"
@@ -12,7 +18,7 @@ path = "src/main.rs"
 clap = { version = "4.5.40", features = ["derive"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
-tailtriage-core = { path = "../tailtriage-core" }
+tailtriage-core = { version = "0.1.0", path = "../tailtriage-core" }
 
 [lints]
 workspace = true

--- a/tailtriage-core/Cargo.toml
+++ b/tailtriage-core/Cargo.toml
@@ -3,6 +3,12 @@ name = "tailtriage-core"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+description = "Core data model and analyzer for Tokio tail-latency triage with evidence-ranked suspects"
+repository = "https://github.com/tailtriage/tailtriage"
+documentation = "https://docs.rs/tailtriage-core"
+readme = "../README.md"
+keywords = ["tokio", "latency", "diagnostics", "performance", "triage"]
+categories = ["asynchronous", "development-tools::profiling", "development-tools::debugging"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/tailtriage-macros/Cargo.toml
+++ b/tailtriage-macros/Cargo.toml
@@ -3,6 +3,12 @@ name = "tailtriage-macros"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+description = "Proc macros for low-friction Tokio request instrumentation in tail-latency triage"
+repository = "https://github.com/tailtriage/tailtriage"
+documentation = "https://docs.rs/tailtriage-macros"
+readme = "../README.md"
+keywords = ["tokio", "latency", "proc-macro", "instrumentation", "triage"]
+categories = ["asynchronous", "development-tools::profiling", "development-tools::debugging"]
 
 [lib]
 proc-macro = true
@@ -17,7 +23,7 @@ workspace = true
 
 [dev-dependencies]
 serde_json = "1"
-tailtriage-core = { path = "../tailtriage-core" }
+tailtriage-core = { version = "0.1.0", path = "../tailtriage-core" }
 tokio = { version = "1", features = ["macros", "rt"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/tailtriage-tokio/Cargo.toml
+++ b/tailtriage-tokio/Cargo.toml
@@ -3,10 +3,16 @@ name = "tailtriage-tokio"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+description = "Tokio runtime sampling and request instrumentation helpers for tail-latency triage"
+repository = "https://github.com/tailtriage/tailtriage"
+documentation = "https://docs.rs/tailtriage-tokio"
+readme = "../README.md"
+keywords = ["tokio", "latency", "instrumentation", "async", "triage"]
+categories = ["asynchronous", "development-tools::profiling", "development-tools::debugging"]
 
 [dependencies]
-tailtriage-core = { path = "../tailtriage-core" }
-tailtriage-macros = { path = "../tailtriage-macros" }
+tailtriage-core = { version = "0.1.0", path = "../tailtriage-core" }
+tailtriage-macros = { version = "0.1.0", path = "../tailtriage-macros" }
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 tracing = "0.1"
 


### PR DESCRIPTION
### Motivation

- Prepare publishable crates for crates.io and docs.rs by adding public-facing metadata aligned to Tokio tail-latency triage positioning. 
- Ensure first-public experience (docs, README link, keywords, categories) is ready per release gates. 
- Make local publish compatibility checks succeed by giving internal `path` dependencies an explicit version for `cargo publish` verification.

### Description

- Added `description`, `repository`, `documentation`, `readme`, `keywords`, and `categories` fields to `tailtriage-core/Cargo.toml`, `tailtriage-tokio/Cargo.toml`, `tailtriage-cli/Cargo.toml`, and `tailtriage-macros/Cargo.toml`. 
- Updated local `path` dependencies to include explicit versions (set to `0.1.0`) so publish checks can resolve dependency versions during dry-runs. 
- Added `docs/launch-checklist-issue-v0.1.md` that documents the `cargo publish --dry-run` outcomes and the next steps for publishing (dependency-order publish instructions). 

### Testing

- Ran `cargo fmt --check` and it succeeded. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it succeeded. 
- Ran `cargo test --workspace` and the full test suite passed. 
- Executed `cargo publish --dry-run` style checks: `tailtriage-core` packaged and verified successfully with `--dry-run`; `tailtriage-macros`, `tailtriage-tokio`, and `tailtriage-cli` dry-runs were blocked until `tailtriage-core` is available on crates.io, and these outcomes are recorded in the launch checklist document.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bda4b1fe588330acf7da6bef5fd514)