### PR TITLE
Add official `tailtriage` facade crate and wire into workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,6 +754,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "tailtriage"
+version = "0.1.1"
+dependencies = [
+ "tailtriage-axum",
+ "tailtriage-controller",
+ "tailtriage-core",
+ "tailtriage-tokio",
+]
+
+[[package]]
 name = "tailtriage-axum"
 version = "0.1.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+  "tailtriage",
   "tailtriage-core",
   "tailtriage-controller",
   "tailtriage-tokio",
@@ -35,7 +36,9 @@ all = "warn"
 pedantic = "warn"
 
 [workspace.dependencies]
+tailtriage = { version = "0.1.1", path = "tailtriage" }
 tailtriage-core = { version = "0.1.1", path = "tailtriage-core" }
 tailtriage-controller = { version = "0.1.1", path = "tailtriage-controller" }
 tailtriage-tokio = { version = "0.1.1", path = "tailtriage-tokio" }
+tailtriage-axum = { version = "0.1.1", path = "tailtriage-axum" }
 demo-support = { version = "0.1.1", path = "demos/demo_support" }

--- a/README.md
+++ b/README.md
@@ -34,11 +34,19 @@ cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
 Use crates.io when adopting `tailtriage` in an external project:
 
 ```bash
-cargo add tailtriage-core
-cargo add tailtriage-tokio # optional, for RuntimeSampler and runtime-pressure evidence
-cargo add tailtriage-axum # optional, only for axum middleware/extractor ergonomics
-cargo add tailtriage-controller # optional, for live arm/disarm bounded capture windows
+cargo add tailtriage
+cargo add tailtriage --features tokio # optional runtime-pressure evidence
+cargo add tailtriage --features "tokio,axum" # optional axum + runtime integrations
 cargo install tailtriage-cli
+```
+
+For tighter dependency control, you can still add focused crates directly:
+
+```bash
+cargo add tailtriage-core
+cargo add tailtriage-controller # optional, enabled by default in facade
+cargo add tailtriage-tokio # optional
+cargo add tailtriage-axum # optional
 ```
 
 ## What you get from the output
@@ -124,7 +132,7 @@ Demo walkthrough and CI coverage details: [`docs/getting-started-demo.md`](docs/
 | User type                                         | Recommendation                                                               |
 | ------------------------------------------------- | ---------------------------------------------------------------------------- |
 | “I just want to try it”                           | Run workspace examples + workspace CLI from source                           |
-| “I have a Tokio service”                          | Start with `tailtriage-core`; add `tailtriage-cli` for analysis              |
+| “I have a Tokio service”                          | Start with `tailtriage`; add `tailtriage-cli` for analysis                   |
 | “I need executor vs blocking evidence”            | Add `tailtriage-tokio`                                                       |
 | “I use axum”                                      | Add `tailtriage-axum`; add `tailtriage-tokio` only if runtime snapshots help |
 | “I only need to read artifacts from CI/incidents” | Install `tailtriage-cli` only                                                |
@@ -133,6 +141,7 @@ Demo walkthrough and CI coverage details: [`docs/getting-started-demo.md`](docs/
 
 | Goal                                                            | Add these crates                                         | Optional                             | Why                                                                                                                        |
 | --------------------------------------------------------------- | -------------------------------------------------------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| Simplest canonical onboarding                                   | `tailtriage`                                             | `tailtriage-cli`                     | Facade re-exports `tailtriage-core` and includes controller convenience by default while keeping integrations feature-gated |
 | Instrument a Tokio service, no runtime snapshots                | `tailtriage-core`                                        | `tailtriage-cli`                     | Core request/queue/stage/inflight instrumentation and JSON artifact writing live in `tailtriage-core`                      |
 | Instrument a Tokio service and capture runtime pressure signals | `tailtriage-core`, `tailtriage-tokio`                    | `tailtriage-cli`                     | `tailtriage-tokio` provides `RuntimeSampler` and runtime snapshot capture on top of the core artifact model                |
 | Use with axum                                                   | `tailtriage-core`, `tailtriage-axum`                     | `tailtriage-tokio`, `tailtriage-cli` | `tailtriage-axum` is the framework ergonomics layer: middleware + extractor. It depends on core, not on `tailtriage-tokio` |

--- a/tailtriage/Cargo.toml
+++ b/tailtriage/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "tailtriage"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Official facade crate and umbrella entry point for tailtriage Tokio tail-latency triage"
+documentation = "https://docs.rs/tailtriage"
+readme = "README.md"
+keywords = ["tokio", "latency", "diagnostics", "performance", "triage"]
+categories = ["asynchronous", "development-tools::profiling", "development-tools::debugging"]
+include = [
+  "Cargo.toml",
+  "README.md",
+  "LICENSE",
+  "src/**",
+]
+
+[features]
+default = ["controller"]
+controller = ["dep:tailtriage-controller"]
+tokio = ["dep:tailtriage-tokio"]
+axum = ["dep:tailtriage-axum"]
+full = ["controller", "tokio", "axum"]
+
+[dependencies]
+tailtriage-core.workspace = true
+tailtriage-controller = { workspace = true, optional = true }
+tailtriage-tokio = { workspace = true, optional = true }
+tailtriage-axum = { workspace = true, optional = true }
+
+[lints]
+workspace = true

--- a/tailtriage/LICENSE
+++ b/tailtriage/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Sebastian
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tailtriage/README.md
+++ b/tailtriage/README.md
@@ -1,0 +1,73 @@
+# tailtriage
+
+`tailtriage` is the official facade crate and umbrella entry point for Tokio tail-latency triage.
+
+It always re-exports `tailtriage-core` as the foundation API and exposes optional integration crates behind feature-gated namespaces.
+
+## Installation
+
+```bash
+cargo add tailtriage
+```
+
+Optional integrations:
+
+```bash
+cargo add tailtriage --features tokio
+cargo add tailtriage --features "tokio,axum"
+```
+
+`controller` is enabled by default and re-exported at `tailtriage::controller`.
+
+## Feature flags
+
+- `controller` (default): enables `tailtriage::controller` (from `tailtriage-controller`)
+- `tokio`: enables `tailtriage::tokio` (from `tailtriage-tokio`)
+- `axum`: enables `tailtriage::axum` (from `tailtriage-axum`)
+- `full`: enables `controller`, `tokio`, and `axum`
+
+Advanced users can still depend on focused crates (`tailtriage-core`, `tailtriage-controller`, `tailtriage-tokio`, `tailtriage-axum`) directly for tighter dependency control.
+
+## Examples
+
+Core-only usage:
+
+```no_run
+use tailtriage::Tailtriage;
+
+# fn demo() -> Result<(), Box<dyn std::error::Error>> {
+let run = Tailtriage::builder("checkout-service")
+    .output("tailtriage-run.json")
+    .build()?;
+run.shutdown()?;
+# Ok(())
+# }
+```
+
+Tokio runtime sampling (requires `tokio` feature):
+
+```no_run
+# #[cfg(feature = "tokio")]
+# async fn demo(run: std::sync::Arc<tailtriage::Tailtriage>) -> Result<(), Box<dyn std::error::Error>> {
+use tailtriage::tokio::RuntimeSampler;
+
+let sampler = RuntimeSampler::builder(run).start()?;
+sampler.shutdown().await;
+# Ok(())
+# }
+```
+
+Controller convenience layer (default `controller` feature):
+
+```no_run
+# #[cfg(feature = "controller")]
+# fn demo() -> Result<(), Box<dyn std::error::Error>> {
+use tailtriage::controller::TailtriageController;
+
+let controller = TailtriageController::builder("checkout-service")
+    .initially_enabled(true)
+    .build()?;
+let _status = controller.status();
+# Ok(())
+# }
+```

--- a/tailtriage/src/lib.rs
+++ b/tailtriage/src/lib.rs
@@ -1,0 +1,43 @@
+#![doc = include_str!("../README.md")]
+#![warn(missing_docs)]
+
+//! Official facade crate for the tailtriage toolkit.
+//!
+//! - [`tailtriage_core`] is always re-exported as the foundational API surface.
+//! - [`controller`] is the default convenience layer when the `controller` feature is enabled.
+//! - [`tokio`] and [`axum`] are opt-in integration namespaces.
+
+pub use tailtriage_core::*;
+
+#[cfg(feature = "axum")]
+pub use tailtriage_axum as axum;
+#[cfg(feature = "controller")]
+pub use tailtriage_controller as controller;
+#[cfg(feature = "tokio")]
+pub use tailtriage_tokio as tokio;
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn core_reexport_exposes_tailtriage() {
+        let _builder = crate::Tailtriage::builder("facade-smoke");
+    }
+
+    #[cfg(feature = "tokio")]
+    #[test]
+    fn tokio_namespace_reexport_compiles() {
+        let _name = crate::tokio::crate_name();
+    }
+
+    #[cfg(feature = "controller")]
+    #[test]
+    fn controller_namespace_reexport_compiles() {
+        let _builder = crate::controller::TailtriageController::builder("facade-controller");
+    }
+
+    #[cfg(feature = "axum")]
+    #[test]
+    fn axum_namespace_reexport_compiles() {
+        let _name = crate::axum::crate_name();
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a canonical, minimal facade crate named `tailtriage` that reserves the top-level crate name and gives a simple onboarding path (`cargo add tailtriage`) while preserving focused crate options. 
- Re-export the stable foundation API (`tailtriage-core`) and surface optional integration layers behind feature flags so users get a single convenient entrypoint without flattening or duplicating existing crate APIs. 
- When present, make the `tailtriage-controller` convenience layer the default experience while keeping `tailtriage-tokio` and `tailtriage-axum` opt-in to avoid surprising dependency expansion.

### Description
- Added a new workspace member crate at `tailtriage/` including `Cargo.toml`, `src/lib.rs`, `README.md`, and `LICENSE`; the package uses workspace-inherited metadata and lints and documents the crate on `docs.rs` via `documentation` field. 
- Implemented the thin facade API in `tailtriage/src/lib.rs` that always re-exports `tailtriage_core` (`pub use tailtriage_core::*;`) and feature-gated namespace re-exports: `controller` (default when present), `tokio` (optional), and `axum` (optional). 
- Wired the root `Cargo.toml` workspace: added `tailtriage` to `members` and added a `tailtriage` entry to `[workspace.dependencies]`, and ensured `tailtriage-controller`, `tailtriage-tokio`, and `tailtriage-axum` are available as workspace-managed dependencies. 
- Updated the repo `README.md` onboarding to recommend `cargo add tailtriage` as the simplest starting point while preserving guidance for adding focused crates directly for tighter dependency control. 

### Testing
- Ran `cargo fmt --check` and fixed formatting issues so formatting check succeeds. (passed) 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and addressed issues so the workspace lints pass. (passed) 
- Ran `cargo test --workspace`; all workspace unit and doc tests ran successfully, including facade smoke tests that verify the core re-export and feature-gated namespace re-exports compile. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e64170022c83309198cc6d1e071efe)