### PR TITLE
Add manual mitigation matrix validation runner

### DIFF
--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -43,3 +43,8 @@ Demos teach scenarios; validation measures bounded diagnostic behavior.
 It writes raw JSONL run records plus summary JSON (and optional Markdown scorecard) for stability metrics including top-1 accuracy, top-2 recall, high-confidence-wrong count, per-scenario primary stability, confidence bucket accuracy, and p95/p99 latency distribution summaries.
 
 This repeated-run validation is currently manual/local (not mandatory CI). Publishable repeated-run outputs are generated locally and are not committed by default. Results are machine/workload scoped. It measures stability under bounded controlled Tokio demo workloads on a specific machine/profile; it does not establish production universality or root-cause proof.
+
+## Mitigation matrix validation (manual/local)
+`scripts/run_mitigation_matrix.py` provides paired baseline/mitigated controlled-demo validation that checks whether expected latency and evidence movement occurs after targeted mitigations.
+
+This is manual/local validation (not mandatory CI), machine/workload scoped, and does not prove root cause. Score movement alone is not interpreted as absolute severity across reports.

--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -66,3 +66,15 @@ Key repeated-run metrics:
 Repeated-run validation remains manual/local for now (not mandatory CI), and results are machine-scoped and workload-scoped. It supports triage confidence checks and reproducibility inspection for controlled Tokio workloads.
 
 Like all tool output, these results are evidence for triage and next checks; they do not prove root cause.
+
+
+## Mitigation matrix validation (manual/local)
+A manual mitigation matrix runner is available at `scripts/run_mitigation_matrix.py`.
+
+It compares paired baseline/degraded and targeted-mitigated demo runs, then checks whether expected evidence movement occurs for the bottleneck family under test (for example queue share drops, service/stage share drops, or blocking-queue-depth drops when available) while p95 generally improves in scenarios designed for improvement.
+
+Interpretation guardrails:
+- score changes are not treated as absolute severity across reports
+- movement checks are scenario-specific and rely on concrete evidence movement, not score drop alone
+- results are controlled-demo, machine/workload scoped, manual/local validation
+- this does not prove root cause

--- a/scripts/run_mitigation_matrix.py
+++ b/scripts/run_mitigation_matrix.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Run paired baseline/mitigated demos and summarize mitigation movement signals."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+try:
+    from _demo_runner import PROFILE_CHOICES, load_report_json, repo_root, run_and_analyze
+except ModuleNotFoundError:  # pragma: no cover
+    from scripts._demo_runner import PROFILE_CHOICES, load_report_json, repo_root, run_and_analyze
+
+CONF_HIGH = {"high", "very_high"}
+DEFAULT_OUT = Path("target/mitigation-runs.jsonl")
+
+SCENARIO_MATRIX: dict[str, dict[str, Any]] = {
+    "queue": {
+        "manifest": "demos/queue_service/Cargo.toml",
+        "before_mode": "baseline",
+        "after_mode": "mitigated",
+        "targeted_suspect": "application_queue_saturation",
+        "acceptable_after_primary": ["application_queue_saturation", "downstream_stage_dominates"],
+        "expected_movements": ["p95_decreases", "queue_share_decreases", "top2_retains_target_or_expected_successor"],
+        "expected_successor": "downstream_stage_dominates",
+        "notes": "Queue mitigation should reduce queue-wait evidence and improve tail latency.",
+    },
+    "blocking": {
+        "manifest": "demos/blocking_service/Cargo.toml",
+        "before_mode": "baseline",
+        "after_mode": "mitigated",
+        "targeted_suspect": "blocking_pool_pressure",
+        "acceptable_after_primary": ["blocking_pool_pressure", "downstream_stage_dominates"],
+        "expected_movements": ["p95_decreases", "blocking_queue_depth_decreases"],
+        "notes": "Blocking mitigation should reduce blocking-pool queue pressure evidence.",
+    },
+    "downstream": {
+        "manifest": "demos/downstream_service/Cargo.toml",
+        "before_mode": "baseline",
+        "after_mode": "mitigated",
+        "targeted_suspect": "downstream_stage_dominates",
+        "acceptable_after_primary": ["downstream_stage_dominates", "application_queue_saturation"],
+        "expected_movements": ["p95_decreases", "service_share_decreases"],
+        "notes": "Downstream mitigation should reduce stage-dominance evidence and latency.",
+    },
+    "db-pool": {
+        "manifest": "demos/db_pool_service/Cargo.toml",
+        "before_mode": "baseline",
+        "after_mode": "mitigated",
+        "targeted_suspect": "application_queue_saturation",
+        "acceptable_after_primary": ["application_queue_saturation", "downstream_stage_dominates"],
+        "expected_movements": ["p95_decreases", "queue_share_decreases"],
+        "notes": "DB/pool mitigation should reduce resource-local wait evidence.",
+    },
+}
+DEFAULT_SCENARIOS = ["queue", "blocking", "downstream", "db-pool"]
+
+
+def top2_kinds(report: dict[str, Any]) -> list[str]:
+    primary = report.get("primary_suspect") or {}
+    secondaries = report.get("secondary_suspects") or []
+    return [s.get("kind") for s in [primary, *secondaries][:2] if s.get("kind")]
+
+
+def suspect_score(report: dict[str, Any], kind: str) -> int | None:
+    for suspect in [(report.get("primary_suspect") or {}), *((report.get("secondary_suspects") or []))]:
+        if suspect.get("kind") == kind:
+            return suspect.get("score")
+    return None
+
+
+def extract_blocking_queue_depth_p95(report: dict[str, Any]) -> int | None:
+    suspects = [(report.get("primary_suspect") or {}), *((report.get("secondary_suspects") or []))]
+    for suspect in suspects:
+        for evidence in suspect.get("evidence") or []:
+            m = re.search(r"(?:p95|95th)[^0-9]{0,12}(\d+)", str(evidence), flags=re.IGNORECASE)
+            if "blocking" in str(evidence).lower() and m:
+                return int(m.group(1))
+    return None
+
+
+def delta(before: int | None, after: int | None) -> int | None:
+    return None if before is None or after is None else after - before
+
+
+def ratio_delta(before: int | None, after: int | None) -> float | None:
+    if before in (None, 0) or after is None:
+        return None
+    return (after - before) / before
+
+
+def build_pair_record(before_report: dict[str, Any], after_report: dict[str, Any], scenario_meta: dict[str, Any], *, profile: str, before_artifact_path: Path, before_analysis_path: Path, after_artifact_path: Path, after_analysis_path: Path) -> dict[str, Any]:
+    targeted = scenario_meta["targeted_suspect"]
+    before_top2 = top2_kinds(before_report)
+    after_top2 = top2_kinds(after_report)
+    bp95 = before_report.get("p95_latency_us")
+    ap95 = after_report.get("p95_latency_us")
+    bp99 = before_report.get("p99_latency_us")
+    ap99 = after_report.get("p99_latency_us")
+    bq = before_report.get("p95_queue_share_permille")
+    aq = after_report.get("p95_queue_share_permille")
+    bs = before_report.get("p95_service_share_permille")
+    a_s = after_report.get("p95_service_share_permille")
+    bbd = extract_blocking_queue_depth_p95(before_report)
+    abd = extract_blocking_queue_depth_p95(after_report)
+    return {
+        "schema_version": 1,
+        "scenario": scenario_meta["name"],
+        "profile": profile,
+        "before_artifact_path": str(before_artifact_path),
+        "before_analysis_path": str(before_analysis_path),
+        "after_artifact_path": str(after_artifact_path),
+        "after_analysis_path": str(after_analysis_path),
+        "targeted_suspect": targeted,
+        "before_primary_kind": (before_report.get("primary_suspect") or {}).get("kind"),
+        "after_primary_kind": (after_report.get("primary_suspect") or {}).get("kind"),
+        "before_top2_kinds": before_top2,
+        "after_top2_kinds": after_top2,
+        "before_p95_latency_us": bp95,
+        "after_p95_latency_us": ap95,
+        "p95_delta_us": delta(bp95, ap95),
+        "p95_delta_ratio": ratio_delta(bp95, ap95),
+        "before_p99_latency_us": bp99,
+        "after_p99_latency_us": ap99,
+        "p99_delta_us": delta(bp99, ap99),
+        "p99_delta_ratio": ratio_delta(bp99, ap99),
+        "before_targeted_score": suspect_score(before_report, targeted),
+        "after_targeted_score": suspect_score(after_report, targeted),
+        "targeted_score_delta": delta(suspect_score(before_report, targeted), suspect_score(after_report, targeted)),
+        "before_p95_queue_share_permille": bq,
+        "after_p95_queue_share_permille": aq,
+        "queue_share_delta_permille": delta(bq, aq),
+        "before_p95_service_share_permille": bs,
+        "after_p95_service_share_permille": a_s,
+        "service_share_delta_permille": delta(bs, a_s),
+        "before_blocking_queue_depth_p95": bbd,
+        "after_blocking_queue_depth_p95": abd,
+        "blocking_queue_depth_delta": delta(bbd, abd),
+        "expected_movements": {},
+        "movement_passed": False,
+        "failed_expectations": [],
+        "high_confidence_wrong_after": False,
+        "notes": scenario_meta["notes"],
+    }
+
+
+def evaluate_movements(record: dict[str, Any], scenario_meta: dict[str, Any], thresholds: dict[str, Any]) -> dict[str, bool]:
+    expected = scenario_meta.get("expected_movements") or []
+    out: dict[str, bool] = {}
+    for key in expected:
+        if key == "p95_decreases":
+            ratio = record.get("p95_delta_ratio")
+            out[key] = ratio is not None and ratio <= -float(thresholds["min_p95_improvement_ratio"])
+        elif key == "p99_nonworsening":
+            d = record.get("p99_delta_us")
+            out[key] = d is not None and d <= 0
+        elif key == "queue_share_decreases":
+            d = record.get("queue_share_delta_permille")
+            out[key] = d is not None and d < 0
+        elif key == "service_share_decreases":
+            d = record.get("service_share_delta_permille")
+            out[key] = d is not None and d < 0
+        elif key == "blocking_queue_depth_decreases":
+            d = record.get("blocking_queue_depth_delta")
+            out[key] = d is not None and d < 0
+        elif key == "targeted_score_nonworsening":
+            d = record.get("targeted_score_delta")
+            out[key] = d is not None and d <= 0
+        elif key == "targeted_score_decreases":
+            d = record.get("targeted_score_delta")
+            out[key] = d is not None and d < 0
+        elif key == "top2_retains_target_or_expected_successor":
+            top2 = set(record.get("after_top2_kinds") or [])
+            out[key] = record["targeted_suspect"] in top2 or scenario_meta.get("expected_successor") in top2
+        elif key == "primary_changes_from_targeted":
+            out[key] = record.get("before_primary_kind") == record["targeted_suspect"] and record.get("after_primary_kind") != record["targeted_suspect"]
+    return out
+
+
+def summarize_records(records: list[dict[str, Any]], profile: str) -> dict[str, Any]:
+    total = len(records)
+    passed = sum(1 for r in records if r.get("movement_passed"))
+    high_wrong = sum(1 for r in records if r.get("high_confidence_wrong_after"))
+    per = {}
+    for r in records:
+        per[r["scenario"]] = {
+            "movement_passed": r["movement_passed"],
+            "failed_expectations": r["failed_expectations"],
+            "p95_delta_us": r["p95_delta_us"],
+            "p95_delta_ratio": r["p95_delta_ratio"],
+            "before_primary_kind": r["before_primary_kind"],
+            "after_primary_kind": r["after_primary_kind"],
+            "before_targeted_score": r["before_targeted_score"],
+            "after_targeted_score": r["after_targeted_score"],
+            "queue_share_delta_permille": r["queue_share_delta_permille"],
+        }
+    return {"schema_version": 1, "profile": profile, "total_scenarios": total, "passed_scenarios": passed, "failed_scenarios": total - passed, "movement_pass_rate": (passed / total if total else 0.0), "high_confidence_wrong_count": high_wrong, "per_scenario": dict(sorted(per.items())), "failed_thresholds": [], "targeted_suspect_by_scenario": {r['scenario']: r.get('targeted_suspect') for r in records}}
+
+
+def write_jsonl(path: Path, records: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for r in records:
+            handle.write(json.dumps(r, sort_keys=True) + "\n")
+
+
+def write_scorecard(path: Path, summary: dict[str, Any]) -> None:
+    lines = ["# Mitigation validation scorecard", "", f"Profile: {summary['profile']}", "", "| Scenario | Passed | Targeted suspect | Before primary | After primary | p95 delta | Evidence movement | Notes |", "|---|---:|---|---|---|---:|---|---|"]
+    for name, row in summary["per_scenario"].items():
+        passed = "yes" if row["movement_passed"] else "no"
+        p95 = row.get("p95_delta_ratio")
+        p95_label = "n/a" if p95 is None else f"{p95 * 100:.1f}%"
+        movement = "ok" if row["movement_passed"] else ", ".join(row["failed_expectations"])
+        lines.append(f"| {name} | {passed} | {summary.get('targeted_suspect_by_scenario', {}).get(name, 'n/a')} | {row.get('before_primary_kind') or 'n/a'} | {row.get('after_primary_kind') or 'n/a'} | {p95_label} | {movement} | mitigation movement check |")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    p.add_argument("--summary", type=Path)
+    p.add_argument("--scorecard", type=Path)
+    p.add_argument("--scenario", action="append", dest="scenarios")
+    p.add_argument("--profile", choices=PROFILE_CHOICES, default="dev")
+    p.add_argument("--artifact-root", type=Path, default=Path("target/mitigation-matrix"))
+    p.add_argument("--no-fail-thresholds", action="store_true")
+    p.add_argument("--min-p95-improvement-ratio", type=float, default=0.05)
+    p.add_argument("--min-p99-improvement-ratio", type=float, default=0.0)
+    p.add_argument("--max-high-confidence-wrong", type=int, default=0)
+    p.add_argument("--require-expected-evidence-movement", action=argparse.BooleanOptionalAction, default=True)
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    selected = args.scenarios or DEFAULT_SCENARIOS
+    unknown = [s for s in selected if s not in SCENARIO_MATRIX]
+    if unknown:
+        raise SystemExit(f"unknown scenarios: {unknown}")
+    root = repo_root(__file__)
+    cli_manifest = root / "tailtriage-cli/Cargo.toml"
+    summary_path = args.summary or args.out.with_name(f"{args.out.stem}-summary.json")
+    records = []
+    for name in selected:
+        spec = {**SCENARIO_MATRIX[name], "name": name}
+        run_dir = args.artifact_root / name
+        run_dir.mkdir(parents=True, exist_ok=True)
+        before_artifact = run_dir / "before-run.json"
+        before_analysis = run_dir / "before-analysis.json"
+        after_artifact = run_dir / "after-run.json"
+        after_analysis = run_dir / "after-analysis.json"
+        manifest = root / spec["manifest"]
+        run_and_analyze(manifest, cli_manifest, before_artifact, before_analysis, spec["before_mode"], profile=args.profile)
+        run_and_analyze(manifest, cli_manifest, after_artifact, after_analysis, spec["after_mode"], profile=args.profile)
+        record = build_pair_record(load_report_json(before_analysis), load_report_json(after_analysis), spec, profile=args.profile, before_artifact_path=before_artifact, before_analysis_path=before_analysis, after_artifact_path=after_artifact, after_analysis_path=after_analysis)
+        after_primary = load_report_json(after_analysis).get("primary_suspect") or {}
+        record["high_confidence_wrong_after"] = after_primary.get("confidence") in CONF_HIGH and after_primary.get("kind") not in spec.get("acceptable_after_primary", [])
+        checks = evaluate_movements(record, spec, {"min_p95_improvement_ratio": args.min_p95_improvement_ratio, "min_p99_improvement_ratio": args.min_p99_improvement_ratio})
+        record["expected_movements"] = checks
+        failed = [k for k, ok in checks.items() if not ok]
+        if record["high_confidence_wrong_after"]:
+            failed.append("high_confidence_wrong_after")
+        record["failed_expectations"] = failed
+        record["movement_passed"] = len(failed) == 0 if args.require_expected_evidence_movement else not record["high_confidence_wrong_after"]
+        records.append(record)
+    write_jsonl(args.out, records)
+    summary = summarize_records(records, args.profile)
+    summary["failed_thresholds"] = [f"{r['scenario']}: {', '.join(r['failed_expectations'])}" for r in records if not r["movement_passed"]]
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.scorecard:
+        write_scorecard(args.scorecard, summary)
+    if summary["high_confidence_wrong_count"] > args.max_high_confidence_wrong and not args.no_fail_thresholds:
+        raise SystemExit(1)
+    if summary["failed_scenarios"] > 0 and not args.no_fail_thresholds:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_run_mitigation_matrix.py
+++ b/scripts/tests/test_run_mitigation_matrix.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import run_mitigation_matrix as rmm
+
+
+class RunMitigationMatrixTests(unittest.TestCase):
+    def report(self, primary="application_queue_saturation", second=None, score=90):
+        return {
+            "primary_suspect": {"kind": primary, "score": score, "confidence": "high", "evidence": ["blocking queue p95 12"]},
+            "secondary_suspects": second or [{"kind": "downstream_stage_dominates", "score": 40, "evidence": []}],
+            "p95_latency_us": 100,
+            "p99_latency_us": 120,
+            "p95_queue_share_permille": 900,
+            "p95_service_share_permille": 100,
+        }
+
+    def test_top2(self):
+        self.assertEqual(rmm.top2_kinds(self.report()), ["application_queue_saturation", "downstream_stage_dominates"])
+
+    def test_suspect_score(self):
+        rep = self.report()
+        self.assertEqual(rmm.suspect_score(rep, "application_queue_saturation"), 90)
+        self.assertEqual(rmm.suspect_score(rep, "downstream_stage_dominates"), 40)
+        self.assertIsNone(rmm.suspect_score(rep, "blocking_pool_pressure"))
+
+    def test_blocking_extract(self):
+        self.assertEqual(rmm.extract_blocking_queue_depth_p95(self.report()), 12)
+
+    def test_delta_ratio(self):
+        self.assertEqual(rmm.delta(10, 6), -4)
+        self.assertIsNone(rmm.delta(None, 1))
+        self.assertAlmostEqual(rmm.ratio_delta(10, 5), -0.5)
+        self.assertIsNone(rmm.ratio_delta(0, 5))
+
+    def test_build_record_shape(self):
+        rec = rmm.build_pair_record(self.report(), self.report(primary="downstream_stage_dominates"), {"name": "queue", "targeted_suspect": "application_queue_saturation", "notes": "n"}, profile="dev", before_artifact_path=Path("a"), before_analysis_path=Path("b"), after_artifact_path=Path("c"), after_analysis_path=Path("d"))
+        self.assertIn("scenario", rec)
+        self.assertIn("p95_delta_ratio", rec)
+
+    def test_evaluate_movements(self):
+        rec = {"p95_delta_ratio": -0.2, "queue_share_delta_permille": -1, "service_share_delta_permille": -1, "blocking_queue_depth_delta": -1, "targeted_score_delta": -1, "after_top2_kinds": ["application_queue_saturation"], "targeted_suspect": "application_queue_saturation", "before_primary_kind": "application_queue_saturation", "after_primary_kind": "downstream_stage_dominates", "p99_delta_us": 0}
+        meta = {"expected_movements": ["p95_decreases", "queue_share_decreases", "service_share_decreases", "blocking_queue_depth_decreases", "targeted_score_decreases", "top2_retains_target_or_expected_successor", "primary_changes_from_targeted"], "expected_successor": "downstream_stage_dominates"}
+        out = rmm.evaluate_movements(rec, meta, {"min_p95_improvement_ratio": 0.05})
+        self.assertTrue(all(out.values()))
+
+    def test_summary_jsonl_scorecard(self):
+        records = [{"scenario": "queue", "movement_passed": True, "failed_expectations": [], "p95_delta_us": -1, "p95_delta_ratio": -0.1, "before_primary_kind": "a", "after_primary_kind": "b", "before_targeted_score": 1, "after_targeted_score": 0, "queue_share_delta_permille": -1, "high_confidence_wrong_after": False}]
+        summary = rmm.summarize_records(records, "dev")
+        self.assertEqual(summary["total_scenarios"], 1)
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / "o.jsonl"
+            rmm.write_jsonl(out, records)
+            self.assertEqual(len(out.read_text().splitlines()), 1)
+            sc = Path(td) / "s.md"
+            rmm.write_scorecard(sc, summary)
+            self.assertIn("| queue |", sc.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -58,6 +58,8 @@ python3 scripts/diagnostic_benchmark.py \
 
 ## Validation tracks
 - deterministic corpus benchmark: `scripts/diagnostic_benchmark.py`
-- repeated-run controlled matrix runner: `scripts/run_diagnostic_matrix.py`
+- adversarial synthetic validation
+- repeated-run diagnostic matrix
+- mitigation matrix
 
 The deterministic corpus checks fixture-labeled contract behavior. The repeated-run runner checks repeated-run stability for selected controlled demo workloads.

--- a/validation/diagnostics/latest/scorecard.md
+++ b/validation/diagnostics/latest/scorecard.md
@@ -14,6 +14,8 @@
 | runtime overhead | Measured separately | see `docs/runtime-cost.md`. |
 | collector limits | Measured separately | see `docs/collector-limits.md`. |
 | repeated-run diagnostic matrix | Manual/local repeated-run validation available | publishable repeated-run outputs are generated locally (JSONL/summary/scorecard) and not committed by default; results are machine/workload scoped. |
+| mitigation validation | Manual/local mitigation matrix available | baseline/mitigated controlled demos compare latency and evidence movement; generated outputs are not committed by default |
 | real service validation | Planned | add curated real-service anonymized artifacts. |
 
 Deterministic synthetic adversarial cases validate benchmark/report contract behavior and humility checks; they are not real-service validation and do not provide root-cause proof.
+


### PR DESCRIPTION
### Motivation
- Provide a manual/local mitigation validation workflow that runs paired baseline and targeted-mitigated demo scenarios and verifies that concrete evidence signals (queue share, service/stage share, blocking queue depth, p95/p99) move in the expected direction after a targeted mitigation.
- Enable a stable, reproducible artifact / summary / scorecard output shape for later analysis and human inspection without changing analyzer scoring, output schema, or adding dependencies.
- Keep the check manual/local and machine/workload scoped and avoid treating analyzer score movement as absolute proof of severity or root cause.

### Description
- Added `scripts/run_mitigation_matrix.py`, a stdlib-only CLI that runs paired `before`/`after` demo runs via existing `_demo_runner` helpers, writes artifacts under `target/mitigation-matrix/<scenario>/`, emits per-pair JSONL records, a stable summary JSON, and an optional Markdown scorecard, and supports the requested CLI flags (including `--out`, `--summary`, `--scorecard`, `--scenario`, `--profile`, `--artifact-root`, `--min-p95-improvement-ratio`, `--min-p99-improvement-ratio`, `--max-high-confidence-wrong`, `--no-fail-thresholds`, and `--require-expected-evidence-movement`).
- Implemented pure helper functions and evaluators (`top2_kinds`, `suspect_score`, `extract_blocking_queue_depth_p95`, `delta`, `ratio_delta`, `build_pair_record`, `evaluate_movements`, `summarize_records`, `write_jsonl`, `write_scorecard`) used by the runner and covered by unit tests.
- Added `scripts/tests/test_run_mitigation_matrix.py` with unit tests for top-2 extraction, suspect score lookup, blocking-depth extraction, delta/ratio helpers, pair-record shape, movement evaluation, JSONL writing, and scorecard generation.
- Updated documentation and validation status artifacts (`VALIDATION.md`, `docs/diagnostic-validation.md`, `validation/diagnostics/README.md`, `validation/diagnostics/latest/scorecard.md`) to document the mitigation matrix track and its interpretation guardrails, while explicitly not changing analyzer behavior or committing generated artifacts.

### Testing
- `python3 scripts/run_mitigation_matrix.py --scenario queue --out target/mitigation-runs-smoke.jsonl --summary target/mitigation-summary-smoke.json --scorecard target/mitigation-scorecard-smoke.md --no-fail-thresholds` — ran and produced artifacts under `target/mitigation-matrix/queue/` (passed).
- `python3 -m unittest scripts.tests.test_run_mitigation_matrix` — unit tests for mitigation helpers and writers ran and passed (passed).
- `python3 scripts/run_diagnostic_matrix.py --runs 1 --scenario queue --out target/diagnostic-runs-smoke.jsonl --summary target/diagnostic-runs-smoke-summary.json --scorecard target/diagnostic-runs-smoke-scorecard.md --no-fail-thresholds` — smoke run executed and produced outputs (passed).
- `python3 -m unittest scripts.tests.test_run_diagnostic_matrix` — repeated-run matrix tests ran and passed (passed).
- `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json` — deterministic benchmark executed (passed).
- `python3 -m unittest scripts.tests.test_diagnostic_benchmark` — benchmark unit tests ran and passed (passed).
- `python3 scripts/validate_docs_contracts.py` — docs contract validation ran and passed (passed).
- `python3 -m unittest scripts.tests.test_validate_docs_contracts` — docs contract unit tests ran and passed (passed).
- `python3 scripts/check_demo_fixture_drift.py --profile dev` — demo fixture drift check executed and reported fixtures up-to-date (passed).
- `cargo fmt --check` — formatting check passed (passed).
- `cargo clippy --workspace --all-targets -- -D warnings` — linter passed without warnings (passed).
- `cargo test --workspace` — Rust test suite passed (passed).

Notes: generated artifacts are written under `target/mitigation-matrix/` by default and are not committed; the runner is manual/local and machine/workload scoped; this change does not modify analyzer scoring, output schema, or add dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b147a710833095f5672c6135e25f)