### PR TITLE
Fix RuntimeSampler shutdown guidance and add minimal_checkout links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ If you are new to `tailtriage`, start in **User docs** below and ignore maintain
 
 - **How triage analysis works:** [diagnostics.md](diagnostics.md)
 - **Demos and fixture workflow:** [getting-started-demo.md](getting-started-demo.md)
+- **Fastest source first run (`minimal_checkout`):** [../tailtriage-tokio/examples/minimal_checkout.rs](../tailtriage-tokio/examples/minimal_checkout.rs)
 - **Framework-based adoption starter (axum):** [../tailtriage-tokio/examples/axum_minimal.rs](../tailtriage-tokio/examples/axum_minimal.rs)
 - **Realistic mini-service integration example (adoption confidence):** [../tailtriage-tokio/examples/mini_service_integration.rs](../tailtriage-tokio/examples/mini_service_integration.rs)
 - **Before/after proof workflow (secondary):** [../demos/retry_storm_service/fixtures/before-after-comparison.json](../demos/retry_storm_service/fixtures/before-after-comparison.json)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -179,7 +179,10 @@ let sampler = RuntimeSampler::start(
 )?;
 // run workload
 sampler.shutdown().await;
+tailtriage.shutdown()?;
 ```
+
+`sampler.shutdown().await` stops runtime snapshot collection, and `tailtriage.shutdown()?` performs the final artifact flush to `tailtriage-run.json`.
 
 ### RuntimeSampler metric availability
 
@@ -212,5 +215,6 @@ After first run, validate one mitigation workflow:
 - [Diagnostics guide](diagnostics.md)
 - [Architecture](architecture.md)
 - [Demo workflow](getting-started-demo.md)
+- [Minimal source first-run example (source)](../tailtriage-tokio/examples/minimal_checkout.rs)
 - [Axum adoption starter example (source)](../tailtriage-tokio/examples/axum_minimal.rs)
 - [Mini-service integration example (source)](../tailtriage-tokio/examples/mini_service_integration.rs)


### PR DESCRIPTION
### Motivation
- Ensure the launch-facing docs present a complete and truthful capture lifecycle and point users to the intended source examples for a correct first-run experience.

### Description
- Append the required final artifact flush (`tailtriage.shutdown()?`) and a short explanatory sentence to the `RuntimeSampler` snippet in `docs/user-guide.md`, and add explicit `minimal_checkout` example links to `docs/user-guide.md` and `docs/README.md` so all three source examples are directly referenced.

### Testing
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, and all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2aab296a48330b96d54818c82b543)