### PR TITLE
Add manual repeated-run diagnostic matrix runner

### DIFF
--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -20,7 +20,6 @@ The corpus now includes deterministic adversarial validation that checks sparse,
 - root-cause proof from one run
 - universal production overhead claims
 - replacement of tracing/metrics/tokio-console
-- repeated-run variance behavior
 - mitigation-effect validation
 - overhead integration into diagnostic accuracy scoring
 - collector-limit integration into diagnostic accuracy scoring
@@ -43,4 +42,4 @@ Demos teach scenarios; validation measures bounded diagnostic behavior.
 
 It writes raw JSONL run records plus summary JSON (and optional Markdown scorecard) for stability metrics including top-1 accuracy, top-2 recall, high-confidence-wrong count, per-scenario primary stability, confidence bucket accuracy, and p95/p99 latency distribution summaries.
 
-This repeated-run validation is currently manual/local (not mandatory CI). It measures stability under bounded controlled Tokio demo workloads on a specific machine/profile; it does not establish production universality or root-cause proof.
+This repeated-run validation is currently manual/local (not mandatory CI). Publishable repeated-run outputs are generated locally and are not committed by default. Results are machine/workload scoped. It measures stability under bounded controlled Tokio demo workloads on a specific machine/profile; it does not establish production universality or root-cause proof.

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -37,3 +37,10 @@ The corpus now includes deterministic adversarial validation that checks sparse,
 - user-facing methodology: `docs/diagnostic-validation.md`
 
 Demos teach scenarios; validation measures bounded diagnostic behavior.
+
+## Repeated-run matrix validation (manual/local)
+`scripts/run_diagnostic_matrix.py` provides repeated-run validation for controlled demo scenarios (queue, blocking, executor, downstream; optional mixed).
+
+It writes raw JSONL run records plus summary JSON (and optional Markdown scorecard) for stability metrics including top-1 accuracy, top-2 recall, high-confidence-wrong count, per-scenario primary stability, confidence bucket accuracy, and p95/p99 latency distribution summaries.
+
+This repeated-run validation is currently manual/local (not mandatory CI). It measures stability under bounded controlled Tokio demo workloads on a specific machine/profile; it does not establish production universality or root-cause proof.

--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -47,3 +47,22 @@ Schema supports `must_include_next_checks`, but the current initial corpus has n
 
 ## Future work
 Repeated-run validation, mitigation validation, overhead integration, collector-limit integration, and expanded real-service validation are separate follow-on work.
+
+## Repeated-run diagnostic matrix validation (manual)
+A manual repeated-run matrix runner is available at `scripts/run_diagnostic_matrix.py`. It repeatedly executes controlled demo scenarios, analyzes each run, and summarizes stability metrics.
+
+This complements deterministic fixture validation:
+- deterministic fixtures validate stable contract behavior on committed artifacts
+- repeated-run matrix validation measures stability across repeated controlled runs on a specific machine/workload profile
+
+Key repeated-run metrics:
+- **Top-1 stability**: fraction of runs where the primary suspect matches the scenario ground truth
+- **Top-2 visibility**: fraction of runs where required causes appear in the top-2 suspects
+- **High-confidence-wrong count**: runs where primary confidence is high/very_high but primary kind is outside acceptable primary kinds
+- **Confidence bucket accuracy**: top-1 accuracy grouped by confidence bucket
+- **Primary stability**: share of runs captured by the most frequent primary suspect kind
+- **p95 IQR**: interquartile range of p95 latency across repeated runs
+
+Repeated-run validation remains manual/local for now (not mandatory CI), and results are machine-scoped and workload-scoped. It supports triage confidence checks and reproducibility inspection for controlled Tokio workloads.
+
+Like all tool output, these results are evidence for triage and next checks; they do not prove root cause.

--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -6,7 +6,7 @@
 The benchmark evaluates a deterministic corpus of analyzer reports against workload-grounded labels. It checks suspect ranking behavior, evidence/warning expectations, and bounded failure semantics.
 
 ## Deterministic vs repeated-run validation
-The current gate is deterministic fixture validation. Repeated-run variance validation is future work.
+The current gate is deterministic fixture validation. Repeated-run variance validation is available as a manual/local workflow.
 
 ## Top-1 vs required top-2
 - **Top-1**: primary suspect matches `ground_truth`.
@@ -46,7 +46,7 @@ The corpus includes insufficient-evidence scenarios to validate conservative fal
 Schema supports `must_include_next_checks`, but the current initial corpus has no non-empty next-check requirements, so next-check substrings are not currently part of the deterministic gate.
 
 ## Future work
-Repeated-run validation, mitigation validation, overhead integration, collector-limit integration, and expanded real-service validation are separate follow-on work.
+Mitigation validation, overhead integration, collector-limit integration, and expanded real-service validation are separate follow-on work.
 
 ## Repeated-run diagnostic matrix validation (manual)
 A manual repeated-run matrix runner is available at `scripts/run_diagnostic_matrix.py`. It repeatedly executes controlled demo scenarios, analyzes each run, and summarizes stability metrics.

--- a/scripts/run_diagnostic_matrix.py
+++ b/scripts/run_diagnostic_matrix.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import shutil
 import statistics
 from collections import Counter, defaultdict
 from pathlib import Path
@@ -225,7 +224,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--scenario", action="append", dest="scenarios")
     parser.add_argument("--profile", choices=PROFILE_CHOICES, default="dev")
     parser.add_argument("--artifact-root", type=Path, default=Path("target/diagnostic-matrix"))
-    parser.add_argument("--keep-artifacts", action="store_true")
     parser.add_argument("--min-top1", type=float, default=0.95)
     parser.add_argument("--min-top2", type=float, default=1.0)
     parser.add_argument("--max-high-confidence-wrong", type=int, default=0)
@@ -266,9 +264,6 @@ def main() -> None:
     summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     if args.scorecard:
         write_scorecard(args.scorecard, summary)
-
-    if not args.keep_artifacts and args.artifact_root.exists():
-        shutil.rmtree(args.artifact_root)
 
     print(f"records={len(records)}")
     print(f"out={args.out}")

--- a/scripts/run_diagnostic_matrix.py
+++ b/scripts/run_diagnostic_matrix.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Run repeated demo scenarios and summarize diagnostic stability metrics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import statistics
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+try:
+    from _demo_runner import PROFILE_CHOICES, load_report_json, repo_root, run_and_analyze
+except ModuleNotFoundError:  # pragma: no cover
+    from scripts._demo_runner import PROFILE_CHOICES, load_report_json, repo_root, run_and_analyze
+
+CONF_HIGH = {"high", "very_high"}
+DEFAULT_OUT = Path("target/diagnostic-runs.jsonl")
+
+SCENARIO_MATRIX = {
+    "queue": {
+        "manifest": "demos/queue_service/Cargo.toml",
+        "variant": "before",
+        "demo_mode": "baseline",
+        "ground_truth": "application_queue_saturation",
+        "acceptable_primary": ["application_queue_saturation"],
+        "required_top2": ["application_queue_saturation"],
+        "top1_required": True,
+    },
+    "blocking": {
+        "manifest": "demos/blocking_service/Cargo.toml",
+        "variant": "before",
+        "demo_mode": "baseline",
+        "ground_truth": "blocking_pool_pressure",
+        "acceptable_primary": ["blocking_pool_pressure"],
+        "required_top2": ["blocking_pool_pressure"],
+        "top1_required": True,
+    },
+    "executor": {
+        "manifest": "demos/executor_pressure_service/Cargo.toml",
+        "variant": "before",
+        "demo_mode": "baseline",
+        "ground_truth": "executor_pressure_suspected",
+        "acceptable_primary": ["executor_pressure_suspected"],
+        "required_top2": ["executor_pressure_suspected"],
+        "top1_required": True,
+    },
+    "downstream": {
+        "manifest": "demos/downstream_service/Cargo.toml",
+        "variant": "before",
+        "demo_mode": "baseline",
+        "ground_truth": "downstream_stage_dominates",
+        "acceptable_primary": ["downstream_stage_dominates", "application_queue_saturation"],
+        "required_top2": ["downstream_stage_dominates"],
+        "top1_required": True,
+    },
+    "mixed": {
+        "manifest": "demos/mixed_contention_service/Cargo.toml",
+        "variant": "before",
+        "demo_mode": "baseline",
+        "ground_truth": "application_queue_saturation",
+        "acceptable_primary": ["application_queue_saturation", "executor_pressure_suspected"],
+        "required_top2": ["application_queue_saturation"],
+        "top1_required": False,
+    },
+}
+
+DEFAULT_SCENARIOS = ["queue", "blocking", "executor", "downstream"]
+
+
+def _iqr(sorted_values: list[float]) -> float:
+    n = len(sorted_values)
+    if n < 2:
+        return 0.0
+    mid = n // 2
+    lower = sorted_values[:mid]
+    upper = sorted_values[mid + 1 :] if n % 2 else sorted_values[mid:]
+    q1 = statistics.median(lower)
+    q3 = statistics.median(upper)
+    return float(q3 - q1)
+
+
+def latency_stats(values: list[int]) -> dict[str, int] | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    return {
+        "median": int(statistics.median(ordered)),
+        "iqr": int(_iqr([float(v) for v in ordered])),
+        "min": ordered[0],
+        "max": ordered[-1],
+    }
+
+
+def build_record(*, report: dict[str, Any], metadata: dict[str, Any], run_index: int, profile: str, artifact_path: Path, analysis_path: Path) -> dict[str, Any]:
+    primary = report.get("primary_suspect") or {}
+    secondaries = report.get("secondary_suspects") or []
+    top2 = [s.get("kind") for s in [primary, *secondaries][:2] if s.get("kind")]
+    primary_kind = primary.get("kind")
+    top1_ok = primary_kind == metadata["ground_truth"]
+    top2_ok = all(kind in top2 for kind in metadata["required_top2"])
+    high_conf_wrong = primary.get("confidence") in CONF_HIGH and primary_kind not in metadata["acceptable_primary"]
+
+    return {
+        "schema_version": 1,
+        "run_index": run_index,
+        "scenario": metadata["name"],
+        "variant": metadata["variant"],
+        "profile": profile,
+        "artifact_path": str(artifact_path),
+        "analysis_path": str(analysis_path),
+        "ground_truth": metadata["ground_truth"],
+        "primary_kind": primary_kind,
+        "primary_confidence": primary.get("confidence"),
+        "primary_score": primary.get("score"),
+        "top2_kinds": top2,
+        "top1_ok": top1_ok,
+        "top2_ok": top2_ok,
+        "high_confidence_wrong": high_conf_wrong,
+        "warnings": report.get("warnings") or [],
+        "request_count": report.get("request_count"),
+        "p95_latency_us": report.get("p95_latency_us"),
+        "p99_latency_us": report.get("p99_latency_us"),
+        "p95_queue_share_permille": report.get("p95_queue_share_permille"),
+        "p95_service_share_permille": report.get("p95_service_share_permille"),
+    }
+
+
+def summarize(records: list[dict[str, Any]], *, runs: int, profile: str) -> dict[str, Any]:
+    total = len(records)
+    top1 = sum(1 for r in records if r["top1_ok"]) / total if total else 0.0
+    top2 = sum(1 for r in records if r["top2_ok"]) / total if total else 0.0
+    high_wrong = sum(1 for r in records if r["high_confidence_wrong"])
+    per: dict[str, dict[str, Any]] = {}
+
+    by_scenario: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for record in records:
+        by_scenario[record["scenario"]].append(record)
+
+    for scenario, rows in by_scenario.items():
+        count = len(rows)
+        primary_counts = Counter(r.get("primary_kind") for r in rows)
+        bucket = defaultdict(lambda: {"records": 0, "top1_correct": 0})
+        for row in rows:
+            conf = row.get("primary_confidence") or "unknown"
+            bucket[conf]["records"] += 1
+            bucket[conf]["top1_correct"] += 1 if row["top1_ok"] else 0
+        conf_summary = {
+            k: {**v, "accuracy": (v["top1_correct"] / v["records"] if v["records"] else 0.0)} for k, v in sorted(bucket.items())
+        }
+        per[scenario] = {
+            "records": count,
+            "top1_accuracy": sum(1 for r in rows if r["top1_ok"]) / count if count else 0.0,
+            "top2_recall": sum(1 for r in rows if r["top2_ok"]) / count if count else 0.0,
+            "high_confidence_wrong_count": sum(1 for r in rows if r["high_confidence_wrong"]),
+            "primary_kind_counts": {str(k): v for k, v in primary_counts.items() if k is not None},
+            "primary_stability": (max(primary_counts.values()) / count) if count else 0.0,
+            "p95_latency_us": latency_stats([r["p95_latency_us"] for r in rows if r.get("p95_latency_us") is not None]),
+            "p99_latency_us": latency_stats([r["p99_latency_us"] for r in rows if r.get("p99_latency_us") is not None]),
+            "confidence_bucket_accuracy": conf_summary,
+        }
+
+    return {
+        "schema_version": 1,
+        "runs": runs,
+        "profile": profile,
+        "total_records": total,
+        "top1_accuracy": top1,
+        "top2_recall": top2,
+        "high_confidence_wrong_count": high_wrong,
+        "per_scenario": dict(sorted(per.items())),
+        "failed_thresholds": [],
+    }
+
+
+def evaluate_thresholds(summary: dict[str, Any], scenario_defs: dict[str, dict[str, Any]], *, min_top1: float, min_top2: float, max_high_confidence_wrong: int) -> list[str]:
+    failed: list[str] = []
+    if summary["high_confidence_wrong_count"] > max_high_confidence_wrong:
+        failed.append(f"overall high_confidence_wrong_count {summary['high_confidence_wrong_count']} exceeds max {max_high_confidence_wrong}")
+    for scenario, metrics in summary["per_scenario"].items():
+        scenario_def = scenario_defs[scenario]
+        if scenario_def.get("top1_required", True) and metrics["top1_accuracy"] < min_top1:
+            failed.append(f"{scenario}: top1_accuracy {metrics['top1_accuracy']:.3f} below {min_top1:.3f}")
+        if metrics["top2_recall"] < min_top2:
+            failed.append(f"{scenario}: top2_recall {metrics['top2_recall']:.3f} below {min_top2:.3f}")
+        if metrics["high_confidence_wrong_count"] > max_high_confidence_wrong:
+            failed.append(f"{scenario}: high_confidence_wrong_count {metrics['high_confidence_wrong_count']} exceeds max {max_high_confidence_wrong}")
+    return failed
+
+
+def write_jsonl(path: Path, records: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for r in records:
+            f.write(json.dumps(r, sort_keys=True) + "\n")
+
+
+def write_scorecard(path: Path, summary: dict[str, Any]) -> None:
+    lines = [
+        "# Repeated-run diagnostic matrix scorecard",
+        "",
+        f"Profile: {summary['profile']}",
+        f"Runs per scenario: {summary['runs']}",
+        "",
+        "| Scenario | Records | Top-1 | Top-2 | Primary stability | High-conf wrong | p95 median | p95 IQR |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for scenario, m in summary["per_scenario"].items():
+        p95 = m.get("p95_latency_us") or {}
+        lines.append(
+            f"| {scenario} | {m['records']} | {m['top1_accuracy']:.3f} | {m['top2_recall']:.3f} | {m['primary_stability']:.3f} | {m['high_confidence_wrong_count']} | {p95.get('median', 'n/a')} | {p95.get('iqr', 'n/a')} |"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--runs", type=int, default=30)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--summary", type=Path)
+    parser.add_argument("--scorecard", type=Path)
+    parser.add_argument("--scenario", action="append", dest="scenarios")
+    parser.add_argument("--profile", choices=PROFILE_CHOICES, default="dev")
+    parser.add_argument("--artifact-root", type=Path, default=Path("target/diagnostic-matrix"))
+    parser.add_argument("--keep-artifacts", action="store_true")
+    parser.add_argument("--min-top1", type=float, default=0.95)
+    parser.add_argument("--min-top2", type=float, default=1.0)
+    parser.add_argument("--max-high-confidence-wrong", type=int, default=0)
+    parser.add_argument("--no-fail-thresholds", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.runs <= 0:
+        raise SystemExit("--runs must be > 0")
+    selected = args.scenarios or DEFAULT_SCENARIOS
+    unknown = [s for s in selected if s not in SCENARIO_MATRIX]
+    if unknown:
+        raise SystemExit(f"unknown scenarios: {unknown}")
+    root = repo_root(__file__)
+    cli_manifest = root / "tailtriage-cli/Cargo.toml"
+    summary_path = args.summary or args.out.with_name(f"{args.out.stem}-summary.json")
+
+    scenario_defs = {name: {**SCENARIO_MATRIX[name], "name": name} for name in selected}
+    records: list[dict[str, Any]] = []
+    for name, spec in scenario_defs.items():
+        demo_manifest = root / spec["manifest"]
+        run_dir = args.artifact_root / name / spec["variant"]
+        run_dir.mkdir(parents=True, exist_ok=True)
+        for i in range(1, args.runs + 1):
+            run_path = run_dir / f"run-{i:03d}-run.json"
+            analysis_path = run_dir / f"run-{i:03d}-analysis.json"
+            run_and_analyze(demo_manifest, cli_manifest, run_path, analysis_path, spec["demo_mode"], profile=args.profile)
+            report = load_report_json(analysis_path)
+            records.append(build_record(report=report, metadata=spec, run_index=i, profile=args.profile, artifact_path=run_path, analysis_path=analysis_path))
+
+    write_jsonl(args.out, records)
+    summary = summarize(records, runs=args.runs, profile=args.profile)
+    failed = evaluate_thresholds(summary, scenario_defs, min_top1=args.min_top1, min_top2=args.min_top2, max_high_confidence_wrong=args.max_high_confidence_wrong)
+    summary["failed_thresholds"] = failed
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.scorecard:
+        write_scorecard(args.scorecard, summary)
+
+    if not args.keep_artifacts and args.artifact_root.exists():
+        shutil.rmtree(args.artifact_root)
+
+    print(f"records={len(records)}")
+    print(f"out={args.out}")
+    print(f"summary={summary_path}")
+    if args.scorecard:
+        print(f"scorecard={args.scorecard}")
+    if failed:
+        for failure in failed:
+            print(f"FAIL: {failure}")
+        if not args.no_fail_thresholds:
+            raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_run_diagnostic_matrix.py
+++ b/scripts/tests/test_run_diagnostic_matrix.py
@@ -1,0 +1,91 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import run_diagnostic_matrix as rdm
+
+
+class RunDiagnosticMatrixTests(unittest.TestCase):
+    def sample_report(self, primary_kind="application_queue_saturation", confidence="high", p95=100, p99=200, second=None):
+        return {
+            "primary_suspect": {"kind": primary_kind, "confidence": confidence, "score": 90},
+            "secondary_suspects": second or [{"kind": "downstream_stage_dominates"}],
+            "warnings": [],
+            "request_count": 10,
+            "p95_latency_us": p95,
+            "p99_latency_us": p99,
+            "p95_queue_share_permille": 900,
+            "p95_service_share_permille": 100,
+        }
+
+    def metadata(self, **updates):
+        base = {
+            "name": "queue",
+            "variant": "before",
+            "ground_truth": "application_queue_saturation",
+            "required_top2": ["application_queue_saturation"],
+            "acceptable_primary": ["application_queue_saturation"],
+            "top1_required": True,
+        }
+        base.update(updates)
+        return base
+
+    def test_extract_run_record(self):
+        rec = rdm.build_record(report=self.sample_report(), metadata=self.metadata(), run_index=1, profile="dev", artifact_path=Path("a.json"), analysis_path=Path("b.json"))
+        self.assertTrue(rec["top1_ok"])
+        self.assertTrue(rec["top2_ok"])
+        self.assertFalse(rec["high_confidence_wrong"])
+
+    def test_high_confidence_wrong(self):
+        rec = rdm.build_record(report=self.sample_report(primary_kind="blocking_pool_pressure"), metadata=self.metadata(), run_index=1, profile="dev", artifact_path=Path("a"), analysis_path=Path("b"))
+        self.assertTrue(rec["high_confidence_wrong"])
+
+    def test_primary_stability_and_confidence_bucket(self):
+        records = [
+            rdm.build_record(report=self.sample_report(), metadata=self.metadata(), run_index=1, profile="dev", artifact_path=Path("a"), analysis_path=Path("b")),
+            rdm.build_record(report=self.sample_report(primary_kind="application_queue_saturation", confidence="medium"), metadata=self.metadata(), run_index=2, profile="dev", artifact_path=Path("a"), analysis_path=Path("b")),
+            rdm.build_record(report=self.sample_report(primary_kind="blocking_pool_pressure"), metadata=self.metadata(acceptable_primary=["application_queue_saturation", "blocking_pool_pressure"]), run_index=3, profile="dev", artifact_path=Path("a"), analysis_path=Path("b")),
+        ]
+        summary = rdm.summarize(records, runs=3, profile="dev")
+        per = summary["per_scenario"]["queue"]
+        self.assertAlmostEqual(per["primary_stability"], 2 / 3)
+        self.assertIn("high", per["confidence_bucket_accuracy"])
+
+    def test_latency_stats_odd_even_and_missing(self):
+        self.assertEqual(rdm.latency_stats([1, 2, 3])["median"], 2)
+        self.assertEqual(rdm.latency_stats([1, 2, 3, 4])["median"], 2)
+        self.assertIsNone(rdm.latency_stats([]))
+
+    def test_threshold_failures(self):
+        rec = rdm.build_record(report=self.sample_report(primary_kind="blocking_pool_pressure"), metadata=self.metadata(), run_index=1, profile="dev", artifact_path=Path("a"), analysis_path=Path("b"))
+        summary = rdm.summarize([rec], runs=1, profile="dev")
+        failures = rdm.evaluate_thresholds(summary, {"queue": self.metadata()}, min_top1=0.95, min_top2=1.0, max_high_confidence_wrong=0)
+        self.assertTrue(any("top1_accuracy" in f for f in failures))
+        self.assertTrue(any("high_confidence_wrong_count" in f for f in failures))
+
+    def test_mixed_without_top1_requirement(self):
+        rec = rdm.build_record(report=self.sample_report(primary_kind="executor_pressure_suspected", second=[{"kind": "application_queue_saturation"}]), metadata=self.metadata(name="mixed", top1_required=False, acceptable_primary=["application_queue_saturation", "executor_pressure_suspected"]), run_index=1, profile="dev", artifact_path=Path("a"), analysis_path=Path("b"))
+        summary = rdm.summarize([rec], runs=1, profile="dev")
+        failures = rdm.evaluate_thresholds(summary, {"mixed": self.metadata(name="mixed", top1_required=False, acceptable_primary=["application_queue_saturation", "executor_pressure_suspected"])}, min_top1=0.95, min_top2=1.0, max_high_confidence_wrong=0)
+        self.assertFalse(any("top1_accuracy" in f for f in failures))
+
+    def test_jsonl_write(self):
+        records = [{"a": 1}, {"b": 2}]
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "out.jsonl"
+            rdm.write_jsonl(path, records)
+            lines = path.read_text(encoding="utf-8").strip().splitlines()
+            self.assertEqual(len(lines), 2)
+            self.assertEqual(json.loads(lines[0])["a"], 1)
+
+    def test_missing_optional_p99_in_summary(self):
+        report = self.sample_report()
+        report.pop("p99_latency_us")
+        rec = rdm.build_record(report=report, metadata=self.metadata(), run_index=1, profile="dev", artifact_path=Path("a"), analysis_path=Path("b"))
+        summary = rdm.summarize([rec], runs=1, profile="dev")
+        self.assertIsNone(summary["per_scenario"]["queue"]["p99_latency_us"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -55,3 +55,9 @@ python3 scripts/diagnostic_benchmark.py \
   --min-top2 0.90 \
   --max-high-confidence-wrong 0
 ```
+
+## Validation tracks
+- deterministic corpus benchmark: `scripts/diagnostic_benchmark.py`
+- repeated-run controlled matrix runner: `scripts/run_diagnostic_matrix.py`
+
+The deterministic corpus checks fixture-labeled contract behavior. The repeated-run runner checks repeated-run stability for selected controlled demo workloads.

--- a/validation/diagnostics/latest/scorecard.md
+++ b/validation/diagnostics/latest/scorecard.md
@@ -13,6 +13,7 @@
 | missing instrumentation warnings | Initial deterministic adversarial coverage | queue/stage/runtime missing and optional-runtime-field warnings are explicitly checked. |
 | runtime overhead | Measured separately | see `docs/runtime-cost.md`. |
 | collector limits | Measured separately | see `docs/collector-limits.md`. |
+| repeated-run diagnostic matrix | Manual repeated-run validation available | publishable repeated-run outputs are generated locally (JSONL/summary/scorecard) and not committed by default. |
 | real service validation | Planned | add curated real-service anonymized artifacts. |
 
 Deterministic synthetic adversarial cases validate benchmark/report contract behavior and humility checks; they are not real-service validation.

--- a/validation/diagnostics/latest/scorecard.md
+++ b/validation/diagnostics/latest/scorecard.md
@@ -13,7 +13,7 @@
 | missing instrumentation warnings | Initial deterministic adversarial coverage | queue/stage/runtime missing and optional-runtime-field warnings are explicitly checked. |
 | runtime overhead | Measured separately | see `docs/runtime-cost.md`. |
 | collector limits | Measured separately | see `docs/collector-limits.md`. |
-| repeated-run diagnostic matrix | Manual repeated-run validation available | publishable repeated-run outputs are generated locally (JSONL/summary/scorecard) and not committed by default. |
+| repeated-run diagnostic matrix | Manual/local repeated-run validation available | publishable repeated-run outputs are generated locally (JSONL/summary/scorecard) and not committed by default; results are machine/workload scoped. |
 | real service validation | Planned | add curated real-service anonymized artifacts. |
 
-Deterministic synthetic adversarial cases validate benchmark/report contract behavior and humility checks; they are not real-service validation.
+Deterministic synthetic adversarial cases validate benchmark/report contract behavior and humility checks; they are not real-service validation and do not provide root-cause proof.


### PR DESCRIPTION
### Motivation
- Provide a stdlib-only, manual repeated-run validation runner to measure diagnostic stability across controlled demo runs rather than relying only on single committed fixtures.
- Support reproducible local inspection of per-run analyzer outputs and stability metrics to track Top-1/Top-2 visibility, confidence calibration, and p95/p99 latency variability for controlled workloads.
- Keep the change scoped to validation tooling without modifying analyzer scoring, adding dependencies, or creating new Rust crates.

### Description
- Added `scripts/run_diagnostic_matrix.py`, a CLI that repeatedly runs selected demo scenarios, analyzes runs with the existing CLI, writes per-run JSONL records under `target/`, computes summary statistics (`build_record`, `summarize`, `latency_stats`, `evaluate_thresholds`), evaluates thresholds, and optionally writes a compact Markdown scorecard.
- Added unit tests `scripts/tests/test_run_diagnostic_matrix.py` covering run-record extraction, summary metrics, confidence-bucket accuracy, primary-stability calculation, latency stats (odd/even/missing), threshold evaluation (including mixed-scenario semantics), and JSONL writing.
- Updated docs and validation metadata to document repeated-run validation: `docs/diagnostic-validation.md`, `VALIDATION.md`, `validation/diagnostics/README.md`, and `validation/diagnostics/latest/scorecard.md` explain the new manual repeated-run track and its limits (machine/workload scoped; not root-cause proof; not CI-mandatory).
- Implementation notes: the runner uses only the Python standard library, writes artifacts under `target/diagnostic-matrix/` (not `demos/*/artifacts`), includes a safe import fallback to allow test imports, and explicitly does not change analyzer behavior or add dependencies.

### Testing
- `python3 scripts/run_diagnostic_matrix.py --runs 1 --scenario queue --out target/diagnostic-runs-smoke.jsonl --summary target/diagnostic-runs-smoke-summary.json --scorecard target/diagnostic-runs-smoke-scorecard.md --no-fail-thresholds` — passed (wrote smoke artifacts and summary).
- `python3 -m unittest scripts.tests.test_run_diagnostic_matrix` — passed (unit tests for metric extraction, summary, thresholds, JSONL, and missing optional fields).
- `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json` — passed (deterministic benchmark ran and reported metrics).
- `python3 -m unittest scripts.tests.test_diagnostic_benchmark` — passed.
- `python3 scripts/validate_docs_contracts.py` — passed (docs contract validation succeeded).
- `python3 -m unittest scripts.tests.test_validate_docs_contracts` — passed.
- `python3 scripts/check_demo_fixture_drift.py --profile dev` — passed (demo fixtures confirmed up-to-date).
- `cargo fmt --check` — passed.
- `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- `cargo test --workspace` — passed.
- `python3 scripts/run_diagnostic_matrix.py --runs 3 --scenario queue --scenario blocking --scenario executor --scenario downstream --out target/diagnostic-runs.jsonl --summary target/diagnostic-runs-summary.json --scorecard target/diagnostic-runs-scorecard.md` — passed (multi-scenario run succeeded and wrote JSONL/summary/scorecard).
- Note: an initial test import error (`ModuleNotFoundError`) was observed during early test runs and was resolved by adding a local import fallback in `run_diagnostic_matrix.py`; subsequent automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a42418988330a484ba555bb6b2ae)