### PR TITLE
docs: align public examples list and demo evidence framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ TOML config is useful when you want to:
 - refresh future capture generations with `reload_config()` while leaving the active generation unchanged
 
 See [`tailtriage-controller/README.md`](tailtriage-controller/README.md) for the TOML field reference, expanded TOML example, and reload semantics.
+For a runnable TOML-backed startup path, see the public example `controller_toml_startup` in `tailtriage-controller/examples/`.
 
 ## Minimal examples
 
@@ -212,13 +213,16 @@ Use the GitHub/workspace path when you want to run packaged examples, inspect in
 
 ## Examples
 
-Five public examples to start with:
+Six public examples to start with:
 
 - `minimal_checkout` — fastest capture-to-analyze loop
 - `axum_core_manual` — manual Axum + `tailtriage-core` framework wiring
 - `axum_service_adoption` — service-shaped Axum adoption example
 - `mini_service_integration` — helper-layer or fractured-code instrumentation shape
 - `controller_minimal` — arm/disarm controller lifecycle starter
+- `controller_toml_startup` — TOML-backed controller startup and activation example
+
+Start with `controller_toml_startup` when you want the most direct example of config-file-driven controller startup.
 
 ```bash
 cargo run -p tailtriage-tokio --example minimal_checkout
@@ -226,6 +230,7 @@ cargo run -p tailtriage-axum --example axum_core_manual
 cargo run -p tailtriage-axum --example axum_service_adoption
 cargo run -p tailtriage-tokio --example mini_service_integration
 cargo run -p tailtriage-controller --example controller_minimal
+cargo run -p tailtriage-controller --example controller_toml_startup
 python3 scripts/smoke_public_examples.py
 ```
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -1,6 +1,6 @@
 # Demo guide: scenarios
 
-The demos are intentionally small services for Tokio tail-latency triage. They are designed to exercise diagnosis behavior with deterministic and reviewable artifacts, not universal causality claims.
+The demos are intentionally small services for Tokio tail-latency triage. They are designed to exercise diagnosis behavior with deterministic and reviewable artifacts, not universal causality proof.
 
 ## Brief introduction
 
@@ -23,7 +23,7 @@ Check out [`../docs/getting-started-demo.md`](../docs/getting-started-demo.md) f
 
 **What it does not prove**
 
-- It is not a demonstration of every production queue topology or all burst regimes.
+- It is not proof of every production queue topology or all burst regimes.
 
 **Realistic vs synthetic**
 
@@ -88,7 +88,7 @@ Check out [`../docs/getting-started-demo.md`](../docs/getting-started-demo.md) f
 **What it does not prove**
 
 - Still a synthetic model of DB pool saturation.
-- Not a demonstration of behavior under a real DB client/driver stack.
+- Not proof of behavior under a real DB client/driver stack.
 
 **Realistic vs synthetic**
 
@@ -124,7 +124,7 @@ These are valuable and should remain first-class docs, but are best after the co
 
 **What it does not prove**
 
-- Not a demonstration that all lock-contention patterns map identically in every production design.
+- Not proof that all lock-contention patterns map identically in every production design.
 
 **Realistic vs synthetic**
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -1,12 +1,12 @@
 # Demo guide: scenarios
 
-The demos are intentionally small services for Tokio tail-latency triage. They are designed to exercise diagnosis behavior with deterministic and reviewable artifacts, not universal causality proof.
+The demos are intentionally small services for Tokio tail-latency triage. They are designed to exercise diagnosis behavior with deterministic and reviewable artifacts, not universal causality claims.
 
 ## Brief introduction
 
 Check out [`../docs/getting-started-demo.md`](../docs/getting-started-demo.md) for a short introduction to the demos and how to run them.
 
-## Strongest public proof demos
+## Strongest public demonstration scenarios
 
 ### `queue_service`
 
@@ -15,15 +15,15 @@ Check out [`../docs/getting-started-demo.md`](../docs/getting-started-demo.md) f
 - Requests compete for a limited semaphore (`worker_permit`).
 - Baseline has tighter capacity and slower work; mitigated raises capacity and shortens work.
 
-**What it proves well**
+**What it shows well**
 
 - One of the strongest demos.
-- Clear and convincing proof of queue-dominant latency.
+- Clear and convincing demonstration of queue-dominant latency in this controlled scenario.
 - Good flagship public demo for first-time readers.
 
 **What it does not prove**
 
-- It is not proof of every production queue topology or all burst regimes.
+- It is not a demonstration of every production queue topology or all burst regimes.
 
 **Realistic vs synthetic**
 
@@ -46,11 +46,11 @@ Check out [`../docs/getting-started-demo.md`](../docs/getting-started-demo.md) f
 - Request flow with a tiny local precheck and a consistently slower downstream stage.
 - No intentional queue bottleneck.
 
-**What it proves well**
+**What it shows well**
 
 - One of the strongest demos.
 - Very clean stage-dominance story.
-- Strong public proof case for downstream-led latency.
+- Strong public demonstration case for downstream-led latency.
 
 **What it does not prove**
 
@@ -79,7 +79,7 @@ Check out [`../docs/getting-started-demo.md`](../docs/getting-started-demo.md) f
 - Separate `db_query` stage timing.
 - Baseline shrinks pool and slows query stage; mitigated does the reverse.
 
-**What it proves well**
+**What it shows well**
 
 - One of the best additional demos.
 - Shows queue-like admission bottleneck and downstream stage time in one common service shape.
@@ -88,7 +88,7 @@ Check out [`../docs/getting-started-demo.md`](../docs/getting-started-demo.md) f
 **What it does not prove**
 
 - Still a synthetic model of DB pool saturation.
-- Not proof of behavior under a real DB client/driver stack.
+- Not a demonstration of behavior under a real DB client/driver stack.
 
 **Realistic vs synthetic**
 
@@ -116,7 +116,7 @@ These are valuable and should remain first-class docs, but are best after the co
 - Lock wait recorded as queue-like time on `shared_state_write_lock`.
 - Critical-section work recorded separately as `shared_state_critical_section`.
 
-**What it proves well**
+**What it shows well**
 
 - Conceptually strong example of non-obvious queue-like waits.
 - Demonstrates that queue here includes lock admission waits, not only channels/semaphores.
@@ -124,7 +124,7 @@ These are valuable and should remain first-class docs, but are best after the co
 
 **What it does not prove**
 
-- Not proof that all lock-contention patterns map identically in every production design.
+- Not a demonstration that all lock-contention patterns map identically in every production design.
 
 **Realistic vs synthetic**
 
@@ -148,7 +148,7 @@ These are valuable and should remain first-class docs, but are best after the co
 - Per-attempt stages (`downstream_attempt_N`) plus full-loop `downstream_total`.
 - Mitigation changes retry count, backoff, jitter, and circuit-break-like cooldown behavior.
 
-**What it proves well**
+**What it shows well**
 
 - One of the most product-interesting demos.
 - Shows downstream dominance can come from retry policy, not just one slow call.
@@ -156,7 +156,7 @@ These are valuable and should remain first-class docs, but are best after the co
 
 **What it does not prove**
 
-- More conceptually advanced and more instrumentation-shaped than core proof demos.
+- More conceptually advanced and more instrumentation-shaped than core demonstration scenarios.
 
 **Realistic vs synthetic**
 
@@ -179,14 +179,14 @@ These are valuable and should remain first-class docs, but are best after the co
 - Combined queue pressure (semaphore admission) and downstream slowness (periodic slow stage).
 - Mitigation mainly reduces admission contention so rank/score can shift.
 
-**What it proves well**
+**What it shows well**
 
 - Multiple suspects can coexist in one diagnosis.
 - Useful supporting demo showing the analyzer is not single-cause-only.
 
 **What it does not prove**
 
-- Less crisp than queue-only or downstream-only stories, so not ideal as first public proof.
+- Less crisp than queue-only or downstream-only stories, so not ideal as first public demonstration.
 
 **Realistic vs synthetic**
 
@@ -209,7 +209,7 @@ These are valuable and should remain first-class docs, but are best after the co
 - Early cohort pays extra `cold_start_stage` delay while burst traffic competes for admission.
 - Mitigation reduces cold cohort and increases admission capacity.
 
-**What it proves well**
+**What it shows well**
 
 - Useful warmup-plus-burst explanation.
 - Shows how stage-level pathology can induce queue effects.
@@ -235,7 +235,7 @@ These are valuable and should remain first-class docs, but are best after the co
 
 ## More synthetic analyzer-contract demos
 
-These remain useful and should stay documented, but docs should treat them as more synthetic proofs.
+These remain useful and should stay documented, but docs should treat them as more synthetic demonstrations.
 
 ### `blocking_service`
 
@@ -245,13 +245,13 @@ These remain useful and should stay documented, but docs should treat them as mo
 - Baseline constrains `max_blocking_threads` and uses longer blocking work.
 - Runtime snapshots include synthetic `blocking_queue_depth` signals.
 
-**What it proves well**
+**What it shows well**
 
 - Directionally useful for exercising blocking-pool-pressure diagnosis behavior.
 
 **What it does not prove**
 
-- More synthetic than a strongest real-world proof case.
+- More synthetic than a strongest real-world demonstration case.
 
 **Realistic vs synthetic**
 
@@ -275,7 +275,7 @@ These remain useful and should stay documented, but docs should treat them as mo
 - Baseline keeps the same worker-thread count as mitigated mode, while increasing fanout tasks, CPU turns, and snapshot depth amplification.
 - Runtime snapshots include runnable-depth signals.
 
-**What it proves well**
+**What it shows well**
 
 - Useful for exercising executor-pressure diagnosis and rank behavior.
 


### PR DESCRIPTION
### Motivation

- The top-level onboarding and demos undercounted and overstated example evidence; the README did not surface the TOML-backed controller example and `demos/README.md` used "proof" language that overclaims.
- Keep docs precise, user-facing, and aligned with the repository’s triage/evidence framing without changing code or behavior.

### Description

- Update `README.md` to list six public examples and add the missing `controller_toml_startup` item in the examples list. 
- Add the runnable command `cargo run -p tailtriage-controller --example controller_toml_startup` to the examples command block. 
- Surface the TOML-backed controller startup path earlier by adding a concise pointer sentence to the controller TOML config section. 
- Revise `demos/README.md` wording to replace "proof" framing with controlled "demonstration"/"shows"/"evidence" language while preserving realism and synthetic-nuance guidance.

### Testing

- Ran `python3 scripts/validate_docs_contracts.py`, which completed successfully. 
- Ran `python3 scripts/smoke_public_examples.py`, which validated all six public examples including `controller_toml_startup` and completed successfully. 
- Changes are docs-only and did not modify Rust code, CLI behavior, or report semantics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea4e49be1c83309d6865fc8fd046d2)