### PR TITLE
ci: add collector-limits Python unit tests to release CI path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,10 @@ jobs:
             --raw demos/collector_stress/artifacts/collector-limits-smoke-raw.jsonl \
             --summary demos/collector_stress/artifacts/collector-limits-smoke-summary.json
 
+      - name: Validate collector limits summary helper unit tests
+        if: matrix.profile == 'release'
+        run: python3 -m unittest scripts.tests.test_measure_collector_limits
+
       - name: Check demo fixture drift
         if: matrix.profile == 'dev'
         run: python3 scripts/check_demo_fixture_drift.py --profile ${{ matrix.profile }}


### PR DESCRIPTION
### Motivation
- Close a CI coverage gap by executing the existing deterministic Python summary-helper unit tests for the collector-limits path alongside the existing smoke and structural validation steps so the release CI validates both end-to-end artifacts and the summary helper logic.

### Description
- Add a release-only step to `.github/workflows/ci.yml` that runs `python3 -m unittest scripts.tests.test_measure_collector_limits` placed next to the existing `measure_collector_limits.py --profile smoke` and `validate_collector_limits_summary.py` steps, leaving those smoke and validation steps unchanged.

### Testing
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, and `cargo test --workspace --locked`, and executed `python3 -m unittest scripts.tests.test_measure_collector_limits`, all of which completed successfully.
- Final collector-limits CI coverage stack is: (1) smoke run via `python3 scripts/measure_collector_limits.py --profile smoke`, (2) structural output validation via `python3 scripts/validate_collector_limits_summary.py`, and (3) Python summary-helper unit tests via `python3 -m unittest scripts.tests.test_measure_collector_limits`; this remains non-flaky because the unit tests use the Python standard library only, contain no timing or numeric performance assertions, and the new step reuses existing deterministic tests with minimal runtime impact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5eb91738c8330a74b29ecd4481eee)