### PR TITLE
Harden CLI run-artifact validation and error messaging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
 name = "blocking-service-demo"
 version = "0.1.0"
 dependencies = [
@@ -159,6 +165,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "executor-pressure-service-demo"
 version = "0.1.0"
 dependencies = [
@@ -167,6 +189,18 @@ dependencies = [
  "tailtriage-core",
  "tokio",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "futures-core"
@@ -204,10 +238,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -226,6 +306,24 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -277,6 +375,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +413,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "retry-storm-service-demo"
 version = "0.1.0"
 dependencies = [
@@ -325,6 +439,25 @@ dependencies = [
  "tailtriage-tokio",
  "tokio",
 ]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -426,6 +559,7 @@ dependencies = [
  "serde_json",
  "tailtriage-core",
  "tailtriage-tokio",
+ "tempfile",
  "tokio",
  "tracing",
 ]
@@ -461,6 +595,19 @@ dependencies = [
  "tailtriage-macros",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -557,6 +704,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,6 +720,58 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "windows-link"
@@ -581,6 +786,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/tailtriage-cli/Cargo.toml
+++ b/tailtriage-cli/Cargo.toml
@@ -24,6 +24,7 @@ tailtriage-core = { version = "0.1.0", path = "../tailtriage-core" }
 workspace = true
 
 [dev-dependencies]
+tempfile = "3.23.0"
 tracing = "0.1.44"
 tokio = { version = "1.48.0", features = ["macros", "rt", "time"] }
 tailtriage-tokio = { version = "0.1.0", path = "../tailtriage-tokio" }

--- a/tailtriage-cli/src/artifact.rs
+++ b/tailtriage-cli/src/artifact.rs
@@ -1,0 +1,241 @@
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+use tailtriage_core::Run;
+
+const SUPPORTED_SCHEMA_VERSION: u64 = 1;
+
+#[derive(Debug)]
+pub struct LoadedArtifact {
+    pub run: Run,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug)]
+pub enum ArtifactLoadError {
+    Read {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    Parse {
+        path: PathBuf,
+        message: String,
+    },
+    UnsupportedSchemaVersion {
+        path: PathBuf,
+        found: u64,
+        supported: u64,
+    },
+    InvalidSchemaVersionType {
+        path: PathBuf,
+    },
+    Validation {
+        path: PathBuf,
+        message: String,
+    },
+}
+
+impl std::fmt::Display for ArtifactLoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Read { path, source } => {
+                write!(f, "failed to read run artifact '{}': {source}", path.display())
+            }
+            Self::Parse { path, message } => {
+                write!(f, "failed to parse run artifact '{}': {message}", path.display())
+            }
+            Self::UnsupportedSchemaVersion {
+                path,
+                found,
+                supported,
+            } => write!(
+                f,
+                "unsupported run artifact schema_version={found} in '{}'; supported schema_version is {supported}. Re-generate the artifact with a compatible tailtriage version.",
+                path.display()
+            ),
+            Self::InvalidSchemaVersionType { path } => write!(
+                f,
+                "invalid run artifact in '{}': schema_version must be an integer when provided.",
+                path.display()
+            ),
+            Self::Validation { path, message } => write!(
+                f,
+                "invalid run artifact '{}': {message}",
+                path.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ArtifactLoadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        if let Self::Read { source, .. } = self {
+            Some(source)
+        } else {
+            None
+        }
+    }
+}
+
+/// Loads and validates a tailtriage run artifact from disk.
+///
+/// # Errors
+/// Returns [`ArtifactLoadError`] when the file cannot be read, the JSON is malformed,
+/// the schema is unsupported, or required sections are missing.
+pub fn load_run_artifact(path: &Path) -> Result<LoadedArtifact, ArtifactLoadError> {
+    let input = std::fs::read_to_string(path).map_err(|source| ArtifactLoadError::Read {
+        path: path.to_path_buf(),
+        source,
+    })?;
+
+    let raw: Value = serde_json::from_str(&input).map_err(|err| ArtifactLoadError::Parse {
+        path: path.to_path_buf(),
+        message: parse_error_message(&err),
+    })?;
+
+    validate_schema_version(&raw, path)?;
+
+    let run: Run = serde_json::from_value(raw).map_err(|err| ArtifactLoadError::Parse {
+        path: path.to_path_buf(),
+        message: format!(
+            "JSON shape does not match the tailtriage run schema ({err}). Check for missing required fields such as metadata.run_id and requests[]."
+        ),
+    })?;
+
+    validate_required_sections(&run, path)?;
+
+    Ok(LoadedArtifact {
+        run,
+        warnings: Vec::new(),
+    })
+}
+
+fn validate_schema_version(raw: &Value, path: &Path) -> Result<(), ArtifactLoadError> {
+    if let Some(version) = raw.get("schema_version") {
+        let Some(found) = version.as_u64() else {
+            return Err(ArtifactLoadError::InvalidSchemaVersionType {
+                path: path.to_path_buf(),
+            });
+        };
+
+        if found != SUPPORTED_SCHEMA_VERSION {
+            return Err(ArtifactLoadError::UnsupportedSchemaVersion {
+                path: path.to_path_buf(),
+                found,
+                supported: SUPPORTED_SCHEMA_VERSION,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_required_sections(run: &Run, path: &Path) -> Result<(), ArtifactLoadError> {
+    if run.requests.is_empty() {
+        return Err(ArtifactLoadError::Validation {
+            path: path.to_path_buf(),
+            message: "requests section is empty. Capture at least one request event before running triage.".to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+fn parse_error_message(error: &serde_json::Error) -> String {
+    match error.classify() {
+        serde_json::error::Category::Eof => {
+            format!("JSON ended unexpectedly ({error}). The artifact may be truncated; re-run capture and ensure the file was fully written.")
+        }
+        serde_json::error::Category::Syntax => {
+            format!("malformed JSON ({error}).")
+        }
+        serde_json::error::Category::Data => {
+            format!("JSON data is incompatible with the expected run schema ({error}).")
+        }
+        serde_json::error::Category::Io => {
+            format!("I/O error while parsing JSON ({error}).")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::load_run_artifact;
+
+    #[test]
+    fn rejects_malformed_json() {
+        let dir = tempfile::tempdir().expect("tempdir should build");
+        let path = dir.path().join("bad.json");
+        std::fs::write(&path, "{ not json").expect("fixture should write");
+
+        let error = load_run_artifact(&path).expect_err("expected parse failure");
+        let message = error.to_string();
+
+        assert!(message.contains("failed to parse run artifact"));
+        assert!(message.contains("malformed JSON"));
+    }
+
+    #[test]
+    fn rejects_missing_required_fields() {
+        let dir = tempfile::tempdir().expect("tempdir should build");
+        let path = dir.path().join("missing-fields.json");
+        std::fs::write(&path, r#"{"metadata":{},"requests":[],"stages":[],"queues":[],"inflight":[],"runtime_snapshots":[]}"#)
+            .expect("fixture should write");
+
+        let error = load_run_artifact(&path).expect_err("expected schema failure");
+        let message = error.to_string();
+
+        assert!(message.contains("JSON shape does not match"));
+        assert!(message.contains("missing required fields"));
+    }
+
+    #[test]
+    fn rejects_empty_requests_section() {
+        let dir = tempfile::tempdir().expect("tempdir should build");
+        let path = dir.path().join("empty-requests.json");
+        std::fs::write(&path, valid_run_json_with_requests("[]")).expect("fixture should write");
+
+        let error = load_run_artifact(&path).expect_err("expected validation failure");
+        let message = error.to_string();
+
+        assert!(message.contains("requests section is empty"));
+    }
+
+    #[test]
+    fn rejects_unsupported_schema_versions() {
+        let dir = tempfile::tempdir().expect("tempdir should build");
+        let path = dir.path().join("unsupported-version.json");
+        std::fs::write(&path, valid_run_json_with_prefix("\"schema_version\": 99,"))
+            .expect("fixture should write");
+
+        let error = load_run_artifact(&path).expect_err("expected version incompatibility");
+        let message = error.to_string();
+
+        assert!(message.contains("unsupported run artifact"));
+        assert!(message.contains("schema_version=99"));
+    }
+
+    #[test]
+    fn flags_truncation_like_parse_errors() {
+        let dir = tempfile::tempdir().expect("tempdir should build");
+        let path = dir.path().join("truncated.json");
+        std::fs::write(&path, "{\"metadata\": {\"run_id\": \"x\"").expect("fixture should write");
+
+        let error = load_run_artifact(&path).expect_err("expected parse failure");
+        let message = error.to_string();
+
+        assert!(message.contains("may be truncated"));
+    }
+
+    fn valid_run_json_with_requests(requests_json: &str) -> String {
+        format!(
+            "{{\"metadata\":{{\"run_id\":\"r1\",\"service_name\":\"svc\",\"service_version\":null,\"started_at_unix_ms\":1,\"finished_at_unix_ms\":2,\"mode\":\"light\",\"host\":null,\"pid\":null}},\"requests\":{requests_json},\"stages\":[],\"queues\":[],\"inflight\":[],\"runtime_snapshots\":[]}}"
+        )
+    }
+
+    fn valid_run_json_with_prefix(prefix: &str) -> String {
+        format!(
+            "{{{prefix}\"metadata\":{{\"run_id\":\"r1\",\"service_name\":\"svc\",\"service_version\":null,\"started_at_unix_ms\":1,\"finished_at_unix_ms\":2,\"mode\":\"light\",\"host\":null,\"pid\":null}},\"requests\":[{{\"request_id\":\"req1\",\"route\":\"/\",\"kind\":null,\"started_at_unix_ms\":1,\"finished_at_unix_ms\":2,\"latency_us\":10,\"outcome\":\"ok\"}}],\"stages\":[],\"queues\":[],\"inflight\":[],\"runtime_snapshots\":[]}}"
+        )
+    }
+}

--- a/tailtriage-cli/src/lib.rs
+++ b/tailtriage-cli/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod analyze;
+pub mod artifact;

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use clap::{Parser, ValueEnum};
 use tailtriage_cli::analyze::{analyze_run, render_text};
-use tailtriage_core::Run;
+use tailtriage_cli::artifact::load_run_artifact;
 
 #[derive(Debug, Parser)]
 #[command(name = "tailtriage")]
@@ -36,9 +36,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     match cli.command {
         Command::Analyze { run_json, format } => {
-            let input = std::fs::read_to_string(&run_json)?;
-            let run: Run = serde_json::from_str(&input)?;
-            let report = analyze_run(&run);
+            let loaded = load_run_artifact(&run_json)?;
+            for warning in &loaded.warnings {
+                eprintln!("warning: {warning}");
+            }
+            let report = analyze_run(&loaded.run);
 
             match format {
                 OutputFormat::Text => {


### PR DESCRIPTION
### Motivation
- The CLI must fail clearly and helpfully when presented with malformed, truncated, incomplete, or incompatible run artifacts so users can quickly triage ingestion issues. 
- Distinguish parse failures from compatibility failures and provide actionable guidance rather than opaque serde errors. 

### Description
- Add a dedicated artifact loader/validator module `tailtriage-cli::artifact` that exposes `load_run_artifact` and `LoadedArtifact` with structured `ArtifactLoadError` variants for read, parse, schema-version, type, and validation failures. 
- Implement `schema_version` validation, a non-empty `requests` section check, and a `parse_error_message` classifier that surfaces EOF/truncation, syntax, data, and I/O parse categories with actionable text. 
- Wire the CLI `analyze` command to call `load_run_artifact` and emit loader warnings to stderr before running `analyze_run`. 
- Add focused unit tests in `tailtriage-cli/src/artifact.rs` covering malformed JSON, truncated/EoF-like input, missing required fields, empty `requests`, and unsupported schema versions, and add `tempfile` as a dev-dependency used by those tests. 

### Testing
- Ran formatting, lints, and full workspace tests with `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`. 
- All automated checks succeeded and unit tests (including the new artifact tests) passed. 
- The CLI now surfaces loader errors with clear messages such as "may be truncated", "malformed JSON", "unsupported run artifact schema_version=...", and "requests section is empty" for the representative failure cases covered by tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be65235f5c8330b7f7e5ab1a78c953)