### PR TITLE
Add controller example + smoke coverage and TOML negative validation tests

### DIFF
--- a/scripts/smoke_public_examples.py
+++ b/scripts/smoke_public_examples.py
@@ -16,10 +16,36 @@ import tempfile
 from pathlib import Path
 
 EXAMPLES = [
-    ("tailtriage-tokio", "minimal_checkout"),
-    ("tailtriage-axum", "axum_minimal"),
-    ("tailtriage-axum", "axum_service_adoption"),
-    ("tailtriage-tokio", "mini_service_integration"),
+    {
+        "package": "tailtriage-tokio",
+        "name": "minimal_checkout",
+        "artifact": "tailtriage-run.json",
+    },
+    {
+        "package": "tailtriage-axum",
+        "name": "axum_minimal",
+        "artifact": "tailtriage-run.json",
+    },
+    {
+        "package": "tailtriage-axum",
+        "name": "axum_service_adoption",
+        "artifact": "tailtriage-run.json",
+    },
+    {
+        "package": "tailtriage-tokio",
+        "name": "mini_service_integration",
+        "artifact": "tailtriage-run.json",
+    },
+    {
+        "package": "tailtriage-controller",
+        "name": "controller_minimal",
+        "artifact": "tailtriage-run-generation-1.json",
+    },
+    {
+        "package": "tailtriage-controller",
+        "name": "controller_toml_startup",
+        "artifact": "tailtriage-run-generation-1.json",
+    },
 ]
 
 EXPECTED_RUN_TOP_LEVEL_KEYS = {
@@ -63,13 +89,16 @@ def assert_keys(payload: dict, expected: set[str], *, context: str) -> None:
         raise SystemExit(f"{context} missing top-level keys: {missing_list}")
 
 
-def validate_example(package: str, name: str) -> None:
+def validate_example(example: dict[str, str]) -> None:
+    package = example["package"]
+    name = example["name"]
+    artifact_name = example["artifact"]
     root = repo_root()
     print(f"==> validating example: {package}::{name}")
 
     with tempfile.TemporaryDirectory(prefix=f"tailtriage-example-smoke-{package}-{name}-") as temp_dir:
         working_dir = Path(temp_dir)
-        artifact_path = working_dir / "tailtriage-run.json"
+        artifact_path = working_dir / artifact_name
 
         run_cmd(
             [
@@ -130,8 +159,8 @@ def validate_example(package: str, name: str) -> None:
 
 def main() -> None:
     print("Smoke-validating public examples...")
-    for package, name in EXAMPLES:
-        validate_example(package, name)
+    for example in EXAMPLES:
+        validate_example(example)
     print("All public examples passed smoke validation.")
 
 

--- a/tailtriage-controller/examples/controller_toml_startup.rs
+++ b/tailtriage-controller/examples/controller_toml_startup.rs
@@ -1,0 +1,33 @@
+use std::fs;
+use std::path::PathBuf;
+
+use tailtriage_controller::TailtriageController;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config_path = PathBuf::from("tailtriage-controller.toml");
+    let config = r#"[controller]
+service_name = "controller-toml-startup"
+initially_enabled = true
+
+[controller.activation]
+mode = "light"
+
+[controller.activation.sink]
+type = "local_json"
+output_path = "tailtriage-run.json"
+"#;
+    fs::write(&config_path, config)?;
+
+    let controller = TailtriageController::builder("controller-toml-startup-builder")
+        .config_path(&config_path)
+        .build()?;
+
+    let started = controller.begin_request("/checkout");
+    started.completion.finish_ok();
+    let _disable = controller.disable()?;
+
+    let artifact = PathBuf::from("tailtriage-run-generation-1.json");
+    println!("Wrote {}", artifact.display());
+    fs::remove_file(config_path)?;
+    Ok(())
+}

--- a/tailtriage-controller/src/lib.rs
+++ b/tailtriage-controller/src/lib.rs
@@ -1752,6 +1752,10 @@ output_path = "{}"
         fs::write(path, content).expect("config write should succeed");
     }
 
+    fn write_raw_config(path: &std::path::Path, content: &str) {
+        fs::write(path, content).expect("config write should succeed");
+    }
+
     #[test]
     fn enable_capture_disable_finalizes_generation() {
         let output = test_output("enable-capture-disable");
@@ -2975,6 +2979,153 @@ kind = "continue_after_limits_hit"
             err,
             ControllerBuildError::ConfigLoad(super::ConfigLoadError::Io { .. })
         ));
+    }
+
+    #[test]
+    fn build_from_toml_with_blank_service_name_returns_empty_service_name_error() {
+        let config = test_config_path("toml-empty-service-name");
+        write_raw_config(
+            &config,
+            r#"[controller]
+service_name = ""
+
+[controller.activation]
+mode = "light"
+
+[controller.activation.sink]
+type = "local_json"
+output_path = "tailtriage-run.json"
+"#,
+        );
+
+        let err = TailtriageController::builder("fallback-service-name")
+            .config_path(&config)
+            .build()
+            .expect_err("blank TOML service_name should fail build");
+        assert!(matches!(err, ControllerBuildError::EmptyServiceName));
+
+        fs::remove_file(config).expect("config cleanup should succeed");
+    }
+
+    #[test]
+    fn build_from_toml_with_invalid_mode_returns_parse_error() {
+        let config = test_config_path("toml-invalid-mode");
+        write_raw_config(
+            &config,
+            r#"[controller]
+
+[controller.activation]
+mode = "not-a-real-mode"
+
+[controller.activation.sink]
+type = "local_json"
+output_path = "tailtriage-run.json"
+"#,
+        );
+
+        let err = TailtriageController::builder("checkout-service")
+            .config_path(&config)
+            .build()
+            .expect_err("invalid mode should fail build");
+        assert!(matches!(
+            err,
+            ControllerBuildError::ConfigLoad(super::ConfigLoadError::Parse { .. })
+        ));
+
+        fs::remove_file(config).expect("config cleanup should succeed");
+    }
+
+    #[test]
+    fn build_from_toml_with_invalid_run_end_policy_kind_returns_parse_error() {
+        let config = test_config_path("toml-invalid-run-end-policy");
+        write_raw_config(
+            &config,
+            r#"[controller]
+
+[controller.activation]
+mode = "light"
+
+[controller.activation.sink]
+type = "local_json"
+output_path = "tailtriage-run.json"
+
+[controller.activation.run_end_policy]
+kind = "not-a-real-policy"
+"#,
+        );
+
+        let err = TailtriageController::builder("checkout-service")
+            .config_path(&config)
+            .build()
+            .expect_err("invalid run_end_policy.kind should fail build");
+        assert!(matches!(
+            err,
+            ControllerBuildError::ConfigLoad(super::ConfigLoadError::Parse { .. })
+        ));
+
+        fs::remove_file(config).expect("config cleanup should succeed");
+    }
+
+    #[test]
+    fn build_from_toml_with_invalid_sink_type_returns_parse_error() {
+        let config = test_config_path("toml-invalid-sink-type");
+        write_raw_config(
+            &config,
+            r#"[controller]
+
+[controller.activation]
+mode = "light"
+
+[controller.activation.sink]
+type = "not-a-real-sink"
+output_path = "tailtriage-run.json"
+"#,
+        );
+
+        let err = TailtriageController::builder("checkout-service")
+            .config_path(&config)
+            .build()
+            .expect_err("invalid sink.type should fail build");
+        assert!(matches!(
+            err,
+            ControllerBuildError::ConfigLoad(super::ConfigLoadError::Parse { .. })
+        ));
+
+        fs::remove_file(config).expect("config cleanup should succeed");
+    }
+
+    #[test]
+    fn build_from_toml_initially_enabled_sampler_without_runtime_returns_initial_enable_error() {
+        let config = test_config_path("toml-initially-enabled-missing-runtime");
+        write_raw_config(
+            &config,
+            r#"[controller]
+initially_enabled = true
+
+[controller.activation]
+mode = "light"
+
+[controller.activation.sink]
+type = "local_json"
+output_path = "tailtriage-run.json"
+
+[controller.activation.runtime_sampler]
+enabled_for_armed_runs = true
+interval_ms = 20
+max_runtime_snapshots = 10
+"#,
+        );
+
+        let err = TailtriageController::builder("checkout-service")
+            .config_path(&config)
+            .build()
+            .expect_err("initially_enabled with sampler should fail outside Tokio runtime");
+        assert!(matches!(
+            err,
+            ControllerBuildError::InitialEnable(EnableError::MissingTokioRuntimeForSampler)
+        ));
+
+        fs::remove_file(config).expect("config cleanup should succeed");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Improve black-box coverage for `tailtriage-controller` examples and close remaining TOML-validation gaps by adding smoke validation and focused negative tests. 
- Ensure the public example flow (artifact generation + `tailtriage-cli analyze`) covers controller-specific artifact naming and TOML-driven startup paths.

### Description
- Updated `scripts/smoke_public_examples.py` to accept per-example artifact filenames and added smoke validation entries for `tailtriage-controller::controller_minimal` and `tailtriage-controller::controller_toml_startup`. 
- Added new public example `tailtriage-controller/examples/controller_toml_startup.rs` which writes a local TOML config, builds a controller with `.config_path(...)` (TOML `initially_enabled = true`), records one request, disables cleanly, and prints the generated artifact path. 
- Added focused negative TOML tests to `tailtriage-controller/src/lib.rs` covering: blank `service_name` (`ControllerBuildError::EmptyServiceName`), invalid activation `mode` (parse error), invalid `run_end_policy.kind` (parse error), invalid `sink.type` (parse error), and `initially_enabled = true` with runtime sampler enabled outside a Tokio runtime (`ControllerBuildError::InitialEnable(EnableError::MissingTokioRuntimeForSampler)`). 
- Introduced a small `write_raw_config` test helper to keep tests compact and consistent with existing test patterns. 
- No production behavior changes were required; all changes are tests/examples and harness adjustments.

### Testing
- Ran `cargo fmt --check` and it passed. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it passed. 
- Ran `cargo test -p tailtriage-controller` and all tests passed (`42 passed; 0 failed`). 
- Ran `python3 scripts/smoke_public_examples.py` and the smoke harness validated all examples including `controller_minimal` and `controller_toml_startup`, confirming generated artifacts (controller artifacts named `*-generation-1.json`) and successful `tailtriage-cli analyze --format json` runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e773bee6288330adb1b49353c9e422)