### PR TITLE
Unify public API: builder + RequestContext and configurable runtime sampling

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -12,7 +12,7 @@ All service demos follow the same pattern:
 2. Create artifact output directory.
 3. Initialize one `Tailtriage` collector.
 4. Generate a deterministic request burst.
-5. Wrap requests with `tailtriage.request(...)`.
+5. Wrap requests with `tailtriage.request_with_meta(...)`.
 6. Instrument admission queue and/or stages.
 7. Flush to JSON and run CLI analysis.
 

--- a/demos/blocking_service/src/main.rs
+++ b/demos/blocking_service/src/main.rs
@@ -88,7 +88,7 @@ async fn run_demo(output_path: PathBuf, settings: ModeSettings) -> anyhow::Resul
             let meta = RequestMeta::new(request_id.clone(), "/blocking-demo");
 
             tailtriage
-                .request(meta, "ok", async {
+                .request_with_meta(meta, "ok", async {
                     let _inflight = tailtriage.inflight("blocking_service_inflight");
                     let _wait = tailtriage
                         .queue(request_id.clone(), "dispatch_overhead")

--- a/demos/cold_start_burst_service/src/main.rs
+++ b/demos/cold_start_burst_service/src/main.rs
@@ -74,7 +74,7 @@ async fn main() -> anyhow::Result<()> {
             let meta = RequestMeta::new(request_id.clone(), "/cold-start-burst-demo");
 
             tailtriage
-                .request(meta, "ok", async {
+                .request_with_meta(meta, "ok", async {
                     let _inflight = tailtriage.inflight("cold_start_burst_inflight");
 
                     let depth = waiting_depth.fetch_add(1, Ordering::SeqCst) + 1;

--- a/demos/db_pool_saturation_service/src/main.rs
+++ b/demos/db_pool_saturation_service/src/main.rs
@@ -62,7 +62,7 @@ async fn main() -> anyhow::Result<()> {
             let meta = RequestMeta::new(request_id.clone(), "/db-pool-saturation-demo");
 
             tailtriage
-                .request(meta, "ok", async {
+                .request_with_meta(meta, "ok", async {
                     let _inflight = tailtriage.inflight("db_pool_saturation_inflight");
 
                     tailtriage

--- a/demos/downstream_service/src/main.rs
+++ b/demos/downstream_service/src/main.rs
@@ -22,7 +22,7 @@ async fn main() -> anyhow::Result<()> {
             let meta = RequestMeta::new(request_id.clone(), "/downstream-demo");
 
             tailtriage
-                .request(meta, "ok", async {
+                .request_with_meta(meta, "ok", async {
                     let _inflight = tailtriage.inflight("downstream_service_inflight");
 
                     tailtriage

--- a/demos/executor_pressure_service/src/main.rs
+++ b/demos/executor_pressure_service/src/main.rs
@@ -96,7 +96,7 @@ async fn run_demo(output_path: PathBuf, settings: ModeSettings) -> anyhow::Resul
             let meta = RequestMeta::new(request_id.clone(), "/executor-pressure");
 
             tailtriage
-                .request(meta, "ok", async {
+                .request_with_meta(meta, "ok", async {
                     let _inflight = tailtriage.inflight("executor_pressure_inflight");
                     tailtriage
                         .queue(request_id.clone(), "admission")

--- a/demos/mixed_contention_service/src/main.rs
+++ b/demos/mixed_contention_service/src/main.rs
@@ -65,7 +65,7 @@ async fn main() -> anyhow::Result<()> {
             let meta = RequestMeta::new(request_id.clone(), "/mixed-contention-demo");
 
             tailtriage
-                .request(meta, "ok", async {
+                .request_with_meta(meta, "ok", async {
                     let _inflight = tailtriage.inflight("mixed_contention_inflight");
 
                     let depth = waiting_depth.fetch_add(1, Ordering::SeqCst) + 1;

--- a/demos/queue_service/src/main.rs
+++ b/demos/queue_service/src/main.rs
@@ -51,7 +51,7 @@ async fn main() -> anyhow::Result<()> {
             let meta = RequestMeta::new(request_id.clone(), "/queue-demo");
 
             tailtriage
-                .request(meta, "ok", async {
+                .request_with_meta(meta, "ok", async {
                     let _inflight = tailtriage.inflight("queue_service_inflight");
 
                     let depth = waiting_depth.fetch_add(1, Ordering::SeqCst) + 1;

--- a/demos/retry_storm_service/src/main.rs
+++ b/demos/retry_storm_service/src/main.rs
@@ -149,7 +149,7 @@ async fn main() -> anyhow::Result<()> {
             let meta = RequestMeta::new(request_id.clone(), "/retry-storm-demo");
 
             tailtriage
-                .request(meta, "ok", async {
+                .request_with_meta(meta, "ok", async {
                     let _inflight = tailtriage.inflight("retry_storm_inflight");
 
                     tailtriage

--- a/demos/runtime_cost/src/main.rs
+++ b/demos/runtime_cost/src/main.rs
@@ -110,7 +110,7 @@ async fn main() -> anyhow::Result<()> {
                     let request_id = format!("request-{idx}");
                     let meta = RequestMeta::new(request_id.clone(), "/runtime-cost");
 
-                    ts.request(meta, "ok", async {
+                    ts.request_with_meta(meta, "ok", async {
                         let _inflight = ts.inflight("runtime_cost_requests");
                         let permit = ts
                             .queue(request_id.clone(), "worker_semaphore")

--- a/demos/shared_state_lock_service/src/main.rs
+++ b/demos/shared_state_lock_service/src/main.rs
@@ -59,7 +59,7 @@ async fn main() -> anyhow::Result<()> {
             let meta = RequestMeta::new(request_id.clone(), "/shared-state-lock-demo");
 
             tailtriage
-                .request(meta, "ok", async {
+                .request_with_meta(meta, "ok", async {
                     let _inflight = tailtriage.inflight("shared_state_lock_inflight");
 
                     tailtriage

--- a/tailtriage-cli/tests/end_to_end_capture_analysis.rs
+++ b/tailtriage-cli/tests/end_to_end_capture_analysis.rs
@@ -1,7 +1,7 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use tailtriage_cli::analyze::{analyze_run, DiagnosisKind};
-use tailtriage_core::{Config, RequestMeta, Run, Tailtriage};
+use tailtriage_core::{Run, Tailtriage};
 use tailtriage_tokio::instrument_request;
 
 fn temp_artifact_path(prefix: &str) -> std::path::PathBuf {
@@ -15,30 +15,32 @@ fn temp_artifact_path(prefix: &str) -> std::path::PathBuf {
 #[tokio::test(flavor = "current_thread")]
 async fn queue_heavy_direct_capture_flush_and_analysis_reports_queue_suspect() {
     let output_path = temp_artifact_path("queue");
-    let mut config = Config::new("e2e-queue");
-    config.output_path = output_path.clone();
-    let tailtriage = Tailtriage::init(config).expect("init should succeed");
+    let tailtriage = Tailtriage::builder("e2e-queue")
+        .output(output_path.clone())
+        .build()
+        .expect("build should succeed");
 
     for index in 0..6 {
-        let request_id = format!("queue-{index}");
-        let request_meta = RequestMeta::new(request_id.clone(), "/checkout");
-
-        tailtriage
-            .request(request_meta, "ok", async {
-                tailtriage
-                    .queue(request_id.clone(), "checkout_queue")
-                    .with_depth_at_start(24)
-                    .await_on(tokio::time::sleep(std::time::Duration::from_millis(8)))
-                    .await;
-                tailtriage
-                    .stage(request_id.clone(), "local_work")
-                    .await_value(tokio::time::sleep(std::time::Duration::from_millis(1)))
-                    .await;
-            })
+        let request = tailtriage.request_with_id("/checkout", format!("queue-{index}"));
+        let started = std::time::Instant::now();
+        let started_at = tailtriage_core::unix_time_ms();
+        request
+            .queue("checkout_queue")
+            .with_depth_at_start(24)
+            .await_on(tokio::time::sleep(std::time::Duration::from_millis(8)))
             .await;
+        request
+            .stage("local_work")
+            .await_value(tokio::time::sleep(std::time::Duration::from_millis(1)))
+            .await;
+        request.complete(
+            (started_at, tailtriage_core::unix_time_ms()),
+            started.elapsed().as_micros().try_into().unwrap_or(u64::MAX),
+            "ok",
+        );
     }
 
-    tailtriage.flush().expect("flush should succeed");
+    tailtriage.shutdown().expect("shutdown should succeed");
 
     let run_json = std::fs::read_to_string(&output_path).expect("artifact should be readable");
     let run: Run = serde_json::from_str(&run_json).expect("artifact should parse as Run");
@@ -79,9 +81,10 @@ async fn downstream_handler(tailtriage: &Tailtriage, request_id: &str) -> Result
 #[tokio::test(flavor = "current_thread")]
 async fn downstream_heavy_macro_capture_flush_and_analysis_reports_stage_suspect() {
     let output_path = temp_artifact_path("downstream");
-    let mut config = Config::new("e2e-downstream");
-    config.output_path = output_path.clone();
-    let tailtriage = Tailtriage::init(config).expect("init should succeed");
+    let tailtriage = Tailtriage::builder("e2e-downstream")
+        .output(output_path.clone())
+        .build()
+        .expect("build should succeed");
 
     for index in 0..5 {
         let request_id = format!("downstream-{index}");
@@ -90,7 +93,7 @@ async fn downstream_heavy_macro_capture_flush_and_analysis_reports_stage_suspect
             .expect("handler should succeed");
     }
 
-    tailtriage.flush().expect("flush should succeed");
+    tailtriage.shutdown().expect("shutdown should succeed");
 
     let run_json = std::fs::read_to_string(&output_path).expect("artifact should be readable");
     let run: Run = serde_json::from_str(&run_json).expect("artifact should parse as Run");
@@ -110,20 +113,22 @@ async fn downstream_heavy_macro_capture_flush_and_analysis_reports_stage_suspect
 #[tokio::test(flavor = "current_thread")]
 async fn request_only_capture_flush_and_analysis_reports_insufficient_evidence() {
     let output_path = temp_artifact_path("insufficient");
-    let mut config = Config::new("e2e-insufficient");
-    config.output_path = output_path.clone();
-    let tailtriage = Tailtriage::init(config).expect("init should succeed");
+    let tailtriage = Tailtriage::builder("e2e-insufficient")
+        .output(output_path.clone())
+        .build()
+        .expect("build should succeed");
 
     for index in 0..3 {
-        let request_meta = RequestMeta::new(format!("insufficient-{index}"), "/health");
-        tailtriage
-            .request(request_meta, "ok", async {
-                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
-            })
+        let request = tailtriage.request_with_id("/health", format!("insufficient-{index}"));
+        request
+            .run(
+                "ok",
+                tokio::time::sleep(std::time::Duration::from_millis(1)),
+            )
             .await;
     }
 
-    tailtriage.flush().expect("flush should succeed");
+    tailtriage.shutdown().expect("shutdown should succeed");
 
     let run_json = std::fs::read_to_string(&output_path).expect("artifact should be readable");
     let run: Run = serde_json::from_str(&run_json).expect("artifact should parse as Run");

--- a/tailtriage-core/src/collector.rs
+++ b/tailtriage-core/src/collector.rs
@@ -6,15 +6,15 @@ use std::time::{Duration, Instant};
 use crate::InflightGuard;
 use crate::RunSink;
 use crate::{
-    unix_time_ms, Config, InFlightSnapshot, InitError, LocalJsonSink, QueueEvent, QueueTimer,
-    RequestEvent, RequestMeta, Run, RunMetadata, RuntimeSnapshot, SinkError, StageEvent,
-    StageTimer,
+    unix_time_ms, BuildError, CaptureLimits, CaptureMode, Config, InFlightSnapshot, LocalJsonSink,
+    QueueEvent, QueueTimer, RequestEvent, RequestMeta, Run, RunMetadata, RuntimeSnapshot,
+    SinkError, StageEvent, StageTimer,
 };
 
 /// Per-run collector that records request events and writes the final artifact.
 ///
 /// [`Tailtriage`] is intentionally small: initialize once per process/run,
-/// wrap request futures with [`Self::request`], wrap critical await points with
+/// wrap request futures with [`Self::request_with_meta`], wrap critical await points with
 /// stage/queue helpers, then flush one JSON artifact for CLI triage.
 ///
 /// # Example
@@ -29,7 +29,7 @@ use crate::{
 /// let request_id = "req-1".to_string();
 /// let meta = RequestMeta::new(request_id.clone(), "/checkout").with_kind("http");
 ///
-/// block_on(tailtriage.request(meta, "ok", async {
+/// block_on(tailtriage.request_with_meta(meta, "ok", async {
 ///     tailtriage
 ///         .queue(request_id.clone(), "ingress")
 ///         .await_on(async {})
@@ -49,17 +49,24 @@ pub struct Tailtriage {
     pub(crate) inflight_counts: Mutex<HashMap<String, u64>>,
     pub(crate) sink: LocalJsonSink,
     pub(crate) limits: crate::CaptureLimits,
+    pub(crate) runtime_sampling_interval: Option<Duration>,
 }
 
 impl Tailtriage {
+    /// Starts a builder for one tailtriage collector instance.
+    #[must_use]
+    pub fn builder(service_name: impl Into<String>) -> TailtriageBuilder {
+        TailtriageBuilder::new(service_name)
+    }
+
     /// Initializes tailtriage collection for one service run.
     ///
     /// # Errors
     ///
     /// Returns [`InitError::EmptyServiceName`] if `config.service_name` is blank.
-    pub fn init(config: Config) -> Result<Self, InitError> {
+    pub fn init(config: Config) -> Result<Self, BuildError> {
         if config.service_name.trim().is_empty() {
-            return Err(InitError::EmptyServiceName);
+            return Err(BuildError::EmptyServiceName);
         }
 
         let now = unix_time_ms();
@@ -79,14 +86,38 @@ impl Tailtriage {
             inflight_counts: Mutex::new(HashMap::new()),
             sink: LocalJsonSink::new(config.output_path),
             limits: config.capture_limits,
+            runtime_sampling_interval: config.runtime_sampling_interval,
         })
+    }
+
+    /// Returns configured Tokio runtime sampling interval.
+    #[must_use]
+    pub fn runtime_sampling_interval(&self) -> Option<Duration> {
+        self.runtime_sampling_interval
+    }
+
+    /// Creates a request context using an auto-generated request ID.
+    #[must_use]
+    pub fn request(&self, route: impl Into<String>) -> RequestContext<'_> {
+        let meta = RequestMeta::for_route(route);
+        RequestContext::new(self, meta.request_id, meta.route)
+    }
+
+    /// Creates a request context using caller-supplied request ID.
+    #[must_use]
+    pub fn request_with_id(
+        &self,
+        route: impl Into<String>,
+        request_id: impl Into<String>,
+    ) -> RequestContext<'_> {
+        RequestContext::new(self, request_id.into(), route.into())
     }
 
     /// Times one request future and records its completion as a [`RequestEvent`].
     ///
     /// `outcome` should represent your application-level request result (for example:
     /// `"ok"`, `"error"`, or `"timeout"`).
-    pub async fn request<Fut, T>(
+    pub async fn request_with_meta<Fut, T>(
         &self,
         meta: RequestMeta,
         outcome: impl Into<String>,
@@ -150,6 +181,15 @@ impl Tailtriage {
         let mut guard = lock_run(&self.run);
         guard.metadata.finished_at_unix_ms = unix_time_ms();
         self.sink.write(&guard)
+    }
+
+    /// Finalizes capture and writes artifact to disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SinkError`] if writing or serialization fails.
+    pub fn shutdown(&self) -> Result<(), SinkError> {
+        self.flush()
     }
 
     /// Returns the output file path used by the configured sink.
@@ -280,6 +320,145 @@ pub(crate) fn lock_map(
 
 pub(crate) fn duration_to_us(duration: Duration) -> u64 {
     duration.as_micros().try_into().unwrap_or(u64::MAX)
+}
+
+/// Builder for [`Tailtriage`].
+#[derive(Debug, Clone)]
+pub struct TailtriageBuilder {
+    config: Config,
+}
+
+impl TailtriageBuilder {
+    #[must_use]
+    pub fn new(service_name: impl Into<String>) -> Self {
+        Self {
+            config: Config::new(service_name),
+        }
+    }
+
+    #[must_use]
+    pub fn light(mut self) -> Self {
+        self.config.mode = CaptureMode::Light;
+        self
+    }
+
+    #[must_use]
+    pub fn investigation(mut self) -> Self {
+        self.config.mode = CaptureMode::Investigation;
+        self
+    }
+
+    #[must_use]
+    pub fn output(mut self, output_path: impl Into<std::path::PathBuf>) -> Self {
+        self.config.output_path = output_path.into();
+        self
+    }
+
+    #[must_use]
+    pub fn service_version(mut self, service_version: impl Into<String>) -> Self {
+        self.config.service_version = Some(service_version.into());
+        self
+    }
+
+    #[must_use]
+    pub fn run_id(mut self, run_id: impl Into<String>) -> Self {
+        self.config.run_id = Some(run_id.into());
+        self
+    }
+
+    #[must_use]
+    pub fn capture_limits(mut self, capture_limits: CaptureLimits) -> Self {
+        self.config.capture_limits = capture_limits;
+        self
+    }
+
+    #[must_use]
+    pub fn runtime_sampling_interval(mut self, interval: Duration) -> Self {
+        self.config.runtime_sampling_interval = Some(interval);
+        self
+    }
+
+    /// Builds a [`Tailtriage`] collector from builder settings.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BuildError::EmptyServiceName`] when service name is blank.
+    pub fn build(self) -> Result<Tailtriage, BuildError> {
+        Tailtriage::init(self.config)
+    }
+}
+
+/// Request-scoped instrumentation context.
+#[derive(Debug)]
+pub struct RequestContext<'a> {
+    tailtriage: &'a Tailtriage,
+    request_id: String,
+    route: String,
+    kind: Option<String>,
+}
+
+impl<'a> RequestContext<'a> {
+    fn new(tailtriage: &'a Tailtriage, request_id: String, route: String) -> Self {
+        Self {
+            tailtriage,
+            request_id,
+            route,
+            kind: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_kind(mut self, kind: impl Into<String>) -> Self {
+        self.kind = Some(kind.into());
+        self
+    }
+
+    #[must_use]
+    pub fn stage(&self, stage: impl Into<String>) -> StageTimer<'a> {
+        self.tailtriage.stage(self.request_id.clone(), stage)
+    }
+
+    #[must_use]
+    pub fn queue(&self, queue: impl Into<String>) -> QueueTimer<'a> {
+        self.tailtriage.queue(self.request_id.clone(), queue)
+    }
+
+    #[must_use]
+    pub fn inflight(&self, gauge: impl Into<String>) -> InflightGuard<'a> {
+        self.tailtriage.inflight(gauge)
+    }
+
+    pub fn complete(
+        self,
+        time_window_unix_ms: (u64, u64),
+        latency_us: u64,
+        outcome: impl Into<String>,
+    ) {
+        self.tailtriage.record_request_fields(
+            self.request_id,
+            self.route,
+            self.kind,
+            time_window_unix_ms,
+            latency_us,
+            outcome,
+        );
+    }
+
+    pub async fn run<Fut, T>(self, outcome: impl Into<String>, fut: Fut) -> T
+    where
+        Fut: std::future::Future<Output = T>,
+    {
+        let started_at_unix_ms = unix_time_ms();
+        let started = Instant::now();
+        let value = fut.await;
+        let finished_at_unix_ms = unix_time_ms();
+        self.complete(
+            (started_at_unix_ms, finished_at_unix_ms),
+            duration_to_us(started.elapsed()),
+            outcome,
+        );
+        value
+    }
 }
 
 fn generate_run_id() -> String {

--- a/tailtriage-core/src/config.rs
+++ b/tailtriage-core/src/config.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 use crate::unix_time_ms;
 use serde::{Deserialize, Serialize};
@@ -45,6 +46,8 @@ pub struct Config {
     pub output_path: PathBuf,
     /// Bounded capture limits for each event/sample section.
     pub capture_limits: CaptureLimits,
+    /// Optional Tokio runtime sampling interval.
+    pub runtime_sampling_interval: Option<Duration>,
 }
 
 impl Config {
@@ -58,6 +61,7 @@ impl Config {
             mode: CaptureMode::Light,
             output_path: PathBuf::from("tailtriage-run.json"),
             capture_limits: CaptureLimits::default(),
+            runtime_sampling_interval: None,
         }
     }
 }
@@ -150,12 +154,12 @@ impl RequestMeta {
 
 /// Errors emitted while initializing tailtriage capture.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum InitError {
+pub enum BuildError {
     /// Service name was empty.
     EmptyServiceName,
 }
 
-impl std::fmt::Display for InitError {
+impl std::fmt::Display for BuildError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::EmptyServiceName => write!(f, "service_name cannot be empty"),
@@ -163,6 +167,9 @@ impl std::fmt::Display for InitError {
     }
 }
 
-impl std::error::Error for InitError {}
+impl std::error::Error for BuildError {}
+
+/// Backward-compatible alias for earlier API naming.
+pub type InitError = BuildError;
 
 static REQUEST_META_SEQUENCE: AtomicU64 = AtomicU64::new(0);

--- a/tailtriage-core/src/lib.rs
+++ b/tailtriage-core/src/lib.rs
@@ -7,8 +7,8 @@ mod sink;
 mod time;
 mod timers;
 
-pub use collector::Tailtriage;
-pub use config::{CaptureLimits, CaptureMode, Config, InitError, RequestMeta};
+pub use collector::{RequestContext, Tailtriage, TailtriageBuilder};
+pub use config::{BuildError, CaptureLimits, CaptureMode, Config, InitError, RequestMeta};
 pub use events::{
     InFlightSnapshot, QueueEvent, RequestEvent, Run, RunMetadata, RuntimeSnapshot, StageEvent,
     TruncationSummary,

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -124,7 +124,8 @@ fn request_records_timing_and_outcome() {
     let mut request = RequestMeta::new("req-42", "/invoice");
     request.kind = Some("create_invoice".to_owned());
 
-    let result = futures_executor::block_on(tailtriage.request(request, "ok", ready(7_u32)));
+    let result =
+        futures_executor::block_on(tailtriage.request_with_meta(request, "ok", ready(7_u32)));
     assert_eq!(result, 7);
 
     let snapshot = tailtriage.snapshot();
@@ -162,7 +163,7 @@ fn request_with_for_route_and_kind_records_expected_fields() {
 
     let tailtriage = Tailtriage::init(config).expect("init should succeed");
     let meta = RequestMeta::for_route("/invoice").with_kind("create_invoice");
-    let result = futures_executor::block_on(tailtriage.request(meta, "ok", ready(9_u32)));
+    let result = futures_executor::block_on(tailtriage.request_with_meta(meta, "ok", ready(9_u32)));
     assert_eq!(result, 9);
 
     let snapshot = tailtriage.snapshot();
@@ -186,7 +187,7 @@ fn request_with_for_route_records_route_and_outcome_without_kind() {
         std::env::temp_dir().join(format!("tailtriage_core_route_only_{nanos}.json"));
 
     let tailtriage = Tailtriage::init(config).expect("init should succeed");
-    let result = futures_executor::block_on(tailtriage.request(
+    let result = futures_executor::block_on(tailtriage.request_with_meta(
         RequestMeta::for_route("/invoice"),
         "error",
         ready(13_u32),

--- a/tailtriage-tokio/examples/mini_service_integration.rs
+++ b/tailtriage-tokio/examples/mini_service_integration.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use tailtriage_core::{Config, RequestMeta, Tailtriage};
+use tailtriage_core::Tailtriage;
 use tokio::sync::{mpsc, oneshot};
 
 #[derive(Debug)]
@@ -22,39 +22,46 @@ async fn handle_checkout(
     tx: &mpsc::Sender<WorkItem>,
     request: CheckoutRequest,
 ) -> Result<(), &'static str> {
-    let meta = RequestMeta::new(request.request_id.clone(), "/checkout").with_kind("http");
-    let request_id = meta.request_id.clone();
+    let request_ctx = tailtriage
+        .request_with_id("/checkout", request.request_id.clone())
+        .with_kind("http");
+    let started_at = tailtriage_core::unix_time_ms();
+    let started = std::time::Instant::now();
+    let result = async {
+        let (completion_tx, completion_rx) = oneshot::channel();
 
-    tailtriage
-        .request(meta, "ok", async {
-            let (completion_tx, completion_rx) = oneshot::channel();
+        request_ctx
+            .queue("checkout_ingress")
+            .await_on(tx.send(WorkItem {
+                request,
+                completion_tx,
+            }))
+            .await
+            .map_err(|_| "worker channel closed")?;
 
-            tailtriage
-                .queue(request_id.clone(), "checkout_ingress")
-                .await_on(tx.send(WorkItem {
-                    request,
-                    completion_tx,
-                }))
-                .await
-                .map_err(|_| "worker channel closed")?;
-
-            completion_rx.await.map_err(|_| "worker dropped response")?
-        })
-        .await
+        completion_rx.await.map_err(|_| "worker dropped response")?
+    }
+    .await;
+    request_ctx.complete(
+        (started_at, tailtriage_core::unix_time_ms()),
+        started.elapsed().as_micros().try_into().unwrap_or(u64::MAX),
+        if result.is_ok() { "ok" } else { "error" },
+    );
+    result
 }
 
 async fn run_worker(tailtriage: Arc<Tailtriage>, mut rx: mpsc::Receiver<WorkItem>) {
     while let Some(work) = rx.recv().await {
-        let request_id = work.request.request_id.clone();
+        let request_ctx = tailtriage.request_with_id("/checkout", work.request.request_id.clone());
 
-        tailtriage
-            .stage(request_id.clone(), "inventory_lookup")
+        request_ctx
+            .stage("inventory_lookup")
             .await_value(tokio::time::sleep(Duration::from_millis(4)))
             .await;
 
         let payment_delay_ms = if work.request.quantity > 2 { 11 } else { 6 };
-        tailtriage
-            .stage(request_id, "payment_authorization")
+        request_ctx
+            .stage("payment_authorization")
             .await_value(tokio::time::sleep(Duration::from_millis(payment_delay_ms)))
             .await;
 
@@ -64,10 +71,11 @@ async fn run_worker(tailtriage: Arc<Tailtriage>, mut rx: mpsc::Receiver<WorkItem
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut config = Config::new("mini-checkout-service");
-    config.output_path = "tailtriage-run.json".into();
-
-    let tailtriage = Arc::new(Tailtriage::init(config)?);
+    let tailtriage = Arc::new(
+        Tailtriage::builder("mini-checkout-service")
+            .output("tailtriage-run.json")
+            .build()?,
+    );
     let (tx, rx) = mpsc::channel(8);
 
     let worker = tokio::spawn(run_worker(Arc::clone(&tailtriage), rx));
@@ -87,7 +95,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     drop(tx);
     worker.await?;
 
-    tailtriage.flush()?;
+    tailtriage.shutdown()?;
 
     println!("wrote tailtriage-run.json from mini_service_integration");
     println!("next: cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json");

--- a/tailtriage-tokio/examples/minimal_checkout.rs
+++ b/tailtriage-tokio/examples/minimal_checkout.rs
@@ -1,31 +1,30 @@
 use std::time::Duration;
-use tailtriage_core::{Config, RequestMeta, Tailtriage};
+use tailtriage_core::Tailtriage;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut config = Config::new("minimal-checkout");
-    config.output_path = "tailtriage-run.json".into();
+    let tailtriage = Tailtriage::builder("minimal-checkout")
+        .output("tailtriage-run.json")
+        .build()?;
 
-    let tailtriage = Tailtriage::init(config)?;
-
-    let meta = RequestMeta::for_route("/checkout").with_kind("http");
-    let request_id = meta.request_id.clone();
-
-    tailtriage
-        .request(meta, "ok", async {
-            tailtriage
-                .queue(request_id.clone(), "ingress_queue")
-                .await_on(tokio::time::sleep(Duration::from_millis(3)))
-                .await;
-
-            tailtriage
-                .stage(request_id, "db_call")
-                .await_value(tokio::time::sleep(Duration::from_millis(8)))
-                .await;
-        })
+    let request = tailtriage.request("/checkout").with_kind("http");
+    let started_at = tailtriage_core::unix_time_ms();
+    let started = std::time::Instant::now();
+    request
+        .queue("ingress_queue")
+        .await_on(tokio::time::sleep(Duration::from_millis(3)))
         .await;
+    request
+        .stage("db_call")
+        .await_value(tokio::time::sleep(Duration::from_millis(8)))
+        .await;
+    request.complete(
+        (started_at, tailtriage_core::unix_time_ms()),
+        started.elapsed().as_micros().try_into().unwrap_or(u64::MAX),
+        "ok",
+    );
 
-    tailtriage.flush()?;
+    tailtriage.shutdown()?;
 
     println!("wrote tailtriage-run.json");
     println!("next: cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json");

--- a/tailtriage-tokio/src/lib.rs
+++ b/tailtriage-tokio/src/lib.rs
@@ -120,6 +120,22 @@ impl RuntimeSampler {
         })
     }
 
+    /// Starts runtime sampling using the interval configured on [`Tailtriage`].
+    ///
+    /// Returns `Ok(None)` when sampling is not configured.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SamplerStartError::ZeroInterval`] when the configured interval is zero.
+    pub fn start_configured(
+        tailtriage: Arc<Tailtriage>,
+    ) -> Result<Option<Self>, SamplerStartError> {
+        match tailtriage.runtime_sampling_interval() {
+            Some(interval) => Self::start(tailtriage, interval).map(Some),
+            None => Ok(None),
+        }
+    }
+
     /// Requests sampler shutdown and waits for task completion.
     pub async fn shutdown(mut self) {
         if let Some(stop_tx) = self.stop_tx.take() {
@@ -233,5 +249,24 @@ mod tests {
             assert_eq!(snapshot.blocking_queue_depth, None);
             assert_eq!(snapshot.remote_schedule_count, None);
         }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn runtime_sampler_starts_from_builder_interval() {
+        let tailtriage = Arc::new(
+            Tailtriage::builder("runtime-configured")
+                .runtime_sampling_interval(Duration::from_millis(5))
+                .build()
+                .expect("builder should succeed"),
+        );
+
+        let maybe_sampler =
+            RuntimeSampler::start_configured(Arc::clone(&tailtriage)).expect("should start");
+        assert!(maybe_sampler.is_some());
+        let sampler = maybe_sampler.expect("sampler expected");
+
+        tokio::time::sleep(Duration::from_millis(15)).await;
+        sampler.shutdown().await;
+        assert!(!tailtriage.snapshot().runtime_snapshots.is_empty());
     }
 }


### PR DESCRIPTION
### Motivation

- Provide a single, teachable public integration path by keeping the direct `RequestContext` request model and adding builder-configured runtime sampling. 
- Make sampling configurable from the same builder surface as other run knobs so runtime evidence can be enabled consistently. 
- Migrate examples/tests to the unified surface so new users learn one obvious API path while preserving backward-compatible internals.

### Description

- Added a builder-first public surface: `Tailtriage::builder(service_name)` and `TailtriageBuilder` with methods `light`, `investigation`, `output`, `service_version`, `run_id`, `capture_limits`, `runtime_sampling_interval`, and `build`.
- Introduced request-scoped API: `Tailtriage::request(route)`, `Tailtriage::request_with_id(route, request_id)` returning `RequestContext` and `RequestContext::{with_kind, queue, stage, inflight, complete, run}`.
- Added runtime-sampling integration: `Config` and `Tailtriage` now carry `runtime_sampling_interval: Option<Duration>`, `Tailtriage::runtime_sampling_interval() -> Option<Duration>`, and `tailtriage-tokio::RuntimeSampler::start_configured(Arc<Tailtriage>) -> Result<Option<Self>, SamplerStartError>` which is a convenience wrapper that starts sampling only when configured.
- Kept compatibility and low-level APIs: `request(...)` was renamed to `request_with_meta(...)` for explicit meta-based timing, `RuntimeSampler::start(...)` remains available, and `BuildError` is used with a retained `InitError` type alias for compatibility.
- Updated crate exports to include `RequestContext`, `TailtriageBuilder`, and `BuildError`; updated examples and CLI e2e tests to use the builder + request-context flow and to call `Tailtriage::shutdown()` as the final write helper.

### Testing

- Ran `cargo fmt --check` and `cargo clippy --workspace --all-targets --locked -- -D warnings`; both passed. 
- Ran the full test suite with `cargo test --workspace --locked`; all unit and integration tests passed. 
- Executed demo validation scripts (`python3 scripts/demo_tool.py validate ...` for queue, blocking, executor, downstream, mixed, cold-start, db-pool, shared-lock, retry-storm) and `python3 scripts/check_demo_fixture_drift.py`; all demo validations passed. 
- Added/ran a tokio test covering the new configured-sampler path (`runtime_sampler_starts_from_builder_interval`) which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf0b5934fc83309cbffc465d04d5d9)