### PR TITLE
docs: document live arm/disarm controller lifecycle and boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Use crates.io when adopting `tailtriage` in an external project:
 cargo add tailtriage-core
 cargo add tailtriage-tokio # optional, for RuntimeSampler and runtime-pressure evidence
 cargo add tailtriage-axum # optional, only for axum middleware/extractor ergonomics
+cargo add tailtriage-controller # optional, for live arm/disarm bounded capture windows
 cargo install tailtriage-cli
 ```
 
@@ -243,6 +244,7 @@ Use workspace/source onboarding for repository examples and contributor workflow
 
 - Docs index: [`docs/README.md`](docs/README.md)
 - Detailed onboarding and lifecycle rules: [`docs/user-guide.md`](docs/user-guide.md)
+- Live arm/disarm controller usage and config semantics: [`tailtriage-controller/README.md`](tailtriage-controller/README.md)
 - Runtime-cost categories and benchmark interpretation: [`docs/runtime-cost.md`](docs/runtime-cost.md)
 - Demo walkthrough and CI coverage details: [`docs/getting-started-demo.md`](docs/getting-started-demo.md)
 - Diagnostics field contract and interpretation: [`docs/diagnostics.md`](docs/diagnostics.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 - **Fastest first run from this repo:** [`user-guide.md#path-a--run-from-this-repo-workspace`](user-guide.md#path-a--run-from-this-repo-workspace)
 - **Use published crates in external projects:** [`user-guide.md#path-b--use-published-crates-from-cratesio`](user-guide.md#path-b--use-published-crates-from-cratesio)
 - **Split lifecycle API contract (`StartedRequest`, `RequestHandle`, `RequestCompletion`):** [`user-guide.md#request-lifecycle-correctness-required`](user-guide.md#request-lifecycle-correctness-required)
+- **Live arm/disarm controller guide:** [`../tailtriage-controller/README.md`](../tailtriage-controller/README.md)
 - **Axum adapter usage (`TailtriageRequest` + middleware):** [`user-guide.md#axum-adapter-surface-optional`](user-guide.md#axum-adapter-surface-optional)
 - **Public examples:** [`../tailtriage-tokio/examples/`](../tailtriage-tokio/examples/) and [`../tailtriage-axum/examples/`](../tailtriage-axum/examples/)
 - **Demo walkthrough and recommended first three demos:** [`getting-started-demo.md`](getting-started-demo.md)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -82,6 +82,17 @@ async fn helper_a(req: &tailtriage_core::RequestHandle<'_>) -> Result<(), MyErro
 - unfinished requests are surfaced in run metadata warnings and unfinished-request samples.
 - `strict_lifecycle(true)` makes `shutdown()` return an error when unfinished requests remain.
 
+## Live arm/disarm controller (optional)
+
+Use direct `Tailtriage::builder(...)` for the standard single-run lifecycle.
+
+Use `tailtriage-controller` only when you need repeated enable/disable triage windows in one
+long-lived process. Its controller surface keeps disabled/closing request calls non-branching via
+inert wrappers, and applies config reloads only to later activations (not to already-active runs).
+
+See [`../tailtriage-controller/README.md`](../tailtriage-controller/README.md) for lifecycle,
+generation isolation, TOML shape, and reload semantics.
+
 ## RuntimeSampler (optional stronger attribution)
 
 `CaptureMode` in core sets retention defaults only. It does not auto-enable `RuntimeSampler`.

--- a/tailtriage-controller/README.md
+++ b/tailtriage-controller/README.md
@@ -16,6 +16,31 @@ This crate provides:
 - run-end policy modeling
 - controller-owned inert request wrappers for disabled/closing periods
 
+## When to use the controller vs `Tailtriage::builder(...)`
+
+Use ordinary `tailtriage-core` builder usage when you want one process-scoped run lifecycle:
+
+- build one `Tailtriage`
+- run workload
+- call `shutdown()`
+
+Use `tailtriage-controller` when your service should stay up while you repeatedly arm/disarm
+bounded capture runs for triage windows.
+
+The controller is a control layer on top of core; it does not replace direct builder usage.
+
+## Live controller semantics
+
+- At most one active generation can exist at a time.
+- `enable()` starts a fresh generation with its own run ID/artifact path.
+- `disable()` stops new admissions for that generation.
+  - If no admitted requests remain, finalize now.
+  - If admitted requests are still in flight, generation enters closing state and finalizes after drain.
+- Requests admitted into a generation remain bound to that generation for completion.
+  - They do not migrate into later generations during disable/re-enable churn.
+- Requests started while disabled/closing are inert controller-owned wrappers and are never later
+  attached to a new generation.
+
 ## Minimal usage
 
 ```rust
@@ -37,10 +62,54 @@ let _ = controller.disable()?;
 # }
 ```
 
+### Disabled-path expectations
+
 When the controller is disabled (or an active generation is closing), `begin_request(...)`
 and `begin_request_with(...)` still return request tokens with the same non-branching
-ergonomics, but those tokens are inert/no-op wrappers owned by this crate. They do not
-interact with `tailtriage-core` state until a generation is actively admitting requests.
+ergonomics, but those tokens are inert/no-op wrappers owned by this crate.
+
+- queue/stage/inflight wrappers are no-op
+- completion methods are no-op lifecycle markers on the inert wrapper
+- inert requests do not write capture events and do not join later generations
+
+This path is intended to be cheap and predictable, but users should still validate overhead in
+their own workload/environment.
+
+## Enable/disable/reload/status snippet
+
+```rust
+use tailtriage_controller::TailtriageController;
+
+fn controller_demo() -> Result<(), Box<dyn std::error::Error>> {
+    let controller = TailtriageController::builder("checkout-service")
+        .output("tailtriage-run.json")
+        .config_path("tailtriage-controller.toml")
+        .initially_enabled(false)
+        .build()?;
+
+    // Arm one bounded generation.
+    let active = controller.enable()?;
+
+    let started = controller.begin_request("/checkout");
+    started.completion.finish_ok();
+
+    // Status reports template + generation snapshot.
+    let _status_during_run = controller.status();
+
+    // Disarm (finalizes immediately or after in-flight drain).
+    let _disable = controller.disable()?;
+
+    // Reload updates template for NEXT activation only.
+    controller.reload_config()?;
+    let _status_after_reload = controller.status();
+
+    // Next enable uses reloaded template.
+    let _next = controller.enable()?;
+
+    # let _ = active;
+    # Ok(())
+    # }
+```
 
 ## TOML config and manual reload
 
@@ -87,3 +156,20 @@ Reload in v1 is explicit and manual:
 - Reload updates only the controller template for **future** activations.
 - If a generation is already active, that generation keeps the exact activation config it started with.
 - The reloaded template is applied the next time `enable()` starts a new generation.
+
+### Run-end policy behavior on limits hit
+
+`[controller.activation.run_end_policy]` controls what happens when capture limits are hit:
+
+- `kind = "manual"`: keep the generation active; additional data can be dropped after saturation
+  until manual disarm/shutdown.
+- `kind = "max_requests"` / `kind = "max_duration_ms"` / `kind = "first_limit_hit"`: controller
+  auto-seals the generation according to the chosen threshold/condition.
+
+## What this feature does not do
+
+- Does **not** mutate an already-active generation when config is reloaded.
+- Does **not** move admitted requests between generations.
+- Does **not** auto-prove root cause; it preserves the same evidence-ranked suspect model.
+- Does **not** force runtime sampling by default; sampler startup is still explicit via
+  `enabled_for_armed_runs`.


### PR DESCRIPTION
### Motivation

- Make the live arm/disarm controller discoverable and unambiguous for users and contributors by clearly explaining its purpose, when to use it vs direct `Tailtriage` builder usage, and its operational boundaries. 
- Prevent incorrect mental models by documenting disabled-path expectations, generation/run semantics, config reload behavior, run-end policy choices, and explicit non-goals so adopters do not overclaim sampler or migration behavior.

### Description

- Expanded `tailtriage-controller/README.md` to document the controller purpose, one-active-generation invariant, disabled-path inert wrapper semantics, admission/drain finalization behavior, generation binding for admitted requests, TOML activation template shape, reload semantics (template applies only to future activations), run-end policy behavior on limits hit, and explicit non-goals. 
- Added a compact usage snippet (create controller, `enable()`, `begin_request()`, `disable()`, `reload_config()`, `status()`) showing the primary non-branching API surface and typical workflow. 
- Updated top-level discovery so users can find controller docs from `README.md` and `docs/README.md`, and added a short pointer in `docs/user-guide.md` that preserves the existing single-run `Tailtriage::builder(...)` guidance for non-controller usage. 

### Testing

- Ran `cargo fmt --check` which succeeded. 
- Ran `cargo clippy --workspace --all-targets --locked -- -D warnings` which completed with no warnings. 
- Ran `cargo test --workspace --locked` which completed and all tests passed, including controller unit tests verifying reload-next-only, disabled inert path, generation isolation, and run-end policies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e638dd8a688330ab292b30273ab7bb)