### PR TITLE
Enforce snake_case suspect kinds in JSON output and fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Representative diagnosis shape:
 ```json
 {
   "primary_suspect": {
-    "kind": "ApplicationQueueSaturation",
+    "kind": "application_queue_saturation",
     "evidence": [
       "Queue wait at p95 consumes 98.2% of request time.",
       "Observed queue depth sample up to 230."

--- a/SPEC.md
+++ b/SPEC.md
@@ -215,11 +215,11 @@ Canonical invocation for demo validation and runtime-cost measurement is **Pytho
 
 MVP categories:
 
-- `ApplicationQueueSaturation`
-- `BlockingPoolPressure`
-- `ExecutorPressureSuspected`
-- `DownstreamStageDominates`
-- `InsufficientEvidence`
+- `application_queue_saturation`
+- `blocking_pool_pressure`
+- `executor_pressure_suspected`
+- `downstream_stage_dominates`
+- `insufficient_evidence`
 
 Important: these are evidence-ranked suspects, **not** proof of root cause.
 
@@ -233,7 +233,7 @@ Validation scripts in `scripts/` must pass for these demos.
 
 ### 9.1 Additional runnable proof case
 
-- `demos/downstream_service`: deterministic downstream-stage dominance scenario that should rank `DownstreamStageDominates` as the primary suspect.
+- `demos/downstream_service`: deterministic downstream-stage dominance scenario that should rank `downstream_stage_dominates` as the primary suspect.
 - `demos/mixed_contention_service`: deterministic mixed queue + downstream contention scenario where both suspects should be present in ranked evidence and mitigation should shift rank and/or score when one bottleneck is reduced.
 - `demos/shared_state_lock_service`: deterministic shared-state lock contention scenario where lock wait is modeled as queue-like wait and lock-protected work is modeled as a service stage; mitigation should reduce queueing/serialization signals.
 - `demos/retry_storm_service`: deterministic retry-heavy downstream scenario with intermittently failing/slow calls; baseline should show downstream-stage dominance with elevated service share, and mitigated mode should improve p95 and lower suspect score via capped retries/jitter/circuit-break style behavior.

--- a/demos/blocking_service/fixtures/after-analysis.json
+++ b/demos/blocking_service/fixtures/after-analysis.json
@@ -1,25 +1,25 @@
 {
   "request_count": 250,
-  "p50_latency_us": 44842,
-  "p95_latency_us": 108312,
-  "p99_latency_us": 118982,
+  "p50_latency_us": 52005,
+  "p95_latency_us": 87606,
+  "p99_latency_us": 92807,
   "p95_queue_share_permille": 67,
-  "p95_service_share_permille": 990,
+  "p95_service_share_permille": 991,
   "inflight_trend": {
     "gauge": "blocking_service_inflight",
     "sample_count": 500,
-    "peak_count": 33,
-    "p95_count": 30,
+    "peak_count": 46,
+    "p95_count": 43,
     "growth_delta": 0,
     "growth_per_sec_milli": 0
   },
   "warnings": [],
   "primary_suspect": {
-    "kind": "BlockingPoolPressure",
+    "kind": "blocking_pool_pressure",
     "score": 80,
     "confidence": "medium",
     "evidence": [
-      "Blocking queue depth p95 is 28, indicating sustained spawn_blocking backlog."
+      "Blocking queue depth p95 is 40, indicating sustained spawn_blocking backlog."
     ],
     "next_checks": [
       "Audit blocking sections and move avoidable synchronous work out of hot paths.",
@@ -28,13 +28,13 @@
   },
   "secondary_suspects": [
     {
-      "kind": "DownstreamStageDominates",
+      "kind": "downstream_stage_dominates",
       "score": 79,
       "confidence": "medium",
       "evidence": [
-        "Stage 'spawn_blocking_path' has p95 latency 107135 us across 250 samples.",
-        "Stage 'spawn_blocking_path' cumulative latency is 11589441 us.",
-        "Stage 'spawn_blocking_path' contributes 970 permille of cumulative request latency."
+        "Stage 'spawn_blocking_path' has p95 latency 86496 us across 250 samples.",
+        "Stage 'spawn_blocking_path' cumulative latency is 12547909 us.",
+        "Stage 'spawn_blocking_path' contributes 977 permille of cumulative request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'spawn_blocking_path'.",

--- a/demos/blocking_service/fixtures/before-after-comparison.json
+++ b/demos/blocking_service/fixtures/before-after-comparison.json
@@ -1,13 +1,13 @@
 {
   "before": {
-    "primary_suspect_kind": "BlockingPoolPressure",
+    "primary_suspect_kind": "blocking_pool_pressure",
     "primary_suspect_score": 80,
     "p95_latency_us": 3528432,
     "p95_service_share_permille": 999,
     "blocking_queue_depth_p95": 244
   },
   "after": {
-    "primary_suspect_kind": "BlockingPoolPressure",
+    "primary_suspect_kind": "blocking_pool_pressure",
     "primary_suspect_score": 80,
     "p95_latency_us": 88888,
     "p95_service_share_permille": 991,

--- a/demos/blocking_service/fixtures/before-analysis.json
+++ b/demos/blocking_service/fixtures/before-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 250,
-  "p50_latency_us": 1890958,
-  "p95_latency_us": 3622573,
-  "p99_latency_us": 3783549,
+  "p50_latency_us": 1870539,
+  "p95_latency_us": 3525872,
+  "p99_latency_us": 3673882,
   "p95_queue_share_permille": 5,
   "p95_service_share_permille": 999,
   "inflight_trend": {
@@ -15,7 +15,7 @@
   },
   "warnings": [],
   "primary_suspect": {
-    "kind": "BlockingPoolPressure",
+    "kind": "blocking_pool_pressure",
     "score": 80,
     "confidence": "medium",
     "evidence": [
@@ -28,12 +28,12 @@
   },
   "secondary_suspects": [
     {
-      "kind": "DownstreamStageDominates",
+      "kind": "downstream_stage_dominates",
       "score": 79,
       "confidence": "medium",
       "evidence": [
-        "Stage 'spawn_blocking_path' has p95 latency 3621361 us across 250 samples.",
-        "Stage 'spawn_blocking_path' cumulative latency is 477143600 us.",
+        "Stage 'spawn_blocking_path' has p95 latency 3524654 us across 250 samples.",
+        "Stage 'spawn_blocking_path' cumulative latency is 466930518 us.",
         "Stage 'spawn_blocking_path' contributes 999 permille of cumulative request latency."
       ],
       "next_checks": [

--- a/demos/blocking_service/fixtures/sample-analysis.json
+++ b/demos/blocking_service/fixtures/sample-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 250,
-  "p50_latency_us": 1890958,
-  "p95_latency_us": 3622573,
-  "p99_latency_us": 3783549,
+  "p50_latency_us": 1870539,
+  "p95_latency_us": 3525872,
+  "p99_latency_us": 3673882,
   "p95_queue_share_permille": 5,
   "p95_service_share_permille": 999,
   "inflight_trend": {
@@ -15,7 +15,7 @@
   },
   "warnings": [],
   "primary_suspect": {
-    "kind": "BlockingPoolPressure",
+    "kind": "blocking_pool_pressure",
     "score": 80,
     "confidence": "medium",
     "evidence": [
@@ -28,12 +28,12 @@
   },
   "secondary_suspects": [
     {
-      "kind": "DownstreamStageDominates",
+      "kind": "downstream_stage_dominates",
       "score": 79,
       "confidence": "medium",
       "evidence": [
-        "Stage 'spawn_blocking_path' has p95 latency 3621361 us across 250 samples.",
-        "Stage 'spawn_blocking_path' cumulative latency is 477143600 us.",
+        "Stage 'spawn_blocking_path' has p95 latency 3524654 us across 250 samples.",
+        "Stage 'spawn_blocking_path' cumulative latency is 466930518 us.",
         "Stage 'spawn_blocking_path' contributes 999 permille of cumulative request latency."
       ],
       "next_checks": [

--- a/demos/cold_start_burst_service/fixtures/after-analysis.json
+++ b/demos/cold_start_burst_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 8428,
-  "p95_latency_us": 9513,
-  "p99_latency_us": 10837,
+  "p50_latency_us": 8463,
+  "p95_latency_us": 8952,
+  "p99_latency_us": 9072,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 999,
   "inflight_trend": {
@@ -11,17 +11,17 @@
     "peak_count": 4,
     "p95_count": 3,
     "growth_delta": -1,
-    "growth_per_sec_milli": -1001
+    "growth_per_sec_milli": -1042
   },
   "warnings": [],
   "primary_suspect": {
-    "kind": "DownstreamStageDominates",
+    "kind": "downstream_stage_dominates",
     "score": 79,
     "confidence": "medium",
     "evidence": [
-      "Stage 'cold_start_stage' has p95 latency 9437 us across 220 samples.",
-      "Stage 'cold_start_stage' cumulative latency is 1851257 us.",
-      "Stage 'cold_start_stage' contributes 993 permille of cumulative request latency."
+      "Stage 'cold_start_stage' has p95 latency 8907 us across 220 samples.",
+      "Stage 'cold_start_stage' cumulative latency is 1820675 us.",
+      "Stage 'cold_start_stage' contributes 996 permille of cumulative request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'cold_start_stage'.",

--- a/demos/cold_start_burst_service/fixtures/before-after-comparison.json
+++ b/demos/cold_start_burst_service/fixtures/before-after-comparison.json
@@ -1,12 +1,12 @@
 {
   "before": {
-    "primary_suspect_kind": "ApplicationQueueSaturation",
+    "primary_suspect_kind": "application_queue_saturation",
     "primary_suspect_score": 90,
     "p95_latency_us": 1190539,
     "p95_queue_share_permille": 993
   },
   "after": {
-    "primary_suspect_kind": "DownstreamStageDominates",
+    "primary_suspect_kind": "downstream_stage_dominates",
     "primary_suspect_score": 79,
     "p95_latency_us": 8793,
     "p95_queue_share_permille": 0

--- a/demos/cold_start_burst_service/fixtures/before-analysis.json
+++ b/demos/cold_start_burst_service/fixtures/before-analysis.json
@@ -1,21 +1,21 @@
 {
   "request_count": 220,
-  "p50_latency_us": 1076829,
-  "p95_latency_us": 1283098,
-  "p99_latency_us": 1298639,
+  "p50_latency_us": 993193,
+  "p95_latency_us": 1190892,
+  "p99_latency_us": 1207027,
   "p95_queue_share_permille": 993,
-  "p95_service_share_permille": 338,
+  "p95_service_share_permille": 336,
   "inflight_trend": {
     "gauge": "cold_start_burst_inflight",
     "sample_count": 440,
     "peak_count": 220,
     "p95_count": 209,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -759
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
   },
   "warnings": [],
   "primary_suspect": {
-    "kind": "ApplicationQueueSaturation",
+    "kind": "application_queue_saturation",
     "score": 90,
     "confidence": "high",
     "evidence": [
@@ -29,12 +29,12 @@
   },
   "secondary_suspects": [
     {
-      "kind": "DownstreamStageDominates",
+      "kind": "downstream_stage_dominates",
       "score": 55,
       "confidence": "low",
       "evidence": [
-        "Stage 'cold_start_stage' has p95 latency 65091 us across 220 samples.",
-        "Stage 'cold_start_stage' cumulative latency is 5225613 us.",
+        "Stage 'cold_start_stage' has p95 latency 63658 us across 220 samples.",
+        "Stage 'cold_start_stage' cumulative latency is 4887272 us.",
         "Stage 'cold_start_stage' contributes 24 permille of cumulative request latency."
       ],
       "next_checks": [

--- a/demos/db_pool_saturation_service/fixtures/after-analysis.json
+++ b/demos/db_pool_saturation_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 13593,
-  "p95_latency_us": 14660,
-  "p99_latency_us": 15037,
+  "p50_latency_us": 13365,
+  "p95_latency_us": 14306,
+  "p99_latency_us": 14364,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,17 +11,17 @@
     "peak_count": 10,
     "p95_count": 10,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2659
+    "growth_per_sec_milli": -2739
   },
   "warnings": [],
   "primary_suspect": {
-    "kind": "DownstreamStageDominates",
+    "kind": "downstream_stage_dominates",
     "score": 75,
     "confidence": "medium",
     "evidence": [
-      "Stage 'db_query' has p95 latency 12010 us across 220 samples.",
-      "Stage 'db_query' cumulative latency is 2469855 us.",
-      "Stage 'db_query' contributes 825 permille of cumulative request latency."
+      "Stage 'db_query' has p95 latency 11942 us across 220 samples.",
+      "Stage 'db_query' cumulative latency is 2442403 us.",
+      "Stage 'db_query' contributes 831 permille of cumulative request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'db_query'.",

--- a/demos/db_pool_saturation_service/fixtures/before-after-comparison.json
+++ b/demos/db_pool_saturation_service/fixtures/before-after-comparison.json
@@ -1,12 +1,12 @@
 {
   "before": {
-    "primary_suspect_kind": "ApplicationQueueSaturation",
+    "primary_suspect_kind": "application_queue_saturation",
     "primary_suspect_score": 90,
     "p95_latency_us": 926156,
     "p95_queue_share_permille": 976
   },
   "after": {
-    "primary_suspect_kind": "DownstreamStageDominates",
+    "primary_suspect_kind": "downstream_stage_dominates",
     "primary_suspect_score": 75,
     "p95_latency_us": 14051,
     "p95_queue_share_permille": 0

--- a/demos/db_pool_saturation_service/fixtures/before-analysis.json
+++ b/demos/db_pool_saturation_service/fixtures/before-analysis.json
@@ -1,27 +1,27 @@
 {
   "request_count": 220,
-  "p50_latency_us": 559689,
-  "p95_latency_us": 1010052,
-  "p99_latency_us": 1044059,
-  "p95_queue_share_permille": 978,
-  "p95_service_share_permille": 409,
+  "p50_latency_us": 491674,
+  "p95_latency_us": 929280,
+  "p99_latency_us": 963924,
+  "p95_queue_share_permille": 977,
+  "p95_service_share_permille": 364,
   "inflight_trend": {
     "gauge": "db_pool_saturation_inflight",
     "sample_count": 440,
-    "peak_count": 200,
-    "p95_count": 189,
-    "growth_delta": 2,
-    "growth_per_sec_milli": 1734
+    "peak_count": 204,
+    "p95_count": 193,
+    "growth_delta": 1,
+    "growth_per_sec_milli": 943
   },
   "warnings": [],
   "primary_suspect": {
-    "kind": "ApplicationQueueSaturation",
+    "kind": "application_queue_saturation",
     "score": 90,
     "confidence": "high",
     "evidence": [
-      "Queue wait at p95 consumes 97.8% of request time.",
-      "Observed queue depth sample up to 196.",
-      "In-flight gauge 'db_pool_saturation_inflight' grew by 2 over the run window (p95=189, peak=200)."
+      "Queue wait at p95 consumes 97.7% of request time.",
+      "Observed queue depth sample up to 197.",
+      "In-flight gauge 'db_pool_saturation_inflight' grew by 1 over the run window (p95=193, peak=204)."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -30,13 +30,13 @@
   },
   "secondary_suspects": [
     {
-      "kind": "DownstreamStageDominates",
+      "kind": "downstream_stage_dominates",
       "score": 55,
       "confidence": "low",
       "evidence": [
-        "Stage 'db_query' has p95 latency 20762 us across 220 samples.",
-        "Stage 'db_query' cumulative latency is 4567850 us.",
-        "Stage 'db_query' contributes 38 permille of cumulative request latency."
+        "Stage 'db_query' has p95 latency 19608 us across 220 samples.",
+        "Stage 'db_query' cumulative latency is 4219372 us.",
+        "Stage 'db_query' contributes 39 permille of cumulative request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'db_query'.",

--- a/demos/downstream_service/fixtures/sample-analysis.json
+++ b/demos/downstream_service/fixtures/sample-analysis.json
@@ -1,27 +1,27 @@
 {
   "request_count": 80,
-  "p50_latency_us": 23818,
-  "p95_latency_us": 24872,
-  "p99_latency_us": 152037,
+  "p50_latency_us": 23708,
+  "p95_latency_us": 24427,
+  "p99_latency_us": 24509,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "downstream_service_inflight",
     "sample_count": 160,
-    "peak_count": 56,
-    "p95_count": 55,
-    "growth_delta": 2,
-    "growth_per_sec_milli": 10050
+    "peak_count": 64,
+    "p95_count": 60,
+    "growth_delta": 4,
+    "growth_per_sec_milli": 68965
   },
   "warnings": [],
   "primary_suspect": {
-    "kind": "DownstreamStageDominates",
-    "score": 76,
+    "kind": "downstream_stage_dominates",
+    "score": 77,
     "confidence": "medium",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 22693 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 1824335 us.",
-      "Stage 'downstream_call' contributes 847 permille of cumulative request latency."
+      "Stage 'downstream_call' has p95 latency 22128 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 1701613 us.",
+      "Stage 'downstream_call' contributes 900 permille of cumulative request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",

--- a/demos/executor_pressure_service/fixtures/after-analysis.json
+++ b/demos/executor_pressure_service/fixtures/after-analysis.json
@@ -1,26 +1,26 @@
 {
   "request_count": 220,
-  "p50_latency_us": 1546490,
-  "p95_latency_us": 1701904,
-  "p99_latency_us": 1721980,
-  "p95_queue_share_permille": 171,
-  "p95_service_share_permille": 998,
+  "p50_latency_us": 1392112,
+  "p95_latency_us": 1480261,
+  "p99_latency_us": 1499635,
+  "p95_queue_share_permille": 111,
+  "p95_service_share_permille": 996,
   "inflight_trend": {
     "gauge": "executor_pressure_inflight",
     "sample_count": 440,
-    "peak_count": 219,
-    "p95_count": 208,
-    "growth_delta": 7,
-    "growth_per_sec_milli": 3854
+    "peak_count": 217,
+    "p95_count": 206,
+    "growth_delta": 4,
+    "growth_per_sec_milli": 2495
   },
   "warnings": [],
   "primary_suspect": {
-    "kind": "ExecutorPressureSuspected",
+    "kind": "executor_pressure_suspected",
     "score": 82,
     "confidence": "medium",
     "evidence": [
-      "Runtime global queue depth p95 is 218, suggesting scheduler contention.",
-      "In-flight gauge 'executor_pressure_inflight' growth is positive (delta=7, peak=219), consistent with accumulating executor pressure."
+      "Runtime global queue depth p95 is 217, suggesting scheduler contention.",
+      "In-flight gauge 'executor_pressure_inflight' growth is positive (delta=4, peak=217), consistent with accumulating executor pressure."
     ],
     "next_checks": [
       "Check for long polls without yielding and uneven task fan-out.",
@@ -29,13 +29,13 @@
   },
   "secondary_suspects": [
     {
-      "kind": "DownstreamStageDominates",
+      "kind": "downstream_stage_dominates",
       "score": 78,
       "confidence": "medium",
       "evidence": [
-        "Stage 'executor_hot_path' has p95 latency 1617746 us across 220 samples.",
-        "Stage 'executor_hot_path' cumulative latency is 298738104 us.",
-        "Stage 'executor_hot_path' contributes 941 permille of cumulative request latency."
+        "Stage 'executor_hot_path' has p95 latency 1402884 us across 220 samples.",
+        "Stage 'executor_hot_path' cumulative latency is 260359288 us.",
+        "Stage 'executor_hot_path' contributes 948 permille of cumulative request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'executor_hot_path'.",

--- a/demos/executor_pressure_service/fixtures/before-after-comparison.json
+++ b/demos/executor_pressure_service/fixtures/before-after-comparison.json
@@ -1,12 +1,12 @@
 {
   "before": {
-    "primary_suspect_kind": "ExecutorPressureSuspected",
+    "primary_suspect_kind": "executor_pressure_suspected",
     "primary_suspect_score": 90,
     "p95_latency_us": 6004079,
     "p95_queue_share_permille": 55
   },
   "after": {
-    "primary_suspect_kind": "ExecutorPressureSuspected",
+    "primary_suspect_kind": "executor_pressure_suspected",
     "primary_suspect_score": 82,
     "p95_latency_us": 1129448,
     "p95_queue_share_permille": 95

--- a/demos/executor_pressure_service/fixtures/before-analysis.json
+++ b/demos/executor_pressure_service/fixtures/before-analysis.json
@@ -1,21 +1,21 @@
 {
   "request_count": 320,
-  "p50_latency_us": 8577010,
-  "p95_latency_us": 8689823,
-  "p99_latency_us": 8752466,
-  "p95_queue_share_permille": 43,
+  "p50_latency_us": 7524354,
+  "p95_latency_us": 7682592,
+  "p99_latency_us": 7697126,
+  "p95_queue_share_permille": 45,
   "p95_service_share_permille": 999,
   "inflight_trend": {
     "gauge": "executor_pressure_inflight",
     "sample_count": 640,
     "peak_count": 320,
     "p95_count": 304,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -113
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
   },
   "warnings": [],
   "primary_suspect": {
-    "kind": "ExecutorPressureSuspected",
+    "kind": "executor_pressure_suspected",
     "score": 85,
     "confidence": "high",
     "evidence": [
@@ -28,13 +28,13 @@
   },
   "secondary_suspects": [
     {
-      "kind": "DownstreamStageDominates",
+      "kind": "downstream_stage_dominates",
       "score": 79,
       "confidence": "medium",
       "evidence": [
-        "Stage 'executor_hot_path' has p95 latency 8617225 us across 320 samples.",
-        "Stage 'executor_hot_path' cumulative latency is 2645785563 us.",
-        "Stage 'executor_hot_path' contributes 971 permille of cumulative request latency."
+        "Stage 'executor_hot_path' has p95 latency 7530413 us across 320 samples.",
+        "Stage 'executor_hot_path' cumulative latency is 2327569590 us.",
+        "Stage 'executor_hot_path' contributes 975 permille of cumulative request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'executor_hot_path'.",

--- a/demos/executor_pressure_service/fixtures/sample-analysis.json
+++ b/demos/executor_pressure_service/fixtures/sample-analysis.json
@@ -1,21 +1,21 @@
 {
   "request_count": 320,
-  "p50_latency_us": 8577010,
-  "p95_latency_us": 8689823,
-  "p99_latency_us": 8752466,
-  "p95_queue_share_permille": 43,
+  "p50_latency_us": 7524354,
+  "p95_latency_us": 7682592,
+  "p99_latency_us": 7697126,
+  "p95_queue_share_permille": 45,
   "p95_service_share_permille": 999,
   "inflight_trend": {
     "gauge": "executor_pressure_inflight",
     "sample_count": 640,
     "peak_count": 320,
     "p95_count": 304,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -113
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
   },
   "warnings": [],
   "primary_suspect": {
-    "kind": "ExecutorPressureSuspected",
+    "kind": "executor_pressure_suspected",
     "score": 85,
     "confidence": "high",
     "evidence": [
@@ -28,13 +28,13 @@
   },
   "secondary_suspects": [
     {
-      "kind": "DownstreamStageDominates",
+      "kind": "downstream_stage_dominates",
       "score": 79,
       "confidence": "medium",
       "evidence": [
-        "Stage 'executor_hot_path' has p95 latency 8617225 us across 320 samples.",
-        "Stage 'executor_hot_path' cumulative latency is 2645785563 us.",
-        "Stage 'executor_hot_path' contributes 971 permille of cumulative request latency."
+        "Stage 'executor_hot_path' has p95 latency 7530413 us across 320 samples.",
+        "Stage 'executor_hot_path' cumulative latency is 2327569590 us.",
+        "Stage 'executor_hot_path' contributes 975 permille of cumulative request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'executor_hot_path'.",

--- a/demos/mixed_contention_service/fixtures/baseline-analysis.json
+++ b/demos/mixed_contention_service/fixtures/baseline-analysis.json
@@ -1,26 +1,26 @@
 {
   "request_count": 220,
-  "p50_latency_us": 401445,
-  "p95_latency_us": 769293,
-  "p99_latency_us": 802805,
-  "p95_queue_share_permille": 980,
-  "p95_service_share_permille": 430,
+  "p50_latency_us": 396325,
+  "p95_latency_us": 739972,
+  "p99_latency_us": 768478,
+  "p95_queue_share_permille": 979,
+  "p95_service_share_permille": 386,
   "inflight_trend": {
     "gauge": "mixed_contention_inflight",
     "sample_count": 440,
-    "peak_count": 200,
+    "peak_count": 201,
     "p95_count": 190,
-    "growth_delta": 0,
-    "growth_per_sec_milli": 0
+    "growth_delta": -1,
+    "growth_per_sec_milli": -1154
   },
   "warnings": [],
   "primary_suspect": {
-    "kind": "ApplicationQueueSaturation",
+    "kind": "application_queue_saturation",
     "score": 90,
     "confidence": "high",
     "evidence": [
-      "Queue wait at p95 consumes 98.0% of request time.",
-      "Observed queue depth sample up to 195."
+      "Queue wait at p95 consumes 97.9% of request time.",
+      "Observed queue depth sample up to 196."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -29,12 +29,12 @@
   },
   "secondary_suspects": [
     {
-      "kind": "DownstreamStageDominates",
+      "kind": "downstream_stage_dominates",
       "score": 56,
       "confidence": "low",
       "evidence": [
-        "Stage 'downstream_call' has p95 latency 32891 us across 220 samples.",
-        "Stage 'downstream_call' cumulative latency is 3858754 us.",
+        "Stage 'downstream_call' has p95 latency 32658 us across 220 samples.",
+        "Stage 'downstream_call' cumulative latency is 3780930 us.",
         "Stage 'downstream_call' contributes 43 permille of cumulative request latency."
       ],
       "next_checks": [

--- a/demos/mixed_contention_service/fixtures/before-after-comparison.json
+++ b/demos/mixed_contention_service/fixtures/before-after-comparison.json
@@ -1,12 +1,12 @@
 {
   "before": {
-    "primary_suspect_kind": "ApplicationQueueSaturation",
+    "primary_suspect_kind": "application_queue_saturation",
     "primary_suspect_score": 90,
     "p95_latency_us": 744182,
     "p95_queue_share_permille": 980
   },
   "after": {
-    "primary_suspect_kind": "DownstreamStageDominates",
+    "primary_suspect_kind": "downstream_stage_dominates",
     "primary_suspect_score": 77,
     "p95_latency_us": 34609,
     "p95_queue_share_permille": 0

--- a/demos/mixed_contention_service/fixtures/mitigated-analysis.json
+++ b/demos/mixed_contention_service/fixtures/mitigated-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 14816,
-  "p95_latency_us": 35019,
-  "p99_latency_us": 36099,
+  "p50_latency_us": 14394,
+  "p95_latency_us": 34611,
+  "p99_latency_us": 34912,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,17 +11,17 @@
     "peak_count": 14,
     "p95_count": 13,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2493
+    "growth_per_sec_milli": -2666
   },
   "warnings": [],
   "primary_suspect": {
-    "kind": "DownstreamStageDominates",
-    "score": 76,
+    "kind": "downstream_stage_dominates",
+    "score": 77,
     "confidence": "medium",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 32893 us across 220 samples.",
-      "Stage 'downstream_call' cumulative latency is 3787746 us.",
-      "Stage 'downstream_call' contributes 878 permille of cumulative request latency."
+      "Stage 'downstream_call' has p95 latency 32377 us across 220 samples.",
+      "Stage 'downstream_call' cumulative latency is 3762069 us.",
+      "Stage 'downstream_call' contributes 888 permille of cumulative request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",

--- a/demos/queue_service/fixtures/after-analysis.json
+++ b/demos/queue_service/fixtures/after-analysis.json
@@ -1,27 +1,27 @@
 {
   "request_count": 250,
-  "p50_latency_us": 16416,
-  "p95_latency_us": 17868,
-  "p99_latency_us": 21340,
+  "p50_latency_us": 16086,
+  "p95_latency_us": 16918,
+  "p99_latency_us": 17107,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
     "peak_count": 12,
-    "p95_count": 10,
+    "p95_count": 11,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2150
+    "growth_per_sec_milli": -2336
   },
   "warnings": [],
   "primary_suspect": {
-    "kind": "DownstreamStageDominates",
+    "kind": "downstream_stage_dominates",
     "score": 79,
     "confidence": "medium",
     "evidence": [
-      "Stage 'simulated_work' has p95 latency 17754 us across 250 samples.",
-      "Stage 'simulated_work' cumulative latency is 4124839 us.",
-      "Stage 'simulated_work' contributes 996 permille of cumulative request latency."
+      "Stage 'simulated_work' has p95 latency 16908 us across 250 samples.",
+      "Stage 'simulated_work' cumulative latency is 4033977 us.",
+      "Stage 'simulated_work' contributes 998 permille of cumulative request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'simulated_work'.",

--- a/demos/queue_service/fixtures/before-analysis.json
+++ b/demos/queue_service/fixtures/before-analysis.json
@@ -1,10 +1,10 @@
 {
   "request_count": 250,
-  "p50_latency_us": 803400,
-  "p95_latency_us": 1552689,
-  "p99_latency_us": 1604927,
+  "p50_latency_us": 782979,
+  "p95_latency_us": 1467750,
+  "p99_latency_us": 1518268,
   "p95_queue_share_permille": 982,
-  "p95_service_share_permille": 286,
+  "p95_service_share_permille": 269,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
@@ -15,7 +15,7 @@
   },
   "warnings": [],
   "primary_suspect": {
-    "kind": "ApplicationQueueSaturation",
+    "kind": "application_queue_saturation",
     "score": 90,
     "confidence": "high",
     "evidence": [
@@ -29,13 +29,13 @@
   },
   "secondary_suspects": [
     {
-      "kind": "DownstreamStageDominates",
+      "kind": "downstream_stage_dominates",
       "score": 55,
       "confidence": "low",
       "evidence": [
-        "Stage 'simulated_work' has p95 latency 29811 us across 250 samples.",
-        "Stage 'simulated_work' cumulative latency is 6928007 us.",
-        "Stage 'simulated_work' contributes 34 permille of cumulative request latency."
+        "Stage 'simulated_work' has p95 latency 26642 us across 250 samples.",
+        "Stage 'simulated_work' cumulative latency is 6569224 us.",
+        "Stage 'simulated_work' contributes 33 permille of cumulative request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'simulated_work'.",

--- a/demos/queue_service/fixtures/sample-analysis.json
+++ b/demos/queue_service/fixtures/sample-analysis.json
@@ -1,10 +1,10 @@
 {
   "request_count": 250,
-  "p50_latency_us": 803400,
-  "p95_latency_us": 1552689,
-  "p99_latency_us": 1604927,
+  "p50_latency_us": 782979,
+  "p95_latency_us": 1467750,
+  "p99_latency_us": 1518268,
   "p95_queue_share_permille": 982,
-  "p95_service_share_permille": 286,
+  "p95_service_share_permille": 269,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
@@ -15,7 +15,7 @@
   },
   "warnings": [],
   "primary_suspect": {
-    "kind": "ApplicationQueueSaturation",
+    "kind": "application_queue_saturation",
     "score": 90,
     "confidence": "high",
     "evidence": [
@@ -29,13 +29,13 @@
   },
   "secondary_suspects": [
     {
-      "kind": "DownstreamStageDominates",
+      "kind": "downstream_stage_dominates",
       "score": 55,
       "confidence": "low",
       "evidence": [
-        "Stage 'simulated_work' has p95 latency 29811 us across 250 samples.",
-        "Stage 'simulated_work' cumulative latency is 6928007 us.",
-        "Stage 'simulated_work' contributes 34 permille of cumulative request latency."
+        "Stage 'simulated_work' has p95 latency 26642 us across 250 samples.",
+        "Stage 'simulated_work' cumulative latency is 6569224 us.",
+        "Stage 'simulated_work' contributes 33 permille of cumulative request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'simulated_work'.",

--- a/demos/retry_storm_service/fixtures/after-analysis.json
+++ b/demos/retry_storm_service/fixtures/after-analysis.json
@@ -1,27 +1,27 @@
 {
   "request_count": 180,
-  "p50_latency_us": 10406,
-  "p95_latency_us": 29724,
-  "p99_latency_us": 30944,
+  "p50_latency_us": 9788,
+  "p95_latency_us": 29428,
+  "p99_latency_us": 29868,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "retry_storm_inflight",
     "sample_count": 360,
-    "peak_count": 17,
-    "p95_count": 15,
+    "peak_count": 16,
+    "p95_count": 14,
     "growth_delta": -1,
     "growth_per_sec_milli": -4545
   },
   "warnings": [],
   "primary_suspect": {
-    "kind": "DownstreamStageDominates",
-    "score": 75,
+    "kind": "downstream_stage_dominates",
+    "score": 76,
     "confidence": "medium",
     "evidence": [
-      "Stage 'downstream_total' has p95 latency 27352 us across 180 samples.",
-      "Stage 'downstream_total' cumulative latency is 2196075 us.",
-      "Stage 'downstream_total' contributes 834 permille of cumulative request latency."
+      "Stage 'downstream_total' has p95 latency 27201 us across 180 samples.",
+      "Stage 'downstream_total' cumulative latency is 2155288 us.",
+      "Stage 'downstream_total' contributes 840 permille of cumulative request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_total'.",

--- a/demos/retry_storm_service/fixtures/before-after-comparison.json
+++ b/demos/retry_storm_service/fixtures/before-after-comparison.json
@@ -1,12 +1,12 @@
 {
   "before": {
-    "primary_suspect_kind": "DownstreamStageDominates",
+    "primary_suspect_kind": "downstream_stage_dominates",
     "primary_suspect_score": 77,
     "p95_latency_us": 40938,
     "p95_queue_share_permille": 0
   },
   "after": {
-    "primary_suspect_kind": "DownstreamStageDominates",
+    "primary_suspect_kind": "downstream_stage_dominates",
     "primary_suspect_score": 76,
     "p95_latency_us": 29421,
     "p95_queue_share_permille": 0

--- a/demos/retry_storm_service/fixtures/before-analysis.json
+++ b/demos/retry_storm_service/fixtures/before-analysis.json
@@ -1,27 +1,27 @@
 {
   "request_count": 180,
-  "p50_latency_us": 10374,
-  "p95_latency_us": 42693,
-  "p99_latency_us": 44346,
+  "p50_latency_us": 9528,
+  "p95_latency_us": 41874,
+  "p99_latency_us": 43684,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "retry_storm_inflight",
     "sample_count": 360,
-    "peak_count": 55,
-    "p95_count": 51,
+    "peak_count": 58,
+    "p95_count": 55,
     "growth_delta": -1,
-    "growth_per_sec_milli": -8771
+    "growth_per_sec_milli": -9259
   },
   "warnings": [],
   "primary_suspect": {
-    "kind": "DownstreamStageDominates",
+    "kind": "downstream_stage_dominates",
     "score": 77,
     "confidence": "medium",
     "evidence": [
-      "Stage 'downstream_total' has p95 latency 40667 us across 180 samples.",
-      "Stage 'downstream_total' cumulative latency is 3086789 us.",
-      "Stage 'downstream_total' contributes 880 permille of cumulative request latency."
+      "Stage 'downstream_total' has p95 latency 39723 us across 180 samples.",
+      "Stage 'downstream_total' cumulative latency is 3044315 us.",
+      "Stage 'downstream_total' contributes 886 permille of cumulative request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_total'.",

--- a/demos/shared_state_lock_service/fixtures/after-analysis.json
+++ b/demos/shared_state_lock_service/fixtures/after-analysis.json
@@ -1,26 +1,26 @@
 {
   "request_count": 220,
-  "p50_latency_us": 990759,
-  "p95_latency_us": 1777000,
-  "p99_latency_us": 1840002,
+  "p50_latency_us": 829942,
+  "p95_latency_us": 1568584,
+  "p99_latency_us": 1627524,
   "p95_queue_share_permille": 993,
-  "p95_service_share_permille": 127,
+  "p95_service_share_permille": 118,
   "inflight_trend": {
     "gauge": "shared_state_lock_inflight",
     "sample_count": 440,
-    "peak_count": 199,
-    "p95_count": 189,
+    "peak_count": 200,
+    "p95_count": 190,
     "growth_delta": -1,
-    "growth_per_sec_milli": -490
+    "growth_per_sec_milli": -552
   },
   "warnings": [],
   "primary_suspect": {
-    "kind": "ApplicationQueueSaturation",
+    "kind": "application_queue_saturation",
     "score": 90,
     "confidence": "high",
     "evidence": [
       "Queue wait at p95 consumes 99.3% of request time.",
-      "Observed queue depth sample up to 197."
+      "Observed queue depth sample up to 199."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -29,12 +29,12 @@
   },
   "secondary_suspects": [
     {
-      "kind": "DownstreamStageDominates",
+      "kind": "downstream_stage_dominates",
       "score": 55,
       "confidence": "low",
       "evidence": [
-        "Stage 'shared_state_critical_section' has p95 latency 10168 us across 220 samples.",
-        "Stage 'shared_state_critical_section' cumulative latency is 2000297 us.",
+        "Stage 'shared_state_critical_section' has p95 latency 8401 us across 220 samples.",
+        "Stage 'shared_state_critical_section' cumulative latency is 1799166 us.",
         "Stage 'shared_state_critical_section' contributes 9 permille of cumulative request latency."
       ],
       "next_checks": [

--- a/demos/shared_state_lock_service/fixtures/before-after-comparison.json
+++ b/demos/shared_state_lock_service/fixtures/before-after-comparison.json
@@ -1,12 +1,12 @@
 {
   "before": {
-    "primary_suspect_kind": "ApplicationQueueSaturation",
+    "primary_suspect_kind": "application_queue_saturation",
     "primary_suspect_score": 90,
     "p95_latency_us": 4802998,
     "p95_queue_share_permille": 994
   },
   "after": {
-    "primary_suspect_kind": "ApplicationQueueSaturation",
+    "primary_suspect_kind": "application_queue_saturation",
     "primary_suspect_score": 90,
     "p95_latency_us": 1565039,
     "p95_queue_share_permille": 993

--- a/demos/shared_state_lock_service/fixtures/before-analysis.json
+++ b/demos/shared_state_lock_service/fixtures/before-analysis.json
@@ -1,21 +1,21 @@
 {
   "request_count": 220,
-  "p50_latency_us": 2662161,
-  "p95_latency_us": 4994458,
-  "p99_latency_us": 5210245,
+  "p50_latency_us": 2544909,
+  "p95_latency_us": 4808253,
+  "p99_latency_us": 4990004,
   "p95_queue_share_permille": 994,
-  "p95_service_share_permille": 101,
+  "p95_service_share_permille": 96,
   "inflight_trend": {
     "gauge": "shared_state_lock_inflight",
     "sample_count": 440,
     "peak_count": 217,
     "p95_count": 206,
     "growth_delta": -1,
-    "growth_per_sec_milli": -187
+    "growth_per_sec_milli": -195
   },
   "warnings": [],
   "primary_suspect": {
-    "kind": "ApplicationQueueSaturation",
+    "kind": "application_queue_saturation",
     "score": 90,
     "confidence": "high",
     "evidence": [
@@ -29,12 +29,12 @@
   },
   "secondary_suspects": [
     {
-      "kind": "DownstreamStageDominates",
+      "kind": "downstream_stage_dominates",
       "score": 55,
       "confidence": "low",
       "evidence": [
-        "Stage 'shared_state_critical_section' has p95 latency 24744 us across 220 samples.",
-        "Stage 'shared_state_critical_section' cumulative latency is 5286489 us.",
+        "Stage 'shared_state_critical_section' has p95 latency 23446 us across 220 samples.",
+        "Stage 'shared_state_critical_section' cumulative latency is 5106285 us.",
         "Stage 'shared_state_critical_section' contributes 9 permille of cumulative request latency."
       ],
       "next_checks": [

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -59,18 +59,18 @@ Rules of thumb:
 
 ## Suspect kinds
 
-- `ApplicationQueueSaturation`
-- `BlockingPoolPressure`
-- `ExecutorPressureSuspected`
-- `DownstreamStageDominates`
-- `InsufficientEvidence`
+- `application_queue_saturation`
+- `blocking_pool_pressure`
+- `executor_pressure_suspected`
+- `downstream_stage_dominates`
+- `insufficient_evidence`
 
 These are **evidence-ranked leads**, not causal proof.
 
 ### Executor pressure vs blocking-pool pressure
 
-- `ExecutorPressureSuspected` emphasizes runtime scheduler backlog signals (for example, elevated global/local runtime queue depth with in-flight growth).
-- `BlockingPoolPressure` emphasizes `spawn_blocking` backlog signals (for example, elevated blocking queue depth evidence).
+- `executor_pressure_suspected` emphasizes runtime scheduler backlog signals (for example, elevated global/local runtime queue depth with in-flight growth).
+- `blocking_pool_pressure` emphasizes `spawn_blocking` backlog signals (for example, elevated blocking queue depth evidence).
 - If blocking queue depth remains low/absent while runtime queue depth rises, prefer executor-pressure next checks before blocking-pool tuning.
 
 Runtime-signal availability caveat:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -133,7 +133,7 @@ Representative diagnosis shape:
 ```json
 {
   "primary_suspect": {
-    "kind": "ApplicationQueueSaturation",
+    "kind": "application_queue_saturation",
     "evidence": [
       "Queue wait at p95 consumes 98.2% of request time.",
       "Observed queue depth sample up to 230."
@@ -148,7 +148,7 @@ Representative diagnosis shape:
 
 Suspects are evidence-ranked leads, not proof of root cause.
 
-## If result is `InsufficientEvidence`
+## If result is `insufficient_evidence`
 
 Add one more queue wrapper and one more stage wrapper around the most likely missing wait points, then rerun with comparable load.
 

--- a/scripts/demo_tool.py
+++ b/scripts/demo_tool.py
@@ -16,10 +16,10 @@ from _demo_runner import (
     write_before_after_comparison,
 )
 
-EXPECTED_QUEUE_KIND = {"application_queue_saturation", "ApplicationQueueSaturation"}
-EXPECTED_BLOCKING_KIND = {"blocking_pool_pressure", "BlockingPoolPressure"}
-EXPECTED_EXECUTOR_KIND = {"executor_pressure_suspected", "ExecutorPressureSuspected"}
-EXPECTED_DOWNSTREAM_KIND = {"downstream_stage_dominates", "DownstreamStageDominates"}
+EXPECTED_QUEUE_KIND = {"application_queue_saturation"}
+EXPECTED_BLOCKING_KIND = {"blocking_pool_pressure"}
+EXPECTED_EXECUTOR_KIND = {"executor_pressure_suspected"}
+EXPECTED_DOWNSTREAM_KIND = {"downstream_stage_dominates"}
 EXPECTED_MIXED_PRIMARY_KINDS = EXPECTED_QUEUE_KIND | EXPECTED_DOWNSTREAM_KIND
 EXPECTED_COLD_START_PRIMARY_KINDS = EXPECTED_QUEUE_KIND | EXPECTED_DOWNSTREAM_KIND
 EXPECTED_DB_POOL_PRIMARY_KINDS = EXPECTED_QUEUE_KIND | EXPECTED_DOWNSTREAM_KIND

--- a/tailtriage-cli/src/analyze.rs
+++ b/tailtriage-cli/src/analyze.rs
@@ -1,9 +1,9 @@
 use std::collections::{BTreeMap, HashMap};
 
-use serde::Serialize;
+use serde::{Serialize, Serializer};
 use tailtriage_core::{InFlightSnapshot, Run, RuntimeSnapshot};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DiagnosisKind {
     ApplicationQueueSaturation,
     BlockingPoolPressure,
@@ -22,6 +22,15 @@ impl DiagnosisKind {
             Self::DownstreamStageDominates => "downstream_stage_dominates",
             Self::InsufficientEvidence => "insufficient_evidence",
         }
+    }
+}
+
+impl Serialize for DiagnosisKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
     }
 }
 

--- a/tailtriage-cli/tests/demo_smoke_fixtures.rs
+++ b/tailtriage-cli/tests/demo_smoke_fixtures.rs
@@ -47,7 +47,7 @@ fn queue_demo_fixture_reports_application_queue_saturation() {
     let fixture = "demos/queue_service/fixtures/sample-analysis.json";
     let report = load_demo_analysis(fixture);
 
-    assert_primary_kind_in_allowed_set(&report, &["ApplicationQueueSaturation"], fixture);
+    assert_primary_kind_in_allowed_set(&report, &["application_queue_saturation"], fixture);
     assert_primary_score_floor(&report, 70, fixture);
 }
 
@@ -56,7 +56,7 @@ fn blocking_demo_fixture_reports_blocking_pool_pressure() {
     let fixture = "demos/blocking_service/fixtures/sample-analysis.json";
     let report = load_demo_analysis(fixture);
 
-    assert_primary_kind_in_allowed_set(&report, &["BlockingPoolPressure"], fixture);
+    assert_primary_kind_in_allowed_set(&report, &["blocking_pool_pressure"], fixture);
     assert_primary_score_floor(&report, 70, fixture);
 }
 
@@ -65,7 +65,7 @@ fn downstream_demo_fixture_reports_downstream_stage_dominance() {
     let fixture = "demos/downstream_service/fixtures/sample-analysis.json";
     let report = load_demo_analysis(fixture);
 
-    assert_primary_kind_in_allowed_set(&report, &["DownstreamStageDominates"], fixture);
+    assert_primary_kind_in_allowed_set(&report, &["downstream_stage_dominates"], fixture);
     assert_primary_score_floor(&report, 60, fixture);
 }
 
@@ -74,7 +74,7 @@ fn executor_demo_fixture_reports_executor_pressure() {
     let fixture = "demos/executor_pressure_service/fixtures/sample-analysis.json";
     let report = load_demo_analysis(fixture);
 
-    assert_primary_kind_in_allowed_set(&report, &["ExecutorPressureSuspected"], fixture);
+    assert_primary_kind_in_allowed_set(&report, &["executor_pressure_suspected"], fixture);
     assert_primary_score_floor(&report, 60, fixture);
 }
 
@@ -85,7 +85,10 @@ fn mixed_contention_baseline_fixture_has_queue_primary_with_secondary_contention
 
     assert_primary_kind_in_allowed_set(
         &report,
-        &["ApplicationQueueSaturation", "ExecutorPressureSuspected"],
+        &[
+            "application_queue_saturation",
+            "executor_pressure_suspected",
+        ],
         fixture,
     );
     assert_primary_evidence_contains_any(
@@ -103,7 +106,10 @@ fn cold_start_burst_before_fixture_has_cold_start_queue_evidence() {
 
     assert_primary_kind_in_allowed_set(
         &report,
-        &["ApplicationQueueSaturation", "ExecutorPressureSuspected"],
+        &[
+            "application_queue_saturation",
+            "executor_pressure_suspected",
+        ],
         fixture,
     );
     assert_primary_evidence_contains_any(
@@ -126,7 +132,7 @@ fn db_pool_saturation_before_fixture_preserves_queue_signal_floor() {
 
     assert_primary_kind_in_allowed_set(
         &report,
-        &["ApplicationQueueSaturation", "DownstreamStageDominates"],
+        &["application_queue_saturation", "downstream_stage_dominates"],
         fixture,
     );
     assert_primary_evidence_contains_any(&report, &["Queue wait", "queue depth"], fixture);
@@ -140,7 +146,7 @@ fn retry_storm_before_fixture_preserves_downstream_retry_cues() {
 
     assert_primary_kind_in_allowed_set(
         &report,
-        &["DownstreamStageDominates", "ApplicationQueueSaturation"],
+        &["downstream_stage_dominates", "application_queue_saturation"],
         fixture,
     );
     assert_primary_evidence_contains_any(


### PR DESCRIPTION
### Motivation

- Provide a single, stable JSON wire format for suspect kinds by using snake_case to remove mixed-format ambiguity.
- Keep the CLI JSON output, validation scripts, fixtures, and docs consistent so downstream tooling and examples have one canonical representation.

### Description

- Implemented a custom `Serialize` impl for `DiagnosisKind` that emits `as_str()` so JSON output is always snake_case (`application_queue_saturation`, `blocking_pool_pressure`, etc.).
- Removed the `Serialize` derive from `DiagnosisKind` and added `use serde::{Serialize, Serializer}` with the manual serializer in `tailtriage-cli/src/analyze.rs`.
- Updated demo validation and helper scripts to accept only snake_case kinds and adjusted smoke tests in `tailtriage-cli/tests/demo_smoke_fixtures.rs` accordingly.
- Refreshed committed demo analysis fixtures and updated `README.md`, `SPEC.md`, and docs under `docs/` to show snake_case suspect kinds.

### Testing

- Ran `cargo fmt --check` and formatting checks passed.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and the lint run completed with no warnings.
- Ran `cargo test --workspace` and all tests passed (`cargo test` reported all tests ok).
- Executed runtime validation steps including `cargo run -p tailtriage-tokio --example minimal_checkout` and `cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json`, which produced snake_case `kind` values as expected.
- Refreshed and verified demo fixtures with `python3 scripts/check_demo_fixture_drift.py --refresh` and `python3 scripts/check_demo_fixture_drift.py`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c04c288a5c8330b25df4ec2d491383)