### PR TITLE
Clarify independent p95 share semantics in docs and CLI output

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
 - `p95_queue_share_permille` (95th percentile of per-request queue-time share)
 - `p95_service_share_permille` (95th percentile of per-request service-time share)
 
+`p95_queue_share_permille` and `p95_service_share_permille` are independent percentile summaries over different per-request series. They are not expected to sum to `1000`.
+
 ### Path B — Adopt in your app (crates.io)
 
 Use this when you are integrating `tailtriage` into your own Tokio service.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -46,10 +46,13 @@ Each suspect includes:
 | `primary_suspect` | `Suspect` | Highest-ranked suspect. |
 | `secondary_suspects` | `Vec<Suspect>` | Remaining ranked suspects. |
 
+The two p95 share fields are independent percentile summaries over different per-request series. They are not complementary totals and are not expected to sum to `1000`.
+
 ## Interpreting shares quickly
 
 - `1000` permille = 100%
 - `500` permille = 50%
+- `p95_queue_share_permille` and `p95_service_share_permille` are each a percentile over their own distribution, so they should not be added together.
 
 Rules of thumb:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -64,6 +64,8 @@ Inspect these fields first:
 - `p95_queue_share_permille` (95th percentile of per-request queue-time share)
 - `p95_service_share_permille` (95th percentile of per-request service-time share)
 
+`p95_queue_share_permille` and `p95_service_share_permille` are independent percentile summaries over different per-request series. They are not expected to sum to `1000`.
+
 ## Path B — Adopt in your app (crates.io)
 
 Use this path when you want to integrate `tailtriage` into your own Tokio application without workspace context.
@@ -133,6 +135,8 @@ Inspect these fields first:
 - `primary_suspect.next_checks[]`
 - `p95_queue_share_permille` (95th percentile of per-request queue-time share)
 - `p95_service_share_permille` (95th percentile of per-request service-time share)
+
+`p95_queue_share_permille` and `p95_service_share_permille` are independent percentile summaries over different per-request series. They are not expected to sum to `1000`.
 
 Representative diagnosis shape:
 

--- a/tailtriage-cli/src/analyze.rs
+++ b/tailtriage-cli/src/analyze.rs
@@ -547,7 +547,7 @@ pub fn render_text(report: &Report) -> String {
             report.p50_latency_us, report.p95_latency_us, report.p99_latency_us
         ),
         format!(
-            "request_time_share_permille p95 queue={:?} service={:?}",
+            "request_time_share_permille p95 queue={:?} service={:?} (independent percentiles; not expected to sum to 1000)",
             report.p95_queue_share_permille, report.p95_service_share_permille
         ),
         inflight_line,
@@ -796,6 +796,7 @@ mod tests {
         assert!(text.contains("inflight_trend gauge=queue_inflight"));
         assert!(text.contains("samples=4"));
         assert!(text.contains("growth_per_sec_milli=Some(2500)"));
+        assert!(text.contains("independent percentiles; not expected to sum to 1000"));
     }
 
     #[test]

--- a/tailtriage-cli/tests/analyzer_fixtures.rs
+++ b/tailtriage-cli/tests/analyzer_fixtures.rs
@@ -57,6 +57,7 @@ fn fixture_reports_render_to_text_and_json() {
     let text = render_text(&report);
     assert!(text.contains("primary:"));
     assert!(text.contains("request_time_share_permille"));
+    assert!(text.contains("independent percentiles; not expected to sum to 1000"));
     assert!(text.contains("secondary suspects") || report.secondary_suspects.is_empty());
 
     let json = serde_json::to_string_pretty(&report).expect("json rendering should work");


### PR DESCRIPTION
### Motivation
- Users were misreading `p95_queue_share_permille` and `p95_service_share_permille` as complementary totals, which can lead to incorrect triage conclusions. 
- The default CLI text and key user docs needed an explicit, concise disambiguation to prevent that misinterpretation.

### Description
- Added explicit clarifications to `README.md`, `docs/user-guide.md`, and `docs/diagnostics.md` stating that `p95_queue_share_permille` and `p95_service_share_permille` are independent percentile summaries and are not expected to sum to `1000`.
- Changed the default CLI text rendering in `tailtriage-cli/src/analyze.rs::render_text` to include the note `(independent percentiles; not expected to sum to 1000)` on the share line.
- Locked the intended CLI wording with updated assertions in `tailtriage-cli/tests/analyzer_fixtures.rs` and added a matching assertion in the relevant unit test in `tailtriage-cli/src/analyze.rs`.
- Made no changes to the JSON field names or report schema; only presentation and docs were updated.

### Testing
- Ran `cargo fmt --check` and it succeeded.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it completed with no warnings/errors.
- Ran `cargo test --workspace` and all tests passed (unit and fixture tests that cover the new CLI wording succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2ad7a39f88330b9e55727103aa1ab)