### PR TITLE
docs: clarify post-limit runtime-cost model and record benchmark for #252

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,13 @@ What mode does **not** do:
 - does **not** change lifecycle semantics
 - does **not** change `strict_lifecycle`; your explicit `strict_lifecycle(...)` setting is preserved
 
+Saturation behavior note:
+
+- Light remains “lower retention defaults,” not “lower evidence density before saturation.”
+- The low-overhead improvement for saturated runs comes from a cheaper post-limit drop path, not from collecting fewer evidence types up front.
+- After saturation, tailtriage still records exact drop counters and `limits_hit`, and analyzer warnings still state that dropped evidence can reduce completeness/confidence.
+- After saturation, dropped events no longer pay the full append/retention path cost; residual cost is mainly branch checks plus truncation/drop accounting.
+
 Artifacts record both selected mode and effective resolved config:
 
 - selected mode: `metadata.mode`

--- a/docs/runtime-cost.md
+++ b/docs/runtime-cost.md
@@ -32,6 +32,36 @@ Important attribution rules for this benchmark:
 - Investigation mode in this demo does not add synthetic stage sleeps or extra fake work.
 - “Sampler configured but not started” is not a meaningful supported state in this API, so it is intentionally reported as N/A instead of benchmarked as a separate mode.
 
+## Post-limit behavior model (issue #252)
+
+Core mode semantics are unchanged:
+
+- `CaptureMode::Light` still means lower core retention defaults than investigation mode.
+- `CaptureMode::Light` does **not** mean sparse evidence before limits are hit.
+- Unsaturated `core_light` and unsaturated `core_investigation` still capture the same evidence kinds; only retention ceilings differ.
+
+The stronger low-overhead story in this change set comes from the cheaper **post-limit** path:
+
+- After a section saturates, capture keeps exact dropped counters and `limits_hit=true`.
+- The collector no longer performs the same pre-saturation append path for events that must be dropped.
+- This lowers saturated-path runtime overhead without redefining mode semantics or adding a second evidence-density policy.
+
+What still happens after saturation:
+
+- request flow and completion semantics stay the same;
+- per-category dropped counters continue increasing;
+- artifacts and analyzer warnings keep calling out that dropped evidence can reduce diagnosis completeness/confidence.
+
+What no longer happens after saturation:
+
+- dropped events do not continue through the normal append/retention path once the section is known saturated.
+
+Residual overhead that remains after saturation:
+
+- branch/check cost on each attempted capture call;
+- atomic/drop-counter accounting and `limits_hit` state updates;
+- synchronization and surrounding request instrumentation overhead that is independent of storage append.
+
 ## Canonical command
 
 ```bash
@@ -91,6 +121,12 @@ Written to `demos/runtime_cost/artifacts/`:
 - Use `Tokio mode overhead` to evaluate full mode cost when runtime sampling is enabled.
 - Use `Incremental runtime sampler overhead` to isolate sampler-on deltas against their same-mode core-only baselines.
 - Use `Post-limit / drop-path overhead` only for saturated-limit behavior; these modes are intentionally non-comparable to unsaturated steady-state runs except as drop-path evidence.
+
+## Decision note for issue #252
+
+Based on this benchmark model, issue #252 is resolved by post-limit optimization alone for the scoped goal: stronger low-overhead behavior after saturation without changing capture-mode meaning.
+
+A future explicit evidence-density policy is optional product exploration, not required to resolve #252.
 
 ## Reading noisy-machine results
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -85,9 +85,17 @@ async fn helper_a(req: &tailtriage_core::RequestHandle<'_>) -> Result<(), MyErro
 ## RuntimeSampler (optional stronger attribution)
 
 `CaptureMode` in core sets retention defaults only. It does not auto-enable `RuntimeSampler`.
+Light mode remains lower retention defaults, not sparse evidence before saturation.
 When limits are hit, artifacts keep per-category drop counters and mark that limits were hit;
 analyzer warnings call out that dropped evidence can reduce completeness/confidence.
 Older artifacts may show `metadata.effective_core_config` as `null` (unknown).
+
+Post-limit behavior (issue #252 scope):
+
+- the cheaper drop path improves saturated-run overhead without changing `CaptureMode` semantics;
+- after saturation, dropped events skip the normal append/retention path;
+- drop counters and `limits_hit` bookkeeping still happen;
+- residual overhead remains from branch checks and drop-accounting state updates.
 
 ### What mode changes in each crate
 
@@ -129,6 +137,8 @@ Overhead terminology used in docs and scripts:
 - Incremental runtime sampler overhead
 - Baked-in overhead
 - Post-limit / drop-path overhead
+
+Decision note: issue #252 is resolved by post-limit optimization alone for the current scope; no new evidence-density policy is required in this change set.
 
 Use runtime snapshots when request-level signals are not enough to separate queueing vs executor vs blocking-pool pressure. For runtime-cost attribution categories and measurement workflow, see [runtime-cost.md](runtime-cost.md).
 


### PR DESCRIPTION
### Motivation
- Prove the cheaper post-limit path (saturated drop-path) reduces runtime overhead and update docs so the low-overhead story is precise and honest while keeping `CaptureMode` semantics unchanged.  
- Provide a reproducible benchmark and clear attribution so users can interpret baked-in, core, sampler, and post-limit costs without conflating sampler cost with core-only modes.

### Description
- Re-ran the runtime-cost demo (`python3 scripts/measure_runtime_cost.py`) and committed the produced artifacts under `demos/runtime_cost/artifacts/` to validate the reporting categories and confirm `measurement_quality: "stable"`.  
- Updated `docs/runtime-cost.md` to document the post-limit behavior model (issue #252), explicitly stating that `CaptureMode::Light` still means lower retention defaults not sparser evidence pre-saturation, that the low-overhead improvement comes from a cheaper post-limit drop path, what still happens after saturation, what no longer happens, and what residual overhead remains.  
- Aligned user-facing guidance by updating `README.md` and `docs/user-guide.md` with the saturation behavior note, truncation honesty, and a decision note stating whether #252 is resolved by this change set.  
- Benchmark interpretation: the summary includes baked-in overhead, unsaturated `core_light`/`core_investigation`, saturated `core_light_drop_path`/`core_investigation_drop_path`, and incremental runtime sampler overhead, and sampler cost is attributed only to sampler-enabled modes.  
- Decision: for the scoped goal in #252, the issue is resolved by the post-limit optimization alone (no new evidence-density policy added).

### Testing
- Ran the runtime-cost measurement script (`python3 scripts/measure_runtime_cost.py`) and produced `demos/runtime_cost/artifacts/runtime-cost-summary.json` with `measurement_quality: "stable"` (succeeded).  
- Ran formatting and static checks with `cargo fmt --check` and `cargo clippy --workspace --all-targets --locked -- -D warnings` (both succeeded).  
- Ran the full test suite with `cargo test --workspace --locked` (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5333e13188330903d1f807bd8f055)