### PR TITLE
Clarify controller artifact naming and axum example positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,14 +215,14 @@ Use the GitHub/workspace path when you want to run packaged examples, inspect in
 Five public examples to start with:
 
 - `minimal_checkout` — fastest capture-to-analyze loop
-- `axum_minimal` — smallest Axum framework starter
+- `axum_core_manual` — manual Axum + `tailtriage-core` framework wiring
 - `axum_service_adoption` — service-shaped Axum adoption example
 - `mini_service_integration` — helper-layer or fractured-code instrumentation shape
 - `controller_minimal` — arm/disarm controller lifecycle starter
 
 ```bash
 cargo run -p tailtriage-tokio --example minimal_checkout
-cargo run -p tailtriage-axum --example axum_minimal
+cargo run -p tailtriage-axum --example axum_core_manual
 cargo run -p tailtriage-axum --example axum_service_adoption
 cargo run -p tailtriage-tokio --example mini_service_integration
 cargo run -p tailtriage-controller --example controller_minimal

--- a/scripts/smoke_public_examples.py
+++ b/scripts/smoke_public_examples.py
@@ -23,7 +23,7 @@ EXAMPLES = [
     },
     {
         "package": "tailtriage-axum",
-        "name": "axum_minimal",
+        "name": "axum_core_manual",
         "artifact": "tailtriage-run.json",
     },
     {

--- a/tailtriage-axum/README.md
+++ b/tailtriage-axum/README.md
@@ -14,6 +14,8 @@ This crate gives you three Axum-facing pieces:
 
 This crate is about integration ergonomics. It does not replace explicit instrumentation inside the request body.
 
+The primary integration path in this crate is `middleware`, `middleware_with_status_classifier(...)`, and `TailtriageRequest`.
+
 ## When to choose this crate
 
 Choose `tailtriage-axum` when:
@@ -62,6 +64,11 @@ fn app(tailtriage: Arc<Tailtriage>) -> Router {
         .layer(from_fn_with_state(tailtriage, middleware))
 }
 ```
+
+## Examples
+
+- `axum_service_adoption`: primary service-shaped example using `tailtriage-axum` middleware + `TailtriageRequest`.
+- `axum_core_manual`: manual Axum + `tailtriage-core` wiring for equivalent framework integration without `tailtriage-axum`.
 
 ## Automatic vs explicit responsibilities
 

--- a/tailtriage-axum/examples/axum_core_manual.rs
+++ b/tailtriage-axum/examples/axum_core_manual.rs
@@ -99,7 +99,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tailtriage.shutdown()?;
 
     println!("Wrote {artifact_path}");
-    println!("This axum example is a framework adoption starter, not a production case study.");
+    println!("This example shows manual Axum + tailtriage-core wiring.");
+    println!("It intentionally does not use tailtriage-axum middleware/extractor.");
     println!("For a larger service-shaped example, run:");
     println!("  cargo run -p tailtriage-axum --example axum_service_adoption");
     println!("Next step:");

--- a/tailtriage-controller/README.md
+++ b/tailtriage-controller/README.md
@@ -22,6 +22,8 @@ cargo add tailtriage-controller
 
 ## Quick start
 
+`output("tailtriage-run.json")` configures the base artifact path template. Each activation writes a per-generation artifact with `-generation-N` in the file name (for example, generation 1 writes `tailtriage-run-generation-1.json`).
+
 ```rust,no_run
 use tailtriage_controller::TailtriageController;
 


### PR DESCRIPTION
### Motivation
- Close two docs/examples gaps so per-crate docs on crates.io/docs.rs are self-contained and not GitHub-centric. 
- Make the `tailtriage-controller` quick-start unambiguous about per-generation artifact naming so readers are not surprised by `-generation-N` files. 
- Remove misleading example naming in `tailtriage-axum` so users can clearly choose the crate integration surface or the manual `tailtriage-core` wiring path.

### Description
- Clarified the `tailtriage-controller` quick-start by adding a short operational note that `.output("tailtriage-run.json")` is a base template and each activation writes a per-generation artifact with `-generation-N` (e.g. `tailtriage-run-generation-1.json`).
- Renamed the Axum example file from `tailtriage-axum/examples/axum_minimal.rs` to `tailtriage-axum/examples/axum_core_manual.rs` and updated its output text to say it demonstrates manual Axum + `tailtriage-core` wiring and intentionally does not use the crate middleware/extractor.
- Updated `tailtriage-axum/README.md` to explicitly call out the crate's integration surface (`middleware`, `middleware_with_status_classifier(...)`, and `TailtriageRequest`) and added a concise `Examples` section describing the renamed manual example and the `axum_service_adoption` middleware-based example.
- Updated workspace-level references to the renamed example in `README.md` and `scripts/smoke_public_examples.py` so example names and run commands match the filesystem; no manifest, feature, API, version, or `rust-version` changes were made.

### Testing
- Ran `cargo fmt --check` and it passed. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it passed. 
- Ran `cargo test --workspace` and the test suite passed. 
- Ran `python3 scripts/validate_docs_contracts.py` and validation passed. 
- Compiled and executed the renamed Axum example with `cargo run -p tailtriage-axum --example axum_core_manual`, which ran and produced the expected run artifact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9d5b10cf08330916bf2663a7fbaaa)