### PR TITLE
docs: add complete controller TOML field reference and contract checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ TOML config is useful when you want to:
 - define runtime sampler template settings when enabled
 - refresh future capture generations with `reload_config()` while leaving the active generation unchanged
 
-See [`tailtriage-controller/README.md`](tailtriage-controller/README.md) for the TOML field reference, expanded starter config, and reload semantics.
+See [`tailtriage-controller/README.md`](tailtriage-controller/README.md) for the TOML field reference, expanded TOML example, and reload semantics.
 
 ## Minimal examples
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ TOML config is useful when you want to:
 - define runtime sampler template settings when enabled
 - refresh future capture generations with `reload_config()` while leaving the active generation unchanged
 
-See [`tailtriage-controller/README.md`](tailtriage-controller/README.md) for a concrete TOML example plus full controller config and reload semantics.
+See [`tailtriage-controller/README.md`](tailtriage-controller/README.md) for the TOML field reference, expanded starter config, and reload semantics.
 
 ## Minimal examples
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -147,7 +147,7 @@ At contract level:
 - reload applies to **future generations only**
 - active generation keeps activation-time config
 
-See crate README for full TOML keys and examples: [tailtriage-controller/README.md](../tailtriage-controller/README.md)
+See crate README for the full TOML field reference and expanded starter example: [tailtriage-controller/README.md](../tailtriage-controller/README.md)
 
 ## 6) Runtime sampler: when and why
 

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -87,6 +87,40 @@ mode = "light"
 type = "local_json"
 output_path = "tailtriage-run.json"
 ```
+
+```toml
+[controller]
+service_name = "checkout-service"
+initially_enabled = false
+
+[controller.activation]
+mode = "investigation"
+strict_lifecycle = true
+
+[controller.activation.capture_limits_override]
+max_requests = 100
+max_stages = 200
+max_queues = 200
+max_inflight_snapshots = 200
+max_runtime_snapshots = 100
+
+[controller.activation.sink]
+type = "local_json"
+output_path = "tailtriage-run.json"
+
+[controller.activation.runtime_sampler]
+enabled_for_armed_runs = true
+mode_override = "investigation"
+interval_ms = 250
+max_runtime_snapshots = 50
+
+[controller.activation.run_end_policy]
+kind = "auto_seal_on_limits_hit"
+```
+
+## TOML field reference
+
+service_name initially_enabled mode strict_lifecycle capture_limits_override max_requests max_stages max_queues max_inflight_snapshots max_runtime_snapshots enabled_for_armed_runs mode_override interval_ms run_end_policy continue_after_limits_hit auto_seal_on_limits_hit
 """
         with tempfile.TemporaryDirectory() as tmp_dir:
             readme_path = Path(tmp_dir) / "README.md"
@@ -95,7 +129,7 @@ output_path = "tailtriage-run.json"
             with mock.patch.object(validate_docs_contracts, "CONTROLLER_README_PATH", readme_path):
                 validate_docs_contracts.validate_controller_readme_toml()
 
-    def test_controller_readme_toml_validation_fails_without_required_toml_fields(self) -> None:
+    def test_controller_readme_toml_validation_fails_without_field_reference_section(self) -> None:
         readme_text = """# tailtriage-controller
 
 ## Config file (TOML)
@@ -106,6 +140,35 @@ service_name = "checkout-service"
 
 [controller.activation]
 mode = "light"
+
+[controller.activation.sink]
+type = "local_json"
+output_path = "tailtriage-run.json"
+```
+
+```toml
+[controller]
+service_name = "checkout-service"
+initially_enabled = false
+
+[controller.activation]
+mode = "light"
+
+[controller.activation.capture_limits_override]
+max_requests = 100
+
+[controller.activation.sink]
+type = "local_json"
+output_path = "tailtriage-run.json"
+
+[controller.activation.runtime_sampler]
+enabled_for_armed_runs = true
+mode_override = "light"
+interval_ms = 250
+max_runtime_snapshots = 50
+
+[controller.activation.run_end_policy]
+kind = "continue_after_limits_hit"
 ```
 """
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -114,7 +177,111 @@ mode = "light"
 
             with mock.patch.object(validate_docs_contracts, "CONTROLLER_README_PATH", readme_path):
                 with self.assertRaisesRegex(
-                    ValueError, r"\[controller\.activation\.sink\]"
+                    ValueError, r"TOML field reference"
+                ):
+                    validate_docs_contracts.validate_controller_readme_toml()
+
+    def test_controller_readme_toml_validation_fails_when_important_tokens_missing(self) -> None:
+        readme_text = """# tailtriage-controller
+
+## Config file (TOML)
+
+```toml
+[controller]
+service_name = "checkout-service"
+
+[controller.activation]
+mode = "light"
+
+[controller.activation.sink]
+type = "local_json"
+output_path = "tailtriage-run.json"
+```
+
+```toml
+[controller]
+service_name = "checkout-service"
+initially_enabled = false
+
+[controller.activation]
+mode = "investigation"
+
+[controller.activation.capture_limits_override]
+max_requests = 100
+max_stages = 200
+max_queues = 200
+max_inflight_snapshots = 200
+max_runtime_snapshots = 100
+
+[controller.activation.sink]
+type = "local_json"
+output_path = "tailtriage-run.json"
+
+[controller.activation.runtime_sampler]
+enabled_for_armed_runs = true
+mode_override = "investigation"
+interval_ms = 250
+max_runtime_snapshots = 50
+
+[controller.activation.run_end_policy]
+kind = "auto_seal_on_limits_hit"
+```
+
+## TOML field reference
+
+service_name initially_enabled mode strict_lifecycle capture_limits_override
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            readme_path = Path(tmp_dir) / "README.md"
+            readme_path.write_text(readme_text, encoding="utf-8")
+
+            with mock.patch.object(validate_docs_contracts, "CONTROLLER_README_PATH", readme_path):
+                with self.assertRaisesRegex(
+                    ValueError, r"missing token"
+                ):
+                    validate_docs_contracts.validate_controller_readme_toml()
+
+    def test_controller_readme_toml_validation_fails_when_expanded_example_missing_sections(self) -> None:
+        readme_text = """# tailtriage-controller
+
+## Config file (TOML)
+
+```toml
+[controller]
+service_name = "checkout-service"
+
+[controller.activation]
+mode = "light"
+
+[controller.activation.sink]
+type = "local_json"
+output_path = "tailtriage-run.json"
+```
+
+```toml
+[controller]
+service_name = "checkout-service"
+initially_enabled = false
+
+[controller.activation]
+mode = "investigation"
+
+[controller.activation.sink]
+type = "local_json"
+output_path = "tailtriage-run.json"
+```
+
+## TOML field reference
+
+service_name initially_enabled mode strict_lifecycle capture_limits_override max_requests max_stages max_queues max_inflight_snapshots max_runtime_snapshots enabled_for_armed_runs mode_override interval_ms run_end_policy continue_after_limits_hit auto_seal_on_limits_hit
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            readme_path = Path(tmp_dir) / "README.md"
+            readme_path.write_text(readme_text, encoding="utf-8")
+
+            with mock.patch.object(validate_docs_contracts, "CONTROLLER_README_PATH", readme_path):
+                with self.assertRaisesRegex(
+                    ValueError, r"capture_limits_override"
                 ):
                     validate_docs_contracts.validate_controller_readme_toml()
 

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -76,6 +76,10 @@ impl Tailtriage {
 
 ## Config file (TOML)
 
+With TOML config loaded, service_name and initially_enabled fall back to builder values when omitted.
+Activation template settings come from TOML when config is loaded.
+Omitted optional activation subfields use TOML contract defaults.
+
 ```toml
 [controller]
 service_name = "checkout-service"
@@ -134,6 +138,10 @@ service_name initially_enabled mode strict_lifecycle capture_limits_override max
 
 ## Config file (TOML)
 
+With TOML config loaded, service_name and initially_enabled fall back to builder values when omitted.
+Activation template settings come from TOML when config is loaded.
+Omitted optional activation subfields use TOML contract defaults.
+
 ```toml
 [controller]
 service_name = "checkout-service"
@@ -185,6 +193,10 @@ kind = "continue_after_limits_hit"
         readme_text = """# tailtriage-controller
 
 ## Config file (TOML)
+
+With TOML config loaded, service_name and initially_enabled fall back to builder values when omitted.
+Activation template settings come from TOML when config is loaded.
+Omitted optional activation subfields use TOML contract defaults.
 
 ```toml
 [controller]
@@ -246,6 +258,10 @@ service_name initially_enabled mode strict_lifecycle capture_limits_override
 
 ## Config file (TOML)
 
+With TOML config loaded, service_name and initially_enabled fall back to builder values when omitted.
+Activation template settings come from TOML when config is loaded.
+Omitted optional activation subfields use TOML contract defaults.
+
 ```toml
 [controller]
 service_name = "checkout-service"
@@ -283,6 +299,66 @@ service_name initially_enabled mode strict_lifecycle capture_limits_override max
                 with self.assertRaisesRegex(
                     ValueError, r"capture_limits_override"
                 ):
+                    validate_docs_contracts.validate_controller_readme_toml()
+
+    def test_controller_readme_toml_validation_fails_on_misleading_precedence_phrase(self) -> None:
+        readme_text = """# tailtriage-controller
+
+## Config file (TOML)
+
+If a TOML field is omitted, builder/default values continue to apply where supported by the config contract.
+
+```toml
+[controller]
+service_name = "checkout-service"
+
+[controller.activation]
+mode = "light"
+
+[controller.activation.sink]
+type = "local_json"
+output_path = "tailtriage-run.json"
+```
+
+```toml
+[controller]
+service_name = "checkout-service"
+initially_enabled = false
+
+[controller.activation]
+mode = "investigation"
+
+[controller.activation.capture_limits_override]
+max_requests = 100
+max_stages = 200
+max_queues = 200
+max_inflight_snapshots = 200
+max_runtime_snapshots = 100
+
+[controller.activation.sink]
+type = "local_json"
+output_path = "tailtriage-run.json"
+
+[controller.activation.runtime_sampler]
+enabled_for_armed_runs = true
+mode_override = "investigation"
+interval_ms = 250
+max_runtime_snapshots = 50
+
+[controller.activation.run_end_policy]
+kind = "auto_seal_on_limits_hit"
+```
+
+## TOML field reference
+
+service_name initially_enabled mode strict_lifecycle capture_limits_override max_requests max_stages max_queues max_inflight_snapshots max_runtime_snapshots enabled_for_armed_runs mode_override interval_ms run_end_policy continue_after_limits_hit auto_seal_on_limits_hit
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            readme_path = Path(tmp_dir) / "README.md"
+            readme_path.write_text(readme_text, encoding="utf-8")
+
+            with mock.patch.object(validate_docs_contracts, "CONTROLLER_README_PATH", readme_path):
+                with self.assertRaisesRegex(ValueError, r"misleading TOML precedence wording"):
                     validate_docs_contracts.validate_controller_readme_toml()
 
 

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -84,6 +84,15 @@ def extract_fenced_block(markdown: str, *, fence: str, anchor: str) -> str:
     return match.group(1)
 
 
+def extract_fenced_blocks_after_anchor(markdown: str, *, fence: str, anchor: str) -> list[str]:
+    anchor_index = markdown.find(anchor)
+    if anchor_index < 0:
+        raise ValueError(f"missing anchor heading: {anchor}")
+
+    pattern = re.compile(rf"```{re.escape(fence)}\n(.*?)\n```", re.DOTALL)
+    return [match.group(1) for match in pattern.finditer(markdown, pos=anchor_index)]
+
+
 def _kind_of(value: Any) -> str:
     if value is None:
         return "null"
@@ -174,48 +183,125 @@ def extract_run_end_policy_kinds_from_source() -> set[str]:
 
 def validate_controller_readme_toml() -> None:
     readme_text = CONTROLLER_README_PATH.read_text(encoding="utf-8")
-    anchor = "## Config file (TOML)"
-    snippet = extract_fenced_block(readme_text, fence="toml", anchor=anchor)
-    parsed = tomllib.loads(snippet)
+    if "## TOML field reference" not in readme_text:
+        raise ValueError("controller README must include a dedicated '## TOML field reference' section")
 
+    required_reference_tokens = (
+        "service_name",
+        "initially_enabled",
+        "mode",
+        "strict_lifecycle",
+        "capture_limits_override",
+        "max_requests",
+        "max_stages",
+        "max_queues",
+        "max_inflight_snapshots",
+        "max_runtime_snapshots",
+        "enabled_for_armed_runs",
+        "mode_override",
+        "interval_ms",
+        "run_end_policy",
+        "continue_after_limits_hit",
+        "auto_seal_on_limits_hit",
+    )
+    for token in required_reference_tokens:
+        if token not in readme_text:
+            raise ValueError(f"controller README TOML field reference missing token: {token}")
+
+    snippets = extract_fenced_blocks_after_anchor(
+        readme_text,
+        fence="toml",
+        anchor="## Config file (TOML)",
+    )
+    if len(snippets) < 2:
+        raise ValueError("controller README must include minimal and expanded TOML examples")
+    minimal_snippet, expanded_snippet = snippets[0], snippets[1]
+    minimal = tomllib.loads(minimal_snippet)
+    expanded = tomllib.loads(expanded_snippet)
+
+    _validate_controller_toml_shape(parsed=minimal, example_name="minimal")
+    _validate_controller_toml_shape(parsed=expanded, example_name="expanded")
+
+    expanded_controller = expanded["controller"]
+    if "initially_enabled" not in expanded_controller:
+        raise ValueError("expanded controller TOML example must include controller.initially_enabled")
+    if expanded_controller["initially_enabled"] is not False:
+        raise ValueError("expanded controller TOML example must set controller.initially_enabled = false")
+
+    expanded_activation = expanded_controller["activation"]
+    for required_table in ("capture_limits_override", "runtime_sampler", "run_end_policy"):
+        if required_table not in expanded_activation or not isinstance(
+            expanded_activation[required_table], dict
+        ):
+            raise ValueError(
+                f"expanded controller TOML example must include [controller.activation.{required_table}]"
+            )
+
+    runtime_sampler = expanded_activation["runtime_sampler"]
+    for key in (
+        "enabled_for_armed_runs",
+        "mode_override",
+        "interval_ms",
+        "max_runtime_snapshots",
+    ):
+        if key not in runtime_sampler:
+            raise ValueError(f"expanded controller TOML example must include runtime_sampler.{key}")
+
+    run_end_policy = expanded_activation["run_end_policy"]
+    if "kind" not in run_end_policy:
+        raise ValueError("expanded controller TOML example must include run_end_policy.kind")
+
+
+def _validate_controller_toml_shape(*, parsed: dict[str, Any], example_name: str) -> None:
     controller = parsed.get("controller")
     if not isinstance(controller, dict):
-        raise ValueError("controller README TOML example must include a [controller] table")
+        raise ValueError(
+            f"{example_name} controller README TOML example must include a [controller] table"
+        )
 
     service_name = controller.get("service_name")
     if not isinstance(service_name, str) or not service_name.strip():
-        raise ValueError("controller README TOML example must include non-empty controller.service_name")
+        raise ValueError(
+            f"{example_name} controller README TOML example must include non-empty controller.service_name"
+        )
 
     activation = controller.get("activation")
     if not isinstance(activation, dict):
-        raise ValueError("controller README TOML example must include a [controller.activation] table")
+        raise ValueError(
+            f"{example_name} controller README TOML example must include a [controller.activation] table"
+        )
 
     mode = activation.get("mode")
     if not isinstance(mode, str) or not mode.strip():
-        raise ValueError("controller README TOML example must include non-empty controller.activation.mode")
+        raise ValueError(
+            f"{example_name} controller README TOML example must include non-empty controller.activation.mode"
+        )
 
     sink = activation.get("sink")
     if not isinstance(sink, dict):
         raise ValueError(
-            "controller README TOML example must include a [controller.activation.sink] table"
+            f"{example_name} controller README TOML example must include a "
+            "[controller.activation.sink] table"
         )
 
     sink_type = sink.get("type")
     output_path = sink.get("output_path")
     if sink_type != "local_json":
         raise ValueError(
-            'controller README TOML example must set controller.activation.sink.type = "local_json"'
+            f'{example_name} controller README TOML example must set '
+            'controller.activation.sink.type = "local_json"'
         )
     if not isinstance(output_path, str) or not output_path.strip():
         raise ValueError(
-            "controller README TOML example must include non-empty controller.activation.sink.output_path"
+            f"{example_name} controller README TOML example must include non-empty "
+            "controller.activation.sink.output_path"
         )
 
     run_end_policy = activation.get("run_end_policy")
     if run_end_policy is None:
         return
     if not isinstance(run_end_policy, dict):
-        raise ValueError("controller README run_end_policy snippet must parse as a table")
+        raise ValueError(f"{example_name} controller README run_end_policy snippet must parse as a table")
 
     documented_kind = run_end_policy.get("kind")
     if not isinstance(documented_kind, str):

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -185,6 +185,22 @@ def validate_controller_readme_toml() -> None:
     readme_text = CONTROLLER_README_PATH.read_text(encoding="utf-8")
     if "## TOML field reference" not in readme_text:
         raise ValueError("controller README must include a dedicated '## TOML field reference' section")
+    if "where supported by the config contract" in readme_text:
+        raise ValueError(
+            "controller README contains misleading TOML precedence wording; "
+            "do not claim broad builder fallback for omitted TOML fields"
+        )
+
+    precedence_tokens = (
+        "service_name",
+        "initially_enabled",
+        "fall back to builder values when omitted",
+        "Activation template settings come from TOML",
+        "Omitted optional activation subfields use TOML contract defaults",
+    )
+    for token in precedence_tokens:
+        if token not in readme_text:
+            raise ValueError(f"controller README precedence guidance missing token: {token}")
 
     required_reference_tokens = (
         "service_name",

--- a/tailtriage-controller/README.md
+++ b/tailtriage-controller/README.md
@@ -8,17 +8,21 @@ Use it when you need to arm/disarm capture without restarting the process.
 
 - [When to use this crate](#when-to-use-this-crate-vs-others)
 - [Config file (TOML)](#config-file-toml)
+- [TOML field reference](#toml-field-reference)
 - [Minimal controller lifecycle example](#minimal-controller-lifecycle-example)
 - [Behavioral guarantees](#behavioral-guarantees)
 - [Runtime requirements](#runtime-requirements)
 
 ## Config file (TOML)
 
-Controller config is intentionally first-class. If you are operating tailtriage in production-like workflows, start here.
+Builder defaults are a good place to start for local exploration.
 
-- Use `config_path(...)` on the builder to load TOML-backed template settings.
-- Use `reload_config()` to refresh **future** generations from the config file.
+Use TOML when you want repeatable operational settings across environments.
+
+- `config_path(...)` loads TOML-backed template settings during build.
+- `reload_config()` refreshes that template from file for **future generations only**.
 - Active generations keep their activation-time config.
+- If a TOML field is omitted, builder/default values continue to apply where supported by the config contract.
 
 Minimal TOML shape:
 
@@ -34,6 +38,38 @@ type = "local_json"
 output_path = "tailtriage-run.json"
 ```
 
+Expanded TOML starter config:
+
+```toml
+[controller]
+service_name = "checkout-service"
+initially_enabled = false
+
+[controller.activation]
+mode = "investigation"
+strict_lifecycle = true
+
+[controller.activation.capture_limits_override]
+max_requests = 150000
+max_stages = 300000
+max_queues = 300000
+max_inflight_snapshots = 300000
+max_runtime_snapshots = 150000
+
+[controller.activation.sink]
+type = "local_json"
+output_path = "tailtriage-run.json"
+
+[controller.activation.runtime_sampler]
+enabled_for_armed_runs = true
+mode_override = "investigation"
+interval_ms = 250
+max_runtime_snapshots = 20000
+
+[controller.activation.run_end_policy]
+kind = "auto_seal_on_limits_hit"
+```
+
 ```rust,no_run
 use tailtriage_controller::TailtriageController;
 
@@ -46,13 +82,67 @@ let controller = TailtriageController::builder("checkout-service")
 # }
 ```
 
-Most important sections to configure in TOML are typically:
+## TOML field reference
 
-1. Service/run identity and artifact output settings
-2. Capture defaults and retention limits
-3. Runtime sampler template settings (when enabled)
+### Top-level: `[controller]`
 
-See the full controller API docs and examples for exact keys and template fields.
+- `service_name` (optional string)
+  - If present, overrides the builder service name.
+  - If provided, it must not be empty.
+- `initially_enabled` (optional boolean)
+  - If omitted, builder/default behavior applies.
+  - If `true`, build immediately starts generation 1.
+
+### Activation: `[controller.activation]`
+
+- `mode` (required string)
+  - Valid values: `light`, `investigation`.
+  - This selects core capture retention defaults.
+  - It does **not** change request lifecycle semantics.
+  - It does **not** automatically start runtime sampling.
+- `strict_lifecycle` (optional boolean)
+  - Default: `false`.
+  - Controls whether unfinished requests can fail finalization/shutdown for that activation.
+
+#### Sink: `[controller.activation.sink]`
+
+- `type` (required string)
+  - Supported value: `local_json`.
+- `output_path` (required string for `local_json`)
+  - Base output path template.
+  - Each activation writes a per-generation artifact with a `-generation-N` suffix.
+
+#### Capture limits override: `[controller.activation.capture_limits_override]`
+
+All fields are optional and override selected mode defaults field-by-field:
+
+- `max_requests`
+- `max_stages`
+- `max_queues`
+- `max_inflight_snapshots`
+- `max_runtime_snapshots`
+
+#### Runtime sampler template: `[controller.activation.runtime_sampler]`
+
+Template fields for future activations:
+
+- `enabled_for_armed_runs`
+- `mode_override`
+- `interval_ms`
+- `max_runtime_snapshots`
+
+Defaults:
+
+- Table is optional.
+- Runtime sampler is disabled by default (`enabled_for_armed_runs = false`).
+- When enabled, sampler startup still requires an active Tokio runtime.
+
+#### Run-end policy: `[controller.activation.run_end_policy]`
+
+- `kind` (optional string)
+  - Valid values:
+    - `continue_after_limits_hit`: keep accepting/dropping after limits are hit until disarm/shutdown.
+    - `auto_seal_on_limits_hit`: on first limits-hit transition, stop admissions and finalize that generation.
 
 ## When to use this crate vs others
 

--- a/tailtriage-controller/README.md
+++ b/tailtriage-controller/README.md
@@ -22,7 +22,9 @@ Use TOML when you want repeatable operational settings across environments.
 - `config_path(...)` loads TOML-backed template settings during build.
 - `reload_config()` refreshes that template from file for **future generations only**.
 - Active generations keep their activation-time config.
-- If a TOML field is omitted, builder/default values continue to apply where supported by the config contract.
+- With TOML config loaded, `service_name` and `initially_enabled` fall back to builder values when omitted.
+- Activation template settings come from TOML when config is loaded.
+- Omitted optional activation subfields use TOML contract defaults (for example `strict_lifecycle = false`), not prior builder overrides.
 
 Minimal TOML shape:
 
@@ -38,7 +40,7 @@ type = "local_json"
 output_path = "tailtriage-run.json"
 ```
 
-Expanded TOML starter config:
+Expanded TOML example:
 
 ```toml
 [controller]


### PR DESCRIPTION
### Motivation

- The controller README exposed only a minimal TOML shape while the real, user-facing TOML contract is larger and must be discoverable on crates.io. 
- The docs should clearly state precedence and reload semantics so operators understand `config_path(...)`, `reload_config()`, and which settings affect future generations.
- The docs-validator must enforce the README contract to prevent accidental regressions.

### Description

- Expand `tailtriage-controller/README.md` with an `## TOML field reference` section and a readable expanded TOML starter example that documents only fields actually parsed by the code (top-level `[controller]`, `[controller.activation]` and sub-tables for `sink`, `capture_limits_override`, `runtime_sampler`, and `run_end_policy`).
- Tighten prose about precedence and reload semantics so it clearly states that builder defaults are a good starting point, `config_path(...)` loads TOML-backed templates, `reload_config()` updates the template for future generations only, and active generations keep activation-time config.
- Update cross-links and wording in `docs/user-guide.md` and root `README.md` to point to the controller README as the canonical TOML field reference and starter example.
- Strengthen `scripts/validate_docs_contracts.py` to require a dedicated TOML field reference section, both minimal and expanded TOML examples, presence of key documentation tokens (e.g. `service_name`, `initially_enabled`, `mode`, `strict_lifecycle`, capture limit keys, runtime sampler keys, and run-end-policy kinds), and structural parsing/shape checks for the fenced TOML snippets; and update `scripts/tests/test_validate_docs_contracts.py` to cover the new expectations.

### Testing

- Ran `python3 scripts/validate_docs_contracts.py` and it printed: `docs contracts validated successfully` (passed).
- Ran unit tests with `python3 -m unittest scripts.tests.test_validate_docs_contracts` and all tests passed (`OK`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e749f212a48330a2f0b2884ab57907)