### PR TITLE
Reorder demo docs by proof strength, caveats, and progression

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,4 +144,4 @@ For concise docs by audience, start at **[docs/README.md](docs/README.md)**.
 
 For the same canonical first-run workflow in walkthrough form, see **[docs/user-guide.md](docs/user-guide.md)**.
 
-For demo-specific behavior and triage expectations, see **[demos/README.md](demos/README.md)**.
+For demo-specific behavior, recommended public progression, and realism/CI-coverage caveats, see **[demos/README.md](demos/README.md)**.

--- a/demos/README.md
+++ b/demos/README.md
@@ -25,132 +25,329 @@ Shared helper code for this setup lives in `demos/demo_support`:
 
 This keeps demo binaries focused on the triage scenario rather than boilerplate.
 
-## Demo catalog
+## Recommended public progression
+
+Use this progression when introducing `tailtriage` publicly:
+
+1. `queue_service`
+2. `downstream_service`
+3. `db_pool_saturation_service`
+4. `shared_state_lock_service`
+5. `retry_storm_service`
+6. `mixed_contention_service`
+7. `cold_start_burst_service`
+8. `blocking_service`
+9. `executor_pressure_service`
+
+This is an explanatory-value order, not an implementation-completeness order.
+
+## Core public proof demos
+
+These are the strongest public proof cases and should usually be run first.
 
 ### `queue_service`
 
-**What happens**
+**What it simulates**
 
 - Requests compete for a limited semaphore (`worker_permit`).
 - Baseline has tighter capacity and slower work; mitigated raises capacity and shortens work.
 
-**Triage being exercised**
+**What it proves well**
 
-- Primary suspect should emphasize application queueing.
-- Evidence should reference queue depth and queue share.
-- Mitigation should reduce queue-dominant evidence and suspect score.
+- One of the strongest demos.
+- Clear and convincing proof of queue-dominant latency.
+- Good flagship public demo for first-time readers.
 
-### `blocking_service`
+**What it does not prove**
 
-**What happens**
+- It is not proof of every production queue topology or all burst regimes.
 
-- Requests dispatch to `spawn_blocking` workloads.
-- Baseline constrains `max_blocking_threads` and uses longer blocking work.
-- Runtime snapshots include a synthetic `blocking_queue_depth` signal.
+**Realistic vs synthetic**
 
-**Triage being exercised**
+- Realistic service shape, intentionally simplified and deterministic.
 
-- Primary suspect should emphasize blocking-pool pressure.
-- Evidence should point at elevated blocking queue depth alongside request timing impact.
-- Mitigation should reduce blocking pressure evidence.
+**Why it belongs**
 
-### `executor_pressure_service`
+- It is the cleanest entry point for understanding queue-saturation diagnosis.
 
-**What happens**
+**Inspect first in report**
 
-- Each request fans out many hot subtasks and does repeated CPU turns with frequent scheduling.
-- Baseline uses fewer worker threads and heavier fanout.
-- Runtime snapshots capture global/local runnable depth signals.
-
-**Triage being exercised**
-
-- Primary suspect should emphasize executor pressure/runnable backlog.
-- Evidence should reference runtime queue depth and scheduling saturation patterns.
-- Mitigation should reduce runnable backlog evidence and score.
+- `primary_suspect.kind`
+- `p95_queue_share_permille`
+- queue-depth and queue-share suspect evidence
 
 ### `downstream_service`
 
-**What happens**
+**What it simulates**
 
-- Request flow has a tiny local precheck and a consistently slower downstream stage.
-- No intentional queue bottleneck is introduced.
+- Request flow with a tiny local precheck and a consistently slower downstream stage.
+- No intentional queue bottleneck.
 
-**Triage being exercised**
+**What it proves well**
 
-- Primary suspect should emphasize downstream stage dominance.
-- Evidence should highlight stage service share (`downstream_call`) rather than admission queueing.
+- One of the strongest demos.
+- Very clean stage-dominance story.
+- Strong public proof case for downstream-led latency.
 
-### `mixed_contention_service`
+**What it does not prove**
 
-**What happens**
+- It does not model all real downstream stack complexity (fanout, retries, connection behavior).
 
-- Requests first queue for worker admission and then call a downstream stage with periodic slow outliers.
-- Baseline keeps both contention sources visible.
-- Mitigated mode reduces admission queueing while keeping downstream behavior comparable.
+**Realistic vs synthetic**
 
-**Triage being exercised**
+- Realistic diagnosis shape with deliberately simple mechanics.
 
-- Ranked suspects should keep both queueing and downstream leads visible.
-- Primary suspect can vary by machine, but evidence should justify the rank.
-- Mitigation should shift score/rank toward the remaining bottleneck.
+**Why it belongs**
 
+- Complements `queue_service` with an equally clean non-queue dominant case.
+
+**Inspect first in report**
+
+- `primary_suspect.kind`
+- `p95_service_share_permille`
+- downstream-stage suspect evidence
 
 ### `db_pool_saturation_service`
 
-**What happens**
+**What it simulates**
 
-- Requests do a tiny `app_precheck` and then queue for a bounded semaphore that represents DB connections.
-- Baseline uses a smaller DB pool and slower `db_query` stage.
-- Mitigated mode increases pool capacity and shortens the `db_query` stage.
+- Bounded DB-pool admission using a semaphore (`db_pool`).
+- Separate `db_query` stage timing.
+- Baseline shrinks pool and slows query stage; mitigated does the reverse.
 
-**Triage being exercised**
+**What it proves well**
 
-- Ranked suspects should include application queue saturation and/or downstream stage dominance.
-- Evidence should reference `queue(..., "db_pool")` wait behavior and `stage(..., "db_query")` service share.
-- Mitigation should improve p95 latency and/or primary suspect score.
+- One of the best additional demos.
+- Shows queue-like admission bottleneck and downstream stage time in one common service shape.
+- Demonstrates mixed attribution within a single request path.
+
+**What it does not prove**
+
+- Still a synthetic model of DB pool saturation.
+- Not proof of behavior under a real DB client/driver stack.
+
+**Realistic vs synthetic**
+
+- Realistic enough to be highly credible, but intentionally modeled.
+
+**Why it belongs**
+
+- Strong bridge between pure queue and pure downstream stories.
+
+**Inspect first in report**
+
+- queue evidence for `queue(..., "db_pool")`
+- stage-share evidence for `stage(..., "db_query")`
+- before/after p95 and primary suspect score
+
+## Supporting pattern demos
+
+These are valuable and should remain first-class docs, but are best after the core three demos.
 
 ### `shared_state_lock_service`
 
-**What happens**
+**What it simulates**
 
-- Requests do small pre-lock work, then contend on a shared `tokio::sync::RwLock` write lock.
-- Baseline keeps a long lock-protected critical section, which serializes many requests.
-- Mitigated mode shortens critical section hold time to reduce lock wait buildup.
+- Contention on a shared `tokio::sync::RwLock` write lock.
+- Lock wait recorded as queue-like time on `shared_state_write_lock`.
+- Critical-section work recorded separately as `shared_state_critical_section`.
 
-**Triage being exercised**
+**What it proves well**
 
-- Lock wait is instrumented as a queue-like wait (`queue(..., "shared_state_write_lock")`), so lock contention can appear as application queueing pressure.
-- Critical section execution is instrumented as a service stage (`stage(..., "shared_state_critical_section")`).
-- Mitigation should lower p95 latency and/or reduce primary suspect score.
+- Conceptually strong example of non-obvious queue-like waits.
+- Demonstrates that queue here includes lock admission waits, not only channels/semaphores.
+- Preserves critical-section stage attribution while surfacing lock admission pressure.
 
-### `cold_start_burst_service`
+**What it does not prove**
 
-**What happens**
+- Not proof that all lock-contention patterns map identically in every production design.
 
-- Early requests pay extra warmup delay in `cold_start_stage` while a burst competes for admission.
-- Baseline has larger cold-start cohort and tighter capacity.
-- Mitigated mode reduces warmup cohort and increases admission capacity.
+**Realistic vs synthetic**
 
-**Triage being exercised**
+- Realistic contention pattern with explicit instrumentation choices.
 
-- Analyzer should surface queueing and/or downstream-stage warmup leads with explicit evidence.
-- Mitigation should lower p95 and reduce primary suspect score.
+**Why it belongs**
+
+- Teaches how to instrument and triage lock-heavy paths without semantic ambiguity.
+
+**Inspect first in report**
+
+- queue evidence for `shared_state_write_lock`
+- stage evidence for `shared_state_critical_section`
+- primary suspect kind and score changes in mitigation
 
 ### `retry_storm_service`
 
-**What happens**
+**What it simulates**
 
-- Requests call an intermittently failing/slow downstream stage.
-- Each retry attempt is instrumented as its own stage timing (`downstream_attempt_N`).
-- A `downstream_total` stage wraps the full retry loop so per-request downstream share stays explicit.
-- Baseline uses aggressive retries with short backoff.
-- Mitigated mode uses capped retries, deterministic jitter, and a circuit-break style cooldown stage.
+- Intermittently failing/slow downstream with explicit retries.
+- Per-attempt stages (`downstream_attempt_N`) plus full-loop `downstream_total`.
+- Mitigation changes retry count, backoff, jitter, and circuit-break-like cooldown behavior.
 
-**Triage being exercised**
+**What it proves well**
 
-- Baseline should rank downstream stage dominance as a primary suspect with elevated service share.
-- Mitigated mode should improve p95 and lower primary suspect score.
-- Recommended next checks should include retry-policy tuning and downstream SLO alignment.
+- One of the most product-interesting demos.
+- Shows downstream dominance can come from retry policy, not just one slow call.
+- Strong diagnosis-pattern demo for advanced readers.
+
+**What it does not prove**
+
+- More conceptually advanced and more instrumentation-shaped than core proof demos.
+
+**Realistic vs synthetic**
+
+- Plausible service behavior, but intentionally structured to isolate retry-policy effects.
+
+**Why it belongs**
+
+- Helps prevent misleading latency interpretation when retries dominate service share.
+
+**Inspect first in report**
+
+- `primary_suspect.kind`
+- service-share evidence for `downstream_total`
+- retry-policy-oriented `next_checks`
+
+### `mixed_contention_service`
+
+**What it simulates**
+
+- Combined queue pressure (semaphore admission) and downstream slowness (periodic slow stage).
+- Mitigation mainly reduces admission contention so rank/score can shift.
+
+**What it proves well**
+
+- Multiple suspects can coexist in one diagnosis.
+- Useful supporting demo showing the analyzer is not single-cause-only.
+
+**What it does not prove**
+
+- Less crisp than queue-only or downstream-only stories, so not ideal as first public proof.
+
+**Realistic vs synthetic**
+
+- Realistic mixed-bottleneck shape with controlled deterministic contours.
+
+**Why it belongs**
+
+- Important second-wave demo for multi-factor triage interpretation.
+
+**Inspect first in report**
+
+- top two suspects and their evidence
+- whether both queue and downstream leads remain visible
+- before/after suspect-rank or score shift
+
+### `cold_start_burst_service`
+
+**What it simulates**
+
+- Early cohort pays extra `cold_start_stage` delay while burst traffic competes for admission.
+- Mitigation reduces cold cohort and increases admission capacity.
+
+**What it proves well**
+
+- Useful warmup-plus-burst explanation.
+- Shows how stage-level pathology can induce queue effects.
+
+**What it does not prove**
+
+- Less universal than queue/downstream/DB-pool scenarios.
+- Models cold start with explicit stage instrumentation, not full platform/framework startup behavior.
+
+**Realistic vs synthetic**
+
+- Plausible but scenario-specific.
+
+**Why it belongs**
+
+- Broadens triage examples beyond steady-state bottlenecks.
+
+**Inspect first in report**
+
+- evidence tied to `cold_start_stage`
+- queue-share impact and p95 changes
+- primary suspect score reduction after mitigation
+
+## More synthetic analyzer-contract demos
+
+These remain useful and should stay documented, but docs should treat them as more synthetic proofs.
+
+### `blocking_service`
+
+**What it simulates**
+
+- Requests dispatch to `spawn_blocking` workloads.
+- Baseline constrains `max_blocking_threads` and uses longer blocking work.
+- Runtime snapshots include synthetic `blocking_queue_depth` signals.
+
+**What it proves well**
+
+- Directionally useful for exercising blocking-pool-pressure diagnosis behavior.
+
+**What it does not prove**
+
+- More synthetic than a strongest real-world proof case.
+
+**Realistic vs synthetic**
+
+- Intentionally synthetic analyzer-contract demo.
+
+**Why it belongs**
+
+- Keeps blocking-pressure diagnosis pathways directly testable.
+
+**Inspect first in report**
+
+- `primary_suspect.kind`
+- blocking-related evidence and runtime depth signals
+- mitigation impact on suspect score
+
+### `executor_pressure_service`
+
+**What it simulates**
+
+- Fanout-heavy request handling with repeated CPU turns and frequent scheduling.
+- Baseline uses fewer worker threads and heavier fanout.
+- Runtime snapshots include runnable-depth signals.
+
+**What it proves well**
+
+- Useful for exercising executor-pressure diagnosis and rank behavior.
+
+**What it does not prove**
+
+- Also more synthetic, because runtime backlog signals are modeled more explicitly than production services naturally expose.
+
+**Realistic vs synthetic**
+
+- Intentionally synthetic analyzer-contract demo.
+
+**Why it belongs**
+
+- Preserves explicit coverage of executor-pressure diagnosis behavior.
+
+**Inspect first in report**
+
+- executor-pressure suspect evidence
+- runnable queue-depth signals
+- contrast with blocking-depth evidence
+
+## CI validation coverage
+
+The demo docs intentionally cover a broader surface than CI currently validates continuously.
+
+In `.github/workflows/ci.yml`, continuous validation currently runs:
+
+- `queue`
+- `downstream`
+- `db-pool`
+- `mixed`
+- `cold-start`
+- `blocking`
+- `executor`
+
+`shared-lock` and `retry-storm` remain documented and fixture-backed, but currently have weaker continuous validation coverage than the list above.
 
 ## Typical local workflow
 
@@ -158,11 +355,14 @@ This keeps demo binaries focused on the triage scenario rather than boilerplate.
 python3 scripts/demo_tool.py run queue
 python3 scripts/demo_tool.py validate queue
 
-python3 scripts/demo_tool.py run blocking
-python3 scripts/demo_tool.py validate blocking
+python3 scripts/demo_tool.py run downstream
+python3 scripts/demo_tool.py validate downstream
+
+python3 scripts/demo_tool.py run db-pool
+python3 scripts/demo_tool.py validate db-pool
 ```
 
-Repeat for the remaining demos (`executor`, `downstream`, `mixed`, `cold-start`, `db-pool`, `shared-lock`, `retry-storm`).
+Then continue through `shared-lock`, `retry-storm`, `mixed`, `cold-start`, `blocking`, and `executor`.
 
 For runtime-cost overhead measurement (separate from suspect-ranking triage), run `python3 scripts/measure_runtime_cost.py` and see `docs/runtime-cost.md` for usage details and interpretation guidance.
 

--- a/docs/getting-started-demo.md
+++ b/docs/getting-started-demo.md
@@ -4,6 +4,48 @@ Use demos to validate diagnosis behavior with deterministic fixtures.
 
 For a scenario-by-scenario explanation of what each demo simulates, what triage it is intended to exercise, and what setup is shared, see **[`demos/README.md`](../demos/README.md)**.
 
+## Recommended public progression
+
+To evaluate `tailtriage` quickly and honestly, run demos in this order:
+
+1. `queue_service`
+2. `downstream_service`
+3. `db_pool_saturation_service`
+4. `shared_state_lock_service`
+5. `retry_storm_service`
+6. `mixed_contention_service`
+7. `cold_start_burst_service`
+8. `blocking_service`
+9. `executor_pressure_service`
+
+This order reflects explanatory clarity and public credibility, not implementation completeness.
+
+## Demo tiers and what they are for
+
+### Core public proof demos
+
+These are the strongest public proof cases:
+
+- `queue_service`
+- `downstream_service`
+- `db_pool_saturation_service`
+
+### Supporting pattern demos
+
+These are valuable second-wave demos:
+
+- `shared_state_lock_service`
+- `retry_storm_service`
+- `mixed_contention_service`
+- `cold_start_burst_service`
+
+### More synthetic analyzer-contract demos
+
+These remain useful, but are more synthetic than the first two tiers:
+
+- `blocking_service`
+- `executor_pressure_service`
+
 ## Artifact policy
 
 - `demos/*/artifacts/`: generated, untracked local outputs.
@@ -15,14 +57,17 @@ For a scenario-by-scenario explanation of what each demo simulates, what triage 
 python3 scripts/demo_tool.py run queue
 python3 scripts/demo_tool.py validate queue
 
-python3 scripts/demo_tool.py run blocking
-python3 scripts/demo_tool.py validate blocking
-
-python3 scripts/demo_tool.py run executor
-python3 scripts/demo_tool.py validate executor
-
 python3 scripts/demo_tool.py run downstream
 python3 scripts/demo_tool.py validate downstream
+
+python3 scripts/demo_tool.py run db-pool
+python3 scripts/demo_tool.py validate db-pool
+
+python3 scripts/demo_tool.py run shared-lock
+python3 scripts/demo_tool.py validate shared-lock
+
+python3 scripts/demo_tool.py run retry-storm
+python3 scripts/demo_tool.py validate retry-storm
 
 python3 scripts/demo_tool.py run mixed
 python3 scripts/demo_tool.py validate mixed
@@ -30,23 +75,42 @@ python3 scripts/demo_tool.py validate mixed
 python3 scripts/demo_tool.py run cold-start
 python3 scripts/demo_tool.py validate cold-start
 
-python3 scripts/demo_tool.py run db-pool
-python3 scripts/demo_tool.py validate db-pool
+python3 scripts/demo_tool.py run blocking
+python3 scripts/demo_tool.py validate blocking
 
+python3 scripts/demo_tool.py run executor
+python3 scripts/demo_tool.py validate executor
 ```
 
-## What each demo demonstrates
+## Quick interpretation map by demo
 
-| Demo | Expected emphasis | Key fields |
-| --- | --- | --- |
-| `queue_service` | application queueing pressure | `primary_suspect.kind`, `p95_queue_share_permille`, suspect evidence |
-| `blocking_service` | blocking-pool pressure | `primary_suspect.kind`, blocking-related evidence, p95 shares |
-| `executor_pressure_service` | executor pressure / runnable backlog | `primary_suspect.kind`, runtime queue-depth evidence, low blocking-depth evidence |
-| `downstream_service` | downstream-stage dominance | `primary_suspect.kind`, `p95_service_share_permille`, suspect evidence |
-| `mixed_contention_service` | queue + downstream contention together | baseline includes both suspects; mitigation should shift rank and/or score |
-| `cold_start_burst_service` | cold-start cohort causes warmup drag and burst queueing | baseline evidence references `cold_start_stage` and/or queue pressure; mitigation lowers p95 and primary suspect score |
-| `db_pool_saturation_service` | DB pool admission + slow DB stage contention | baseline suspect includes queue saturation and/or downstream dominance; mitigation improves p95 and/or score |
-| `runtime_cost` | instrumentation overhead measurement (not suspect-ranking triage) | run via `python3 scripts/measure_runtime_cost.py`; writes `demos/runtime_cost/artifacts/` |
+Use this table for first-pass diagnosis reading. Suspects are leads, not proof.
+
+| Demo | What it proves well | What it does not prove | First report fields to inspect |
+| --- | --- | --- | --- |
+| `queue_service` | Clear, convincing queue-dominant latency story; one of the strongest flagship demos. | Not a proof of every real queue topology under production burst behavior. | `primary_suspect.kind`, `p95_queue_share_permille`, queue-depth evidence. |
+| `downstream_service` | Very clean stage-dominance story; one of the strongest public proof cases. | Not a full model of all downstream path complexity. | `primary_suspect.kind`, `p95_service_share_permille`, downstream stage evidence. |
+| `db_pool_saturation_service` | Strong split between DB admission wait (`db_pool`) and DB stage time (`db_query`) in one common service shape. | Still a synthetic DB-pool model, not proof under a real DB driver/client stack. | Queue wait evidence for `db_pool` plus stage-share evidence for `db_query`. |
+| `shared_state_lock_service` | Strong lock-contention framing: lock admission wait as queue-like pressure plus separate critical-section stage attribution. | Not a claim that all lock contention behaves identically across real services. | Queue evidence for `shared_state_write_lock` and stage evidence for `shared_state_critical_section`. |
+| `retry_storm_service` | Product-interesting diagnosis pattern: downstream dominance from retry policy, not only one slow call. | More advanced and instrumentation-shaped than core proof demos. | `primary_suspect.kind`, `downstream_total` service-share evidence, retry-policy next checks. |
+| `mixed_contention_service` | Shows multiple suspects can coexist and ranking can shift after mitigation. | Less crisp than queue-only or downstream-only proof cases. | Top two suspects, evidence mix across queue and downstream, before/after rank shift. |
+| `cold_start_burst_service` | Useful warmup-plus-burst pattern with both stage and admission effects. | Less universal than queue/downstream/DB-pool scenarios. | Evidence tied to `cold_start_stage`, queue-share impact, before/after p95 change. |
+| `blocking_service` | Directionally useful for exercising blocking-pool diagnosis behavior. | More synthetic than a strongest real-world proof case. | Blocking-pressure suspect evidence and blocking-related runtime signals. |
+| `executor_pressure_service` | Useful for exercising executor-pressure diagnosis and runnable-backlog evidence. | More synthetic because backlog signals are modeled explicitly. | Executor-pressure suspect evidence, runtime queue-depth signals, blocking-depth contrast. |
+
+## CI validation coverage caveat
+
+The documented demo surface is broader than the currently CI-validated surface. In `.github/workflows/ci.yml`, CI validates:
+
+- `queue`
+- `downstream`
+- `db-pool`
+- `mixed`
+- `cold-start`
+- `blocking`
+- `executor`
+
+At the time of writing, `shared-lock` and `retry-storm` are documented and fixture-backed, but have weaker continuous validation coverage than the demos above.
 
 ## Runtime-cost demo path (separate from triage scenarios)
 
@@ -59,22 +123,6 @@ python3 scripts/measure_runtime_cost.py
 ```
 
 For mode definitions, metrics, and interpretation details, see **[`docs/runtime-cost.md`](./runtime-cost.md)**.
-
-## Mixed-contention expected rank behavior
-
-- Baseline profile intentionally keeps both contention sources visible in report evidence:
-  - application queue saturation from semaphore worker limits
-  - downstream-stage latency from a deterministic slow-stage ratio
-- One of these is expected to be the primary suspect, and the other should appear in the ranked suspects list.
-- Mitigation profile reduces one bottleneck (worker-limit queueing), and validation expects a rank/score shift in the primary suspect.
-
-## Cold-start burst expected interpretation
-
-- `before` intentionally sends a burst while an initial cohort pays a larger `cold_start_stage` delay.
-- Diagnosis should rank either queue saturation or downstream-stage dominance as the top suspect and include evidence tied to warmup stage share and/or queue impact.
-- `after` applies a mitigated profile (smaller cold cohort + staggered startup + more admission capacity), and validation expects:
-  - lower `p95_latency_us`
-  - lower primary suspect score
 
 ## If local results differ from fixtures
 


### PR DESCRIPTION
### Motivation

- Make the public demo surface honest and helpful by ordering demos by explanatory credibility rather than presenting a flat list.
- Ensure readers know which demos are strongest public proof cases, which are supporting patterns, and which are more synthetic analyzer-contract examples.
- Surface realism caveats and current CI-validation coverage so readers do not infer equal regression confidence across all demos.

### Description

- Rewrote `demos/README.md` to present a recommended public progression and split demos into three tiers: core public proof demos, supporting pattern demos, and more synthetic analyzer-contract demos, with per-demo notes on what each simulates, what it proves, what it does not prove, realism framing, and what to inspect first in reports.
- Updated `docs/getting-started-demo.md` to show the recommended progression, tiering, a quick interpretation map, and added the missing run/validate commands for `shared-lock` and `retry-storm` in the canonical workflow.
- Updated the root `README.md` to point readers to the new demo guide wording that mentions progression and realism/CI-coverage caveats.
- Added an explicit CI coverage caveat listing which demos are continuously validated and which (`shared-lock`, `retry-storm`) currently have weaker continuous validation.

### Testing

- Ran `cargo fmt --check` and it succeeded. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it succeeded with no warnings. 
- Ran `cargo test --workspace` and all unit and integration tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be7004748c8330b1b06a1a6d4be99b)