### PR TITLE
Clarify tailtriage-controller example contract as workspace-only

### DIFF
--- a/scripts/smoke_controller_example.py
+++ b/scripts/smoke_controller_example.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-"""Smoke-check the controller public adoption example.
+"""Smoke-check the controller example contract.
 
 Validation steps:
-1) run the controller example in release mode
+1) run the repository/workspace controller example in release mode
 2) verify artifact exists
 3) verify artifact has expected top-level schema keys
 4) verify artifact recorded exactly one request
+5) verify packaged crate contents do not include repository examples
 """
 
 from __future__ import annotations
@@ -48,9 +49,31 @@ def assert_keys(payload: dict, expected: set[str], *, context: str) -> None:
         raise SystemExit(f"{context} missing top-level keys: {missing_list}")
 
 
+def assert_packaged_contract(root: Path) -> None:
+    package_listing = run_cmd(
+        [
+            "cargo",
+            "package",
+            "--allow-dirty",
+            "--manifest-path",
+            str(root / "tailtriage-controller/Cargo.toml"),
+            "--list",
+        ],
+        cwd=root,
+    )
+    packaged_paths = [line.strip() for line in package_listing.stdout.splitlines() if line.strip()]
+    example_paths = [path for path in packaged_paths if path.startswith("examples/")]
+    if example_paths:
+        rendered = ", ".join(sorted(example_paths))
+        raise SystemExit(
+            "tailtriage-controller packaged crate unexpectedly includes examples: "
+            f"{rendered}"
+        )
+
+
 def main() -> None:
     root = repo_root()
-    print("Smoke-checking controller public example...")
+    print("Smoke-checking controller example contract...")
 
     with tempfile.TemporaryDirectory(prefix="tailtriage-controller-example-smoke-") as temp_dir:
         working_dir = Path(temp_dir)
@@ -97,8 +120,11 @@ def main() -> None:
                 f"found {len(requests)}"
             )
 
+        assert_packaged_contract(root)
+
         print("validated: tailtriage-controller::controller_minimal")
         print(f"  artifact: {artifact_path}")
+        print("validated: packaged crate excludes repository/workspace examples")
 
 
 if __name__ == "__main__":

--- a/tailtriage-controller/Cargo.toml
+++ b/tailtriage-controller/Cargo.toml
@@ -15,6 +15,7 @@ include = [
   "LICENSE",
   "src/**",
 ]
+exclude = ["examples/**"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/tailtriage-controller/README.md
+++ b/tailtriage-controller/README.md
@@ -62,7 +62,37 @@ let _ = controller.disable()?;
 # }
 ```
 
-Runnable version: `cargo run -p tailtriage-controller --example controller_minimal`.
+### Runnable workspace example (repository/source checkout)
+
+`controller_minimal` is a **repository/workspace example**. Run it from this repository checkout:
+
+`cargo run --manifest-path tailtriage-controller/Cargo.toml --example controller_minimal`
+
+### Published-crate onboarding (crates.io)
+
+Published users should copy the minimal snippet into their service (the packaged crate does not promise
+bundled runnable examples):
+
+```bash
+cargo add tailtriage-controller
+```
+
+```rust
+use tailtriage_controller::TailtriageController;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let controller = TailtriageController::builder("checkout-service")
+        .initially_enabled(false)
+        .output("tailtriage-run.json")
+        .build()?;
+
+    let _generation = controller.enable()?;
+    let started = controller.begin_request("/checkout");
+    started.completion.finish_ok();
+    let _ = controller.disable()?;
+    Ok(())
+}
+```
 
 ### Disabled-path expectations
 


### PR DESCRIPTION
### Motivation

- Chose Option A: treat `controller_minimal` as a repository/workspace-only example because the repo already exercises examples from workspace paths in CI and it is simpler and more honest than promising packaged examples.  
- Remove ambiguity and make CI/packaging/docs agree on a single contract so a user following the documented path succeeds as described.

### Description

- Update `tailtriage-controller/README.md` to explicitly mark `controller_minimal` as a repository/workspace example and add a separate published-crate onboarding snippet that does not rely on packaged examples.  
- Make the packaging contract explicit in `tailtriage-controller/Cargo.toml` by adding `exclude = ["examples/**"]` so examples are not included in the published crate.  
- Extend `scripts/smoke_controller_example.py` to (1) run the workspace example and validate the produced artifact schema and request count, and (2) run `cargo package --list` to assert the packaged crate does not include `examples/**`.

### Testing

- I ran `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --locked`, and `python3 scripts/smoke_controller_example.py` as the validation commands.  
- All validation commands passed: `cargo fmt --check` (passed), `cargo clippy --workspace --all-targets --locked -- -D warnings` (passed), `cargo test --workspace --locked` (passed), and `python3 scripts/smoke_controller_example.py` (passed).  
- Files changed: `tailtriage-controller/README.md`, `tailtriage-controller/Cargo.toml`, and `scripts/smoke_controller_example.py`.  
- Acceptance criteria (reproduced): [x] The README clearly states whether `controller_minimal` is repo-only or part of the published crate surface; [x] Packaging configuration matches the README claim; [x] CI validates the chosen contract; [x] A user following the documented example path succeeds in the environment the docs claim; [x] No remaining docs imply a stronger example-availability promise than the repo actually provides; [x] `cargo fmt --check` passes; [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` passes; [x] `cargo test --workspace --locked` passes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e67bf3a8ac83308d1844ee62cc6bc4)