### PR TITLE
Add manual mitigation matrix validation runner

### DIFF
--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -43,3 +43,9 @@ Demos teach scenarios; validation measures bounded diagnostic behavior.
 It writes raw JSONL run records plus summary JSON (and optional Markdown scorecard) for stability metrics including top-1 accuracy, top-2 recall, high-confidence-wrong count, per-scenario primary stability, confidence bucket accuracy, and p95/p99 latency distribution summaries.
 
 This repeated-run validation is currently manual/local (not mandatory CI). Publishable repeated-run outputs are generated locally and are not committed by default. Results are machine/workload scoped. It measures stability under bounded controlled Tokio demo workloads on a specific machine/profile; it does not establish production universality or root-cause proof.
+
+
+## Mitigation matrix validation (manual/local)
+`scripts/run_mitigation_matrix.py` runs paired baseline/mitigated controlled demo scenarios and summarizes whether expected latency/evidence movement occurs after targeted mitigations.
+
+This validation is manual/local (not mandatory CI), machine/workload scoped, and does not prove root cause. It checks triage-direction usefulness under controlled workloads.

--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -66,3 +66,12 @@ Key repeated-run metrics:
 Repeated-run validation remains manual/local for now (not mandatory CI), and results are machine-scoped and workload-scoped. It supports triage confidence checks and reproducibility inspection for controlled Tokio workloads.
 
 Like all tool output, these results are evidence for triage and next checks; they do not prove root cause.
+
+## Mitigation matrix validation (manual/local)
+A manual mitigation matrix runner is available at `scripts/run_mitigation_matrix.py`. It executes controlled baseline/mitigated demo pairs and checks whether evidence moves in the expected direction for triage usefulness.
+
+It compares before/after signals such as p95 latency, queue/service-share movement, blocking queue-depth evidence, targeted suspect score non-worsening, and explainable top-2 movement.
+
+Score changes are not interpreted as absolute severity across reports. Scores are evidence-ranking values within one report. Mitigation validation therefore prefers concrete movement checks, not score drop alone.
+
+This track is manual/local, machine-scoped, and workload-scoped. It does not prove root cause or production universality.

--- a/scripts/run_mitigation_matrix.py
+++ b/scripts/run_mitigation_matrix.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Run baseline/mitigated demo pairs and summarize evidence movement."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+try:
+    from _demo_runner import PROFILE_CHOICES, load_report_json, repo_root, run_and_analyze, variant_paths
+except ModuleNotFoundError:  # pragma: no cover
+    from scripts._demo_runner import PROFILE_CHOICES, load_report_json, repo_root, run_and_analyze, variant_paths
+
+DEFAULT_OUT = Path("target/mitigation-runs.jsonl")
+CONF_HIGH = {"high", "very_high"}
+
+SCENARIO_MATRIX = {
+    "queue": {"manifest": "demos/queue_service/Cargo.toml", "before_mode": "baseline", "after_mode": "mitigated", "targeted_suspect": "application_queue_saturation", "acceptable_after_primary": ["application_queue_saturation", "downstream_stage_dominates"], "expected_movements": ["p95_decreases", "queue_share_decreases", "targeted_score_nonworsening", "top2_retains_target_or_expected_successor"], "notes": "Queue mitigation should reduce queue wait evidence and improve tail latency."},
+    "blocking": {"manifest": "demos/blocking_service/Cargo.toml", "before_mode": "baseline", "after_mode": "mitigated", "targeted_suspect": "blocking_pool_pressure", "acceptable_after_primary": ["blocking_pool_pressure", "downstream_stage_dominates"], "expected_movements": ["p95_decreases", "blocking_queue_depth_decreases", "targeted_score_nonworsening"], "notes": "Blocking mitigation should reduce blocking queue pressure signals."},
+    "downstream": {"manifest": "demos/downstream_service/Cargo.toml", "before_mode": "baseline", "after_mode": "mitigated", "targeted_suspect": "downstream_stage_dominates", "acceptable_after_primary": ["downstream_stage_dominates", "application_queue_saturation"], "expected_movements": ["p95_decreases", "service_share_decreases", "targeted_score_nonworsening", "top2_retains_target_or_expected_successor"], "notes": "Downstream mitigation should reduce stage-dominance evidence."},
+    "db-pool": {"manifest": "demos/db_pool_service/Cargo.toml", "before_mode": "baseline", "after_mode": "mitigated", "targeted_suspect": "application_queue_saturation", "acceptable_after_primary": ["application_queue_saturation", "downstream_stage_dominates"], "expected_movements": ["p95_decreases", "queue_share_decreases", "targeted_score_nonworsening"], "notes": "DB/pool mitigation should reduce resource-local waiting and tail latency."},
+}
+DEFAULT_SCENARIOS = ["queue", "blocking", "downstream", "db-pool"]
+
+
+def top2_kinds(report: dict[str, Any]) -> list[str]:
+    primary = report.get("primary_suspect") or {}
+    secondary = report.get("secondary_suspects") or []
+    return [s.get("kind") for s in [primary, *secondary][:2] if s.get("kind")]
+
+
+def suspect_score(report: dict[str, Any], kind: str) -> int | float | None:
+    for suspect in [report.get("primary_suspect") or {}, *(report.get("secondary_suspects") or [])]:
+        if suspect.get("kind") == kind:
+            return suspect.get("score")
+    return None
+
+
+def extract_blocking_queue_depth_p95(report: dict[str, Any]) -> int | None:
+    suspects = [report.get("primary_suspect") or {}, *(report.get("secondary_suspects") or [])]
+    pattern = re.compile(r"blocking queue depth(?:[^0-9]+p95)?[^0-9]+([0-9]+)", re.IGNORECASE)
+    for suspect in suspects:
+        for evidence in suspect.get("evidence") or []:
+            m = pattern.search(evidence)
+            if m:
+                return int(m.group(1))
+    return None
+
+
+def delta(before: Any, after: Any) -> Any:
+    if before is None or after is None:
+        return None
+    return after - before
+
+
+def ratio_delta(before: Any, after: Any) -> float | None:
+    if before in (None, 0) or after is None:
+        return None
+    return (after - before) / before
+
+
+def build_pair_record(before_report: dict[str, Any], after_report: dict[str, Any], scenario_meta: dict[str, Any], paths: dict[str, Path], profile: str) -> dict[str, Any]:
+    t = scenario_meta["targeted_suspect"]
+    return {
+        "schema_version": 1, "scenario": scenario_meta["name"], "profile": profile,
+        "before_artifact_path": str(paths["before_artifact_path"]), "before_analysis_path": str(paths["before_analysis_path"]),
+        "after_artifact_path": str(paths["after_artifact_path"]), "after_analysis_path": str(paths["after_analysis_path"]),
+        "targeted_suspect": t,
+        "before_primary_kind": (before_report.get("primary_suspect") or {}).get("kind"),
+        "after_primary_kind": (after_report.get("primary_suspect") or {}).get("kind"),
+        "before_top2_kinds": top2_kinds(before_report), "after_top2_kinds": top2_kinds(after_report),
+        "before_p95_latency_us": before_report.get("p95_latency_us"), "after_p95_latency_us": after_report.get("p95_latency_us"),
+        "p95_delta_us": delta(before_report.get("p95_latency_us"), after_report.get("p95_latency_us")),
+        "p95_delta_ratio": ratio_delta(before_report.get("p95_latency_us"), after_report.get("p95_latency_us")),
+        "before_p99_latency_us": before_report.get("p99_latency_us"), "after_p99_latency_us": after_report.get("p99_latency_us"),
+        "p99_delta_us": delta(before_report.get("p99_latency_us"), after_report.get("p99_latency_us")),
+        "p99_delta_ratio": ratio_delta(before_report.get("p99_latency_us"), after_report.get("p99_latency_us")),
+        "before_targeted_score": suspect_score(before_report, t), "after_targeted_score": suspect_score(after_report, t),
+        "targeted_score_delta": delta(suspect_score(before_report, t), suspect_score(after_report, t)),
+        "before_p95_queue_share_permille": before_report.get("p95_queue_share_permille"), "after_p95_queue_share_permille": after_report.get("p95_queue_share_permille"),
+        "queue_share_delta_permille": delta(before_report.get("p95_queue_share_permille"), after_report.get("p95_queue_share_permille")),
+        "before_p95_service_share_permille": before_report.get("p95_service_share_permille"), "after_p95_service_share_permille": after_report.get("p95_service_share_permille"),
+        "service_share_delta_permille": delta(before_report.get("p95_service_share_permille"), after_report.get("p95_service_share_permille")),
+        "before_blocking_queue_depth_p95": extract_blocking_queue_depth_p95(before_report), "after_blocking_queue_depth_p95": extract_blocking_queue_depth_p95(after_report),
+        "blocking_queue_depth_delta": delta(extract_blocking_queue_depth_p95(before_report), extract_blocking_queue_depth_p95(after_report)),
+        "expected_movements": {}, "movement_passed": False, "failed_expectations": [], "notes": scenario_meta["notes"],
+    }
+
+
+def evaluate_movements(record: dict[str, Any], scenario_meta: dict[str, Any], thresholds: dict[str, Any]) -> dict[str, bool]:
+    expected = scenario_meta["expected_movements"]
+    results: dict[str, bool] = {}
+    results["p95_decreases"] = (record.get("p95_delta_ratio") is not None and record["p95_delta_ratio"] <= -thresholds["min_p95_improvement_ratio"])
+    results["p99_nonworsening"] = record.get("p99_delta_ratio") is None or record["p99_delta_ratio"] <= thresholds["min_p99_improvement_ratio"]
+    results["queue_share_decreases"] = record.get("queue_share_delta_permille") is not None and record["queue_share_delta_permille"] < 0
+    results["service_share_decreases"] = record.get("service_share_delta_permille") is not None and record["service_share_delta_permille"] < 0
+    results["blocking_queue_depth_decreases"] = record.get("blocking_queue_depth_delta") is not None and record["blocking_queue_depth_delta"] < 0
+    results["targeted_score_nonworsening"] = record.get("targeted_score_delta") is not None and record["targeted_score_delta"] <= 0
+    results["targeted_score_decreases"] = record.get("targeted_score_delta") is not None and record["targeted_score_delta"] < 0
+    results["top2_retains_target_or_expected_successor"] = (record["targeted_suspect"] in record["after_top2_kinds"]) or (record["after_primary_kind"] in scenario_meta.get("acceptable_after_primary", []))
+    results["primary_changes_from_targeted"] = record["before_primary_kind"] == record["targeted_suspect"] and record["after_primary_kind"] != record["targeted_suspect"]
+    failed = [k for k in expected if not results.get(k, False)]
+    # guard: targeted score movement cannot be sole passing signal
+    if expected == ["targeted_score_decreases"] and not failed:
+        failed.append("targeted_score_decreases_requires_concrete_companion")
+    high_wrong = (record.get("after_primary_confidence") in CONF_HIGH and record.get("after_primary_kind") not in scenario_meta.get("acceptable_after_primary", []))
+    if high_wrong:
+        failed.append("high_confidence_wrong_after_mitigation")
+    record["expected_movements"] = {k: results[k] for k in expected if k in results}
+    record["failed_expectations"] = failed
+    record["movement_passed"] = len(failed) == 0
+    return results
+
+
+def summarize_records(records: list[dict[str, Any]], profile: str, max_high_confidence_wrong: int) -> dict[str, Any]:
+    per = {}
+    high_wrong = 0
+    for r in records:
+        if "high_confidence_wrong_after_mitigation" in r.get("failed_expectations", []):
+            high_wrong += 1
+        per[r["scenario"]] = {k: r.get(k) for k in ["movement_passed", "failed_expectations", "p95_delta_us", "p95_delta_ratio", "before_primary_kind", "after_primary_kind", "before_targeted_score", "after_targeted_score", "queue_share_delta_permille"]}
+    passed = sum(1 for r in records if r.get("movement_passed"))
+    summary = {"schema_version": 1, "profile": profile, "total_scenarios": len(records), "passed_scenarios": passed, "failed_scenarios": len(records)-passed, "movement_pass_rate": (passed/len(records) if records else 0.0), "high_confidence_wrong_count": high_wrong, "per_scenario": per, "failed_thresholds": []}
+    if high_wrong > max_high_confidence_wrong:
+        summary["failed_thresholds"].append(f"high_confidence_wrong_count {high_wrong} exceeds max {max_high_confidence_wrong}")
+    return summary
+
+
+def write_jsonl(path: Path, records: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for rec in records:
+            f.write(json.dumps(rec, sort_keys=True) + "\n")
+
+
+def write_scorecard(path: Path, summary: dict[str, Any], records: list[dict[str, Any]]) -> None:
+    lines = ["# Mitigation validation scorecard", "", f"Profile: {summary['profile']}", "", "| Scenario | Passed | Targeted suspect | Before primary | After primary | p95 delta | Evidence movement | Notes |", "|---|---:|---|---|---|---:|---|---|"]
+    for r in records:
+        ratio = r.get("p95_delta_ratio")
+        ratio_txt = "n/a" if ratio is None else f"{ratio*100:.1f}%"
+        evidence = ", ".join([k for k,v in r.get("expected_movements",{}).items() if v]) or "none"
+        lines.append(f"| {r['scenario']} | {'yes' if r['movement_passed'] else 'no'} | {r['targeted_suspect']} | {r['before_primary_kind']} | {r['after_primary_kind']} | {ratio_txt} | {evidence} | {r['notes']} |")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines)+"\n", encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    p.add_argument("--summary", type=Path)
+    p.add_argument("--scorecard", type=Path)
+    p.add_argument("--scenario", action="append", dest="scenarios")
+    p.add_argument("--profile", choices=PROFILE_CHOICES, default="dev")
+    p.add_argument("--artifact-root", type=Path, default=Path("target/mitigation-matrix"))
+    p.add_argument("--no-fail-thresholds", action="store_true")
+    p.add_argument("--min-p95-improvement-ratio", type=float, default=0.05)
+    p.add_argument("--min-p99-improvement-ratio", type=float, default=0.0)
+    p.add_argument("--max-high-confidence-wrong", type=int, default=0)
+    p.add_argument("--require-expected-evidence-movement", action="store_true", default=True)
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    selected = args.scenarios or DEFAULT_SCENARIOS
+    unknown = [s for s in selected if s not in SCENARIO_MATRIX]
+    if unknown:
+        raise SystemExit(f"unknown scenarios: {unknown}")
+    summary_path = args.summary or args.out.with_name(f"{args.out.stem}-summary.json")
+    root = repo_root(__file__)
+    cli_manifest = root / "tailtriage-cli/Cargo.toml"
+    records = []
+    thresholds = {"min_p95_improvement_ratio": args.min_p95_improvement_ratio, "min_p99_improvement_ratio": args.min_p99_improvement_ratio}
+    for name in selected:
+        spec = {**SCENARIO_MATRIX[name], "name": name}
+        run_dir = args.artifact_root / name
+        before_artifact, before_analysis = variant_paths(run_dir, "before")
+        after_artifact, after_analysis = variant_paths(run_dir, "after")
+        demo_manifest = root / spec["manifest"]
+        run_and_analyze(demo_manifest, cli_manifest, before_artifact, before_analysis, spec["before_mode"], profile=args.profile)
+        run_and_analyze(demo_manifest, cli_manifest, after_artifact, after_analysis, spec["after_mode"], profile=args.profile)
+        br, ar = load_report_json(before_analysis), load_report_json(after_analysis)
+        rec = build_pair_record(br, ar, spec, {"before_artifact_path": before_artifact, "before_analysis_path": before_analysis, "after_artifact_path": after_artifact, "after_analysis_path": after_analysis}, args.profile)
+        rec["after_primary_confidence"] = (ar.get("primary_suspect") or {}).get("confidence")
+        evaluate_movements(rec, spec, thresholds)
+        records.append(rec)
+    write_jsonl(args.out, records)
+    summary = summarize_records(records, args.profile, args.max_high_confidence_wrong)
+    for r in records:
+        if not r["movement_passed"]:
+            summary["failed_thresholds"].append(f"{r['scenario']}: failed expectations {r['failed_expectations']}")
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True)+"\n", encoding="utf-8")
+    if args.scorecard:
+        write_scorecard(args.scorecard, summary, records)
+    if summary["failed_thresholds"] and not args.no_fail_thresholds:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_run_mitigation_matrix.py
+++ b/scripts/tests/test_run_mitigation_matrix.py
@@ -1,0 +1,73 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import run_mitigation_matrix as rmm
+
+
+class RunMitigationMatrixTests(unittest.TestCase):
+    def report(self, pk="application_queue_saturation", ps=90, sk="downstream_stage_dominates", p95=1000, p99=1200, q=900, s=100, evidence=None, conf="high"):
+        return {
+            "primary_suspect": {"kind": pk, "score": ps, "confidence": conf, "evidence": evidence or ["blocking queue depth p95 12"]},
+            "secondary_suspects": [{"kind": sk, "score": 40, "evidence": []}],
+            "p95_latency_us": p95,
+            "p99_latency_us": p99,
+            "p95_queue_share_permille": q,
+            "p95_service_share_permille": s,
+        }
+
+    def test_top2_and_score_helpers(self):
+        rp = self.report()
+        self.assertEqual(rmm.top2_kinds(rp), ["application_queue_saturation", "downstream_stage_dominates"])
+        self.assertEqual(rmm.suspect_score(rp, "application_queue_saturation"), 90)
+        self.assertEqual(rmm.suspect_score(rp, "downstream_stage_dominates"), 40)
+        self.assertIsNone(rmm.suspect_score(rp, "blocking_pool_pressure"))
+
+    def test_blocking_depth_extract(self):
+        self.assertEqual(rmm.extract_blocking_queue_depth_p95(self.report()), 12)
+
+    def test_delta_ratio(self):
+        self.assertEqual(rmm.delta(10, 7), -3)
+        self.assertIsNone(rmm.delta(None, 7))
+        self.assertAlmostEqual(rmm.ratio_delta(10, 7), -0.3)
+        self.assertIsNone(rmm.ratio_delta(0, 7))
+
+    def test_build_pair_record_shape(self):
+        meta = {"name": "queue", "targeted_suspect": "application_queue_saturation", "notes": "n"}
+        rec = rmm.build_pair_record(self.report(), self.report(p95=800, q=700), meta, {k: Path(k) for k in ["before_artifact_path", "before_analysis_path", "after_artifact_path", "after_analysis_path"]}, "dev")
+        self.assertEqual(rec["schema_version"], 1)
+        self.assertIn("before_top2_kinds", rec)
+
+    def test_expectations_and_summary_and_writes(self):
+        meta = {"name": "queue", "targeted_suspect": "application_queue_saturation", "expected_movements": ["p95_decreases", "queue_share_decreases", "targeted_score_nonworsening"], "acceptable_after_primary": ["application_queue_saturation", "downstream_stage_dominates"], "notes": "n"}
+        rec = rmm.build_pair_record(self.report(ps=90, p95=1000, q=900), self.report(ps=70, p95=800, q=700), meta, {k: Path(k) for k in ["before_artifact_path", "before_analysis_path", "after_artifact_path", "after_analysis_path"]}, "dev")
+        rec["after_primary_confidence"] = "medium"
+        rmm.evaluate_movements(rec, meta, {"min_p95_improvement_ratio": 0.05, "min_p99_improvement_ratio": 0.0})
+        self.assertTrue(rec["movement_passed"])
+
+        bad = dict(rec)
+        bad["expected_movements"] = {}
+        bad["movement_passed"] = False
+        bad["failed_expectations"] = ["high_confidence_wrong_after_mitigation"]
+        summary = rmm.summarize_records([rec, bad], "dev", 0)
+        self.assertEqual(summary["schema_version"], 1)
+
+        with tempfile.TemporaryDirectory() as td:
+            j = Path(td) / "a.jsonl"
+            rmm.write_jsonl(j, [rec, bad])
+            self.assertEqual(len(j.read_text().strip().splitlines()), 2)
+            md = Path(td) / "s.md"
+            rmm.write_scorecard(md, summary, [rec, bad])
+            self.assertIn("| queue |", md.read_text())
+
+    def test_targeted_score_only_not_sufficient(self):
+        meta = {"name": "queue", "targeted_suspect": "application_queue_saturation", "expected_movements": ["targeted_score_decreases"], "acceptable_after_primary": ["application_queue_saturation"], "notes": "n"}
+        rec = rmm.build_pair_record(self.report(ps=90), self.report(ps=70), meta, {k: Path(k) for k in ["before_artifact_path", "before_analysis_path", "after_artifact_path", "after_analysis_path"]}, "dev")
+        rec["after_primary_confidence"] = "low"
+        rmm.evaluate_movements(rec, meta, {"min_p95_improvement_ratio": 0.05, "min_p99_improvement_ratio": 0.0})
+        self.assertFalse(rec["movement_passed"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -58,6 +58,8 @@ python3 scripts/diagnostic_benchmark.py \
 
 ## Validation tracks
 - deterministic corpus benchmark: `scripts/diagnostic_benchmark.py`
+- adversarial synthetic validation: `validation/diagnostics/manifest.json` (via benchmark)
 - repeated-run controlled matrix runner: `scripts/run_diagnostic_matrix.py`
+- mitigation matrix: `scripts/run_mitigation_matrix.py`
 
 The deterministic corpus checks fixture-labeled contract behavior. The repeated-run runner checks repeated-run stability for selected controlled demo workloads.

--- a/validation/diagnostics/latest/scorecard.md
+++ b/validation/diagnostics/latest/scorecard.md
@@ -14,6 +14,7 @@
 | runtime overhead | Measured separately | see `docs/runtime-cost.md`. |
 | collector limits | Measured separately | see `docs/collector-limits.md`. |
 | repeated-run diagnostic matrix | Manual/local repeated-run validation available | publishable repeated-run outputs are generated locally (JSONL/summary/scorecard) and not committed by default; results are machine/workload scoped. |
+| mitigation validation | Manual/local mitigation matrix available | baseline/mitigated controlled demos compare latency and evidence movement; generated outputs are not committed by default |
 | real service validation | Planned | add curated real-service anonymized artifacts. |
 
 Deterministic synthetic adversarial cases validate benchmark/report contract behavior and humility checks; they are not real-service validation and do not provide root-cause proof.


### PR DESCRIPTION
### Motivation
- Provide a manual/local validation runner that checks whether targeted mitigations in controlled demo workloads move evidence and latency in the expected direction to improve triage usefulness. 
- Validate movement of concrete signals (p95, p99, queue/service shares, blocking depth, targeted suspect score, top-2 visibility) instead of treating analyzer score changes as absolute proof. 
- Keep the change local to validation tooling (Python stdlib only) and avoid any analyzer scoring/schema or Rust code changes. 

### Description
- Added `scripts/run_mitigation_matrix.py`, a stdlib-only CLI that runs paired baseline/mitigated demo scenarios, stores artifacts under `target/mitigation-matrix/<scenario>/`, builds per-pair JSON records (JSONL), writes a stable summary JSON, and optionally emits a Markdown scorecard; it supports the requested CLI flags including `--out`, `--summary`, `--scorecard`, `--scenario`, `--profile`, `--artifact-root`, `--min-p95-improvement-ratio`, `--min-p99-improvement-ratio`, `--max-high-confidence-wrong`, and `--no-fail-thresholds`. 
- Implemented pure helper functions and movement/evaluation logic: `top2_kinds`, `suspect_score`, `extract_blocking_queue_depth_p95`, `delta`, `ratio_delta`, `build_pair_record`, `evaluate_movements`, `summarize_records`, `write_jsonl`, and `write_scorecard`. 
- Added unit tests `scripts/tests/test_run_mitigation_matrix.py` covering helpers, blocking-depth extraction, delta/ratio semantics, pair-record shape, movement evaluation rules (including the guard that targeted-score-only is not sufficient), JSONL and scorecard writing, and summary shape. 
- Updated documentation and validation metadata to include the mitigation matrix track and explain limitations, adding entries to `docs/diagnostic-validation.md`, `VALIDATION.md`, `validation/diagnostics/README.md`, and `validation/diagnostics/latest/scorecard.md`. 
- Preserved policies: no analyzer behavior, schema, or Rust code changes; no new dependencies; generated artifacts are written under `target/` and not committed. 

### Testing
- `python3 scripts/run_mitigation_matrix.py --scenario queue --out target/mitigation-runs-smoke.jsonl --summary target/mitigation-summary-smoke.json --scorecard target/mitigation-scorecard-smoke.md --no-fail-thresholds` — passed (produced artifacts under `target/mitigation-matrix/queue/`).
- `python3 -m unittest scripts.tests.test_run_mitigation_matrix` — passed (unit tests for mitigation helpers and outputs).
- `python3 scripts/run_diagnostic_matrix.py --runs 1 --scenario queue --out target/diagnostic-runs-smoke.jsonl --summary target/diagnostic-runs-smoke-summary.json --scorecard target/diagnostic-runs-smoke-scorecard.md --no-fail-thresholds` — passed (diagnostic matrix smoke run).
- `python3 -m unittest scripts.tests.test_run_diagnostic_matrix` — passed (diagnostic matrix unit tests).
- `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json` — passed (deterministic benchmark run).
- `python3 -m unittest scripts.tests.test_diagnostic_benchmark` — passed (deterministic benchmark unit tests).
- `python3 scripts/validate_docs_contracts.py` — passed (docs contract validation).
- `python3 -m unittest scripts.tests.test_validate_docs_contracts` — passed (docs contract unit tests).
- `python3 scripts/check_demo_fixture_drift.py --profile dev` — passed (demo fixture smoke checks).
- `cargo fmt --check` — passed.
- `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- `cargo test --workspace` — passed.

Limitations
- Mitigation validation is manual/local and machine/workload scoped and does not prove root cause. 
- Movement checks prefer concrete evidence changes and do not treat score drop alone as sufficient. 
- This change does not add any runtime/collector validation or modify analyzer scoring; unified validation orchestration is left for future work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b147a710833095f5672c6135e25f)