### PR TITLE
Make api-change the canonical API path on main

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Declared the `api-change` line as the canonical public API direction for `main`, prioritizing one unified onboarding path over overlapping legacy integration styles.
 - Added a fresh dated MVP audit snapshot (`docs/mvp-audit-2026-03-20.md`) with current acceptance/milestone/scope verification results.
 - Consolidated documentation structure around `docs/README.md` as the canonical docs index.
 - Reduced duplication across README/user guide/diagnostics/demo docs while keeping MVP integration and diagnosis guidance intact.


### PR DESCRIPTION
### Motivation
- The project is converging on a single unified public API and docs should direct users to one canonical onboarding path to avoid teaching multiple competing integration styles.

### Description
- Added a single unreleased changelog entry in `docs/changelog.md` declaring the `api-change` line as the canonical public API direction for `main` and documenting the intent to prioritize one onboarding path over legacy alternatives.

### Testing
- Ran `cargo fmt --check` which succeeded. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` which completed without warnings. 
- Ran `cargo test --workspace` and the full test suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfc0e5fe0c83308701777a3c75fd6f)