### PR TITLE
Add adversarial diagnostic validation cases and confidence ceilings

### DIFF
--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -6,14 +6,16 @@
 ## What this PR establishes
 This PR introduces an initial deterministic validation corpus for controlled Tokio workload fixtures. The corpus and benchmark validate bounded diagnostic behavior on committed fixtures, not universal production behavior.
 
-## Initial deterministic checks
+## Deterministic checks
 The deterministic benchmark validates:
 - evidence-ranked suspect correctness against corpus labels
 - required top-2 visibility (`required_top2` appears in primary or first secondary)
 - warning expectations (`expected_warnings` required; unexpected warnings rejected unless explicitly allowed)
 - required evidence substrings
+- required next-check substrings where configured
+- case-level confidence ceilings (`max_primary_confidence`) for humility checks in sparse/missing/truncated/mixed adversarial cases
 
-Next-check substring validation is schema-supported in the manifest (`must_include_next_checks`) but is not currently gated by the initial corpus because no current case requires next checks.
+Tailtriage validation now checks that sparse, missing, truncated, or mixed evidence is warned about and does not produce overconfident unsupported classifications.
 
 ## What this does **not** validate
 - root-cause proof from one run

--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -28,6 +28,12 @@ The scorecard includes confidence-bucket accuracy summaries (low/medium/high buc
 - `expected_warnings` substrings are required.
 - observed warnings are allowed only if they match `expected_warnings` or `allowed_warnings`.
 
+## Negative/adversarial validation
+The corpus includes deterministic synthetic adversarial cases for sparse samples, missing instrumentation, truncated artifacts, and mixed-signal ambiguity. These cases validate conservative triage behavior when evidence is partial or misleading.
+
+## Confidence ceilings (humility checks)
+Cases may set `max_primary_confidence` to cap allowed primary confidence (`low` to `very_high`). This checks humility semantics: sparse, missing, truncated, noisy, or ambiguous evidence should not produce overconfident specific suspects.
+
 ## Insufficient-evidence validation
 The corpus includes insufficient-evidence scenarios to validate conservative fallback behavior and warning handling when signal is limited.
 

--- a/scripts/diagnostic_benchmark.py
+++ b/scripts/diagnostic_benchmark.py
@@ -12,6 +12,7 @@ ALLOWED_GROUND_TRUTH = {
     "insufficient_evidence",
 }
 CONF_HIGH = {"high", "very_high"}
+CONF_ORDER = {"low": 0, "medium": 1, "high": 2, "very_high": 3}
 
 
 def load_json(path):
@@ -70,6 +71,12 @@ def validate_manifest(manifest):
             raise ValueError(f"top1_required must be a bool for {cid}")
         if not isinstance(case["notes"], str) or not case["notes"].strip():
             raise ValueError(f"notes must be a non-empty string for {cid}")
+        if "max_primary_confidence" in case:
+            ceiling = case["max_primary_confidence"]
+            if not isinstance(ceiling, str):
+                raise ValueError(f"max_primary_confidence must be a string for {cid}")
+            if ceiling not in CONF_ORDER:
+                raise ValueError(f"max_primary_confidence must be one of low/medium/high/very_high for {cid}")
 
 
 def confidence_bucket(conf):
@@ -154,6 +161,8 @@ def run(manifest_path, min_top1, min_top2, max_high_confidence_wrong):
     next_check_required_cases = 0
     next_check_passed_cases = 0
     next_check_presence_cases = 0
+    confidence_ceiling_cases = 0
+    confidence_ceiling_passed_cases = 0
 
     for case in manifest["cases"]:
         report = load_json(root / case["artifact"])
@@ -173,6 +182,13 @@ def run(manifest_path, min_top1, min_top2, max_high_confidence_wrong):
             conf_buckets[bucket]["correct"] += 1
         if ext["primary_confidence"] in CONF_HIGH and ext["top1"] not in case["acceptable_primary"]:
             high_conf_wrong += 1
+        confidence_ceiling_ok = True
+        max_primary_confidence = case.get("max_primary_confidence")
+        if max_primary_confidence is not None:
+            confidence_ceiling_cases += 1
+            confidence_ceiling_ok = CONF_ORDER[ext["primary_confidence"]] <= CONF_ORDER[max_primary_confidence]
+            if confidence_ceiling_ok:
+                confidence_ceiling_passed_cases += 1
 
         ev_ok = all(any(req.lower() in ev.lower() for ev in ext["evidence"]) for req in case["must_include_evidence"])
         evidence_pass += 1 if ev_ok else 0
@@ -192,8 +208,8 @@ def run(manifest_path, min_top1, min_top2, max_high_confidence_wrong):
         unexpected_warning_count += len(unexpected)
         missing_expected_warning_count += len(missing_expected)
 
-        case_failed = (not top2_ok) or (case["top1_required"] and not top1_ok) or (not ev_ok) or (not next_check_ok) or bool(unexpected) or bool(missing_expected)
-        row = {"id": case["id"], "top1_ok": top1_ok, "top2_ok": top2_ok, "evidence_ok": ev_ok, "next_check_ok": next_check_ok, "unexpected_warnings": unexpected, "missing_expected_warnings": missing_expected}
+        case_failed = (not top2_ok) or (case["top1_required"] and not top1_ok) or (not ev_ok) or (not next_check_ok) or (not confidence_ceiling_ok) or bool(unexpected) or bool(missing_expected)
+        row = {"id": case["id"], "top1_ok": top1_ok, "top2_ok": top2_ok, "evidence_ok": ev_ok, "next_check_ok": next_check_ok, "confidence_ceiling_ok": confidence_ceiling_ok, "max_primary_confidence": max_primary_confidence, "primary_confidence": ext["primary_confidence"], "unexpected_warnings": unexpected, "missing_expected_warnings": missing_expected}
         results.append(row)
         if case_failed:
             failed_cases.append({**row, "top1_required": case["top1_required"]})
@@ -215,6 +231,9 @@ def run(manifest_path, min_top1, min_top2, max_high_confidence_wrong):
         "next_check_passed_cases": next_check_passed_cases,
         "next_check_presence_rate": (next_check_presence_cases / total) if total else 0.0,
         "next_check_pass_rate": (next_check_passed_cases / next_check_required_cases) if next_check_required_cases else None,
+        "confidence_ceiling_cases": confidence_ceiling_cases,
+        "confidence_ceiling_passed_cases": confidence_ceiling_passed_cases,
+        "confidence_ceiling_pass_rate": (confidence_ceiling_passed_cases / confidence_ceiling_cases) if confidence_ceiling_cases else None,
         "unexpected_warning_count": unexpected_warning_count,
         "missing_expected_warning_count": missing_expected_warning_count,
         "failed_cases": failed_cases,
@@ -262,6 +281,11 @@ def main():
     print(f"next_check_required_cases={metrics['next_check_required_cases']}")
     print(f"next_check_pass_rate={next_check_pass_rate_text}")
     print(f"next_check_presence_rate={metrics['next_check_presence_rate']:.3f}")
+    confidence_ceiling_pass_rate = metrics["confidence_ceiling_pass_rate"]
+    confidence_ceiling_pass_rate_text = "n/a" if confidence_ceiling_pass_rate is None else f"{confidence_ceiling_pass_rate:.3f}"
+    print(f"confidence_ceiling_cases={metrics['confidence_ceiling_cases']}")
+    print(f"confidence_ceiling_passed_cases={metrics['confidence_ceiling_passed_cases']}")
+    print(f"confidence_ceiling_pass_rate={confidence_ceiling_pass_rate_text}")
     print(f"failed_case_count={len(metrics['failed_cases'])}")
 
     if failures:

--- a/scripts/tests/test_diagnostic_benchmark.py
+++ b/scripts/tests/test_diagnostic_benchmark.py
@@ -124,6 +124,15 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
             db.validate_manifest(self.make_manifest(self.make_case(top1_required="yes")))
         with self.assertRaisesRegex(ValueError, "notes"):
             db.validate_manifest(self.make_manifest(self.make_case(notes="")))
+    
+    def test_manifest_max_primary_confidence_rules(self):
+        db.validate_manifest(self.make_manifest(self.make_case()))
+        for value in ["low", "medium", "high", "very_high"]:
+            db.validate_manifest(self.make_manifest(self.make_case(max_primary_confidence=value)))
+        with self.assertRaisesRegex(ValueError, "max_primary_confidence must be one of"):
+            db.validate_manifest(self.make_manifest(self.make_case(max_primary_confidence="bad")))
+        with self.assertRaisesRegex(ValueError, "max_primary_confidence must be a string"):
+            db.validate_manifest(self.make_manifest(self.make_case(max_primary_confidence=1)))
 
     # Report validation tests
     def test_report_missing_primary_fails(self):
@@ -243,8 +252,29 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
         metrics, _ = self.run_single_case(case, valid_report(primary_kind="blocking_pool_pressure", warnings=[]))
         self.assertEqual(len(metrics["failed_cases"]), 1)
         row = metrics["failed_cases"][0]
-        for field in ["id", "top1_ok", "top2_ok", "evidence_ok", "next_check_ok", "unexpected_warnings", "missing_expected_warnings", "top1_required"]:
+        for field in ["id", "top1_ok", "top2_ok", "evidence_ok", "next_check_ok", "confidence_ceiling_ok", "max_primary_confidence", "primary_confidence", "unexpected_warnings", "missing_expected_warnings", "top1_required"]:
             self.assertIn(field, row)
+
+    def test_confidence_ceiling_pass_and_fail_behavior(self):
+        case = self.make_case(max_primary_confidence="medium")
+        metrics, failures = self.run_single_case(case, valid_report(confidence="medium"))
+        self.assertFalse(failures)
+        self.assertEqual(metrics["confidence_ceiling_cases"], 1)
+        self.assertEqual(metrics["confidence_ceiling_passed_cases"], 1)
+        self.assertEqual(metrics["confidence_ceiling_pass_rate"], 1.0)
+
+        metrics, failures = self.run_single_case(case, valid_report(confidence="low"))
+        self.assertFalse(failures)
+        self.assertEqual(metrics["confidence_ceiling_passed_cases"], 1)
+
+        metrics, failures = self.run_single_case(case, valid_report(confidence="high"))
+        self.assertTrue(failures)
+        row = metrics["failed_cases"][0]
+        self.assertFalse(row["confidence_ceiling_ok"])
+        self.assertEqual(row["max_primary_confidence"], "medium")
+        self.assertEqual(row["primary_confidence"], "high")
+        self.assertEqual(metrics["confidence_ceiling_passed_cases"], 0)
+        self.assertEqual(metrics["confidence_ceiling_pass_rate"], 0.0)
 
     # Threshold and output/path tests
     def test_threshold_failures(self):
@@ -274,7 +304,8 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
                 "total_cases", "top1_accuracy", "top2_recall", "high_confidence_wrong_count",
                 "per_ground_truth_counts", "confusion_matrix", "confidence_bucket_accuracy",
                 "required_evidence_pass_rate", "next_check_required_cases", "next_check_passed_cases",
-                "next_check_presence_rate", "next_check_pass_rate", "unexpected_warning_count",
+                "next_check_presence_rate", "next_check_pass_rate", "confidence_ceiling_cases",
+                "confidence_ceiling_passed_cases", "confidence_ceiling_pass_rate", "unexpected_warning_count",
                 "missing_expected_warning_count", "failed_cases",
             }
             self.assertEqual(set(metrics.keys()), expected_keys)

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -17,6 +17,7 @@ Demos teach; validation measures.
 - `top1_required`: when `true`, primary kind must equal `ground_truth`.
 - `must_include_evidence`: evidence substrings that must appear in primary or secondary evidence.
 - `must_include_next_checks`: next-check substrings that must appear when required by a case. Schema-supported; current initial corpus has no required next-check cases.
+- `max_primary_confidence`: optional per-case confidence ceiling (`low|medium|high|very_high`). If set, primary confidence must be less than or equal to this ceiling.
 - `expected_warnings`: warning substrings that must appear.
 - `allowed_warnings`: warning substrings that may appear in addition to expected warnings.
 - `notes`: workload-intent note explaining why labels are set.
@@ -29,7 +30,10 @@ Demos teach; validation measures.
   - `required_top2` = required visibility of true causes.
   - `acceptable_primary` = tolerated primary classification for ambiguity handling/high-confidence-wrong interpretation.
 - Do not use wildcard warning allowlists (`"*"` is invalid).
+- `expected_warnings` are required; `allowed_warnings` are tolerated extras only.
+- Use `max_primary_confidence` for humility checks in sparse, missing-instrumentation, truncated-artifact, noise-only, or close mixed-signal cases.
 - Keep synthetic fixtures small, hand-readable, and explicitly scoped to gaps.
+- Synthetic fixtures are report-shaped adversarial validation artifacts; they are not substitutes for analyzer-generated capture truth.
 
 ## Running the benchmark
 

--- a/validation/diagnostics/corpus/blocking-correlated-stage.json
+++ b/validation/diagnostics/corpus/blocking-correlated-stage.json
@@ -1,0 +1,23 @@
+{
+  "warnings": [],
+  "primary_suspect": {
+    "kind": "blocking_pool_pressure",
+    "confidence": "high",
+    "evidence": [
+      "Blocking queue depth is persistently elevated during tail spikes.",
+      "The dominant stage latency rises in lockstep with blocking backlog."
+    ],
+    "next_checks": [
+      "Audit spawn_blocking and blocking callsites on the hot path."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "downstream_stage_dominates",
+      "confidence": "medium",
+      "evidence": [
+        "Stage latency is elevated but appears blocking-correlated."
+      ]
+    }
+  ]
+}

--- a/validation/diagnostics/corpus/high-latency-missing-instrumentation.json
+++ b/validation/diagnostics/corpus/high-latency-missing-instrumentation.json
@@ -1,0 +1,17 @@
+{
+  "warnings": [
+    "High latency observed but explanatory instrumentation is missing.",
+    "Queue, stage, and runtime instrumentation are incomplete for classification."
+  ],
+  "primary_suspect": {
+    "kind": "insufficient_evidence",
+    "confidence": "low",
+    "evidence": [
+      "p99 latency is high, but missing queue/stage/runtime evidence prevents a supported bottleneck classification."
+    ],
+    "next_checks": [
+      "Enable queue, stage, and runtime instrumentation before assigning a bottleneck family."
+    ]
+  },
+  "secondary_suspects": []
+}

--- a/validation/diagnostics/corpus/low-request-count.json
+++ b/validation/diagnostics/corpus/low-request-count.json
@@ -1,0 +1,17 @@
+{
+  "warnings": [
+    "Low request count; tail estimates are unstable."
+  ],
+  "primary_suspect": {
+    "kind": "insufficient_evidence",
+    "confidence": "low",
+    "evidence": [
+      "Only 18 requests were observed, which is too few for stable p95/p99 dominance estimates."
+    ],
+    "next_checks": [
+      "Re-run with enough requests to stabilize tail percentiles.",
+      "Enable queue and stage instrumentation during the rerun."
+    ]
+  },
+  "secondary_suspects": []
+}

--- a/validation/diagnostics/corpus/missing-optional-runtime-fields.json
+++ b/validation/diagnostics/corpus/missing-optional-runtime-fields.json
@@ -1,0 +1,26 @@
+{
+  "warnings": [
+    "Optional runtime fields are unavailable (blocking_queue_depth/local_queue_depth); interpretation is partial."
+  ],
+  "primary_suspect": {
+    "kind": "blocking_pool_pressure",
+    "confidence": "medium",
+    "evidence": [
+      "Runtime snapshots exist, but optional blocking/local queue fields are missing.",
+      "Observed runtime pressure cannot fully separate executor from blocking contributors."
+    ],
+    "next_checks": [
+      "Use available runtime metrics and compare with tokio-console or tokio-metrics.",
+      "If appropriate, enable tokio_unstable to expose optional runtime fields."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "executor_pressure_suspected",
+      "confidence": "medium",
+      "evidence": [
+        "Partial runtime fields keep executor pressure plausible."
+      ]
+    }
+  ]
+}

--- a/validation/diagnostics/corpus/no-queue-events.json
+++ b/validation/diagnostics/corpus/no-queue-events.json
@@ -1,0 +1,28 @@
+{
+  "warnings": [
+    "Queue instrumentation is missing or sparse; queue saturation cannot be excluded."
+  ],
+  "primary_suspect": {
+    "kind": "downstream_stage_dominates",
+    "confidence": "medium",
+    "evidence": [
+      "Stage checkout latency dominates the observed tail.",
+      "Queue evidence is missing, so queue saturation cannot be excluded."
+    ],
+    "next_checks": [
+      "Enable queue wait/depth instrumentation and re-run."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "application_queue_saturation",
+      "confidence": "low",
+      "evidence": [
+        "Missing queue events leave a plausible queue bottleneck unresolved."
+      ],
+      "next_checks": [
+        "Capture queue wait and queue depth around admission."
+      ]
+    }
+  ]
+}

--- a/validation/diagnostics/corpus/no-runtime-snapshots.json
+++ b/validation/diagnostics/corpus/no-runtime-snapshots.json
@@ -1,0 +1,28 @@
+{
+  "warnings": [
+    "Runtime snapshots are missing; executor/blocking separation may be weak."
+  ],
+  "primary_suspect": {
+    "kind": "executor_pressure_suspected",
+    "confidence": "medium",
+    "evidence": [
+      "In-flight and latency growth suggest runtime contention.",
+      "Runtime snapshot data is missing, limiting executor versus blocking separation."
+    ],
+    "next_checks": [
+      "Enable runtime sampling and compare global queue and blocking metrics."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "blocking_pool_pressure",
+      "confidence": "medium",
+      "evidence": [
+        "Without runtime snapshots, blocking-pool pressure remains plausible."
+      ],
+      "next_checks": [
+        "Collect blocking queue depth snapshots in the same capture window."
+      ]
+    }
+  ]
+}

--- a/validation/diagnostics/corpus/no-stage-events.json
+++ b/validation/diagnostics/corpus/no-stage-events.json
@@ -1,0 +1,28 @@
+{
+  "warnings": [
+    "Stage instrumentation is missing or sparse; downstream dominance cannot be excluded."
+  ],
+  "primary_suspect": {
+    "kind": "application_queue_saturation",
+    "confidence": "medium",
+    "evidence": [
+      "Queue wait dominates observed request time.",
+      "No stage events were captured, so downstream contribution is unresolved."
+    ],
+    "next_checks": [
+      "Enable stage instrumentation around major awaits and re-run."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "downstream_stage_dominates",
+      "confidence": "low",
+      "evidence": [
+        "Missing stage evidence leaves downstream dominance plausible."
+      ],
+      "next_checks": [
+        "Add stage wrappers around key downstream calls."
+      ]
+    }
+  ]
+}

--- a/validation/diagnostics/corpus/noise-only-workload.json
+++ b/validation/diagnostics/corpus/noise-only-workload.json
@@ -1,0 +1,16 @@
+{
+  "warnings": [
+    "No dominant signal: workload appears noisy with mixed low-strength indicators."
+  ],
+  "primary_suspect": {
+    "kind": "insufficient_evidence",
+    "confidence": "low",
+    "evidence": [
+      "No suspect family has coherent dominant evidence across queue, stage, or runtime signals."
+    ],
+    "next_checks": [
+      "Re-run a controlled workload with focused instrumentation."
+    ]
+  },
+  "secondary_suspects": []
+}

--- a/validation/diagnostics/corpus/truncated-artifact-adversarial.json
+++ b/validation/diagnostics/corpus/truncated-artifact-adversarial.json
@@ -1,0 +1,26 @@
+{
+  "warnings": [
+    "Artifact is truncated or partial; dropped records may hide competing signals."
+  ],
+  "primary_suspect": {
+    "kind": "downstream_stage_dominates",
+    "confidence": "medium",
+    "evidence": [
+      "Stage cache_fill appears dominant in captured tail.",
+      "Capture truncation means the observed ranking is based on partial data."
+    ],
+    "next_checks": [
+      "Re-run with larger capture limits.",
+      "Check collector drop counters for dropped records."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "blocking_pool_pressure",
+      "confidence": "low",
+      "evidence": [
+        "Blocking hints are present but partial data limits ranking certainty."
+      ]
+    }
+  ]
+}

--- a/validation/diagnostics/corpus/weak-blocking-strong-downstream.json
+++ b/validation/diagnostics/corpus/weak-blocking-strong-downstream.json
@@ -1,0 +1,23 @@
+{
+  "warnings": [],
+  "primary_suspect": {
+    "kind": "downstream_stage_dominates",
+    "confidence": "high",
+    "evidence": [
+      "Downstream stage payment_api contributes most p95 tail time.",
+      "Blocking queue depth spikes are weak and intermittent."
+    ],
+    "next_checks": [
+      "Inspect downstream dependency latency and retry behavior first."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "blocking_pool_pressure",
+      "confidence": "low",
+      "evidence": [
+        "Blocking queue depth signal is weak relative to downstream tail contribution."
+      ]
+    }
+  ]
+}

--- a/validation/diagnostics/latest/scorecard.md
+++ b/validation/diagnostics/latest/scorecard.md
@@ -1,15 +1,19 @@
-# Diagnostic validation scorecard (initial)
+# Diagnostic validation scorecard
+
+Status labels describe deterministic corpus coverage only. Synthetic adversarial rows validate report/benchmark humility behavior and are not real-service validation.
 
 | Area | Status | Notes |
 |---|---|---|
-| queue saturation | Initial deterministic evidence | queue before/sample + mixed/cold-start/db-pool support. |
-| downstream dominance | Initial deterministic evidence | downstream before/after/sample + retry/shared-lock scenarios. |
-| db/pool wait | Partially validated | covered via db-pool scenario labels; broaden with non-demo corpora later. |
-| blocking-pool pressure | Initial deterministic evidence | blocking before/sample coverage included. |
-| executor pressure | Initial deterministic evidence | executor before/sample plus mixed coverage. |
-| mixed bottlenecks | Partially validated | mixed baseline + synthetic ambiguity case. |
-| insufficient evidence | Initial deterministic evidence | dedicated synthetic insufficient-evidence case. |
-| truncation handling | Partially validated | synthetic truncation warning case; add real truncated captures later. |
-| runtime overhead | Measured separately | see `docs/runtime-cost.md`. |
-| collector limits | Measured separately | see `docs/collector-limits.md`. |
-| real service validation | Planned | add curated real-service anonymized artifacts. |
+| queue saturation | Initial deterministic evidence | Demo fixtures plus synthetic missing-stage coverage. |
+| downstream dominance | Initial deterministic evidence | Demo fixtures plus weak-blocking/strong-downstream adversarial coverage. |
+| blocking-pool pressure | Initial deterministic evidence | Demo fixtures plus blocking-correlated-stage adversarial coverage. |
+| executor pressure | Initial deterministic evidence | Demo fixtures plus missing-runtime and partial-runtime-field adversarial coverage. |
+| low request count | Initial deterministic adversarial coverage | Synthetic sparse-sample case enforces insufficient-evidence + low confidence ceiling. |
+| missing queue/stage/runtime instrumentation | Initial deterministic adversarial coverage | Synthetic no-queue, no-stage, and no-runtime cases enforce warnings and conservative confidence. |
+| missing optional runtime fields | Initial deterministic adversarial coverage | Synthetic partial-runtime-fields case enforces warning and medium confidence ceiling. |
+| truncation / partial artifact | Initial deterministic adversarial coverage | Synthetic truncated artifact case enforces warning, follow-up checks, and confidence ceiling. |
+| noise-only / insufficient evidence | Initial deterministic adversarial coverage | Synthetic noise-only and high-latency-with-missing-instrumentation cases enforce low-confidence insufficient-evidence fallback. |
+| mixed-signal top-2 behavior | Initial deterministic adversarial coverage | Synthetic mixed cases enforce true-cause visibility in required top-2. |
+| runtime overhead | Measured separately | See `docs/runtime-cost.md`. |
+| collector limits | Measured separately | See `docs/collector-limits.md`. |
+| real service validation | Planned | Add curated anonymized real-service artifacts in future work. |

--- a/validation/diagnostics/manifest.json
+++ b/validation/diagnostics/manifest.json
@@ -707,6 +707,331 @@
         "downstream_stage_dominates"
       ],
       "must_include_next_checks": []
+    },
+    {
+      "id": "adversarial_low_request_count",
+      "artifact": "corpus/low-request-count.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "insufficient_evidence",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "sparse-sample"
+      ],
+      "must_include_evidence": [
+        "too few",
+        "stable p95/p99"
+      ],
+      "notes": "Synthetic adversarial fixture: too few requests make tail dominance unstable, so triage should stay at insufficient evidence with low confidence.",
+      "expected_warnings": [
+        "Low request count"
+      ],
+      "top1_required": true,
+      "allowed_warnings": [],
+      "required_top2": [
+        "insufficient_evidence"
+      ],
+      "acceptable_primary": [
+        "insufficient_evidence"
+      ],
+      "must_include_next_checks": [
+        "enough requests",
+        "Enable queue and stage"
+      ],
+      "max_primary_confidence": "low"
+    },
+    {
+      "id": "adversarial_no_queue_events",
+      "artifact": "corpus/no-queue-events.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "downstream_stage_dominates",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "missing-queue"
+      ],
+      "must_include_evidence": [
+        "Stage checkout",
+        "Queue evidence is missing"
+      ],
+      "notes": "Synthetic adversarial fixture: stage looks dominant but missing queue instrumentation keeps queue saturation plausible and visible in top-2.",
+      "expected_warnings": [
+        "Queue instrumentation is missing"
+      ],
+      "top1_required": false,
+      "allowed_warnings": [],
+      "required_top2": [
+        "downstream_stage_dominates",
+        "application_queue_saturation"
+      ],
+      "acceptable_primary": [
+        "downstream_stage_dominates"
+      ],
+      "must_include_next_checks": [
+        "queue wait/depth"
+      ],
+      "max_primary_confidence": "medium"
+    },
+    {
+      "id": "adversarial_no_stage_events",
+      "artifact": "corpus/no-stage-events.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "application_queue_saturation",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "missing-stage"
+      ],
+      "must_include_evidence": [
+        "Queue wait dominates",
+        "No stage events"
+      ],
+      "notes": "Synthetic adversarial fixture: queue appears dominant, but missing stage instrumentation keeps downstream dominance plausible in top-2.",
+      "expected_warnings": [
+        "Stage instrumentation is missing"
+      ],
+      "top1_required": false,
+      "allowed_warnings": [],
+      "required_top2": [
+        "application_queue_saturation",
+        "downstream_stage_dominates"
+      ],
+      "acceptable_primary": [
+        "application_queue_saturation"
+      ],
+      "must_include_next_checks": [
+        "Enable stage instrumentation"
+      ],
+      "max_primary_confidence": "medium"
+    },
+    {
+      "id": "adversarial_no_runtime_snapshots",
+      "artifact": "corpus/no-runtime-snapshots.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "executor_pressure_suspected",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "missing-runtime"
+      ],
+      "must_include_evidence": [
+        "Runtime snapshot data is missing",
+        "runtime contention"
+      ],
+      "notes": "Synthetic adversarial fixture: runtime snapshots are absent so executor vs blocking separation should remain conservative with both suspects visible.",
+      "expected_warnings": [
+        "Runtime snapshots are missing"
+      ],
+      "top1_required": false,
+      "allowed_warnings": [],
+      "required_top2": [
+        "executor_pressure_suspected",
+        "blocking_pool_pressure"
+      ],
+      "acceptable_primary": [
+        "executor_pressure_suspected",
+        "blocking_pool_pressure"
+      ],
+      "must_include_next_checks": [
+        "Enable runtime sampling"
+      ],
+      "max_primary_confidence": "medium"
+    },
+    {
+      "id": "adversarial_missing_optional_runtime_fields",
+      "artifact": "corpus/missing-optional-runtime-fields.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "blocking_pool_pressure",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "runtime-partial"
+      ],
+      "must_include_evidence": [
+        "optional blocking/local queue fields are missing",
+        "partial"
+      ],
+      "notes": "Synthetic adversarial fixture: optional runtime fields are unavailable, so blocking vs executor interpretation must remain partial and confidence-capped.",
+      "expected_warnings": [
+        "Optional runtime fields are unavailable"
+      ],
+      "top1_required": false,
+      "allowed_warnings": [],
+      "required_top2": [
+        "blocking_pool_pressure",
+        "executor_pressure_suspected"
+      ],
+      "acceptable_primary": [
+        "blocking_pool_pressure",
+        "executor_pressure_suspected"
+      ],
+      "must_include_next_checks": [
+        "tokio_unstable",
+        "tokio-console"
+      ],
+      "max_primary_confidence": "medium"
+    },
+    {
+      "id": "adversarial_truncated_artifact",
+      "artifact": "corpus/truncated-artifact-adversarial.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "downstream_stage_dominates",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "truncation",
+        "partial-data"
+      ],
+      "must_include_evidence": [
+        "Capture truncation",
+        "partial data"
+      ],
+      "notes": "Synthetic adversarial fixture: ranking is plausible but artifact truncation requires explicit warning and no overconfident primary.",
+      "expected_warnings": [
+        "truncated or partial"
+      ],
+      "top1_required": false,
+      "allowed_warnings": [],
+      "required_top2": [
+        "downstream_stage_dominates",
+        "blocking_pool_pressure"
+      ],
+      "acceptable_primary": [
+        "downstream_stage_dominates",
+        "blocking_pool_pressure"
+      ],
+      "must_include_next_checks": [
+        "larger capture limits",
+        "drop counters"
+      ],
+      "max_primary_confidence": "medium"
+    },
+    {
+      "id": "adversarial_weak_blocking_strong_downstream",
+      "artifact": "corpus/weak-blocking-strong-downstream.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "downstream_stage_dominates",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "mixed",
+        "blocking",
+        "downstream"
+      ],
+      "must_include_evidence": [
+        "payment_api",
+        "weak and intermittent"
+      ],
+      "notes": "Synthetic adversarial fixture: weak blocking hints should not displace strong downstream stage dominance.",
+      "expected_warnings": [],
+      "top1_required": true,
+      "allowed_warnings": [],
+      "required_top2": [
+        "downstream_stage_dominates",
+        "blocking_pool_pressure"
+      ],
+      "acceptable_primary": [
+        "downstream_stage_dominates"
+      ],
+      "must_include_next_checks": [
+        "downstream dependency latency"
+      ]
+    },
+    {
+      "id": "adversarial_blocking_correlated_stage",
+      "artifact": "corpus/blocking-correlated-stage.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "blocking_pool_pressure",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "mixed",
+        "blocking",
+        "stage-correlation"
+      ],
+      "must_include_evidence": [
+        "Blocking queue depth is persistently elevated",
+        "lockstep with blocking backlog"
+      ],
+      "notes": "Synthetic adversarial fixture: stage latency appears high but is blocking-correlated, so blocking_pool_pressure should remain primary.",
+      "expected_warnings": [],
+      "top1_required": true,
+      "allowed_warnings": [],
+      "required_top2": [
+        "blocking_pool_pressure",
+        "downstream_stage_dominates"
+      ],
+      "acceptable_primary": [
+        "blocking_pool_pressure"
+      ],
+      "must_include_next_checks": [
+        "spawn_blocking",
+        "blocking callsites"
+      ]
+    },
+    {
+      "id": "adversarial_noise_only_workload",
+      "artifact": "corpus/noise-only-workload.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "insufficient_evidence",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "noise",
+        "mixed"
+      ],
+      "must_include_evidence": [
+        "No suspect family has coherent dominant evidence"
+      ],
+      "notes": "Synthetic adversarial fixture: mixed low-signal workload should resolve to insufficient evidence rather than a specific confident suspect.",
+      "expected_warnings": [
+        "No dominant signal"
+      ],
+      "top1_required": true,
+      "allowed_warnings": [],
+      "required_top2": [
+        "insufficient_evidence"
+      ],
+      "acceptable_primary": [
+        "insufficient_evidence"
+      ],
+      "must_include_next_checks": [
+        "controlled workload"
+      ],
+      "max_primary_confidence": "low"
+    },
+    {
+      "id": "adversarial_high_latency_missing_instrumentation",
+      "artifact": "corpus/high-latency-missing-instrumentation.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "insufficient_evidence",
+      "tags": [
+        "synthetic",
+        "adversarial",
+        "high-latency",
+        "missing-instrumentation"
+      ],
+      "must_include_evidence": [
+        "p99 latency is high",
+        "missing queue/stage/runtime evidence"
+      ],
+      "notes": "Synthetic adversarial fixture: high latency without explanatory queue/stage/runtime instrumentation should stay insufficient evidence at low confidence.",
+      "expected_warnings": [
+        "High latency observed but explanatory instrumentation is missing",
+        "Queue, stage, and runtime instrumentation are incomplete"
+      ],
+      "top1_required": true,
+      "allowed_warnings": [],
+      "required_top2": [
+        "insufficient_evidence"
+      ],
+      "acceptable_primary": [
+        "insufficient_evidence"
+      ],
+      "must_include_next_checks": [
+        "Enable queue, stage, and runtime"
+      ],
+      "max_primary_confidence": "low"
     }
   ],
   "schema_version": 1


### PR DESCRIPTION
### Motivation
- Strengthen deterministic validation coverage by adding adversarial synthetic report-shaped fixtures that exercise sparse, missing, truncated, noisy, and mixed-signal capture conditions so the benchmark can enforce conservative triage behavior. 
- Validate humility semantics so the analyzer cannot produce high-confidence specific suspects when explanatory instrumentation or sufficient samples are absent. 
- Build on the existing deterministic foundation without changing analyzer logic, runtime behavior, or adding dependencies.

### Description
- Add 10 small, hand-readable synthetic fixtures under `validation/diagnostics/corpus/` covering low-request-count, missing queue/stage/runtime signals, missing optional runtime fields, truncated artifacts, weak-blocking vs strong-downstream, blocking-correlated-stage, noise-only workload, and high-latency-without-instrumentation. 
- Extend `validation/diagnostics/manifest.json` with the 10 `artifact_type: "synthetic_analysis_report"` cases including `required_top2`, `acceptable_primary`, `must_include_evidence`, `must_include_next_checks`, `expected_warnings`, `allowed_warnings`, and per-case `max_primary_confidence` ceilings where appropriate. 
- Update `scripts/diagnostic_benchmark.py` to validate `max_primary_confidence` in the manifest, enforce per-case confidence ceilings (ordered `low < medium < high < very_high`), include per-case `confidence_ceiling_ok`/`max_primary_confidence`/`primary_confidence` in failed rows, and expose aggregate metrics (`confidence_ceiling_cases`, `confidence_ceiling_passed_cases`, `confidence_ceiling_pass_rate`) in CLI and JSON output. 
- Add unit tests in `scripts/tests/test_diagnostic_benchmark.py` for manifest validation of `max_primary_confidence`, and for pass/fail metric behavior and metrics-shape changes; and update validation docs and scorecards (`validation/diagnostics/README.md`, `docs/diagnostic-validation.md`, `VALIDATION.md`, `validation/diagnostics/latest/scorecard.md`) to document adversarial coverage and confidence-ceiling (humility) checks; analyzer behavior, Rust code, and dependencies were not changed.
- Limitations: these synthetic fixtures validate benchmark/report semantics and humility checks only and are not a substitute for analyzer-generated adversarial captures or repeated-run statistical validation.

### Testing
- Ran `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json` and it completed successfully with zero failed cases and reported confidence-ceiling metrics (see CLI output). ✅
- Ran `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --output target/diagnostic-benchmark.json` and JSON output was written successfully. ✅
- Ran unit tests `python3 -m unittest scripts.tests.test_diagnostic_benchmark` and all tests passed (OK). ✅
- Ran docs validation `python3 scripts/validate_docs_contracts.py` and it reported success. ✅
- Ran `python3 -m unittest scripts.tests.test_validate_docs_contracts` and tests passed (OK). ✅
- Ran demo fixture drift check `python3 scripts/check_demo_fixture_drift.py --profile dev` which completed and refreshed demo fixtures as expected. ✅
- Ran `cargo fmt --check` and it passed. ✅
- Ran `cargo clippy --workspace --all-targets -- -D warnings` (full workspace lint) and it completed without warnings. ✅
- Ran `cargo test --workspace` and the Rust test suite completed successfully. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f79ec02ae4833090944ea39fec5cd6)