### PR TITLE
Simplify RequestContext lifecycle to finish-only terminal API

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ let tailtriage = Tailtriage::builder("checkout-service")
 
 Important request-lifecycle safety note:
 
-- `RequestContext` is `#[must_use]`, so a dropped unfinished request emits a warning.
-- Finish each request with `complete(...)`, `run(...)`, `run_ok(...)`, or `run_result(...)`.
+- `RequestContext` is `#[must_use]`, and debug builds assert if it is dropped unfinished.
+- Finish each request with `finish(...)`, `finish_ok(...)`, or `finish_result(...)`.
 
 Capture limit knobs:
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -79,14 +79,14 @@ request
     .await_on(customer_api.fetch())
     .await?;
 
-request.complete(tailtriage_core::Outcome::Ok);
+request.finish(tailtriage_core::Outcome::Ok);
 ```
 
 Completion helpers on the same request-context model:
 
 ```rust
-let value = request.run_ok(async { 42 }).await;
-let result: Result<(), MyError> = request.run_result(async { downstream_call().await }).await;
+request.finish_ok();
+let result: Result<(), MyError> = request.finish_result(downstream_call().await);
 ```
 
 ### 5.3 In-flight tracking

--- a/demos/blocking_service/src/main.rs
+++ b/demos/blocking_service/src/main.rs
@@ -112,7 +112,7 @@ async fn run_demo(output_path: PathBuf, settings: ModeSettings) -> anyhow::Resul
                     .await;
                 pending_blocking.fetch_sub(1, Ordering::SeqCst);
             }
-            request.complete(tailtriage_core::Outcome::Ok);
+            request.finish(tailtriage_core::Outcome::Ok);
         }));
 
         if request_number % settings.inter_arrival_pause_every == 0 {

--- a/demos/cold_start_burst_service/src/main.rs
+++ b/demos/cold_start_burst_service/src/main.rs
@@ -94,7 +94,7 @@ async fn main() -> anyhow::Result<()> {
                     .await_value(tokio::time::sleep(stage_delay))
                     .await;
             }
-            request.complete(tailtriage_core::Outcome::Ok);
+            request.finish(tailtriage_core::Outcome::Ok);
         }));
 
         if request_number % settings.inter_arrival_pause_every == 0 {

--- a/demos/db_pool_saturation_service/src/main.rs
+++ b/demos/db_pool_saturation_service/src/main.rs
@@ -87,7 +87,7 @@ async fn main() -> anyhow::Result<()> {
                     .await_value(tokio::time::sleep(settings.db_query_delay))
                     .await;
             }
-            request.complete(tailtriage_core::Outcome::Ok);
+            request.finish(tailtriage_core::Outcome::Ok);
         }));
 
         if request_number % settings.inter_arrival_pause_every == 0 {

--- a/demos/downstream_service/src/main.rs
+++ b/demos/downstream_service/src/main.rs
@@ -36,7 +36,7 @@ async fn main() -> anyhow::Result<()> {
                     .await_value(tokio::time::sleep(Duration::from_millis(20)))
                     .await;
             }
-            request.complete(tailtriage_core::Outcome::Ok);
+            request.finish(tailtriage_core::Outcome::Ok);
         }));
 
         if request_number.is_multiple_of(8) {

--- a/demos/executor_pressure_service/src/main.rs
+++ b/demos/executor_pressure_service/src/main.rs
@@ -139,7 +139,7 @@ async fn run_demo(output_path: PathBuf, settings: ModeSettings) -> anyhow::Resul
 
                 runnable_backlog.fetch_sub(1, Ordering::SeqCst);
             }
-            request.complete(tailtriage_core::Outcome::Ok);
+            request.finish(tailtriage_core::Outcome::Ok);
         }));
 
         if request_number % settings.burst_pause_every == 0 {

--- a/demos/mixed_contention_service/src/main.rs
+++ b/demos/mixed_contention_service/src/main.rs
@@ -97,7 +97,7 @@ async fn main() -> anyhow::Result<()> {
                     ))
                     .await;
             }
-            request.complete(tailtriage_core::Outcome::Ok);
+            request.finish(tailtriage_core::Outcome::Ok);
         }));
 
         if request_number % settings.inter_arrival_pause_every == 0 {

--- a/demos/queue_service/src/main.rs
+++ b/demos/queue_service/src/main.rs
@@ -70,7 +70,7 @@ async fn main() -> anyhow::Result<()> {
                     .await_value(tokio::time::sleep(work_duration))
                     .await;
             }
-            request.complete(tailtriage_core::Outcome::Ok);
+            request.finish(tailtriage_core::Outcome::Ok);
         }));
 
         if request_number % inter_arrival_pause_every == 0 {

--- a/demos/retry_storm_service/src/main.rs
+++ b/demos/retry_storm_service/src/main.rs
@@ -167,7 +167,7 @@ async fn main() -> anyhow::Result<()> {
                     ))
                     .await;
             }
-            request.complete(tailtriage_core::Outcome::Ok);
+            request.finish(tailtriage_core::Outcome::Ok);
         }));
 
         if request_number % mode_settings.inter_arrival_pause_every == 0 {

--- a/demos/runtime_cost/src/main.rs
+++ b/demos/runtime_cost/src/main.rs
@@ -139,7 +139,7 @@ async fn main() -> anyhow::Result<()> {
 
                         drop(permit);
                     }
-                    request.complete(tailtriage_core::Outcome::Ok);
+                    request.finish(tailtriage_core::Outcome::Ok);
                 }
                 (_, None) => unreachable!("instrumented modes require a collector"),
             }

--- a/demos/shared_state_lock_service/src/main.rs
+++ b/demos/shared_state_lock_service/src/main.rs
@@ -85,7 +85,7 @@ async fn main() -> anyhow::Result<()> {
                     })
                     .await;
             }
-            request.complete(tailtriage_core::Outcome::Ok);
+            request.finish(tailtriage_core::Outcome::Ok);
         }));
 
         if request_number % settings.inter_arrival_pause_every == 0 {

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -85,7 +85,7 @@ request
         Ok::<(), &'static str>(())
     })
     .await?;
-request.run_ok(async {}).await;
+request.finish_ok();
 
 tailtriage.shutdown()?;
 ```

--- a/tailtriage-cli/tests/end_to_end_capture_analysis.rs
+++ b/tailtriage-cli/tests/end_to_end_capture_analysis.rs
@@ -37,7 +37,7 @@ async fn queue_and_stage_data_drives_ranked_suspects() {
             .stage("local_work")
             .await_value(tokio::time::sleep(std::time::Duration::from_millis(1)))
             .await;
-        request.complete(tailtriage_core::Outcome::Ok);
+        request.finish(tailtriage_core::Outcome::Ok);
     }
 
     tailtriage.shutdown().expect("shutdown should succeed");
@@ -82,7 +82,7 @@ async fn downstream_heavy_stage_is_ranked() {
             .stage("render_response")
             .await_value(tokio::time::sleep(std::time::Duration::from_millis(2)))
             .await;
-        request.complete(tailtriage_core::Outcome::Ok);
+        request.finish(tailtriage_core::Outcome::Ok);
     }
 
     tailtriage.shutdown().expect("shutdown should succeed");
@@ -109,7 +109,7 @@ async fn low_evidence_run_yields_insufficient_signal() {
             tailtriage_core::RequestOptions::new().request_id(format!("insufficient-{index}")),
         );
         tokio::time::sleep(std::time::Duration::from_millis(1)).await;
-        request.complete(tailtriage_core::Outcome::Ok);
+        request.finish(tailtriage_core::Outcome::Ok);
     }
 
     tailtriage.shutdown().expect("shutdown should succeed");

--- a/tailtriage-core/src/collector.rs
+++ b/tailtriage-core/src/collector.rs
@@ -29,7 +29,7 @@ impl std::fmt::Debug for Tailtriage {
 }
 
 /// Reusable request context that carries correlation and timing state.
-#[must_use = "request contexts must be completed via complete(...) or a run_* helper"]
+#[must_use = "request contexts must be finished via finish(...) or a finish_* helper"]
 #[derive(Debug)]
 pub struct RequestContext<'a> {
     tailtriage: &'a Tailtriage,
@@ -38,6 +38,7 @@ pub struct RequestContext<'a> {
     kind: Option<String>,
     started_at_unix_ms: u64,
     started: Instant,
+    finished: bool,
 }
 
 impl Tailtriage {
@@ -94,6 +95,7 @@ impl Tailtriage {
             kind: None,
             started_at_unix_ms: unix_time_ms(),
             started: Instant::now(),
+            finished: false,
         }
     }
 
@@ -234,56 +236,57 @@ impl RequestContext<'_> {
         self.tailtriage.inflight(gauge)
     }
 
-    pub fn complete(self, outcome: Outcome) {
+    pub fn finish(mut self, outcome: Outcome) {
+        self.finish_internal(outcome);
+    }
+
+    pub fn finish_ok(self) {
+        self.finish(Outcome::Ok);
+    }
+
+    /// Records `ok`/`error` based on `result` and returns it unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns `result` unchanged, including the original `Err(E)` value.
+    pub fn finish_result<T, E>(self, result: Result<T, E>) -> Result<T, E> {
+        let outcome = if result.is_ok() {
+            Outcome::Ok
+        } else {
+            Outcome::Error
+        };
+        self.finish(outcome);
+        result
+    }
+
+    fn finish_internal(&mut self, outcome: Outcome) {
+        if self.finished {
+            debug_assert!(
+                !self.finished,
+                "tailtriage request context was finished more than once; each request must be finished exactly once"
+            );
+            return;
+        }
+        self.finished = true;
         let outcome = outcome.into_string();
         self.tailtriage.record_request_event(RequestEvent {
-            request_id: self.request_id,
-            route: self.route,
-            kind: self.kind,
+            request_id: self.request_id.clone(),
+            route: self.route.clone(),
+            kind: self.kind.clone(),
             started_at_unix_ms: self.started_at_unix_ms,
             finished_at_unix_ms: unix_time_ms(),
             latency_us: duration_to_us(self.started.elapsed()),
             outcome,
         });
     }
+}
 
-    /// Runs `fut` and records `outcome` when it finishes.
-    pub async fn run<Fut, T>(self, outcome: Outcome, fut: Fut) -> T
-    where
-        Fut: std::future::Future<Output = T>,
-    {
-        let output = fut.await;
-        self.complete(outcome);
-        output
-    }
-
-    /// Runs an infallible future and records [`Outcome::Ok`] on completion.
-    pub async fn run_ok<Fut, T>(self, fut: Fut) -> T
-    where
-        Fut: std::future::Future<Output = T>,
-    {
-        self.run(Outcome::Ok, fut).await
-    }
-
-    /// Runs a `Result` future and records `ok`/`error` automatically.
-    ///
-    /// `Ok(_)` is recorded as [`Outcome::Ok`], and `Err(_)` as [`Outcome::Error`].
-    ///
-    /// # Errors
-    ///
-    /// Returns any error produced by `fut` unchanged.
-    pub async fn run_result<Fut, T, E>(self, fut: Fut) -> Result<T, E>
-    where
-        Fut: std::future::Future<Output = Result<T, E>>,
-    {
-        let output = fut.await;
-        let outcome = if output.is_ok() {
-            Outcome::Ok
-        } else {
-            Outcome::Error
-        };
-        self.complete(outcome);
-        output
+impl Drop for RequestContext<'_> {
+    fn drop(&mut self) {
+        debug_assert!(
+            self.finished || std::thread::panicking(),
+            "tailtriage request context dropped without finish(...), finish_ok(), or finish_result(...)"
+        );
     }
 }
 

--- a/tailtriage-core/src/lib.rs
+++ b/tailtriage-core/src/lib.rs
@@ -11,7 +11,7 @@
 //! let request = tailtriage
 //!     .request_with("/checkout", RequestOptions::new().request_id("req-1"))
 //!     .with_kind("http");
-//! request.run_ok(async {}).await;
+//! request.finish_ok();
 //!
 //! tailtriage.shutdown()?;
 //! # Ok(())

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -1,4 +1,5 @@
 use std::future::ready;
+use std::panic::AssertUnwindSafe;
 use std::sync::{Arc, Mutex};
 
 use crate::{BuildError, CaptureLimits, Outcome, RequestOptions, Tailtriage};
@@ -40,7 +41,7 @@ fn request_context_records_request_event() {
     assert_eq!(request.route(), "/invoice");
     assert_eq!(request.kind(), Some("http"));
     futures_executor::block_on(request.stage("db").await_value(ready(())));
-    request.complete(Outcome::Ok);
+    request.finish_ok();
 
     let snapshot = tailtriage.snapshot();
     assert_eq!(snapshot.requests.len(), 1);
@@ -57,6 +58,8 @@ fn generated_request_ids_are_unique() {
     let first = tailtriage.request("/invoice");
     let second = tailtriage.request("/invoice");
     assert_ne!(first.request_id(), second.request_id());
+    first.finish_ok();
+    second.finish_ok();
 }
 
 #[test]
@@ -69,7 +72,7 @@ fn queue_stage_and_inflight_are_recorded() {
         let _: Result<(), ()> =
             futures_executor::block_on(request.stage("persist").await_on(ready(Ok(()))));
     }
-    request.complete(Outcome::Ok);
+    request.finish_ok();
 
     let snapshot = tailtriage.snapshot();
     assert_eq!(snapshot.inflight.len(), 2);
@@ -86,7 +89,7 @@ fn shutdown_writes_artifact() {
         .expect("build should succeed");
 
     let request = tailtriage.request("/health");
-    request.complete(Outcome::Ok);
+    request.finish_ok();
     tailtriage.shutdown().expect("shutdown should succeed");
 
     let bytes = std::fs::read(output).expect("artifact should exist");
@@ -114,12 +117,12 @@ fn capture_limits_apply_to_all_sections() {
     {
         let _guard = first.inflight("g");
     }
-    first.complete(Outcome::Ok);
+    first.finish_ok();
 
     let second = tailtriage.request_with("/invoice", RequestOptions::new().request_id("req-2"));
     futures_executor::block_on(second.stage("db").await_value(ready(())));
     futures_executor::block_on(second.queue("q").await_on(ready(())));
-    second.complete(Outcome::Ok);
+    second.finish_ok();
     tailtriage.record_runtime_snapshot(crate::RuntimeSnapshot {
         at_unix_ms: crate::unix_time_ms(),
         alive_tasks: Some(1),
@@ -146,12 +149,9 @@ fn capture_limits_apply_to_all_sections() {
 }
 
 #[test]
-fn run_records_outcome_after_future_completion() {
-    let tailtriage = build_for_test("payments", "tailtriage-core-run-sugar.json");
-    let request = tailtriage.request("/run-sugar");
-
-    let value = futures_executor::block_on(request.run(Outcome::Ok, ready(7_u8)));
-    assert_eq!(value, 7);
+fn finish_records_outcome() {
+    let tailtriage = build_for_test("payments", "tailtriage-core-finish.json");
+    tailtriage.request("/finish").finish(Outcome::Ok);
 
     let snapshot = tailtriage.snapshot();
     assert_eq!(snapshot.requests.len(), 1);
@@ -159,11 +159,10 @@ fn run_records_outcome_after_future_completion() {
 }
 
 #[test]
-fn run_ok_records_ok_outcome_for_infallible_future() {
-    let tailtriage = build_for_test("payments", "tailtriage-core-run-ok.json");
+fn finish_ok_records_ok_outcome() {
+    let tailtriage = build_for_test("payments", "tailtriage-core-finish-ok.json");
 
-    let value = futures_executor::block_on(tailtriage.request("/run-ok").run_ok(ready(11_u8)));
-    assert_eq!(value, 11);
+    tailtriage.request("/finish-ok").finish_ok();
 
     let snapshot = tailtriage.snapshot();
     assert_eq!(snapshot.requests.len(), 1);
@@ -171,25 +170,19 @@ fn run_ok_records_ok_outcome_for_infallible_future() {
 }
 
 #[test]
-fn run_result_maps_result_to_request_outcome() {
-    let tailtriage = build_for_test("payments", "tailtriage-core-run-result.json");
+fn finish_result_maps_result_to_request_outcome() {
+    let tailtriage = build_for_test("payments", "tailtriage-core-finish-result.json");
 
-    let ok_value =
-        futures_executor::block_on(tailtriage.request("/run-result-ok").run_result(ready::<
-            Result<u8, &'static str>,
-        >(Ok(
-            3,
-        ))))
-        .expect("ok future should return ok");
+    let ok_value = tailtriage
+        .request("/finish-result-ok")
+        .finish_result(Ok::<u8, &'static str>(3))
+        .expect("ok result should remain ok");
     assert_eq!(ok_value, 3);
 
-    let err =
-        futures_executor::block_on(tailtriage.request("/run-result-err").run_result(ready::<
-            Result<u8, &'static str>,
-        >(
-            Err("boom")
-        )))
-        .expect_err("err future should return err");
+    let err = tailtriage
+        .request("/finish-result-err")
+        .finish_result::<u8, _>(Err("boom"))
+        .expect_err("err result should remain err");
     assert_eq!(err, "boom");
 
     let snapshot = tailtriage.snapshot();
@@ -223,7 +216,7 @@ fn request_context_supports_fractured_code_usage() {
         .expect("helper stage should succeed");
     futures_executor::block_on(stage_in_helper_layer(&request, "layer_b"))
         .expect("helper stage should succeed");
-    request.complete(Outcome::Ok);
+    request.finish_ok();
 
     let snapshot = tailtriage.snapshot();
     assert_eq!(snapshot.requests.len(), 1);
@@ -239,7 +232,7 @@ fn custom_sink_receives_shutdown_run() {
         .build()
         .expect("build should succeed");
 
-    tailtriage.request("/sink-test").complete(Outcome::Ok);
+    tailtriage.request("/sink-test").finish_ok();
     tailtriage.shutdown().expect("shutdown should succeed");
 
     let stored = sink
@@ -249,4 +242,14 @@ fn custom_sink_receives_shutdown_run() {
         .clone()
         .expect("sink should receive run");
     assert_eq!(stored.requests.len(), 1);
+}
+
+#[cfg(debug_assertions)]
+#[test]
+fn dropping_unfinished_request_panics_in_debug() {
+    let tailtriage = build_for_test("payments", "tailtriage-core-drop-unfinished.json");
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        let _request = tailtriage.request("/unfinished");
+    }));
+    assert!(result.is_err(), "unfinished request should panic in debug");
 }

--- a/tailtriage-tokio/examples/mini_service_integration.rs
+++ b/tailtriage-tokio/examples/mini_service_integration.rs
@@ -67,10 +67,7 @@ async fn handle_checkout(
         authorize_payment(&request_ctx).await?;
     }
 
-    request_ctx
-        .run_result(async { Ok::<(), &'static str>(()) })
-        .await?;
-    Ok(())
+    request_ctx.finish_result(Ok(()))
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/tailtriage-tokio/examples/minimal_checkout.rs
+++ b/tailtriage-tokio/examples/minimal_checkout.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         })
         .await?;
 
-    request.run_ok(async {}).await;
+    request.finish_ok();
 
     tailtriage.shutdown()?;
     println!("Wrote {artifact_path}");


### PR DESCRIPTION
### Motivation

- The request lifecycle surface was noisy: multiple terminal helpers (`complete`, `run`, `run_ok`, `run_result`) encouraged wrapper-style usage and taught the trailing no-op future pattern in examples. 
- The public API should present one clear terminal concept that works naturally across fractured code paths and is easy to teach and use.
- Make unfinished-request misuse easier to catch during development without adding production-side noise.

### Description

- Replaced the old terminal API on `RequestContext` with a lean `finish` family: added `finish(self, Outcome)`, `finish_ok(self)`, and `finish_result(self, Result<T,E>) -> Result<T,E>`, and removed `run`, `run_ok`, and `run_result`.
- Introduced an internal `finished: bool` flag to prevent double-recording and added debug-only assertions on double-finish and on `Drop` when a context is dropped unfinished (except during panic unwinding), keeping production behavior quiet.
- Updated rustdoc, `README.md`, `docs/user-guide.md`, `SPEC.md`, tokio examples (`minimal_checkout`, `mini_service_integration`), demo binaries, CLI end-to-end tests, and core unit tests to use the `finish*` API and to remove trailing fake futures.
- Adjusted unit tests to cover `finish`, `finish_ok`, `finish_result` behavior and added a debug-only test asserting unfinished-drop detection.

### Testing

- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it passed.
- Ran the full test suite with `cargo test --workspace` and all tests passed.
- Ran demo validation `python3 scripts/tests/test_demo_scripts.py` and all demo script checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfb01253708330a684e90a940d6bac)