### PR TITLE
docs: split documentation index into user vs maintainer sections

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,28 +2,33 @@
 
 Use this page as the single entry point for project documentation.
 
-## Start here
+## User docs (start here)
 
 - **Try from this repo (source/workspace quickstart):** [user-guide.md#path-a--try-from-this-repo-sourceworkspace](user-guide.md#path-a--try-from-this-repo-sourceworkspace)
 - **Adopt in your app (crates.io quickstart):** [user-guide.md#path-b--adopt-in-your-app-cratesio](user-guide.md#path-b--adopt-in-your-app-cratesio)
-- **How triage analysis works:** [diagnostics.md](diagnostics.md)
-- **Before/after proof workflow (secondary):** [../demos/retry_storm_service/fixtures/before-after-comparison.json](../demos/retry_storm_service/fixtures/before-after-comparison.json)
 
-## Core references
+### First-run and triage workflow
+
+- **How triage analysis works:** [diagnostics.md](diagnostics.md)
+- **Demos and fixture workflow:** [getting-started-demo.md](getting-started-demo.md)
+- **Before/after proof workflow (secondary):** [../demos/retry_storm_service/fixtures/before-after-comparison.json](../demos/retry_storm_service/fixtures/before-after-comparison.json)
+- **Runtime cost measurement:** [runtime-cost.md](runtime-cost.md)
+
+### Product and architecture references
 
 - **Architecture and crate responsibilities:** [architecture.md](architecture.md)
 - **MVP product contract (Tokio tail-latency triage):** [../SPEC.md](../SPEC.md)
 - **Release/polish plan:** [../IMPLEMENTATION_PLAN.md](../IMPLEMENTATION_PLAN.md)
-- **v0.1 release decision gates and launch order:** [release-gates-v0.1.md](release-gates-v0.1.md)
-- **Public visibility readiness checklist:** [public-readiness-checklist.md](public-readiness-checklist.md)
-
-## Reproducibility and operations
-
-- **Demos and fixture workflow:** [getting-started-demo.md](getting-started-demo.md)
-- **Runtime cost measurement:** [runtime-cost.md](runtime-cost.md)
 - **Project changelog:** [changelog.md](changelog.md)
 
-## Historical snapshot
+## Maintainer / launch / operational docs
+
+- **v0.1 release decision gates and launch order:** [release-gates-v0.1.md](release-gates-v0.1.md)
+- **Public visibility readiness checklist:** [public-readiness-checklist.md](public-readiness-checklist.md)
+- **Launch checklist issue template (v0.1):** [launch-checklist-issue-v0.1.md](launch-checklist-issue-v0.1.md)
+- **GitHub repository operations:** [github-repo-ops.md](github-repo-ops.md)
+
+### Historical audits and snapshots
 
 - **MVP audit (2026-03-20):** [mvp-audit-2026-03-20.md](mvp-audit-2026-03-20.md)
 - **MVP audit (2026-03-19):** [mvp-audit-2026-03-19.md](mvp-audit-2026-03-19.md)


### PR DESCRIPTION
### Motivation
- Reorganize `docs/README.md` so first-time users land on user-facing quickstart and triage workflow docs first while maintainer/launch/runbook material remains discoverable but deprioritized.

### Description
- Update `docs/README.md` to introduce a `User docs (start here)` top section with `First-run and triage workflow` and `Product and architecture references` subsections, and a `Maintainer / launch / operational docs` section that groups release gates, readiness checklist, launch checklist template, repo ops, and historical audits.

### Testing
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69beab8bad94833091ca100b9435be03)