### PR TITLE
Add related documentation links to axum README

### DIFF
--- a/tailtriage-axum/README.md
+++ b/tailtriage-axum/README.md
@@ -48,3 +48,10 @@ let app: Router<()> = Router::new()
 ```
 
 Suspects in analysis output are leads, not proof of root cause.
+
+## Related docs
+
+- Repo docs index: <https://github.com/SG-devel/tailtriage/tree/main/docs>
+- Core crate: <https://github.com/SG-devel/tailtriage/tree/main/tailtriage-core>
+- Tokio integration crate: <https://github.com/SG-devel/tailtriage/tree/main/tailtriage-tokio>
+- CLI crate: <https://github.com/SG-devel/tailtriage/tree/main/tailtriage-cli>


### PR DESCRIPTION
## Summary

links other docs from axum readme

## Why this change

easier navigation

## Validation

docs only 

## Scope check

docs only

## Contribution license check

- [x] I have the right to submit this contribution under the MIT License.
- [x] I agree that this contribution is licensed under the repository's MIT License.
