### PR TITLE
Add CODE_OF_CONDUCT and SECURITY policies and reference them from CONTRIBUTING.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -30,7 +30,7 @@ This Code of Conduct applies in all repository spaces and in public spaces when 
 
 ## Reporting
 
-If you experience or witness unacceptable behavior, report it to the maintainers at **security@tailtriage.dev**.
+If you experience or witness unacceptable behavior, report it to the maintainers at **github.postage998@passinbox.com**.
 
 ## Enforcement
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,43 @@
+# Code of Conduct
+
+## Our commitment
+
+We want `tailtriage` to be a welcoming, respectful project for contributors of all backgrounds and experience levels.
+
+## Expected behavior
+
+When participating in this project, please:
+
+- be respectful and constructive
+- assume good intent and ask clarifying questions
+- give actionable, technical feedback
+- accept and offer feedback gracefully
+- keep discussions focused on improving the project
+
+## Unacceptable behavior
+
+The following are not acceptable in project spaces (issues, pull requests, discussions, and related channels):
+
+- harassment, hate speech, or personal attacks
+- trolling, intimidation, or sustained disruption
+- sexualized language or unwelcome sexual attention
+- doxxing or sharing private information without consent
+- other conduct that a reasonable person would consider abusive or hostile
+
+## Scope
+
+This Code of Conduct applies in all repository spaces and in public spaces when someone is representing this project.
+
+## Reporting
+
+If you experience or witness unacceptable behavior, report it to the maintainers at **security@tailtriage.dev**.
+
+## Enforcement
+
+Maintainers may take any action they consider appropriate, including warning, temporary restriction, or removal from project spaces.
+
+Maintainers will review reports in good faith and aim to respond fairly and promptly.
+
+## Attribution
+
+This policy is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,11 @@ Thanks for helping improve `tailtriage`.
 
 The project focuses on producing **evidence-ranked suspects** and **next checks** from one run artifact. Suspects are leads, not proof of root cause.
 
+## Community and security policies
+
+- Please follow the project [Code of Conduct](CODE_OF_CONDUCT.md).
+- For security vulnerabilities, follow the private reporting instructions in [SECURITY.md](SECURITY.md) and avoid opening public issues before a fix is available.
+
 ## License for contributions
 
 By submitting a contribution to this repository, you agree that your contribution is licensed under the repository's MIT License.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a vulnerability
 
-Please report suspected security vulnerabilities privately to **security@tailtriage.dev**.
+Please report suspected security vulnerabilities privately to **github.postage998@passinbox.com**.
 
 - Do **not** open public GitHub issues for unpatched security vulnerabilities.
 - Include reproduction steps, impact, and any suggested mitigation if available.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report suspected security vulnerabilities privately to **security@tailtriage.dev**.
+
+- Do **not** open public GitHub issues for unpatched security vulnerabilities.
+- Include reproduction steps, impact, and any suggested mitigation if available.
+
+## What to expect
+
+Maintainers will:
+
+1. acknowledge receipt as soon as practical
+2. validate and triage the report
+3. coordinate a fix and release when needed
+4. credit the reporter if they want public acknowledgment
+
+Response times may vary based on maintainer availability. `tailtriage` is a small project and does not currently provide formal SLA guarantees.
+
+## Scope and expectations
+
+This project aims to handle reports responsibly, but it does not currently operate a paid bug bounty program or a dedicated security response team.


### PR DESCRIPTION
### Motivation

- Improve public-repo readiness by adding standard, concise community and security policies appropriate for a small OSS project.
- Provide a private reporting path and realistic maintainer expectations for security issues without overpromising a formal program.
- Surface these policies to contributors by adding a clear reference from `CONTRIBUTING.md` so new contributors can find them easily.

### Description

- Add `CODE_OF_CONDUCT.md` with a short, public-facing code of conduct adapted from Contributor Covenant 2.1 covering expected and unacceptable behavior, scope, reporting, and enforcement.
- Add `SECURITY.md` with private reporting instructions (report to `security@tailtriage.dev`), guidance to avoid public issues for unpatched vulnerabilities, and an outline of maintainer handling expectations.
- Update `CONTRIBUTING.md` to include a `Community and security policies` section that links to `CODE_OF_CONDUCT.md` and `SECURITY.md`.

### Testing

- Ran `cargo fmt --check` and it succeeded.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it completed without warnings.
- Ran `cargo test --workspace` and the test suite passed (all automated tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2c623fe0c8330a89d4d0825d4edbd)