### PR TITLE
Follow-up: enforce split lifecycle API and fix pending request keying

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -62,12 +62,16 @@ let tailtriage = Tailtriage::builder("invoice-api")
     .build()?;
 ```
 
-### 5.2 Request-context instrumentation
+### 5.2 Split request lifecycle instrumentation
 
 ```rust
-let request = tailtriage
-    .begin_request_with("/invoice", RequestOptions::new().request_id("req-123"))
-    .with_kind("create_invoice");
+let started = tailtriage.begin_request_with(
+    "/invoice",
+    RequestOptions::new()
+        .request_id("req-123")
+        .kind("create_invoice"),
+);
+let request = started.handle.clone();
 
 request
     .queue("invoice_worker")
@@ -79,14 +83,14 @@ request
     .await_on(customer_api.fetch())
     .await?;
 
-request.finish(tailtriage_core::Outcome::Ok);
+started.completion.finish(tailtriage_core::Outcome::Ok);
 ```
 
-Completion helpers on the same request-context model:
+Completion helpers on `RequestCompletion`:
 
 ```rust
-request.finish_ok();
-let result: Result<(), MyError> = request.finish_result(downstream_call().await);
+started.completion.finish_ok();
+let result: Result<(), MyError> = started.completion.finish_result(downstream_call().await);
 ```
 
 ### 5.2.1 Request lifecycle contract

--- a/demos/blocking_service/src/main.rs
+++ b/demos/blocking_service/src/main.rs
@@ -85,10 +85,11 @@ async fn run_demo(output_path: PathBuf, settings: ModeSettings) -> anyhow::Resul
 
         tasks.push(tokio::spawn(async move {
             let request_id = format!("request-{request_number}");
-            let request = tailtriage.request_with(
+            let started = tailtriage.begin_request_with(
                 "/blocking-demo",
                 tailtriage_core::RequestOptions::new().request_id(request_id.clone()),
             );
+            let request = started.handle.clone();
 
             {
                 let _inflight = request.inflight("blocking_service_inflight");
@@ -112,7 +113,7 @@ async fn run_demo(output_path: PathBuf, settings: ModeSettings) -> anyhow::Resul
                     .await;
                 pending_blocking.fetch_sub(1, Ordering::SeqCst);
             }
-            request.finish(tailtriage_core::Outcome::Ok);
+            started.completion.finish(tailtriage_core::Outcome::Ok);
         }));
 
         if request_number % settings.inter_arrival_pause_every == 0 {

--- a/demos/cold_start_burst_service/src/main.rs
+++ b/demos/cold_start_burst_service/src/main.rs
@@ -70,10 +70,11 @@ async fn main() -> anyhow::Result<()> {
 
         tasks.push(tokio::spawn(async move {
             let request_id = format!("request-{request_number}");
-            let request = tailtriage.request_with(
+            let started = tailtriage.begin_request_with(
                 "/cold-start-burst-demo",
                 tailtriage_core::RequestOptions::new().request_id(request_id.clone()),
             );
+            let request = started.handle.clone();
 
             {
                 let _inflight = request.inflight("cold_start_burst_inflight");
@@ -94,7 +95,7 @@ async fn main() -> anyhow::Result<()> {
                     .await_value(tokio::time::sleep(stage_delay))
                     .await;
             }
-            request.finish(tailtriage_core::Outcome::Ok);
+            started.completion.finish(tailtriage_core::Outcome::Ok);
         }));
 
         if request_number % settings.inter_arrival_pause_every == 0 {

--- a/demos/db_pool_saturation_service/src/main.rs
+++ b/demos/db_pool_saturation_service/src/main.rs
@@ -58,10 +58,11 @@ async fn main() -> anyhow::Result<()> {
 
         tasks.push(tokio::spawn(async move {
             let request_id = format!("request-{request_number}");
-            let request = tailtriage.request_with(
+            let started = tailtriage.begin_request_with(
                 "/db-pool-saturation-demo",
                 tailtriage_core::RequestOptions::new().request_id(request_id.clone()),
             );
+            let request = started.handle.clone();
 
             {
                 let _inflight = request.inflight("db_pool_saturation_inflight");
@@ -87,7 +88,7 @@ async fn main() -> anyhow::Result<()> {
                     .await_value(tokio::time::sleep(settings.db_query_delay))
                     .await;
             }
-            request.finish(tailtriage_core::Outcome::Ok);
+            started.completion.finish(tailtriage_core::Outcome::Ok);
         }));
 
         if request_number % settings.inter_arrival_pause_every == 0 {

--- a/demos/downstream_service/src/main.rs
+++ b/demos/downstream_service/src/main.rs
@@ -41,10 +41,11 @@ async fn main() -> anyhow::Result<()> {
 
         tasks.push(tokio::spawn(async move {
             let request_id = format!("request-{request_number}");
-            let request = tailtriage.request_with(
+            let started = tailtriage.begin_request_with(
                 "/downstream-demo",
                 tailtriage_core::RequestOptions::new().request_id(request_id.clone()),
             );
+            let request = started.handle.clone();
 
             {
                 let _inflight = request.inflight("downstream_service_inflight");
@@ -59,7 +60,7 @@ async fn main() -> anyhow::Result<()> {
                     .await_value(tokio::time::sleep(settings.downstream_delay))
                     .await;
             }
-            request.finish(tailtriage_core::Outcome::Ok);
+            started.completion.finish(tailtriage_core::Outcome::Ok);
         }));
 
         if request_number.is_multiple_of(8) {

--- a/demos/executor_pressure_service/src/main.rs
+++ b/demos/executor_pressure_service/src/main.rs
@@ -165,10 +165,11 @@ async fn run_request_cohort(
             start_gate.wait().await;
             if let Some(collector) = collector {
                 let request_id = format!("request-{request_number}");
-                let request = collector.request_with(
+                let started = collector.begin_request_with(
                     "/executor-pressure",
                     tailtriage_core::RequestOptions::new().request_id(request_id),
                 );
+                let request = started.handle.clone();
                 let inflight_guard = request.inflight("executor_pressure_inflight");
                 execute_request_work(
                     fanout_tasks,
@@ -178,7 +179,7 @@ async fn run_request_cohort(
                 )
                 .await;
                 drop(inflight_guard);
-                request.finish(tailtriage_core::Outcome::Ok);
+                started.completion.finish(tailtriage_core::Outcome::Ok);
             } else {
                 execute_request_work(
                     fanout_tasks,

--- a/demos/mixed_contention_service/src/main.rs
+++ b/demos/mixed_contention_service/src/main.rs
@@ -61,10 +61,11 @@ async fn main() -> anyhow::Result<()> {
 
         tasks.push(tokio::spawn(async move {
             let request_id = format!("request-{request_number}");
-            let request = tailtriage.request_with(
+            let started = tailtriage.begin_request_with(
                 "/mixed-contention-demo",
                 tailtriage_core::RequestOptions::new().request_id(request_id.clone()),
             );
+            let request = started.handle.clone();
 
             {
                 let _inflight = request.inflight("mixed_contention_inflight");
@@ -97,7 +98,7 @@ async fn main() -> anyhow::Result<()> {
                     ))
                     .await;
             }
-            request.finish(tailtriage_core::Outcome::Ok);
+            started.completion.finish(tailtriage_core::Outcome::Ok);
         }));
 
         if request_number % settings.inter_arrival_pause_every == 0 {

--- a/demos/queue_service/src/main.rs
+++ b/demos/queue_service/src/main.rs
@@ -47,10 +47,11 @@ async fn main() -> anyhow::Result<()> {
 
         tasks.push(tokio::spawn(async move {
             let request_id = format!("request-{request_number}");
-            let request = tailtriage.request_with(
+            let started = tailtriage.begin_request_with(
                 "/queue-demo",
                 tailtriage_core::RequestOptions::new().request_id(request_id.clone()),
             );
+            let request = started.handle.clone();
 
             {
                 let _inflight = request.inflight("queue_service_inflight");
@@ -70,7 +71,7 @@ async fn main() -> anyhow::Result<()> {
                     .await_value(tokio::time::sleep(work_duration))
                     .await;
             }
-            request.finish(tailtriage_core::Outcome::Ok);
+            started.completion.finish(tailtriage_core::Outcome::Ok);
         }));
 
         if request_number % inter_arrival_pause_every == 0 {

--- a/demos/runtime_cost/src/main.rs
+++ b/demos/runtime_cost/src/main.rs
@@ -112,10 +112,11 @@ async fn main() -> anyhow::Result<()> {
                 }
                 (_, Some(ts)) => {
                     let request_id = format!("request-{idx}");
-                    let request = ts.request_with(
+                    let started = ts.begin_request_with(
                         "/runtime-cost",
                         tailtriage_core::RequestOptions::new().request_id(request_id),
                     );
+                    let request = started.handle.clone();
 
                     {
                         let _inflight = request.inflight("runtime_cost_requests");
@@ -139,7 +140,7 @@ async fn main() -> anyhow::Result<()> {
 
                         drop(permit);
                     }
-                    request.finish(tailtriage_core::Outcome::Ok);
+                    started.completion.finish(tailtriage_core::Outcome::Ok);
                 }
                 (_, None) => unreachable!("instrumented modes require a collector"),
             }

--- a/demos/shared_state_lock_service/src/main.rs
+++ b/demos/shared_state_lock_service/src/main.rs
@@ -55,10 +55,11 @@ async fn main() -> anyhow::Result<()> {
 
         tasks.push(tokio::spawn(async move {
             let request_id = format!("request-{request_number}");
-            let request = tailtriage.request_with(
+            let started = tailtriage.begin_request_with(
                 "/shared-state-lock-demo",
                 tailtriage_core::RequestOptions::new().request_id(request_id.clone()),
             );
+            let request = started.handle.clone();
 
             {
                 let _inflight = request.inflight("shared_state_lock_inflight");
@@ -85,7 +86,7 @@ async fn main() -> anyhow::Result<()> {
                     })
                     .await;
             }
-            request.finish(tailtriage_core::Outcome::Ok);
+            started.completion.finish(tailtriage_core::Outcome::Ok);
         }));
 
         if request_number % settings.inter_arrival_pause_every == 0 {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,7 +26,7 @@ The project is split into three crates so service instrumentation, Tokio runtime
 
 - runtime sampling (`RuntimeSampler`)
 - runtime snapshot capture (`capture_runtime_snapshot`)
-- request context instrumentation via `Tailtriage::begin_request(...)` and `RequestHandle` helpers
+- split request lifecycle instrumentation via `Tailtriage::begin_request(...)`, `RequestHandle` helpers, and explicit `RequestCompletion`
 
 Some runtime metrics require `tokio_unstable`; unavailable fields are recorded as `None`.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -36,14 +36,20 @@ The p95 share fields are independent percentile summaries and are not expected t
 
 ## Request lifecycle correctness (required)
 
-Every `RequestHandle` starts one lifecycle and must be finished **exactly once**.
+Every request lifecycle starts as a `StartedRequest` and must be finished **exactly once** through its `RequestCompletion`.
 
 ```rust
-let request = tailtriage.begin_request("/checkout").with_kind("http");
+use tailtriage_core::RequestOptions;
+
+let started = tailtriage.begin_request_with(
+    "/checkout",
+    RequestOptions::new().kind("http"),
+);
+let request = started.handle.clone();
 
 // queue/stage/inflight instrumentation here
 
-request.finish_ok();
+started.completion.finish_ok();
 ```
 
 Terminal methods:
@@ -52,7 +58,7 @@ Terminal methods:
 - `finish_ok()`
 - `finish_result(...)`
 
-`queue(...)`, `stage(...)`, and `inflight(...)` do not finish the request. `Drop` is only a debug-time misuse detector and does not record completion automatically.
+`queue(...)`, `stage(...)`, and `inflight(...)` on `RequestHandle` do not finish the request. `Drop` is only a debug-time misuse detector and does not record completion automatically.
 
 ## RuntimeSampler (optional stronger attribution)
 

--- a/scripts/smoke_external_consumer.py
+++ b/scripts/smoke_external_consumer.py
@@ -79,9 +79,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .output("tailtriage-run.json")
         .build()?;
 
-    let request = tailtriage
-        .request_with("/smoke", RequestOptions::new().request_id("external-req-1"))
-        .with_kind("cli");
+    let started = tailtriage.begin_request_with(
+        "/smoke",
+        RequestOptions::new()
+            .request_id("external-req-1")
+            .kind("cli"),
+    );
+    let request = started.handle.clone();
 
     request
         .queue("ingress")
@@ -94,7 +98,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await_value(tokio::time::sleep(Duration::from_millis(3)))
         .await;
 
-    request.finish_ok();
+    started.completion.finish_ok();
     tailtriage.shutdown()?;
     Ok(())
 }

--- a/tailtriage-cli/tests/end_to_end_capture_analysis.rs
+++ b/tailtriage-cli/tests/end_to_end_capture_analysis.rs
@@ -21,12 +21,13 @@ async fn queue_and_stage_data_drives_ranked_suspects() {
 
     for index in 0..30 {
         let request_id = format!("req-{index}");
-        let request = tailtriage
-            .request_with(
-                "/checkout",
-                tailtriage_core::RequestOptions::new().request_id(request_id),
-            )
-            .with_kind("http");
+        let started = tailtriage.begin_request_with(
+            "/checkout",
+            tailtriage_core::RequestOptions::new()
+                .request_id(request_id)
+                .kind("http"),
+        );
+        let request = started.handle.clone();
 
         request
             .queue("ingress")
@@ -37,7 +38,7 @@ async fn queue_and_stage_data_drives_ranked_suspects() {
             .stage("local_work")
             .await_value(tokio::time::sleep(std::time::Duration::from_millis(1)))
             .await;
-        request.finish(tailtriage_core::Outcome::Ok);
+        started.completion.finish(tailtriage_core::Outcome::Ok);
     }
 
     tailtriage.shutdown().expect("shutdown should succeed");
@@ -59,12 +60,13 @@ async fn downstream_heavy_stage_is_ranked() {
         .expect("build should succeed");
 
     for index in 0..36 {
-        let request = tailtriage
-            .request_with(
-                "/invoice",
-                tailtriage_core::RequestOptions::new().request_id(format!("req-{index}")),
-            )
-            .with_kind("http");
+        let started = tailtriage.begin_request_with(
+            "/invoice",
+            tailtriage_core::RequestOptions::new()
+                .request_id(format!("req-{index}"))
+                .kind("http"),
+        );
+        let request = started.handle.clone();
         request
             .queue("ingress")
             .with_depth_at_start(1)
@@ -82,7 +84,7 @@ async fn downstream_heavy_stage_is_ranked() {
             .stage("render_response")
             .await_value(tokio::time::sleep(std::time::Duration::from_millis(2)))
             .await;
-        request.finish(tailtriage_core::Outcome::Ok);
+        started.completion.finish(tailtriage_core::Outcome::Ok);
     }
 
     tailtriage.shutdown().expect("shutdown should succeed");
@@ -104,12 +106,12 @@ async fn low_evidence_run_yields_insufficient_signal() {
         .expect("build should succeed");
 
     for index in 0..3 {
-        let request = tailtriage.request_with(
+        let started = tailtriage.begin_request_with(
             "/health",
             tailtriage_core::RequestOptions::new().request_id(format!("insufficient-{index}")),
         );
         tokio::time::sleep(std::time::Duration::from_millis(1)).await;
-        request.finish(tailtriage_core::Outcome::Ok);
+        started.completion.finish(tailtriage_core::Outcome::Ok);
     }
 
     tailtriage.shutdown().expect("shutdown should succeed");

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -37,9 +37,10 @@ let tailtriage = Tailtriage::builder("checkout-service")
     .output("tailtriage-run.json")
     .build()?;
 
-let started = tailtriage
-    .begin_request_with("/checkout", RequestOptions::new().request_id("req-1"))
-    .with_kind("http");
+let started = tailtriage.begin_request_with(
+    "/checkout",
+    RequestOptions::new().request_id("req-1").kind("http"),
+);
 let request = started.handle.clone();
 
 request.queue("ingress").await_on(async {}).await;

--- a/tailtriage-core/src/collector.rs
+++ b/tailtriage-core/src/collector.rs
@@ -17,7 +17,7 @@ use crate::{
 pub struct Tailtriage {
     pub(crate) run: Mutex<Run>,
     pub(crate) inflight_counts: Mutex<HashMap<String, u64>>,
-    pending_requests: Mutex<HashMap<String, PendingRequest>>,
+    pending_requests: Mutex<HashMap<u64, PendingRequest>>,
     pub(crate) sink: Arc<dyn RunSink + Send + Sync>,
     pub(crate) limits: crate::CaptureLimits,
     pub(crate) strict_lifecycle: bool,
@@ -25,6 +25,7 @@ pub struct Tailtriage {
 
 #[derive(Debug, Clone)]
 struct PendingRequest {
+    request_id: String,
     route: String,
     kind: Option<String>,
     started_at_unix_ms: u64,
@@ -65,6 +66,7 @@ pub struct RequestHandle<'a> {
 pub struct RequestCompletion<'a> {
     tailtriage: &'a Tailtriage,
     request_id: String,
+    pending_key: u64,
     finished: bool,
 }
 
@@ -120,13 +122,15 @@ impl Tailtriage {
             .request_id
             .unwrap_or_else(|| generate_request_id(&route));
         let kind = options.kind;
+        let pending_key = PENDING_SEQUENCE.fetch_add(1, Ordering::Relaxed);
         let pending = PendingRequest {
+            request_id: request_id.clone(),
             route: route.clone(),
             kind: kind.clone(),
             started_at_unix_ms: unix_time_ms(),
             started: Instant::now(),
         };
-        lock_pending(&self.pending_requests).insert(request_id.clone(), pending);
+        lock_pending(&self.pending_requests).insert(pending_key, pending);
 
         StartedRequest {
             handle: RequestHandle {
@@ -138,23 +142,10 @@ impl Tailtriage {
             completion: RequestCompletion {
                 tailtriage: self,
                 request_id,
+                pending_key,
                 finished: false,
             },
         }
-    }
-
-    /// Back-compat alias for `begin_request`.
-    pub fn request(&self, route: impl Into<String>) -> StartedRequest<'_> {
-        self.begin_request(route)
-    }
-
-    /// Back-compat alias for `begin_request_with`.
-    pub fn request_with(
-        &self,
-        route: impl Into<String>,
-        options: RequestOptions,
-    ) -> StartedRequest<'_> {
-        self.begin_request_with(route, options)
     }
 
     /// Returns a clone of the current in-memory run state.
@@ -172,9 +163,9 @@ impl Tailtriage {
         let mut pending_samples = Vec::new();
         let pending_count = {
             let pending = lock_pending(&self.pending_requests);
-            pending_samples.extend(pending.iter().take(5).map(|(request_id, req)| {
+            pending_samples.extend(pending.iter().take(5).map(|(_, req)| {
                 UnfinishedRequestSample {
-                    request_id: request_id.clone(),
+                    request_id: req.request_id.clone(),
                     route: req.route.clone(),
                 }
             }));
@@ -271,76 +262,6 @@ impl Tailtriage {
     }
 }
 
-impl StartedRequest<'_> {
-    /// Sets an optional semantic kind for this request (for example `http` or `job`).
-    pub fn with_kind(mut self, kind: impl Into<String>) -> Self {
-        let kind = Some(kind.into());
-        self.handle.kind.clone_from(&kind);
-        if let Some(pending) =
-            lock_pending(&self.handle.tailtriage.pending_requests).get_mut(&self.handle.request_id)
-        {
-            pending.kind = kind;
-        }
-        self
-    }
-
-    /// Returns the stable request ID for this request lifecycle.
-    #[must_use]
-    pub fn request_id(&self) -> &str {
-        self.handle.request_id()
-    }
-
-    /// Returns the route or operation name associated with this request.
-    #[must_use]
-    pub fn route(&self) -> &str {
-        self.handle.route()
-    }
-
-    /// Returns the optional semantic request kind.
-    #[must_use]
-    pub fn kind(&self) -> Option<&str> {
-        self.handle.kind()
-    }
-
-    /// Starts queue-wait timing instrumentation for `queue`.
-    #[must_use]
-    pub fn queue(&self, queue: impl Into<String>) -> QueueTimer<'_> {
-        self.handle.queue(queue)
-    }
-
-    /// Starts stage timing instrumentation for `stage`.
-    #[must_use]
-    pub fn stage(&self, stage: impl Into<String>) -> StageTimer<'_> {
-        self.handle.stage(stage)
-    }
-
-    /// Increments in-flight gauge tracking for `gauge` until the returned guard drops.
-    #[must_use]
-    pub fn inflight(&self, gauge: impl Into<String>) -> InflightGuard<'_> {
-        self.handle.inflight(gauge)
-    }
-
-    /// Finishes this request with an explicit [`Outcome`].
-    pub fn finish(self, outcome: Outcome) {
-        self.completion.finish(outcome);
-    }
-
-    /// Convenience helper for successfully completed requests.
-    pub fn finish_ok(self) {
-        self.completion.finish_ok();
-    }
-
-    /// Finishes this request from `result` and returns `result` unchanged.
-    ///
-    /// # Errors
-    ///
-    /// This method does not create new errors. It returns `result` unchanged,
-    /// including the original `Err(E)` value.
-    pub fn finish_result<T, E>(self, result: Result<T, E>) -> Result<T, E> {
-        self.completion.finish_result(result)
-    }
-}
-
 impl RequestHandle<'_> {
     /// Returns the stable request ID for this request lifecycle.
     #[must_use]
@@ -424,7 +345,7 @@ impl RequestCompletion<'_> {
             return;
         }
 
-        let pending = lock_pending(&self.tailtriage.pending_requests).remove(&self.request_id);
+        let pending = lock_pending(&self.tailtriage.pending_requests).remove(&self.pending_key);
         let Some(pending) = pending else {
             debug_assert!(
                 false,
@@ -473,8 +394,8 @@ pub(crate) fn lock_map(
 }
 
 fn lock_pending(
-    map: &Mutex<HashMap<String, PendingRequest>>,
-) -> std::sync::MutexGuard<'_, HashMap<String, PendingRequest>> {
+    map: &Mutex<HashMap<u64, PendingRequest>>,
+) -> std::sync::MutexGuard<'_, HashMap<u64, PendingRequest>> {
     match map.lock() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
@@ -499,3 +420,4 @@ fn generate_request_id(route: &str) -> String {
 }
 
 static REQUEST_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+static PENDING_SEQUENCE: AtomicU64 = AtomicU64::new(0);

--- a/tailtriage-core/src/config.rs
+++ b/tailtriage-core/src/config.rs
@@ -189,7 +189,7 @@ impl TailtriageBuilder {
     }
 }
 
-/// Optional request start settings used by [`crate::Tailtriage::request_with`].
+/// Optional request start settings used by [`crate::Tailtriage::begin_request_with`].
 ///
 /// When `request_id` is not provided, a request ID is generated automatically.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]

--- a/tailtriage-core/src/lib.rs
+++ b/tailtriage-core/src/lib.rs
@@ -11,9 +11,10 @@
 //!     .output("tailtriage-run.json")
 //!     .build()?;
 //!
-//! let started = tailtriage
-//!     .begin_request_with("/checkout", RequestOptions::new().request_id("req-1"))
-//!     .with_kind("http");
+//! let started = tailtriage.begin_request_with(
+//!     "/checkout",
+//!     RequestOptions::new().request_id("req-1").kind("http"),
+//! );
 //! let request = started.handle.clone();
 //!
 //! // queue(...), stage(...), and inflight(...) instrumentation can happen here.

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -36,12 +36,10 @@ fn rejects_blank_service_name() {
 #[test]
 fn started_request_records_request_event() {
     let tailtriage = build_for_test("payments", "tailtriage-core-request.json");
-    let started = tailtriage
-        .begin_request_with(
-            "/invoice",
-            RequestOptions::new().request_id("req-42").kind("http"),
-        )
-        .with_kind("http");
+    let started = tailtriage.begin_request_with(
+        "/invoice",
+        RequestOptions::new().request_id("req-42").kind("http"),
+    );
     let request = started.handle;
     assert_eq!(request.route(), "/invoice");
     assert_eq!(request.kind(), Some("http"));
@@ -65,6 +63,23 @@ fn generated_request_ids_are_unique() {
     assert_ne!(first.handle.request_id(), second.handle.request_id());
     first.completion.finish_ok();
     second.completion.finish_ok();
+}
+
+#[test]
+fn duplicate_explicit_request_ids_do_not_clobber_pending_lifecycles() {
+    let tailtriage = build_for_test("payments", "tailtriage-core-duplicate-explicit-id.json");
+    let first =
+        tailtriage.begin_request_with("/invoice", RequestOptions::new().request_id("req-shared"));
+    let second =
+        tailtriage.begin_request_with("/invoice", RequestOptions::new().request_id("req-shared"));
+
+    first.completion.finish_ok();
+    second.completion.finish_ok();
+
+    let snapshot = tailtriage.snapshot();
+    assert_eq!(snapshot.requests.len(), 2);
+    assert_eq!(snapshot.requests[0].request_id, "req-shared");
+    assert_eq!(snapshot.requests[1].request_id, "req-shared");
 }
 
 #[test]

--- a/tailtriage-tokio/examples/axum_minimal.rs
+++ b/tailtriage-tokio/examples/axum_minimal.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use axum::{extract::State, http::StatusCode, routing::get, Router};
-use tailtriage_core::Tailtriage;
+use tailtriage_core::{RequestOptions, Tailtriage};
 use tokio::sync::{oneshot, Semaphore};
 
 #[derive(Clone)]
@@ -16,8 +16,7 @@ struct AppState {
 async fn checkout_handler(State(state): State<AppState>) -> StatusCode {
     let started = state
         .tailtriage
-        .begin_request("/checkout")
-        .with_kind("http");
+        .begin_request_with("/checkout", RequestOptions::new().kind("http"));
     let request = started.handle.clone();
 
     let result = async {

--- a/tailtriage-tokio/examples/mini_service_integration.rs
+++ b/tailtriage-tokio/examples/mini_service_integration.rs
@@ -39,12 +39,12 @@ async fn handle_checkout(
     tailtriage: Arc<Tailtriage>,
     request: CheckoutRequest,
 ) -> Result<(), &'static str> {
-    let started = tailtriage
-        .begin_request_with(
-            "/checkout",
-            RequestOptions::new().request_id(request.request_id),
-        )
-        .with_kind("http");
+    let started = tailtriage.begin_request_with(
+        "/checkout",
+        RequestOptions::new()
+            .request_id(request.request_id)
+            .kind("http"),
+    );
     let request_ctx = started.handle.clone();
 
     let result = async {

--- a/tailtriage-tokio/examples/minimal_checkout.rs
+++ b/tailtriage-tokio/examples/minimal_checkout.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use tailtriage_core::Tailtriage;
+use tailtriage_core::{RequestOptions, Tailtriage};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -9,7 +9,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .output(artifact_path)
         .build()?;
 
-    let request = tailtriage.request("/checkout").with_kind("http");
+    let started = tailtriage.begin_request_with("/checkout", RequestOptions::new().kind("http"));
+    let request = started.handle.clone();
 
     request
         .queue("checkout_worker_queue")
@@ -33,7 +34,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         })
         .await?;
 
-    request.finish_ok();
+    started.completion.finish_ok();
 
     tailtriage.shutdown()?;
     println!("Wrote {artifact_path}");


### PR DESCRIPTION
### Motivation

- Make the split lifecycle model the single, unavoidable public API so instrumentation and completion ownership are explicit and not weakened by compatibility shims.  
- Fix correctness bug where pending lifecycles were keyed by the caller-visible `request_id`, which allowed duplicate caller IDs to overwrite pending entries and corrupt artifacts.  
- Align docs, examples, demos, and tests with the stricter split ownership model so users learn the intended usage pattern.  

### Description

- Remove legacy one-object constructor aliases (`Tailtriage::request` and `Tailtriage::request_with`) and remove `StartedRequest` passthrough convenience methods so the split model (start → handle / completion) is the canonical API.  
- Change pending-request registry to use an internal monotonic `pending_key` (`u64`) instead of the caller `request_id`, and store `request_id` inside `PendingRequest`; add `PENDING_SEQUENCE` and propagate `pending_key` into `RequestCompletion`.  
- Update completion path to remove pending entries by `pending_key`, and snapshot/sampling logic to include the original `request_id` from `PendingRequest` when surfacing unfinished samples.  
- Update all docs, SPEC, examples, demos, and tests to use `begin_request[_with]`, `let request = started.handle.clone()`, and finish only via `started.completion` (e.g., `started.completion.finish_ok()`); add a regression unit test `duplicate_explicit_request_ids_do_not_clobber_pending_lifecycles`.  

### Testing

- Ran `cargo fmt --check` and the workspace is formatted (passed).  
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and there were no lints (passed).  
- Ran `cargo test --workspace`, including the new regression test for duplicate explicit request IDs, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3abfb68e88330a20f63bbdf8d2097)