### PR TITLE
Add manual repeated-run diagnostic matrix runner

### DIFF
--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -37,3 +37,12 @@ The corpus now includes deterministic adversarial validation that checks sparse,
 - user-facing methodology: `docs/diagnostic-validation.md`
 
 Demos teach scenarios; validation measures bounded diagnostic behavior.
+
+## Repeated-run diagnostic matrix (manual)
+
+A manual repeated-run matrix runner is available via `scripts/run_diagnostic_matrix.py`.
+It repeatedly executes controlled demos, analyzes each run, writes JSONL run records, and summarizes stability metrics (Top-1, Top-2, high-confidence-wrong, confidence-bucket accuracy, primary stability, and p95/p99 median+IQR stats).
+
+This validation is controlled-demo and machine/workload scoped. It measures repeated-run triage stability, not production universality and not root-cause proof.
+
+This matrix is not mandatory CI yet.

--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -47,3 +47,29 @@ Schema supports `must_include_next_checks`, but the current initial corpus has n
 
 ## Future work
 Repeated-run validation, mitigation validation, overhead integration, collector-limit integration, and expanded real-service validation are separate follow-on work.
+
+## Repeated-run diagnostic matrix (manual/local)
+
+Repeated-run validation complements deterministic fixture validation by re-running controlled demo scenarios and checking stability across runs.
+
+- deterministic fixture validation checks bounded per-fixture diagnosis behavior on committed artifacts.
+- repeated-run matrix validation checks run-to-run stability for the same controlled workload shape.
+
+Run locally:
+
+```bash
+python3 scripts/run_diagnostic_matrix.py --runs 30 --out target/diagnostic-runs.jsonl
+```
+
+Key repeated-run metrics:
+
+- **Top-1**: primary suspect equals scenario ground truth.
+- **Top-2**: required cause kind appears in primary/secondary visibility.
+- **High-confidence-wrong**: high/very-high primary outside acceptable primary set.
+- **Primary stability**: most-common primary kind frequency per scenario.
+- **Confidence bucket accuracy**: top-1 correctness by confidence bucket.
+- **p95 IQR**: interquartile spread of p95 latency across repeated runs.
+
+Repeated-run outputs are controlled-workload and machine scoped. They support triage stability inspection; they do not prove universal behavior or root cause.
+
+Repeated-run validation is currently manual/local and not mandatory CI.

--- a/scripts/run_diagnostic_matrix.py
+++ b/scripts/run_diagnostic_matrix.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import statistics
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+try:
+    from _demo_runner import PROFILE_CHOICES, load_report_json, repo_root, run_and_analyze
+except ModuleNotFoundError:
+    from scripts._demo_runner import PROFILE_CHOICES, load_report_json, repo_root, run_and_analyze
+
+CONF_HIGH = {"high", "very_high"}
+
+SCENARIO_MATRIX = {
+    "queue": {
+        "demo_manifest": "demos/queue_service/Cargo.toml",
+        "variant": "before",
+        "demo_mode": "baseline",
+        "ground_truth": "application_queue_saturation",
+        "acceptable_primary": ["application_queue_saturation"],
+        "required_top2": ["application_queue_saturation"],
+        "top1_required": True,
+    },
+    "blocking": {
+        "demo_manifest": "demos/blocking_service/Cargo.toml",
+        "variant": "before",
+        "demo_mode": "baseline",
+        "ground_truth": "blocking_pool_pressure",
+        "acceptable_primary": ["blocking_pool_pressure"],
+        "required_top2": ["blocking_pool_pressure"],
+        "top1_required": True,
+    },
+    "executor": {
+        "demo_manifest": "demos/executor_pressure_service/Cargo.toml",
+        "variant": "before",
+        "demo_mode": "baseline",
+        "ground_truth": "executor_pressure_suspected",
+        "acceptable_primary": ["executor_pressure_suspected"],
+        "required_top2": ["executor_pressure_suspected"],
+        "top1_required": True,
+    },
+    "downstream": {
+        "demo_manifest": "demos/downstream_service/Cargo.toml",
+        "variant": "before",
+        "demo_mode": "baseline",
+        "ground_truth": "downstream_stage_dominates",
+        "acceptable_primary": ["downstream_stage_dominates", "application_queue_saturation"],
+        "required_top2": ["downstream_stage_dominates"],
+        "top1_required": True,
+    },
+    "mixed": {
+        "demo_manifest": "demos/mixed_contention_service/Cargo.toml",
+        "variant": "before",
+        "demo_mode": "baseline",
+        "ground_truth": "application_queue_saturation",
+        "acceptable_primary": ["application_queue_saturation", "executor_pressure_suspected"],
+        "required_top2": ["application_queue_saturation"],
+        "top1_required": False,
+    },
+}
+DEFAULT_SCENARIOS = ["queue", "blocking", "executor", "downstream"]
+
+
+def top2_kinds(report: dict[str, Any]) -> list[str]:
+    primary = report.get("primary_suspect") or {}
+    secondary = report.get("secondary_suspects") or []
+    suspects = [primary, *secondary]
+    return [s.get("kind") for s in suspects[:2] if isinstance(s, dict) and s.get("kind")]
+
+
+def extract_run_record(report: dict[str, Any], *, scenario_name: str, scenario: dict[str, Any], run_index: int, profile: str, artifact_path: Path, analysis_path: Path) -> dict[str, Any]:
+    primary = report.get("primary_suspect") or {}
+    primary_kind = primary.get("kind")
+    confidence = primary.get("confidence")
+    required_top2 = scenario["required_top2"]
+    top2 = top2_kinds(report)
+    top1_ok = primary_kind == scenario["ground_truth"]
+    top2_ok = all(kind in top2 for kind in required_top2)
+    high_conf_wrong = confidence in CONF_HIGH and primary_kind not in scenario["acceptable_primary"]
+
+    return {
+        "schema_version": 1,
+        "run_index": run_index,
+        "scenario": scenario_name,
+        "variant": scenario["variant"],
+        "profile": profile,
+        "artifact_path": str(artifact_path),
+        "analysis_path": str(analysis_path),
+        "ground_truth": scenario["ground_truth"],
+        "primary_kind": primary_kind,
+        "primary_confidence": confidence,
+        "primary_score": primary.get("score"),
+        "top2_kinds": top2,
+        "top1_ok": top1_ok,
+        "top2_ok": top2_ok,
+        "high_confidence_wrong": high_conf_wrong,
+        "warnings": report.get("warnings") if isinstance(report.get("warnings"), list) else [],
+        "request_count": report.get("request_count"),
+        "p95_latency_us": report.get("p95_latency_us"),
+        "p99_latency_us": report.get("p99_latency_us"),
+        "p95_queue_share_permille": report.get("p95_queue_share_permille"),
+        "p95_service_share_permille": report.get("p95_service_share_permille"),
+    }
+
+
+def quartiles(values: list[int]) -> tuple[float, float]:
+    vals = sorted(values)
+    n = len(vals)
+    if n == 1:
+        return float(vals[0]), float(vals[0])
+    lower = vals[: n // 2]
+    upper = vals[n // 2 :] if n % 2 == 0 else vals[(n // 2) + 1 :]
+    return float(statistics.median(lower)), float(statistics.median(upper))
+
+
+def latency_stats(values: list[int]) -> dict[str, float | int] | None:
+    if not values:
+        return None
+    q1, q3 = quartiles(values)
+    return {
+        "median": int(statistics.median(values)),
+        "iqr": int(q3 - q1),
+        "min": min(values),
+        "max": max(values),
+    }
+
+
+def confidence_bucket_accuracy(records: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    grouped: dict[str, dict[str, int]] = defaultdict(lambda: {"records": 0, "top1_correct": 0})
+    for row in records:
+        bucket = row.get("primary_confidence")
+        if bucket is None:
+            continue
+        grouped[bucket]["records"] += 1
+        if row.get("top1_ok"):
+            grouped[bucket]["top1_correct"] += 1
+    out = {}
+    for bucket, data in grouped.items():
+        recs = data["records"]
+        out[bucket] = {
+            "records": recs,
+            "top1_correct": data["top1_correct"],
+            "accuracy": (data["top1_correct"] / recs) if recs else 0.0,
+        }
+    return out
+
+
+def summarize_records(records: list[dict[str, Any]], *, runs: int, profile: str) -> dict[str, Any]:
+    by_scenario: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in records:
+        by_scenario[row["scenario"]].append(row)
+
+    per_scenario = {}
+    for name, rows in by_scenario.items():
+        primary_counts = Counter(row.get("primary_kind") for row in rows)
+        p95_values = [row["p95_latency_us"] for row in rows if isinstance(row.get("p95_latency_us"), int)]
+        p99_values = [row["p99_latency_us"] for row in rows if isinstance(row.get("p99_latency_us"), int)]
+        per_scenario[name] = {
+            "records": len(rows),
+            "top1_accuracy": sum(1 for row in rows if row["top1_ok"]) / len(rows),
+            "top2_recall": sum(1 for row in rows if row["top2_ok"]) / len(rows),
+            "high_confidence_wrong_count": sum(1 for row in rows if row["high_confidence_wrong"]),
+            "primary_kind_counts": dict(primary_counts),
+            "primary_stability": (max(primary_counts.values()) / len(rows)) if rows else 0.0,
+            "p95_latency_us": latency_stats(p95_values),
+            "p99_latency_us": latency_stats(p99_values),
+            "confidence_bucket_accuracy": confidence_bucket_accuracy(rows),
+        }
+
+    total = len(records)
+    return {
+        "schema_version": 1,
+        "runs": runs,
+        "profile": profile,
+        "total_records": total,
+        "top1_accuracy": (sum(1 for row in records if row["top1_ok"]) / total) if total else 0.0,
+        "top2_recall": (sum(1 for row in records if row["top2_ok"]) / total) if total else 0.0,
+        "high_confidence_wrong_count": sum(1 for row in records if row["high_confidence_wrong"]),
+        "per_scenario": per_scenario,
+        "failed_thresholds": [],
+    }
+
+
+def evaluate_thresholds(summary: dict[str, Any], scenarios: list[str], min_top1: float, min_top2: float, max_high_conf_wrong: int) -> list[str]:
+    failures = []
+    if summary["high_confidence_wrong_count"] > max_high_conf_wrong:
+        failures.append(f"overall high_confidence_wrong_count {summary['high_confidence_wrong_count']} exceeds {max_high_conf_wrong}")
+    for name in scenarios:
+        info = summary["per_scenario"][name]
+        spec = SCENARIO_MATRIX[name]
+        if spec["top1_required"] and info["top1_accuracy"] < min_top1:
+            failures.append(f"{name} top1_accuracy {info['top1_accuracy']:.3f} below {min_top1:.3f}")
+        top2_req = 0.95 if name == "mixed" else min_top2
+        if info["top2_recall"] < top2_req:
+            failures.append(f"{name} top2_recall {info['top2_recall']:.3f} below {top2_req:.3f}")
+        if info["high_confidence_wrong_count"] > max_high_conf_wrong:
+            failures.append(f"{name} high_confidence_wrong_count {info['high_confidence_wrong_count']} exceeds {max_high_conf_wrong}")
+    return failures
+
+
+def write_jsonl(path: Path, records: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for row in records:
+            f.write(json.dumps(row, sort_keys=True) + "\n")
+
+
+def write_scorecard(path: Path, summary: dict[str, Any]) -> None:
+    lines = ["# Repeated-run diagnostic matrix scorecard", "", f"Profile: {summary['profile']}", f"Runs per scenario: {summary['runs']}", "", "| Scenario | Records | Top-1 | Top-2 | Primary stability | High-conf wrong | p95 median | p95 IQR |", "|---|---:|---:|---:|---:|---:|---:|---:|"]
+    for scenario, data in summary["per_scenario"].items():
+        p95 = data.get("p95_latency_us") or {}
+        lines.append(
+            f"| {scenario} | {data['records']} | {data['top1_accuracy']:.3f} | {data['top2_recall']:.3f} | {data['primary_stability']:.3f} | {data['high_confidence_wrong_count']} | {p95.get('median', 'n/a')} | {p95.get('iqr', 'n/a')} |"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--runs", type=int, default=30)
+    ap.add_argument("--out", default="target/diagnostic-runs.jsonl")
+    ap.add_argument("--summary")
+    ap.add_argument("--scorecard")
+    ap.add_argument("--scenario", action="append", choices=sorted(SCENARIO_MATRIX.keys()))
+    ap.add_argument("--profile", choices=PROFILE_CHOICES, default="dev")
+    ap.add_argument("--artifact-root", default="target/diagnostic-matrix")
+    ap.add_argument("--keep-artifacts", action="store_true")
+    ap.add_argument("--min-top1", type=float, default=0.95)
+    ap.add_argument("--min-top2", type=float, default=1.0)
+    ap.add_argument("--max-high-confidence-wrong", type=int, default=0)
+    ap.add_argument("--no-fail-thresholds", action="store_true")
+    args = ap.parse_args()
+
+    root = repo_root(__file__)
+    cli_manifest = root / "tailtriage-cli/Cargo.toml"
+    selected = args.scenario or DEFAULT_SCENARIOS
+    artifact_root = Path(args.artifact_root)
+    out_path = Path(args.out)
+    summary_path = Path(args.summary) if args.summary else out_path.with_name(f"{out_path.stem}-summary.json")
+
+    records = []
+    for scenario_name in selected:
+        scenario = SCENARIO_MATRIX[scenario_name]
+        demo_manifest = root / scenario["demo_manifest"]
+        scenario_artifact_dir = artifact_root / scenario_name / scenario["variant"]
+        for run_index in range(1, args.runs + 1):
+            run_path = scenario_artifact_dir / f"run-{run_index:03d}-run.json"
+            analysis_path = scenario_artifact_dir / f"run-{run_index:03d}-analysis.json"
+            run_and_analyze(demo_manifest, cli_manifest, run_path, analysis_path, scenario["demo_mode"], profile=args.profile)
+            report = load_report_json(analysis_path)
+            records.append(extract_run_record(report, scenario_name=scenario_name, scenario=scenario, run_index=run_index, profile=args.profile, artifact_path=run_path, analysis_path=analysis_path))
+
+    write_jsonl(out_path, records)
+    summary = summarize_records(records, runs=args.runs, profile=args.profile)
+    failures = evaluate_thresholds(summary, selected, args.min_top1, args.min_top2, args.max_high_confidence_wrong)
+    summary["failed_thresholds"] = failures
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.scorecard:
+        write_scorecard(Path(args.scorecard), summary)
+
+    if not args.keep_artifacts and artifact_root.exists():
+        shutil.rmtree(artifact_root)
+
+    if failures and not args.no_fail_thresholds:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_run_diagnostic_matrix.py
+++ b/scripts/tests/test_run_diagnostic_matrix.py
@@ -1,0 +1,73 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import run_diagnostic_matrix as rdm
+
+
+class RunDiagnosticMatrixTests(unittest.TestCase):
+    def sample_report(self, primary_kind="application_queue_saturation", confidence="high", secondary_kind="downstream_stage_dominates"):
+        return {
+            "request_count": 10,
+            "p95_latency_us": 100,
+            "p99_latency_us": 150,
+            "p95_queue_share_permille": 900,
+            "p95_service_share_permille": 100,
+            "warnings": [],
+            "primary_suspect": {"kind": primary_kind, "confidence": confidence, "score": 99},
+            "secondary_suspects": [{"kind": secondary_kind, "confidence": "low", "score": 10}],
+        }
+
+    def test_extract_run_record_minimal(self):
+        rec = rdm.extract_run_record(self.sample_report(), scenario_name="queue", scenario=rdm.SCENARIO_MATRIX["queue"], run_index=1, profile="dev", artifact_path=Path("a"), analysis_path=Path("b"))
+        self.assertTrue(rec["top1_ok"])
+        self.assertTrue(rec["top2_ok"])
+
+    def test_top1_top2_high_conf_wrong(self):
+        rec = rdm.extract_run_record(self.sample_report(primary_kind="blocking_pool_pressure"), scenario_name="queue", scenario=rdm.SCENARIO_MATRIX["queue"], run_index=1, profile="dev", artifact_path=Path("a"), analysis_path=Path("b"))
+        self.assertFalse(rec["top1_ok"])
+        self.assertFalse(rec["top2_ok"])
+        self.assertTrue(rec["high_confidence_wrong"])
+
+    def test_primary_stability_and_confidence_bucket(self):
+        rows = []
+        for i in range(3):
+            rec = rdm.extract_run_record(self.sample_report(), scenario_name="queue", scenario=rdm.SCENARIO_MATRIX["queue"], run_index=i + 1, profile="dev", artifact_path=Path("a"), analysis_path=Path("b"))
+            rows.append(rec)
+        rows.append(rdm.extract_run_record(self.sample_report(primary_kind="downstream_stage_dominates", confidence="medium"), scenario_name="queue", scenario={**rdm.SCENARIO_MATRIX["queue"], "acceptable_primary": ["application_queue_saturation", "downstream_stage_dominates"]}, run_index=4, profile="dev", artifact_path=Path("a"), analysis_path=Path("b")))
+        summary = rdm.summarize_records(rows, runs=4, profile="dev")
+        self.assertEqual(summary["per_scenario"]["queue"]["primary_stability"], 0.75)
+        self.assertIn("high", summary["per_scenario"]["queue"]["confidence_bucket_accuracy"])
+
+    def test_latency_stats_even_odd_and_missing(self):
+        self.assertEqual(rdm.latency_stats([1, 2, 3])["median"], 2)
+        self.assertEqual(rdm.latency_stats([1, 2, 3, 4])["iqr"], 2)
+        self.assertIsNone(rdm.latency_stats([]))
+
+    def test_summary_shape_and_threshold_failures(self):
+        rows = [rdm.extract_run_record(self.sample_report(primary_kind="blocking_pool_pressure"), scenario_name="queue", scenario=rdm.SCENARIO_MATRIX["queue"], run_index=1, profile="dev", artifact_path=Path("a"), analysis_path=Path("b"))]
+        summary = rdm.summarize_records(rows, runs=1, profile="dev")
+        self.assertIn("per_scenario", summary)
+        fails = rdm.evaluate_thresholds(summary, ["queue"], 0.95, 1.0, 0)
+        self.assertTrue(any("top1_accuracy" in item for item in fails))
+        self.assertTrue(any("high_confidence_wrong_count" in item for item in fails))
+
+    def test_mixed_threshold_top2_only(self):
+        rows = [rdm.extract_run_record(self.sample_report(primary_kind="executor_pressure_suspected"), scenario_name="mixed", scenario=rdm.SCENARIO_MATRIX["mixed"], run_index=1, profile="dev", artifact_path=Path("a"), analysis_path=Path("b"))]
+        summary = rdm.summarize_records(rows, runs=1, profile="dev")
+        fails = rdm.evaluate_thresholds(summary, ["mixed"], 0.95, 1.0, 0)
+        self.assertFalse(any("top1_accuracy" in item for item in fails))
+
+    def test_jsonl_write(self):
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / "x.jsonl"
+            rows = [{"a": 1}, {"b": 2}]
+            rdm.write_jsonl(out, rows)
+            lines = out.read_text(encoding="utf-8").strip().splitlines()
+            self.assertEqual(len(lines), 2)
+            self.assertEqual(json.loads(lines[0])["a"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -55,3 +55,8 @@ python3 scripts/diagnostic_benchmark.py \
   --min-top2 0.90 \
   --max-high-confidence-wrong 0
 ```
+
+
+## Repeated-run matrix runner
+
+Use `scripts/run_diagnostic_matrix.py` for manual repeated-run stability validation on controlled demos. This complements deterministic corpus benchmarking and synthetic adversarial fixtures.

--- a/validation/diagnostics/latest/scorecard.md
+++ b/validation/diagnostics/latest/scorecard.md
@@ -13,6 +13,7 @@
 | missing instrumentation warnings | Initial deterministic adversarial coverage | queue/stage/runtime missing and optional-runtime-field warnings are explicitly checked. |
 | runtime overhead | Measured separately | see `docs/runtime-cost.md`. |
 | collector limits | Measured separately | see `docs/collector-limits.md`. |
+| repeated-run diagnostic matrix | Manual runner available | Manual repeated-run validation available; publishable results are not committed by default. |
 | real service validation | Planned | add curated real-service anonymized artifacts. |
 
 Deterministic synthetic adversarial cases validate benchmark/report contract behavior and humility checks; they are not real-service validation.


### PR DESCRIPTION
### Motivation

- Extend validation beyond single committed fixtures by adding a manual repeated-run matrix to measure diagnostic stability across controlled demo runs, focusing on triage stability (not root-cause proof). 

### Description

- Add `scripts/run_diagnostic_matrix.py`, a stdlib-only CLI that repeatedly runs selected demo scenarios, analyzes each run, writes raw per-run JSONL records, computes summary stability metrics, and optionally emits a compact Markdown scorecard. 
- Implement pure, testable metric helpers: `extract_run_record`, `quartiles`/`latency_stats`, `confidence_bucket_accuracy`, `summarize_records`, `evaluate_thresholds`, and `write_jsonl` so metric logic is unit-testable without invoking subprocesses. 
- Provide a small default scenario matrix (`queue`, `blocking`, `executor`, `downstream`, `mixed`), artifact layout under `target/diagnostic-matrix`, and CLI knobs for runs, scenarios, profile, artifact root, thresholds, `--no-fail-thresholds`, `--summary`, and `--scorecard`. 
- Add unit tests `scripts/tests/test_run_diagnostic_matrix.py` covering extraction, top-1/top-2 semantics, high-confidence-wrong counting, primary stability, confidence-bucket accuracy, median/IQR stats, threshold evaluation, and JSONL writing. 
- Update docs and validation artifacts (`docs/diagnostic-validation.md`, `VALIDATION.md`, `validation/diagnostics/README.md`, and `validation/diagnostics/latest/scorecard.md`) to document the repeated-run matrix as a manual/local validation complementing deterministic corpus checks while preserving non-claims (triage leads, not proof). 

### Testing

- Ran a smoke repeated-run invocation: `python3 scripts/run_diagnostic_matrix.py --runs 1 --scenario queue --out target/diagnostic-runs-smoke.jsonl --summary target/diagnostic-runs-smoke-summary.json --scorecard target/diagnostic-runs-smoke-scorecard.md --no-fail-thresholds` and it completed successfully. ✅
- Unit tests: `python3 -m unittest scripts.tests.test_run_diagnostic_matrix` and `python3 -m unittest scripts.tests.test_diagnostic_benchmark` both passed. ✅
- Validation and integration checks: `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json`, `python3 scripts/validate_docs_contracts.py`, `python3 -m unittest scripts.tests.test_validate_docs_contracts`, and `python3 scripts/check_demo_fixture_drift.py --profile dev` all completed successfully. ✅
- Workspace formatting/lint/build/tests: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` all succeeded. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a42418988330a484ba555bb6b2ae)