### PR TITLE
Seal RuntimeSampler metadata registration and publish controller examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,18 +116,20 @@ cargo add tailtriage-axum # optional
 
 ## Examples
 
-Four public examples to start with:
+Five public examples to start with:
 
 - `minimal_checkout` — fastest capture→analyze loop
 - `axum_minimal` — smallest axum framework starter (adapter crate)
 - `axum_service_adoption` — service-shaped axum adoption example using the adapter surface
 - `mini_service_integration` — helper-layer/fractured-code instrumentation shape
+- `controller_minimal` — arm/disarm controller lifecycle starter
 
 ```bash
 cargo run -p tailtriage-tokio --example minimal_checkout
 cargo run -p tailtriage-axum --example axum_minimal
 cargo run -p tailtriage-axum --example axum_service_adoption
 cargo run -p tailtriage-tokio --example mini_service_integration
+cargo run -p tailtriage-controller --example controller_minimal
 python3 scripts/smoke_public_examples.py
 ```
 

--- a/scripts/smoke_controller_example.py
+++ b/scripts/smoke_controller_example.py
@@ -6,7 +6,7 @@ Validation steps:
 2) verify artifact exists
 3) verify artifact has expected top-level schema keys
 4) verify artifact recorded exactly one request
-5) verify packaged crate contents do not include repository examples
+5) verify public example-bearing crates package their examples
 """
 
 from __future__ import annotations
@@ -49,25 +49,38 @@ def assert_keys(payload: dict, expected: set[str], *, context: str) -> None:
         raise SystemExit(f"{context} missing top-level keys: {missing_list}")
 
 
-def assert_packaged_contract(root: Path) -> None:
+def assert_packaged_examples(root: Path, crate_dir: str) -> list[str]:
     package_listing = run_cmd(
         [
             "cargo",
             "package",
             "--allow-dirty",
             "--manifest-path",
-            str(root / "tailtriage-controller/Cargo.toml"),
+            str(root / crate_dir / "Cargo.toml"),
             "--list",
         ],
         cwd=root,
     )
     packaged_paths = [line.strip() for line in package_listing.stdout.splitlines() if line.strip()]
-    example_paths = [path for path in packaged_paths if path.startswith("examples/")]
-    if example_paths:
-        rendered = ", ".join(sorted(example_paths))
+    return sorted(path for path in packaged_paths if path.startswith("examples/"))
+
+
+def assert_example_packaging_policy(root: Path) -> None:
+    public_crates_with_examples = [
+        "tailtriage-controller",
+        "tailtriage-tokio",
+        "tailtriage-axum",
+    ]
+    missing_examples: list[str] = []
+    for crate_dir in public_crates_with_examples:
+        packaged_examples = assert_packaged_examples(root, crate_dir)
+        if not packaged_examples:
+            missing_examples.append(crate_dir)
+    if missing_examples:
+        rendered = ", ".join(missing_examples)
         raise SystemExit(
-            "tailtriage-controller packaged crate unexpectedly includes examples: "
-            f"{rendered}"
+            "example packaging contract drifted; these crates no longer package "
+            f"examples/**: {rendered}"
         )
 
 
@@ -120,11 +133,14 @@ def main() -> None:
                 f"found {len(requests)}"
             )
 
-        assert_packaged_contract(root)
+        assert_example_packaging_policy(root)
 
         print("validated: tailtriage-controller::controller_minimal")
         print(f"  artifact: {artifact_path}")
-        print("validated: packaged crate excludes repository/workspace examples")
+        print(
+            "validated: examples/** is packaged for tailtriage-controller, "
+            "tailtriage-tokio, and tailtriage-axum"
+        )
 
 
 if __name__ == "__main__":

--- a/tailtriage-controller/Cargo.toml
+++ b/tailtriage-controller/Cargo.toml
@@ -14,8 +14,8 @@ include = [
   "README.md",
   "LICENSE",
   "src/**",
+  "examples/**",
 ]
-exclude = ["examples/**"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/tailtriage-controller/README.md
+++ b/tailtriage-controller/README.md
@@ -62,20 +62,21 @@ let _ = controller.disable()?;
 # }
 ```
 
-### Runnable workspace example (repository/source checkout)
+### Runnable example (workspace checkout or published crate)
 
-`controller_minimal` is a **repository/workspace example**. Run it from this repository checkout:
+`controller_minimal` is bundled in the repository/workspace and in the published crate package.
+Run it from a repository checkout:
 
 `cargo run --manifest-path tailtriage-controller/Cargo.toml --example controller_minimal`
 
-### Published-crate onboarding (crates.io)
-
-Published users should copy the minimal snippet into their service (the packaged crate does not promise
-bundled runnable examples):
+or from a standalone project after adding `tailtriage-controller` from crates.io:
 
 ```bash
 cargo add tailtriage-controller
+cargo run --example controller_minimal
 ```
+
+You can also copy the minimal snippet directly into your service:
 
 ```rust
 use tailtriage_controller::TailtriageController;

--- a/tailtriage-core/src/collector.rs
+++ b/tailtriage-core/src/collector.rs
@@ -410,7 +410,7 @@ impl Tailtriage {
     ///
     /// Returns [`RuntimeSamplerRegistrationError::DuplicateStart`] when a sampler
     /// was already registered for this run.
-    pub fn register_tokio_runtime_sampler(
+    pub(crate) fn register_tokio_runtime_sampler(
         &self,
         config: crate::EffectiveTokioSamplerConfig,
     ) -> Result<(), RuntimeSamplerRegistrationError> {
@@ -425,6 +425,18 @@ impl Tailtriage {
         let mut run = lock_run(&self.run);
         run.metadata.effective_tokio_sampler_config = Some(config);
         Ok(())
+    }
+
+    /// Internal integration path used by `tailtriage-tokio` to register
+    /// sampler metadata only after successful real startup preconditions.
+    ///
+    /// This is not a stable public API surface.
+    #[doc(hidden)]
+    pub fn __tailtriage_internal_register_tokio_runtime_sampler(
+        &self,
+        config: crate::EffectiveTokioSamplerConfig,
+    ) -> Result<(), RuntimeSamplerRegistrationError> {
+        self.register_tokio_runtime_sampler(config)
     }
 
     pub(crate) fn record_stage_event(&self, event: StageEvent) {

--- a/tailtriage-tokio/src/lib.rs
+++ b/tailtriage-tokio/src/lib.rs
@@ -205,7 +205,9 @@ impl RuntimeSamplerBuilder {
         let resolved = self.resolve_config()?;
         let handle = Handle::try_current().map_err(|_| SamplerStartError::MissingRuntime)?;
         self.tailtriage
-            .register_tokio_runtime_sampler(resolved.into_effective_metadata())
+            .__tailtriage_internal_register_tokio_runtime_sampler(
+                resolved.into_effective_metadata(),
+            )
             .map_err(|err| match err {
                 RuntimeSamplerRegistrationError::DuplicateStart => {
                     SamplerStartError::DuplicateStart


### PR DESCRIPTION
### Motivation
- Prevent ordinary consumers from fabricating `effective_tokio_sampler_config` metadata via a public `Tailtriage` API and ensure metadata is only recorded after a real Tokio sampler startup.
- Make example publication policy consistent across public example-bearing crates so onboarding is uniform and reproducible.

### Description
- Make `Tailtriage::register_tokio_runtime_sampler` crate-internal (`pub(crate)`) and add a hidden integration hook `__tailtriage_internal_register_tokio_runtime_sampler` to allow the Tokio integration to register metadata without exposing a public forge path.
- Route `tailtriage-tokio` sampler startup to the hidden integration hook by calling `__tailtriage_internal_register_tokio_runtime_sampler` from `RuntimeSamplerBuilder::start` to preserve typed errors and one-time registration semantics.
- Include `examples/**` in `tailtriage-controller/Cargo.toml` (remove the repo-only exception) and update `tailtriage-controller/README.md` and top-level `README.md` so `controller_minimal` is documented as bundled in the published crate.
- Add packaging-policy validation to `scripts/smoke_controller_example.py` so CI verifies `examples/**` are packaged for `tailtriage-controller`, `tailtriage-tokio`, and `tailtriage-axum`.
- Files changed: `tailtriage-core/src/collector.rs`, `tailtriage-tokio/src/lib.rs`, `tailtriage-controller/Cargo.toml`, `tailtriage-controller/README.md`, `README.md`, `scripts/smoke_controller_example.py`.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets --locked -- -D warnings` and it passed.
- Ran `cargo test --workspace --locked` and all tests passed.
- Ran `python3 scripts/smoke_controller_example.py` and it validated the `controller_minimal` artifact and confirmed `examples/**` are packaged for `tailtriage-controller`, `tailtriage-tokio`, and `tailtriage-axum`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e682472ed08330b566cf295387316d)