### PR TITLE
Follow-up: enforce strict schema_version contract for run artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ cargo run -p tailtriage-tokio --example mini_service_integration
 
 That example is intentionally outside `demos/` and exists only as a realistic integration reference (not a production case study).
 
-2) Analyze that artifact with the workspace CLI crate:
+2) Analyze that artifact with the workspace CLI crate (artifacts include required top-level `schema_version: 1`):
 
 ```bash
 cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json

--- a/demos/blocking_service/fixtures/after-analysis.json
+++ b/demos/blocking_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 250,
-  "p50_latency_us": 55720,
-  "p95_latency_us": 88888,
-  "p99_latency_us": 92354,
-  "p95_queue_share_permille": 55,
-  "p95_service_share_permille": 991,
+  "p50_latency_us": 44842,
+  "p95_latency_us": 108312,
+  "p99_latency_us": 118982,
+  "p95_queue_share_permille": 67,
+  "p95_service_share_permille": 990,
   "inflight_trend": {
     "gauge": "blocking_service_inflight",
     "sample_count": 500,
-    "peak_count": 49,
-    "p95_count": 47,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -2040
+    "peak_count": 33,
+    "p95_count": 30,
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
   },
   "warnings": [],
   "primary_suspect": {
@@ -19,7 +19,7 @@
     "score": 80,
     "confidence": "medium",
     "evidence": [
-      "Blocking queue depth p95 is 45, indicating sustained spawn_blocking backlog."
+      "Blocking queue depth p95 is 28, indicating sustained spawn_blocking backlog."
     ],
     "next_checks": [
       "Audit blocking sections and move avoidable synchronous work out of hot paths.",
@@ -32,9 +32,9 @@
       "score": 79,
       "confidence": "medium",
       "evidence": [
-        "Stage 'spawn_blocking_path' has p95 latency 87633 us across 250 samples.",
-        "Stage 'spawn_blocking_path' cumulative latency is 13557163 us.",
-        "Stage 'spawn_blocking_path' contributes 978 permille of cumulative request latency."
+        "Stage 'spawn_blocking_path' has p95 latency 107135 us across 250 samples.",
+        "Stage 'spawn_blocking_path' cumulative latency is 11589441 us.",
+        "Stage 'spawn_blocking_path' contributes 970 permille of cumulative request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'spawn_blocking_path'.",

--- a/demos/blocking_service/fixtures/before-analysis.json
+++ b/demos/blocking_service/fixtures/before-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 250,
-  "p50_latency_us": 1868837,
-  "p95_latency_us": 3528432,
-  "p99_latency_us": 3676994,
+  "p50_latency_us": 1890958,
+  "p95_latency_us": 3622573,
+  "p99_latency_us": 3783549,
   "p95_queue_share_permille": 5,
   "p95_service_share_permille": 999,
   "inflight_trend": {
@@ -32,8 +32,8 @@
       "score": 79,
       "confidence": "medium",
       "evidence": [
-        "Stage 'spawn_blocking_path' has p95 latency 3527249 us across 250 samples.",
-        "Stage 'spawn_blocking_path' cumulative latency is 466827768 us.",
+        "Stage 'spawn_blocking_path' has p95 latency 3621361 us across 250 samples.",
+        "Stage 'spawn_blocking_path' cumulative latency is 477143600 us.",
         "Stage 'spawn_blocking_path' contributes 999 permille of cumulative request latency."
       ],
       "next_checks": [

--- a/demos/blocking_service/fixtures/sample-analysis.json
+++ b/demos/blocking_service/fixtures/sample-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 250,
-  "p50_latency_us": 1868837,
-  "p95_latency_us": 3528432,
-  "p99_latency_us": 3676994,
+  "p50_latency_us": 1890958,
+  "p95_latency_us": 3622573,
+  "p99_latency_us": 3783549,
   "p95_queue_share_permille": 5,
   "p95_service_share_permille": 999,
   "inflight_trend": {
@@ -32,8 +32,8 @@
       "score": 79,
       "confidence": "medium",
       "evidence": [
-        "Stage 'spawn_blocking_path' has p95 latency 3527249 us across 250 samples.",
-        "Stage 'spawn_blocking_path' cumulative latency is 466827768 us.",
+        "Stage 'spawn_blocking_path' has p95 latency 3621361 us across 250 samples.",
+        "Stage 'spawn_blocking_path' cumulative latency is 477143600 us.",
         "Stage 'spawn_blocking_path' contributes 999 permille of cumulative request latency."
       ],
       "next_checks": [

--- a/demos/cold_start_burst_service/fixtures/after-analysis.json
+++ b/demos/cold_start_burst_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 8472,
-  "p95_latency_us": 8793,
-  "p99_latency_us": 8930,
+  "p50_latency_us": 8428,
+  "p95_latency_us": 9513,
+  "p99_latency_us": 10837,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 999,
   "inflight_trend": {
     "gauge": "cold_start_burst_inflight",
     "sample_count": 440,
     "peak_count": 4,
-    "p95_count": 2,
+    "p95_count": 3,
     "growth_delta": -1,
-    "growth_per_sec_milli": -1066
+    "growth_per_sec_milli": -1001
   },
   "warnings": [],
   "primary_suspect": {
@@ -19,9 +19,9 @@
     "score": 79,
     "confidence": "medium",
     "evidence": [
-      "Stage 'cold_start_stage' has p95 latency 8757 us across 220 samples.",
-      "Stage 'cold_start_stage' cumulative latency is 1813418 us.",
-      "Stage 'cold_start_stage' contributes 997 permille of cumulative request latency."
+      "Stage 'cold_start_stage' has p95 latency 9437 us across 220 samples.",
+      "Stage 'cold_start_stage' cumulative latency is 1851257 us.",
+      "Stage 'cold_start_stage' contributes 993 permille of cumulative request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'cold_start_stage'.",

--- a/demos/cold_start_burst_service/fixtures/before-analysis.json
+++ b/demos/cold_start_burst_service/fixtures/before-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 993912,
-  "p95_latency_us": 1190539,
-  "p99_latency_us": 1207352,
+  "p50_latency_us": 1076829,
+  "p95_latency_us": 1283098,
+  "p99_latency_us": 1298639,
   "p95_queue_share_permille": 993,
-  "p95_service_share_permille": 329,
+  "p95_service_share_permille": 338,
   "inflight_trend": {
     "gauge": "cold_start_burst_inflight",
     "sample_count": 440,
     "peak_count": 220,
     "p95_count": 209,
-    "growth_delta": 1,
-    "growth_per_sec_milli": 816
+    "growth_delta": -1,
+    "growth_per_sec_milli": -759
   },
   "warnings": [],
   "primary_suspect": {
@@ -20,8 +20,7 @@
     "confidence": "high",
     "evidence": [
       "Queue wait at p95 consumes 99.3% of request time.",
-      "Observed queue depth sample up to 216.",
-      "In-flight gauge 'cold_start_burst_inflight' grew by 1 over the run window (p95=209, peak=220)."
+      "Observed queue depth sample up to 216."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -34,8 +33,8 @@
       "score": 55,
       "confidence": "low",
       "evidence": [
-        "Stage 'cold_start_stage' has p95 latency 63606 us across 220 samples.",
-        "Stage 'cold_start_stage' cumulative latency is 4878331 us.",
+        "Stage 'cold_start_stage' has p95 latency 65091 us across 220 samples.",
+        "Stage 'cold_start_stage' cumulative latency is 5225613 us.",
         "Stage 'cold_start_stage' contributes 24 permille of cumulative request latency."
       ],
       "next_checks": [

--- a/demos/db_pool_saturation_service/fixtures/after-analysis.json
+++ b/demos/db_pool_saturation_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 13087,
-  "p95_latency_us": 14051,
-  "p99_latency_us": 14581,
+  "p50_latency_us": 13593,
+  "p95_latency_us": 14660,
+  "p99_latency_us": 15037,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,7 +11,7 @@
     "peak_count": 10,
     "p95_count": 10,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2717
+    "growth_per_sec_milli": -2659
   },
   "warnings": [],
   "primary_suspect": {
@@ -19,9 +19,9 @@
     "score": 75,
     "confidence": "medium",
     "evidence": [
-      "Stage 'db_query' has p95 latency 11860 us across 220 samples.",
-      "Stage 'db_query' cumulative latency is 2450083 us.",
-      "Stage 'db_query' contributes 837 permille of cumulative request latency."
+      "Stage 'db_query' has p95 latency 12010 us across 220 samples.",
+      "Stage 'db_query' cumulative latency is 2469855 us.",
+      "Stage 'db_query' contributes 825 permille of cumulative request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'db_query'.",

--- a/demos/db_pool_saturation_service/fixtures/before-analysis.json
+++ b/demos/db_pool_saturation_service/fixtures/before-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 493037,
-  "p95_latency_us": 926156,
-  "p99_latency_us": 960192,
-  "p95_queue_share_permille": 976,
-  "p95_service_share_permille": 360,
+  "p50_latency_us": 559689,
+  "p95_latency_us": 1010052,
+  "p99_latency_us": 1044059,
+  "p95_queue_share_permille": 978,
+  "p95_service_share_permille": 409,
   "inflight_trend": {
     "gauge": "db_pool_saturation_inflight",
     "sample_count": 440,
-    "peak_count": 203,
-    "p95_count": 193,
+    "peak_count": 200,
+    "p95_count": 189,
     "growth_delta": 2,
-    "growth_per_sec_milli": 1888
+    "growth_per_sec_milli": 1734
   },
   "warnings": [],
   "primary_suspect": {
@@ -19,9 +19,9 @@
     "score": 90,
     "confidence": "high",
     "evidence": [
-      "Queue wait at p95 consumes 97.6% of request time.",
+      "Queue wait at p95 consumes 97.8% of request time.",
       "Observed queue depth sample up to 196.",
-      "In-flight gauge 'db_pool_saturation_inflight' grew by 2 over the run window (p95=193, peak=203)."
+      "In-flight gauge 'db_pool_saturation_inflight' grew by 2 over the run window (p95=189, peak=200)."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -34,8 +34,8 @@
       "score": 55,
       "confidence": "low",
       "evidence": [
-        "Stage 'db_query' has p95 latency 19607 us across 220 samples.",
-        "Stage 'db_query' cumulative latency is 4212930 us.",
+        "Stage 'db_query' has p95 latency 20762 us across 220 samples.",
+        "Stage 'db_query' cumulative latency is 4567850 us.",
         "Stage 'db_query' contributes 38 permille of cumulative request latency."
       ],
       "next_checks": [

--- a/demos/downstream_service/fixtures/sample-analysis.json
+++ b/demos/downstream_service/fixtures/sample-analysis.json
@@ -1,27 +1,27 @@
 {
   "request_count": 80,
-  "p50_latency_us": 23104,
-  "p95_latency_us": 23899,
-  "p99_latency_us": 23909,
+  "p50_latency_us": 23818,
+  "p95_latency_us": 24872,
+  "p99_latency_us": 152037,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "downstream_service_inflight",
     "sample_count": 160,
-    "peak_count": 64,
-    "p95_count": 62,
-    "growth_delta": 5,
-    "growth_per_sec_milli": 92592
+    "peak_count": 56,
+    "p95_count": 55,
+    "growth_delta": 2,
+    "growth_per_sec_milli": 10050
   },
   "warnings": [],
   "primary_suspect": {
     "kind": "DownstreamStageDominates",
-    "score": 77,
+    "score": 76,
     "confidence": "medium",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 21625 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 1682612 us.",
-      "Stage 'downstream_call' contributes 907 permille of cumulative request latency."
+      "Stage 'downstream_call' has p95 latency 22693 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 1824335 us.",
+      "Stage 'downstream_call' contributes 847 permille of cumulative request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",

--- a/demos/executor_pressure_service/fixtures/after-analysis.json
+++ b/demos/executor_pressure_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 1042256,
-  "p95_latency_us": 1129448,
-  "p99_latency_us": 1143294,
-  "p95_queue_share_permille": 95,
-  "p95_service_share_permille": 997,
+  "p50_latency_us": 1546490,
+  "p95_latency_us": 1701904,
+  "p99_latency_us": 1721980,
+  "p95_queue_share_permille": 171,
+  "p95_service_share_permille": 998,
   "inflight_trend": {
     "gauge": "executor_pressure_inflight",
     "sample_count": 440,
-    "peak_count": 215,
-    "p95_count": 206,
-    "growth_delta": 5,
-    "growth_per_sec_milli": 4152
+    "peak_count": 219,
+    "p95_count": 208,
+    "growth_delta": 7,
+    "growth_per_sec_milli": 3854
   },
   "warnings": [],
   "primary_suspect": {
@@ -19,8 +19,8 @@
     "score": 82,
     "confidence": "medium",
     "evidence": [
-      "Runtime global queue depth p95 is 214, suggesting scheduler contention.",
-      "In-flight gauge 'executor_pressure_inflight' growth is positive (delta=5, peak=215), consistent with accumulating executor pressure."
+      "Runtime global queue depth p95 is 218, suggesting scheduler contention.",
+      "In-flight gauge 'executor_pressure_inflight' growth is positive (delta=7, peak=219), consistent with accumulating executor pressure."
     ],
     "next_checks": [
       "Check for long polls without yielding and uneven task fan-out.",
@@ -33,9 +33,9 @@
       "score": 78,
       "confidence": "medium",
       "evidence": [
-        "Stage 'executor_hot_path' has p95 latency 1086211 us across 220 samples.",
-        "Stage 'executor_hot_path' cumulative latency is 201838141 us.",
-        "Stage 'executor_hot_path' contributes 951 permille of cumulative request latency."
+        "Stage 'executor_hot_path' has p95 latency 1617746 us across 220 samples.",
+        "Stage 'executor_hot_path' cumulative latency is 298738104 us.",
+        "Stage 'executor_hot_path' contributes 941 permille of cumulative request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'executor_hot_path'.",

--- a/demos/executor_pressure_service/fixtures/before-analysis.json
+++ b/demos/executor_pressure_service/fixtures/before-analysis.json
@@ -1,26 +1,25 @@
 {
   "request_count": 320,
-  "p50_latency_us": 5907090,
-  "p95_latency_us": 6004079,
-  "p99_latency_us": 6030449,
-  "p95_queue_share_permille": 55,
+  "p50_latency_us": 8577010,
+  "p95_latency_us": 8689823,
+  "p99_latency_us": 8752466,
+  "p95_queue_share_permille": 43,
   "p95_service_share_permille": 999,
   "inflight_trend": {
     "gauge": "executor_pressure_inflight",
     "sample_count": 640,
     "peak_count": 320,
     "p95_count": 304,
-    "growth_delta": 3,
-    "growth_per_sec_milli": 495
+    "growth_delta": -1,
+    "growth_per_sec_milli": -113
   },
   "warnings": [],
   "primary_suspect": {
     "kind": "ExecutorPressureSuspected",
-    "score": 90,
+    "score": 85,
     "confidence": "high",
     "evidence": [
-      "Runtime global queue depth p95 is 320, suggesting scheduler contention.",
-      "In-flight gauge 'executor_pressure_inflight' growth is positive (delta=3, peak=320), consistent with accumulating executor pressure."
+      "Runtime global queue depth p95 is 320, suggesting scheduler contention."
     ],
     "next_checks": [
       "Check for long polls without yielding and uneven task fan-out.",
@@ -33,9 +32,9 @@
       "score": 79,
       "confidence": "medium",
       "evidence": [
-        "Stage 'executor_hot_path' has p95 latency 5934696 us across 320 samples.",
-        "Stage 'executor_hot_path' cumulative latency is 1825447296 us.",
-        "Stage 'executor_hot_path' contributes 975 permille of cumulative request latency."
+        "Stage 'executor_hot_path' has p95 latency 8617225 us across 320 samples.",
+        "Stage 'executor_hot_path' cumulative latency is 2645785563 us.",
+        "Stage 'executor_hot_path' contributes 971 permille of cumulative request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'executor_hot_path'.",

--- a/demos/executor_pressure_service/fixtures/sample-analysis.json
+++ b/demos/executor_pressure_service/fixtures/sample-analysis.json
@@ -1,26 +1,25 @@
 {
   "request_count": 320,
-  "p50_latency_us": 5907090,
-  "p95_latency_us": 6004079,
-  "p99_latency_us": 6030449,
-  "p95_queue_share_permille": 55,
+  "p50_latency_us": 8577010,
+  "p95_latency_us": 8689823,
+  "p99_latency_us": 8752466,
+  "p95_queue_share_permille": 43,
   "p95_service_share_permille": 999,
   "inflight_trend": {
     "gauge": "executor_pressure_inflight",
     "sample_count": 640,
     "peak_count": 320,
     "p95_count": 304,
-    "growth_delta": 3,
-    "growth_per_sec_milli": 495
+    "growth_delta": -1,
+    "growth_per_sec_milli": -113
   },
   "warnings": [],
   "primary_suspect": {
     "kind": "ExecutorPressureSuspected",
-    "score": 90,
+    "score": 85,
     "confidence": "high",
     "evidence": [
-      "Runtime global queue depth p95 is 320, suggesting scheduler contention.",
-      "In-flight gauge 'executor_pressure_inflight' growth is positive (delta=3, peak=320), consistent with accumulating executor pressure."
+      "Runtime global queue depth p95 is 320, suggesting scheduler contention."
     ],
     "next_checks": [
       "Check for long polls without yielding and uneven task fan-out.",
@@ -33,9 +32,9 @@
       "score": 79,
       "confidence": "medium",
       "evidence": [
-        "Stage 'executor_hot_path' has p95 latency 5934696 us across 320 samples.",
-        "Stage 'executor_hot_path' cumulative latency is 1825447296 us.",
-        "Stage 'executor_hot_path' contributes 975 permille of cumulative request latency."
+        "Stage 'executor_hot_path' has p95 latency 8617225 us across 320 samples.",
+        "Stage 'executor_hot_path' cumulative latency is 2645785563 us.",
+        "Stage 'executor_hot_path' contributes 971 permille of cumulative request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'executor_hot_path'.",

--- a/demos/mixed_contention_service/fixtures/baseline-analysis.json
+++ b/demos/mixed_contention_service/fixtures/baseline-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 391327,
-  "p95_latency_us": 744182,
-  "p99_latency_us": 767870,
+  "p50_latency_us": 401445,
+  "p95_latency_us": 769293,
+  "p99_latency_us": 802805,
   "p95_queue_share_permille": 980,
-  "p95_service_share_permille": 440,
+  "p95_service_share_permille": 430,
   "inflight_trend": {
     "gauge": "mixed_contention_inflight",
     "sample_count": 440,
-    "peak_count": 201,
-    "p95_count": 192,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -1158
+    "peak_count": 200,
+    "p95_count": 190,
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
   },
   "warnings": [],
   "primary_suspect": {
@@ -20,7 +20,7 @@
     "confidence": "high",
     "evidence": [
       "Queue wait at p95 consumes 98.0% of request time.",
-      "Observed queue depth sample up to 196."
+      "Observed queue depth sample up to 195."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -33,8 +33,8 @@
       "score": 56,
       "confidence": "low",
       "evidence": [
-        "Stage 'downstream_call' has p95 latency 32556 us across 220 samples.",
-        "Stage 'downstream_call' cumulative latency is 3771855 us.",
+        "Stage 'downstream_call' has p95 latency 32891 us across 220 samples.",
+        "Stage 'downstream_call' cumulative latency is 3858754 us.",
         "Stage 'downstream_call' contributes 43 permille of cumulative request latency."
       ],
       "next_checks": [

--- a/demos/mixed_contention_service/fixtures/mitigated-analysis.json
+++ b/demos/mixed_contention_service/fixtures/mitigated-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 14544,
-  "p95_latency_us": 34609,
-  "p99_latency_us": 34946,
+  "p50_latency_us": 14816,
+  "p95_latency_us": 35019,
+  "p99_latency_us": 36099,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,17 +11,17 @@
     "peak_count": 14,
     "p95_count": 13,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2659
+    "growth_per_sec_milli": -2493
   },
   "warnings": [],
   "primary_suspect": {
     "kind": "DownstreamStageDominates",
-    "score": 77,
+    "score": 76,
     "confidence": "medium",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 32553 us across 220 samples.",
-      "Stage 'downstream_call' cumulative latency is 3758133 us.",
-      "Stage 'downstream_call' contributes 888 permille of cumulative request latency."
+      "Stage 'downstream_call' has p95 latency 32893 us across 220 samples.",
+      "Stage 'downstream_call' cumulative latency is 3787746 us.",
+      "Stage 'downstream_call' contributes 878 permille of cumulative request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",

--- a/demos/queue_service/fixtures/after-analysis.json
+++ b/demos/queue_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 250,
-  "p50_latency_us": 16140,
-  "p95_latency_us": 16756,
-  "p99_latency_us": 16963,
+  "p50_latency_us": 16416,
+  "p95_latency_us": 17868,
+  "p99_latency_us": 21340,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
     "peak_count": 12,
-    "p95_count": 12,
+    "p95_count": 10,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2415
+    "growth_per_sec_milli": -2150
   },
   "warnings": [],
   "primary_suspect": {
@@ -19,9 +19,9 @@
     "score": 79,
     "confidence": "medium",
     "evidence": [
-      "Stage 'simulated_work' has p95 latency 16744 us across 250 samples.",
-      "Stage 'simulated_work' cumulative latency is 4034843 us.",
-      "Stage 'simulated_work' contributes 998 permille of cumulative request latency."
+      "Stage 'simulated_work' has p95 latency 17754 us across 250 samples.",
+      "Stage 'simulated_work' cumulative latency is 4124839 us.",
+      "Stage 'simulated_work' contributes 996 permille of cumulative request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'simulated_work'.",

--- a/demos/queue_service/fixtures/before-analysis.json
+++ b/demos/queue_service/fixtures/before-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 250,
-  "p50_latency_us": 788171,
-  "p95_latency_us": 1476281,
-  "p99_latency_us": 1527061,
+  "p50_latency_us": 803400,
+  "p95_latency_us": 1552689,
+  "p99_latency_us": 1604927,
   "p95_queue_share_permille": 982,
-  "p95_service_share_permille": 268,
+  "p95_service_share_permille": 286,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
     "peak_count": 234,
-    "p95_count": 223,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -601
+    "p95_count": 222,
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
   },
   "warnings": [],
   "primary_suspect": {
@@ -33,9 +33,9 @@
       "score": 55,
       "confidence": "low",
       "evidence": [
-        "Stage 'simulated_work' has p95 latency 26757 us across 250 samples.",
-        "Stage 'simulated_work' cumulative latency is 6569871 us.",
-        "Stage 'simulated_work' contributes 33 permille of cumulative request latency."
+        "Stage 'simulated_work' has p95 latency 29811 us across 250 samples.",
+        "Stage 'simulated_work' cumulative latency is 6928007 us.",
+        "Stage 'simulated_work' contributes 34 permille of cumulative request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'simulated_work'.",

--- a/demos/queue_service/fixtures/sample-analysis.json
+++ b/demos/queue_service/fixtures/sample-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 250,
-  "p50_latency_us": 788171,
-  "p95_latency_us": 1476281,
-  "p99_latency_us": 1527061,
+  "p50_latency_us": 803400,
+  "p95_latency_us": 1552689,
+  "p99_latency_us": 1604927,
   "p95_queue_share_permille": 982,
-  "p95_service_share_permille": 268,
+  "p95_service_share_permille": 286,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
     "peak_count": 234,
-    "p95_count": 223,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -601
+    "p95_count": 222,
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
   },
   "warnings": [],
   "primary_suspect": {
@@ -33,9 +33,9 @@
       "score": 55,
       "confidence": "low",
       "evidence": [
-        "Stage 'simulated_work' has p95 latency 26757 us across 250 samples.",
-        "Stage 'simulated_work' cumulative latency is 6569871 us.",
-        "Stage 'simulated_work' contributes 33 permille of cumulative request latency."
+        "Stage 'simulated_work' has p95 latency 29811 us across 250 samples.",
+        "Stage 'simulated_work' cumulative latency is 6928007 us.",
+        "Stage 'simulated_work' contributes 34 permille of cumulative request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'simulated_work'.",

--- a/demos/retry_storm_service/fixtures/after-analysis.json
+++ b/demos/retry_storm_service/fixtures/after-analysis.json
@@ -1,27 +1,27 @@
 {
   "request_count": 180,
-  "p50_latency_us": 9250,
-  "p95_latency_us": 29421,
-  "p99_latency_us": 29678,
+  "p50_latency_us": 10406,
+  "p95_latency_us": 29724,
+  "p99_latency_us": 30944,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "retry_storm_inflight",
     "sample_count": 360,
-    "peak_count": 16,
+    "peak_count": 17,
     "p95_count": 15,
     "growth_delta": -1,
-    "growth_per_sec_milli": -4739
+    "growth_per_sec_milli": -4545
   },
   "warnings": [],
   "primary_suspect": {
     "kind": "DownstreamStageDominates",
-    "score": 76,
+    "score": 75,
     "confidence": "medium",
     "evidence": [
-      "Stage 'downstream_total' has p95 latency 27315 us across 180 samples.",
-      "Stage 'downstream_total' cumulative latency is 2138366 us.",
-      "Stage 'downstream_total' contributes 848 permille of cumulative request latency."
+      "Stage 'downstream_total' has p95 latency 27352 us across 180 samples.",
+      "Stage 'downstream_total' cumulative latency is 2196075 us.",
+      "Stage 'downstream_total' contributes 834 permille of cumulative request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_total'.",

--- a/demos/retry_storm_service/fixtures/before-analysis.json
+++ b/demos/retry_storm_service/fixtures/before-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 180,
-  "p50_latency_us": 9634,
-  "p95_latency_us": 40938,
-  "p99_latency_us": 41967,
+  "p50_latency_us": 10374,
+  "p95_latency_us": 42693,
+  "p99_latency_us": 44346,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "retry_storm_inflight",
     "sample_count": 360,
-    "peak_count": 59,
-    "p95_count": 57,
+    "peak_count": 55,
+    "p95_count": 51,
     "growth_delta": -1,
-    "growth_per_sec_milli": -9615
+    "growth_per_sec_milli": -8771
   },
   "warnings": [],
   "primary_suspect": {
@@ -19,9 +19,9 @@
     "score": 77,
     "confidence": "medium",
     "evidence": [
-      "Stage 'downstream_total' has p95 latency 38781 us across 180 samples.",
-      "Stage 'downstream_total' cumulative latency is 3003468 us.",
-      "Stage 'downstream_total' contributes 887 permille of cumulative request latency."
+      "Stage 'downstream_total' has p95 latency 40667 us across 180 samples.",
+      "Stage 'downstream_total' cumulative latency is 3086789 us.",
+      "Stage 'downstream_total' contributes 880 permille of cumulative request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_total'.",

--- a/demos/shared_state_lock_service/fixtures/after-analysis.json
+++ b/demos/shared_state_lock_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 828185,
-  "p95_latency_us": 1565039,
-  "p99_latency_us": 1623749,
+  "p50_latency_us": 990759,
+  "p95_latency_us": 1777000,
+  "p99_latency_us": 1840002,
   "p95_queue_share_permille": 993,
-  "p95_service_share_permille": 119,
+  "p95_service_share_permille": 127,
   "inflight_trend": {
     "gauge": "shared_state_lock_inflight",
     "sample_count": 440,
-    "peak_count": 201,
-    "p95_count": 191,
+    "peak_count": 199,
+    "p95_count": 189,
     "growth_delta": -1,
-    "growth_per_sec_milli": -554
+    "growth_per_sec_milli": -490
   },
   "warnings": [],
   "primary_suspect": {
@@ -20,7 +20,7 @@
     "confidence": "high",
     "evidence": [
       "Queue wait at p95 consumes 99.3% of request time.",
-      "Observed queue depth sample up to 200."
+      "Observed queue depth sample up to 197."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -33,8 +33,8 @@
       "score": 55,
       "confidence": "low",
       "evidence": [
-        "Stage 'shared_state_critical_section' has p95 latency 8298 us across 220 samples.",
-        "Stage 'shared_state_critical_section' cumulative latency is 1792596 us.",
+        "Stage 'shared_state_critical_section' has p95 latency 10168 us across 220 samples.",
+        "Stage 'shared_state_critical_section' cumulative latency is 2000297 us.",
         "Stage 'shared_state_critical_section' contributes 9 permille of cumulative request latency."
       ],
       "next_checks": [

--- a/demos/shared_state_lock_service/fixtures/before-analysis.json
+++ b/demos/shared_state_lock_service/fixtures/before-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 2540778,
-  "p95_latency_us": 4802998,
-  "p99_latency_us": 4984628,
+  "p50_latency_us": 2662161,
+  "p95_latency_us": 4994458,
+  "p99_latency_us": 5210245,
   "p95_queue_share_permille": 994,
-  "p95_service_share_permille": 100,
+  "p95_service_share_permille": 101,
   "inflight_trend": {
     "gauge": "shared_state_lock_inflight",
     "sample_count": 440,
     "peak_count": 217,
     "p95_count": 206,
     "growth_delta": -1,
-    "growth_per_sec_milli": -195
+    "growth_per_sec_milli": -187
   },
   "warnings": [],
   "primary_suspect": {
@@ -33,8 +33,8 @@
       "score": 55,
       "confidence": "low",
       "evidence": [
-        "Stage 'shared_state_critical_section' has p95 latency 23389 us across 220 samples.",
-        "Stage 'shared_state_critical_section' cumulative latency is 5099697 us.",
+        "Stage 'shared_state_critical_section' has p95 latency 24744 us across 220 samples.",
+        "Stage 'shared_state_critical_section' cumulative latency is 5286489 us.",
         "Stage 'shared_state_critical_section' contributes 9 permille of cumulative request latency."
       ],
       "next_checks": [

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -2,6 +2,16 @@
 
 This document explains how `tailtriage analyze` produces a triage report and how to use it.
 
+## Run artifact schema contract
+
+`tailtriage-cli` requires every input run artifact to include a top-level `schema_version` integer. The current supported value is `1`.
+
+Loader behavior is strict:
+
+- missing `schema_version` is rejected
+- non-integer `schema_version` is rejected
+- unsupported `schema_version` is rejected
+
 ## Report contents
 
 `tailtriage analyze <run.json>` outputs:

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -44,3 +44,8 @@ tailtriage analyze tailtriage-run.json --format json
 - Data capture API (`tailtriage-core`): <https://docs.rs/tailtriage-core>
 - Tokio runtime sampling (`tailtriage-tokio`): <https://docs.rs/tailtriage-tokio>
 - Repository docs and demos: <https://github.com/SG-devel/tailtriage>
+
+
+## Artifact schema contract
+
+`tailtriage-cli` requires a top-level `schema_version` field in every run artifact. Current supported value: `1`. Missing, non-integer, or unsupported values fail fast with a clear error so triage runs against a known schema contract.

--- a/tailtriage-cli/src/analyze.rs
+++ b/tailtriage-cli/src/analyze.rs
@@ -578,7 +578,9 @@ pub fn render_text(report: &Report) -> String {
 
 #[cfg(test)]
 mod tests {
-    use tailtriage_core::{CaptureMode, RequestEvent, Run, RunMetadata, StageEvent};
+    use tailtriage_core::{
+        CaptureMode, RequestEvent, Run, RunMetadata, StageEvent, SCHEMA_VERSION,
+    };
 
     use crate::analyze::{
         analyze_run, render_text, Confidence, DiagnosisKind, InflightTrend, Report, Suspect,
@@ -586,6 +588,7 @@ mod tests {
 
     fn test_run() -> Run {
         Run {
+            schema_version: SCHEMA_VERSION,
             metadata: RunMetadata {
                 run_id: "run-1".to_owned(),
                 service_name: "svc".to_owned(),

--- a/tailtriage-cli/src/artifact.rs
+++ b/tailtriage-cli/src/artifact.rs
@@ -1,9 +1,9 @@
 use std::path::{Path, PathBuf};
 
 use serde_json::Value;
-use tailtriage_core::Run;
+use tailtriage_core::{Run, SCHEMA_VERSION};
 
-const SUPPORTED_SCHEMA_VERSION: u64 = 1;
+const SUPPORTED_SCHEMA_VERSION: u64 = SCHEMA_VERSION;
 
 #[derive(Debug)]
 pub struct LoadedArtifact {
@@ -25,6 +25,9 @@ pub enum ArtifactLoadError {
         path: PathBuf,
         found: u64,
         supported: u64,
+    },
+    MissingSchemaVersion {
+        path: PathBuf,
     },
     InvalidSchemaVersionType {
         path: PathBuf,
@@ -53,9 +56,14 @@ impl std::fmt::Display for ArtifactLoadError {
                 "unsupported run artifact schema_version={found} in '{}'; supported schema_version is {supported}. Re-generate the artifact with a compatible tailtriage version.",
                 path.display()
             ),
+            Self::MissingSchemaVersion { path } => write!(
+                f,
+                "invalid run artifact in '{}': missing required top-level schema_version.",
+                path.display()
+            ),
             Self::InvalidSchemaVersionType { path } => write!(
                 f,
-                "invalid run artifact in '{}': schema_version must be an integer when provided.",
+                "invalid run artifact in '{}': schema_version must be an integer.",
                 path.display()
             ),
             Self::Validation { path, message } => write!(
@@ -111,20 +119,24 @@ pub fn load_run_artifact(path: &Path) -> Result<LoadedArtifact, ArtifactLoadErro
 }
 
 fn validate_schema_version(raw: &Value, path: &Path) -> Result<(), ArtifactLoadError> {
-    if let Some(version) = raw.get("schema_version") {
-        let Some(found) = version.as_u64() else {
-            return Err(ArtifactLoadError::InvalidSchemaVersionType {
-                path: path.to_path_buf(),
-            });
-        };
+    let Some(version) = raw.get("schema_version") else {
+        return Err(ArtifactLoadError::MissingSchemaVersion {
+            path: path.to_path_buf(),
+        });
+    };
 
-        if found != SUPPORTED_SCHEMA_VERSION {
-            return Err(ArtifactLoadError::UnsupportedSchemaVersion {
-                path: path.to_path_buf(),
-                found,
-                supported: SUPPORTED_SCHEMA_VERSION,
-            });
-        }
+    let Some(found) = version.as_u64() else {
+        return Err(ArtifactLoadError::InvalidSchemaVersionType {
+            path: path.to_path_buf(),
+        });
+    };
+
+    if found != SUPPORTED_SCHEMA_VERSION {
+        return Err(ArtifactLoadError::UnsupportedSchemaVersion {
+            path: path.to_path_buf(),
+            found,
+            supported: SUPPORTED_SCHEMA_VERSION,
+        });
     }
 
     Ok(())
@@ -179,7 +191,7 @@ mod tests {
     fn rejects_missing_required_fields() {
         let dir = tempfile::tempdir().expect("tempdir should build");
         let path = dir.path().join("missing-fields.json");
-        std::fs::write(&path, r#"{"metadata":{},"requests":[],"stages":[],"queues":[],"inflight":[],"runtime_snapshots":[]}"#)
+        std::fs::write(&path, r#"{"schema_version":1,"metadata":{},"requests":[],"stages":[],"queues":[],"inflight":[],"runtime_snapshots":[]}"#)
             .expect("fixture should write");
 
         let error = load_run_artifact(&path).expect_err("expected schema failure");
@@ -199,6 +211,34 @@ mod tests {
         let message = error.to_string();
 
         assert!(message.contains("requests section is empty"));
+    }
+
+    #[test]
+    fn rejects_missing_schema_version() {
+        let dir = tempfile::tempdir().expect("tempdir should build");
+        let path = dir.path().join("missing-version.json");
+        std::fs::write(&path, valid_run_json_with_prefix("")).expect("fixture should write");
+
+        let error = load_run_artifact(&path).expect_err("expected missing version failure");
+        let message = error.to_string();
+
+        assert!(message.contains("missing required top-level schema_version"));
+    }
+
+    #[test]
+    fn rejects_non_integer_schema_versions() {
+        let dir = tempfile::tempdir().expect("tempdir should build");
+        let path = dir.path().join("string-version.json");
+        std::fs::write(
+            &path,
+            valid_run_json_with_prefix("\"schema_version\": \"1\","),
+        )
+        .expect("fixture should write");
+
+        let error = load_run_artifact(&path).expect_err("expected schema type failure");
+        let message = error.to_string();
+
+        assert!(message.contains("schema_version must be an integer"));
     }
 
     #[test]
@@ -229,7 +269,7 @@ mod tests {
 
     fn valid_run_json_with_requests(requests_json: &str) -> String {
         format!(
-            "{{\"metadata\":{{\"run_id\":\"r1\",\"service_name\":\"svc\",\"service_version\":null,\"started_at_unix_ms\":1,\"finished_at_unix_ms\":2,\"mode\":\"light\",\"host\":null,\"pid\":null}},\"requests\":{requests_json},\"stages\":[],\"queues\":[],\"inflight\":[],\"runtime_snapshots\":[]}}"
+            "{{\"schema_version\":1,\"metadata\":{{\"run_id\":\"r1\",\"service_name\":\"svc\",\"service_version\":null,\"started_at_unix_ms\":1,\"finished_at_unix_ms\":2,\"mode\":\"light\",\"host\":null,\"pid\":null}},\"requests\":{requests_json},\"stages\":[],\"queues\":[],\"inflight\":[],\"runtime_snapshots\":[]}}"
         )
     }
 

--- a/tailtriage-cli/tests/boundary_thresholds.rs
+++ b/tailtriage-cli/tests/boundary_thresholds.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use tailtriage_cli::analyze::{analyze_run, DiagnosisKind};
 use tailtriage_core::{
     CaptureMode, QueueEvent, RequestEvent, Run, RunMetadata, RuntimeSnapshot, StageEvent,
-    TruncationSummary,
+    TruncationSummary, SCHEMA_VERSION,
 };
 
 fn load_fixture(name: &str) -> Run {
@@ -14,6 +14,7 @@ fn load_fixture(name: &str) -> Run {
 
 fn base_run() -> Run {
     Run {
+        schema_version: SCHEMA_VERSION,
         metadata: RunMetadata {
             run_id: "threshold-run".to_string(),
             service_name: "svc".to_string(),

--- a/tailtriage-cli/tests/fixtures/blocking_pressure.json
+++ b/tailtriage-cli/tests/fixtures/blocking_pressure.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": 1,
   "metadata": {
     "run_id": "blocking-run",
     "service_name": "svc",

--- a/tailtriage-cli/tests/fixtures/downstream_stage.json
+++ b/tailtriage-cli/tests/fixtures/downstream_stage.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": 1,
   "metadata": {
     "run_id": "stage-run",
     "service_name": "svc",

--- a/tailtriage-cli/tests/fixtures/executor_pressure.json
+++ b/tailtriage-cli/tests/fixtures/executor_pressure.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": 1,
   "metadata": {
     "run_id": "executor-run",
     "service_name": "svc",

--- a/tailtriage-cli/tests/fixtures/insufficient_evidence.json
+++ b/tailtriage-cli/tests/fixtures/insufficient_evidence.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": 1,
   "metadata": {
     "run_id": "insufficient-run",
     "service_name": "svc",

--- a/tailtriage-cli/tests/fixtures/mixed_blocking_vs_downstream.json
+++ b/tailtriage-cli/tests/fixtures/mixed_blocking_vs_downstream.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": 1,
   "metadata": {
     "run_id": "mixed-blocking-vs-downstream",
     "service_name": "svc",

--- a/tailtriage-cli/tests/fixtures/mixed_queue_vs_blocking.json
+++ b/tailtriage-cli/tests/fixtures/mixed_queue_vs_blocking.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": 1,
   "metadata": {
     "run_id": "mixed-queue-vs-blocking",
     "service_name": "svc",

--- a/tailtriage-cli/tests/fixtures/queue_saturation.json
+++ b/tailtriage-cli/tests/fixtures/queue_saturation.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": 1,
   "metadata": {
     "run_id": "queue-run",
     "service_name": "svc",

--- a/tailtriage-core/src/events.rs
+++ b/tailtriage-core/src/events.rs
@@ -2,6 +2,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::CaptureMode;
 
+/// Current schema version for `Run` JSON artifacts.
+pub const SCHEMA_VERSION: u64 = 1;
+
 /// Logical request outcome categories used by the public API.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Outcome {
@@ -42,6 +45,8 @@ impl Outcome {
 /// A full output artifact for one tailtriage capture run.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Run {
+    /// Run artifact schema version.
+    pub schema_version: u64,
     /// Metadata for the capture session.
     pub metadata: RunMetadata,
     /// Request timing events.
@@ -64,6 +69,7 @@ impl Run {
     #[must_use]
     pub fn new(metadata: RunMetadata) -> Self {
         Self {
+            schema_version: SCHEMA_VERSION,
             metadata,
             requests: Vec::new(),
             stages: Vec::new(),

--- a/tailtriage-core/src/lib.rs
+++ b/tailtriage-core/src/lib.rs
@@ -36,7 +36,7 @@ pub use collector::{RequestContext, Tailtriage};
 pub use config::{BuildError, CaptureLimits, CaptureMode, RequestOptions, TailtriageBuilder};
 pub use events::{
     InFlightSnapshot, Outcome, QueueEvent, RequestEvent, Run, RunMetadata, RuntimeSnapshot,
-    StageEvent, TruncationSummary,
+    StageEvent, TruncationSummary, SCHEMA_VERSION,
 };
 pub use sink::{LocalJsonSink, RunSink, SinkError};
 pub use time::{system_time_to_unix_ms, unix_time_ms};

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -94,6 +94,7 @@ fn shutdown_writes_artifact() {
 
     let bytes = std::fs::read(output).expect("artifact should exist");
     let run: crate::Run = serde_json::from_slice(&bytes).expect("artifact should deserialize");
+    assert_eq!(run.schema_version, crate::SCHEMA_VERSION);
     assert_eq!(run.requests.len(), 1);
 }
 


### PR DESCRIPTION
### Motivation
- Lock the run-artifact contract before first public release by making `schema_version` an explicit, required top-level field.\
- Ensure writer and loader share a single source of truth for the schema so artifacts are produced and validated consistently.\
- Fail fast on missing/invalid/unsupported artifacts to avoid ambiguous behavior for early users.\

### Description
- Add `pub const SCHEMA_VERSION: u64 = 1` to `tailtriage-core` and include a `schema_version: u64` field on the `Run` struct so new artifacts always emit the version via `Run::new`.\
- Re-export `SCHEMA_VERSION` from `tailtriage-core` and make the CLI use that constant (`SUPPORTED_SCHEMA_VERSION`) so writer and loader share the same value.\
- Make the CLI loader strict in `tailtriage-cli/src/artifact.rs`: reject missing `schema_version`, reject non-integer types, and reject unsupported numeric versions with clear error variants/messages.\
- Update and extend unit tests to cover missing, non-integer, and unsupported `schema_version` cases and update in-memory `Run` constructors in tests to include `schema_version`.\
- Regenerate and update committed JSON fixtures and demo analysis outputs so every sample artifact contains `"schema_version": 1`.\
- Update docs (`README.md`, `docs/diagnostics.md`, and `tailtriage-cli/README.md`) to declare the required artifact contract and loader behavior.\

### Testing
- Ran `cargo fmt --check` and it succeeded.\
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it succeeded.\
- Ran `cargo test --workspace` and all tests passed.\
- Executed `cargo run -p tailtriage-tokio --example minimal_checkout` to generate a live artifact and confirmed the file contains `"schema_version": 1`.\
- Executed `cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json` and the CLI analyzed the artifact successfully.\
- Ran `python3 scripts/check_demo_fixture_drift.py --refresh` and `python3 scripts/check_demo_fixture_drift.py` to refresh and validate demo fixtures; both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c048de29548330b807ee7828863323)