### PR TITLE
docs: clarify numeric mode defaults and Tokio sampler precedence (#250)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,31 +163,47 @@ When you use `RuntimeSampler::builder(...)`, Tokio defaults are resolved from th
 
 `shutdown()` validates unfinished pending requests and records warnings/metadata. It does not fabricate completion timing. With `strict_lifecycle(true)`, `shutdown()` fails when unfinished requests remain.
 
-## CaptureMode behavior in core (current)
+## What mode changes in each crate
 
-In `tailtriage-core`, `CaptureMode` currently controls **retention defaults only**.
+In `tailtriage-core`, `CaptureMode` controls **retention defaults only**:
 
-- `Light` defaults to lower retention limits.
-- `Investigation` defaults to higher retention limits.
-- Mode does **not** auto-enable Tokio runtime sampling.
-- Mode does **not** require Tokio.
-- Mode does **not** change event types.
-- Mode does **not** change lifecycle semantics.
-- Mode does **not** change `strict_lifecycle`; your explicit `strict_lifecycle(...)` setting is preserved.
+- Light core defaults: `max_requests=100_000`, `max_stages=200_000`, `max_queues=200_000`, `max_inflight_snapshots=200_000`, `max_runtime_snapshots=100_000`
+- Investigation core defaults: `max_requests=300_000`, `max_stages=600_000`, `max_queues=600_000`, `max_inflight_snapshots=600_000`, `max_runtime_snapshots=300_000`
 
-For Tokio runtime sampling, config resolution precedence is:
+In `tailtriage-tokio`, mode affects Tokio sampler defaults **only when `RuntimeSampler` is started**:
+
+- Light Tokio defaults: `cadence=500ms`, `max_runtime_snapshots=5_000`
+- Investigation Tokio defaults: `cadence=100ms`, `max_runtime_snapshots=50_000`
+
+Precedence for Tokio sampler config resolution:
 
 1. inherited mode from selected core mode
 2. optional explicit Tokio mode override via `.mode(...)`
 3. optional explicit cadence override via `.interval(...)`
 4. optional explicit runtime snapshot retention override via `.max_runtime_snapshots(...)`
 
-`RuntimeSampler` must be started explicitly; mode selection never auto-starts sampler tasks.
+What mode does **not** do:
 
-Artifacts record both selected mode (`metadata.mode`) and resolved config:
+- does **not** auto-enable Tokio sampling (`CaptureMode` never auto-starts `RuntimeSampler`)
+- does **not** imply sampler cost by itself (core Investigation alone has no sampler startup cost)
+- does **not** require Tokio
+- does **not** change event types
+- does **not** change lifecycle semantics
+- does **not** change `strict_lifecycle`; your explicit `strict_lifecycle(...)` setting is preserved
 
-- core: `metadata.effective_core_config`
-- Tokio sampler (when started): `metadata.effective_tokio_sampler_config`
+Artifacts record both selected mode and effective resolved config:
+
+- selected mode: `metadata.mode`
+- core effective config: `metadata.effective_core_config`
+- Tokio sampler effective config (when sampler is started): `metadata.effective_tokio_sampler_config`
+
+Overhead terminology used in docs and scripts:
+
+- Core mode overhead
+- Tokio mode overhead
+- Incremental runtime sampler overhead
+- Baked-in overhead
+- Post-limit / drop-path overhead
 
 Older artifacts may have `metadata.effective_core_config = null` when effective config was not captured.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -89,21 +89,46 @@ When limits are hit, artifacts keep per-category drop counters and mark that lim
 analyzer warnings call out that dropped evidence can reduce completeness/confidence.
 Older artifacts may show `metadata.effective_core_config` as `null` (unknown).
 
-What mode changes in core:
+### What mode changes in each crate
 
-- default core retention limits (`CaptureLimits`)
+Core defaults (`tailtriage-core`):
 
-What mode changes in Tokio (only if sampler is started):
+- Light: `max_requests=100_000`, `max_stages=200_000`, `max_queues=200_000`, `max_inflight_snapshots=200_000`, `max_runtime_snapshots=100_000`
+- Investigation: `max_requests=300_000`, `max_stages=600_000`, `max_queues=600_000`, `max_inflight_snapshots=600_000`, `max_runtime_snapshots=300_000`
 
-- default runtime sampler cadence
-- default runtime snapshot retention target (clamped by the core cap)
+Tokio defaults (`tailtriage-tokio`, only when sampler is started):
+
+- Light: `cadence=500ms`, `max_runtime_snapshots=5_000`
+- Investigation: `cadence=100ms`, `max_runtime_snapshots=50_000`
+
+Tokio sampler override precedence:
+
+1. inherited mode from selected core mode
+2. explicit Tokio override via `.mode(...)`
+3. explicit cadence override via `.interval(...)`
+4. explicit runtime snapshot retention override via `.max_runtime_snapshots(...)`
 
 What mode does **not** do:
 
 - does **not** auto-enable Tokio sampling
+- does **not** imply sampler cost by itself (core Investigation alone does not start a sampler)
 - does **not** require Tokio
 - does **not** change `strict_lifecycle`
 - does **not** change event types
+
+Artifacts record both selected mode and effective resolved config:
+
+- selected mode: `metadata.mode`
+- core effective config: `metadata.effective_core_config`
+- Tokio sampler effective config (when sampler starts): `metadata.effective_tokio_sampler_config`
+
+Overhead terminology used in docs and scripts:
+
+- Core mode overhead
+- Tokio mode overhead
+- Incremental runtime sampler overhead
+- Baked-in overhead
+- Post-limit / drop-path overhead
 
 Use runtime snapshots when request-level signals are not enough to separate queueing vs executor vs blocking-pool pressure.
 
@@ -117,13 +142,6 @@ Use runtime snapshots when request-level signals are not enough to separate queu
 `CaptureMode` does not auto-start runtime sampling.
 Resolved runtime snapshot retention is clamped to the core collector limit for
 `max_runtime_snapshots`.
-
-Override precedence is:
-
-1. inherited mode from selected core mode
-2. explicit Tokio override via `.mode(...)`
-3. explicit cadence override via `.interval(...)`
-4. explicit runtime snapshot retention override via `.max_runtime_snapshots(...)`
 
 ```rust
 use std::sync::Arc;

--- a/tailtriage-core/src/config.rs
+++ b/tailtriage-core/src/config.rs
@@ -9,8 +9,24 @@ use crate::{LocalJsonSink, RunSink};
 #[serde(rename_all = "snake_case")]
 pub enum CaptureMode {
     /// Low-overhead mode.
+    ///
+    /// Core-owned defaults in this mode are:
+    ///
+    /// - `max_requests = 100_000`
+    /// - `max_stages = 200_000`
+    /// - `max_queues = 200_000`
+    /// - `max_inflight_snapshots = 200_000`
+    /// - `max_runtime_snapshots = 100_000`
     Light,
     /// Higher-detail mode for incident investigation.
+    ///
+    /// Core-owned defaults in this mode are:
+    ///
+    /// - `max_requests = 300_000`
+    /// - `max_stages = 600_000`
+    /// - `max_queues = 600_000`
+    /// - `max_inflight_snapshots = 600_000`
+    /// - `max_runtime_snapshots = 300_000`
     Investigation,
 }
 
@@ -18,7 +34,8 @@ impl CaptureMode {
     /// Returns core-owned default capture limits for this mode.
     ///
     /// These mode defaults only affect retention limits in `tailtriage-core`.
-    /// They do not change event types or request lifecycle semantics.
+    /// They do not change event types or request lifecycle semantics, and they
+    /// do not auto-start Tokio runtime sampling.
     #[must_use]
     pub const fn core_defaults(self) -> CaptureLimits {
         match self {

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -57,6 +57,11 @@ When `tokio_unstable` is not enabled, unstable-only fields are recorded as `None
 3. optional cadence override via `.interval(...)`
 4. optional retention override via `.max_runtime_snapshots(...)`
 
+Tokio mode defaults (applied only if sampler is started):
+
+- Light: `cadence = 500ms`, `max_runtime_snapshots = 5_000`
+- Investigation: `cadence = 100ms`, `max_runtime_snapshots = 50_000`
+
 `CaptureMode` never auto-starts runtime sampling; you must call `.start()`.
 `CaptureMode` does not change core event types or `strict_lifecycle`.
 Resolved runtime snapshot retention is clamped to the core run's

--- a/tailtriage-tokio/src/lib.rs
+++ b/tailtriage-tokio/src/lib.rs
@@ -49,6 +49,14 @@ pub struct RuntimeSampler {
 }
 
 /// Tokio-owned defaults for runtime sampler behavior by capture mode.
+///
+/// Numeric defaults:
+///
+/// - Light: `cadence = 500ms`, `max_runtime_snapshots = 5_000`
+/// - Investigation: `cadence = 100ms`, `max_runtime_snapshots = 50_000`
+///
+/// These Tokio defaults are applied only when [`RuntimeSampler`] is started.
+/// Selecting core [`CaptureMode`] never auto-starts runtime sampling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TokioSamplerModeDefaults {
     /// Default periodic sampler cadence.
@@ -152,6 +160,17 @@ impl RuntimeSamplerBuilder {
     }
 
     /// Resolves configuration and starts periodic runtime metrics sampling.
+    ///
+    /// Resolution precedence:
+    ///
+    /// 1. inherited mode from the core-selected mode on [`Tailtriage`]
+    /// 2. optional explicit Tokio override via [`Self::mode`]
+    /// 3. optional cadence override via [`Self::interval`]
+    /// 4. optional runtime snapshot retention override via
+    ///    [`Self::max_runtime_snapshots`]
+    ///
+    /// Resolved runtime snapshot retention is clamped by the core run cap
+    /// (`effective_core_config.capture_limits.max_runtime_snapshots`).
     ///
     /// # Errors
     ///


### PR DESCRIPTION
### Motivation

- Close the remaining documentation/API-doc gap by publishing the exact numeric defaults for core and Tokio modes so users and artifact consumers know the concrete retention and sampler settings. 
- Make explicit that `CaptureMode` in `tailtriage-core` only controls retention defaults and does not auto-start the `RuntimeSampler`, and standardize overhead terminology across docs to avoid ambiguity. 
- Keep scope strictly documentation-only and avoid changing any runtime behavior, public API semantics, or capture defaults beyond rustdoc and tests that validate docs-adjacent invariants.

### Description

- Added explicit numeric core `CaptureMode` defaults into `tailtriage-core/src/config.rs` rustdocs for `Light` and `Investigation` modes. 
- Added numeric Tokio sampler defaults and a clear resolution precedence blurb into `tailtriage-tokio/src/lib.rs` rustdocs, and reflected the same numeric defaults in `tailtriage-tokio/README.md`. 
- Added a compact “What mode changes in each crate” section and standardized overhead terminology in the top-level `README.md` and `docs/user-guide.md`, and made explicit that artifacts record both selected mode and effective resolved config. 
- No behavior, public API, or dependency changes were made; all changes are documentation and rustdoc-only and preserve existing semantics such as `strict_lifecycle` and `RuntimeSampler` startup behavior. 

Files changed: `tailtriage-core/src/config.rs`, `tailtriage-tokio/src/lib.rs`, `tailtriage-tokio/README.md`, `README.md`, and `docs/user-guide.md`.

Final public numeric defaults (as documented):

- Core (`tailtriage-core`): Light: `max_requests=100_000`, `max_stages=200_000`, `max_queues=200_000`, `max_inflight_snapshots=200_000`, `max_runtime_snapshots=100_000`; Investigation: `max_requests=300_000`, `max_stages=600_000`, `max_queues=600_000`, `max_inflight_snapshots=600_000`, `max_runtime_snapshots=300_000`.
- Tokio (`tailtriage-tokio`, applied only when `RuntimeSampler` is started): Light: `cadence=500ms`, `max_runtime_snapshots=5_000`; Investigation: `cadence=100ms`, `max_runtime_snapshots=50_000`.

Intentionally deferred items (still belonging to #250):

- No runtime-cost measurement, benchmark updates, or additional docs outside the touched files were performed in this change set.
- No behavioral or API changes (including sampler auto-start, event types, or `strict_lifecycle`) were implemented; these remain out of scope for this PR.

### Testing

- Ran `cargo fmt --check` which succeeded. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` which succeeded. 
- Ran `cargo test --workspace` which completed with all tests passing. 

All automated checks passed after the documentation updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5201c62688330905238cda2b0b7be)