### PR TITLE
Add diagnostic validation framework: corpus, benchmark, tests, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Demo walkthrough and CI coverage details: [`docs/getting-started-demo.md`](docs/
 - Runtime sampler docs: [`tailtriage-tokio/README.md`](tailtriage-tokio/README.md)
 - Analyzer/report contract: [`tailtriage-cli/README.md`](tailtriage-cli/README.md)
 - Diagnostics field reference and interpretation: [`docs/diagnostics.md`](docs/diagnostics.md)
+- Diagnostic validation corpus and benchmark metrics: [`docs/diagnostic-validation.md`](docs/diagnostic-validation.md)
 - Demo walkthrough and recommended first demos: [`docs/getting-started-demo.md`](docs/getting-started-demo.md)
 - Runtime-overhead measurement path: [`docs/runtime-cost.md`](docs/runtime-cost.md)
 - Collector-stress, truncation, artifact-size, and memory guidance: [`docs/collector-limits.md`](docs/collector-limits.md)

--- a/demos/README.md
+++ b/demos/README.md
@@ -6,6 +6,8 @@ The demos are intentionally small services for Tokio tail-latency triage. They a
 
 Check out [`../docs/getting-started-demo.md`](../docs/getting-started-demo.md) for a short introduction to the demos and how to run them.
 
+Demos teach scenarios and provide smoke-check artifacts. Diagnostic quality measurement lives in [`../validation/diagnostics/`](../validation/diagnostics/) via a labeled validation corpus.
+
 ## Strongest public demonstration scenarios
 
 ### `queue_service`

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ This is the canonical user-facing docs index for `tailtriage`.
 ## Core workflow and interpretation
 
 - [Diagnostics guide](diagnostics.md) — quick reading flow plus concise field reference for analyzer output.
+- [Diagnostic validation](diagnostic-validation.md) — labeled corpus metrics for analyzer-quality validation.
 - [CLI README (`tailtriage-cli`)](../tailtriage-cli/README.md) — analyzer/report contract and CLI usage.
 
 ## Capture surfaces

--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -1,0 +1,48 @@
+# Diagnostic validation
+
+`tailtriage` demos are educational scenario walkthroughs and smoke checks. The diagnostic validation corpus is where we measure analyzer quality against labeled cases.
+
+## What ground truth means here
+
+Ground truth is the injected or independently known dominant bottleneck family for a case. It is used to evaluate triage ranking quality, not to claim causal proof.
+
+## Metrics
+
+`scripts/diagnostic_benchmark.py` reports:
+
+- top-1 accuracy
+- top-2 recall
+- per-ground-truth counts
+- confusion matrix
+- confidence-bucket accuracy
+- required evidence pass rate
+- unexpected warning count
+- failed case details
+
+Top-1 is not expected to be perfect. Mixed or correlated cases can be valid when the ground truth appears in top-2.
+
+## Evidence and warning validation
+
+Each case can require evidence substrings via `must_include_evidence`.
+Warnings are validated with `allowed_warnings`; unmatched warnings count as unexpected failures.
+
+## Confidence calibration checks
+
+The benchmark groups top-1 correctness by primary suspect confidence bucket (`high`, `medium`, `low`) so we can track whether confidence levels remain directionally calibrated.
+
+## Add a new case
+
+1. Add or reuse an artifact (prefer existing demo analysis fixtures first).
+2. Add a case entry in `validation/diagnostics/manifest.json`.
+3. Set `ground_truth`, `acceptable_top2`, evidence checks, warning expectations, and notes.
+4. Run benchmark and tests.
+
+## Run locally
+
+```bash
+python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json
+python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --output target/diagnostic-benchmark.json
+python3 -m unittest scripts.tests.test_diagnostic_benchmark
+```
+
+This validation layer measures diagnostic behavior quality over a labeled corpus; it does not prove causal certainty.

--- a/scripts/diagnostic_benchmark.py
+++ b/scripts/diagnostic_benchmark.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+
+ALLOWED_KINDS = {
+    "application_queue_saturation",
+    "blocking_pool_pressure",
+    "executor_pressure_suspected",
+    "downstream_stage_dominates",
+    "insufficient_evidence",
+}
+CONFIDENCE_BUCKETS = {"high", "medium", "low"}
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Run diagnostic validation benchmark corpus")
+    p.add_argument("--manifest", required=True)
+    p.add_argument("--output")
+    p.add_argument("--min-top1", type=float, default=0.75)
+    p.add_argument("--min-top2", type=float, default=0.90)
+    return p.parse_args()
+
+
+def _error(msg: str) -> SystemExit:
+    return SystemExit(f"error: {msg}")
+
+
+def load_manifest(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data.get("cases"), list):
+        raise _error("manifest must include cases array")
+    seen = set()
+    for case in data["cases"]:
+        for k in ["id", "artifact", "artifact_type", "ground_truth", "acceptable_top2", "tags", "must_include_evidence", "allowed_warnings", "notes"]:
+            if k not in case:
+                raise _error(f"case missing required field: {k}")
+        if case["id"] in seen:
+            raise _error(f"duplicate case id: {case['id']}")
+        seen.add(case["id"])
+        if case["artifact_type"] != "analysis_report":
+            raise _error(f"unsupported artifact_type for {case['id']}: {case['artifact_type']}")
+        if case["ground_truth"] not in ALLOWED_KINDS:
+            raise _error(f"unknown ground_truth for {case['id']}: {case['ground_truth']}")
+        if case["ground_truth"] not in case["acceptable_top2"]:
+            raise _error(f"acceptable_top2 must include ground_truth for {case['id']}")
+    return data
+
+
+def confidence_bucket(value: str) -> str:
+    return value if value in CONFIDENCE_BUCKETS else "unknown"
+
+
+def run(manifest_path: Path) -> dict:
+    manifest = load_manifest(manifest_path)
+    root = manifest_path.parent.parent.parent
+    failed = []
+    confusion = defaultdict(Counter)
+    per_gt = defaultdict(lambda: {"cases": 0, "top1_correct": 0, "top2_correct": 0})
+    conf_acc = defaultdict(lambda: {"cases": 0, "top1_correct": 0})
+    top1 = 0
+    top2 = 0
+    req_evidence_pass = 0
+    unexpected_warning_count = 0
+
+    for case in manifest["cases"]:
+        report = json.loads((root / case["artifact"]).read_text(encoding="utf-8"))
+        primary = report["primary_suspect"]
+        secondary = report.get("secondary_suspects", [])
+        predicted = primary["kind"]
+        top2_kinds = [predicted] + [s["kind"] for s in secondary[:1]]
+        truths = case["acceptable_top2"]
+
+        is_top1 = predicted == case["ground_truth"]
+        is_top2 = any(k in truths for k in top2_kinds)
+        top1 += int(is_top1)
+        top2 += int(is_top2)
+
+        per = per_gt[case["ground_truth"]]
+        per["cases"] += 1
+        per["top1_correct"] += int(is_top1)
+        per["top2_correct"] += int(is_top2)
+        confusion[case["ground_truth"]][predicted] += 1
+
+        bucket = confidence_bucket(primary.get("confidence", "unknown"))
+        conf_acc[bucket]["cases"] += 1
+        conf_acc[bucket]["top1_correct"] += int(is_top1)
+
+        all_evidence = list(primary.get("evidence", []))
+        for s in secondary:
+            all_evidence.extend(s.get("evidence", []))
+        evidence_ok = all(any(needle in ev for ev in all_evidence) for needle in case["must_include_evidence"])
+        req_evidence_pass += int(evidence_ok)
+
+        warnings = report.get("warnings", [])
+        allowed = case["allowed_warnings"]
+        bad_warn = []
+        for warning in warnings:
+            if not any(token in warning for token in allowed):
+                bad_warn.append(warning)
+        unexpected_warning_count += len(bad_warn)
+
+        if (not evidence_ok) or bad_warn:
+            failed.append({"id": case["id"], "evidence_ok": evidence_ok, "unexpected_warnings": bad_warn})
+
+    total = len(manifest["cases"])
+    return {
+        "total_cases": total,
+        "top1_accuracy": top1 / total if total else 0.0,
+        "top2_recall": top2 / total if total else 0.0,
+        "required_evidence_pass_rate": req_evidence_pass / total if total else 0.0,
+        "unexpected_warning_count": unexpected_warning_count,
+        "per_ground_truth": dict(sorted(per_gt.items())),
+        "confidence_bucket_accuracy": dict(sorted(conf_acc.items())),
+        "confusion_matrix": {k: dict(v) for k, v in sorted(confusion.items())},
+        "failed_cases": failed,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    metrics = run(Path(args.manifest))
+    print(f"Cases: {metrics['total_cases']}")
+    print(f"Top-1 accuracy: {metrics['top1_accuracy']:.3f}")
+    print(f"Top-2 recall: {metrics['top2_recall']:.3f}")
+    print(f"Required evidence pass rate: {metrics['required_evidence_pass_rate']:.3f}")
+    print(f"Unexpected warnings: {metrics['unexpected_warning_count']}")
+    if args.output:
+        Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.output).write_text(json.dumps(metrics, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if metrics["failed_cases"]:
+        return 1
+    if metrics["top1_accuracy"] < args.min_top1 or metrics["top2_recall"] < args.min_top2:
+        return 1
+    if metrics["unexpected_warning_count"] > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_diagnostic_benchmark.py
+++ b/scripts/tests/test_diagnostic_benchmark.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import diagnostic_benchmark
+
+
+class DiagnosticBenchmarkTests(unittest.TestCase):
+    def _write(self, root: Path, rel: str, data: dict):
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(data), encoding="utf-8")
+
+    def _manifest(self, cases):
+        return {"version": 1, "cases": cases}
+
+    def test_manifest_rejects_missing_fields(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "m.json"
+            p.write_text(json.dumps({"cases": [{"id": "x"}]}), encoding="utf-8")
+            with self.assertRaises(SystemExit):
+                diagnostic_benchmark.load_manifest(p)
+
+    def test_duplicate_and_unknown_gt(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "m.json"
+            case = {"id":"a","artifact":"a.json","artifact_type":"analysis_report","ground_truth":"unknown","acceptable_top2":["unknown"],"tags":[],"must_include_evidence":[],"allowed_warnings":[],"notes":"n"}
+            p.write_text(json.dumps(self._manifest([case, dict(case)])), encoding="utf-8")
+            with self.assertRaises(SystemExit):
+                diagnostic_benchmark.load_manifest(p)
+
+    def test_metrics_and_output_shape(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            report = {"primary_suspect":{"kind":"application_queue_saturation","score":80,"confidence":"high","evidence":["Queue wait at p95"],"next_checks":[]},"secondary_suspects":[{"kind":"downstream_stage_dominates","score":50,"confidence":"low","evidence":["Stage x"],"next_checks":[]}],"warnings":[]}
+            self._write(root, "a.json", report)
+            m = self._manifest([{"id":"c1","artifact":"a.json","artifact_type":"analysis_report","ground_truth":"application_queue_saturation","acceptable_top2":["application_queue_saturation"],"tags":[],"must_include_evidence":["Stage"],"allowed_warnings":[],"notes":"n"}])
+            mp = root / "validation/diagnostics/manifest.json"
+            mp.parent.mkdir(parents=True)
+            mp.write_text(json.dumps(m), encoding="utf-8")
+            out = diagnostic_benchmark.run(mp)
+            self.assertEqual(out["total_cases"], 1)
+            self.assertEqual(out["top1_accuracy"], 1.0)
+            self.assertEqual(out["top2_recall"], 1.0)
+            self.assertIn("high", out["confidence_bucket_accuracy"])
+            self.assertEqual(out["required_evidence_pass_rate"], 1.0)
+
+    def test_warnings_and_threshold_failure(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            report = {"primary_suspect":{"kind":"downstream_stage_dominates","score":70,"confidence":"medium","evidence":["Stage slow"],"next_checks":[]},"secondary_suspects":[],"warnings":["unexpected warning"]}
+            self._write(root, "a.json", report)
+            m = self._manifest([{"id":"c1","artifact":"a.json","artifact_type":"analysis_report","ground_truth":"downstream_stage_dominates","acceptable_top2":["downstream_stage_dominates"],"tags":[],"must_include_evidence":["Stage"],"allowed_warnings":["known"],"notes":"n"}])
+            mp = root / "validation/diagnostics/manifest.json"
+            mp.parent.mkdir(parents=True)
+            mp.write_text(json.dumps(m), encoding="utf-8")
+            out = diagnostic_benchmark.run(mp)
+            self.assertEqual(out["unexpected_warning_count"], 1)
+            self.assertTrue(out["failed_cases"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -444,6 +444,7 @@ service_name initially_enabled mode strict_lifecycle capture_limits_override max
 
 - [Guide](user-guide.md)
 - [Diag](diagnostics.md)
+- [Diagnostic validation](diagnostic-validation.md)
 - [Controller crate](../tailtriage-controller/README.md)
 - [Sampler crate](../tailtriage-tokio/README.md)
 - [CLI crate](../tailtriage-cli/README.md)

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -51,6 +51,7 @@ STALE_CONTROLLER_POLICY_NAMES = (
 DOCS_REQUIRED_LINKS = (
     "[User guide](user-guide.md)",
     "[Diagnostics guide](diagnostics.md)",
+    "[Diagnostic validation](diagnostic-validation.md)",
     "[Controller README (`tailtriage-controller`)](../tailtriage-controller/README.md)",
     "[Tokio runtime sampler README (`tailtriage-tokio`)](../tailtriage-tokio/README.md)",
     "[CLI README (`tailtriage-cli`)](../tailtriage-cli/README.md)",
@@ -66,6 +67,7 @@ README_DOC_MAP_REQUIRED_LINKS = (
     "(tailtriage-tokio/README.md)",
     "(tailtriage-cli/README.md)",
     "(docs/diagnostics.md)",
+    "(docs/diagnostic-validation.md)",
     "(docs/runtime-cost.md)",
     "(docs/collector-limits.md)",
     "(docs/getting-started-demo.md)",

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -1,0 +1,40 @@
+# Diagnostic validation corpus
+
+This directory is the diagnostic validation surface for analyzer quality measurement.
+
+## What this is
+
+- `manifest.json` defines labeled validation cases.
+- Cases reference committed analysis artifacts and check whether evidence-ranked suspects match expected diagnostic labels.
+- This is different from demos: demos teach scenarios; validation measures diagnostic behavior.
+
+## Manifest format
+
+Each case includes:
+
+- `id` unique case id
+- `artifact` relative path to an analysis report
+- `artifact_type` (`analysis_report` for now)
+- `ground_truth` expected suspect kind
+- `acceptable_top2` acceptable kinds in top-2 (must include `ground_truth`)
+- `tags` searchable labels
+- `must_include_evidence` evidence substrings that must appear across primary/secondary suspects
+- `allowed_warnings` warning substrings explicitly tolerated for that case
+- `notes` short label rationale
+
+## Labeling rules
+
+- Choose `ground_truth` from injected or independently known bottleneck family.
+- Use top-1 for clean scenarios and top-2 tolerance for mixed/ambiguous scenarios.
+- Do not use labels to claim causal proof.
+
+## Evidence and warnings checks
+
+- `must_include_evidence` is matched as substring against primary and secondary suspect evidence.
+- `allowed_warnings` controls warning expectations:
+  - empty list means no warnings are expected
+  - warnings not matching allowed substrings are counted as unexpected
+
+## Synthetic fixtures
+
+Add synthetic fixtures under `validation/diagnostics/corpus/` only when existing demo artifacts do not cover an important diagnostic case (for example insufficient evidence or correlated mixed signals). Keep them small and hand-readable.

--- a/validation/diagnostics/corpus/blocking-correlated-stage-analysis.json
+++ b/validation/diagnostics/corpus/blocking-correlated-stage-analysis.json
@@ -1,0 +1,35 @@
+{
+  "request_count": 120,
+  "p50_latency_us": 1000,
+  "p95_latency_us": 4000,
+  "p99_latency_us": 7000,
+  "p95_queue_share_permille": 300,
+  "p95_service_share_permille": 700,
+  "inflight_trend": null,
+  "warnings": [],
+  "primary_suspect": {
+    "kind": "blocking_pool_pressure",
+    "score": 90,
+    "confidence": "high",
+    "evidence": [
+      "Blocking pool queue depth peak reached 42.",
+      "Stage 'render_pdf' likely waits on spawn_blocking work."
+    ],
+    "next_checks": [
+      "Profile blocking pool saturation."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "downstream_stage_dominates",
+      "score": 58,
+      "confidence": "low",
+      "evidence": [
+        "Stage 'render_pdf' contributes 280 permille of cumulative latency."
+      ],
+      "next_checks": [
+        "Validate whether render_pdf itself is slow."
+      ]
+    }
+  ]
+}

--- a/validation/diagnostics/corpus/low-request-analysis.json
+++ b/validation/diagnostics/corpus/low-request-analysis.json
@@ -1,0 +1,24 @@
+{
+  "request_count": 12,
+  "p50_latency_us": 1000,
+  "p95_latency_us": 4000,
+  "p99_latency_us": 7000,
+  "p95_queue_share_permille": 300,
+  "p95_service_share_permille": 700,
+  "inflight_trend": null,
+  "warnings": [
+    "Low request count may reduce confidence."
+  ],
+  "primary_suspect": {
+    "kind": "insufficient_evidence",
+    "score": 40,
+    "confidence": "low",
+    "evidence": [
+      "Insufficient evidence to rank a dominant suspect."
+    ],
+    "next_checks": [
+      "Capture more requests and add stage/queue instrumentation."
+    ]
+  },
+  "secondary_suspects": []
+}

--- a/validation/diagnostics/corpus/missing-runtime-analysis.json
+++ b/validation/diagnostics/corpus/missing-runtime-analysis.json
@@ -1,0 +1,24 @@
+{
+  "request_count": 120,
+  "p50_latency_us": 1000,
+  "p95_latency_us": 4000,
+  "p99_latency_us": 7000,
+  "p95_queue_share_permille": 300,
+  "p95_service_share_permille": 700,
+  "inflight_trend": null,
+  "warnings": [
+    "Runtime snapshots unavailable."
+  ],
+  "primary_suspect": {
+    "kind": "insufficient_evidence",
+    "score": 40,
+    "confidence": "low",
+    "evidence": [
+      "Runtime snapshots are unavailable; executor pressure confidence is limited."
+    ],
+    "next_checks": [
+      "Capture more requests and add stage/queue instrumentation."
+    ]
+  },
+  "secondary_suspects": []
+}

--- a/validation/diagnostics/corpus/weak-blocking-strong-downstream-analysis.json
+++ b/validation/diagnostics/corpus/weak-blocking-strong-downstream-analysis.json
@@ -1,0 +1,34 @@
+{
+  "request_count": 120,
+  "p50_latency_us": 1000,
+  "p95_latency_us": 4000,
+  "p99_latency_us": 7000,
+  "p95_queue_share_permille": 300,
+  "p95_service_share_permille": 700,
+  "inflight_trend": null,
+  "warnings": [],
+  "primary_suspect": {
+    "kind": "downstream_stage_dominates",
+    "score": 78,
+    "confidence": "medium",
+    "evidence": [
+      "Stage 'db_call' contributes 620 permille of cumulative request latency."
+    ],
+    "next_checks": [
+      "Inspect downstream db_call latency."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "blocking_pool_pressure",
+      "score": 62,
+      "confidence": "low",
+      "evidence": [
+        "Blocking pool queue depth observed, but contribution is limited."
+      ],
+      "next_checks": [
+        "Check spawn_blocking fanout."
+      ]
+    }
+  ]
+}

--- a/validation/diagnostics/manifest.json
+++ b/validation/diagnostics/manifest.json
@@ -1,0 +1,443 @@
+{
+  "version": 1,
+  "cases": [
+    {
+      "id": "queue_before_primary",
+      "artifact": "demos/queue_service/fixtures/before-analysis.json",
+      "artifact_type": "analysis_report",
+      "ground_truth": "application_queue_saturation",
+      "acceptable_top2": [
+        "application_queue_saturation"
+      ],
+      "tags": [
+        "queue",
+        "demo",
+        "before"
+      ],
+      "must_include_evidence": [
+        "Queue wait at p95"
+      ],
+      "allowed_warnings": [],
+      "notes": "Queue service baseline intentionally saturates admission and should rank queueing first."
+    },
+    {
+      "id": "queue_after_primary",
+      "artifact": "demos/queue_service/fixtures/after-analysis.json",
+      "artifact_type": "analysis_report",
+      "ground_truth": "application_queue_saturation",
+      "acceptable_top2": [
+        "application_queue_saturation",
+        "downstream_stage_dominates"
+      ],
+      "tags": [
+        "queue",
+        "demo",
+        "after"
+      ],
+      "must_include_evidence": [
+        "p95"
+      ],
+      "allowed_warnings": [],
+      "notes": "Mitigated queue case still retains queue signal, though less severe."
+    },
+    {
+      "id": "blocking_before",
+      "artifact": "demos/blocking_service/fixtures/before-analysis.json",
+      "artifact_type": "analysis_report",
+      "ground_truth": "blocking_pool_pressure",
+      "acceptable_top2": [
+        "blocking_pool_pressure"
+      ],
+      "tags": [
+        "blocking",
+        "demo",
+        "before"
+      ],
+      "must_include_evidence": [
+        "Blocking"
+      ],
+      "allowed_warnings": [
+        "Runtime snapshots are missing blocking_queue_depth",
+        "Top suspects are close in score"
+      ],
+      "notes": "Blocking baseline should surface blocking-pool pressure with direct evidence."
+    },
+    {
+      "id": "blocking_after",
+      "artifact": "demos/blocking_service/fixtures/after-analysis.json",
+      "artifact_type": "analysis_report",
+      "ground_truth": "blocking_pool_pressure",
+      "acceptable_top2": [
+        "blocking_pool_pressure",
+        "downstream_stage_dominates"
+      ],
+      "tags": [
+        "blocking",
+        "demo",
+        "after"
+      ],
+      "must_include_evidence": [
+        "Blocking"
+      ],
+      "allowed_warnings": [
+        "Runtime snapshots are missing blocking_queue_depth",
+        "Top suspects are close in score"
+      ],
+      "notes": "Mitigated blocking path still exercises blocking heuristics."
+    },
+    {
+      "id": "executor_before",
+      "artifact": "demos/executor_pressure_service/fixtures/before-analysis.json",
+      "artifact_type": "analysis_report",
+      "ground_truth": "executor_pressure_suspected",
+      "acceptable_top2": [
+        "executor_pressure_suspected"
+      ],
+      "tags": [
+        "executor",
+        "demo",
+        "before"
+      ],
+      "must_include_evidence": [
+        "Runtime"
+      ],
+      "allowed_warnings": [],
+      "notes": "Executor pressure baseline should highlight scheduler contention signals."
+    },
+    {
+      "id": "executor_after",
+      "artifact": "demos/executor_pressure_service/fixtures/after-analysis.json",
+      "artifact_type": "analysis_report",
+      "ground_truth": "executor_pressure_suspected",
+      "acceptable_top2": [
+        "executor_pressure_suspected",
+        "application_queue_saturation"
+      ],
+      "tags": [
+        "executor",
+        "demo",
+        "after"
+      ],
+      "must_include_evidence": [
+        "Runtime"
+      ],
+      "allowed_warnings": [],
+      "notes": "Mitigated executor case may still keep runtime pressure in top suspects."
+    },
+    {
+      "id": "downstream_before",
+      "artifact": "demos/downstream_service/fixtures/before-analysis.json",
+      "artifact_type": "analysis_report",
+      "ground_truth": "downstream_stage_dominates",
+      "acceptable_top2": [
+        "downstream_stage_dominates"
+      ],
+      "tags": [
+        "downstream",
+        "demo",
+        "before"
+      ],
+      "must_include_evidence": [
+        "Stage"
+      ],
+      "allowed_warnings": [],
+      "notes": "Downstream baseline intentionally makes one stage dominate tail latency."
+    },
+    {
+      "id": "downstream_after",
+      "artifact": "demos/downstream_service/fixtures/after-analysis.json",
+      "artifact_type": "analysis_report",
+      "ground_truth": "downstream_stage_dominates",
+      "acceptable_top2": [
+        "downstream_stage_dominates",
+        "application_queue_saturation"
+      ],
+      "tags": [
+        "downstream",
+        "demo",
+        "after"
+      ],
+      "must_include_evidence": [
+        "Stage"
+      ],
+      "allowed_warnings": [],
+      "notes": "Mitigated downstream case should preserve downstream-led diagnosis pattern."
+    },
+    {
+      "id": "mixed_baseline",
+      "artifact": "demos/mixed_contention_service/fixtures/baseline-analysis.json",
+      "artifact_type": "analysis_report",
+      "ground_truth": "application_queue_saturation",
+      "acceptable_top2": [
+        "application_queue_saturation",
+        "downstream_stage_dominates"
+      ],
+      "tags": [
+        "mixed",
+        "demo",
+        "baseline"
+      ],
+      "must_include_evidence": [
+        "Queue"
+      ],
+      "allowed_warnings": [],
+      "notes": "Mixed baseline has queue contention with downstream contribution; top-2 is important."
+    },
+    {
+      "id": "mixed_mitigated",
+      "artifact": "demos/mixed_contention_service/fixtures/mitigated-analysis.json",
+      "artifact_type": "analysis_report",
+      "ground_truth": "downstream_stage_dominates",
+      "acceptable_top2": [
+        "downstream_stage_dominates",
+        "application_queue_saturation"
+      ],
+      "tags": [
+        "mixed",
+        "demo",
+        "mitigated"
+      ],
+      "must_include_evidence": [
+        "Stage"
+      ],
+      "allowed_warnings": [],
+      "notes": "After mitigation, downstream contribution can remain a leading suspect."
+    },
+    {
+      "id": "cold_before",
+      "artifact": "demos/cold_start_burst_service/fixtures/before-analysis.json",
+      "artifact_type": "analysis_report",
+      "ground_truth": "application_queue_saturation",
+      "acceptable_top2": [
+        "application_queue_saturation",
+        "downstream_stage_dominates"
+      ],
+      "tags": [
+        "cold-start",
+        "demo",
+        "before"
+      ],
+      "must_include_evidence": [
+        "Queue"
+      ],
+      "allowed_warnings": [],
+      "notes": "Cold-start burst scenario drives admission delays and queue-like evidence."
+    },
+    {
+      "id": "cold_after",
+      "artifact": "demos/cold_start_burst_service/fixtures/after-analysis.json",
+      "artifact_type": "analysis_report",
+      "ground_truth": "application_queue_saturation",
+      "acceptable_top2": [
+        "application_queue_saturation",
+        "downstream_stage_dominates"
+      ],
+      "tags": [
+        "cold-start",
+        "demo",
+        "after"
+      ],
+      "must_include_evidence": [
+        "p95"
+      ],
+      "allowed_warnings": [],
+      "notes": "Mitigated cold-start case still exercises queue and stage interpretation."
+    },
+    {
+      "id": "db_before",
+      "artifact": "demos/db_pool_saturation_service/fixtures/before-analysis.json",
+      "artifact_type": "analysis_report",
+      "ground_truth": "application_queue_saturation",
+      "acceptable_top2": [
+        "application_queue_saturation",
+        "downstream_stage_dominates"
+      ],
+      "tags": [
+        "db-pool",
+        "demo",
+        "before"
+      ],
+      "must_include_evidence": [
+        "queue"
+      ],
+      "allowed_warnings": [],
+      "notes": "DB pool admission limits create queue-style bottleneck signals."
+    },
+    {
+      "id": "db_after",
+      "artifact": "demos/db_pool_saturation_service/fixtures/after-analysis.json",
+      "artifact_type": "analysis_report",
+      "ground_truth": "downstream_stage_dominates",
+      "acceptable_top2": [
+        "downstream_stage_dominates",
+        "application_queue_saturation"
+      ],
+      "tags": [
+        "db-pool",
+        "demo",
+        "after"
+      ],
+      "must_include_evidence": [
+        "db_query"
+      ],
+      "allowed_warnings": [],
+      "notes": "After mitigation, stage contribution can remain a valid lead."
+    },
+    {
+      "id": "lock_before",
+      "artifact": "demos/shared_state_lock_service/fixtures/before-analysis.json",
+      "artifact_type": "analysis_report",
+      "ground_truth": "application_queue_saturation",
+      "acceptable_top2": [
+        "application_queue_saturation"
+      ],
+      "tags": [
+        "lock",
+        "demo",
+        "before"
+      ],
+      "must_include_evidence": [
+        "p95"
+      ],
+      "allowed_warnings": [],
+      "notes": "Shared-state lock contention is modeled as queue-like admission wait."
+    },
+    {
+      "id": "lock_after",
+      "artifact": "demos/shared_state_lock_service/fixtures/after-analysis.json",
+      "artifact_type": "analysis_report",
+      "ground_truth": "application_queue_saturation",
+      "acceptable_top2": [
+        "application_queue_saturation",
+        "downstream_stage_dominates"
+      ],
+      "tags": [
+        "lock",
+        "demo",
+        "after"
+      ],
+      "must_include_evidence": [
+        "p95"
+      ],
+      "allowed_warnings": [],
+      "notes": "Mitigated lock case should keep queue-related evidence present."
+    },
+    {
+      "id": "retry_before",
+      "artifact": "demos/retry_storm_service/fixtures/before-analysis.json",
+      "artifact_type": "analysis_report",
+      "ground_truth": "downstream_stage_dominates",
+      "acceptable_top2": [
+        "downstream_stage_dominates"
+      ],
+      "tags": [
+        "retry",
+        "demo",
+        "before"
+      ],
+      "must_include_evidence": [
+        "downstream"
+      ],
+      "allowed_warnings": [],
+      "notes": "Retry storm baseline should emphasize downstream aggregate stage impact."
+    },
+    {
+      "id": "retry_after",
+      "artifact": "demos/retry_storm_service/fixtures/after-analysis.json",
+      "artifact_type": "analysis_report",
+      "ground_truth": "downstream_stage_dominates",
+      "acceptable_top2": [
+        "downstream_stage_dominates",
+        "application_queue_saturation"
+      ],
+      "tags": [
+        "retry",
+        "demo",
+        "after"
+      ],
+      "must_include_evidence": [
+        "downstream"
+      ],
+      "allowed_warnings": [],
+      "notes": "Mitigated retries still retain downstream-led diagnostic shape."
+    },
+    {
+      "id": "insufficient_low_count",
+      "artifact": "validation/diagnostics/corpus/low-request-analysis.json",
+      "artifact_type": "analysis_report",
+      "ground_truth": "insufficient_evidence",
+      "acceptable_top2": [
+        "insufficient_evidence"
+      ],
+      "tags": [
+        "synthetic",
+        "low-count"
+      ],
+      "must_include_evidence": [
+        "Insufficient evidence"
+      ],
+      "allowed_warnings": [
+        "Low request count"
+      ],
+      "notes": "Low sample count should map to insufficient-evidence diagnosis."
+    },
+    {
+      "id": "insufficient_missing_runtime",
+      "artifact": "validation/diagnostics/corpus/missing-runtime-analysis.json",
+      "artifact_type": "analysis_report",
+      "ground_truth": "insufficient_evidence",
+      "acceptable_top2": [
+        "insufficient_evidence"
+      ],
+      "tags": [
+        "synthetic",
+        "missing-runtime"
+      ],
+      "must_include_evidence": [
+        "Runtime snapshots"
+      ],
+      "allowed_warnings": [
+        "Runtime snapshots unavailable"
+      ],
+      "notes": "Missing runtime snapshots can limit confidence and remain insufficient."
+    },
+    {
+      "id": "weak_blocking_real_downstream",
+      "artifact": "validation/diagnostics/corpus/weak-blocking-strong-downstream-analysis.json",
+      "artifact_type": "analysis_report",
+      "ground_truth": "downstream_stage_dominates",
+      "acceptable_top2": [
+        "downstream_stage_dominates",
+        "blocking_pool_pressure"
+      ],
+      "tags": [
+        "synthetic",
+        "mixed"
+      ],
+      "must_include_evidence": [
+        "db_call"
+      ],
+      "allowed_warnings": [],
+      "notes": "Case captures weak blocking alongside true downstream dominance."
+    },
+    {
+      "id": "blocking_correlated_stage",
+      "artifact": "validation/diagnostics/corpus/blocking-correlated-stage-analysis.json",
+      "artifact_type": "analysis_report",
+      "ground_truth": "blocking_pool_pressure",
+      "acceptable_top2": [
+        "blocking_pool_pressure",
+        "downstream_stage_dominates"
+      ],
+      "tags": [
+        "synthetic",
+        "blocking"
+      ],
+      "must_include_evidence": [
+        "queue depth"
+      ],
+      "allowed_warnings": [],
+      "notes": "Blocking-correlated stage should still rank blocking pressure first."
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation

- Provide a deterministic, reviewable validation surface to measure analyzer diagnostic quality over labeled cases rather than relying on demos alone.
- Make analyzer correctness and evidence checks reproducible and automatable without changing analyzer scoring, schema, or adding dependencies.
- Enable regression protection and confidence-calibration tracking for the analyzer so future changes can be evaluated against a stable corpus.

### Description

- Added a labeled validation corpus at `validation/diagnostics/manifest.json` with 22 cases covering all suspect kinds (`application_queue_saturation`, `blocking_pool_pressure`, `executor_pressure_suspected`, `downstream_stage_dominates`, `insufficient_evidence`) and small synthetic fixtures under `validation/diagnostics/corpus/` for edge cases.
- Implemented a stdlib-only benchmark/runner at `scripts/diagnostic_benchmark.py` that validates the manifest, loads analysis reports, extracts primary/secondary suspects, evidence and warnings, computes top-1/top-2 metrics, per-class counts, confusion matrix, confidence-bucket accuracy, evidence pass rate, unexpected warning counts, and emits stable JSON when requested.
- Added unit tests at `scripts/tests/test_diagnostic_benchmark.py` to validate manifest checks, metric computations, evidence scanning across primary+secondary suspects, allowed-warning behavior, and failure-paths; and updated `scripts/validate_docs_contracts.py` and its tests to link the new docs.
- Added documentation: user-facing `docs/diagnostic-validation.md` and maintainer guidance `validation/diagnostics/README.md`, and updated docs index/readmes to point to the new validation surface.

### Testing

- Ran the benchmark against the new manifest with `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json` which produced metrics: `total_cases: 22`, `top1_accuracy: 0.864`, `top2_recall: 1.000`, `required_evidence_pass_rate: 1.000`, and `unexpected_warning_count: 0`.
- Executed the benchmark with JSON output via `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --output target/diagnostic-benchmark.json` and verified stable JSON was written; the run returned success under default thresholds (`--min-top1 0.75`, `--min-top2 0.90`).
- Ran unit tests `python3 -m unittest scripts.tests.test_diagnostic_benchmark` and `python3 -m unittest scripts.tests.test_validate_docs_contracts` which passed after minor test harness fixes.
- Validated docs contract and demo fixture drift with `python3 scripts/validate_docs_contracts.py` and `python3 scripts/check_demo_fixture_drift.py --profile dev`, and ran repository checks `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, and `cargo test --workspace --all-targets --all-features --locked`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f657c87e848330ba5cde041499498a)