### PR TITLE
Align demo crate metadata with workspace package settings

### DIFF
--- a/demos/blocking_service/Cargo.toml
+++ b/demos/blocking_service/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "blocking-service-demo"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]

--- a/demos/cold_start_burst_service/Cargo.toml
+++ b/demos/cold_start_burst_service/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "cold-start-burst-service-demo"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]

--- a/demos/db_pool_saturation_service/Cargo.toml
+++ b/demos/db_pool_saturation_service/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "db-pool-saturation-service-demo"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]

--- a/demos/demo_support/Cargo.toml
+++ b/demos/demo_support/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "demo-support"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]

--- a/demos/downstream_service/Cargo.toml
+++ b/demos/downstream_service/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "downstream_service"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]

--- a/demos/executor_pressure_service/Cargo.toml
+++ b/demos/executor_pressure_service/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "executor-pressure-service-demo"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]

--- a/demos/mixed_contention_service/Cargo.toml
+++ b/demos/mixed_contention_service/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "mixed_contention_service"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]

--- a/demos/queue_service/Cargo.toml
+++ b/demos/queue_service/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "queue-service-demo"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]

--- a/demos/retry_storm_service/Cargo.toml
+++ b/demos/retry_storm_service/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "retry-storm-service-demo"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]

--- a/demos/shared_state_lock_service/Cargo.toml
+++ b/demos/shared_state_lock_service/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "shared-state-lock-service-demo"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]


### PR DESCRIPTION
### Motivation
- Keep demo crate metadata consistent with the workspace `package` settings to avoid duplicated literals and ensure demos carry the workspace license.
- Explicitly surface the workspace `MIT` license in demo crates so licenses are unambiguous when crates are inspected individually.

### Description
- Updated ten demo `Cargo.toml` files under `demos/` to use `version.workspace = true`, `edition.workspace = true`, and `license.workspace = true` instead of hard-coded `version` and `edition` values. 
- Left other crate metadata (for example `publish = false`) and dependencies unchanged to preserve demo behavior.
- This centralizes `version`, `edition`, and `license` to the top-level `[workspace.package]` where `edition = "2021"`, `license = "MIT"`, and `version = "0.1.0"` are declared.

### Testing
- Ran `cargo fmt --check` which succeeded. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` which completed without warnings. 
- Ran `cargo test --workspace` and all workspace tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c50713cdc88330b3ad508323e4b6bf)