### PR TITLE
Refresh stale demo analysis fixtures and align quickstart evidence snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Representative diagnosis shape:
   "primary_suspect": {
     "kind": "ApplicationQueueSaturation",
     "evidence": [
-      "Queue wait at p95 consumes 98.4% of request time.",
+      "Queue wait at p95 consumes 98.2% of request time.",
       "Observed queue depth sample up to 230."
     ],
     "next_checks": [

--- a/demos/blocking_service/fixtures/after-analysis.json
+++ b/demos/blocking_service/fixtures/after-analysis.json
@@ -1,24 +1,25 @@
 {
   "request_count": 250,
-  "p50_latency_us": 54654,
-  "p95_latency_us": 73409,
-  "p99_latency_us": 76883,
-  "p95_queue_share_permille": 62,
-  "p95_service_share_permille": 986,
+  "p50_latency_us": 55720,
+  "p95_latency_us": 88888,
+  "p99_latency_us": 92354,
+  "p95_queue_share_permille": 55,
+  "p95_service_share_permille": 991,
   "inflight_trend": {
     "gauge": "blocking_service_inflight",
     "sample_count": 500,
-    "peak_count": 40,
-    "p95_count": 38,
+    "peak_count": 49,
+    "p95_count": 47,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2032
+    "growth_per_sec_milli": -2040
   },
+  "warnings": [],
   "primary_suspect": {
     "kind": "BlockingPoolPressure",
     "score": 80,
     "confidence": "medium",
     "evidence": [
-      "Blocking queue depth p95 is 38, indicating sustained spawn_blocking backlog."
+      "Blocking queue depth p95 is 45, indicating sustained spawn_blocking backlog."
     ],
     "next_checks": [
       "Audit blocking sections and move avoidable synchronous work out of hot paths.",
@@ -28,15 +29,17 @@
   "secondary_suspects": [
     {
       "kind": "DownstreamStageDominates",
-      "score": 60,
-      "confidence": "low",
+      "score": 79,
+      "confidence": "medium",
       "evidence": [
-        "Stage 'spawn_blocking_path' has p95 latency 72227 us across 250 samples.",
-        "Stage 'spawn_blocking_path' cumulative latency is 12298332 us."
+        "Stage 'spawn_blocking_path' has p95 latency 87633 us across 250 samples.",
+        "Stage 'spawn_blocking_path' cumulative latency is 13557163 us.",
+        "Stage 'spawn_blocking_path' contributes 978 permille of cumulative request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
-        "Collect downstream service timings and retry behavior during tail windows."
+        "Collect downstream service timings and retry behavior during tail windows.",
+        "Review downstream SLO/error budget and align retry budget/backoff with it."
       ]
     }
   ]

--- a/demos/blocking_service/fixtures/before-after-comparison.json
+++ b/demos/blocking_service/fixtures/before-after-comparison.json
@@ -2,21 +2,22 @@
   "before": {
     "primary_suspect_kind": "BlockingPoolPressure",
     "primary_suspect_score": 80,
-    "p95_latency_us": 3531941,
+    "p95_latency_us": 3528432,
     "p95_service_share_permille": 999,
     "blocking_queue_depth_p95": 244
   },
   "after": {
     "primary_suspect_kind": "BlockingPoolPressure",
     "primary_suspect_score": 80,
-    "p95_latency_us": 73409,
-    "p95_service_share_permille": 986,
-    "blocking_queue_depth_p95": 38
+    "p95_latency_us": 88888,
+    "p95_service_share_permille": 991,
+    "blocking_queue_depth_p95": 45
   },
   "delta": {
-    "p95_latency_us": -3458532,
+    "primary_suspect_kind": null,
     "primary_suspect_score": 0,
-    "p95_service_share_permille": -13,
-    "blocking_queue_depth_p95": -206
+    "p95_latency_us": -3439544,
+    "p95_service_share_permille": -8,
+    "blocking_queue_depth_p95": -199
   }
 }

--- a/demos/blocking_service/fixtures/before-analysis.json
+++ b/demos/blocking_service/fixtures/before-analysis.json
@@ -1,18 +1,19 @@
 {
   "request_count": 250,
-  "p50_latency_us": 1874771,
-  "p95_latency_us": 3531941,
-  "p99_latency_us": 3681253,
-  "p95_queue_share_permille": 6,
+  "p50_latency_us": 1868837,
+  "p95_latency_us": 3528432,
+  "p99_latency_us": 3676994,
+  "p95_queue_share_permille": 5,
   "p95_service_share_permille": 999,
   "inflight_trend": {
     "gauge": "blocking_service_inflight",
     "sample_count": 500,
     "peak_count": 246,
     "p95_count": 234,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -264
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
   },
+  "warnings": [],
   "primary_suspect": {
     "kind": "BlockingPoolPressure",
     "score": 80,
@@ -28,15 +29,17 @@
   "secondary_suspects": [
     {
       "kind": "DownstreamStageDominates",
-      "score": 60,
-      "confidence": "low",
+      "score": 79,
+      "confidence": "medium",
       "evidence": [
-        "Stage 'spawn_blocking_path' has p95 latency 3531772 us across 250 samples.",
-        "Stage 'spawn_blocking_path' cumulative latency is 467502659 us."
+        "Stage 'spawn_blocking_path' has p95 latency 3527249 us across 250 samples.",
+        "Stage 'spawn_blocking_path' cumulative latency is 466827768 us.",
+        "Stage 'spawn_blocking_path' contributes 999 permille of cumulative request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
-        "Collect downstream service timings and retry behavior during tail windows."
+        "Collect downstream service timings and retry behavior during tail windows.",
+        "Review downstream SLO/error budget and align retry budget/backoff with it."
       ]
     }
   ]

--- a/demos/blocking_service/fixtures/sample-analysis.json
+++ b/demos/blocking_service/fixtures/sample-analysis.json
@@ -1,18 +1,19 @@
 {
   "request_count": 250,
-  "p50_latency_us": 1874771,
-  "p95_latency_us": 3531941,
-  "p99_latency_us": 3681253,
-  "p95_queue_share_permille": 6,
+  "p50_latency_us": 1868837,
+  "p95_latency_us": 3528432,
+  "p99_latency_us": 3676994,
+  "p95_queue_share_permille": 5,
   "p95_service_share_permille": 999,
   "inflight_trend": {
     "gauge": "blocking_service_inflight",
     "sample_count": 500,
     "peak_count": 246,
     "p95_count": 234,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -264
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
   },
+  "warnings": [],
   "primary_suspect": {
     "kind": "BlockingPoolPressure",
     "score": 80,
@@ -28,15 +29,17 @@
   "secondary_suspects": [
     {
       "kind": "DownstreamStageDominates",
-      "score": 60,
-      "confidence": "low",
+      "score": 79,
+      "confidence": "medium",
       "evidence": [
-        "Stage 'spawn_blocking_path' has p95 latency 3531772 us across 250 samples.",
-        "Stage 'spawn_blocking_path' cumulative latency is 467502659 us."
+        "Stage 'spawn_blocking_path' has p95 latency 3527249 us across 250 samples.",
+        "Stage 'spawn_blocking_path' cumulative latency is 466827768 us.",
+        "Stage 'spawn_blocking_path' contributes 999 permille of cumulative request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
-        "Collect downstream service timings and retry behavior during tail windows."
+        "Collect downstream service timings and retry behavior during tail windows.",
+        "Review downstream SLO/error budget and align retry budget/backoff with it."
       ]
     }
   ]

--- a/demos/cold_start_burst_service/fixtures/after-analysis.json
+++ b/demos/cold_start_burst_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 8463,
-  "p95_latency_us": 8780,
-  "p99_latency_us": 18231,
+  "p50_latency_us": 8472,
+  "p95_latency_us": 8793,
+  "p99_latency_us": 8930,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 999,
   "inflight_trend": {
@@ -11,19 +11,22 @@
     "peak_count": 4,
     "p95_count": 2,
     "growth_delta": -1,
-    "growth_per_sec_milli": -1049
+    "growth_per_sec_milli": -1066
   },
+  "warnings": [],
   "primary_suspect": {
     "kind": "DownstreamStageDominates",
-    "score": 60,
-    "confidence": "low",
+    "score": 79,
+    "confidence": "medium",
     "evidence": [
-      "Stage 'cold_start_stage' has p95 latency 8752 us across 220 samples.",
-      "Stage 'cold_start_stage' cumulative latency is 1833446 us."
+      "Stage 'cold_start_stage' has p95 latency 8757 us across 220 samples.",
+      "Stage 'cold_start_stage' cumulative latency is 1813418 us.",
+      "Stage 'cold_start_stage' contributes 997 permille of cumulative request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'cold_start_stage'.",
-      "Collect downstream service timings and retry behavior during tail windows."
+      "Collect downstream service timings and retry behavior during tail windows.",
+      "Review downstream SLO/error budget and align retry budget/backoff with it."
     ]
   },
   "secondary_suspects": []

--- a/demos/cold_start_burst_service/fixtures/before-after-comparison.json
+++ b/demos/cold_start_burst_service/fixtures/before-after-comparison.json
@@ -2,19 +2,19 @@
   "before": {
     "primary_suspect_kind": "ApplicationQueueSaturation",
     "primary_suspect_score": 90,
-    "p95_latency_us": 1191110,
+    "p95_latency_us": 1190539,
     "p95_queue_share_permille": 993
   },
   "after": {
     "primary_suspect_kind": "DownstreamStageDominates",
-    "primary_suspect_score": 60,
-    "p95_latency_us": 8780,
+    "primary_suspect_score": 79,
+    "p95_latency_us": 8793,
     "p95_queue_share_permille": 0
   },
   "delta": {
     "primary_suspect_kind": null,
-    "primary_suspect_score": -30,
-    "p95_latency_us": -1182330,
+    "primary_suspect_score": -11,
+    "p95_latency_us": -1181746,
     "p95_queue_share_permille": -993
   }
 }

--- a/demos/cold_start_burst_service/fixtures/before-analysis.json
+++ b/demos/cold_start_burst_service/fixtures/before-analysis.json
@@ -1,10 +1,10 @@
 {
   "request_count": 220,
-  "p50_latency_us": 992065,
-  "p95_latency_us": 1191110,
-  "p99_latency_us": 1207494,
+  "p50_latency_us": 993912,
+  "p95_latency_us": 1190539,
+  "p99_latency_us": 1207352,
   "p95_queue_share_permille": 993,
-  "p95_service_share_permille": 333,
+  "p95_service_share_permille": 329,
   "inflight_trend": {
     "gauge": "cold_start_burst_inflight",
     "sample_count": 440,
@@ -13,6 +13,7 @@
     "growth_delta": 1,
     "growth_per_sec_milli": 816
   },
+  "warnings": [],
   "primary_suspect": {
     "kind": "ApplicationQueueSaturation",
     "score": 90,
@@ -30,15 +31,17 @@
   "secondary_suspects": [
     {
       "kind": "DownstreamStageDominates",
-      "score": 60,
+      "score": 55,
       "confidence": "low",
       "evidence": [
-        "Stage 'cold_start_stage' has p95 latency 63580 us across 220 samples.",
-        "Stage 'cold_start_stage' cumulative latency is 4877683 us."
+        "Stage 'cold_start_stage' has p95 latency 63606 us across 220 samples.",
+        "Stage 'cold_start_stage' cumulative latency is 4878331 us.",
+        "Stage 'cold_start_stage' contributes 24 permille of cumulative request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'cold_start_stage'.",
-        "Collect downstream service timings and retry behavior during tail windows."
+        "Collect downstream service timings and retry behavior during tail windows.",
+        "Review downstream SLO/error budget and align retry budget/backoff with it."
       ]
     }
   ]

--- a/demos/db_pool_saturation_service/fixtures/after-analysis.json
+++ b/demos/db_pool_saturation_service/fixtures/after-analysis.json
@@ -1,9 +1,9 @@
 {
   "request_count": 220,
-  "p50_latency_us": 14465,
-  "p95_latency_us": 23631,
-  "p99_latency_us": 102348,
-  "p95_queue_share_permille": 1,
+  "p50_latency_us": 13087,
+  "p95_latency_us": 14051,
+  "p99_latency_us": 14581,
+  "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "db_pool_saturation_inflight",
@@ -11,19 +11,22 @@
     "peak_count": 10,
     "p95_count": 10,
     "growth_delta": -1,
-    "growth_per_sec_milli": -1872
+    "growth_per_sec_milli": -2717
   },
+  "warnings": [],
   "primary_suspect": {
     "kind": "DownstreamStageDominates",
-    "score": 60,
-    "confidence": "low",
+    "score": 75,
+    "confidence": "medium",
     "evidence": [
-      "Stage 'db_query' has p95 latency 18218 us across 220 samples.",
-      "Stage 'db_query' cumulative latency is 3100313 us."
+      "Stage 'db_query' has p95 latency 11860 us across 220 samples.",
+      "Stage 'db_query' cumulative latency is 2450083 us.",
+      "Stage 'db_query' contributes 837 permille of cumulative request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'db_query'.",
-      "Collect downstream service timings and retry behavior during tail windows."
+      "Collect downstream service timings and retry behavior during tail windows.",
+      "Review downstream SLO/error budget and align retry budget/backoff with it."
     ]
   },
   "secondary_suspects": []

--- a/demos/db_pool_saturation_service/fixtures/before-after-comparison.json
+++ b/demos/db_pool_saturation_service/fixtures/before-after-comparison.json
@@ -2,19 +2,19 @@
   "before": {
     "primary_suspect_kind": "ApplicationQueueSaturation",
     "primary_suspect_score": 90,
-    "p95_latency_us": 1000477,
-    "p95_queue_share_permille": 977
+    "p95_latency_us": 926156,
+    "p95_queue_share_permille": 976
   },
   "after": {
     "primary_suspect_kind": "DownstreamStageDominates",
-    "primary_suspect_score": 60,
-    "p95_latency_us": 23631,
-    "p95_queue_share_permille": 1
+    "primary_suspect_score": 75,
+    "p95_latency_us": 14051,
+    "p95_queue_share_permille": 0
   },
   "delta": {
     "primary_suspect_kind": null,
-    "primary_suspect_score": -30,
-    "p95_latency_us": -976846,
+    "primary_suspect_score": -15,
+    "p95_latency_us": -912105,
     "p95_queue_share_permille": -976
   }
 }

--- a/demos/db_pool_saturation_service/fixtures/before-analysis.json
+++ b/demos/db_pool_saturation_service/fixtures/before-analysis.json
@@ -1,25 +1,27 @@
 {
   "request_count": 220,
-  "p50_latency_us": 572910,
-  "p95_latency_us": 1000477,
-  "p99_latency_us": 1064713,
-  "p95_queue_share_permille": 977,
-  "p95_service_share_permille": 377,
+  "p50_latency_us": 493037,
+  "p95_latency_us": 926156,
+  "p99_latency_us": 960192,
+  "p95_queue_share_permille": 976,
+  "p95_service_share_permille": 360,
   "inflight_trend": {
     "gauge": "db_pool_saturation_inflight",
     "sample_count": 440,
-    "peak_count": 195,
-    "p95_count": 185,
-    "growth_delta": 0,
-    "growth_per_sec_milli": 0
+    "peak_count": 203,
+    "p95_count": 193,
+    "growth_delta": 2,
+    "growth_per_sec_milli": 1888
   },
+  "warnings": [],
   "primary_suspect": {
     "kind": "ApplicationQueueSaturation",
     "score": 90,
     "confidence": "high",
     "evidence": [
-      "Queue wait at p95 consumes 97.7% of request time.",
-      "Observed queue depth sample up to 190."
+      "Queue wait at p95 consumes 97.6% of request time.",
+      "Observed queue depth sample up to 196.",
+      "In-flight gauge 'db_pool_saturation_inflight' grew by 2 over the run window (p95=193, peak=203)."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -29,15 +31,17 @@
   "secondary_suspects": [
     {
       "kind": "DownstreamStageDominates",
-      "score": 60,
+      "score": 55,
       "confidence": "low",
       "evidence": [
-        "Stage 'db_query' has p95 latency 22329 us across 220 samples.",
-        "Stage 'db_query' cumulative latency is 4665893 us."
+        "Stage 'db_query' has p95 latency 19607 us across 220 samples.",
+        "Stage 'db_query' cumulative latency is 4212930 us.",
+        "Stage 'db_query' contributes 38 permille of cumulative request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'db_query'.",
-        "Collect downstream service timings and retry behavior during tail windows."
+        "Collect downstream service timings and retry behavior during tail windows.",
+        "Review downstream SLO/error budget and align retry budget/backoff with it."
       ]
     }
   ]

--- a/demos/downstream_service/fixtures/sample-analysis.json
+++ b/demos/downstream_service/fixtures/sample-analysis.json
@@ -1,29 +1,32 @@
 {
   "request_count": 80,
-  "p50_latency_us": 24618,
-  "p95_latency_us": 25920,
-  "p99_latency_us": 26706,
+  "p50_latency_us": 23104,
+  "p95_latency_us": 23899,
+  "p99_latency_us": 23909,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "downstream_service_inflight",
     "sample_count": 160,
-    "peak_count": 56,
-    "p95_count": 55,
+    "peak_count": 64,
+    "p95_count": 62,
     "growth_delta": 5,
-    "growth_per_sec_milli": 76923
+    "growth_per_sec_milli": 92592
   },
+  "warnings": [],
   "primary_suspect": {
     "kind": "DownstreamStageDominates",
-    "score": 60,
-    "confidence": "low",
+    "score": 77,
+    "confidence": "medium",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 22680 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 1718786 us."
+      "Stage 'downstream_call' has p95 latency 21625 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 1682612 us.",
+      "Stage 'downstream_call' contributes 907 permille of cumulative request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",
-      "Collect downstream service timings and retry behavior during tail windows."
+      "Collect downstream service timings and retry behavior during tail windows.",
+      "Review downstream SLO/error budget and align retry budget/backoff with it."
     ]
   },
   "secondary_suspects": []

--- a/demos/executor_pressure_service/fixtures/after-analysis.json
+++ b/demos/executor_pressure_service/fixtures/after-analysis.json
@@ -1,24 +1,26 @@
 {
   "request_count": 220,
-  "p50_latency_us": 1083569,
-  "p95_latency_us": 1175696,
-  "p99_latency_us": 1194281,
-  "p95_queue_share_permille": 167,
-  "p95_service_share_permille": 999,
+  "p50_latency_us": 1042256,
+  "p95_latency_us": 1129448,
+  "p99_latency_us": 1143294,
+  "p95_queue_share_permille": 95,
+  "p95_service_share_permille": 997,
   "inflight_trend": {
     "gauge": "executor_pressure_inflight",
     "sample_count": 440,
-    "peak_count": 219,
-    "p95_count": 209,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -790
+    "peak_count": 215,
+    "p95_count": 206,
+    "growth_delta": 5,
+    "growth_per_sec_milli": 4152
   },
+  "warnings": [],
   "primary_suspect": {
     "kind": "ExecutorPressureSuspected",
-    "score": 77,
+    "score": 82,
     "confidence": "medium",
     "evidence": [
-      "Runtime global queue depth p95 is 216, suggesting scheduler contention."
+      "Runtime global queue depth p95 is 214, suggesting scheduler contention.",
+      "In-flight gauge 'executor_pressure_inflight' growth is positive (delta=5, peak=215), consistent with accumulating executor pressure."
     ],
     "next_checks": [
       "Check for long polls without yielding and uneven task fan-out.",
@@ -28,15 +30,17 @@
   "secondary_suspects": [
     {
       "kind": "DownstreamStageDominates",
-      "score": 60,
-      "confidence": "low",
+      "score": 78,
+      "confidence": "medium",
       "evidence": [
-        "Stage 'executor_hot_path' has p95 latency 1108231 us across 220 samples.",
-        "Stage 'executor_hot_path' cumulative latency is 203785081 us."
+        "Stage 'executor_hot_path' has p95 latency 1086211 us across 220 samples.",
+        "Stage 'executor_hot_path' cumulative latency is 201838141 us.",
+        "Stage 'executor_hot_path' contributes 951 permille of cumulative request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'executor_hot_path'.",
-        "Collect downstream service timings and retry behavior during tail windows."
+        "Collect downstream service timings and retry behavior during tail windows.",
+        "Review downstream SLO/error budget and align retry budget/backoff with it."
       ]
     }
   ]

--- a/demos/executor_pressure_service/fixtures/before-after-comparison.json
+++ b/demos/executor_pressure_service/fixtures/before-after-comparison.json
@@ -1,20 +1,20 @@
 {
   "before": {
     "primary_suspect_kind": "ExecutorPressureSuspected",
-    "primary_suspect_score": 85,
-    "p95_latency_us": 6031022,
-    "p95_queue_share_permille": 77
+    "primary_suspect_score": 90,
+    "p95_latency_us": 6004079,
+    "p95_queue_share_permille": 55
   },
   "after": {
     "primary_suspect_kind": "ExecutorPressureSuspected",
-    "primary_suspect_score": 77,
-    "p95_latency_us": 1175696,
-    "p95_queue_share_permille": 167
+    "primary_suspect_score": 82,
+    "p95_latency_us": 1129448,
+    "p95_queue_share_permille": 95
   },
   "delta": {
     "primary_suspect_kind": null,
     "primary_suspect_score": -8,
-    "p95_latency_us": -4855326,
-    "p95_queue_share_permille": 90
+    "p95_latency_us": -4874631,
+    "p95_queue_share_permille": 40
   }
 }

--- a/demos/executor_pressure_service/fixtures/before-analysis.json
+++ b/demos/executor_pressure_service/fixtures/before-analysis.json
@@ -1,24 +1,26 @@
 {
   "request_count": 320,
-  "p50_latency_us": 5899474,
-  "p95_latency_us": 6031022,
-  "p99_latency_us": 6057607,
-  "p95_queue_share_permille": 77,
+  "p50_latency_us": 5907090,
+  "p95_latency_us": 6004079,
+  "p99_latency_us": 6030449,
+  "p95_queue_share_permille": 55,
   "p95_service_share_permille": 999,
   "inflight_trend": {
     "gauge": "executor_pressure_inflight",
     "sample_count": 640,
     "peak_count": 320,
     "p95_count": 304,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -163
+    "growth_delta": 3,
+    "growth_per_sec_milli": 495
   },
+  "warnings": [],
   "primary_suspect": {
     "kind": "ExecutorPressureSuspected",
-    "score": 85,
+    "score": 90,
     "confidence": "high",
     "evidence": [
-      "Runtime global queue depth p95 is 320, suggesting scheduler contention."
+      "Runtime global queue depth p95 is 320, suggesting scheduler contention.",
+      "In-flight gauge 'executor_pressure_inflight' growth is positive (delta=3, peak=320), consistent with accumulating executor pressure."
     ],
     "next_checks": [
       "Check for long polls without yielding and uneven task fan-out.",
@@ -28,15 +30,17 @@
   "secondary_suspects": [
     {
       "kind": "DownstreamStageDominates",
-      "score": 60,
-      "confidence": "low",
+      "score": 79,
+      "confidence": "medium",
       "evidence": [
-        "Stage 'executor_hot_path' has p95 latency 5994102 us across 320 samples.",
-        "Stage 'executor_hot_path' cumulative latency is 1810769561 us."
+        "Stage 'executor_hot_path' has p95 latency 5934696 us across 320 samples.",
+        "Stage 'executor_hot_path' cumulative latency is 1825447296 us.",
+        "Stage 'executor_hot_path' contributes 975 permille of cumulative request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'executor_hot_path'.",
-        "Collect downstream service timings and retry behavior during tail windows."
+        "Collect downstream service timings and retry behavior during tail windows.",
+        "Review downstream SLO/error budget and align retry budget/backoff with it."
       ]
     }
   ]

--- a/demos/executor_pressure_service/fixtures/sample-analysis.json
+++ b/demos/executor_pressure_service/fixtures/sample-analysis.json
@@ -1,24 +1,26 @@
 {
   "request_count": 320,
-  "p50_latency_us": 5899474,
-  "p95_latency_us": 6031022,
-  "p99_latency_us": 6057607,
-  "p95_queue_share_permille": 77,
+  "p50_latency_us": 5907090,
+  "p95_latency_us": 6004079,
+  "p99_latency_us": 6030449,
+  "p95_queue_share_permille": 55,
   "p95_service_share_permille": 999,
   "inflight_trend": {
     "gauge": "executor_pressure_inflight",
     "sample_count": 640,
     "peak_count": 320,
     "p95_count": 304,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -163
+    "growth_delta": 3,
+    "growth_per_sec_milli": 495
   },
+  "warnings": [],
   "primary_suspect": {
     "kind": "ExecutorPressureSuspected",
-    "score": 85,
+    "score": 90,
     "confidence": "high",
     "evidence": [
-      "Runtime global queue depth p95 is 320, suggesting scheduler contention."
+      "Runtime global queue depth p95 is 320, suggesting scheduler contention.",
+      "In-flight gauge 'executor_pressure_inflight' growth is positive (delta=3, peak=320), consistent with accumulating executor pressure."
     ],
     "next_checks": [
       "Check for long polls without yielding and uneven task fan-out.",
@@ -28,15 +30,17 @@
   "secondary_suspects": [
     {
       "kind": "DownstreamStageDominates",
-      "score": 60,
-      "confidence": "low",
+      "score": 79,
+      "confidence": "medium",
       "evidence": [
-        "Stage 'executor_hot_path' has p95 latency 5994102 us across 320 samples.",
-        "Stage 'executor_hot_path' cumulative latency is 1810769561 us."
+        "Stage 'executor_hot_path' has p95 latency 5934696 us across 320 samples.",
+        "Stage 'executor_hot_path' cumulative latency is 1825447296 us.",
+        "Stage 'executor_hot_path' contributes 975 permille of cumulative request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'executor_hot_path'.",
-        "Collect downstream service timings and retry behavior during tail windows."
+        "Collect downstream service timings and retry behavior during tail windows.",
+        "Review downstream SLO/error budget and align retry budget/backoff with it."
       ]
     }
   ]

--- a/demos/mixed_contention_service/fixtures/baseline-analysis.json
+++ b/demos/mixed_contention_service/fixtures/baseline-analysis.json
@@ -1,25 +1,26 @@
 {
   "request_count": 220,
-  "p50_latency_us": 397747,
-  "p95_latency_us": 744661,
-  "p99_latency_us": 775005,
+  "p50_latency_us": 391327,
+  "p95_latency_us": 744182,
+  "p99_latency_us": 767870,
   "p95_queue_share_permille": 980,
-  "p95_service_share_permille": 390,
+  "p95_service_share_permille": 440,
   "inflight_trend": {
     "gauge": "mixed_contention_inflight",
     "sample_count": 440,
-    "peak_count": 202,
-    "p95_count": 191,
+    "peak_count": 201,
+    "p95_count": 192,
     "growth_delta": -1,
-    "growth_per_sec_milli": -1157
+    "growth_per_sec_milli": -1158
   },
+  "warnings": [],
   "primary_suspect": {
     "kind": "ApplicationQueueSaturation",
     "score": 90,
     "confidence": "high",
     "evidence": [
       "Queue wait at p95 consumes 98.0% of request time.",
-      "Observed queue depth sample up to 197."
+      "Observed queue depth sample up to 196."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -29,15 +30,17 @@
   "secondary_suspects": [
     {
       "kind": "DownstreamStageDominates",
-      "score": 60,
+      "score": 56,
       "confidence": "low",
       "evidence": [
-        "Stage 'downstream_call' has p95 latency 32680 us across 220 samples.",
-        "Stage 'downstream_call' cumulative latency is 3785567 us."
+        "Stage 'downstream_call' has p95 latency 32556 us across 220 samples.",
+        "Stage 'downstream_call' cumulative latency is 3771855 us.",
+        "Stage 'downstream_call' contributes 43 permille of cumulative request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'downstream_call'.",
-        "Collect downstream service timings and retry behavior during tail windows."
+        "Collect downstream service timings and retry behavior during tail windows.",
+        "Review downstream SLO/error budget and align retry budget/backoff with it."
       ]
     }
   ]

--- a/demos/mixed_contention_service/fixtures/before-after-comparison.json
+++ b/demos/mixed_contention_service/fixtures/before-after-comparison.json
@@ -2,19 +2,19 @@
   "before": {
     "primary_suspect_kind": "ApplicationQueueSaturation",
     "primary_suspect_score": 90,
-    "p95_latency_us": 744661,
+    "p95_latency_us": 744182,
     "p95_queue_share_permille": 980
   },
   "after": {
     "primary_suspect_kind": "DownstreamStageDominates",
-    "primary_suspect_score": 60,
-    "p95_latency_us": 34718,
+    "primary_suspect_score": 77,
+    "p95_latency_us": 34609,
     "p95_queue_share_permille": 0
   },
   "delta": {
     "primary_suspect_kind": null,
-    "primary_suspect_score": -30,
-    "p95_latency_us": -709943,
+    "primary_suspect_score": -13,
+    "p95_latency_us": -709573,
     "p95_queue_share_permille": -980
   }
 }

--- a/demos/mixed_contention_service/fixtures/mitigated-analysis.json
+++ b/demos/mixed_contention_service/fixtures/mitigated-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 14372,
-  "p95_latency_us": 34718,
-  "p99_latency_us": 34955,
+  "p50_latency_us": 14544,
+  "p95_latency_us": 34609,
+  "p99_latency_us": 34946,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,19 +11,22 @@
     "peak_count": 14,
     "p95_count": 13,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2631
+    "growth_per_sec_milli": -2659
   },
+  "warnings": [],
   "primary_suspect": {
     "kind": "DownstreamStageDominates",
-    "score": 60,
-    "confidence": "low",
+    "score": 77,
+    "confidence": "medium",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 32449 us across 220 samples.",
-      "Stage 'downstream_call' cumulative latency is 3769992 us."
+      "Stage 'downstream_call' has p95 latency 32553 us across 220 samples.",
+      "Stage 'downstream_call' cumulative latency is 3758133 us.",
+      "Stage 'downstream_call' contributes 888 permille of cumulative request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",
-      "Collect downstream service timings and retry behavior during tail windows."
+      "Collect downstream service timings and retry behavior during tail windows.",
+      "Review downstream SLO/error budget and align retry budget/backoff with it."
     ]
   },
   "secondary_suspects": []

--- a/demos/queue_service/fixtures/after-analysis.json
+++ b/demos/queue_service/fixtures/after-analysis.json
@@ -1,21 +1,32 @@
 {
   "request_count": 250,
-  "p50_latency_us": 17043,
-  "p95_latency_us": 24745,
-  "p99_latency_us": 26891,
-  "p95_queue_share_permille": 5,
+  "p50_latency_us": 16140,
+  "p95_latency_us": 16756,
+  "p99_latency_us": 16963,
+  "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
+  "inflight_trend": {
+    "gauge": "queue_service_inflight",
+    "sample_count": 500,
+    "peak_count": 12,
+    "p95_count": 12,
+    "growth_delta": -1,
+    "growth_per_sec_milli": -2415
+  },
+  "warnings": [],
   "primary_suspect": {
     "kind": "DownstreamStageDominates",
-    "score": 60,
-    "confidence": "low",
+    "score": 79,
+    "confidence": "medium",
     "evidence": [
-      "Stage 'simulated_work' has p95 latency 24066 us across 250 samples.",
-      "Stage 'simulated_work' cumulative latency is 4468249 us."
+      "Stage 'simulated_work' has p95 latency 16744 us across 250 samples.",
+      "Stage 'simulated_work' cumulative latency is 4034843 us.",
+      "Stage 'simulated_work' contributes 998 permille of cumulative request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'simulated_work'.",
-      "Collect downstream service timings and retry behavior during tail windows."
+      "Collect downstream service timings and retry behavior during tail windows.",
+      "Review downstream SLO/error budget and align retry budget/backoff with it."
     ]
   },
   "secondary_suspects": []

--- a/demos/queue_service/fixtures/before-analysis.json
+++ b/demos/queue_service/fixtures/before-analysis.json
@@ -1,17 +1,26 @@
 {
   "request_count": 250,
-  "p50_latency_us": 892107,
-  "p95_latency_us": 1682454,
-  "p99_latency_us": 1753285,
-  "p95_queue_share_permille": 981,
-  "p95_service_share_permille": 263,
+  "p50_latency_us": 788171,
+  "p95_latency_us": 1476281,
+  "p99_latency_us": 1527061,
+  "p95_queue_share_permille": 982,
+  "p95_service_share_permille": 268,
+  "inflight_trend": {
+    "gauge": "queue_service_inflight",
+    "sample_count": 500,
+    "peak_count": 234,
+    "p95_count": 223,
+    "growth_delta": -1,
+    "growth_per_sec_milli": -601
+  },
+  "warnings": [],
   "primary_suspect": {
     "kind": "ApplicationQueueSaturation",
     "score": 90,
     "confidence": "high",
     "evidence": [
-      "Queue wait at p95 consumes 98.1% of request time.",
-      "Observed queue depth sample up to 223."
+      "Queue wait at p95 consumes 98.2% of request time.",
+      "Observed queue depth sample up to 230."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -21,15 +30,17 @@
   "secondary_suspects": [
     {
       "kind": "DownstreamStageDominates",
-      "score": 60,
+      "score": 55,
       "confidence": "low",
       "evidence": [
-        "Stage 'simulated_work' has p95 latency 36111 us across 250 samples.",
-        "Stage 'simulated_work' cumulative latency is 7566556 us."
+        "Stage 'simulated_work' has p95 latency 26757 us across 250 samples.",
+        "Stage 'simulated_work' cumulative latency is 6569871 us.",
+        "Stage 'simulated_work' contributes 33 permille of cumulative request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'simulated_work'.",
-        "Collect downstream service timings and retry behavior during tail windows."
+        "Collect downstream service timings and retry behavior during tail windows.",
+        "Review downstream SLO/error budget and align retry budget/backoff with it."
       ]
     }
   ]

--- a/demos/queue_service/fixtures/sample-analysis.json
+++ b/demos/queue_service/fixtures/sample-analysis.json
@@ -1,14 +1,25 @@
 {
   "request_count": 250,
-  "p50_latency_us": 913603,
-  "p95_latency_us": 1729997,
-  "p99_latency_us": 1807406,
+  "p50_latency_us": 788171,
+  "p95_latency_us": 1476281,
+  "p99_latency_us": 1527061,
+  "p95_queue_share_permille": 982,
+  "p95_service_share_permille": 268,
+  "inflight_trend": {
+    "gauge": "queue_service_inflight",
+    "sample_count": 500,
+    "peak_count": 234,
+    "p95_count": 223,
+    "growth_delta": -1,
+    "growth_per_sec_milli": -601
+  },
+  "warnings": [],
   "primary_suspect": {
     "kind": "ApplicationQueueSaturation",
     "score": 90,
     "confidence": "high",
     "evidence": [
-      "Queue wait at p95 consumes 98.4% of request time.",
+      "Queue wait at p95 consumes 98.2% of request time.",
       "Observed queue depth sample up to 230."
     ],
     "next_checks": [
@@ -19,15 +30,17 @@
   "secondary_suspects": [
     {
       "kind": "DownstreamStageDominates",
-      "score": 60,
+      "score": 55,
       "confidence": "low",
       "evidence": [
-        "Stage 'simulated_work' has p95 latency 39564 us across 250 samples.",
-        "Stage 'simulated_work' cumulative latency is 7664590 us."
+        "Stage 'simulated_work' has p95 latency 26757 us across 250 samples.",
+        "Stage 'simulated_work' cumulative latency is 6569871 us.",
+        "Stage 'simulated_work' contributes 33 permille of cumulative request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'simulated_work'.",
-        "Collect downstream service timings and retry behavior during tail windows."
+        "Collect downstream service timings and retry behavior during tail windows.",
+        "Review downstream SLO/error budget and align retry budget/backoff with it."
       ]
     }
   ]

--- a/demos/retry_storm_service/fixtures/after-analysis.json
+++ b/demos/retry_storm_service/fixtures/after-analysis.json
@@ -1,26 +1,27 @@
 {
   "request_count": 180,
-  "p50_latency_us": 10235,
-  "p95_latency_us": 30027,
-  "p99_latency_us": 30962,
+  "p50_latency_us": 9250,
+  "p95_latency_us": 29421,
+  "p99_latency_us": 29678,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "retry_storm_inflight",
     "sample_count": 360,
-    "peak_count": 18,
-    "p95_count": 16,
+    "peak_count": 16,
+    "p95_count": 15,
     "growth_delta": -1,
-    "growth_per_sec_milli": -4629
+    "growth_per_sec_milli": -4739
   },
+  "warnings": [],
   "primary_suspect": {
     "kind": "DownstreamStageDominates",
-    "score": 80,
+    "score": 76,
     "confidence": "medium",
     "evidence": [
-      "Stage 'downstream_total' has p95 latency 27235 us across 180 samples.",
-      "Stage 'downstream_total' cumulative latency is 2184024 us.",
-      "Stage 'downstream_total' contributes 839 permille of cumulative request latency."
+      "Stage 'downstream_total' has p95 latency 27315 us across 180 samples.",
+      "Stage 'downstream_total' cumulative latency is 2138366 us.",
+      "Stage 'downstream_total' contributes 848 permille of cumulative request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_total'.",

--- a/demos/retry_storm_service/fixtures/before-after-comparison.json
+++ b/demos/retry_storm_service/fixtures/before-after-comparison.json
@@ -1,20 +1,20 @@
 {
   "before": {
     "primary_suspect_kind": "DownstreamStageDominates",
-    "primary_suspect_score": 81,
-    "p95_latency_us": 42044,
+    "primary_suspect_score": 77,
+    "p95_latency_us": 40938,
     "p95_queue_share_permille": 0
   },
   "after": {
     "primary_suspect_kind": "DownstreamStageDominates",
-    "primary_suspect_score": 80,
-    "p95_latency_us": 30027,
+    "primary_suspect_score": 76,
+    "p95_latency_us": 29421,
     "p95_queue_share_permille": 0
   },
   "delta": {
     "primary_suspect_kind": null,
     "primary_suspect_score": -1,
-    "p95_latency_us": -12017,
+    "p95_latency_us": -11517,
     "p95_queue_share_permille": 0
   }
 }

--- a/demos/retry_storm_service/fixtures/before-analysis.json
+++ b/demos/retry_storm_service/fixtures/before-analysis.json
@@ -1,26 +1,27 @@
 {
   "request_count": 180,
-  "p50_latency_us": 10181,
-  "p95_latency_us": 42044,
-  "p99_latency_us": 43178,
+  "p50_latency_us": 9634,
+  "p95_latency_us": 40938,
+  "p99_latency_us": 41967,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "retry_storm_inflight",
     "sample_count": 360,
-    "peak_count": 55,
-    "p95_count": 52,
+    "peak_count": 59,
+    "p95_count": 57,
     "growth_delta": -1,
-    "growth_per_sec_milli": -8849
+    "growth_per_sec_milli": -9615
   },
+  "warnings": [],
   "primary_suspect": {
     "kind": "DownstreamStageDominates",
-    "score": 81,
+    "score": 77,
     "confidence": "medium",
     "evidence": [
-      "Stage 'downstream_total' has p95 latency 39730 us across 180 samples.",
-      "Stage 'downstream_total' cumulative latency is 3061084 us.",
-      "Stage 'downstream_total' contributes 877 permille of cumulative request latency."
+      "Stage 'downstream_total' has p95 latency 38781 us across 180 samples.",
+      "Stage 'downstream_total' cumulative latency is 3003468 us.",
+      "Stage 'downstream_total' contributes 887 permille of cumulative request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_total'.",

--- a/demos/shared_state_lock_service/fixtures/after-analysis.json
+++ b/demos/shared_state_lock_service/fixtures/after-analysis.json
@@ -1,25 +1,26 @@
 {
   "request_count": 220,
-  "p50_latency_us": 944016,
-  "p95_latency_us": 1820403,
-  "p99_latency_us": 1879203,
+  "p50_latency_us": 828185,
+  "p95_latency_us": 1565039,
+  "p99_latency_us": 1623749,
   "p95_queue_share_permille": 993,
-  "p95_service_share_permille": 153,
+  "p95_service_share_permille": 119,
   "inflight_trend": {
     "gauge": "shared_state_lock_inflight",
     "sample_count": 440,
-    "peak_count": 199,
-    "p95_count": 189,
+    "peak_count": 201,
+    "p95_count": 191,
     "growth_delta": -1,
-    "growth_per_sec_milli": -481
+    "growth_per_sec_milli": -554
   },
+  "warnings": [],
   "primary_suspect": {
     "kind": "ApplicationQueueSaturation",
     "score": 90,
     "confidence": "high",
     "evidence": [
       "Queue wait at p95 consumes 99.3% of request time.",
-      "Observed queue depth sample up to 198."
+      "Observed queue depth sample up to 200."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -29,15 +30,17 @@
   "secondary_suspects": [
     {
       "kind": "DownstreamStageDominates",
-      "score": 60,
+      "score": 55,
       "confidence": "low",
       "evidence": [
-        "Stage 'shared_state_critical_section' has p95 latency 9650 us across 220 samples.",
-        "Stage 'shared_state_critical_section' cumulative latency is 2038815 us."
+        "Stage 'shared_state_critical_section' has p95 latency 8298 us across 220 samples.",
+        "Stage 'shared_state_critical_section' cumulative latency is 1792596 us.",
+        "Stage 'shared_state_critical_section' contributes 9 permille of cumulative request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'shared_state_critical_section'.",
-        "Collect downstream service timings and retry behavior during tail windows."
+        "Collect downstream service timings and retry behavior during tail windows.",
+        "Review downstream SLO/error budget and align retry budget/backoff with it."
       ]
     }
   ]

--- a/demos/shared_state_lock_service/fixtures/before-after-comparison.json
+++ b/demos/shared_state_lock_service/fixtures/before-after-comparison.json
@@ -2,19 +2,19 @@
   "before": {
     "primary_suspect_kind": "ApplicationQueueSaturation",
     "primary_suspect_score": 90,
-    "p95_latency_us": 5270251,
-    "p95_queue_share_permille": 995
+    "p95_latency_us": 4802998,
+    "p95_queue_share_permille": 994
   },
   "after": {
     "primary_suspect_kind": "ApplicationQueueSaturation",
     "primary_suspect_score": 90,
-    "p95_latency_us": 1820403,
+    "p95_latency_us": 1565039,
     "p95_queue_share_permille": 993
   },
   "delta": {
     "primary_suspect_kind": null,
     "primary_suspect_score": 0,
-    "p95_latency_us": -3449848,
-    "p95_queue_share_permille": -2
+    "p95_latency_us": -3237959,
+    "p95_queue_share_permille": -1
   }
 }

--- a/demos/shared_state_lock_service/fixtures/before-analysis.json
+++ b/demos/shared_state_lock_service/fixtures/before-analysis.json
@@ -1,25 +1,26 @@
 {
   "request_count": 220,
-  "p50_latency_us": 2739217,
-  "p95_latency_us": 5270251,
-  "p99_latency_us": 5459301,
-  "p95_queue_share_permille": 995,
-  "p95_service_share_permille": 119,
+  "p50_latency_us": 2540778,
+  "p95_latency_us": 4802998,
+  "p99_latency_us": 4984628,
+  "p95_queue_share_permille": 994,
+  "p95_service_share_permille": 100,
   "inflight_trend": {
     "gauge": "shared_state_lock_inflight",
     "sample_count": 440,
     "peak_count": 217,
     "p95_count": 206,
     "growth_delta": -1,
-    "growth_per_sec_milli": -178
+    "growth_per_sec_milli": -195
   },
+  "warnings": [],
   "primary_suspect": {
     "kind": "ApplicationQueueSaturation",
     "score": 90,
     "confidence": "high",
     "evidence": [
-      "Queue wait at p95 consumes 99.5% of request time.",
-      "Observed queue depth sample up to 215."
+      "Queue wait at p95 consumes 99.4% of request time.",
+      "Observed queue depth sample up to 216."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -29,15 +30,17 @@
   "secondary_suspects": [
     {
       "kind": "DownstreamStageDominates",
-      "score": 60,
+      "score": 55,
       "confidence": "low",
       "evidence": [
-        "Stage 'shared_state_critical_section' has p95 latency 24765 us across 220 samples.",
-        "Stage 'shared_state_critical_section' cumulative latency is 5530991 us."
+        "Stage 'shared_state_critical_section' has p95 latency 23389 us across 220 samples.",
+        "Stage 'shared_state_critical_section' cumulative latency is 5099697 us.",
+        "Stage 'shared_state_critical_section' contributes 9 permille of cumulative request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'shared_state_critical_section'.",
-        "Collect downstream service timings and retry behavior during tail windows."
+        "Collect downstream service timings and retry behavior during tail windows.",
+        "Review downstream SLO/error budget and align retry budget/backoff with it."
       ]
     }
   ]

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -44,7 +44,7 @@ Representative diagnosis shape:
   "primary_suspect": {
     "kind": "ApplicationQueueSaturation",
     "evidence": [
-      "Queue wait at p95 consumes 98.4% of request time.",
+      "Queue wait at p95 consumes 98.2% of request time.",
       "Observed queue depth sample up to 230."
     ],
     "next_checks": [


### PR DESCRIPTION
### Motivation
- Committed demo analysis fixtures had drifted from the analyzer output, causing docs and fixtures to present inconsistent example evidence and before/after comparisons. 
- Keep public demo artifacts and example snippets trustworthy for readers and CI-driven validation. 
- Preserve deterministic, reproducible fixture generation while refreshing artifacts to current analyzer behavior.

### Description
- Regenerated and replaced committed analysis fixtures for all demos under `demos/*/fixtures/` so JSON fixtures match current analyzer output produced by `scripts/demo_tool.py run ...` (queue, blocking, executor pressure, downstream, mixed contention, cold-start, db-pool, shared-lock, retry-storm). 
- Updated before/after comparison artifacts under affected demos so snapshot and delta fields align with regenerated analyses. 
- Aligned quoted example evidence in `README.md` and `docs/user-guide.md` (updated the representative queue-share line to match refreshed fixtures) and preserved analyzer behavior by restricting this change to fixtures/docs only.

### Testing
- Ran each demo scenario via `python3 scripts/demo_tool.py run <scenario> both` (and `downstream` with `--artifact-path`) to regenerate artifacts and validate outputs, and these demo runs completed successfully. 
- Ran repository checks `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings`, both of which passed without failures. 
- Ran unit and integration tests with `cargo test --workspace`, and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be9e37c46483309b7294a394f14064)