### PR TITLE
Add CI smoke validation for launch-critical public examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,10 @@ jobs:
 
       - name: Validate retry-storm demo
         run: python3 scripts/demo_tool.py validate retry-storm --profile ${{ matrix.profile }}
+
+      - name: Smoke-check launch-critical public examples
+        if: matrix.profile == 'dev'
+        run: python3 scripts/smoke_public_examples.py
         
       - name: Check demo fixture drift
         if: matrix.profile == 'dev'

--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ All three write tailtriage-run.json and can be analyzed with:
 cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
 ```
 
+CI smoke-validates this exact public flow with:
+
+```bash
+python3 scripts/smoke_public_examples.py
+```
+
 Use minimal_checkout for the quickest first result, axum_minimal for framework-style adoption shape, and mini_service_integration when you want to see instrumentation flow through helper layers.
 
 The examples are found in tailtriage-tokio/examples.

--- a/scripts/smoke_public_examples.py
+++ b/scripts/smoke_public_examples.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Smoke-validate launch-critical public examples.
+
+This script validates the public onboarding flow for selected examples:
+1) run the example
+2) confirm it writes a run artifact
+3) confirm the artifact has the expected top-level schema shape
+4) confirm `tailtriage-cli analyze ... --format json` succeeds
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+EXAMPLES = [
+    "minimal_checkout",
+    "axum_minimal",
+    "mini_service_integration",
+]
+
+EXPECTED_RUN_TOP_LEVEL_KEYS = {
+    "schema_version",
+    "metadata",
+    "requests",
+    "stages",
+    "queues",
+    "inflight",
+    "runtime_snapshots",
+    "truncation",
+}
+
+EXPECTED_ANALYSIS_TOP_LEVEL_KEYS = {
+    "request_count",
+    "p95_latency_us",
+    "primary_suspect",
+    "secondary_suspects",
+    "warnings",
+}
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def run_cmd(cmd: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def assert_keys(payload: dict, expected: set[str], *, context: str) -> None:
+    missing = sorted(expected - set(payload.keys()))
+    if missing:
+        missing_list = ", ".join(missing)
+        raise SystemExit(f"{context} missing top-level keys: {missing_list}")
+
+
+def validate_example(name: str) -> None:
+    root = repo_root()
+    print(f"==> validating example: {name}")
+
+    with tempfile.TemporaryDirectory(prefix=f"tailtriage-example-smoke-{name}-") as temp_dir:
+        working_dir = Path(temp_dir)
+        artifact_path = working_dir / "tailtriage-run.json"
+
+        run_cmd(
+            [
+                "cargo",
+                "run",
+                "--quiet",
+                "--manifest-path",
+                str(root / "tailtriage-tokio/Cargo.toml"),
+                "--example",
+                name,
+            ],
+            cwd=working_dir,
+        )
+
+        if not artifact_path.exists():
+            raise SystemExit(
+                f"example '{name}' did not create expected artifact: {artifact_path}"
+            )
+
+        run_payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+        if not isinstance(run_payload, dict):
+            raise SystemExit(f"example '{name}' artifact is not a JSON object")
+
+        assert_keys(
+            run_payload,
+            EXPECTED_RUN_TOP_LEVEL_KEYS,
+            context=f"example '{name}' run artifact",
+        )
+
+        analysis = run_cmd(
+            [
+                "cargo",
+                "run",
+                "--quiet",
+                "--manifest-path",
+                str(root / "tailtriage-cli/Cargo.toml"),
+                "--",
+                "analyze",
+                str(artifact_path),
+                "--format",
+                "json",
+            ],
+            cwd=root,
+        )
+        analysis_payload = json.loads(analysis.stdout)
+        if not isinstance(analysis_payload, dict):
+            raise SystemExit(f"example '{name}' analysis output is not a JSON object")
+
+        assert_keys(
+            analysis_payload,
+            EXPECTED_ANALYSIS_TOP_LEVEL_KEYS,
+            context=f"example '{name}' analysis report",
+        )
+
+        print(f"validated: {name}")
+        print(f"  artifact: {artifact_path}")
+
+
+def main() -> None:
+    print("Smoke-validating launch-critical public examples...")
+    for name in EXAMPLES:
+        validate_example(name)
+    print("All launch-critical public examples passed smoke validation.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Prevent onboarding drift by smoke-validating the three launch-critical public examples (`minimal_checkout`, `axum_minimal`, `mini_service_integration`) in CI. 
- Ensure the full public flow (example run → run artifact → `tailtriage-cli analyze`) stays functional and produces the expected schema shape. 
- Keep runtime reasonable by adding one dedicated, maintainable check scoped to the `dev` CI profile.

### Description
- Add `scripts/smoke_public_examples.py`, a CI-friendly smoke validator that runs each example via `cargo run --manifest-path ... --example <name>`, verifies `tailtriage-run.json` is produced, checks required top-level run-artifact keys, runs `tailtriage-cli analyze ... --format json`, and checks required top-level analysis keys. 
- Wire the smoke validator into `.github/workflows/ci.yml` as a single step named `Smoke-check launch-critical public examples` that runs only when `matrix.profile == 'dev'`. 
- Update `README.md` to document the smoke-validation command (`python3 scripts/smoke_public_examples.py`) for the public onboarding examples.

### Testing
- Ran the smoke script locally with `python3 scripts/smoke_public_examples.py`, which completed successfully and validated all three examples. 
- Ran formatting and lint checks with `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings`, both of which passed. 
- Executed the full test suite with `cargo test --workspace`, which passed. 
- Confirmed the CI workflow change is a single dev-profile step to limit added runtime while surfacing onboarding drift in CI logs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2b1f12eac833083bb5105b406ff49)