### PR TITLE
docs: align report warning semantics and executor demo description

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -272,7 +272,7 @@ These remain useful and should stay documented, but docs should treat them as mo
 **What it simulates**
 
 - Fanout-heavy request handling with repeated CPU turns and frequent scheduling.
-- Baseline uses fewer worker threads and heavier fanout.
+- Baseline keeps the same worker-thread count as mitigated mode, while increasing fanout tasks, CPU turns, and snapshot depth amplification.
 - Runtime snapshots include runnable-depth signals.
 
 **What it proves well**

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -30,7 +30,7 @@ Current supported schema version: `1`.
 - request latency percentiles (`p50`, `p95`, `p99`)
 - p95 queue/service share summaries
 - optional in-flight trend summary
-- warnings (including truncation/lifecycle context)
+- warnings (analyzer/report warnings, especially truncation-related)
 - ranked suspects (primary + secondary)
 
 Each suspect includes:
@@ -49,7 +49,7 @@ Each suspect includes:
 - `p50_latency_us` / `p95_latency_us` / `p99_latency_us`: request latency percentiles in microseconds.
 - `p95_queue_share_permille`: p95 queue-time share per request (0..1000 scale).
 - `p95_service_share_permille`: p95 service-time share per request (0..1000 scale).
-- `warnings[]`: analyzer warnings, including truncation and unfinished lifecycle context when present.
+- `warnings[]`: analyzer/report warnings, especially truncation-related warnings from captured-data limits. Loader/lifecycle warnings (including unfinished-request warnings) are emitted separately by the CLI loader to stderr before the report output.
 - `primary_suspect`: highest-ranked suspect with evidence and next checks.
 - `secondary_suspects[]`: additional ranked suspects.
 - `inflight_trend` (optional): dominant in-flight gauge trend summary when snapshots exist.

--- a/tailtriage/README.md
+++ b/tailtriage/README.md
@@ -79,6 +79,8 @@ Choose a focused crate only when you need a narrower boundary:
 - `axum` _(opt-in)_: enables `tailtriage::axum`
 - `full`: enables `controller`, `tokio`, and `axum`
 
+Docs.rs note: `tailtriage` docs are built with `all-features = true`, so docs.rs may render optional namespaces such as `tailtriage::tokio` and `tailtriage::axum`. In downstream crates, those namespaces are available only when their Cargo features are enabled.
+
 ## Important constraints
 
 - Capture and analysis are separate: this crate writes artifacts, `tailtriage-cli` analyzes them.


### PR DESCRIPTION
### Motivation
- Clarify documentation mismatches found in the repo audit so published docs match implementation semantics and demos. 
- Ensure users reading crate READMEs and `docs/` see accurate guidance about where lifecycle warnings appear and what the executor demo actually exercises.

### Description
- Update `docs/diagnostics.md` to state that `warnings[]` in the report contains analyzer/report warnings (especially truncation-related) and to note that loader/lifecycle warnings (including unfinished-request warnings) are emitted separately by the CLI loader to stderr before report output. 
- Edit the `executor_pressure_service` section in `demos/README.md` to remove the incorrect claim about reduced worker threads and to document that the baseline keeps the same worker-thread count while increasing fanout, CPU turns, and snapshot depth amplification. 
- Add a brief `docs.rs` clarification to `tailtriage/README.md` explaining that docs.rs is built with `all-features = true` so optional namespaces (for example `tailtriage::tokio` and `tailtriage::axum`) may appear in rendered docs while downstream availability still depends on Cargo feature flags. 

### Testing
- Ran the repository docs contract validator with `python3 scripts/validate_docs_contracts.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2f54e36c833094b29225a8a173ed)