### PR TITLE
Add dedicated collector_stress demo binary with explicit stress knobs

### DIFF
--- a/demos/collector_stress/src/main.rs
+++ b/demos/collector_stress/src/main.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -14,7 +15,7 @@ const DEFAULT_CONCURRENCY: usize = 256;
 const DEFAULT_WORK_MS: u64 = 2;
 const DEFAULT_QUEUES_PER_REQUEST: usize = 3;
 const DEFAULT_STAGES_PER_REQUEST: usize = 4;
-const DEFAULT_INFLIGHT_TRANSITIONS: usize = 6;
+const DEFAULT_INFLIGHT_CYCLES: usize = 6;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -60,14 +61,23 @@ impl Mode {
 struct Cli {
     mode: Mode,
     duration_secs: u64,
-    max_requests: Option<usize>,
+    request_limit: Option<usize>,
     concurrency: usize,
     queue_slots: usize,
     queues_per_request: usize,
     stages_per_request: usize,
-    inflight_transitions_per_request: usize,
-    work_ms: u64,
+    inflight_cycles_per_request: usize,
+    work_duration: Duration,
+    work_label: WorkLabel,
     output_dir: PathBuf,
+    sampler_interval_ms: Option<u64>,
+    sampler_max_runtime_snapshots: Option<usize>,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum WorkLabel {
+    Millis(u64),
+    Micros(u64),
 }
 
 #[derive(Debug, Serialize)]
@@ -75,18 +85,19 @@ struct Measurement {
     #[serde(rename = "measurement_kind")]
     kind: &'static str,
     mode: Mode,
-    duration_secs: u64,
-    max_requests: Option<usize>,
+    requests_completed: usize,
     concurrency: usize,
-    queue_slots: usize,
+    run_duration_secs: f64,
+    configured_duration_secs: u64,
+    request_limit: Option<usize>,
+    throughput_rps: f64,
     event_shape: EventShape,
     sampler_settings: SamplerSettings,
-    throughput_rps: f64,
     latency: LatencySummary,
-    retained_events: RetainedEvents,
-    truncation: TruncationMeasurement,
+    retained_counts: RetainedCounts,
+    truncation_counts: TruncationCounts,
     artifact: ArtifactSummary,
-    memory: MemoryMeasurement,
+    peak_memory: PeakMemory,
     #[serde(rename = "measurement_notes")]
     notes: Vec<String>,
 }
@@ -95,8 +106,9 @@ struct Measurement {
 struct EventShape {
     queues_per_request: usize,
     stages_per_request: usize,
-    inflight_transitions_per_request: usize,
-    work_ms: u64,
+    inflight_cycles_per_request: usize,
+    work_ms: Option<u64>,
+    work_us: Option<u64>,
 }
 
 #[derive(Debug, Serialize)]
@@ -107,6 +119,8 @@ struct SamplerSettings {
     resolved_mode: Option<String>,
     resolved_sampler_cadence_ms: Option<u64>,
     resolved_runtime_snapshot_retention: Option<usize>,
+    cli_interval_ms_override: Option<u64>,
+    cli_max_runtime_snapshots_override: Option<usize>,
 }
 
 #[derive(Debug, Serialize)]
@@ -119,7 +133,7 @@ struct LatencySummary {
 }
 
 #[derive(Debug, Serialize)]
-struct RetainedEvents {
+struct RetainedCounts {
     requests: usize,
     stages: usize,
     queues: usize,
@@ -128,7 +142,7 @@ struct RetainedEvents {
 }
 
 #[derive(Debug, Serialize)]
-struct TruncationMeasurement {
+struct TruncationCounts {
     limits_hit: bool,
     dropped_requests: u64,
     dropped_stages: u64,
@@ -144,11 +158,11 @@ struct ArtifactSummary {
 }
 
 #[derive(Debug, Serialize)]
-struct MemoryMeasurement {
+struct PeakMemory {
     backend: &'static str,
+    collector_peak_rss_bytes: Option<u64>,
     collector_start_rss_bytes: Option<u64>,
     collector_end_rss_bytes: Option<u64>,
-    collector_peak_rss_bytes: Option<u64>,
     notes: Vec<String>,
 }
 
@@ -182,11 +196,11 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let mut notes = vec![
-        "This collector-stress path measures sustained collector behavior under high concurrency and dense request event shapes.".to_string(),
-        "It does not prove root cause and is not a general-purpose benchmark framework.".to_string(),
+        "Synthetic stress shape intentionally amplifies queue/stage/inflight event volume per request.".to_string(),
+        "This output ranks collector pressure signals; it does not prove root cause.".to_string(),
     ];
 
-    let (retained_events, truncation, sampler_settings) =
+    let (retained_counts, truncation_counts, sampler_settings) =
         if let Some(tailtriage) = instrumentation.tailtriage.as_ref() {
             let snapshot = tailtriage.snapshot();
             let sampler_settings = snapshot
@@ -200,6 +214,8 @@ async fn main() -> anyhow::Result<()> {
                         resolved_mode: None,
                         resolved_sampler_cadence_ms: None,
                         resolved_runtime_snapshot_retention: None,
+                        cli_interval_ms_override: cli.sampler_interval_ms,
+                        cli_max_runtime_snapshots_override: cli.sampler_max_runtime_snapshots,
                     },
                     |cfg| SamplerSettings {
                         enabled: true,
@@ -212,18 +228,20 @@ async fn main() -> anyhow::Result<()> {
                         resolved_runtime_snapshot_retention: Some(
                             cfg.resolved_runtime_snapshot_retention,
                         ),
+                        cli_interval_ms_override: cli.sampler_interval_ms,
+                        cli_max_runtime_snapshots_override: cli.sampler_max_runtime_snapshots,
                     },
                 );
 
             (
-                RetainedEvents {
+                RetainedCounts {
                     requests: snapshot.requests.len(),
                     stages: snapshot.stages.len(),
                     queues: snapshot.queues.len(),
                     inflight_snapshots: snapshot.inflight.len(),
                     runtime_snapshots: snapshot.runtime_snapshots.len(),
                 },
-                TruncationMeasurement {
+                TruncationCounts {
                     limits_hit: snapshot.truncation.limits_hit,
                     dropped_requests: snapshot.truncation.dropped_requests,
                     dropped_stages: snapshot.truncation.dropped_stages,
@@ -235,14 +253,14 @@ async fn main() -> anyhow::Result<()> {
             )
         } else {
             (
-                RetainedEvents {
+                RetainedCounts {
                     requests: 0,
                     stages: 0,
                     queues: 0,
                     inflight_snapshots: 0,
                     runtime_snapshots: 0,
                 },
-                TruncationMeasurement {
+                TruncationCounts {
                     limits_hit: false,
                     dropped_requests: 0,
                     dropped_stages: 0,
@@ -257,6 +275,8 @@ async fn main() -> anyhow::Result<()> {
                     resolved_mode: None,
                     resolved_sampler_cadence_ms: None,
                     resolved_runtime_snapshot_retention: None,
+                    cli_interval_ms_override: cli.sampler_interval_ms,
+                    cli_max_runtime_snapshots_override: cli.sampler_max_runtime_snapshots,
                 },
             )
         };
@@ -265,7 +285,7 @@ async fn main() -> anyhow::Result<()> {
         tailtriage.shutdown()?;
     }
 
-    let artifact_summary = if let Some(path) = instrumentation.artifact_path {
+    let artifact = if let Some(path) = instrumentation.artifact_path {
         let artifact_size_bytes = std::fs::metadata(&path).map(|meta| meta.len()).ok();
         ArtifactSummary {
             artifact_path: Some(path.display().to_string()),
@@ -273,7 +293,8 @@ async fn main() -> anyhow::Result<()> {
         }
     } else {
         notes.push(
-            "baseline mode intentionally does not produce a tailtriage run artifact; artifact size is omitted".to_string(),
+            "baseline mode intentionally skips tailtriage artifact output to isolate workload baseline"
+                .to_string(),
         );
         ArtifactSummary {
             artifact_path: None,
@@ -281,25 +302,32 @@ async fn main() -> anyhow::Result<()> {
         }
     };
 
-    let mem_end = read_linux_proc_mem();
-    let memory = memory_measurement(mem_start, mem_end);
+    let memory = memory_measurement(mem_start, read_linux_proc_mem());
 
     latencies_us.sort_unstable();
     let measurement = Measurement {
         kind: "collector_stress",
         mode: cli.mode,
-        duration_secs: cli.duration_secs,
-        max_requests: cli.max_requests,
+        requests_completed: completed_requests,
         concurrency: cli.concurrency,
-        queue_slots: cli.queue_slots,
+        run_duration_secs: elapsed.as_secs_f64(),
+        configured_duration_secs: cli.duration_secs,
+        request_limit: cli.request_limit,
+        throughput_rps: requests_per_second(completed_requests, elapsed)?,
         event_shape: EventShape {
             queues_per_request: cli.queues_per_request,
             stages_per_request: cli.stages_per_request,
-            inflight_transitions_per_request: cli.inflight_transitions_per_request,
-            work_ms: cli.work_ms,
+            inflight_cycles_per_request: cli.inflight_cycles_per_request,
+            work_ms: match cli.work_label {
+                WorkLabel::Millis(ms) => Some(ms),
+                WorkLabel::Micros(_) => None,
+            },
+            work_us: match cli.work_label {
+                WorkLabel::Millis(ms) => ms.checked_mul(1_000),
+                WorkLabel::Micros(us) => Some(us),
+            },
         },
         sampler_settings,
-        throughput_rps: requests_per_second(completed_requests, elapsed)?,
         latency: LatencySummary {
             count: latencies_us.len(),
             p50_ms: percentile_ms(&latencies_us, 50, 100)?,
@@ -310,10 +338,10 @@ async fn main() -> anyhow::Result<()> {
                 .copied()
                 .map_or(Ok(0.0), micros_to_millis_f64)?,
         },
-        retained_events,
-        truncation,
-        artifact: artifact_summary,
-        memory,
+        retained_counts,
+        truncation_counts,
+        artifact,
+        peak_memory: memory,
         notes,
     };
 
@@ -342,7 +370,14 @@ fn build_instrumentation(cli: &Cli) -> anyhow::Result<Instrumentation> {
 
     let tailtriage = Arc::new(builder.build()?);
     let sampler = if cli.mode.uses_tokio_sampler() {
-        Some(RuntimeSampler::builder(Arc::clone(&tailtriage)).start()?)
+        let mut sampler_builder = RuntimeSampler::builder(Arc::clone(&tailtriage));
+        if let Some(interval_ms) = cli.sampler_interval_ms {
+            sampler_builder = sampler_builder.interval(Duration::from_millis(interval_ms));
+        }
+        if let Some(max_runtime_snapshots) = cli.sampler_max_runtime_snapshots {
+            sampler_builder = sampler_builder.max_runtime_snapshots(max_runtime_snapshots);
+        }
+        Some(sampler_builder.start()?)
     } else {
         None
     };
@@ -360,7 +395,8 @@ async fn run_requests(
 ) -> anyhow::Result<(Vec<u64>, Duration, usize)> {
     let latencies_us = Arc::new(Mutex::new(Vec::<u64>::new()));
     let queue_semaphore = Arc::new(tokio::sync::Semaphore::new(cli.queue_slots));
-    let next_request = Arc::new(AtomicUsize::new(0));
+    let issued_requests = Arc::new(AtomicUsize::new(0));
+    let completed_requests = Arc::new(AtomicUsize::new(0));
 
     let deadline = Instant::now() + Duration::from_secs(cli.duration_secs);
     let wall_start = Instant::now();
@@ -369,13 +405,14 @@ async fn run_requests(
     for _worker in 0..cli.concurrency {
         let latencies = Arc::clone(&latencies_us);
         let sem = Arc::clone(&queue_semaphore);
-        let request_counter = Arc::clone(&next_request);
+        let issued = Arc::clone(&issued_requests);
+        let completed = Arc::clone(&completed_requests);
         let mode = cli.mode;
-        let max_requests = cli.max_requests;
-        let work_duration = Duration::from_millis(cli.work_ms);
+        let request_limit = cli.request_limit;
+        let work_duration = cli.work_duration;
         let queues_per_request = cli.queues_per_request;
         let stages_per_request = cli.stages_per_request;
-        let inflight_transitions = cli.inflight_transitions_per_request;
+        let inflight_cycles = cli.inflight_cycles_per_request;
         let tailtriage = tailtriage.map(Arc::clone);
 
         tasks.push(tokio::spawn(async move {
@@ -384,11 +421,9 @@ async fn run_requests(
                     break;
                 }
 
-                let request_idx = request_counter.fetch_add(1, Ordering::Relaxed);
-                if let Some(max) = max_requests {
-                    if request_idx >= max {
-                        break;
-                    }
+                let request_idx = issued.fetch_add(1, Ordering::Relaxed);
+                if request_limit.is_some_and(|max| request_idx >= max) {
+                    break;
                 }
 
                 let start = Instant::now();
@@ -410,13 +445,14 @@ async fn run_requests(
                             &sem,
                             queues_per_request,
                             stages_per_request,
-                            inflight_transitions,
+                            inflight_cycles,
                         )
                         .await;
                     }
                     (_, None) => unreachable!("instrumented modes require collector"),
                 }
 
+                completed.fetch_add(1, Ordering::Relaxed);
                 let elapsed_us = u64::try_from(start.elapsed().as_micros()).unwrap_or(u64::MAX);
                 latencies.lock().await.push(elapsed_us);
             }
@@ -432,7 +468,11 @@ async fn run_requests(
         .expect("all latency refs dropped")
         .into_inner();
 
-    Ok((latencies, elapsed, next_request.load(Ordering::Relaxed)))
+    Ok((
+        latencies,
+        elapsed,
+        completed_requests.load(Ordering::Relaxed),
+    ))
 }
 
 async fn run_baseline_request(
@@ -460,7 +500,7 @@ async fn run_instrumented_request(
     queue_semaphore: &tokio::sync::Semaphore,
     queues_per_request: usize,
     stages_per_request: usize,
-    inflight_transitions: usize,
+    inflight_cycles: usize,
 ) {
     let request_id = format!("request-{request_idx}");
     let started = tailtriage.begin_request_with(
@@ -469,8 +509,8 @@ async fn run_instrumented_request(
     );
     let request = started.handle.clone();
 
-    for transition in 0..inflight_transitions {
-        let gauge = format!("collector_stress_inflight_{transition}");
+    for cycle in 0..inflight_cycles {
+        let gauge = format!("collector_stress_inflight_{cycle}");
         let inflight_guard = request.inflight(gauge);
         tokio::task::yield_now().await;
         drop(inflight_guard);
@@ -499,25 +539,28 @@ async fn run_instrumented_request(
     started.completion.finish(Outcome::Ok);
 }
 
-fn memory_measurement(start: Option<LinuxProcMem>, end: Option<LinuxProcMem>) -> MemoryMeasurement {
+fn memory_measurement(start: Option<LinuxProcMem>, end: Option<LinuxProcMem>) -> PeakMemory {
     match (start, end) {
-        (Some(start_mem), Some(end_mem)) => MemoryMeasurement {
+        (Some(start_mem), Some(end_mem)) => PeakMemory {
             backend: "linux_proc_status",
+            collector_peak_rss_bytes: Some(end_mem.vm_hwm_bytes),
             collector_start_rss_bytes: Some(start_mem.vm_rss_bytes),
             collector_end_rss_bytes: Some(end_mem.vm_rss_bytes),
-            collector_peak_rss_bytes: Some(end_mem.vm_hwm_bytes),
             notes: vec![
-                "VmRSS is point-in-time resident memory and VmHWM is peak resident set size for the process lifetime.".to_string(),
-                "Linux /proc/self/status is the primary supported memory path for collector-stress runs.".to_string(),
+                "VmRSS is point-in-time resident memory and VmHWM is process-lifetime peak RSS."
+                    .to_string(),
+                "If external orchestration measures memory separately, join by mode/concurrency/event_shape from this JSON output."
+                    .to_string(),
             ],
         },
-        _ => MemoryMeasurement {
+        _ => PeakMemory {
             backend: "unsupported",
+            collector_peak_rss_bytes: None,
             collector_start_rss_bytes: None,
             collector_end_rss_bytes: None,
-            collector_peak_rss_bytes: None,
             notes: vec![
-                "Memory measurement unavailable: collector-stress currently supports Linux /proc/self/status as primary memory backend.".to_string(),
+                "Memory measurement unavailable in-process; orchestration should join external memory stats by run metadata."
+                    .to_string(),
             ],
         },
     }
@@ -554,24 +597,37 @@ fn parse_status_kib(line: &str, key: &str) -> Option<u64> {
     Some(value)
 }
 
-#[allow(clippy::too_many_lines)]
 fn parse_cli() -> anyhow::Result<Cli> {
+    parse_cli_from(std::env::args_os().skip(1))
+}
+
+#[allow(clippy::too_many_lines)]
+fn parse_cli_from<I, T>(args: I) -> anyhow::Result<Cli>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString>,
+{
     let mut mode = None;
     let mut duration_secs = DEFAULT_DURATION_SECS;
-    let mut max_requests = None;
+    let mut request_limit = None;
     let mut concurrency = DEFAULT_CONCURRENCY;
     let mut queue_slots = None;
     let mut queues_per_request = DEFAULT_QUEUES_PER_REQUEST;
     let mut stages_per_request = DEFAULT_STAGES_PER_REQUEST;
-    let mut inflight_transitions_per_request = DEFAULT_INFLIGHT_TRANSITIONS;
-    let mut work_ms = DEFAULT_WORK_MS;
+    let mut inflight_cycles_per_request = DEFAULT_INFLIGHT_CYCLES;
+    let mut work_label = WorkLabel::Millis(DEFAULT_WORK_MS);
     let mut output_dir = PathBuf::from("demos/collector_stress/artifacts");
+    let mut sampler_interval_ms = None;
+    let mut sampler_max_runtime_snapshots = None;
 
-    let mut args = std::env::args().skip(1);
-    while let Some(arg) = args.next() {
+    let mut iter = args.into_iter().map(|value| {
+        let value: OsString = value.into();
+        value.to_string_lossy().into_owned()
+    });
+    while let Some(arg) = iter.next() {
         match arg.as_str() {
             "--mode" => {
-                let value = args.next().context("missing value for --mode")?;
+                let value = iter.next().context("missing value for --mode")?;
                 mode = Mode::parse(&value);
                 if mode.is_none() {
                     bail!(
@@ -580,22 +636,22 @@ fn parse_cli() -> anyhow::Result<Cli> {
                 }
             }
             "--duration-secs" => {
-                duration_secs = args
+                duration_secs = iter
                     .next()
                     .context("missing value for --duration-secs")?
                     .parse()
                     .context("invalid integer for --duration-secs")?;
             }
-            "--max-requests" => {
-                max_requests = Some(
-                    args.next()
-                        .context("missing value for --max-requests")?
+            "--requests" | "--max-requests" => {
+                request_limit = Some(
+                    iter.next()
+                        .context("missing value for --requests")?
                         .parse()
-                        .context("invalid integer for --max-requests")?,
+                        .context("invalid integer for --requests")?,
                 );
             }
             "--concurrency" => {
-                concurrency = args
+                concurrency = iter
                     .next()
                     .context("missing value for --concurrency")?
                     .parse()
@@ -603,42 +659,67 @@ fn parse_cli() -> anyhow::Result<Cli> {
             }
             "--queue-slots" => {
                 queue_slots = Some(
-                    args.next()
+                    iter.next()
                         .context("missing value for --queue-slots")?
                         .parse()
                         .context("invalid integer for --queue-slots")?,
                 );
             }
             "--queues-per-request" => {
-                queues_per_request = args
+                queues_per_request = iter
                     .next()
                     .context("missing value for --queues-per-request")?
                     .parse()
                     .context("invalid integer for --queues-per-request")?;
             }
             "--stages-per-request" => {
-                stages_per_request = args
+                stages_per_request = iter
                     .next()
                     .context("missing value for --stages-per-request")?
                     .parse()
                     .context("invalid integer for --stages-per-request")?;
             }
-            "--inflight-transitions-per-request" => {
-                inflight_transitions_per_request = args
+            "--inflight-cycles-per-request" | "--inflight-transitions-per-request" => {
+                inflight_cycles_per_request = iter
                     .next()
-                    .context("missing value for --inflight-transitions-per-request")?
+                    .context("missing value for --inflight-cycles-per-request")?
                     .parse()
-                    .context("invalid integer for --inflight-transitions-per-request")?;
+                    .context("invalid integer for --inflight-cycles-per-request")?;
             }
             "--work-ms" => {
-                work_ms = args
+                let work_ms = iter
                     .next()
                     .context("missing value for --work-ms")?
                     .parse()
                     .context("invalid integer for --work-ms")?;
+                work_label = WorkLabel::Millis(work_ms);
+            }
+            "--work-us" => {
+                let work_us = iter
+                    .next()
+                    .context("missing value for --work-us")?
+                    .parse()
+                    .context("invalid integer for --work-us")?;
+                work_label = WorkLabel::Micros(work_us);
             }
             "--output-dir" => {
-                output_dir = PathBuf::from(args.next().context("missing value for --output-dir")?);
+                output_dir = PathBuf::from(iter.next().context("missing value for --output-dir")?);
+            }
+            "--sampler-interval-ms" => {
+                sampler_interval_ms = Some(
+                    iter.next()
+                        .context("missing value for --sampler-interval-ms")?
+                        .parse()
+                        .context("invalid integer for --sampler-interval-ms")?,
+                );
+            }
+            "--sampler-max-runtime-snapshots" => {
+                sampler_max_runtime_snapshots = Some(
+                    iter.next()
+                        .context("missing value for --sampler-max-runtime-snapshots")?
+                        .parse()
+                        .context("invalid integer for --sampler-max-runtime-snapshots")?,
+                );
             }
             "--help" | "-h" => {
                 print_help();
@@ -655,35 +736,57 @@ fn parse_cli() -> anyhow::Result<Cli> {
         bail!("--duration-secs must be > 0");
     }
 
+    let work_duration = match work_label {
+        WorkLabel::Millis(ms) if ms > 0 => Duration::from_millis(ms),
+        WorkLabel::Micros(us) if us > 0 => Duration::from_micros(us),
+        WorkLabel::Millis(_) | WorkLabel::Micros(_) => {
+            bail!("--work-ms/--work-us must be > 0")
+        }
+    };
+
     if concurrency == 0
         || queue_slots == 0
         || queues_per_request == 0
         || stages_per_request == 0
-        || inflight_transitions_per_request == 0
-        || work_ms == 0
+        || inflight_cycles_per_request == 0
     {
         bail!(
-            "--concurrency, --queue-slots, --queues-per-request, --stages-per-request, --inflight-transitions-per-request, and --work-ms must be > 0"
+            "--concurrency, --queue-slots, --queues-per-request, --stages-per-request, and --inflight-cycles-per-request must be > 0"
         );
+    }
+
+    if request_limit.is_some_and(|limit| limit == 0) {
+        bail!("--requests must be > 0 when provided");
+    }
+
+    if sampler_interval_ms.is_some_and(|value| value == 0) {
+        bail!("--sampler-interval-ms must be > 0 when provided");
+    }
+
+    if sampler_max_runtime_snapshots.is_some_and(|value| value == 0) {
+        bail!("--sampler-max-runtime-snapshots must be > 0 when provided");
     }
 
     Ok(Cli {
         mode,
         duration_secs,
-        max_requests,
+        request_limit,
         concurrency,
         queue_slots,
         queues_per_request,
         stages_per_request,
-        inflight_transitions_per_request,
-        work_ms,
+        inflight_cycles_per_request,
+        work_duration,
+        work_label,
         output_dir,
+        sampler_interval_ms,
+        sampler_max_runtime_snapshots,
     })
 }
 
 fn print_help() {
     eprintln!(
-        "collector_stress --mode <baseline|core_light|core_investigation|core_light_tokio_sampler|core_investigation_tokio_sampler> [--duration-secs N] [--max-requests N] [--concurrency N] [--queue-slots N] [--queues-per-request N] [--stages-per-request N] [--inflight-transitions-per-request N] [--work-ms N] [--output-dir DIR]"
+        "collector_stress --mode <baseline|core_light|core_investigation|core_light_tokio_sampler|core_investigation_tokio_sampler> [--duration-secs N|--requests N] [--concurrency N] [--work-ms N|--work-us N] [--queues-per-request N] [--stages-per-request N] [--inflight-cycles-per-request N] [--output-dir DIR] [--sampler-interval-ms N] [--sampler-max-runtime-snapshots N]"
     );
     eprintln!(
         "collector-stress note: this path is for sustained high-concurrency collector behavior and artifact growth characterization, distinct from runtime_cost overhead attribution."
@@ -726,5 +829,77 @@ const fn capture_mode_label(mode: CaptureMode) -> &'static str {
     match mode {
         CaptureMode::Light => "light",
         CaptureMode::Investigation => "investigation",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_cli_from, Mode, WorkLabel};
+
+    #[test]
+    fn parse_cli_supports_required_knobs() {
+        let cli = parse_cli_from([
+            "--mode",
+            "core_light_tokio_sampler",
+            "--duration-secs",
+            "12",
+            "--requests",
+            "150",
+            "--concurrency",
+            "64",
+            "--work-us",
+            "350",
+            "--queues-per-request",
+            "5",
+            "--stages-per-request",
+            "7",
+            "--inflight-cycles-per-request",
+            "9",
+            "--sampler-interval-ms",
+            "17",
+            "--sampler-max-runtime-snapshots",
+            "321",
+            "--output-dir",
+            "tmp/out",
+        ])
+        .expect("args should parse");
+
+        assert_eq!(cli.mode, Mode::CoreLightTokioSampler);
+        assert_eq!(cli.duration_secs, 12);
+        assert_eq!(cli.request_limit, Some(150));
+        assert_eq!(cli.concurrency, 64);
+        assert_eq!(cli.queues_per_request, 5);
+        assert_eq!(cli.stages_per_request, 7);
+        assert_eq!(cli.inflight_cycles_per_request, 9);
+        assert_eq!(cli.sampler_interval_ms, Some(17));
+        assert_eq!(cli.sampler_max_runtime_snapshots, Some(321));
+        assert!(matches!(cli.work_label, WorkLabel::Micros(350)));
+        assert_eq!(cli.output_dir.to_string_lossy(), "tmp/out");
+    }
+
+    #[test]
+    fn parse_cli_rejects_zero_requests() {
+        let err = parse_cli_from(["--mode", "baseline", "--requests", "0"])
+            .expect_err("zero requests must fail");
+        assert!(err.to_string().contains("--requests must be > 0"));
+    }
+
+    #[test]
+    fn parse_cli_accepts_legacy_aliases() {
+        let cli = parse_cli_from([
+            "--mode",
+            "core_investigation",
+            "--max-requests",
+            "12",
+            "--inflight-transitions-per-request",
+            "4",
+            "--work-ms",
+            "3",
+        ])
+        .expect("legacy aliases should parse");
+
+        assert_eq!(cli.request_limit, Some(12));
+        assert_eq!(cli.inflight_cycles_per_request, 4);
+        assert!(matches!(cli.work_label, WorkLabel::Millis(3)));
     }
 }

--- a/scripts/measure_collector_stress.py
+++ b/scripts/measure_collector_stress.py
@@ -23,7 +23,7 @@ DEFAULT_CONCURRENCY = "128,256"
 DEFAULT_DURATION_SECS = "30"
 DEFAULT_QUEUES_PER_REQUEST = "3,6"
 DEFAULT_STAGES_PER_REQUEST = "4"
-DEFAULT_INFLIGHT_TRANSITIONS = "6"
+DEFAULT_INFLIGHT_CYCLES = "6"
 DEFAULT_WORK_MS = "2"
 DEFAULT_REPEATS = 2
 
@@ -77,9 +77,9 @@ def parse_args() -> argparse.Namespace:
         help="Comma-separated stage events per request.",
     )
     parser.add_argument(
-        "--inflight-transitions-matrix",
-        default=os.environ.get("COLLECTOR_STRESS_INFLIGHT", DEFAULT_INFLIGHT_TRANSITIONS),
-        help="Comma-separated inflight transition counts per request.",
+        "--inflight-cycles-matrix",
+        default=os.environ.get("COLLECTOR_STRESS_INFLIGHT_CYCLES", DEFAULT_INFLIGHT_CYCLES),
+        help="Comma-separated inflight cycle counts per request.",
     )
     parser.add_argument(
         "--work-ms-matrix",
@@ -93,7 +93,7 @@ def parse_args() -> argparse.Namespace:
         help="Explicit queue slots for all matrix runs; defaults to max(concurrency/2,1) in binary.",
     )
     parser.add_argument(
-        "--max-requests",
+        "--requests",
         type=int,
         default=None,
         help="Optional hard stop for requests per run.",
@@ -142,7 +142,7 @@ def run_case(
     duration_secs: int,
     queues_per_request: int,
     stages_per_request: int,
-    inflight_transitions: int,
+    inflight_cycles: int,
     work_ms: int,
     queue_slots: int | None,
     max_requests: int | None,
@@ -159,8 +159,8 @@ def run_case(
         str(queues_per_request),
         "--stages-per-request",
         str(stages_per_request),
-        "--inflight-transitions-per-request",
-        str(inflight_transitions),
+        "--inflight-cycles-per-request",
+        str(inflight_cycles),
         "--work-ms",
         str(work_ms),
         "--output-dir",
@@ -169,7 +169,7 @@ def run_case(
     if queue_slots is not None:
         cmd.extend(["--queue-slots", str(queue_slots)])
     if max_requests is not None:
-        cmd.extend(["--max-requests", str(max_requests)])
+        cmd.extend(["--requests", str(max_requests)])
 
     result = subprocess.run(cmd, check=True, capture_output=True, text=True)
     output_lines = [line for line in result.stdout.splitlines() if line.strip()]
@@ -202,9 +202,9 @@ def summarize(rows: list[dict]) -> dict:
     for row in rows:
         event_shape = row["event_shape"]
         key = (
-            f"mode={row['mode']};concurrency={row['concurrency']};duration_secs={row['duration_secs']};"
+            f"mode={row['mode']};concurrency={row['concurrency']};duration_secs={row.get('configured_duration_secs', row.get('duration_secs'))};"
             f"queues={event_shape['queues_per_request']};stages={event_shape['stages_per_request']};"
-            f"inflight={event_shape['inflight_transitions_per_request']};work_ms={event_shape['work_ms']}"
+            f"inflight={event_shape.get('inflight_cycles_per_request', event_shape.get('inflight_transitions_per_request'))};work_ms={event_shape.get('work_ms')}"
         )
         grouped.setdefault(key, []).append(row)
 
@@ -222,43 +222,43 @@ def summarize(rows: list[dict]) -> dict:
                 ]
             ),
             "retained_events": {
-                "requests": summarize_values([float(entry["retained_events"]["requests"]) for entry in case_rows]),
-                "stages": summarize_values([float(entry["retained_events"]["stages"]) for entry in case_rows]),
-                "queues": summarize_values([float(entry["retained_events"]["queues"]) for entry in case_rows]),
+                "requests": summarize_values([float(entry.get("retained_counts", entry.get("retained_events", {}))["requests"]) for entry in case_rows]),
+                "stages": summarize_values([float(entry.get("retained_counts", entry.get("retained_events", {}))["stages"]) for entry in case_rows]),
+                "queues": summarize_values([float(entry.get("retained_counts", entry.get("retained_events", {}))["queues"]) for entry in case_rows]),
                 "inflight_snapshots": summarize_values(
-                    [float(entry["retained_events"]["inflight_snapshots"]) for entry in case_rows]
+                    [float(entry.get("retained_counts", entry.get("retained_events", {}))["inflight_snapshots"]) for entry in case_rows]
                 ),
                 "runtime_snapshots": summarize_values(
-                    [float(entry["retained_events"]["runtime_snapshots"]) for entry in case_rows]
+                    [float(entry.get("retained_counts", entry.get("retained_events", {}))["runtime_snapshots"]) for entry in case_rows]
                 ),
             },
             "dropped_events": {
                 "dropped_requests": summarize_values(
-                    [float(entry["truncation"]["dropped_requests"]) for entry in case_rows]
+                    [float(entry.get("truncation_counts", entry.get("truncation", {}))["dropped_requests"]) for entry in case_rows]
                 ),
-                "dropped_stages": summarize_values([float(entry["truncation"]["dropped_stages"]) for entry in case_rows]),
-                "dropped_queues": summarize_values([float(entry["truncation"]["dropped_queues"]) for entry in case_rows]),
+                "dropped_stages": summarize_values([float(entry.get("truncation_counts", entry.get("truncation", {}))["dropped_stages"]) for entry in case_rows]),
+                "dropped_queues": summarize_values([float(entry.get("truncation_counts", entry.get("truncation", {}))["dropped_queues"]) for entry in case_rows]),
                 "dropped_inflight_snapshots": summarize_values(
-                    [float(entry["truncation"]["dropped_inflight_snapshots"]) for entry in case_rows]
+                    [float(entry.get("truncation_counts", entry.get("truncation", {}))["dropped_inflight_snapshots"]) for entry in case_rows]
                 ),
                 "dropped_runtime_snapshots": summarize_values(
-                    [float(entry["truncation"]["dropped_runtime_snapshots"]) for entry in case_rows]
+                    [float(entry.get("truncation_counts", entry.get("truncation", {}))["dropped_runtime_snapshots"]) for entry in case_rows]
                 ),
-                "limits_hit_runs": sum(1 for entry in case_rows if entry["truncation"]["limits_hit"]),
+                "limits_hit_runs": sum(1 for entry in case_rows if entry.get("truncation_counts", entry.get("truncation", {}))["limits_hit"]),
             },
             "memory": {
                 "collector_end_rss_bytes": summarize_values(
                     [
-                        float(entry["memory"]["collector_end_rss_bytes"])
+                        float(entry.get("peak_memory", entry.get("memory", {}))["collector_end_rss_bytes"])
                         for entry in case_rows
-                        if entry["memory"]["collector_end_rss_bytes"] is not None
+                        if entry.get("peak_memory", entry.get("memory", {}))["collector_end_rss_bytes"] is not None
                     ]
                 ),
                 "collector_peak_rss_bytes": summarize_values(
                     [
-                        float(entry["memory"]["collector_peak_rss_bytes"])
+                        float(entry.get("peak_memory", entry.get("memory", {}))["collector_peak_rss_bytes"])
                         for entry in case_rows
-                        if entry["memory"]["collector_peak_rss_bytes"] is not None
+                        if entry.get("peak_memory", entry.get("memory", {}))["collector_peak_rss_bytes"] is not None
                     ]
                 ),
             },
@@ -283,8 +283,8 @@ def main() -> None:
         raise SystemExit("--repeats must be > 0")
     if args.queue_slots is not None and args.queue_slots <= 0:
         raise SystemExit("--queue-slots must be > 0")
-    if args.max_requests is not None and args.max_requests <= 0:
-        raise SystemExit("--max-requests must be > 0")
+    if args.requests is not None and args.requests <= 0:
+        raise SystemExit("--requests must be > 0")
 
     root_dir = Path(__file__).resolve().parent.parent
     artifact_dir = Path(args.artifact_dir)
@@ -297,7 +297,7 @@ def main() -> None:
     durations = parse_csv_ints(args.duration_secs_matrix, "duration-secs-matrix")
     queues = parse_csv_ints(args.queues_per_request_matrix, "queues-per-request-matrix")
     stages = parse_csv_ints(args.stages_per_request_matrix, "stages-per-request-matrix")
-    inflights = parse_csv_ints(args.inflight_transitions_matrix, "inflight-transitions-matrix")
+    inflights = parse_csv_ints(args.inflight_cycles_matrix, "inflight-cycles-matrix")
     work_values = parse_csv_ints(args.work_ms_matrix, "work-ms-matrix")
 
     raw_path = artifact_dir / "collector-stress-raw.jsonl"
@@ -335,7 +335,7 @@ def main() -> None:
                                         inflight_count,
                                         work_ms,
                                         args.queue_slots,
-                                        args.max_requests,
+                                        args.requests,
                                     )
                                     row["repeat"] = repeat
                                     all_rows.append(row)


### PR DESCRIPTION
### Motivation

- Provide a dedicated, reviewable demo that can generate sustained high-concurrency, event-heavy request shapes to exercise collector retention/truncation and artifact growth that `runtime_cost` is not designed to reveal. 
- Keep the stress path separate from small-mode overhead attribution while preserving existing `CaptureMode` semantics and enabling explicit runtime-sampler density comparisons.

### Description

- Implemented the `collector_stress` demo binary with a compact CLI and event-heavy synthetic request model (repeated inflight cycles + queue waits + staged work) in `demos/collector_stress/src/main.rs`, mapping modes to `CaptureMode::{Light, Investigation}` and enabling the Tokio `RuntimeSampler` only for sampler modes. 
- Added CLI knobs and aliases: `--mode <baseline|core_light|core_investigation|core_light_tokio_sampler|core_investigation_tokio_sampler>`, `--duration-secs` / `--requests` (accepts legacy `--max-requests`), `--concurrency`, `--work-ms` or `--work-us`, `--queues-per-request`, `--stages-per-request`, `--inflight-cycles-per-request` (accepts legacy transitions alias), `--output-dir`, and sampler settings `--sampler-interval-ms` / `--sampler-max-runtime-snapshots`.
- Emit one machine-readable JSON object per run containing run metadata and measurements (mode, requests completed, configured and measured duration, concurrency, throughput, latency p50/p95/p99/max, truncation counts, retained counts by section, artifact path/size, peak-memory metadata or join guidance, and explicit sampler attribution).
- Updated orchestration script `scripts/measure_collector_stress.py` to use the new flag names, accept `--requests`, rename inflight matrix to cycles, and tolerate both old/new JSON field keys for backward compatibility, and added focused unit tests for CLI parsing and legacy-alias handling in the demo binary.

### Testing

- Ran formatting and lint/validation: `cargo fmt --check` succeeded. 
- Ran static checks: `cargo clippy --workspace --all-targets --locked -- -D warnings` completed successfully. 
- Ran the full test suite: `cargo test --workspace --locked` completed successfully, including the new deterministic unit tests for CLI parsing in `collector_stress`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c1b5ac2c8330936fe16f260dd44b)