### PR TITLE
docs: sharpen README/docs front door and add fastest try‑it path

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 `tailtriage` is a Rust toolkit for **Tokio tail-latency triage**.
 
-It is built for ordinary Rust/Tokio developers who need a useful first answer without being expert performance engineers.
+It is for Rust/Tokio developers who need a fast first triage answer without being expert performance engineers.
+
+It is not an observability backend, distributed tracing system, or automated root-cause proof engine.
 
 Core question:
 
@@ -35,6 +37,19 @@ On stable Tokio, unstable-only fields are captured as `None`, so executor-pressu
 - people who want a fast local triage loop before adopting heavier observability workflows
 
 ## Quickstart: choose your path
+
+### Fastest try-it path (about 60 seconds)
+
+If you want the quickest first run from this repository, run:
+
+```bash
+cargo run -p tailtriage-tokio --example minimal_checkout
+cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
+```
+
+Then inspect `primary_suspect.kind`, `primary_suspect.evidence[]`, and `primary_suspect.next_checks[]`.
+
+Need route-by-route setup guidance? Start at **[docs/README.md](docs/README.md)**, then follow **[docs/user-guide.md](docs/user-guide.md)**.
 
 ### Path A — Try from this repo (source/workspace)
 
@@ -125,11 +140,17 @@ Representative diagnosis shape:
 
 Suspects are evidence-ranked leads, not proof of root cause.
 
-## Before/after proof path (secondary)
+## Demo realism and before/after proof path
+
+Demo guidance: the strongest public proof demos are `queue_service`, `downstream_service`, and `db_pool_saturation_service`; later demos include intentionally more synthetic analyzer-contract exercises.
+
+Suspects remain evidence-ranked leads, not proof of root cause.
 
 After first run, use one fixture-backed before/after workflow to validate changes:
 
 - [`demos/retry_storm_service/fixtures/before-after-comparison.json`](demos/retry_storm_service/fixtures/before-after-comparison.json)
+- Full demo guide and progression notes: **[demos/README.md](demos/README.md)**
+- Demo walkthrough for first-time users: **[docs/getting-started-demo.md](docs/getting-started-demo.md)**
 
 ## Why not just use tokio-console or tokio-metrics?
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,10 +2,13 @@
 
 Use this page as the single entry point for project documentation.
 
+If you are new to `tailtriage`, start in **User docs** below and ignore maintainer sections on your first pass.
+
 ## User docs (start here)
 
-- **Try from this repo (source/workspace quickstart):** [user-guide.md#path-a--try-from-this-repo-sourceworkspace](user-guide.md#path-a--try-from-this-repo-sourceworkspace)
-- **Adopt in your app (crates.io quickstart):** [user-guide.md#path-b--adopt-in-your-app-cratesio](user-guide.md#path-b--adopt-in-your-app-cratesio)
+1. **Try from this repo (fastest first run):** [user-guide.md#path-a--try-from-this-repo-sourceworkspace](user-guide.md#path-a--try-from-this-repo-sourceworkspace)
+2. **Adopt in your app (crates.io quickstart):** [user-guide.md#path-b--adopt-in-your-app-cratesio](user-guide.md#path-b--adopt-in-your-app-cratesio)
+3. **Run demos with realism notes:** [getting-started-demo.md](getting-started-demo.md)
 
 ### First-run and triage workflow
 
@@ -23,7 +26,7 @@ Use this page as the single entry point for project documentation.
 - **Release/polish plan:** [../IMPLEMENTATION_PLAN.md](../IMPLEMENTATION_PLAN.md)
 - **Project changelog:** [changelog.md](changelog.md)
 
-## Maintainer / launch / operational docs
+## Maintainer / launch / operational docs (for contributors/maintainers)
 
 - **v0.1 release decision gates and launch order:** [release-gates-v0.1.md](release-gates-v0.1.md)
 - **Public visibility readiness checklist:** [public-readiness-checklist.md](public-readiness-checklist.md)

--- a/docs/getting-started-demo.md
+++ b/docs/getting-started-demo.md
@@ -2,6 +2,8 @@
 
 Use demos to validate diagnosis behavior with deterministic fixtures.
 
+Demo honesty note: this suite mixes strongest public proof demos with intentionally more synthetic analyzer-contract demos. Use suspects as triage leads, not root-cause proof.
+
 For a scenario-by-scenario explanation of what each demo simulates, what triage it is intended to exercise, and what setup is shared, see **[`demos/README.md`](../demos/README.md)**.
 
 ## Recommended public progression


### PR DESCRIPTION
### Motivation

- Make the repository front door clearer for first-time visitors by surfacing the fastest capture→analyze path and explicit product framing. 
- Reinforce honest demo realism so newcomers interpret analyzer output as evidence-ranked leads rather than claimed root-cause proof.

### Description

- Tightened the top of `README.md` to state the intended audience and explicit non-goals in short, direct sentences. 
- Added a prominent `Fastest try-it path` block that shows the minimal capture and analyze sequence (`cargo run -p tailtriage-tokio --example minimal_checkout` + `cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json`).
- Added demo-realism guidance to `README.md` and a short "demo honesty" note to `docs/getting-started-demo.md` clarifying which demos are strongest proof cases and that suspects are leads not proof. 
- Updated `docs/README.md` to route first-time visitors to User docs first and to label maintainer/operational sections more explicitly.

### Testing

- Ran `cargo fmt --check` and it passed. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it passed with no warnings. 
- Ran `cargo test --workspace` and all tests completed successfully (`all unit and integration tests passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0574f37b4833095465b89f31dbf8c)