### PR TITLE
Add mini-service adoption-confidence integration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ cargo run -p tailtriage-tokio --example minimal_checkout
 
 This writes `tailtriage-run.json` in the current directory.
 
+Want a small **adoption-confidence** example that looks more like a service than the synthetic demos? Run:
+
+```bash
+cargo run -p tailtriage-tokio --example mini_service_integration
+```
+
+That example is intentionally outside `demos/` and exists only as a realistic integration reference (not a production case study).
+
 2) Analyze that artifact with the workspace CLI crate:
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Use this page as the single entry point for project documentation.
 
 - **How triage analysis works:** [diagnostics.md](diagnostics.md)
 - **Demos and fixture workflow:** [getting-started-demo.md](getting-started-demo.md)
+- **Realistic mini-service integration example (adoption confidence):** [../tailtriage-tokio/examples/mini_service_integration.rs](../tailtriage-tokio/examples/mini_service_integration.rs)
 - **Before/after proof workflow (secondary):** [../demos/retry_storm_service/fixtures/before-after-comparison.json](../demos/retry_storm_service/fixtures/before-after-comparison.json)
 - **Runtime cost measurement:** [runtime-cost.md](runtime-cost.md)
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -14,6 +14,14 @@ cargo run -p tailtriage-tokio --example minimal_checkout
 
 Expected output includes `wrote tailtriage-run.json`.
 
+If you want a more realistic request + queue + worker shape outside the synthetic demos, run:
+
+```bash
+cargo run -p tailtriage-tokio --example mini_service_integration
+```
+
+This mini-service example is an adoption-confidence reference and does **not** replace the demo suite.
+
 ### 2) Analyze with the workspace CLI crate
 
 ```bash
@@ -123,3 +131,4 @@ After first run, validate one mitigation workflow:
 - [Diagnostics guide](diagnostics.md)
 - [Architecture](architecture.md)
 - [Demo workflow](getting-started-demo.md)
+- [Mini-service integration example (source)](../tailtriage-tokio/examples/mini_service_integration.rs)

--- a/tailtriage-tokio/examples/mini_service_integration.rs
+++ b/tailtriage-tokio/examples/mini_service_integration.rs
@@ -1,0 +1,97 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use tailtriage_core::{Config, RequestMeta, Tailtriage};
+use tokio::sync::{mpsc, oneshot};
+
+#[derive(Debug)]
+struct CheckoutRequest {
+    request_id: String,
+    sku: &'static str,
+    quantity: u32,
+}
+
+#[derive(Debug)]
+struct WorkItem {
+    request: CheckoutRequest,
+    completion_tx: oneshot::Sender<Result<(), &'static str>>,
+}
+
+async fn handle_checkout(
+    tailtriage: &Tailtriage,
+    tx: &mpsc::Sender<WorkItem>,
+    request: CheckoutRequest,
+) -> Result<(), &'static str> {
+    let meta = RequestMeta::new(request.request_id.clone(), "/checkout").with_kind("http");
+    let request_id = meta.request_id.clone();
+
+    tailtriage
+        .request(meta, "ok", async {
+            let (completion_tx, completion_rx) = oneshot::channel();
+
+            tailtriage
+                .queue(request_id.clone(), "checkout_ingress")
+                .await_on(tx.send(WorkItem {
+                    request,
+                    completion_tx,
+                }))
+                .await
+                .map_err(|_| "worker channel closed")?;
+
+            completion_rx.await.map_err(|_| "worker dropped response")?
+        })
+        .await
+}
+
+async fn run_worker(tailtriage: Arc<Tailtriage>, mut rx: mpsc::Receiver<WorkItem>) {
+    while let Some(work) = rx.recv().await {
+        let request_id = work.request.request_id.clone();
+
+        tailtriage
+            .stage(request_id.clone(), "inventory_lookup")
+            .await_value(tokio::time::sleep(Duration::from_millis(4)))
+            .await;
+
+        let payment_delay_ms = if work.request.quantity > 2 { 11 } else { 6 };
+        tailtriage
+            .stage(request_id, "payment_authorization")
+            .await_value(tokio::time::sleep(Duration::from_millis(payment_delay_ms)))
+            .await;
+
+        let _ = work.completion_tx.send(Ok(()));
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut config = Config::new("mini-checkout-service");
+    config.output_path = "tailtriage-run.json".into();
+
+    let tailtriage = Arc::new(Tailtriage::init(config)?);
+    let (tx, rx) = mpsc::channel(8);
+
+    let worker = tokio::spawn(run_worker(Arc::clone(&tailtriage), rx));
+
+    for index in 0..12 {
+        let request = CheckoutRequest {
+            request_id: format!("checkout-{index}"),
+            sku: "SKU-123",
+            quantity: if index % 4 == 0 { 3 } else { 1 },
+        };
+
+        if request.sku.starts_with("SKU-") {
+            handle_checkout(&tailtriage, &tx, request).await?;
+        }
+    }
+
+    drop(tx);
+    worker.await?;
+
+    tailtriage.flush()?;
+
+    println!("wrote tailtriage-run.json from mini_service_integration");
+    println!("next: cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json");
+    println!("inspect first: primary_suspect.kind, evidence[], next_checks[]");
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Provide one small, realistic Tokio mini-service integration example that helps external adopters gain confidence without replacing the synthetic demos. 
- Make it easy to see how request-level instrumentation, queue admission, worker stages, and analysis fit together in a compact, runnable sample.

### Description
- Add a new example `tailtriage-tokio/examples/mini_service_integration.rs` implementing a small checkout flow with a request handler, channel-backed ingress queue, worker stages (`inventory_lookup`, `payment_authorization`), and a flushed `tailtriage` run artifact. 
- Surface the example in quickstarts and docs by updating `README.md`, `docs/user-guide.md`, and `docs/README.md` with a clear “adoption-confidence” link and guidance to run `cargo run -p tailtriage-tokio --example mini_service_integration`.
- Keep scope intentionally small and distinct from `demos/` so the example serves as an integration reference, not a production case study.

### Testing
- Ran formatting check with `cargo fmt --check` which passed. 
- Ran lints with `cargo clippy --workspace --all-targets -- -D warnings` which passed. 
- Ran the full test suite with `cargo test --workspace` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bead3a9b2c83308363c9748e95a02f)