### PR TITLE
Axum: map HTTP status to richer Outcome and add configurable classifier

### DIFF
--- a/tailtriage-axum/src/lib.rs
+++ b/tailtriage-axum/src/lib.rs
@@ -6,6 +6,8 @@
 //! This crate provides a focused middleware + extractor path so handlers can
 //! access request instrumentation without repeating request start/finish wiring.
 
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 
 use axum::extract::{FromRequestParts, MatchedPath, State};
@@ -14,6 +16,8 @@ use axum::http::{Request, StatusCode};
 use axum::middleware::Next;
 use axum::response::IntoResponse;
 use tailtriage_core::{Outcome, OwnedRequestHandle, RequestOptions, Tailtriage};
+
+type MiddlewareFuture = Pin<Box<dyn Future<Output = axum::response::Response> + Send + 'static>>;
 
 /// Returns the crate name for smoke-testing workspace wiring.
 #[must_use]
@@ -35,14 +39,32 @@ pub async fn middleware(
     request: Request<axum::body::Body>,
     next: Next,
 ) -> axum::response::Response {
-    middleware_with_status_classifier(tailtriage, request, next, default_status_to_outcome).await
+    run_middleware_with_status_classifier(tailtriage, request, next, default_status_to_outcome)
+        .await
 }
 
-/// Middleware implementation with an explicit response-status classifier.
+/// Returns middleware with an explicit response-status classifier.
 ///
 /// This keeps [`middleware`] ergonomic as the default path while allowing
 /// future callers to choose a different status-to-outcome policy.
-pub async fn middleware_with_status_classifier<C>(
+pub fn middleware_with_status_classifier<C>(
+    classify_status: C,
+) -> impl Clone
+       + Send
+       + 'static
+       + Fn(State<Arc<Tailtriage>>, Request<axum::body::Body>, Next) -> MiddlewareFuture
+where
+    C: Fn(StatusCode) -> Outcome + Clone + Send + Sync + 'static,
+{
+    move |State(tailtriage), request, next| {
+        let classify_status = classify_status.clone();
+        Box::pin(async move {
+            run_middleware_with_status_classifier(tailtriage, request, next, classify_status).await
+        })
+    }
+}
+
+async fn run_middleware_with_status_classifier<C>(
     tailtriage: Arc<Tailtriage>,
     mut request: Request<axum::body::Body>,
     next: Next,

--- a/tailtriage-axum/src/lib.rs
+++ b/tailtriage-axum/src/lib.rs
@@ -27,12 +27,30 @@ pub const fn crate_name() -> &'static str {
 /// `Arc<Tailtriage>` in middleware state.
 ///
 /// The middleware records route labels from `MatchedPath` when available and
-/// otherwise falls back to the raw URI path.
+/// otherwise falls back to the raw URI path. By default it maps 2xx/3xx to
+/// [`Outcome::Ok`], 4xx to [`Outcome::Rejected`] (except 408 to
+/// [`Outcome::Timeout`]), and 5xx to [`Outcome::Error`].
 pub async fn middleware(
     State(tailtriage): State<Arc<Tailtriage>>,
-    mut request: Request<axum::body::Body>,
+    request: Request<axum::body::Body>,
     next: Next,
 ) -> axum::response::Response {
+    middleware_with_status_classifier(tailtriage, request, next, default_status_to_outcome).await
+}
+
+/// Middleware implementation with an explicit response-status classifier.
+///
+/// This keeps [`middleware`] ergonomic as the default path while allowing
+/// future callers to choose a different status-to-outcome policy.
+pub async fn middleware_with_status_classifier<C>(
+    tailtriage: Arc<Tailtriage>,
+    mut request: Request<axum::body::Body>,
+    next: Next,
+    classify_status: C,
+) -> axum::response::Response
+where
+    C: Fn(StatusCode) -> Outcome,
+{
     let route = request_route_label(&request);
     let started = tailtriage.begin_request_with_owned(route, RequestOptions::new().kind("http"));
 
@@ -43,7 +61,7 @@ pub async fn middleware(
     let response = next.run(request).await;
     let status = response.status();
 
-    started.completion.finish(status_to_outcome(status));
+    started.completion.finish(classify_status(status));
     response
 }
 
@@ -99,9 +117,15 @@ fn request_route_label(request: &Request<axum::body::Body>) -> String {
         .to_owned()
 }
 
-fn status_to_outcome(status: StatusCode) -> Outcome {
-    if status.is_server_error() {
+/// Default HTTP response status to [`Outcome`] classifier for this crate.
+#[must_use]
+pub fn default_status_to_outcome(status: StatusCode) -> Outcome {
+    if status == StatusCode::REQUEST_TIMEOUT {
+        Outcome::Timeout
+    } else if status.is_server_error() {
         Outcome::Error
+    } else if status.is_client_error() {
+        Outcome::Rejected
     } else {
         Outcome::Ok
     }
@@ -109,7 +133,9 @@ fn status_to_outcome(status: StatusCode) -> Outcome {
 
 #[cfg(test)]
 mod tests {
-    use super::{crate_name, status_to_outcome};
+    use super::{crate_name, default_status_to_outcome};
+    use axum::http::StatusCode;
+    use tailtriage_core::Outcome;
 
     #[test]
     fn crate_name_is_stable() {
@@ -117,14 +143,52 @@ mod tests {
     }
 
     #[test]
-    fn maps_server_errors_to_error_outcome() {
+    fn default_status_mapping_matches_http_contract() {
+        assert_eq!(default_status_to_outcome(StatusCode::OK), Outcome::Ok);
         assert_eq!(
-            status_to_outcome(axum::http::StatusCode::INTERNAL_SERVER_ERROR),
-            tailtriage_core::Outcome::Error
+            default_status_to_outcome(StatusCode::NO_CONTENT),
+            Outcome::Ok
+        );
+        assert_eq!(default_status_to_outcome(StatusCode::FOUND), Outcome::Ok);
+        assert_eq!(
+            default_status_to_outcome(StatusCode::BAD_REQUEST),
+            Outcome::Rejected
         );
         assert_eq!(
-            status_to_outcome(axum::http::StatusCode::BAD_REQUEST),
-            tailtriage_core::Outcome::Ok
+            default_status_to_outcome(StatusCode::UNAUTHORIZED),
+            Outcome::Rejected
+        );
+        assert_eq!(
+            default_status_to_outcome(StatusCode::FORBIDDEN),
+            Outcome::Rejected
+        );
+        assert_eq!(
+            default_status_to_outcome(StatusCode::NOT_FOUND),
+            Outcome::Rejected
+        );
+        assert_eq!(
+            default_status_to_outcome(StatusCode::CONFLICT),
+            Outcome::Rejected
+        );
+        assert_eq!(
+            default_status_to_outcome(StatusCode::UNPROCESSABLE_ENTITY),
+            Outcome::Rejected
+        );
+        assert_eq!(
+            default_status_to_outcome(StatusCode::TOO_MANY_REQUESTS),
+            Outcome::Rejected
+        );
+        assert_eq!(
+            default_status_to_outcome(StatusCode::REQUEST_TIMEOUT),
+            Outcome::Timeout
+        );
+        assert_eq!(
+            default_status_to_outcome(StatusCode::INTERNAL_SERVER_ERROR),
+            Outcome::Error
+        );
+        assert_eq!(
+            default_status_to_outcome(StatusCode::SERVICE_UNAVAILABLE),
+            Outcome::Error
         );
     }
 }

--- a/tailtriage-axum/tests/axum_adapter.rs
+++ b/tailtriage-axum/tests/axum_adapter.rs
@@ -43,21 +43,6 @@ async fn timeout_handler(TailtriageRequest(_): TailtriageRequest) -> StatusCode 
     StatusCode::REQUEST_TIMEOUT
 }
 
-async fn custom_classifier_middleware(
-    State(tailtriage): State<Arc<Tailtriage>>,
-    request: Request<Body>,
-    next: axum::middleware::Next,
-) -> axum::response::Response {
-    tailtriage_axum::middleware_with_status_classifier(tailtriage, request, next, |status| {
-        if status == StatusCode::BAD_REQUEST {
-            Outcome::Other("client_error".to_owned())
-        } else {
-            tailtriage_axum::default_status_to_outcome(status)
-        }
-    })
-    .await
-}
-
 #[tokio::test(flavor = "current_thread")]
 async fn middleware_injects_request_handle_and_finishes_from_response_status() {
     let nanos = SystemTime::now()
@@ -199,7 +184,13 @@ async fn configurable_middleware_classifier_changes_recorded_outcome() {
         .route("/bad", get(bad_request_handler))
         .layer(from_fn_with_state(
             Arc::clone(&tailtriage),
-            custom_classifier_middleware,
+            tailtriage_axum::middleware_with_status_classifier(|status| {
+                if status == StatusCode::BAD_REQUEST {
+                    Outcome::Other("client_error".to_owned())
+                } else {
+                    tailtriage_axum::default_status_to_outcome(status)
+                }
+            }),
         ))
         .with_state(AppState {
             gate: Arc::new(Semaphore::new(1)),

--- a/tailtriage-axum/tests/axum_adapter.rs
+++ b/tailtriage-axum/tests/axum_adapter.rs
@@ -9,7 +9,7 @@ use axum::middleware::from_fn_with_state;
 use axum::routing::get;
 use axum::Router;
 use tailtriage_axum::TailtriageRequest;
-use tailtriage_core::Tailtriage;
+use tailtriage_core::{Outcome, Tailtriage};
 use tokio::sync::Semaphore;
 use tower::ServiceExt;
 
@@ -41,6 +41,21 @@ async fn bad_request_handler(TailtriageRequest(_): TailtriageRequest) -> StatusC
 
 async fn timeout_handler(TailtriageRequest(_): TailtriageRequest) -> StatusCode {
     StatusCode::REQUEST_TIMEOUT
+}
+
+async fn custom_classifier_middleware(
+    State(tailtriage): State<Arc<Tailtriage>>,
+    request: Request<Body>,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    tailtriage_axum::middleware_with_status_classifier(tailtriage, request, next, |status| {
+        if status == StatusCode::BAD_REQUEST {
+            Outcome::Other("client_error".to_owned())
+        } else {
+            tailtriage_axum::default_status_to_outcome(status)
+        }
+    })
+    .await
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -170,4 +185,39 @@ async fn middleware_records_default_http_outcomes_in_snapshot() {
     assert_eq!(outcome_for("/bad"), "rejected");
     assert_eq!(outcome_for("/timeout"), "timeout");
     assert_eq!(outcome_for("/fail"), "error");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn configurable_middleware_classifier_changes_recorded_outcome() {
+    let tailtriage = Arc::new(
+        Tailtriage::builder("axum-adapter-custom-classifier-test")
+            .build()
+            .expect("build should succeed"),
+    );
+
+    let app = Router::new()
+        .route("/bad", get(bad_request_handler))
+        .layer(from_fn_with_state(
+            Arc::clone(&tailtriage),
+            custom_classifier_middleware,
+        ))
+        .with_state(AppState {
+            gate: Arc::new(Semaphore::new(1)),
+        });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/bad")
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("request should succeed");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let snapshot = tailtriage.snapshot();
+    assert_eq!(snapshot.requests.len(), 1);
+    assert_eq!(snapshot.requests[0].route, "/bad");
+    assert_eq!(snapshot.requests[0].outcome, "client_error");
 }

--- a/tailtriage-axum/tests/axum_adapter.rs
+++ b/tailtriage-axum/tests/axum_adapter.rs
@@ -35,6 +35,14 @@ async fn failure_handler(TailtriageRequest(_): TailtriageRequest) -> StatusCode 
     StatusCode::INTERNAL_SERVER_ERROR
 }
 
+async fn bad_request_handler(TailtriageRequest(_): TailtriageRequest) -> StatusCode {
+    StatusCode::BAD_REQUEST
+}
+
+async fn timeout_handler(TailtriageRequest(_): TailtriageRequest) -> StatusCode {
+    StatusCode::REQUEST_TIMEOUT
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn middleware_injects_request_handle_and_finishes_from_response_status() {
     let nanos = SystemTime::now()
@@ -103,4 +111,63 @@ async fn middleware_injects_request_handle_and_finishes_from_response_status() {
         .find(|req| req.route == "/fail")
         .expect("failure request should exist");
     assert_eq!(failure.outcome, "error");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn middleware_records_default_http_outcomes_in_snapshot() {
+    let tailtriage = Arc::new(
+        Tailtriage::builder("axum-adapter-outcomes-test")
+            .build()
+            .expect("build should succeed"),
+    );
+
+    let app = Router::new()
+        .route("/ok", get(ok_handler))
+        .route("/bad", get(bad_request_handler))
+        .route("/timeout", get(timeout_handler))
+        .route("/fail", get(failure_handler))
+        .layer(from_fn_with_state(
+            Arc::clone(&tailtriage),
+            tailtriage_axum::middleware,
+        ))
+        .with_state(AppState {
+            gate: Arc::new(Semaphore::new(1)),
+        });
+
+    for (route, expected_status) in [
+        ("/ok", StatusCode::OK),
+        ("/bad", StatusCode::BAD_REQUEST),
+        ("/timeout", StatusCode::REQUEST_TIMEOUT),
+        ("/fail", StatusCode::INTERNAL_SERVER_ERROR),
+    ] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(route)
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(response.status(), expected_status);
+    }
+
+    let snapshot = tailtriage.snapshot();
+
+    assert_eq!(snapshot.requests.len(), 4);
+
+    let outcome_for = |route: &str| {
+        snapshot
+            .requests
+            .iter()
+            .find(|request| request.route == route)
+            .map(|request| request.outcome.as_str())
+            .expect("request route should be present")
+    };
+
+    assert_eq!(outcome_for("/ok"), "ok");
+    assert_eq!(outcome_for("/bad"), "rejected");
+    assert_eq!(outcome_for("/timeout"), "timeout");
+    assert_eq!(outcome_for("/fail"), "error");
 }


### PR DESCRIPTION
### Motivation
- The previous Axum adapter flattened almost all non-5xx responses to `Outcome::Ok`, which made client errors like `400`, `401`, `404`, `429`, etc. appear as successful requests in artifacts.   
- The crate already exposes richer `Outcome` variants (`Ok`, `Rejected`, `Timeout`, `Error`, `Other`), so the adapter should use that surface and be future-proofed for alternative policies.  

### Description
- Introduced a public classifier `default_status_to_outcome(StatusCode) -> Outcome` that implements the required default mapping: `2xx/3xx -> Outcome::Ok`, `4xx -> Outcome::Rejected`, `408 -> Outcome::Timeout`, and `5xx -> Outcome::Error` (with `408` treated specially).  
- Kept the ergonomic `middleware` entry point and made it delegate to the classifier, and added an additive `middleware_with_status_classifier(...)` variant so callers can provide a custom status->outcome policy without rewriting middleware internals.  
- Replaced the previous private ad-hoc mapping with the public helper and updated the middleware to call the provided classifier when finishing requests.  
- Added unit tests that assert the explicit mappings for `200`, `204`, a `3xx`, `400`, `401`, `403`, `404`, `409`, `422`, `429`, `408`, `500`, and `503`, and added a middleware-level behavior test that sends Axum requests through the middleware and verifies the recorded snapshot outcomes for `200 -> ok`, `400 -> rejected`, `408 -> timeout`, and `500 -> error`.  
- Minimal rustdoc added to `middleware` to state the default mapping behavior so it is not surprising to users.  

### Testing
- Ran formatting check with `cargo fmt --check` and it passed.  
- Ran linting with `cargo clippy --workspace --all-targets --locked -- -D warnings` and it passed.  
- Ran the full test suite with `cargo test --workspace --locked` which passed, including the new unit tests and the Axum middleware behavior tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7c2e85a0c833088be2309d70d0975)