### PR TITLE
Polish docs.rs-facing docs across public crates

### DIFF
--- a/tailtriage-axum/README.md
+++ b/tailtriage-axum/README.md
@@ -1,35 +1,26 @@
 # tailtriage-axum
 
-Axum adapter crate for `tailtriage` request-boundary triage wiring.
+`tailtriage-axum` provides **Axum ergonomics** for `tailtriage-core` request instrumentation.
 
-This crate isolates framework-specific middleware and extractor ergonomics so `tailtriage-tokio` can stay framework-agnostic.
+It is a focused adapter crate: middleware starts/finishes request lifecycle, and an extractor gives handlers access to the request-scoped instrumentation handle.
 
-## Use from the repo
+## When to use this crate vs others
+
+- Use `tailtriage-core` for framework-agnostic instrumentation.
+- Add `tailtriage-axum` when you want Axum middleware/extractor wiring.
+- Add `tailtriage-tokio` separately if you also need runtime-pressure snapshots.
+
+## Installation
 
 ```bash
-cargo run -p tailtriage-axum --example axum_minimal
-cargo run -p tailtriage-axum --example axum_service_adoption
-cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
+cargo add tailtriage-core tailtriage-axum
 ```
 
-## Add from crates.io
-
-```toml
-[dependencies]
-tailtriage-core = "0.1.1"
-tailtriage-axum = "0.1.1"
-```
-
-## What this crate provides
-
-- `middleware` to start and finish one tailtriage request per axum request
-- `TailtriageRequest` extractor for request-scoped instrumentation handles
-- `TailtriageExtractorError` rejection when middleware wiring is missing
-
-## Minimal usage
+## Minimal example
 
 ```rust,no_run
 use std::sync::Arc;
+
 use axum::{extract::State, middleware::from_fn_with_state, routing::get, Router};
 use tailtriage_axum::{middleware, TailtriageRequest};
 use tailtriage_core::Tailtriage;
@@ -47,11 +38,9 @@ let app: Router<()> = Router::new()
 # }
 ```
 
-Suspects in analysis output are leads, not proof of root cause.
+## Runtime and wiring notes
 
-## Related docs
-
-- Repo docs index: <https://github.com/SG-devel/tailtriage/tree/main/docs>
-- Core crate: <https://github.com/SG-devel/tailtriage/tree/main/tailtriage-core>
-- Tokio integration crate: <https://github.com/SG-devel/tailtriage/tree/main/tailtriage-tokio>
-- CLI crate: <https://github.com/SG-devel/tailtriage/tree/main/tailtriage-cli>
+- Add `middleware` before using `TailtriageRequest` extractor.
+- Missing middleware causes `TailtriageExtractorError` (HTTP 500).
+- Route labeling prefers Axum `MatchedPath`; fallback is raw URI path.
+- This crate is ergonomics-only and does not replace analysis from `tailtriage-cli`.

--- a/tailtriage-axum/src/lib.rs
+++ b/tailtriage-axum/src/lib.rs
@@ -25,6 +25,9 @@ pub const fn crate_name() -> &'static str {
 ///
 /// Use this with `axum::middleware::from_fn_with_state` and pass the same
 /// `Arc<Tailtriage>` in middleware state.
+///
+/// The middleware records route labels from `MatchedPath` when available and
+/// otherwise falls back to the raw URI path.
 pub async fn middleware(
     State(tailtriage): State<Arc<Tailtriage>>,
     mut request: Request<axum::body::Body>,
@@ -46,7 +49,10 @@ pub async fn middleware(
 
 /// Handler extractor for the request-scoped instrumentation handle.
 #[derive(Debug, Clone)]
-pub struct TailtriageRequest(pub OwnedRequestHandle);
+pub struct TailtriageRequest(
+    /// Request-scoped instrumentation handle created by [`middleware`].
+    pub OwnedRequestHandle,
+);
 
 impl TailtriageRequest {
     /// Returns the wrapped request handle.

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -1,36 +1,36 @@
 # tailtriage-cli
 
-Command-line triage analyzer for one `tailtriage` run artifact.
+`tailtriage-cli` is the **analysis and report generation** crate for `tailtriage` artifacts.
 
-## Use from the repo
+Use it after capture to produce evidence-ranked suspects and next checks.
 
-```bash
-cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
-```
+## When to use this crate vs others
 
-## Install from crates.io
+- `tailtriage-core` / `tailtriage-*` crates capture runtime data.
+- `tailtriage-cli` loads captured artifacts and produces triage reports.
+
+## Installation
 
 ```bash
 cargo install tailtriage-cli
+```
+
+## Minimal usage
+
+```bash
 tailtriage analyze tailtriage-run.json --format json
 ```
 
-## Output shape to inspect first
+## Output fields to inspect first
 
 1. `primary_suspect.kind`
 2. `primary_suspect.evidence[]`
 3. `primary_suspect.next_checks[]`
 
-Suspects are evidence-ranked leads, not proof of root cause.
+Suspects are investigation leads, not proof of root cause.
 
-## Artifact schema contract
+## Artifact contract
 
-`tailtriage-cli` requires a top-level `schema_version` field. Current supported value: `1`.
-
-When artifacts contain unfinished lifecycle metadata, the loader surfaces warnings (unfinished count/sample) but does not fabricate missing completion events.
-
-## Related docs
-
-- Repo docs index: <https://github.com/SG-devel/tailtriage/tree/main/docs>
-- Core crate: <https://github.com/SG-devel/tailtriage/tree/main/tailtriage-core>
-- Tokio integration crate: <https://github.com/SG-devel/tailtriage/tree/main/tailtriage-tokio>
+- Requires top-level `schema_version`.
+- Current supported schema version: `1`.
+- Loader warnings include lifecycle warnings and unfinished request notices when present.

--- a/tailtriage-controller/README.md
+++ b/tailtriage-controller/README.md
@@ -1,90 +1,27 @@
 # tailtriage-controller
 
-Long-lived controller scaffolding for live arm/disarm capture workflows in `tailtriage`.
+`tailtriage-controller` is the **long-lived control layer** for `tailtriage` capture.
 
-## Layering
+Use it when your service must stay running while you repeatedly arm/disarm bounded capture generations.
 
-- `tailtriage-core`: per-run collector and artifact model.
-- `tailtriage-controller`: helper/control layer for repeated bounded activations.
+## When to use this crate vs others
 
-This crate provides:
+- Use `tailtriage-core` for one run lifecycle (`build -> capture -> shutdown`).
+- Use `tailtriage-controller` for repeated live capture windows with enable/disable control.
+- Add `tailtriage-tokio` integration through controller runtime sampler template when runtime pressure evidence is needed.
 
-- controller builder/template/status types
-- enable/disable arm-disarm lifecycle with one-active-generation invariant
-- per-generation admission gating and drain-aware finalization
-- generation-specific artifact paths and run IDs
-- run-end policy modeling
-- controller-owned inert request wrappers for disabled/closing periods
+## Installation
 
-## When to use the controller vs `Tailtriage::builder(...)`
+```bash
+cargo add tailtriage-controller
+```
 
-Use ordinary `tailtriage-core` builder usage when you want one process-scoped run lifecycle:
+## Minimal example
 
-- build one `Tailtriage`
-- run workload
-- call `shutdown()`
-
-Use `tailtriage-controller` when your service should stay up while you repeatedly arm/disarm
-bounded capture runs for triage windows.
-
-The controller is a control layer on top of core; it does not replace direct builder usage.
-
-## Live controller semantics
-
-- At most one active generation can exist at a time.
-- `enable()` starts a fresh generation with its own run ID/artifact path.
-- `disable()` stops new admissions for that generation.
-  - If no admitted requests remain, finalize now.
-  - If admitted requests are still in flight, generation enters closing state and finalizes after drain.
-- Requests admitted into a generation remain bound to that generation for completion.
-  - They do not migrate into later generations during disable/re-enable churn.
-- Requests started while disabled/closing are inert controller-owned wrappers and are never later
-  attached to a new generation.
-
-## Minimal usage
-
-```rust
+```rust,no_run
 use tailtriage_controller::TailtriageController;
 
 fn demo() -> Result<(), Box<dyn std::error::Error>> {
-let controller = TailtriageController::builder("checkout-service")
-    .initially_enabled(false)
-    .output("tailtriage-run.json")
-    .build()?;
-
-let generation = controller.enable()?;
-let started = controller.begin_request("/checkout");
-started.completion.finish_ok();
-let _ = controller.disable()?;
-
-# let _ = generation;
-# Ok(())
-# }
-```
-
-### Runnable example (workspace checkout)
-
-`controller_minimal` is bundled in the repository/workspace and in the published crate package.
-Run it from a repository checkout:
-
-`cargo run --manifest-path tailtriage-controller/Cargo.toml --example controller_minimal`
-
-### Published crate examples (reference/adoption source)
-
-`tailtriage-controller` packages `examples/**` in the published crate so consumers can read/copy
-the exact example source from docs.rs or the crate source package.
-
-Important: dependency examples are **not** runnable in an arbitrary consumer project by first
-adding `tailtriage-controller` as a dependency and then running
-`cargo run --example controller_minimal`. `cargo run --example ...` runs examples defined by the
-current package.
-
-You can also copy the minimal snippet directly into your service:
-
-```rust
-use tailtriage_controller::TailtriageController;
-
-fn main() -> Result<(), Box<dyn std::error::Error>> {
     let controller = TailtriageController::builder("checkout-service")
         .initially_enabled(false)
         .output("tailtriage-run.json")
@@ -94,133 +31,28 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let started = controller.begin_request("/checkout");
     started.completion.finish_ok();
     let _ = controller.disable()?;
+
     Ok(())
 }
 ```
 
-### Disabled-path expectations
+## Behavioral guarantees
 
-When the controller is disabled (or an active generation is closing), `begin_request(...)`
-and `begin_request_with(...)` still return request tokens with the same non-branching
-ergonomics, but those tokens are inert/no-op wrappers owned by this crate.
+- At most one generation is active at a time.
+- `enable()` creates a fresh generation (new run ID/artifact path).
+- `disable()` stops admissions and finalizes immediately or after admitted requests drain.
+- Requests admitted to a generation stay bound to that generation.
+- Requests started while disabled/closing are inert wrappers and never migrate into later generations.
 
-- queue/stage/inflight wrappers are no-op
-- completion methods are no-op lifecycle markers on the inert wrapper
-- inert requests do not write capture events and do not join later generations
-- inert metadata preserves explicit `request_id`/`kind`; if `request_id` is omitted,
-  controller assigns a non-empty local fallback ID (`inert-{N}`)
+## Config/reload summary
 
-This path is intended to be cheap and predictable, but users should still validate overhead in
-their own workload/environment.
+- Optional TOML config can be provided via `config_path(...)`.
+- `reload_config()` updates only the template for **future** generations.
+- Active generations keep their original activation config.
+- `reload_template(...)` is a compatibility helper that panics on invalid templates.
+- Prefer `try_reload_template(...)` for explicit error handling.
 
-## Enable/disable/reload/status snippet
+## Runtime requirements
 
-```rust
-use tailtriage_controller::TailtriageController;
-
-fn controller_demo() -> Result<(), Box<dyn std::error::Error>> {
-    let controller = TailtriageController::builder("checkout-service")
-        .output("tailtriage-run.json")
-        .config_path("tailtriage-controller.toml")
-        .initially_enabled(false)
-        .build()?;
-
-    // Arm one bounded generation.
-    let active = controller.enable()?;
-
-    let started = controller.begin_request("/checkout");
-    started.completion.finish_ok();
-
-    // Status reports template + generation snapshot.
-    let _status_during_run = controller.status();
-
-    // Disarm (finalizes immediately or after in-flight drain).
-    let _disable = controller.disable()?;
-
-    // Reload updates template for NEXT activation only.
-    controller.reload_config()?;
-    let _status_after_reload = controller.status();
-
-    // Next enable uses reloaded template.
-    let _next = controller.enable()?;
-
-    # let _ = active;
-    # Ok(())
-    # }
-```
-
-## TOML config and manual reload
-
-`tailtriage-controller` accepts a TOML file via `TailtriageController::builder(...).config_path(...)`.
-
-```toml
-[controller]
-# optional; falls back to builder service name if omitted
-service_name = "checkout-service"
-# optional; falls back to builder.initially_enabled(...) if omitted
-initially_enabled = false
-
-[controller.activation]
-mode = "light"                 # "light" | "investigation"
-strict_lifecycle = false
-
-[controller.activation.capture_limits_override]
-max_requests = 100000
-max_stages = 200000
-# max_queues = ...
-# max_inflight_snapshots = ...
-# max_runtime_snapshots = ...
-
-[controller.activation.sink]
-type = "local_json"
-output_path = "tailtriage-run.json"
-
-[controller.activation.runtime_sampler]
-enabled_for_armed_runs = true
-mode_override = "investigation"  # optional
-interval_ms = 200                # optional
-max_runtime_snapshots = 100000   # optional
-
-[controller.activation.run_end_policy]
-# "continue_after_limits_hit" | "auto_seal_on_limits_hit"
-kind = "continue_after_limits_hit"
-```
-
-Reload in v1 is explicit and manual:
-
-- `controller.reload_config()?` re-reads TOML from `config_path`.
-- Reload updates only the controller template for **future** activations.
-- `reload_config()` validates the reloaded template immediately and returns an error
-  instead of deferring invalid-template failures to the next `enable()`.
-- If a generation is already active, that generation keeps the exact activation config it started with.
-- The reloaded template is applied the next time `enable()` starts a new generation.
-
-Direct template replacement has two forms:
-
-- `try_reload_template(...) -> Result<_, ReloadTemplateError>` validates immediately and
-  returns errors.
-- `reload_template(...)` remains as a compatibility helper and panics on invalid templates.
-
-Poisoned internal controller mutexes are recovered by taking ownership of the poisoned
-state, so controller methods do not panic solely because a previous panic poisoned an
-internal lock.
-
-### Run-end policy behavior on limits hit
-
-`[controller.activation.run_end_policy]` controls what happens when capture limits are hit:
-
-- `kind = "continue_after_limits_hit"`: keep the generation active; additional data can be dropped after saturation
-  until manual disarm/shutdown.
-- `kind = "auto_seal_on_limits_hit"`: on the first transition to `limits_hit` in any capture path
-  (request events, runtime snapshots, stage events, queue events, or in-flight snapshots),
-  controller immediately stops new admissions and moves the current generation into
-  sealing/finalization. If admitted requests are still in flight, the generation remains closing
-  and finalizes as soon as those admitted requests drain.
-
-## What this feature does not do
-
-- Does **not** mutate an already-active generation when config is reloaded.
-- Does **not** move admitted requests between generations.
-- Does **not** auto-prove root cause; it preserves the same evidence-ranked suspect model.
-- Does **not** force runtime sampling by default; sampler startup is still explicit via
-  `enabled_for_armed_runs`.
+- Runtime sampler startup (if enabled in template) requires an active Tokio runtime.
+- This crate does not prove root cause; it preserves evidence-ranked suspects and next checks downstream in `tailtriage-cli`.

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -1,66 +1,24 @@
 # tailtriage-core
 
-Core run schema, split request lifecycle API, and instrumentation primitives for `tailtriage`.
+`tailtriage-core` is the **instrumentation foundation** for `tailtriage`.
 
-## Use from the repo
+Use this crate when you want to capture request lifecycle timing and emit one bounded JSON run artifact, without pulling framework or runtime-specific adapters.
 
-From the workspace root, run examples and analysis directly:
+## When to use this crate vs others
+
+- Use `tailtriage-core` for direct, explicit request instrumentation.
+- Add `tailtriage-tokio` if you also need Tokio runtime-pressure snapshots.
+- Add `tailtriage-axum` if you want Axum middleware/extractor helpers.
+- Use `tailtriage-controller` if capture must be armed/disarmed repeatedly in a long-lived process.
+- Use `tailtriage-cli` to analyze artifacts.
+
+## Installation
 
 ```bash
-cargo run -p tailtriage-tokio --example minimal_checkout
-cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
+cargo add tailtriage-core
 ```
 
-## Add from crates.io
-
-```toml
-[dependencies]
-tailtriage-core = "0.1.1"
-```
-
-## What this crate owns
-
-- Run artifact schema (`Run`, requests, stages, queues, inflight snapshots, runtime snapshots)
-- Unified started-request model (`Tailtriage`, `StartedRequest`, `RequestHandle`, `RequestCompletion`)
-- Queue/stage/in-flight instrumentation primitives
-- Explicit completion token lifecycle (`finish`, `finish_ok`, `finish_result`) and final artifact flush (`shutdown`)
-
-## `CaptureMode` defaults and overrides
-
-`CaptureMode` is a real core preset for **retention defaults** only.
-
-- It changes default `CaptureLimits` values.
-- It does **not** require Tokio.
-- It does **not** auto-enable `RuntimeSampler`.
-- It does **not** change event types.
-- It does **not** change lifecycle semantics.
-- It does **not** change `strict_lifecycle` unless you set `strict_lifecycle(...)` yourself.
-
-Concrete core defaults:
-
-- `CaptureMode::Light`
-  - `max_requests`: 100_000
-  - `max_stages`: 200_000
-  - `max_queues`: 200_000
-  - `max_inflight_snapshots`: 200_000
-  - `max_runtime_snapshots`: 100_000
-- `CaptureMode::Investigation`
-  - `max_requests`: 300_000
-  - `max_stages`: 600_000
-  - `max_queues`: 600_000
-  - `max_inflight_snapshots`: 600_000
-  - `max_runtime_snapshots`: 300_000
-
-Override precedence:
-
-1. `capture_limits(...)` full override
-2. `capture_limits_override(CaptureLimitsOverride { ... })` field-level override over mode defaults
-3. selected mode defaults
-
-Artifacts include both selected mode (`metadata.mode`) and resolved config (`metadata.effective_core_config`).
-For older artifacts that predate this field, `metadata.effective_core_config` is `null` (unknown).
-
-## Minimal usage
+## Minimal example
 
 ```rust,no_run
 use tailtriage_core::{RequestOptions, Tailtriage};
@@ -83,27 +41,27 @@ tailtriage.shutdown()?;
 # }
 ```
 
-## Lifecycle ownership
+## Runtime and lifecycle notes
 
-`begin_request(...)` / `begin_request_with(...)` returns `StartedRequest { handle, completion }`:
+- `CaptureMode` changes only retention defaults.
+- `CaptureMode` does **not** auto-start Tokio runtime sampling.
+- `queue(...)`, `stage(...)`, and `inflight(...)` never finish a request.
+- Every request must be finished exactly once with `finish(...)`, `finish_ok()`, or `finish_result(...)`.
+- `shutdown()` flushes the run artifact and does not fabricate missing completions.
+- `strict_lifecycle(true)` makes `shutdown()` fail if unfinished requests remain.
 
-- `started.handle` (`RequestHandle`) is instrumentation-only
-- `started.completion` (`RequestCompletion`) is the only finish path
+## Capture-mode retention defaults
 
-`queue(...)`, `stage(...)`, and `inflight(...)` do not finish the request. Every request must be finished exactly once via `finish(...)`, `finish_ok()`, or `finish_result(...)`.
+`Light`
+- `max_requests = 100_000`
+- `max_stages = 200_000`
+- `max_queues = 200_000`
+- `max_inflight_snapshots = 200_000`
+- `max_runtime_snapshots = 100_000`
 
-## Shutdown semantics
-
-- `shutdown()` does **not** auto-finish requests.
-- `shutdown()` does **not** fabricate timings or outcomes.
-- unfinished requests are surfaced in run metadata warnings and unfinished-request samples.
-- `strict_lifecycle(true)` makes `shutdown()` return an error when unfinished requests remain.
-
-
-Runtime-cost attribution categories and measurement workflow are documented in [`docs/runtime-cost.md`](../docs/runtime-cost.md).
-
-## Related docs
-
-- Repo docs index: <https://github.com/SG-devel/tailtriage/tree/main/docs>
-- Tokio integration crate: <https://github.com/SG-devel/tailtriage/tree/main/tailtriage-tokio>
-- CLI crate: <https://github.com/SG-devel/tailtriage/tree/main/tailtriage-cli>
+`Investigation`
+- `max_requests = 300_000`
+- `max_stages = 600_000`
+- `max_queues = 600_000`
+- `max_inflight_snapshots = 600_000`
+- `max_runtime_snapshots = 300_000`

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -1,75 +1,27 @@
 # tailtriage-tokio
 
-Tokio integration for `tailtriage`, including `RuntimeSampler` for periodic runtime snapshots.
+`tailtriage-tokio` adds **Tokio runtime-pressure evidence** to a `tailtriage-core` run.
 
-## Use from the repo
+Use this crate when core request instrumentation alone is not enough to separate:
+
+- application queueing,
+- executor pressure,
+- blocking-pool pressure, and
+- downstream stage slowdown.
+
+## When to use this crate vs others
+
+- Use `tailtriage-core` for request lifecycle instrumentation.
+- Add `tailtriage-tokio` to periodically capture runtime metrics into the same artifact.
+- Use `tailtriage-axum` only for Axum ergonomics (independent of runtime sampling).
+
+## Installation
 
 ```bash
-cargo run -p tailtriage-tokio --example minimal_checkout
-cargo run -p tailtriage-cli -- analyze tailtriage-run.json --format json
+cargo add tailtriage-core tailtriage-tokio
 ```
 
-## Add from crates.io
-
-```toml
-[dependencies]
-tailtriage-core = "0.1.1"
-tailtriage-tokio = "0.1.1"
-```
-
-## What this crate provides
-
-- `RuntimeSampler` for periodic Tokio runtime snapshots
-- Runtime evidence enrichment on the same run artifact used for request instrumentation
-- Works alongside the split lifecycle API from `tailtriage-core` (`StartedRequest { handle, completion }`)
-
-## Split lifecycle reminder
-
-Request lifecycle ownership stays in `tailtriage-core`:
-
-- start with `begin_request` / `begin_request_with`
-- instrument via `started.handle`
-- finish exactly once via `started.completion`
-
-`shutdown()` does not auto-finish pending requests. Unfinished requests are surfaced in run metadata, and `strict_lifecycle(true)` can make shutdown fail.
-
-## `RuntimeSampler` metric availability
-
-Always available on stable Tokio:
-
-- `alive_tasks`
-- `global_queue_depth`
-
-Requires `tokio_unstable`:
-
-- `local_queue_depth`
-- `blocking_queue_depth`
-- `remote_schedule_count`
-
-When `tokio_unstable` is not enabled, unstable-only fields are recorded as `None`.
-
-## `RuntimeSampler` mode inheritance and overrides
-
-`RuntimeSampler::builder(...)` resolves sampler config in this order:
-
-1. **inherited mode** from `Tailtriage` selected mode (`light` / `investigation`)
-2. optional **explicit Tokio override** via `.mode(...)`
-3. optional cadence override via `.interval(...)`
-4. optional retention override via `.max_runtime_snapshots(...)`
-
-Tokio mode defaults (applied only if sampler is started):
-
-- Light: `cadence = 500ms`, `max_runtime_snapshots = 5_000`
-- Investigation: `cadence = 100ms`, `max_runtime_snapshots = 50_000`
-
-`CaptureMode` never auto-starts runtime sampling; you must call `.start()`.
-`CaptureMode` does not change core event types or `strict_lifecycle`.
-Resolved runtime snapshot retention is clamped to the core run's
-`max_runtime_snapshots` cap so artifact metadata matches actual retention.
-Startup requires an active Tokio runtime, and each `Tailtriage` run allows only
-one successful sampler start.
-
-## Minimal usage
+## Minimal example
 
 ```rust,no_run
 use std::sync::Arc;
@@ -78,36 +30,38 @@ use tailtriage_core::Tailtriage;
 use tailtriage_tokio::RuntimeSampler;
 
 # async fn demo() -> Result<(), Box<dyn std::error::Error>> {
-let tailtriage = Arc::new(
+let run = Arc::new(
     Tailtriage::builder("checkout-service")
         .output("tailtriage-run.json")
         .investigation()
         .build()?,
 );
 
-let sampler = RuntimeSampler::builder(Arc::clone(&tailtriage))
-    // inherits Investigation mode from core when mode(...) is omitted
-    .start()?;
+let sampler = RuntimeSampler::builder(Arc::clone(&run)).start()?;
 
-// ... run workload ...
+// ... workload ...
 
 sampler.shutdown().await;
-tailtriage.shutdown()?;
+run.shutdown()?;
 # Ok(())
 # }
 ```
 
+## Runtime requirements and feature notes
 
-For runtime-cost attribution categories (including incremental sampler cost), see [`docs/runtime-cost.md`](../docs/runtime-cost.md).
+- `RuntimeSampler::start` must run inside an active Tokio runtime.
+- Each `Tailtriage` run allows only one successful sampler start.
+- `CaptureMode` does not auto-start sampling.
+- Stable Tokio metrics: `alive_tasks`, `global_queue_depth`.
+- `tokio_unstable` metrics: `local_queue_depth`, `blocking_queue_depth`, `remote_schedule_count`.
 
-## Related docs
+## Configuration precedence
 
-- Repo docs index: <https://github.com/SG-devel/tailtriage/tree/main/docs>
-- Core crate: <https://github.com/SG-devel/tailtriage/tree/main/tailtriage-core>
-- CLI crate: <https://github.com/SG-devel/tailtriage/tree/main/tailtriage-cli>
+`RuntimeSampler::builder(...)` resolves settings in this order:
 
-## Axum adapter crate
+1. inherited mode from `Tailtriage`
+2. explicit `.mode(...)` override
+3. explicit `.interval(...)` override
+4. explicit `.max_runtime_snapshots(...)` override
 
-Axum adoption helpers and axum examples live in `tailtriage-axum`.
-
-The adapter is an ergonomics layer over core primitives. It does not claim production-hardening or zero-instrumentation auto-diagnosis.
+Resolved runtime snapshot retention is clamped by core capture limits.

--- a/tailtriage/Cargo.toml
+++ b/tailtriage/Cargo.toml
@@ -29,5 +29,9 @@ tailtriage-controller = { workspace = true, optional = true }
 tailtriage-tokio = { workspace = true, optional = true }
 tailtriage-axum = { workspace = true, optional = true }
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [lints]
 workspace = true

--- a/tailtriage/README.md
+++ b/tailtriage/README.md
@@ -1,8 +1,15 @@
 # tailtriage
 
-`tailtriage` is the official facade crate and umbrella entry point for Tokio tail-latency triage.
+`tailtriage` is the **default facade crate** for Tokio tail-latency triage.
 
-It always re-exports `tailtriage-core` as the foundation API and exposes optional integration crates behind feature-gated namespaces.
+Use this crate when you want one dependency that can expose:
+
+- `tailtriage-core` (always) as the instrumentation foundation
+- `tailtriage::controller` (default feature) for long-lived arm/disarm capture control
+- `tailtriage::tokio` (feature) for runtime-pressure evidence
+- `tailtriage::axum` (feature) for Axum middleware/extractor ergonomics
+
+If you want tighter dependency control, depend on focused crates directly.
 
 ## Installation
 
@@ -10,27 +17,21 @@ It always re-exports `tailtriage-core` as the foundation API and exposes optiona
 cargo add tailtriage
 ```
 
-Optional integrations:
+Enable optional integrations:
 
 ```bash
 cargo add tailtriage --features tokio
 cargo add tailtriage --features "tokio,axum"
 ```
 
-`controller` is enabled by default and re-exported at `tailtriage::controller`.
-
 ## Feature flags
 
-- `controller` (default): enables `tailtriage::controller` (from `tailtriage-controller`)
-- `tokio`: enables `tailtriage::tokio` (from `tailtriage-tokio`)
-- `axum`: enables `tailtriage::axum` (from `tailtriage-axum`)
+- `controller` (default): enables `tailtriage::controller` (`tailtriage-controller`)
+- `tokio`: enables `tailtriage::tokio` (`tailtriage-tokio`)
+- `axum`: enables `tailtriage::axum` (`tailtriage-axum`)
 - `full`: enables `controller`, `tokio`, and `axum`
 
-Advanced users can still depend on focused crates (`tailtriage-core`, `tailtriage-controller`, `tailtriage-tokio`, `tailtriage-axum`) directly for tighter dependency control.
-
-## Examples
-
-Core-only usage:
+## Minimal example
 
 ```no_run
 use tailtriage::Tailtriage;
@@ -39,35 +40,20 @@ use tailtriage::Tailtriage;
 let run = Tailtriage::builder("checkout-service")
     .output("tailtriage-run.json")
     .build()?;
+
+let started = run.begin_request("/checkout");
+started.completion.finish_ok();
+
 run.shutdown()?;
 # Ok(())
 # }
 ```
 
-Tokio runtime sampling (requires `tokio` feature):
+## Choosing crates in this workspace
 
-```no_run
-# #[cfg(feature = "tokio")]
-# async fn demo(run: std::sync::Arc<tailtriage::Tailtriage>) -> Result<(), Box<dyn std::error::Error>> {
-use tailtriage::tokio::RuntimeSampler;
-
-let sampler = RuntimeSampler::builder(run).start()?;
-sampler.shutdown().await;
-# Ok(())
-# }
-```
-
-Controller convenience layer (default `controller` feature):
-
-```no_run
-# #[cfg(feature = "controller")]
-# fn demo() -> Result<(), Box<dyn std::error::Error>> {
-use tailtriage::controller::TailtriageController;
-
-let controller = TailtriageController::builder("checkout-service")
-    .initially_enabled(true)
-    .build()?;
-let _status = controller.status();
-# Ok(())
-# }
-```
+- Use **`tailtriage`** for most integrations and docs.rs onboarding.
+- Use **`tailtriage-core`** when you only want core request lifecycle instrumentation.
+- Use **`tailtriage-controller`** when capture must be repeatedly armed/disarmed without restarting the service.
+- Use **`tailtriage-tokio`** when you need runtime-pressure evidence in the same run artifact.
+- Use **`tailtriage-axum`** for Axum-specific ergonomics.
+- Use **`tailtriage-cli`** to analyze captured artifacts into evidence-ranked suspects and next checks.

--- a/tailtriage/src/lib.rs
+++ b/tailtriage/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! Official facade crate for the tailtriage toolkit.
 //!
@@ -10,10 +11,13 @@
 pub use tailtriage_core::*;
 
 #[cfg(feature = "axum")]
+#[cfg_attr(docsrs, doc(cfg(feature = "axum")))]
 pub use tailtriage_axum as axum;
 #[cfg(feature = "controller")]
+#[cfg_attr(docsrs, doc(cfg(feature = "controller")))]
 pub use tailtriage_controller as controller;
 #[cfg(feature = "tokio")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub use tailtriage_tokio as tokio;
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation
- Crate-level documentation and README messaging were inconsistent across the workspace, making docs.rs landing pages unclear for adopters.
- Feature-gated facade namespaces were not surfaced for docs.rs consumers, so optional integrations could be hard to discover on docs.rs.
- A small public rustdoc gap in the Axum adapter (middleware route-label behavior and extractor tuple field) reduced clarity for first-time users.

### Description
- Rewrote and standardized the crate-level README/docs.rs landing pages for the public crates to make adoption guidance crisp and truthful for each crate's role. 
- Added docs.rs publication polish: `[package.metadata.docs.rs] all-features = true` and `rustdoc-args = ["--cfg", "docsrs"]` in `tailtriage/Cargo.toml` and enabled `#![cfg_attr(docsrs, feature(doc_cfg))]` plus `#[cfg_attr(docsrs, doc(cfg(feature = "...")))]` on feature-gated re-exports in `tailtriage/src/lib.rs` so feature namespaces render on docs.rs. 
- Improved `tailtriage-axum` public rustdoc by documenting middleware route-label fallback behavior and adding a doc comment for the extractor tuple field. 
- Files changed: `tailtriage/README.md`, `tailtriage-core/README.md`, `tailtriage-controller/README.md`, `tailtriage-tokio/README.md`, `tailtriage-axum/README.md`, `tailtriage-cli/README.md`, `tailtriage/src/lib.rs`, `tailtriage/Cargo.toml`, and `tailtriage-axum/src/lib.rs`.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets --locked -- -D warnings` and it passed.
- Ran `cargo test --workspace --locked` and the full test suite passed.

Acceptance checklist:
- [x] All major public crates have crisp, truthful crate-level docs appropriate for docs.rs.
- [x] Public functions, methods, types, and error surfaces are properly documented across the workspace (small targeted rustdoc additions where needed).
- [x] Feature-gated APIs are documented clearly and consistently via `doc(cfg)` annotations and docs.rs metadata.
- [x] README/rustdoc messaging is consistent across crates.
- [x] Minimal usage examples in docs are current and truthful.
- [x] Internal-only or unstable integration hooks are not presented as supported public APIs.
- [x] The docs are publication-ready for crates.io/docs.rs.
- [x] `cargo fmt --check` passes.
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` passes.
- [x] `cargo test --workspace --locked` passes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e691c4c3c88330a3052c4ed5570b39)