### PR TITLE
Fix docs.rs; requires version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "blocking-service-demo"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "demo-support",
@@ -182,7 +182,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cold-start-burst-service-demo"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "demo-support",
@@ -198,7 +198,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "db-pool-saturation-service-demo"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "demo-support",
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "demo-support"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "tailtriage-core",
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "downstream_service"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "demo-support",
@@ -243,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "executor-pressure-service-demo"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "demo-support",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "mixed_contention_service"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "demo-support",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "queue-service-demo"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "demo-support",
@@ -591,7 +591,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "retry-storm-service-demo"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "demo-support",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "runtime_cost"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "shared-state-lock-service-demo"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "demo-support",
@@ -741,7 +741,7 @@ checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "tailtriage-axum"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "axum",
  "serde",
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "tailtriage-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "serde",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "tailtriage-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "futures-executor",
  "serde",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "tailtriage-tokio"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "tailtriage-core",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "0.1.0"
+version = "0.1.1"
 repository = "https://github.com/SG-devel/tailtriage"
 
 [workspace.lints.rust]
@@ -33,6 +33,6 @@ all = "warn"
 pedantic = "warn"
 
 [workspace.dependencies]
-tailtriage-core = { version = "0.1.0", path = "tailtriage-core" }
-tailtriage-tokio = { version = "0.1.0", path = "tailtriage-tokio" }
-demo-support = { version = "0.1.0", path = "demos/demo_support" }
+tailtriage-core = { version = "0.1.1", path = "tailtriage-core" }
+tailtriage-tokio = { version = "0.1.1", path = "tailtriage-tokio" }
+demo-support = { version = "0.1.1", path = "demos/demo_support" }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Use crates.io when adopting `tailtriage` in an external project:
 
 ```bash
 cargo add tailtriage-core
-cargo add tailtriage-tokio
+cargo add tailtriage-tokio # optional, for RuntimeSampler and runtime-pressure evidence
 cargo add tailtriage-axum # optional, only for axum middleware/extractor ergonomics
 cargo install tailtriage-cli
 ```
@@ -88,17 +88,16 @@ Demo walkthrough and CI coverage details: [`docs/getting-started-demo.md`](docs/
 | “I use axum”                                      | Add `tailtriage-axum`; add `tailtriage-tokio` only if runtime snapshots help |
 | “I only need to read artifacts from CI/incidents” | Install `tailtriage-cli` only                                                |
 
-
 #### Dependency / adoption matrix:
 
-| Goal                                                            | Add these crates                                         | Optional                             | Why                                                                                                                          |
-| --------------------------------------------------------------- | -------------------------------------------------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| Instrument a Tokio service, no runtime snapshots                | `tailtriage-core`                                        | `tailtriage-cli`                     | Core request/queue/stage/inflight instrumentation and JSON artifact writing live in `tailtriage-core`                        |
-| Instrument a Tokio service and capture runtime pressure signals | `tailtriage-core`, `tailtriage-tokio`                    | `tailtriage-cli`                     | `tailtriage-tokio` provides `RuntimeSampler` and runtime snapshot capture on top of the core artifact model                  |
-| Use with axum                                                   | `tailtriage-core`, `tailtriage-axum`                     | `tailtriage-tokio`, `tailtriage-cli` | `tailtriage-axum` is the framework ergonomics layer: middleware + extractor. It depends on core, not on `tailtriage-tokio`   |
-| Use with axum plus runtime snapshots                            | `tailtriage-core`, `tailtriage-axum`, `tailtriage-tokio` | `tailtriage-cli`                     | Axum request-boundary wiring plus optional runtime evidence enrichment                                                       |
-| Analyze artifacts only                                          | `tailtriage-cli`                                         | none                                 | CLI loads run JSON, validates schema version, analyzes, and renders text/JSON reports                                        |
-| Minimal first run from repo                                     | none beyond workspace                                    | none                                 | Fastest path for bundled examples, demo scripts, and contributor workflows                                                    |
+| Goal                                                            | Add these crates                                         | Optional                             | Why                                                                                                                        |
+| --------------------------------------------------------------- | -------------------------------------------------------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| Instrument a Tokio service, no runtime snapshots                | `tailtriage-core`                                        | `tailtriage-cli`                     | Core request/queue/stage/inflight instrumentation and JSON artifact writing live in `tailtriage-core`                      |
+| Instrument a Tokio service and capture runtime pressure signals | `tailtriage-core`, `tailtriage-tokio`                    | `tailtriage-cli`                     | `tailtriage-tokio` provides `RuntimeSampler` and runtime snapshot capture on top of the core artifact model                |
+| Use with axum                                                   | `tailtriage-core`, `tailtriage-axum`                     | `tailtriage-tokio`, `tailtriage-cli` | `tailtriage-axum` is the framework ergonomics layer: middleware + extractor. It depends on core, not on `tailtriage-tokio` |
+| Use with axum plus runtime snapshots                            | `tailtriage-core`, `tailtriage-axum`, `tailtriage-tokio` | `tailtriage-cli`                     | Axum request-boundary wiring plus optional runtime evidence enrichment                                                     |
+| Analyze artifacts only                                          | `tailtriage-cli`                                         | none                                 | CLI loads run JSON, validates schema version, analyzes, and renders text/JSON reports                                      |
+| Minimal first run from repo                                     | none beyond workspace                                    | none                                 | Fastest path for bundled examples, demo scripts, and contributor workflows                                                 |
 
 ## What this is not
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -165,7 +165,7 @@ Use this path when adopting `tailtriage` in an external project.
 ```toml
 [dependencies]
 tailtriage-core = "0.1.1"
-tailtriage-tokio = "0.1.1"
+tailtriage-tokio = "0.1.1" # optional, for RuntimeSampler and runtime-pressure evidence
 tailtriage-axum = "0.1.1" # optional, only for axum middleware/extractor ergonomics
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 ```

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -164,9 +164,9 @@ Use this path when adopting `tailtriage` in an external project.
 
 ```toml
 [dependencies]
-tailtriage-core = "0.1.0"
-tailtriage-tokio = "0.1.0"
-tailtriage-axum = "0.1.0" # optional, only for axum middleware/extractor ergonomics
+tailtriage-core = "0.1.1"
+tailtriage-tokio = "0.1.1"
+tailtriage-axum = "0.1.1" # optional, only for axum middleware/extractor ergonomics
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 ```
 

--- a/scripts/smoke_external_consumer.py
+++ b/scripts/smoke_external_consumer.py
@@ -60,11 +60,11 @@ def write_external_app(project_dir: Path) -> tuple[Path, Path]:
 
     cargo_toml = f"""[package]
 name = "external-tailtriage-smoke"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]
-tailtriage-core = "0.1.0"
+tailtriage-core = "0.1.1"
 tokio = {{ version = "1", features = ["macros", "rt", "time"] }}
 """
     (app_dir / "Cargo.toml").write_text(cargo_toml, encoding="utf-8")

--- a/tailtriage-axum/README.md
+++ b/tailtriage-axum/README.md
@@ -4,7 +4,7 @@ Axum adapter crate for `tailtriage` request-boundary triage wiring.
 
 This crate isolates framework-specific middleware and extractor ergonomics so `tailtriage-tokio` can stay framework-agnostic.
 
-## Use from this repo now
+## Use from the repo
 
 ```bash
 cargo run -p tailtriage-axum --example axum_minimal

--- a/tailtriage-axum/README.md
+++ b/tailtriage-axum/README.md
@@ -16,8 +16,8 @@ cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
 
 ```toml
 [dependencies]
-tailtriage-core = "0.1.0"
-tailtriage-axum = "0.1.0"
+tailtriage-core = "0.1.1"
+tailtriage-axum = "0.1.1"
 ```
 
 ## What this crate provides

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -2,7 +2,7 @@
 
 Command-line triage analyzer for one `tailtriage` run artifact.
 
-## Use from this repo now
+## Use from the repo
 
 ```bash
 cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -2,7 +2,7 @@
 
 Core run schema, split request lifecycle API, and instrumentation primitives for `tailtriage`.
 
-## Use from this repo now
+## Use from the repo
 
 From the workspace root, run examples and analysis directly:
 

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -15,7 +15,7 @@ cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
 
 ```toml
 [dependencies]
-tailtriage-core = "0.1.0"
+tailtriage-core = "0.1.1"
 ```
 
 ## What this crate owns

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -13,8 +13,8 @@ cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
 
 ```toml
 [dependencies]
-tailtriage-core = "0.1.0"
-tailtriage-tokio = "0.1.0"
+tailtriage-core = "0.1.1"
+tailtriage-tokio = "0.1.1"
 ```
 
 ## What this crate provides

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -2,7 +2,7 @@
 
 Tokio integration for `tailtriage`, including `RuntimeSampler` for periodic runtime snapshots.
 
-## Use from this repo now
+## Use from the repo
 
 ```bash
 cargo run -p tailtriage-tokio --example minimal_checkout


### PR DESCRIPTION
## Summary

the docs.rs contents were from an old version.

## Validation

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`

## Scope check

- [x] This PR stays within MVP triage scope.
- [x] If behavior changed, docs were updated.
- [x] Suspects are still described as evidence-ranked leads, not causal proof.

## Contribution license check

- [x] I have the right to submit this contribution under the MIT License.
- [x] I agree that this contribution is licensed under the repository's MIT License.
