### PR TITLE
toml: includes, linting, repository.workspace, tailtriage-core.workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ resolver = "2"
 edition = "2021"
 license = "MIT"
 version = "0.1.0"
+repository = "https://github.com/SG-devel/tailtriage"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"
@@ -30,3 +31,6 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(tokio_unstable)"] }
 [workspace.lints.clippy]
 all = "warn"
 pedantic = "warn"
+
+[workspace.dependencies]
+tailtriage-core = { version = "0.1.0", path = "tailtriage-core" }

--- a/demos/blocking_service/Cargo.toml
+++ b/demos/blocking_service/Cargo.toml
@@ -3,10 +3,14 @@ name = "blocking-service-demo"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 publish = false
 
 [dependencies]
 anyhow = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }
-tailtriage-core = { path = "../../tailtriage-core" }
+tailtriage-core.workspace = true
 demo-support = { path = "../demo_support" }
+
+[lints]
+workspace = true

--- a/demos/blocking_service/src/main.rs
+++ b/demos/blocking_service/src/main.rs
@@ -76,7 +76,8 @@ async fn run_demo(output_path: PathBuf, settings: ModeSettings) -> anyhow::Resul
         })
     };
 
-    let mut tasks = Vec::with_capacity(settings.offered_requests as usize);
+    let capacity = usize::try_from(settings.offered_requests)?;
+    let mut tasks = Vec::with_capacity(capacity);
 
     for request_number in 0..settings.offered_requests {
         let tailtriage = Arc::clone(&tailtriage);
@@ -108,7 +109,7 @@ async fn run_demo(output_path: PathBuf, settings: ModeSettings) -> anyhow::Resul
                     .await_value(async {
                         handle
                             .await
-                            .expect("spawn_blocking workload should complete")
+                            .expect("spawn_blocking workload should complete");
                     })
                     .await;
                 pending_blocking.fetch_sub(1, Ordering::SeqCst);

--- a/demos/cold_start_burst_service/Cargo.toml
+++ b/demos/cold_start_burst_service/Cargo.toml
@@ -3,10 +3,14 @@ name = "cold-start-burst-service-demo"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 publish = false
 
 [dependencies]
 anyhow = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
-tailtriage-core = { path = "../../tailtriage-core" }
+tailtriage-core.workspace = true
 demo-support = { path = "../demo_support" }
+
+[lints]
+workspace = true

--- a/demos/cold_start_burst_service/src/main.rs
+++ b/demos/cold_start_burst_service/src/main.rs
@@ -60,7 +60,8 @@ async fn main() -> anyhow::Result<()> {
     let semaphore = Arc::new(Semaphore::new(settings.service_capacity));
     let waiting_depth = Arc::new(AtomicU64::new(0));
 
-    let mut tasks = Vec::with_capacity(settings.offered_requests as usize);
+    let task_capacity = usize::try_from(settings.offered_requests)?;
+    let mut tasks = Vec::with_capacity(task_capacity);
 
     for request_number in 0..settings.offered_requests {
         let tailtriage = Arc::clone(&tailtriage);

--- a/demos/db_pool_saturation_service/Cargo.toml
+++ b/demos/db_pool_saturation_service/Cargo.toml
@@ -3,10 +3,14 @@ name = "db-pool-saturation-service-demo"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 publish = false
 
 [dependencies]
 anyhow = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
-tailtriage-core = { path = "../../tailtriage-core" }
+tailtriage-core.workspace = true
 demo-support = { path = "../demo_support" }
+
+[lints]
+workspace = true

--- a/demos/db_pool_saturation_service/src/main.rs
+++ b/demos/db_pool_saturation_service/src/main.rs
@@ -49,7 +49,8 @@ async fn main() -> anyhow::Result<()> {
     let db_pool = Arc::new(Semaphore::new(settings.db_pool_size));
     let waiting_depth = Arc::new(AtomicU64::new(0));
 
-    let mut tasks = Vec::with_capacity(settings.offered_requests as usize);
+    let task_capacity = usize::try_from(settings.offered_requests)?;
+    let mut tasks = Vec::with_capacity(task_capacity);
 
     for request_number in 0..settings.offered_requests {
         let tailtriage = Arc::clone(&tailtriage);

--- a/demos/demo_support/Cargo.toml
+++ b/demos/demo_support/Cargo.toml
@@ -3,9 +3,13 @@ name = "demo-support"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 publish = false
 
 [dependencies]
 anyhow = "1"
-tailtriage-core = { path = "../../tailtriage-core" }
+tailtriage-core.workspace = true
 tokio = { version = "1", features = ["sync", "time"] }
+
+[lints]
+workspace = true

--- a/demos/demo_support/src/lib.rs
+++ b/demos/demo_support/src/lib.rs
@@ -9,7 +9,9 @@ use tokio::sync::Barrier;
 /// Demo profile selector used by before/after style demo binaries.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum DemoMode {
+    /// Run the baseline or "before" profile.
     Baseline,
+    /// Run the mitigated or "after" profile.
     Mitigated,
 }
 
@@ -21,10 +23,15 @@ impl DemoMode {
     /// - `mitigated` or `after`
     ///
     /// If omitted, defaults to `baseline`.
-    pub fn from_arg(value: Option<String>) -> anyhow::Result<Self> {
-        match value.as_deref() {
-            None | Some("baseline") | Some("before") => Ok(Self::Baseline),
-            Some("mitigated") | Some("after") => Ok(Self::Mitigated),
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `value` is present but is not one of:
+    /// `baseline`, `before`, `mitigated`, or `after`.
+    pub fn from_arg(value: Option<&String>) -> anyhow::Result<Self> {
+        match value.map(String::as_str) {
+            None | Some("baseline" | "before") => Ok(Self::Baseline),
+            Some("mitigated" | "after") => Ok(Self::Mitigated),
             Some(other) => anyhow::bail!(
                 "unsupported mode '{other}', expected one of: baseline, before, mitigated, after"
             ),
@@ -32,30 +39,51 @@ impl DemoMode {
     }
 }
 
+/// Parsed common demo CLI arguments.
 pub struct DemoArgs {
+    /// Output path for the generated demo artifact.
     pub output_path: PathBuf,
+    /// Selected demo mode.
     pub mode: DemoMode,
 }
 
 /// Parse common `<output_path> [mode]` demo arguments.
+///
+/// The first positional argument, if present, is parsed as the output path.
+/// Otherwise, `default_output_path` is used.
+///
+/// The second positional argument, if present, is parsed as the demo mode.
+/// Accepted values are `baseline`/`before` and `mitigated`/`after`.
+/// If omitted, the mode defaults to `baseline`.
+///
+/// # Errors
+///
+/// Returns an error if the mode argument is unsupported, or if preparing the
+/// parent directory for the output path fails.
 pub fn parse_demo_args(default_output_path: &str) -> anyhow::Result<DemoArgs> {
     let mut args = std::env::args().skip(1);
     let output_path = args
         .next()
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from(default_output_path));
-    let mode = DemoMode::from_arg(args.next())?;
+        .map_or_else(|| PathBuf::from(default_output_path), PathBuf::from);
+    let mode = DemoMode::from_arg(args.next().as_ref())?;
     ensure_parent_dir(&output_path)?;
 
     Ok(DemoArgs { output_path, mode })
 }
 
-/// Parse common `<output_path>` demo arguments.
+/// Parse a common `<output_path>` demo argument.
+///
+/// The first positional argument, if present, is used as the output path.
+/// Otherwise, `default_output_path` is used.
+///
+/// # Errors
+///
+/// Returns an error if preparing the parent directory for the resolved output
+/// path fails.
 pub fn parse_output_arg(default_output_path: &str) -> anyhow::Result<PathBuf> {
     let output_path = std::env::args()
         .nth(1)
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from(default_output_path));
+        .map_or_else(|| PathBuf::from(default_output_path), PathBuf::from);
     ensure_parent_dir(&output_path)?;
     Ok(output_path)
 }
@@ -68,7 +96,14 @@ fn ensure_parent_dir(output_path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Build a Tailtriage instance for a demo service name and output artifact path.
+/// Initialize a shared `Tailtriage` collector for the given service and output path.
+///
+/// The collector is configured with `service_name` and writes its output to
+/// `output_path`.
+///
+/// # Errors
+///
+/// Returns an error if building the `Tailtriage` collector fails.
 pub fn init_collector(service_name: &str, output_path: &Path) -> anyhow::Result<Arc<Tailtriage>> {
     let collector = Tailtriage::builder(service_name)
         .output(output_path)
@@ -87,6 +122,7 @@ pub struct CohortStart {
 
 impl CohortStart {
     /// Create a cohort barrier for `participant_count` async tasks.
+    #[must_use]
     pub fn new(participant_count: usize) -> Self {
         Self {
             barrier: Arc::new(Barrier::new(participant_count)),

--- a/demos/downstream_service/Cargo.toml
+++ b/demos/downstream_service/Cargo.toml
@@ -3,10 +3,14 @@ name = "downstream_service"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 publish = false
 
 [dependencies]
 anyhow = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
-tailtriage-core = { path = "../../tailtriage-core" }
+tailtriage-core.workspace = true
 demo-support = { path = "../demo_support" }
+
+[lints]
+workspace = true

--- a/demos/downstream_service/src/main.rs
+++ b/demos/downstream_service/src/main.rs
@@ -34,7 +34,8 @@ async fn main() -> anyhow::Result<()> {
     let tailtriage = init_collector("downstream_service_demo", &output_path)?;
 
     let offered_requests = 80_u64;
-    let mut tasks = Vec::with_capacity(offered_requests as usize);
+    let task_capacity = usize::try_from(offered_requests)?;
+    let mut tasks = Vec::with_capacity(task_capacity);
 
     for request_number in 0..offered_requests {
         let tailtriage = Arc::clone(&tailtriage);

--- a/demos/executor_pressure_service/Cargo.toml
+++ b/demos/executor_pressure_service/Cargo.toml
@@ -3,10 +3,14 @@ name = "executor-pressure-service-demo"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 publish = false
 
 [dependencies]
 anyhow = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }
-tailtriage-core = { path = "../../tailtriage-core" }
+tailtriage-core.workspace = true
 demo-support = { path = "../demo_support" }
+
+[lints]
+workspace = true

--- a/demos/executor_pressure_service/src/main.rs
+++ b/demos/executor_pressure_service/src/main.rs
@@ -62,8 +62,8 @@ async fn run_demo(output_path: PathBuf, settings: ModeSettings) -> anyhow::Resul
 
     let runnable_backlog = Arc::new(AtomicU64::new(0));
     let hot_slice_local_depth = Arc::new(AtomicU64::new(0));
-    let warmup_count = settings.warmup_requests as usize;
-    let measured_count = measured_requests as usize;
+    let warmup_count = usize::try_from(settings.warmup_requests)?;
+    let measured_count = usize::try_from(measured_requests)?;
 
     run_warmup_then_measured(
         warmup_count,

--- a/demos/mixed_contention_service/Cargo.toml
+++ b/demos/mixed_contention_service/Cargo.toml
@@ -3,10 +3,14 @@ name = "mixed_contention_service"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 publish = false
 
 [dependencies]
 anyhow = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
-tailtriage-core = { path = "../../tailtriage-core" }
+tailtriage-core.workspace = true
 demo-support = { path = "../demo_support" }
+
+[lints]
+workspace = true

--- a/demos/mixed_contention_service/src/main.rs
+++ b/demos/mixed_contention_service/src/main.rs
@@ -52,7 +52,8 @@ async fn main() -> anyhow::Result<()> {
     let semaphore = Arc::new(Semaphore::new(settings.service_capacity));
     let waiting_depth = Arc::new(AtomicU64::new(0));
 
-    let mut tasks = Vec::with_capacity(settings.offered_requests as usize);
+    let capacity = usize::try_from(settings.offered_requests)?;
+    let mut tasks = Vec::with_capacity(capacity);
 
     for request_number in 0..settings.offered_requests {
         let tailtriage = Arc::clone(&tailtriage);

--- a/demos/queue_service/Cargo.toml
+++ b/demos/queue_service/Cargo.toml
@@ -3,10 +3,14 @@ name = "queue-service-demo"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 publish = false
 
 [dependencies]
 anyhow = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
-tailtriage-core = { path = "../../tailtriage-core" }
+tailtriage-core.workspace = true
 demo-support = { path = "../demo_support" }
+
+[lints]
+workspace = true

--- a/demos/queue_service/src/main.rs
+++ b/demos/queue_service/src/main.rs
@@ -38,7 +38,8 @@ async fn main() -> anyhow::Result<()> {
     let semaphore = Arc::new(Semaphore::new(service_capacity));
     let waiting_depth = Arc::new(AtomicU64::new(0));
 
-    let mut tasks = Vec::with_capacity(offered_requests as usize);
+    let capacity = usize::try_from(offered_requests)?;
+    let mut tasks = Vec::with_capacity(capacity);
 
     for request_number in 0..offered_requests {
         let tailtriage = Arc::clone(&tailtriage);

--- a/demos/retry_storm_service/Cargo.toml
+++ b/demos/retry_storm_service/Cargo.toml
@@ -3,10 +3,14 @@ name = "retry-storm-service-demo"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 publish = false
 
 [dependencies]
 anyhow = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
-tailtriage-core = { path = "../../tailtriage-core" }
+tailtriage-core.workspace = true
 demo-support = { path = "../demo_support" }
+
+[lints]
+workspace = true

--- a/demos/retry_storm_service/src/main.rs
+++ b/demos/retry_storm_service/src/main.rs
@@ -137,7 +137,8 @@ async fn main() -> anyhow::Result<()> {
 
     let tailtriage = init_collector("retry_storm_service_demo", &args.output_path)?;
 
-    let mut tasks = Vec::with_capacity(mode_settings.offered_requests as usize);
+    let capacity = usize::try_from(mode_settings.offered_requests)?;
+    let mut tasks = Vec::with_capacity(capacity);
 
     for request_number in 0..mode_settings.offered_requests {
         let tailtriage = Arc::clone(&tailtriage);

--- a/demos/runtime_cost/Cargo.toml
+++ b/demos/runtime_cost/Cargo.toml
@@ -3,12 +3,16 @@ name = "runtime_cost"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 publish = false
 
 [dependencies]
 anyhow = "1"
-tailtriage-core = { path = "../../tailtriage-core" }
+tailtriage-core.workspace = true
 tailtriage-tokio = { path = "../../tailtriage-tokio" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[lints]
+workspace = true

--- a/demos/runtime_cost/src/main.rs
+++ b/demos/runtime_cost/src/main.rs
@@ -29,6 +29,14 @@ impl Mode {
             _ => None,
         }
     }
+
+    fn capture_mode(self) -> Option<CaptureMode> {
+        match self {
+            Self::Baseline => None,
+            Self::Light => Some(CaptureMode::Light),
+            Self::Investigation => Some(CaptureMode::Investigation),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -52,42 +60,83 @@ struct Measurement {
     latency_p99_ms: f64,
 }
 
+struct Instrumentation {
+    tailtriage: Option<Arc<Tailtriage>>,
+    sampler: Option<RuntimeSampler>,
+}
+
 #[tokio::main(flavor = "multi_thread", worker_threads = 4)]
 async fn main() -> anyhow::Result<()> {
     let cli = parse_cli()?;
     std::fs::create_dir_all(&cli.output_dir)
         .with_context(|| format!("failed to create {}", cli.output_dir.display()))?;
 
-    let mut tailtriage = None;
-    let mut sampler = None;
+    let instrumentation = build_instrumentation(&cli)?;
+    let (mut latencies, elapsed) = run_requests(&cli, instrumentation.tailtriage.as_ref()).await?;
 
-    if cli.mode != Mode::Baseline {
-        let mode = match cli.mode {
-            Mode::Light => CaptureMode::Light,
-            Mode::Investigation => CaptureMode::Investigation,
-            Mode::Baseline => CaptureMode::Light,
-        };
-        let mut builder = Tailtriage::builder("runtime_cost_demo").output(
-            cli.output_dir
-                .join(format!("run-{:?}.json", cli.mode).to_lowercase()),
-        );
-        builder = match mode {
-            CaptureMode::Light => builder.light(),
-            CaptureMode::Investigation => builder.investigation(),
-        };
-
-        let instance = Arc::new(builder.build()?);
-
-        if cli.mode == Mode::Investigation {
-            sampler = Some(RuntimeSampler::start(
-                Arc::clone(&instance),
-                Duration::from_millis(2),
-            )?);
-        }
-
-        tailtriage = Some(instance);
+    if let Some(sampler) = instrumentation.sampler {
+        sampler.shutdown().await;
     }
 
+    if let Some(tailtriage) = instrumentation.tailtriage {
+        tailtriage.shutdown()?;
+    }
+
+    latencies.sort_unstable();
+
+    let measurement = Measurement {
+        mode: cli.mode,
+        requests: cli.requests,
+        concurrency: cli.concurrency,
+        work_ms: cli.work_ms,
+        throughput_rps: requests_per_second(cli.requests, elapsed)?,
+        latency_p50_ms: percentile_ms(&latencies, 50, 100)?,
+        latency_p95_ms: percentile_ms(&latencies, 95, 100)?,
+        latency_p99_ms: percentile_ms(&latencies, 99, 100)?,
+    };
+
+    println!("{}", serde_json::to_string(&measurement)?);
+
+    Ok(())
+}
+
+fn build_instrumentation(cli: &Cli) -> anyhow::Result<Instrumentation> {
+    let Some(capture_mode) = cli.mode.capture_mode() else {
+        return Ok(Instrumentation {
+            tailtriage: None,
+            sampler: None,
+        });
+    };
+
+    let mut builder = Tailtriage::builder("runtime_cost_demo").output(
+        cli.output_dir
+            .join(format!("run-{:?}.json", cli.mode).to_lowercase()),
+    );
+    builder = match capture_mode {
+        CaptureMode::Light => builder.light(),
+        CaptureMode::Investigation => builder.investigation(),
+    };
+
+    let tailtriage = Arc::new(builder.build()?);
+    let sampler = if cli.mode == Mode::Investigation {
+        Some(RuntimeSampler::start(
+            Arc::clone(&tailtriage),
+            Duration::from_millis(2),
+        )?)
+    } else {
+        None
+    };
+
+    Ok(Instrumentation {
+        tailtriage: Some(tailtriage),
+        sampler,
+    })
+}
+
+async fn run_requests(
+    cli: &Cli,
+    tailtriage: Option<&Arc<Tailtriage>>,
+) -> anyhow::Result<(Vec<u64>, Duration)> {
     let latencies_us = Arc::new(Mutex::new(Vec::<u64>::with_capacity(cli.requests)));
     let semaphore = Arc::new(Semaphore::new(cli.concurrency));
 
@@ -99,7 +148,7 @@ async fn main() -> anyhow::Result<()> {
         let latencies = Arc::clone(&latencies_us);
         let mode = cli.mode;
         let work_duration = Duration::from_millis(cli.work_ms);
-        let tailtriage = tailtriage.as_ref().map(Arc::clone);
+        let tailtriage = tailtriage.map(Arc::clone);
 
         tasks.push(tokio::spawn(async move {
             let start = Instant::now();
@@ -140,6 +189,7 @@ async fn main() -> anyhow::Result<()> {
 
                         drop(permit);
                     }
+
                     started.completion.finish(tailtriage_core::Outcome::Ok);
                 }
                 (_, None) => unreachable!("instrumented modes require a collector"),
@@ -155,34 +205,11 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let elapsed = wall_start.elapsed();
-
-    if let Some(sampler) = sampler {
-        sampler.shutdown().await;
-    }
-
-    if let Some(ts) = tailtriage {
-        ts.shutdown()?;
-    }
-
-    let mut latencies = Arc::into_inner(latencies_us)
+    let latencies = Arc::into_inner(latencies_us)
         .expect("all task refs dropped")
         .into_inner();
-    latencies.sort_unstable();
 
-    let measurement = Measurement {
-        mode: cli.mode,
-        requests: cli.requests,
-        concurrency: cli.concurrency,
-        work_ms: cli.work_ms,
-        throughput_rps: cli.requests as f64 / elapsed.as_secs_f64(),
-        latency_p50_ms: percentile_ms(&latencies, 0.50),
-        latency_p95_ms: percentile_ms(&latencies, 0.95),
-        latency_p99_ms: percentile_ms(&latencies, 0.99),
-    };
-
-    println!("{}", serde_json::to_string(&measurement)?);
-
-    Ok(())
+    Ok((latencies, elapsed))
 }
 
 fn parse_cli() -> anyhow::Result<Cli> {
@@ -258,15 +285,34 @@ fn print_help() {
     );
 }
 
-fn percentile_ms(sorted_us: &[u64], percentile: f64) -> f64 {
-    let len = sorted_us.len();
-    if len == 0 {
-        return 0.0;
+fn requests_per_second(request_count: usize, elapsed: Duration) -> anyhow::Result<f64> {
+    let total_requests = u64::try_from(request_count)?;
+    let request_rate_input = total_requests.to_string().parse::<f64>()?;
+    Ok(request_rate_input / elapsed.as_secs_f64())
+}
+
+fn percentile_ms(sorted_us: &[u64], numerator: u64, denominator: u64) -> anyhow::Result<f64> {
+    if sorted_us.is_empty() {
+        return Ok(0.0);
     }
 
-    let max_index = len - 1;
-    let target = (max_index as f64 * percentile).round();
-    let index = target.clamp(0.0, max_index as f64) as usize;
+    anyhow::ensure!(denominator != 0, "percentile denominator must be non-zero");
+    anyhow::ensure!(
+        numerator <= denominator,
+        "percentile numerator must be <= denominator"
+    );
 
-    sorted_us[index] as f64 / 1_000.0
+    let max_index = sorted_us.len() - 1;
+    let max_index_u64 = u64::try_from(max_index)?;
+    let scaled = u128::from(max_index_u64) * u128::from(numerator);
+    let rounded = scaled + (u128::from(denominator) / 2);
+    let index_u128 = rounded / u128::from(denominator);
+    let index = usize::try_from(index_u128)?;
+
+    micros_to_millis_f64(sorted_us[index])
+}
+
+fn micros_to_millis_f64(micros: u64) -> anyhow::Result<f64> {
+    let micros_value = micros.to_string().parse::<f64>()?;
+    Ok(micros_value / 1_000.0)
 }

--- a/demos/shared_state_lock_service/Cargo.toml
+++ b/demos/shared_state_lock_service/Cargo.toml
@@ -3,10 +3,14 @@ name = "shared-state-lock-service-demo"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 publish = false
 
 [dependencies]
 anyhow = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
-tailtriage-core = { path = "../../tailtriage-core" }
+tailtriage-core.workspace = true
 demo-support = { path = "../demo_support" }
+
+[lints]
+workspace = true

--- a/demos/shared_state_lock_service/src/main.rs
+++ b/demos/shared_state_lock_service/src/main.rs
@@ -46,7 +46,8 @@ async fn main() -> anyhow::Result<()> {
     let shared_state = Arc::new(RwLock::new(0_u64));
     let waiting_writers = Arc::new(AtomicU64::new(0));
 
-    let mut tasks = Vec::with_capacity(settings.offered_requests as usize);
+    let capacity = usize::try_from(settings.offered_requests)?;
+    let mut tasks = Vec::with_capacity(capacity);
 
     for request_number in 0..settings.offered_requests {
         let tailtriage = Arc::clone(&tailtriage);

--- a/tailtriage-axum/Cargo.toml
+++ b/tailtriage-axum/Cargo.toml
@@ -3,16 +3,21 @@ name = "tailtriage-axum"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Axum adapter for tailtriage request-boundary triage wiring"
-repository = "https://github.com/SG-devel/tailtriage"
 documentation = "https://docs.rs/tailtriage-axum"
 readme = "README.md"
 keywords = ["axum", "tokio", "latency", "instrumentation", "triage"]
 categories = ["asynchronous", "development-tools::profiling", "development-tools::debugging"]
+include = [
+  "Cargo.toml",
+  "README.md",
+  "src/**",
+]
 
 [dependencies]
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "matched-path", "tokio"] }
-tailtriage-core = { version = "0.1.0", path = "../tailtriage-core" }
+tailtriage-core.workspace = true
 
 [lints]
 workspace = true

--- a/tailtriage-cli/Cargo.toml
+++ b/tailtriage-cli/Cargo.toml
@@ -3,12 +3,17 @@ name = "tailtriage-cli"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "CLI for tailtriage artifact loading, diagnosis, and report generation"
-repository = "https://github.com/SG-devel/tailtriage"
 documentation = "https://docs.rs/tailtriage-cli"
 readme = "README.md"
 keywords = ["tokio", "latency", "cli", "diagnostics", "triage"]
 categories = ["command-line-utilities", "development-tools::profiling", "development-tools::debugging"]
+include = [
+  "Cargo.toml",
+  "README.md",
+  "src/**",
+]
 
 [[bin]]
 name = "tailtriage"
@@ -18,7 +23,7 @@ path = "src/main.rs"
 clap = { version = "4.5.40", features = ["derive"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
-tailtriage-core = { version = "0.1.0", path = "../tailtriage-core" }
+tailtriage-core.workspace = true
 
 [lints]
 workspace = true

--- a/tailtriage-core/Cargo.toml
+++ b/tailtriage-core/Cargo.toml
@@ -3,12 +3,17 @@ name = "tailtriage-core"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Core schema and request instrumentation primitives for Tokio tail-latency triage"
-repository = "https://github.com/SG-devel/tailtriage"
 documentation = "https://docs.rs/tailtriage-core"
 readme = "README.md"
 keywords = ["tokio", "latency", "diagnostics", "performance", "triage"]
 categories = ["asynchronous", "development-tools::profiling", "development-tools::debugging"]
+include = [
+  "Cargo.toml",
+  "README.md",
+  "src/**",
+]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/tailtriage-tokio/Cargo.toml
+++ b/tailtriage-tokio/Cargo.toml
@@ -3,15 +3,20 @@ name = "tailtriage-tokio"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Tokio runtime sampling integration for tailtriage run artifacts"
-repository = "https://github.com/SG-devel/tailtriage"
 documentation = "https://docs.rs/tailtriage-tokio"
 readme = "README.md"
 keywords = ["tokio", "latency", "instrumentation", "async", "triage"]
 categories = ["asynchronous", "development-tools::profiling", "development-tools::debugging"]
+include = [
+  "Cargo.toml",
+  "README.md",
+  "src/**",
+]
 
 [dependencies]
-tailtriage-core = { version = "0.1.0", path = "../tailtriage-core" }
+tailtriage-core.workspace = true
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 
 [lints]


### PR DESCRIPTION
## Summary

- root workspace now defines repository and a shared tailtriage-core dependency in [workspace.package] / [workspace.dependencies]
- the four publishable crates switched from hardcoded repository = ... to repository.workspace = true
- the three crates that depend on tailtriage-core switched from repeated version + path entries to tailtriage-core.workspace = true
- the four publishable crates now have a strict minimal include allowlist: Cargo.toml, README.md, src/**
- all demo crates remain publish = false and now align with workspace lints/metadata better

Linter fixes:
- add missing rustdoc and `# Errors` docs in `demo_support`
- make `DemoMode::from_arg` clippy-clean without changing behavior
- refactor `runtime_cost` to resolve line-count, match-arm, and numeric-cast lints
- replace lossy `u64 -> usize` casts in demo binaries with checked conversions
- fix minor style lints such as missing semicolons

No intended functional changes to demo behavior. 

Discovered separate platform-dependent test errors in `tailtriage-core`. PR will follow.

## Contribution license check

- [x] I have the right to submit this contribution under the MIT License.
- [x] I agree that this contribution is licensed under the repository's MIT License.
