### PR TITLE
docs: tighten capture-mode/runtime-cost wording for #250 sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,5 +222,6 @@ Use workspace/source onboarding for repository examples and contributor workflow
 
 - Docs index: [`docs/README.md`](docs/README.md)
 - Detailed onboarding and lifecycle rules: [`docs/user-guide.md`](docs/user-guide.md)
+- Runtime-cost categories and benchmark interpretation: [`docs/runtime-cost.md`](docs/runtime-cost.md)
 - Demo walkthrough and CI coverage details: [`docs/getting-started-demo.md`](docs/getting-started-demo.md)
 - Diagnostics field contract and interpretation: [`docs/diagnostics.md`](docs/diagnostics.md)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -130,7 +130,7 @@ Overhead terminology used in docs and scripts:
 - Baked-in overhead
 - Post-limit / drop-path overhead
 
-Use runtime snapshots when request-level signals are not enough to separate queueing vs executor vs blocking-pool pressure.
+Use runtime snapshots when request-level signals are not enough to separate queueing vs executor vs blocking-pool pressure. For runtime-cost attribution categories and measurement workflow, see [runtime-cost.md](runtime-cost.md).
 
 `RuntimeSampler` resolves Tokio config from:
 

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -99,6 +99,9 @@ tailtriage.shutdown()?;
 - unfinished requests are surfaced in run metadata warnings and unfinished-request samples.
 - `strict_lifecycle(true)` makes `shutdown()` return an error when unfinished requests remain.
 
+
+Runtime-cost attribution categories and measurement workflow are documented in [`docs/runtime-cost.md`](../docs/runtime-cost.md).
+
 ## Related docs
 
 - Repo docs index: <https://github.com/SG-devel/tailtriage/tree/main/docs>

--- a/tailtriage-core/src/config.rs
+++ b/tailtriage-core/src/config.rs
@@ -8,7 +8,7 @@ use crate::{LocalJsonSink, RunSink};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CaptureMode {
-    /// Low-overhead mode.
+    /// Lower-runtime-cost mode for core-only capture categories (see `docs/runtime-cost.md`).
     ///
     /// Core-owned defaults in this mode are:
     ///
@@ -18,7 +18,7 @@ pub enum CaptureMode {
     /// - `max_inflight_snapshots = 200_000`
     /// - `max_runtime_snapshots = 100_000`
     Light,
-    /// Higher-detail mode for incident investigation.
+    /// Higher-retention mode for incident investigation.
     ///
     /// Core-owned defaults in this mode are:
     ///
@@ -245,8 +245,7 @@ impl TailtriageBuilder {
 
     /// Sets capture mode to [`CaptureMode::Light`].
     ///
-    /// Light mode is the default and favors low overhead with enough signal for
-    /// first-pass triage.
+    /// Light mode is the default and favors lower runtime cost in core-only capture categories (see `docs/runtime-cost.md`) with enough signal for first-pass triage.
     #[must_use]
     pub fn light(mut self) -> Self {
         self.mode = CaptureMode::Light;

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -95,6 +95,9 @@ tailtriage.shutdown()?;
 # }
 ```
 
+
+For runtime-cost attribution categories (including incremental sampler cost), see [`docs/runtime-cost.md`](../docs/runtime-cost.md).
+
 ## Related docs
 
 - Repo docs index: <https://github.com/SG-devel/tailtriage/tree/main/docs>

--- a/tailtriage-tokio/src/lib.rs
+++ b/tailtriage-tokio/src/lib.rs
@@ -116,7 +116,7 @@ impl RuntimeSampler {
     ///
     /// Use this during incident triage when runtime pressure evidence is needed
     /// to rank suspects (for example: global queue growth or alive-task spikes).
-    /// For minimal-overhead capture, skip sampler startup.
+    /// For lower runtime-cost core-only capture categories, skip sampler startup (see `docs/runtime-cost.md`).
     ///
     /// # Errors
     ///


### PR DESCRIPTION
### Motivation
- Remove ambiguous wording that could imply `CaptureMode` auto-starts `RuntimeSampler`, that Investigation mode includes sampler cost, or that modes are metadata-only, and point runtime-cost claims to the benchmark document so readers have a single authoritative measurement reference.
- Make the top-level teaching surface unambiguous so #252 can start without doc/semantic confusion.

### Description
- Updated the repo docs map in `README.md` to explicitly point to `docs/runtime-cost.md` for runtime-cost categories and interpretation.
- Added runtime-cost pointers in `docs/user-guide.md`, `tailtriage-core/README.md`, and `tailtriage-tokio/README.md` to centralize measurement guidance.
- Reworded `CaptureMode` docs in `tailtriage-core/src/config.rs` to replace ambiguous "low-overhead" phrasing with a benchmark-linked description (`docs/runtime-cost.md`) and clarified `Investigation` as a higher-retention mode.
- Reworded `RuntimeSampler::start` rustdoc in `tailtriage-tokio/src/lib.rs` to avoid an ambiguous "minimal-overhead" claim and to point readers to `docs/runtime-cost.md` for attribution categories.

### Testing
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`; all checks and tests passed.
- The existing unit test that protects the runtime behavior contract (`sampler_does_not_autostart_from_capture_mode`) passed, so no new regression test was required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e527807f848330867c72e6acce59f9)