### PR TITLE
Enforce bounded capture limits and record truncation metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,10 @@ use tailtriage_core::{Config, RequestMeta, Tailtriage};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut config = Config::new("checkout-service");
-    config.output_path = "tailtriage-run.json".into();
-    let tailtriage = Tailtriage::init(config)?;
+let mut config = Config::new("checkout-service");
+config.output_path = "tailtriage-run.json".into();
+config.capture_limits.max_requests = 50_000;
+let tailtriage = Tailtriage::init(config)?;
 
     let meta = RequestMeta::for_route("/checkout").with_kind("http");
     let request_id = meta.request_id.clone();
@@ -119,6 +120,20 @@ Start with:
 - `primary_suspect.next_checks[]`
 - `p95_queue_share_permille`
 - `p95_service_share_permille`
+
+If the run artifact includes truncation counters (`truncation.*`), treat the diagnosis as lower-confidence and re-run with higher limits for the saturated sections.
+
+## Bounded capture and truncation
+
+`tailtriage` keeps run data in memory until flush. To keep this bounded in production-like runs, configure per-section capture limits:
+
+- `max_requests`
+- `max_stages`
+- `max_queues`
+- `max_inflight_snapshots`
+- `max_runtime_snapshots`
+
+When a section reaches its configured max, `tailtriage` drops additional entries of that type and increments `truncation` counters in the output artifact. The analyzer also emits warnings when truncation is present so suspects are interpreted as leads from partial data.
 
 ## Minimal runnable example
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -58,6 +58,7 @@ use tailtriage_core::{Config, Tailtriage};
 
 let mut config = Config::new("invoice-api");
 config.output_path = "tailtriage-run.json".into();
+config.capture_limits.max_requests = 50_000;
 let tailtriage = Tailtriage::init(config)?;
 ```
 
@@ -160,8 +161,11 @@ Supported arguments:
 - `queues`
 - `inflight`
 - `runtime_snapshots`
+- `truncation` (per-section dropped counters when capture limits are hit)
 
 Each section captures timestamped events/snapshots used by the CLI triage rules.
+
+Capture limits are configurable through `Config.capture_limits` (`max_requests`, `max_stages`, `max_queues`, `max_inflight_snapshots`, `max_runtime_snapshots`). When limits are hit, capture is deterministically truncated for that section and analyzer output should be interpreted as evidence-ranked suspects from partial data.
 
 ## 7. Analyzer CLI (`tailtriage-cli`)
 
@@ -183,6 +187,7 @@ The report includes:
 - primary suspect
 - secondary suspects
 - per-suspect evidence + next checks
+- warnings when run capture was truncated
 
 ## Script portability strategy
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -12,6 +12,7 @@ This document explains how `tailtriage analyze` produces a triage report and how
   - `p95_queue_share_permille`
   - `p95_service_share_permille`
 - optional in-flight trend summary
+- optional truncation warnings when capture limits were hit
 - ranked suspects (one primary, zero or more secondary)
 
 Each suspect includes:
@@ -31,6 +32,7 @@ Each suspect includes:
 | `p95_queue_share_permille` | `Option<u64>` | Queue-time share of p95 request latency (0-1000). |
 | `p95_service_share_permille` | `Option<u64>` | Service/stage share of p95 request latency (0-1000). |
 | `inflight_trend` | `Option<InflightTrend>` | Dominant in-flight gauge trend when snapshots exist. |
+| `warnings` | `Vec<String>` | Analyzer warnings, including capture truncation context from run artifacts. |
 | `primary_suspect` | `Suspect` | Highest-ranked suspect. |
 | `secondary_suspects` | `Vec<Suspect>` | Remaining ranked suspects. |
 
@@ -73,6 +75,10 @@ When present:
 - `growth_per_sec_milli`
 
 Positive growth means in-flight work accumulated during the run.
+
+## Truncation interpretation
+
+If the run artifact has non-zero `truncation` counters, treat the report as diagnosis from partial data. Prioritize re-running with higher capture limits for truncated sections before ruling suspects in or out.
 
 ## Practical triage workflow
 

--- a/tailtriage-cli/src/analyze.rs
+++ b/tailtriage-cli/src/analyze.rs
@@ -90,6 +90,7 @@ pub struct Report {
     pub p95_queue_share_permille: Option<u64>,
     pub p95_service_share_permille: Option<u64>,
     pub inflight_trend: Option<InflightTrend>,
+    pub warnings: Vec<String>,
     pub primary_suspect: Suspect,
     pub secondary_suspects: Vec<Suspect>,
 }
@@ -164,9 +165,45 @@ pub fn analyze_run(run: &Run) -> Report {
         p95_queue_share_permille,
         p95_service_share_permille,
         inflight_trend,
+        warnings: truncation_warnings(run),
         primary_suspect,
         secondary_suspects: ranked.collect(),
     }
+}
+
+fn truncation_warnings(run: &Run) -> Vec<String> {
+    let mut warnings = Vec::new();
+    if run.truncation.dropped_requests > 0 {
+        warnings.push(format!(
+            "Capture truncated requests: dropped {} request events after reaching the configured max_requests limit.",
+            run.truncation.dropped_requests
+        ));
+    }
+    if run.truncation.dropped_stages > 0 {
+        warnings.push(format!(
+            "Capture truncated stages: dropped {} stage events after reaching the configured max_stages limit.",
+            run.truncation.dropped_stages
+        ));
+    }
+    if run.truncation.dropped_queues > 0 {
+        warnings.push(format!(
+            "Capture truncated queues: dropped {} queue events after reaching the configured max_queues limit.",
+            run.truncation.dropped_queues
+        ));
+    }
+    if run.truncation.dropped_inflight_snapshots > 0 {
+        warnings.push(format!(
+            "Capture truncated in-flight snapshots: dropped {} entries after reaching max_inflight_snapshots.",
+            run.truncation.dropped_inflight_snapshots
+        ));
+    }
+    if run.truncation.dropped_runtime_snapshots > 0 {
+        warnings.push(format!(
+            "Capture truncated runtime snapshots: dropped {} entries after reaching max_runtime_snapshots.",
+            run.truncation.dropped_runtime_snapshots
+        ));
+    }
+    warnings
 }
 
 fn queue_saturation_suspect(run: &Run, inflight_trend: Option<&InflightTrend>) -> Option<Suspect> {
@@ -512,6 +549,9 @@ pub fn render_text(report: &Report) -> String {
             report.primary_suspect.score
         ),
     ];
+    for warning in &report.warnings {
+        lines.push(format!("warning {warning}"));
+    }
 
     for evidence in &report.primary_suspect.evidence {
         lines.push(format!("  evidence: {evidence}"));
@@ -589,6 +629,7 @@ mod tests {
             queues: Vec::new(),
             inflight: Vec::new(),
             runtime_snapshots: Vec::new(),
+            truncation: tailtriage_core::TruncationSummary::default(),
         }
     }
 
@@ -728,6 +769,7 @@ mod tests {
                 growth_delta: 5,
                 growth_per_sec_milli: Some(2_500),
             }),
+            warnings: Vec::new(),
             primary_suspect: Suspect {
                 kind: DiagnosisKind::ApplicationQueueSaturation,
                 score: 90,
@@ -754,6 +796,7 @@ mod tests {
             p95_queue_share_permille: None,
             p95_service_share_permille: None,
             inflight_trend: None,
+            warnings: vec!["Capture truncated requests.".to_owned()],
             primary_suspect: Suspect {
                 kind: DiagnosisKind::InsufficientEvidence,
                 score: 50,
@@ -766,5 +809,24 @@ mod tests {
 
         let text = render_text(&report);
         assert!(text.contains("inflight_trend none"));
+        assert!(text.contains("warning Capture truncated requests."));
+    }
+
+    #[test]
+    fn analyze_run_emits_truncation_warnings() {
+        let mut run = test_run();
+        run.truncation.dropped_requests = 2;
+        run.truncation.dropped_runtime_snapshots = 1;
+
+        let report = analyze_run(&run);
+        assert_eq!(report.warnings.len(), 2);
+        assert!(report
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("dropped 2 request events")));
+        assert!(report
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("dropped 1 entries")));
     }
 }

--- a/tailtriage-cli/tests/boundary_thresholds.rs
+++ b/tailtriage-cli/tests/boundary_thresholds.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use tailtriage_cli::analyze::{analyze_run, DiagnosisKind};
 use tailtriage_core::{
     CaptureMode, QueueEvent, RequestEvent, Run, RunMetadata, RuntimeSnapshot, StageEvent,
+    TruncationSummary,
 };
 
 fn load_fixture(name: &str) -> Run {
@@ -56,6 +57,7 @@ fn base_run() -> Run {
         queues: Vec::new(),
         inflight: Vec::new(),
         runtime_snapshots: Vec::new(),
+        truncation: TruncationSummary::default(),
     }
 }
 

--- a/tailtriage-core/src/collector.rs
+++ b/tailtriage-core/src/collector.rs
@@ -6,8 +6,9 @@ use std::time::{Duration, Instant};
 use crate::InflightGuard;
 use crate::RunSink;
 use crate::{
-    unix_time_ms, Config, InFlightSnapshot, InitError, LocalJsonSink, QueueTimer, RequestEvent,
-    RequestMeta, Run, RunMetadata, RuntimeSnapshot, SinkError, StageTimer,
+    unix_time_ms, Config, InFlightSnapshot, InitError, LocalJsonSink, QueueEvent, QueueTimer,
+    RequestEvent, RequestMeta, Run, RunMetadata, RuntimeSnapshot, SinkError, StageEvent,
+    StageTimer,
 };
 
 /// Per-run collector that records request events and writes the final artifact.
@@ -16,6 +17,7 @@ pub struct Tailtriage {
     pub(crate) run: Mutex<Run>,
     pub(crate) inflight_counts: Mutex<HashMap<String, u64>>,
     pub(crate) sink: LocalJsonSink,
+    pub(crate) limits: crate::CaptureLimits,
 }
 
 impl Tailtriage {
@@ -45,6 +47,7 @@ impl Tailtriage {
             run: Mutex::new(run),
             inflight_counts: Mutex::new(HashMap::new()),
             sink: LocalJsonSink::new(config.output_path),
+            limits: config.capture_limits,
         })
     }
 
@@ -95,7 +98,7 @@ impl Tailtriage {
         outcome: impl Into<String>,
     ) {
         let (started_at_unix_ms, finished_at_unix_ms) = time_window_unix_ms;
-        lock_run(&self.run).requests.push(RequestEvent {
+        let event = RequestEvent {
             request_id: request_id.into(),
             route: route.into(),
             kind,
@@ -103,7 +106,8 @@ impl Tailtriage {
             finished_at_unix_ms,
             latency_us,
             outcome: outcome.into(),
-        });
+        };
+        self.record_request_event(event);
     }
 
     /// Writes the current run to the configured sink.
@@ -137,7 +141,7 @@ impl Tailtriage {
             *entry
         };
 
-        lock_run(&self.run).inflight.push(InFlightSnapshot {
+        self.record_inflight_snapshot(InFlightSnapshot {
             gauge: gauge.clone(),
             at_unix_ms: unix_time_ms(),
             count,
@@ -172,7 +176,50 @@ impl Tailtriage {
 
     /// Records one Tokio runtime metrics sample.
     pub fn record_runtime_snapshot(&self, snapshot: RuntimeSnapshot) {
-        lock_run(&self.run).runtime_snapshots.push(snapshot);
+        let mut run = lock_run(&self.run);
+        if run.runtime_snapshots.len() >= self.limits.max_runtime_snapshots {
+            run.truncation.dropped_runtime_snapshots =
+                run.truncation.dropped_runtime_snapshots.saturating_add(1);
+        } else {
+            run.runtime_snapshots.push(snapshot);
+        }
+    }
+
+    pub(crate) fn record_stage_event(&self, event: StageEvent) {
+        let mut run = lock_run(&self.run);
+        if run.stages.len() >= self.limits.max_stages {
+            run.truncation.dropped_stages = run.truncation.dropped_stages.saturating_add(1);
+        } else {
+            run.stages.push(event);
+        }
+    }
+
+    pub(crate) fn record_queue_event(&self, event: QueueEvent) {
+        let mut run = lock_run(&self.run);
+        if run.queues.len() >= self.limits.max_queues {
+            run.truncation.dropped_queues = run.truncation.dropped_queues.saturating_add(1);
+        } else {
+            run.queues.push(event);
+        }
+    }
+
+    pub(crate) fn record_inflight_snapshot(&self, snapshot: InFlightSnapshot) {
+        let mut run = lock_run(&self.run);
+        if run.inflight.len() >= self.limits.max_inflight_snapshots {
+            run.truncation.dropped_inflight_snapshots =
+                run.truncation.dropped_inflight_snapshots.saturating_add(1);
+        } else {
+            run.inflight.push(snapshot);
+        }
+    }
+
+    fn record_request_event(&self, event: RequestEvent) {
+        let mut run = lock_run(&self.run);
+        if run.requests.len() >= self.limits.max_requests {
+            run.truncation.dropped_requests = run.truncation.dropped_requests.saturating_add(1);
+        } else {
+            run.requests.push(event);
+        }
     }
 }
 

--- a/tailtriage-core/src/config.rs
+++ b/tailtriage-core/src/config.rs
@@ -27,6 +27,8 @@ pub struct Config {
     pub mode: CaptureMode,
     /// JSON artifact path for this run.
     pub output_path: PathBuf,
+    /// Bounded capture limits for each event/sample section.
+    pub capture_limits: CaptureLimits,
 }
 
 impl Config {
@@ -39,6 +41,29 @@ impl Config {
             run_id: None,
             mode: CaptureMode::Light,
             output_path: PathBuf::from("tailtriage-run.json"),
+            capture_limits: CaptureLimits::default(),
+        }
+    }
+}
+
+/// Limits that bound in-memory capture growth for each run section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CaptureLimits {
+    pub max_requests: usize,
+    pub max_stages: usize,
+    pub max_queues: usize,
+    pub max_inflight_snapshots: usize,
+    pub max_runtime_snapshots: usize,
+}
+
+impl Default for CaptureLimits {
+    fn default() -> Self {
+        Self {
+            max_requests: 100_000,
+            max_stages: 200_000,
+            max_queues: 200_000,
+            max_inflight_snapshots: 200_000,
+            max_runtime_snapshots: 100_000,
         }
     }
 }

--- a/tailtriage-core/src/events.rs
+++ b/tailtriage-core/src/events.rs
@@ -17,6 +17,9 @@ pub struct Run {
     pub inflight: Vec<InFlightSnapshot>,
     /// Tokio runtime metrics snapshots.
     pub runtime_snapshots: Vec<RuntimeSnapshot>,
+    /// Capture truncation summary for bounded collection.
+    #[serde(default)]
+    pub truncation: TruncationSummary,
 }
 
 impl Run {
@@ -30,7 +33,35 @@ impl Run {
             queues: Vec::new(),
             inflight: Vec::new(),
             runtime_snapshots: Vec::new(),
+            truncation: TruncationSummary::default(),
         }
+    }
+}
+
+/// Per-section counters indicating dropped samples due to capture limits.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct TruncationSummary {
+    /// Number of request events dropped after `max_requests` was reached.
+    pub dropped_requests: u64,
+    /// Number of stage events dropped after `max_stages` was reached.
+    pub dropped_stages: u64,
+    /// Number of queue events dropped after `max_queues` was reached.
+    pub dropped_queues: u64,
+    /// Number of in-flight snapshots dropped after `max_inflight_snapshots` was reached.
+    pub dropped_inflight_snapshots: u64,
+    /// Number of runtime snapshots dropped after `max_runtime_snapshots` was reached.
+    pub dropped_runtime_snapshots: u64,
+}
+
+impl TruncationSummary {
+    /// Returns true when any capture section was truncated.
+    #[must_use]
+    pub const fn is_truncated(&self) -> bool {
+        self.dropped_requests > 0
+            || self.dropped_stages > 0
+            || self.dropped_queues > 0
+            || self.dropped_inflight_snapshots > 0
+            || self.dropped_runtime_snapshots > 0
     }
 }
 

--- a/tailtriage-core/src/lib.rs
+++ b/tailtriage-core/src/lib.rs
@@ -8,9 +8,10 @@ mod time;
 mod timers;
 
 pub use collector::Tailtriage;
-pub use config::{CaptureMode, Config, InitError, RequestMeta};
+pub use config::{CaptureLimits, CaptureMode, Config, InitError, RequestMeta};
 pub use events::{
     InFlightSnapshot, QueueEvent, RequestEvent, Run, RunMetadata, RuntimeSnapshot, StageEvent,
+    TruncationSummary,
 };
 pub use sink::{LocalJsonSink, RunSink, SinkError};
 pub use time::{system_time_to_unix_ms, unix_time_ms};

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -2,8 +2,8 @@ use std::future::ready;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::{
-    CaptureMode, Config, InFlightSnapshot, InitError, LocalJsonSink, QueueEvent, RequestEvent,
-    RequestMeta, Run, RunMetadata, RunSink, RuntimeSnapshot, StageEvent, Tailtriage,
+    CaptureLimits, CaptureMode, Config, InFlightSnapshot, InitError, LocalJsonSink, QueueEvent,
+    RequestEvent, RequestMeta, Run, RunMetadata, RunSink, RuntimeSnapshot, StageEvent, Tailtriage,
 };
 
 fn sample_run() -> Run {
@@ -266,6 +266,61 @@ fn stage_wrapper_records_stage_event() {
     assert_eq!(event.stage, "fetch_customer");
     assert!(event.success);
     assert!(event.finished_at_unix_ms >= event.started_at_unix_ms);
+}
+
+#[test]
+fn capture_limits_drop_events_and_track_truncation_counters() {
+    let mut config = Config::new("payments");
+    config.capture_limits = CaptureLimits {
+        max_requests: 1,
+        max_stages: 1,
+        max_queues: 1,
+        max_inflight_snapshots: 1,
+        max_runtime_snapshots: 1,
+    };
+    let tailtriage = Tailtriage::init(config).expect("init should succeed");
+
+    tailtriage.record_request_fields("req-1", "/a", None, (1, 2), 10, "ok");
+    tailtriage.record_request_fields("req-2", "/b", None, (1, 2), 10, "ok");
+    futures_executor::block_on(tailtriage.stage("req-1", "db").await_value(ready(())));
+    futures_executor::block_on(tailtriage.stage("req-1", "cache").await_value(ready(())));
+    futures_executor::block_on(tailtriage.queue("req-1", "q").await_on(ready(())));
+    futures_executor::block_on(tailtriage.queue("req-1", "q2").await_on(ready(())));
+    {
+        let _guard = tailtriage.inflight("g");
+    }
+    {
+        let _guard = tailtriage.inflight("g");
+    }
+    tailtriage.record_runtime_snapshot(RuntimeSnapshot {
+        at_unix_ms: 1,
+        alive_tasks: Some(1),
+        global_queue_depth: None,
+        local_queue_depth: None,
+        blocking_queue_depth: None,
+        remote_schedule_count: None,
+    });
+    tailtriage.record_runtime_snapshot(RuntimeSnapshot {
+        at_unix_ms: 2,
+        alive_tasks: Some(2),
+        global_queue_depth: None,
+        local_queue_depth: None,
+        blocking_queue_depth: None,
+        remote_schedule_count: None,
+    });
+
+    let run = tailtriage.snapshot();
+    assert_eq!(run.requests.len(), 1);
+    assert_eq!(run.stages.len(), 1);
+    assert_eq!(run.queues.len(), 1);
+    assert_eq!(run.inflight.len(), 1);
+    assert_eq!(run.runtime_snapshots.len(), 1);
+    assert_eq!(run.truncation.dropped_requests, 1);
+    assert_eq!(run.truncation.dropped_stages, 1);
+    assert_eq!(run.truncation.dropped_queues, 1);
+    assert_eq!(run.truncation.dropped_inflight_snapshots, 3);
+    assert_eq!(run.truncation.dropped_runtime_snapshots, 1);
+    assert!(run.truncation.is_truncated());
 }
 
 #[test]

--- a/tailtriage-core/src/timers.rs
+++ b/tailtriage-core/src/timers.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use crate::collector::{duration_to_us, lock_map, lock_run};
+use crate::collector::{duration_to_us, lock_map};
 use crate::{unix_time_ms, InFlightSnapshot, QueueEvent, StageEvent, Tailtriage};
 
 /// RAII guard tracking one in-flight unit for a named gauge.
@@ -21,13 +21,11 @@ impl Drop for InflightGuard<'_> {
             *entry
         };
 
-        lock_run(&self.tailtriage.run)
-            .inflight
-            .push(InFlightSnapshot {
-                gauge: self.gauge.clone(),
-                at_unix_ms: unix_time_ms(),
-                count,
-            });
+        self.tailtriage.record_inflight_snapshot(InFlightSnapshot {
+            gauge: self.gauge.clone(),
+            at_unix_ms: unix_time_ms(),
+            count,
+        });
     }
 }
 
@@ -59,7 +57,7 @@ impl StageTimer<'_> {
         let finished_at_unix_ms = unix_time_ms();
         let success = value.is_ok();
 
-        lock_run(&self.tailtriage.run).stages.push(StageEvent {
+        self.tailtriage.record_stage_event(StageEvent {
             request_id: self.request_id,
             stage: self.stage,
             started_at_unix_ms,
@@ -81,7 +79,7 @@ impl StageTimer<'_> {
         let value = fut.await;
         let finished_at_unix_ms = unix_time_ms();
 
-        lock_run(&self.tailtriage.run).stages.push(StageEvent {
+        self.tailtriage.record_stage_event(StageEvent {
             request_id: self.request_id,
             stage: self.stage,
             started_at_unix_ms,
@@ -121,7 +119,7 @@ impl QueueTimer<'_> {
         let value = fut.await;
         let waited_until_unix_ms = unix_time_ms();
 
-        lock_run(&self.tailtriage.run).queues.push(QueueEvent {
+        self.tailtriage.record_queue_event(QueueEvent {
             request_id: self.request_id,
             queue: self.queue,
             waited_from_unix_ms,


### PR DESCRIPTION
### Motivation
- Prevent unbounded in-memory growth for long or heavy runs by adding configurable per-section capture limits and deterministic truncation behavior.
- Ensure artifacts explicitly indicate when data was dropped so analyzer output can flag reduced confidence and guide re-runs with higher limits.

### Description
- Added `CaptureLimits` to `Config` with defaults and exposed it via `tailtriage-core` (`Config.capture_limits`, `CaptureLimits`).
- Extended the run schema with `truncation: TruncationSummary` containing per-section dropped counters and `is_truncated()` helper, and preserved backward-compatible deserialization defaults (`tailtriage-core/src/events.rs`).
- Enforced limits in the collector: requests, stages, queues, in-flight snapshots, and runtime snapshots stop being recorded when their `max_*` is reached and increment the appropriate `truncation.*` counter (`tailtriage-core/src/collector.rs`, `timers.rs`).
- Updated timers to use the collector-recording helpers (`record_stage_event`, `record_queue_event`, `record_inflight_snapshot`) so truncation logic is centralized (`tailtriage-core/src/timers.rs`).
- Added analyzer warnings (`Report.warnings`) and included warning lines in text output when truncation is present, with a helper that formats per-section messages (`tailtriage-cli/src/analyze.rs`).
- Updated docs (`README.md`, `SPEC.md`, `docs/diagnostics.md`) to document capture limits, truncation semantics, and interpretation guidance.
- Added and updated tests to cover bounded recording, truncation counters, and analyzer warning emission (`tailtriage-core` and `tailtriage-cli` test updates).

### Testing
- Ran `cargo fmt --check` and formatting checks passed.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and there were no lints (passed).
- Ran `cargo test --workspace` and the full test suite passed (unit tests in `tailtriage-core` and `tailtriage-cli` including new truncation-related tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be689711dc8330af6d145e0b974e91)