### PR TITLE
docs: align split lifecycle guidance across user-facing docs

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -167,6 +167,7 @@ let sampler = RuntimeSampler::start(
 )?;
 // ... run workload ...
 sampler.shutdown().await;
+tailtriage.shutdown()?;
 ```
 
 ## 6. Run data model
@@ -206,6 +207,7 @@ The report includes:
 - secondary suspects
 - per-suspect evidence + next checks
 - warnings when run capture was truncated
+- warnings when unfinished request lifecycle state was detected at shutdown
 
 ## Script portability strategy
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,14 +19,18 @@ The project is split into three crates so service instrumentation, Tokio runtime
 
 - run schema (`Run`, metadata, events, snapshots)
 - collection lifecycle (`Tailtriage::builder(...).build`, `shutdown`, `snapshot`)
-- split request lifecycle API (`begin_request`, `RequestHandle`, `RequestCompletion`) plus instrumentation wrappers (`queue`, `stage`, `inflight`)
+- split request lifecycle API (`begin_request` / `begin_request_with` returning `StartedRequest { handle, completion }`)
+- instrumentation wrappers on `RequestHandle` (`queue`, `stage`, `inflight`)
+- completion wrappers on `RequestCompletion` (`finish`, `finish_ok`, `finish_result`)
 - local JSON sink (`LocalJsonSink`)
 
 ### `tailtriage-tokio`
 
 - runtime sampling (`RuntimeSampler`)
 - runtime snapshot capture (`capture_runtime_snapshot`)
-- request lifecycle starts via `Tailtriage::begin_request(...)`; `RequestHandle` is instrumentation-only and `RequestCompletion` is finish-only
+- request lifecycle starts via `Tailtriage::begin_request(...)` / `begin_request_with(...)`
+- `RequestHandle` is instrumentation-only
+- `RequestCompletion` is explicit finish-only
 
 Some runtime metrics require `tokio_unstable`; unavailable fields are recorded as `None`.
 
@@ -38,6 +42,8 @@ Some runtime metrics require `tokio_unstable`; unavailable fields are recorded a
 - render text or JSON report
 
 The CLI consumes run artifacts and does not need to be embedded into your service.
+
+`shutdown()` does not auto-finish requests or fabricate request outcomes/timings. Unfinished pending requests are surfaced in run metadata warnings, and `strict_lifecycle(true)` can make `shutdown()` fail.
 
 ## Contract boundary
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -36,31 +36,50 @@ The p95 share fields are independent percentile summaries and are not expected t
 
 ## Request lifecycle correctness (required)
 
-`begin_request(...)` returns a split `StartedRequest` with:
-- `started.handle` for instrumentation
-- `started.completion` for explicit finish
+`Tailtriage::begin_request(...)` / `begin_request_with(...)` returns a split `StartedRequest { handle, completion }`:
+
+- `started.handle` (`RequestHandle`) is instrumentation-only
+- `started.completion` (`RequestCompletion`) is explicit finish-only
 
 ```rust
+use tailtriage_core::RequestOptions;
+
 let started = tailtriage.begin_request_with(
     "/checkout",
-    RequestOptions::new().kind("http"),
+    RequestOptions::new().request_id("req-1").kind("http"),
 );
-let request = started.handle.clone();
+let req = started.handle.clone();
 
-// queue/stage/inflight instrumentation here
+helper_a(&req).await?;
+helper_b(&req).await?;
 
 started.completion.finish_ok();
 ```
 
-Terminal methods:
+Terminal methods on `RequestCompletion`:
 
 - `finish(...)`
 - `finish_ok()`
 - `finish_result(...)`
 
-`queue(...)`, `stage(...)`, and `inflight(...)` do not finish the request. `Drop` is only a debug-time misuse detector and does not record completion automatically.
+`queue(...)`, `stage(...)`, and `inflight(...)` on `RequestHandle` do not finish the request. `Drop` is only a debug-time misuse detector and does not record completion automatically.
 
-On `shutdown()`, tailtriage validates unfinished pending requests and surfaces lifecycle warnings plus unfinished request count/sample in run metadata. It does not invent completion timing. If you set `strict_lifecycle(true)`, `shutdown()` returns an error when unfinished requests remain.
+Helper-layer functions should take `&RequestHandle<'_>` so instrumentation can be spread across middleware/handlers/service helpers while completion remains single-owner:
+
+```rust
+async fn helper_a(req: &tailtriage_core::RequestHandle<'_>) -> Result<(), MyError> {
+    req.stage("helper_a").await_on(do_work_a()).await
+}
+```
+
+### Shutdown lifecycle semantics
+
+`tailtriage.shutdown()` only finalizes and writes the run. It does not complete pending requests.
+
+- `shutdown()` does **not** auto-finish requests.
+- `shutdown()` does **not** fabricate timings or outcomes.
+- unfinished requests are surfaced in run metadata warnings and unfinished-request samples.
+- `strict_lifecycle(true)` makes `shutdown()` return an error when unfinished requests remain.
 
 ## RuntimeSampler (optional stronger attribution)
 

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -22,7 +22,7 @@ tailtriage-core = "0.1"
 
 ## What this crate owns
 
-- Run artifact schema (`RunArtifact`, requests, runtime snapshots)
+- Run artifact schema (`Run`, requests, stages, queues, inflight snapshots, runtime snapshots)
 - Unified started-request model (`Tailtriage`, `StartedRequest`, `RequestHandle`, `RequestCompletion`)
 - Queue/stage/in-flight instrumentation primitives
 - Explicit completion token lifecycle (`finish`, `finish_ok`, `finish_result`) and final artifact flush (`shutdown`)
@@ -49,6 +49,22 @@ tailtriage.shutdown()?;
 # Ok(())
 # }
 ```
+
+## Lifecycle ownership
+
+`begin_request(...)` / `begin_request_with(...)` returns `StartedRequest { handle, completion }`:
+
+- `started.handle` (`RequestHandle`) is instrumentation-only
+- `started.completion` (`RequestCompletion`) is the only finish path
+
+`queue(...)`, `stage(...)`, and `inflight(...)` do not finish the request. Every request must be finished exactly once via `finish(...)`, `finish_ok()`, or `finish_result(...)`.
+
+## Shutdown semantics
+
+- `shutdown()` does **not** auto-finish requests.
+- `shutdown()` does **not** fabricate timings or outcomes.
+- unfinished requests are surfaced in run metadata warnings and unfinished-request samples.
+- `strict_lifecycle(true)` makes `shutdown()` return an error when unfinished requests remain.
 
 ## Related docs
 

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -25,6 +25,16 @@ tailtriage-tokio = "0.1"
 - Runtime evidence enrichment on the same run artifact used for request instrumentation
 - Works alongside the split lifecycle API from `tailtriage-core` (`StartedRequest { handle, completion }`)
 
+## Split lifecycle reminder
+
+Request lifecycle ownership stays in `tailtriage-core`:
+
+- start with `begin_request` / `begin_request_with`
+- instrument via `started.handle`
+- finish exactly once via `started.completion`
+
+`shutdown()` does not auto-finish pending requests. Unfinished requests are surfaced in run metadata, and `strict_lifecycle(true)` can make shutdown fail.
+
 ## `RuntimeSampler` metric availability
 
 Always available on stable Tokio:


### PR DESCRIPTION
### Motivation

- Align user-facing documentation with the new split lifecycle API (`begin_request` / `begin_request_with` → `StartedRequest { handle, completion }`) and remove stale wording that implied a single request object or implicit completion at shutdown.

### Description

- Replace the Request lifecycle section in `docs/user-guide.md` with explicit `StartedRequest { handle, completion }` guidance, example snippets showing `RequestHandle` instrumentation usage and `RequestCompletion` finish helpers, and a clear `shutdown()` lifecycle semantics paragraph.
- Update `docs/architecture.md` to reflect the split lifecycle API with separate bullets for the `begin_request` shape, `RequestHandle` instrumentation wrappers, and `RequestCompletion` completion wrappers, and add an explicit shutdown contract paragraph.
- Update `tailtriage-core/README.md` to clarify the run artifact wording (`Run`, requests, stages, queues, inflight snapshots, runtime snapshots) and add `Lifecycle ownership` and `Shutdown semantics` sections describing the single-owner completion token and shutdown behavior. 
- Update `tailtriage-tokio/README.md` with a `Split lifecycle reminder` describing start/instrument/finish ownership and the `shutdown()` semantics. 
- Update `SPEC.md` runtime-sampler example to call both `sampler.shutdown().await;` and `tailtriage.shutdown()?;`, and add an analyzer report bullet documenting warnings when unfinished request lifecycle state is detected at shutdown. 
- Performed a repo-wide docs pass for stale lifecycle wording and adjusted the five files above; no Rust source or tests were modified.

Changed files: `docs/user-guide.md`, `docs/architecture.md`, `tailtriage-core/README.md`, `tailtriage-tokio/README.md`, `SPEC.md`.

### Testing

- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, all of which completed successfully with tests passing. 
- Performed a repo search for stale lifecycle phrases to confirm no other example-facing Markdown required edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3cbe6a0f483308cda61a17a851290)