### PR TITLE
Add adversarial diagnostic validation cases and confidence-ceiling checks

### DIFF
--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -6,14 +6,15 @@
 ## What this PR establishes
 This PR introduces an initial deterministic validation corpus for controlled Tokio workload fixtures. The corpus and benchmark validate bounded diagnostic behavior on committed fixtures, not universal production behavior.
 
-## Initial deterministic checks
+## Deterministic checks
 The deterministic benchmark validates:
 - evidence-ranked suspect correctness against corpus labels
 - required top-2 visibility (`required_top2` appears in primary or first secondary)
 - warning expectations (`expected_warnings` required; unexpected warnings rejected unless explicitly allowed)
 - required evidence substrings
+- case-level confidence ceilings (`max_primary_confidence`) for sparse/missing/truncated/mixed evidence humility checks
 
-Next-check substring validation is schema-supported in the manifest (`must_include_next_checks`) but is not currently gated by the initial corpus because no current case requires next checks.
+The corpus now includes deterministic adversarial validation that checks sparse, missing, truncated, or mixed evidence is warned about and does not produce overconfident unsupported classifications.
 
 ## What this does **not** validate
 - root-cause proof from one run

--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -28,6 +28,14 @@ The scorecard includes confidence-bucket accuracy summaries (low/medium/high buc
 - `expected_warnings` substrings are required.
 - observed warnings are allowed only if they match `expected_warnings` or `allowed_warnings`.
 
+## Negative and adversarial validation
+The corpus includes deterministic synthetic adversarial cases for sparse samples, missing instrumentation, truncated artifacts, and mixed-signal workloads. These cases validate triage humility and evidence-ranked suspect visibility under partial data.
+
+## Confidence ceilings (`max_primary_confidence`)
+Case-level confidence ceilings enforce conservative confidence behavior for conditions where data is sparse, missing, truncated, noisy, or intentionally ambiguous. A case fails if primary confidence exceeds its configured ceiling.
+
+This check validates humility in diagnosis ranking behavior. It does not claim calibrated truth probability.
+
 ## Insufficient-evidence validation
 The corpus includes insufficient-evidence scenarios to validate conservative fallback behavior and warning handling when signal is limited.
 

--- a/scripts/diagnostic_benchmark.py
+++ b/scripts/diagnostic_benchmark.py
@@ -12,6 +12,7 @@ ALLOWED_GROUND_TRUTH = {
     "insufficient_evidence",
 }
 CONF_HIGH = {"high", "very_high"}
+CONFIDENCE_ORDER = {"low": 0, "medium": 1, "high": 2, "very_high": 3}
 
 
 def load_json(path):
@@ -70,6 +71,12 @@ def validate_manifest(manifest):
             raise ValueError(f"top1_required must be a bool for {cid}")
         if not isinstance(case["notes"], str) or not case["notes"].strip():
             raise ValueError(f"notes must be a non-empty string for {cid}")
+        if "max_primary_confidence" in case:
+            ceiling = case["max_primary_confidence"]
+            if not isinstance(ceiling, str):
+                raise ValueError(f"max_primary_confidence must be a string for {cid}")
+            if ceiling not in CONFIDENCE_ORDER:
+                raise ValueError(f"max_primary_confidence must be one of low/medium/high/very_high for {cid}")
 
 
 def confidence_bucket(conf):
@@ -154,6 +161,8 @@ def run(manifest_path, min_top1, min_top2, max_high_confidence_wrong):
     next_check_required_cases = 0
     next_check_passed_cases = 0
     next_check_presence_cases = 0
+    confidence_ceiling_cases = 0
+    confidence_ceiling_passed_cases = 0
 
     for case in manifest["cases"]:
         report = load_json(root / case["artifact"])
@@ -186,14 +195,21 @@ def run(manifest_path, min_top1, min_top2, max_high_confidence_wrong):
                 next_check_passed_cases += 1
         if ext["next_checks"]:
             next_check_presence_cases += 1
+        max_primary_confidence = case.get("max_primary_confidence")
+        confidence_ceiling_ok = True
+        if max_primary_confidence is not None:
+            confidence_ceiling_cases += 1
+            confidence_ceiling_ok = CONFIDENCE_ORDER[ext["primary_confidence"]] <= CONFIDENCE_ORDER[max_primary_confidence]
+            if confidence_ceiling_ok:
+                confidence_ceiling_passed_cases += 1
 
         unexpected = [w for w in ext["warnings"] if not any(exp.lower() in w.lower() for exp in (case["expected_warnings"] + case["allowed_warnings"]))]
         missing_expected = [exp for exp in case["expected_warnings"] if not any(exp.lower() in w.lower() for w in ext["warnings"])]
         unexpected_warning_count += len(unexpected)
         missing_expected_warning_count += len(missing_expected)
 
-        case_failed = (not top2_ok) or (case["top1_required"] and not top1_ok) or (not ev_ok) or (not next_check_ok) or bool(unexpected) or bool(missing_expected)
-        row = {"id": case["id"], "top1_ok": top1_ok, "top2_ok": top2_ok, "evidence_ok": ev_ok, "next_check_ok": next_check_ok, "unexpected_warnings": unexpected, "missing_expected_warnings": missing_expected}
+        case_failed = (not top2_ok) or (case["top1_required"] and not top1_ok) or (not ev_ok) or (not next_check_ok) or (not confidence_ceiling_ok) or bool(unexpected) or bool(missing_expected)
+        row = {"id": case["id"], "top1_ok": top1_ok, "top2_ok": top2_ok, "evidence_ok": ev_ok, "next_check_ok": next_check_ok, "confidence_ceiling_ok": confidence_ceiling_ok, "max_primary_confidence": max_primary_confidence, "primary_confidence": ext["primary_confidence"], "unexpected_warnings": unexpected, "missing_expected_warnings": missing_expected}
         results.append(row)
         if case_failed:
             failed_cases.append({**row, "top1_required": case["top1_required"]})
@@ -215,6 +231,9 @@ def run(manifest_path, min_top1, min_top2, max_high_confidence_wrong):
         "next_check_passed_cases": next_check_passed_cases,
         "next_check_presence_rate": (next_check_presence_cases / total) if total else 0.0,
         "next_check_pass_rate": (next_check_passed_cases / next_check_required_cases) if next_check_required_cases else None,
+        "confidence_ceiling_cases": confidence_ceiling_cases,
+        "confidence_ceiling_passed_cases": confidence_ceiling_passed_cases,
+        "confidence_ceiling_pass_rate": (confidence_ceiling_passed_cases / confidence_ceiling_cases) if confidence_ceiling_cases else None,
         "unexpected_warning_count": unexpected_warning_count,
         "missing_expected_warning_count": missing_expected_warning_count,
         "failed_cases": failed_cases,
@@ -257,6 +276,11 @@ def main():
     print(f"top2_recall={metrics['top2_recall']:.3f}")
     print(f"high_confidence_wrong_count={metrics['high_confidence_wrong_count']}")
     print(f"required_evidence_pass_rate={metrics['required_evidence_pass_rate']:.3f}")
+    confidence_ceiling_pass_rate = metrics["confidence_ceiling_pass_rate"]
+    confidence_ceiling_pass_rate_text = "n/a" if confidence_ceiling_pass_rate is None else f"{confidence_ceiling_pass_rate:.3f}"
+    print(f"confidence_ceiling_cases={metrics['confidence_ceiling_cases']}")
+    print(f"confidence_ceiling_passed_cases={metrics['confidence_ceiling_passed_cases']}")
+    print(f"confidence_ceiling_pass_rate={confidence_ceiling_pass_rate_text}")
     print(f"unexpected_warning_count={metrics['unexpected_warning_count']}")
     print(f"missing_expected_warning_count={metrics['missing_expected_warning_count']}")
     print(f"next_check_required_cases={metrics['next_check_required_cases']}")

--- a/scripts/tests/test_diagnostic_benchmark.py
+++ b/scripts/tests/test_diagnostic_benchmark.py
@@ -124,6 +124,14 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
             db.validate_manifest(self.make_manifest(self.make_case(top1_required="yes")))
         with self.assertRaisesRegex(ValueError, "notes"):
             db.validate_manifest(self.make_manifest(self.make_case(notes="")))
+    def test_manifest_max_primary_confidence_rules(self):
+        db.validate_manifest(self.make_manifest(self.make_case()))
+        for allowed in ["low", "medium", "high", "very_high"]:
+            db.validate_manifest(self.make_manifest(self.make_case(max_primary_confidence=allowed)))
+        with self.assertRaisesRegex(ValueError, "max_primary_confidence must be one of"):
+            db.validate_manifest(self.make_manifest(self.make_case(max_primary_confidence="extreme")))
+        with self.assertRaisesRegex(ValueError, "max_primary_confidence must be a string"):
+            db.validate_manifest(self.make_manifest(self.make_case(max_primary_confidence=1)))
 
     # Report validation tests
     def test_report_missing_primary_fails(self):
@@ -243,8 +251,27 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
         metrics, _ = self.run_single_case(case, valid_report(primary_kind="blocking_pool_pressure", warnings=[]))
         self.assertEqual(len(metrics["failed_cases"]), 1)
         row = metrics["failed_cases"][0]
-        for field in ["id", "top1_ok", "top2_ok", "evidence_ok", "next_check_ok", "unexpected_warnings", "missing_expected_warnings", "top1_required"]:
+        for field in ["id", "top1_ok", "top2_ok", "evidence_ok", "next_check_ok", "confidence_ceiling_ok", "max_primary_confidence", "primary_confidence", "unexpected_warnings", "missing_expected_warnings", "top1_required"]:
             self.assertIn(field, row)
+    def test_confidence_ceiling_semantics_and_metrics(self):
+        base_case = self.make_case(max_primary_confidence="medium")
+        metrics, failures = self.run_single_case(base_case, valid_report(confidence="medium"))
+        self.assertFalse(failures)
+        self.assertEqual(metrics["confidence_ceiling_cases"], 1)
+        self.assertEqual(metrics["confidence_ceiling_passed_cases"], 1)
+        self.assertEqual(metrics["confidence_ceiling_pass_rate"], 1.0)
+
+        metrics, failures = self.run_single_case(base_case, valid_report(confidence="low"))
+        self.assertFalse(failures)
+        self.assertEqual(metrics["confidence_ceiling_passed_cases"], 1)
+
+        metrics, failures = self.run_single_case(base_case, valid_report(confidence="high"))
+        self.assertTrue(failures)
+        self.assertEqual(metrics["confidence_ceiling_passed_cases"], 0)
+        row = metrics["failed_cases"][0]
+        self.assertFalse(row["confidence_ceiling_ok"])
+        self.assertEqual(row["max_primary_confidence"], "medium")
+        self.assertEqual(row["primary_confidence"], "high")
 
     # Threshold and output/path tests
     def test_threshold_failures(self):
@@ -274,7 +301,8 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
                 "total_cases", "top1_accuracy", "top2_recall", "high_confidence_wrong_count",
                 "per_ground_truth_counts", "confusion_matrix", "confidence_bucket_accuracy",
                 "required_evidence_pass_rate", "next_check_required_cases", "next_check_passed_cases",
-                "next_check_presence_rate", "next_check_pass_rate", "unexpected_warning_count",
+                "next_check_presence_rate", "next_check_pass_rate", "confidence_ceiling_cases",
+                "confidence_ceiling_passed_cases", "confidence_ceiling_pass_rate", "unexpected_warning_count",
                 "missing_expected_warning_count", "failed_cases",
             }
             self.assertEqual(set(metrics.keys()), expected_keys)

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -15,10 +15,11 @@ Demos teach; validation measures.
 - `required_top2`: diagnosis kinds that must appear in primary or first secondary suspect. Usually `[ground_truth]`. Must include `ground_truth`.
 - `acceptable_primary`: diagnosis kinds acceptable as primary for mixed/ambiguous interpretation. Must include `ground_truth`. This does **not** satisfy `required_top2` by itself.
 - `top1_required`: when `true`, primary kind must equal `ground_truth`.
+- `max_primary_confidence`: optional confidence ceiling for primary suspect (`low|medium|high|very_high`).
 - `must_include_evidence`: evidence substrings that must appear in primary or secondary evidence.
 - `must_include_next_checks`: next-check substrings that must appear when required by a case. Schema-supported; current initial corpus has no required next-check cases.
 - `expected_warnings`: warning substrings that must appear.
-- `allowed_warnings`: warning substrings that may appear in addition to expected warnings.
+- `allowed_warnings`: warning substrings that may appear in addition to expected warnings (tolerated extras only).
 - `notes`: workload-intent note explaining why labels are set.
 - `tags`: non-empty string tags for grouping/filtering.
 
@@ -30,6 +31,9 @@ Demos teach; validation measures.
   - `acceptable_primary` = tolerated primary classification for ambiguity handling/high-confidence-wrong interpretation.
 - Do not use wildcard warning allowlists (`"*"` is invalid).
 - Keep synthetic fixtures small, hand-readable, and explicitly scoped to gaps.
+- Use `max_primary_confidence` for humility checks in sparse-sample, missing-instrumentation, truncation, noise-only, or close mixed-signal cases.
+- Confidence ceilings validate conservative triage behavior, not truth probabilities.
+- Synthetic fixtures are report-shaped adversarial coverage artifacts, not substitutes for analyzer-generated captures.
 
 ## Running the benchmark
 

--- a/validation/diagnostics/corpus/blocking-correlated-stage.json
+++ b/validation/diagnostics/corpus/blocking-correlated-stage.json
@@ -1,0 +1,23 @@
+{
+  "warnings": [],
+  "primary_suspect": {
+    "kind": "blocking_pool_pressure",
+    "confidence": "high",
+    "evidence": [
+      "Blocking queue depth remains elevated through the tail window.",
+      "Dominant stage latency is strongly correlated with blocking callsites."
+    ],
+    "next_checks": [
+      "Audit spawn_blocking and other blocking callsites in dominant stage path."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "downstream_stage_dominates",
+      "confidence": "medium",
+      "evidence": [
+        "Stage latency appears high but may be a blocking-correlated symptom."
+      ]
+    }
+  ]
+}

--- a/validation/diagnostics/corpus/high-latency-missing-instrumentation.json
+++ b/validation/diagnostics/corpus/high-latency-missing-instrumentation.json
@@ -1,0 +1,25 @@
+{
+  "warnings": [
+    "High latency observed but queue/stage/runtime instrumentation is incomplete."
+  ],
+  "primary_suspect": {
+    "kind": "insufficient_evidence",
+    "confidence": "low",
+    "evidence": [
+      "High p99 latency is present, but explanatory instrumentation is missing."
+    ],
+    "next_checks": [
+      "Enable queue, stage, and runtime instrumentation before assigning a bottleneck family.",
+      "Rerun capture with complete instrumentation coverage."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "downstream_stage_dominates",
+      "confidence": "low",
+      "evidence": [
+        "Downstream dominance is plausible but unsupported without stage/runtime signals."
+      ]
+    }
+  ]
+}

--- a/validation/diagnostics/corpus/low-request-count.json
+++ b/validation/diagnostics/corpus/low-request-count.json
@@ -1,0 +1,28 @@
+{
+  "warnings": [
+    "Low request count: tail estimates may be unstable."
+  ],
+  "primary_suspect": {
+    "kind": "insufficient_evidence",
+    "confidence": "low",
+    "evidence": [
+      "Only 14 requests observed; p95/p99 estimates are unstable for triage ranking."
+    ],
+    "next_checks": [
+      "Rerun with enough requests to stabilize tail estimates.",
+      "Enable queue and stage instrumentation during the rerun."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "application_queue_saturation",
+      "confidence": "low",
+      "evidence": [
+        "Queue contribution appears elevated in sparse samples."
+      ],
+      "next_checks": [
+        "Collect queue wait and depth over a larger workload window."
+      ]
+    }
+  ]
+}

--- a/validation/diagnostics/corpus/missing-optional-runtime-fields.json
+++ b/validation/diagnostics/corpus/missing-optional-runtime-fields.json
@@ -1,0 +1,26 @@
+{
+  "warnings": [
+    "Optional runtime fields missing: blocking_queue_depth/local_queue_depth unavailable."
+  ],
+  "primary_suspect": {
+    "kind": "blocking_pool_pressure",
+    "confidence": "medium",
+    "evidence": [
+      "Runtime snapshots exist but optional runtime fields are partial.",
+      "Blocking indicators are present but not complete for full separation."
+    ],
+    "next_checks": [
+      "Use available runtime metrics and corroborate with tokio-console/tokio-metrics.",
+      "Enable tokio_unstable where appropriate to capture optional runtime fields."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "executor_pressure_suspected",
+      "confidence": "low",
+      "evidence": [
+        "Missing local_queue_depth limits executor-vs-blocking confidence."
+      ]
+    }
+  ]
+}

--- a/validation/diagnostics/corpus/no-queue-events.json
+++ b/validation/diagnostics/corpus/no-queue-events.json
@@ -1,0 +1,26 @@
+{
+  "warnings": [
+    "Queue instrumentation missing: queue saturation cannot be excluded."
+  ],
+  "primary_suspect": {
+    "kind": "downstream_stage_dominates",
+    "confidence": "medium",
+    "evidence": [
+      "Stage process_payment dominates tail latency contribution.",
+      "No queue wait/depth events were captured."
+    ],
+    "next_checks": [
+      "Enable queue wait/depth instrumentation to confirm queue contribution.",
+      "Inspect downstream dependency latency distribution."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "application_queue_saturation",
+      "confidence": "low",
+      "evidence": [
+        "Missing queue instrumentation leaves queue saturation plausible."
+      ]
+    }
+  ]
+}

--- a/validation/diagnostics/corpus/no-runtime-snapshots.json
+++ b/validation/diagnostics/corpus/no-runtime-snapshots.json
@@ -1,0 +1,25 @@
+{
+  "warnings": [
+    "Runtime snapshots missing: executor and blocking separation is limited."
+  ],
+  "primary_suspect": {
+    "kind": "executor_pressure_suspected",
+    "confidence": "medium",
+    "evidence": [
+      "Request queueing aligns with executor pressure, but runtime snapshots are absent."
+    ],
+    "next_checks": [
+      "Enable runtime sampling snapshots.",
+      "Compare runtime queue depth and blocking queue depth in the same window."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "blocking_pool_pressure",
+      "confidence": "medium",
+      "evidence": [
+        "Without runtime snapshots, blocking pool pressure cannot be ruled out."
+      ]
+    }
+  ]
+}

--- a/validation/diagnostics/corpus/no-stage-events.json
+++ b/validation/diagnostics/corpus/no-stage-events.json
@@ -1,0 +1,26 @@
+{
+  "warnings": [
+    "Stage instrumentation missing: downstream stage dominance cannot be excluded."
+  ],
+  "primary_suspect": {
+    "kind": "application_queue_saturation",
+    "confidence": "medium",
+    "evidence": [
+      "Queue wait dominates captured request time.",
+      "No stage latency events were captured."
+    ],
+    "next_checks": [
+      "Enable stage instrumentation around major awaits.",
+      "Re-run to compare queue and stage contributions."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "downstream_stage_dominates",
+      "confidence": "low",
+      "evidence": [
+        "Missing stage data keeps downstream dominance plausible."
+      ]
+    }
+  ]
+}

--- a/validation/diagnostics/corpus/noise-only-workload.json
+++ b/validation/diagnostics/corpus/noise-only-workload.json
@@ -1,0 +1,26 @@
+{
+  "warnings": [
+    "No dominant signal detected; workload appears noisy with mixed low-signal indicators."
+  ],
+  "primary_suspect": {
+    "kind": "insufficient_evidence",
+    "confidence": "low",
+    "evidence": [
+      "No bottleneck family reaches dominant tail contribution.",
+      "Signals are weak and mixed across queue, stage, and runtime indicators."
+    ],
+    "next_checks": [
+      "Collect a more controlled workload with focused instrumentation.",
+      "Rerun with queue, stage, and runtime signals enabled together."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "executor_pressure_suspected",
+      "confidence": "low",
+      "evidence": [
+        "Executor pressure appears intermittently but without dominant evidence."
+      ]
+    }
+  ]
+}

--- a/validation/diagnostics/corpus/truncated-artifact-adversarial.json
+++ b/validation/diagnostics/corpus/truncated-artifact-adversarial.json
@@ -1,0 +1,26 @@
+{
+  "warnings": [
+    "Artifact appears truncated; records may be dropped or partial."
+  ],
+  "primary_suspect": {
+    "kind": "downstream_stage_dominates",
+    "confidence": "medium",
+    "evidence": [
+      "Downstream stage parse_order dominates observed tail in captured records.",
+      "Truncation warning indicates partial data for this capture."
+    ],
+    "next_checks": [
+      "Rerun with larger collector limits.",
+      "Check collector drop counters for dropped records."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "blocking_pool_pressure",
+      "confidence": "low",
+      "evidence": [
+        "Weak blocking hints appear but truncated data limits confidence."
+      ]
+    }
+  ]
+}

--- a/validation/diagnostics/corpus/weak-blocking-strong-downstream.json
+++ b/validation/diagnostics/corpus/weak-blocking-strong-downstream.json
@@ -1,0 +1,23 @@
+{
+  "warnings": [],
+  "primary_suspect": {
+    "kind": "downstream_stage_dominates",
+    "confidence": "high",
+    "evidence": [
+      "Stage fetch_inventory contributes most p95 tail time.",
+      "Blocking queue depth spikes are weak and brief relative to stage latency."
+    ],
+    "next_checks": [
+      "Inspect downstream dependency latency and saturation behavior."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "blocking_pool_pressure",
+      "confidence": "low",
+      "evidence": [
+        "Blocking hints are present but weaker than downstream stage evidence."
+      ]
+    }
+  ]
+}

--- a/validation/diagnostics/latest/scorecard.md
+++ b/validation/diagnostics/latest/scorecard.md
@@ -1,15 +1,18 @@
-# Diagnostic validation scorecard (initial)
+# Diagnostic validation scorecard (deterministic + adversarial)
 
 | Area | Status | Notes |
 |---|---|---|
-| queue saturation | Initial deterministic evidence | queue before/sample + mixed/cold-start/db-pool support. |
-| downstream dominance | Initial deterministic evidence | downstream before/after/sample + retry/shared-lock scenarios. |
+| queue saturation | Initial deterministic + adversarial coverage | includes no-stage-events and low-request humility checks. |
+| downstream dominance | Initial deterministic + adversarial coverage | includes no-queue-events and weak-blocking-vs-strong-downstream checks. |
 | db/pool wait | Partially validated | covered via db-pool scenario labels; broaden with non-demo corpora later. |
-| blocking-pool pressure | Initial deterministic evidence | blocking before/sample coverage included. |
-| executor pressure | Initial deterministic evidence | executor before/sample plus mixed coverage. |
-| mixed bottlenecks | Partially validated | mixed baseline + synthetic ambiguity case. |
-| insufficient evidence | Initial deterministic evidence | dedicated synthetic insufficient-evidence case. |
-| truncation handling | Partially validated | synthetic truncation warning case; add real truncated captures later. |
+| blocking-pool pressure | Initial deterministic + adversarial coverage | includes blocking-correlated-stage and partial-runtime-field checks. |
+| executor pressure | Initial deterministic + adversarial coverage | includes no-runtime-snapshots ambiguity checks. |
+| mixed bottlenecks | Initial deterministic adversarial coverage | explicit top-2 checks for mixed and misleading-signal fixtures. |
+| insufficient evidence | Initial deterministic adversarial coverage | low-request-count, noise-only, and high-latency-missing-instrumentation cases enforce low-confidence fallback. |
+| truncation handling | Initial deterministic adversarial coverage | truncated-artifact adversarial case enforces warning + confidence ceiling. |
+| missing instrumentation warnings | Initial deterministic adversarial coverage | queue/stage/runtime missing and optional-runtime-field warnings are explicitly checked. |
 | runtime overhead | Measured separately | see `docs/runtime-cost.md`. |
 | collector limits | Measured separately | see `docs/collector-limits.md`. |
 | real service validation | Planned | add curated real-service anonymized artifacts. |
+
+Deterministic synthetic adversarial cases validate benchmark/report contract behavior and humility checks; they are not real-service validation.

--- a/validation/diagnostics/manifest.json
+++ b/validation/diagnostics/manifest.json
@@ -707,6 +707,331 @@
         "downstream_stage_dominates"
       ],
       "must_include_next_checks": []
+    },
+    {
+      "id": "adversarial_low_request_count",
+      "artifact": "corpus/low-request-count.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "insufficient_evidence",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "sparse-sample"
+      ],
+      "must_include_evidence": [
+        "unstable",
+        "requests"
+      ],
+      "must_include_next_checks": [
+        "Rerun with enough requests",
+        "Enable queue and stage instrumentation"
+      ],
+      "expected_warnings": [
+        "Low request count"
+      ],
+      "allowed_warnings": [],
+      "top1_required": true,
+      "required_top2": [
+        "insufficient_evidence"
+      ],
+      "acceptable_primary": [
+        "insufficient_evidence"
+      ],
+      "max_primary_confidence": "low",
+      "notes": "Synthetic adversarial case for sparse sample humility: too few requests should force insufficient-evidence with low confidence."
+    },
+    {
+      "id": "adversarial_no_queue_events",
+      "artifact": "corpus/no-queue-events.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "downstream_stage_dominates",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "missing-queue"
+      ],
+      "must_include_evidence": [
+        "Stage",
+        "No queue"
+      ],
+      "must_include_next_checks": [
+        "Enable queue wait/depth instrumentation"
+      ],
+      "expected_warnings": [
+        "Queue instrumentation missing"
+      ],
+      "allowed_warnings": [],
+      "top1_required": false,
+      "required_top2": [
+        "downstream_stage_dominates",
+        "application_queue_saturation"
+      ],
+      "acceptable_primary": [
+        "downstream_stage_dominates",
+        "application_queue_saturation"
+      ],
+      "max_primary_confidence": "medium",
+      "notes": "Synthetic adversarial missing-queue case: downstream can lead, but queue saturation must remain visible in top-2 and confidence must stay conservative."
+    },
+    {
+      "id": "adversarial_no_stage_events",
+      "artifact": "corpus/no-stage-events.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "application_queue_saturation",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "missing-stage"
+      ],
+      "must_include_evidence": [
+        "Queue wait",
+        "No stage"
+      ],
+      "must_include_next_checks": [
+        "Enable stage instrumentation"
+      ],
+      "expected_warnings": [
+        "Stage instrumentation missing"
+      ],
+      "allowed_warnings": [],
+      "top1_required": false,
+      "required_top2": [
+        "application_queue_saturation",
+        "downstream_stage_dominates"
+      ],
+      "acceptable_primary": [
+        "application_queue_saturation",
+        "downstream_stage_dominates"
+      ],
+      "max_primary_confidence": "medium",
+      "notes": "Synthetic adversarial missing-stage case: queue may lead, but downstream dominance cannot be excluded without stage events."
+    },
+    {
+      "id": "adversarial_no_runtime_snapshots",
+      "artifact": "corpus/no-runtime-snapshots.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "executor_pressure_suspected",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "missing-runtime"
+      ],
+      "must_include_evidence": [
+        "runtime snapshots are absent"
+      ],
+      "must_include_next_checks": [
+        "Enable runtime sampling snapshots"
+      ],
+      "expected_warnings": [
+        "Runtime snapshots missing"
+      ],
+      "allowed_warnings": [],
+      "top1_required": false,
+      "required_top2": [
+        "executor_pressure_suspected",
+        "blocking_pool_pressure"
+      ],
+      "acceptable_primary": [
+        "executor_pressure_suspected",
+        "blocking_pool_pressure"
+      ],
+      "max_primary_confidence": "medium",
+      "notes": "Synthetic adversarial runtime-missing case: executor and blocking suspects should both remain visible with capped confidence."
+    },
+    {
+      "id": "adversarial_missing_optional_runtime_fields",
+      "artifact": "corpus/missing-optional-runtime-fields.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "blocking_pool_pressure",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "runtime-fields"
+      ],
+      "must_include_evidence": [
+        "optional runtime fields",
+        "partial"
+      ],
+      "must_include_next_checks": [
+        "tokio_unstable",
+        "tokio-console/tokio-metrics"
+      ],
+      "expected_warnings": [
+        "Optional runtime fields missing"
+      ],
+      "allowed_warnings": [],
+      "top1_required": false,
+      "required_top2": [
+        "blocking_pool_pressure",
+        "executor_pressure_suspected"
+      ],
+      "acceptable_primary": [
+        "blocking_pool_pressure",
+        "executor_pressure_suspected"
+      ],
+      "max_primary_confidence": "medium",
+      "notes": "Synthetic adversarial partial-runtime-fields case: optional Tokio fields missing should limit confidence while retaining plausible runtime suspects."
+    },
+    {
+      "id": "adversarial_truncated_artifact",
+      "artifact": "corpus/truncated-artifact-adversarial.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "downstream_stage_dominates",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "truncation",
+        "partial-data"
+      ],
+      "must_include_evidence": [
+        "Truncation warning",
+        "partial data"
+      ],
+      "must_include_next_checks": [
+        "larger collector limits",
+        "drop counters"
+      ],
+      "expected_warnings": [
+        "Artifact appears truncated"
+      ],
+      "allowed_warnings": [],
+      "top1_required": false,
+      "required_top2": [
+        "downstream_stage_dominates"
+      ],
+      "acceptable_primary": [
+        "downstream_stage_dominates",
+        "blocking_pool_pressure"
+      ],
+      "max_primary_confidence": "medium",
+      "notes": "Synthetic adversarial truncation case: plausible dominant stage signal is retained but confidence is capped and truncation follow-up is required."
+    },
+    {
+      "id": "adversarial_weak_blocking_strong_downstream",
+      "artifact": "corpus/weak-blocking-strong-downstream.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "downstream_stage_dominates",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "mixed",
+        "downstream",
+        "blocking"
+      ],
+      "must_include_evidence": [
+        "tail time",
+        "weak"
+      ],
+      "must_include_next_checks": [
+        "downstream dependency"
+      ],
+      "expected_warnings": [],
+      "allowed_warnings": [],
+      "top1_required": true,
+      "required_top2": [
+        "downstream_stage_dominates",
+        "blocking_pool_pressure"
+      ],
+      "acceptable_primary": [
+        "downstream_stage_dominates"
+      ],
+      "notes": "Synthetic adversarial mixed-signal case: strong downstream evidence should outrank weak blocking hints while keeping blocking visible in top-2."
+    },
+    {
+      "id": "adversarial_blocking_correlated_stage",
+      "artifact": "corpus/blocking-correlated-stage.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "blocking_pool_pressure",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "mixed",
+        "blocking",
+        "stage-correlation"
+      ],
+      "must_include_evidence": [
+        "Blocking queue depth",
+        "correlated"
+      ],
+      "must_include_next_checks": [
+        "spawn_blocking",
+        "blocking callsites"
+      ],
+      "expected_warnings": [],
+      "allowed_warnings": [],
+      "top1_required": true,
+      "required_top2": [
+        "blocking_pool_pressure",
+        "downstream_stage_dominates"
+      ],
+      "acceptable_primary": [
+        "blocking_pool_pressure"
+      ],
+      "notes": "Synthetic adversarial correlation case: stage latency is visible but blocking pressure should win when blocking correlation evidence is strong."
+    },
+    {
+      "id": "adversarial_noise_only_workload",
+      "artifact": "corpus/noise-only-workload.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "insufficient_evidence",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "noise",
+        "mixed-low-signal"
+      ],
+      "must_include_evidence": [
+        "No bottleneck family",
+        "weak and mixed"
+      ],
+      "must_include_next_checks": [
+        "controlled workload"
+      ],
+      "expected_warnings": [
+        "No dominant signal"
+      ],
+      "allowed_warnings": [],
+      "top1_required": true,
+      "required_top2": [
+        "insufficient_evidence"
+      ],
+      "acceptable_primary": [
+        "insufficient_evidence"
+      ],
+      "max_primary_confidence": "low",
+      "notes": "Synthetic adversarial noise-only case: mixed low-signal evidence should remain insufficient-evidence with low confidence."
+    },
+    {
+      "id": "adversarial_high_latency_missing_instrumentation",
+      "artifact": "corpus/high-latency-missing-instrumentation.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "insufficient_evidence",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "high-latency",
+        "missing-instrumentation"
+      ],
+      "must_include_evidence": [
+        "High p99 latency",
+        "instrumentation is missing"
+      ],
+      "must_include_next_checks": [
+        "Enable queue, stage, and runtime instrumentation"
+      ],
+      "expected_warnings": [
+        "High latency observed"
+      ],
+      "allowed_warnings": [],
+      "top1_required": true,
+      "required_top2": [
+        "insufficient_evidence"
+      ],
+      "acceptable_primary": [
+        "insufficient_evidence"
+      ],
+      "max_primary_confidence": "low",
+      "notes": "Synthetic adversarial high-latency-without-explanatory-signals case: latency alone should not force a specific high-confidence suspect."
     }
   ],
   "schema_version": 1


### PR DESCRIPTION
### Motivation
- Improve deterministic validation coverage with negative/adversarial cases that exercise sparse, partial, truncated, and mixed signals so the benchmark can enforce conservative triage behavior.
- Explicitly validate humility: sparse or missing instrumentation, truncated artifacts, and noise-only workloads must not yield overconfident specific suspects.
- Keep validation scoped to report-shaped fixtures and policy checks; do not change analyzer behavior or add dependencies.

### Description
- Added 10 small synthetic adversarial fixtures under `validation/diagnostics/corpus/` covering low-request-count, missing-queue, missing-stage, missing-runtime snapshots, missing optional runtime fields, truncated artifact, weak-blocking/strong-downstream, blocking-correlated-stage, noise-only workload, and high-latency-with-missing-instrumentation cases.
- Extended `validation/diagnostics/manifest.json` with corresponding adversarial entries including `max_primary_confidence` ceilings, tags, `must_include_evidence`, `must_include_next_checks`, `expected_warnings`, `required_top2`, and `acceptable_primary` as appropriate per case.
- Updated `scripts/diagnostic_benchmark.py` to validate `max_primary_confidence`, enforce an ordered confidence ceiling (`low < medium < high < very_high`), add per-case failure debug fields (`confidence_ceiling_ok`, `max_primary_confidence`, `primary_confidence`), and emit aggregate metrics (`confidence_ceiling_cases`, `confidence_ceiling_passed_cases`, `confidence_ceiling_pass_rate`).
- Expanded `scripts/tests/test_diagnostic_benchmark.py` to cover manifest validation of `max_primary_confidence`, pass/fail semantics for ceilings, failed-case debug fields, and the updated metrics shape.
- Updated validation docs and scorecard (`validation/diagnostics/README.md`, `docs/diagnostic-validation.md`, `VALIDATION.md`, and `validation/diagnostics/latest/scorecard.md`) to document adversarial validation and confidence-humility checks while preserving product framing: triage, evidence-ranked suspects, and next checks.
- No analyzer code or Rust behavior changed; no new dependencies were added.

### Testing
- Ran `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json` (initial run reported one per-case evidence check failure, manifest entry adjusted to match fixture semantics, re-run passed). ✅
- Ran `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --output target/diagnostic-benchmark.json` (passed and wrote JSON). ✅
- Ran `python3 -m unittest scripts.tests.test_diagnostic_benchmark` (all tests passed). ✅
- Ran `python3 scripts/validate_docs_contracts.py` (docs contract validation passed). ✅
- Ran `python3 -m unittest scripts.tests.test_validate_docs_contracts` (all tests passed). ✅
- Ran `python3 scripts/check_demo_fixture_drift.py --profile dev` (demo fixture drift check completed; fixtures up to date). ✅
- Ran `cargo fmt --check` (Rust format check passed). ✅
- Ran `cargo clippy --workspace --all-targets -- -D warnings` (lint completed without warnings). ✅
- Ran `cargo test --workspace` (all Rust unit/integration tests passed). ✅

Limitations
- Synthetic adversarial fixtures validate benchmark/report contract and humility checks and are not substitutes for analyzer-generated adversarial captures.
- Statistical/repeated-run validation, real truncated-collector captures, collector-limit integration, and runtime-overhead experiments remain future work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f79ec02ae4833090944ea39fec5cd6)