### PR TITLE
Strengthen API rustdoc and add compile-checked Tokio macro example

### DIFF
--- a/tailtriage-core/src/collector.rs
+++ b/tailtriage-core/src/collector.rs
@@ -12,6 +12,37 @@ use crate::{
 };
 
 /// Per-run collector that records request events and writes the final artifact.
+///
+/// [`Tailtriage`] is intentionally small: initialize once per process/run,
+/// wrap request futures with [`Self::request`], wrap critical await points with
+/// stage/queue helpers, then flush one JSON artifact for CLI triage.
+///
+/// # Example
+/// ```
+/// use futures_executor::block_on;
+/// use tailtriage_core::{Config, RequestMeta, Tailtriage};
+///
+/// let mut config = Config::new("api");
+/// config.output_path = std::env::temp_dir().join("tailtriage-api.json");
+/// let tailtriage = Tailtriage::init(config)?;
+///
+/// let request_id = "req-1".to_string();
+/// let meta = RequestMeta::new(request_id.clone(), "/checkout").with_kind("http");
+///
+/// block_on(tailtriage.request(meta, "ok", async {
+///     tailtriage
+///         .queue(request_id.clone(), "ingress")
+///         .await_on(async {})
+///         .await;
+///     tailtriage
+///         .stage(request_id, "db")
+///         .await_value(async {})
+///         .await;
+/// }));
+///
+/// tailtriage.flush()?;
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
 #[derive(Debug)]
 pub struct Tailtriage {
     pub(crate) run: Mutex<Run>,
@@ -154,6 +185,11 @@ impl Tailtriage {
     }
 
     /// Returns a stage timing wrapper for one awaited operation.
+    ///
+    /// Use stage wrappers for downstream work such as DB/HTTP/cache calls.
+    /// Pick [`crate::StageTimer::await_on`] when the stage naturally returns
+    /// `Result<T, E>`, or [`crate::StageTimer::await_value`] for infallible
+    /// futures where success should always be recorded as `true`.
     #[must_use]
     pub fn stage(&self, request_id: impl Into<String>, stage: impl Into<String>) -> StageTimer<'_> {
         StageTimer {
@@ -164,6 +200,9 @@ impl Tailtriage {
     }
 
     /// Returns a queue timing wrapper for one awaited operation.
+    ///
+    /// Use this around waits caused by application queueing/backpressure
+    /// (for example a semaphore permit wait or bounded channel receive).
     #[must_use]
     pub fn queue(&self, request_id: impl Into<String>, queue: impl Into<String>) -> QueueTimer<'_> {
         QueueTimer {

--- a/tailtriage-core/src/config.rs
+++ b/tailtriage-core/src/config.rs
@@ -15,6 +15,22 @@ pub enum CaptureMode {
 }
 
 /// Configuration used to initialize one tailtriage capture run.
+///
+/// This is the main integration entry point for setup: create a config, tune
+/// capture limits when needed, then call [`crate::Tailtriage::init`].
+///
+/// # Example
+/// ```
+/// use tailtriage_core::{Config, Tailtriage};
+///
+/// let mut config = Config::new("checkout-service");
+/// config.service_version = Some("1.4.2".to_string());
+/// config.output_path = std::env::temp_dir().join("tailtriage-run.json");
+///
+/// let tailtriage = Tailtriage::init(config)?;
+/// assert_eq!(tailtriage.output_path().file_name().unwrap(), "tailtriage-run.json");
+/// # Ok::<(), tailtriage_core::InitError>(())
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Config {
     /// Service/application name.
@@ -69,6 +85,19 @@ impl Default for CaptureLimits {
 }
 
 /// Runtime request metadata captured by [`crate::Tailtriage::request`].
+///
+/// Use [`RequestMeta::new`] when you already have a stable request ID from your
+/// framework or gateway. Use [`RequestMeta::for_route`] when you need a local,
+/// readable ID for light-touch instrumentation.
+///
+/// # Example
+/// ```
+/// use tailtriage_core::RequestMeta;
+///
+/// let meta = RequestMeta::for_route("/checkout").with_kind("http");
+/// assert_eq!(meta.route, "/checkout");
+/// assert_eq!(meta.kind.as_deref(), Some("http"));
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RequestMeta {
     /// Correlation ID for the request.

--- a/tailtriage-core/src/timers.rs
+++ b/tailtriage-core/src/timers.rs
@@ -43,6 +43,9 @@ impl StageTimer<'_> {
     /// This helper is intended for fallible stage work where success can be
     /// derived from `Result::is_ok`.
     ///
+    /// Prefer this method when your stage naturally returns `Result<T, E>` and
+    /// you want success/failure evidence in the resulting triage report.
+    ///
     /// # Errors
     ///
     /// Returns the same error value produced by `fut` after recording the
@@ -70,6 +73,9 @@ impl StageTimer<'_> {
     }
 
     /// Awaits an infallible stage future and records a successful stage event.
+    ///
+    /// Use this method when there is no meaningful stage-level error signal
+    /// (for example, internal CPU work or a prevalidated transformation).
     pub async fn await_value<Fut, T>(self, fut: Fut) -> T
     where
         Fut: std::future::Future<Output = T>,
@@ -110,6 +116,10 @@ impl QueueTimer<'_> {
     }
 
     /// Awaits `fut`, records queue wait duration, and returns the original output.
+    ///
+    /// Queue events are interpreted as application-level wait evidence (a lead,
+    /// not proof). Record these around bounded resources to help separate
+    /// queueing pressure from slow downstream stage time.
     pub async fn await_on<Fut, T>(self, fut: Fut) -> T
     where
         Fut: std::future::Future<Output = T>,

--- a/tailtriage-tokio/src/lib.rs
+++ b/tailtriage-tokio/src/lib.rs
@@ -5,8 +5,12 @@
 //! - [`instrument_request`] for request entry-point tracing and optional
 //!   request-event recording into a [`tailtriage_core::Tailtriage`] collector.
 //!
-//! Macro example:
-//! ```ignore
+//! `instrument_request` is optional convenience. You can either:
+//! - annotate handlers with the macro for request-level timing and tracing, or
+//! - call [`tailtriage_core::Tailtriage::request`] directly for explicit control.
+//!
+//! Macro example (compile-checked):
+//! ```no_run
 //! use tailtriage_core::Tailtriage;
 //! use tailtriage_tokio::instrument_request;
 //!
@@ -23,7 +27,19 @@
 //! ) -> Result<(), &'static str> {
 //!     Ok(())
 //! }
+//!
+//! # #[tokio::main(flavor = "current_thread")]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let config = tailtriage_core::Config::new("billing");
+//! # let tailtriage = Tailtriage::init(config)?;
+//! handle_invoice(&tailtriage, "req-123".to_string()).await?;
+//! # Ok(())
+//! # }
 //! ```
+//!
+//! Runtime sampling is worth enabling when you need extra evidence to separate
+//! executor or blocking-pool pressure from application-level queue/stage waits.
+//! Keep it disabled for the lowest-overhead light runs.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -67,6 +83,10 @@ pub struct RuntimeSampler {
 
 impl RuntimeSampler {
     /// Starts periodic runtime metrics sampling on the current Tokio runtime.
+    ///
+    /// Use this during incident triage when runtime pressure evidence is needed
+    /// to rank suspects (for example: global queue growth or alive-task spikes).
+    /// For minimal-overhead capture, skip sampler startup.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
### Motivation
- Make the public API easier to adopt by providing clearer rustdoc guidance and small, compile-checked examples that show typical integration patterns. 
- Reduce friction for library adopters by clarifying when to use stage/queue helpers and when runtime sampling is appropriate.

### Description
- Expanded rustdoc for `Config` and added a small compile-checked example showing `Config::new` and `Tailtriage::init` usage in `tailtriage-core/src/config.rs`.
- Added a practical, narrow end-to-end example and integration guidance to `Tailtriage` docs, and clarified `queue`/`stage` helper intent in `tailtriage-core/src/collector.rs`.
- Clarified `StageTimer` and `QueueTimer` method semantics (when to use `await_on(...)` vs `await_value(...)` and how queue events should be interpreted) in `tailtriage-core/src/timers.rs`.
- Replaced an ignored macro snippet with a compile-checked `no_run` macro example and added guidance about `RuntimeSampler` trade-offs in `tailtriage-tokio/src/lib.rs`.

### Testing
- Ran `cargo fmt --check` which succeeded.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` which completed without warnings/errors.
- Ran `cargo test --workspace` and all tests and doctests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be798a98788330b24adf5247e7e1d8)