### PR TITLE
Align public-readiness and demo docs with current CI workflow

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -335,19 +335,19 @@ These remain useful and should stay documented, but docs should treat them as mo
 
 ## CI validation coverage
 
-The demo docs intentionally cover a broader surface than CI currently validates continuously.
+The demo docs and CI validation surface are aligned.
 
-In `.github/workflows/ci.yml`, continuous validation currently runs:
+In `.github/workflows/ci.yml`, the `CI` workflow continuously validates:
 
 - `queue`
 - `downstream`
 - `db-pool`
+- `shared-lock`
+- `retry-storm`
 - `mixed`
 - `cold-start`
 - `blocking`
 - `executor`
-
-`shared-lock` and `retry-storm` remain documented and fixture-backed, but currently have weaker continuous validation coverage than the list above.
 
 ## Typical local workflow
 

--- a/docs/getting-started-demo.md
+++ b/docs/getting-started-demo.md
@@ -98,13 +98,15 @@ Use this table for first-pass diagnosis reading. Suspects are leads, not proof.
 | `blocking_service` | Directionally useful for exercising blocking-pool diagnosis behavior. | More synthetic than a strongest real-world proof case. | Blocking-pressure suspect evidence and blocking-related runtime signals. |
 | `executor_pressure_service` | Useful for exercising executor-pressure diagnosis and runnable-backlog evidence. | More synthetic because backlog signals are modeled explicitly. | Executor-pressure suspect evidence, runtime queue-depth signals, blocking-depth contrast. |
 
-## CI validation coverage caveat
+## CI validation coverage
 
-The documented demo surface is broader than the currently CI-validated surface. In `.github/workflows/ci.yml`, CI validates:
+The documented demo surface matches the CI validation surface. In `.github/workflows/ci.yml`, the `CI` workflow validates:
 
 - `queue`
 - `downstream`
 - `db-pool`
+- `shared-lock`
+- `retry-storm`
 - `mixed`
 - `cold-start`
 - `blocking`

--- a/docs/github-repo-ops.md
+++ b/docs/github-repo-ops.md
@@ -22,7 +22,6 @@ Apply these settings to the default branch (`main`) in:
   - [x] Require branches to be up to date before merging
   - [x] Required status checks:
     - `CI`
-    - `Python Demo Checks`
 - [x] **Block force pushes**
 - [x] **Block branch deletion**
 
@@ -78,7 +77,7 @@ If you add extra topics, keep them narrowly relevant to Tokio async-service tria
 Complete this checklist before switching repository visibility from private to public:
 
 1. Apply the branch protection rule in Section 1 to `main`.
-2. Confirm required status checks are exactly `CI` and `Python Demo Checks`.
+2. Confirm required status checks are exactly `CI`.
 3. Normalize labels using Section 2.
 4. Set description and topics using Section 3.
 5. Verify README opening clearly positions `tailtriage` as a Tokio tail-latency triage toolkit.
@@ -101,9 +100,8 @@ Run these checks after changing branch rules, labels, topics, or description.
 1. Open **Settings → Branches** and confirm the `main` rule is active.
 2. Open a test PR from a branch behind `main`:
    - Verify merge is blocked until required checks pass and branch is updated.
-3. Confirm both checks appear in required checks:
+3. Confirm the required check appears in required checks:
    - `CI`
-   - `Python Demo Checks`
 4. Confirm force-push and delete controls are disabled for `main`.
 
 ### B. Label verification

--- a/docs/public-readiness-checklist.md
+++ b/docs/public-readiness-checklist.md
@@ -10,8 +10,8 @@ For exact GitHub operations (branch rules, required checks, labels, topics, owne
 - [ ] Topics are intentional (for example: `rust`, `tokio`, `performance`, `latency`, `diagnostics`).
 - [ ] Default branch is correct and protected.
 - [ ] Branch protection requires passing CI and blocks force-pushes/deletions.
-- [ ] Required status checks reference current workflow names (`CI`, `Python Demo Checks`) and avoid transient job-level names.
-- [ ] Required checks include Rust quality gates (`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`) and deterministic triage validations for: `queue`, `blocking`, `executor`, `downstream`, `mixed`, `cold-start`, and `db-pool`.
+- [ ] Required status checks reference current workflow names (`CI`) and avoid transient job-level names.
+- [ ] Required checks include Rust quality gates (`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`) and deterministic triage validations for: `queue`, `blocking`, `executor`, `downstream`, `mixed`, `cold-start`, `db-pool`, `shared-lock`, and `retry-storm`.
 - [ ] Runtime-cost measurement remains informational/non-blocking (it should not gate merges).
 - [ ] Tag and release policy is intentional (no accidental internal tags).
 
@@ -51,6 +51,8 @@ python3 scripts/demo_tool.py validate downstream
 python3 scripts/demo_tool.py validate mixed
 python3 scripts/demo_tool.py validate cold-start
 python3 scripts/demo_tool.py validate db-pool
+python3 scripts/demo_tool.py validate shared-lock
+python3 scripts/demo_tool.py validate retry-storm
 ```
 
 Optional/non-blocking measurement:


### PR DESCRIPTION
### Motivation
- Public-facing launch and demo docs contained stale references that no longer matched `.github/workflows/ci.yml`, which risks confusing visitors about what the CI actually validates. 
- Docs must be exact and conservative so the repository's readiness guidance remains trustworthy and actionable.

### Description
- Updated demo coverage statements to include `shared-lock` and `retry-storm` so the demo docs match the `CI` workflow (`demos/README.md` and `docs/getting-started-demo.md`).
- Removed stale `Python Demo Checks` references and standardized required status-check guidance to a single `CI` check (`docs/github-repo-ops.md`).
- Reconciled the public-readiness checklist and launch-readiness command list to include `shared-lock` and `retry-storm` validation commands and to reference only `CI` (`docs/public-readiness-checklist.md`).
- Kept changes conservative and limited to documentation so no CI behavior or repository settings were modified.

### Testing
- Ran `cargo fmt --check` and it completed successfully. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it completed successfully. 
- Ran `cargo test --workspace` and all tests passed (unit, integration, and fixture tests completed without failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be9b0df0408330bc5286105e0a9f94)