### PR TITLE
Add controller public example and release smoke coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,10 @@ jobs:
         if: matrix.profile == 'release'
         run: python3 scripts/smoke_external_consumer.py
 
+      - name: Smoke-check controller public example
+        if: matrix.profile == 'release'
+        run: python3 scripts/smoke_controller_example.py
+
       - name: Measure collector limits (smoke)
         if: matrix.profile == 'release'
         run: python3 scripts/measure_collector_limits.py --profile smoke

--- a/scripts/smoke_controller_example.py
+++ b/scripts/smoke_controller_example.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Smoke-check the controller public adoption example.
+
+Validation steps:
+1) run the controller example in release mode
+2) verify artifact exists
+3) verify artifact has expected top-level schema keys
+4) verify artifact recorded exactly one request
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+EXPECTED_RUN_TOP_LEVEL_KEYS = {
+    "schema_version",
+    "metadata",
+    "requests",
+    "stages",
+    "queues",
+    "inflight",
+    "runtime_snapshots",
+    "truncation",
+}
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def run_cmd(cmd: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def assert_keys(payload: dict, expected: set[str], *, context: str) -> None:
+    missing = sorted(expected - set(payload.keys()))
+    if missing:
+        missing_list = ", ".join(missing)
+        raise SystemExit(f"{context} missing top-level keys: {missing_list}")
+
+
+def main() -> None:
+    root = repo_root()
+    print("Smoke-checking controller public example...")
+
+    with tempfile.TemporaryDirectory(prefix="tailtriage-controller-example-smoke-") as temp_dir:
+        working_dir = Path(temp_dir)
+
+        run_cmd(
+            [
+                "cargo",
+                "run",
+                "--quiet",
+                "--release",
+                "--manifest-path",
+                str(root / "tailtriage-controller/Cargo.toml"),
+                "--example",
+                "controller_minimal",
+            ],
+            cwd=working_dir,
+        )
+
+        artifacts = sorted(working_dir.glob("tailtriage-run-generation-*.json"))
+
+        if len(artifacts) != 1:
+            raise SystemExit(
+                "controller example should create exactly one generation artifact, "
+                f"found {len(artifacts)}"
+            )
+
+        artifact_path = artifacts[0]
+        run_payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+        if not isinstance(run_payload, dict):
+            raise SystemExit("controller example artifact is not a JSON object")
+
+        assert_keys(
+            run_payload,
+            EXPECTED_RUN_TOP_LEVEL_KEYS,
+            context="controller example run artifact",
+        )
+
+        requests = run_payload.get("requests")
+        if not isinstance(requests, list):
+            raise SystemExit("controller example artifact 'requests' field is not an array")
+        if len(requests) != 1:
+            raise SystemExit(
+                "controller example should emit exactly one request, "
+                f"found {len(requests)}"
+            )
+
+        print("validated: tailtriage-controller::controller_minimal")
+        print(f"  artifact: {artifact_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tailtriage-controller/README.md
+++ b/tailtriage-controller/README.md
@@ -62,6 +62,8 @@ let _ = controller.disable()?;
 # }
 ```
 
+Runnable version: `cargo run -p tailtriage-controller --example controller_minimal`.
+
 ### Disabled-path expectations
 
 When the controller is disabled (or an active generation is closing), `begin_request(...)`

--- a/tailtriage-controller/examples/controller_minimal.rs
+++ b/tailtriage-controller/examples/controller_minimal.rs
@@ -1,0 +1,22 @@
+use tailtriage_controller::TailtriageController;
+use tailtriage_core::CaptureLimitsOverride;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let artifact_template = "tailtriage-run.json";
+    let controller = TailtriageController::builder("controller-minimal")
+        .output(artifact_template)
+        .capture_limits_override(CaptureLimitsOverride {
+            max_requests: Some(8),
+            ..CaptureLimitsOverride::default()
+        })
+        .build()?;
+
+    controller.enable()?;
+    let started = controller.begin_request("/checkout");
+    started.completion.finish_ok();
+    let _disable = controller.disable()?;
+
+    println!("Wrote tailtriage-run-generation-1.json");
+    println!("This example records exactly one request before disable().");
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Provide a tiny, deterministic end-to-end public example for the controller adoption path so users can exercise the main enable/begin/finish/disable flow without reading tests. 
- Harden CI coverage for the controller path with a low-cost smoke check that exercises the public example in a bounded way. 

### Description

- Add a minimal public example `tailtriage-controller/examples/controller_minimal.rs` that builds a `TailtriageController`, `enable()`s a generation, `begin_request(...)`, calls `finish_ok()` on the completion, and `disable()`s, producing one generation artifact. 
- Add `scripts/smoke_controller_example.py`, a release-mode smoke script that runs the example in a temporary directory, verifies one `tailtriage-run-generation-*.json` artifact was produced, asserts the artifact top-level schema keys, and checks exactly one request was recorded. 
- Wire the smoke script into CI by adding a `Smoke-check controller public example` step to `.github/workflows/ci.yml` that runs only in the `release` matrix profile. 
- Add a short README pointer in `tailtriage-controller/README.md` to show the runnable example command. 

### Testing

- Ran `cargo fmt --check` and it passed. 
- Ran `cargo clippy --workspace --all-targets --locked -- -D warnings` and it passed. 
- Ran `cargo test --workspace --locked` and the full test suite passed. 
- Executed `python3 scripts/smoke_controller_example.py` which successfully ran the example in a temp directory, validated the artifact structure, and confirmed exactly one request was emitted.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e63cbb7b7c83308e5dd28b64192f6e)