### PR TITLE
Harden LocalJsonSink writes with temp-file + atomic rename

### DIFF
--- a/tailtriage-core/src/sink.rs
+++ b/tailtriage-core/src/sink.rs
@@ -55,7 +55,7 @@ impl RunSink for LocalJsonSink {
                 .into_inner()
                 .map_err(|err| SinkError::Io(err.into_error()))?;
             file.sync_all().map_err(SinkError::Io)?;
-            fs::rename(&temp_path, &self.path).map_err(SinkError::Io)
+            finalize_temp_file(&temp_path, &self.path).map_err(SinkError::Io)
         })();
 
         if write_result.is_err() {
@@ -78,6 +78,37 @@ fn create_temp_path(parent: &Path, final_path: &Path) -> PathBuf {
         ".{file_name}.tmp-{}-{epoch_nanos}",
         std::process::id()
     ))
+}
+
+fn finalize_temp_file(temp_path: &Path, final_path: &Path) -> Result<(), IoError> {
+    #[cfg(unix)]
+    {
+        fs::rename(temp_path, final_path)
+    }
+
+    #[cfg(windows)]
+    {
+        match fs::rename(temp_path, final_path) {
+            Ok(()) => Ok(()),
+            Err(first_err) if final_path.exists() => {
+                // Windows does not replace an existing destination on rename.
+                // We fall back to remove + rename to preserve the single-file UX.
+                // This fallback is not atomic across power loss/crash boundaries.
+                fs::remove_file(final_path)?;
+                fs::rename(temp_path, final_path).map_err(|second_err| {
+                    IoError::other(format!(
+                        "failed to finalize run output after removing existing destination: first rename error: {first_err}; second rename error: {second_err}"
+                    ))
+                })
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        fs::rename(temp_path, final_path)
+    }
 }
 
 /// Errors emitted while writing run artifacts.
@@ -121,7 +152,7 @@ impl std::error::Error for SinkError {
 
 #[cfg(test)]
 mod tests {
-    use super::{LocalJsonSink, RunSink, SinkError};
+    use super::{finalize_temp_file, LocalJsonSink, RunSink, SinkError};
     use crate::{CaptureMode, Run, RunMetadata, UnfinishedRequests, SCHEMA_VERSION};
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -168,7 +199,54 @@ mod tests {
     }
 
     #[test]
-    fn local_sink_failed_rename_cleans_up_temp_file_and_preserves_final_path() {
+    fn local_sink_write_replaces_existing_destination_with_new_run() {
+        let output = unique_path("replace-existing");
+        let sink = LocalJsonSink::new(&output);
+
+        let mut first_run = sample_run();
+        first_run.metadata.run_id = "run-first".to_string();
+        sink.write(&first_run).expect("first write should succeed");
+
+        let mut second_run = sample_run();
+        second_run.metadata.run_id = "run-second".to_string();
+        second_run.requests.push(crate::RequestEvent {
+            request_id: "req-2".to_string(),
+            route: "/checkout".to_string(),
+            kind: Some("http".to_string()),
+            started_at_unix_ms: 10,
+            finished_at_unix_ms: 20,
+            latency_us: 10_000,
+            outcome: "ok".to_string(),
+        });
+        sink.write(&second_run)
+            .expect("second write should replace existing artifact");
+
+        let bytes = std::fs::read(&output).expect("artifact should be written");
+        let restored: Run = serde_json::from_slice(&bytes).expect("artifact should deserialize");
+        assert_eq!(restored, second_run, "existing file should be replaced");
+
+        let _ = std::fs::remove_file(output);
+    }
+
+    #[test]
+    fn failed_finalization_keeps_existing_destination_unchanged() {
+        let output = unique_path("finalization-failure");
+        let original_payload = b"{\"run_id\":\"existing\"}";
+        std::fs::write(&output, original_payload).expect("initial artifact should be writable");
+        let missing_temp = unique_path("missing-temp");
+
+        let err = finalize_temp_file(&missing_temp, &output)
+            .expect_err("finalization should fail when temp is missing");
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+
+        let final_payload = std::fs::read(&output).expect("existing final artifact should remain");
+        assert_eq!(final_payload, original_payload);
+
+        let _ = std::fs::remove_file(output);
+    }
+
+    #[test]
+    fn local_sink_failed_finalization_cleans_up_temp_file_and_preserves_final_path() {
         let output = std::env::temp_dir().join(format!(
             "tailtriage-core-sink-dir-target-{}-{}",
             std::process::id(),

--- a/tailtriage-core/src/sink.rs
+++ b/tailtriage-core/src/sink.rs
@@ -1,6 +1,7 @@
-use std::fs::File;
-use std::io::{BufWriter, Error as IoError};
+use std::fs::{self, OpenOptions};
+use std::io::{BufWriter, Error as IoError, Write};
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::Run;
 
@@ -39,11 +40,44 @@ impl LocalJsonSink {
 
 impl RunSink for LocalJsonSink {
     fn write(&self, run: &Run) -> Result<(), SinkError> {
-        let file = File::create(&self.path).map_err(SinkError::Io)?;
-        let mut writer = BufWriter::new(file);
-        serde_json::to_writer_pretty(&mut writer, run).map_err(SinkError::Serialize)?;
-        Ok(())
+        let parent = self.path.parent().unwrap_or_else(|| Path::new("."));
+        let temp_path = create_temp_path(parent, &self.path);
+        let write_result = (|| {
+            let file = OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&temp_path)
+                .map_err(SinkError::Io)?;
+            let mut writer = BufWriter::new(file);
+            serde_json::to_writer_pretty(&mut writer, run).map_err(SinkError::Serialize)?;
+            writer.flush().map_err(SinkError::Io)?;
+            let file = writer
+                .into_inner()
+                .map_err(|err| SinkError::Io(err.into_error()))?;
+            file.sync_all().map_err(SinkError::Io)?;
+            fs::rename(&temp_path, &self.path).map_err(SinkError::Io)
+        })();
+
+        if write_result.is_err() {
+            let _ = fs::remove_file(&temp_path);
+        }
+
+        write_result
     }
+}
+
+fn create_temp_path(parent: &Path, final_path: &Path) -> PathBuf {
+    let file_name = final_path
+        .file_name()
+        .and_then(std::ffi::OsStr::to_str)
+        .unwrap_or("tailtriage-run.json");
+    let epoch_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    parent.join(format!(
+        ".{file_name}.tmp-{}-{epoch_nanos}",
+        std::process::id()
+    ))
 }
 
 /// Errors emitted while writing run artifacts.
@@ -82,5 +116,97 @@ impl std::error::Error for SinkError {
             Self::Serialize(err) => Some(err),
             Self::Lifecycle { .. } => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LocalJsonSink, RunSink, SinkError};
+    use crate::{CaptureMode, Run, RunMetadata, UnfinishedRequests, SCHEMA_VERSION};
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_path(suffix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |duration| duration.as_nanos());
+        std::env::temp_dir().join(format!(
+            "tailtriage-core-sink-{suffix}-{}-{nanos}.json",
+            std::process::id()
+        ))
+    }
+
+    fn sample_run() -> Run {
+        Run::new(RunMetadata {
+            run_id: "run-1".to_string(),
+            service_name: "checkout".to_string(),
+            service_version: Some("1.0.0".to_string()),
+            started_at_unix_ms: 1,
+            finished_at_unix_ms: 2,
+            mode: CaptureMode::Light,
+            host: None,
+            pid: Some(123),
+            lifecycle_warnings: Vec::new(),
+            unfinished_requests: UnfinishedRequests::default(),
+        })
+    }
+
+    #[test]
+    fn local_sink_write_creates_deserializable_artifact() {
+        let output = unique_path("success");
+        let sink = LocalJsonSink::new(&output);
+        let run = sample_run();
+
+        sink.write(&run).expect("write should succeed");
+
+        let bytes = std::fs::read(&output).expect("artifact should be written");
+        let restored: Run = serde_json::from_slice(&bytes).expect("artifact should deserialize");
+        assert_eq!(restored, run);
+        assert_eq!(restored.schema_version, SCHEMA_VERSION);
+
+        let _ = std::fs::remove_file(output);
+    }
+
+    #[test]
+    fn local_sink_failed_rename_cleans_up_temp_file_and_preserves_final_path() {
+        let output = std::env::temp_dir().join(format!(
+            "tailtriage-core-sink-dir-target-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map_or(0, |duration| duration.as_nanos())
+        ));
+        std::fs::create_dir_all(&output).expect("directory target should be created");
+        let sink = LocalJsonSink::new(&output);
+
+        let err = sink
+            .write(&sample_run())
+            .expect_err("rename to directory should fail");
+        assert!(matches!(err, SinkError::Io(_)));
+        assert!(
+            output.is_dir(),
+            "existing final directory should remain untouched"
+        );
+
+        let parent = output
+            .parent()
+            .expect("directory target should always have a parent");
+        let final_name = output
+            .file_name()
+            .and_then(std::ffi::OsStr::to_str)
+            .expect("directory target should be valid utf-8 for this test");
+        let temp_prefix = format!(".{final_name}.tmp-");
+        let leftover_temp = std::fs::read_dir(parent)
+            .expect("parent should be readable")
+            .filter_map(Result::ok)
+            .map(|entry| entry.file_name())
+            .filter_map(|name| name.to_str().map(str::to_owned))
+            .any(|name| name.starts_with(&temp_prefix));
+        assert!(
+            !leftover_temp,
+            "temporary file should be cleaned up on failed finalization"
+        );
+
+        let _ = std::fs::remove_dir_all(output);
     }
 }


### PR DESCRIPTION
### Motivation
- Avoid exposing a partially written or truncated JSON artifact at the final output path during normal write failures. 
- Make the default local sink crash-safer while preserving the existing single-file UX. 
- Keep error messages clear and perform best-effort cleanup of temporary artifacts.

### Description
- Rewrite `LocalJsonSink::write` to serialize into a temp file placed in the same directory as the final path, then finalize with `fs::rename` to replace the final file atomically. 
- Use `OpenOptions::create_new` + `BufWriter`, call `flush` and `sync_all` on the temp file before rename, and attempt `fs::remove_file` on the temp path when finalization fails. 
- Add `create_temp_path` helper to produce per-process, timestamped temp filenames in the target directory. 
- Add unit tests validating a successful write produces a deserializable final artifact and that a failed finalization (forced by using a directory as the final target) does not leave a corrupted final path and cleans up temp files.

### Testing
- Ran `cargo fmt --check` and it passed. 
- Ran `cargo clippy --workspace --all-targets --locked -- -D warnings` and it passed. 
- Ran `cargo test --workspace --locked` and all tests, including the new sink tests, passed. 
- Ran the example and CLI flow with `cargo run -p tailtriage-tokio --example minimal_checkout` and `cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json` and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3d483679c833092dc06ab524a55aa)