### PR TITLE
Fix run metadata defaults, host capture, and controller service_name precedence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +360,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +479,16 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -628,6 +655,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "semver"
@@ -804,8 +837,10 @@ name = "tailtriage-core"
 version = "0.1.1"
 dependencies = [
  "futures-executor",
+ "hostname",
  "serde",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -941,6 +976,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,6 +1008,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]

--- a/tailtriage-controller/README.md
+++ b/tailtriage-controller/README.md
@@ -12,7 +12,7 @@ Use `tailtriage-controller` when you need repeated arm/disarm windows in one pro
 
 Use `tailtriage-core` for a single explicit `build -> capture -> shutdown` run.
 
-Use `tailtriage` when you want the default entry point with optional controller support behind a feature.
+Use `tailtriage` when you want the default entry point with controller support enabled by default (or disabled via Cargo features).
 
 ## Installation
 
@@ -113,7 +113,8 @@ kind = "auto_seal_on_limits_hit"
 
 When TOML is loaded with `config_path(...)`:
 
-- `service_name` falls back to the builder value when omitted.
+- `service_name` from TOML overrides the builder value when present.
+- builder `service_name` is a fallback only when TOML omits `service_name`.
 - `initially_enabled` falls back to the builder value when omitted.
 - activation template settings come from TOML.
 - omitted optional activation subfields use TOML contract defaults.

--- a/tailtriage-controller/src/lib.rs
+++ b/tailtriage-controller/src/lib.rs
@@ -114,8 +114,11 @@ impl TailtriageControllerBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`ControllerBuildError::EmptyServiceName`] when the builder value and
-    /// any loaded config both resolve to a blank `service_name`.
+    /// When `config_path(...)` is set, `controller.service_name` from TOML takes
+    /// precedence when present; the builder value is used only when TOML omits it.
+    ///
+    /// Returns [`ControllerBuildError::EmptyServiceName`] when the final resolved
+    /// `service_name` is blank.
     ///
     /// Returns [`ControllerBuildError::ConfigLoad`] when `config_path(...)` is set and
     /// reading or parsing the TOML file fails.
@@ -125,10 +128,6 @@ impl TailtriageControllerBuilder {
     /// armed.
     pub fn build(self) -> Result<TailtriageController, ControllerBuildError> {
         let mut service_name = self.service_name;
-        if service_name.trim().is_empty() {
-            return Err(ControllerBuildError::EmptyServiceName);
-        }
-
         let mut initially_enabled = self.initially_enabled;
         let mut sink_template = self.sink_template;
         let mut selected_mode = CaptureMode::Light;
@@ -1835,6 +1834,32 @@ mod tests {
         fs::write(path, content).expect("config write should succeed");
     }
 
+    fn write_config_with_optional_service_name(
+        path: &Path,
+        output: &Path,
+        service_name: Option<&str>,
+    ) {
+        let content = toml::to_string(&TestControllerConfigToml {
+            controller: TestControllerConfigBodyToml {
+                service_name: service_name.map(str::to_owned),
+                initially_enabled: Some(false),
+                activation: TestActivationToml {
+                    mode: "light",
+                    capture_limits_override: None,
+                    strict_lifecycle: None,
+                    sink: TestSinkToml {
+                        sink_type: "local_json",
+                        output_path: output.to_path_buf(),
+                    },
+                    runtime_sampler: None,
+                    run_end_policy: None,
+                },
+            },
+        })
+        .expect("config TOML serialization should succeed");
+        fs::write(path, content).expect("config write should succeed");
+    }
+
     fn write_raw_config(path: &std::path::Path, content: &str) {
         fs::write(path, content).expect("config write should succeed");
     }
@@ -3086,6 +3111,65 @@ kind = "continue_after_limits_hit"
             err,
             ControllerBuildError::ConfigLoad(super::ConfigLoadError::Io { .. })
         ));
+    }
+
+    #[test]
+    fn config_service_name_overrides_builder_service_name_when_present() {
+        let output = test_output("build-config-service-name-overrides");
+        let config = test_config_path("build-config-service-name-overrides");
+        write_config_with_optional_service_name(&config, &output, Some("toml-service-name"));
+
+        let controller = TailtriageController::builder("builder-service-name")
+            .config_path(&config)
+            .build()
+            .expect("build should succeed");
+        assert_eq!(
+            controller.status().template.service_name,
+            "toml-service-name"
+        );
+
+        fs::remove_file(config).expect("config cleanup should succeed");
+    }
+
+    #[test]
+    fn blank_builder_service_name_uses_non_blank_toml_service_name() {
+        let output = test_output("build-blank-builder-uses-toml");
+        let config = test_config_path("build-blank-builder-uses-toml");
+        write_config_with_optional_service_name(&config, &output, Some("toml-service-name"));
+
+        let controller = TailtriageController::builder("   ")
+            .config_path(&config)
+            .build()
+            .expect("build should succeed");
+        assert_eq!(
+            controller.status().template.service_name,
+            "toml-service-name"
+        );
+
+        fs::remove_file(config).expect("config cleanup should succeed");
+    }
+
+    #[test]
+    fn blank_builder_service_name_without_config_fails_build() {
+        let err = TailtriageController::builder("   ")
+            .build()
+            .expect_err("blank builder service_name without config should fail");
+        assert!(matches!(err, ControllerBuildError::EmptyServiceName));
+    }
+
+    #[test]
+    fn blank_builder_and_blank_toml_service_name_fail_build() {
+        let output = test_output("build-blank-builder-blank-toml");
+        let config = test_config_path("build-blank-builder-blank-toml");
+        write_config_with_optional_service_name(&config, &output, Some(""));
+
+        let err = TailtriageController::builder("   ")
+            .config_path(&config)
+            .build()
+            .expect_err("blank builder and blank TOML service_name should fail");
+        assert!(matches!(err, ControllerBuildError::EmptyServiceName));
+
+        fs::remove_file(config).expect("config cleanup should succeed");
     }
 
     #[test]

--- a/tailtriage-core/Cargo.toml
+++ b/tailtriage-core/Cargo.toml
@@ -19,6 +19,8 @@ include = [
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+uuid = { version = "1", features = ["v4"] }
+hostname = "0.4"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/tailtriage-core/src/collector.rs
+++ b/tailtriage-core/src/collector.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::ffi::OsString;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -239,7 +240,7 @@ impl Tailtriage {
             mode: config.mode,
             effective_core_config: Some(config.effective_core),
             effective_tokio_sampler_config: None,
-            host: None,
+            host: lookup_host_name(),
             pid: Some(std::process::id()),
             lifecycle_warnings: Vec::new(),
             unfinished_requests: crate::UnfinishedRequests::default(),
@@ -346,7 +347,8 @@ impl Tailtriage {
     /// the final artifact through the configured sink.
     ///
     /// `snapshot()` is useful for diagnostics and tests while capture is still
-    /// running.
+    /// running. While capture is active, `metadata.finished_at_unix_ms` in this
+    /// in-memory view is not yet finalized.
     #[must_use]
     pub fn snapshot(&self) -> Run {
         let mut run = lock_run(&self.run).clone();
@@ -901,7 +903,21 @@ pub(crate) fn duration_to_us(duration: Duration) -> u64 {
 }
 
 fn generate_run_id() -> String {
-    format!("run-{}", unix_time_ms())
+    format!("run-{}", uuid::Uuid::new_v4())
+}
+
+fn lookup_host_name() -> Option<String> {
+    let os_host = hostname::get().ok()?;
+    normalize_host_name(os_host)
+}
+
+fn normalize_host_name(host: OsString) -> Option<String> {
+    let host = host.into_string().ok()?;
+    let trimmed = host.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(trimmed.to_owned())
 }
 
 fn generate_request_id(route: &str) -> String {
@@ -915,3 +931,23 @@ fn generate_request_id(route: &str) -> String {
 
 static REQUEST_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 static PENDING_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_host_name;
+    use std::ffi::OsString;
+
+    #[test]
+    fn normalize_host_name_rejects_blank_values() {
+        assert_eq!(normalize_host_name(OsString::from("")), None);
+        assert_eq!(normalize_host_name(OsString::from("   ")), None);
+    }
+
+    #[test]
+    fn normalize_host_name_trims_non_blank_values() {
+        assert_eq!(
+            normalize_host_name(OsString::from(" checkout-host \n")),
+            Some("checkout-host".to_owned())
+        );
+    }
+}

--- a/tailtriage-core/src/events.rs
+++ b/tailtriage-core/src/events.rs
@@ -123,7 +123,10 @@ impl TruncationSummary {
 /// Top-level metadata for one capture run.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RunMetadata {
-    /// A unique identifier for the run.
+    /// Identifier for the run.
+    ///
+    /// When not supplied by the caller, `tailtriage-core` generates a UUID-based
+    /// identifier.
     pub run_id: String,
     /// Service/application name.
     pub service_name: String,
@@ -132,6 +135,10 @@ pub struct RunMetadata {
     /// Timestamp (milliseconds since epoch UTC) when collection started.
     pub started_at_unix_ms: u64,
     /// Timestamp (milliseconds since epoch UTC) when collection ended.
+    ///
+    /// During active capture, in-memory snapshots may still show the start-time
+    /// placeholder. `shutdown()` writes the finalized end timestamp to the
+    /// persisted artifact.
     pub finished_at_unix_ms: u64,
     /// Capture mode, such as "light" or "investigation".
     pub mode: CaptureMode,
@@ -146,7 +153,7 @@ pub struct RunMetadata {
     /// It may be `None` for runs without Tokio sampling and for older artifacts.
     #[serde(default)]
     pub effective_tokio_sampler_config: Option<EffectiveTokioSamplerConfig>,
-    /// Hostname if available.
+    /// Hostname captured at run creation when available as valid UTF-8.
     pub host: Option<String>,
     /// Process identifier if available.
     pub pid: Option<u32>,

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -69,6 +69,31 @@ fn generated_request_ids_are_unique() {
 }
 
 #[test]
+fn generated_default_run_ids_are_unique() {
+    let first = Tailtriage::builder("payments")
+        .build()
+        .expect("first build should succeed");
+    let second = Tailtriage::builder("payments")
+        .build()
+        .expect("second build should succeed");
+
+    assert_ne!(
+        first.snapshot().metadata.run_id,
+        second.snapshot().metadata.run_id
+    );
+}
+
+#[test]
+fn explicit_run_id_is_preserved() {
+    let run = Tailtriage::builder("payments")
+        .run_id("user-supplied-run-id")
+        .build()
+        .expect("build should succeed");
+
+    assert_eq!(run.snapshot().metadata.run_id, "user-supplied-run-id");
+}
+
+#[test]
 fn duplicate_explicit_request_ids_are_tracked_and_finished_independently() {
     let tailtriage = build_for_test("payments", "tailtriage-core-duplicate-explicit-id.json");
     let first = tailtriage.begin_request_with(


### PR DESCRIPTION
### Motivation
- Make auto-generated `run_id` truly unique by default and preserve user-supplied `run_id` behavior. 
- Populate `RunMetadata.host` at run creation using a cross-platform lookup where available and safe. 
- Ensure `TailtriageController` honors TOML `controller.service_name` over the builder value when present while still rejecting a final blank name. 
- Align docs and rustdoc with the implemented behavior for `finished_at_unix_ms`, `run_id`, and controller precedence without changing schema shapes.

### Description
- Replaced timestamp-only default run IDs with UUID v4 generation in `tailtriage-core::generate_run_id()` so auto-generated IDs are unique by default and left explicit `run_id` passthrough unchanged. 
- Added a lightweight cross-platform hostname capture using the `hostname` crate and a `normalize_host_name` helper that rejects non-UTF-8 or blank values and populates `RunMetadata.host` at run creation. 
- Clarified `RunMetadata` rustdocs for `run_id`, `finished_at_unix_ms`, and `host` to reflect runtime behavior (notably that in-memory snapshots show a placeholder end timestamp until `shutdown()` finalizes it). 
- Fixed `TailtriageControllerBuilder::build` so a TOML `controller.service_name` overrides the builder value when present and the builder value is used only if TOML omits it; kept final blank-name rejection. 
- Added focused unit tests: two core tests for default `run_id` uniqueness and explicit `run_id` passthrough, helper tests for `normalize_host_name`, and controller tests covering the requested `service_name` precedence/failure combinations. 
- Updated `tailtriage-controller/README.md` to make feature defaults and `service_name` precedence explicit. 
- Added minimal dependencies (`uuid` v1 with the `v4` feature and `hostname`) and no schema changes (no `schema_version` change and no change to the type of `RunMetadata.finished_at_unix_ms`).

### Testing
- Ran `cargo fmt --check` and formatting check passed. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and the lint pass completed with no warnings. 
- Ran the full test suite with `cargo test --workspace` and all workspace tests passed (including the new unit tests). 
- Ran the docs contract validator `python3 scripts/validate_docs_contracts.py` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9f64c895c83308901a96cce823516)