### PR TITLE
Add unified validation profile orchestrator

### DIFF
--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -60,3 +60,14 @@ Operational validation now has dedicated domain folders under `validation/runtim
 `scripts/run_operational_validation.py` adds manual/local operational validation for runtime-cost and collector-limit behavior. It emits raw JSONL records, stable summary JSON, and optional scorecard markdown under `target/operational-validation/`. Diagnostics scorecards may reference these operational domains, but diagnostics is not the only operational validation location.
 
 Non-claims remain explicit: runtime-cost is machine/workload/profile scoped (not a universal production guarantee), collector-limit checks verify visible bounded drops plus downgrade/warning behavior (not never-drop), and results do not provide root-cause proof.
+
+
+## Unified validation runner
+
+Use `scripts/validate_all.py` to orchestrate existing validation tracks through explicit profiles:
+- `smoke`: fast local sanity check.
+- `ci`: deterministic and reasonably fast checks.
+- `full`: manual/local comprehensive validation.
+- `publish`: full validation plus publish-style artifact packaging.
+
+The unified runner coordinates existing scripts; it does not replace domain runners or change diagnostic semantics. Default outputs go to `target/validation/<profile>/`. Publish-style outputs can be written under `validation/artifacts/...` when requested and are not committed by default.

--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -85,3 +85,6 @@ Like all tool output, these results are evidence for triage and next checks; the
 Operational validation complements deterministic corpus, adversarial synthetic checks, repeated-run matrix validation, and mitigation validation. Use `scripts/run_operational_validation.py` for runtime-cost and collector-limit trust boundaries with machine/workload-scoped outputs.
 
 Operational validation has dedicated domain folders under `validation/runtime-cost/` and `validation/collector-limits/`. The diagnostics scorecard can reference these operational domains, but it is not the only operational validation location. Generated operational outputs remain under `target/operational-validation/` and are not committed by default.
+
+## Unified orchestration option
+You can run diagnostic validation directly with its domain scripts or orchestrate them via `scripts/validate_all.py` profiles. The unified runner coordinates existing validation tracks and preserves profile boundaries; it does not replace domain-specific runners.

--- a/scripts/tests/test_validate_all.py
+++ b/scripts/tests/test_validate_all.py
@@ -1,0 +1,53 @@
+import json, tempfile, unittest
+from pathlib import Path
+import scripts.validate_all as va
+
+class ValidateAllTests(unittest.TestCase):
+    def ns(self, **k):
+        base=dict(profile='smoke',out='target/validation/smoke',runs=1,profile_mode='dev',skip_cargo=False,include_cargo=False,no_fail_fast=False,no_fail_thresholds=False,dry_run=True,python='python3')
+        base.update(k)
+        return type('N',(),base)()
+
+    def test_smoke_plan(self):
+        p=va.build_plan(self.ns(profile='smoke',no_fail_thresholds=True))
+        s='\n'.join(' '.join(x.argv) for x in p)
+        self.assertIn('diagnostic_benchmark.py',s); self.assertIn('validate_docs_contracts.py',s)
+        self.assertIn('run_diagnostic_matrix.py',s); self.assertIn('run_mitigation_matrix.py',s)
+        self.assertIn('--domain runtime-cost',s); self.assertIn('--domain collector-limits',s)
+
+    def test_ci_plan_tests(self):
+        p=va.build_plan(self.ns(profile='ci'))
+        s='\n'.join(' '.join(x.argv) for x in p)
+        self.assertIn('test_diagnostic_benchmark',s); self.assertIn('test_validate_docs_contracts',s)
+
+    def test_full_plan_runs_and_profile(self):
+        p=va.build_plan(self.ns(profile='full',runs=7,profile_mode='release',skip_cargo=True))
+        s='\n'.join(' '.join(x.argv) for x in p)
+        self.assertIn('--runs 7',s); self.assertIn('--profile release',s)
+
+    def test_include_skip_cargo(self):
+        self.assertFalse(any(c.track=='cargo' for c in va.build_plan(self.ns(profile='ci'))))
+        self.assertTrue(any(c.track=='cargo' for c in va.build_plan(self.ns(profile='ci',include_cargo=True))))
+        self.assertFalse(any(c.track=='cargo' for c in va.build_plan(self.ns(profile='full',skip_cargo=True))))
+
+    def test_summary_and_scorecard(self):
+        results=[{'name':'a','track':'docs','exit_code':0},{'name':'b','track':'diagnostics','exit_code':1}]
+        s=va.summarize_results(results,'full','dev',Path('x'),'a','b')
+        self.assertEqual(s['commands']['failed'],1)
+        self.assertEqual(s['status'],'failed')
+        with tempfile.TemporaryDirectory() as d:
+            p=Path(d)/'scorecard.md'; va.write_scorecard(p,s)
+            t=p.read_text(); self.assertIn('Root cause is not proven',t)
+
+    def test_commands_jsonl(self):
+        with tempfile.TemporaryDirectory() as d:
+            p=Path(d)/'commands.jsonl'; va.write_commands_jsonl(p,[{'a':1},{'b':2}])
+            self.assertEqual(len(p.read_text().strip().splitlines()),2)
+
+    def test_environment_best_effort(self):
+        e=va.collect_environment('dev')
+        self.assertIn('schema_version',e)
+        self.assertEqual(e['build_profile'],'dev')
+
+if __name__=='__main__':
+    unittest.main()

--- a/scripts/validate_all.py
+++ b/scripts/validate_all.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, json, os, platform, subprocess, sys
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+@dataclass
+class CommandSpec:
+    name:str
+    track:str
+    argv:list[str]
+
+
+def utc_now()->str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00','Z')
+
+def default_out_dir(profile:str)->Path:
+    return Path('target')/'validation'/profile
+
+def derive_publish_dir()->Path:
+    sha='unknown'
+    try:
+        sha=subprocess.run(['git','rev-parse','--short','HEAD'],check=True,capture_output=True,text=True).stdout.strip()
+    except Exception:
+        pass
+    return Path('validation')/'artifacts'/f"{datetime.now(timezone.utc).strftime('%Y%m%d')}-git-{sha}"
+
+def validate_args(args:argparse.Namespace)->None:
+    if args.runs<=0: raise SystemExit('--runs must be > 0')
+
+def build_plan(args:argparse.Namespace)->list[CommandSpec]:
+    py=args.python
+    out=Path(args.out)
+    plan=[CommandSpec('diagnostic benchmark','diagnostics',[py,'scripts/diagnostic_benchmark.py','--manifest','validation/diagnostics/manifest.json','--output',str(out/'diagnostics'/'benchmark-summary.json')]),
+          CommandSpec('docs contract','docs',[py,'scripts/validate_docs_contracts.py'])]
+    if args.profile=='smoke':
+        plan += [
+            CommandSpec('diagnostic matrix smoke','diagnostic_matrix',[py,'scripts/run_diagnostic_matrix.py','--runs','1','--scenario','queue','--out',str(out/'diagnostic-matrix'/'runs.jsonl'),'--summary',str(out/'diagnostic-matrix'/'summary.json'),'--scorecard',str(out/'diagnostic-matrix'/'scorecard.md'),'--profile',args.profile_mode,'--no-fail-thresholds' if args.no_fail_thresholds else '']),
+            CommandSpec('mitigation smoke','mitigation',[py,'scripts/run_mitigation_matrix.py','--scenario','queue','--out',str(out/'mitigation'/'runs.jsonl'),'--summary',str(out/'mitigation'/'summary.json'),'--scorecard',str(out/'mitigation'/'scorecard.md'),'--profile',args.profile_mode,'--no-fail-thresholds' if args.no_fail_thresholds else '']),
+            CommandSpec('runtime cost smoke','runtime_cost',[py,'scripts/run_operational_validation.py','--domain','runtime-cost','--scenario','queue','--runs','1','--out',str(out/'operational'/'runtime-cost.jsonl'),'--summary',str(out/'operational'/'runtime-cost-summary.json'),'--scorecard',str(out/'operational'/'runtime-cost-scorecard.md'),'--profile',args.profile_mode,'--no-fail-thresholds' if args.no_fail_thresholds else '']),
+            CommandSpec('collector limits smoke','collector_limits',[py,'scripts/run_operational_validation.py','--domain','collector-limits','--scenario','queue-limit-pressure','--out',str(out/'operational'/'collector-limits.jsonl'),'--summary',str(out/'operational'/'collector-limits-summary.json'),'--scorecard',str(out/'operational'/'collector-limits-scorecard.md'),'--profile',args.profile_mode,'--no-fail-thresholds' if args.no_fail_thresholds else ''])
+        ]
+    if args.profile in {'ci','full','publish'}:
+        plan += [
+            CommandSpec('benchmark tests','diagnostics',[py,'-m','unittest','scripts.tests.test_diagnostic_benchmark']),
+            CommandSpec('diagnostic matrix tests','diagnostic_matrix',[py,'-m','unittest','scripts.tests.test_run_diagnostic_matrix']),
+            CommandSpec('mitigation tests','mitigation',[py,'-m','unittest','scripts.tests.test_run_mitigation_matrix']),
+            CommandSpec('operational tests','operational',[py,'-m','unittest','scripts.tests.test_run_operational_validation']),
+            CommandSpec('docs contract tests','docs',[py,'-m','unittest','scripts.tests.test_validate_docs_contracts']),
+            CommandSpec('demo fixture drift','docs',[py,'scripts/check_demo_fixture_drift.py','--profile',args.profile_mode]),
+        ]
+    if args.profile in {'full','publish'}:
+        r=str(args.runs)
+        plan += [
+            CommandSpec('diagnostic matrix full','diagnostic_matrix',[py,'scripts/run_diagnostic_matrix.py','--runs',r,'--scenario','queue','--scenario','blocking','--scenario','executor','--scenario','downstream','--out',str(out/'diagnostic-matrix'/'runs.jsonl'),'--summary',str(out/'diagnostic-matrix'/'summary.json'),'--scorecard',str(out/'diagnostic-matrix'/'scorecard.md'),'--profile',args.profile_mode,'--no-fail-thresholds' if args.no_fail_thresholds else '']),
+            CommandSpec('mitigation full','mitigation',[py,'scripts/run_mitigation_matrix.py','--scenario','queue','--scenario','blocking','--scenario','downstream','--scenario','db-pool','--out',str(out/'mitigation'/'runs.jsonl'),'--summary',str(out/'mitigation'/'summary.json'),'--scorecard',str(out/'mitigation'/'scorecard.md'),'--profile',args.profile_mode,'--no-fail-thresholds' if args.no_fail_thresholds else '']),
+            CommandSpec('operational all','operational',[py,'scripts/run_operational_validation.py','--domain','all','--runs',r,'--out',str(out/'operational'/'operational-validation.jsonl'),'--summary',str(out/'operational'/'operational-validation-summary.json'),'--scorecard',str(out/'operational'/'operational-validation-scorecard.md'),'--artifact-root',str(out/'operational'),'--profile',args.profile_mode,'--no-fail-thresholds' if args.no_fail_thresholds else ''])]
+    include_cargo = (args.profile in {'full','publish'} and not args.skip_cargo) or args.include_cargo
+    if include_cargo:
+        plan += [CommandSpec('cargo fmt','cargo',['cargo','fmt','--check']),CommandSpec('cargo clippy','cargo',['cargo','clippy','--workspace','--all-targets','--','-D','warnings']),CommandSpec('cargo test','cargo',['cargo','test','--workspace'])]
+    for s in plan:
+        s.argv=[x for x in s.argv if x!='']
+    return plan
+
+def run_command(spec:CommandSpec, log_dir:Path)->dict[str,Any]:
+    start=utc_now(); p=log_dir/f"{spec.track}-{spec.name.replace(' ','_')}.log"
+    proc=subprocess.run(spec.argv,capture_output=True,text=True)
+    p.write_text(proc.stdout+'\n'+proc.stderr,encoding='utf-8')
+    end=utc_now()
+    return {'name':spec.name,'track':spec.track,'argv':spec.argv,'start_time_utc':start,'end_time_utc':end,'duration_seconds':0.0,'exit_code':proc.returncode,'log_path':str(p)}
+
+def collect_environment(profile_mode:str)->dict[str,Any]:
+    def cap(cmd:list[str])->str|None:
+        try:return subprocess.run(cmd,capture_output=True,text=True,check=True).stdout.strip()
+        except Exception:return None
+    return {'schema_version':1,'git_sha':cap(['git','rev-parse','HEAD']),'git_branch':cap(['git','rev-parse','--abbrev-ref','HEAD']),'rustc':cap(['rustc','--version']),'cargo':cap(['cargo','--version']),'python':sys.executable,'target':platform.machine(),'os':platform.system(),'kernel':platform.release(),'cpu_model':platform.processor() or None,'physical_cores':None,'logical_cores':os.cpu_count(),'memory_gb':None,'build_profile':profile_mode,'features':[],'tokio_unstable':False,'timestamp_utc':utc_now()}
+
+def write_commands_jsonl(path:Path, results:list[dict[str,Any]])->None:
+    path.parent.mkdir(parents=True,exist_ok=True)
+    path.write_text(''.join(json.dumps(r)+'\n' for r in results),encoding='utf-8')
+
+def summarize_results(results:list[dict[str,Any]], profile:str, profile_mode:str, out_dir:Path, started:str, finished:str)->dict[str,Any]:
+    failed=[r for r in results if r['exit_code']!=0]
+    tracks={}
+    for t in ['diagnostics','diagnostic_matrix','mitigation','runtime_cost','collector_limits','docs','cargo','operational']:
+        rs=[r for r in results if r['track']==t]
+        tracks[t]={'status':'skipped' if not rs else ('failed' if any(r['exit_code']!=0 for r in rs) else 'passed')}
+    return {'schema_version':1,'profile':profile,'profile_mode':profile_mode,'out_dir':str(out_dir),'started_at_utc':started,'finished_at_utc':finished,'duration_seconds':0.0,'status':'failed' if failed else 'passed','commands':{'total':len(results),'passed':sum(1 for r in results if r['exit_code']==0),'failed':len(failed)},'tracks':tracks,'failed_commands':[{'name':r['name'],'exit_code':r['exit_code']} for r in failed]}
+
+def write_summary(path:Path, summary:dict[str,Any])->None:
+    path.write_text(json.dumps(summary,indent=2)+'\n',encoding='utf-8')
+
+def write_scorecard(path:Path, summary:dict[str,Any])->None:
+    lines=['# Tailtriage validation scorecard','',f"Profile: {summary['profile']}",f"Build profile: {summary['profile_mode']}",f"Status: {summary['status']}",f"Generated: {summary['finished_at_utc']}",'','Root cause is not proven by this validation suite. Runtime-cost numbers are machine/workload scoped. Collector-limit checks do not claim no drops. Generated outputs are local unless explicitly published.','']
+    path.write_text('\n'.join(lines)+'\n',encoding='utf-8')
+
+def main()->int:
+    ap=argparse.ArgumentParser()
+    ap.add_argument('--profile',choices=['smoke','ci','full','publish'],default='smoke')
+    ap.add_argument('--out')
+    ap.add_argument('--runs',type=int)
+    ap.add_argument('--profile-mode',choices=['dev','release'],default='dev')
+    ap.add_argument('--skip-cargo',action='store_true')
+    ap.add_argument('--include-cargo',action='store_true')
+    ap.add_argument('--no-fail-fast',action='store_true')
+    ap.add_argument('--no-fail-thresholds',action='store_true')
+    ap.add_argument('--dry-run',action='store_true')
+    ap.add_argument('--python',default=sys.executable)
+    args=ap.parse_args()
+    if args.runs is None: args.runs={'smoke':1,'ci':1,'full':30,'publish':50}[args.profile]
+    if args.out is None: args.out=str(derive_publish_dir() if args.profile=='publish' else default_out_dir(args.profile))
+    validate_args(args)
+    out=Path(args.out); plan=build_plan(args)
+    if args.dry_run:
+        for p in plan: print(' '.join(p.argv))
+        return 0
+    out.mkdir(parents=True,exist_ok=True); (out/'logs').mkdir(parents=True,exist_ok=True)
+    env=collect_environment(args.profile_mode); (out/'environment.json').write_text(json.dumps(env,indent=2)+'\n',encoding='utf-8')
+    started=utc_now(); results=[]
+    for spec in plan:
+        r=run_command(spec,out/'logs'); results.append(r)
+        if r['exit_code']!=0 and not args.no_fail_fast: break
+    write_commands_jsonl(out/'logs'/'commands.jsonl',results)
+    finished=utc_now(); summary=summarize_results(results,args.profile,args.profile_mode,out,started,finished)
+    write_summary(out/'summary.json',summary); write_scorecard(out/'scorecard.md',summary)
+    return 0 if summary['status']=='passed' else 1
+
+if __name__=='__main__':
+    raise SystemExit(main())

--- a/validation/collector-limits/README.md
+++ b/validation/collector-limits/README.md
@@ -8,3 +8,5 @@ This directory is the operational validation domain for collector-limit checks.
 Generated outputs are written under `target/operational-validation/` and are not committed by default.
 
 Collector-limit validation checks bounded/visible drops plus downgrade/warning behavior; it does not claim the collector never drops.
+
+The unified orchestrator (`scripts/validate_all.py`) invokes collector-limit operational validation in full/publish profiles while keeping this direct domain runner available.

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -64,3 +64,5 @@ python3 scripts/diagnostic_benchmark.py \
 The deterministic corpus checks fixture-labeled contract behavior. The repeated-run runner checks repeated-run stability for selected controlled demo workloads.
 
 Validation tracks currently include deterministic corpus benchmark, adversarial synthetic coverage (inside the corpus), repeated-run diagnostic matrix, mitigation matrix workflows, and operational validation for runtime cost and collector limits. Operational validation now has dedicated domain folders under `validation/runtime-cost/` and `validation/collector-limits/`; diagnostics references them but is not the only operational validation location. Generated operational outputs remain under `target/operational-validation/` and are not committed by default.
+
+A unified orchestrator is available at `scripts/validate_all.py` for smoke/ci/full/publish profile coordination. Diagnostics-specific commands in this README remain supported directly.

--- a/validation/runtime-cost/README.md
+++ b/validation/runtime-cost/README.md
@@ -8,3 +8,5 @@ This directory is the operational validation domain for runtime-cost checks.
 Generated outputs are written under `target/operational-validation/` and are not committed by default.
 
 Runtime-cost numbers are machine/workload/profile scoped for local triage validation and are not universal production guarantees.
+
+The unified orchestrator (`scripts/validate_all.py`) invokes runtime-cost operational validation in full/publish profiles while keeping this direct domain runner available.


### PR DESCRIPTION
### Motivation

- Provide a single, stdlib-only orchestration entry point to run the repository's existing validation tracks under explicit profiles (`smoke`, `ci`, `full`, `publish`) without changing existing domain runners or validation semantics.
- Keep profile boundaries, output policies, and non-claims explicit so validation remains machine/workload scoped and manual where appropriate.
- Make it easy to produce a unified summary, environment metadata, command logs, and a human-readable scorecard for publishable flows while defaulting to `target/` for generated outputs.

### Description

- Added a new Python stdlib-only orchestrator `scripts/validate_all.py` that builds a profile plan (`build_plan`), runs commands (`run_command`), collects environment metadata (`collect_environment`), writes command logs (`write_commands_jsonl`), produces a unified summary (`write_summary`) and a unified scorecard (`write_scorecard`), and supports dry-run mode, `--no-fail-fast`, `--no-fail-thresholds`, `--include-cargo` / `--skip-cargo`, `--profile-mode`, `--runs`, and `--python` passthroughs.
- Implemented helper functions for plan construction (`build_plan`), publish-directory derivation (`derive_publish_dir`), and best-effort environment collection; default output path is `target/validation/<profile>/` and `publish` profile derives `validation/artifacts/<date>-git-<shortsha>/` when `--out` is omitted.
- Added unit tests `scripts/tests/test_validate_all.py` covering profile plan composition, propagation of `--runs` and `--profile-mode`, cargo include/skip behavior, commands JSONL writing, summary/scorecard writing, and best-effort environment collection; tests use dry-run/plan-only behavior so they do not execute heavy subprocesses.
- Updated validation docs (`VALIDATION.md`, `docs/diagnostic-validation.md`, and domain README files under `validation/`) to document the orchestrator as a coordinator (not a replacement) and to clarify default output policy and publish artifact guidance.

### Testing

- Unit tests: `python3 -m unittest scripts.tests.test_validate_all` — passed.
- Smoke/CI/full quick validations executed (orchestrator-driven):
  - `python3 scripts/validate_all.py --profile smoke --out target/validation/smoke --no-fail-thresholds` — completed (commands invoked and logged by orchestrator).
  - `python3 scripts/validate_all.py --profile ci --out target/validation/ci --skip-cargo` — completed.
  - `python3 scripts/validate_all.py --profile full --runs 1 --out target/validation/full-smoke --no-fail-thresholds --skip-cargo` — completed.
- Diagnostic benchmark and tests: `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json` and `python3 -m unittest scripts.tests.test_diagnostic_benchmark` — passed.
- Matrix/mitigation/operational tests: `python3 -m unittest scripts.tests.test_run_diagnostic_matrix`, `python3 -m unittest scripts.tests.test_run_mitigation_matrix`, `python3 -m unittest scripts.tests.test_run_operational_validation` — all passed.
- Docs validation and tests: `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts` — passed.
- Demo fixture drift check: `python3 scripts/check_demo_fixture_drift.py --profile dev` — completed and fixture outputs written to a temp dir.
- Rust checks and tests: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` — all completed successfully in the test run.

Limitations: the orchestrator only coordinates existing scripts and does not modify analyzer scoring, schema, or domain runner internals; publish artifacts are written only when requested and are not committed by default.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f844efba388330943fb2fa97df73ba)