### PR TITLE
Expand runtime-cost benchmark matrix with baked-in and saturated Investigation coverage

### DIFF
--- a/demos/runtime_cost/src/main.rs
+++ b/demos/runtime_cost/src/main.rs
@@ -16,22 +16,26 @@ const DEFAULT_WORK_MS: u64 = 3;
 #[serde(rename_all = "snake_case")]
 enum Mode {
     Baseline,
+    BakedInNoRequestContext,
     CoreLight,
     CoreInvestigation,
     CoreLightTokioSampler,
     CoreInvestigationTokioSampler,
     CoreLightDropPath,
+    CoreInvestigationDropPath,
 }
 
 impl Mode {
     fn parse(value: &str) -> Option<Self> {
         match value {
             "baseline" => Some(Self::Baseline),
+            "baked_in_no_request_context" => Some(Self::BakedInNoRequestContext),
             "core_light" => Some(Self::CoreLight),
             "core_investigation" => Some(Self::CoreInvestigation),
             "core_light_tokio_sampler" => Some(Self::CoreLightTokioSampler),
             "core_investigation_tokio_sampler" => Some(Self::CoreInvestigationTokioSampler),
             "core_light_drop_path" => Some(Self::CoreLightDropPath),
+            "core_investigation_drop_path" => Some(Self::CoreInvestigationDropPath),
             _ => None,
         }
     }
@@ -39,12 +43,13 @@ impl Mode {
     fn core_mode(self) -> Option<CaptureMode> {
         match self {
             Self::Baseline => None,
-            Self::CoreLight | Self::CoreLightTokioSampler | Self::CoreLightDropPath => {
-                Some(CaptureMode::Light)
-            }
-            Self::CoreInvestigation | Self::CoreInvestigationTokioSampler => {
-                Some(CaptureMode::Investigation)
-            }
+            Self::BakedInNoRequestContext
+            | Self::CoreLight
+            | Self::CoreLightTokioSampler
+            | Self::CoreLightDropPath => Some(CaptureMode::Light),
+            Self::CoreInvestigation
+            | Self::CoreInvestigationTokioSampler
+            | Self::CoreInvestigationDropPath => Some(CaptureMode::Investigation),
         }
     }
 
@@ -56,7 +61,14 @@ impl Mode {
     }
 
     fn uses_drop_path_limits(self) -> bool {
-        matches!(self, Self::CoreLightDropPath)
+        matches!(
+            self,
+            Self::CoreLightDropPath | Self::CoreInvestigationDropPath
+        )
+    }
+
+    fn omits_request_context(self) -> bool {
+        matches!(self, Self::BakedInNoRequestContext)
     }
 }
 
@@ -214,6 +226,11 @@ async fn run_requests(
                     tokio::time::sleep(work_duration).await;
                     drop(permit);
                 }
+                (mode, Some(_)) if mode.omits_request_context() => {
+                    let permit = sem.acquire().await.expect("semaphore closed");
+                    tokio::time::sleep(work_duration).await;
+                    drop(permit);
+                }
                 (_, Some(ts)) => {
                     let request_id = format!("request-{idx}");
                     let started = ts.begin_request_with(
@@ -275,7 +292,7 @@ fn parse_cli() -> anyhow::Result<Cli> {
                 mode = Mode::parse(&value);
                 if mode.is_none() {
                     bail!(
-                        "invalid --mode {value}; expected baseline|core_light|core_investigation|core_light_tokio_sampler|core_investigation_tokio_sampler|core_light_drop_path"
+                        "invalid --mode {value}; expected baseline|baked_in_no_request_context|core_light|core_investigation|core_light_tokio_sampler|core_investigation_tokio_sampler|core_light_drop_path|core_investigation_drop_path"
                     );
                 }
             }
@@ -328,10 +345,10 @@ fn parse_cli() -> anyhow::Result<Cli> {
 
 fn print_help() {
     eprintln!(
-        "runtime_cost --mode <baseline|core_light|core_investigation|core_light_tokio_sampler|core_investigation_tokio_sampler|core_light_drop_path> [--requests N] [--concurrency N] [--work-ms N] [--output-dir DIR]"
+        "runtime_cost --mode <baseline|baked_in_no_request_context|core_light|core_investigation|core_light_tokio_sampler|core_investigation_tokio_sampler|core_light_drop_path|core_investigation_drop_path> [--requests N] [--concurrency N] [--work-ms N] [--output-dir DIR]"
     );
     eprintln!(
-        "mode semantics: core_* changes only core retention defaults; *_tokio_sampler additionally starts RuntimeSampler; *_drop_path intentionally hits capture limits."
+        "mode semantics: baked_in_no_request_context starts tailtriage but skips request-context instrumentation; core_* adds request-context instrumentation; *_tokio_sampler additionally starts RuntimeSampler; *_drop_path intentionally hits capture limits."
     );
 }
 

--- a/docs/runtime-cost.md
+++ b/docs/runtime-cost.md
@@ -11,17 +11,21 @@ All measurements use the same shared request scenario (same request shape, concu
 The runtime-cost demo benchmarks these categories:
 
 - `baseline`: no `tailtriage` instrumentation.
+- `baked_in_no_request_context`: `tailtriage` is initialized in light mode, but request-context instrumentation is intentionally skipped (near-no-op baked-in state).
 - `core_light`: `tailtriage-core` in `CaptureMode::Light`, no Tokio sampler.
 - `core_investigation`: `tailtriage-core` in `CaptureMode::Investigation`, no Tokio sampler.
 - `core_light_tokio_sampler`: core light plus `RuntimeSampler` (Tokio-mode defaults inherited from light).
 - `core_investigation_tokio_sampler`: core investigation plus `RuntimeSampler` (Tokio-mode defaults inherited from investigation).
 - `core_light_drop_path`: core light with intentionally tiny capture limits to exercise post-limit drop behavior.
+- `core_investigation_drop_path`: core investigation with intentionally tiny capture limits to exercise post-limit drop behavior.
 
 Important attribution rules for this benchmark:
 
 - Core mode overhead is measured without sampler startup.
 - Tokio sampler overhead is measured in sampler-enabled modes, not attributed to core-only modes.
+- Baked-in overhead is measured only from `baked_in_no_request_context` versus `baseline`.
 - Investigation mode in this demo does not add synthetic stage sleeps or extra fake work.
+- “Sampler configured but not started” is not a meaningful supported state in this API, so it is intentionally reported as N/A instead of benchmarked as a separate mode.
 
 ## Canonical command
 
@@ -66,14 +70,22 @@ Written to `demos/runtime_cost/artifacts/`:
 - `runtime-cost-summary.json`
   - Includes absolute metrics for each mode.
   - Includes explicit deltas from baseline under these headings:
+    - `Baked-in overhead`
     - `Core mode overhead`
     - `Tokio mode overhead`
     - `Post-limit / drop-path overhead`
   - Includes explicit incremental sampler deltas under:
     - `Incremental runtime sampler overhead`
-  - The current matrix does **not** include a distinct baked-in / near-no-op mode, so no separate `Baked-in overhead` section is reported.
   - Includes machine-readable measurement quality and optional stability warning reasons.
   - Includes sample-count context (`measured_rounds`, `samples_per_mode`, and minimum rounds required for `stable`).
+
+## Interpretation guidance
+
+- Use `Baked-in overhead` to isolate “collector present but request context omitted” cost from fully instrumented request paths.
+- Use `Core mode overhead` to compare request-context instrumentation cost in light vs investigation without runtime sampler effects.
+- Use `Tokio mode overhead` to evaluate full mode cost when runtime sampling is enabled.
+- Use `Incremental runtime sampler overhead` to isolate sampler-on deltas against their same-mode core-only baselines.
+- Use `Post-limit / drop-path overhead` only for saturated-limit behavior; these modes are intentionally non-comparable to unsaturated steady-state runs except as drop-path evidence.
 
 ## Reading noisy-machine results
 

--- a/scripts/measure_runtime_cost.py
+++ b/scripts/measure_runtime_cost.py
@@ -13,11 +13,13 @@ from pathlib import Path
 
 MODES = (
     "baseline",
+    "baked_in_no_request_context",
     "core_light",
     "core_investigation",
     "core_light_tokio_sampler",
     "core_investigation_tokio_sampler",
     "core_light_drop_path",
+    "core_investigation_drop_path",
 )
 METRIC_KEYS = ("throughput_rps", "latency_p50_ms", "latency_p95_ms", "latency_p99_ms")
 DEFAULT_REQUESTS = 6000
@@ -160,11 +162,13 @@ def assess_quality(summary: dict, measured_rounds: list[dict]) -> tuple[str, lis
             reasons.append(f"{mode} p95 CV is elevated ({p95_cv:.3f} >= 0.080)")
 
     core_mode_pairs = (
+        ("baked_in_no_request_context", "Baked-in overhead"),
         ("core_light", "Core mode overhead"),
         ("core_investigation", "Core mode overhead"),
         ("core_light_tokio_sampler", "Tokio mode overhead"),
         ("core_investigation_tokio_sampler", "Tokio mode overhead"),
         ("core_light_drop_path", "Post-limit / drop-path overhead"),
+        ("core_investigation_drop_path", "Post-limit / drop-path overhead"),
     )
     for mode, _heading in core_mode_pairs:
         throughput_deltas = paired_delta_rows(measured_rounds, mode, "throughput_rps")
@@ -220,6 +224,7 @@ def summarize(raw_path: Path, summary_path: Path) -> dict:
         "execution_profile": "release_binary",
         "absolute_metrics": {},
         "delta_vs_baseline_pct": {
+            "Baked-in overhead": {},
             "Core mode overhead": {},
             "Tokio mode overhead": {},
             "Post-limit / drop-path overhead": {},
@@ -238,6 +243,9 @@ def summarize(raw_path: Path, summary_path: Path) -> dict:
             for metric in METRIC_KEYS
         }
 
+    summary["delta_vs_baseline_pct"]["Baked-in overhead"]["baked_in_no_request_context"] = baseline_delta(
+        "baked_in_no_request_context"
+    )
     summary["delta_vs_baseline_pct"]["Core mode overhead"]["core_light"] = baseline_delta("core_light")
     summary["delta_vs_baseline_pct"]["Core mode overhead"]["core_investigation"] = baseline_delta("core_investigation")
     summary["delta_vs_baseline_pct"]["Tokio mode overhead"]["core_light_tokio_sampler"] = baseline_delta(
@@ -248,6 +256,9 @@ def summarize(raw_path: Path, summary_path: Path) -> dict:
     )
     summary["delta_vs_baseline_pct"]["Post-limit / drop-path overhead"]["core_light_drop_path"] = baseline_delta(
         "core_light_drop_path"
+    )
+    summary["delta_vs_baseline_pct"]["Post-limit / drop-path overhead"]["core_investigation_drop_path"] = baseline_delta(
+        "core_investigation_drop_path"
     )
 
     summary["incremental_runtime_sampler_overhead_pct"]["Incremental runtime sampler overhead"] = {


### PR DESCRIPTION
### Motivation

- Close the remaining measurement gap called out in issue #250 by adding a near-no-op baked-in mode and giving Investigation a saturated drop-path so both Light and Investigation have post-limit coverage.
- Keep attribution clear by preserving core-only vs Tokio-sampler separation and avoiding any attribution of RuntimeSampler cost to core-only modes.
- Preserve the shared scenario family and raw JSONL shape while producing a richer, machine-readable summary that prepares a clean baseline for issue #252.

### Description

- Add `baked_in_no_request_context` mode to `demos/runtime_cost/src/main.rs` which initializes the collector but omits request-context instrumentation as an explicit near-no-op baked-in state.
- Add `core_investigation_drop_path` and extend `core_*_drop_path` handling so both Light and Investigation produce saturated/drop-path samples, and wire a `omits_request_context` predicate used by the runner to skip request instrumentation for the baked-in mode.
- Extend `scripts/measure_runtime_cost.py` to include the new modes in `MODES`, add a `Baked-in overhead` delta section, expand `Post-limit / drop-path overhead` to include Investigation, and preserve the `Incremental runtime sampler overhead` grouping while keeping raw and summary JSON structures compatible and extended.
- Update `docs/runtime-cost.md` to replace the note that baked-in coverage was missing with the new real matrix, add interpretation guidance, and explicitly state that "sampler configured but not started" is N/A in the current API semantics.

### Testing

- Ran formatting check with `cargo fmt --check`, which succeeded.
- Ran linting with `cargo clippy --workspace --all-targets -- -D warnings`, which succeeded.
- Ran the full test suite with `cargo test --workspace`, which succeeded.
- Performed a sanity run of the measurement harness with `python3 scripts/measure_runtime_cost.py --warmup-rounds 0 --rounds 1 --requests 50 --concurrency 10 --work-ms 1` which completed and produced the extended summary JSON (the script correctly reported `insufficient_data` for a single measured round as expected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5239486708330bf0a313dc4a6de26)