### PR TITLE
ci: add cargo deny check to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Install cargo-deny
-        if: matrix.profile == 'dev'
+        if: matrix.profile == 'release'
         uses: taiki-e/install-action@cargo-deny
 
       - name: Cache Rust build artifacts
@@ -130,7 +130,7 @@ jobs:
         run: cargo test --workspace --locked ${{ matrix.profile == 'release' && '--release' || '' }}
 
       - name: Cargo deny
-        if: matrix.profile == 'dev'
+        if: matrix.profile == 'release'
         run: cargo deny check
 
       - name: Validate queue demo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,10 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      - name: Install cargo-deny
+        if: matrix.profile == 'dev'
+        uses: taiki-e/install-action@cargo-deny
+
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
         with:
@@ -124,6 +128,10 @@ jobs:
 
       - name: Cargo test
         run: cargo test --workspace --locked ${{ matrix.profile == 'release' && '--release' || '' }}
+
+      - name: Cargo deny
+        if: matrix.profile == 'dev'
+        run: cargo deny check
 
       - name: Validate queue demo
         run: python3 scripts/demo_tool.py validate queue --profile ${{ matrix.profile }}


### PR DESCRIPTION
### Motivation
- Enforce dependency, license, and advisory checks in CI by running `cargo deny check` so dependency issues are caught by the pipeline.

### Description
- Install `cargo-deny` in the `verify` job for the `dev` matrix profile using `taiki-e/install-action@cargo-deny` and add a conditional step that runs `cargo deny check` when `matrix.profile == 'dev'` in `.github/workflows/ci.yml`.

### Testing
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` locally and they all succeeded.
- Executing `cargo deny check` locally failed with `no such command: deny` because `cargo-deny` was not installed in this environment, which the CI change addresses by installing the tool before running the check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e734038c04833088c43a8b3a883c17)