### PR TITLE
Strengthen AutoSealOnLimitsHit to trigger on first limits_hit across all capture paths

### DIFF
--- a/tailtriage-controller/README.md
+++ b/tailtriage-controller/README.md
@@ -165,8 +165,11 @@ Reload in v1 is explicit and manual:
 
 - `kind = "manual"`: keep the generation active; additional data can be dropped after saturation
   until manual disarm/shutdown.
-- `kind = "max_requests"` / `kind = "max_duration_ms"` / `kind = "first_limit_hit"`: controller
-  auto-seals the generation according to the chosen threshold/condition.
+- `kind = "max_requests"` / `kind = "max_duration_ms"` / `kind = "first_limit_hit"`: on the first
+  transition to `limits_hit` in any capture path (request events, runtime snapshots, stage events,
+  queue events, or in-flight snapshots), controller immediately stops new admissions and moves the
+  current generation into sealing/finalization. If admitted requests are still in flight, the
+  generation remains closing and finalizes as soon as those admitted requests drain.
 
 ## What this feature does not do
 

--- a/tailtriage-controller/src/lib.rs
+++ b/tailtriage-controller/src/lib.rs
@@ -394,27 +394,6 @@ impl TailtriageController {
         builder = builder.strict_lifecycle(template.strict_lifecycle);
 
         let run = Arc::new(builder.build().map_err(EnableError::Build)?);
-        let runtime_sampler = if template.runtime_sampler.enabled_for_armed_runs {
-            let _ = tokio::runtime::Handle::try_current()
-                .map_err(|_| EnableError::MissingTokioRuntimeForSampler)?;
-            let mut sampler_builder = RuntimeSampler::builder(Arc::clone(&run));
-            if let Some(mode_override) = template.runtime_sampler.mode_override {
-                sampler_builder = sampler_builder.mode(mode_override);
-            }
-            if let Some(interval_ms) = template.runtime_sampler.interval_ms {
-                sampler_builder = sampler_builder.interval(Duration::from_millis(interval_ms));
-            }
-            if let Some(max_runtime_snapshots) = template.runtime_sampler.max_runtime_snapshots {
-                sampler_builder = sampler_builder.max_runtime_snapshots(max_runtime_snapshots);
-            }
-            Some(
-                sampler_builder
-                    .start()
-                    .map_err(EnableError::StartRuntimeSampler)?,
-            )
-        } else {
-            None
-        };
         let runtime = Arc::new(ActiveGenerationRuntime {
             state: ActiveGenerationState {
                 generation_id: next_generation,
@@ -435,14 +414,45 @@ impl TailtriageController {
                 },
             },
             artifact_path,
-            run,
+            run: Arc::clone(&run),
             accepting_new: AtomicBool::new(true),
             closing: AtomicBool::new(false),
             inflight_captured: AtomicU64::new(0),
             finalize_started: AtomicBool::new(false),
             last_finalize_error: Mutex::new(None),
-            runtime_sampler: Mutex::new(runtime_sampler),
+            runtime_sampler: Mutex::new(None),
         });
+        if template.run_end_policy == RunEndPolicy::AutoSealOnLimitsHit {
+            let active = Arc::downgrade(&runtime);
+            let inner = Arc::downgrade(&self.inner);
+            let listener: Arc<dyn Fn() + Send + Sync> = Arc::new(move || {
+                TailtriageController::on_limits_hit_signal(&inner, &active);
+            });
+            runtime.run.set_limits_hit_listener(Some(listener));
+        }
+
+        if template.runtime_sampler.enabled_for_armed_runs {
+            let _ = tokio::runtime::Handle::try_current()
+                .map_err(|_| EnableError::MissingTokioRuntimeForSampler)?;
+            let mut sampler_builder = RuntimeSampler::builder(Arc::clone(&run));
+            if let Some(mode_override) = template.runtime_sampler.mode_override {
+                sampler_builder = sampler_builder.mode(mode_override);
+            }
+            if let Some(interval_ms) = template.runtime_sampler.interval_ms {
+                sampler_builder = sampler_builder.interval(Duration::from_millis(interval_ms));
+            }
+            if let Some(max_runtime_snapshots) = template.runtime_sampler.max_runtime_snapshots {
+                sampler_builder = sampler_builder.max_runtime_snapshots(max_runtime_snapshots);
+            }
+            let runtime_sampler = sampler_builder
+                .start()
+                .map_err(EnableError::StartRuntimeSampler)?;
+            let mut sampler_slot = runtime
+                .runtime_sampler
+                .lock()
+                .expect("generation runtime sampler lock poisoned");
+            *sampler_slot = Some(runtime_sampler);
+        }
 
         *lifecycle = ControllerLifecycle::Active {
             active: Arc::clone(&runtime),
@@ -772,6 +782,26 @@ impl TailtriageController {
             .set_run_end_reason_if_absent(RunEndReason::AutoSealOnLimitsHit);
         active.accepting_new.store(false, Ordering::Release);
         active.closing.store(true, Ordering::Release);
+    }
+
+    fn on_limits_hit_signal(inner: &Weak<ControllerInner>, active: &Weak<ActiveGenerationRuntime>) {
+        let Some(active) = active.upgrade() else {
+            return;
+        };
+        active
+            .run
+            .set_run_end_reason_if_absent(RunEndReason::AutoSealOnLimitsHit);
+        active.accepting_new.store(false, Ordering::Release);
+        active.closing.store(true, Ordering::Release);
+
+        if active.inflight_captured.load(Ordering::Acquire) > 0 {
+            return;
+        }
+
+        let Some(inner) = inner.upgrade() else {
+            return;
+        };
+        let _ = TailtriageController::finalize_generation_shared(&inner, &active);
     }
 }
 
@@ -1121,7 +1151,7 @@ pub struct RuntimeSamplerTemplate {
 pub enum RunEndPolicy {
     /// Keep cheap-dropping after limits are hit until manual disarm or shutdown.
     ContinueAfterLimitsHit,
-    /// Stop admissions and seal the run once limits are hit.
+    /// On first transition to `limits_hit`, stop admissions and seal/finalize the run.
     AutoSealOnLimitsHit,
 }
 
@@ -1534,7 +1564,9 @@ mod tests {
         DisableOutcome, EnableError, GenerationState, RunEndPolicy, RuntimeSamplerTemplate,
         TailtriageController,
     };
-    use tailtriage_core::{CaptureLimitsOverride, CaptureMode, RequestOptions, Run};
+    use tailtriage_core::{
+        CaptureLimitsOverride, CaptureMode, RequestOptions, Run, RuntimeSnapshot,
+    };
 
     fn test_output(base: &str) -> std::path::PathBuf {
         let unique = format!(
@@ -1825,6 +1857,105 @@ kind = "auto_seal_on_limits_hit"
         let run = read_run(&active.artifact_path);
         assert!(run.truncation.limits_hit);
         assert!(run.truncation.dropped_requests > 0);
+        assert_eq!(
+            run.metadata.run_end_reason,
+            Some(tailtriage_core::RunEndReason::AutoSealOnLimitsHit)
+        );
+
+        fs::remove_file(active.artifact_path).expect("cleanup should succeed");
+    }
+
+    #[test]
+    fn runtime_snapshot_saturation_triggers_auto_seal() {
+        let output = test_output("auto-seal-runtime-snapshot");
+        let controller = TailtriageController::builder("checkout-service")
+            .output(&output)
+            .run_end_policy(RunEndPolicy::AutoSealOnLimitsHit)
+            .capture_limits_override(CaptureLimitsOverride {
+                max_runtime_snapshots: Some(1),
+                ..CaptureLimitsOverride::default()
+            })
+            .build()
+            .expect("build should succeed");
+
+        let active = controller.enable().expect("enable should succeed");
+        let runtime = active_runtime(&controller);
+
+        runtime.run.record_runtime_snapshot(RuntimeSnapshot {
+            at_unix_ms: tailtriage_core::unix_time_ms(),
+            alive_tasks: Some(1),
+            global_queue_depth: Some(1),
+            local_queue_depth: Some(1),
+            blocking_queue_depth: Some(0),
+            remote_schedule_count: Some(1),
+        });
+        runtime.run.record_runtime_snapshot(RuntimeSnapshot {
+            at_unix_ms: tailtriage_core::unix_time_ms(),
+            alive_tasks: Some(2),
+            global_queue_depth: Some(2),
+            local_queue_depth: Some(2),
+            blocking_queue_depth: Some(0),
+            remote_schedule_count: Some(2),
+        });
+
+        assert!(matches!(
+            controller.status().generation,
+            GenerationState::Disabled { next_generation: 2 }
+        ));
+        let run = read_run(&active.artifact_path);
+        assert!(run.truncation.limits_hit);
+        assert!(run.truncation.dropped_runtime_snapshots > 0);
+        assert_eq!(
+            run.metadata.run_end_reason,
+            Some(tailtriage_core::RunEndReason::AutoSealOnLimitsHit)
+        );
+
+        fs::remove_file(active.artifact_path).expect("cleanup should succeed");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn queue_saturation_triggers_auto_seal_and_waits_for_inflight_drain() {
+        let output = test_output("auto-seal-queue-saturation");
+        let controller = TailtriageController::builder("checkout-service")
+            .output(&output)
+            .run_end_policy(RunEndPolicy::AutoSealOnLimitsHit)
+            .capture_limits_override(CaptureLimitsOverride {
+                max_queues: Some(1),
+                ..CaptureLimitsOverride::default()
+            })
+            .build()
+            .expect("build should succeed");
+
+        let active = controller.enable().expect("enable should succeed");
+        let started = controller.begin_request("/checkout");
+        let request = started.handle.clone();
+        request
+            .queue("primary")
+            .with_depth_at_start(1)
+            .await_on(async {})
+            .await;
+        request
+            .queue("primary")
+            .with_depth_at_start(2)
+            .await_on(async {})
+            .await;
+
+        let status = controller.status();
+        let GenerationState::Active(active_status) = status.generation else {
+            panic!("generation should remain active while admitted request is still in-flight");
+        };
+        assert!(active_status.closing);
+        assert!(!active_status.accepting_new_admissions);
+
+        started.completion.finish_ok();
+
+        assert!(matches!(
+            controller.status().generation,
+            GenerationState::Disabled { next_generation: 2 }
+        ));
+        let run = read_run(&active.artifact_path);
+        assert!(run.truncation.limits_hit);
+        assert!(run.truncation.dropped_queues > 0);
         assert_eq!(
             run.metadata.run_end_reason,
             Some(tailtriage_core::RunEndReason::AutoSealOnLimitsHit)

--- a/tailtriage-core/src/collector.rs
+++ b/tailtriage-core/src/collector.rs
@@ -25,6 +25,7 @@ pub struct Tailtriage {
     pub(crate) strict_lifecycle: bool,
     truncation_state: TruncationState,
     runtime_sampler_registered: AtomicBool,
+    limits_hit_listener: Mutex<Option<Arc<dyn Fn() + Send + Sync>>>,
 }
 
 #[derive(Debug, Default)]
@@ -63,8 +64,10 @@ struct TruncationState {
 }
 
 impl TruncationState {
-    fn mark_limits_hit(&self) {
-        self.limits_hit.store(true, Ordering::Relaxed);
+    fn mark_limits_hit(&self) -> bool {
+        self.limits_hit
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
     }
 
     fn merge_into(&self, truncation: &mut crate::TruncationSummary) {
@@ -210,6 +213,7 @@ impl Tailtriage {
             strict_lifecycle: config.strict_lifecycle,
             truncation_state: TruncationState::default(),
             runtime_sampler_registered: AtomicBool::new(false),
+            limits_hit_listener: Mutex::new(None),
         })
     }
 
@@ -332,6 +336,22 @@ impl Tailtriage {
         }
     }
 
+    /// Registers or clears a callback fired on the first transition to `limits_hit`.
+    ///
+    /// The callback is invoked at most once per run, exactly when truncation first
+    /// transitions from `false` to `true`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the limits-hit listener mutex is poisoned.
+    pub fn set_limits_hit_listener(&self, listener: Option<Arc<dyn Fn() + Send + Sync>>) {
+        let mut guard = self
+            .limits_hit_listener
+            .lock()
+            .expect("limits-hit listener lock poisoned");
+        *guard = listener;
+    }
+
     /// Creates an in-flight guard for `gauge`.
     #[must_use]
     pub(crate) fn inflight(&self, gauge: impl Into<String>) -> InflightGuard<'_> {
@@ -360,19 +380,25 @@ impl Tailtriage {
     pub fn record_runtime_snapshot(&self, snapshot: RuntimeSnapshot) {
         if self.truncation_state.runtime_snapshots.is_saturated() {
             self.truncation_state.runtime_snapshots.increment_drop();
-            self.truncation_state.mark_limits_hit();
+            self.notify_limits_hit_transition();
             return;
         }
 
-        let mut run = lock_run(&self.run);
-        if run.runtime_snapshots.len() >= self.limits.max_runtime_snapshots {
-            run.truncation.limits_hit = true;
-            run.truncation.dropped_runtime_snapshots =
-                run.truncation.dropped_runtime_snapshots.saturating_add(1);
-            self.truncation_state.runtime_snapshots.mark_saturated();
-            self.truncation_state.mark_limits_hit();
-        } else {
-            run.runtime_snapshots.push(snapshot);
+        let mut notify_limits_hit = false;
+        {
+            let mut run = lock_run(&self.run);
+            if run.runtime_snapshots.len() >= self.limits.max_runtime_snapshots {
+                run.truncation.limits_hit = true;
+                run.truncation.dropped_runtime_snapshots =
+                    run.truncation.dropped_runtime_snapshots.saturating_add(1);
+                self.truncation_state.runtime_snapshots.mark_saturated();
+                notify_limits_hit = true;
+            } else {
+                run.runtime_snapshots.push(snapshot);
+            }
+        }
+        if notify_limits_hit {
+            self.notify_limits_hit_transition();
         }
     }
 
@@ -404,73 +430,111 @@ impl Tailtriage {
     pub(crate) fn record_stage_event(&self, event: StageEvent) {
         if self.truncation_state.stages.is_saturated() {
             self.truncation_state.stages.increment_drop();
-            self.truncation_state.mark_limits_hit();
+            self.notify_limits_hit_transition();
             return;
         }
 
-        let mut run = lock_run(&self.run);
-        if run.stages.len() >= self.limits.max_stages {
-            run.truncation.limits_hit = true;
-            run.truncation.dropped_stages = run.truncation.dropped_stages.saturating_add(1);
-            self.truncation_state.stages.mark_saturated();
-            self.truncation_state.mark_limits_hit();
-        } else {
-            run.stages.push(event);
+        let mut notify_limits_hit = false;
+        {
+            let mut run = lock_run(&self.run);
+            if run.stages.len() >= self.limits.max_stages {
+                run.truncation.limits_hit = true;
+                run.truncation.dropped_stages = run.truncation.dropped_stages.saturating_add(1);
+                self.truncation_state.stages.mark_saturated();
+                notify_limits_hit = true;
+            } else {
+                run.stages.push(event);
+            }
+        }
+        if notify_limits_hit {
+            self.notify_limits_hit_transition();
         }
     }
 
     pub(crate) fn record_queue_event(&self, event: QueueEvent) {
         if self.truncation_state.queues.is_saturated() {
             self.truncation_state.queues.increment_drop();
-            self.truncation_state.mark_limits_hit();
+            self.notify_limits_hit_transition();
             return;
         }
 
-        let mut run = lock_run(&self.run);
-        if run.queues.len() >= self.limits.max_queues {
-            run.truncation.limits_hit = true;
-            run.truncation.dropped_queues = run.truncation.dropped_queues.saturating_add(1);
-            self.truncation_state.queues.mark_saturated();
-            self.truncation_state.mark_limits_hit();
-        } else {
-            run.queues.push(event);
+        let mut notify_limits_hit = false;
+        {
+            let mut run = lock_run(&self.run);
+            if run.queues.len() >= self.limits.max_queues {
+                run.truncation.limits_hit = true;
+                run.truncation.dropped_queues = run.truncation.dropped_queues.saturating_add(1);
+                self.truncation_state.queues.mark_saturated();
+                notify_limits_hit = true;
+            } else {
+                run.queues.push(event);
+            }
+        }
+        if notify_limits_hit {
+            self.notify_limits_hit_transition();
         }
     }
 
     pub(crate) fn record_inflight_snapshot(&self, snapshot: InFlightSnapshot) {
         if self.truncation_state.inflight.is_saturated() {
             self.truncation_state.inflight.increment_drop();
-            self.truncation_state.mark_limits_hit();
+            self.notify_limits_hit_transition();
             return;
         }
 
-        let mut run = lock_run(&self.run);
-        if run.inflight.len() >= self.limits.max_inflight_snapshots {
-            run.truncation.limits_hit = true;
-            run.truncation.dropped_inflight_snapshots =
-                run.truncation.dropped_inflight_snapshots.saturating_add(1);
-            self.truncation_state.inflight.mark_saturated();
-            self.truncation_state.mark_limits_hit();
-        } else {
-            run.inflight.push(snapshot);
+        let mut notify_limits_hit = false;
+        {
+            let mut run = lock_run(&self.run);
+            if run.inflight.len() >= self.limits.max_inflight_snapshots {
+                run.truncation.limits_hit = true;
+                run.truncation.dropped_inflight_snapshots =
+                    run.truncation.dropped_inflight_snapshots.saturating_add(1);
+                self.truncation_state.inflight.mark_saturated();
+                notify_limits_hit = true;
+            } else {
+                run.inflight.push(snapshot);
+            }
+        }
+        if notify_limits_hit {
+            self.notify_limits_hit_transition();
         }
     }
 
     fn record_request_event(&self, event: RequestEvent) {
         if self.truncation_state.requests.is_saturated() {
             self.truncation_state.requests.increment_drop();
-            self.truncation_state.mark_limits_hit();
+            self.notify_limits_hit_transition();
             return;
         }
 
-        let mut run = lock_run(&self.run);
-        if run.requests.len() >= self.limits.max_requests {
-            run.truncation.limits_hit = true;
-            run.truncation.dropped_requests = run.truncation.dropped_requests.saturating_add(1);
-            self.truncation_state.requests.mark_saturated();
-            self.truncation_state.mark_limits_hit();
-        } else {
-            run.requests.push(event);
+        let mut notify_limits_hit = false;
+        {
+            let mut run = lock_run(&self.run);
+            if run.requests.len() >= self.limits.max_requests {
+                run.truncation.limits_hit = true;
+                run.truncation.dropped_requests = run.truncation.dropped_requests.saturating_add(1);
+                self.truncation_state.requests.mark_saturated();
+                notify_limits_hit = true;
+            } else {
+                run.requests.push(event);
+            }
+        }
+        if notify_limits_hit {
+            self.notify_limits_hit_transition();
+        }
+    }
+
+    fn notify_limits_hit_transition(&self) {
+        if !self.truncation_state.mark_limits_hit() {
+            return;
+        }
+        let listener = self
+            .limits_hit_listener
+            .lock()
+            .expect("limits-hit listener lock poisoned")
+            .clone();
+        if let Some(listener) = listener {
+            listener();
         }
     }
 


### PR DESCRIPTION
### Motivation
- AutoSealOnLimitsHit should be a strong contract that seals a generation on the first transition to `limits_hit`, not an opportunistic side-effect observed only during request admission/completion flows.
- Limits can be hit from non-request paths (runtime snapshots, stages, queues, inflight snapshots) and those paths must be able to deterministically notify the controller so sealing is immediate and testable.
- Preserve the existing `ContinueAfterLimitsHit` semantics while making auto-seal deterministic, low-cost, and reusable by the controller finalization logic.

### Description
- Add an explicit per-run limits-hit listener in `tailtriage-core` (`Tailtriage::set_limits_hit_listener`) and make the core detect the first transition to `limits_hit` atomically via `compare_exchange`, invoking the listener exactly once on that transition. 
- Replace opportunistic `mark_limits_hit` calls with a `notify_limits_hit_transition()` helper that triggers the listener from all saturation paths (requests, runtime snapshots, stages, queues, inflight snapshots) and only invokes the listener on the first transition. 
- Wire the controller to register a listener when enabling a generation with `RunEndPolicy::AutoSealOnLimitsHit`; the listener sets `RunEndReason::AutoSealOnLimitsHit`, stops admissions (`accepting_new=false`), marks closing, and reuses the hardened finalization path to finalize immediately when no admitted requests remain in flight; runtime sampler startup remains unchanged and is delayed until after listener registration. 
- Add unit tests in the controller for request saturation, runtime-snapshot saturation, queue saturation (with in-flight drain semantics), and preserve existing continue/manual expectations; update the controller README to match the strengthened contract exactly.

### Testing
- Ran validation commands: `cargo fmt --check` (passed), `cargo clippy --workspace --all-targets --locked -- -D warnings` (passed), and `cargo test --workspace --locked` (passed). 
- Tests added and executed include `auto_seal_policy_ends_generation_after_limits_hit`, `runtime_snapshot_saturation_triggers_auto_seal`, and `queue_saturation_triggers_auto_seal_and_waits_for_inflight_drain`, and all controller/core test suites passed. 
- Files changed: `tailtriage-core/src/collector.rs`, `tailtriage-controller/src/lib.rs`, and `tailtriage-controller/README.md`. 
- Acceptance criteria checklist: 
  - [x] Implementation and docs agree on the meaning of `AutoSealOnLimitsHit`. 
  - [x] Request saturation triggers auto-seal behavior. 
  - [x] Runtime snapshot saturation triggers auto-seal behavior. 
  - [x] At least one additional non-request saturation path (queue) triggers auto-seal behavior. 
  - [x] `ContinueAfterLimitsHit` behavior remains unchanged. 
  - [x] Tests cover the new contract across request and non-request saturation paths. 
  - [x] `cargo fmt --check` passes. 
  - [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` passes. 
  - [x] `cargo test --workspace --locked` passes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e67210d83083308d4cd9aaa5d4211a)