### PR TITLE
docs: replace pre-release wording and add crates.io adoption guidance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,11 +104,11 @@ jobs:
       - name: Validate retry-storm demo
         run: python3 scripts/demo_tool.py validate retry-storm --profile ${{ matrix.profile }}
 
-      - name: Smoke-check launch-critical public examples
+      - name: Smoke-check public examples
         if: matrix.profile == 'dev'
         run: python3 scripts/smoke_public_examples.py
 
-      - name: Smoke-check external consumer adoption flow
+      - name: Smoke-check external crates.io consumer adoption flow
         if: matrix.profile == 'release'
         run: python3 scripts/smoke_external_consumer.py
         

--- a/README.md
+++ b/README.md
@@ -10,13 +10,24 @@ When a Tokio service gets slow, `tailtriage` helps you answer a first practical 
 
 It produces **evidence-ranked suspects** with **next checks**. Suspects are leads, not proof of root cause.
 
-## Fastest first run
+## Fastest first run from this repo
 
-Use the source/workspace path from this public repository:
+Use the workspace/source path when you want to run bundled examples and hack on this repository:
 
 ```bash
 cargo run -p tailtriage-tokio --example minimal_checkout
 cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
+```
+
+## Use published crates in your own project
+
+Use crates.io when adopting `tailtriage` in an external project:
+
+```bash
+cargo add tailtriage-core
+cargo add tailtriage-tokio
+cargo add tailtriage-axum # optional, only for axum middleware/extractor ergonomics
+cargo install tailtriage-cli
 ```
 
 ## What you get from the output
@@ -87,7 +98,7 @@ Demo walkthrough and CI coverage details: [`docs/getting-started-demo.md`](docs/
 | Use with axum                                                   | `tailtriage-core`, `tailtriage-axum`                     | `tailtriage-tokio`, `tailtriage-cli` | `tailtriage-axum` is the framework ergonomics layer: middleware + extractor. It depends on core, not on `tailtriage-tokio`   |
 | Use with axum plus runtime snapshots                            | `tailtriage-core`, `tailtriage-axum`, `tailtriage-tokio` | `tailtriage-cli`                     | Axum request-boundary wiring plus optional runtime evidence enrichment                                                       |
 | Analyze artifacts only                                          | `tailtriage-cli`                                         | none                                 | CLI loads run JSON, validates schema version, analyzes, and renders text/JSON reports                                        |
-| Minimal first run from repo                                     | none beyond workspace                                    | none                                 | Recommended launch path today is source/workspace use, not crates.io-first onboarding                                        |
+| Minimal first run from repo                                     | none beyond workspace                                    | none                                 | Fastest path for bundled examples, demo scripts, and contributor workflows                                                    |
 
 ## What this is not
 
@@ -117,9 +128,14 @@ Those tools are complementary building blocks. `tailtriage` is the triage layer 
 
 ## Current public status
 
-The repository is public and ready to use **from source/workspace now**.
+The repository is public, and the crates are available now on crates.io:
 
-Today, the recommended onboarding path is the source path in this repo. Crates.io install snippets are treated as **post-publish** guidance and are not the primary launch path yet.
+- <https://crates.io/crates/tailtriage-core>
+- <https://crates.io/crates/tailtriage-tokio>
+- <https://crates.io/crates/tailtriage-axum>
+- <https://crates.io/crates/tailtriage-cli>
+
+Use workspace/source onboarding for repository examples and contributor workflows, and use crates.io onboarding for external-project adoption.
 
 ## Documentation map
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,8 @@
 
 ## Start here
 
-- **Fastest first run from this repo:** [`user-guide.md#path-a--use-from-this-repo-now`](user-guide.md#path-a--use-from-this-repo-now)
+- **Fastest first run from this repo:** [`user-guide.md#path-a--run-from-this-repo-workspace`](user-guide.md#path-a--run-from-this-repo-workspace)
+- **Use published crates in external projects:** [`user-guide.md#path-b--use-published-crates-from-cratesio`](user-guide.md#path-b--use-published-crates-from-cratesio)
 - **Split lifecycle API contract (`StartedRequest`, `RequestHandle`, `RequestCompletion`):** [`user-guide.md#request-lifecycle-correctness-required`](user-guide.md#request-lifecycle-correctness-required)
 - **Axum adapter usage (`TailtriageRequest` + middleware):** [`user-guide.md#axum-adapter-surface-optional`](user-guide.md#axum-adapter-surface-optional)
 - **Public examples:** [`../tailtriage-tokio/examples/`](../tailtriage-tokio/examples/) and [`../tailtriage-axum/examples/`](../tailtriage-axum/examples/)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2,9 +2,9 @@
 
 Use this guide for a reliable capture → analyze → next-check loop.
 
-## Path A — Use from this repo now
+## Path A — Run from this repo workspace
 
-This is the recommended public path today.
+Use this path to run bundled examples, demos, and contributor workflows from this repository.
 
 ### 1) Capture one artifact
 
@@ -158,15 +158,15 @@ Example split:
 
 Add one queue wrapper and one stage wrapper around the most likely missing waits, rerun under comparable load, then compare suspects/evidence.
 
-## Path B — After crates are published (post-publish path)
+## Path B — Use published crates from crates.io
 
-Use this path only after crates are released. For launch-day public docs, Path A is the supported path.
+Use this path when adopting `tailtriage` in an external project.
 
 ```toml
 [dependencies]
-tailtriage-core = "0.1"
-tailtriage-tokio = "0.1"
-tailtriage-axum = "0.1" # optional, only for axum middleware/extractor ergonomics
+tailtriage-core = "0.1.0"
+tailtriage-tokio = "0.1.0"
+tailtriage-axum = "0.1.0" # optional, only for axum middleware/extractor ergonomics
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 ```
 

--- a/scripts/smoke_external_consumer.py
+++ b/scripts/smoke_external_consumer.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Smoke-test an external consumer app outside the workspace.
+"""Smoke-test external crates.io adoption outside the workspace.
 
 This script creates a temporary Cargo app outside the repository, consumes
-`tailtriage-core` via path dependency, produces a run artifact, and analyzes it
+`tailtriage-core` from crates.io, produces a run artifact, and analyzes it
 with the workspace CLI.
 """
 
@@ -54,7 +54,7 @@ def assert_keys(payload: dict, expected: set[str], *, context: str) -> None:
         raise SystemExit(f"{context} missing top-level keys: {missing_list}")
 
 
-def write_external_app(project_dir: Path, root: Path) -> tuple[Path, Path]:
+def write_external_app(project_dir: Path) -> tuple[Path, Path]:
     app_dir = project_dir / "external-tailtriage-smoke"
     run_cmd(["cargo", "new", "--bin", app_dir.name], cwd=project_dir)
 
@@ -64,7 +64,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tailtriage-core = {{ path = \"{(root / 'tailtriage-core').as_posix()}\" }}
+tailtriage-core = "0.1.0"
 tokio = {{ version = "1", features = ["macros", "rt", "time"] }}
 """
     (app_dir / "Cargo.toml").write_text(cargo_toml, encoding="utf-8")
@@ -110,11 +110,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 def main() -> None:
     root = repo_root()
-    print("Smoke-validating an external consumer app outside the workspace...")
+    print("Smoke-validating external crates.io consumer adoption outside the workspace...")
 
     with tempfile.TemporaryDirectory(prefix="tailtriage-external-consumer-") as temp_dir:
         external_root = Path(temp_dir)
-        app_dir, artifact_path = write_external_app(external_root, root)
+        app_dir, artifact_path = write_external_app(external_root)
 
         print(f"==> created external app: {app_dir}")
         run_cmd(["cargo", "run", "--quiet"], cwd=app_dir)

--- a/scripts/smoke_public_examples.py
+++ b/scripts/smoke_public_examples.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Smoke-validate launch-critical public examples.
+"""Smoke-validate public examples.
 
 This script validates the public onboarding flow for selected examples:
 1) run the example
@@ -129,10 +129,10 @@ def validate_example(package: str, name: str) -> None:
 
 
 def main() -> None:
-    print("Smoke-validating launch-critical public examples...")
+    print("Smoke-validating public examples...")
     for package, name in EXAMPLES:
         validate_example(package, name)
-    print("All launch-critical public examples passed smoke validation.")
+    print("All public examples passed smoke validation.")
 
 
 if __name__ == "__main__":

--- a/tailtriage-axum/README.md
+++ b/tailtriage-axum/README.md
@@ -12,12 +12,12 @@ cargo run -p tailtriage-axum --example axum_service_adoption
 cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
 ```
 
-## Post-publish crate add (when released)
+## Add from crates.io
 
 ```toml
 [dependencies]
-tailtriage-core = "0.1"
-tailtriage-axum = "0.1"
+tailtriage-core = "0.1.0"
+tailtriage-axum = "0.1.0"
 ```
 
 ## What this crate provides

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -2,15 +2,13 @@
 
 Command-line triage analyzer for one `tailtriage` run artifact.
 
-For the public repo launch, the primary path is running the CLI from source in this workspace. `cargo install` is post-publish guidance.
-
 ## Use from this repo now
 
 ```bash
 cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
 ```
 
-## Post-publish install (when released)
+## Install from crates.io
 
 ```bash
 cargo install tailtriage-cli

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -2,8 +2,6 @@
 
 Core run schema, split request lifecycle API, and instrumentation primitives for `tailtriage`.
 
-For the public repo launch, the primary path is workspace/source integration from this repository. Crates.io snippets below are post-publish guidance.
-
 ## Use from this repo now
 
 From the workspace root, run examples and analysis directly:
@@ -13,11 +11,11 @@ cargo run -p tailtriage-tokio --example minimal_checkout
 cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
 ```
 
-## Post-publish crate add (when released)
+## Add from crates.io
 
 ```toml
 [dependencies]
-tailtriage-core = "0.1"
+tailtriage-core = "0.1.0"
 ```
 
 ## What this crate owns

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -2,8 +2,6 @@
 
 Tokio integration for `tailtriage`, including `RuntimeSampler` for periodic runtime snapshots.
 
-For the public repo launch, use workspace/source integration first. Crates.io dependency snippets are post-publish guidance.
-
 ## Use from this repo now
 
 ```bash
@@ -11,12 +9,12 @@ cargo run -p tailtriage-tokio --example minimal_checkout
 cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
 ```
 
-## Post-publish crate add (when released)
+## Add from crates.io
 
 ```toml
 [dependencies]
-tailtriage-core = "0.1"
-tailtriage-tokio = "0.1"
+tailtriage-core = "0.1.0"
+tailtriage-tokio = "0.1.0"
 ```
 
 ## What this crate provides


### PR DESCRIPTION
### Motivation

- The crates are published and the public documentation still contained pre-release/post-publish wording that confused adopters. 
- Update docs to present both repository (workspace/source) and crates.io onboarding as current, accurate paths without removing contributor workflows. 
- Ensure install snippets, versioned dependencies, anchors, and navigation are consistent across repo README, crate READMEs, and docs. 

### Description

- Rewrote onboarding wording and added a clear crates.io adoption section in `README.md`, including `cargo add`/`cargo install` examples. 
- Converted `docs/user-guide.md` Path A/B language to present-tense usage (`Path A` = run from workspace, `Path B` = crates.io adoption) and updated dependency snippets to `0.1.0`. 
- Updated `docs/README.md` anchors and navigation to match the renamed sections. 
- Cleaned crate README surfaces to remove remaining launch/post-publish phrasing and normalize install/adoption sections in `tailtriage-core/README.md`, `tailtriage-tokio/README.md`, `tailtriage-axum/README.md`, and `tailtriage-cli/README.md`. 
- Key files changed: `README.md`, `docs/README.md`, `docs/user-guide.md`, `tailtriage-core/README.md`, `tailtriage-tokio/README.md`, `tailtriage-axum/README.md`, and `tailtriage-cli/README.md`. 
- Preserved all technical caveats and diagnosis wording (suspects-as-leads, lifecycle semantics, `RuntimeSampler`/`tokio_unstable` notes). 

### Testing

- Ran `cargo fmt --check` and it succeeded. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it succeeded. 
- Ran `cargo test --workspace` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c659958c488330aa09702ffcabaab4)