### PR TITLE
fix platform dep. issues (windows)

### DIFF
--- a/tailtriage-core/src/sink.rs
+++ b/tailtriage-core/src/sink.rs
@@ -80,6 +80,21 @@ fn create_temp_path(parent: &Path, final_path: &Path) -> PathBuf {
     ))
 }
 
+fn create_backup_path(final_path: &Path) -> PathBuf {
+    let parent = final_path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = final_path
+        .file_name()
+        .and_then(std::ffi::OsStr::to_str)
+        .unwrap_or("tailtriage-run.json");
+    let epoch_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    parent.join(format!(
+        ".{file_name}.bak-{}-{epoch_nanos}",
+        std::process::id()
+    ))
+}
+
 fn finalize_temp_file(temp_path: &Path, final_path: &Path) -> Result<(), IoError> {
     #[cfg(unix)]
     {
@@ -90,16 +105,36 @@ fn finalize_temp_file(temp_path: &Path, final_path: &Path) -> Result<(), IoError
     {
         match fs::rename(temp_path, final_path) {
             Ok(()) => Ok(()),
-            Err(first_err) if final_path.exists() => {
+            Err(first_err) if final_path.is_file() && temp_path.is_file() => {
                 // Windows does not replace an existing destination on rename.
-                // We fall back to remove + rename to preserve the single-file UX.
-                // This fallback is not atomic across power loss/crash boundaries.
-                fs::remove_file(final_path)?;
-                fs::rename(temp_path, final_path).map_err(|second_err| {
-                    IoError::other(format!(
-                        "failed to finalize run output after removing existing destination: first rename error: {first_err}; second rename error: {second_err}"
-                    ))
-                })
+                // Preserve the existing destination by moving it aside first,
+                // then restore it if the second rename fails.
+                let backup_path = create_backup_path(final_path);
+                fs::rename(final_path, &backup_path)?;
+
+                match fs::rename(temp_path, final_path) {
+                    Ok(()) => {
+                        let _ = fs::remove_file(&backup_path);
+                        Ok(())
+                    }
+                    Err(second_err) => {
+                        let restore_result = fs::rename(&backup_path, final_path);
+                        match restore_result {
+                            Ok(()) => Err(IoError::new(
+                                second_err.kind(),
+                                format!(
+                                    "failed to finalize run output after preserving existing destination: first rename error: {first_err}; second rename error: {second_err}"
+                                ),
+                            )),
+                            Err(restore_err) => Err(IoError::new(
+                                second_err.kind(),
+                                format!(
+                                    "failed to finalize run output and failed to restore existing destination: first rename error: {first_err}; second rename error: {second_err}; restore error: {restore_err}"
+                                ),
+                            )),
+                        }
+                    }
+                }
             }
             Err(err) => Err(err),
         }

--- a/tailtriage-core/src/sink.rs
+++ b/tailtriage-core/src/sink.rs
@@ -80,6 +80,7 @@ fn create_temp_path(parent: &Path, final_path: &Path) -> PathBuf {
     ))
 }
 
+#[cfg(windows)]
 fn create_backup_path(final_path: &Path) -> PathBuf {
     let parent = final_path.parent().unwrap_or_else(|| Path::new("."));
     let file_name = final_path

--- a/tailtriage-core/src/time.rs
+++ b/tailtriage-core/src/time.rs
@@ -1,4 +1,11 @@
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Converts a [`Duration`] since [`UNIX_EPOCH`] to unix epoch milliseconds,
+/// saturating at [`u64::MAX`].
+#[must_use]
+fn duration_to_unix_ms(duration: Duration) -> u64 {
+    duration.as_millis().try_into().unwrap_or(u64::MAX)
+}
 
 /// Converts a [`SystemTime`] to unix epoch milliseconds.
 ///
@@ -7,7 +14,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 #[must_use]
 pub fn system_time_to_unix_ms(time: SystemTime) -> u64 {
     match time.duration_since(UNIX_EPOCH) {
-        Ok(duration) => duration.as_millis().try_into().unwrap_or(u64::MAX),
+        Ok(duration) => duration_to_unix_ms(duration),
         Err(_) => 0,
     }
 }
@@ -20,7 +27,7 @@ pub fn unix_time_ms() -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use super::system_time_to_unix_ms;
+    use super::{duration_to_unix_ms, system_time_to_unix_ms};
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     #[test]
@@ -33,10 +40,7 @@ mod tests {
         let overflow_duration = Duration::from_millis(u64::MAX)
             .checked_add(Duration::from_millis(1))
             .expect("overflow test duration should be representable");
-        let overflow = UNIX_EPOCH
-            .checked_add(overflow_duration)
-            .expect("overflow test timestamp should be representable");
-        assert_eq!(system_time_to_unix_ms(overflow), u64::MAX);
+        assert_eq!(duration_to_unix_ms(overflow_duration), u64::MAX);
 
         assert_eq!(system_time_to_unix_ms(UNIX_EPOCH), 0);
         assert_eq!(


### PR DESCRIPTION
## Summary

Fix platform-dependent behavior and tests in `tailtriage-core`.
- make Windows sink finalization preserve the existing destination if replacement fails
- replace destructive remove-and-rename fallback with backup/restore behavior
- make unix-ms overflow coverage platform-robust by avoiding assumptions about representable `SystemTime` ranges

No intended product behavior changes beyond cross-platform correctness and more reliable tests.

## Why this change

test errors on windows

## Validation

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`

## Contribution license check

- [x] I have the right to submit this contribution under the MIT License.
- [x] I agree that this contribution is licensed under the repository's MIT License.
