### PR TITLE
Optimize saturated collector hot paths in tailtriage-core

### DIFF
--- a/tailtriage-core/src/collector.rs
+++ b/tailtriage-core/src/collector.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
@@ -23,6 +23,68 @@ pub struct Tailtriage {
     pub(crate) effective_core_config: crate::EffectiveCoreConfig,
     pub(crate) limits: crate::CaptureLimits,
     pub(crate) strict_lifecycle: bool,
+    truncation_state: TruncationState,
+}
+
+#[derive(Debug, Default)]
+struct SectionSaturationState {
+    saturated: AtomicBool,
+    dropped_after_saturation: AtomicU64,
+}
+
+impl SectionSaturationState {
+    fn is_saturated(&self) -> bool {
+        self.saturated.load(Ordering::Relaxed)
+    }
+
+    fn mark_saturated(&self) {
+        self.saturated.store(true, Ordering::Relaxed);
+    }
+
+    fn increment_drop(&self) {
+        self.dropped_after_saturation
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn dropped_after_saturation(&self) -> u64 {
+        self.dropped_after_saturation.load(Ordering::Relaxed)
+    }
+}
+
+#[derive(Debug, Default)]
+struct TruncationState {
+    limits_hit: AtomicBool,
+    requests: SectionSaturationState,
+    stages: SectionSaturationState,
+    queues: SectionSaturationState,
+    inflight: SectionSaturationState,
+    runtime_snapshots: SectionSaturationState,
+}
+
+impl TruncationState {
+    fn mark_limits_hit(&self) {
+        self.limits_hit.store(true, Ordering::Relaxed);
+    }
+
+    fn merge_into(&self, truncation: &mut crate::TruncationSummary) {
+        truncation.dropped_requests = truncation
+            .dropped_requests
+            .saturating_add(self.requests.dropped_after_saturation());
+        truncation.dropped_stages = truncation
+            .dropped_stages
+            .saturating_add(self.stages.dropped_after_saturation());
+        truncation.dropped_queues = truncation
+            .dropped_queues
+            .saturating_add(self.queues.dropped_after_saturation());
+        truncation.dropped_inflight_snapshots = truncation
+            .dropped_inflight_snapshots
+            .saturating_add(self.inflight.dropped_after_saturation());
+        truncation.dropped_runtime_snapshots = truncation
+            .dropped_runtime_snapshots
+            .saturating_add(self.runtime_snapshots.dropped_after_saturation());
+        truncation.limits_hit |=
+            self.limits_hit.load(Ordering::Relaxed) || truncation.is_truncated();
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -137,6 +199,7 @@ impl Tailtriage {
             effective_core_config: config.effective_core,
             limits: config.effective_core.capture_limits,
             strict_lifecycle: config.strict_lifecycle,
+            truncation_state: TruncationState::default(),
         })
     }
 
@@ -211,7 +274,9 @@ impl Tailtriage {
     /// Returns a clone of the current in-memory run state.
     #[must_use]
     pub fn snapshot(&self) -> Run {
-        lock_run(&self.run).clone()
+        let mut run = lock_run(&self.run).clone();
+        self.truncation_state.merge_into(&mut run.truncation);
+        run
     }
 
     /// Writes the current run artifact and finishes the run lifecycle.
@@ -245,6 +310,7 @@ impl Tailtriage {
             }
         }
 
+        self.truncation_state.merge_into(&mut guard.truncation);
         self.sink.write(&guard)
     }
 
@@ -273,11 +339,19 @@ impl Tailtriage {
 
     /// Records one runtime metrics sample captured by an integration crate.
     pub fn record_runtime_snapshot(&self, snapshot: RuntimeSnapshot) {
+        if self.truncation_state.runtime_snapshots.is_saturated() {
+            self.truncation_state.runtime_snapshots.increment_drop();
+            self.truncation_state.mark_limits_hit();
+            return;
+        }
+
         let mut run = lock_run(&self.run);
         if run.runtime_snapshots.len() >= self.limits.max_runtime_snapshots {
             run.truncation.limits_hit = true;
             run.truncation.dropped_runtime_snapshots =
                 run.truncation.dropped_runtime_snapshots.saturating_add(1);
+            self.truncation_state.runtime_snapshots.mark_saturated();
+            self.truncation_state.mark_limits_hit();
         } else {
             run.runtime_snapshots.push(snapshot);
         }
@@ -294,41 +368,73 @@ impl Tailtriage {
     }
 
     pub(crate) fn record_stage_event(&self, event: StageEvent) {
+        if self.truncation_state.stages.is_saturated() {
+            self.truncation_state.stages.increment_drop();
+            self.truncation_state.mark_limits_hit();
+            return;
+        }
+
         let mut run = lock_run(&self.run);
         if run.stages.len() >= self.limits.max_stages {
             run.truncation.limits_hit = true;
             run.truncation.dropped_stages = run.truncation.dropped_stages.saturating_add(1);
+            self.truncation_state.stages.mark_saturated();
+            self.truncation_state.mark_limits_hit();
         } else {
             run.stages.push(event);
         }
     }
 
     pub(crate) fn record_queue_event(&self, event: QueueEvent) {
+        if self.truncation_state.queues.is_saturated() {
+            self.truncation_state.queues.increment_drop();
+            self.truncation_state.mark_limits_hit();
+            return;
+        }
+
         let mut run = lock_run(&self.run);
         if run.queues.len() >= self.limits.max_queues {
             run.truncation.limits_hit = true;
             run.truncation.dropped_queues = run.truncation.dropped_queues.saturating_add(1);
+            self.truncation_state.queues.mark_saturated();
+            self.truncation_state.mark_limits_hit();
         } else {
             run.queues.push(event);
         }
     }
 
     pub(crate) fn record_inflight_snapshot(&self, snapshot: InFlightSnapshot) {
+        if self.truncation_state.inflight.is_saturated() {
+            self.truncation_state.inflight.increment_drop();
+            self.truncation_state.mark_limits_hit();
+            return;
+        }
+
         let mut run = lock_run(&self.run);
         if run.inflight.len() >= self.limits.max_inflight_snapshots {
             run.truncation.limits_hit = true;
             run.truncation.dropped_inflight_snapshots =
                 run.truncation.dropped_inflight_snapshots.saturating_add(1);
+            self.truncation_state.inflight.mark_saturated();
+            self.truncation_state.mark_limits_hit();
         } else {
             run.inflight.push(snapshot);
         }
     }
 
     fn record_request_event(&self, event: RequestEvent) {
+        if self.truncation_state.requests.is_saturated() {
+            self.truncation_state.requests.increment_drop();
+            self.truncation_state.mark_limits_hit();
+            return;
+        }
+
         let mut run = lock_run(&self.run);
         if run.requests.len() >= self.limits.max_requests {
             run.truncation.limits_hit = true;
             run.truncation.dropped_requests = run.truncation.dropped_requests.saturating_add(1);
+            self.truncation_state.requests.mark_saturated();
+            self.truncation_state.mark_limits_hit();
         } else {
             run.requests.push(event);
         }

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -306,6 +306,161 @@ fn limit_hit_flag_is_set_when_truncation_occurs() {
 }
 
 #[test]
+fn saturation_preserves_exact_drop_counts_across_sections() {
+    let tailtriage = Tailtriage::builder("payments")
+        .capture_limits(CaptureLimits {
+            max_requests: 1,
+            max_stages: 1,
+            max_queues: 1,
+            max_inflight_snapshots: 1,
+            max_runtime_snapshots: 1,
+        })
+        .build()
+        .expect("build should succeed");
+
+    let first = tailtriage.begin_request("/invoice");
+    futures_executor::block_on(first.handle.stage("db").await_value(ready(())));
+    futures_executor::block_on(first.handle.stage("cache").await_value(ready(())));
+    futures_executor::block_on(first.handle.stage("serialize").await_value(ready(())));
+    futures_executor::block_on(first.handle.queue("permit").await_on(ready(())));
+    futures_executor::block_on(first.handle.queue("backend").await_on(ready(())));
+    futures_executor::block_on(first.handle.queue("egress").await_on(ready(())));
+    {
+        let _inflight = first.handle.inflight("requests");
+    }
+    {
+        let _inflight = first.handle.inflight("requests");
+    }
+    {
+        let _inflight = first.handle.inflight("requests");
+    }
+    first.completion.finish_ok();
+
+    tailtriage.begin_request("/invoice").completion.finish_ok();
+    tailtriage.begin_request("/invoice").completion.finish_ok();
+
+    for i in 1..=3 {
+        tailtriage.record_runtime_snapshot(crate::RuntimeSnapshot {
+            at_unix_ms: crate::unix_time_ms(),
+            alive_tasks: Some(i),
+            global_queue_depth: Some(i),
+            local_queue_depth: None,
+            blocking_queue_depth: None,
+            remote_schedule_count: None,
+        });
+    }
+
+    let snapshot = tailtriage.snapshot();
+    assert!(snapshot.truncation.limits_hit);
+    assert_eq!(snapshot.requests.len(), 1);
+    assert_eq!(snapshot.stages.len(), 1);
+    assert_eq!(snapshot.queues.len(), 1);
+    assert_eq!(snapshot.inflight.len(), 1);
+    assert_eq!(snapshot.runtime_snapshots.len(), 1);
+    assert_eq!(snapshot.truncation.dropped_requests, 2);
+    assert_eq!(snapshot.truncation.dropped_stages, 2);
+    assert_eq!(snapshot.truncation.dropped_queues, 2);
+    assert_eq!(snapshot.truncation.dropped_inflight_snapshots, 5);
+    assert_eq!(snapshot.truncation.dropped_runtime_snapshots, 2);
+}
+
+#[test]
+fn shutdown_artifact_includes_post_saturation_drops() {
+    let sink = Arc::new(RecordingSink::default());
+    let tailtriage = Tailtriage::builder("payments")
+        .capture_limits(CaptureLimits {
+            max_requests: 1,
+            max_stages: 1,
+            max_queues: 1,
+            max_inflight_snapshots: 1,
+            max_runtime_snapshots: 1,
+        })
+        .sink(sink.clone())
+        .build()
+        .expect("build should succeed");
+
+    tailtriage.begin_request("/a").completion.finish_ok();
+    tailtriage.begin_request("/b").completion.finish_ok();
+    tailtriage.begin_request("/c").completion.finish_ok();
+
+    tailtriage.record_runtime_snapshot(crate::RuntimeSnapshot {
+        at_unix_ms: crate::unix_time_ms(),
+        alive_tasks: Some(1),
+        global_queue_depth: Some(1),
+        local_queue_depth: None,
+        blocking_queue_depth: None,
+        remote_schedule_count: None,
+    });
+    tailtriage.record_runtime_snapshot(crate::RuntimeSnapshot {
+        at_unix_ms: crate::unix_time_ms(),
+        alive_tasks: Some(2),
+        global_queue_depth: Some(2),
+        local_queue_depth: None,
+        blocking_queue_depth: None,
+        remote_schedule_count: None,
+    });
+    tailtriage.record_runtime_snapshot(crate::RuntimeSnapshot {
+        at_unix_ms: crate::unix_time_ms(),
+        alive_tasks: Some(3),
+        global_queue_depth: Some(3),
+        local_queue_depth: None,
+        blocking_queue_depth: None,
+        remote_schedule_count: None,
+    });
+
+    tailtriage.shutdown().expect("shutdown should succeed");
+    let artifact = sink
+        .run
+        .lock()
+        .expect("lock should succeed")
+        .clone()
+        .expect("run should be captured");
+
+    assert!(artifact.truncation.limits_hit);
+    assert_eq!(artifact.truncation.dropped_requests, 2);
+    assert_eq!(artifact.truncation.dropped_runtime_snapshots, 2);
+}
+
+#[test]
+fn unsaturated_runs_keep_zero_truncation_counters() {
+    let tailtriage = Tailtriage::builder("payments")
+        .capture_limits(CaptureLimits {
+            max_requests: 10,
+            max_stages: 10,
+            max_queues: 10,
+            max_inflight_snapshots: 10,
+            max_runtime_snapshots: 10,
+        })
+        .build()
+        .expect("build should succeed");
+
+    let started = tailtriage.begin_request("/ok");
+    futures_executor::block_on(started.handle.stage("db").await_value(ready(())));
+    futures_executor::block_on(started.handle.queue("permit").await_on(ready(())));
+    {
+        let _guard = started.handle.inflight("requests");
+    }
+    started.completion.finish_ok();
+    tailtriage.record_runtime_snapshot(crate::RuntimeSnapshot {
+        at_unix_ms: crate::unix_time_ms(),
+        alive_tasks: Some(1),
+        global_queue_depth: Some(1),
+        local_queue_depth: None,
+        blocking_queue_depth: None,
+        remote_schedule_count: None,
+    });
+
+    let snapshot = tailtriage.snapshot();
+    assert!(!snapshot.truncation.is_truncated());
+    assert!(!snapshot.truncation.limits_hit);
+    assert_eq!(snapshot.truncation.dropped_requests, 0);
+    assert_eq!(snapshot.truncation.dropped_stages, 0);
+    assert_eq!(snapshot.truncation.dropped_queues, 0);
+    assert_eq!(snapshot.truncation.dropped_inflight_snapshots, 0);
+    assert_eq!(snapshot.truncation.dropped_runtime_snapshots, 0);
+}
+
+#[test]
 fn mode_does_not_change_event_types_or_lifecycle_shape() {
     let light = Tailtriage::builder("payments")
         .light()


### PR DESCRIPTION
### Motivation

- Reduce overhead on the hot write paths after a capture section reaches its configured limit so the collector remains cheap under saturation while preserving existing public behavior.
- Preserve `CaptureMode` semantics, event types, and `strict_lifecycle` behavior while making post-limit work lock-free where safe.

### Description

- Introduce an internal `TruncationState` with per-section `SectionSaturationState` using atomics to track a `saturated` flag and post-saturation dropped counters without changing public types or schemas.
- Add a fast-path early return in the five write paths (`requests`, `stages`, `queues`, `inflight snapshots`, `runtime snapshots`) that, after saturation, only performs atomic increments and sets the `limits_hit` marker instead of taking the main `run` mutex or allocating/pushing into vectors.
- Keep the first transition race-safe by performing the canonical overflow check under the `run` lock and marking the section saturated immediately after incrementing the emitted truncation counter so no retained entries are overwritten and no drops are undercounted.
- Merge live atomic drop counters into emitted artifacts by calling `truncation_state.merge_into(...)` from `snapshot()` and `shutdown()` so emitted `TruncationSummary` fields and `limits_hit` remain correct and externally visible.

### Testing

- Added/updated unit tests: `saturation_preserves_exact_drop_counts_across_sections`, `shutdown_artifact_includes_post_saturation_drops`, and `unsaturated_runs_keep_zero_truncation_counters`, covering per-section drop counting, `limits_hit`, snapshot visibility, and shutdown artifact visibility after saturation.
- Ran repository validation: `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, and `cargo test --workspace --locked`; all commands completed successfully and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e52f47ed5c8330b1fe0801d41204e8)