### PR TITLE
Follow-up: correct p95 share metric wording in public docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
 - `primary_suspect.kind`
 - `primary_suspect.evidence[]`
 - `primary_suspect.next_checks[]`
-- `p95_queue_share_permille`
-- `p95_service_share_permille`
+- `p95_queue_share_permille` (95th percentile of per-request queue-time share)
+- `p95_service_share_permille` (95th percentile of per-request service-time share)
 
 ### Path B — Adopt in your app (crates.io)
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -8,7 +8,7 @@ This document explains how `tailtriage analyze` produces a triage report and how
 
 - request count
 - request latency percentiles (p50/p95/p99)
-- p95 request-time shares:
+- p95 per-request share percentiles:
   - `p95_queue_share_permille`
   - `p95_service_share_permille`
 - optional in-flight trend summary
@@ -29,8 +29,8 @@ Each suspect includes:
 | --- | --- | --- |
 | `request_count` | `usize` | Requests observed in the run. |
 | `p50_latency_us` / `p95_latency_us` / `p99_latency_us` | `Option<u64>` | Request latency percentiles (microseconds). |
-| `p95_queue_share_permille` | `Option<u64>` | Queue-time share of p95 request latency (0-1000). |
-| `p95_service_share_permille` | `Option<u64>` | Service/stage share of p95 request latency (0-1000). |
+| `p95_queue_share_permille` | `Option<u64>` | 95th percentile of per-request queue-time share (0-1000). |
+| `p95_service_share_permille` | `Option<u64>` | 95th percentile of per-request service-time share (0-1000). |
 | `inflight_trend` | `Option<InflightTrend>` | Dominant in-flight gauge trend when snapshots exist. |
 | `warnings` | `Vec<String>` | Analyzer warnings, including capture truncation context from run artifacts. |
 | `primary_suspect` | `Suspect` | Highest-ranked suspect. |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -55,8 +55,8 @@ Inspect these fields first:
 - `primary_suspect.kind`
 - `primary_suspect.evidence[]`
 - `primary_suspect.next_checks[]`
-- `p95_queue_share_permille`
-- `p95_service_share_permille`
+- `p95_queue_share_permille` (95th percentile of per-request queue-time share)
+- `p95_service_share_permille` (95th percentile of per-request service-time share)
 
 ## Path B — Adopt in your app (crates.io)
 
@@ -125,8 +125,8 @@ Inspect these fields first:
 - `primary_suspect.kind`
 - `primary_suspect.evidence[]`
 - `primary_suspect.next_checks[]`
-- `p95_queue_share_permille`
-- `p95_service_share_permille`
+- `p95_queue_share_permille` (95th percentile of per-request queue-time share)
+- `p95_service_share_permille` (95th percentile of per-request service-time share)
 
 Representative diagnosis shape:
 


### PR DESCRIPTION
### Motivation
- Public docs implied the metrics described a single p95 request decomposition while the analyzer computes the 95th percentile across per-request share values, so wording needed to be corrected for trustworthy interpretation. 

### Description
- Clarified metric wording in `README.md` to state `p95_queue_share_permille` and `p95_service_share_permille` are the 95th percentiles of per-request queue/service-time share. 
- Applied identical wording updates in both interpretation sections of `docs/user-guide.md` (workspace and crates.io adoption guidance). 
- Updated `docs/diagnostics.md` to use “p95 per-request share percentiles” and adjusted the JSON field table to match implementation semantics.

### Testing
- Ran `cargo fmt --check` and it succeeded. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it succeeded. 
- Ran `cargo test --workspace` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bff73ef8c88330b6a010db93f457c8)