### PR TITLE
Add adversarial diagnostic validation corpus and enforce per-case confidence ceilings

### DIFF
--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -4,9 +4,9 @@
 `tailtriage` is a triage tool, not root-cause proof. It produces evidence-ranked suspects and next checks, where suspects are leads and not causal certainty.
 
 ## What this PR establishes
-This PR introduces an initial deterministic validation corpus for controlled Tokio workload fixtures. The corpus and benchmark validate bounded diagnostic behavior on committed fixtures, not universal production behavior.
+This repository maintains deterministic validation for controlled Tokio workload fixtures plus synthetic adversarial fixtures. The corpus and benchmark validate bounded diagnostic behavior on committed fixtures, not universal production behavior.
 
-## Initial deterministic checks
+## Deterministic checks (including adversarial coverage)
 The deterministic benchmark validates:
 - evidence-ranked suspect correctness against corpus labels
 - required top-2 visibility (`required_top2` appears in primary or first secondary)
@@ -36,3 +36,6 @@ Next-check substring validation is schema-supported in the manifest (`must_inclu
 - user-facing methodology: `docs/diagnostic-validation.md`
 
 Demos teach scenarios; validation measures bounded diagnostic behavior.
+
+
+Tailtriage validation now checks that sparse, missing, truncated, or mixed evidence is warned about and does not produce overconfident unsupported classifications.

--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -39,3 +39,12 @@ Schema supports `must_include_next_checks`, but the current initial corpus has n
 
 ## Future work
 Repeated-run validation, mitigation validation, overhead integration, collector-limit integration, and expanded real-service validation are separate follow-on work.
+
+
+## Negative and adversarial validation
+The corpus includes deterministic adversarial fixtures for sparse samples, missing instrumentation, truncated artifacts, noisy workloads, and mixed signals. These cases validate conservative triage behavior and explicit warnings when evidence is limited.
+
+## Confidence ceilings and humility checks
+Cases can set `max_primary_confidence` to prevent overconfident classifications when evidence is sparse, missing, truncated, or mixed. This is a humility check on report behavior, not a probability-of-truth claim.
+
+High latency alone is not sufficient for a high-confidence specific suspect when explanatory queue/stage/runtime instrumentation is missing.

--- a/scripts/diagnostic_benchmark.py
+++ b/scripts/diagnostic_benchmark.py
@@ -12,6 +12,7 @@ ALLOWED_GROUND_TRUTH = {
     "insufficient_evidence",
 }
 CONF_HIGH = {"high", "very_high"}
+CONFIDENCE_ORDER = {"low": 0, "medium": 1, "high": 2, "very_high": 3}
 
 
 def load_json(path):
@@ -70,6 +71,12 @@ def validate_manifest(manifest):
             raise ValueError(f"top1_required must be a bool for {cid}")
         if not isinstance(case["notes"], str) or not case["notes"].strip():
             raise ValueError(f"notes must be a non-empty string for {cid}")
+        if "max_primary_confidence" in case:
+            cap = case["max_primary_confidence"]
+            if not isinstance(cap, str):
+                raise ValueError(f"max_primary_confidence must be a string for {cid}")
+            if cap not in CONFIDENCE_ORDER:
+                raise ValueError(f"unknown max_primary_confidence for {cid}: {cap}")
 
 
 def confidence_bucket(conf):
@@ -80,6 +87,10 @@ def confidence_bucket(conf):
     if conf == "low":
         return "low"
     raise ValueError("report.primary_suspect.confidence must be one of low/medium/high/very_high")
+
+
+def confidence_at_or_below(value, ceiling):
+    return CONFIDENCE_ORDER[value] <= CONFIDENCE_ORDER[ceiling]
 
 
 def extract(report):
@@ -149,6 +160,8 @@ def run(manifest_path, min_top1, min_top2, max_high_confidence_wrong):
     evidence_pass = 0
     unexpected_warning_count = 0
     missing_expected_warning_count = 0
+    confidence_ceiling_cases = 0
+    confidence_ceiling_passed_cases = 0
     high_conf_wrong = 0
     conf_buckets = defaultdict(lambda: {"total": 0, "correct": 0})
     next_check_required_cases = 0
@@ -191,9 +204,16 @@ def run(manifest_path, min_top1, min_top2, max_high_confidence_wrong):
         missing_expected = [exp for exp in case["expected_warnings"] if not any(exp.lower() in w.lower() for w in ext["warnings"])]
         unexpected_warning_count += len(unexpected)
         missing_expected_warning_count += len(missing_expected)
+        confidence_ceiling = case.get("max_primary_confidence")
+        confidence_ceiling_ok = True
+        if confidence_ceiling is not None:
+            confidence_ceiling_cases += 1
+            confidence_ceiling_ok = confidence_at_or_below(ext["primary_confidence"], confidence_ceiling)
+            if confidence_ceiling_ok:
+                confidence_ceiling_passed_cases += 1
 
-        case_failed = (not top2_ok) or (case["top1_required"] and not top1_ok) or (not ev_ok) or (not next_check_ok) or bool(unexpected) or bool(missing_expected)
-        row = {"id": case["id"], "top1_ok": top1_ok, "top2_ok": top2_ok, "evidence_ok": ev_ok, "next_check_ok": next_check_ok, "unexpected_warnings": unexpected, "missing_expected_warnings": missing_expected}
+        case_failed = (not top2_ok) or (case["top1_required"] and not top1_ok) or (not ev_ok) or (not next_check_ok) or bool(unexpected) or bool(missing_expected) or (not confidence_ceiling_ok)
+        row = {"id": case["id"], "top1_ok": top1_ok, "top2_ok": top2_ok, "evidence_ok": ev_ok, "next_check_ok": next_check_ok, "unexpected_warnings": unexpected, "missing_expected_warnings": missing_expected, "confidence_ceiling_ok": confidence_ceiling_ok, "max_primary_confidence": confidence_ceiling, "primary_confidence": ext["primary_confidence"]}
         results.append(row)
         if case_failed:
             failed_cases.append({**row, "top1_required": case["top1_required"]})
@@ -217,6 +237,9 @@ def run(manifest_path, min_top1, min_top2, max_high_confidence_wrong):
         "next_check_pass_rate": (next_check_passed_cases / next_check_required_cases) if next_check_required_cases else None,
         "unexpected_warning_count": unexpected_warning_count,
         "missing_expected_warning_count": missing_expected_warning_count,
+        "confidence_ceiling_cases": confidence_ceiling_cases,
+        "confidence_ceiling_passed_cases": confidence_ceiling_passed_cases,
+        "confidence_ceiling_pass_rate": (confidence_ceiling_passed_cases / confidence_ceiling_cases) if confidence_ceiling_cases else None,
         "failed_cases": failed_cases,
     }
 
@@ -258,6 +281,11 @@ def main():
     print(f"high_confidence_wrong_count={metrics['high_confidence_wrong_count']}")
     print(f"required_evidence_pass_rate={metrics['required_evidence_pass_rate']:.3f}")
     print(f"unexpected_warning_count={metrics['unexpected_warning_count']}")
+    cap_rate = metrics["confidence_ceiling_pass_rate"]
+    cap_rate_text = "n/a" if cap_rate is None else f"{cap_rate:.3f}"
+    print(f"confidence_ceiling_cases={metrics['confidence_ceiling_cases']}")
+    print(f"confidence_ceiling_passed_cases={metrics['confidence_ceiling_passed_cases']}")
+    print(f"confidence_ceiling_pass_rate={cap_rate_text}")
     print(f"missing_expected_warning_count={metrics['missing_expected_warning_count']}")
     print(f"next_check_required_cases={metrics['next_check_required_cases']}")
     print(f"next_check_pass_rate={next_check_pass_rate_text}")

--- a/scripts/tests/test_diagnostic_benchmark.py
+++ b/scripts/tests/test_diagnostic_benchmark.py
@@ -124,6 +124,15 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
             db.validate_manifest(self.make_manifest(self.make_case(top1_required="yes")))
         with self.assertRaisesRegex(ValueError, "notes"):
             db.validate_manifest(self.make_manifest(self.make_case(notes="")))
+    
+    def test_manifest_max_primary_confidence_rules(self):
+        db.validate_manifest(self.make_manifest(self.make_case()))
+        for value in ["low", "medium", "high", "very_high"]:
+            db.validate_manifest(self.make_manifest(self.make_case(max_primary_confidence=value)))
+        with self.assertRaisesRegex(ValueError, "max_primary_confidence must be a string"):
+            db.validate_manifest(self.make_manifest(self.make_case(max_primary_confidence=1)))
+        with self.assertRaisesRegex(ValueError, "unknown max_primary_confidence"):
+            db.validate_manifest(self.make_manifest(self.make_case(max_primary_confidence="extreme")))
 
     # Report validation tests
     def test_report_missing_primary_fails(self):
@@ -243,8 +252,25 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
         metrics, _ = self.run_single_case(case, valid_report(primary_kind="blocking_pool_pressure", warnings=[]))
         self.assertEqual(len(metrics["failed_cases"]), 1)
         row = metrics["failed_cases"][0]
-        for field in ["id", "top1_ok", "top2_ok", "evidence_ok", "next_check_ok", "unexpected_warnings", "missing_expected_warnings", "top1_required"]:
+        for field in ["id", "top1_ok", "top2_ok", "evidence_ok", "next_check_ok", "unexpected_warnings", "missing_expected_warnings", "top1_required", "confidence_ceiling_ok", "max_primary_confidence", "primary_confidence"]:
             self.assertIn(field, row)
+
+    def test_confidence_ceiling_behavior_and_metrics(self):
+        case = self.make_case(max_primary_confidence="medium")
+        metrics, failures = self.run_single_case(case, valid_report(confidence="medium"), max_high_confidence_wrong=99)
+        self.assertFalse(failures)
+        self.assertEqual(metrics["confidence_ceiling_cases"], 1)
+        self.assertEqual(metrics["confidence_ceiling_passed_cases"], 1)
+        self.assertEqual(metrics["confidence_ceiling_pass_rate"], 1.0)
+
+        metrics, failures = self.run_single_case(case, valid_report(confidence="low"), max_high_confidence_wrong=99)
+        self.assertFalse(failures)
+
+        metrics, failures = self.run_single_case(case, valid_report(confidence="high"), max_high_confidence_wrong=99)
+        self.assertTrue(failures)
+        self.assertEqual(metrics["confidence_ceiling_passed_cases"], 0)
+        self.assertEqual(metrics["confidence_ceiling_pass_rate"], 0.0)
+        self.assertFalse(metrics["failed_cases"][0]["confidence_ceiling_ok"])
 
     # Threshold and output/path tests
     def test_threshold_failures(self):
@@ -275,7 +301,8 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
                 "per_ground_truth_counts", "confusion_matrix", "confidence_bucket_accuracy",
                 "required_evidence_pass_rate", "next_check_required_cases", "next_check_passed_cases",
                 "next_check_presence_rate", "next_check_pass_rate", "unexpected_warning_count",
-                "missing_expected_warning_count", "failed_cases",
+                "missing_expected_warning_count", "confidence_ceiling_cases",
+                "confidence_ceiling_passed_cases", "confidence_ceiling_pass_rate", "failed_cases",
             }
             self.assertEqual(set(metrics.keys()), expected_keys)
 

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -19,6 +19,7 @@ Demos teach; validation measures.
 - `must_include_next_checks`: next-check substrings that must appear when required by a case. Schema-supported; current initial corpus has no required next-check cases.
 - `expected_warnings`: warning substrings that must appear.
 - `allowed_warnings`: warning substrings that may appear in addition to expected warnings.
+- `max_primary_confidence` (optional): per-case confidence ceiling (`low|medium|high|very_high`) used to enforce conservative confidence on sparse/missing/partial-data scenarios.
 - `notes`: workload-intent note explaining why labels are set.
 - `tags`: non-empty string tags for grouping/filtering.
 
@@ -51,3 +52,12 @@ python3 scripts/diagnostic_benchmark.py \
   --min-top2 0.90 \
   --max-high-confidence-wrong 0
 ```
+
+
+## Negative/adversarial coverage rules
+
+Use `max_primary_confidence` for low-request-count, missing instrumentation, truncation, noise-only, and mixed-signal ambiguity cases to validate humility (not truth probability).
+
+Warning checks are strict: `expected_warnings` are required, while `allowed_warnings` are only tolerated extras.
+
+Synthetic fixtures must remain small, scoped, and report-shaped; they fill validation coverage gaps and are not substitutes for analyzer-generated captures.

--- a/validation/diagnostics/corpus/blocking-correlated-stage.json
+++ b/validation/diagnostics/corpus/blocking-correlated-stage.json
@@ -1,0 +1,23 @@
+{
+  "warnings": [],
+  "primary_suspect": {
+    "kind": "blocking_pool_pressure",
+    "confidence": "high",
+    "evidence": [
+      "Blocking queue depth remains elevated at tail intervals.",
+      "Dominant stage latency is strongly correlated with blocking callsites."
+    ],
+    "next_checks": [
+      "Audit spawn_blocking and other blocking callsites in the correlated stage."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "downstream_stage_dominates",
+      "confidence": "medium",
+      "evidence": [
+        "Stage latency is visible but likely downstream of blocking-pool pressure."
+      ]
+    }
+  ]
+}

--- a/validation/diagnostics/corpus/high-latency-missing-instrumentation.json
+++ b/validation/diagnostics/corpus/high-latency-missing-instrumentation.json
@@ -1,0 +1,16 @@
+{
+  "warnings": [
+    "High latency observed but queue/stage/runtime instrumentation is missing."
+  ],
+  "primary_suspect": {
+    "kind": "insufficient_evidence",
+    "confidence": "low",
+    "evidence": [
+      "Overall latency is high, but explanatory queue, stage, and runtime instrumentation is insufficient."
+    ],
+    "next_checks": [
+      "Enable queue, stage, and runtime instrumentation before assigning a bottleneck family."
+    ]
+  },
+  "secondary_suspects": []
+}

--- a/validation/diagnostics/corpus/low-request-count.json
+++ b/validation/diagnostics/corpus/low-request-count.json
@@ -1,0 +1,17 @@
+{
+  "warnings": [
+    "Low request count: tail estimates are unstable with sparse samples."
+  ],
+  "primary_suspect": {
+    "kind": "insufficient_evidence",
+    "confidence": "low",
+    "evidence": [
+      "Too few requests captured to make stable p95/p99 dominance estimates."
+    ],
+    "next_checks": [
+      "Re-run with enough requests for stable tail estimates.",
+      "Enable queue wait/depth and stage instrumentation for the next run."
+    ]
+  },
+  "secondary_suspects": []
+}

--- a/validation/diagnostics/corpus/missing-optional-runtime-fields.json
+++ b/validation/diagnostics/corpus/missing-optional-runtime-fields.json
@@ -1,0 +1,25 @@
+{
+  "warnings": [
+    "Optional runtime fields missing (blocking_queue_depth/local_queue_depth unavailable)."
+  ],
+  "primary_suspect": {
+    "kind": "blocking_pool_pressure",
+    "confidence": "medium",
+    "evidence": [
+      "Runtime snapshots are partial; optional runtime fields are unavailable in this capture."
+    ],
+    "next_checks": [
+      "Use available runtime metrics and validate with tokio-console or tokio-metrics.",
+      "Enable tokio_unstable if appropriate to expose optional runtime fields."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "executor_pressure_suspected",
+      "confidence": "medium",
+      "evidence": [
+        "Partial runtime fields limit executor vs blocking separation."
+      ]
+    }
+  ]
+}

--- a/validation/diagnostics/corpus/no-queue-events.json
+++ b/validation/diagnostics/corpus/no-queue-events.json
@@ -1,0 +1,25 @@
+{
+  "warnings": [
+    "Queue instrumentation missing: no queue wait/depth events were observed."
+  ],
+  "primary_suspect": {
+    "kind": "downstream_stage_dominates",
+    "confidence": "medium",
+    "evidence": [
+      "Stage checkout_db dominates tail contribution in captured requests.",
+      "No queue evidence was captured so queue saturation cannot be excluded."
+    ],
+    "next_checks": [
+      "Enable queue wait/depth instrumentation to confirm or exclude application queue saturation."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "application_queue_saturation",
+      "confidence": "low",
+      "evidence": [
+        "Queue instrumentation is missing; queue saturation remains plausible."
+      ]
+    }
+  ]
+}

--- a/validation/diagnostics/corpus/no-runtime-snapshots.json
+++ b/validation/diagnostics/corpus/no-runtime-snapshots.json
@@ -1,0 +1,24 @@
+{
+  "warnings": [
+    "Runtime snapshots are missing; executor vs blocking separation is limited."
+  ],
+  "primary_suspect": {
+    "kind": "executor_pressure_suspected",
+    "confidence": "medium",
+    "evidence": [
+      "Scheduler pressure hints are present, but runtime snapshots are missing."
+    ],
+    "next_checks": [
+      "Enable runtime sampling and compare runtime global queue depth against blocking queue depth."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "blocking_pool_pressure",
+      "confidence": "medium",
+      "evidence": [
+        "Without runtime snapshots, blocking-pool pressure remains a close alternative."
+      ]
+    }
+  ]
+}

--- a/validation/diagnostics/corpus/no-stage-events.json
+++ b/validation/diagnostics/corpus/no-stage-events.json
@@ -1,0 +1,25 @@
+{
+  "warnings": [
+    "Stage instrumentation missing: major await segments were not captured."
+  ],
+  "primary_suspect": {
+    "kind": "application_queue_saturation",
+    "confidence": "medium",
+    "evidence": [
+      "Queue wait dominates observed request latency.",
+      "No stage evidence was captured so downstream dominance cannot be excluded."
+    ],
+    "next_checks": [
+      "Enable stage instrumentation around major awaits to separate downstream stage latency from queueing."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "downstream_stage_dominates",
+      "confidence": "low",
+      "evidence": [
+        "Stage coverage is missing; downstream stage dominance remains plausible."
+      ]
+    }
+  ]
+}

--- a/validation/diagnostics/corpus/noise-only-workload.json
+++ b/validation/diagnostics/corpus/noise-only-workload.json
@@ -1,0 +1,24 @@
+{
+  "warnings": [
+    "No dominant signal: mixed low-signal workload across suspects."
+  ],
+  "primary_suspect": {
+    "kind": "insufficient_evidence",
+    "confidence": "low",
+    "evidence": [
+      "No suspect family has coherent dominant evidence; signals are weak and mixed."
+    ],
+    "next_checks": [
+      "Collect focused instrumentation and re-run a controlled workload."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "downstream_stage_dominates",
+      "confidence": "low",
+      "evidence": [
+        "Minor stage hints are present but not dominant."
+      ]
+    }
+  ]
+}

--- a/validation/diagnostics/corpus/truncated-artifact-adversarial.json
+++ b/validation/diagnostics/corpus/truncated-artifact-adversarial.json
@@ -1,0 +1,24 @@
+{
+  "warnings": [
+    "Artifact is truncated: partial records/dropped collector events detected."
+  ],
+  "primary_suspect": {
+    "kind": "downstream_stage_dominates",
+    "confidence": "medium",
+    "evidence": [
+      "Downstream stage evidence appears strong, but artifact truncation means evidence is partial."
+    ],
+    "next_checks": [
+      "Re-run with larger capture limits and inspect collector drop counters."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "application_queue_saturation",
+      "confidence": "low",
+      "evidence": [
+        "Partial artifact may hide queue-side contribution."
+      ]
+    }
+  ]
+}

--- a/validation/diagnostics/corpus/weak-blocking-strong-downstream.json
+++ b/validation/diagnostics/corpus/weak-blocking-strong-downstream.json
@@ -1,0 +1,23 @@
+{
+  "warnings": [],
+  "primary_suspect": {
+    "kind": "downstream_stage_dominates",
+    "confidence": "high",
+    "evidence": [
+      "Stage inventory_rpc has the largest p95 and tail share contribution.",
+      "Blocking queue depth hints are weak and non-dominant."
+    ],
+    "next_checks": [
+      "Inspect downstream dependency latency and retry behavior for inventory_rpc."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "blocking_pool_pressure",
+      "confidence": "low",
+      "evidence": [
+        "Weak blocking queue depth signal appears but does not dominate."
+      ]
+    }
+  ]
+}

--- a/validation/diagnostics/latest/scorecard.md
+++ b/validation/diagnostics/latest/scorecard.md
@@ -1,15 +1,17 @@
-# Diagnostic validation scorecard (initial)
+# Diagnostic validation scorecard (deterministic)
 
 | Area | Status | Notes |
 |---|---|---|
-| queue saturation | Initial deterministic evidence | queue before/sample + mixed/cold-start/db-pool support. |
-| downstream dominance | Initial deterministic evidence | downstream before/after/sample + retry/shared-lock scenarios. |
-| db/pool wait | Partially validated | covered via db-pool scenario labels; broaden with non-demo corpora later. |
-| blocking-pool pressure | Initial deterministic evidence | blocking before/sample coverage included. |
-| executor pressure | Initial deterministic evidence | executor before/sample plus mixed coverage. |
-| mixed bottlenecks | Partially validated | mixed baseline + synthetic ambiguity case. |
-| insufficient evidence | Initial deterministic evidence | dedicated synthetic insufficient-evidence case. |
-| truncation handling | Partially validated | synthetic truncation warning case; add real truncated captures later. |
-| runtime overhead | Measured separately | see `docs/runtime-cost.md`. |
-| collector limits | Measured separately | see `docs/collector-limits.md`. |
+| low request count | Initial deterministic adversarial coverage | synthetic sparse-sample case enforces low-confidence insufficient-evidence fallback. |
+| missing queue instrumentation | Initial deterministic adversarial coverage | synthetic no-queue-events case requires warning and top-2 queue visibility. |
+| missing stage instrumentation | Initial deterministic adversarial coverage | synthetic no-stage-events case requires warning and top-2 downstream visibility. |
+| missing runtime snapshots | Initial deterministic adversarial coverage | synthetic runtime-missing case requires warning and bounded confidence. |
+| missing optional runtime fields | Initial deterministic adversarial coverage | synthetic partial-runtime-fields case requires warning and conservative confidence. |
+| truncation / partial artifacts | Initial deterministic adversarial coverage | synthetic truncation case requires warning, bounded confidence, and rerun next checks. |
+| weak blocking vs strong downstream | Initial deterministic adversarial coverage | synthetic mixed-signal case keeps downstream as clear top-1 with blocking as secondary. |
+| blocking-correlated stage | Initial deterministic adversarial coverage | synthetic mixed-signal case keeps blocking as top-1 with downstream visible in top-2. |
+| noise-only workload | Initial deterministic adversarial coverage | synthetic low-signal case enforces insufficient-evidence + low confidence. |
+| high latency + missing explanatory instrumentation | Initial deterministic adversarial coverage | synthetic case enforces insufficient-evidence with instrumentation-focused next checks. |
 | real service validation | Planned | add curated real-service anonymized artifacts. |
+
+These adversarial rows are deterministic synthetic validation coverage, not real service validation.

--- a/validation/diagnostics/manifest.json
+++ b/validation/diagnostics/manifest.json
@@ -707,6 +707,319 @@
         "downstream_stage_dominates"
       ],
       "must_include_next_checks": []
+    },
+    {
+      "id": "low_request_count",
+      "artifact": "corpus/low-request-count.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "insufficient_evidence",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "sparse-sample"
+      ],
+      "must_include_evidence": [
+        "too few requests"
+      ],
+      "must_include_next_checks": [
+        "re-run with enough requests",
+        "enable queue wait/depth"
+      ],
+      "expected_warnings": [
+        "low request count"
+      ],
+      "allowed_warnings": [],
+      "top1_required": true,
+      "required_top2": [
+        "insufficient_evidence"
+      ],
+      "acceptable_primary": [
+        "insufficient_evidence"
+      ],
+      "max_primary_confidence": "low",
+      "notes": "Synthetic sparse-sample case ensures low-confidence insufficient-evidence fallback when request count is too small."
+    },
+    {
+      "id": "no_queue_events",
+      "artifact": "corpus/no-queue-events.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "downstream_stage_dominates",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "missing-queue"
+      ],
+      "must_include_evidence": [
+        "stage checkout_db dominates",
+        "no queue evidence"
+      ],
+      "must_include_next_checks": [
+        "enable queue wait/depth"
+      ],
+      "expected_warnings": [
+        "queue instrumentation missing"
+      ],
+      "allowed_warnings": [],
+      "top1_required": false,
+      "required_top2": [
+        "downstream_stage_dominates",
+        "application_queue_saturation"
+      ],
+      "acceptable_primary": [
+        "downstream_stage_dominates"
+      ],
+      "max_primary_confidence": "medium",
+      "notes": "Synthetic missing-queue instrumentation case: downstream appears primary but queue saturation remains plausible and must stay visible in top-2."
+    },
+    {
+      "id": "no_stage_events",
+      "artifact": "corpus/no-stage-events.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "application_queue_saturation",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "missing-stage"
+      ],
+      "must_include_evidence": [
+        "queue wait dominates",
+        "no stage evidence"
+      ],
+      "must_include_next_checks": [
+        "enable stage instrumentation"
+      ],
+      "expected_warnings": [
+        "stage instrumentation missing"
+      ],
+      "allowed_warnings": [],
+      "top1_required": false,
+      "required_top2": [
+        "application_queue_saturation",
+        "downstream_stage_dominates"
+      ],
+      "acceptable_primary": [
+        "application_queue_saturation"
+      ],
+      "max_primary_confidence": "medium",
+      "notes": "Synthetic missing-stage instrumentation case: queue appears primary but downstream remains plausible and must stay top-2."
+    },
+    {
+      "id": "no_runtime_snapshots",
+      "artifact": "corpus/no-runtime-snapshots.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "executor_pressure_suspected",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "missing-runtime"
+      ],
+      "must_include_evidence": [
+        "runtime snapshots are missing"
+      ],
+      "must_include_next_checks": [
+        "enable runtime sampling"
+      ],
+      "expected_warnings": [
+        "runtime snapshots are missing"
+      ],
+      "allowed_warnings": [],
+      "top1_required": false,
+      "required_top2": [
+        "executor_pressure_suspected",
+        "blocking_pool_pressure"
+      ],
+      "acceptable_primary": [
+        "executor_pressure_suspected",
+        "blocking_pool_pressure"
+      ],
+      "max_primary_confidence": "medium",
+      "notes": "Synthetic runtime-missing case ensures executor vs blocking ambiguity remains visible with bounded confidence."
+    },
+    {
+      "id": "missing_optional_runtime_fields",
+      "artifact": "corpus/missing-optional-runtime-fields.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "blocking_pool_pressure",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "partial-runtime"
+      ],
+      "must_include_evidence": [
+        "runtime snapshots are partial"
+      ],
+      "must_include_next_checks": [
+        "tokio_unstable",
+        "tokio-console"
+      ],
+      "expected_warnings": [
+        "optional runtime fields missing"
+      ],
+      "allowed_warnings": [],
+      "top1_required": false,
+      "required_top2": [
+        "blocking_pool_pressure",
+        "executor_pressure_suspected"
+      ],
+      "acceptable_primary": [
+        "blocking_pool_pressure",
+        "executor_pressure_suspected"
+      ],
+      "max_primary_confidence": "medium",
+      "notes": "Synthetic partial-runtime-fields case validates warnings and conservative confidence when optional runtime metrics are unavailable."
+    },
+    {
+      "id": "truncated_artifact_adversarial",
+      "artifact": "corpus/truncated-artifact-adversarial.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "downstream_stage_dominates",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "truncation"
+      ],
+      "must_include_evidence": [
+        "artifact truncation means evidence is partial"
+      ],
+      "must_include_next_checks": [
+        "larger capture limits",
+        "drop counters"
+      ],
+      "expected_warnings": [
+        "artifact is truncated"
+      ],
+      "allowed_warnings": [],
+      "top1_required": false,
+      "required_top2": [
+        "downstream_stage_dominates",
+        "application_queue_saturation"
+      ],
+      "acceptable_primary": [
+        "downstream_stage_dominates"
+      ],
+      "max_primary_confidence": "medium",
+      "notes": "Synthetic truncation case ensures partial artifacts produce truncation warnings and capped confidence while retaining plausible top-2 suspects."
+    },
+    {
+      "id": "weak_blocking_strong_downstream",
+      "artifact": "corpus/weak-blocking-strong-downstream.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "downstream_stage_dominates",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "mixed",
+        "downstream"
+      ],
+      "must_include_evidence": [
+        "largest p95 and tail share contribution",
+        "blocking queue depth hints are weak"
+      ],
+      "must_include_next_checks": [
+        "inspect downstream dependency"
+      ],
+      "expected_warnings": [],
+      "allowed_warnings": [],
+      "top1_required": true,
+      "required_top2": [
+        "downstream_stage_dominates"
+      ],
+      "acceptable_primary": [
+        "downstream_stage_dominates"
+      ],
+      "max_primary_confidence": "high",
+      "notes": "Synthetic mixed-signal case where strong downstream evidence should outrank weak blocking hints."
+    },
+    {
+      "id": "blocking_correlated_stage",
+      "artifact": "corpus/blocking-correlated-stage.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "blocking_pool_pressure",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "mixed",
+        "blocking"
+      ],
+      "must_include_evidence": [
+        "blocking queue depth remains elevated",
+        "correlated with blocking callsites"
+      ],
+      "must_include_next_checks": [
+        "audit spawn_blocking"
+      ],
+      "expected_warnings": [],
+      "allowed_warnings": [],
+      "top1_required": true,
+      "required_top2": [
+        "blocking_pool_pressure",
+        "downstream_stage_dominates"
+      ],
+      "acceptable_primary": [
+        "blocking_pool_pressure"
+      ],
+      "max_primary_confidence": "high",
+      "notes": "Synthetic adversarial case where stage latency is blocking-correlated, so blocking pressure should win while downstream remains visible."
+    },
+    {
+      "id": "noise_only_workload",
+      "artifact": "corpus/noise-only-workload.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "insufficient_evidence",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "noise"
+      ],
+      "must_include_evidence": [
+        "no suspect family has coherent dominant evidence"
+      ],
+      "must_include_next_checks": [
+        "controlled workload"
+      ],
+      "expected_warnings": [
+        "no dominant signal"
+      ],
+      "allowed_warnings": [],
+      "top1_required": true,
+      "required_top2": [
+        "insufficient_evidence"
+      ],
+      "acceptable_primary": [
+        "insufficient_evidence"
+      ],
+      "max_primary_confidence": "low",
+      "notes": "Synthetic low-signal noise case ensures conservative insufficient-evidence classification with low confidence."
+    },
+    {
+      "id": "high_latency_missing_instrumentation",
+      "artifact": "corpus/high-latency-missing-instrumentation.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "insufficient_evidence",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "missing-instrumentation"
+      ],
+      "must_include_evidence": [
+        "latency is high, but explanatory queue, stage, and runtime instrumentation is insufficient"
+      ],
+      "must_include_next_checks": [
+        "enable queue, stage, and runtime instrumentation"
+      ],
+      "expected_warnings": [
+        "high latency observed but queue/stage/runtime instrumentation is missing"
+      ],
+      "allowed_warnings": [],
+      "top1_required": true,
+      "required_top2": [
+        "insufficient_evidence"
+      ],
+      "acceptable_primary": [
+        "insufficient_evidence"
+      ],
+      "max_primary_confidence": "low",
+      "notes": "Synthetic high-latency case validates that high latency alone does not justify overconfident specific suspects without explanatory instrumentation."
     }
   ],
   "schema_version": 1


### PR DESCRIPTION
### Motivation
- Improve deterministic validation coverage with adversarial/negative cases that exercise sparse, partial, truncated, noisy, and mixed-signal captures so the benchmark validates conservative triage behavior. 
- Ensure the analyzer remains humble on limited or missing instrumentation by capping allowed primary confidence for selected synthetic cases. 
- Complement the existing deterministic corpus (PR 334) with small hand-readable `synthetic_analysis_report` fixtures that protect against overconfident, brittle classifications without changing analyzer logic.

### Description
- Added 10 synthetic adversarial fixtures under `validation/diagnostics/corpus/` covering low-request-count, missing-queue, missing-stage, missing runtime snapshots, missing optional runtime fields, truncated artifact, weak-blocking vs strong-downstream, blocking-correlated-stage, noise-only workload, and high-latency-with-missing-instrumentation. 
- Extended `validation/diagnostics/manifest.json` entries for the new cases and introduced the optional per-case `max_primary_confidence` field (allowed values `low|medium|high|very_high`) with notes, required evidence/next-check substrings, and expected warnings. 
- Updated `scripts/diagnostic_benchmark.py` to validate `max_primary_confidence`, enforce an ordered confidence ceiling per case, include per-case failure fields (`confidence_ceiling_ok`, `max_primary_confidence`, `primary_confidence`), and emit aggregate metrics: `confidence_ceiling_cases`, `confidence_ceiling_passed_cases`, and `confidence_ceiling_pass_rate`. 
- Expanded `scripts/tests/test_diagnostic_benchmark.py` to test manifest validation for `max_primary_confidence`, to exercise pass/fail semantics for confidence ceilings, and to update expected metrics shape and failed-case fields. 
- Updated validation docs and scorecard (`validation/diagnostics/README.md`, `docs/diagnostic-validation.md`, `VALIDATION.md`, `validation/diagnostics/latest/scorecard.md`) to document negative/adversarial coverage and the humility / confidence-ceiling checks. 
- No analyzer behavior, Rust code, or new dependencies were introduced; this change only augments validation fixtures, manifest schema usage, benchmark logic, tests, and docs.

### Testing
- `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json` — ran successfully (printed metrics; `failed_case_count=0`).
- `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --output target/diagnostic-benchmark.json` — ran successfully and wrote JSON output.
- `python3 -m unittest scripts.tests.test_diagnostic_benchmark` — all tests passed after changes (OK).
- `python3 scripts/validate_docs_contracts.py` — docs contract checks passed (OK).
- `python3 -m unittest scripts.tests.test_validate_docs_contracts` — docs contract unit tests passed (OK).
- `python3 scripts/check_demo_fixture_drift.py --profile dev` — demo fixture drift check passed (OK).
- `cargo fmt --check` — passed (OK).
- `cargo clippy --workspace --all-targets -- -D warnings` — passed (OK).
- `cargo test --workspace` — all Rust tests passed (OK).

Limitations: the new fixtures are synthetic adversarial report-shaped artifacts for deterministic validation and are not a replacement for analyzer-generated adversarial captures or repeated-run statistical validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f79ec02ae4833090944ea39fec5cd6)