### PR TITLE
Add repeated-run diagnostic matrix runner for stability validation

### DIFF
--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -37,3 +37,11 @@ The corpus now includes deterministic adversarial validation that checks sparse,
 - user-facing methodology: `docs/diagnostic-validation.md`
 
 Demos teach scenarios; validation measures bounded diagnostic behavior.
+
+
+## Repeated-run matrix validation (manual/local)
+- `scripts/run_diagnostic_matrix.py` runs repeated controlled demo scenarios and summarizes repeated-run diagnostic stability.
+- It reports top-1 accuracy, top-2 recall, high-confidence-wrong count, confidence-bucket accuracy, primary-suspect stability, and p95/p99 median+IQR+range.
+- This is manual/local in the current phase, not mandatory CI.
+- Results are machine/workload scoped and validate stability for controlled demo workloads, not production universality.
+- As with all tool output, this is triage guidance and not root-cause proof.

--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -46,4 +46,22 @@ The corpus includes insufficient-evidence scenarios to validate conservative fal
 Schema supports `must_include_next_checks`, but the current initial corpus has no non-empty next-check requirements, so next-check substrings are not currently part of the deterministic gate.
 
 ## Future work
-Repeated-run validation, mitigation validation, overhead integration, collector-limit integration, and expanded real-service validation are separate follow-on work.
+Mitigation validation, overhead integration, collector-limit integration, and expanded real-service validation are separate follow-on work.
+
+## Repeated-run diagnostic matrix (manual/local)
+Use `scripts/run_diagnostic_matrix.py` to run controlled demo scenarios repeatedly, analyze each run, and summarize stability metrics.
+
+This repeated-run matrix complements deterministic fixture validation:
+- deterministic fixture validation checks bounded behavior on committed fixtures;
+- repeated-run matrix validation checks repeated-run stability on controlled demo workloads.
+
+Key repeated-run metrics:
+- **Top-1**: primary suspect matches scenario ground truth.
+- **Top-2**: expected causes remain visible in primary + first secondary suspects.
+- **High-confidence-wrong**: high/very-high confidence primary suspect is outside acceptable primary kinds.
+- **Primary stability**: most-common primary suspect frequency within a scenario.
+- **Confidence bucket accuracy**: top-1 accuracy within each confidence bucket.
+- **p95 IQR**: interquartile range of repeated p95 latency values (variance summary only, not a gate yet).
+
+Repeated-run validation is manual/local in the current phase (not mandatory CI). Results are workload- and machine-scoped and support triage quality inspection under bounded controlled Tokio workloads; they are not root-cause proof.
+

--- a/scripts/run_diagnostic_matrix.py
+++ b/scripts/run_diagnostic_matrix.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import statistics
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from _demo_runner import load_report_json, repo_root, run_and_analyze
+
+CONF_HIGH = {"high", "very_high"}
+
+
+@dataclass(frozen=True)
+class ScenarioDef:
+    name: str
+    manifest_path: str
+    variant: str
+    ground_truth: str
+    acceptable_primary: tuple[str, ...]
+    required_top2: tuple[str, ...]
+    top1_required: bool
+    min_top1: float | None = None
+    min_top2: float | None = None
+
+
+def default_scenarios() -> dict[str, ScenarioDef]:
+    return {
+        "queue": ScenarioDef("queue", "demos/queue_service/Cargo.toml", "before", "application_queue_saturation", ("application_queue_saturation",), ("application_queue_saturation",), True),
+        "blocking": ScenarioDef("blocking", "demos/blocking_service/Cargo.toml", "before", "blocking_pool_pressure", ("blocking_pool_pressure",), ("blocking_pool_pressure",), True),
+        "executor": ScenarioDef("executor", "demos/executor_pressure_service/Cargo.toml", "before", "executor_pressure_suspected", ("executor_pressure_suspected",), ("executor_pressure_suspected",), True),
+        "downstream": ScenarioDef("downstream", "demos/downstream_service/Cargo.toml", "before", "downstream_stage_dominates", ("downstream_stage_dominates",), ("downstream_stage_dominates",), True),
+        "mixed": ScenarioDef("mixed", "demos/mixed_contention_service/Cargo.toml", "baseline", "application_queue_saturation", ("application_queue_saturation", "executor_pressure_suspected"), ("application_queue_saturation", "executor_pressure_suspected"), False, min_top2=0.95),
+    }
+
+
+def top2_kinds(report: dict[str, Any]) -> list[str]:
+    suspects = [report.get("primary_suspect", {})] + report.get("secondary_suspects", [])
+    return [s.get("kind") for s in suspects[:2] if isinstance(s, dict) and s.get("kind")]
+
+
+def extract_run_record(report: dict[str, Any], scenario: ScenarioDef, run_index: int, profile: str, artifact_path: Path, analysis_path: Path) -> dict[str, Any]:
+    primary = report.get("primary_suspect") or {}
+    primary_kind = primary.get("kind")
+    primary_conf = primary.get("confidence")
+    kinds = top2_kinds(report)
+    top1_ok = primary_kind == scenario.ground_truth
+    top2_ok = all(req in kinds for req in scenario.required_top2)
+    high_wrong = primary_conf in CONF_HIGH and primary_kind not in scenario.acceptable_primary
+    return {
+        "schema_version": 1,
+        "run_index": run_index,
+        "scenario": scenario.name,
+        "variant": scenario.variant,
+        "profile": profile,
+        "artifact_path": str(artifact_path),
+        "analysis_path": str(analysis_path),
+        "ground_truth": scenario.ground_truth,
+        "primary_kind": primary_kind,
+        "primary_confidence": primary_conf,
+        "primary_score": primary.get("score"),
+        "top2_kinds": kinds,
+        "top1_ok": top1_ok,
+        "top2_ok": top2_ok,
+        "high_confidence_wrong": high_wrong,
+        "warnings": report.get("warnings", []),
+        "request_count": report.get("request_count"),
+        "p95_latency_us": report.get("p95_latency_us"),
+        "p99_latency_us": report.get("p99_latency_us"),
+        "p95_queue_share_permille": report.get("p95_queue_share_permille"),
+        "p95_service_share_permille": report.get("p95_service_share_permille"),
+    }
+
+
+def iqr_stats(values: list[float | int]) -> dict[str, float | int] | None:
+    if not values:
+        return None
+    data = sorted(values)
+    n = len(data)
+    mid = n // 2
+    lower = data[:mid]
+    upper = data[mid:] if n % 2 == 0 else data[mid + 1 :]
+    q1 = statistics.median(lower) if lower else data[0]
+    q3 = statistics.median(upper) if upper else data[-1]
+    return {"median": statistics.median(data), "iqr": q3 - q1, "min": data[0], "max": data[-1]}
+
+
+def summarize_records(records: list[dict[str, Any]], runs: int, profile: str) -> dict[str, Any]:
+    total = len(records)
+    top1 = (sum(1 for r in records if r["top1_ok"]) / total) if total else 0.0
+    top2 = (sum(1 for r in records if r["top2_ok"]) / total) if total else 0.0
+    high_wrong = sum(1 for r in records if r["high_confidence_wrong"])
+    by_scenario = defaultdict(list)
+    for r in records:
+        by_scenario[r["scenario"]].append(r)
+    per = {}
+    for name, group in by_scenario.items():
+        gtotal = len(group)
+        pk = Counter(r["primary_kind"] for r in group)
+        p95 = iqr_stats([r["p95_latency_us"] for r in group if r.get("p95_latency_us") is not None])
+        p99 = iqr_stats([r["p99_latency_us"] for r in group if r.get("p99_latency_us") is not None])
+        conf = defaultdict(lambda: {"records": 0, "top1_correct": 0})
+        for r in group:
+            bucket = r.get("primary_confidence") or "unknown"
+            conf[bucket]["records"] += 1
+            conf[bucket]["top1_correct"] += 1 if r["top1_ok"] else 0
+        conf_out = {k: {**v, "accuracy": (v["top1_correct"] / v["records"]) if v["records"] else 0.0} for k, v in conf.items()}
+        per[name] = {
+            "records": gtotal,
+            "top1_accuracy": sum(1 for r in group if r["top1_ok"]) / gtotal,
+            "top2_recall": sum(1 for r in group if r["top2_ok"]) / gtotal,
+            "high_confidence_wrong_count": sum(1 for r in group if r["high_confidence_wrong"]),
+            "primary_kind_counts": dict(pk),
+            "primary_stability": (max(pk.values()) / gtotal) if pk else 0.0,
+            "p95_latency_us": p95,
+            "p99_latency_us": p99,
+            "confidence_bucket_accuracy": conf_out,
+        }
+    return {"schema_version": 1, "runs": runs, "profile": profile, "total_records": total, "top1_accuracy": top1, "top2_recall": top2, "high_confidence_wrong_count": high_wrong, "per_scenario": per, "failed_thresholds": []}
+
+
+def evaluate_thresholds(summary: dict[str, Any], scenarios: list[ScenarioDef], min_top1: float, min_top2: float, max_high_wrong: int) -> list[str]:
+    failures = []
+    if summary["high_confidence_wrong_count"] > max_high_wrong:
+        failures.append(f"overall high_confidence_wrong_count {summary['high_confidence_wrong_count']} exceeds max {max_high_wrong}")
+    for s in scenarios:
+        ps = summary["per_scenario"].get(s.name)
+        if not ps:
+            continue
+        s_top1 = s.min_top1 if s.min_top1 is not None else (min_top1 if s.top1_required else None)
+        s_top2 = s.min_top2 if s.min_top2 is not None else min_top2
+        if s_top1 is not None and ps["top1_accuracy"] < s_top1:
+            failures.append(f"{s.name} top1_accuracy {ps['top1_accuracy']:.3f} below threshold {s_top1:.3f}")
+        if ps["top2_recall"] < s_top2:
+            failures.append(f"{s.name} top2_recall {ps['top2_recall']:.3f} below threshold {s_top2:.3f}")
+        if ps["high_confidence_wrong_count"] > max_high_wrong:
+            failures.append(f"{s.name} high_confidence_wrong_count {ps['high_confidence_wrong_count']} exceeds max {max_high_wrong}")
+    return failures
+
+
+def write_jsonl(path: Path, records: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for r in records:
+            f.write(json.dumps(r, sort_keys=True) + "\n")
+
+
+def write_scorecard(path: Path, summary: dict[str, Any]) -> None:
+    lines = ["# Repeated-run diagnostic matrix scorecard", "", f"Profile: {summary['profile']}", f"Runs per scenario: {summary['runs']}", "", "| Scenario | Records | Top-1 | Top-2 | Primary stability | High-conf wrong | p95 median | p95 IQR |", "|---|---:|---:|---:|---:|---:|---:|---:|"]
+    for name, row in sorted(summary["per_scenario"].items()):
+        p95 = row.get("p95_latency_us") or {}
+        lines.append(f"| {name} | {row['records']} | {row['top1_accuracy']:.3f} | {row['top2_recall']:.3f} | {row['primary_stability']:.3f} | {row['high_confidence_wrong_count']} | {p95.get('median', 'n/a')} | {p95.get('iqr', 'n/a')} |")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--runs", type=int, default=30)
+    ap.add_argument("--out", type=Path, default=Path("target/diagnostic-runs.jsonl"))
+    ap.add_argument("--summary", type=Path)
+    ap.add_argument("--scorecard", type=Path)
+    ap.add_argument("--scenario", action="append", default=[])
+    ap.add_argument("--profile", choices=["dev", "release"], default="dev")
+    ap.add_argument("--artifact-root", type=Path, default=Path("target/diagnostic-matrix"))
+    ap.add_argument("--keep-artifacts", action="store_true")
+    ap.add_argument("--min-top1", type=float, default=0.95)
+    ap.add_argument("--min-top2", type=float, default=1.0)
+    ap.add_argument("--max-high-confidence-wrong", type=int, default=0)
+    ap.add_argument("--no-fail-thresholds", action="store_true")
+    args = ap.parse_args()
+    scenario_map = default_scenarios()
+    selected_names = args.scenario or ["queue", "blocking", "executor", "downstream"]
+    selected = [scenario_map[n] for n in selected_names]
+    root = repo_root(__file__)
+    cli_manifest = root / "tailtriage-cli" / "Cargo.toml"
+    records = []
+    if not args.keep_artifacts and args.artifact_root.exists():
+        shutil.rmtree(args.artifact_root)
+    for s in selected:
+        for idx in range(1, args.runs + 1):
+            run_path = args.artifact_root / s.name / s.variant / f"run-{idx:03d}-run.json"
+            analysis_path = args.artifact_root / s.name / s.variant / f"run-{idx:03d}-analysis.json"
+            run_and_analyze(root / s.manifest_path, cli_manifest, run_path, analysis_path, s.variant, profile=args.profile)
+            report = load_report_json(analysis_path)
+            records.append(extract_run_record(report, s, idx, args.profile, run_path, analysis_path))
+    write_jsonl(args.out, records)
+    summary_path = args.summary or args.out.with_name(f"{args.out.stem}-summary.json")
+    summary = summarize_records(records, args.runs, args.profile)
+    failures = evaluate_thresholds(summary, selected, args.min_top1, args.min_top2, args.max_high_confidence_wrong)
+    summary["failed_thresholds"] = failures
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.scorecard:
+        write_scorecard(args.scorecard, summary)
+    if failures and not args.no_fail_thresholds:
+        for f in failures:
+            print(f"FAIL: {f}")
+        return 1
+    print(f"wrote {len(records)} records to {args.out}")
+    print(f"wrote summary to {summary_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_run_diagnostic_matrix.py
+++ b/scripts/tests/test_run_diagnostic_matrix.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import run_diagnostic_matrix as rdm
+
+
+class MatrixTests(unittest.TestCase):
+    def scenario(self, **kwargs):
+        base = rdm.ScenarioDef("queue", "demos/queue_service/Cargo.toml", "before", "application_queue_saturation", ("application_queue_saturation",), ("application_queue_saturation",), True)
+        return rdm.ScenarioDef(**{**base.__dict__, **kwargs})
+
+    def report(self, **kwargs):
+        rep = {
+            "primary_suspect": {"kind": "application_queue_saturation", "confidence": "high", "score": 95},
+            "secondary_suspects": [{"kind": "downstream_stage_dominates"}],
+            "warnings": [],
+            "request_count": 10,
+            "p95_latency_us": 100,
+            "p99_latency_us": 120,
+            "p95_queue_share_permille": 900,
+            "p95_service_share_permille": 100,
+        }
+        rep.update(kwargs)
+        return rep
+
+    def test_extract_record(self):
+        rec = rdm.extract_run_record(self.report(), self.scenario(), 1, "dev", Path("a"), Path("b"))
+        self.assertTrue(rec["top1_ok"])
+        self.assertTrue(rec["top2_ok"])
+
+    def test_high_conf_wrong(self):
+        rep = self.report(primary_suspect={"kind": "blocking_pool_pressure", "confidence": "high", "score": 90})
+        rec = rdm.extract_run_record(rep, self.scenario(), 1, "dev", Path("a"), Path("b"))
+        self.assertTrue(rec["high_confidence_wrong"])
+
+    def test_primary_stability_and_bucket(self):
+        s = self.scenario()
+        recs = [rdm.extract_run_record(self.report(), s, i, "dev", Path("a"), Path("b")) for i in range(1, 4)]
+        summary = rdm.summarize_records(recs, 3, "dev")
+        self.assertEqual(summary["per_scenario"]["queue"]["primary_stability"], 1.0)
+        self.assertEqual(summary["per_scenario"]["queue"]["confidence_bucket_accuracy"]["high"]["accuracy"], 1.0)
+
+    def test_iqr_stats_even_odd(self):
+        self.assertEqual(rdm.iqr_stats([1, 2, 3])["iqr"], 2)
+        self.assertEqual(rdm.iqr_stats([1, 2, 3, 4])["iqr"], 2)
+
+    def test_threshold_failures(self):
+        s = self.scenario()
+        bad = rdm.extract_run_record(self.report(primary_suspect={"kind": "blocking_pool_pressure", "confidence": "high"}), s, 1, "dev", Path("a"), Path("b"))
+        summary = rdm.summarize_records([bad], 1, "dev")
+        fails = rdm.evaluate_thresholds(summary, [s], 0.95, 1.0, 0)
+        self.assertTrue(any("top1_accuracy" in f for f in fails))
+        self.assertTrue(any("high_confidence_wrong" in f for f in fails))
+
+    def test_mixed_top2_without_top1(self):
+        mixed = self.scenario(name="mixed", top1_required=False, required_top2=("application_queue_saturation", "executor_pressure_suspected"))
+        rep = self.report(primary_suspect={"kind": "executor_pressure_suspected", "confidence": "medium"}, secondary_suspects=[{"kind": "application_queue_saturation"}])
+        rec = rdm.extract_run_record(rep, mixed, 1, "dev", Path("a"), Path("b"))
+        summary = rdm.summarize_records([rec], 1, "dev")
+        fails = rdm.evaluate_thresholds(summary, [mixed], 0.95, 1.0, 0)
+        self.assertFalse(any("top1_accuracy" in f for f in fails))
+
+    def test_jsonl_write(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "x.jsonl"
+            rdm.write_jsonl(p, [{"a": 1}, {"a": 2}])
+            lines = p.read_text().strip().splitlines()
+            self.assertEqual(len(lines), 2)
+            self.assertEqual(json.loads(lines[0])["a"], 1)
+
+    def test_missing_optional_latency(self):
+        rep = self.report()
+        del rep["p99_latency_us"]
+        s = self.scenario()
+        rec = rdm.extract_run_record(rep, s, 1, "dev", Path("a"), Path("b"))
+        summary = rdm.summarize_records([rec], 1, "dev")
+        self.assertIsNone(summary["per_scenario"]["queue"]["p99_latency_us"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -55,3 +55,9 @@ python3 scripts/diagnostic_benchmark.py \
   --min-top2 0.90 \
   --max-high-confidence-wrong 0
 ```
+
+
+## Validation tracks
+- Deterministic corpus benchmark: committed fixtures and deterministic pass/fail semantics.
+- Synthetic adversarial corpus: deterministic humility and warning behavior checks under sparse/missing/truncated/mixed evidence.
+- Repeated-run runner: manual/local repeated controlled demo runs to measure stability metrics across runs.

--- a/validation/diagnostics/latest/scorecard.md
+++ b/validation/diagnostics/latest/scorecard.md
@@ -16,3 +16,6 @@
 | real service validation | Planned | add curated real-service anonymized artifacts. |
 
 Deterministic synthetic adversarial cases validate benchmark/report contract behavior and humility checks; they are not real-service validation.
+
+
+| Repeated-run diagnostic matrix | Manual repeated-run validation available; publishable results not committed by default. |


### PR DESCRIPTION
### Motivation
- Move validation beyond single committed fixtures by measuring diagnostic stability across repeated controlled demo runs. 
- Provide reproducible, inspectable per-run records and a stable summary for evidence-ranked suspects and next-check stability analysis. 
- Keep this as a manual/local validation tool that complements the existing deterministic corpus without changing analyzer behavior or adding dependencies.

### Description
- Add a stdlib-only runner `scripts/run_diagnostic_matrix.py` that repeatedly executes selected demo scenarios, analyzes each run, writes per-run JSONL records, computes stability metrics, evaluates thresholds, and optionally emits a compact Markdown scorecard. 
- Implement metric extraction and summarization features including top-1 accuracy, top-2 recall, high-confidence-wrong counts, per-scenario primary-kind counts and primary-stability, confidence-bucket accuracy, and p95/p99 median/IQR/min/max summaries. 
- Add unit tests `scripts/tests/test_run_diagnostic_matrix.py` with pure functions testable without invoking subprocess-heavy flows (record extraction, summary, IQR, thresholds, JSONL writing, and missing optional fields). 
- Update docs: `docs/diagnostic-validation.md`, `VALIDATION.md`, `validation/diagnostics/README.md`, and `validation/diagnostics/latest/scorecard.md` to document the repeated-run matrix as a manual/local validation track and to explain metrics and non-claims. 
- Conservative defaults and semantics: safe default scenario set (`queue`, `blocking`, `executor`, `downstream`, optional `mixed`), artifact root under `target/diagnostic-matrix`, do not write to `demos/*/artifacts`, and do not change analyzer scoring/schema.

### Testing
- `python3 scripts/run_diagnostic_matrix.py --runs 1 --scenario queue --out target/diagnostic-runs-smoke.jsonl --summary target/diagnostic-runs-smoke-summary.json --scorecard target/diagnostic-runs-smoke-scorecard.md --no-fail-thresholds` — passed and produced smoke artifacts. 
- `python3 -m unittest scripts.tests.test_run_diagnostic_matrix` — passed (all unit tests OK). 
- `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json` — passed (deterministic benchmark executed and reported metrics). 
- `python3 -m unittest scripts.tests.test_diagnostic_benchmark` — passed. 
- `python3 scripts/validate_docs_contracts.py` — passed. 
- `python3 -m unittest scripts.tests.test_validate_docs_contracts` — passed. 
- `python3 scripts/check_demo_fixture_drift.py --profile dev` — passed (demo fixtures validated/updated). 
- `cargo fmt --check` — passed. 
- `cargo clippy --workspace --all-targets -- -D warnings` — passed. 
- `cargo test --workspace` — passed. 
- `python3 scripts/run_diagnostic_matrix.py --runs 3 --scenario queue --scenario blocking --scenario executor --scenario downstream --out target/diagnostic-runs.jsonl --summary target/diagnostic-runs-summary.json --scorecard target/diagnostic-runs-scorecard.md` — passed and produced multi-run artifacts and summary. 

Note: all automated tests and checks run in this change set completed successfully in the authoring environment; the repeated-run matrix is manual/local for now and its outputs are workload- and machine-scoped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a42418988330a484ba555bb6b2ae)