### PR TITLE
tighten cargo-deny policy and fix workspace path dependency wildcard violations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,5 @@ pedantic = "warn"
 
 [workspace.dependencies]
 tailtriage-core = { version = "0.1.0", path = "tailtriage-core" }
+tailtriage-tokio = { version = "0.1.0", path = "tailtriage-tokio" }
+demo-support = { version = "0.1.0", path = "demos/demo_support" }

--- a/demos/blocking_service/Cargo.toml
+++ b/demos/blocking_service/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }
 tailtriage-core.workspace = true
-demo-support = { path = "../demo_support" }
+demo-support.workspace = true
 
 [lints]
 workspace = true

--- a/demos/cold_start_burst_service/Cargo.toml
+++ b/demos/cold_start_burst_service/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
 tailtriage-core.workspace = true
-demo-support = { path = "../demo_support" }
+demo-support.workspace = true
 
 [lints]
 workspace = true

--- a/demos/db_pool_saturation_service/Cargo.toml
+++ b/demos/db_pool_saturation_service/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
 tailtriage-core.workspace = true
-demo-support = { path = "../demo_support" }
+demo-support.workspace = true
 
 [lints]
 workspace = true

--- a/demos/downstream_service/Cargo.toml
+++ b/demos/downstream_service/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 tailtriage-core.workspace = true
-demo-support = { path = "../demo_support" }
+demo-support.workspace = true
 
 [lints]
 workspace = true

--- a/demos/executor_pressure_service/Cargo.toml
+++ b/demos/executor_pressure_service/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }
 tailtriage-core.workspace = true
-demo-support = { path = "../demo_support" }
+demo-support.workspace = true
 
 [lints]
 workspace = true

--- a/demos/mixed_contention_service/Cargo.toml
+++ b/demos/mixed_contention_service/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
 tailtriage-core.workspace = true
-demo-support = { path = "../demo_support" }
+demo-support.workspace = true
 
 [lints]
 workspace = true

--- a/demos/queue_service/Cargo.toml
+++ b/demos/queue_service/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
 tailtriage-core.workspace = true
-demo-support = { path = "../demo_support" }
+demo-support.workspace = true
 
 [lints]
 workspace = true

--- a/demos/retry_storm_service/Cargo.toml
+++ b/demos/retry_storm_service/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 tailtriage-core.workspace = true
-demo-support = { path = "../demo_support" }
+demo-support.workspace = true
 
 [lints]
 workspace = true

--- a/demos/runtime_cost/Cargo.toml
+++ b/demos/runtime_cost/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1"
 tailtriage-core.workspace = true
-tailtriage-tokio = { path = "../../tailtriage-tokio" }
+tailtriage-tokio.workspace = true
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/demos/shared_state_lock_service/Cargo.toml
+++ b/demos/shared_state_lock_service/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
 tailtriage-core.workspace = true
-demo-support = { path = "../demo_support" }
+demo-support.workspace = true
 
 [lints]
 workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -1,240 +1,43 @@
-# This template contains all of the possible sections and their default values
-
-# Note that all fields that take a lint level have these possible values:
-# * deny - An error will be produced and the check will fail
-# * warn - A warning will be produced, but the check will not fail
-# * allow - No warning or error will be produced, though in some cases a note
-# will be
-
-# The values provided in this template are the default values that will be used
-# when any section or field is not specified in your own configuration
-
-# Root options
-
-# The graph table configures how the dependency graph is constructed and thus
-# which crates the checks are performed against
 [graph]
-# If 1 or more target triples (and optionally, target_features) are specified,
-# only the specified targets will be checked when running `cargo deny check`.
-# This means, if a particular package is only ever used as a target specific
-# dependency, such as, for example, the `nix` crate only being used via the
-# `target_family = "unix"` configuration, that only having windows targets in
-# this list would mean the nix crate, as well as any of its exclusive
-# dependencies not shared by any other crates, would be ignored, as the target
-# list here is effectively saying which targets you are building for.
-targets = [
-    # The triple can be any string, but only the target triples built in to
-    # rustc (as of 1.40) can be checked against actual config expressions
-    #"x86_64-unknown-linux-musl",
-    # You can also specify which target_features you promise are enabled for a
-    # particular target. target_features are currently not validated against
-    # the actual valid features supported by the target architecture.
-    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
-]
-# When creating the dependency graph used as the source of truth when checks are
-# executed, this field can be used to prune crates from the graph, removing them
-# from the view of cargo-deny. This is an extremely heavy hammer, as if a crate
-# is pruned from the graph, all of its dependencies will also be pruned unless
-# they are connected to another crate in the graph that hasn't been pruned,
-# so it should be used with care. The identifiers are [Package ID Specifications]
-# (https://doc.rust-lang.org/cargo/reference/pkgid-spec.html)
-#exclude = []
-# If true, metadata will be collected with `--all-features`. Note that this can't
-# be toggled off if true, if you want to conditionally enable `--all-features` it
-# is recommended to pass `--all-features` on the cmd line instead
-all-features = false
-# If true, metadata will be collected with `--no-default-features`. The same
-# caveat with `all-features` applies
+all-features = true
 no-default-features = false
-# If set, these feature will be enabled when collecting metadata. If `--features`
-# is specified on the cmd line they will take precedence over this option.
-#features = []
+# optionally add explicit targets you care about
+# targets = [
+#   "x86_64-unknown-linux-gnu",
+#   "aarch64-apple-darwin",
+#   "x86_64-pc-windows-msvc",
+# ]
 
-# The output table provides options for how/if diagnostics are outputted
-[output]
-# When outputting inclusion graphs in diagnostics that include features, this
-# option can be used to specify the depth at which feature edges will be added.
-# This option is included since the graphs can be quite large and the addition
-# of features from the crate(s) to all of the graph roots can be far too verbose.
-# This option can be overridden via `--feature-depth` on the cmd line
-feature-depth = 1
-
-# This section is considered when running `cargo deny check advisories`
-# More documentation for the advisories section can be found here:
-# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
-[advisories]
-# The path where the advisory databases are cloned/fetched into
-#db-path = "$CARGO_HOME/advisory-dbs"
-# The url(s) of the advisory databases to use
-#db-urls = ["https://github.com/rustsec/advisory-db"]
-# A list of advisory IDs to ignore. Note that ignored advisories will still
-# output a note when they are encountered.
-ignore = [
-    #"RUSTSEC-0000-0000",
-    #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
-    #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
-    #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
-]
-# If this is true, then cargo deny will use the git executable to fetch advisory database.
-# If this is false, then it uses a built-in git library.
-# Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
-# See Git Authentication for more information about setting up git authentication.
-#git-fetch-with-cli = true
-
-# This section is considered when running `cargo deny check licenses`
-# More documentation for the licenses section can be found here:
-# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
-# List of explicitly allowed licenses
-# See https://spdx.org/licenses/ for list of possible licenses
-# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+confidence-threshold = 0.93
 allow = [
-    "MIT",
-    "Apache-2.0",
-    "BSD-3-Clause",
-    "Unicode-3.0"
+  "MIT",
+  "Apache-2.0",
+  "BSD-3-Clause",
+  "Unicode-3.0",
 ]
-# The confidence threshold for detecting a license from license text.
-# The higher the value, the more closely the license text must be to the
-# canonical license text of a valid SPDX license file.
-# [possible values: any between 0.0 and 1.0].
-confidence-threshold = 0.8
-# Allow 1 or more licenses on a per-crate basis, so that particular licenses
-# aren't accepted for every possible crate as with the normal allow list
-exceptions = [
-    # Each entry is the crate and version constraint, and its specific allow
-    # list
-    #{ allow = ["Zlib"], crate = "adler32" },
-]
-
-# Some crates don't have (easily) machine readable licensing information,
-# adding a clarification entry for it allows you to manually specify the
-# licensing information
-#[[licenses.clarify]]
-# The package spec the clarification applies to
-#crate = "ring"
-# The SPDX expression for the license requirements of the crate
-#expression = "MIT AND ISC AND OpenSSL"
-# One or more files in the crate's source used as the "source of truth" for
-# the license expression. If the contents match, the clarification will be used
-# when running the license check, otherwise the clarification will be ignored
-# and the crate will be checked normally, which may produce warnings or errors
-# depending on the rest of your configuration
-#license-files = [
-# Each entry is a crate relative path, and the (opaque) hash of its contents
-#{ path = "LICENSE", hash = 0xbd0eed23 }
-#]
+exceptions = []
 
 [licenses.private]
-# If true, ignores workspace crates that aren't published, or are only
-# published to private registries.
-# To see how to mark a crate as unpublished (to the official registry),
-# visit https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field.
 ignore = false
-# One or more private registries that you might publish crates to, if a crate
-# is only published to private registries, and ignore is true, the crate will
-# not have its license(s) checked
-registries = [
-    #"https://sekretz.com/registry
-]
 
-# This section is considered when running `cargo deny check bans`.
-# More documentation about the 'bans' section can be found here:
-# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
-[bans]
-# Lint level for when multiple versions of the same crate are detected
-multiple-versions = "warn"
-# Lint level for when a crate version requirement is `*`
-wildcards = "allow"
-# The graph highlighting used when creating dotgraphs for crates
-# with multiple versions
-# * lowest-version - The path to the lowest versioned duplicate is highlighted
-# * simplest-path - The path to the version with the fewest edges is highlighted
-# * all - Both lowest-version and simplest-path are used
-highlight = "all"
-# The default lint level for `default` features for crates that are members of
-# the workspace that is being checked. This can be overridden by allowing/denying
-# `default` on a crate-by-crate basis if desired.
-workspace-default-features = "allow"
-# The default lint level for `default` features for external crates that are not
-# members of the workspace. This can be overridden by allowing/denying `default`
-# on a crate-by-crate basis if desired.
-external-default-features = "allow"
-# List of crates that are allowed. Use with care!
-allow = [
-    #"ansi_term@0.11.0",
-    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is allowed" },
-]
-# If true, workspace members are automatically allowed even when using deny-by-default
-# This is useful for organizations that want to deny all external dependencies by default
-# but allow their own workspace crates without having to explicitly list them
-allow-workspace = false
-# List of crates to deny
-deny = [
-    #"ansi_term@0.11.0",
-    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is banned" },
-    # Wrapper crates can optionally be specified to allow the crate when it
-    # is a direct dependency of the otherwise banned crate
-    #{ crate = "ansi_term@0.11.0", wrappers = ["this-crate-directly-depends-on-ansi_term"] },
-]
-
-# List of features to allow/deny
-# Each entry the name of a crate and a version range. If version is
-# not specified, all versions will be matched.
-#[[bans.features]]
-#crate = "reqwest"
-# Features to not allow
-#deny = ["json"]
-# Features to allow
-#allow = [
-#    "rustls",
-#    "__rustls",
-#    "__tls",
-#    "hyper-rustls",
-#    "rustls",
-#    "rustls-pemfile",
-#    "rustls-tls-webpki-roots",
-#    "tokio-rustls",
-#    "webpki-roots",
-#]
-# If true, the allowed features must exactly match the enabled feature set. If
-# this is set there is no point setting `deny`
-#exact = true
-
-# Certain crates/versions that will be skipped when doing duplicate detection.
-skip = [
-    #"ansi_term@0.11.0",
-    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason why it can't be updated/removed" },
-]
-# Similarly to `skip` allows you to skip certain crates during duplicate
-# detection. Unlike skip, it also includes the entire tree of transitive
-# dependencies starting at the specified crate, up to a certain depth, which is
-# by default infinite.
-skip-tree = [
-    #"ansi_term@0.11.0", # will be skipped along with _all_ of its direct and transitive dependencies
-    #{ crate = "ansi_term@0.11.0", depth = 20 },
-]
-
-# This section is considered when running `cargo deny check sources`.
-# More documentation about the 'sources' section can be found here:
-# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
 [sources]
-# Lint level for what to happen when a crate from a crate registry that is not
-# in the allow list is encountered
-unknown-registry = "warn"
-# Lint level for what to happen when a crate from a git repository that is not
-# in the allow list is encountered
-unknown-git = "warn"
-# List of URLs for allowed crate registries. Defaults to the crates.io index
-# if not specified. If it is specified but empty, no registries are allowed.
+unknown-registry = "deny"
+unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-# List of URLs for allowed Git repositories
 allow-git = []
 
-[sources.allow-org]
-# github.com organizations to allow git sources for
-github = []
-# gitlab.com organizations to allow git sources for
-gitlab = []
-# bitbucket.org organizations to allow git sources for
-bitbucket = []
+[advisories]
+ignore = []
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+highlight = "all"
+workspace-default-features = "allow"
+external-default-features = "allow"
+allow-workspace = false
+allow = []
+deny = []
+skip = []
+skip-tree = []


### PR DESCRIPTION
## Summary

This PR tightens our `cargo-deny` policy for license/source hygiene and fixes wildcard dependency violations caused by internal workspace path dependencies.

### What changed

* replaced path-only internal dependencies with explicit workspace-managed dependencies
* added versioned internal crates to `[workspace.dependencies]`
* updated leaf manifests to use `.workspace = true` where appropriate
* kept the policy goal of permissive-only licensing
* preserved strict `cargo-deny` wildcard enforcement instead of weakening it globally

### Why

`cargo-deny` treats path-only dependencies like wildcard version requirements, which caused failures such as:

* `tailtriage-tokio = { path = "../../tailtriage-tokio" }`
* `demo-support = { path = "../demo_support" }`

By declaring these internal crates in `[workspace.dependencies]` with both `version` and `path`, then consuming them via `.workspace = true`, we eliminate the wildcard errors without relaxing policy.

### Result

* internal workspace crates remain local/internal
* `cargo-deny` no longer flags those path-only dependencies as wildcard requirements
* the repo keeps a stricter compliance posture instead of papering over the issue with `wildcards = "allow"` or `warn`

## Notes

This change is policy-preserving, not policy-weakening: it fixes the manifests so they comply with strict `cargo-deny` rules.

## Contribution license check

- [x] I have the right to submit this contribution under the MIT License.
- [x] I agree that this contribution is licensed under the repository's MIT License.
