### PR TITLE
docs: close rustdoc error gaps and make docs-contract checks less brittle

### DIFF
--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -87,7 +87,7 @@ impl Tailtriage {
     def test_sampler_integration_boundary_contract_validates(self) -> None:
         validate_docs_contracts.validate_sampler_integration_boundary()
 
-    def test_controller_readme_toml_validation_requires_current_anchor(self) -> None:
+    def test_controller_readme_toml_validation_allows_equivalent_headings(self) -> None:
         readme_text = """# tailtriage-controller
 
 ## Config file (TOML)
@@ -317,65 +317,24 @@ service_name initially_enabled mode strict_lifecycle capture_limits_override max
                 ):
                     validate_docs_contracts.validate_controller_readme_toml()
 
-    def test_controller_readme_toml_validation_fails_on_misleading_precedence_phrase(self) -> None:
-        readme_text = """# tailtriage-controller
+    def test_validate_docs_index_contract_checks_paths_not_link_labels(self) -> None:
+        docs_index = """# Documentation index
 
-## Config file (TOML)
-
-If a TOML field is omitted, builder/default values continue to apply where supported by the config contract.
-
-```toml
-[controller]
-service_name = "checkout-service"
-
-[controller.activation]
-mode = "light"
-
-[controller.activation.sink]
-type = "local_json"
-output_path = "tailtriage-run.json"
-```
-
-```toml
-[controller]
-service_name = "checkout-service"
-initially_enabled = false
-
-[controller.activation]
-mode = "investigation"
-
-[controller.activation.capture_limits_override]
-max_requests = 100
-max_stages = 200
-max_queues = 200
-max_inflight_snapshots = 200
-max_runtime_snapshots = 100
-
-[controller.activation.sink]
-type = "local_json"
-output_path = "tailtriage-run.json"
-
-[controller.activation.runtime_sampler]
-enabled_for_armed_runs = true
-mode_override = "investigation"
-interval_ms = 250
-max_runtime_snapshots = 50
-
-[controller.activation.run_end_policy]
-kind = "auto_seal_on_limits_hit"
-```
-
-## TOML field reference
-
-service_name initially_enabled mode strict_lifecycle capture_limits_override max_requests max_stages max_queues max_inflight_snapshots max_runtime_snapshots enabled_for_armed_runs mode_override interval_ms run_end_policy continue_after_limits_hit auto_seal_on_limits_hit
+- [Guide](user-guide.md)
+- [Diag](diagnostics.md)
+- [Controller crate](../tailtriage-controller/README.md)
+- [Sampler crate](../tailtriage-tokio/README.md)
+- [CLI crate](../tailtriage-cli/README.md)
+- [Runtime cost notes](runtime-cost.md)
+- [Collector limits notes](collector-limits.md)
+- [Demos](getting-started-demo.md)
+- [Architecture overview](architecture.md)
 """
         with tempfile.TemporaryDirectory() as tmp_dir:
-            readme_path = Path(tmp_dir) / "README.md"
-            readme_path.write_text(readme_text, encoding="utf-8")
-
-            with mock.patch.object(validate_docs_contracts, "CONTROLLER_README_PATH", readme_path):
-                with self.assertRaisesRegex(ValueError, r"misleading TOML precedence wording"):
-                    validate_docs_contracts.validate_controller_readme_toml()
+            docs_path = Path(tmp_dir) / "README.md"
+            docs_path.write_text(docs_index, encoding="utf-8")
+            with mock.patch.object(validate_docs_contracts, "DOCS_INDEX_PATH", docs_path):
+                validate_docs_contracts.validate_docs_index_contract()
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -317,6 +317,128 @@ service_name initially_enabled mode strict_lifecycle capture_limits_override max
                 ):
                     validate_docs_contracts.validate_controller_readme_toml()
 
+    def test_controller_readme_toml_validation_accepts_semantic_precedence_wording(self) -> None:
+        readme_text = """# tailtriage-controller
+
+## Config behavior
+
+If omitted in TOML, `service_name` uses the builder value.
+If omitted in TOML, `initially_enabled` uses the builder value.
+Activation template settings are TOML-owned.
+Any omitted optional activation fields use contract defaults.
+
+```toml
+[controller]
+service_name = "checkout-service"
+
+[controller.activation]
+mode = "light"
+
+[controller.activation.sink]
+type = "local_json"
+output_path = "tailtriage-run.json"
+```
+
+```toml
+[controller]
+service_name = "checkout-service"
+initially_enabled = false
+
+[controller.activation]
+mode = "investigation"
+
+[controller.activation.capture_limits_override]
+max_requests = 100
+max_stages = 200
+max_queues = 200
+max_inflight_snapshots = 200
+max_runtime_snapshots = 100
+
+[controller.activation.sink]
+type = "local_json"
+output_path = "tailtriage-run.json"
+
+[controller.activation.runtime_sampler]
+enabled_for_armed_runs = true
+mode_override = "investigation"
+interval_ms = 250
+max_runtime_snapshots = 50
+
+[controller.activation.run_end_policy]
+kind = "auto_seal_on_limits_hit"
+```
+
+## TOML field reference
+
+service_name initially_enabled mode strict_lifecycle capture_limits_override max_requests max_stages max_queues max_inflight_snapshots max_runtime_snapshots enabled_for_armed_runs mode_override interval_ms run_end_policy continue_after_limits_hit auto_seal_on_limits_hit
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            readme_path = Path(tmp_dir) / "README.md"
+            readme_path.write_text(readme_text, encoding="utf-8")
+
+            with mock.patch.object(validate_docs_contracts, "CONTROLLER_README_PATH", readme_path):
+                validate_docs_contracts.validate_controller_readme_toml()
+
+    def test_controller_readme_toml_validation_fails_without_precedence_semantics(self) -> None:
+        readme_text = """# tailtriage-controller
+
+## Config behavior
+
+TOML controls config for this crate.
+
+```toml
+[controller]
+service_name = "checkout-service"
+
+[controller.activation]
+mode = "light"
+
+[controller.activation.sink]
+type = "local_json"
+output_path = "tailtriage-run.json"
+```
+
+```toml
+[controller]
+service_name = "checkout-service"
+initially_enabled = false
+
+[controller.activation]
+mode = "investigation"
+
+[controller.activation.capture_limits_override]
+max_requests = 100
+max_stages = 200
+max_queues = 200
+max_inflight_snapshots = 200
+max_runtime_snapshots = 100
+
+[controller.activation.sink]
+type = "local_json"
+output_path = "tailtriage-run.json"
+
+[controller.activation.runtime_sampler]
+enabled_for_armed_runs = true
+mode_override = "investigation"
+interval_ms = 250
+max_runtime_snapshots = 50
+
+[controller.activation.run_end_policy]
+kind = "auto_seal_on_limits_hit"
+```
+
+## TOML field reference
+
+service_name initially_enabled mode strict_lifecycle capture_limits_override max_requests max_stages max_queues max_inflight_snapshots max_runtime_snapshots enabled_for_armed_runs mode_override interval_ms run_end_policy continue_after_limits_hit auto_seal_on_limits_hit
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            readme_path = Path(tmp_dir) / "README.md"
+            readme_path.write_text(readme_text, encoding="utf-8")
+
+            with mock.patch.object(validate_docs_contracts, "CONTROLLER_README_PATH", readme_path):
+                with self.assertRaisesRegex(ValueError, r"precedence guidance missing semantic rule"):
+                    validate_docs_contracts.validate_controller_readme_toml()
+
     def test_validate_docs_index_contract_checks_paths_not_link_labels(self) -> None:
         docs_index = """# Documentation index
 

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -218,6 +218,7 @@ def validate_controller_readme_toml() -> None:
     readme_text = CONTROLLER_README_PATH.read_text(encoding="utf-8")
     if not has_markdown_heading(readme_text, r"TOML\s+field\s+reference"):
         raise ValueError("controller README must include a TOML field reference section")
+    _validate_controller_precedence_semantics(readme_text)
 
     required_reference_tokens = (
         "service_name",
@@ -291,6 +292,31 @@ def validate_controller_readme_toml() -> None:
     run_end_policy = expanded_activation["run_end_policy"]
     if "kind" not in run_end_policy:
         raise ValueError("expanded controller TOML example must include run_end_policy.kind")
+
+
+def _validate_controller_precedence_semantics(readme_text: str) -> None:
+    semantic_checks = (
+        (
+            "service_name fallback",
+            r"service_name[\s\S]{0,200}(?:fall[s]?\s+back|uses?)[\s\S]{0,120}builder",
+        ),
+        (
+            "initially_enabled fallback",
+            r"initially_enabled[\s\S]{0,200}(?:fall[s]?\s+back|uses?)[\s\S]{0,120}builder",
+        ),
+        (
+            "activation settings owned by TOML",
+            r"(?:activation[\s\S]{0,200}(?:comes?\s+from|owned\s+by)[\s\S]{0,80}toml|toml[\s\S]{0,80}owned[\s\S]{0,120}activation)",
+        ),
+        (
+            "activation optional-subfield defaults",
+            r"omitted[\s\S]{0,120}activation[\s\S]{0,120}default",
+        ),
+    )
+    lower_text = readme_text.lower()
+    for check_name, pattern in semantic_checks:
+        if re.search(pattern, lower_text, flags=re.IGNORECASE) is None:
+            raise ValueError(f"controller README precedence guidance missing semantic rule: {check_name}")
 
 
 def _validate_controller_toml_shape(*, parsed: dict[str, Any], example_name: str) -> None:

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -76,7 +76,6 @@ README_DOC_MAP_REQUIRED_LINKS = (
 DOCS_DISALLOWED_HISTORY_PATTERNS = (
     r"issue\s*#\d+",
     r"PR\s*#\d+",
-    r"roadmap",
 )
 
 DIAGNOSTICS_FIELD_REFERENCE_LABELS = (
@@ -109,6 +108,22 @@ def extract_fenced_blocks_after_anchor(markdown: str, *, fence: str, anchor: str
 
     pattern = re.compile(rf"```{re.escape(fence)}\n(.*?)\n```", re.DOTALL)
     return [match.group(1) for match in pattern.finditer(markdown, pos=anchor_index)]
+
+
+def extract_all_fenced_blocks(markdown: str, *, fence: str) -> list[str]:
+    pattern = re.compile(rf"```{re.escape(fence)}\n(.*?)\n```", re.DOTALL)
+    return [match.group(1) for match in pattern.finditer(markdown)]
+
+
+def markdown_links(markdown: str) -> set[str]:
+    return set(re.findall(r"\[[^\]]+\]\(([^)]+)\)", markdown))
+
+
+def has_markdown_heading(markdown: str, heading_pattern: str) -> bool:
+    return (
+        re.search(rf"^\s*#+\s+{heading_pattern}\s*$", markdown, flags=re.IGNORECASE | re.MULTILINE)
+        is not None
+    )
 
 
 def _kind_of(value: Any) -> str:
@@ -201,24 +216,8 @@ def extract_run_end_policy_kinds_from_source() -> set[str]:
 
 def validate_controller_readme_toml() -> None:
     readme_text = CONTROLLER_README_PATH.read_text(encoding="utf-8")
-    if "## TOML field reference" not in readme_text:
-        raise ValueError("controller README must include a dedicated '## TOML field reference' section")
-    if "where supported by the config contract" in readme_text:
-        raise ValueError(
-            "controller README contains misleading TOML precedence wording; "
-            "do not claim broad builder fallback for omitted TOML fields"
-        )
-
-    precedence_tokens = (
-        r"service_name",
-        r"initially_enabled",
-        r"fall[s]?\s+back\s+to\s+(?:the\s+)?builder\s+value[s]?\s+when\s+omitted",
-        r"activation template settings(?:\s*\([^)]*\))?\s+come from TOML",
-        r"omitted optional activation subfields use TOML contract defaults",
-    )
-    for token in precedence_tokens:
-        if re.search(token, readme_text, flags=re.IGNORECASE) is None:
-            raise ValueError(f"controller README precedence guidance missing token: {token}")
+    if not has_markdown_heading(readme_text, r"TOML\s+field\s+reference"):
+        raise ValueError("controller README must include a TOML field reference section")
 
     required_reference_tokens = (
         "service_name",
@@ -254,11 +253,7 @@ def validate_controller_readme_toml() -> None:
             anchor="## Expanded TOML example",
         )
     else:
-        snippets = extract_fenced_blocks_after_anchor(
-            readme_text,
-            fence="toml",
-            anchor="## Config precedence and reload rules",
-        )
+        snippets = extract_all_fenced_blocks(readme_text, fence="toml")
         if len(snippets) < 2:
             raise ValueError("controller README must include minimal and expanded TOML examples")
         minimal_snippet, expanded_snippet = snippets[0], snippets[1]
@@ -377,19 +372,27 @@ def validate_no_stale_controller_policy_names() -> None:
 
 def validate_docs_index_contract() -> None:
     text = DOCS_INDEX_PATH.read_text(encoding="utf-8")
-    for required_link in DOCS_REQUIRED_LINKS:
-        if required_link not in text:
-            raise ValueError(f"docs index missing required link: {required_link}")
+    links = markdown_links(text)
+    required_paths = {
+        match.group(1)
+        for link in DOCS_REQUIRED_LINKS
+        for match in [re.search(r"\(([^)]+)\)\s*$", link)]
+        if match is not None
+    }
+    missing = sorted(required_paths.difference(links))
+    if missing:
+        raise ValueError(f"docs index missing required links: {missing}")
 
 
 def validate_user_guide_contract() -> None:
     text = USER_GUIDE_PATH.read_text(encoding="utf-8")
-    required_tokens = (
-        "Default adoption path",
-        "Request lifecycle contract (required)",
-        "Direct capture vs controller",
-        "Controller TOML config and reload semantics",
-        "TailtriageController::builder(",
+    lower_text = text.lower()
+    required_concepts = (
+        "default adoption path",
+        "request lifecycle contract",
+        "direct capture vs controller",
+        "controller toml config",
+        "tailtriagecontroller::builder(",
         "[controller]",
         "[controller.activation]",
         "[controller.activation.sink]",
@@ -397,9 +400,9 @@ def validate_user_guide_contract() -> None:
         "future generations only",
         "insufficient_evidence",
     )
-    for token in required_tokens:
-        if token not in text:
-            raise ValueError(f"user guide missing required section/token: {token}")
+    for concept in required_concepts:
+        if concept not in lower_text:
+            raise ValueError(f"user guide missing required concept/token: {concept}")
 
     toml_snippet = extract_fenced_block(
         text,
@@ -441,9 +444,16 @@ def validate_user_guide_contract() -> None:
 
 def validate_root_readme_docs_map_parity() -> None:
     text = README_PATH.read_text(encoding="utf-8")
-    for required_link in README_DOC_MAP_REQUIRED_LINKS:
-        if required_link not in text:
-            raise ValueError(f"root README docs map missing required link: {required_link}")
+    links = markdown_links(text)
+    required_paths = {
+        match.group(1)
+        for link in README_DOC_MAP_REQUIRED_LINKS
+        for match in [re.search(r"\(([^)]+)\)\s*$", link)]
+        if match is not None
+    }
+    missing = sorted(required_paths.difference(links))
+    if missing:
+        raise ValueError(f"root README docs map missing required links: {missing}")
 
 
 def validate_diagnostics_contract_truthfulness() -> None:

--- a/tailtriage-controller/src/lib.rs
+++ b/tailtriage-controller/src/lib.rs
@@ -414,8 +414,8 @@ impl TailtriageController {
     /// template startup is enabled but `enable()` is called outside an active Tokio runtime.
     ///
     /// Returns [`EnableError::StartRuntimeSampler`] when runtime sampler startup is
-    /// enabled but sampler initialization fails (for example, duplicate sampler start
-    /// on the same run).
+    /// enabled but sampler initialization fails (for example, when config sets
+    /// `interval_ms = 0`).
     ///
     pub fn enable(&self) -> Result<ActiveGenerationState, EnableError> {
         let template = self

--- a/tailtriage-controller/src/lib.rs
+++ b/tailtriage-controller/src/lib.rs
@@ -114,7 +114,15 @@ impl TailtriageControllerBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`ControllerBuildError::EmptyServiceName`] when `service_name` is blank.
+    /// Returns [`ControllerBuildError::EmptyServiceName`] when the builder value and
+    /// any loaded config both resolve to a blank `service_name`.
+    ///
+    /// Returns [`ControllerBuildError::ConfigLoad`] when `config_path(...)` is set and
+    /// reading or parsing the TOML file fails.
+    ///
+    /// Returns [`ControllerBuildError::InitialEnable`] when
+    /// [`Self::initially_enabled`] is `true` and the first generation cannot be
+    /// armed.
     pub fn build(self) -> Result<TailtriageController, ControllerBuildError> {
         let mut service_name = self.service_name;
         if service_name.trim().is_empty() {
@@ -398,8 +406,16 @@ impl TailtriageController {
     ///
     /// # Errors
     ///
-    /// Returns [`EnableError::AlreadyActive`] when another generation is already active,
-    /// and [`EnableError::Build`] when the run cannot be constructed.
+    /// Returns [`EnableError::AlreadyActive`] when another generation is already active.
+    ///
+    /// Returns [`EnableError::Build`] when constructing the generation run fails.
+    ///
+    /// Returns [`EnableError::MissingTokioRuntimeForSampler`] when runtime sampler
+    /// template startup is enabled but `enable()` is called outside an active Tokio runtime.
+    ///
+    /// Returns [`EnableError::StartRuntimeSampler`] when runtime sampler startup is
+    /// enabled but sampler initialization fails (for example, duplicate sampler start
+    /// on the same run).
     ///
     pub fn enable(&self) -> Result<ActiveGenerationState, EnableError> {
         let template = self

--- a/tailtriage-tokio/src/lib.rs
+++ b/tailtriage-tokio/src/lib.rs
@@ -139,6 +139,9 @@ impl RuntimeSampler {
     ///
     /// Returns [`SamplerStartError::MissingRuntime`] when called outside an
     /// active Tokio runtime.
+    ///
+    /// Returns [`SamplerStartError::DuplicateStart`] when runtime sampling was
+    /// already started for this run.
     pub fn start(
         tailtriage: Arc<Tailtriage>,
         interval: Duration,


### PR DESCRIPTION
### Motivation
- Make public crate docs truthful about all user-visible error variants so crates.io/docs.rs readers see accurate failure modes.
- Reduce CI fragility by relaxing exact-prose coupling in `scripts/validate_docs_contracts.py` so maintenance edits don't cause false positives.

### Description
- Tightened `tailtriage-controller` rustdoc for `TailtriageControllerBuilder::build()` to list `EmptyServiceName`, `ConfigLoad(...)`, and `InitialEnable(...)` as public failure modes. 
- Tightened `tailtriage-controller` rustdoc for `TailtriageController::enable()` to list `AlreadyActive`, `Build(...)`, `MissingTokioRuntimeForSampler`, and `StartRuntimeSampler(...)` as public failure modes.
- Tightened `tailtriage-tokio` rustdoc for `RuntimeSampler::start(...)` to include `DuplicateStart` as an explicit error case.
- Reduced docs-validator brittleness in `scripts/validate_docs_contracts.py` by adding semantic helpers and relaxing exact-text checks: added `markdown_links`, `has_markdown_heading`, and `extract_all_fenced_blocks`; switched index and README map checks to verify link targets by path instead of exact label text; made user-guide checks case-insensitive concept presence checks; accepted equivalent TOML-field-reference headings and tolerant TOML example extraction; removed the broad `roadmap` ban that caused spurious failures.
- Updated unit tests in `scripts/tests/test_validate_docs_contracts.py` to match the new validator behavior and to include a path-based docs-index test.

### Testing
- Ran `python3 scripts/validate_docs_contracts.py`, which printed "docs contracts validated successfully" and exited with status 0.
- Ran `python3 -m unittest scripts.tests.test_validate_docs_contracts`, which executed the test suite (`19` tests) and passed (`OK`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e92ae3b7f48330b385749d087b0474)