### PR TITLE
Version bump 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blocking-service-demo"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "demo-support",
@@ -188,7 +188,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cold-start-burst-service-demo"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "demo-support",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "collector_stress"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "serde",
@@ -216,7 +216,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "db-pool-saturation-service-demo"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "demo-support",
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "demo-support"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "tailtriage-core",
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "downstream_service"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "demo-support",
@@ -261,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "executor-pressure-service-demo"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "demo-support",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "mixed_contention_service"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "demo-support",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "queue-service-demo"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "demo-support",
@@ -623,7 +623,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "retry-storm-service-demo"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "demo-support",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "runtime_cost"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "serde",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "shared-state-lock-service-demo"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "demo-support",
@@ -788,7 +788,7 @@ checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "tailtriage"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "tailtriage-axum",
  "tailtriage-controller",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "tailtriage-axum"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "axum",
  "serde",
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "tailtriage-cli"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "serde",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "tailtriage-controller"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "tailtriage-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "futures-executor",
  "hostname",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "tailtriage-tokio"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "tailtriage-core",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "0.1.1"
+version = "0.1.2"
 repository = "https://github.com/SG-devel/tailtriage"
 
 [workspace.lints.rust]
@@ -36,9 +36,9 @@ all = "warn"
 pedantic = "warn"
 
 [workspace.dependencies]
-tailtriage = { version = "0.1.1", path = "tailtriage" }
-tailtriage-core = { version = "0.1.1", path = "tailtriage-core" }
-tailtriage-controller = { version = "0.1.1", path = "tailtriage-controller" }
-tailtriage-tokio = { version = "0.1.1", path = "tailtriage-tokio" }
-tailtriage-axum = { version = "0.1.1", path = "tailtriage-axum" }
-demo-support = { version = "0.1.1", path = "demos/demo_support" }
+tailtriage = { version = "0.1.2", path = "tailtriage" }
+tailtriage-core = { version = "0.1.2", path = "tailtriage-core" }
+tailtriage-controller = { version = "0.1.2", path = "tailtriage-controller" }
+tailtriage-tokio = { version = "0.1.2", path = "tailtriage-tokio" }
+tailtriage-axum = { version = "0.1.2", path = "tailtriage-axum" }
+demo-support = { version = "0.1.2", path = "demos/demo_support" }

--- a/docs/getting-started-demo.md
+++ b/docs/getting-started-demo.md
@@ -2,15 +2,13 @@
 
 Demos are deterministic triage exercises. They provide reproducible diagnosis behavior for this repository's scenarios, not universal causality proof.
 
-## Recommended first demos
+Scenario details: [demos/README.md](../demos/README.md)
 
-If you run three first, run:
+## Recommended first demos
 
 - `queue_service`
 - `downstream_service`
 - `db_pool_saturation_service`
-
-Scenario details: [demos/README.md](../demos/README.md)
 
 ## Additional useful demos
 

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -70,12 +70,8 @@ Then run one targeted check, change one thing, and re-run under comparable load.
     "kind": "application_queue_saturation",
     "score": 90,
     "confidence": "high",
-    "evidence": [
-      "Queue wait at p95 consumes 98.2% of request time."
-    ],
-    "next_checks": [
-      "Inspect queue admission limits and producer burst patterns."
-    ]
+    "evidence": ["Queue wait at p95 consumes 98.2% of request time."],
+    "next_checks": ["Inspect queue admission limits and producer burst patterns."]
   },
   "secondary_suspects": []
 }
@@ -155,15 +151,8 @@ Usually the next step is to add more structure to capture:
 
 Use capture-side crates for that:
 
-- `tailtriage`
-- `tailtriage-core`
-- `tailtriage-controller`
-- `tailtriage-tokio`
-- `tailtriage-axum`
-
-## Related crates
-
 - `tailtriage`: recommended capture-side entry point
 - `tailtriage-core`: direct instrumentation primitives
-- `tailtriage-tokio`: runtime-pressure sampling
 - `tailtriage-controller`: repeated bounded windows
+- `tailtriage-tokio`: runtime-pressure sampling
+- `tailtriage-axum`: Axum request-boundary integration


### PR DESCRIPTION
## Summary

version bump and minor doc adjustments.

## Why this change

added -controller 
added default crate
added collector limits
improved capture mode and runtime cost measurement
overhauled docs

## Validation

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`

## Scope check

- [x] This PR stays within MVP triage scope.
- [x] If behavior changed, docs were updated.
- [x] Suspects are still described as evidence-ranked leads, not causal proof.

## Contribution license check

- [x] I have the right to submit this contribution under the MIT License.
- [x] I agree that this contribution is licensed under the repository's MIT License.
