### PR TITLE
Improve request-context lifecycle safety; add run_ok/run_result helpers; update examples/docs/tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ cargo install tailtriage-cli
 
 3) Capture one run artifact in your app, then analyze it:
 
-- Capture in your service with `Tailtriage::builder(...).build()?`, explicit request queue/stage wrappers, and `tailtriage.shutdown()?` at process shutdown (see [`docs/user-guide.md`](docs/user-guide.md)).
+- Capture in your service with `Tailtriage::builder(...).build()?`, explicit request queue/stage wrappers, and `tailtriage.shutdown()?` at process shutdown (see [`docs/user-guide.md`](docs/user-guide.md)). Complete each request with `request.complete(...)`, `request.run_ok(...)`, or `request.run_result(...)`.
 
 ```bash
 tailtriage analyze tailtriage-run.json --format json
@@ -152,7 +152,7 @@ MVP scope is intentionally narrow:
 
 ## Bounded capture and truncation
 
-`tailtriage` keeps run data in memory until shutdown. To keep this bounded in production-like runs, configure per-section capture limits:
+`tailtriage` keeps run data in memory until shutdown. To keep this bounded in production-like runs, configure per-section capture limits via `Tailtriage::builder(...).capture_limits(...)`:
 
 - `max_requests`
 - `max_stages`

--- a/SPEC.md
+++ b/SPEC.md
@@ -79,7 +79,7 @@ request
     .await_on(customer_api.fetch())
     .await?;
 
-request.complete(tailtriage_core::Outcome::Ok);
+request.run_result(async { Ok::<(), anyhow::Error>(()) }).await?;
 ```
 
 ### 5.3 In-flight tracking
@@ -161,7 +161,7 @@ sampler.shutdown().await;
 
 Each section captures timestamped events/snapshots used by the CLI triage rules.
 
-Capture limits are configurable through `Config.capture_limits` (`max_requests`, `max_stages`, `max_queues`, `max_inflight_snapshots`, `max_runtime_snapshots`). When limits are hit, capture is deterministically truncated for that section and analyzer output should be interpreted as evidence-ranked suspects from partial data.
+Capture limits are configurable through `Tailtriage::builder(...).capture_limits(...)` (`max_requests`, `max_stages`, `max_queues`, `max_inflight_snapshots`, `max_runtime_snapshots`). When limits are hit, capture is deterministically truncated for that section and analyzer output should be interpreted as evidence-ranked suspects from partial data.
 
 ## 7. Analyzer CLI (`tailtriage-cli`)
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -6,22 +6,22 @@ Each one answers a specific triage question by producing an artifact that should
 
 ## Shared ideas across all demos
 
-All service demos follow the same pattern:
+All service demos follow the same unified API pattern:
 
 1. Parse output path and optional mode (`baseline`/`before`, `mitigated`/`after`).
 2. Create artifact output directory.
-3. Initialize one `Tailtriage` collector.
+3. Build one `Tailtriage` instance with `Tailtriage::builder(...)`.
 4. Generate a deterministic request burst.
 5. Wrap requests with `tailtriage.request(...)`.
 6. Instrument admission queue and/or stages.
-7. Flush to JSON and run CLI analysis.
+7. Complete request contexts, call `tailtriage.shutdown()`, and run CLI analysis.
 
 Shared helper code for this setup lives in `demos/demo_support`:
 
 - `DemoMode` and mode parsing
 - common CLI argument parsing
 - artifact directory creation
-- collector initialization
+- `Tailtriage::builder(...)` setup
 
 This keeps demo binaries focused on the triage scenario rather than boilerplate.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -12,7 +12,10 @@ Use this path when you are evaluating `tailtriage` from a local clone of this re
 cargo run -p tailtriage-tokio --example minimal_checkout
 ```
 
-Expected output includes `wrote tailtriage-run.json`.
+Expected output includes:
+
+- `wrote tailtriage-run.json`
+- `next: cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json`
 
 If you want a more realistic request + queue + worker shape outside the synthetic demos, run:
 
@@ -66,7 +69,7 @@ Create one `Tailtriage` instance, wrap request/queue/stage boundaries, and shut 
 Minimal shape:
 
 ```rust
-use tailtriage_core::{Outcome, Tailtriage};
+use tailtriage_core::Tailtriage;
 
 let tailtriage = Tailtriage::builder("checkout-service")
     .output("tailtriage-run.json")
@@ -79,9 +82,12 @@ request
     .await;
 request
     .stage("db_call")
-    .await_on(async { Ok::<(), &'static str>(()) })
+    .await_on(async {
+        tokio::time::sleep(std::time::Duration::from_millis(12)).await;
+        Ok::<(), &'static str>(())
+    })
     .await?;
-request.complete(Outcome::Ok);
+request.run_ok(async {}).await;
 
 tailtriage.shutdown()?;
 ```
@@ -140,6 +146,7 @@ use tailtriage_tokio::RuntimeSampler;
 
 let tailtriage = Arc::new(
     Tailtriage::builder("checkout-service")
+        .output("tailtriage-run.json")
         .build()?,
 );
 let sampler = RuntimeSampler::start(

--- a/scripts/demo_tool.py
+++ b/scripts/demo_tool.py
@@ -529,13 +529,15 @@ def validate_shared_lock(root_dir: Path) -> None:
     before_score = before["primary_suspect"]["score"]
     after_score = after["primary_suspect"]["score"]
 
-    # Shared-lock mitigation reliably reduces latency, but the queue-vs-stage score split can
-    # remain tied depending on scheduler interleavings in this synthetic scenario.
-    # Accept a flat score when p95 latency still improves.
-    if after_p95 >= before_p95 and after_score >= before_score:
+    if after_p95 >= before_p95:
         raise SystemExit(
-            "expected mitigation to improve p95 and/or primary suspect score, "
-            f"got p95 {before_p95}->{after_p95} and score {before_score}->{after_score}"
+            f"expected mitigated p95 to drop, got before={before_p95}us after={after_p95}us"
+        )
+
+    if after_score > before_score:
+        raise SystemExit(
+            "expected mitigated suspect score to stay flat or drop, "
+            f"got before={before_score} after={after_score}"
         )
 
     print(

--- a/tailtriage-cli/tests/end_to_end_capture_analysis.rs
+++ b/tailtriage-cli/tests/end_to_end_capture_analysis.rs
@@ -37,7 +37,7 @@ async fn queue_and_stage_data_drives_ranked_suspects() {
             .stage("local_work")
             .await_value(tokio::time::sleep(std::time::Duration::from_millis(1)))
             .await;
-        request.complete(tailtriage_core::Outcome::Ok);
+        request.run_ok(async {}).await;
     }
 
     tailtriage.shutdown().expect("shutdown should succeed");
@@ -58,21 +58,30 @@ async fn downstream_heavy_stage_is_ranked() {
         .build()
         .expect("build should succeed");
 
-    let request = tailtriage
-        .request_with(
-            "/invoice",
-            tailtriage_core::RequestOptions::new().request_id("req-1"),
-        )
-        .with_kind("http");
-    request
-        .stage("downstream_db")
-        .await_on(async {
-            tokio::time::sleep(std::time::Duration::from_millis(40)).await;
-            Ok::<(), &'static str>(())
-        })
-        .await
-        .expect("stage should succeed");
-    request.complete(tailtriage_core::Outcome::Ok);
+    for index in 0..48 {
+        let request = tailtriage
+            .request_with(
+                "/invoice",
+                tailtriage_core::RequestOptions::new().request_id(format!("downstream-{index}")),
+            )
+            .with_kind("http");
+
+        request
+            .stage("downstream_db")
+            .await_on(async {
+                tokio::time::sleep(std::time::Duration::from_millis(28)).await;
+                Ok::<(), &'static str>(())
+            })
+            .await
+            .expect("stage should succeed");
+
+        request
+            .stage("marshal_response")
+            .await_value(tokio::time::sleep(std::time::Duration::from_millis(1)))
+            .await;
+
+        request.run_ok(async {}).await;
+    }
 
     tailtriage.shutdown().expect("shutdown should succeed");
 
@@ -80,7 +89,7 @@ async fn downstream_heavy_stage_is_ranked() {
     let report = analyze_run(&run);
     assert_eq!(
         report.primary_suspect.kind.as_str(),
-        "insufficient_evidence"
+        "downstream_stage_dominates"
     );
 }
 
@@ -98,7 +107,7 @@ async fn low_evidence_run_yields_insufficient_signal() {
             tailtriage_core::RequestOptions::new().request_id(format!("insufficient-{index}")),
         );
         tokio::time::sleep(std::time::Duration::from_millis(1)).await;
-        request.complete(tailtriage_core::Outcome::Ok);
+        request.run_ok(async {}).await;
     }
 
     tailtriage.shutdown().expect("shutdown should succeed");

--- a/tailtriage-core/src/collector.rs
+++ b/tailtriage-core/src/collector.rs
@@ -29,6 +29,7 @@ impl std::fmt::Debug for Tailtriage {
 }
 
 /// Reusable request context that carries correlation and timing state.
+#[must_use = "request contexts must be completed via complete(...) or a run_* helper"]
 #[derive(Debug)]
 pub struct RequestContext<'a> {
     tailtriage: &'a Tailtriage,
@@ -189,7 +190,6 @@ impl Tailtriage {
 }
 
 impl RequestContext<'_> {
-    #[must_use]
     pub fn with_kind(mut self, kind: impl Into<String>) -> Self {
         self.kind = Some(kind.into());
         self
@@ -252,6 +252,34 @@ impl RequestContext<'_> {
         Fut: std::future::Future<Output = T>,
     {
         let output = fut.await;
+        self.complete(outcome);
+        output
+    }
+
+    /// Runs an infallible request future and records [`Outcome::Ok`].
+    pub async fn run_ok<Fut, T>(self, fut: Fut) -> T
+    where
+        Fut: std::future::Future<Output = T>,
+    {
+        self.run(Outcome::Ok, fut).await
+    }
+
+    /// Runs a fallible request future and maps `Ok(_)` to [`Outcome::Ok`],
+    /// `Err(_)` to [`Outcome::Error`].
+    ///
+    /// # Errors
+    ///
+    /// Returns the same error produced by `fut`.
+    pub async fn run_result<Fut, T, E>(self, fut: Fut) -> Result<T, E>
+    where
+        Fut: std::future::Future<Output = Result<T, E>>,
+    {
+        let output = fut.await;
+        let outcome = if output.is_ok() {
+            Outcome::Ok
+        } else {
+            Outcome::Error
+        };
         self.complete(outcome);
         output
     }

--- a/tailtriage-core/src/lib.rs
+++ b/tailtriage-core/src/lib.rs
@@ -1,9 +1,9 @@
 //! Core run schema and request-context instrumentation API for tailtriage.
 //!
 //! ```no_run
-//! use tailtriage_core::{Outcome, RequestOptions, Tailtriage};
+//! use tailtriage_core::{RequestOptions, Tailtriage};
 //!
-//! # fn demo() -> Result<(), Box<dyn std::error::Error>> {
+//! # async fn demo() -> Result<(), Box<dyn std::error::Error>> {
 //! let tailtriage = Tailtriage::builder("checkout-service")
 //!     .output("tailtriage-run.json")
 //!     .build()?;
@@ -11,7 +11,7 @@
 //! let request = tailtriage
 //!     .request_with("/checkout", RequestOptions::new().request_id("req-1"))
 //!     .with_kind("http");
-//! request.complete(Outcome::Ok);
+//! request.run_ok(async {}).await;
 //!
 //! tailtriage.shutdown()?;
 //! # Ok(())

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -159,6 +159,74 @@ fn run_records_outcome_after_future_completion() {
 }
 
 #[test]
+fn run_ok_records_ok_outcome() {
+    let tailtriage = build_for_test("payments", "tailtriage-core-run-ok.json");
+    let request = tailtriage.request("/run-ok");
+
+    let value = futures_executor::block_on(request.run_ok(ready(11_u8)));
+    assert_eq!(value, 11);
+
+    let snapshot = tailtriage.snapshot();
+    assert_eq!(snapshot.requests.len(), 1);
+    assert_eq!(snapshot.requests[0].outcome, "ok");
+}
+
+#[test]
+fn run_result_records_ok_and_error_outcomes() {
+    let tailtriage = build_for_test("payments", "tailtriage-core-run-result.json");
+
+    let ok_value = futures_executor::block_on(
+        tailtriage
+            .request_with("/run-result", RequestOptions::new().request_id("ok-req"))
+            .run_result(ready(Ok::<u8, &'static str>(5))),
+    )
+    .expect("request should succeed");
+    assert_eq!(ok_value, 5);
+
+    let err_value = futures_executor::block_on(
+        tailtriage
+            .request_with("/run-result", RequestOptions::new().request_id("err-req"))
+            .run_result(ready(Err::<u8, &'static str>("boom"))),
+    )
+    .expect_err("request should fail");
+    assert_eq!(err_value, "boom");
+
+    let snapshot = tailtriage.snapshot();
+    assert_eq!(snapshot.requests.len(), 2);
+    assert_eq!(snapshot.requests[0].outcome, "ok");
+    assert_eq!(snapshot.requests[1].outcome, "error");
+}
+
+#[test]
+fn fractured_code_helpers_can_share_request_context() {
+    fn instrument_queue(request: &crate::RequestContext<'_>) {
+        futures_executor::block_on(request.queue("worker").await_on(ready(())));
+    }
+
+    async fn instrument_stage(request: &crate::RequestContext<'_>) -> Result<(), &'static str> {
+        request
+            .stage("db")
+            .await_on(async { Ok::<(), &'static str>(()) })
+            .await
+    }
+
+    let tailtriage = build_for_test("payments", "tailtriage-core-fractured.json");
+    let request = tailtriage.request_with(
+        "/fractured",
+        RequestOptions::new().request_id("fractured-req"),
+    );
+
+    instrument_queue(&request);
+    futures_executor::block_on(instrument_stage(&request)).expect("stage should succeed");
+    futures_executor::block_on(request.run_ok(ready(())));
+
+    let snapshot = tailtriage.snapshot();
+    assert_eq!(snapshot.requests.len(), 1);
+    assert_eq!(snapshot.queues.len(), 1);
+    assert_eq!(snapshot.stages.len(), 1);
+}
+
+#[test]
 fn custom_sink_receives_shutdown_run() {
     let sink = Arc::new(RecordingSink::default());
     let tailtriage = Tailtriage::builder("payments")

--- a/tailtriage-tokio/examples/mini_service_integration.rs
+++ b/tailtriage-tokio/examples/mini_service_integration.rs
@@ -1,22 +1,45 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use tailtriage_core::{Outcome, RequestOptions, Tailtriage};
-use tailtriage_tokio::RuntimeSampler;
+use tailtriage_core::{RequestContext, RequestOptions, Tailtriage};
 
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 struct CheckoutRequest {
-    request_id: String,
+    request_index: usize,
     cart_total_cents: u64,
 }
 
-async fn authorize_payment(
-    request: &tailtriage_core::RequestContext<'_>,
-) -> Result<(), &'static str> {
+async fn queue_for_worker(request: &RequestContext<'_>, depth: u64) {
     request
-        .stage("payment_authorization")
-        .await_on(async {
-            tokio::time::sleep(Duration::from_millis(4)).await;
+        .queue("checkout_worker")
+        .with_depth_at_start(depth)
+        .await_on(tokio::time::sleep(Duration::from_millis(3 + depth)))
+        .await;
+}
+
+async fn load_inventory(
+    request: &RequestContext<'_>,
+    cart_total_cents: u64,
+) -> Result<(), &'static str> {
+    let extra = cart_total_cents / 120;
+    request
+        .stage("inventory_db")
+        .await_on(async move {
+            tokio::time::sleep(Duration::from_millis(8 + extra)).await;
+            Ok::<(), &'static str>(())
+        })
+        .await
+}
+
+async fn authorize_payment(
+    request: &RequestContext<'_>,
+    request_index: usize,
+) -> Result<(), &'static str> {
+    let attempt_cost = if request_index % 3 == 0 { 11 } else { 6 };
+    request
+        .stage("payment_gateway")
+        .await_on(async move {
+            tokio::time::sleep(Duration::from_millis(attempt_cost)).await;
             Ok::<(), &'static str>(())
         })
         .await
@@ -26,65 +49,60 @@ async fn handle_checkout(
     tailtriage: Arc<Tailtriage>,
     request: CheckoutRequest,
 ) -> Result<(), &'static str> {
+    let request_id = format!("req-{:02}", request.request_index);
     let request_ctx = tailtriage
-        .request_with(
-            "/checkout",
-            RequestOptions::new().request_id(request.request_id),
-        )
+        .request_with("/checkout", RequestOptions::new().request_id(request_id))
         .with_kind("http");
 
     {
         let _inflight = request_ctx.inflight("checkout_inflight");
-
-        request_ctx
-            .queue("checkout_permit")
-            .with_depth_at_start(2)
-            .await_on(tokio::time::sleep(Duration::from_millis(2)))
-            .await;
-
-        request_ctx
-            .stage("inventory_lookup")
-            .await_on(async {
-                tokio::time::sleep(Duration::from_millis(3)).await;
-                Ok::<(), &'static str>(())
-            })
-            .await?;
-
-        request_ctx
-            .stage("pricing")
-            .await_value(tokio::time::sleep(Duration::from_millis(
-                request.cart_total_cents / 50,
-            )))
-            .await;
-
-        authorize_payment(&request_ctx).await?;
+        queue_for_worker(&request_ctx, 2 + (request.request_index % 4) as u64).await;
+        load_inventory(&request_ctx, request.cart_total_cents).await?;
+        authorize_payment(&request_ctx, request.request_index).await?;
     }
-    request_ctx.complete(Outcome::Ok);
-    Ok(())
+
+    request_ctx
+        .run_result(async { Ok::<(), &'static str>(()) })
+        .await
 }
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let output_path = std::env::temp_dir().join("tailtriage-mini-service.json");
+    let output_path = "tailtriage-mini-service.json";
     let tailtriage = Arc::new(
         Tailtriage::builder("mini-checkout-service")
-            .output(&output_path)
-            .investigation()
+            .output(output_path)
             .build()?,
     );
 
-    let sampler = RuntimeSampler::start(Arc::clone(&tailtriage), Duration::from_millis(5))?;
+    for request in [
+        CheckoutRequest {
+            request_index: 0,
+            cart_total_cents: 220,
+        },
+        CheckoutRequest {
+            request_index: 1,
+            cart_total_cents: 640,
+        },
+        CheckoutRequest {
+            request_index: 2,
+            cart_total_cents: 175,
+        },
+        CheckoutRequest {
+            request_index: 3,
+            cart_total_cents: 470,
+        },
+        CheckoutRequest {
+            request_index: 4,
+            cart_total_cents: 310,
+        },
+    ] {
+        handle_checkout(Arc::clone(&tailtriage), request).await?;
+    }
 
-    let request = CheckoutRequest {
-        request_id: "req-123".to_string(),
-        cart_total_cents: 240,
-    };
-
-    handle_checkout(Arc::clone(&tailtriage), request).await?;
-
-    sampler.shutdown().await;
     tailtriage.shutdown()?;
 
-    println!("artifact: {}", output_path.display());
+    println!("wrote {output_path}");
+    println!("next: cargo run -p tailtriage-cli -- analyze {output_path} --format json");
     Ok(())
 }

--- a/tailtriage-tokio/examples/minimal_checkout.rs
+++ b/tailtriage-tokio/examples/minimal_checkout.rs
@@ -1,30 +1,35 @@
-use tailtriage_core::{Outcome, Tailtriage};
+use std::time::Duration;
+
+use tailtriage_core::Tailtriage;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let tailtriage = Tailtriage::builder("minimal-checkout")
-        .output(std::env::temp_dir().join("tailtriage-minimal-checkout.json"))
+        .output("tailtriage-run.json")
         .build()?;
 
-    let request = tailtriage.request("/checkout").with_kind("http");
+    let checkout = tailtriage.request("/checkout").with_kind("http");
 
-    {
-        let _inflight = request.inflight("checkout_inflight");
+    checkout
+        .queue("checkout_permit")
+        .with_depth_at_start(4)
+        .await_on(tokio::time::sleep(Duration::from_millis(8)))
+        .await;
 
-        request
-            .queue("queue_wait")
-            .with_depth_at_start(3)
-            .await_on(tokio::time::sleep(std::time::Duration::from_millis(5)))
-            .await;
+    checkout
+        .stage("inventory_db")
+        .await_on(async {
+            tokio::time::sleep(Duration::from_millis(14)).await;
+            Ok::<(), &'static str>(())
+        })
+        .await?;
 
-        request
-            .stage("db_call")
-            .await_on(async { Ok::<(), &'static str>(()) })
-            .await?;
-    }
-
-    request.complete(Outcome::Ok);
+    checkout
+        .run_ok(tokio::time::sleep(Duration::from_millis(6)))
+        .await;
 
     tailtriage.shutdown()?;
+    println!("wrote tailtriage-run.json");
+    println!("next: cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json");
     Ok(())
 }


### PR DESCRIPTION
### Motivation
- Prevent accidental forgetting of request completion by making the request-context lifecycle harder to ignore at compile time.
- Provide ergonomic helpers for the two common completion patterns (infallible futures and `Result<T, E>` futures) without creating a second onboarding path.
- Restore example realism and validation rigor so demos and end-to-end tests give robust, deterministic evidence for diagnosis categories.

### Description
- Add `#[must_use = "request contexts must be completed via complete(...) or a run_* helper"]` to `RequestContext` and keep `complete(...)`/`run(...)` on the same API surface. (`tailtriage-core/src/collector.rs`)
- Add ergonomic helpers `run_ok(self, fut)` and `run_result(self, fut)` to automatically record `Outcome::Ok` or map `Ok/Err` to `Outcome::Ok`/`Outcome::Error` while preserving return types. (`tailtriage-core/src/collector.rs`)
- Add focused API ergonomics tests for `run_ok`, `run_result`, and fractured-code usage where request contexts are used across helper layers. (`tailtriage-core/src/tests.rs`)
- Improve `tailtriage-tokio` examples: `minimal_checkout` now writes `tailtriage-run.json`, includes a queue wait and realistic stage latency, and prints a clear analyze command; `mini_service_integration` demonstrates a multi-request flow with queue + worker boundary and variable downstream latency. (`tailtriage-tokio/examples/*.rs`)
- Tighten end-to-end diagnosis proof and demo validation: increase downstream test volume/weight to deterministically surface `downstream_stage_dominates`, preserve queue- and low-evidence cases, and strengthen shared-lock mitigation checks in `scripts/demo_tool.py`. (`tailtriage-cli/tests/end_to_end_capture_analysis.rs`, `scripts/demo_tool.py`)
- Update launch-facing docs and crate rustdoc to reflect the unified builder + request-context path and new helper APIs, and to correct capture-limits wording. (`README.md`, `docs/user-guide.md`, `SPEC.md`, `tailtriage-core/src/lib.rs`, `demos/README.md`)

### Testing
- Ran `cargo fmt --check` (passed).
- Ran `cargo clippy --workspace --all-targets -- -D warnings` (passed).
- Ran `cargo test --workspace` (all workspace tests, doctests, and crate unit tests passed).
- Ran `python3 -m pytest scripts/tests/test_demo_scripts.py` (all demo validation Python tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfac1fb8888330b4769f5d1b714cba)