### PR TITLE
Simplify sink artifact finalization to a single rename path

### DIFF
--- a/tailtriage-core/src/sink.rs
+++ b/tailtriage-core/src/sink.rs
@@ -106,71 +106,8 @@ fn create_temp_path(parent: &Path, final_path: &Path) -> PathBuf {
     ))
 }
 
-#[cfg(windows)]
-fn create_backup_path(final_path: &Path) -> PathBuf {
-    let parent = final_path.parent().unwrap_or_else(|| Path::new("."));
-    let file_name = final_path
-        .file_name()
-        .and_then(std::ffi::OsStr::to_str)
-        .unwrap_or("tailtriage-run.json");
-    let epoch_nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |duration| duration.as_nanos());
-    parent.join(format!(
-        ".{file_name}.bak-{}-{epoch_nanos}",
-        std::process::id()
-    ))
-}
-
 fn finalize_temp_file(temp_path: &Path, final_path: &Path) -> Result<(), IoError> {
-    #[cfg(unix)]
-    {
-        fs::rename(temp_path, final_path)
-    }
-
-    #[cfg(windows)]
-    {
-        match fs::rename(temp_path, final_path) {
-            Ok(()) => Ok(()),
-            Err(first_err) if final_path.is_file() && temp_path.is_file() => {
-                // Windows does not replace an existing destination on rename.
-                // Preserve the existing destination by moving it aside first,
-                // then restore it if the second rename fails.
-                let backup_path = create_backup_path(final_path);
-                fs::rename(final_path, &backup_path)?;
-
-                match fs::rename(temp_path, final_path) {
-                    Ok(()) => {
-                        let _ = fs::remove_file(&backup_path);
-                        Ok(())
-                    }
-                    Err(second_err) => {
-                        let restore_result = fs::rename(&backup_path, final_path);
-                        match restore_result {
-                            Ok(()) => Err(IoError::new(
-                                second_err.kind(),
-                                format!(
-                                    "failed to finalize run output after preserving existing destination: first rename error: {first_err}; second rename error: {second_err}"
-                                ),
-                            )),
-                            Err(restore_err) => Err(IoError::new(
-                                second_err.kind(),
-                                format!(
-                                    "failed to finalize run output and failed to restore existing destination: first rename error: {first_err}; second rename error: {second_err}; restore error: {restore_err}"
-                                ),
-                            )),
-                        }
-                    }
-                }
-            }
-            Err(err) => Err(err),
-        }
-    }
-
-    #[cfg(not(any(unix, windows)))]
-    {
-        fs::rename(temp_path, final_path)
-    }
+    fs::rename(temp_path, final_path)
 }
 
 /// Errors emitted while writing run artifacts.


### PR DESCRIPTION
### Motivation
- Remove platform-specific finalize logic and the Windows backup/restore dance to make finalization simpler and OS-agnostic. 
- Prefer a single, predictable path that delegates to the standard `rename` behavior and avoids the non-atomic backup window on Windows. 

### Description
- Removed the Windows-only `create_backup_path` helper from `tailtriage-core/src/sink.rs`.
- Replaced the cfg-split `finalize_temp_file` implementation with a single line that delegates to `std::fs::rename(temp_path, final_path)`.
- Eliminated the `#[cfg(unix)]`, `#[cfg(windows)]`, and fallback branches previously used for finalization while keeping the temp-file creation and write flow unchanged.
- Preserved `LocalJsonSink::write` semantics including creating the temp file in the destination directory, JSON serialization, `flush`/`into_inner`/`sync_all`, attempt to finalize, and cleanup of the temp file on failure.

### Testing
- Ran `cargo fmt --all --check` and it succeeded.
- Ran `cargo test -p tailtriage-core` and all tests passed (including existing sink tests in `tailtriage-core/src/sink.rs`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4fd4e144c83308691c31068f204fe)