### PR TITLE
Add unified validation profile orchestrator (scripts/validate_all.py)

### DIFF
--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -60,3 +60,22 @@ Operational validation now has dedicated domain folders under `validation/runtim
 `scripts/run_operational_validation.py` adds manual/local operational validation for runtime-cost and collector-limit behavior. It emits raw JSONL records, stable summary JSON, and optional scorecard markdown under `target/operational-validation/`. Diagnostics scorecards may reference these operational domains, but diagnostics is not the only operational validation location.
 
 Non-claims remain explicit: runtime-cost is machine/workload/profile scoped (not a universal production guarantee), collector-limit checks verify visible bounded drops plus downgrade/warning behavior (not never-drop), and results do not provide root-cause proof.
+
+
+## Unified validation runner
+
+Use `scripts/validate_all.py` to orchestrate existing validation tracks through explicit profiles. The unified runner coordinates existing scripts; it does not replace domain runners or change their validation semantics.
+
+Profiles:
+- `smoke`: fast local sanity check.
+- `ci`: deterministic, reasonably fast checks suitable for mandatory CI later.
+- `full`: manual/local comprehensive validation.
+- `publish`: full validation plus publish-style artifact packaging.
+
+Examples:
+- `python3 scripts/validate_all.py --profile smoke`
+- `python3 scripts/validate_all.py --profile ci --skip-cargo`
+- `python3 scripts/validate_all.py --profile full --runs 30`
+- `python3 scripts/validate_all.py --profile publish --runs 50 --out validation/artifacts/<date>-git-<sha>`
+
+Generated outputs default to `target/validation/<profile>/` for smoke/ci/full. Publish outputs may be directed to `validation/artifacts/...` explicitly. Generated validation artifacts are local by default and should not be committed unless a separate release/publication process explicitly requires it.

--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -85,3 +85,7 @@ Like all tool output, these results are evidence for triage and next checks; the
 Operational validation complements deterministic corpus, adversarial synthetic checks, repeated-run matrix validation, and mitigation validation. Use `scripts/run_operational_validation.py` for runtime-cost and collector-limit trust boundaries with machine/workload-scoped outputs.
 
 Operational validation has dedicated domain folders under `validation/runtime-cost/` and `validation/collector-limits/`. The diagnostics scorecard can reference these operational domains, but it is not the only operational validation location. Generated operational outputs remain under `target/operational-validation/` and are not committed by default.
+
+
+## Unified runner orchestration
+Diagnostic validation can run directly with domain scripts or through `scripts/validate_all.py` profiles. The unified runner orchestrates existing validation tracks and outputs; it does not replace diagnostics-specific scripts.

--- a/scripts/tests/test_validate_all.py
+++ b/scripts/tests/test_validate_all.py
@@ -1,0 +1,74 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from scripts import validate_all as va
+
+
+class ValidateAllTests(unittest.TestCase):
+    def args(self, **kw):
+        base = {
+            "profile": "smoke", "python": "python3", "runs": 1, "profile_mode": "dev", "skip_cargo": False,
+            "include_cargo": False, "no_fail_fast": False, "no_fail_thresholds": False,
+        }
+        base.update(kw)
+        return type("Args", (), base)()
+
+    def test_smoke_plan_contains_expected_tracks(self):
+        plan = va.build_plan(self.args(profile="smoke"), Path("target/validation/smoke"))
+        names = [p.name for p in plan]
+        self.assertIn("diagnostic_benchmark", names)
+        self.assertIn("validate_docs_contracts", names)
+        self.assertIn("diagnostic_matrix_smoke", names)
+        self.assertIn("mitigation_smoke", names)
+        self.assertIn("runtime_cost_smoke", names)
+        self.assertIn("collector_limits_smoke", names)
+
+    def test_ci_plan_contains_tests(self):
+        plan = va.build_plan(self.args(profile="ci"), Path("target/validation/ci"))
+        names = [p.name for p in plan]
+        self.assertIn("test_diagnostic_benchmark", names)
+        self.assertIn("test_validate_docs_contracts", names)
+        self.assertIn("test_run_diagnostic_matrix", names)
+
+    def test_full_plan_has_runs_and_operational(self):
+        plan = va.build_plan(self.args(profile="full", runs=7), Path("x"))
+        cmd = next(p for p in plan if p.name == "diagnostic_matrix_full").argv
+        self.assertIn("7", cmd)
+        self.assertTrue(any(p.name == "operational_all" for p in plan))
+
+    def test_include_skip_cargo_flags(self):
+        self.assertFalse(any(p.track == "cargo" for p in va.build_plan(self.args(profile="ci"), Path("x"))))
+        self.assertTrue(any(p.track == "cargo" for p in va.build_plan(self.args(profile="ci", include_cargo=True), Path("x"))))
+        self.assertFalse(any(p.track == "cargo" for p in va.build_plan(self.args(profile="full", skip_cargo=True), Path("x"))))
+
+    def test_profile_mode_propagates(self):
+        plan = va.build_plan(self.args(profile="smoke", profile_mode="release"), Path("x"))
+        self.assertTrue(any("release" in p.argv for p in plan if "run_" in p.argv[1]))
+
+    def test_summary_and_scorecard_and_jsonl(self):
+        r1 = va.CommandResult("a", "docs", ["x"], "s", "f", 1.0, 0, "o", "e")
+        r2 = va.CommandResult("b", "cargo", ["x"], "s", "f", 1.0, 1, "o", "e")
+        s = va.summarize_results([r1, r2], "ci", "dev", Path("x"), "s", "f")
+        self.assertEqual(s["status"], "failed")
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            va.write_commands_jsonl(td / "c.jsonl", [r1, r2])
+            self.assertEqual(len((td / "c.jsonl").read_text().strip().splitlines()), 2)
+            va.write_scorecard(td / "scorecard.md", s)
+            self.assertIn("Deterministic diagnostics", (td / "scorecard.md").read_text())
+
+    def test_environment_best_effort(self):
+        with mock.patch("scripts.validate_all.safe_cmd", return_value="unknown"):
+            e = va.collect_environment("dev")
+            self.assertIn("git_sha", e)
+
+    def test_dry_run_plan_builds(self):
+        plan = va.build_plan(self.args(profile="publish", runs=3), Path("validation/artifacts/x"))
+        self.assertTrue(len(plan) > 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_all.py
+++ b/scripts/validate_all.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import subprocess
+import sys
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class CommandSpec:
+    name: str
+    track: str
+    argv: list[str]
+
+
+@dataclass
+class CommandResult:
+    name: str
+    track: str
+    argv: list[str]
+    started_at_utc: str
+    finished_at_utc: str
+    duration_seconds: float
+    exit_code: int
+    stdout_path: str
+    stderr_path: str
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def default_out_dir(profile: str) -> Path:
+    return Path("target") / "validation" / profile
+
+
+def derive_publish_dir() -> Path:
+    sha = safe_cmd(["git", "rev-parse", "--short", "HEAD"], default="unknown")
+    return Path("validation") / "artifacts" / f"{datetime.now(timezone.utc):%Y%m%d}-git-{sha}"
+
+
+def safe_cmd(argv: list[str], default: str = "unknown") -> str:
+    try:
+        p = subprocess.run(argv, check=True, capture_output=True, text=True)
+        return p.stdout.strip() or default
+    except Exception:
+        return default
+
+
+def add_cargo(specs: list[CommandSpec]) -> None:
+    specs.extend([
+        CommandSpec("cargo_fmt", "cargo", ["cargo", "fmt", "--check"]),
+        CommandSpec("cargo_clippy", "cargo", ["cargo", "clippy", "--workspace", "--all-targets", "--", "-D", "warnings"]),
+        CommandSpec("cargo_test", "cargo", ["cargo", "test", "--workspace"]),
+    ])
+
+
+def build_plan(args: argparse.Namespace, out: Path) -> list[CommandSpec]:
+    py = args.python
+    specs: list[CommandSpec] = []
+    specs.append(CommandSpec("diagnostic_benchmark", "diagnostics", [py, "scripts/diagnostic_benchmark.py", "--manifest", "validation/diagnostics/manifest.json", "--output", str(out / "diagnostics/benchmark-summary.json")]))
+
+    if args.profile in {"smoke", "ci", "full", "publish"}:
+        specs.append(CommandSpec("validate_docs_contracts", "docs", [py, "scripts/validate_docs_contracts.py"]))
+
+    if args.profile == "smoke":
+        specs.extend([
+            CommandSpec("diagnostic_matrix_smoke", "diagnostic_matrix", [py, "scripts/run_diagnostic_matrix.py", "--runs", "1", "--scenario", "queue", "--profile", args.profile_mode, "--out", str(out / "diagnostic-matrix/runs.jsonl"), "--summary", str(out / "diagnostic-matrix/summary.json"), "--scorecard", str(out / "diagnostic-matrix/scorecard.md"), "--no-fail-thresholds"]),
+            CommandSpec("mitigation_smoke", "mitigation", [py, "scripts/run_mitigation_matrix.py", "--scenario", "queue", "--profile", args.profile_mode, "--out", str(out / "mitigation/runs.jsonl"), "--summary", str(out / "mitigation/summary.json"), "--scorecard", str(out / "mitigation/scorecard.md"), "--no-fail-thresholds"]),
+            CommandSpec("runtime_cost_smoke", "runtime_cost", [py, "scripts/run_operational_validation.py", "--domain", "runtime-cost", "--scenario", "queue", "--runs", "1", "--profile", args.profile_mode, "--out", str(out / "operational/runtime-cost.jsonl"), "--summary", str(out / "operational/runtime-cost-summary.json"), "--scorecard", str(out / "operational/runtime-cost-scorecard.md"), "--no-fail-thresholds"]),
+            CommandSpec("collector_limits_smoke", "collector_limits", [py, "scripts/run_operational_validation.py", "--domain", "collector-limits", "--scenario", "queue-limit-pressure", "--profile", args.profile_mode, "--out", str(out / "operational/collector-limits.jsonl"), "--summary", str(out / "operational/collector-limits-summary.json"), "--scorecard", str(out / "operational/collector-limits-scorecard.md"), "--no-fail-thresholds"]),
+        ])
+    if args.profile == "ci":
+        specs.extend([
+            CommandSpec("test_diagnostic_benchmark", "diagnostics", [py, "-m", "unittest", "scripts.tests.test_diagnostic_benchmark"]),
+            CommandSpec("test_validate_docs_contracts", "docs", [py, "-m", "unittest", "scripts.tests.test_validate_docs_contracts"]),
+            CommandSpec("test_run_diagnostic_matrix", "diagnostic_matrix", [py, "-m", "unittest", "scripts.tests.test_run_diagnostic_matrix"]),
+            CommandSpec("test_run_mitigation_matrix", "mitigation", [py, "-m", "unittest", "scripts.tests.test_run_mitigation_matrix"]),
+            CommandSpec("test_run_operational_validation", "operational", [py, "-m", "unittest", "scripts.tests.test_run_operational_validation"]),
+            CommandSpec("check_demo_fixture_drift", "diagnostics", [py, "scripts/check_demo_fixture_drift.py", "--profile", args.profile_mode]),
+        ])
+    if args.profile in {"full", "publish"}:
+        runs = str(args.runs)
+        specs.extend([
+            CommandSpec("diagnostic_matrix_full", "diagnostic_matrix", [py, "scripts/run_diagnostic_matrix.py", "--runs", runs, "--scenario", "queue", "--scenario", "blocking", "--scenario", "executor", "--scenario", "downstream", "--profile", args.profile_mode, "--out", str(out / "diagnostic-matrix/runs.jsonl"), "--summary", str(out / "diagnostic-matrix/summary.json"), "--scorecard", str(out / "diagnostic-matrix/scorecard.md")]),
+            CommandSpec("mitigation_full", "mitigation", [py, "scripts/run_mitigation_matrix.py", "--scenario", "queue", "--scenario", "blocking", "--scenario", "downstream", "--scenario", "db-pool", "--profile", args.profile_mode, "--out", str(out / "mitigation/runs.jsonl"), "--summary", str(out / "mitigation/summary.json"), "--scorecard", str(out / "mitigation/scorecard.md")]),
+            CommandSpec("operational_all", "operational", [py, "scripts/run_operational_validation.py", "--domain", "all", "--runs", runs, "--profile", args.profile_mode, "--out", str(out / "operational/operational-validation.jsonl"), "--summary", str(out / "operational/operational-validation-summary.json"), "--scorecard", str(out / "operational/operational-validation-scorecard.md")]),
+        ])
+
+    if args.no_fail_thresholds:
+        for s in specs:
+            if s.argv[1].endswith(("run_diagnostic_matrix.py", "run_mitigation_matrix.py", "run_operational_validation.py")) and "--no-fail-thresholds" not in s.argv:
+                s.argv.append("--no-fail-thresholds")
+
+    if args.profile in {"full", "publish"} and not args.skip_cargo:
+        add_cargo(specs)
+    if args.profile in {"smoke", "ci"} and args.include_cargo and not args.skip_cargo:
+        add_cargo(specs)
+    return specs
+
+
+def run_command(spec: CommandSpec, log_dir: Path) -> CommandResult:
+    started = datetime.now(timezone.utc)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    outp = log_dir / f"{spec.name}.stdout.log"
+    errp = log_dir / f"{spec.name}.stderr.log"
+    p = subprocess.run(spec.argv, text=True, capture_output=True)
+    outp.write_text(p.stdout or "", encoding="utf-8")
+    errp.write_text(p.stderr or "", encoding="utf-8")
+    finished = datetime.now(timezone.utc)
+    return CommandResult(spec.name, spec.track, spec.argv, started.isoformat(), finished.isoformat(), (finished - started).total_seconds(), p.returncode, str(outp), str(errp))
+
+
+def write_commands_jsonl(path: Path, results: list[CommandResult]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for r in results:
+            f.write(json.dumps(asdict(r), sort_keys=True) + "\n")
+
+
+def collect_environment(profile_mode: str) -> dict[str, Any]:
+    return {"schema_version": 1, "git_sha": safe_cmd(["git", "rev-parse", "HEAD"]), "git_branch": safe_cmd(["git", "rev-parse", "--abbrev-ref", "HEAD"]), "rustc": safe_cmd(["rustc", "--version"]), "cargo": safe_cmd(["cargo", "--version"]), "python": sys.executable, "target": platform.machine(), "os": platform.system(), "kernel": platform.release(), "cpu_model": platform.processor() or "unknown", "physical_cores": None, "logical_cores": os.cpu_count() or 0, "memory_gb": None, "build_profile": profile_mode, "features": [], "tokio_unstable": False, "timestamp_utc": utc_now()}
+
+
+def summarize_results(results: list[CommandResult], profile: str, profile_mode: str, out: Path, started: str, finished: str) -> dict[str, Any]:
+    failed = [r for r in results if r.exit_code != 0]
+    tracks = {}
+    for track in ["diagnostics", "diagnostic_matrix", "mitigation", "runtime_cost", "collector_limits", "docs", "cargo", "operational"]:
+        rows = [r for r in results if r.track == track]
+        tracks[track] = {"status": "skipped" if not rows else ("failed" if any(r.exit_code != 0 for r in rows) else "passed")}
+    return {"schema_version": 1, "profile": profile, "profile_mode": profile_mode, "out_dir": str(out), "started_at_utc": started, "finished_at_utc": finished, "duration_seconds": None, "status": "failed" if failed else "passed", "commands": {"total": len(results), "passed": len(results)-len(failed), "failed": len(failed)}, "tracks": tracks, "failed_commands": [asdict(r) for r in failed]}
+
+
+def write_scorecard(path: Path, summary: dict[str, Any]) -> None:
+    t=summary["tracks"]
+    lines=["# Tailtriage validation scorecard","",f"Profile: {summary['profile']}",f"Build profile: {summary['profile_mode']}",f"Status: {summary['status']}",f"Generated: {summary['finished_at_utc']}","","| Track | Status | Output | Notes |","|---|---|---|---|",
+           f"| Deterministic diagnostics | {t['diagnostics']['status']} | diagnostics/benchmark-summary.json | corpus benchmark |",
+           f"| Repeated-run diagnostic matrix | {t['diagnostic_matrix']['status']} | diagnostic-matrix/summary.json | machine/workload scoped |",
+           f"| Mitigation matrix | {t['mitigation']['status']} | mitigation/summary.json | baseline vs mitigated evidence movement |",
+           f"| Runtime cost | {t['runtime_cost']['status']} | operational/runtime-cost-summary.json | measured, not universal |",
+           f"| Collector limits | {t['collector_limits']['status']} | operational/collector-limits-summary.json | visible bounded drops + warnings/downgrades |",
+           f"| Docs contracts | {t['docs']['status']} | logs/commands.jsonl | docs consistency |",
+           f"| Cargo checks | {t['cargo']['status']} | logs/commands.jsonl | skipped by profile/config when not selected |",
+           "","> Suspects are leads, not proof of root cause.","> Runtime-cost values are machine/workload/profile scoped.","> Collector-limit checks do not claim no drops.","> Generated outputs are local unless explicitly published."]
+    path.write_text("\n".join(lines)+"\n", encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    p=argparse.ArgumentParser()
+    p.add_argument("--profile", choices=["smoke","ci","full","publish"], default="smoke")
+    p.add_argument("--out")
+    p.add_argument("--runs", type=int)
+    p.add_argument("--profile-mode", choices=["dev","release"], default="dev")
+    p.add_argument("--skip-cargo", action="store_true")
+    p.add_argument("--include-cargo", action="store_true")
+    p.add_argument("--no-fail-fast", action="store_true")
+    p.add_argument("--no-fail-thresholds", action="store_true")
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--python", default=sys.executable)
+    return p.parse_args()
+
+
+def main() -> int:
+    args=parse_args()
+    if args.runs is None:
+        args.runs = {"smoke":1,"ci":1,"full":30,"publish":50}[args.profile]
+    out = Path(args.out) if args.out else (derive_publish_dir() if args.profile=="publish" else default_out_dir(args.profile))
+    plan=build_plan(args,out)
+    if args.dry_run:
+        print(json.dumps([asdict(s) for s in plan], indent=2))
+        return 0
+    out.mkdir(parents=True, exist_ok=True)
+    env = collect_environment(args.profile_mode)
+    (out/"environment.json").write_text(json.dumps(env, indent=2)+"\n", encoding="utf-8")
+    started=utc_now(); results=[]
+    for spec in plan:
+        r=run_command(spec, out/"logs")
+        results.append(r)
+        if r.exit_code!=0 and not args.no_fail_fast:
+            break
+    finished=utc_now()
+    write_commands_jsonl(out/"logs/commands.jsonl", results)
+    summary=summarize_results(results,args.profile,args.profile_mode,out,started,finished)
+    (out/"summary.json").write_text(json.dumps(summary, indent=2)+"\n", encoding="utf-8")
+    write_scorecard(out/"scorecard.md", summary)
+    return 0 if args.dry_run or summary["commands"]["failed"]==0 else 1
+
+
+if __name__=="__main__":
+    raise SystemExit(main())

--- a/validation/collector-limits/README.md
+++ b/validation/collector-limits/README.md
@@ -8,3 +8,6 @@ This directory is the operational validation domain for collector-limit checks.
 Generated outputs are written under `target/operational-validation/` and are not committed by default.
 
 Collector-limit validation checks bounded/visible drops plus downgrade/warning behavior; it does not claim the collector never drops.
+
+
+> `scripts/validate_all.py` orchestrates collector-limit operational validation in full/publish profiles. Direct collector-limit commands remain available for domain-specific validation details.

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -64,3 +64,6 @@ python3 scripts/diagnostic_benchmark.py \
 The deterministic corpus checks fixture-labeled contract behavior. The repeated-run runner checks repeated-run stability for selected controlled demo workloads.
 
 Validation tracks currently include deterministic corpus benchmark, adversarial synthetic coverage (inside the corpus), repeated-run diagnostic matrix, mitigation matrix workflows, and operational validation for runtime cost and collector limits. Operational validation now has dedicated domain folders under `validation/runtime-cost/` and `validation/collector-limits/`; diagnostics references them but is not the only operational validation location. Generated operational outputs remain under `target/operational-validation/` and are not committed by default.
+
+
+> The unified `scripts/validate_all.py` runner can orchestrate diagnostics in smoke/ci/full/publish profiles. Keep using this document for diagnostics-specific corpus and command details.

--- a/validation/runtime-cost/README.md
+++ b/validation/runtime-cost/README.md
@@ -8,3 +8,6 @@ This directory is the operational validation domain for runtime-cost checks.
 Generated outputs are written under `target/operational-validation/` and are not committed by default.
 
 Runtime-cost numbers are machine/workload/profile scoped for local triage validation and are not universal production guarantees.
+
+
+> `scripts/validate_all.py` orchestrates runtime-cost operational validation in full/publish profiles. Direct runtime-cost commands remain the source for domain-specific validation details.


### PR DESCRIPTION
### Motivation
- Provide a single, stdlib-only orchestrator to run existing validation tracks (deterministic diagnostics, repeated-run diagnostic matrix, mitigation matrix, and operational domains) through explicit profiles without changing domain semantics. 
- Keep profile boundaries explicit, default generated outputs under `target/`, and only allow publish-style artifact packaging when explicitly requested.
- Preserve existing scripts, tests, analyzer scoring/outputs, and no new dependencies while making validation easier to run and summarize.

### Description
- Added `scripts/validate_all.py`, a stdlib-only runner that builds a profile-aware command plan, executes commands via `subprocess.run`, captures per-command logs and timing, writes `environment.json`, a unified `summary.json`, a `scorecard.md`, and command logs at `<out>/logs/commands.jsonl`, and derives a publish folder when `--profile publish` is used. 
- Implemented planner and helpers: `build_plan`, `default_out_dir`, `derive_publish_dir`, `collect_environment`, `run_command`, `write_commands_jsonl`, `summarize_results`, and `write_scorecard`, and CLI flags `--profile`, `--out`, `--runs`, `--profile-mode`, `--skip-cargo`, `--include-cargo`, `--no-fail-fast`, `--no-fail-thresholds`, `--dry-run`, and `--python`.
- Added unit tests `scripts/tests/test_validate_all.py` covering plan composition for `smoke|ci|full|publish`, propagation of `--runs` and `--profile-mode`, cargo inclusion/skipping, dry-run plan behavior, environment collection best-effort, and command-log/scorecard writing without running subprocess-heavy commands.
- Updated docs to mention and document the unified runner in `VALIDATION.md`, `docs/diagnostic-validation.md`, and the domain READMEs under `validation/diagnostics/`, `validation/runtime-cost/`, and `validation/collector-limits/`, emphasizing orchestration (not replacement) and generated-artifact policy.

### Testing
- Unit tests for the new runner: `python3 -m unittest scripts.tests.test_validate_all` — OK.
- Smoke profile run: `python3 scripts/validate_all.py --profile smoke --out target/validation/smoke --no-fail-thresholds` — completed (commands executed and logs written).
- CI profile run (skip cargo): `python3 scripts/validate_all.py --profile ci --out target/validation/ci --skip-cargo` — completed.
- Full profile smoke run (1 run, skip cargo): `python3 scripts/validate_all.py --profile full --runs 1 --out target/validation/full-smoke --no-fail-thresholds --skip-cargo` — completed.
- Deterministic diagnostic benchmark and tests: `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json` and `python3 -m unittest scripts.tests.test_diagnostic_benchmark` — OK.
- Matrix/mitigation/operational unit tests: `python3 -m unittest scripts.tests.test_run_diagnostic_matrix`, `python3 -m unittest scripts.tests.test_run_mitigation_matrix`, `python3 -m unittest scripts.tests.test_run_operational_validation` — all OK.
- Docs contract validation and tests: `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts` — OK.
- Demo fixture drift check: `python3 scripts/check_demo_fixture_drift.py --profile dev` — completed and fixtures up-to-date.
- Rust toolchain checks: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` — completed OK in this run.

All automated tests and checks listed above passed in the verification run; the runner wrote outputs under `target/validation/<profile>/` by default and created a publish-style output when requested with `--profile publish --out ...`. Limitations remain documented: the runner orchestrates existing scripts (does not change validation semantics), runtime-cost and collector-limits results are machine/workload scoped, and publish artifacts are local unless explicitly published.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f844efba388330943fb2fa97df73ba)