### PR TITLE
Clarify collector-limits vs runtime-cost measurement paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,13 @@ For measurement-path details and conservative interpretation guidance:
 - Collector stress methodology/findings/limits: [`docs/collector-limits.md`](docs/collector-limits.md)
 - Runtime overhead attribution path: [`docs/runtime-cost.md`](docs/runtime-cost.md)
 
+Use these as distinct measurement paths:
+
+- **Runtime overhead attribution:** isolate baked-in/core/sampler/drop-path overhead categories (`docs/runtime-cost.md`).
+- **Sustained-load collector limits:** stress retention and truncation behavior under high event volume (`docs/collector-limits.md`).
+- **Artifact-size scaling:** compare shape-driven artifact growth in the collector-limits matrix (`docs/collector-limits.md`).
+- **Memory-growth behavior:** compare peak/end RSS trends across stress cases and modes (`docs/collector-limits.md`).
+
 ## What this is not
 
 `tailtriage` is not:

--- a/demos/collector_stress/src/main.rs
+++ b/demos/collector_stress/src/main.rs
@@ -198,6 +198,7 @@ async fn main() -> anyhow::Result<()> {
     let mut notes = vec![
         "Synthetic stress shape intentionally amplifies queue/stage/inflight event volume per request.".to_string(),
         "This output ranks collector pressure signals; it does not prove root cause.".to_string(),
+        "Operating ranges must be validated from measured output on the current machine/workload; this run does not provide cross-machine numeric guarantees.".to_string(),
     ];
 
     let (retained_counts, truncation_counts, sampler_settings) =

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,5 +13,5 @@
 ## Reference
 
 - **Architecture and crate responsibilities:** [`architecture.md`](architecture.md)
-- **Collector-stress methodology, findings, limits, and operating guidance:** [`collector-limits.md`](collector-limits.md)
-- **Runtime-cost measurement notes:** [`runtime-cost.md`](runtime-cost.md)
+- **Collector-limits measurement path (stress matrix + operating guidance):** [`collector-limits.md`](collector-limits.md)
+- **Runtime-cost attribution path (baked-in/core/sampler/drop-path):** [`runtime-cost.md`](runtime-cost.md)

--- a/docs/collector-limits.md
+++ b/docs/collector-limits.md
@@ -13,6 +13,13 @@ In short:
 - `runtime-cost.md`: overhead attribution across fixed benchmark modes.
 - `collector-limits.md` (this page): sustained-load operating behavior, retention/truncation behavior, artifact/memory growth, and sampler density behavior under stress-shaped event volume.
 
+Use this distinction when choosing a measurement path:
+
+- Runtime overhead attribution -> `runtime-cost.md`
+- Sustained-load collector limits -> this page + `scripts/measure_collector_limits.py`
+- Artifact-size scaling under stress-shaped event volume -> this page
+- Memory-growth behavior under stress-shaped event volume -> this page
+
 ## Measurement path and methodology
 
 The measured path is:
@@ -22,6 +29,8 @@ The measured path is:
 3. **Output artifacts:**
    - Raw JSONL: `demos/collector_stress/artifacts/collector-limits-<profile>-raw.jsonl`
    - Summary JSON: `demos/collector_stress/artifacts/collector-limits-<profile>-summary.json`
+
+Treat this as the canonical collector-limits measurement path for issue #107.
 
 ### Workload shape and measured dimensions
 

--- a/docs/runtime-cost.md
+++ b/docs/runtime-cost.md
@@ -2,6 +2,9 @@
 
 This document covers the reproducible local benchmark path for tailtriage runtime-cost triage.
 
+It is intentionally focused on **runtime overhead attribution** for one shared scenario family.
+It is not the operating-limits path for sustained collector stress, artifact scaling, or memory-growth trend mapping; use [`collector-limits.md`](collector-limits.md) for those.
+
 ## Scenario family
 
 All measurements use the same shared request scenario (same request shape, concurrency model, and simulated work) so comparisons stay interpretable.

--- a/scripts/measure_collector_limits.py
+++ b/scripts/measure_collector_limits.py
@@ -613,11 +613,11 @@ def summarize(rows: list[dict[str, Any]], profile: str, selected_modes: tuple[st
         "collector_stress_signals": {
             "per_mode": mode_signals,
             "collector_bottleneck_indicators": [
-                "Throughput declines while p95 latency rises when moving from baseline_shape to high_concurrency.",
-                "Artifact growth jumps in heavy_event_shape relative to baseline_shape.",
-                "Memory peak RSS grows in longer_run relative to baseline_shape.",
-                "Sampler dense runs degrade throughput/latency versus sampler baseline.",
-                "limits_hit or dropped_* counters appear and persist across repeats/cases.",
+                "Look for throughput decline alongside p95 latency increase when moving baseline_shape -> high_concurrency.",
+                "Look for artifact-size growth in heavy_event_shape relative to baseline_shape.",
+                "Look for peak RSS growth in longer_run relative to baseline_shape.",
+                "Look for sampler_dense deltas versus sampler baseline; do not assume direction without measured output.",
+                "Look for limits_hit or persistent dropped_* counters across repeats/cases.",
             ],
         },
         "measurement_quality": {


### PR DESCRIPTION
### Motivation

- Make the new collector-stress measurement path discoverable and distinct from the runtime-cost attribution path so users choose the correct workflow for overhead attribution vs sustained-load limits analysis. 
- Remove wording that could conflate the two paths or imply cross-machine numeric guarantees or misattributed sampler cost.

### Description

- Updated top-level guidance and docs index to present `collector-limits` (stress/operating guidance) and `runtime-cost` (overhead attribution) as distinct measurement paths (`README.md`, `docs/README.md`).
- Scoped `docs/runtime-cost.md` explicitly to runtime overhead attribution and pointed readers to `collector-limits.md` for sustained-load, artifact-scaling, and memory-growth analysis.
- Strengthened `docs/collector-limits.md` to mark `demos/collector_stress` + `scripts/measure_collector_limits.py` as the canonical collector-limits path for issue #107 and clarified which questions each path answers.
- Tightened demo output wording in `demos/collector_stress/src/main.rs` to avoid cross-machine numeric guarantees and emphasize run-scoped validation.
- Reworded orchestration summary indicators in `scripts/measure_collector_limits.py` from assertive statements to observational guidance (e.g. changed to "Look for ..." and removed direction-assuming phrasing about sampler density).

### Testing

- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets --locked -- -D warnings` and the workspace checked cleanly with no warnings/failures.
- Ran `cargo test --workspace --locked` and all tests passed (unit and integration/demo smoke checks completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5ce60a1708330af3f0555428c9e64)