### PR TITLE
docs: align crates.io onboarding with unified Tailtriage API

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 cargo install tailtriage-cli
 ```
 
-3) Capture and analyze one run artifact:
+3) Capture one run artifact in your app, then analyze it:
+
+- Capture in your service with `Tailtriage::builder(...).build()?`, explicit request queue/stage wrappers, and `tailtriage.shutdown()?` at process shutdown (see [`docs/user-guide.md`](docs/user-guide.md)).
 
 ```bash
 tailtriage analyze tailtriage-run.json --format json

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -61,9 +61,32 @@ The installed binary name is `tailtriage`.
 
 ### 3) Capture one artifact in your app
 
-Create a `TailTriage` instance, wrap request/queue/stage boundaries, and shutdown the artifact to disk at shutdown.
+Create one `Tailtriage` instance, wrap request/queue/stage boundaries, and shut down the artifact to disk at process shutdown.
 
-For a concrete instrumentation shape, mirror the minimal example in [`tailtriage-tokio/examples/minimal_checkout.rs`](../tailtriage-tokio/examples/minimal_checkout.rs).
+Minimal shape:
+
+```rust
+use tailtriage_core::Tailtriage;
+
+let tailtriage = Tailtriage::builder("checkout-service")
+    .output("tailtriage-run.json")
+    .build()?;
+
+let request = tailtriage.request("/checkout").with_kind("http");
+request
+    .queue("queue_wait")
+    .await_on(async {})
+    .await;
+request
+    .stage("db_call")
+    .await_on(async { Ok::<(), &'static str>(()) })
+    .await?;
+request.complete("ok");
+
+tailtriage.shutdown()?;
+```
+
+For a concrete end-to-end instrumentation shape, mirror [`tailtriage-tokio/examples/minimal_checkout.rs`](../tailtriage-tokio/examples/minimal_checkout.rs).
 
 ### 4) Analyze your artifact with the installed binary
 


### PR DESCRIPTION
### Motivation
- Update the crates.io onboarding docs to match the unified `Tailtriage` public API and provide a concrete minimal capture example so external adopters are not misled by stale wording or an underspecified capture step.

### Description
- Add a minimal in-app capture snippet to `docs/user-guide.md` demonstrating `Tailtriage::builder(...).output(...).build()?`, explicit request `queue`/`stage` wrappers, `request.complete(...)`, and `tailtriage.shutdown()?`.
- Clarify README Path B to explicitly instruct users to capture a run in their service with `Tailtriage::builder(...).build()?` and `tailtriage.shutdown()?` before running `tailtriage analyze`.
- Replace stale naming/wording and tighten the crates.io onboarding prose for consistency with the unified API.

### Testing
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, and all automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf1df795fc833092d0ca04500ceff4)