### PR TITLE
Follow-up: crate-specific landing pages for core/tokio/cli packages

### DIFF
--- a/tailtriage-cli/Cargo.toml
+++ b/tailtriage-cli/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 description = "CLI for Tokio tail-latency triage reports with evidence-ranked suspects and next checks"
 repository = "https://github.com/tailtriage/tailtriage"
 documentation = "https://docs.rs/tailtriage-cli"
-readme = "../README.md"
+readme = "README.md"
 keywords = ["tokio", "latency", "cli", "diagnostics", "triage"]
 categories = ["command-line-utilities", "development-tools::profiling", "development-tools::debugging"]
 

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -1,0 +1,46 @@
+# tailtriage-cli
+
+Command-line diagnosis tool for one `tailtriage` run artifact.
+
+`tailtriage-cli` reads a JSON artifact and produces a report with evidence-ranked suspects and next checks.
+
+## Install
+
+This repository is pre-publish.
+
+- **After first crates.io publish:** install with `cargo install tailtriage-cli`.
+- **Before publish (current state):** run from source in this repository.
+
+## Analyze one artifact
+
+From this repository today (pre-publish):
+
+```bash
+cargo run -p tailtriage-cli -- analyze tailtriage-run.json
+```
+
+Post-publish path:
+
+```bash
+tailtriage analyze tailtriage-run.json
+```
+
+## Output shape to inspect first
+
+Start with:
+
+1. Top-ranked suspects and their evidence,
+2. `next_checks` to decide what to instrument or capture next,
+3. confidence/coverage caveats (suspects are leads, not proof).
+
+For machine processing, use JSON output:
+
+```bash
+tailtriage analyze tailtriage-run.json --format json
+```
+
+## Related docs
+
+- Data capture API (`tailtriage-core`): <https://docs.rs/tailtriage-core>
+- Tokio runtime sampling (`tailtriage-tokio`): <https://docs.rs/tailtriage-tokio>
+- Repository docs and demos: <https://github.com/tailtriage/tailtriage>

--- a/tailtriage-cli/src/lib.rs
+++ b/tailtriage-cli/src/lib.rs
@@ -1,2 +1,4 @@
+#![doc = include_str!("../README.md")]
+
 pub mod analyze;
 pub mod artifact;

--- a/tailtriage-core/Cargo.toml
+++ b/tailtriage-core/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 description = "Core data model and analyzer for Tokio tail-latency triage with evidence-ranked suspects"
 repository = "https://github.com/tailtriage/tailtriage"
 documentation = "https://docs.rs/tailtriage-core"
-readme = "../README.md"
+readme = "README.md"
 keywords = ["tokio", "latency", "diagnostics", "performance", "triage"]
 categories = ["asynchronous", "development-tools::profiling", "development-tools::debugging"]
 

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -1,0 +1,65 @@
+# tailtriage-core
+
+Core run schema, request-context lifecycle, and instrumentation primitives for `tailtriage`.
+
+`tailtriage-core` is the crate that owns the data model consumed by the CLI analyzer and the per-request capture API used by integrations.
+
+## What this crate owns
+
+- Run artifact schema (`RunArtifact`, requests, runtime snapshots).
+- Unified request-context model (`Tailtriage`, `RequestContext`).
+- Instrumentation primitives for queue wait, stage timing, and in-flight spans.
+- Request lifecycle completion (`finish`, `finish_ok`, `finish_result`) and final artifact flush (`shutdown`).
+
+## When to depend on `tailtriage-core` directly
+
+Use this crate directly when you want to:
+
+- instrument request/work-item flow in your service,
+- produce run JSON artifacts for triage,
+- or build custom integration code without Tokio runtime sampling.
+
+If you also want periodic Tokio runtime metrics in the same run artifact, add `tailtriage-tokio` alongside this crate.
+
+## Minimal usage
+
+```rust,no_run
+use tailtriage_core::{RequestOptions, Tailtriage};
+
+# async fn demo() -> Result<(), Box<dyn std::error::Error>> {
+let tailtriage = Tailtriage::builder("checkout-service")
+    .output("tailtriage-run.json")
+    .build()?;
+
+let request = tailtriage
+    .request_with("/checkout", RequestOptions::new().request_id("req-1"))
+    .with_kind("http");
+
+request.queue("ingress").await_on(async {
+    // wait for semaphore / bounded queue
+}).await;
+
+request.stage("db").await_on(async {
+    // downstream stage call
+    Ok::<(), std::io::Error>(())
+}).await?;
+
+request.finish_ok();
+
+tailtriage.shutdown()?;
+# Ok(())
+# }
+```
+
+## First-use guidance
+
+This repository is pre-publish.
+
+- **After first crates.io publish:** add `tailtriage-core` in your app's `Cargo.toml`.
+- **Before publish (current state):** use the workspace path dependency from this repository.
+
+## Related docs
+
+- Tokio integration and `RuntimeSampler`: <https://docs.rs/tailtriage-tokio>
+- CLI analysis workflow: <https://docs.rs/tailtriage-cli>
+- Repository guide and demos: <https://github.com/tailtriage/tailtriage>

--- a/tailtriage-core/src/lib.rs
+++ b/tailtriage-core/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 //! Core run schema and request-context instrumentation API for tailtriage.
 //!
 //! ```no_run

--- a/tailtriage-tokio/Cargo.toml
+++ b/tailtriage-tokio/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 description = "Tokio runtime sampling and request instrumentation helpers for tail-latency triage"
 repository = "https://github.com/tailtriage/tailtriage"
 documentation = "https://docs.rs/tailtriage-tokio"
-readme = "../README.md"
+readme = "README.md"
 keywords = ["tokio", "latency", "instrumentation", "async", "triage"]
 categories = ["asynchronous", "development-tools::profiling", "development-tools::debugging"]
 

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -1,0 +1,74 @@
+# tailtriage-tokio
+
+Tokio-specific integration for `tailtriage`, including `RuntimeSampler` for periodic runtime snapshots.
+
+This crate extends the same `tailtriage-core` request-context workflow with Tokio runtime evidence.
+
+## What this crate provides
+
+- `RuntimeSampler`: periodic Tokio runtime metrics collection into the active run.
+- Integration points that keep runtime evidence and request instrumentation in one artifact.
+
+## What `RuntimeSampler` does
+
+`RuntimeSampler` periodically records runtime snapshots such as:
+
+- worker saturation hints,
+- queue/backlog indicators,
+- blocking-pool pressure indicators.
+
+These snapshots improve triage reports when you need separation between executor pressure, blocking-pool pressure, and application-level queueing.
+
+## When runtime sampling is useful vs optional
+
+Use runtime sampling when:
+
+- service slowdowns are intermittent,
+- queueing/executor/blocking-pool suspects are hard to separate from request data alone,
+- you want richer evidence-ranked suspects in one run artifact.
+
+Skip runtime sampling when:
+
+- you only need request-level stage and queue instrumentation,
+- or you want the lowest-overhead capture mode first.
+
+`tailtriage-core` remains valid without this crate; `tailtriage-tokio` is an optional enrichment path.
+
+## Minimal usage
+
+```rust,no_run
+use std::sync::Arc;
+use std::time::Duration;
+
+use tailtriage_core::Tailtriage;
+use tailtriage_tokio::RuntimeSampler;
+
+# async fn demo() -> Result<(), Box<dyn std::error::Error>> {
+let tailtriage = Arc::new(
+    Tailtriage::builder("checkout-service")
+        .output("tailtriage-run.json")
+        .build()?,
+);
+
+let sampler = RuntimeSampler::start(Arc::clone(&tailtriage), Duration::from_millis(200))?;
+
+// ... run workload ...
+
+sampler.shutdown().await;
+tailtriage.shutdown()?;
+# Ok(())
+# }
+```
+
+## First-use guidance
+
+This repository is pre-publish.
+
+- **After first crates.io publish:** add `tailtriage-tokio` and `tailtriage-core` to your app dependencies.
+- **Before publish (current state):** use workspace path dependencies from this repository.
+
+## Related docs
+
+- Core request instrumentation API: <https://docs.rs/tailtriage-core>
+- CLI diagnosis workflow: <https://docs.rs/tailtriage-cli>
+- Repository guide and demos: <https://github.com/tailtriage/tailtriage>

--- a/tailtriage-tokio/src/lib.rs
+++ b/tailtriage-tokio/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 //! Tokio runtime integration for tailtriage.
 //!
 //! This crate provides [`RuntimeSampler`] for periodic Tokio runtime metrics


### PR DESCRIPTION
### Motivation

- Ensure each publishable crate presents a crate-appropriate landing surface on crates.io/docs.rs instead of the workspace root README. 
- Provide clear first-use guidance per crate so package users are not guided to workspace-first onboarding.

### Description

- Added crate-specific `README.md` files for `tailtriage-core`, `tailtriage-tokio`, and `tailtriage-cli` with focused first-use guidance and truthful pre-publish wording. 
- Updated each crate `Cargo.toml` to point `readme = "README.md"` so crates.io/docs.rs and packaging use the crate-local README. 
- Included each crate README as crate-level rustdoc via `#![doc = include_str!("../README.md")]` in the library entry points to make docs.rs landing content crate-specific. 
- Adjusted example snippets in the READMEs to match the current public API (e.g., use `RuntimeSampler::start`, `QueueTimer::await_on`, and `Arc` where appropriate). 

### Testing

- Ran `cargo fmt --check` and it passed. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it passed. 
- Ran `cargo test --workspace` and all tests (including doc-tests) passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bff761791c833099f6eb2c94b0e16e)