### PR TITLE
Add bounded artifact-scaling view to collector-limits path

### DIFF
--- a/docs/collector-limits.md
+++ b/docs/collector-limits.md
@@ -34,7 +34,7 @@ Treat this as the canonical collector-limits measurement path for issue #107.
 
 ### Workload shape and measured dimensions
 
-The default matrix now includes an explicit pressure progression, plus two orthogonal stress checks:
+The default matrix includes an explicit pressure progression, plus two orthogonal stress checks:
 
 1. `low_concurrency` (lower-pressure point)
 2. `baseline_shape` (mid-pressure reference)
@@ -44,6 +44,15 @@ The default matrix now includes an explicit pressure progression, plus two ortho
 6. `sampler_dense` (sampler-enabled modes only; cadence stress check)
 
 This keeps one coherent measurement path while making onset/range interpretation practical.
+
+To characterize artifact-size scaling before truncation dominates, there is also a bounded profile:
+
+- `--profile artifact_scaling`
+  - request-volume axis: `artifact_scale_volume_low` -> `artifact_scale_volume_mid` -> `artifact_scale_volume_high`
+  - event-density axis: `artifact_scale_density_low` -> `artifact_scale_density_mid` -> `artifact_scale_density_high`
+  - sampler cadence axis (sampler modes only): `artifact_scale_density_mid` -> `artifact_scale_sampler_dense`
+
+This profile intentionally uses bounded request counts and shorter duration so at least part of each progression can remain mostly unsaturated on many hosts, while still allowing later points to cross into truncation.
 
 Across supported modes:
 
@@ -79,6 +88,12 @@ From this path, we measure these dimensions directly:
    - first case where each dropped category becomes non-zero
    - first case where artifact growth crosses the configured threshold (currently +25% vs `baseline_shape`)
    - first case where memory growth crosses the configured threshold (currently +25% vs `baseline_shape`)
+6. **Derived artifact-scaling view** in `artifact_scaling`:
+   - `mode_comparisons` summarizes request-volume and event-density growth progression where scaling cases exist
+   - each point is labeled as:
+     - `mostly_unsaturated` (`limits_hit_runs == 0` and dropped means are zero), or
+     - `actively_truncated` (limits hit and/or dropped means non-zero)
+   - `growth_by_regime` separates data points by those two regimes
 
 ## Regime interpretation model (comfortable vs onset vs stressed)
 
@@ -113,6 +128,20 @@ Interpretation for this machine/run:
 - onset signals are still useful because they localize which retained categories begin dropping earliest;
 - this run supports practical onset-marker guidance, but does **not** provide a comfortable unsaturated bound for this mode on this host.
 
+## How to interpret artifact growth without over-claiming
+
+Artifact-size growth is directly interpretable when comparing points that are mostly unsaturated:
+
+- use `artifact_scaling.mode_comparisons.<mode>.<axis>.points[*].regime == "mostly_unsaturated"`
+- compare `artifact_size_bytes_mean` together with `requests_completed_mean`
+- keep conclusions scoped to the measured mode/axis/profile
+
+Artifact-size growth becomes potentially misleading once truncation is active:
+
+- if any compared point has `regime == "actively_truncated"`, raw artifact bytes can flatten or invert because dropped events cap retained output
+- in that regime, treat artifact-byte comparisons as lower-bound/retention-limited signals, not total-event-volume signals
+- rely on truncation context (`limits_hit_runs`, dropped counters) before claiming a growth trend
+
 ## What these results do **not** prove
 
 These measurements do **not** prove:
@@ -142,6 +171,12 @@ Default matrix:
 
 ```bash
 python3 scripts/measure_collector_limits.py --profile default
+```
+
+Bounded artifact-scaling matrix:
+
+```bash
+python3 scripts/measure_collector_limits.py --profile artifact_scaling
 ```
 
 Quick smoke matrix:

--- a/scripts/measure_collector_limits.py
+++ b/scripts/measure_collector_limits.py
@@ -28,6 +28,7 @@ SAMPLER_MODES: tuple[str, ...] = (
 )
 ONSET_ARTIFACT_GROWTH_THRESHOLD_PCT = 25.0
 ONSET_MEMORY_GROWTH_THRESHOLD_PCT = 25.0
+MOSTLY_UNSATURATED_DROPS_MAX = 0.0
 
 
 @dataclass(frozen=True)
@@ -157,6 +158,88 @@ SMOKE_CASES: tuple[Case, ...] = (
     ),
 )
 
+ARTIFACT_SCALING_CASES: tuple[Case, ...] = (
+    Case(
+        case_id="artifact_scale_volume_low",
+        description="Bounded lower-volume reference for artifact growth before truncation dominates.",
+        concurrency=24,
+        duration_secs=8,
+        queues_per_request=2,
+        stages_per_request=2,
+        inflight_cycles_per_request=2,
+        work_ms=1,
+        requests=300,
+    ),
+    Case(
+        case_id="artifact_scale_volume_mid",
+        description="Bounded mid-volume point on same event shape for request-volume growth.",
+        concurrency=24,
+        duration_secs=8,
+        queues_per_request=2,
+        stages_per_request=2,
+        inflight_cycles_per_request=2,
+        work_ms=1,
+        requests=800,
+    ),
+    Case(
+        case_id="artifact_scale_volume_high",
+        description="Bounded higher-volume point to capture growth near truncation onset.",
+        concurrency=24,
+        duration_secs=8,
+        queues_per_request=2,
+        stages_per_request=2,
+        inflight_cycles_per_request=2,
+        work_ms=1,
+        requests=1400,
+    ),
+    Case(
+        case_id="artifact_scale_density_low",
+        description="Bounded low-density event shape for event-density artifact scaling.",
+        concurrency=24,
+        duration_secs=8,
+        queues_per_request=2,
+        stages_per_request=2,
+        inflight_cycles_per_request=2,
+        work_ms=1,
+        requests=800,
+    ),
+    Case(
+        case_id="artifact_scale_density_mid",
+        description="Bounded mid-density event shape for event-density artifact scaling.",
+        concurrency=24,
+        duration_secs=8,
+        queues_per_request=4,
+        stages_per_request=4,
+        inflight_cycles_per_request=5,
+        work_ms=1,
+        requests=800,
+    ),
+    Case(
+        case_id="artifact_scale_density_high",
+        description="Bounded high-density event shape to expose growth where truncation may become active.",
+        concurrency=24,
+        duration_secs=8,
+        queues_per_request=7,
+        stages_per_request=7,
+        inflight_cycles_per_request=9,
+        work_ms=1,
+        requests=800,
+    ),
+    Case(
+        case_id="artifact_scale_sampler_dense",
+        description="Bounded denser sampler cadence check for sampler-enabled modes in scaling path.",
+        concurrency=24,
+        duration_secs=8,
+        queues_per_request=2,
+        stages_per_request=2,
+        inflight_cycles_per_request=2,
+        work_ms=1,
+        requests=800,
+        sampler_interval_ms=30,
+        modes=SAMPLER_MODES,
+    ),
+)
+
 
 def parse_args() -> argparse.Namespace:
     root_dir = Path(__file__).resolve().parent.parent
@@ -168,9 +251,9 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--profile",
-        choices=("default", "smoke"),
+        choices=("default", "smoke", "artifact_scaling"),
         default="default",
-        help="default runs the full documented matrix; smoke runs a bounded quick matrix for CI/dev checks.",
+        help="default runs the full documented matrix; smoke runs a bounded quick matrix for CI/dev checks; artifact_scaling runs a bounded artifact-growth matrix.",
     )
     parser.add_argument(
         "--repeats",
@@ -354,6 +437,18 @@ def pct_delta(base: float | None, observed: float | None) -> float | None:
     if base is None or observed is None or base == 0:
         return None
     return ((observed - base) / base) * 100.0
+
+
+def is_mostly_unsaturated(summary: dict[str, Any]) -> bool:
+    trunc = summary["truncation"]
+    return (
+        trunc["limits_hit_runs"] == 0
+        and (trunc["dropped_requests"]["mean"] or 0.0) <= MOSTLY_UNSATURATED_DROPS_MAX
+        and (trunc["dropped_stages"]["mean"] or 0.0) <= MOSTLY_UNSATURATED_DROPS_MAX
+        and (trunc["dropped_queues"]["mean"] or 0.0) <= MOSTLY_UNSATURATED_DROPS_MAX
+        and (trunc["dropped_inflight_snapshots"]["mean"] or 0.0) <= MOSTLY_UNSATURATED_DROPS_MAX
+        and (trunc["dropped_runtime_snapshots"]["mean"] or 0.0) <= MOSTLY_UNSATURATED_DROPS_MAX
+    )
 
 
 def signal_for_mode(summary_by_case_mode: dict[str, Any], mode: str) -> dict[str, Any]:
@@ -684,6 +779,91 @@ def summarize(rows: list[dict[str, Any]], profile: str, selected_modes: tuple[st
             "dense_sampler_cadence_ms": dense["sampler_settings"].get("cli_interval_ms_override") if dense["sampler_settings"] else None,
         }
 
+    artifact_scaling_case_groups = {
+        "request_volume": [
+            "artifact_scale_volume_low",
+            "artifact_scale_volume_mid",
+            "artifact_scale_volume_high",
+        ],
+        "event_density": [
+            "artifact_scale_density_low",
+            "artifact_scale_density_mid",
+            "artifact_scale_density_high",
+        ],
+    }
+
+    artifact_scaling_summary: dict[str, Any] = {
+        "modes_with_scaling_cases": [],
+        "mode_comparisons": {},
+        "growth_by_regime": {
+            "mostly_unsaturated": [],
+            "actively_truncated": [],
+        },
+        "regime_definition": {
+            "mostly_unsaturated": "limits_hit_runs == 0 and all dropped_* means are 0",
+            "actively_truncated": "limits_hit_runs > 0 or any dropped_* mean > 0",
+        },
+    }
+
+    for mode in selected_modes:
+        mode_summary: dict[str, Any] = {}
+        for axis, case_ids in artifact_scaling_case_groups.items():
+            available = [by_case_mode.get(f"{case_id}::{mode}") for case_id in case_ids]
+            available = [entry for entry in available if entry is not None]
+            if len(available) < 2:
+                continue
+
+            artifact_values = [
+                entry["artifact_size"]["size_bytes_measured_by_script"]["mean"]
+                for entry in available
+            ]
+            if any(value is None for value in artifact_values):
+                continue
+
+            case_points = []
+            for entry in available:
+                case_points.append(
+                    {
+                        "case_id": entry["case_id"],
+                        "artifact_size_bytes_mean": entry["artifact_size"]["size_bytes_measured_by_script"]["mean"],
+                        "requests_completed_mean": entry["absolute_metrics"]["requests_completed"]["mean"],
+                        "limits_hit_runs": entry["truncation"]["limits_hit_runs"],
+                        "dropped_means": {
+                            "dropped_requests": entry["truncation"]["dropped_requests"]["mean"],
+                            "dropped_stages": entry["truncation"]["dropped_stages"]["mean"],
+                            "dropped_queues": entry["truncation"]["dropped_queues"]["mean"],
+                            "dropped_inflight_snapshots": entry["truncation"]["dropped_inflight_snapshots"]["mean"],
+                            "dropped_runtime_snapshots": entry["truncation"]["dropped_runtime_snapshots"]["mean"],
+                        },
+                        "regime": "mostly_unsaturated" if is_mostly_unsaturated(entry) else "actively_truncated",
+                    }
+                )
+
+            first = case_points[0]
+            last = case_points[-1]
+            mode_summary[axis] = {
+                "case_ids": [point["case_id"] for point in case_points],
+                "artifact_growth_first_to_last_pct": pct_delta(
+                    first["artifact_size_bytes_mean"], last["artifact_size_bytes_mean"]
+                ),
+                "points": case_points,
+            }
+
+            for point in case_points:
+                artifact_scaling_summary["growth_by_regime"][point["regime"]].append(
+                    {
+                        "mode": mode,
+                        "axis": axis,
+                        "case_id": point["case_id"],
+                        "artifact_size_bytes_mean": point["artifact_size_bytes_mean"],
+                        "requests_completed_mean": point["requests_completed_mean"],
+                    }
+                )
+
+        if mode_summary:
+            artifact_scaling_summary["modes_with_scaling_cases"].append(mode)
+            artifact_scaling_summary["mode_comparisons"][mode] = mode_summary
+
     mode_signals = [signal_for_mode(by_case_mode, mode) for mode in selected_modes]
     onset_markers = [onset_markers_for_mode(by_case_mode, mode) for mode in selected_modes]
 
@@ -767,6 +947,7 @@ def summarize(rows: list[dict[str, Any]], profile: str, selected_modes: tuple[st
                 "sections": [
                     "absolute metrics",
                     "artifact size summaries",
+                    "artifact scaling by request volume/event density and truncation regime",
                     "memory summaries",
                     "truncation context",
                     "metadata and caveats",
@@ -781,6 +962,7 @@ def summarize(rows: list[dict[str, Any]], profile: str, selected_modes: tuple[st
         },
         "cases_by_mode": by_case_mode,
         "sampler_density_impact": sampler_density_impact,
+        "artifact_scaling": artifact_scaling_summary,
         "collector_stress_signals": {
             "per_mode": mode_signals,
             "collector_bottleneck_indicators": [
@@ -817,7 +999,12 @@ def main() -> None:
     artifact_dir.mkdir(parents=True, exist_ok=True)
 
     selected_modes = parse_modes(args.modes)
-    profile_cases = DEFAULT_CASES if args.profile == "default" else SMOKE_CASES
+    if args.profile == "default":
+        profile_cases = DEFAULT_CASES
+    elif args.profile == "smoke":
+        profile_cases = SMOKE_CASES
+    else:
+        profile_cases = ARTIFACT_SCALING_CASES
 
     cases = tuple(
         Case(**{**case.__dict__, "modes": tuple(mode for mode in case.modes if mode in selected_modes)})


### PR DESCRIPTION
### Motivation

- Artifact-size scaling under stress was hard to interpret once truncation started, so we need a bounded sub-path that yields interpretable growth before truncation dominates.  
- The change must stay inside the existing collector-limits measurement path and summary model and must not alter collector capture semantics.  

### Description

- Add a new `--profile artifact_scaling` to `scripts/measure_collector_limits.py` and a bounded case family `ARTIFACT_SCALING_CASES` with request-volume and event-density progressions plus a bounded sampler-dense case for sampler-enabled modes.  
- Add `MOSTLY_UNSATURATED_DROPS_MAX` and `is_mostly_unsaturated()` and derive `artifact_scaling` summary output that: classifies each scaling point as `mostly_unsaturated` vs `actively_truncated`, computes `artifact_growth_first_to_last_pct` per axis, and splits points into `growth_by_regime` and `mode_comparisons`.  
- Wire the new summary section into the existing `summary` JSON, extend the documented `summary_format` sections, and update `docs/collector-limits.md` with the new profile, interpretation guidance, and explicit cautions about when truncation makes artifact-size comparisons misleading.  
- The collector capture/retention semantics were not changed; this only adds bounded measurement cases and conservative, regime-aware derived fields and docs; the new profile is intended to show artifact growth where at least part of the progression remains mostly unsaturated.  
- New artifact-scaling profile summary (implemented and documented): `artifact_scaling` contains `mode_comparisons` for `request_volume` and `event_density` axes and a `growth_by_regime` split that enables defensible comparisons when points are `mostly_unsaturated`.  
- Defensible artifact-growth statements enabled by this change: comparisons across request-volume and event-density where points are labeled `mostly_unsaturated` (the `artifact_scaling` output now surfaces these).  
- Still-not-defensible claims: growth trends in `actively_truncated` regimes and any universal/cross-machine extrapolations remain non-defensible and must be treated as lower-bound/retention-limited signals.  

### Testing

- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, and `cargo test --workspace --locked`, all of which completed successfully.  
- Executed the measurement checks: `python3 scripts/measure_collector_limits.py --profile smoke` and `python3 scripts/measure_collector_limits.py --profile artifact_scaling`, and inspected generated summary artifacts (the `artifact_scaling` summary showed `modes_with_scaling_cases` populated and `growth_by_regime` separating `mostly_unsaturated` points).  
- No collector code paths or capture semantics were modified, and all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5d6b9ecf083309c7bb977df707616)