### PR TITLE
Add manual mitigation matrix validation runner and docs

### DIFF
--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -43,3 +43,12 @@ Demos teach scenarios; validation measures bounded diagnostic behavior.
 It writes raw JSONL run records plus summary JSON (and optional Markdown scorecard) for stability metrics including top-1 accuracy, top-2 recall, high-confidence-wrong count, per-scenario primary stability, confidence bucket accuracy, and p95/p99 latency distribution summaries.
 
 This repeated-run validation is currently manual/local (not mandatory CI). Publishable repeated-run outputs are generated locally and are not committed by default. Results are machine/workload scoped. It measures stability under bounded controlled Tokio demo workloads on a specific machine/profile; it does not establish production universality or root-cause proof.
+
+## Mitigation matrix validation (manual/local)
+`scripts/run_mitigation_matrix.py` runs paired baseline/mitigated controlled demo scenarios and compares latency plus evidence movement for targeted mitigations.
+
+It writes JSONL pair records, summary JSON, and optional scorecard Markdown under `target/` paths. Generated outputs are local/manual and are not committed by default.
+
+Mitigation validation checks whether expected evidence-ranked suspect movement appears under controlled workloads (for example: queue-share drops, service-share drops, blocking queue-depth drops, and explainable top-2/primary movement), while treating score movement as intra-report ranking signal rather than absolute cross-report severity.
+
+This workflow is machine/workload scoped and supports triage next checks. It does not prove root cause and is not mandatory CI.

--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -46,7 +46,20 @@ The corpus includes insufficient-evidence scenarios to validate conservative fal
 Schema supports `must_include_next_checks`, but the current initial corpus has no non-empty next-check requirements, so next-check substrings are not currently part of the deterministic gate.
 
 ## Future work
-Mitigation validation, overhead integration, collector-limit integration, and expanded real-service validation are separate follow-on work.
+Overhead integration, collector-limit integration, and expanded real-service validation are separate follow-on work.
+
+## Mitigation matrix validation (manual/local)
+A manual mitigation matrix runner is available at `scripts/run_mitigation_matrix.py`. It compares degraded/baseline runs against targeted mitigated runs for controlled demos and summarizes whether expected latency/evidence movement occurs.
+
+Typical expected movement by bottleneck family:
+- queue-oriented scenarios: p95 improves and queue-share evidence weakens
+- downstream-stage scenarios: p95 improves and service/stage share evidence weakens
+- blocking scenarios: p95 improves and blocking queue-depth evidence weakens
+- db/pool scenarios: p95 improves and queueing/service evidence moves in an explainable direction
+
+Important interpretation rule: suspect score changes are evidence-ranking changes inside each report, not absolute severity values across reports. Mitigation validation therefore uses concrete movement checks (latency, share/depth metrics, and explainable top suspect movement), not score-drop-only gating.
+
+Like repeated-run validation, mitigation validation is manual/local, machine/workload scoped, and designed for triage guidance and next checks. It does not prove root cause.
 
 ## Repeated-run diagnostic matrix validation (manual)
 A manual repeated-run matrix runner is available at `scripts/run_diagnostic_matrix.py`. It repeatedly executes controlled demo scenarios, analyzes each run, and summarizes stability metrics.

--- a/scripts/run_mitigation_matrix.py
+++ b/scripts/run_mitigation_matrix.py
@@ -161,10 +161,23 @@ def evaluate_movements(record: dict[str, Any], scenario_meta: dict[str, Any], th
         elif key == "primary_changes_from_targeted":
             passed = record.get("before_primary_kind") == record["targeted_suspect"] and record.get("after_primary_kind") != record["targeted_suspect"]
         else:
-            passed = True
+            passed = False
         checks[key] = passed
         if not passed:
-            failed.append(key)
+            if key in {
+                "p95_decreases",
+                "p99_nonworsening",
+                "queue_share_decreases",
+                "service_share_decreases",
+                "blocking_queue_depth_decreases",
+                "targeted_score_nonworsening",
+                "targeted_score_decreases",
+                "top2_retains_target_or_expected_successor",
+                "primary_changes_from_targeted",
+            }:
+                failed.append(key)
+            else:
+                failed.append(f"unknown_movement_key:{key}")
 
     after_conf = record.get("after_primary_confidence")
     record["high_confidence_wrong_after"] = bool(after_conf in CONF_HIGH and record.get("after_primary_kind") not in set(scenario_meta.get("expected_after_top2") or [record["targeted_suspect"]]))

--- a/scripts/run_mitigation_matrix.py
+++ b/scripts/run_mitigation_matrix.py
@@ -29,18 +29,20 @@ SCENARIOS = {
         "demo_manifest": "demos/blocking_service/Cargo.toml",
         "targeted_suspect": "blocking_pool_pressure",
         "expected_movements": ["p95_decreases", "blocking_queue_depth_decreases", "targeted_score_nonworsening"],
+        "expected_after_top2": ["downstream_stage_dominates", "blocking_pool_pressure"],
         "notes": "Blocking mitigation should reduce blocking queue pressure and improve latency.",
     },
     "downstream": {
         "demo_manifest": "demos/downstream_service/Cargo.toml",
         "targeted_suspect": "downstream_stage_dominates",
-        "expected_movements": ["p95_decreases", "service_share_decreases", "targeted_score_nonworsening"],
+        "expected_movements": ["p95_decreases", "targeted_score_nonworsening"],
         "notes": "Downstream mitigation should reduce stage/service contribution and improve latency.",
     },
     "db-pool": {
         "demo_manifest": "demos/db_pool_saturation_service/Cargo.toml",
         "targeted_suspect": "application_queue_saturation",
         "expected_movements": ["p95_decreases", "queue_share_decreases", "targeted_score_nonworsening"],
+        "expected_after_top2": ["downstream_stage_dominates", "application_queue_saturation"],
         "notes": "DB/pool mitigation should reduce queueing pressure and improve latency.",
     },
 }

--- a/scripts/run_mitigation_matrix.py
+++ b/scripts/run_mitigation_matrix.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Run paired baseline/mitigated demo scenarios and validate mitigation movement."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    from _demo_runner import PROFILE_CHOICES, load_report_json, repo_root, run_and_analyze
+except ModuleNotFoundError:  # pragma: no cover
+    from scripts._demo_runner import PROFILE_CHOICES, load_report_json, repo_root, run_and_analyze
+
+CONF_HIGH = {"high", "very_high"}
+DEFAULT_OUT = Path("target/mitigation-runs.jsonl")
+
+SCENARIOS = {
+    "queue": {
+        "demo_manifest": "demos/queue_service/Cargo.toml",
+        "targeted_suspect": "application_queue_saturation",
+        "expected_movements": ["p95_decreases", "queue_share_decreases", "targeted_score_nonworsening"],
+        "expected_after_top2": ["downstream_stage_dominates", "application_queue_saturation"],
+        "notes": "Queue mitigation should reduce queue-wait evidence and improve tail latency.",
+    },
+    "blocking": {
+        "demo_manifest": "demos/blocking_service/Cargo.toml",
+        "targeted_suspect": "blocking_pool_pressure",
+        "expected_movements": ["p95_decreases", "blocking_queue_depth_decreases", "targeted_score_nonworsening"],
+        "notes": "Blocking mitigation should reduce blocking queue pressure and improve latency.",
+    },
+    "downstream": {
+        "demo_manifest": "demos/downstream_service/Cargo.toml",
+        "targeted_suspect": "downstream_stage_dominates",
+        "expected_movements": ["p95_decreases", "service_share_decreases", "targeted_score_nonworsening"],
+        "notes": "Downstream mitigation should reduce stage/service contribution and improve latency.",
+    },
+    "db-pool": {
+        "demo_manifest": "demos/db_pool_saturation_service/Cargo.toml",
+        "targeted_suspect": "application_queue_saturation",
+        "expected_movements": ["p95_decreases", "queue_share_decreases", "targeted_score_nonworsening"],
+        "notes": "DB/pool mitigation should reduce queueing pressure and improve latency.",
+    },
+}
+DEFAULT_SCENARIOS = ["queue", "blocking", "downstream", "db-pool"]
+
+
+def top2_kinds(report: dict[str, Any]) -> list[str]:
+    suspects = [report.get("primary_suspect") or {}, *(report.get("secondary_suspects") or [])]
+    return [s.get("kind") for s in suspects[:2] if s.get("kind")]
+
+
+def suspect_score(report: dict[str, Any], kind: str) -> int | None:
+    suspects = [report.get("primary_suspect") or {}, *(report.get("secondary_suspects") or [])]
+    for suspect in suspects:
+        if suspect.get("kind") == kind:
+            return suspect.get("score")
+    return None
+
+
+def extract_blocking_queue_depth_p95(report: dict[str, Any]) -> int | None:
+    suspects = [report.get("primary_suspect") or {}, *(report.get("secondary_suspects") or [])]
+    for suspect in suspects:
+        for evidence in suspect.get("evidence") or []:
+            match = re.search(r"Blocking queue depth p95 is (\d+)", evidence)
+            if match:
+                return int(match.group(1))
+    return None
+
+
+def delta(before: int | None, after: int | None) -> int | None:
+    if before is None or after is None:
+        return None
+    return after - before
+
+
+def ratio_delta(before: int | None, after: int | None) -> float | None:
+    if before is None or after is None or before == 0:
+        return None
+    return (after - before) / float(before)
+
+
+def build_pair_record(before_report: dict[str, Any], after_report: dict[str, Any], scenario_meta: dict[str, Any], *, before_artifact: Path, before_analysis: Path, after_artifact: Path, after_analysis: Path, profile: str, scenario: str) -> dict[str, Any]:
+    targeted = scenario_meta["targeted_suspect"]
+    record = {
+        "schema_version": 1,
+        "scenario": scenario,
+        "profile": profile,
+        "before_artifact_path": str(before_artifact),
+        "before_analysis_path": str(before_analysis),
+        "after_artifact_path": str(after_artifact),
+        "after_analysis_path": str(after_analysis),
+        "targeted_suspect": targeted,
+        "before_primary_kind": (before_report.get("primary_suspect") or {}).get("kind"),
+        "after_primary_kind": (after_report.get("primary_suspect") or {}).get("kind"),
+        "before_primary_confidence": (before_report.get("primary_suspect") or {}).get("confidence"),
+        "after_primary_confidence": (after_report.get("primary_suspect") or {}).get("confidence"),
+        "before_top2_kinds": top2_kinds(before_report),
+        "after_top2_kinds": top2_kinds(after_report),
+        "before_p95_latency_us": before_report.get("p95_latency_us"),
+        "after_p95_latency_us": after_report.get("p95_latency_us"),
+        "p95_delta_us": delta(before_report.get("p95_latency_us"), after_report.get("p95_latency_us")),
+        "p95_delta_ratio": ratio_delta(before_report.get("p95_latency_us"), after_report.get("p95_latency_us")),
+        "before_p99_latency_us": before_report.get("p99_latency_us"),
+        "after_p99_latency_us": after_report.get("p99_latency_us"),
+        "p99_delta_us": delta(before_report.get("p99_latency_us"), after_report.get("p99_latency_us")),
+        "p99_delta_ratio": ratio_delta(before_report.get("p99_latency_us"), after_report.get("p99_latency_us")),
+        "before_targeted_score": suspect_score(before_report, targeted),
+        "after_targeted_score": suspect_score(after_report, targeted),
+        "targeted_score_delta": delta(suspect_score(before_report, targeted), suspect_score(after_report, targeted)),
+        "before_p95_queue_share_permille": before_report.get("p95_queue_share_permille"),
+        "after_p95_queue_share_permille": after_report.get("p95_queue_share_permille"),
+        "queue_share_delta_permille": delta(before_report.get("p95_queue_share_permille"), after_report.get("p95_queue_share_permille")),
+        "before_p95_service_share_permille": before_report.get("p95_service_share_permille"),
+        "after_p95_service_share_permille": after_report.get("p95_service_share_permille"),
+        "service_share_delta_permille": delta(before_report.get("p95_service_share_permille"), after_report.get("p95_service_share_permille")),
+        "before_blocking_queue_depth_p95": extract_blocking_queue_depth_p95(before_report),
+        "after_blocking_queue_depth_p95": extract_blocking_queue_depth_p95(after_report),
+        "blocking_queue_depth_delta": delta(extract_blocking_queue_depth_p95(before_report), extract_blocking_queue_depth_p95(after_report)),
+        "expected_movements": {},
+        "movement_passed": False,
+        "failed_expectations": [],
+        "high_confidence_wrong_after": False,
+        "notes": scenario_meta.get("notes"),
+    }
+    return record
+
+
+def evaluate_movements(record: dict[str, Any], scenario_meta: dict[str, Any], thresholds: dict[str, Any]) -> dict[str, Any]:
+    checks: dict[str, bool] = {}
+    failed: list[str] = []
+    for key in scenario_meta.get("expected_movements", []):
+        if key == "p95_decreases":
+            ratio = record.get("p95_delta_ratio")
+            passed = ratio is not None and ratio <= -thresholds["min_p95_improvement_ratio"]
+        elif key == "p99_nonworsening":
+            d = record.get("p99_delta_us")
+            passed = d is None or d <= 0
+        elif key == "queue_share_decreases":
+            d = record.get("queue_share_delta_permille")
+            passed = d is not None and d < 0
+        elif key == "service_share_decreases":
+            d = record.get("service_share_delta_permille")
+            passed = d is not None and d < 0
+        elif key == "blocking_queue_depth_decreases":
+            d = record.get("blocking_queue_depth_delta")
+            passed = d is not None and d < 0
+        elif key == "targeted_score_nonworsening":
+            d = record.get("targeted_score_delta")
+            passed = d is None or d <= 0
+        elif key == "targeted_score_decreases":
+            d = record.get("targeted_score_delta")
+            passed = d is not None and d < 0
+        elif key == "top2_retains_target_or_expected_successor":
+            expected = set([record["targeted_suspect"], *(scenario_meta.get("expected_after_top2") or [])])
+            passed = any(kind in expected for kind in (record.get("after_top2_kinds") or []))
+        elif key == "primary_changes_from_targeted":
+            passed = record.get("before_primary_kind") == record["targeted_suspect"] and record.get("after_primary_kind") != record["targeted_suspect"]
+        else:
+            passed = True
+        checks[key] = passed
+        if not passed:
+            failed.append(key)
+
+    after_conf = record.get("after_primary_confidence")
+    record["high_confidence_wrong_after"] = bool(after_conf in CONF_HIGH and record.get("after_primary_kind") not in set(scenario_meta.get("expected_after_top2") or [record["targeted_suspect"]]))
+    if record["high_confidence_wrong_after"]:
+        failed.append("high_confidence_wrong_after")
+
+    if checks.get("targeted_score_decreases") and len(checks) == 1:
+        failed.append("targeted_score_only_not_sufficient")
+
+    record["expected_movements"] = checks
+    record["failed_expectations"] = failed
+    record["movement_passed"] = len(failed) == 0
+    return record
+
+
+def summarize_records(records: list[dict[str, Any]], profile: str) -> dict[str, Any]:
+    total = len(records)
+    passed = sum(1 for r in records if r["movement_passed"])
+    per = {}
+    for r in records:
+        per[r["scenario"]] = {
+            "movement_passed": r["movement_passed"],
+            "failed_expectations": r["failed_expectations"],
+            "p95_delta_us": r["p95_delta_us"],
+            "p95_delta_ratio": r["p95_delta_ratio"],
+            "before_primary_kind": r["before_primary_kind"],
+            "after_primary_kind": r["after_primary_kind"],
+            "before_targeted_score": r["before_targeted_score"],
+            "after_targeted_score": r["after_targeted_score"],
+            "queue_share_delta_permille": r["queue_share_delta_permille"],
+        }
+    return {
+        "schema_version": 1,
+        "profile": profile,
+        "total_scenarios": total,
+        "passed_scenarios": passed,
+        "failed_scenarios": total - passed,
+        "movement_pass_rate": (passed / total) if total else 0.0,
+        "high_confidence_wrong_count": sum(1 for r in records if r.get("high_confidence_wrong_after")),
+        "per_scenario": dict(sorted(per.items())),
+        "failed_thresholds": [],
+    }
+
+
+def write_jsonl(path: Path, records: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for row in records:
+            f.write(json.dumps(row, sort_keys=True) + "\n")
+
+
+def write_scorecard(path: Path, summary: dict[str, Any], records: list[dict[str, Any]]) -> None:
+    by_scenario = {r["scenario"]: r for r in records}
+    lines = ["# Mitigation validation scorecard", "", f"Profile: {summary['profile']}", "", "| Scenario | Passed | Targeted suspect | Before primary | After primary | p95 delta | Evidence movement | Notes |", "|---|---:|---|---|---|---:|---|---|"]
+    for scenario, metrics in summary["per_scenario"].items():
+        row = by_scenario[scenario]
+        p95 = metrics.get("p95_delta_ratio")
+        p95_txt = "n/a" if p95 is None else f"{p95*100:.1f}%"
+        movement = ", ".join(k for k, v in (row.get("expected_movements") or {}).items() if v) or "none"
+        lines.append(f"| {scenario} | {'yes' if metrics['movement_passed'] else 'no'} | {row['targeted_suspect']} | {metrics['before_primary_kind']} | {metrics['after_primary_kind']} | {p95_txt} | {movement} | {row.get('notes') or ''} |")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    p.add_argument("--summary", type=Path)
+    p.add_argument("--scorecard", type=Path)
+    p.add_argument("--scenario", action="append", choices=sorted(SCENARIOS))
+    p.add_argument("--profile", default="dev", choices=PROFILE_CHOICES)
+    p.add_argument("--artifact-root", type=Path, default=Path("target/mitigation-matrix"))
+    p.add_argument("--no-fail-thresholds", action="store_true")
+    p.add_argument("--min-p95-improvement-ratio", type=float, default=0.05)
+    p.add_argument("--min-p99-improvement-ratio", type=float, default=0.0)
+    p.add_argument("--max-high-confidence-wrong", type=int, default=0)
+    args = p.parse_args()
+
+    scenarios = args.scenario or DEFAULT_SCENARIOS
+    summary_path = args.summary or args.out.with_name(f"{args.out.stem}-summary.json")
+    root = repo_root(__file__)
+    cli_manifest = root / "tailtriage-cli/Cargo.toml"
+
+    records = []
+    thresholds = {"min_p95_improvement_ratio": args.min_p95_improvement_ratio, "min_p99_improvement_ratio": args.min_p99_improvement_ratio}
+    for scenario in scenarios:
+        meta = dict(SCENARIOS[scenario])
+        demo_manifest = root / meta["demo_manifest"]
+        out_dir = root / args.artifact_root / scenario
+        before_artifact = out_dir / "before-run.json"
+        before_analysis = out_dir / "before-analysis.json"
+        after_artifact = out_dir / "after-run.json"
+        after_analysis = out_dir / "after-analysis.json"
+        run_and_analyze(demo_manifest, cli_manifest, before_artifact, before_analysis, "baseline", profile=args.profile)
+        run_and_analyze(demo_manifest, cli_manifest, after_artifact, after_analysis, "mitigated", profile=args.profile)
+        before = load_report_json(before_analysis)
+        after = load_report_json(after_analysis)
+        meta["after_report"] = after
+        rec = build_pair_record(before, after, meta, before_artifact=before_artifact, before_analysis=before_analysis, after_artifact=after_artifact, after_analysis=after_analysis, profile=args.profile, scenario=scenario)
+        evaluate_movements(rec, meta, thresholds)
+        records.append(rec)
+
+    write_jsonl(args.out, records)
+    summary = summarize_records(records, args.profile)
+    failures = []
+    if summary["high_confidence_wrong_count"] > args.max_high_confidence_wrong:
+        failures.append("high_confidence_wrong_count exceeded")
+    failures.extend([f"{r['scenario']}: {','.join(r['failed_expectations'])}" for r in records if not r["movement_passed"]])
+    summary["failed_thresholds"] = failures
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    if args.scorecard:
+        write_scorecard(args.scorecard, summary, records)
+    if failures and not args.no_fail_thresholds:
+        for f in failures:
+            print(f"threshold failure: {f}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_run_mitigation_matrix.py
+++ b/scripts/tests/test_run_mitigation_matrix.py
@@ -67,6 +67,15 @@ class RunMitigationMatrixTests(unittest.TestCase):
         out = rmm.evaluate_movements(rec, {"targeted_suspect": "application_queue_saturation", "expected_movements": [], "expected_after_top2": ["application_queue_saturation"]}, {"min_p95_improvement_ratio": 0.05})
         self.assertFalse(out["movement_passed"])
 
+    def test_unknown_movement_key_fails_loudly(self):
+        rec = rmm.build_pair_record(self.report(), self.report(p95=800), {"targeted_suspect": "application_queue_saturation"}, before_artifact=Path("b1"), before_analysis=Path("b2"), after_artifact=Path("a1"), after_analysis=Path("a2"), profile="dev", scenario="queue")
+        meta = {"targeted_suspect": "application_queue_saturation", "expected_movements": ["p95_decreases", "typo_queue_share_decreases"]}
+        out = rmm.evaluate_movements(rec, meta, {"min_p95_improvement_ratio": 0.05})
+        self.assertTrue(out["expected_movements"]["p95_decreases"])
+        self.assertFalse(out["expected_movements"]["typo_queue_share_decreases"])
+        self.assertFalse(out["movement_passed"])
+        self.assertIn("unknown_movement_key:typo_queue_share_decreases", out["failed_expectations"])
+
     def test_summary_jsonl_scorecard(self):
         rec = {"scenario": "queue", "movement_passed": True, "failed_expectations": [], "p95_delta_us": -10, "p95_delta_ratio": -0.1, "before_primary_kind": "a", "after_primary_kind": "b", "before_targeted_score": 90, "after_targeted_score": 70, "queue_share_delta_permille": -100, "high_confidence_wrong_after": False, "expected_movements": {"p95_decreases": True}, "targeted_suspect": "application_queue_saturation", "notes": "n"}
         summary = rmm.summarize_records([rec], "dev")

--- a/scripts/tests/test_run_mitigation_matrix.py
+++ b/scripts/tests/test_run_mitigation_matrix.py
@@ -1,0 +1,84 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import run_mitigation_matrix as rmm
+
+
+class RunMitigationMatrixTests(unittest.TestCase):
+    def report(self, primary="application_queue_saturation", second=None, score=90, p95=1000, p99=1200, q=900, s=100, confidence="high", evidence=None):
+        return {
+            "primary_suspect": {"kind": primary, "score": score, "confidence": confidence, "evidence": evidence or []},
+            "secondary_suspects": second or [{"kind": "downstream_stage_dominates", "score": 40, "evidence": []}],
+            "p95_latency_us": p95,
+            "p99_latency_us": p99,
+            "p95_queue_share_permille": q,
+            "p95_service_share_permille": s,
+        }
+
+    def test_top2(self):
+        self.assertEqual(rmm.top2_kinds(self.report()), ["application_queue_saturation", "downstream_stage_dominates"])
+
+    def test_suspect_score(self):
+        rep = self.report()
+        self.assertEqual(rmm.suspect_score(rep, "application_queue_saturation"), 90)
+        self.assertEqual(rmm.suspect_score(rep, "downstream_stage_dominates"), 40)
+        self.assertIsNone(rmm.suspect_score(rep, "missing"))
+
+    def test_extract_blocking_depth(self):
+        rep = self.report(primary="blocking_pool_pressure", evidence=["Blocking queue depth p95 is 12"])
+        self.assertEqual(rmm.extract_blocking_queue_depth_p95(rep), 12)
+
+    def test_delta_ratio(self):
+        self.assertEqual(rmm.delta(5, 1), -4)
+        self.assertIsNone(rmm.delta(None, 1))
+        self.assertAlmostEqual(rmm.ratio_delta(100, 50), -0.5)
+        self.assertIsNone(rmm.ratio_delta(0, 10))
+
+    def test_build_pair_record_required_fields(self):
+        rec = rmm.build_pair_record(self.report(), self.report(p95=500), {"targeted_suspect": "application_queue_saturation", "notes": "x"}, before_artifact=Path("b1"), before_analysis=Path("b2"), after_artifact=Path("a1"), after_analysis=Path("a2"), profile="dev", scenario="queue")
+        self.assertEqual(rec["schema_version"], 1)
+        self.assertEqual(rec["scenario"], "queue")
+        self.assertIn("before_top2_kinds", rec)
+
+    def test_movement_checks(self):
+        rec = rmm.build_pair_record(self.report(), self.report(p95=800, q=500, s=80), {"targeted_suspect": "application_queue_saturation", "notes": "x"}, before_artifact=Path("b1"), before_analysis=Path("b2"), after_artifact=Path("a1"), after_analysis=Path("a2"), profile="dev", scenario="queue")
+        meta = {"targeted_suspect": "application_queue_saturation", "expected_movements": ["p95_decreases", "queue_share_decreases", "service_share_decreases"]}
+        out = rmm.evaluate_movements(rec, meta, {"min_p95_improvement_ratio": 0.05})
+        self.assertTrue(out["movement_passed"])
+
+    def test_blocking_movement(self):
+        b = self.report(primary="blocking_pool_pressure", evidence=["Blocking queue depth p95 is 12"])
+        a = self.report(primary="blocking_pool_pressure", evidence=["Blocking queue depth p95 is 2"], p95=700)
+        rec = rmm.build_pair_record(b, a, {"targeted_suspect": "blocking_pool_pressure"}, before_artifact=Path("b1"), before_analysis=Path("b2"), after_artifact=Path("a1"), after_analysis=Path("a2"), profile="dev", scenario="blocking")
+        out = rmm.evaluate_movements(rec, {"targeted_suspect": "blocking_pool_pressure", "expected_movements": ["blocking_queue_depth_decreases"]}, {"min_p95_improvement_ratio": 0.05})
+        self.assertTrue(out["movement_passed"])
+
+    def test_targeted_score_only_not_enough(self):
+        before = self.report(score=90)
+        after = self.report(score=70)
+        rec = rmm.build_pair_record(before, after, {"targeted_suspect": "application_queue_saturation"}, before_artifact=Path("b1"), before_analysis=Path("b2"), after_artifact=Path("a1"), after_analysis=Path("a2"), profile="dev", scenario="queue")
+        out = rmm.evaluate_movements(rec, {"targeted_suspect": "application_queue_saturation", "expected_movements": ["targeted_score_decreases"]}, {"min_p95_improvement_ratio": 0.05})
+        self.assertFalse(out["movement_passed"])
+
+    def test_high_conf_wrong_fails(self):
+        rec = rmm.build_pair_record(self.report(), self.report(primary="executor_pressure_suspected", confidence="high"), {"targeted_suspect": "application_queue_saturation"}, before_artifact=Path("b1"), before_analysis=Path("b2"), after_artifact=Path("a1"), after_analysis=Path("a2"), profile="dev", scenario="queue")
+        out = rmm.evaluate_movements(rec, {"targeted_suspect": "application_queue_saturation", "expected_movements": [], "expected_after_top2": ["application_queue_saturation"]}, {"min_p95_improvement_ratio": 0.05})
+        self.assertFalse(out["movement_passed"])
+
+    def test_summary_jsonl_scorecard(self):
+        rec = {"scenario": "queue", "movement_passed": True, "failed_expectations": [], "p95_delta_us": -10, "p95_delta_ratio": -0.1, "before_primary_kind": "a", "after_primary_kind": "b", "before_targeted_score": 90, "after_targeted_score": 70, "queue_share_delta_permille": -100, "high_confidence_wrong_after": False, "expected_movements": {"p95_decreases": True}, "targeted_suspect": "application_queue_saturation", "notes": "n"}
+        summary = rmm.summarize_records([rec], "dev")
+        self.assertEqual(summary["schema_version"], 1)
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "out.jsonl"
+            rmm.write_jsonl(p, [rec])
+            self.assertEqual(len(p.read_text().strip().splitlines()), 1)
+            m = Path(td) / "score.md"
+            rmm.write_scorecard(m, summary, [rec])
+            self.assertIn("| queue |", m.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -59,5 +59,8 @@ python3 scripts/diagnostic_benchmark.py \
 ## Validation tracks
 - deterministic corpus benchmark: `scripts/diagnostic_benchmark.py`
 - repeated-run controlled matrix runner: `scripts/run_diagnostic_matrix.py`
+- mitigation matrix runner: `scripts/run_mitigation_matrix.py`
 
 The deterministic corpus checks fixture-labeled contract behavior. The repeated-run runner checks repeated-run stability for selected controlled demo workloads.
+
+Validation tracks currently include deterministic corpus benchmark, adversarial synthetic coverage (inside the corpus), repeated-run diagnostic matrix, and mitigation matrix workflows.

--- a/validation/diagnostics/latest/scorecard.md
+++ b/validation/diagnostics/latest/scorecard.md
@@ -14,6 +14,7 @@
 | runtime overhead | Measured separately | see `docs/runtime-cost.md`. |
 | collector limits | Measured separately | see `docs/collector-limits.md`. |
 | repeated-run diagnostic matrix | Manual/local repeated-run validation available | publishable repeated-run outputs are generated locally (JSONL/summary/scorecard) and not committed by default; results are machine/workload scoped. |
+| mitigation validation | Manual/local mitigation matrix available | baseline/mitigated controlled demos compare latency and evidence movement; generated outputs are not committed by default. |
 | real service validation | Planned | add curated real-service anonymized artifacts. |
 
 Deterministic synthetic adversarial cases validate benchmark/report contract behavior and humility checks; they are not real-service validation and do not provide root-cause proof.


### PR DESCRIPTION
### Motivation
- Provide a manual/local validation workflow that checks whether targeted mitigations in controlled demo scenarios produce expected evidence movement and latency improvements. 
- Focus on concrete evidence movement (queue/service/share/depth and p95/p99) rather than treating analyzer score changes as absolute cross-run severity. 

### Description
- Add `scripts/run_mitigation_matrix.py`, a stdlib-only runner that executes paired baseline/mitigated demo runs, writes before/after artifacts under `target/mitigation-matrix`, emits per-scenario JSONL pair records, a stable summary JSON, and an optional Markdown scorecard. 
- Implement pure helper/evaluation functions (`top2_kinds`, `suspect_score`, `extract_blocking_queue_depth_p95`, `delta`, `ratio_delta`, `build_pair_record`, `evaluate_movements`, `summarize_records`, `write_jsonl`, `write_scorecard`) and scenario-specific movement checks with high-confidence-wrong detection. 
- Add unit tests `scripts/tests/test_run_mitigation_matrix.py` covering extraction, delta/ratio logic, movement evaluation, blocking evidence extraction, JSONL and scorecard writing, and the `targeted_score_only_not_sufficient` rule; tests are pure-Python and do not run cargo or demos. 
- Update validation docs and the diagnostics scorecard to document the mitigation matrix as a manual/local track, clarify scope/interpretation rules, and state that this does not change analyzer behavior or add dependencies. 

### Testing
- Ran the mitigation smoke invocation `python3 scripts/run_mitigation_matrix.py --scenario queue --out target/mitigation-runs-smoke.jsonl --summary target/mitigation-summary-smoke.json --scorecard target/mitigation-scorecard-smoke.md --no-fail-thresholds` which completed and wrote artifacts (passed). 
- Ran the unit test suite for the new helpers `python3 -m unittest scripts.tests.test_run_mitigation_matrix` (passed), and also ran `python3 -m unittest scripts.tests.test_run_diagnostic_matrix`, `python3 -m unittest scripts.tests.test_diagnostic_benchmark`, and `python3 -m unittest scripts.tests.test_validate_docs_contracts` which all passed. 
- Executed validation/measurement utilities `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json` and `python3 scripts/check_demo_fixture_drift.py --profile dev` which completed successfully. 
- Ran repository checks `python3 scripts/validate_docs_contracts.py`, `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, and all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b147a710833095f5672c6135e25f)