### PR TITLE
Add explicit `finalized_at_unix_ms` to RunMetadata to mark finalized artifacts

### DIFF
--- a/tailtriage-cli/src/analyze.rs
+++ b/tailtriage-cli/src/analyze.rs
@@ -171,6 +171,7 @@ pub struct Report {
 ///         service_version: None,
 ///         started_at_unix_ms: 1,
 ///         finished_at_unix_ms: 2,
+///         finalized_at_unix_ms: Some(2),
 ///         mode: CaptureMode::Light,
 ///         effective_core_config: Some(EffectiveCoreConfig {
 ///             mode: CaptureMode::Light,
@@ -743,6 +744,7 @@ mod tests {
                 service_version: None,
                 started_at_unix_ms: 1,
                 finished_at_unix_ms: 2,
+                finalized_at_unix_ms: Some(2),
                 mode: CaptureMode::Light,
                 effective_core_config: Some(EffectiveCoreConfig {
                     mode: CaptureMode::Light,

--- a/tailtriage-cli/tests/boundary_thresholds.rs
+++ b/tailtriage-cli/tests/boundary_thresholds.rs
@@ -21,6 +21,7 @@ fn base_run() -> Run {
             service_version: None,
             started_at_unix_ms: 1,
             finished_at_unix_ms: 2,
+            finalized_at_unix_ms: Some(2),
             mode: CaptureMode::Light,
             effective_core_config: Some(tailtriage_core::EffectiveCoreConfig {
                 mode: CaptureMode::Light,

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -112,6 +112,14 @@ req.queue("ingress")
 - Non-strict lifecycle: `shutdown()` writes the artifact and records unfinished-request warnings/metadata.
 - `strict_lifecycle(true)`: unfinished requests cause `shutdown()` to return an error and no artifact is written.
 
+Finalization timestamps:
+
+- Active `snapshot()` output is not finalized (`metadata.finalized_at_unix_ms == None`).
+- `shutdown()` writes final artifacts with both:
+  - `metadata.finished_at_unix_ms` set to shutdown time
+  - `metadata.finalized_at_unix_ms` set to that same timestamp
+- Older artifacts may deserialize with `metadata.finalized_at_unix_ms == None`.
+
 ## Capture modes
 
 Modes change retention defaults only. They do not change lifecycle semantics and do **not** auto-start runtime sampling.

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -119,7 +119,7 @@ Finalization timestamps:
   - `metadata.finished_at_unix_ms` set to shutdown time
   - `metadata.finalized_at_unix_ms` set to that same timestamp
 - Older artifacts may deserialize with `metadata.finalized_at_unix_ms == None`.
-- When `metadata.finalized_at_unix_ms` is present, prefer that field as the finalization signal; finished_at_unix_ms remains for backward compatibility.
+- When `finalized_at_unix_ms` is present, prefer that field as the finalization signal; `finished_at_unix_ms` remains for backward compatibility.
 
 ## Capture modes
 

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -119,6 +119,7 @@ Finalization timestamps:
   - `metadata.finished_at_unix_ms` set to shutdown time
   - `metadata.finalized_at_unix_ms` set to that same timestamp
 - Older artifacts may deserialize with `metadata.finalized_at_unix_ms == None`.
+- When `metadata.finalized_at_unix_ms` is present, prefer that field as the finalization signal; finished_at_unix_ms remains for backward compatibility.
 
 ## Capture modes
 

--- a/tailtriage-core/src/collector.rs
+++ b/tailtriage-core/src/collector.rs
@@ -237,6 +237,7 @@ impl Tailtriage {
             service_version: config.service_version,
             started_at_unix_ms: now,
             finished_at_unix_ms: now,
+            finalized_at_unix_ms: None,
             mode: config.mode,
             effective_core_config: Some(config.effective_core),
             effective_tokio_sampler_config: None,
@@ -347,8 +348,8 @@ impl Tailtriage {
     /// the final artifact through the configured sink.
     ///
     /// `snapshot()` is useful for diagnostics and tests while capture is still
-    /// running. While capture is active, `metadata.finished_at_unix_ms` in this
-    /// in-memory view is not yet finalized.
+    /// running. While capture is active, `metadata.finalized_at_unix_ms` remains
+    /// `None` and `metadata.finished_at_unix_ms` is still provisional.
     #[must_use]
     pub fn snapshot(&self) -> Run {
         let mut run = lock_run(&self.run).clone();
@@ -380,7 +381,9 @@ impl Tailtriage {
         };
 
         let mut guard = lock_run(&self.run);
-        guard.metadata.finished_at_unix_ms = unix_time_ms();
+        let finalized_at = unix_time_ms();
+        guard.metadata.finished_at_unix_ms = finalized_at;
+        guard.metadata.finalized_at_unix_ms = Some(finalized_at);
         if pending_count > 0 {
             guard.metadata.lifecycle_warnings.push(format!(
                 "{pending_count} unfinished request(s) remained at shutdown; run includes no fabricated completions"

--- a/tailtriage-core/src/events.rs
+++ b/tailtriage-core/src/events.rs
@@ -140,6 +140,12 @@ pub struct RunMetadata {
     /// placeholder. `shutdown()` writes the finalized end timestamp to the
     /// persisted artifact.
     pub finished_at_unix_ms: u64,
+    /// Finalization timestamp (milliseconds since epoch UTC) for persisted artifacts.
+    ///
+    /// This is `None` for active in-memory snapshots and for older artifacts
+    /// written before this field existed.
+    #[serde(default)]
+    pub finalized_at_unix_ms: Option<u64>,
     /// Capture mode, such as "light" or "investigation".
     pub mode: CaptureMode,
     /// Effective resolved core configuration after applying mode defaults and overrides.

--- a/tailtriage-core/src/sink.rs
+++ b/tailtriage-core/src/sink.rs
@@ -236,6 +236,7 @@ mod tests {
             service_version: Some("1.0.0".to_string()),
             started_at_unix_ms: 1,
             finished_at_unix_ms: 2,
+            finalized_at_unix_ms: Some(2),
             mode: CaptureMode::Light,
             effective_core_config: Some(crate::EffectiveCoreConfig {
                 mode: CaptureMode::Light,

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -84,6 +84,16 @@ fn generated_default_run_ids_are_unique() {
 }
 
 #[test]
+fn active_snapshot_is_not_finalized() {
+    let tailtriage = Tailtriage::builder("payments")
+        .build()
+        .expect("build should succeed");
+
+    let snapshot = tailtriage.snapshot();
+    assert!(snapshot.metadata.finalized_at_unix_ms.is_none());
+}
+
+#[test]
 fn explicit_run_id_is_preserved() {
     let run = Tailtriage::builder("payments")
         .run_id("user-supplied-run-id")
@@ -184,6 +194,10 @@ fn shutdown_writes_artifact() {
             .expect("effective core config should be present for new runs")
             .capture_limits,
         CaptureMode::Light.core_defaults()
+    );
+    assert!(
+        run.metadata.finalized_at_unix_ms.is_some(),
+        "shutdown artifact should include finalized timestamp"
     );
 }
 
@@ -620,6 +634,47 @@ fn legacy_artifact_without_effective_core_config_deserializes_as_unknown() {
     let parsed: crate::Run = serde_json::from_value(legacy).expect("legacy run should parse");
     assert_eq!(parsed.metadata.mode, CaptureMode::Investigation);
     assert!(parsed.metadata.effective_core_config.is_none());
+    assert!(parsed.metadata.finalized_at_unix_ms.is_none());
+}
+
+#[test]
+fn run_deserialization_ignores_unknown_metadata_fields() {
+    let with_extra = serde_json::json!({
+        "schema_version": crate::SCHEMA_VERSION,
+        "metadata": {
+            "run_id": "run-extra",
+            "service_name": "payments",
+            "service_version": null,
+            "started_at_unix_ms": 1,
+            "finished_at_unix_ms": 2,
+            "mode": "light",
+            "host": null,
+            "pid": 123,
+            "lifecycle_warnings": [],
+            "unfinished_requests": {
+                "count": 0,
+                "sample": []
+            },
+            "future_metadata_field": "still-compatible"
+        },
+        "requests": [],
+        "stages": [],
+        "queues": [],
+        "inflight": [],
+        "runtime_snapshots": [],
+        "truncation": {
+            "dropped_requests": 0,
+            "dropped_stages": 0,
+            "dropped_queues": 0,
+            "dropped_inflight_snapshots": 0,
+            "dropped_runtime_snapshots": 0
+        }
+    });
+
+    let parsed: crate::Run =
+        serde_json::from_value(with_extra).expect("run with extra fields should parse");
+    assert_eq!(parsed.metadata.run_id, "run-extra");
+    assert!(parsed.metadata.finalized_at_unix_ms.is_none());
 }
 
 #[test]


### PR DESCRIPTION
### Motivation

- Active in-memory `Run` snapshots exposed `metadata.finished_at_unix_ms` as a provisional value, which misleadingly implied the run was finalized. This change makes finalization explicit.
- Preserve `schema_version = 1` compatibility while adding a clear signal that persisted artifacts are finalized. 

### Description

- Added `pub finalized_at_unix_ms: Option<u64>` to `RunMetadata` with `#[serde(default)]` and documentation clarifying that active snapshots and older artifacts have `None` for this field. (`tailtriage-core/src/events.rs`).
- Initialize `finalized_at_unix_ms` to `None` when creating a run via `Tailtriage::from_config`. (`tailtriage-core/src/collector.rs`).
- Update `Tailtriage::shutdown()` to write a single timestamp into both `metadata.finished_at_unix_ms` and `metadata.finalized_at_unix_ms = Some(...)` at finalization. (`tailtriage-core/src/collector.rs`).
- Updated examples/tests/docs literals and rustdoc: added the new field to sample `RunMetadata` literals used by `tailtriage-cli` tests and `tailtriage-core` sink tests, and clarified finalization semantics in `tailtriage-core/README.md` and inline rustdoc. (`tailtriage-core/README.md`, `tailtriage-cli/src/analyze.rs`, `tailtriage-cli/tests/boundary_thresholds.rs`, `tailtriage-core/src/sink.rs`).
- Added tests in `tailtriage-core/src/tests.rs` to verify: active snapshots have `finalized_at_unix_ms == None`, shutdown artifacts set `finalized_at_unix_ms`, legacy JSON without the field still deserializes, and unknown metadata fields remain compatible.
- Did not change `schema_version` nor remove/rename `finished_at_unix_ms`, preserving backward compatibility for older artifacts and tools.

### Testing

- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it passed with no warnings.
- Ran `cargo test --workspace` and all workspace tests passed (unit tests, doc-tests, and integration tests).
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1d77e6bc8330beb5201d79436da8)