### PR TITLE
Harden RuntimeSampler startup contract and metadata registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Use these as distinct measurement paths:
 `RuntimeSampler` works on stable Tokio, but some runtime fields (`local_queue_depth`, `blocking_queue_depth`, `remote_schedule_count`) require `tokio_unstable`. See [`docs/user-guide.md`](docs/user-guide.md) for details.
 
 When you use `RuntimeSampler::builder(...)`, Tokio defaults are resolved from the core-selected mode by default (inherited mode), and you can provide an explicit Tokio override with `.mode(...)`.
+`RuntimeSampler::start()` requires an active Tokio runtime and allows only one sampler startup per `Tailtriage` run.
 
 ## Request lifecycle shape (public API)
 
@@ -226,7 +227,7 @@ Artifacts record both selected mode and effective resolved config:
 
 - selected mode: `metadata.mode`
 - core effective config: `metadata.effective_core_config`
-- Tokio sampler effective config (when sampler is started): `metadata.effective_tokio_sampler_config`
+- Tokio sampler effective config (recorded only by successful sampler startup): `metadata.effective_tokio_sampler_config`
 
 Overhead terminology used in docs and scripts:
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -26,7 +26,7 @@ Mode/config metadata in artifacts:
 
 - `metadata.mode` stores the selected core capture mode.
 - `metadata.effective_core_config` stores resolved core settings used for the run.
-- `metadata.effective_tokio_sampler_config` stores resolved Tokio sampler settings when `RuntimeSampler` was started.
+- `metadata.effective_tokio_sampler_config` stores resolved Tokio sampler settings recorded by successful `RuntimeSampler` startup.
 
 ## Report contents
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -139,7 +139,7 @@ Artifacts record both selected mode and effective resolved config:
 
 - selected mode: `metadata.mode`
 - core effective config: `metadata.effective_core_config`
-- Tokio sampler effective config (when sampler starts): `metadata.effective_tokio_sampler_config`
+- Tokio sampler effective config (recorded only by successful sampler startup): `metadata.effective_tokio_sampler_config`
 
 Overhead terminology used in docs and scripts:
 
@@ -163,6 +163,8 @@ Use runtime snapshots when request-level signals are not enough to separate queu
 `CaptureMode` does not auto-start runtime sampling.
 Resolved runtime snapshot retention is clamped to the core collector limit for
 `max_runtime_snapshots`.
+Sampler startup requires an active Tokio runtime, and each `Tailtriage` run
+accepts only one successful `RuntimeSampler::start()` registration.
 
 ```rust
 use std::sync::Arc;

--- a/tailtriage-core/src/collector.rs
+++ b/tailtriage-core/src/collector.rs
@@ -24,6 +24,7 @@ pub struct Tailtriage {
     pub(crate) limits: crate::CaptureLimits,
     pub(crate) strict_lifecycle: bool,
     truncation_state: TruncationState,
+    runtime_sampler_registered: AtomicBool,
 }
 
 #[derive(Debug, Default)]
@@ -162,6 +163,13 @@ pub struct OwnedRequestCompletion {
     finished: bool,
 }
 
+/// Error returned when registering Tokio runtime sampler metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeSamplerRegistrationError {
+    /// A runtime sampler was already registered for this run.
+    DuplicateStart,
+}
+
 impl Tailtriage {
     /// Creates a builder-based setup path for one service run.
     #[must_use]
@@ -201,6 +209,7 @@ impl Tailtriage {
             limits: config.effective_core.capture_limits,
             strict_lifecycle: config.strict_lifecycle,
             truncation_state: TruncationState::default(),
+            runtime_sampler_registered: AtomicBool::new(false),
         })
     }
 
@@ -367,14 +376,29 @@ impl Tailtriage {
         }
     }
 
-    /// Records effective resolved Tokio sampler configuration in run metadata.
+    /// Registers one Tokio sampler startup and records effective sampler metadata.
     ///
-    /// Integration crates call this when they configure and start optional runtime
-    /// sampling so artifacts can show inherited mode, explicit overrides, and
-    /// resolved sampler settings used for the run.
-    pub fn record_tokio_sampler_config(&self, config: crate::EffectiveTokioSamplerConfig) {
+    /// This method succeeds at most once per run.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RuntimeSamplerRegistrationError::DuplicateStart`] when a sampler
+    /// was already registered for this run.
+    pub fn register_tokio_runtime_sampler(
+        &self,
+        config: crate::EffectiveTokioSamplerConfig,
+    ) -> Result<(), RuntimeSamplerRegistrationError> {
+        if self
+            .runtime_sampler_registered
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return Err(RuntimeSamplerRegistrationError::DuplicateStart);
+        }
+
         let mut run = lock_run(&self.run);
         run.metadata.effective_tokio_sampler_config = Some(config);
+        Ok(())
     }
 
     pub(crate) fn record_stage_event(&self, event: StageEvent) {

--- a/tailtriage-core/src/lib.rs
+++ b/tailtriage-core/src/lib.rs
@@ -35,7 +35,7 @@ mod timers;
 
 pub use collector::{
     OwnedRequestCompletion, OwnedRequestHandle, OwnedStartedRequest, RequestCompletion,
-    RequestHandle, StartedRequest, Tailtriage,
+    RequestHandle, RuntimeSamplerRegistrationError, StartedRequest, Tailtriage,
 };
 pub use config::{
     BuildError, CaptureLimits, CaptureLimitsOverride, CaptureMode, EffectiveCoreConfig,

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -4,8 +4,8 @@ use std::panic::AssertUnwindSafe;
 use std::sync::{Arc, Mutex};
 
 use crate::{
-    BuildError, CaptureLimits, CaptureLimitsOverride, CaptureMode, Outcome, RequestOptions,
-    SinkError, Tailtriage,
+    BuildError, CaptureLimits, CaptureLimitsOverride, CaptureMode, EffectiveTokioSamplerConfig,
+    Outcome, RequestOptions, RuntimeSamplerRegistrationError, SinkError, Tailtriage,
 };
 
 #[derive(Debug, Default)]
@@ -309,6 +309,41 @@ fn selected_mode_and_effective_config_are_preserved_in_metadata() {
             .capture_limits
             .max_queues,
         7
+    );
+}
+
+#[test]
+fn runtime_sampler_registration_is_single_start_and_metadata_cannot_be_overwritten() {
+    let tailtriage = Tailtriage::builder("payments")
+        .build()
+        .expect("build should succeed");
+    let first = EffectiveTokioSamplerConfig {
+        inherited_mode: CaptureMode::Light,
+        explicit_mode_override: None,
+        resolved_mode: CaptureMode::Light,
+        resolved_sampler_cadence_ms: 500,
+        resolved_runtime_snapshot_retention: 5_000,
+    };
+    let second = EffectiveTokioSamplerConfig {
+        inherited_mode: CaptureMode::Light,
+        explicit_mode_override: Some(CaptureMode::Investigation),
+        resolved_mode: CaptureMode::Investigation,
+        resolved_sampler_cadence_ms: 100,
+        resolved_runtime_snapshot_retention: 50_000,
+    };
+
+    tailtriage
+        .register_tokio_runtime_sampler(first)
+        .expect("first sampler registration should succeed");
+    let err = tailtriage
+        .register_tokio_runtime_sampler(second)
+        .expect_err("duplicate registration should fail");
+    assert_eq!(err, RuntimeSamplerRegistrationError::DuplicateStart);
+
+    let snapshot = tailtriage.snapshot();
+    assert_eq!(
+        snapshot.metadata.effective_tokio_sampler_config,
+        Some(first)
     );
 }
 

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -66,6 +66,8 @@ Tokio mode defaults (applied only if sampler is started):
 `CaptureMode` does not change core event types or `strict_lifecycle`.
 Resolved runtime snapshot retention is clamped to the core run's
 `max_runtime_snapshots` cap so artifact metadata matches actual retention.
+Startup requires an active Tokio runtime, and each `Tailtriage` run allows only
+one successful sampler start.
 
 ## Minimal usage
 

--- a/tailtriage-tokio/src/lib.rs
+++ b/tailtriage-tokio/src/lib.rs
@@ -12,7 +12,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tailtriage_core::{
-    unix_time_ms, CaptureMode, EffectiveTokioSamplerConfig, RuntimeSnapshot, Tailtriage,
+    unix_time_ms, CaptureMode, EffectiveTokioSamplerConfig, RuntimeSamplerRegistrationError,
+    RuntimeSnapshot, Tailtriage,
 };
 use tokio::runtime::Handle;
 use tokio::sync::oneshot;
@@ -29,12 +30,26 @@ pub const fn crate_name() -> &'static str {
 pub enum SamplerStartError {
     /// Sampling interval must be greater than zero.
     ZeroInterval,
+    /// Runtime sampling requires an active Tokio runtime.
+    MissingRuntime,
+    /// Only one runtime sampler may be started for each Tailtriage run.
+    DuplicateStart,
 }
 
 impl std::fmt::Display for SamplerStartError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::ZeroInterval => write!(f, "runtime sampling interval must be greater than zero"),
+            Self::MissingRuntime => write!(
+                f,
+                "runtime sampling requires an active Tokio runtime on the current thread"
+            ),
+            Self::DuplicateStart => {
+                write!(
+                    f,
+                    "only one runtime sampler may be started per Tailtriage run"
+                )
+            }
         }
     }
 }
@@ -121,6 +136,9 @@ impl RuntimeSampler {
     /// # Errors
     ///
     /// Returns [`SamplerStartError::ZeroInterval`] when `interval` is zero.
+    ///
+    /// Returns [`SamplerStartError::MissingRuntime`] when called outside an
+    /// active Tokio runtime.
     pub fn start(
         tailtriage: Arc<Tailtriage>,
         interval: Duration,
@@ -177,19 +195,32 @@ impl RuntimeSamplerBuilder {
     /// # Errors
     ///
     /// Returns [`SamplerStartError::ZeroInterval`] when resolved cadence is zero.
+    ///
+    /// Returns [`SamplerStartError::MissingRuntime`] when called outside an
+    /// active Tokio runtime.
+    ///
+    /// Returns [`SamplerStartError::DuplicateStart`] when a sampler was already
+    /// started for this run.
     pub fn start(self) -> Result<RuntimeSampler, SamplerStartError> {
         let resolved = self.resolve_config()?;
+        let handle = Handle::try_current().map_err(|_| SamplerStartError::MissingRuntime)?;
         self.tailtriage
-            .record_tokio_sampler_config(resolved.into_effective_metadata());
+            .register_tokio_runtime_sampler(resolved.into_effective_metadata())
+            .map_err(|err| match err {
+                RuntimeSamplerRegistrationError::DuplicateStart => {
+                    SamplerStartError::DuplicateStart
+                }
+            })?;
 
         let tailtriage = Arc::clone(&self.tailtriage);
-        let handle = Handle::current();
         let (stop_tx, mut stop_rx) = oneshot::channel();
-        let mut ticker = tokio::time::interval(resolved.resolved_interval);
         let mut captured: usize = 0;
         let max_runtime_snapshots = resolved.resolved_max_runtime_snapshots;
+        let resolved_interval = resolved.resolved_interval;
 
-        let task = tokio::spawn(async move {
+        let runtime_handle = handle.clone();
+        let task = handle.spawn(async move {
+            let mut ticker = tokio::time::interval(resolved_interval);
             loop {
                 tokio::select! {
                     _ = &mut stop_rx => break,
@@ -198,7 +229,7 @@ impl RuntimeSamplerBuilder {
                             break;
                         }
 
-                        tailtriage.record_runtime_snapshot(capture_runtime_snapshot(&handle));
+                        tailtriage.record_runtime_snapshot(capture_runtime_snapshot(&runtime_handle));
                         captured = captured.saturating_add(1);
                     }
                 }
@@ -354,6 +385,30 @@ mod tests {
         let err = RuntimeSampler::start(tailtriage, Duration::ZERO)
             .expect_err("zero interval should fail");
         assert_eq!(err, SamplerStartError::ZeroInterval);
+    }
+
+    #[test]
+    fn runtime_sampler_requires_active_runtime() {
+        let tailtriage = Arc::new(
+            Tailtriage::builder("runtime-test")
+                .output(std::env::temp_dir().join("tailtriage_tokio_missing_runtime.json"))
+                .build()
+                .expect("build should succeed"),
+        );
+
+        let err = RuntimeSampler::builder(Arc::clone(&tailtriage))
+            .interval(Duration::from_millis(5))
+            .start()
+            .expect_err("starting outside runtime should fail");
+        assert_eq!(err, SamplerStartError::MissingRuntime);
+        assert!(
+            tailtriage
+                .snapshot()
+                .metadata
+                .effective_tokio_sampler_config
+                .is_none(),
+            "failed startup must not mutate sampler metadata"
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -615,5 +670,38 @@ mod tests {
             assert_eq!(snapshot.blocking_queue_depth, None);
             assert_eq!(snapshot.remote_schedule_count, None);
         }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn runtime_sampler_rejects_duplicate_start_for_same_run() {
+        let tailtriage = Arc::new(
+            Tailtriage::builder("runtime-test")
+                .output(std::env::temp_dir().join("tailtriage_tokio_duplicate_start.json"))
+                .build()
+                .expect("build should succeed"),
+        );
+
+        let sampler = RuntimeSampler::builder(Arc::clone(&tailtriage))
+            .interval(Duration::from_millis(11))
+            .start()
+            .expect("first sampler should start");
+
+        let err = RuntimeSampler::builder(Arc::clone(&tailtriage))
+            .interval(Duration::from_millis(17))
+            .start()
+            .expect_err("duplicate sampler start should fail");
+        assert_eq!(err, SamplerStartError::DuplicateStart);
+
+        sampler.shutdown().await;
+
+        let metadata = tailtriage
+            .snapshot()
+            .metadata
+            .effective_tokio_sampler_config
+            .expect("first sampler startup should record metadata");
+        assert_eq!(
+            metadata.resolved_sampler_cadence_ms, 11,
+            "duplicate start must not overwrite prior metadata"
+        );
     }
 }


### PR DESCRIPTION
### Motivation

- Runtime sampler startup could panic when called outside a Tokio runtime because it used `Handle::current()` instead of a fallible check.  
- `metadata.effective_tokio_sampler_config` could be set via an unconstrained public API and thus be forged or overwritten after a failed or later start attempt.  
- Nothing prevented multiple `RuntimeSampler` instances from being started against the same `Tailtriage` run, producing inconsistent metadata and race conditions.

### Description

- Make startup fallible and single-registration: `RuntimeSampler` startup now uses `Handle::try_current()` and returns typed `SamplerStartError::MissingRuntime` when no runtime is present, and `SamplerStartError::DuplicateStart` for duplicate startup attempts.  
- Enforce one sampler registration and atomic metadata recording: replaced the unconstrained metadata setter with `Tailtriage::register_tokio_runtime_sampler(config) -> Result<(), RuntimeSamplerRegistrationError>` implemented with an `AtomicBool` guard so metadata is recorded only on successful, one-time registration.  
- Keep behavior and spawn semantics safe: sampler task is spawned on the verified `Handle` (cloned) so sampling uses the confirmed runtime, and `ZeroInterval` behavior remains `SamplerStartError::ZeroInterval`.  
- Files changed: `tailtriage-tokio/src/lib.rs` (startup errors, `try_current`, task spawn, tests), `tailtriage-core/src/collector.rs` (atomic registration + API), `tailtriage-core/src/lib.rs` (re-export), `tailtriage-core/src/tests.rs` (regression test), README/docs updates (`README.md`, `docs/user-guide.md`, `docs/diagnostics.md`, `tailtriage-tokio/README.md`).

### Testing

- Ran formatting, lint, and tests: `cargo fmt --check` (passed), `cargo clippy --workspace --all-targets --locked -- -D warnings` (passed), and `cargo test --workspace --locked` (passed).  
- Added and ran regression tests covering: `runtime_sampler_requires_active_runtime` (starting outside runtime returns `SamplerStartError::MissingRuntime` and does not mutate metadata), `runtime_sampler_rejects_duplicate_start_for_same_run` (second start returns `SamplerStartError::DuplicateStart` and does not overwrite metadata), and `runtime_sampler_registration_is_single_start_and_metadata_cannot_be_overwritten` in core tests, all of which passed under `cargo test`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6655eccfc8330a7768f58ce0c734d)