### PR TITLE
Follow-up: align crate README repo links with canonical URL

### DIFF
--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -43,4 +43,4 @@ tailtriage analyze tailtriage-run.json --format json
 
 - Data capture API (`tailtriage-core`): <https://docs.rs/tailtriage-core>
 - Tokio runtime sampling (`tailtriage-tokio`): <https://docs.rs/tailtriage-tokio>
-- Repository docs and demos: <https://github.com/tailtriage/tailtriage>
+- Repository docs and demos: <https://github.com/SG-devel/tailtriage>

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -62,4 +62,4 @@ This repository is pre-publish.
 
 - Tokio integration and `RuntimeSampler`: <https://docs.rs/tailtriage-tokio>
 - CLI analysis workflow: <https://docs.rs/tailtriage-cli>
-- Repository guide and demos: <https://github.com/tailtriage/tailtriage>
+- Repository guide and demos: <https://github.com/SG-devel/tailtriage>

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -71,4 +71,4 @@ This repository is pre-publish.
 
 - Core request instrumentation API: <https://docs.rs/tailtriage-core>
 - CLI diagnosis workflow: <https://docs.rs/tailtriage-cli>
-- Repository guide and demos: <https://github.com/tailtriage/tailtriage>
+- Repository guide and demos: <https://github.com/SG-devel/tailtriage>


### PR DESCRIPTION
### Motivation

- Prevent public-facing docs from pointing to a stale future/org URL and ensure docs.rs or other external pages don’t send users to the wrong repository.
- Resolve a mismatch where crate `Cargo.toml` `repository` fields used `https://github.com/SG-devel/tailtriage` while some crate READMEs referenced `https://github.com/tailtriage/tailtriage`.

### Description

- Replaced the repository link in `tailtriage-core/README.md` to `https://github.com/SG-devel/tailtriage`.
- Replaced the repository link in `tailtriage-tokio/README.md` to `https://github.com/SG-devel/tailtriage`.
- Replaced the repository link in `tailtriage-cli/README.md` to `https://github.com/SG-devel/tailtriage`.

### Testing

- Ran `grep -R "github.com/tailtriage/tailtriage" -n .` and confirmed there are no remaining matches.
- Ran `grep -R "github.com/SG-devel/tailtriage" -n .` to verify canonical occurrences remain where expected.
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0440db5d88330b666b55d57627aaf)