### PR TITLE
Add manual mitigation matrix validation runner

### DIFF
--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -20,7 +20,6 @@ The corpus now includes deterministic adversarial validation that checks sparse,
 - root-cause proof from one run
 - universal production overhead claims
 - replacement of tracing/metrics/tokio-console
-- mitigation-effect validation
 - overhead integration into diagnostic accuracy scoring
 - collector-limit integration into diagnostic accuracy scoring
 - real-service validation coverage
@@ -43,3 +42,8 @@ Demos teach scenarios; validation measures bounded diagnostic behavior.
 It writes raw JSONL run records plus summary JSON (and optional Markdown scorecard) for stability metrics including top-1 accuracy, top-2 recall, high-confidence-wrong count, per-scenario primary stability, confidence bucket accuracy, and p95/p99 latency distribution summaries.
 
 This repeated-run validation is currently manual/local (not mandatory CI). Publishable repeated-run outputs are generated locally and are not committed by default. Results are machine/workload scoped. It measures stability under bounded controlled Tokio demo workloads on a specific machine/profile; it does not establish production universality or root-cause proof.
+
+## Mitigation matrix validation (manual/local)
+`scripts/run_mitigation_matrix.py` adds manual/local mitigation validation for controlled baseline/mitigated demo pairs. It checks whether expected evidence moves in the intended direction after a targeted mitigation (for example queue share, service share, or blocking queue-depth reduction) and whether p95 latency generally improves for scenarios designed to improve.
+
+This validation is machine/workload scoped, generated outputs are local by default, and results do not prove root cause. Score movement alone is not treated as absolute severity change across reports.

--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -46,7 +46,19 @@ The corpus includes insufficient-evidence scenarios to validate conservative fal
 Schema supports `must_include_next_checks`, but the current initial corpus has no non-empty next-check requirements, so next-check substrings are not currently part of the deterministic gate.
 
 ## Future work
-Mitigation validation, overhead integration, collector-limit integration, and expanded real-service validation are separate follow-on work.
+Overhead integration, collector-limit integration, and expanded real-service validation are separate follow-on work.
+
+## Mitigation matrix validation (manual/local)
+A manual mitigation matrix runner is available at `scripts/run_mitigation_matrix.py`. It compares paired baseline/degraded and targeted mitigated runs for controlled demos, then summarizes latency and evidence movement per scenario.
+
+Mitigation validation checks whether evidence-ranked suspects point to useful next checks under controlled workloads. It evaluates scenario-specific movement such as:
+- p95 latency improvement
+- queue-share reduction when queueing is targeted
+- service/stage-share reduction when downstream stages are targeted
+- blocking queue-depth reduction when blocking pressure is targeted
+- explainable primary/top-2 suspect movement after mitigation
+
+Score changes are interpreted as in-report evidence-ranking signals, not absolute cross-report severity values. This validation does not prove root cause, is machine/workload scoped, and remains manual/local (not mandatory CI).
 
 ## Repeated-run diagnostic matrix validation (manual)
 A manual repeated-run matrix runner is available at `scripts/run_diagnostic_matrix.py`. It repeatedly executes controlled demo scenarios, analyzes each run, and summarizes stability metrics.

--- a/scripts/run_mitigation_matrix.py
+++ b/scripts/run_mitigation_matrix.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Run manual mitigation validation over paired baseline/mitigated demo scenarios."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+try:
+    from _demo_runner import PROFILE_CHOICES, load_report_json, repo_root, run_and_analyze
+except ModuleNotFoundError:  # pragma: no cover
+    from scripts._demo_runner import PROFILE_CHOICES, load_report_json, repo_root, run_and_analyze
+
+CONF_HIGH = {"high", "very_high"}
+DEFAULT_OUT = Path("target/mitigation-runs.jsonl")
+DEFAULT_ARTIFACT_ROOT = Path("target/mitigation-matrix")
+DEFAULT_SCENARIOS = ["queue", "blocking", "downstream", "db-pool"]
+
+SCENARIOS = {
+    "queue": {
+        "demo_manifest": "demos/queue_service/Cargo.toml",
+        "targeted_suspect": "application_queue_saturation",
+        "expected_movements": ["p95_decreases", "queue_share_decreases", "targeted_score_nonworsening"],
+        "notes": "Queue mitigation should reduce queue-wait evidence and improve tail latency.",
+    },
+    "blocking": {
+        "demo_manifest": "demos/blocking_service/Cargo.toml",
+        "targeted_suspect": "blocking_pool_pressure",
+        "expected_movements": ["p95_decreases", "blocking_queue_depth_decreases", "targeted_score_nonworsening"],
+        "notes": "Blocking mitigation should reduce blocking backlog evidence.",
+    },
+    "downstream": {
+        "demo_manifest": "demos/downstream_service/Cargo.toml",
+        "targeted_suspect": "downstream_stage_dominates",
+        "expected_movements": ["p95_decreases", "service_share_decreases", "targeted_score_nonworsening"],
+        "notes": "Downstream mitigation should reduce stage/service dominance evidence.",
+    },
+    "db-pool": {
+        "demo_manifest": "demos/db_pool_saturation_service/Cargo.toml",
+        "targeted_suspect": "application_queue_saturation",
+        "expected_movements": ["p95_decreases", "queue_share_decreases", "targeted_score_nonworsening"],
+        "notes": "DB/pool mitigation should reduce wait evidence represented as queue or stage contribution.",
+    },
+}
+
+
+def top2_kinds(report: dict[str, Any]) -> list[str]:
+    primary = report.get("primary_suspect") or {}
+    secondaries = report.get("secondary_suspects") or []
+    return [s.get("kind") for s in [primary, *secondaries][:2] if s.get("kind")]
+
+
+def suspect_score(report: dict[str, Any], kind: str) -> int | None:
+    suspects = [report.get("primary_suspect") or {}, *(report.get("secondary_suspects") or [])]
+    for suspect in suspects:
+        if suspect.get("kind") == kind:
+            return suspect.get("score")
+    return None
+
+
+def extract_blocking_queue_depth_p95(report: dict[str, Any]) -> int | None:
+    suspects = [report.get("primary_suspect") or {}, *(report.get("secondary_suspects") or [])]
+    for suspect in suspects:
+        for evidence in suspect.get("evidence") or []:
+            match = re.search(r"Blocking queue depth p95 is (\d+)", evidence)
+            if match:
+                return int(match.group(1))
+    return None
+
+
+def delta(before: int | None, after: int | None) -> int | None:
+    if before is None or after is None:
+        return None
+    return after - before
+
+
+def ratio_delta(before: int | None, after: int | None) -> float | None:
+    if before in (None, 0) or after is None:
+        return None
+    return (after - before) / before
+
+
+def build_pair_record(before_report: dict[str, Any], after_report: dict[str, Any], scenario_meta: dict[str, Any], *, scenario: str, profile: str, before_artifact_path: Path, before_analysis_path: Path, after_artifact_path: Path, after_analysis_path: Path) -> dict[str, Any]:
+    targeted = scenario_meta["targeted_suspect"]
+    return {
+        "schema_version": 1,
+        "scenario": scenario,
+        "profile": profile,
+        "before_artifact_path": str(before_artifact_path),
+        "before_analysis_path": str(before_analysis_path),
+        "after_artifact_path": str(after_artifact_path),
+        "after_analysis_path": str(after_analysis_path),
+        "targeted_suspect": targeted,
+        "before_primary_kind": (before_report.get("primary_suspect") or {}).get("kind"),
+        "after_primary_kind": (after_report.get("primary_suspect") or {}).get("kind"),
+        "before_top2_kinds": top2_kinds(before_report),
+        "after_top2_kinds": top2_kinds(after_report),
+        "before_p95_latency_us": before_report.get("p95_latency_us"),
+        "after_p95_latency_us": after_report.get("p95_latency_us"),
+        "p95_delta_us": delta(before_report.get("p95_latency_us"), after_report.get("p95_latency_us")),
+        "p95_delta_ratio": ratio_delta(before_report.get("p95_latency_us"), after_report.get("p95_latency_us")),
+        "before_p99_latency_us": before_report.get("p99_latency_us"),
+        "after_p99_latency_us": after_report.get("p99_latency_us"),
+        "p99_delta_us": delta(before_report.get("p99_latency_us"), after_report.get("p99_latency_us")),
+        "p99_delta_ratio": ratio_delta(before_report.get("p99_latency_us"), after_report.get("p99_latency_us")),
+        "before_targeted_score": suspect_score(before_report, targeted),
+        "after_targeted_score": suspect_score(after_report, targeted),
+        "targeted_score_delta": delta(suspect_score(before_report, targeted), suspect_score(after_report, targeted)),
+        "before_p95_queue_share_permille": before_report.get("p95_queue_share_permille"),
+        "after_p95_queue_share_permille": after_report.get("p95_queue_share_permille"),
+        "queue_share_delta_permille": delta(before_report.get("p95_queue_share_permille"), after_report.get("p95_queue_share_permille")),
+        "before_p95_service_share_permille": before_report.get("p95_service_share_permille"),
+        "after_p95_service_share_permille": after_report.get("p95_service_share_permille"),
+        "service_share_delta_permille": delta(before_report.get("p95_service_share_permille"), after_report.get("p95_service_share_permille")),
+        "before_blocking_queue_depth_p95": extract_blocking_queue_depth_p95(before_report),
+        "after_blocking_queue_depth_p95": extract_blocking_queue_depth_p95(after_report),
+        "blocking_queue_depth_delta": delta(extract_blocking_queue_depth_p95(before_report), extract_blocking_queue_depth_p95(after_report)),
+        "expected_movements": {},
+        "movement_passed": False,
+        "failed_expectations": [],
+        "high_confidence_wrong": False,
+        "notes": scenario_meta["notes"],
+    }
+
+
+def evaluate_movements(record: dict[str, Any], scenario_meta: dict[str, Any], thresholds: dict[str, Any]) -> dict[str, Any]:
+    checks = {}
+    checks["p95_decreases"] = (record["p95_delta_ratio"] is not None) and (record["p95_delta_ratio"] <= -thresholds["min_p95_improvement_ratio"])
+    checks["p99_nonworsening"] = (record["p99_delta_ratio"] is None) or (record["p99_delta_ratio"] <= 0.0)
+    checks["queue_share_decreases"] = (record["queue_share_delta_permille"] is None) or (record["queue_share_delta_permille"] < 0)
+    checks["service_share_decreases"] = (record["service_share_delta_permille"] is None) or (record["service_share_delta_permille"] < 0)
+    checks["blocking_queue_depth_decreases"] = (record["blocking_queue_depth_delta"] is None) or (record["blocking_queue_depth_delta"] < 0)
+    checks["targeted_score_nonworsening"] = (record["targeted_score_delta"] is None) or (record["targeted_score_delta"] <= 0)
+    checks["targeted_score_decreases"] = (record["targeted_score_delta"] is not None) and (record["targeted_score_delta"] < 0)
+    checks["primary_changes_from_targeted"] = record["before_primary_kind"] == record["targeted_suspect"] and record["after_primary_kind"] != record["targeted_suspect"]
+    checks["top2_retains_target_or_expected_successor"] = record["targeted_suspect"] in record["after_top2_kinds"]
+
+    after_primary = record["after_primary_kind"]
+    after_conf = scenario_meta.get("after_primary_confidence", "")
+    record["high_confidence_wrong"] = bool(after_primary and after_primary not in [record["targeted_suspect"], *record["after_top2_kinds"][:1]] and after_conf in CONF_HIGH)
+
+    expected = scenario_meta.get("expected_movements", [])
+    record["expected_movements"] = {name: checks.get(name, False) for name in expected}
+    failed = [name for name in expected if not checks.get(name, False)]
+
+    if "targeted_score_decreases" in expected and len(expected) == 1:
+        failed.append("targeted_score_decreases_requires_additional_concrete_movement")
+
+    if record["high_confidence_wrong"]:
+        failed.append("high_confidence_wrong_after_mitigation")
+
+    record["failed_expectations"] = sorted(set(failed))
+    record["movement_passed"] = len(record["failed_expectations"]) == 0
+    return record
+
+
+def summarize_records(records: list[dict[str, Any]], profile: str, max_high_confidence_wrong: int) -> dict[str, Any]:
+    total = len(records)
+    passed = sum(1 for r in records if r["movement_passed"])
+    high_wrong = sum(1 for r in records if r.get("high_confidence_wrong"))
+    per = {}
+    for r in records:
+        per[r["scenario"]] = {
+            "movement_passed": r["movement_passed"],
+            "failed_expectations": r["failed_expectations"],
+            "p95_delta_us": r["p95_delta_us"],
+            "p95_delta_ratio": r["p95_delta_ratio"],
+            "before_primary_kind": r["before_primary_kind"],
+            "after_primary_kind": r["after_primary_kind"],
+            "before_targeted_score": r["before_targeted_score"],
+            "after_targeted_score": r["after_targeted_score"],
+            "queue_share_delta_permille": r["queue_share_delta_permille"],
+        }
+    failed_thresholds = []
+    if high_wrong > max_high_confidence_wrong:
+        failed_thresholds.append(f"high_confidence_wrong_count {high_wrong} exceeds max {max_high_confidence_wrong}")
+    return {
+        "schema_version": 1,
+        "profile": profile,
+        "total_scenarios": total,
+        "passed_scenarios": passed,
+        "failed_scenarios": total - passed,
+        "movement_pass_rate": (passed / total) if total else 0.0,
+        "high_confidence_wrong_count": high_wrong,
+        "per_scenario": per,
+        "failed_thresholds": failed_thresholds,
+    }
+
+
+def write_jsonl(path: Path, records: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for r in records:
+            fh.write(json.dumps(r, sort_keys=True) + "\n")
+
+
+def write_scorecard(path: Path, summary: dict[str, Any], records: list[dict[str, Any]]) -> None:
+    lines = [
+        "# Mitigation validation scorecard",
+        "",
+        f"Profile: {summary['profile']}",
+        "",
+        "| Scenario | Passed | Targeted suspect | Before primary | After primary | p95 delta | Evidence movement | Notes |",
+        "|---|---:|---|---|---|---:|---|---|",
+    ]
+    for r in records:
+        p95 = r.get("p95_delta_ratio")
+        p95_str = "n/a" if p95 is None else f"{p95 * 100:.1f}%"
+        moves = ", ".join(sorted(k for k, v in (r.get("expected_movements") or {}).items() if v)) or "none"
+        lines.append(f"| {r['scenario']} | {'yes' if r['movement_passed'] else 'no'} | {r['targeted_suspect']} | {r['before_primary_kind']} | {r['after_primary_kind']} | {p95_str} | {moves} | {r['notes']} |")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    p.add_argument("--summary", type=Path)
+    p.add_argument("--scorecard", type=Path)
+    p.add_argument("--scenario", action="append", choices=sorted(SCENARIOS.keys()))
+    p.add_argument("--profile", choices=PROFILE_CHOICES, default="dev")
+    p.add_argument("--artifact-root", type=Path, default=DEFAULT_ARTIFACT_ROOT)
+    p.add_argument("--no-fail-thresholds", action="store_true")
+    p.add_argument("--min-p95-improvement-ratio", type=float, default=0.05)
+    p.add_argument("--min-p99-improvement-ratio", type=float, default=0.0)
+    p.add_argument("--max-high-confidence-wrong", type=int, default=0)
+    p.add_argument("--require-expected-evidence-movement", action=argparse.BooleanOptionalAction, default=True)
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = repo_root(__file__)
+    cli_manifest = root / "tailtriage-cli/Cargo.toml"
+    scenarios = args.scenario or DEFAULT_SCENARIOS
+    records = []
+    for scenario in scenarios:
+        meta = SCENARIOS[scenario]
+        artifact_dir = args.artifact_root / scenario
+        before_artifact = artifact_dir / "before-run.json"
+        before_analysis = artifact_dir / "before-analysis.json"
+        after_artifact = artifact_dir / "after-run.json"
+        after_analysis = artifact_dir / "after-analysis.json"
+        run_and_analyze(root / meta["demo_manifest"], cli_manifest, before_artifact, before_analysis, "baseline", profile=args.profile)
+        run_and_analyze(root / meta["demo_manifest"], cli_manifest, after_artifact, after_analysis, "mitigated", profile=args.profile)
+        rec = build_pair_record(load_report_json(before_analysis), load_report_json(after_analysis), meta, scenario=scenario, profile=args.profile, before_artifact_path=before_artifact, before_analysis_path=before_analysis, after_artifact_path=after_artifact, after_analysis_path=after_analysis)
+        rec = evaluate_movements(rec, meta, {"min_p95_improvement_ratio": args.min_p95_improvement_ratio, "min_p99_improvement_ratio": args.min_p99_improvement_ratio})
+        records.append(rec)
+    summary_path = args.summary or args.out.with_name(f"{args.out.stem}-summary.json")
+    write_jsonl(args.out, records)
+    summary = summarize_records(records, args.profile, args.max_high_confidence_wrong)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    if args.scorecard:
+        write_scorecard(args.scorecard, summary, records)
+
+    any_fail = any(not r["movement_passed"] for r in records) or bool(summary["failed_thresholds"])
+    if args.no_fail_thresholds:
+        return 0
+    return 1 if any_fail else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_run_mitigation_matrix.py
+++ b/scripts/tests/test_run_mitigation_matrix.py
@@ -1,0 +1,74 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import run_mitigation_matrix as rmm
+
+
+class RunMitigationMatrixTests(unittest.TestCase):
+    def sample_report(self, primary="application_queue_saturation", secondary=None, p95=1000, p99=1200):
+        return {
+            "primary_suspect": {"kind": primary, "score": 90, "confidence": "high", "evidence": ["Blocking queue depth p95 is 12"]},
+            "secondary_suspects": secondary or [{"kind": "downstream_stage_dominates", "score": 60}],
+            "p95_latency_us": p95,
+            "p99_latency_us": p99,
+            "p95_queue_share_permille": 800,
+            "p95_service_share_permille": 200,
+        }
+
+    def test_top2(self):
+        self.assertEqual(rmm.top2_kinds(self.sample_report()), ["application_queue_saturation", "downstream_stage_dominates"])
+
+    def test_suspect_score_lookup(self):
+        rep = self.sample_report()
+        self.assertEqual(rmm.suspect_score(rep, "application_queue_saturation"), 90)
+        self.assertEqual(rmm.suspect_score(rep, "downstream_stage_dominates"), 60)
+        self.assertIsNone(rmm.suspect_score(rep, "blocking_pool_pressure"))
+
+    def test_blocking_depth_extract(self):
+        self.assertEqual(rmm.extract_blocking_queue_depth_p95(self.sample_report()), 12)
+
+    def test_delta_ratio(self):
+        self.assertEqual(rmm.delta(10, 7), -3)
+        self.assertIsNone(rmm.delta(None, 7))
+        self.assertAlmostEqual(rmm.ratio_delta(10, 5), -0.5)
+        self.assertIsNone(rmm.ratio_delta(0, 5))
+
+    def test_build_pair_record_required(self):
+        before = self.sample_report(p95=1000)
+        after = self.sample_report(p95=700)
+        rec = rmm.build_pair_record(before, after, rmm.SCENARIOS["queue"], scenario="queue", profile="dev", before_artifact_path=Path("a"), before_analysis_path=Path("b"), after_artifact_path=Path("c"), after_analysis_path=Path("d"))
+        self.assertEqual(rec["scenario"], "queue")
+        self.assertIn("p95_delta_ratio", rec)
+
+    def test_evaluate_checks(self):
+        before = self.sample_report(p95=1000)
+        after = self.sample_report(p95=800)
+        rec = rmm.build_pair_record(before, after, rmm.SCENARIOS["queue"], scenario="queue", profile="dev", before_artifact_path=Path("a"), before_analysis_path=Path("b"), after_artifact_path=Path("c"), after_analysis_path=Path("d"))
+        rec["after_p95_queue_share_permille"] = 600
+        rec["queue_share_delta_permille"] = -200
+        out = rmm.evaluate_movements(rec, rmm.SCENARIOS["queue"], {"min_p95_improvement_ratio": 0.05, "min_p99_improvement_ratio": 0.0})
+        self.assertTrue(out["expected_movements"]["p95_decreases"])
+
+    def test_targeted_score_alone_not_sufficient(self):
+        rec = {"targeted_score_delta": -1, "before_primary_kind": "a", "targeted_suspect": "a", "after_primary_kind": "a", "after_top2_kinds": ["a"], "p95_delta_ratio": None, "p99_delta_ratio": None, "queue_share_delta_permille": None, "service_share_delta_permille": None, "blocking_queue_depth_delta": None}
+        meta = {"expected_movements": ["targeted_score_decreases"]}
+        out = rmm.evaluate_movements(rec, meta, {"min_p95_improvement_ratio": 0.05, "min_p99_improvement_ratio": 0.0})
+        self.assertIn("targeted_score_decreases_requires_additional_concrete_movement", out["failed_expectations"])
+
+    def test_summary_jsonl_scorecard(self):
+        rec = {"scenario": "queue", "movement_passed": True, "failed_expectations": [], "p95_delta_us": -1, "p95_delta_ratio": -0.1, "before_primary_kind": "a", "after_primary_kind": "b", "before_targeted_score": 10, "after_targeted_score": 9, "queue_share_delta_permille": -10, "high_confidence_wrong": False, "targeted_suspect": "a", "expected_movements": {"p95_decreases": True}, "notes": "n"}
+        summary = rmm.summarize_records([rec], "dev", 0)
+        self.assertEqual(summary["total_scenarios"], 1)
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "x.jsonl"
+            rmm.write_jsonl(p, [rec])
+            self.assertEqual(len(p.read_text().strip().splitlines()), 1)
+            md = Path(td) / "x.md"
+            rmm.write_scorecard(md, summary, [rec])
+            self.assertIn("| queue |", md.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -59,5 +59,6 @@ python3 scripts/diagnostic_benchmark.py \
 ## Validation tracks
 - deterministic corpus benchmark: `scripts/diagnostic_benchmark.py`
 - repeated-run controlled matrix runner: `scripts/run_diagnostic_matrix.py`
+- mitigation matrix runner: `scripts/run_mitigation_matrix.py`
 
-The deterministic corpus checks fixture-labeled contract behavior. The repeated-run runner checks repeated-run stability for selected controlled demo workloads.
+The deterministic corpus checks fixture-labeled contract behavior. The repeated-run runner checks repeated-run stability for selected controlled demo workloads. The mitigation runner checks baseline/mitigated evidence movement under controlled demos.

--- a/validation/diagnostics/latest/scorecard.md
+++ b/validation/diagnostics/latest/scorecard.md
@@ -14,6 +14,7 @@
 | runtime overhead | Measured separately | see `docs/runtime-cost.md`. |
 | collector limits | Measured separately | see `docs/collector-limits.md`. |
 | repeated-run diagnostic matrix | Manual/local repeated-run validation available | publishable repeated-run outputs are generated locally (JSONL/summary/scorecard) and not committed by default; results are machine/workload scoped. |
+| mitigation validation | Manual/local mitigation matrix available | baseline/mitigated controlled demos compare latency and evidence movement; generated outputs are not committed by default. |
 | real service validation | Planned | add curated real-service anonymized artifacts. |
 
 Deterministic synthetic adversarial cases validate benchmark/report contract behavior and humility checks; they are not real-service validation and do not provide root-cause proof.


### PR DESCRIPTION
### Motivation
- Add a manual mitigation validation workflow that verifies whether targeted mitigations (baseline → mitigated) produce the expected evidence movement and latency improvements on controlled demo workloads. 
- Provide a reproducible local runner that writes paired before/after artifacts, per-scenario JSONL records, a stable summary JSON, and an optional Markdown scorecard for human review. 
- Keep the scope narrow: this validates evidence movement for triage workflows (not root-cause proof), uses controlled demos, and must not change analyzer scoring/ranking or add dependencies. 

### Description
- Added `scripts/run_mitigation_matrix.py`, a stdlib-only CLI that runs paired baseline/mitigated demo runs into `target/mitigation-matrix/<scenario>/` and produces JSONL records, a summary JSON, and an optional Markdown scorecard; it supports `--out`, `--summary`, `--scorecard`, `--scenario`, `--profile`, `--artifact-root`, `--min-p95-improvement-ratio`, `--min-p99-improvement-ratio`, `--max-high-confidence-wrong`, `--no-fail-thresholds`, and `--require-expected-evidence-movement` flags. 
- Implemented pure helper functions for metric extraction and evaluation (`top2_kinds`, `suspect_score`, `extract_blocking_queue_depth_p95`, `delta`, `ratio_delta`, `build_pair_record`, `evaluate_movements`, `summarize_records`, `write_jsonl`, `write_scorecard`) so movement logic is testable without running cargo. 
- Added unit tests in `scripts/tests/test_run_mitigation_matrix.py` covering extraction, deltas/ratios, pair-record building, movement evaluation semantics (including the targeted-score-alone guard), JSONL emission, and scorecard writing; tests avoid running demos or cargo. 
- Updated docs to document mitigation validation as a manual/local track: `docs/diagnostic-validation.md`, `VALIDATION.md`, `validation/diagnostics/README.md`, and added a scorecard row in `validation/diagnostics/latest/scorecard.md`. 
- No analyzer behavior, Rust code, output schema, or dependencies were changed; the runner uses existing demo/analyze helpers from `scripts/_demo_runner.py` and standard library only. 

### Testing
- `python3 scripts/run_mitigation_matrix.py --scenario queue --out target/mitigation-runs-smoke.jsonl --summary target/mitigation-summary-smoke.json --scorecard target/mitigation-scorecard-smoke.md --no-fail-thresholds` — PASS (wrote artifacts under `target/mitigation-matrix/queue/`).
- `python3 -m unittest scripts.tests.test_run_mitigation_matrix` — PASS (unit tests for helpers and evaluation logic: OK).
- `python3 scripts/run_diagnostic_matrix.py --runs 1 --scenario queue --out target/diagnostic-runs-smoke.jsonl --summary target/diagnostic-runs-smoke-summary.json --scorecard target/diagnostic-runs-smoke-scorecard.md --no-fail-thresholds` — PASS (diagnostic matrix smoke run).
- `python3 -m unittest scripts.tests.test_run_diagnostic_matrix` — PASS.
- `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json` — PASS (deterministic benchmark run).
- `python3 -m unittest scripts.tests.test_diagnostic_benchmark` — PASS.
- `python3 scripts/validate_docs_contracts.py` — PASS (docs contract validation succeeded).
- `python3 -m unittest scripts.tests.test_validate_docs_contracts` — PASS.
- `python3 scripts/check_demo_fixture_drift.py --profile dev` — PASS (fixture drift check wrote temporary artifacts as expected).
- `cargo fmt --check` — PASS.
- `cargo clippy --workspace --all-targets -- -D warnings` — PASS.
- `cargo test --workspace` — PASS.

Limitations: mitigation validation is manual/local and machine/workload scoped, does not prove root cause, is not yet CI-mandated, and does not rely on score drops alone as the success condition.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b147a710833095f5672c6135e25f)