### PR TITLE
Lock v0.1 publish scope and unblock macros dry-run

### DIFF
--- a/docs/launch-checklist-issue-v0.1.md
+++ b/docs/launch-checklist-issue-v0.1.md
@@ -1,26 +1,71 @@
 # Launch checklist issue: crates metadata and dry-run publish status (v0.1)
 
-Date: 2026-03-20
+Date: 2026-03-21
 
 ## Scope
 
-- Added public-facing crates.io metadata to publishable crates:
-  - `tailtriage-core`
-  - `tailtriage-macros`
-  - `tailtriage-tokio`
-  - `tailtriage-cli`
-- Ran `cargo publish --dry-run` for each publishable crate.
+This checklist resolves v0.1 crates.io publication readiness for the MVP crates.
 
-## Metadata checklist
+It includes:
 
-- [x] `description` added and aligned with Tokio tail-latency triage positioning.
-- [x] `repository` added (`https://github.com/tailtriage/tailtriage`).
-- [x] `documentation` added (docs.rs URL per crate).
-- [x] `readme` added (`../README.md`).
-- [x] `keywords` added for crates.io discovery.
-- [x] `categories` added for crates.io discovery.
+- explicit crate publication scope (publish now vs workspace-only)
+- finalized first-release package versions (`0.1.0`)
+- metadata validation for all publishable crates
+- local `cargo publish --dry-run` checks in dependency order
+- docs.rs surface and owner/access setup notes
 
-## Dry-run outcomes
+## Publication scope decision
+
+### Publish now (v0.1.0)
+
+These crates are part of the first public release surface:
+
+1. `tailtriage-core`
+2. `tailtriage-macros`
+3. `tailtriage-tokio`
+4. `tailtriage-cli` (binary crate shipping `tailtriage`)
+
+### Workspace-only (publish later / do not publish)
+
+These are intentionally not part of the crates.io MVP surface right now:
+
+- all demo crates under `demos/*` (`publish = false`)
+- `demos/demo_support` (`publish = false`)
+- `demos/runtime_cost` (`publish = false`)
+
+Rationale: demos are proof workflows, not stable crate APIs.
+
+## Metadata checklist (publish-now crates)
+
+- [x] `description` present and aligned with Tokio tail-latency triage positioning.
+- [x] `license` present (`MIT`).
+- [x] `repository` present (`https://github.com/tailtriage/tailtriage`).
+- [x] `documentation` present (docs.rs URL per crate).
+- [x] `readme` configured (`../README.md`).
+- [x] `keywords` present for crates.io discovery.
+- [x] `categories` present for crates.io discovery.
+
+## Installation-path alignment
+
+README installation examples use publish-now crate names:
+
+- `tailtriage-core = "0.1"`
+- `tailtriage-tokio = "0.1"`
+
+CLI analysis command uses the `tailtriage` binary from `tailtriage-cli`.
+
+## docs.rs landing-page check
+
+Expected docs.rs pages for first publish:
+
+- <https://docs.rs/tailtriage-core>
+- <https://docs.rs/tailtriage-macros>
+- <https://docs.rs/tailtriage-tokio>
+- <https://docs.rs/tailtriage-cli>
+
+All publish-now crates set `readme = "../README.md"` so docs.rs presents a consistent entry surface.
+
+## Dry-run outcomes (dependency order)
 
 ### 1) `tailtriage-core`
 
@@ -40,14 +85,7 @@ Command:
 cargo publish -p tailtriage-macros --dry-run --allow-dirty
 ```
 
-Outcome: ⚠️ Blocked in pre-publish sequence because `tailtriage-core` is not yet available on crates.io in this local dry-run context.
-
-Error excerpt:
-
-```text
-no matching package named `tailtriage-core` found
-location searched: crates.io index
-```
+Outcome: ✅ Success (packaging + verification completed; upload aborted due to dry-run).
 
 ### 3) `tailtriage-tokio`
 
@@ -57,7 +95,7 @@ Command:
 cargo publish -p tailtriage-tokio --dry-run --allow-dirty
 ```
 
-Outcome: ⚠️ Blocked in pre-publish sequence because `tailtriage-core` is not yet available on crates.io in this local dry-run context.
+Outcome: ⚠️ Expected dependency-order block before first real publish because `tailtriage-core` is not yet available on crates.io.
 
 Error excerpt:
 
@@ -74,7 +112,7 @@ Command:
 cargo publish -p tailtriage-cli --dry-run --allow-dirty
 ```
 
-Outcome: ⚠️ Blocked in pre-publish sequence because `tailtriage-core` is not yet available on crates.io in this local dry-run context.
+Outcome: ⚠️ Expected dependency-order block before first real publish because `tailtriage-core` is not yet available on crates.io.
 
 Error excerpt:
 
@@ -83,8 +121,23 @@ no matching package named `tailtriage-core` found
 location searched: crates.io index
 ```
 
-## Next checks
+## Owner/access setup
 
-1. Publish `tailtriage-core` first.
-2. Re-run dry-runs for `tailtriage-macros`, `tailtriage-tokio`, and `tailtriage-cli` after `tailtriage-core` is available on crates.io.
-3. Publish remaining crates in dependency order and confirm docs.rs pages resolve.
+Before first publish, configure crate owners for each publish-now crate:
+
+```bash
+cargo owner --add github:tailtriage:owners tailtriage-core
+cargo owner --add github:tailtriage:owners tailtriage-macros
+cargo owner --add github:tailtriage:owners tailtriage-tokio
+cargo owner --add github:tailtriage:owners tailtriage-cli
+```
+
+If a GitHub team owner is unavailable, add at least two individual maintainers and record the intended team owner migration.
+
+## Publish sequence and immediate next checks
+
+1. Publish `tailtriage-core`.
+2. Re-run dry-runs for `tailtriage-tokio` and `tailtriage-cli`.
+3. Publish `tailtriage-macros`, then `tailtriage-tokio`, then `tailtriage-cli`.
+4. Verify docs.rs builds for all four crates and confirm README rendering on each page.
+5. Re-check README install commands from a clean environment.

--- a/tailtriage-macros/Cargo.toml
+++ b/tailtriage-macros/Cargo.toml
@@ -23,7 +23,7 @@ workspace = true
 
 [dev-dependencies]
 serde_json = "1"
-tailtriage-core = { version = "0.1.0", path = "../tailtriage-core" }
+tailtriage-core = { path = "../tailtriage-core" }
 tokio = { version = "1", features = ["macros", "rt"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"


### PR DESCRIPTION
### Motivation

- Prepare the workspace for a first public crates.io release by finalizing which crates are part of the v0.1 public surface and which remain workspace-only. 
- Ensure local packaging checks can run in dependency order and remove an accidental dry-run blocker for the macros crate. 

### Description

- Added a clarified `docs/launch-checklist-issue-v0.1.md` that records explicit `publish-now` vs workspace-only crates, first-release versioning (`0.1.0`), metadata/install/docs.rs expectations, owner/access setup commands, and a dependency-order-aware publish sequence. 
- Marked demos and demo-support crates as workspace-only (they already have `publish = false`) and documented the rationale that demos are not part of the stable public API. 
- Adjusted `tailtriage-macros/Cargo.toml` to use a path-only dev-dependency on `tailtriage-core` (removed the explicit `version = "0.1.0"` entry) so `cargo publish --dry-run` for the macros crate succeeds before `tailtriage-core` is live on crates.io. 

### Testing

- Ran `cargo publish -p tailtriage-core --dry-run --allow-dirty` which succeeded (packaging + verification completed). 
- Ran `cargo publish -p tailtriage-macros --dry-run --allow-dirty` which succeeded after switching the dev-dependency to path-only. 
- `cargo publish --dry-run` for `tailtriage-tokio` and `tailtriage-cli` showed the expected dependency-order block until `tailtriage-core` is actually published to crates.io. 
- Ran workspace checks `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be810dca508330b3f044a65179528d)