### PR TITLE
Add release external-consumer smoke adoption validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,10 @@ jobs:
       - name: Smoke-check launch-critical public examples
         if: matrix.profile == 'dev'
         run: python3 scripts/smoke_public_examples.py
+
+      - name: Smoke-check external consumer adoption flow
+        if: matrix.profile == 'release'
+        run: python3 scripts/smoke_external_consumer.py
         
       - name: Check demo fixture drift
         if: matrix.profile == 'dev'

--- a/scripts/smoke_external_consumer.py
+++ b/scripts/smoke_external_consumer.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Smoke-test an external consumer app outside the workspace.
+
+This script creates a temporary Cargo app outside the repository, consumes
+`tailtriage-core` via path dependency, produces a run artifact, and analyzes it
+with the workspace CLI.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+EXPECTED_RUN_TOP_LEVEL_KEYS = {
+    "schema_version",
+    "metadata",
+    "requests",
+    "stages",
+    "queues",
+    "inflight",
+    "runtime_snapshots",
+    "truncation",
+}
+
+EXPECTED_ANALYSIS_TOP_LEVEL_KEYS = {
+    "request_count",
+    "p95_latency_us",
+    "primary_suspect",
+    "secondary_suspects",
+    "warnings",
+}
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def run_cmd(cmd: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def assert_keys(payload: dict, expected: set[str], *, context: str) -> None:
+    missing = sorted(expected - set(payload.keys()))
+    if missing:
+        missing_list = ", ".join(missing)
+        raise SystemExit(f"{context} missing top-level keys: {missing_list}")
+
+
+def write_external_app(project_dir: Path, root: Path) -> tuple[Path, Path]:
+    app_dir = project_dir / "external-tailtriage-smoke"
+    run_cmd(["cargo", "new", "--bin", app_dir.name], cwd=project_dir)
+
+    cargo_toml = f"""[package]
+name = "external-tailtriage-smoke"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tailtriage-core = {{ path = \"{(root / 'tailtriage-core').as_posix()}\" }}
+tokio = {{ version = "1", features = ["macros", "rt", "time"] }}
+"""
+    (app_dir / "Cargo.toml").write_text(cargo_toml, encoding="utf-8")
+
+    main_rs = """use std::time::Duration;
+
+use tailtriage_core::{RequestOptions, Tailtriage};
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let tailtriage = Tailtriage::builder("external-consumer-smoke")
+        .output("tailtriage-run.json")
+        .build()?;
+
+    let request = tailtriage
+        .request_with("/smoke", RequestOptions::new().request_id("external-req-1"))
+        .with_kind("cli");
+
+    request
+        .queue("ingress")
+        .with_depth_at_start(1)
+        .await_on(tokio::time::sleep(Duration::from_millis(2)))
+        .await;
+
+    request
+        .stage("compute")
+        .await_value(tokio::time::sleep(Duration::from_millis(3)))
+        .await;
+
+    request.finish_ok();
+    tailtriage.shutdown()?;
+    Ok(())
+}
+"""
+    (app_dir / "src/main.rs").write_text(main_rs, encoding="utf-8")
+
+    return app_dir, app_dir / "tailtriage-run.json"
+
+
+def main() -> None:
+    root = repo_root()
+    print("Smoke-validating an external consumer app outside the workspace...")
+
+    with tempfile.TemporaryDirectory(prefix="tailtriage-external-consumer-") as temp_dir:
+        external_root = Path(temp_dir)
+        app_dir, artifact_path = write_external_app(external_root, root)
+
+        print(f"==> created external app: {app_dir}")
+        run_cmd(["cargo", "run", "--quiet"], cwd=app_dir)
+
+        if not artifact_path.exists():
+            raise SystemExit(
+                "external app did not create expected artifact: "
+                f"{artifact_path}"
+            )
+
+        run_payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+        if not isinstance(run_payload, dict):
+            raise SystemExit("external app artifact is not a JSON object")
+
+        assert_keys(
+            run_payload,
+            EXPECTED_RUN_TOP_LEVEL_KEYS,
+            context="external app run artifact",
+        )
+
+        analysis = run_cmd(
+            [
+                "cargo",
+                "run",
+                "--quiet",
+                "--manifest-path",
+                str(root / "tailtriage-cli/Cargo.toml"),
+                "--",
+                "analyze",
+                str(artifact_path),
+                "--format",
+                "json",
+            ],
+            cwd=root,
+        )
+        analysis_payload = json.loads(analysis.stdout)
+        if not isinstance(analysis_payload, dict):
+            raise SystemExit("analysis output is not a JSON object")
+
+        assert_keys(
+            analysis_payload,
+            EXPECTED_ANALYSIS_TOP_LEVEL_KEYS,
+            context="external app analysis report",
+        )
+
+        print("External consumer smoke test passed.")
+        print(f"  artifact: {artifact_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide an automated, CI-friendly proof that an external app can consume the workspace crates via local path dependencies and use the public API surface. 
- The goal is a deterministic, release-intended smoke check that validates a minimal capture + analyze flow outside the workspace without requiring crates.io publication.

### Description
- Add `scripts/smoke_external_consumer.py`, a script that creates a temporary Cargo binary project outside the repo, depends on `tailtriage-core` via a path dependency, builds and runs a minimal capture flow using the public API (`Tailtriage::builder`, `request_with`, `queue`, `stage`, `finish_ok`, `shutdown`), and writes a `tailtriage-run.json` artifact.
- The script validates the produced run artifact top-level schema keys and runs the workspace CLI analyze path with `tailtriage-cli analyze --format json`, asserting expected top-level report keys.
- Wire the new smoke script into CI by updating `.github/workflows/ci.yml` to run the external-consumer smoke check only for the `release` matrix profile.
- Keep the smoke validation focused on public APIs and path-dependency adoption ergonomics, not full feature coverage.

### Testing
- Ran `cargo fmt --check`, which succeeded.
- Ran `python3 scripts/smoke_external_consumer.py`, which created the external app, produced `tailtriage-run.json`, and passed the analysis validation.
- Ran `cargo clippy --workspace --all-targets -- -D warnings`, which succeeded in this environment.
- Ran `cargo test --workspace`; this run failed due to an existing failing assertion in `tailtriage-cli/tests/end_to_end_capture_analysis.rs::downstream_heavy_stage_is_ranked` (observed `application_queue_saturation` vs expected `downstream_stage_dominates`), which is unrelated to the new smoke-path changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2b5f477f48330a67396f1d809df5b)