### PR TITLE
docs: split onboarding into repo try and crates.io adoption paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,39 @@ Workflow in one line: **capture -> analyze -> choose next check -> re-run**.
 - teams with latency/backpressure incidents but limited perf-engineering bandwidth
 - people who want a fast local triage loop before adopting heavier observability workflows
 
-## Canonical first run (recommended)
+## Quickstart: choose your path
 
-Use this as the shortest path from repo landing page to first useful diagnosis.
+### Path A — Try from this repo (source/workspace)
 
-### 1) Add dependencies
+Use this when you are exploring `tailtriage` directly from this repository.
+
+1) Run the minimal example and generate an artifact:
+
+```bash
+cargo run -p tailtriage-tokio --example minimal_checkout
+```
+
+This writes `tailtriage-run.json` in the current directory.
+
+2) Analyze that artifact with the workspace CLI crate:
+
+```bash
+cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
+```
+
+3) Read the first useful fields:
+
+- `primary_suspect.kind`
+- `primary_suspect.evidence[]`
+- `primary_suspect.next_checks[]`
+- `p95_queue_share_permille`
+- `p95_service_share_permille`
+
+### Path B — Adopt in your app (crates.io)
+
+Use this when you are integrating `tailtriage` into your own Tokio service.
+
+1) Add library dependencies in your app:
 
 ```toml
 [dependencies]
@@ -38,33 +66,19 @@ tailtriage-tokio = "0.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 ```
 
-For local workspace development, swap version entries for path dependencies.
-
-### 2) Capture one run artifact
-
-Run the minimal end-to-end example:
+2) Install the published CLI binary:
 
 ```bash
-cargo run -p tailtriage-tokio --example minimal_checkout
+cargo install tailtriage-cli
 ```
 
-This writes `tailtriage-run.json` in the current directory.
-
-### 3) Analyze the artifact
+3) Capture and analyze one run artifact:
 
 ```bash
-cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
+tailtriage analyze tailtriage-run.json --format json
 ```
 
-### 4) Interpret the first useful answer
-
-Inspect these fields first:
-
-- `primary_suspect.kind`
-- `primary_suspect.evidence[]`
-- `primary_suspect.next_checks[]`
-- `p95_queue_share_permille`
-- `p95_service_share_permille`
+If you want the smallest realistic capture + analyze flow for an external app, follow **[docs/user-guide.md](docs/user-guide.md)** and use the “Adopt in your app (crates.io)” section.
 
 Representative diagnosis shape:
 
@@ -142,6 +156,6 @@ When a section reaches its configured max, `tailtriage` drops additional entries
 
 For concise docs by audience, start at **[docs/README.md](docs/README.md)**.
 
-For the same canonical first-run workflow in walkthrough form, see **[docs/user-guide.md](docs/user-guide.md)**.
+For source/workspace and crates.io adoption walkthroughs, see **[docs/user-guide.md](docs/user-guide.md)**.
 
 For demo-specific behavior, recommended public progression, and realism/CI-coverage caveats, see **[demos/README.md](demos/README.md)**.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,8 @@ Use this page as the single entry point for project documentation.
 
 ## Start here
 
-- **Canonical first run (capture -> analyze -> interpret):** [user-guide.md](user-guide.md)
+- **Try from this repo (source/workspace quickstart):** [user-guide.md#path-a--try-from-this-repo-sourceworkspace](user-guide.md#path-a--try-from-this-repo-sourceworkspace)
+- **Adopt in your app (crates.io quickstart):** [user-guide.md#path-b--adopt-in-your-app-cratesio](user-guide.md#path-b--adopt-in-your-app-cratesio)
 - **How triage analysis works:** [diagnostics.md](diagnostics.md)
 - **Before/after proof workflow (secondary):** [../demos/retry_storm_service/fixtures/before-after-comparison.json](../demos/retry_storm_service/fixtures/before-after-comparison.json)
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,8 +1,40 @@
-# User guide (canonical first run)
+# User guide
 
-This is the shortest capture -> analyze -> interpret path.
+Use this page for the shortest path to a first useful triage answer.
 
-## 1) Add dependencies
+## Path A — Try from this repo (source/workspace)
+
+Use this path when you are evaluating `tailtriage` from a local clone of this repository.
+
+### 1) Capture one artifact from the repo example
+
+```bash
+cargo run -p tailtriage-tokio --example minimal_checkout
+```
+
+Expected output includes `wrote tailtriage-run.json`.
+
+### 2) Analyze with the workspace CLI crate
+
+```bash
+cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
+```
+
+### 3) Interpret the diagnosis
+
+Inspect these fields first:
+
+- `primary_suspect.kind`
+- `primary_suspect.evidence[]`
+- `primary_suspect.next_checks[]`
+- `p95_queue_share_permille`
+- `p95_service_share_permille`
+
+## Path B — Adopt in your app (crates.io)
+
+Use this path when you want to integrate `tailtriage` into your own Tokio application without workspace context.
+
+### 1) Add dependencies to your app
 
 ```toml
 [dependencies]
@@ -11,23 +43,27 @@ tailtriage-tokio = "0.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 ```
 
-## 2) Capture one artifact
-
-Use the minimal runnable example:
+### 2) Install the published CLI
 
 ```bash
-cargo run -p tailtriage-tokio --example minimal_checkout
+cargo install tailtriage-cli
 ```
 
-Expected output includes `wrote tailtriage-run.json`.
+The installed binary name is `tailtriage`.
 
-## 3) Analyze
+### 3) Capture one artifact in your app
+
+Create a `TailTriage` instance, wrap request/queue/stage boundaries, and flush the artifact to disk at shutdown.
+
+For a concrete instrumentation shape, mirror the minimal example in [`tailtriage-tokio/examples/minimal_checkout.rs`](../tailtriage-tokio/examples/minimal_checkout.rs).
+
+### 4) Analyze your artifact with the installed binary
 
 ```bash
-cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
+tailtriage analyze tailtriage-run.json --format json
 ```
 
-## 4) Interpret the diagnosis
+### 5) Interpret the first useful answer
 
 Inspect these fields first:
 
@@ -57,11 +93,11 @@ Representative diagnosis shape:
 
 Suspects are evidence-ranked leads, not proof of root cause.
 
-## 5) If result is `InsufficientEvidence`
+## If result is `InsufficientEvidence`
 
 Add one more queue wrapper and one more stage wrapper around the most likely missing wait points, then rerun with comparable load.
 
-## 6) Optional stronger attribution
+## Optional stronger attribution
 
 Enable runtime snapshots when queue/stage instrumentation is still ambiguous:
 
@@ -83,6 +119,7 @@ After first run, validate one mitigation workflow:
 
 ## Next docs
 
+- [Documentation index](README.md)
 - [Diagnostics guide](diagnostics.md)
 - [Architecture](architecture.md)
 - [Demo workflow](getting-started-demo.md)


### PR DESCRIPTION
### Motivation

- Remove ambiguity in the public onboarding flow by presenting two explicit, separate paths for local repo evaluation and external package adoption. 
- Ensure the shortest “first useful triage” funnel remains obvious while preventing crates.io consumers from following repo-only workspace commands by mistake.

### Description

- Update `README.md` to provide a quickstart chooser with **Path A — Try from this repo (source/workspace)** using `cargo run -p ...` and **Path B — Adopt in your app (crates.io)** with dependency snippets and `cargo install tailtriage-cli` plus the `tailtriage analyze ...` command. 
- Rework `docs/user-guide.md` to mirror the two paths with concrete, non-workspace guidance for the crates.io consumer and an explicit repo example for local evaluation. 
- Update `docs/README.md` documentation index to point intentionally to both the source/workspace quickstart and the crates.io quickstart so audiences land on the correct workflow.

### Testing

- Ran `cargo fmt --check` and it completed successfully. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and the workspace lints passed with no warnings. 
- Ran `cargo test --workspace` and the full test suite completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bea44e9e1c8330920848c038ddee5b)