### PR TITLE
Document RuntimeSampler stable vs tokio_unstable capability boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ Core question:
 
 Workflow in one line: **capture -> analyze -> choose next check -> re-run**.
 
+## RuntimeSampler availability note (stable Tokio vs `tokio_unstable`)
+
+When you enable `tailtriage-tokio::RuntimeSampler`, runtime snapshot fields differ by Tokio build mode:
+
+- Always available on stable Tokio: `alive_tasks`, `global_queue_depth`
+- Requires `tokio_unstable`: `local_queue_depth`, `blocking_queue_depth`, `remote_schedule_count`
+
+On stable Tokio, unstable-only fields are captured as `None`, so executor-pressure vs blocking-pool-pressure separation can be weaker depending on captured request/runtime evidence.
+
 ## Who it is for
 
 - developers shipping Tokio services

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -63,6 +63,12 @@ These are **evidence-ranked leads**, not causal proof.
 - `BlockingPoolPressure` emphasizes `spawn_blocking` backlog signals (for example, elevated blocking queue depth evidence).
 - If blocking queue depth remains low/absent while runtime queue depth rises, prefer executor-pressure next checks before blocking-pool tuning.
 
+Runtime-signal availability caveat:
+
+- On stable Tokio, `RuntimeSampler` always captures `alive_tasks` and `global_queue_depth`.
+- `local_queue_depth`, `blocking_queue_depth`, and `remote_schedule_count` require `tokio_unstable` and are otherwise `None`.
+- As a result, blocking-pool vs executor suspect separation may be weaker on stable builds; treat ranking as directional triage and prioritize follow-up checks.
+
 ## In-flight trend fields
 
 When present:

--- a/docs/getting-started-demo.md
+++ b/docs/getting-started-demo.md
@@ -46,6 +46,8 @@ These remain useful, but are more synthetic than the first two tiers:
 - `blocking_service`
 - `executor_pressure_service`
 
+Important: these two demos intentionally model stronger blocking/executor contrast signals than many real services naturally expose by default. They are useful triage-contract exercises, not proof that equivalent runtime signals are always present in user applications.
+
 ## Artifact policy
 
 - `demos/*/artifacts/`: generated, untracked local outputs.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -175,6 +175,25 @@ let sampler = RuntimeSampler::start(
 sampler.shutdown().await;
 ```
 
+### RuntimeSampler metric availability
+
+`RuntimeSampler` does not expose the same fields in all Tokio build modes.
+
+Always available on stable Tokio:
+
+- `alive_tasks`
+- `global_queue_depth`
+
+Available only with `tokio_unstable`:
+
+- `local_queue_depth`
+- `blocking_queue_depth`
+- `remote_schedule_count`
+
+Without `tokio_unstable`, unstable-only fields are captured as `None`.
+
+This means runtime sampling still helps triage on stable Tokio, but blocking-pool vs executor separation can be less decisive depending on which request-level signals you captured.
+
 ## Before/after proof path
 
 After first run, validate one mitigation workflow:

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -19,6 +19,30 @@ This crate extends the same `tailtriage-core` request-context workflow with Toki
 
 These snapshots improve triage reports when you need separation between executor pressure, blocking-pool pressure, and application-level queueing.
 
+## `RuntimeSampler` metric availability (stable Tokio vs `tokio_unstable`)
+
+`RuntimeSampler` records a `RuntimeSnapshot` with fields that map directly to Tokio runtime metrics.
+
+Always available on stable Tokio:
+
+- `alive_tasks`
+- `global_queue_depth`
+
+Available only when compiling with `--cfg tokio_unstable`:
+
+- `local_queue_depth`
+- `blocking_queue_depth`
+- `remote_schedule_count`
+
+When `tokio_unstable` is not enabled, those unstable-only fields are recorded as `None` in snapshots.
+
+Practical triage implication:
+
+- on stable Tokio, `tailtriage` can still provide useful runtime enrichment,
+- but executor-pressure vs blocking-pool-pressure separation is often weaker because some scheduler and blocking-pool signals are unavailable.
+
+Treat suspects as evidence-ranked leads and follow the recommended next checks before concluding root cause.
+
 ## When runtime sampling is useful vs optional
 
 Use runtime sampling when:


### PR DESCRIPTION
### Motivation

- Make public docs honest about which Tokio runtime metrics `RuntimeSampler` can access so users do not infer stronger out-of-the-box attribution than the implementation provides. 
- Clarify how metric availability affects executor-pressure vs blocking-pool-pressure separation and demo interpretation.

### Description

- Added an explicit capability matrix to `tailtriage-tokio/README.md` describing which `RuntimeSnapshot` fields are always available (`alive_tasks`, `global_queue_depth`) and which require `tokio_unstable` (`local_queue_depth`, `blocking_queue_depth`, `remote_schedule_count`).
- Added the same `RuntimeSampler` availability note to the workspace `README.md` and the `docs/user-guide.md` runtime-sampling section. 
- Extended `docs/diagnostics.md` to include a runtime-signal availability caveat when interpreting executor vs blocking suspects. 
- Clarified in `docs/getting-started-demo.md` that the `blocking_service` and `executor_pressure_service` demos are synthetic exercises and not proof that equivalent runtime signals are always present in user applications.

### Testing

- Ran `cargo fmt --check` and it succeeded. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings`; it initially failed on a documentation markdown lint which was fixed, and the final `cargo clippy` run succeeded. 
- Ran `cargo test --workspace` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0463039e883309813b6e592e02ed1)