### PR TITLE
Add cross-crate end-to-end capture→flush→analyze integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,6 +425,9 @@ dependencies = [
  "serde",
  "serde_json",
  "tailtriage-core",
+ "tailtriage-tokio",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/tailtriage-cli/Cargo.toml
+++ b/tailtriage-cli/Cargo.toml
@@ -22,3 +22,8 @@ tailtriage-core = { version = "0.1.0", path = "../tailtriage-core" }
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+tracing = "0.1.44"
+tokio = { version = "1.48.0", features = ["macros", "rt", "time"] }
+tailtriage-tokio = { version = "0.1.0", path = "../tailtriage-tokio" }

--- a/tailtriage-cli/tests/end_to_end_capture_analysis.rs
+++ b/tailtriage-cli/tests/end_to_end_capture_analysis.rs
@@ -1,0 +1,142 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tailtriage_cli::analyze::{analyze_run, DiagnosisKind};
+use tailtriage_core::{Config, RequestMeta, Run, Tailtriage};
+use tailtriage_tokio::instrument_request;
+
+fn temp_artifact_path(prefix: &str) -> std::path::PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time before epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("tailtriage_e2e_{prefix}_{nanos}.json"))
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn queue_heavy_direct_capture_flush_and_analysis_reports_queue_suspect() {
+    let output_path = temp_artifact_path("queue");
+    let mut config = Config::new("e2e-queue");
+    config.output_path = output_path.clone();
+    let tailtriage = Tailtriage::init(config).expect("init should succeed");
+
+    for index in 0..6 {
+        let request_id = format!("queue-{index}");
+        let request_meta = RequestMeta::new(request_id.clone(), "/checkout");
+
+        tailtriage
+            .request(request_meta, "ok", async {
+                tailtriage
+                    .queue(request_id.clone(), "checkout_queue")
+                    .with_depth_at_start(24)
+                    .await_on(tokio::time::sleep(std::time::Duration::from_millis(8)))
+                    .await;
+                tailtriage
+                    .stage(request_id.clone(), "local_work")
+                    .await_value(tokio::time::sleep(std::time::Duration::from_millis(1)))
+                    .await;
+            })
+            .await;
+    }
+
+    tailtriage.flush().expect("flush should succeed");
+
+    let run_json = std::fs::read_to_string(&output_path).expect("artifact should be readable");
+    let run: Run = serde_json::from_str(&run_json).expect("artifact should parse as Run");
+    assert_eq!(run.requests.len(), 6);
+    assert_eq!(run.queues.len(), 6);
+
+    let report = analyze_run(&run);
+    assert_eq!(
+        report.primary_suspect.kind,
+        DiagnosisKind::ApplicationQueueSaturation
+    );
+    assert!(!report.primary_suspect.evidence.is_empty());
+
+    let report_json = serde_json::to_value(&report).expect("report should serialize");
+    assert!(report_json["primary_suspect"]["evidence"].is_array());
+
+    std::fs::remove_file(output_path).expect("temp artifact should be removable");
+}
+
+#[instrument_request(
+    route = "/checkout",
+    kind = "place_order",
+    tailtriage = tailtriage,
+    request_id = request_id.to_string(),
+    skip(tailtriage)
+)]
+async fn downstream_handler(tailtriage: &Tailtriage, request_id: &str) -> Result<(), ()> {
+    tailtriage
+        .stage(request_id, "downstream_db")
+        .await_on(async {
+            tokio::time::sleep(std::time::Duration::from_millis(12)).await;
+            Ok::<(), ()>(())
+        })
+        .await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn downstream_heavy_macro_capture_flush_and_analysis_reports_stage_suspect() {
+    let output_path = temp_artifact_path("downstream");
+    let mut config = Config::new("e2e-downstream");
+    config.output_path = output_path.clone();
+    let tailtriage = Tailtriage::init(config).expect("init should succeed");
+
+    for index in 0..5 {
+        let request_id = format!("downstream-{index}");
+        downstream_handler(&tailtriage, &request_id)
+            .await
+            .expect("handler should succeed");
+    }
+
+    tailtriage.flush().expect("flush should succeed");
+
+    let run_json = std::fs::read_to_string(&output_path).expect("artifact should be readable");
+    let run: Run = serde_json::from_str(&run_json).expect("artifact should parse as Run");
+    assert_eq!(run.requests.len(), 5);
+    assert_eq!(run.stages.len(), 5);
+
+    let report = analyze_run(&run);
+    assert_eq!(
+        report.primary_suspect.kind,
+        DiagnosisKind::DownstreamStageDominates
+    );
+    assert!(!report.primary_suspect.next_checks.is_empty());
+
+    std::fs::remove_file(output_path).expect("temp artifact should be removable");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn request_only_capture_flush_and_analysis_reports_insufficient_evidence() {
+    let output_path = temp_artifact_path("insufficient");
+    let mut config = Config::new("e2e-insufficient");
+    config.output_path = output_path.clone();
+    let tailtriage = Tailtriage::init(config).expect("init should succeed");
+
+    for index in 0..3 {
+        let request_meta = RequestMeta::new(format!("insufficient-{index}"), "/health");
+        tailtriage
+            .request(request_meta, "ok", async {
+                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            })
+            .await;
+    }
+
+    tailtriage.flush().expect("flush should succeed");
+
+    let run_json = std::fs::read_to_string(&output_path).expect("artifact should be readable");
+    let run: Run = serde_json::from_str(&run_json).expect("artifact should parse as Run");
+    assert_eq!(run.requests.len(), 3);
+    assert!(run.queues.is_empty());
+    assert!(run.stages.is_empty());
+
+    let report = analyze_run(&run);
+    assert_eq!(
+        report.primary_suspect.kind,
+        DiagnosisKind::InsufficientEvidence
+    );
+    assert!(!report.primary_suspect.evidence.is_empty());
+
+    std::fs::remove_file(output_path).expect("temp artifact should be removable");
+}


### PR DESCRIPTION
### Motivation
- Provide deterministic, cross-crate triage coverage that exercises the full capture -> flush -> artifact read -> analyze workflow rather than only crate-local unit tests.  
- Validate that analysis produces evidence-ranked suspects and clear next checks for common tail-latency scenarios.  
- Ensure regressions in the real end-to-end workflow are caught in CI for the major triage paths (queue, downstream, and sparse instrumentation).

### Description
- Add `tailtriage-cli/tests/end_to_end_capture_analysis.rs` with three Tokio-powered tests that create a `Tailtriage` run artifact, flush it to disk, read it back as a `Run`, and call `analyze_run` for verification.  
- Cover three deterministic scenarios: a queue-heavy direct-API path asserting `ApplicationQueueSaturation`, a downstream-heavy macro-assisted path using `#[instrument_request]` asserting `DownstreamStageDominates`, and a request-only sparse scenario asserting `InsufficientEvidence`.  
- Verify analysis output shape and fields by asserting report primary suspect kinds, presence of evidence and next checks, and JSON-serializability of the produced report.  
- Add necessary test-only dev-dependencies to `tailtriage-cli/Cargo.toml` (`tokio`, `tailtriage-tokio`, and `tracing`) so macro-assisted instrumentation and Tokio tests build in the `tailtriage-cli` test target.

### Testing
- Ran `cargo fmt --check` and formatting passed after test file formatting adjustments.  
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and the workspace passed without warnings.  
- Ran `cargo test --workspace` and all workspace tests (including the three new end-to-end tests) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be600b86648330b30c6cd62ddc1094)