### PR TITLE
Mark RequestContext #[must_use], add run_ok/run_result helpers, improve examples and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,20 @@ MVP scope is intentionally narrow:
 
 ## Bounded capture and truncation
 
-`tailtriage` keeps run data in memory until shutdown. To keep this bounded in production-like runs, configure per-section capture limits:
+`tailtriage` keeps run data in memory until shutdown. To keep this bounded in production-like runs, configure per-section capture limits on the builder:
+
+```rust
+let tailtriage = Tailtriage::builder("checkout-service")
+    .capture_limits(tailtriage_core::CaptureLimits::default())
+    .build()?;
+```
+
+Important request-lifecycle safety note:
+
+- `RequestContext` is `#[must_use]`, so a dropped unfinished request emits a warning.
+- Finish each request with `complete(...)`, `run(...)`, `run_ok(...)`, or `run_result(...)`.
+
+Capture limit knobs:
 
 - `max_requests`
 - `max_stages`

--- a/SPEC.md
+++ b/SPEC.md
@@ -82,6 +82,13 @@ request
 request.complete(tailtriage_core::Outcome::Ok);
 ```
 
+Completion helpers on the same request-context model:
+
+```rust
+let value = request.run_ok(async { 42 }).await;
+let result: Result<(), MyError> = request.run_result(async { downstream_call().await }).await;
+```
+
 ### 5.3 In-flight tracking
 
 ```rust
@@ -161,7 +168,7 @@ sampler.shutdown().await;
 
 Each section captures timestamped events/snapshots used by the CLI triage rules.
 
-Capture limits are configurable through `Config.capture_limits` (`max_requests`, `max_stages`, `max_queues`, `max_inflight_snapshots`, `max_runtime_snapshots`). When limits are hit, capture is deterministically truncated for that section and analyzer output should be interpreted as evidence-ranked suspects from partial data.
+Capture limits are configurable through `Tailtriage::builder(...).capture_limits(...)` (`max_requests`, `max_stages`, `max_queues`, `max_inflight_snapshots`, `max_runtime_snapshots`). When limits are hit, capture is deterministically truncated for that section and analyzer output should be interpreted as evidence-ranked suspects from partial data.
 
 ## 7. Analyzer CLI (`tailtriage-cli`)
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -66,7 +66,7 @@ Create one `Tailtriage` instance, wrap request/queue/stage boundaries, and shut 
 Minimal shape:
 
 ```rust
-use tailtriage_core::{Outcome, Tailtriage};
+use tailtriage_core::Tailtriage;
 
 let tailtriage = Tailtriage::builder("checkout-service")
     .output("tailtriage-run.json")
@@ -75,13 +75,17 @@ let tailtriage = Tailtriage::builder("checkout-service")
 let request = tailtriage.request("/checkout").with_kind("http");
 request
     .queue("queue_wait")
-    .await_on(async {})
+    .with_depth_at_start(3)
+    .await_on(tokio::time::sleep(std::time::Duration::from_millis(5)))
     .await;
 request
     .stage("db_call")
-    .await_on(async { Ok::<(), &'static str>(()) })
+    .await_on(async {
+        tokio::time::sleep(std::time::Duration::from_millis(8)).await;
+        Ok::<(), &'static str>(())
+    })
     .await?;
-request.complete(Outcome::Ok);
+request.run_ok(async {}).await;
 
 tailtriage.shutdown()?;
 ```
@@ -140,6 +144,7 @@ use tailtriage_tokio::RuntimeSampler;
 
 let tailtriage = Arc::new(
     Tailtriage::builder("checkout-service")
+        .output("tailtriage-run.json")
         .build()?,
 );
 let sampler = RuntimeSampler::start(

--- a/scripts/demo_tool.py
+++ b/scripts/demo_tool.py
@@ -529,13 +529,14 @@ def validate_shared_lock(root_dir: Path) -> None:
     before_score = before["primary_suspect"]["score"]
     after_score = after["primary_suspect"]["score"]
 
-    # Shared-lock mitigation reliably reduces latency, but the queue-vs-stage score split can
-    # remain tied depending on scheduler interleavings in this synthetic scenario.
-    # Accept a flat score when p95 latency still improves.
-    if after_p95 >= before_p95 and after_score >= before_score:
+    if after_p95 >= before_p95:
         raise SystemExit(
-            "expected mitigation to improve p95 and/or primary suspect score, "
-            f"got p95 {before_p95}->{after_p95} and score {before_score}->{after_score}"
+            f"expected mitigated p95 to drop, got before={before_p95}us after={after_p95}us"
+        )
+    if after_score > before_score:
+        raise SystemExit(
+            "expected mitigated suspect score to stay flat or drop, "
+            f"got before={before_score} after={after_score}"
         )
 
     print(

--- a/tailtriage-cli/tests/end_to_end_capture_analysis.rs
+++ b/tailtriage-cli/tests/end_to_end_capture_analysis.rs
@@ -58,21 +58,32 @@ async fn downstream_heavy_stage_is_ranked() {
         .build()
         .expect("build should succeed");
 
-    let request = tailtriage
-        .request_with(
-            "/invoice",
-            tailtriage_core::RequestOptions::new().request_id("req-1"),
-        )
-        .with_kind("http");
-    request
-        .stage("downstream_db")
-        .await_on(async {
-            tokio::time::sleep(std::time::Duration::from_millis(40)).await;
-            Ok::<(), &'static str>(())
-        })
-        .await
-        .expect("stage should succeed");
-    request.complete(tailtriage_core::Outcome::Ok);
+    for index in 0..36 {
+        let request = tailtriage
+            .request_with(
+                "/invoice",
+                tailtriage_core::RequestOptions::new().request_id(format!("req-{index}")),
+            )
+            .with_kind("http");
+        request
+            .queue("ingress")
+            .with_depth_at_start(1)
+            .await_on(tokio::time::sleep(std::time::Duration::from_millis(1)))
+            .await;
+        request
+            .stage("downstream_db")
+            .await_on(async {
+                tokio::time::sleep(std::time::Duration::from_millis(26)).await;
+                Ok::<(), &'static str>(())
+            })
+            .await
+            .expect("stage should succeed");
+        request
+            .stage("render_response")
+            .await_value(tokio::time::sleep(std::time::Duration::from_millis(2)))
+            .await;
+        request.complete(tailtriage_core::Outcome::Ok);
+    }
 
     tailtriage.shutdown().expect("shutdown should succeed");
 
@@ -80,7 +91,7 @@ async fn downstream_heavy_stage_is_ranked() {
     let report = analyze_run(&run);
     assert_eq!(
         report.primary_suspect.kind.as_str(),
-        "insufficient_evidence"
+        "downstream_stage_dominates"
     );
 }
 

--- a/tailtriage-core/src/collector.rs
+++ b/tailtriage-core/src/collector.rs
@@ -29,6 +29,7 @@ impl std::fmt::Debug for Tailtriage {
 }
 
 /// Reusable request context that carries correlation and timing state.
+#[must_use = "request contexts must be completed via complete(...) or a run_* helper"]
 #[derive(Debug)]
 pub struct RequestContext<'a> {
     tailtriage: &'a Tailtriage,
@@ -189,7 +190,6 @@ impl Tailtriage {
 }
 
 impl RequestContext<'_> {
-    #[must_use]
     pub fn with_kind(mut self, kind: impl Into<String>) -> Self {
         self.kind = Some(kind.into());
         self
@@ -247,11 +247,41 @@ impl RequestContext<'_> {
         });
     }
 
+    /// Runs `fut` and records `outcome` when it finishes.
     pub async fn run<Fut, T>(self, outcome: Outcome, fut: Fut) -> T
     where
         Fut: std::future::Future<Output = T>,
     {
         let output = fut.await;
+        self.complete(outcome);
+        output
+    }
+
+    /// Runs an infallible future and records [`Outcome::Ok`] on completion.
+    pub async fn run_ok<Fut, T>(self, fut: Fut) -> T
+    where
+        Fut: std::future::Future<Output = T>,
+    {
+        self.run(Outcome::Ok, fut).await
+    }
+
+    /// Runs a `Result` future and records `ok`/`error` automatically.
+    ///
+    /// `Ok(_)` is recorded as [`Outcome::Ok`], and `Err(_)` as [`Outcome::Error`].
+    ///
+    /// # Errors
+    ///
+    /// Returns any error produced by `fut` unchanged.
+    pub async fn run_result<Fut, T, E>(self, fut: Fut) -> Result<T, E>
+    where
+        Fut: std::future::Future<Output = Result<T, E>>,
+    {
+        let output = fut.await;
+        let outcome = if output.is_ok() {
+            Outcome::Ok
+        } else {
+            Outcome::Error
+        };
         self.complete(outcome);
         output
     }

--- a/tailtriage-core/src/lib.rs
+++ b/tailtriage-core/src/lib.rs
@@ -1,9 +1,9 @@
 //! Core run schema and request-context instrumentation API for tailtriage.
 //!
 //! ```no_run
-//! use tailtriage_core::{Outcome, RequestOptions, Tailtriage};
+//! use tailtriage_core::{RequestOptions, Tailtriage};
 //!
-//! # fn demo() -> Result<(), Box<dyn std::error::Error>> {
+//! # async fn demo() -> Result<(), Box<dyn std::error::Error>> {
 //! let tailtriage = Tailtriage::builder("checkout-service")
 //!     .output("tailtriage-run.json")
 //!     .build()?;
@@ -11,7 +11,7 @@
 //! let request = tailtriage
 //!     .request_with("/checkout", RequestOptions::new().request_id("req-1"))
 //!     .with_kind("http");
-//! request.complete(Outcome::Ok);
+//! request.run_ok(async {}).await;
 //!
 //! tailtriage.shutdown()?;
 //! # Ok(())

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -159,6 +159,79 @@ fn run_records_outcome_after_future_completion() {
 }
 
 #[test]
+fn run_ok_records_ok_outcome_for_infallible_future() {
+    let tailtriage = build_for_test("payments", "tailtriage-core-run-ok.json");
+
+    let value = futures_executor::block_on(tailtriage.request("/run-ok").run_ok(ready(11_u8)));
+    assert_eq!(value, 11);
+
+    let snapshot = tailtriage.snapshot();
+    assert_eq!(snapshot.requests.len(), 1);
+    assert_eq!(snapshot.requests[0].outcome, "ok");
+}
+
+#[test]
+fn run_result_maps_result_to_request_outcome() {
+    let tailtriage = build_for_test("payments", "tailtriage-core-run-result.json");
+
+    let ok_value =
+        futures_executor::block_on(tailtriage.request("/run-result-ok").run_result(ready::<
+            Result<u8, &'static str>,
+        >(Ok(
+            3,
+        ))))
+        .expect("ok future should return ok");
+    assert_eq!(ok_value, 3);
+
+    let err =
+        futures_executor::block_on(tailtriage.request("/run-result-err").run_result(ready::<
+            Result<u8, &'static str>,
+        >(
+            Err("boom")
+        )))
+        .expect_err("err future should return err");
+    assert_eq!(err, "boom");
+
+    let snapshot = tailtriage.snapshot();
+    assert_eq!(snapshot.requests.len(), 2);
+    assert_eq!(snapshot.requests[0].outcome, "ok");
+    assert_eq!(snapshot.requests[1].outcome, "error");
+}
+
+async fn stage_in_helper_layer(
+    request: &crate::RequestContext<'_>,
+    stage_name: &str,
+) -> Result<(), &'static str> {
+    request
+        .stage(stage_name)
+        .await_on(ready(Ok::<(), &'static str>(())))
+        .await
+}
+
+#[test]
+fn request_context_supports_fractured_code_usage() {
+    let tailtriage = build_for_test("payments", "tailtriage-core-fractured.json");
+    let request = tailtriage
+        .request_with(
+            "/fractured",
+            RequestOptions::new().request_id("req-fractured"),
+        )
+        .with_kind("http");
+
+    futures_executor::block_on(request.queue("q").await_on(ready(())));
+    futures_executor::block_on(stage_in_helper_layer(&request, "layer_a"))
+        .expect("helper stage should succeed");
+    futures_executor::block_on(stage_in_helper_layer(&request, "layer_b"))
+        .expect("helper stage should succeed");
+    request.complete(Outcome::Ok);
+
+    let snapshot = tailtriage.snapshot();
+    assert_eq!(snapshot.requests.len(), 1);
+    assert_eq!(snapshot.stages.len(), 2);
+    assert_eq!(snapshot.queues.len(), 1);
+}
+
+#[test]
 fn custom_sink_receives_shutdown_run() {
     let sink = Arc::new(RecordingSink::default());
     let tailtriage = Tailtriage::builder("payments")

--- a/tailtriage-tokio/examples/mini_service_integration.rs
+++ b/tailtriage-tokio/examples/mini_service_integration.rs
@@ -1,8 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use tailtriage_core::{Outcome, RequestOptions, Tailtriage};
-use tailtriage_tokio::RuntimeSampler;
+use tailtriage_core::{RequestOptions, Tailtriage};
 
 #[derive(Clone)]
 struct CheckoutRequest {
@@ -17,6 +16,20 @@ async fn authorize_payment(
         .stage("payment_authorization")
         .await_on(async {
             tokio::time::sleep(Duration::from_millis(4)).await;
+            Ok::<(), &'static str>(())
+        })
+        .await
+}
+
+async fn reserve_inventory(
+    request: &tailtriage_core::RequestContext<'_>,
+    cart_total_cents: u64,
+) -> Result<(), &'static str> {
+    let reserve_ms = if cart_total_cents > 700 { 9 } else { 4 };
+    request
+        .stage("reserve_inventory")
+        .await_on(async move {
+            tokio::time::sleep(Duration::from_millis(reserve_ms)).await;
             Ok::<(), &'static str>(())
         })
         .await
@@ -42,13 +55,7 @@ async fn handle_checkout(
             .await_on(tokio::time::sleep(Duration::from_millis(2)))
             .await;
 
-        request_ctx
-            .stage("inventory_lookup")
-            .await_on(async {
-                tokio::time::sleep(Duration::from_millis(3)).await;
-                Ok::<(), &'static str>(())
-            })
-            .await?;
+        reserve_inventory(&request_ctx, request.cart_total_cents).await?;
 
         request_ctx
             .stage("pricing")
@@ -59,32 +66,46 @@ async fn handle_checkout(
 
         authorize_payment(&request_ctx).await?;
     }
-    request_ctx.complete(Outcome::Ok);
+
+    request_ctx
+        .run_result(async { Ok::<(), &'static str>(()) })
+        .await?;
     Ok(())
 }
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let output_path = std::env::temp_dir().join("tailtriage-mini-service.json");
+    let output_path = "tailtriage-run.json";
     let tailtriage = Arc::new(
         Tailtriage::builder("mini-checkout-service")
-            .output(&output_path)
+            .output(output_path)
             .investigation()
             .build()?,
     );
+    let requests = [
+        CheckoutRequest {
+            request_id: "req-101".to_string(),
+            cart_total_cents: 180,
+        },
+        CheckoutRequest {
+            request_id: "req-102".to_string(),
+            cart_total_cents: 950,
+        },
+        CheckoutRequest {
+            request_id: "req-103".to_string(),
+            cart_total_cents: 320,
+        },
+    ];
 
-    let sampler = RuntimeSampler::start(Arc::clone(&tailtriage), Duration::from_millis(5))?;
+    for request in requests {
+        handle_checkout(Arc::clone(&tailtriage), request).await?;
+    }
 
-    let request = CheckoutRequest {
-        request_id: "req-123".to_string(),
-        cart_total_cents: 240,
-    };
-
-    handle_checkout(Arc::clone(&tailtriage), request).await?;
-
-    sampler.shutdown().await;
     tailtriage.shutdown()?;
 
-    println!("artifact: {}", output_path.display());
+    println!("Wrote {output_path}");
+    println!("This example demonstrates a small integration flow across helper layers.");
+    println!("Analyze it with:");
+    println!("  cargo run -p tailtriage-cli -- analyze {output_path} --format json");
     Ok(())
 }

--- a/tailtriage-tokio/examples/minimal_checkout.rs
+++ b/tailtriage-tokio/examples/minimal_checkout.rs
@@ -1,30 +1,43 @@
-use tailtriage_core::{Outcome, Tailtriage};
+use std::time::Duration;
+
+use tailtriage_core::Tailtriage;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let artifact_path = "tailtriage-run.json";
     let tailtriage = Tailtriage::builder("minimal-checkout")
-        .output(std::env::temp_dir().join("tailtriage-minimal-checkout.json"))
+        .output(artifact_path)
         .build()?;
 
     let request = tailtriage.request("/checkout").with_kind("http");
 
-    {
-        let _inflight = request.inflight("checkout_inflight");
+    request
+        .queue("checkout_worker_queue")
+        .with_depth_at_start(4)
+        .await_on(tokio::time::sleep(Duration::from_millis(6)))
+        .await;
 
-        request
-            .queue("queue_wait")
-            .with_depth_at_start(3)
-            .await_on(tokio::time::sleep(std::time::Duration::from_millis(5)))
-            .await;
+    request
+        .stage("inventory_lookup")
+        .await_on(async {
+            tokio::time::sleep(Duration::from_millis(8)).await;
+            Ok::<(), &'static str>(())
+        })
+        .await?;
 
-        request
-            .stage("db_call")
-            .await_on(async { Ok::<(), &'static str>(()) })
-            .await?;
-    }
+    request
+        .stage("payment_gateway")
+        .await_on(async {
+            tokio::time::sleep(Duration::from_millis(12)).await;
+            Ok::<(), &'static str>(())
+        })
+        .await?;
 
-    request.complete(Outcome::Ok);
+    request.run_ok(async {}).await;
 
     tailtriage.shutdown()?;
+    println!("Wrote {artifact_path}");
+    println!("Next step:");
+    println!("  cargo run -p tailtriage-cli -- analyze {artifact_path} --format json");
     Ok(())
 }


### PR DESCRIPTION
### Motivation
- Make the unified request-context API harder to misuse by making completion visible at compile time and providing ergonomic helpers for common completion patterns.
- Improve first-time adoption examples so they are realistic, deterministic, and clearly teach the new API surface.
- Restore and strengthen end-to-end validation rigor so demo proof-cases remain robust and deterministic under the new API.

### Description
- Mark `RequestContext` as `#[must_use = "request contexts must be completed via complete(...) or a run_* helper"]` to warn on dropped unfinished requests and preserve the single unified API model.
- Add `run_ok(self, fut)` for infallible futures and `run_result(self, fut)` which maps `Ok(_) -> Outcome::Ok` and `Err(_) -> Outcome::Error`, while keeping `complete(...)` and `run(...)` available for explicit control; update crate docs to show these helpers. 
- Add focused tests in `tailtriage-core/src/tests.rs` covering `run_ok`, `run_result`, and fractured-code usage where a `RequestContext` is used across helper layers. 
- Improve examples: `tailtriage-tokio/examples/minimal_checkout.rs` now writes `tailtriage-run.json` in CWD, includes a queue wait plus realistic stage latencies, and prints a clear analyze-next-step; `mini_service_integration.rs` demonstrates multiple requests, queueing, and fractured-layer stage instrumentation using the new API only. 
- Strengthen validation and demo tooling: updated `tailtriage-cli/tests/end_to_end_capture_analysis.rs` to restore a deterministic downstream-stage proof case, and tightened `scripts/demo_tool.py` validation checks so mitigations must show real improvement signals.

### Testing
- Ran `cargo fmt --check` and it passed. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it passed. 
- Ran `cargo test --workspace` and all workspace tests passed. 
- Ran `python3 scripts/tests/test_demo_scripts.py` and the demo script tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf2e9d33648330b7996eceebdaea3e)