### PR TITLE
Gate external consumer smoke test on published workspace version changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ on:
       - "rust-toolchain.toml"
       - ".github/workflows/**/*.yml"
       - ".github/workflows/**/*.yaml"
-  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -46,9 +45,12 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
       docs: ${{ steps.filter.outputs.docs }}
+      published_version_changed: ${{ steps.published_version.outputs.published_version_changed }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Detect changed file groups
         id: filter
@@ -67,6 +69,65 @@ jobs:
               - '.github/workflows/**/*.yaml'
             docs:
               - '**/*.md'
+
+      - name: Detect published workspace version change
+        id: published_version
+        env:
+          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GITHUB_EVENT_BEFORE: ${{ github.event.before }}
+        run: |
+          python3 - <<'PY'
+          import os
+          import subprocess
+          import tomllib
+
+
+          def read_workspace_version(ref: str) -> str:
+              cargo_toml = subprocess.check_output(
+                  ["git", "show", f"{ref}:Cargo.toml"]
+              ).decode("utf-8")
+              parsed = tomllib.loads(cargo_toml)
+              return parsed["workspace"]["package"]["version"]
+
+
+          event_name = os.environ["GITHUB_EVENT_NAME"]
+          head_ref = os.environ["GITHUB_SHA"]
+          base_ref = ""
+
+          if event_name == "pull_request":
+              base_ref = os.environ.get("GITHUB_BASE_SHA", "")
+          elif event_name == "push":
+              base_ref = os.environ.get("GITHUB_EVENT_BEFORE", "")
+
+          changed = True
+          if base_ref and set(base_ref) != {"0"}:
+              try:
+                  old_version = read_workspace_version(base_ref)
+                  new_version = read_workspace_version(head_ref)
+                  changed = old_version != new_version
+                  print(
+                      "published workspace version comparison:",
+                      f"base={base_ref} ({old_version})",
+                      f"head={head_ref} ({new_version})",
+                  )
+              except Exception as exc:
+                  changed = True
+                  print(
+                      "failed to read workspace version history; "
+                      "failing safe with published_version_changed=true:",
+                      exc,
+                  )
+          else:
+              print(
+                  "missing or zeroed base ref; "
+                  "failing safe with published_version_changed=true"
+              )
+
+          output_value = "true" if changed else "false"
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"published_version_changed={output_value}\n")
+          print(f"published_version_changed={output_value}")
+          PY
 
   docs-contracts:
     name: docs contracts
@@ -166,7 +227,7 @@ jobs:
         run: python3 scripts/smoke_public_examples.py
 
       - name: Smoke-check external crates.io consumer adoption flow
-        if: matrix.profile == 'release'
+        if: matrix.profile == 'release' && github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.published_version_changed == 'true'
         run: python3 scripts/smoke_external_consumer.py
 
       - name: Smoke-check controller public example

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,59 +75,7 @@ jobs:
         env:
           GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           GITHUB_EVENT_BEFORE: ${{ github.event.before }}
-        run: |
-          python3 - <<'PY'
-          import os
-          import subprocess
-          import tomllib
-
-
-          def read_workspace_version(ref: str) -> str:
-              cargo_toml = subprocess.check_output(
-                  ["git", "show", f"{ref}:Cargo.toml"]
-              ).decode("utf-8")
-              parsed = tomllib.loads(cargo_toml)
-              return parsed["workspace"]["package"]["version"]
-
-
-          event_name = os.environ["GITHUB_EVENT_NAME"]
-          head_ref = os.environ["GITHUB_SHA"]
-          base_ref = ""
-
-          if event_name == "pull_request":
-              base_ref = os.environ.get("GITHUB_BASE_SHA", "")
-          elif event_name == "push":
-              base_ref = os.environ.get("GITHUB_EVENT_BEFORE", "")
-
-          changed = True
-          if base_ref and set(base_ref) != {"0"}:
-              try:
-                  old_version = read_workspace_version(base_ref)
-                  new_version = read_workspace_version(head_ref)
-                  changed = old_version != new_version
-                  print(
-                      "published workspace version comparison:",
-                      f"base={base_ref} ({old_version})",
-                      f"head={head_ref} ({new_version})",
-                  )
-              except Exception as exc:
-                  changed = True
-                  print(
-                      "failed to read workspace version history; "
-                      "failing safe with published_version_changed=true:",
-                      exc,
-                  )
-          else:
-              print(
-                  "missing or zeroed base ref; "
-                  "failing safe with published_version_changed=true"
-              )
-
-          output_value = "true" if changed else "false"
-          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
-              output.write(f"published_version_changed={output_value}\n")
-          print(f"published_version_changed={output_value}")
-          PY
+        run: python3 scripts/ci_detect_published_version_change.py
 
   docs-contracts:
     name: docs contracts

--- a/scripts/ci_detect_published_version_change.py
+++ b/scripts/ci_detect_published_version_change.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Detect published workspace version changes across CI event boundaries.
+
+This script compares root Cargo.toml `workspace.package.version` between a base
+ref and head ref for pull_request/push events and writes
+`published_version_changed=true|false` to `GITHUB_OUTPUT`.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tomllib
+
+
+def read_workspace_version(ref: str) -> str:
+    cargo_toml = subprocess.check_output(
+        ["git", "show", f"{ref}:Cargo.toml"]
+    ).decode("utf-8")
+    parsed = tomllib.loads(cargo_toml)
+    return parsed["workspace"]["package"]["version"]
+
+
+def base_ref_for_event(event_name: str) -> str:
+    if event_name == "pull_request":
+        return os.environ.get("GITHUB_BASE_SHA", "")
+    if event_name == "push":
+        return os.environ.get("GITHUB_EVENT_BEFORE", "")
+    return ""
+
+
+def write_output(value: str) -> None:
+    with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+        output.write(f"published_version_changed={value}\n")
+
+
+def main() -> None:
+    event_name = os.environ["GITHUB_EVENT_NAME"]
+    head_ref = os.environ["GITHUB_SHA"]
+    base_ref = base_ref_for_event(event_name)
+
+    changed = True
+    if base_ref and set(base_ref) != {"0"}:
+        try:
+            old_version = read_workspace_version(base_ref)
+            new_version = read_workspace_version(head_ref)
+            changed = old_version != new_version
+            print(
+                "published workspace version comparison:",
+                f"base={base_ref} ({old_version})",
+                f"head={head_ref} ({new_version})",
+            )
+        except Exception as exc:
+            changed = True
+            print(
+                "failed to read workspace version history; "
+                "failing safe with published_version_changed=true:",
+                exc,
+            )
+    else:
+        print(
+            "missing or zeroed base ref; "
+            "failing safe with published_version_changed=true"
+        )
+
+    output_value = "true" if changed else "false"
+    write_output(output_value)
+    print(f"published_version_changed={output_value}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke_external_consumer.py
+++ b/scripts/smoke_external_consumer.py
@@ -2,7 +2,7 @@
 """Smoke-test external crates.io adoption outside the workspace.
 
 This script creates a temporary Cargo app outside the repository, consumes
-`tailtriage-core` from crates.io, produces a run artifact, and analyzes it
+`tailtriage` from crates.io, produces a run artifact, and analyzes it
 with the workspace CLI.
 """
 
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import subprocess
 import tempfile
+import tomllib
 from pathlib import Path
 
 EXPECTED_RUN_TOP_LEVEL_KEYS = {
@@ -37,6 +38,12 @@ def repo_root() -> Path:
     return Path(__file__).resolve().parent.parent
 
 
+def workspace_version(root: Path) -> str:
+    cargo_toml = root / "Cargo.toml"
+    parsed = tomllib.loads(cargo_toml.read_text(encoding="utf-8"))
+    return parsed["workspace"]["package"]["version"]
+
+
 def run_cmd(cmd: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         cmd,
@@ -54,7 +61,7 @@ def assert_keys(payload: dict, expected: set[str], *, context: str) -> None:
         raise SystemExit(f"{context} missing top-level keys: {missing_list}")
 
 
-def write_external_app(project_dir: Path) -> tuple[Path, Path]:
+def write_external_app(project_dir: Path, published_version: str) -> tuple[Path, Path]:
     app_dir = project_dir / "external-tailtriage-smoke"
     run_cmd(["cargo", "new", "--bin", app_dir.name], cwd=project_dir)
 
@@ -64,14 +71,14 @@ version = "0.1.1"
 edition = "2021"
 
 [dependencies]
-tailtriage-core = "0.1.1"
+tailtriage = "{published_version}"
 tokio = {{ version = "1", features = ["macros", "rt", "time"] }}
 """
     (app_dir / "Cargo.toml").write_text(cargo_toml, encoding="utf-8")
 
     main_rs = """use std::time::Duration;
 
-use tailtriage_core::{RequestOptions, Tailtriage};
+use tailtriage::{RequestOptions, Tailtriage};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -110,11 +117,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 def main() -> None:
     root = repo_root()
+    published_version = workspace_version(root)
     print("Smoke-validating external crates.io consumer adoption outside the workspace...")
+    print(f"Using published tailtriage crate version: {published_version}")
 
     with tempfile.TemporaryDirectory(prefix="tailtriage-external-consumer-") as temp_dir:
         external_root = Path(temp_dir)
-        app_dir, artifact_path = write_external_app(external_root)
+        app_dir, artifact_path = write_external_app(external_root, published_version)
 
         print(f"==> created external app: {app_dir}")
         run_cmd(["cargo", "run", "--quiet"], cwd=app_dir)


### PR DESCRIPTION
### Motivation

- Prevent routine CI from inflating crates.io download counts by running the external published-consumer smoke test only when a published workspace version actually changes.
- Exercise the canonical published onboarding surface (the `tailtriage` facade crate) instead of the low-level `tailtriage-core` crate so the smoke test validates the real published consumer experience.

### Description

- Removed `workflow_dispatch` from `.github/workflows/ci.yml` so the workflow runs only on `pull_request` and `push` triggers. 
- Added a `changes` job output `published_version_changed` and a new step that fetches full history (`fetch-depth: 0`) and compares `workspace.package.version` from the root `Cargo.toml` across the event boundary using an inline Python script with `tomllib`; the script fails safe by emitting `true` if it cannot read history.
- Gated the existing external consumer smoke step in the `verify` job so it runs only when `matrix.profile == 'release'` AND `github.event_name == 'push'` AND `github.ref == 'refs/heads/main'` AND `needs.changes.outputs.published_version_changed == 'true'`.
- Updated `scripts/smoke_external_consumer.py` to depend on the published facade crate by injecting `tailtriage = "<workspace version>"` (read from root `Cargo.toml` via `tomllib`), changed the generated `main.rs` import to `use tailtriage::{RequestOptions, Tailtriage};`, and preserved the existing external run-artifact creation and workspace CLI analysis/validation behavior.

### Testing

- Ran `python3 -m py_compile scripts/smoke_external_consumer.py` and it succeeded. 
- Parsed the workflow YAML with `YAML.load_file` (via a small Ruby check) to confirm syntactic validity and it succeeded. 
- Inspected the workflow conditions and script changes (`rg` / `git diff`) to verify the smoke test is now gated to main pushes with a published-version change and that the generated external dependency is `tailtriage = "<workspace version>"`; inspections matched expectations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e736435f2883309edfd83bdf9de1e8)