### PR TITLE
Fix README/controller docs drift and add lightweight docs-contract CI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
       - "**/Cargo.lock"
       - "**/build.rs"
       - "scripts/**/*.py"
+      - "**/*.md"
       - "rust-toolchain"
       - "rust-toolchain.toml"
       - ".github/workflows/**/*.yml"
@@ -21,6 +22,7 @@ on:
       - "**/Cargo.lock"
       - "**/build.rs"
       - "scripts/**/*.py"
+      - "**/*.md"
       - "rust-toolchain"
       - "rust-toolchain.toml"
       - ".github/workflows/**/*.yml"
@@ -38,8 +40,55 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect changed file groups
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            code:
+              - '**/*.rs'
+              - '**/Cargo.toml'
+              - '**/Cargo.lock'
+              - '**/build.rs'
+              - 'scripts/**/*.py'
+              - 'rust-toolchain'
+              - 'rust-toolchain.toml'
+              - '.github/workflows/**/*.yml'
+              - '.github/workflows/**/*.yaml'
+            docs:
+              - '**/*.md'
+
+  docs-contracts:
+    name: docs contracts
+    needs: changes
+    if: ${{ needs.changes.outputs.docs == 'true' || needs.changes.outputs.code == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate public docs contracts
+        run: python3 scripts/validate_docs_contracts.py
+
+      - name: Validate docs contract helper unit tests
+        run: python3 -m unittest scripts.tests.test_validate_docs_contracts
+
   verify:
     name: fmt / clippy / test / demos (${{ matrix.profile }})
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:

--- a/README.md
+++ b/README.md
@@ -68,28 +68,48 @@ cargo add tailtriage-axum # optional
 
 ```json
 {
-  "primary_suspect": "application_queueing",
-  "suspects": [
+  "request_count": 1200,
+  "p50_latency_us": 41200,
+  "p95_latency_us": 108900,
+  "p99_latency_us": 144300,
+  "p95_queue_share_permille": 732,
+  "p95_service_share_permille": 418,
+  "inflight_trend": {
+    "gauge": "checkout_inflight",
+    "sample_count": 320,
+    "peak_count": 74,
+    "p95_count": 69,
+    "growth_delta": 12,
+    "growth_per_sec_milli": 153
+  },
+  "warnings": [],
+  "primary_suspect": {
+    "kind": "application_queue_saturation",
+    "score": 89,
+    "confidence": "high",
+    "evidence": [
+      "Queue wait at p95 consumes 73.2% of request time.",
+      "Observed queue depth sample up to 68."
+    ],
+    "next_checks": [
+      "Inspect queue admission limits and producer burst patterns.",
+      "Compare queue wait distribution before and after increasing worker parallelism."
+    ]
+  },
+  "secondary_suspects": [
     {
-      "key": "application_queueing",
-      "score": 0.91,
-      "why": "Queue share p95 is high and dominates request time."
-    },
-    {
-      "key": "downstream_stage_latency",
-      "score": 0.34,
-      "why": "One downstream stage contributes a meaningful but smaller p95 share."
+      "kind": "downstream_stage_dominates",
+      "score": 54,
+      "confidence": "low",
+      "evidence": [
+        "Stage 'db' has p95 latency 38700 us across 1200 samples.",
+        "Stage 'db' contributes 241 permille of cumulative request latency."
+      ],
+      "next_checks": [
+        "Inspect downstream dependency behind stage 'db'.",
+        "Collect downstream service timings and retry behavior during tail windows."
+      ]
     }
-  ],
-  "evidence": [
-    "request_count=1200",
-    "queue_share_p95=0.43",
-    "stage.db_p95_ms=38.7"
-  ],
-  "next_checks": [
-    "Confirm upstream/backlog source for queue growth under load.",
-    "Run the same workload after reducing queue depth or concurrency burst.",
-    "If queue share drops, compare suspect ranking changes."
   ]
 }
 ```

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Tests for public-docs contract validation helpers."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import validate_docs_contracts  # noqa: E402
+
+
+class ValidateDocsContractsTests(unittest.TestCase):
+    def test_run_end_policy_variants_include_expected_kinds(self) -> None:
+        kinds = validate_docs_contracts.extract_run_end_policy_kinds_from_source()
+        self.assertEqual(
+            kinds,
+            {"continue_after_limits_hit", "auto_seal_on_limits_hit"},
+        )
+
+    def test_markdown_examples_validate_against_contract(self) -> None:
+        validate_docs_contracts.validate_readme_analyzer_example()
+        validate_docs_contracts.validate_controller_readme_toml()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Validate README/controller docs against current structural contracts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import tomllib
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README_PATH = REPO_ROOT / "README.md"
+CONTROLLER_README_PATH = REPO_ROOT / "tailtriage-controller" / "README.md"
+ANALYSIS_FIXTURE_PATH = REPO_ROOT / "demos" / "queue_service" / "fixtures" / "sample-analysis.json"
+CONTROLLER_SOURCE_PATH = REPO_ROOT / "tailtriage-controller" / "src" / "lib.rs"
+PUBLIC_DOCS_GLOB = (REPO_ROOT / "docs").glob("*.md")
+
+STALE_CONTROLLER_POLICY_NAMES = (
+    "kind = \"manual\"",
+    "kind = \"max_requests\"",
+    "kind = \"max_duration_ms\"",
+    "kind = \"first_limit_hit\"",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate public docs examples against analyzer/controller contracts."
+    )
+    return parser.parse_args()
+
+
+def extract_fenced_block(markdown: str, *, fence: str, anchor: str) -> str:
+    anchor_index = markdown.find(anchor)
+    if anchor_index < 0:
+        raise ValueError(f"missing anchor heading: {anchor}")
+
+    pattern = re.compile(rf"```{re.escape(fence)}\n(.*?)\n```", re.DOTALL)
+    match = pattern.search(markdown, pos=anchor_index)
+    if match is None:
+        raise ValueError(f"missing fenced {fence} block after anchor: {anchor}")
+    return match.group(1)
+
+
+def _kind_of(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, int):
+        return "int"
+    if isinstance(value, float):
+        return "float"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    raise TypeError(f"unsupported JSON value type: {type(value)}")
+
+
+def assert_same_object_shape(*, name: str, actual: dict[str, Any], expected: dict[str, Any]) -> None:
+    actual_keys = set(actual.keys())
+    expected_keys = set(expected.keys())
+    if actual_keys != expected_keys:
+        raise ValueError(
+            f"{name} key drift: expected {sorted(expected_keys)}, got {sorted(actual_keys)}"
+        )
+
+    for key, expected_value in expected.items():
+        actual_kind = _kind_of(actual[key])
+        expected_kind = _kind_of(expected_value)
+        if actual_kind != expected_kind:
+            raise ValueError(
+                f"{name}.{key} type drift: expected {expected_kind}, got {actual_kind}"
+            )
+
+
+def validate_readme_analyzer_example() -> None:
+    readme_text = README_PATH.read_text(encoding="utf-8")
+    snippet = extract_fenced_block(
+        readme_text,
+        fence="json",
+        anchor="### Example output (JSON)",
+    )
+    readme_json = json.loads(snippet)
+    if not isinstance(readme_json, dict):
+        raise ValueError("README analyzer example must be a top-level JSON object")
+
+    fixture = json.loads(ANALYSIS_FIXTURE_PATH.read_text(encoding="utf-8"))
+    if not isinstance(fixture, dict):
+        raise ValueError("analysis fixture must be a top-level JSON object")
+
+    assert_same_object_shape(name="README report", actual=readme_json, expected=fixture)
+
+    primary = readme_json.get("primary_suspect")
+    fixture_primary = fixture.get("primary_suspect")
+    if not isinstance(primary, dict) or not isinstance(fixture_primary, dict):
+        raise ValueError("primary_suspect must be an object")
+    assert_same_object_shape(
+        name="README primary_suspect",
+        actual=primary,
+        expected=fixture_primary,
+    )
+
+    secondary = readme_json.get("secondary_suspects")
+    fixture_secondary = fixture.get("secondary_suspects")
+    if not isinstance(secondary, list) or not isinstance(fixture_secondary, list):
+        raise ValueError("secondary_suspects must be an array")
+    if not secondary:
+        raise ValueError("README secondary_suspects must include at least one suspect")
+
+    first_secondary = secondary[0]
+    first_fixture_secondary = fixture_secondary[0]
+    if not isinstance(first_secondary, dict) or not isinstance(first_fixture_secondary, dict):
+        raise ValueError("secondary_suspects[0] must be an object")
+    assert_same_object_shape(
+        name="README secondary_suspects[0]",
+        actual=first_secondary,
+        expected=first_fixture_secondary,
+    )
+
+
+def extract_run_end_policy_kinds_from_source() -> set[str]:
+    source = CONTROLLER_SOURCE_PATH.read_text(encoding="utf-8")
+    block_match = re.search(
+        r"enum\s+RunEndPolicyConfigToml\s*\{(?P<body>.*?)\}\n\nimpl\s+From<RunEndPolicyConfigToml>",
+        source,
+        flags=re.DOTALL,
+    )
+    if block_match is None:
+        raise ValueError("unable to locate RunEndPolicyConfigToml enum in controller source")
+
+    body = block_match.group("body")
+    variants = re.findall(r"\b([A-Z][A-Za-z0-9_]*)\b\s*,", body)
+    if not variants:
+        raise ValueError("RunEndPolicyConfigToml enum has no variants")
+
+    return {
+        re.sub(r"(?<!^)(?=[A-Z])", "_", variant).lower()
+        for variant in variants
+    }
+
+
+def validate_controller_readme_toml() -> None:
+    readme_text = CONTROLLER_README_PATH.read_text(encoding="utf-8")
+    snippet = extract_fenced_block(
+        readme_text,
+        fence="toml",
+        anchor="## TOML config and manual reload",
+    )
+    parsed = tomllib.loads(snippet)
+
+    run_end_policy = (
+        parsed.get("controller", {})
+        .get("activation", {})
+        .get("run_end_policy", {})
+    )
+    if not isinstance(run_end_policy, dict):
+        raise ValueError("controller README run_end_policy snippet must parse as a table")
+
+    documented_kind = run_end_policy.get("kind")
+    if not isinstance(documented_kind, str):
+        raise ValueError("controller README run_end_policy.kind must be a string")
+
+    supported_kinds = extract_run_end_policy_kinds_from_source()
+    if documented_kind not in supported_kinds:
+        raise ValueError(
+            "controller README run_end_policy.kind drift: "
+            f"{documented_kind!r} not in supported {sorted(supported_kinds)}"
+        )
+
+
+def validate_no_stale_controller_policy_names() -> None:
+    paths = [README_PATH, CONTROLLER_README_PATH, *sorted(PUBLIC_DOCS_GLOB)]
+    hits: list[str] = []
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        for token in STALE_CONTROLLER_POLICY_NAMES:
+            if token in text:
+                hits.append(f"{path.relative_to(REPO_ROOT)} contains stale token: {token}")
+
+    if hits:
+        joined = "\n".join(hits)
+        raise ValueError(f"stale controller run_end_policy docs found:\n{joined}")
+
+
+def main() -> int:
+    _ = parse_args()
+    validate_readme_analyzer_example()
+    validate_controller_readme_toml()
+    validate_no_stale_controller_policy_names()
+    print("docs contracts validated successfully")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tailtriage-controller/README.md
+++ b/tailtriage-controller/README.md
@@ -146,10 +146,8 @@ interval_ms = 200                # optional
 max_runtime_snapshots = 100000   # optional
 
 [controller.activation.run_end_policy]
-# "manual" | "max_requests" | "max_duration_ms" | "first_limit_hit"
-kind = "manual"
-# max_requests = 50000      # for kind = "max_requests"
-# max_duration_ms = 30000   # for kind = "max_duration_ms"
+# "continue_after_limits_hit" | "auto_seal_on_limits_hit"
+kind = "continue_after_limits_hit"
 ```
 
 Reload in v1 is explicit and manual:
@@ -163,13 +161,13 @@ Reload in v1 is explicit and manual:
 
 `[controller.activation.run_end_policy]` controls what happens when capture limits are hit:
 
-- `kind = "manual"`: keep the generation active; additional data can be dropped after saturation
+- `kind = "continue_after_limits_hit"`: keep the generation active; additional data can be dropped after saturation
   until manual disarm/shutdown.
-- `kind = "max_requests"` / `kind = "max_duration_ms"` / `kind = "first_limit_hit"`: on the first
-  transition to `limits_hit` in any capture path (request events, runtime snapshots, stage events,
-  queue events, or in-flight snapshots), controller immediately stops new admissions and moves the
-  current generation into sealing/finalization. If admitted requests are still in flight, the
-  generation remains closing and finalizes as soon as those admitted requests drain.
+- `kind = "auto_seal_on_limits_hit"`: on the first transition to `limits_hit` in any capture path
+  (request events, runtime snapshots, stage events, queue events, or in-flight snapshots),
+  controller immediately stops new admissions and moves the current generation into
+  sealing/finalization. If admitted requests are still in flight, the generation remains closing
+  and finalizes as soon as those admitted requests drain.
 
 ## What this feature does not do
 


### PR DESCRIPTION
### Motivation
- Fix two confirmed public-docs drifts: the top-level `README.md` analyzer JSON example no longer matched the analyzer report contract, and `tailtriage-controller/README.md` documented stale `run_end_policy` names.
- Prevent future regressions by adding a cheap, structural docs-validation path that runs for Markdown-only PRs and fails fast on shape or token drift. 
- Keep validation low-flake by comparing JSON/TOML shapes to real committed fixtures and extracting supported policy variants from source rather than brittle full-text checks.

### Description
- Update `README.md` analyzer JSON example to match the current analyzer report shape (request percentiles/shares, `warnings`, `primary_suspect` object with `kind/score/confidence/evidence/next_checks`, and `secondary_suspects`).
- Update `tailtriage-controller/README.md` to document only the implemented `run_end_policy.kind` values: `continue_after_limits_hit` and `auto_seal_on_limits_hit`, and adjust the TOML example/behavior text accordingly.
- Add a lightweight validator `scripts/validate_docs_contracts.py` that:
  - extracts the fenced `json` block under `### Example output (JSON)` and validates object key/type shape against the real fixture at `demos/queue_service/fixtures/sample-analysis.json`,
  - extracts the fenced `toml` block under `## TOML config and manual reload`, parses it, and verifies `run_end_policy.kind` against variants parsed from `tailtriage-controller/src/lib.rs`, and
  - scans public docs for stale controller policy tokens.
- Add focused unit tests `scripts/tests/test_validate_docs_contracts.py` for the validator functions.
- Update CI `.github/workflows/ci.yml` so Markdown-only changes trigger the lightweight `docs-contracts` job (via a new `changes` path-filter job), while keeping the heavy `verify` job gated to code changes only.
- Files changed: `README.md`, `tailtriage-controller/README.md`, `scripts/validate_docs_contracts.py`, `scripts/tests/test_validate_docs_contracts.py`, and `.github/workflows/ci.yml`.

### Testing
- Ran the new docs validator: `python3 scripts/validate_docs_contracts.py` — passed (printed: "docs contracts validated successfully").
- Ran validator unit tests: `python3 -m unittest scripts.tests.test_validate_docs_contracts` — passed (2 tests, OK).
- Formatting check: `cargo fmt --check` — passed.
- Lints: `cargo clippy --workspace --all-targets --locked -- -D warnings` — passed.
- Unit test suite: `cargo test --workspace --locked` — passed (all workspace tests passed).

Acceptance checklist
- [x] Top-level README example matches the current analyzer report shape
- [x] Controller README documents only actually supported `run_end_policy` values
- [x] A repeatable docs-validation path exists for these public contracts
- [x] Markdown-only changes trigger docs validation in CI
- [x] The new docs validation would catch the previously observed README / controller drift
- [x] No remaining public docs mention stale controller `run_end_policy` names
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` passes
- [x] `cargo test --workspace --locked` passes

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e676b5e3948330b26adcfbc415f312)