### PR TITLE
ci: add bounded collector-limits smoke coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,18 @@ jobs:
       - name: Smoke-check external crates.io consumer adoption flow
         if: matrix.profile == 'release'
         run: python3 scripts/smoke_external_consumer.py
-        
+
+      - name: Measure collector limits (smoke)
+        if: matrix.profile == 'release'
+        run: python3 scripts/measure_collector_limits.py --profile smoke
+
+      - name: Validate collector limits smoke outputs
+        if: matrix.profile == 'release'
+        run: |
+          python3 scripts/validate_collector_limits_summary.py \
+            --raw demos/collector_stress/artifacts/collector-limits-smoke-raw.jsonl \
+            --summary demos/collector_stress/artifacts/collector-limits-smoke-summary.json
+
       - name: Check demo fixture drift
         if: matrix.profile == 'dev'
         run: python3 scripts/check_demo_fixture_drift.py --profile ${{ matrix.profile }}

--- a/scripts/tests/test_validate_collector_limits_summary.py
+++ b/scripts/tests/test_validate_collector_limits_summary.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Tests for collector-limits smoke summary structural validation."""
+
+from __future__ import annotations
+
+import unittest
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import validate_collector_limits_summary  # noqa: E402
+
+
+class ValidateCollectorLimitsSummaryTests(unittest.TestCase):
+    def test_accepts_summary_with_required_shape(self) -> None:
+        summary = {
+            "measurement_kind": "collector_limits",
+            "profile": "smoke",
+            "default_matrix": [
+                {"case_id": "smoke_baseline_shape"},
+                {"case_id": "smoke_sampler_dense"},
+            ],
+            "cases_by_mode": {},
+            "collector_stress_signals": {},
+            "collector_pressure_onset_markers": {},
+            "measurement_quality": {},
+        }
+
+        validate_collector_limits_summary.validate_summary_shape(summary)
+
+    def test_rejects_summary_missing_sampler_dense_case(self) -> None:
+        summary = {
+            "measurement_kind": "collector_limits",
+            "profile": "smoke",
+            "default_matrix": [{"case_id": "smoke_baseline_shape"}],
+            "cases_by_mode": {},
+            "collector_stress_signals": {},
+            "collector_pressure_onset_markers": {},
+            "measurement_quality": {},
+        }
+
+        with self.assertRaises(ValueError):
+            validate_collector_limits_summary.validate_summary_shape(summary)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_collector_limits_summary.py
+++ b/scripts/validate_collector_limits_summary.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Lightweight structural validation for collector-limits smoke artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+REQUIRED_TOP_LEVEL_KEYS = (
+    "measurement_kind",
+    "profile",
+    "default_matrix",
+    "cases_by_mode",
+    "collector_stress_signals",
+    "collector_pressure_onset_markers",
+    "measurement_quality",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate collector-limits smoke summary shape (structural only)."
+    )
+    parser.add_argument("--raw", type=Path, required=True, help="Path to raw JSONL output.")
+    parser.add_argument("--summary", type=Path, required=True, help="Path to summary JSON output.")
+    return parser.parse_args()
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} did not contain a top-level JSON object")
+    return value
+
+
+def validate_raw_exists(raw_path: Path) -> None:
+    if not raw_path.is_file():
+        raise FileNotFoundError(f"raw JSONL output not found: {raw_path}")
+    lines = [line for line in raw_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    if not lines:
+        raise ValueError(f"raw JSONL output is empty: {raw_path}")
+    for index, line in enumerate(lines, start=1):
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"raw JSONL line {index} is not valid JSON: {exc}") from exc
+        if not isinstance(parsed, dict):
+            raise ValueError(f"raw JSONL line {index} is not a JSON object")
+
+
+def validate_summary_shape(summary: dict[str, Any]) -> None:
+    missing = [key for key in REQUIRED_TOP_LEVEL_KEYS if key not in summary]
+    if missing:
+        raise ValueError(f"summary JSON missing top-level keys: {missing}")
+
+    matrix = summary.get("default_matrix")
+    if not isinstance(matrix, list) or not matrix:
+        raise ValueError("summary JSON must include a non-empty default_matrix list")
+
+    case_ids = []
+    for case in matrix:
+        if isinstance(case, dict):
+            case_id = case.get("case_id")
+            if isinstance(case_id, str):
+                case_ids.append(case_id)
+
+    if not any("baseline" in case_id for case_id in case_ids):
+        raise ValueError("expected at least one baseline case in default_matrix.case_id")
+    if not any("sampler_dense" in case_id for case_id in case_ids):
+        raise ValueError("expected at least one sampler-density case in default_matrix.case_id")
+
+
+def main() -> int:
+    args = parse_args()
+    validate_raw_exists(args.raw)
+    summary = _load_json(args.summary)
+    validate_summary_shape(summary)
+    print("collector-limits smoke artifacts validated successfully")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Provide lightweight, non-flaky CI coverage for the new collector-limits measurement path for issue #107 without turning CI into a heavy perf lab. 
- Ensure the smoke run is bounded and guarded so CI runtime stays reasonable by running only a small matrix and avoiding numeric pass/fail thresholds. 

### Description
- Add a release-only CI step to run the bounded smoke matrix with `python3 scripts/measure_collector_limits.py --profile smoke` in `.github/workflows/ci.yml`. 
- Add a release-only structural validation step that invokes a new helper script rather than embedding complex shell logic in YAML. 
- Add `scripts/validate_collector_limits_summary.py` which verifies raw JSONL presence/parsing, summary JSON presence/parsing, required top-level sections, and that `default_matrix` contains at least one baseline and one sampler-density case; checks are structural only and avoid performance thresholds. 
- Add unit tests `scripts/tests/test_validate_collector_limits_summary.py` covering accepted and rejected summary shapes. 

### Testing
- Ran `cargo fmt --check` and it passed. 
- Ran `cargo clippy --workspace --all-targets --locked -- -D warnings` and it passed. 
- Ran `cargo test --workspace --locked` and all Rust tests passed. 
- Ran Python unit tests `python3 -m unittest scripts.tests.test_validate_collector_limits_summary` and they passed. 
- Performed a local smoke run `python3 scripts/measure_collector_limits.py --profile smoke` and validated outputs with `python3 scripts/validate_collector_limits_summary.py --raw demos/collector_stress/artifacts/collector-limits-smoke-raw.jsonl --summary demos/collector_stress/artifacts/collector-limits-smoke-summary.json`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5e23cdf888330b20c956f10db57da)