### PR TITLE
Validate controller README TOML example and update docs validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ TOML config is useful when you want to:
 - define runtime sampler template settings when enabled
 - refresh future capture generations with `reload_config()` while leaving the active generation unchanged
 
-See [`tailtriage-controller/README.md`](tailtriage-controller/README.md) for full controller config and reload semantics.
+See [`tailtriage-controller/README.md`](tailtriage-controller/README.md) for a concrete TOML example plus full controller config and reload semantics.
 
 ## Minimal examples
 

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -4,8 +4,10 @@
 from __future__ import annotations
 
 import sys
+import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS_DIR = REPO_ROOT / "scripts"
@@ -68,6 +70,53 @@ impl Tailtriage {
 
     def test_sampler_integration_boundary_contract_validates(self) -> None:
         validate_docs_contracts.validate_sampler_integration_boundary()
+
+    def test_controller_readme_toml_validation_requires_current_anchor(self) -> None:
+        readme_text = """# tailtriage-controller
+
+## Config file (TOML)
+
+```toml
+[controller]
+service_name = "checkout-service"
+
+[controller.activation]
+mode = "light"
+
+[controller.activation.sink]
+type = "local_json"
+output_path = "tailtriage-run.json"
+```
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            readme_path = Path(tmp_dir) / "README.md"
+            readme_path.write_text(readme_text, encoding="utf-8")
+
+            with mock.patch.object(validate_docs_contracts, "CONTROLLER_README_PATH", readme_path):
+                validate_docs_contracts.validate_controller_readme_toml()
+
+    def test_controller_readme_toml_validation_fails_without_required_toml_fields(self) -> None:
+        readme_text = """# tailtriage-controller
+
+## Config file (TOML)
+
+```toml
+[controller]
+service_name = "checkout-service"
+
+[controller.activation]
+mode = "light"
+```
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            readme_path = Path(tmp_dir) / "README.md"
+            readme_path.write_text(readme_text, encoding="utf-8")
+
+            with mock.patch.object(validate_docs_contracts, "CONTROLLER_README_PATH", readme_path):
+                with self.assertRaisesRegex(
+                    ValueError, r"\[controller\.activation\.sink\]"
+                ):
+                    validate_docs_contracts.validate_controller_readme_toml()
 
 
 if __name__ == "__main__":

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -174,14 +174,46 @@ def extract_run_end_policy_kinds_from_source() -> set[str]:
 
 def validate_controller_readme_toml() -> None:
     readme_text = CONTROLLER_README_PATH.read_text(encoding="utf-8")
-    anchor = "## TOML config and manual reload"
-    if anchor not in readme_text:
-        return
-
+    anchor = "## Config file (TOML)"
     snippet = extract_fenced_block(readme_text, fence="toml", anchor=anchor)
     parsed = tomllib.loads(snippet)
 
-    run_end_policy = parsed.get("controller", {}).get("activation", {}).get("run_end_policy", {})
+    controller = parsed.get("controller")
+    if not isinstance(controller, dict):
+        raise ValueError("controller README TOML example must include a [controller] table")
+
+    service_name = controller.get("service_name")
+    if not isinstance(service_name, str) or not service_name.strip():
+        raise ValueError("controller README TOML example must include non-empty controller.service_name")
+
+    activation = controller.get("activation")
+    if not isinstance(activation, dict):
+        raise ValueError("controller README TOML example must include a [controller.activation] table")
+
+    mode = activation.get("mode")
+    if not isinstance(mode, str) or not mode.strip():
+        raise ValueError("controller README TOML example must include non-empty controller.activation.mode")
+
+    sink = activation.get("sink")
+    if not isinstance(sink, dict):
+        raise ValueError(
+            "controller README TOML example must include a [controller.activation.sink] table"
+        )
+
+    sink_type = sink.get("type")
+    output_path = sink.get("output_path")
+    if sink_type != "local_json":
+        raise ValueError(
+            'controller README TOML example must set controller.activation.sink.type = "local_json"'
+        )
+    if not isinstance(output_path, str) or not output_path.strip():
+        raise ValueError(
+            "controller README TOML example must include non-empty controller.activation.sink.output_path"
+        )
+
+    run_end_policy = activation.get("run_end_policy")
+    if run_end_policy is None:
+        return
     if not isinstance(run_end_policy, dict):
         raise ValueError("controller README run_end_policy snippet must parse as a table")
 

--- a/tailtriage-controller/README.md
+++ b/tailtriage-controller/README.md
@@ -20,6 +20,20 @@ Controller config is intentionally first-class. If you are operating tailtriage 
 - Use `reload_config()` to refresh **future** generations from the config file.
 - Active generations keep their activation-time config.
 
+Minimal TOML shape:
+
+```toml
+[controller]
+service_name = "checkout-service"
+
+[controller.activation]
+mode = "light"
+
+[controller.activation.sink]
+type = "local_json"
+output_path = "tailtriage-run.json"
+```
+
 ```rust,no_run
 use tailtriage_controller::TailtriageController;
 


### PR DESCRIPTION
### Motivation
- The controller README lacked a concrete TOML example and the docs validator skipped TOML validation because it looked for a stale heading. 
- The validator should parse and enforce the real config shape so docs stay truthful and the docs-contract test path is exercised.

### Description
- Added a minimal, truthful TOML snippet under the existing `## Config file (TOML)` section in `tailtriage-controller/README.md` using the real parser-backed shape (`[controller]`, `service_name`, `[controller.activation]`, `mode`, `[controller.activation.sink]`, `type = "local_json"`, `output_path`).
- Updated `validate_controller_readme_toml()` to target the current heading, extract and parse the fenced `toml` block, validate presence and non-empty values of `controller.service_name`, `controller.activation.mode`, `controller.activation.sink`, enforce `controller.activation.sink.type == "local_json"`, and keep optional `run_end_policy` kind drift validation when present.
- Extended `scripts/tests/test_validate_docs_contracts.py` with tests that exercise the updated controller README TOML validation path and assert failure when required TOML fields are missing.
- Made a tiny wording alignment in `README.md` to note the controller README now includes a concrete TOML example.

### Testing
- Ran `python3 scripts/validate_docs_contracts.py` and it completed successfully with the message "docs contracts validated successfully".
- Ran `python3 -m unittest scripts.tests.test_validate_docs_contracts` and all tests passed (`OK`).
- Ran repository-level checks `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, and they all completed successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e74545ab188330858dc7ebf3592df7)