### PR TITLE
Polish finish-based lifecycle docs and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,26 @@ MVP scope is intentionally narrow:
 - no live UI
 - no exporter/backend requirement
 
+## Request lifecycle
+
+Every `RequestContext` starts one request lifecycle and must be finished **exactly once**.
+
+```rust
+let request = tailtriage.request("/checkout").with_kind("http");
+
+// queue/stage/inflight instrumentation here
+
+request.finish_ok();
+```
+
+Lifecycle contract:
+
+- `queue(...)`, `stage(...)`, and `inflight(...)` record instrumentation only; they do **not** finish the request.
+- You must call one terminal method exactly once: `finish(...)`, `finish_ok()`, or `finish_result(...)`.
+- `Drop` is a debug-time misuse detector only: unfinished `RequestContext` values trigger a debug assertion in development builds.
+- `Drop` does **not** infer success/error and does **not** record request completion automatically.
+- Do not rely on scope exit as request completion.
+
 ## Bounded capture and truncation
 
 `tailtriage` keeps run data in memory until shutdown. To keep this bounded in production-like runs, configure per-section capture limits on the builder:
@@ -163,7 +183,7 @@ let tailtriage = Tailtriage::builder("checkout-service")
 Important request-lifecycle safety note:
 
 - `RequestContext` is `#[must_use]`, and debug builds assert if it is dropped unfinished.
-- Finish each request with `finish(...)`, `finish_ok(...)`, or `finish_result(...)`.
+- Finish each request with `finish(...)`, `finish_ok()`, or `finish_result(...)`; scope exit does not finish requests.
 
 Capture limit knobs:
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -89,6 +89,18 @@ request.finish_ok();
 let result: Result<(), MyError> = request.finish_result(downstream_call().await);
 ```
 
+### 5.2.1 Request lifecycle contract
+
+`RequestContext` starts a request lifecycle and instrumentation wrappers (`queue(...)`, `stage(...)`, `inflight(...)`) do not complete it.
+
+Every request context must call exactly one terminal method:
+
+- `finish(...)`
+- `finish_ok()`
+- `finish_result(...)`
+
+If a request context is dropped unfinished, debug builds assert to surface misuse during development. This assertion is a development aid only: `Drop` does **not** infer an outcome and does **not** auto-record request completion.
+
 ### 5.3 In-flight tracking
 
 ```rust

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -12,7 +12,7 @@ Use this path when you are evaluating `tailtriage` from a local clone of this re
 cargo run -p tailtriage-tokio --example minimal_checkout
 ```
 
-Expected output includes `wrote tailtriage-run.json`.
+Expected output includes `Wrote tailtriage-run.json`.
 
 If you want a more realistic request + queue + worker shape outside the synthetic demos, run:
 
@@ -21,6 +21,26 @@ cargo run -p tailtriage-tokio --example mini_service_integration
 ```
 
 This mini-service example is an adoption-confidence reference and does **not** replace the demo suite.
+
+## Finish every request explicitly
+
+Every `RequestContext` starts one request lifecycle. Queue/stage/inflight instrumentation does not finish that lifecycle; you must finish it explicitly exactly once.
+
+```rust
+let request = tailtriage.request("/checkout").with_kind("http");
+
+// queue/stage/inflight instrumentation here
+
+request.finish_ok();
+```
+
+Use one terminal method per request:
+
+- `finish(...)`
+- `finish_ok()`
+- `finish_result(...)`
+
+`Drop` is only a debug-time misuse detector. In debug builds, dropping an unfinished context asserts so you catch forgotten finishes during development. `Drop` does **not** infer an outcome and does **not** record request completion automatically.
 
 ### 2) Analyze with the workspace CLI crate
 

--- a/tailtriage-core/src/collector.rs
+++ b/tailtriage-core/src/collector.rs
@@ -29,6 +29,14 @@ impl std::fmt::Debug for Tailtriage {
 }
 
 /// Reusable request context that carries correlation and timing state.
+///
+/// A `RequestContext` starts one request lifecycle. Instrumentation helpers
+/// (`queue(...)`, `stage(...)`, and `inflight(...)`) do not finish that lifecycle.
+/// You must call exactly one terminal method: [`Self::finish`], [`Self::finish_ok`],
+/// or [`Self::finish_result`].
+///
+/// `Drop` only detects misuse in debug builds (unfinished contexts). It does not
+/// infer an outcome and does not auto-record request completion.
 #[must_use = "request contexts must be finished via finish(...) or a finish_* helper"]
 #[derive(Debug)]
 pub struct RequestContext<'a> {
@@ -236,14 +244,25 @@ impl RequestContext<'_> {
         self.tailtriage.inflight(gauge)
     }
 
+    /// Finishes this request with an explicit [`Outcome`].
+    ///
+    /// Use this when you already know the terminal outcome.
     pub fn finish(mut self, outcome: Outcome) {
         self.finish_internal(outcome);
     }
 
+    /// Convenience helper for successfully completed requests.
+    ///
+    /// Equivalent to `finish(Outcome::Ok)`.
     pub fn finish_ok(self) {
         self.finish(Outcome::Ok);
     }
 
+    /// Finishes this request from `result` and returns `result` unchanged.
+    ///
+    /// Use this when your request handler already ends in a `Result` and you want
+    /// a single terminal expression like `request.finish_result(result)`.
+    ///
     /// Records `ok`/`error` based on `result` and returns it unchanged.
     ///
     /// # Errors
@@ -281,6 +300,9 @@ impl RequestContext<'_> {
     }
 }
 
+/// Debug-only misuse detection for unfinished request contexts.
+///
+/// This does not auto-finish requests or record request outcomes.
 impl Drop for RequestContext<'_> {
     fn drop(&mut self) {
         debug_assert!(

--- a/tailtriage-core/src/lib.rs
+++ b/tailtriage-core/src/lib.rs
@@ -11,7 +11,12 @@
 //! let request = tailtriage
 //!     .request_with("/checkout", RequestOptions::new().request_id("req-1"))
 //!     .with_kind("http");
+//!
+//! // queue(...), stage(...), and inflight(...) instrumentation can happen here.
+//! // They do not finish the request lifecycle.
 //! request.finish_ok();
+//! // You must finish each request exactly once via finish(...), finish_ok(), or finish_result(...).
+//! // Drop only asserts on unfinished requests in debug builds; it does not auto-record completion.
 //!
 //! tailtriage.shutdown()?;
 //! # Ok(())

--- a/tailtriage-tokio/examples/mini_service_integration.rs
+++ b/tailtriage-tokio/examples/mini_service_integration.rs
@@ -46,7 +46,7 @@ async fn handle_checkout(
         )
         .with_kind("http");
 
-    {
+    let result = async {
         let _inflight = request_ctx.inflight("checkout_inflight");
 
         request_ctx
@@ -64,10 +64,11 @@ async fn handle_checkout(
             )))
             .await;
 
-        authorize_payment(&request_ctx).await?;
+        authorize_payment(&request_ctx).await
     }
+    .await;
 
-    request_ctx.finish_result(Ok(()))
+    request_ctx.finish_result(result)
 }
 
 #[tokio::main(flavor = "current_thread")]


### PR DESCRIPTION
### Motivation

- Make the finish-based request lifecycle explicit and unambiguous across launch-facing docs and examples so users understand they must explicitly finish every request. 
- Emphasize that `Drop` is only a debug-time misuse detector and is not a substitute for calling a terminal finish method. 

### Description

- Add a dedicated "Request lifecycle" section to `README.md` that states every `RequestContext` must be finished exactly once and that `queue(...)`, `stage(...)`, and `inflight(...)` are non-terminal instrumentation. 
- Add a "Finish every request explicitly" section to `docs/user-guide.md` and add a lifecycle contract subsection to `SPEC.md` with the required terminal methods: `finish(...)`, `finish_ok()`, and `finish_result(...)`. 
- Strengthen rustdoc: update `tailtriage-core/src/lib.rs` and `tailtriage-core/src/collector.rs` to document when to use `finish`, `finish_ok`, and `finish_result`, and to state that `Drop` only asserts on unfinished contexts (it does not auto-record completion). 
- Improve example teaching: update `tailtriage-tokio/examples/mini_service_integration.rs` to use the natural `let result = ...; request_ctx.finish_result(result)` pattern and fix a small output wording mismatch (`Wrote tailtriage-run.json`) in docs/examples. 

### Testing

- Ran `cargo fmt --check` and it passed. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it passed. 
- Ran `cargo test --workspace` and the full test-suite passed. 
- Ran `python3 scripts/tests/test_demo_scripts.py` and the demo script tests passed (all tests OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfb33baab48330a5130fcf07d04aae)