### PR TITLE
Add CI package/publish-surface validation for workspace crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,10 @@ jobs:
         if: matrix.profile == 'dev'
         run: python3 scripts/check_demo_fixture_drift.py --profile ${{ matrix.profile }}
 
+      - name: Validate publishable crates
+        if: matrix.profile == 'dev'
+        run: python3 scripts/validate_publishable_crates.py
+
       - name: Measure runtime cost (non-blocking)
         continue-on-error: true
         run: python3 scripts/measure_runtime_cost.py

--- a/scripts/validate_publishable_crates.py
+++ b/scripts/validate_publishable_crates.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Validate publishable crate package surfaces.
+
+This script performs two checks for each publishable crate:
+1) `cargo package --list` to show what would be packaged.
+2) `cargo publish --dry-run` to validate publishability without publishing.
+
+If any crate cannot pass dry-run publication (for example because a dependency is
+not yet available on crates.io), the script exits non-zero with a summary.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+PUBLISHABLE_CRATES = [
+    "tailtriage-core",
+    "tailtriage-tokio",
+    "tailtriage-cli",
+]
+
+
+@dataclass
+class CommandResult:
+    command: list[str]
+    success: bool
+    stderr: str
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def run_checked(cmd: list[str], cwd: Path) -> CommandResult:
+    printable_cmd = " ".join(cmd)
+    print(f"\n$ {printable_cmd}")
+    completed = subprocess.run(
+        cmd,
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+    )
+    if completed.stdout:
+        print(completed.stdout, end="")
+    if completed.stderr:
+        print(completed.stderr, end="")
+    return CommandResult(
+        command=cmd,
+        success=completed.returncode == 0,
+        stderr=completed.stderr,
+    )
+
+
+def validate_crate(crate: str, root: Path) -> list[CommandResult]:
+    print(f"\n==> validating publish package surface for {crate}")
+    results: list[CommandResult] = []
+    results.append(run_checked(["cargo", "package", "--list", "--locked", "-p", crate], root))
+    results.append(run_checked(["cargo", "publish", "--dry-run", "--locked", "-p", crate], root))
+    return results
+
+
+def main() -> None:
+    root = repo_root()
+    print("Validating package contents and publish dry-run for all publishable crates...")
+
+    failures: list[CommandResult] = []
+    for crate in PUBLISHABLE_CRATES:
+        for result in validate_crate(crate, root):
+            if not result.success:
+                failures.append(result)
+
+    if failures:
+        print("\nPackage validation failures detected:")
+        for failure in failures:
+            print(f"- {' '.join(failure.command)}")
+            if failure.stderr:
+                first_line = failure.stderr.strip().splitlines()[-1]
+                print(f"  last error line: {first_line}")
+        raise SystemExit(1)
+
+    print("\nAll publishable crate package validations passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Ensure the package surface for each publishable crate is validated automatically before release so publish-time surprises are caught early. 
- Surface publish-order and registry dependency issues (e.g. local path deps) in CI with clear, actionable output.

### Description
- Add `scripts/validate_publishable_crates.py` which runs `cargo package --list --locked -p <crate>` and `cargo publish --dry-run --locked -p <crate>` for `tailtriage-core`, `tailtriage-tokio`, and `tailtriage-cli`, printing per-command output and collecting failures. 
- Aggregate failures and print a concise summary with the last error line for each failing command so CI reveals all package/publishability problems in one run. 
- Wire the script into `.github/workflows/ci.yml` as a `Validate publishable crates` step on the `dev` matrix profile to keep validation maintainable and scoped. 
- Keep the checks strictly dry-run and non-publishing; the script exits non-zero on detected package validation issues.

### Testing
- Ran `cargo fmt --check` and it passed. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it passed. 
- Ran `cargo test --workspace` and all tests passed. 
- Ran `python3 scripts/validate_publishable_crates.py` which correctly exercised the new checks and reported failures: `tailtriage-core` dry-run succeeded but `tailtriage-tokio` and `tailtriage-cli` dry-run failed due to their dependency on `tailtriage-core` not being available on crates.io, demonstrating the script surfaces publish-order assumptions as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2bf29a0f083308e0a8e67a67e4ecb)