### PR TITLE
Polish publish-facing crate docs for docs.rs and add docs.rs metadata

### DIFF
--- a/tailtriage-axum/Cargo.toml
+++ b/tailtriage-axum/Cargo.toml
@@ -21,6 +21,9 @@ include = [
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "matched-path", "tokio"] }
 tailtriage-core.workspace = true
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+
 [lints]
 workspace = true
 

--- a/tailtriage-axum/README.md
+++ b/tailtriage-axum/README.md
@@ -45,24 +45,21 @@ cargo add tailtriage --features axum
 ```rust,no_run
 use std::sync::Arc;
 
-use axum::{extract::State, middleware::from_fn_with_state, routing::get, Router};
+use axum::{middleware::from_fn_with_state, routing::get, Router};
 use tailtriage_axum::{middleware, TailtriageRequest};
 use tailtriage_core::Tailtriage;
 
-async fn app(tailtriage: Arc<Tailtriage>) {
-    async fn checkout(TailtriageRequest(req): TailtriageRequest, State(_): State<()>) {
-        let _: Result<(), ()> = req
-            .stage("inventory_lookup")
-            .await_on(async { Ok(()) })
-            .await;
-    }
+async fn checkout(TailtriageRequest(req): TailtriageRequest) {
+    let _: Result<(), ()> = req
+        .stage("inventory_lookup")
+        .await_on(async { Ok(()) })
+        .await;
+}
 
-    let app: Router<()> = Router::new()
+fn app(tailtriage: Arc<Tailtriage>) -> Router {
+    Router::new()
         .route("/checkout", get(checkout))
         .layer(from_fn_with_state(tailtriage, middleware))
-        .with_state(());
-
-    let _ = app;
 }
 ```
 
@@ -73,6 +70,7 @@ Automatic at the Axum boundary:
 - request start
 - request finish
 - request-scoped handle injection into handlers
+- request `kind` is set to `"http"`
 
 Still explicit in your code:
 

--- a/tailtriage-axum/src/lib.rs
+++ b/tailtriage-axum/src/lib.rs
@@ -31,7 +31,8 @@ pub const fn crate_name() -> &'static str {
 /// `Arc<Tailtriage>` in middleware state.
 ///
 /// The middleware records route labels from `MatchedPath` when available and
-/// otherwise falls back to the raw URI path. By default it maps 2xx/3xx to
+/// otherwise falls back to the raw URI path. Started requests are tagged with
+/// `RequestOptions::kind("http")`. By default it maps 2xx/3xx to
 /// [`Outcome::Ok`], 4xx to [`Outcome::Rejected`] (except 408 to
 /// [`Outcome::Timeout`]), and 5xx to [`Outcome::Error`].
 pub async fn middleware(

--- a/tailtriage-cli/Cargo.toml
+++ b/tailtriage-cli/Cargo.toml
@@ -26,6 +26,9 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 tailtriage-core.workspace = true
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+
 [lints]
 workspace = true
 

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -42,7 +42,7 @@ Machine-readable JSON output:
 tailtriage analyze tailtriage-run.json --format json
 ```
 
-The input artifact must include at least one request event in `requests`.
+The CLI artifact loader requires at least one request event in `requests`.
 
 ## How to read the result
 
@@ -114,6 +114,11 @@ Current contract:
 - current supported schema version is `1`
 - `requests` must contain at least one request event
 - artifacts with an empty `requests` array are rejected by the CLI loader
+
+Library note:
+
+- this crate's library analyzer API, `analyze::analyze_run(&Run)`, can analyze an in-memory `Run` with zero requests
+- the stricter non-empty `requests` rule applies to CLI artifact loading from disk
 
 ## Important interpretation notes
 

--- a/tailtriage-cli/src/analyze.rs
+++ b/tailtriage-cli/src/analyze.rs
@@ -138,7 +138,7 @@ pub struct Report {
     pub p95_queue_share_permille: Option<u64>,
     /// p95 non-queue service-time share per request in permille (`0..=1000`).
     pub p95_service_share_permille: Option<u64>,
-    /// Dominant in-flight trend signal, if enough samples exist.
+    /// Dominant in-flight trend signal, when at least one in-flight gauge has samples.
     pub inflight_trend: Option<InflightTrend>,
     /// Non-fatal analysis warnings (for example, capture truncation notices).
     pub warnings: Vec<String>,
@@ -154,6 +154,8 @@ pub struct Report {
 /// claim causal certainty or proven root cause.
 ///
 /// # Examples
+///
+/// Library API example (this does not use the CLI file-loader contract):
 ///
 /// ```
 /// use tailtriage_cli::analyze::analyze_run;
@@ -190,6 +192,7 @@ pub struct Report {
 ///     truncation: Default::default(),
 /// };
 ///
+/// // `analyze_run(&Run)` can operate on an in-memory run with zero requests.
 /// let report = analyze_run(&run);
 /// assert_eq!(report.request_count, 0);
 /// ```

--- a/tailtriage-cli/src/lib.rs
+++ b/tailtriage-cli/src/lib.rs
@@ -1,6 +1,10 @@
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
 
+//! Contract note: CLI artifact loading requires non-empty `requests`, while
+//! [`analyze::analyze_run`] can analyze an in-memory [`tailtriage_core::Run`]
+//! that has zero requests.
+//!
 /// Heuristic triage analyzer and text-report rendering.
 pub mod analyze;
 /// Artifact loading and validation helpers for CLI workflows.

--- a/tailtriage-controller/Cargo.toml
+++ b/tailtriage-controller/Cargo.toml
@@ -28,5 +28,8 @@ toml = "0.8"
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+
 [lints]
 workspace = true

--- a/tailtriage-controller/README.md
+++ b/tailtriage-controller/README.md
@@ -94,6 +94,26 @@ kind = "auto_seal_on_limits_hit"
 - Requests started while disabled or closing are inert wrappers and never join a later generation.
 - Each activation writes a per-generation artifact using `-generation-N` in the file name.
 
+## Lifecycle states (plain language)
+
+- **enabled**: capture is active and admitting requests.
+- **disabled**: capture is off.
+- **closing**: new captured admissions are blocked; the current generation finalizes after already-admitted captured requests drain.
+- **inert request**: request wrapper returned while disabled/closing; it preserves request metadata but records no capture events.
+
+`disable()` outcomes:
+
+- `already disabled`: no active generation existed.
+- `closing`: admissions were stopped and finalization is waiting on in-flight captured requests.
+- `finalized`: generation finalized immediately (or had already drained) and artifact writing completed.
+
+Artifact path generation for `local_json` sinks:
+
+- generated file names append `-generation-N`
+- parent directory from the configured path is preserved
+- base file stem is reused
+- original extension is preserved when present, otherwise `.json` is used
+
 ## Reload semantics
 
 `reload_config()` updates the template for future generations only.
@@ -159,7 +179,7 @@ The controller can start a Tokio runtime sampler for armed generations when enab
 ### `[controller.activation.sink]`
 
 - `type` *(required string)*: `local_json`.
-- `output_path` *(required string for `local_json`)*: base path template; output uses `-generation-N` suffix.
+- `output_path` *(required string for `local_json`)*: base path template for per-generation files.
 
 ### `[controller.activation.capture_limits_override]`
 

--- a/tailtriage-core/Cargo.toml
+++ b/tailtriage-core/Cargo.toml
@@ -20,6 +20,9 @@ include = [
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+
 [lints]
 workspace = true
 

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -20,7 +20,7 @@ The artifact produced here is analyzed by `tailtriage-cli`.
 
 Use `tailtriage-core` when you want the smallest framework-agnostic capture surface.
 
-Use `tailtriage` when you want the default all-in-one entry point.
+Use `tailtriage` when you want the recommended default entry point: an aggregator/re-export crate with optional integrations behind features.
 
 ## Installation
 

--- a/tailtriage-tokio/Cargo.toml
+++ b/tailtriage-tokio/Cargo.toml
@@ -21,5 +21,8 @@ include = [
 tailtriage-core.workspace = true
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+
 [lints]
 workspace = true

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -79,6 +79,8 @@ async fn demo() -> Result<(), Box<dyn std::error::Error>> {
 
 ## What gets added to the artifact
 
+On successful sampler start, tailtriage records effective sampler configuration metadata into the run artifact metadata before runtime snapshots are captured.
+
 When the sampler is running, the run artifact can include runtime snapshots such as:
 
 - `alive_tasks`

--- a/tailtriage/README.md
+++ b/tailtriage/README.md
@@ -1,8 +1,8 @@
 # tailtriage
 
-`tailtriage` is the default crate for **Tokio tail-latency triage**.
+`tailtriage` is the recommended default entry point for **Tokio tail-latency triage**.
 
-It gives you one capture-side entry point with optional integrations for controller workflows, Tokio runtime sampling, and Axum request boundaries.
+It re-exports `tailtriage-core` at the crate root and exposes integration namespaces for controller workflows, Tokio runtime sampling, and Axum request boundaries. Only `controller` is enabled by default; `tokio` and `axum` are opt-in features.
 
 ## What problem this solves
 
@@ -75,8 +75,8 @@ Choose a focused crate only when you need a narrower boundary:
 ## Feature flags
 
 - `controller` *(default)*: enables `tailtriage::controller`
-- `tokio`: enables `tailtriage::tokio`
-- `axum`: enables `tailtriage::axum`
+- `tokio` *(opt-in)*: enables `tailtriage::tokio`
+- `axum` *(opt-in)*: enables `tailtriage::axum`
 - `full`: enables `controller`, `tokio`, and `axum`
 
 ## Important constraints

--- a/tailtriage/src/lib.rs
+++ b/tailtriage/src/lib.rs
@@ -2,22 +2,29 @@
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-// Official default crate for the tailtriage toolkit.
-//
-// - [`tailtriage_core`] is always re-exported as the foundational API surface.
-// - [`controller`] is the default convenience layer when the `controller` feature is enabled.
-// - [`tokio`] and [`axum`] are opt-in integration namespaces.
-
+/// Re-export of `tailtriage-core`, always available at the crate root.
+///
+/// This crate is the recommended default entry point: start with core APIs here,
+/// then enable optional integration namespaces via feature flags as needed.
 pub use tailtriage_core::*;
 
 #[cfg(feature = "axum")]
 #[cfg_attr(docsrs, doc(cfg(feature = "axum")))]
+/// Optional Axum integration namespace (`tailtriage::axum`).
+///
+/// Enable with the `axum` feature.
 pub use tailtriage_axum as axum;
 #[cfg(feature = "controller")]
 #[cfg_attr(docsrs, doc(cfg(feature = "controller")))]
+/// Controller integration namespace (`tailtriage::controller`).
+///
+/// Enabled by default via the `controller` feature.
 pub use tailtriage_controller as controller;
 #[cfg(feature = "tokio")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
+/// Optional Tokio runtime sampler namespace (`tailtriage::tokio`).
+///
+/// Enable with the `tokio` feature.
 pub use tailtriage_tokio as tokio;
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation

- Make publish-facing crate docs self-contained and friendly for `crates.io` / `docs.rs` without changing runtime behavior. 
- Ensure the umbrella crate and public re-exports are clearly documented so users landing on docs.rs understand the recommended entry point and feature layout. 
- Fix small doc-truth issues (controller lifecycle semantics, tokio sampler metadata, axum request kind, CLI vs library contract, and `inflight_trend` wording) so docs reflect actual behavior. 

### Description

- Added `[package.metadata.docs.rs] rustdoc-args = ["--cfg", "docsrs"]` to the Cargo.toml of `tailtriage-core`, `tailtriage-controller`, `tailtriage-tokio`, `tailtriage-axum`, and `tailtriage-cli`. 
- Clarified `tailtriage` README and added rustdoc comments in `tailtriage/src/lib.rs` to state it is the recommended default entry point, re-exports `tailtriage-core`, and that `controller` is default while `tokio`/`axum` are opt-in. 
- Reworded `tailtriage-core/README.md` to avoid “all-in-one” phrasing and describe `tailtriage` as an aggregator/re-export entry point with optional integrations. 
- Expanded `tailtriage-controller/README.md` with a concise plain-language lifecycle section (enabled/disabled/closing/inert), explicit `disable()` outcomes, and clear artifact path generation rules (`-generation-N`, preserved parent/stem/extension, `.json` fallback). 
- Updated `tailtriage-tokio/README.md` to explicitly state that a successful sampler start records effective sampler configuration metadata into the run artifact. 
- Updated `tailtriage-axum/README.md` and `tailtriage-axum/src/lib.rs` to note that middleware starts requests with `kind = "http"` and simplified the quick-start example for docs.rs readability. 
- Updated `tailtriage-cli` docs and sources to clarify the CLI loader requires non-empty `requests` while the library `analyze::analyze_run(&Run)` accepts an in-memory `Run` with zero requests, and changed `Report.inflight_trend` wording to match the implementation (present when at least one gauge has samples). 

### Testing

- Ran formatting and verification: `cargo fmt --all` succeeded and `cargo check --workspace` completed without errors. 
- Ran the full test suite including doctests: `cargo test --workspace` and `cargo test --workspace --doc` both succeeded. 
- Attempted crate packaging verification with `cargo package -p <crate> --allow-dirty`: packaging succeeded for `tailtriage-core` and `tailtriage-axum`, while packaging `tailtriage`, `tailtriage-controller`, `tailtriage-tokio`, and `tailtriage-cli` failed during crates.io-index verification due to unresolved published sibling package resolution/version skew (these packaging failures appear to be pre-existing publish-order/version issues and not regressions from the docs-only changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e89ae82b9483309ea4e2da60e6e92a)