### PR TITLE
docs: finalize public-facing launch docs and align claims with repo state

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,281 +2,98 @@
 
 `tailtriage` is a Rust toolkit for **Tokio tail-latency triage**.
 
-It is for Rust/Tokio developers who need a fast first triage answer without being expert performance engineers.
+## What problem this solves
 
-It is not an observability backend, distributed tracing system, or automated root-cause proof engine.
+When a Tokio service gets slow, `tailtriage` helps you answer a first practical question quickly:
 
-Core question:
+> Is this slow because of application-level queueing, executor pressure, blocking-pool pressure, or a slow downstream stage?
 
-> Is this request path slow because of **application queueing**, **executor pressure**, **blocking-pool pressure**, or a **slow downstream stage**?
+It produces **evidence-ranked suspects** with **next checks**. Suspects are leads, not proof of root cause.
 
-## What it is
+## Fastest first run
 
-`tailtriage` is an interpretation-first diagnosis layer:
-
-- capture one local run artifact from lightweight request, queue, stage, and runtime instrumentation
-- analyze it into evidence-ranked suspects
-- get concrete next checks for the highest-ranked suspect
-- compare before/after runs to keep diagnosis reproducible
-
-Workflow in one line: **capture -> analyze -> choose next check -> re-run**.
-
-## Who it is for
-
-- developers shipping Tokio services
-- teams with latency/backpressure incidents but limited perf-engineering bandwidth
-- people who want a fast local triage loop before adopting heavier observability workflows
-
-## Quickstart: choose your path
-
-### Fastest try-it path (about 60 seconds)
-
-If you want the quickest first run from this repository, run:
+Use the source/workspace path from this public repository:
 
 ```bash
 cargo run -p tailtriage-tokio --example minimal_checkout
 cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
 ```
 
-Then inspect `primary_suspect.kind`, `primary_suspect.evidence[]`, and `primary_suspect.next_checks[]`.
+## What you get from the output
 
-Need route-by-route setup guidance? Start at **[docs/README.md](docs/README.md)**, then follow **[docs/user-guide.md](docs/user-guide.md)**.
-
-Profile note: commands use Cargo's default **dev/debug** profile unless you pass `--release` (or `--profile release` in script-based demo helpers). Diagnosis shape should usually stay directionally stable across profiles, while exact timings and borderline score/ranking relationships can differ.
-
-### Path A — Try from this repo (source/workspace)
-
-Use this when you are exploring `tailtriage` directly from this repository.
-
-1) Run the minimal example and generate an artifact:
-
-```bash
-cargo run -p tailtriage-tokio --example minimal_checkout
-```
-
-This writes `tailtriage-run.json` in the current directory.
-
-Want the recommended framework-based adoption starter for a tiny local service? Run:
-
-```bash
-cargo run -p tailtriage-tokio --example axum_minimal
-```
-
-This axum example is intentionally outside `demos/` and is an adoption starter (not a production case study and not a replacement for the synthetic demo suite).
-
-Need a non-framework mini integration that focuses on helper-layer instrumentation shape? Run:
-
-```bash
-cargo run -p tailtriage-tokio --example mini_service_integration
-```
-
-2) Analyze that artifact with the workspace CLI crate (artifacts include required top-level `schema_version: 1`):
-
-```bash
-cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
-```
-
-3) Read the first useful fields:
+Start with:
 
 - `primary_suspect.kind`
 - `primary_suspect.evidence[]`
 - `primary_suspect.next_checks[]`
-- `p95_queue_share_permille` (95th percentile of per-request queue-time share)
-- `p95_service_share_permille` (95th percentile of per-request service-time share)
+- `p95_queue_share_permille` and `p95_service_share_permille` as directional context
 
-`p95_queue_share_permille` and `p95_service_share_permille` are independent percentile summaries over different per-request series. They are not expected to sum to `1000`.
-
-### Path B — Adopt in your app (crates.io)
-
-Use this when you are integrating `tailtriage` into your own Tokio service.
-
-1) Add library dependencies in your app:
-
-```toml
-[dependencies]
-tailtriage-core = "0.1"
-tailtriage-tokio = "0.1"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
-```
-
-2) Install the published CLI binary:
-
-```bash
-cargo install tailtriage-cli
-```
-
-3) Capture one run artifact in your app, then analyze it:
-
-- Capture in your service with `Tailtriage::builder(...).build()?`, explicit request queue/stage wrappers, and `tailtriage.shutdown()?` at process shutdown (see [`docs/user-guide.md`](docs/user-guide.md)).
-
-```bash
-tailtriage analyze tailtriage-run.json --format json
-```
-
-If you want the smallest realistic capture + analyze flow for an external app, follow **[docs/user-guide.md](docs/user-guide.md)** and use the “Adopt in your app (crates.io)” section.
-
-Representative diagnosis shape:
-
-```json
-{
-  "primary_suspect": {
-    "kind": "application_queue_saturation",
-    "evidence": [
-      "Queue wait at p95 consumes 98.2% of request time.",
-      "Observed queue depth sample up to 230."
-    ],
-    "next_checks": [
-      "Inspect queue admission limits and producer burst patterns.",
-      "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
-  }
-}
-```
-
-Suspects are evidence-ranked leads, not proof of root cause.
+The two p95 share fields are independent percentiles and are not expected to sum to `1000`.
 
 ## Examples
 
-Use these as the three main starting points from this repository:
+Three public examples to start with:
 
-- **`minimal_checkout`** — fastest first run; the smallest capture → analyze loop from source
-- **`axum_minimal`** — recommended framework-based adoption starter for a tiny local axum service
-- **`mini_service_integration`** — non-framework integration example showing request instrumentation across helper layers
-
-Run them with:
+- `minimal_checkout` — fastest capture→analyze loop
+- `axum_minimal` — framework-based adoption starter
+- `mini_service_integration` — helper-layer/fractured-code instrumentation shape
 
 ```bash
 cargo run -p tailtriage-tokio --example minimal_checkout
 cargo run -p tailtriage-tokio --example axum_minimal
 cargo run -p tailtriage-tokio --example mini_service_integration
-```
-
-All three write tailtriage-run.json and can be analyzed with:
-
-```bash
-cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
-```
-
-CI smoke-validates this exact public flow with:
-
-```bash
 python3 scripts/smoke_public_examples.py
 ```
 
-Use minimal_checkout for the quickest first result, axum_minimal for framework-style adoption shape, and mini_service_integration when you want to see instrumentation flow through helper layers.
+## Demos: strongest proof vs synthetic surface
 
-The examples are found in tailtriage-tokio/examples.
+Run these three first:
 
-## Demo realism and before/after proof path
+```bash
+python3 scripts/demo_tool.py validate queue
+python3 scripts/demo_tool.py validate downstream
+python3 scripts/demo_tool.py validate db-pool
+```
 
-Demo guidance: the strongest public proof demos are `queue_service`, `downstream_service`, and `db_pool_saturation_service`; later demos include intentionally more synthetic analyzer-contract exercises.
+Strongest public proof demos:
 
-Suspects remain evidence-ranked leads, not proof of root cause.
+- `queue_service`
+- `downstream_service`
+- `db_pool_saturation_service`
 
-After first run, use one fixture-backed before/after workflow to validate changes:
+Useful but intentionally more synthetic analyzer-contract demos:
 
-- [`demos/retry_storm_service/fixtures/before-after-comparison.json`](demos/retry_storm_service/fixtures/before-after-comparison.json)
-- Full demo guide and progression notes: **[demos/README.md](demos/README.md)**
-- Demo walkthrough for first-time users: **[docs/getting-started-demo.md](docs/getting-started-demo.md)**
+- `blocking_service`
+- `executor_pressure_service`
 
-The “before/after proof path” is the repo’s way of showing that tailtriage is useful not just for labeling a run, but for validating whether a change actually improved the suspected bottleneck.
--  “before” means: run the service or demo in a baseline/problematic configuration
-- “after” means: run it again after a mitigation or configuration change
+Use before/after comparisons as a reproducible mitigation confirmation loop, not causal proof.
 
-## Why not just use tokio-console or tokio-metrics?
+## Current public status
 
-Those tools are valuable and complementary:
+The repository is public and ready to use **from source/workspace now**.
 
-- **Live debugger/console tools** (for example `tokio-console`) are great for interactive inspection and runtime/task debugging.
-- **Raw metrics libraries** (for example `tokio-metrics`) are great for exposing runtime/task measurements.
-- **General observability stacks** are great when you need broad telemetry storage, querying, and cross-service operations.
+Today, the recommended onboarding path is the source path in this repo. Crates.io install snippets are treated as **post-publish** guidance and are not the primary launch path yet.
 
-`tailtriage` is different: it focuses on a first useful **triage** answer from a small, local run artifact by ranking suspects and recommending next checks. It is not trying to replace those tools.
+## What this is not
 
-## What it is not
+`tailtriage` is not:
 
-`tailtriage` is intentionally **not**:
-
-- a live debugging console
-- a generalized telemetry/export platform
 - an observability backend
 - a distributed tracing system
-- an automated root-cause proof engine
+- a general telemetry platform
+- a root-cause proof engine
 
-Outputs are evidence-ranked leads, not proof of causality.
+## Documentation map
 
-## Current scope
+- User-first docs index: [`docs/README.md`](docs/README.md)
+- Detailed onboarding and lifecycle rules: [`docs/user-guide.md`](docs/user-guide.md)
+- Demo walkthrough and CI coverage details: [`docs/getting-started-demo.md`](docs/getting-started-demo.md)
+- Diagnostics field contract and interpretation: [`docs/diagnostics.md`](docs/diagnostics.md)
 
-MVP scope is intentionally narrow:
+## Why not just tokio-console or tokio-metrics?
 
-- Tokio-only
-- single-process diagnosis
-- local run artifact + CLI analysis
-- rule-based suspect ranking
-- no distributed tracing backend
-- no live UI
-- no exporter/backend requirement
+Those tools are complementary building blocks. `tailtriage` is the triage layer that converts one run artifact into evidence-ranked suspects and next checks.
 
-## RuntimeSampler availability note (stable Tokio vs `tokio_unstable`)
+## RuntimeSampler note (short)
 
-When you enable `tailtriage-tokio::RuntimeSampler`, runtime snapshot fields differ by Tokio build mode:
-
-- Always available on stable Tokio: `alive_tasks`, `global_queue_depth`
-- Requires `tokio_unstable`: `local_queue_depth`, `blocking_queue_depth`, `remote_schedule_count`
-
-On stable Tokio, unstable-only fields are captured as `None`, so executor-pressure vs blocking-pool-pressure separation can be weaker depending on captured request/runtime evidence.
-
-## Request lifecycle
-
-Every `RequestContext` starts one request lifecycle and must be finished **exactly once**.
-
-```rust
-let request = tailtriage.request("/checkout").with_kind("http");
-
-// queue/stage/inflight instrumentation here
-
-request.finish_ok();
-```
-
-Lifecycle contract:
-
-- `queue(...)`, `stage(...)`, and `inflight(...)` record instrumentation only; they do **not** finish the request.
-- You must call one terminal method exactly once: `finish(...)`, `finish_ok()`, or `finish_result(...)`.
-- `Drop` is a debug-time misuse detector only: unfinished `RequestContext` values trigger a debug assertion in development builds.
-- `Drop` does **not** infer success/error and does **not** record request completion automatically.
-- Do not rely on scope exit as request completion.
-
-For latency/queueing/runtime-representative measurements, prefer release mode (`cargo ... --release`).
-
-## Bounded capture and truncation
-
-`tailtriage` keeps run data in memory until shutdown. To keep this bounded in production-like runs, configure per-section capture limits on the builder:
-
-```rust
-let tailtriage = Tailtriage::builder("checkout-service")
-    .capture_limits(tailtriage_core::CaptureLimits::default())
-    .build()?;
-```
-
-Important request-lifecycle safety note:
-
-- `RequestContext` is `#[must_use]`, and debug builds assert if it is dropped unfinished.
-- Finish each request with `finish(...)`, `finish_ok()`, or `finish_result(...)`; scope exit does not finish requests.
-
-Capture limit knobs:
-
-- `max_requests`
-- `max_stages`
-- `max_queues`
-- `max_inflight_snapshots`
-- `max_runtime_snapshots`
-
-When a section reaches its configured max, `tailtriage` drops additional entries of that type and increments `truncation` counters in the output artifact. The analyzer also emits warnings when truncation is present so suspects are interpreted as leads from partial data.
-
-## Documentation
-
-For concise docs by audience, start at **[docs/README.md](docs/README.md)**.
-
-For source/workspace and crates.io adoption walkthroughs, see **[docs/user-guide.md](docs/user-guide.md)**.
-
-For demo-specific behavior, recommended public progression, and realism/CI-coverage caveats, see **[demos/README.md](demos/README.md)**.
+`RuntimeSampler` works on stable Tokio, but some runtime fields (`local_queue_depth`, `blocking_queue_depth`, `remote_schedule_count`) require `tokio_unstable`. See [`docs/user-guide.md`](docs/user-guide.md) for details.

--- a/demos/README.md
+++ b/demos/README.md
@@ -63,4 +63,293 @@ CI validates all listed demos in `dev` and `release` **except** `executor`.
 
 Use before/after fixtures as a reproducible mitigation comparison loop and confirmation aid. They provide practical evidence for whether a change helped in that scenario; they are not universal causal proof.
 
-For scenario details and commands, see [`../docs/getting-started-demo.md`](../docs/getting-started-demo.md).
+## Stronges public proof demos
+
+### `queue_service`
+
+**What it simulates**
+
+- Requests compete for a limited semaphore (`worker_permit`).
+- Baseline has tighter capacity and slower work; mitigated raises capacity and shortens work.
+
+**What it proves well**
+
+- One of the strongest demos.
+- Clear and convincing proof of queue-dominant latency.
+- Good flagship public demo for first-time readers.
+
+**What it does not prove**
+
+- It is not proof of every production queue topology or all burst regimes.
+
+**Realistic vs synthetic**
+
+- Realistic service shape, intentionally simplified and deterministic.
+
+**Why it belongs**
+
+- It is the cleanest entry point for understanding queue-saturation diagnosis.
+
+**Inspect first in report**
+
+- `primary_suspect.kind`
+- `p95_queue_share_permille`
+- queue-depth and queue-share suspect evidence
+
+### `downstream_service`
+
+**What it simulates**
+
+- Request flow with a tiny local precheck and a consistently slower downstream stage.
+- No intentional queue bottleneck.
+
+**What it proves well**
+
+- One of the strongest demos.
+- Very clean stage-dominance story.
+- Strong public proof case for downstream-led latency.
+
+**What it does not prove**
+
+- It does not model all real downstream stack complexity (fanout, retries, connection behavior).
+
+**Realistic vs synthetic**
+
+- Realistic diagnosis shape with deliberately simple mechanics.
+
+**Why it belongs**
+
+- Complements `queue_service` with an equally clean non-queue dominant case.
+
+**Inspect first in report**
+
+- `primary_suspect.kind`
+- `p95_service_share_permille`
+- downstream-stage suspect evidence
+- before/after p95 and suspect-score movement in `before-after-comparison.json`
+
+### `db_pool_saturation_service`
+
+**What it simulates**
+
+- Bounded DB-pool admission using a semaphore (`db_pool`).
+- Separate `db_query` stage timing.
+- Baseline shrinks pool and slows query stage; mitigated does the reverse.
+
+**What it proves well**
+
+- One of the best additional demos.
+- Shows queue-like admission bottleneck and downstream stage time in one common service shape.
+- Demonstrates mixed attribution within a single request path.
+
+**What it does not prove**
+
+- Still a synthetic model of DB pool saturation.
+- Not proof of behavior under a real DB client/driver stack.
+
+**Realistic vs synthetic**
+
+- Realistic enough to be highly credible, but intentionally modeled.
+
+**Why it belongs**
+
+- Strong bridge between pure queue and pure downstream stories.
+
+**Inspect first in report**
+
+- queue evidence for `queue(..., "db_pool")`
+- stage-share evidence for `stage(..., "db_query")`
+- before/after p95 and primary suspect score
+
+## Supporting pattern demos
+
+These are valuable and should remain first-class docs, but are best after the core three demos.
+
+### `shared_state_lock_service`
+
+**What it simulates**
+
+- Contention on a shared `tokio::sync::RwLock` write lock.
+- Lock wait recorded as queue-like time on `shared_state_write_lock`.
+- Critical-section work recorded separately as `shared_state_critical_section`.
+
+**What it proves well**
+
+- Conceptually strong example of non-obvious queue-like waits.
+- Demonstrates that queue here includes lock admission waits, not only channels/semaphores.
+- Preserves critical-section stage attribution while surfacing lock admission pressure.
+
+**What it does not prove**
+
+- Not proof that all lock-contention patterns map identically in every production design.
+
+**Realistic vs synthetic**
+
+- Realistic contention pattern with explicit instrumentation choices.
+
+**Why it belongs**
+
+- Teaches how to instrument and triage lock-heavy paths without semantic ambiguity.
+
+**Inspect first in report**
+
+- queue evidence for `shared_state_write_lock`
+- stage evidence for `shared_state_critical_section`
+- primary suspect kind and score changes in mitigation
+
+### `retry_storm_service`
+
+**What it simulates**
+
+- Intermittently failing/slow downstream with explicit retries.
+- Per-attempt stages (`downstream_attempt_N`) plus full-loop `downstream_total`.
+- Mitigation changes retry count, backoff, jitter, and circuit-break-like cooldown behavior.
+
+**What it proves well**
+
+- One of the most product-interesting demos.
+- Shows downstream dominance can come from retry policy, not just one slow call.
+- Strong diagnosis-pattern demo for advanced readers.
+
+**What it does not prove**
+
+- More conceptually advanced and more instrumentation-shaped than core proof demos.
+
+**Realistic vs synthetic**
+
+- Plausible service behavior, but intentionally structured to isolate retry-policy effects.
+
+**Why it belongs**
+
+- Helps prevent misleading latency interpretation when retries dominate service share.
+
+**Inspect first in report**
+
+- `primary_suspect.kind`
+- service-share evidence for `downstream_total`
+- retry-policy-oriented `next_checks`
+
+### `mixed_contention_service`
+
+**What it simulates**
+
+- Combined queue pressure (semaphore admission) and downstream slowness (periodic slow stage).
+- Mitigation mainly reduces admission contention so rank/score can shift.
+
+**What it proves well**
+
+- Multiple suspects can coexist in one diagnosis.
+- Useful supporting demo showing the analyzer is not single-cause-only.
+
+**What it does not prove**
+
+- Less crisp than queue-only or downstream-only stories, so not ideal as first public proof.
+
+**Realistic vs synthetic**
+
+- Realistic mixed-bottleneck shape with controlled deterministic contours.
+
+**Why it belongs**
+
+- Important second-wave demo for multi-factor triage interpretation.
+
+**Inspect first in report**
+
+- top two suspects and their evidence
+- whether both queue and downstream leads remain visible
+- before/after suspect-rank or score shift
+
+### `cold_start_burst_service`
+
+**What it simulates**
+
+- Early cohort pays extra `cold_start_stage` delay while burst traffic competes for admission.
+- Mitigation reduces cold cohort and increases admission capacity.
+
+**What it proves well**
+
+- Useful warmup-plus-burst explanation.
+- Shows how stage-level pathology can induce queue effects.
+
+**What it does not prove**
+
+- Less universal than queue/downstream/DB-pool scenarios.
+- Models cold start with explicit stage instrumentation, not full platform/framework startup behavior.
+
+**Realistic vs synthetic**
+
+- Plausible but scenario-specific.
+
+**Why it belongs**
+
+- Broadens triage examples beyond steady-state bottlenecks.
+
+**Inspect first in report**
+
+- evidence tied to `cold_start_stage`
+- queue-share impact and p95 changes
+- primary suspect score reduction after mitigation
+
+## More synthetic analyzer-contract demos
+
+These remain useful and should stay documented, but docs should treat them as more synthetic proofs.
+
+### `blocking_service`
+
+**What it simulates**
+
+- Requests dispatch to `spawn_blocking` workloads.
+- Baseline constrains `max_blocking_threads` and uses longer blocking work.
+- Runtime snapshots include synthetic `blocking_queue_depth` signals.
+
+**What it proves well**
+
+- Directionally useful for exercising blocking-pool-pressure diagnosis behavior.
+
+**What it does not prove**
+
+- More synthetic than a strongest real-world proof case.
+
+**Realistic vs synthetic**
+
+- Intentionally synthetic analyzer-contract demo.
+
+**Why it belongs**
+
+- Keeps blocking-pressure diagnosis pathways directly testable.
+
+**Inspect first in report**
+
+- `primary_suspect.kind`
+- blocking-related evidence and runtime depth signals
+- mitigation impact on suspect score
+
+### `executor_pressure_service`
+
+**What it simulates**
+
+- Fanout-heavy request handling with repeated CPU turns and frequent scheduling.
+- Baseline uses fewer worker threads and heavier fanout.
+- Runtime snapshots include runnable-depth signals.
+
+**What it proves well**
+
+- Useful for exercising executor-pressure diagnosis and rank behavior.
+
+**What it does not prove**
+
+- Also more synthetic, because runtime backlog signals are modeled more explicitly than production services naturally expose.
+
+**Realistic vs synthetic**
+
+- Intentionally synthetic analyzer-contract demo.
+
+**Why it belongs**
+
+- Preserves explicit coverage of executor-pressure diagnosis behavior.
+
+**Inspect first in report**
+
+- executor-pressure suspect evidence
+- runnable queue-depth signals
+- contrast with blocking-depth evidence

--- a/demos/README.md
+++ b/demos/README.md
@@ -1,35 +1,46 @@
-# Demo guide: what each demo does and what triage it exercises
+# Demo guide: scenarios, realism tiers, and triage intent
 
-The demos are intentionally small synthetic services for Tokio tail-latency triage.
+The demos are intentionally small services for Tokio tail-latency triage. They are designed to exercise diagnosis behavior with deterministic, reviewable artifacts.
 
-Each one answers a specific triage question by producing an artifact that should drive the analyzer toward evidence-ranked suspects. Suspects are leads, not proof.
+## First-time public path
 
-## Shared ideas across all demos
+If you only run three demos first, run:
 
-All service demos follow the same pattern:
+```bash
+python3 scripts/demo_tool.py validate queue
+python3 scripts/demo_tool.py validate downstream
+python3 scripts/demo_tool.py validate db-pool
+```
 
-1. Parse output path and optional mode (`baseline`/`before`, `mitigated`/`after`).
-2. Create artifact output directory.
-3. Initialize one `Tailtriage` collector.
-4. Generate a deterministic request burst.
-5. Wrap requests with `tailtriage.request(...)`.
-6. Instrument admission queue and/or stages.
-7. Flush to JSON and run CLI analysis.
+## Demo honesty tiers
 
-Shared helper code for this setup lives in `demos/demo_support`:
+### Strongest public proof demos
 
-- `DemoMode` and mode parsing
-- common CLI argument parsing
-- artifact directory creation
-- collector initialization
-- synchronized cohort start helpers for stable request-release shaping
-- warmup/measurement phase helper primitives
+- `queue_service`
+- `downstream_service`
+- `db_pool_saturation_service`
 
-This keeps demo binaries focused on the triage scenario rather than boilerplate.
+### Useful supporting demos
 
-## Baseline diagnosis contract (dev + release)
+- `shared_state_lock_service`
+- `retry_storm_service`
+- `mixed_contention_service`
+- `cold_start_burst_service`
 
-The demo validation contract is intentionally exact across profiles.
+### More synthetic analyzer-contract demos
+
+- `blocking_service`
+- `executor_pressure_service`
+
+`blocking_service` and `executor_pressure_service` are valuable for diagnosis contract coverage but intentionally more synthetic than the strongest three demos.
+
+## CI validation coverage (matches workflow)
+
+CI validates all listed demos in `dev` and `release` **except** `executor`.
+
+`executor` is validated in **release only**.
+
+## Baseline diagnosis contract
 
 | Scenario | Expected baseline primary suspect | Required supporting signal |
 | --- | --- | --- |
@@ -43,386 +54,13 @@ The demo validation contract is intentionally exact across profiles.
 | `shared-lock` | `application_queue_saturation` | Queue wait/depth evidence from lock contention |
 | `retry-storm` | `downstream_stage_dominates` | Elevated service-share evidence from retry-heavy stage |
 
-For tuning and profile-robustness checks, use:
+## Artifact policy
 
-```bash
-python3 scripts/demo_tool.py diagnosis-matrix
-```
+- `demos/*/artifacts/`: generated, untracked outputs
+- `demos/*/fixtures/`: committed deterministic references
 
-## Recommended public progression
+## Before/after comparison positioning
 
-Use this progression when introducing `tailtriage` publicly:
+Use before/after fixtures as a reproducible mitigation comparison loop and confirmation aid. They provide practical evidence for whether a change helped in that scenario; they are not universal causal proof.
 
-1. `queue_service`
-2. `downstream_service`
-3. `db_pool_saturation_service`
-4. `shared_state_lock_service`
-5. `retry_storm_service`
-6. `mixed_contention_service`
-7. `cold_start_burst_service`
-8. `blocking_service`
-9. `executor_pressure_service`
-
-This is an explanatory-value order, not an implementation-completeness order.
-
-## Core public proof demos
-
-These are the strongest public proof cases and should usually be run first.
-
-### `queue_service`
-
-**What it simulates**
-
-- Requests compete for a limited semaphore (`worker_permit`).
-- Baseline has tighter capacity and slower work; mitigated raises capacity and shortens work.
-
-**What it proves well**
-
-- One of the strongest demos.
-- Clear and convincing proof of queue-dominant latency.
-- Good flagship public demo for first-time readers.
-
-**What it does not prove**
-
-- It is not proof of every production queue topology or all burst regimes.
-
-**Realistic vs synthetic**
-
-- Realistic service shape, intentionally simplified and deterministic.
-
-**Why it belongs**
-
-- It is the cleanest entry point for understanding queue-saturation diagnosis.
-
-**Inspect first in report**
-
-- `primary_suspect.kind`
-- `p95_queue_share_permille`
-- queue-depth and queue-share suspect evidence
-
-### `downstream_service`
-
-**What it simulates**
-
-- Request flow with a tiny local precheck and a consistently slower downstream stage.
-- No intentional queue bottleneck.
-
-**What it proves well**
-
-- One of the strongest demos.
-- Very clean stage-dominance story.
-- Strong public proof case for downstream-led latency.
-
-**What it does not prove**
-
-- It does not model all real downstream stack complexity (fanout, retries, connection behavior).
-
-**Realistic vs synthetic**
-
-- Realistic diagnosis shape with deliberately simple mechanics.
-
-**Why it belongs**
-
-- Complements `queue_service` with an equally clean non-queue dominant case.
-
-**Inspect first in report**
-
-- `primary_suspect.kind`
-- `p95_service_share_permille`
-- downstream-stage suspect evidence
-- before/after p95 and suspect-score movement in `before-after-comparison.json`
-
-### `db_pool_saturation_service`
-
-**What it simulates**
-
-- Bounded DB-pool admission using a semaphore (`db_pool`).
-- Separate `db_query` stage timing.
-- Baseline shrinks pool and slows query stage; mitigated does the reverse.
-
-**What it proves well**
-
-- One of the best additional demos.
-- Shows queue-like admission bottleneck and downstream stage time in one common service shape.
-- Demonstrates mixed attribution within a single request path.
-
-**What it does not prove**
-
-- Still a synthetic model of DB pool saturation.
-- Not proof of behavior under a real DB client/driver stack.
-
-**Realistic vs synthetic**
-
-- Realistic enough to be highly credible, but intentionally modeled.
-
-**Why it belongs**
-
-- Strong bridge between pure queue and pure downstream stories.
-
-**Inspect first in report**
-
-- queue evidence for `queue(..., "db_pool")`
-- stage-share evidence for `stage(..., "db_query")`
-- before/after p95 and primary suspect score
-
-## Supporting pattern demos
-
-These are valuable and should remain first-class docs, but are best after the core three demos.
-
-### `shared_state_lock_service`
-
-**What it simulates**
-
-- Contention on a shared `tokio::sync::RwLock` write lock.
-- Lock wait recorded as queue-like time on `shared_state_write_lock`.
-- Critical-section work recorded separately as `shared_state_critical_section`.
-
-**What it proves well**
-
-- Conceptually strong example of non-obvious queue-like waits.
-- Demonstrates that queue here includes lock admission waits, not only channels/semaphores.
-- Preserves critical-section stage attribution while surfacing lock admission pressure.
-
-**What it does not prove**
-
-- Not proof that all lock-contention patterns map identically in every production design.
-
-**Realistic vs synthetic**
-
-- Realistic contention pattern with explicit instrumentation choices.
-
-**Why it belongs**
-
-- Teaches how to instrument and triage lock-heavy paths without semantic ambiguity.
-
-**Inspect first in report**
-
-- queue evidence for `shared_state_write_lock`
-- stage evidence for `shared_state_critical_section`
-- primary suspect kind and score changes in mitigation
-
-### `retry_storm_service`
-
-**What it simulates**
-
-- Intermittently failing/slow downstream with explicit retries.
-- Per-attempt stages (`downstream_attempt_N`) plus full-loop `downstream_total`.
-- Mitigation changes retry count, backoff, jitter, and circuit-break-like cooldown behavior.
-
-**What it proves well**
-
-- One of the most product-interesting demos.
-- Shows downstream dominance can come from retry policy, not just one slow call.
-- Strong diagnosis-pattern demo for advanced readers.
-
-**What it does not prove**
-
-- More conceptually advanced and more instrumentation-shaped than core proof demos.
-
-**Realistic vs synthetic**
-
-- Plausible service behavior, but intentionally structured to isolate retry-policy effects.
-
-**Why it belongs**
-
-- Helps prevent misleading latency interpretation when retries dominate service share.
-
-**Inspect first in report**
-
-- `primary_suspect.kind`
-- service-share evidence for `downstream_total`
-- retry-policy-oriented `next_checks`
-
-### `mixed_contention_service`
-
-**What it simulates**
-
-- Combined queue pressure (semaphore admission) and downstream slowness (periodic slow stage).
-- Mitigation mainly reduces admission contention so rank/score can shift.
-
-**What it proves well**
-
-- Multiple suspects can coexist in one diagnosis.
-- Useful supporting demo showing the analyzer is not single-cause-only.
-
-**What it does not prove**
-
-- Less crisp than queue-only or downstream-only stories, so not ideal as first public proof.
-
-**Realistic vs synthetic**
-
-- Realistic mixed-bottleneck shape with controlled deterministic contours.
-
-**Why it belongs**
-
-- Important second-wave demo for multi-factor triage interpretation.
-
-**Inspect first in report**
-
-- top two suspects and their evidence
-- whether both queue and downstream leads remain visible
-- before/after suspect-rank or score shift
-
-### `cold_start_burst_service`
-
-**What it simulates**
-
-- Early cohort pays extra `cold_start_stage` delay while burst traffic competes for admission.
-- Mitigation reduces cold cohort and increases admission capacity.
-
-**What it proves well**
-
-- Useful warmup-plus-burst explanation.
-- Shows how stage-level pathology can induce queue effects.
-
-**What it does not prove**
-
-- Less universal than queue/downstream/DB-pool scenarios.
-- Models cold start with explicit stage instrumentation, not full platform/framework startup behavior.
-
-**Realistic vs synthetic**
-
-- Plausible but scenario-specific.
-
-**Why it belongs**
-
-- Broadens triage examples beyond steady-state bottlenecks.
-
-**Inspect first in report**
-
-- evidence tied to `cold_start_stage`
-- queue-share impact and p95 changes
-- primary suspect score reduction after mitigation
-
-## More synthetic analyzer-contract demos
-
-These remain useful and should stay documented, but docs should treat them as more synthetic proofs.
-
-### `blocking_service`
-
-**What it simulates**
-
-- Requests dispatch to `spawn_blocking` workloads.
-- Baseline constrains `max_blocking_threads` and uses longer blocking work.
-- Runtime snapshots include synthetic `blocking_queue_depth` signals.
-
-**What it proves well**
-
-- Directionally useful for exercising blocking-pool-pressure diagnosis behavior.
-
-**What it does not prove**
-
-- More synthetic than a strongest real-world proof case.
-
-**Realistic vs synthetic**
-
-- Intentionally synthetic analyzer-contract demo.
-
-**Why it belongs**
-
-- Keeps blocking-pressure diagnosis pathways directly testable.
-
-**Inspect first in report**
-
-- `primary_suspect.kind`
-- blocking-related evidence and runtime depth signals
-- mitigation impact on suspect score
-
-### `executor_pressure_service`
-
-**What it simulates**
-
-- Fanout-heavy request handling with repeated CPU turns and frequent scheduling.
-- Baseline uses fewer worker threads and heavier fanout.
-- Runtime snapshots include runnable-depth signals.
-
-**What it proves well**
-
-- Useful for exercising executor-pressure diagnosis and rank behavior.
-
-**What it does not prove**
-
-- Also more synthetic, because runtime backlog signals are modeled more explicitly than production services naturally expose.
-
-**Realistic vs synthetic**
-
-- Intentionally synthetic analyzer-contract demo.
-
-**Why it belongs**
-
-- Preserves explicit coverage of executor-pressure diagnosis behavior.
-
-**Inspect first in report**
-
-- executor-pressure suspect evidence
-- runnable queue-depth signals
-- contrast with blocking-depth evidence
-
-## CI validation coverage
-
-The demo docs and CI validation surface are aligned.
-
-In `.github/workflows/ci.yml`, the `CI` workflow continuously validates:
-
-- `queue`
-- `downstream`
-- `db-pool`
-- `shared-lock`
-- `retry-storm`
-- `mixed`
-- `cold-start`
-- `blocking`
-- `executor`
-
-The CI workflow runs this full set in both `dev` and `release` profiles.
-
-Fixture drift checks are intentionally run in `dev` profile only (`python3 scripts/check_demo_fixture_drift.py`) so fixture comparisons stay deterministic while release-path validation remains covered by per-scenario `validate ... --release` checks.
-
-## Typical local workflow
-
-```bash
-python3 scripts/demo_tool.py run queue
-python3 scripts/demo_tool.py validate queue
-
-python3 scripts/demo_tool.py run downstream
-python3 scripts/demo_tool.py validate downstream
-
-python3 scripts/demo_tool.py run db-pool
-python3 scripts/demo_tool.py validate db-pool
-```
-
-Then continue through `shared-lock`, `retry-storm`, `mixed`, `cold-start`, `blocking`, and `executor`.
-
-For release-profile validation (production-representative runtime behavior), append `--release`:
-
-```bash
-python3 scripts/demo_tool.py validate queue --release
-python3 scripts/demo_tool.py validate downstream --release
-```
-
-Running `downstream` follows the same before/after artifact contract as the other comparison demos:
-
-- `demos/downstream_service/artifacts/before-run.json`
-- `demos/downstream_service/artifacts/before-analysis.json`
-- `demos/downstream_service/artifacts/after-run.json`
-- `demos/downstream_service/artifacts/after-analysis.json`
-- `demos/downstream_service/artifacts/before-after-comparison.json`
-
-For runtime-cost overhead measurement (separate from suspect-ranking triage), run `python3 scripts/measure_runtime_cost.py` and see `docs/runtime-cost.md` for usage details and interpretation guidance.
-
-## `runtime_cost`
-
-**Purpose**
-
-- Measures instrumentation overhead across `baseline`, `light`, and `investigation` modes.
-- This is a runtime-cost measurement path, not a suspect-ranking triage scenario.
-
-**Canonical command**
-
-```bash
-python3 scripts/measure_runtime_cost.py
-```
-
-**Output artifacts**
-
-- `demos/runtime_cost/artifacts/`
+For scenario details and commands, see [`../docs/getting-started-demo.md`](../docs/getting-started-demo.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,47 +1,28 @@
 # Documentation map
 
-Use this page as the single entry point for project documentation.
+## Start here
 
-If you are new to `tailtriage`, start in **User docs** below and ignore maintainer sections on your first pass.
+- **Fastest first run from this repo:** [`user-guide.md#path-a--use-from-this-repo-now`](user-guide.md#path-a--use-from-this-repo-now)
+- **Public examples:** [`../tailtriage-tokio/examples/`](../tailtriage-tokio/examples/)
+- **Demo walkthrough and recommended first three demos:** [`getting-started-demo.md`](getting-started-demo.md)
+- **How to read diagnosis output:** [`diagnostics.md`](diagnostics.md)
 
-## User docs (start here)
+## Reference
 
-1. **Try from this repo (fastest first run):** [user-guide.md#path-a--try-from-this-repo-sourceworkspace](user-guide.md#path-a--try-from-this-repo-sourceworkspace)
-2. **Adopt in your app (crates.io quickstart):** [user-guide.md#path-b--adopt-in-your-app-cratesio](user-guide.md#path-b--adopt-in-your-app-cratesio)
-3. **Run demos with realism notes:** [getting-started-demo.md](getting-started-demo.md)
+- **Architecture and crate responsibilities:** [`architecture.md`](architecture.md)
+- **Runtime-cost measurement notes:** [`runtime-cost.md`](runtime-cost.md)
+- **Changelog:** [`changelog.md`](changelog.md)
 
-### First-run and triage workflow
+## Maintainer docs
 
-- **How triage analysis works:** [diagnostics.md](diagnostics.md)
-- **Demos and fixture workflow:** [getting-started-demo.md](getting-started-demo.md)
-- **Fastest source first run (`minimal_checkout`):** [../tailtriage-tokio/examples/minimal_checkout.rs](../tailtriage-tokio/examples/minimal_checkout.rs)
-- **Framework-based adoption starter (axum):** [../tailtriage-tokio/examples/axum_minimal.rs](../tailtriage-tokio/examples/axum_minimal.rs)
-- **Realistic mini-service integration example (adoption confidence):** [../tailtriage-tokio/examples/mini_service_integration.rs](../tailtriage-tokio/examples/mini_service_integration.rs)
-- **Before/after proof workflow (secondary):** [../demos/retry_storm_service/fixtures/before-after-comparison.json](../demos/retry_storm_service/fixtures/before-after-comparison.json)
-- **Runtime cost measurement:** [runtime-cost.md](runtime-cost.md)
+Maintainer-only launch/readiness/ops material (not required for normal first-time user onboarding):
 
-### Product and architecture references
+- [`release-gates-v0.1.md`](release-gates-v0.1.md)
+- [`public-readiness-checklist.md`](public-readiness-checklist.md)
+- [`launch-checklist-issue-v0.1.md`](launch-checklist-issue-v0.1.md)
+- [`github-repo-ops.md`](github-repo-ops.md)
 
-- **Architecture and crate responsibilities:** [architecture.md](architecture.md)
-- **MVP product contract (Tokio tail-latency triage):** [../SPEC.md](../SPEC.md)
-- **Release/polish plan:** [../IMPLEMENTATION_PLAN.md](../IMPLEMENTATION_PLAN.md)
-- **Project changelog:** [changelog.md](changelog.md)
+Historical audits:
 
-## Maintainer / launch / operational docs (for contributors/maintainers)
-
-- **v0.1 release decision gates and launch order:** [release-gates-v0.1.md](release-gates-v0.1.md)
-- **Public visibility readiness checklist:** [public-readiness-checklist.md](public-readiness-checklist.md)
-- **Launch checklist issue template (v0.1):** [launch-checklist-issue-v0.1.md](launch-checklist-issue-v0.1.md)
-- **GitHub repository operations:** [github-repo-ops.md](github-repo-ops.md)
-
-### Historical audits and snapshots
-
-- **MVP audit (2026-03-20):** [mvp-audit-2026-03-20.md](mvp-audit-2026-03-20.md)
-- **MVP audit (2026-03-19):** [mvp-audit-2026-03-19.md](mvp-audit-2026-03-19.md)
-
-## Documentation conventions
-
-- `demos/*/artifacts/` = generated, untracked outputs.
-- `demos/*/fixtures/` = committed reference snapshots used for deterministic validation.
-- Suspects are evidence-ranked leads, not causal proof.
-- Prefer triage language for product/category descriptions.
+- [`mvp-audit-2026-03-20.md`](mvp-audit-2026-03-20.md)
+- [`mvp-audit-2026-03-19.md`](mvp-audit-2026-03-19.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,10 @@
 # Architecture (MVP)
 
-`tailtriage` is a file-based diagnosis pipeline over one instrumented run.
+`tailtriage` is a file-based triage pipeline over one instrumented run.
+
+## Why three crates
+
+The project is split into three crates so service instrumentation, Tokio runtime enrichment, and artifact diagnosis can evolve independently while staying on one shared run schema.
 
 ## Flow
 
@@ -24,7 +28,7 @@
 - runtime snapshot capture (`capture_runtime_snapshot`)
 - request context instrumentation via `Tailtriage::request(...)` and `RequestContext` helpers
 
-Note: some runtime metrics require `tokio_unstable`; unavailable fields are recorded as `None`.
+Some runtime metrics require `tokio_unstable`; unavailable fields are recorded as `None`.
 
 ### `tailtriage-cli`
 
@@ -33,17 +37,10 @@ Note: some runtime metrics require `tokio_unstable`; unavailable fields are reco
 - apply rule-based diagnosis ranking
 - render text or JSON report
 
+The CLI consumes run artifacts and does not need to be embedded into your service.
+
 ## Contract boundary
 
 - Input: one local `Run` JSON artifact.
 - Output: ranked suspects with evidence and next checks.
 - Non-claim: proven root cause.
-
-## Recommended integration sequence
-
-1. init one collector
-2. wrap request handlers
-3. instrument key queue waits
-4. instrument key downstream stages
-5. optionally enable runtime sampler
-6. shutdown and analyze

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,16 +4,8 @@
 
 ### Changed
 
-- Added a fresh dated MVP audit snapshot (`docs/mvp-audit-2026-03-20.md`) with current acceptance/milestone/scope verification results.
-- Consolidated documentation structure around `docs/README.md` as the canonical docs index.
-- Reduced duplication across README/user guide/diagnostics/demo docs while keeping MVP integration and diagnosis guidance intact.
-- Simplified the historical MVP audit doc and removed stale cross-document references.
-- Simplified `tailtriage-cli` dependencies by removing a direct `tailtriage-tokio` dependency; the CLI only consumes `tailtriage-core` analyzer APIs.
-
-### Development timeline (condensed)
-
-- **Foundation (PRs #2-#17, 2026-03-18 to 2026-03-19):** Bootstrapped the Rust workspace, defined the run/report schema and local JSON sink, and shipped first-class request instrumentation plus Tokio runtime metrics sampling.
-- **Diagnosis MVP (PRs #21-#34, 2026-03-19):** Implemented core diagnosis rules and fixtures, then connected reproducible queue/backpressure and blocking-contamination demos with end-to-end smoke coverage.
-- **Signal quality and architecture hardening (PRs #42-#50, 2026-03-19):** Added explicit in-flight trend evidence, addressed issue-driven correctness gaps (including fixes tracked via #36/#37), modularized `tailtriage-core`, and improved integration ergonomics.
-- **Developer workflow and reproducibility (PRs #46-#71, 2026-03-19 to 2026-03-20):** Standardized demo tooling and helper scripts, introduced baseline/mitigated scenario workflows, and tightened portability + CI checks for repeatable local diagnosis runs.
-- **Documentation and MVP readiness (PRs #51-#75, 2026-03-19 to 2026-03-20):** Expanded onboarding docs (quickstart, first-use, mental model, canonical integration path), aligned report contracts with regression tests, and completed repeated acceptance/scope audits to prepare a clear MVP handoff.
+- Made launch-facing docs user-first for public GitHub onboarding, with source/workspace as the primary path.
+- Marked crates.io install/dependency snippets as post-publish guidance instead of launch-day defaults.
+- Corrected demo/CI wording to match workflow coverage: all listed demos in dev+release except `executor` in release only.
+- Demoted maintainer launch/readiness/ops docs from the main user onboarding path.
+- Sharpened demo honesty language to distinguish strongest proof demos, supporting demos, and synthetic analyzer-contract demos.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,10 +1,20 @@
 # Diagnostics guide
 
-This document explains how `tailtriage analyze` produces a triage report and how to use it.
+This guide explains how `tailtriage analyze` turns one run artifact into a triage report.
+
+## How to read one report in 30 seconds
+
+1. Check `primary_suspect.kind`.
+2. Read `primary_suspect.evidence[]`.
+3. Read `primary_suspect.next_checks[]`.
+4. Use `p95_queue_share_permille` and `p95_service_share_permille` as directional context.
+5. Change one thing, rerun, and compare.
+
+Ranking is rule-based and directional. Suspects are evidence-ranked leads, not proof of root cause.
 
 ## Run artifact schema contract
 
-`tailtriage-cli` requires every input run artifact to include a top-level `schema_version` integer. The current supported value is `1`.
+`tailtriage-cli` requires a top-level `schema_version` integer in every input artifact. Current supported value: `1`.
 
 Loader behavior is strict:
 
@@ -46,19 +56,7 @@ Each suspect includes:
 | `primary_suspect` | `Suspect` | Highest-ranked suspect. |
 | `secondary_suspects` | `Vec<Suspect>` | Remaining ranked suspects. |
 
-The two p95 share fields are independent percentile summaries over different per-request series. They are not complementary totals and are not expected to sum to `1000`.
-
-## Interpreting shares quickly
-
-- `1000` permille = 100%
-- `500` permille = 50%
-- `p95_queue_share_permille` and `p95_service_share_permille` are each a percentile over their own distribution, so they should not be added together.
-
-Rules of thumb:
-
-- high queue share suggests queue saturation
-- high service share plus dominant stage suggests downstream latency dominance
-- use suspect evidence and next checks to choose one follow-up experiment
+`p95_queue_share_permille` and `p95_service_share_permille` are independent percentiles over different per-request series, so they are not expected to sum to `1000`.
 
 ## Suspect kinds
 
@@ -68,19 +66,17 @@ Rules of thumb:
 - `downstream_stage_dominates`
 - `insufficient_evidence`
 
-These are **evidence-ranked leads**, not causal proof.
+## Executor pressure vs blocking-pool pressure
 
-### Executor pressure vs blocking-pool pressure
+- `executor_pressure_suspected` emphasizes runtime scheduler backlog signals.
+- `blocking_pool_pressure` emphasizes `spawn_blocking` backlog signals.
+- If blocking queue depth stays low/absent while runtime queue depth rises, prioritize executor-focused next checks first.
 
-- `executor_pressure_suspected` emphasizes runtime scheduler backlog signals (for example, elevated global/local runtime queue depth with in-flight growth).
-- `blocking_pool_pressure` emphasizes `spawn_blocking` backlog signals (for example, elevated blocking queue depth evidence).
-- If blocking queue depth remains low/absent while runtime queue depth rises, prefer executor-pressure next checks before blocking-pool tuning.
-
-Runtime-signal availability caveat:
+Runtime-signal caveat:
 
 - On stable Tokio, `RuntimeSampler` always captures `alive_tasks` and `global_queue_depth`.
 - `local_queue_depth`, `blocking_queue_depth`, and `remote_schedule_count` require `tokio_unstable` and are otherwise `None`.
-- As a result, blocking-pool vs executor suspect separation may be weaker on stable builds; treat ranking as directional triage and prioritize follow-up checks.
+- Separation between blocking-pool and executor suspects can therefore be weaker on stable builds.
 
 ## In-flight trend fields
 
@@ -93,19 +89,17 @@ When present:
 - `growth_delta`
 - `growth_per_sec_milli`
 
-Positive growth means in-flight work accumulated during the run.
+Positive growth indicates in-flight work accumulated during the run.
 
 ## Truncation interpretation
 
-If the run artifact has non-zero `truncation` counters, treat the report as diagnosis from partial data. Prioritize re-running with higher capture limits for truncated sections before ruling suspects in or out.
+If artifact `truncation` counters are non-zero, treat the diagnosis as partial-data triage and rerun with higher capture limits before drawing stronger conclusions.
 
-## Practical triage workflow
+## Practical triage loop
 
 1. Capture one run.
 2. Analyze and inspect primary suspect evidence.
-3. Run the suggested next check for that suspect.
+3. Run one recommended next check.
 4. Change one thing.
-5. Re-run under comparable load.
-6. Compare p95 shares and suspect evidence.
-
-For reproducible before/after demo workflows, see [getting-started-demo.md](getting-started-demo.md).
+5. Rerun with comparable load.
+6. Compare suspect ranking and p95 shares.

--- a/docs/getting-started-demo.md
+++ b/docs/getting-started-demo.md
@@ -1,14 +1,40 @@
 # Getting started with demos
 
-Use demos to validate diagnosis behavior with deterministic fixtures.
+Demos provide deterministic triage exercises. They give reproducible evidence for diagnosis behavior, not universal causality proof.
 
-Demo honesty note: this suite mixes strongest public proof demos with intentionally more synthetic analyzer-contract demos. Use suspects as triage leads, not root-cause proof.
+## If you only run three demos, run these three
 
-For a scenario-by-scenario explanation of what each demo simulates, what triage it is intended to exercise, and what setup is shared, see **[`demos/README.md`](../demos/README.md)**.
+```bash
+python3 scripts/demo_tool.py validate queue
+python3 scripts/demo_tool.py validate downstream
+python3 scripts/demo_tool.py validate db-pool
+```
 
-## Recommended public progression
+These are the strongest public proof surface for first-time evaluation.
 
-To evaluate `tailtriage` quickly and honestly, run demos in this order:
+## Demo tiers
+
+### Strongest public proof demos
+
+- `queue_service`
+- `downstream_service`
+- `db_pool_saturation_service`
+
+### Useful supporting demos
+
+- `shared_state_lock_service`
+- `retry_storm_service`
+- `mixed_contention_service`
+- `cold_start_burst_service`
+
+### More synthetic analyzer-contract demos
+
+- `blocking_service`
+- `executor_pressure_service`
+
+`blocking_service` and `executor_pressure_service` are intentionally more synthetic and are best treated as contract exercises for suspect behavior.
+
+## Recommended progression
 
 1. `queue_service`
 2. `downstream_service`
@@ -20,40 +46,20 @@ To evaluate `tailtriage` quickly and honestly, run demos in this order:
 8. `blocking_service`
 9. `executor_pressure_service`
 
-This order reflects explanatory clarity and public credibility, not implementation completeness.
+## CI validation coverage (truthful to workflow)
 
-## Demo tiers and what they are for
+In `.github/workflows/ci.yml`, CI validates these demos in **both** `dev` and `release` profiles:
 
-### Core public proof demos
+- `queue`
+- `downstream`
+- `db-pool`
+- `shared-lock`
+- `retry-storm`
+- `mixed`
+- `cold-start`
+- `blocking`
 
-These are the strongest public proof cases:
-
-- `queue_service`
-- `downstream_service`
-- `db_pool_saturation_service`
-
-### Supporting pattern demos
-
-These are valuable second-wave demos:
-
-- `shared_state_lock_service`
-- `retry_storm_service`
-- `mixed_contention_service`
-- `cold_start_burst_service`
-
-### More synthetic analyzer-contract demos
-
-These remain useful, but are more synthetic than the first two tiers:
-
-- `blocking_service`
-- `executor_pressure_service`
-
-Important: these two demos intentionally model stronger blocking/executor contrast signals than many real services naturally expose by default. They are useful triage-contract exercises, not proof that equivalent runtime signals are always present in user applications.
-
-## Artifact policy
-
-- `demos/*/artifacts/`: generated, untracked local outputs.
-- `demos/*/fixtures/`: committed reference snapshots.
+`executor` is validated in **release only**.
 
 ## Run + validate commands
 
@@ -83,92 +89,15 @@ python3 scripts/demo_tool.py run blocking
 python3 scripts/demo_tool.py validate blocking
 
 python3 scripts/demo_tool.py run executor
-python3 scripts/demo_tool.py validate executor
+python3 scripts/demo_tool.py validate executor --profile release
 ```
 
-`run downstream` now writes the same before/after artifact set as other comparison demos:
+## Before/after comparison guidance
 
-- `demos/downstream_service/artifacts/before-run.json`
-- `demos/downstream_service/artifacts/before-analysis.json`
-- `demos/downstream_service/artifacts/after-run.json`
-- `demos/downstream_service/artifacts/after-analysis.json`
-- `demos/downstream_service/artifacts/before-after-comparison.json`
+Use fixture-backed before/after results as a reproducible mitigation comparison loop:
 
-## Quick interpretation map by demo
+- compare one baseline run and one mitigated run
+- inspect p95 movement and suspect/evidence movement
+- treat it as evidence for the next decision, not proof of universal root cause
 
-Use this table for first-pass diagnosis reading. Suspects are leads, not proof.
-
-| Demo | What it proves well | What it does not prove | First report fields to inspect |
-| --- | --- | --- | --- |
-| `queue_service` | Clear, convincing queue-dominant latency story; one of the strongest flagship demos. | Not a proof of every real queue topology under production burst behavior. | `primary_suspect.kind`, `p95_queue_share_permille`, queue-depth evidence. |
-| `downstream_service` | Very clean stage-dominance story; one of the strongest public proof cases with a mitigation comparison. | Not a full model of all downstream path complexity. | `primary_suspect.kind`, `p95_service_share_permille`, downstream stage evidence, and before/after p95 change. |
-| `db_pool_saturation_service` | Strong split between DB admission wait (`db_pool`) and DB stage time (`db_query`) in one common service shape. | Still a synthetic DB-pool model, not proof under a real DB driver/client stack. | Queue wait evidence for `db_pool` plus stage-share evidence for `db_query`. |
-| `shared_state_lock_service` | Strong lock-contention framing: lock admission wait as queue-like pressure plus separate critical-section stage attribution. | Not a claim that all lock contention behaves identically across real services. | Queue evidence for `shared_state_write_lock` and stage evidence for `shared_state_critical_section`. |
-| `retry_storm_service` | Product-interesting diagnosis pattern: downstream dominance from retry policy, not only one slow call. | More advanced and instrumentation-shaped than core proof demos. | `primary_suspect.kind`, `downstream_total` service-share evidence, retry-policy next checks. |
-| `mixed_contention_service` | Shows multiple suspects can coexist and ranking can shift after mitigation. | Less crisp than queue-only or downstream-only proof cases. | Top two suspects, evidence mix across queue and downstream, before/after rank shift. |
-| `cold_start_burst_service` | Useful warmup-plus-burst pattern with both stage and admission effects. | Less universal than queue/downstream/DB-pool scenarios. | Evidence tied to `cold_start_stage`, queue-share impact, before/after p95 change. |
-| `blocking_service` | Directionally useful for exercising blocking-pool diagnosis behavior. | More synthetic than a strongest real-world proof case. | Blocking-pressure suspect evidence and blocking-related runtime signals. |
-| `executor_pressure_service` | Useful for exercising executor-pressure diagnosis and runnable-backlog evidence. | More synthetic because backlog signals are modeled explicitly. | Executor-pressure suspect evidence, runtime queue-depth signals, blocking-depth contrast. |
-
-## CI validation coverage
-
-The documented demo surface matches the CI validation surface. In `.github/workflows/ci.yml`, the `CI` workflow validates:
-
-- `queue`
-- `downstream`
-- `db-pool`
-- `shared-lock`
-- `retry-storm`
-- `mixed`
-- `cold-start`
-- `blocking`
-- `executor`
-
-CI runs this same validation surface in both Cargo profiles:
-
-- `dev` (default/debug-oriented developer path)
-- `release` (production-representative latency/queueing/runtime behavior path)
-
-## Runtime-cost demo path (separate from triage scenarios)
-
-`runtime_cost` is a measurement demo that uses a separate script entrypoint rather than `scripts/demo_tool.py`.
-
-Use:
-
-```bash
-python3 scripts/measure_runtime_cost.py
-```
-
-For mode definitions, metrics, and interpretation details, see **[`docs/runtime-cost.md`](./runtime-cost.md)**.
-
-## Demo fixture drift guard and refresh workflow
-
-`python3 scripts/check_demo_fixture_drift.py` regenerates demo analysis outputs and fails if committed fixtures are stale.
-
-Fixture drift policy is explicit: committed fixtures are **dev-profile canonical** for deterministic drift checks in CI.  
-Release runs are still validated in CI via `scripts/demo_tool.py validate ... --profile release`, but fixture drift comparison remains anchored to dev outputs because borderline suspect rank/score relationships can legitimately shift by profile.
-
-When analyzer output changes intentionally, refresh fixtures with:
-
-```bash
-python3 scripts/check_demo_fixture_drift.py --refresh
-python3 scripts/check_demo_fixture_drift.py --release --refresh
-```
-
-Then review the fixture diffs, commit them, and re-run the drift guard to confirm the refresh is complete.
-
-## If local results differ from fixtures
-
-1. rerun on an otherwise idle machine
-2. confirm script success first
-3. compare fixture JSONs before interpreting local artifact drift
-
-To run the full demo validations in release profile locally, pass `--release` (or `--profile release`) per scenario:
-
-```bash
-python3 scripts/demo_tool.py validate queue --release
-python3 scripts/demo_tool.py validate downstream --release
-python3 scripts/demo_tool.py validate db-pool --release
-python3 scripts/demo_tool.py validate shared-lock --release
-python3 scripts/demo_tool.py validate retry-storm --release
-```
+See [`../demos/README.md`](../demos/README.md) for scenario details.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,36 +1,42 @@
 # User guide
 
-Use this page for the shortest path to a first useful triage answer.
+Use this guide for a reliable capture → analyze → next-check loop.
 
-## Path A — Try from this repo (source/workspace)
+## Path A — Use from this repo now
 
-Use this path when you are evaluating `tailtriage` from a local clone of this repository.
+This is the recommended public path today.
 
-### 1) Capture one artifact from the repo example
+### 1) Capture one artifact
 
 ```bash
 cargo run -p tailtriage-tokio --example minimal_checkout
 ```
 
-Expected output includes `Wrote tailtriage-run.json`.
-
-For the recommended framework-based adoption starter, run:
+Optional additional examples:
 
 ```bash
 cargo run -p tailtriage-tokio --example axum_minimal
-```
-
-This axum example is an adoption starter and does **not** replace the demo suite or claim production-hardening.
-
-If you want a non-framework helper-layer reference, run:
-
-```bash
 cargo run -p tailtriage-tokio --example mini_service_integration
 ```
 
-## Finish every request explicitly
+### 2) Analyze with the workspace CLI
 
-Every `RequestContext` starts one request lifecycle. Queue/stage/inflight instrumentation does not finish that lifecycle; you must finish it explicitly exactly once.
+```bash
+cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
+```
+
+### 3) Read the report in order
+
+1. `primary_suspect.kind`
+2. `primary_suspect.evidence[]`
+3. `primary_suspect.next_checks[]`
+4. `p95_queue_share_permille` / `p95_service_share_permille` as directional context
+
+The p95 share fields are independent percentile summaries and are not expected to sum to `1000`.
+
+## Request lifecycle correctness (required)
+
+Every `RequestContext` starts one lifecycle and must be finished **exactly once**.
 
 ```rust
 let request = tailtriage.request("/checkout").with_kind("http");
@@ -40,37 +46,54 @@ let request = tailtriage.request("/checkout").with_kind("http");
 request.finish_ok();
 ```
 
-Use one terminal method per request:
+Terminal methods:
 
 - `finish(...)`
 - `finish_ok()`
 - `finish_result(...)`
 
-`Drop` is only a debug-time misuse detector. In debug builds, dropping an unfinished context asserts so you catch forgotten finishes during development. `Drop` does **not** infer an outcome and does **not** record request completion automatically.
+`queue(...)`, `stage(...)`, and `inflight(...)` do not finish the request. `Drop` is only a debug-time misuse detector and does not record completion automatically.
 
-### 2) Analyze with the workspace CLI crate
+## RuntimeSampler (optional stronger attribution)
 
-```bash
-cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
+Use runtime snapshots when request-level signals are not enough to separate queueing vs executor vs blocking-pool pressure.
+
+```rust
+use std::sync::Arc;
+use std::time::Duration;
+use tailtriage_core::Tailtriage;
+use tailtriage_tokio::RuntimeSampler;
+
+# async fn demo() -> Result<(), Box<dyn std::error::Error>> {
+let tailtriage = Arc::new(
+    Tailtriage::builder("checkout-service")
+        .output("tailtriage-run.json")
+        .build()?,
+);
+let sampler = RuntimeSampler::start(Arc::clone(&tailtriage), Duration::from_millis(200))?;
+
+// run workload
+
+sampler.shutdown().await;
+tailtriage.shutdown()?;
+# Ok(())
+# }
 ```
 
-### 3) Interpret the diagnosis
+Always call both shutdowns:
 
-Inspect these fields first:
+- `sampler.shutdown().await`
+- `tailtriage.shutdown()?`
 
-- `primary_suspect.kind`
-- `primary_suspect.evidence[]`
-- `primary_suspect.next_checks[]`
-- `p95_queue_share_permille` (95th percentile of per-request queue-time share)
-- `p95_service_share_permille` (95th percentile of per-request service-time share)
+Stable Tokio always captures `alive_tasks` and `global_queue_depth`. `local_queue_depth`, `blocking_queue_depth`, and `remote_schedule_count` require `tokio_unstable`.
 
-`p95_queue_share_permille` and `p95_service_share_permille` are independent percentile summaries over different per-request series. They are not expected to sum to `1000`.
+## If report shows `insufficient_evidence`
 
-## Path B — Adopt in your app (crates.io)
+Add one queue wrapper and one stage wrapper around the most likely missing waits, rerun under comparable load, then compare suspects/evidence.
 
-Use this path when you want to integrate `tailtriage` into your own Tokio application without workspace context.
+## Path B — After crates are published (post-publish path)
 
-### 1) Add dependencies to your app
+Use this path only after crates are released. For launch-day public docs, Path A is the supported path.
 
 ```toml
 [dependencies]
@@ -79,146 +102,14 @@ tailtriage-tokio = "0.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 ```
 
-### 2) Install the published CLI
-
 ```bash
 cargo install tailtriage-cli
-```
-
-The installed binary name is `tailtriage`.
-
-### 3) Capture one artifact in your app
-
-Create one `Tailtriage` instance, wrap request/queue/stage boundaries, and shut down the artifact to disk at process shutdown.
-
-Minimal shape:
-
-```rust
-use tailtriage_core::Tailtriage;
-
-let tailtriage = Tailtriage::builder("checkout-service")
-    .output("tailtriage-run.json")
-    .build()?;
-
-let request = tailtriage.request("/checkout").with_kind("http");
-request
-    .queue("queue_wait")
-    .with_depth_at_start(3)
-    .await_on(tokio::time::sleep(std::time::Duration::from_millis(5)))
-    .await;
-request
-    .stage("db_call")
-    .await_on(async {
-        tokio::time::sleep(std::time::Duration::from_millis(8)).await;
-        Ok::<(), &'static str>(())
-    })
-    .await?;
-request.finish_ok();
-
-tailtriage.shutdown()?;
-```
-
-For a concrete end-to-end instrumentation shape, mirror [`tailtriage-tokio/examples/minimal_checkout.rs`](../tailtriage-tokio/examples/minimal_checkout.rs).
-
-### 4) Analyze your artifact with the installed binary
-
-```bash
 tailtriage analyze tailtriage-run.json --format json
 ```
-
-### 5) Interpret the first useful answer
-
-Inspect these fields first:
-
-- `primary_suspect.kind`
-- `primary_suspect.evidence[]`
-- `primary_suspect.next_checks[]`
-- `p95_queue_share_permille` (95th percentile of per-request queue-time share)
-- `p95_service_share_permille` (95th percentile of per-request service-time share)
-
-`p95_queue_share_permille` and `p95_service_share_permille` are independent percentile summaries over different per-request series. They are not expected to sum to `1000`.
-
-Representative diagnosis shape:
-
-```json
-{
-  "primary_suspect": {
-    "kind": "application_queue_saturation",
-    "evidence": [
-      "Queue wait at p95 consumes 98.2% of request time.",
-      "Observed queue depth sample up to 230."
-    ],
-    "next_checks": [
-      "Inspect queue admission limits and producer burst patterns.",
-      "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
-  }
-}
-```
-
-Suspects are evidence-ranked leads, not proof of root cause.
-
-## If result is `insufficient_evidence`
-
-Add one more queue wrapper and one more stage wrapper around the most likely missing wait points, then rerun with comparable load.
-
-## Optional stronger attribution
-
-Enable runtime snapshots when queue/stage instrumentation is still ambiguous:
-
-```rust
-use std::time::Duration;
-use std::sync::Arc;
-use tailtriage_core::Tailtriage;
-use tailtriage_tokio::RuntimeSampler;
-
-let tailtriage = Arc::new(
-    Tailtriage::builder("checkout-service")
-        .output("tailtriage-run.json")
-        .build()?,
-);
-let sampler = RuntimeSampler::start(
-    Arc::clone(&tailtriage),
-    Duration::from_millis(200),
-)?;
-// run workload
-sampler.shutdown().await;
-tailtriage.shutdown()?;
-```
-
-`sampler.shutdown().await` stops runtime snapshot collection, and `tailtriage.shutdown()?` performs the final artifact flush to `tailtriage-run.json`.
-
-### RuntimeSampler metric availability
-
-`RuntimeSampler` does not expose the same fields in all Tokio build modes.
-
-Always available on stable Tokio:
-
-- `alive_tasks`
-- `global_queue_depth`
-
-Available only with `tokio_unstable`:
-
-- `local_queue_depth`
-- `blocking_queue_depth`
-- `remote_schedule_count`
-
-Without `tokio_unstable`, unstable-only fields are captured as `None`.
-
-This means runtime sampling still helps triage on stable Tokio, but blocking-pool vs executor separation can be less decisive depending on which request-level signals you captured.
-
-## Before/after proof path
-
-After first run, validate one mitigation workflow:
-
-- [retry_storm_service before/after comparison](../demos/retry_storm_service/fixtures/before-after-comparison.json)
 
 ## Next docs
 
 - [Documentation index](README.md)
-- [Diagnostics guide](diagnostics.md)
+- [Demo walkthrough](getting-started-demo.md)
+- [Diagnostics details](diagnostics.md)
 - [Architecture](architecture.md)
-- [Demo workflow](getting-started-demo.md)
-- [Minimal source first-run example (source)](../tailtriage-tokio/examples/minimal_checkout.rs)
-- [Axum adoption starter example (source)](../tailtriage-tokio/examples/axum_minimal.rs)
-- [Mini-service integration example (source)](../tailtriage-tokio/examples/mini_service_integration.rs)

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -1,49 +1,36 @@
 # tailtriage-cli
 
-Command-line diagnosis tool for one `tailtriage` run artifact.
+Command-line triage analyzer for one `tailtriage` run artifact.
 
-`tailtriage-cli` loads a JSON artifact and produces a report with evidence-ranked suspects and next checks.
+For the public repo launch, the primary path is running the CLI from source in this workspace. `cargo install` is post-publish guidance.
 
-## Install
+## Use from this repo now
+
+```bash
+cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
+```
+
+## Post-publish install (when released)
 
 ```bash
 cargo install tailtriage-cli
-```
-
-If you are developing inside this repository, run from source with `cargo run -p tailtriage-cli -- ...`.
-
-## Analyze one artifact
-
-```bash
-tailtriage analyze tailtriage-run.json
-```
-
-From a source checkout, use:
-
-```bash
-cargo run -p tailtriage-cli -- analyze tailtriage-run.json
+tailtriage analyze tailtriage-run.json --format json
 ```
 
 ## Output shape to inspect first
 
-Start with:
+1. `primary_suspect.kind`
+2. `primary_suspect.evidence[]`
+3. `primary_suspect.next_checks[]`
 
-1. Top-ranked suspects and their evidence,
-2. `next_checks` to decide what to instrument or capture next,
-3. confidence/coverage caveats (suspects are leads, not proof).
-
-For machine processing, use JSON output:
-
-```bash
-tailtriage analyze tailtriage-run.json --format json
-```
-
-## Related docs
-
-- Data capture API (`tailtriage-core`): <https://docs.rs/tailtriage-core>
-- Tokio runtime sampling (`tailtriage-tokio`): <https://docs.rs/tailtriage-tokio>
-- Repository docs and demos: <https://github.com/SG-devel/tailtriage>
+Suspects are evidence-ranked leads, not proof of root cause.
 
 ## Artifact schema contract
 
-`tailtriage-cli` requires a top-level `schema_version` field in every run artifact. Current supported value: `1`. Missing, non-integer, or unsupported values fail fast with a clear error so triage runs against a known schema contract.
+`tailtriage-cli` requires a top-level `schema_version` field. Current supported value: `1`.
+
+## Related docs
+
+- Repo docs index: <https://github.com/SG-devel/tailtriage/tree/main/docs>
+- Core crate: <https://github.com/SG-devel/tailtriage/tree/main/tailtriage-core>
+- Tokio integration crate: <https://github.com/SG-devel/tailtriage/tree/main/tailtriage-tokio>

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -2,35 +2,30 @@
 
 Core run schema, request-context lifecycle, and instrumentation primitives for `tailtriage`.
 
-`tailtriage-core` owns the run artifact data model and the per-request capture API consumed by integrations and the CLI diagnosis workflow.
+For the public repo launch, the primary path is workspace/source integration from this repository. Crates.io snippets below are post-publish guidance.
 
-## Install
+## Use from this repo now
 
-Add this crate to your application:
+From the workspace root, run examples and analysis directly:
+
+```bash
+cargo run -p tailtriage-tokio --example minimal_checkout
+cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
+```
+
+## Post-publish crate add (when released)
 
 ```toml
 [dependencies]
 tailtriage-core = "0.1"
 ```
 
-If you are developing inside this repository, you can also use a workspace path dependency.
-
 ## What this crate owns
 
-- Run artifact schema (`RunArtifact`, requests, runtime snapshots).
-- Unified request-context model (`Tailtriage`, `RequestContext`).
-- Instrumentation primitives for queue wait, stage timing, and in-flight spans.
-- Request lifecycle completion (`finish`, `finish_ok`, `finish_result`) and final artifact flush (`shutdown`).
-
-## When to depend on `tailtriage-core` directly
-
-Use this crate directly when you want to:
-
-- instrument request/work-item flow in your service,
-- produce run JSON artifacts for triage,
-- or build custom integration code without Tokio runtime sampling.
-
-If you also want periodic Tokio runtime metrics in the same run artifact, add `tailtriage-tokio` alongside this crate.
+- Run artifact schema (`RunArtifact`, requests, runtime snapshots)
+- Unified request-context model (`Tailtriage`, `RequestContext`)
+- Queue/stage/in-flight instrumentation primitives
+- Request lifecycle completion (`finish`, `finish_ok`, `finish_result`) and final artifact flush (`shutdown`)
 
 ## Minimal usage
 
@@ -46,15 +41,8 @@ let request = tailtriage
     .request_with("/checkout", RequestOptions::new().request_id("req-1"))
     .with_kind("http");
 
-request.queue("ingress").await_on(async {
-    // wait for semaphore / bounded queue
-}).await;
-
-request.stage("db").await_on(async {
-    // downstream stage call
-    Ok::<(), std::io::Error>(())
-}).await?;
-
+request.queue("ingress").await_on(async {}).await;
+request.stage("db").await_on(async { Ok::<(), std::io::Error>(()) }).await?;
 request.finish_ok();
 
 tailtriage.shutdown()?;
@@ -64,6 +52,6 @@ tailtriage.shutdown()?;
 
 ## Related docs
 
-- Tokio integration and `RuntimeSampler`: <https://docs.rs/tailtriage-tokio>
-- CLI analysis workflow: <https://docs.rs/tailtriage-cli>
-- Repository guide and demos: <https://github.com/SG-devel/tailtriage>
+- Repo docs index: <https://github.com/SG-devel/tailtriage/tree/main/docs>
+- Tokio integration crate: <https://github.com/SG-devel/tailtriage/tree/main/tailtriage-tokio>
+- CLI crate: <https://github.com/SG-devel/tailtriage/tree/main/tailtriage-cli>

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -1,12 +1,17 @@
 # tailtriage-tokio
 
-Tokio-specific integration for `tailtriage`, including `RuntimeSampler` for periodic runtime snapshots.
+Tokio integration for `tailtriage`, including `RuntimeSampler` for periodic runtime snapshots.
 
-This crate extends the same `tailtriage-core` request-context workflow with Tokio runtime evidence.
+For the public repo launch, use workspace/source integration first. Crates.io dependency snippets are post-publish guidance.
 
-## Install
+## Use from this repo now
 
-Add this crate and `tailtriage-core`:
+```bash
+cargo run -p tailtriage-tokio --example minimal_checkout
+cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
+```
+
+## Post-publish crate add (when released)
 
 ```toml
 [dependencies]
@@ -14,61 +19,25 @@ tailtriage-core = "0.1"
 tailtriage-tokio = "0.1"
 ```
 
-If you are developing inside this repository, you can also use workspace path dependencies.
-
 ## What this crate provides
 
-- `RuntimeSampler`: periodic Tokio runtime metrics collection into the active run.
-- Integration points that keep runtime evidence and request instrumentation in one artifact.
+- `RuntimeSampler` for periodic Tokio runtime snapshots
+- Runtime evidence enrichment on the same run artifact used for request instrumentation
 
-## What `RuntimeSampler` does
-
-`RuntimeSampler` periodically records runtime snapshots such as:
-
-- worker saturation hints,
-- queue/backlog indicators,
-- blocking-pool pressure indicators.
-
-These snapshots improve triage reports when you need separation between executor pressure, blocking-pool pressure, and application-level queueing.
-
-## `RuntimeSampler` metric availability (stable Tokio vs `tokio_unstable`)
-
-`RuntimeSampler` records a `RuntimeSnapshot` with fields that map directly to Tokio runtime metrics.
+## `RuntimeSampler` metric availability
 
 Always available on stable Tokio:
 
 - `alive_tasks`
 - `global_queue_depth`
 
-Available only when compiling with `--cfg tokio_unstable`:
+Requires `tokio_unstable`:
 
 - `local_queue_depth`
 - `blocking_queue_depth`
 - `remote_schedule_count`
 
-When `tokio_unstable` is not enabled, those unstable-only fields are recorded as `None` in snapshots.
-
-Practical triage implication:
-
-- on stable Tokio, `tailtriage` can still provide useful runtime enrichment,
-- but executor-pressure vs blocking-pool-pressure separation is often weaker because some scheduler and blocking-pool signals are unavailable.
-
-Treat suspects as evidence-ranked leads and follow the recommended next checks before concluding root cause.
-
-## When runtime sampling is useful vs optional
-
-Use runtime sampling when:
-
-- service slowdowns are intermittent,
-- queueing/executor/blocking-pool suspects are hard to separate from request data alone,
-- you want richer evidence-ranked suspects in one run artifact.
-
-Skip runtime sampling when:
-
-- you only need request-level stage and queue instrumentation,
-- or you want the lowest-overhead capture mode first.
-
-`tailtriage-core` remains valid without this crate; `tailtriage-tokio` is an optional enrichment path.
+When `tokio_unstable` is not enabled, unstable-only fields are recorded as `None`.
 
 ## Minimal usage
 
@@ -98,6 +67,6 @@ tailtriage.shutdown()?;
 
 ## Related docs
 
-- Core request instrumentation API: <https://docs.rs/tailtriage-core>
-- CLI diagnosis workflow: <https://docs.rs/tailtriage-cli>
-- Repository guide and demos: <https://github.com/SG-devel/tailtriage>
+- Repo docs index: <https://github.com/SG-devel/tailtriage/tree/main/docs>
+- Core crate: <https://github.com/SG-devel/tailtriage/tree/main/tailtriage-core>
+- CLI crate: <https://github.com/SG-devel/tailtriage/tree/main/tailtriage-cli>


### PR DESCRIPTION
### Motivation

- Make the repository launch-ready for public GitHub consumption by making the source/workspace path the primary onboarding route and removing any launch-day crates.io assumptions. 
- Ensure demo and CI claims are truthful to the actual workflow (executor demo validated only in `release`) and sharpen demo honesty tiers so readers can distinguish strongest proof demos from synthetic contract exercises. 
- Preserve the product framing and triage semantics: evidence-ranked suspects, next checks, and explicit lifecycle and RuntimeSampler caveats without adding new runtime or analyzer features. 

### Description

- Rewrote and tightened the root `README.md` to present a short front door (problem, fastest source-first run, what to inspect in output, examples, demo-first steps, current public status, and docs map). 
- Restructured `docs/README.md` into three clear sections (`Start here` / `Reference` / `Maintainer docs`) and demoted maintainer/launch material from the main user path. 
- Updated user-facing docs: `docs/user-guide.md`, `docs/diagnostics.md`, and `docs/getting-started-demo.md` to mark `Path A` (use from this repo now) as the recommended launch path, add a quick “read one report in 30 seconds”, and correct demo/CI coverage wording. 
- Clarified demos and demo positioning in `demos/README.md` and added a short “run these three first” recommendation (`queue`, `downstream`, `db-pool`). 
- Polished crate readmes (`tailtriage-core/README.md`, `tailtriage-tokio/README.md`, `tailtriage-cli/README.md`) to emphasize workspace/source usage for launch and treat crates.io snippets as post-publish guidance. 
- Small doc-quality fix to satisfy clippy doc rules (backtick `RuntimeSampler` heading) and added a concise `Unreleased` changelog entry in `docs/changelog.md`. 

### Testing

- Ran `cargo fmt --check` successfully. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and fixed doc-markdown warnings, with the final run succeeding. 
- Ran `cargo test --workspace` and all unit and integration tests passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2d3b8d4cc8330a6d10dd0defb6ff7)