### PR TITLE
Add collector-stress measurement path for sustained-load collector limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,9 +66,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
@@ -114,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blocking-service-demo"
@@ -142,9 +142,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -187,6 +187,18 @@ dependencies = [
  "anyhow",
  "demo-support",
  "tailtriage-core",
+ "tokio",
+]
+
+[[package]]
+name = "collector_stress"
+version = "0.1.1"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
+ "tailtriage-core",
+ "tailtriage-tokio",
  "tokio",
 ]
 
@@ -253,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "foldhash"
@@ -331,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -388,9 +400,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -402,7 +414,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
 ]
@@ -430,12 +441,12 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -460,9 +471,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -496,9 +507,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -538,12 +549,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "prettyplease"
@@ -626,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -795,9 +800,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "libc",
  "mio",
@@ -809,9 +814,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -871,11 +876,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -884,7 +889,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -944,6 +949,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
   "demos/shared_state_lock_service",
   "demos/retry_storm_service",
   "demos/runtime_cost",
+  "demos/collector_stress",
 ]
 resolver = "2"
 

--- a/demos/collector_stress/Cargo.toml
+++ b/demos/collector_stress/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "collector_stress"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[dependencies]
+anyhow = "1"
+tailtriage-core.workspace = true
+tailtriage-tokio.workspace = true
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[lints]
+workspace = true

--- a/demos/collector_stress/src/main.rs
+++ b/demos/collector_stress/src/main.rs
@@ -1,0 +1,730 @@
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::{bail, Context};
+use serde::Serialize;
+use tailtriage_core::{CaptureMode, Outcome, RequestOptions, Tailtriage};
+use tailtriage_tokio::RuntimeSampler;
+use tokio::sync::Mutex;
+
+const DEFAULT_DURATION_SECS: u64 = 30;
+const DEFAULT_CONCURRENCY: usize = 256;
+const DEFAULT_WORK_MS: u64 = 2;
+const DEFAULT_QUEUES_PER_REQUEST: usize = 3;
+const DEFAULT_STAGES_PER_REQUEST: usize = 4;
+const DEFAULT_INFLIGHT_TRANSITIONS: usize = 6;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum Mode {
+    Baseline,
+    CoreLight,
+    CoreInvestigation,
+    CoreLightTokioSampler,
+    CoreInvestigationTokioSampler,
+}
+
+impl Mode {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "baseline" => Some(Self::Baseline),
+            "core_light" => Some(Self::CoreLight),
+            "core_investigation" => Some(Self::CoreInvestigation),
+            "core_light_tokio_sampler" => Some(Self::CoreLightTokioSampler),
+            "core_investigation_tokio_sampler" => Some(Self::CoreInvestigationTokioSampler),
+            _ => None,
+        }
+    }
+
+    fn core_mode(self) -> Option<CaptureMode> {
+        match self {
+            Self::Baseline => None,
+            Self::CoreLight | Self::CoreLightTokioSampler => Some(CaptureMode::Light),
+            Self::CoreInvestigation | Self::CoreInvestigationTokioSampler => {
+                Some(CaptureMode::Investigation)
+            }
+        }
+    }
+
+    fn uses_tokio_sampler(self) -> bool {
+        matches!(
+            self,
+            Self::CoreLightTokioSampler | Self::CoreInvestigationTokioSampler
+        )
+    }
+}
+
+#[derive(Debug)]
+struct Cli {
+    mode: Mode,
+    duration_secs: u64,
+    max_requests: Option<usize>,
+    concurrency: usize,
+    queue_slots: usize,
+    queues_per_request: usize,
+    stages_per_request: usize,
+    inflight_transitions_per_request: usize,
+    work_ms: u64,
+    output_dir: PathBuf,
+}
+
+#[derive(Debug, Serialize)]
+struct Measurement {
+    #[serde(rename = "measurement_kind")]
+    kind: &'static str,
+    mode: Mode,
+    duration_secs: u64,
+    max_requests: Option<usize>,
+    concurrency: usize,
+    queue_slots: usize,
+    event_shape: EventShape,
+    sampler_settings: SamplerSettings,
+    throughput_rps: f64,
+    latency: LatencySummary,
+    retained_events: RetainedEvents,
+    truncation: TruncationMeasurement,
+    artifact: ArtifactSummary,
+    memory: MemoryMeasurement,
+    #[serde(rename = "measurement_notes")]
+    notes: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct EventShape {
+    queues_per_request: usize,
+    stages_per_request: usize,
+    inflight_transitions_per_request: usize,
+    work_ms: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct SamplerSettings {
+    enabled: bool,
+    inherited_mode: Option<String>,
+    explicit_mode_override: Option<String>,
+    resolved_mode: Option<String>,
+    resolved_sampler_cadence_ms: Option<u64>,
+    resolved_runtime_snapshot_retention: Option<usize>,
+}
+
+#[derive(Debug, Serialize)]
+struct LatencySummary {
+    count: usize,
+    p50_ms: f64,
+    p95_ms: f64,
+    p99_ms: f64,
+    max_ms: f64,
+}
+
+#[derive(Debug, Serialize)]
+struct RetainedEvents {
+    requests: usize,
+    stages: usize,
+    queues: usize,
+    inflight_snapshots: usize,
+    runtime_snapshots: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct TruncationMeasurement {
+    limits_hit: bool,
+    dropped_requests: u64,
+    dropped_stages: u64,
+    dropped_queues: u64,
+    dropped_inflight_snapshots: u64,
+    dropped_runtime_snapshots: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct ArtifactSummary {
+    artifact_path: Option<String>,
+    artifact_size_bytes: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+struct MemoryMeasurement {
+    backend: &'static str,
+    collector_start_rss_bytes: Option<u64>,
+    collector_end_rss_bytes: Option<u64>,
+    collector_peak_rss_bytes: Option<u64>,
+    notes: Vec<String>,
+}
+
+struct Instrumentation {
+    tailtriage: Option<Arc<Tailtriage>>,
+    sampler: Option<RuntimeSampler>,
+    artifact_path: Option<PathBuf>,
+}
+
+#[derive(Clone, Copy)]
+struct LinuxProcMem {
+    vm_rss_bytes: u64,
+    vm_hwm_bytes: u64,
+}
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 8)]
+#[allow(clippy::too_many_lines)]
+async fn main() -> anyhow::Result<()> {
+    let cli = parse_cli()?;
+    std::fs::create_dir_all(&cli.output_dir)
+        .with_context(|| format!("failed to create {}", cli.output_dir.display()))?;
+
+    let mem_start = read_linux_proc_mem();
+    let instrumentation = build_instrumentation(&cli)?;
+
+    let (mut latencies_us, elapsed, completed_requests) =
+        run_requests(&cli, instrumentation.tailtriage.as_ref()).await?;
+
+    if let Some(sampler) = instrumentation.sampler {
+        sampler.shutdown().await;
+    }
+
+    let mut notes = vec![
+        "This collector-stress path measures sustained collector behavior under high concurrency and dense request event shapes.".to_string(),
+        "It does not prove root cause and is not a general-purpose benchmark framework.".to_string(),
+    ];
+
+    let (retained_events, truncation, sampler_settings) =
+        if let Some(tailtriage) = instrumentation.tailtriage.as_ref() {
+            let snapshot = tailtriage.snapshot();
+            let sampler_settings = snapshot
+                .metadata
+                .effective_tokio_sampler_config
+                .map_or_else(
+                    || SamplerSettings {
+                        enabled: false,
+                        inherited_mode: None,
+                        explicit_mode_override: None,
+                        resolved_mode: None,
+                        resolved_sampler_cadence_ms: None,
+                        resolved_runtime_snapshot_retention: None,
+                    },
+                    |cfg| SamplerSettings {
+                        enabled: true,
+                        inherited_mode: Some(capture_mode_label(cfg.inherited_mode).to_string()),
+                        explicit_mode_override: cfg
+                            .explicit_mode_override
+                            .map(|mode| capture_mode_label(mode).to_string()),
+                        resolved_mode: Some(capture_mode_label(cfg.resolved_mode).to_string()),
+                        resolved_sampler_cadence_ms: Some(cfg.resolved_sampler_cadence_ms),
+                        resolved_runtime_snapshot_retention: Some(
+                            cfg.resolved_runtime_snapshot_retention,
+                        ),
+                    },
+                );
+
+            (
+                RetainedEvents {
+                    requests: snapshot.requests.len(),
+                    stages: snapshot.stages.len(),
+                    queues: snapshot.queues.len(),
+                    inflight_snapshots: snapshot.inflight.len(),
+                    runtime_snapshots: snapshot.runtime_snapshots.len(),
+                },
+                TruncationMeasurement {
+                    limits_hit: snapshot.truncation.limits_hit,
+                    dropped_requests: snapshot.truncation.dropped_requests,
+                    dropped_stages: snapshot.truncation.dropped_stages,
+                    dropped_queues: snapshot.truncation.dropped_queues,
+                    dropped_inflight_snapshots: snapshot.truncation.dropped_inflight_snapshots,
+                    dropped_runtime_snapshots: snapshot.truncation.dropped_runtime_snapshots,
+                },
+                sampler_settings,
+            )
+        } else {
+            (
+                RetainedEvents {
+                    requests: 0,
+                    stages: 0,
+                    queues: 0,
+                    inflight_snapshots: 0,
+                    runtime_snapshots: 0,
+                },
+                TruncationMeasurement {
+                    limits_hit: false,
+                    dropped_requests: 0,
+                    dropped_stages: 0,
+                    dropped_queues: 0,
+                    dropped_inflight_snapshots: 0,
+                    dropped_runtime_snapshots: 0,
+                },
+                SamplerSettings {
+                    enabled: false,
+                    inherited_mode: None,
+                    explicit_mode_override: None,
+                    resolved_mode: None,
+                    resolved_sampler_cadence_ms: None,
+                    resolved_runtime_snapshot_retention: None,
+                },
+            )
+        };
+
+    if let Some(tailtriage) = instrumentation.tailtriage {
+        tailtriage.shutdown()?;
+    }
+
+    let artifact_summary = if let Some(path) = instrumentation.artifact_path {
+        let artifact_size_bytes = std::fs::metadata(&path).map(|meta| meta.len()).ok();
+        ArtifactSummary {
+            artifact_path: Some(path.display().to_string()),
+            artifact_size_bytes,
+        }
+    } else {
+        notes.push(
+            "baseline mode intentionally does not produce a tailtriage run artifact; artifact size is omitted".to_string(),
+        );
+        ArtifactSummary {
+            artifact_path: None,
+            artifact_size_bytes: None,
+        }
+    };
+
+    let mem_end = read_linux_proc_mem();
+    let memory = memory_measurement(mem_start, mem_end);
+
+    latencies_us.sort_unstable();
+    let measurement = Measurement {
+        kind: "collector_stress",
+        mode: cli.mode,
+        duration_secs: cli.duration_secs,
+        max_requests: cli.max_requests,
+        concurrency: cli.concurrency,
+        queue_slots: cli.queue_slots,
+        event_shape: EventShape {
+            queues_per_request: cli.queues_per_request,
+            stages_per_request: cli.stages_per_request,
+            inflight_transitions_per_request: cli.inflight_transitions_per_request,
+            work_ms: cli.work_ms,
+        },
+        sampler_settings,
+        throughput_rps: requests_per_second(completed_requests, elapsed)?,
+        latency: LatencySummary {
+            count: latencies_us.len(),
+            p50_ms: percentile_ms(&latencies_us, 50, 100)?,
+            p95_ms: percentile_ms(&latencies_us, 95, 100)?,
+            p99_ms: percentile_ms(&latencies_us, 99, 100)?,
+            max_ms: latencies_us
+                .last()
+                .copied()
+                .map_or(Ok(0.0), micros_to_millis_f64)?,
+        },
+        retained_events,
+        truncation,
+        artifact: artifact_summary,
+        memory,
+        notes,
+    };
+
+    println!("{}", serde_json::to_string(&measurement)?);
+    Ok(())
+}
+
+fn build_instrumentation(cli: &Cli) -> anyhow::Result<Instrumentation> {
+    let Some(capture_mode) = cli.mode.core_mode() else {
+        return Ok(Instrumentation {
+            tailtriage: None,
+            sampler: None,
+            artifact_path: None,
+        });
+    };
+
+    let artifact_path = cli
+        .output_dir
+        .join(format!("collector-stress-run-{:?}.json", cli.mode).to_lowercase());
+
+    let mut builder = Tailtriage::builder("collector_stress_demo").output(artifact_path.clone());
+    builder = match capture_mode {
+        CaptureMode::Light => builder.light(),
+        CaptureMode::Investigation => builder.investigation(),
+    };
+
+    let tailtriage = Arc::new(builder.build()?);
+    let sampler = if cli.mode.uses_tokio_sampler() {
+        Some(RuntimeSampler::builder(Arc::clone(&tailtriage)).start()?)
+    } else {
+        None
+    };
+
+    Ok(Instrumentation {
+        tailtriage: Some(tailtriage),
+        sampler,
+        artifact_path: Some(artifact_path),
+    })
+}
+
+async fn run_requests(
+    cli: &Cli,
+    tailtriage: Option<&Arc<Tailtriage>>,
+) -> anyhow::Result<(Vec<u64>, Duration, usize)> {
+    let latencies_us = Arc::new(Mutex::new(Vec::<u64>::new()));
+    let queue_semaphore = Arc::new(tokio::sync::Semaphore::new(cli.queue_slots));
+    let next_request = Arc::new(AtomicUsize::new(0));
+
+    let deadline = Instant::now() + Duration::from_secs(cli.duration_secs);
+    let wall_start = Instant::now();
+
+    let mut tasks = Vec::with_capacity(cli.concurrency);
+    for _worker in 0..cli.concurrency {
+        let latencies = Arc::clone(&latencies_us);
+        let sem = Arc::clone(&queue_semaphore);
+        let request_counter = Arc::clone(&next_request);
+        let mode = cli.mode;
+        let max_requests = cli.max_requests;
+        let work_duration = Duration::from_millis(cli.work_ms);
+        let queues_per_request = cli.queues_per_request;
+        let stages_per_request = cli.stages_per_request;
+        let inflight_transitions = cli.inflight_transitions_per_request;
+        let tailtriage = tailtriage.map(Arc::clone);
+
+        tasks.push(tokio::spawn(async move {
+            loop {
+                if Instant::now() >= deadline {
+                    break;
+                }
+
+                let request_idx = request_counter.fetch_add(1, Ordering::Relaxed);
+                if let Some(max) = max_requests {
+                    if request_idx >= max {
+                        break;
+                    }
+                }
+
+                let start = Instant::now();
+                match (mode, &tailtriage) {
+                    (Mode::Baseline, _) => {
+                        run_baseline_request(
+                            work_duration,
+                            &sem,
+                            queues_per_request,
+                            stages_per_request,
+                        )
+                        .await;
+                    }
+                    (_, Some(ts)) => {
+                        run_instrumented_request(
+                            ts,
+                            request_idx,
+                            work_duration,
+                            &sem,
+                            queues_per_request,
+                            stages_per_request,
+                            inflight_transitions,
+                        )
+                        .await;
+                    }
+                    (_, None) => unreachable!("instrumented modes require collector"),
+                }
+
+                let elapsed_us = u64::try_from(start.elapsed().as_micros()).unwrap_or(u64::MAX);
+                latencies.lock().await.push(elapsed_us);
+            }
+        }));
+    }
+
+    for task in tasks {
+        task.await.context("worker task panicked")?;
+    }
+
+    let elapsed = wall_start.elapsed();
+    let latencies = Arc::into_inner(latencies_us)
+        .expect("all latency refs dropped")
+        .into_inner();
+
+    Ok((latencies, elapsed, next_request.load(Ordering::Relaxed)))
+}
+
+async fn run_baseline_request(
+    work_duration: Duration,
+    queue_semaphore: &tokio::sync::Semaphore,
+    queues_per_request: usize,
+    stages_per_request: usize,
+) {
+    for _ in 0..queues_per_request {
+        if let Ok(permit) = queue_semaphore.acquire().await {
+            tokio::time::sleep(work_duration).await;
+            drop(permit);
+        }
+    }
+
+    for _ in 0..stages_per_request {
+        tokio::time::sleep(work_duration).await;
+    }
+}
+
+async fn run_instrumented_request(
+    tailtriage: &Arc<Tailtriage>,
+    request_idx: usize,
+    work_duration: Duration,
+    queue_semaphore: &tokio::sync::Semaphore,
+    queues_per_request: usize,
+    stages_per_request: usize,
+    inflight_transitions: usize,
+) {
+    let request_id = format!("request-{request_idx}");
+    let started = tailtriage.begin_request_with(
+        "/collector-stress",
+        RequestOptions::new().request_id(request_id),
+    );
+    let request = started.handle.clone();
+
+    for transition in 0..inflight_transitions {
+        let gauge = format!("collector_stress_inflight_{transition}");
+        let inflight_guard = request.inflight(gauge);
+        tokio::task::yield_now().await;
+        drop(inflight_guard);
+    }
+
+    for queue_idx in 0..queues_per_request {
+        let queue_name = format!("worker_queue_{queue_idx}");
+        if let Ok(permit) = request
+            .queue(queue_name)
+            .await_on(queue_semaphore.acquire())
+            .await
+        {
+            tokio::time::sleep(work_duration).await;
+            drop(permit);
+        }
+    }
+
+    for stage_idx in 0..stages_per_request {
+        let stage_name = format!("simulated_stage_{stage_idx}");
+        request
+            .stage(stage_name)
+            .await_value(tokio::time::sleep(work_duration))
+            .await;
+    }
+
+    started.completion.finish(Outcome::Ok);
+}
+
+fn memory_measurement(start: Option<LinuxProcMem>, end: Option<LinuxProcMem>) -> MemoryMeasurement {
+    match (start, end) {
+        (Some(start_mem), Some(end_mem)) => MemoryMeasurement {
+            backend: "linux_proc_status",
+            collector_start_rss_bytes: Some(start_mem.vm_rss_bytes),
+            collector_end_rss_bytes: Some(end_mem.vm_rss_bytes),
+            collector_peak_rss_bytes: Some(end_mem.vm_hwm_bytes),
+            notes: vec![
+                "VmRSS is point-in-time resident memory and VmHWM is peak resident set size for the process lifetime.".to_string(),
+                "Linux /proc/self/status is the primary supported memory path for collector-stress runs.".to_string(),
+            ],
+        },
+        _ => MemoryMeasurement {
+            backend: "unsupported",
+            collector_start_rss_bytes: None,
+            collector_end_rss_bytes: None,
+            collector_peak_rss_bytes: None,
+            notes: vec![
+                "Memory measurement unavailable: collector-stress currently supports Linux /proc/self/status as primary memory backend.".to_string(),
+            ],
+        },
+    }
+}
+
+fn read_linux_proc_mem() -> Option<LinuxProcMem> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    let mut vm_rss_kib = None;
+    let mut vm_hwm_kib = None;
+
+    for line in status.lines() {
+        if let Some(value) = parse_status_kib(line, "VmRSS:") {
+            vm_rss_kib = Some(value);
+        }
+        if let Some(value) = parse_status_kib(line, "VmHWM:") {
+            vm_hwm_kib = Some(value);
+        }
+    }
+
+    Some(LinuxProcMem {
+        vm_rss_bytes: vm_rss_kib?.saturating_mul(1024),
+        vm_hwm_bytes: vm_hwm_kib?.saturating_mul(1024),
+    })
+}
+
+fn parse_status_kib(line: &str, key: &str) -> Option<u64> {
+    let rest = line.strip_prefix(key)?.trim();
+    let mut parts = rest.split_whitespace();
+    let value: u64 = parts.next()?.parse().ok()?;
+    let unit = parts.next()?;
+    if unit != "kB" {
+        return None;
+    }
+    Some(value)
+}
+
+#[allow(clippy::too_many_lines)]
+fn parse_cli() -> anyhow::Result<Cli> {
+    let mut mode = None;
+    let mut duration_secs = DEFAULT_DURATION_SECS;
+    let mut max_requests = None;
+    let mut concurrency = DEFAULT_CONCURRENCY;
+    let mut queue_slots = None;
+    let mut queues_per_request = DEFAULT_QUEUES_PER_REQUEST;
+    let mut stages_per_request = DEFAULT_STAGES_PER_REQUEST;
+    let mut inflight_transitions_per_request = DEFAULT_INFLIGHT_TRANSITIONS;
+    let mut work_ms = DEFAULT_WORK_MS;
+    let mut output_dir = PathBuf::from("demos/collector_stress/artifacts");
+
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--mode" => {
+                let value = args.next().context("missing value for --mode")?;
+                mode = Mode::parse(&value);
+                if mode.is_none() {
+                    bail!(
+                        "invalid --mode {value}; expected baseline|core_light|core_investigation|core_light_tokio_sampler|core_investigation_tokio_sampler"
+                    );
+                }
+            }
+            "--duration-secs" => {
+                duration_secs = args
+                    .next()
+                    .context("missing value for --duration-secs")?
+                    .parse()
+                    .context("invalid integer for --duration-secs")?;
+            }
+            "--max-requests" => {
+                max_requests = Some(
+                    args.next()
+                        .context("missing value for --max-requests")?
+                        .parse()
+                        .context("invalid integer for --max-requests")?,
+                );
+            }
+            "--concurrency" => {
+                concurrency = args
+                    .next()
+                    .context("missing value for --concurrency")?
+                    .parse()
+                    .context("invalid integer for --concurrency")?;
+            }
+            "--queue-slots" => {
+                queue_slots = Some(
+                    args.next()
+                        .context("missing value for --queue-slots")?
+                        .parse()
+                        .context("invalid integer for --queue-slots")?,
+                );
+            }
+            "--queues-per-request" => {
+                queues_per_request = args
+                    .next()
+                    .context("missing value for --queues-per-request")?
+                    .parse()
+                    .context("invalid integer for --queues-per-request")?;
+            }
+            "--stages-per-request" => {
+                stages_per_request = args
+                    .next()
+                    .context("missing value for --stages-per-request")?
+                    .parse()
+                    .context("invalid integer for --stages-per-request")?;
+            }
+            "--inflight-transitions-per-request" => {
+                inflight_transitions_per_request = args
+                    .next()
+                    .context("missing value for --inflight-transitions-per-request")?
+                    .parse()
+                    .context("invalid integer for --inflight-transitions-per-request")?;
+            }
+            "--work-ms" => {
+                work_ms = args
+                    .next()
+                    .context("missing value for --work-ms")?
+                    .parse()
+                    .context("invalid integer for --work-ms")?;
+            }
+            "--output-dir" => {
+                output_dir = PathBuf::from(args.next().context("missing value for --output-dir")?);
+            }
+            "--help" | "-h" => {
+                print_help();
+                std::process::exit(0);
+            }
+            _ => bail!("unknown arg: {arg}"),
+        }
+    }
+
+    let mode = mode.context("--mode is required")?;
+    let queue_slots = queue_slots.unwrap_or_else(|| concurrency.saturating_div(2).max(1));
+
+    if duration_secs == 0 {
+        bail!("--duration-secs must be > 0");
+    }
+
+    if concurrency == 0
+        || queue_slots == 0
+        || queues_per_request == 0
+        || stages_per_request == 0
+        || inflight_transitions_per_request == 0
+        || work_ms == 0
+    {
+        bail!(
+            "--concurrency, --queue-slots, --queues-per-request, --stages-per-request, --inflight-transitions-per-request, and --work-ms must be > 0"
+        );
+    }
+
+    Ok(Cli {
+        mode,
+        duration_secs,
+        max_requests,
+        concurrency,
+        queue_slots,
+        queues_per_request,
+        stages_per_request,
+        inflight_transitions_per_request,
+        work_ms,
+        output_dir,
+    })
+}
+
+fn print_help() {
+    eprintln!(
+        "collector_stress --mode <baseline|core_light|core_investigation|core_light_tokio_sampler|core_investigation_tokio_sampler> [--duration-secs N] [--max-requests N] [--concurrency N] [--queue-slots N] [--queues-per-request N] [--stages-per-request N] [--inflight-transitions-per-request N] [--work-ms N] [--output-dir DIR]"
+    );
+    eprintln!(
+        "collector-stress note: this path is for sustained high-concurrency collector behavior and artifact growth characterization, distinct from runtime_cost overhead attribution."
+    );
+}
+
+fn requests_per_second(request_count: usize, elapsed: Duration) -> anyhow::Result<f64> {
+    let total_requests = u64::try_from(request_count)?;
+    let request_rate_input = total_requests.to_string().parse::<f64>()?;
+    Ok(request_rate_input / elapsed.as_secs_f64())
+}
+
+fn percentile_ms(sorted_us: &[u64], numerator: u64, denominator: u64) -> anyhow::Result<f64> {
+    if sorted_us.is_empty() {
+        return Ok(0.0);
+    }
+
+    anyhow::ensure!(denominator != 0, "percentile denominator must be non-zero");
+    anyhow::ensure!(
+        numerator <= denominator,
+        "percentile numerator must be <= denominator"
+    );
+
+    let max_index = sorted_us.len() - 1;
+    let max_index_u64 = u64::try_from(max_index)?;
+    let scaled = u128::from(max_index_u64) * u128::from(numerator);
+    let rounded = scaled + (u128::from(denominator) / 2);
+    let index_u128 = rounded / u128::from(denominator);
+    let index = usize::try_from(index_u128)?;
+
+    micros_to_millis_f64(sorted_us[index])
+}
+
+fn micros_to_millis_f64(micros: u64) -> anyhow::Result<f64> {
+    let micros_value = micros.to_string().parse::<f64>()?;
+    Ok(micros_value / 1_000.0)
+}
+
+const fn capture_mode_label(mode: CaptureMode) -> &'static str {
+    match mode {
+        CaptureMode::Light => "light",
+        CaptureMode::Investigation => "investigation",
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,3 +14,4 @@
 
 - **Architecture and crate responsibilities:** [`architecture.md`](architecture.md)
 - **Runtime-cost measurement notes:** [`runtime-cost.md`](runtime-cost.md)
+- **Collector-stress operating-limit measurement path:** [`collector-limits.md`](collector-limits.md)

--- a/docs/collector-limits.md
+++ b/docs/collector-limits.md
@@ -1,0 +1,88 @@
+# Collector-stress measurement path
+
+This document describes the dedicated **collector-stress** path introduced for issue #107.
+
+## Why this path exists
+
+`runtime_cost` and `collector_stress` answer different questions:
+
+- `runtime_cost` is for compact, comparable **overhead attribution** across fixed modes on one shared scenario.
+- `collector_stress` is for **sustained-load operating limits** under higher concurrency and denser per-request event shapes.
+
+This separation keeps one coherent triage-oriented measurement path per question, rather than growing a generic benchmark framework.
+
+## What it measures
+
+The `collector_stress` binary and orchestrator focus on measured output for:
+
+- collector behavior at higher concurrency than the runtime-cost path
+- queue/stage/inflight-heavy request shapes
+- runtime sampler density impact in sampler-enabled modes
+- sustained run behavior over configurable duration (and optional request cap)
+- retained event growth and drop/truncation counters
+- run artifact size growth
+- Linux process memory readings via `/proc/self/status` (`VmRSS`, `VmHWM`)
+
+Supported modes in this path:
+
+- `baseline`
+- `core_light`
+- `core_investigation`
+- `core_light_tokio_sampler`
+- `core_investigation_tokio_sampler`
+
+## What it does not prove
+
+- It does **not** prove root cause.
+- It does **not** redefine `CaptureMode` semantics.
+- It does **not** redesign collector internals.
+- It is **not** a portability benchmark suite for all platforms.
+
+Memory behavior is primarily supported on Linux through `/proc/self/status`. On non-Linux environments, memory fields are intentionally reported as unavailable with explicit notes.
+
+## Structured output model
+
+Each binary run emits one JSON record with these fields:
+
+- `mode`
+- `concurrency`
+- `duration_secs` and optional `max_requests`
+- `event_shape` (`queues_per_request`, `stages_per_request`, `inflight_transitions_per_request`, `work_ms`)
+- `sampler_settings`
+- `throughput_rps`
+- `latency` summary (`count`, `p50_ms`, `p95_ms`, `p99_ms`, `max_ms`)
+- `retained_events`
+- `truncation` (dropped counters + `limits_hit`)
+- `artifact` (`artifact_path`, `artifact_size_bytes`)
+- `memory`
+- `measurement_notes`
+
+The Python orchestrator writes:
+
+- `demos/collector_stress/artifacts/collector-stress-raw.jsonl`
+- `demos/collector_stress/artifacts/collector-stress-summary.json`
+
+## Commands
+
+Run a single stress case directly:
+
+```bash
+cargo run --release --manifest-path demos/collector_stress/Cargo.toml -- \
+  --mode core_light \
+  --duration-secs 30 \
+  --concurrency 256 \
+  --queues-per-request 6 \
+  --stages-per-request 4 \
+  --inflight-transitions-per-request 6 \
+  --work-ms 2
+```
+
+Run matrix orchestration and summary:
+
+```bash
+python3 scripts/measure_collector_stress.py
+```
+
+## Policy reminder
+
+Keep claims conservative and based on measured output artifacts generated for the current machine/run. Do not hardcode machine-specific “latest numbers” into docs.

--- a/scripts/measure_collector_stress.py
+++ b/scripts/measure_collector_stress.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Run collector-stress mode/shape matrices and summarize sustained collector behavior."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+
+MODES = (
+    "baseline",
+    "core_light",
+    "core_investigation",
+    "core_light_tokio_sampler",
+    "core_investigation_tokio_sampler",
+)
+
+DEFAULT_CONCURRENCY = "128,256"
+DEFAULT_DURATION_SECS = "30"
+DEFAULT_QUEUES_PER_REQUEST = "3,6"
+DEFAULT_STAGES_PER_REQUEST = "4"
+DEFAULT_INFLIGHT_TRANSITIONS = "6"
+DEFAULT_WORK_MS = "2"
+DEFAULT_REPEATS = 2
+
+
+def parse_csv_ints(value: str, name: str) -> list[int]:
+    values = []
+    for part in value.split(","):
+        stripped = part.strip()
+        if not stripped:
+            continue
+        try:
+            parsed = int(stripped)
+        except ValueError as err:
+            raise SystemExit(f"invalid integer in --{name}: {stripped}") from err
+        if parsed <= 0:
+            raise SystemExit(f"--{name} values must be > 0")
+        values.append(parsed)
+
+    if not values:
+        raise SystemExit(f"--{name} must include at least one integer value")
+    return values
+
+
+def parse_args() -> argparse.Namespace:
+    root_dir = Path(__file__).resolve().parent.parent
+    parser = argparse.ArgumentParser(description="Measure collector stress behavior.")
+    parser.add_argument(
+        "--artifact-dir",
+        default=str(root_dir / "demos/collector_stress/artifacts"),
+        help="Directory for raw and summary output files.",
+    )
+    parser.add_argument("--modes", default=",".join(MODES), help="Comma-separated modes to execute.")
+    parser.add_argument(
+        "--concurrency-matrix",
+        default=os.environ.get("COLLECTOR_STRESS_CONCURRENCY", DEFAULT_CONCURRENCY),
+        help="Comma-separated concurrency values.",
+    )
+    parser.add_argument(
+        "--duration-secs-matrix",
+        default=os.environ.get("COLLECTOR_STRESS_DURATION", DEFAULT_DURATION_SECS),
+        help="Comma-separated duration values in seconds.",
+    )
+    parser.add_argument(
+        "--queues-per-request-matrix",
+        default=os.environ.get("COLLECTOR_STRESS_QUEUES", DEFAULT_QUEUES_PER_REQUEST),
+        help="Comma-separated queue events per request.",
+    )
+    parser.add_argument(
+        "--stages-per-request-matrix",
+        default=os.environ.get("COLLECTOR_STRESS_STAGES", DEFAULT_STAGES_PER_REQUEST),
+        help="Comma-separated stage events per request.",
+    )
+    parser.add_argument(
+        "--inflight-transitions-matrix",
+        default=os.environ.get("COLLECTOR_STRESS_INFLIGHT", DEFAULT_INFLIGHT_TRANSITIONS),
+        help="Comma-separated inflight transition counts per request.",
+    )
+    parser.add_argument(
+        "--work-ms-matrix",
+        default=os.environ.get("COLLECTOR_STRESS_WORK_MS", DEFAULT_WORK_MS),
+        help="Comma-separated simulated work duration values in milliseconds.",
+    )
+    parser.add_argument(
+        "--queue-slots",
+        type=int,
+        default=None,
+        help="Explicit queue slots for all matrix runs; defaults to max(concurrency/2,1) in binary.",
+    )
+    parser.add_argument(
+        "--max-requests",
+        type=int,
+        default=None,
+        help="Optional hard stop for requests per run.",
+    )
+    parser.add_argument("--repeats", type=int, default=DEFAULT_REPEATS, help="Repeated samples per mode/shape.")
+    return parser.parse_args()
+
+
+def build_release_binary(root_dir: Path) -> Path:
+    manifest_path = root_dir / "demos/collector_stress/Cargo.toml"
+    print("Building collector_stress demo in release mode...", file=sys.stderr)
+    subprocess.run(
+        [
+            "cargo",
+            "build",
+            "--release",
+            "--quiet",
+            "--manifest-path",
+            str(manifest_path),
+        ],
+        check=True,
+    )
+
+    binary_name = "collector_stress.exe" if os.name == "nt" else "collector_stress"
+    binary_path = root_dir / "target/release" / binary_name
+    if not binary_path.exists():
+        raise SystemExit(f"release binary not found at {binary_path}")
+    return binary_path
+
+
+def mode_list(raw_modes: str) -> list[str]:
+    modes = [mode.strip() for mode in raw_modes.split(",") if mode.strip()]
+    if not modes:
+        raise SystemExit("--modes must include at least one mode")
+    unknown = sorted(set(modes) - set(MODES))
+    if unknown:
+        raise SystemExit(f"unsupported mode(s): {', '.join(unknown)}")
+    return modes
+
+
+def run_case(
+    binary_path: Path,
+    artifact_dir: Path,
+    mode: str,
+    concurrency: int,
+    duration_secs: int,
+    queues_per_request: int,
+    stages_per_request: int,
+    inflight_transitions: int,
+    work_ms: int,
+    queue_slots: int | None,
+    max_requests: int | None,
+) -> dict:
+    cmd = [
+        str(binary_path),
+        "--mode",
+        mode,
+        "--concurrency",
+        str(concurrency),
+        "--duration-secs",
+        str(duration_secs),
+        "--queues-per-request",
+        str(queues_per_request),
+        "--stages-per-request",
+        str(stages_per_request),
+        "--inflight-transitions-per-request",
+        str(inflight_transitions),
+        "--work-ms",
+        str(work_ms),
+        "--output-dir",
+        str(artifact_dir),
+    ]
+    if queue_slots is not None:
+        cmd.extend(["--queue-slots", str(queue_slots)])
+    if max_requests is not None:
+        cmd.extend(["--max-requests", str(max_requests)])
+
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    output_lines = [line for line in result.stdout.splitlines() if line.strip()]
+    if not output_lines:
+        raise SystemExit("missing measurement output from collector_stress")
+    return json.loads(output_lines[-1])
+
+
+def summarize_values(values: list[float]) -> dict[str, float]:
+    if not values:
+        return {
+            "mean": 0.0,
+            "median": 0.0,
+            "min": 0.0,
+            "max": 0.0,
+            "stdev": 0.0,
+        }
+
+    return {
+        "mean": statistics.fmean(values),
+        "median": statistics.median(values),
+        "min": min(values),
+        "max": max(values),
+        "stdev": statistics.stdev(values) if len(values) > 1 else 0.0,
+    }
+
+
+def summarize(rows: list[dict]) -> dict:
+    grouped: dict[str, list[dict]] = {}
+    for row in rows:
+        event_shape = row["event_shape"]
+        key = (
+            f"mode={row['mode']};concurrency={row['concurrency']};duration_secs={row['duration_secs']};"
+            f"queues={event_shape['queues_per_request']};stages={event_shape['stages_per_request']};"
+            f"inflight={event_shape['inflight_transitions_per_request']};work_ms={event_shape['work_ms']}"
+        )
+        grouped.setdefault(key, []).append(row)
+
+    by_case = {}
+    for key, case_rows in grouped.items():
+        by_case[key] = {
+            "samples": len(case_rows),
+            "throughput_rps": summarize_values([entry["throughput_rps"] for entry in case_rows]),
+            "latency_p95_ms": summarize_values([entry["latency"]["p95_ms"] for entry in case_rows]),
+            "artifact_size_bytes": summarize_values(
+                [
+                    float(entry["artifact"]["artifact_size_bytes"])
+                    for entry in case_rows
+                    if entry["artifact"]["artifact_size_bytes"] is not None
+                ]
+            ),
+            "retained_events": {
+                "requests": summarize_values([float(entry["retained_events"]["requests"]) for entry in case_rows]),
+                "stages": summarize_values([float(entry["retained_events"]["stages"]) for entry in case_rows]),
+                "queues": summarize_values([float(entry["retained_events"]["queues"]) for entry in case_rows]),
+                "inflight_snapshots": summarize_values(
+                    [float(entry["retained_events"]["inflight_snapshots"]) for entry in case_rows]
+                ),
+                "runtime_snapshots": summarize_values(
+                    [float(entry["retained_events"]["runtime_snapshots"]) for entry in case_rows]
+                ),
+            },
+            "dropped_events": {
+                "dropped_requests": summarize_values(
+                    [float(entry["truncation"]["dropped_requests"]) for entry in case_rows]
+                ),
+                "dropped_stages": summarize_values([float(entry["truncation"]["dropped_stages"]) for entry in case_rows]),
+                "dropped_queues": summarize_values([float(entry["truncation"]["dropped_queues"]) for entry in case_rows]),
+                "dropped_inflight_snapshots": summarize_values(
+                    [float(entry["truncation"]["dropped_inflight_snapshots"]) for entry in case_rows]
+                ),
+                "dropped_runtime_snapshots": summarize_values(
+                    [float(entry["truncation"]["dropped_runtime_snapshots"]) for entry in case_rows]
+                ),
+                "limits_hit_runs": sum(1 for entry in case_rows if entry["truncation"]["limits_hit"]),
+            },
+            "memory": {
+                "collector_end_rss_bytes": summarize_values(
+                    [
+                        float(entry["memory"]["collector_end_rss_bytes"])
+                        for entry in case_rows
+                        if entry["memory"]["collector_end_rss_bytes"] is not None
+                    ]
+                ),
+                "collector_peak_rss_bytes": summarize_values(
+                    [
+                        float(entry["memory"]["collector_peak_rss_bytes"])
+                        for entry in case_rows
+                        if entry["memory"]["collector_peak_rss_bytes"] is not None
+                    ]
+                ),
+            },
+            "measurement_notes": case_rows[0]["measurement_notes"],
+        }
+
+    return {
+        "measurement_kind": "collector_stress",
+        "run_count": len(rows),
+        "case_count": len(by_case),
+        "cases": by_case,
+        "notes": [
+            "collector_stress complements runtime_cost by targeting sustained high-concurrency collector behavior and artifact scaling rather than small-mode overhead attribution.",
+            "results are measured output for this machine and should not be hardcoded into docs as universal numbers.",
+        ],
+    }
+
+
+def main() -> None:
+    args = parse_args()
+    if args.repeats <= 0:
+        raise SystemExit("--repeats must be > 0")
+    if args.queue_slots is not None and args.queue_slots <= 0:
+        raise SystemExit("--queue-slots must be > 0")
+    if args.max_requests is not None and args.max_requests <= 0:
+        raise SystemExit("--max-requests must be > 0")
+
+    root_dir = Path(__file__).resolve().parent.parent
+    artifact_dir = Path(args.artifact_dir)
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    binary_path = build_release_binary(root_dir)
+    selected_modes = mode_list(args.modes)
+
+    concurrencies = parse_csv_ints(args.concurrency_matrix, "concurrency-matrix")
+    durations = parse_csv_ints(args.duration_secs_matrix, "duration-secs-matrix")
+    queues = parse_csv_ints(args.queues_per_request_matrix, "queues-per-request-matrix")
+    stages = parse_csv_ints(args.stages_per_request_matrix, "stages-per-request-matrix")
+    inflights = parse_csv_ints(args.inflight_transitions_matrix, "inflight-transitions-matrix")
+    work_values = parse_csv_ints(args.work_ms_matrix, "work-ms-matrix")
+
+    raw_path = artifact_dir / "collector-stress-raw.jsonl"
+    summary_path = artifact_dir / "collector-stress-summary.json"
+    raw_path.write_text("", encoding="utf-8")
+
+    all_rows: list[dict] = []
+    case_index = 0
+
+    for repeat in range(args.repeats):
+        for mode in selected_modes:
+            for concurrency in concurrencies:
+                for duration_secs in durations:
+                    for queue_count in queues:
+                        for stage_count in stages:
+                            for inflight_count in inflights:
+                                for work_ms in work_values:
+                                    case_index += 1
+                                    print(
+                                        (
+                                            f"case={case_index} repeat={repeat + 1}/{args.repeats} mode={mode} "
+                                            f"concurrency={concurrency} duration={duration_secs}s queues={queue_count} "
+                                            f"stages={stage_count} inflight={inflight_count} work_ms={work_ms}"
+                                        ),
+                                        file=sys.stderr,
+                                    )
+                                    row = run_case(
+                                        binary_path,
+                                        artifact_dir,
+                                        mode,
+                                        concurrency,
+                                        duration_secs,
+                                        queue_count,
+                                        stage_count,
+                                        inflight_count,
+                                        work_ms,
+                                        args.queue_slots,
+                                        args.max_requests,
+                                    )
+                                    row["repeat"] = repeat
+                                    all_rows.append(row)
+                                    with raw_path.open("a", encoding="utf-8") as raw_file:
+                                        raw_file.write(json.dumps(row) + "\n")
+
+    summary = summarize(all_rows)
+    summary_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+
+    print(json.dumps(summary, indent=2))
+    print(f"raw results: {raw_path}")
+    print(f"summary: {summary_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- Provide one coherent collector-stress measurement path to characterize collector contention, artifact scaling, memory growth, and sustained-load operating limits without turning the repo into a general benchmarking framework.
- Complement the existing `runtime_cost` path by targeting sustained high-concurrency, queue/stage/inflight-dense request shapes and sampler-density effects rather than compact mode overhead attribution.
- Keep semantics stable: do not redefine `CaptureMode`, do not change analyzer semantics, and keep Linux as the primary supported memory-measurement path.

### Description

- Add a new demo crate `demos/collector_stress` containing a release-mode binary that runs sustained stress cases with knobs for `--duration-secs`/`--max-requests`, `--concurrency`, `--queue-slots`, `--queues-per-request`, `--stages-per-request`, `--inflight-transitions-per-request`, and `--work-ms` and supports modes `baseline`, `core_light`, `core_investigation`, `core_light_tokio_sampler`, and `core_investigation_tokio_sampler`.
- Implement a structured JSON output model emitted per run that includes at minimum: `mode`, `concurrency`, `duration_secs`/`max_requests`, `event_shape`, `sampler_settings`, `throughput_rps`, `latency` summary (`count`, `p50_ms`, `p95_ms`, `p99_ms`, `max_ms`), `retained_events`, `truncation` (dropped counters + `limits_hit`), `artifact` (path + size bytes), `memory` (Linux `/proc/self/status` fields when available), and `measurement_notes`.
- Add `scripts/measure_collector_stress.py`, a Python orchestrator that builds the release binary once, executes mode/shape matrices, writes raw JSONL at `demos/collector_stress/artifacts/collector-stress-raw.jsonl`, and produces a grouped summary JSON at `demos/collector_stress/artifacts/collector-stress-summary.json`.
- Add `docs/collector-limits.md` describing intent, scope, structured output contract, Linux primary-memory behavior, and usage; link it from `docs/README.md`.
- Wire the new demo into the workspace (`Cargo.toml`) and include the generated lockfile entries so the workspace builds cleanly.
- Implementation choices favor minimal dependencies and deterministic, CLI-driven execution; memory reads use Linux `/proc/self/status` and explicitly record unsupported status on non-Linux platforms.

Files added/modified (high level):
- Added `demos/collector_stress/Cargo.toml` and `demos/collector_stress/src/main.rs`.
- Added `scripts/measure_collector_stress.py` (executable orchestrator).
- Added `docs/collector-limits.md` and linked it from `docs/README.md`.
- Updated workspace `Cargo.toml` to include the new demo and updated `Cargo.lock` accordingly.

### Testing

- Ran formatting and lints: `cargo fmt --check` and `cargo clippy --workspace --all-targets --locked -- -D warnings`, both completed successfully.
- Ran the full test suite: `cargo test --workspace --locked`, which completed with all tests passing.
- Smoke-run of the new binary in release mode: `cargo run --release --manifest-path demos/collector_stress/Cargo.toml -- --mode core_light --duration-secs 1 --max-requests 20 --concurrency 8 --queues-per-request 2 --stages-per-request 2 --inflight-transitions-per-request 2 --work-ms 1 --output-dir demos/collector_stress/artifacts`, which executed and emitted a JSON record successfully.
- Smoke-run of the orchestrator: `python3 scripts/measure_collector_stress.py --modes baseline,core_light --concurrency-matrix 8 --duration-secs-matrix 1 --queues-per-request-matrix 1 --stages-per-request-matrix 1 --inflight-transitions-matrix 1 --work-ms-matrix 1 --max-requests 10 --repeats 1`, which built the release binary, ran the two cases, and produced a summary JSON; the run completed successfully.

All automated validation steps listed in the repo guidance were executed and passed for the modified code and the added demo/orchestrator.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5b5b8d2b083308216573b889780ad)