### PR TITLE
docs: align validation contract and guidance (VALIDATION, SPEC, AGENTS, IMPLEMENTATION_PLAN, docs)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,41 @@ Docs in `docs/` are user-facing product documentation.
   - update the validator and related tests so they enforce the new truthful contract.
 - When changing the validator, keep checks aligned with code truth and current public guidance, not stale phrasing.
 
+
+## Validation documentation contract
+
+Validation docs are part of the public trust surface.
+
+When editing validation-related files, preserve these rules:
+
+- Describe `tailtriage` as a triage tool, not a root-cause proof engine.
+- Keep validation claims bounded to the evidence actually produced.
+- Do not use PR-history wording such as “this PR introduces” in stable public docs.
+- Do not call a validation path a CI gate unless CI actually runs it.
+- Distinguish deterministic fixture validation, repeated-run validation, mitigation validation, runtime-cost validation, collector-limit validation, and real-service validation.
+- State whether each validation path is mandatory CI, manual/local, release-only, or planned.
+- Treat generated runtime-cost, collector-limit, repeated-run, and mitigation outputs as machine/workload/profile scoped unless explicitly proven otherwise.
+- Never present runtime overhead measurements as universal production guarantees.
+- Never present collector-limit validation as “no drops”; it validates visible bounded drops, warnings, and downgrade behavior.
+- Never present mitigation movement as formal causal proof; it supports the capture -> analyze -> next check -> re-run workflow.
+
+If validation corpus schema or benchmark semantics change, update together:
+
+- `VALIDATION.md`
+- `docs/diagnostic-validation.md`
+- `validation/diagnostics/README.md`
+- `validation/diagnostics/latest/scorecard.md`
+- relevant scripts and tests
+- docs contract validation, if public docs requirements changed
+
+Validation scorecards should distinguish:
+
+- covered area
+- latest run status
+- generated metrics, if available
+- manual/local versus CI status
+- known non-claims
+
 ## Scope guardrails
 
 Only expand scope when at least one of these is true:

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -47,30 +47,75 @@ A change is out of scope when it mainly adds adjacent platform capabilities or c
 
 ## Active workstreams
 
-### 1) Real-world validation
+### 1) Validation truth and presentation
 
-- Gather reproducible artifacts and concrete user pain points.
-- Prioritize repeated problems over one-off requests.
-- Confirm users can complete capture -> analyze -> next check -> re-run with current surfaces.
+Make validation easy to understand, truthful, and reproducible.
 
-### 2) Product tightening
+Near-term tasks:
 
-- Improve ergonomics where they reduce real triage friction.
-- Improve diagnosis wording and next-check clarity when users misread results.
-- Keep behavior explicit around lifecycle, truncation, and confidence limits.
+- remove PR-history wording from public validation docs
+- keep deterministic, repeated-run, mitigation, runtime-cost, and collector-limit validation clearly separated
+- make CI/manual/release status explicit for each validation path
+- add generated metrics to scorecards where available
+- keep validation non-claims visible
+- ensure docs match the current manifest and scripts
 
-### 3) Documentation and teaching surface alignment
+### 2) Diagnostic corpus tightening
 
-- Keep `README.md`, `docs/`, and crate READMEs synchronized.
-- Keep docs user-facing, present-tense, and truthful to current behavior.
-- Keep examples/demos aligned with the same default usage story.
-- Update docs contract tests when docs structure or required index links change.
+Improve deterministic validation without turning fixtures into marketing claims.
 
-### 4) Repository coherence
+Near-term tasks:
 
-- Keep one coherent product story across crates and docs.
-- Reject additions that push the project toward a general observability platform.
-- Prefer smaller cohesive changes over scattered feature growth.
+- keep adversarial sparse/missing/truncated/mixed cases small and reviewable
+- require next-check substrings where next-check behavior is part of the contract
+- preserve confidence ceilings for weak or ambiguous evidence
+- avoid labeling analyzer output as causal proof
+- keep `ground_truth` defined as fixture intent, not production truth
+
+### 3) Real-world validation
+
+Gather reproducible artifacts and concrete user pain points.
+
+Near-term tasks:
+
+- collect anonymized real-service artifacts when available
+- compare user interpretation against intended report semantics
+- identify repeated adoption friction
+- prioritize changes backed by observed confusion or real triage failures
+
+### 4) Product tightening
+
+Improve ergonomics where they reduce real triage friction.
+
+Near-term tasks:
+
+- improve diagnosis wording and next-check clarity when users misread results
+- keep lifecycle, truncation, and confidence behavior explicit
+- remove stale examples or docs that teach superseded paths
+- avoid adding new product categories
+
+### 5) Documentation and teaching surface alignment
+
+Keep public docs synchronized.
+
+Near-term tasks:
+
+- keep `README.md`, `docs/README.md`, crate READMEs, demos, and examples aligned
+- keep validation docs present-tense and stable, not PR-history oriented
+- update docs contract tests when public docs structure intentionally changes
+
+## Near-term sequencing
+
+Before the next public promotion or release:
+
+1. update repository guidance for validation docs and scorecards
+2. update the product spec with the validation contract
+3. update this implementation plan with validation-presentation work
+4. clean `VALIDATION.md` public wording
+5. fix stale diagnostic-validation wording
+6. add generated metric summaries to the deterministic scorecard
+7. clarify which validation profiles run in CI
+8. run docs contract validation and relevant validation scripts
 
 ## Quality gates for changes
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -49,6 +49,7 @@ Supporting repository areas:
 
 - `docs/`
 - `scripts/`
+- `validation/`
 
 ## 5. Public integration surfaces
 
@@ -167,7 +168,87 @@ Primary suspect kinds:
 
 These are ranked suspects, not proof.
 
-## 8. Runtime-cost and limits measurement contract
+
+## 8. Validation contract
+
+Validation exists to show bounded diagnostic behavior, not root-cause proof.
+
+The validation surface includes:
+
+1. deterministic diagnostic corpus validation
+2. adversarial synthetic fixtures for sparse, missing, truncated, noisy, or mixed evidence
+3. repeated-run controlled demo validation
+4. mitigation matrix validation
+5. runtime-cost operational validation
+6. collector-limit operational validation
+7. future real-service validation
+
+### 8.1 Deterministic diagnostic corpus
+
+The deterministic corpus validates analyzer/report behavior against labeled fixtures.
+
+It may check:
+
+- primary suspect expectations
+- required top-2 suspect visibility
+- expected and allowed warnings
+- required evidence substrings
+- required next-check substrings
+- confidence ceilings for sparse, missing, truncated, noisy, or ambiguous evidence
+- high-confidence-wrong counts
+
+Corpus labels describe expected diagnostic-family behavior for controlled fixtures. They are not production root-cause proof.
+
+### 8.2 Repeated-run validation
+
+Repeated-run validation measures stability across repeated controlled demo runs on a specific machine and workload profile.
+
+It may report:
+
+- top-1 accuracy
+- top-2 visibility
+- primary suspect stability
+- high-confidence-wrong count
+- confidence bucket summaries
+- p95/p99 latency distribution summaries
+
+Repeated-run validation is machine-scoped and workload-scoped.
+
+### 8.3 Mitigation validation
+
+Mitigation validation compares baseline and mitigated controlled runs.
+
+It may check:
+
+- p95/p99 movement
+- queue-share movement
+- service/stage-share movement
+- runtime-pressure movement
+- blocking-depth movement
+- explainable suspect movement
+
+Mitigation validation supports next-check usefulness. It does not prove formal causality.
+
+### 8.4 Operational validation
+
+Runtime-cost validation measures overhead under documented synthetic workloads.
+
+Collector-limit validation measures bounded retention behavior, visible drops, truncation warnings, and confidence downgrade behavior.
+
+Operational validation is machine-scoped, workload-scoped, and profile-scoped. It is not a universal production guarantee.
+
+### 8.5 Validation non-claims
+
+Validation does not claim:
+
+- root-cause proof from one run
+- universal production accuracy
+- universal production overhead
+- replacement of tracing, metrics, tokio-console, or tokio-metrics
+- zero collector drops under all load
+- real-service validation until curated real-service artifacts exist
+
+## 9. Runtime-cost and limits measurement contract
 
 Repository-local measurement paths:
 
@@ -189,7 +270,7 @@ Collector-limits interpretation tracks at least:
 - dropped-category progression
 - artifact-size and memory trends under stress profiles
 
-## 9. Documentation contract
+## 10. Documentation contract
 
 When behavior or public guidance changes, update relevant public docs together:
 

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -3,46 +3,38 @@
 ## Summary
 `tailtriage` is a triage tool, not root-cause proof. It produces evidence-ranked suspects and next checks, where suspects are leads and not causal certainty.
 
-## What this PR establishes
-This PR introduces an initial deterministic validation corpus for controlled Tokio workload fixtures. The corpus and benchmark validate bounded diagnostic behavior on committed fixtures, not universal production behavior.
+## Current validation status
+This repository includes an initial deterministic validation corpus for controlled Tokio workload fixtures. The corpus and benchmark validate bounded diagnostic behavior on committed fixtures, not universal production behavior.
 
-## Deterministic checks
+## Evidence levels
+
+| Level | Runs in CI? | What it supports | What it does not prove |
+|---|---|---|---|
+| Unit/helper tests | Yes | script/helper correctness checks for validation tooling | end-to-end diagnostic behavior by itself |
+| Deterministic corpus | No (manual/local) | bounded analyzer/report behavior on committed fixtures | production root cause certainty or universal accuracy |
+| Repeated-run matrix | No (manual/local) | stability metrics across repeated controlled runs on one machine/workload profile | universal stability across production environments |
+| Mitigation matrix | No (manual/local) | baseline vs mitigated movement checks for next-check usefulness | formal causal proof |
+| Runtime-cost measurement | Partially (non-blocking measure in CI) | overhead measurement under documented synthetic workloads | universal production overhead guarantees |
+| Collector-limit stress | Yes (smoke profile + summary validation) | bounded drop/truncation/warning/downgrade behavior under stress | zero drops under all load |
+| Real-service validation | No (planned) | future curated real-service truth checks when artifacts exist | current real-service validation coverage |
+
+## Deterministic corpus validation
 The deterministic benchmark validates:
 - evidence-ranked suspect correctness against corpus labels
 - required top-2 visibility (`required_top2` appears in primary or first secondary)
 - warning expectations (`expected_warnings` required; unexpected warnings rejected unless explicitly allowed)
 - required evidence substrings
+- required next-check substrings when required by a case
 - case-level confidence ceilings (`max_primary_confidence`) for sparse/missing/truncated/mixed evidence humility checks
 
-The corpus now includes deterministic adversarial validation that checks sparse, missing, truncated, or mixed evidence is warned about and does not produce overconfident unsupported classifications.
-
-## What this does **not** validate
-- root-cause proof from one run
-- universal production overhead claims
-- replacement of tracing/metrics/tokio-console
-- mitigation-effect validation
-- overhead integration into diagnostic accuracy scoring
-- collector-limit integration into diagnostic accuracy scoring
-- real-service validation coverage
-
-## Execution model
-- `scripts/diagnostic_benchmark.py` is currently a local/manual deterministic gate.
-- Benchmark helper unit tests run in CI (`python3 -m unittest scripts.tests.test_diagnostic_benchmark`).
-
-## Related artifacts
-- corpus contract: `validation/diagnostics/README.md`
-- corpus data: `validation/diagnostics/manifest.json`
-- current scorecard: `validation/diagnostics/latest/scorecard.md`
-- user-facing methodology: `docs/diagnostic-validation.md`
-
-Demos teach scenarios; validation measures bounded diagnostic behavior.
+The corpus includes deterministic adversarial validation that checks sparse, missing, truncated, or mixed evidence is warned about and does not produce overconfident unsupported classifications.
 
 ## Repeated-run matrix validation (manual/local)
 `scripts/run_diagnostic_matrix.py` provides repeated-run validation for controlled demo scenarios (queue, blocking, executor, downstream; optional mixed).
 
 It writes raw JSONL run records plus summary JSON (and optional Markdown scorecard) for stability metrics including top-1 accuracy, top-2 recall, high-confidence-wrong count, per-scenario primary stability, confidence bucket accuracy, and p95/p99 latency distribution summaries.
 
-This repeated-run validation is currently manual/local (not mandatory CI). Publishable repeated-run outputs are generated locally and are not committed by default. Results are machine/workload scoped. It measures stability under bounded controlled Tokio demo workloads on a specific machine/profile; it does not establish production universality or root-cause proof.
+This repeated-run validation is manual/local (not mandatory CI). Publishable repeated-run outputs are generated locally and are not committed by default. Results are machine/workload scoped.
 
 ## Mitigation matrix validation (manual/local)
 `scripts/run_mitigation_matrix.py` runs paired baseline/mitigated controlled demo scenarios and compares latency plus evidence movement for targeted mitigations.
@@ -51,31 +43,34 @@ It writes JSONL pair records, summary JSON, and optional scorecard Markdown unde
 
 Mitigation validation checks whether expected evidence-ranked suspect movement appears under controlled workloads (for example: queue-share drops, service-share drops, blocking queue-depth drops, and explainable top-2/primary movement), while treating score movement as intra-report ranking signal rather than absolute cross-report severity.
 
-This workflow is machine/workload scoped and supports triage next checks. It does not prove root cause and is not mandatory CI.
+This workflow is machine/workload scoped and supports triage next checks. Mitigation movement is not formal causal proof.
 
-## Operational validation (manual/local)
+## Runtime-cost / operational validation
+Operational validation has dedicated domain folders under `validation/runtime-cost/` and `validation/collector-limits/`.
 
-Operational validation now has dedicated domain folders under `validation/runtime-cost/` and `validation/collector-limits/`.
+`scripts/run_operational_validation.py` adds manual/local operational validation for runtime-cost and collector-limit behavior. It emits raw JSONL records, stable summary JSON, and optional scorecard markdown under `target/operational-validation/`.
 
-`scripts/run_operational_validation.py` adds manual/local operational validation for runtime-cost and collector-limit behavior. It emits raw JSONL records, stable summary JSON, and optional scorecard markdown under `target/operational-validation/`. Diagnostics scorecards may reference these operational domains, but diagnostics is not the only operational validation location.
+Runtime-cost results are machine/workload/profile scoped and are not universal production guarantees.
 
-Non-claims remain explicit: runtime-cost is machine/workload/profile scoped (not a universal production guarantee), collector-limit checks verify visible bounded drops plus downgrade/warning behavior (not never-drop), and results do not provide root-cause proof.
+## Collector-limit validation
+Collector-limit validation checks visible bounded drops, truncation warnings, and confidence downgrade behavior.
+
+It does not claim no drops.
+
+## Real-service validation (future)
+Real-service validation is planned for curated anonymized real-service artifacts.
 
 ## Unified validation runner
-
-Use `scripts/validate_all.py` to orchestrate existing validation tracks through explicit profiles.
-
-Profiles:
-- `smoke`: fast local sanity, including deterministic diagnostics, docs contracts, and single-scenario smoke runs for diagnostic matrix, mitigation, runtime-cost, and collector-limits (with optional `--no-fail-thresholds`).
-- `ci`: deterministic benchmark + validation/unit-test checks suitable for reasonably fast CI.
-- `full`: manual/local comprehensive run (repeated-run matrix, mitigation matrix, operational validation, optional cargo checks).
-- `publish`: full run plus artifact packaging to a chosen output directory.
+Use `scripts/validate_all.py` to orchestrate existing validation tracks through explicit profiles (`smoke`, `ci`, `full`, `publish`).
 
 The unified runner orchestrates existing scripts; it does not replace domain runners or change analyzer behavior.
 
-Generated-output policy:
-- default output for smoke/ci/full is `target/validation/<profile>/`
-- publish output may target `validation/artifacts/<date>-git-<sha>/`
-- generated artifacts are local by default and are not committed automatically
+## Validation non-claims
+Validation does not claim:
+- root-cause proof from one run
+- universal production overhead
+- replacement for tracing, metrics, tokio-console, or tokio-metrics
+- real-service validation unless curated real-service artifacts exist
+- mitigation movement as formal causal proof
 
-Non-claims remain explicit: no root-cause proof, runtime-cost is machine/workload scoped, and collector-limit checks do not claim zero drops.
+Demos teach scenarios; validation measures bounded diagnostic behavior.

--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -6,11 +6,14 @@
 The benchmark evaluates a deterministic corpus of analyzer reports against workload-grounded labels. It checks suspect ranking behavior, evidence/warning expectations, and bounded failure semantics.
 
 ## Deterministic vs repeated-run validation
-The current gate is deterministic fixture validation. Repeated-run variance validation is available as a manual/local workflow.
+Deterministic fixture validation is a manual/local validation path. Repeated-run variance validation is also manual/local. CI currently runs helper/unit checks for validation scripts, not the full deterministic corpus benchmark.
 
 ## Top-1 vs required top-2
 - **Top-1**: primary suspect matches `ground_truth`.
 - **Required top-2**: every kind in `required_top2` appears in primary or first secondary suspect.
+
+## Ground-truth interpretation
+`ground_truth` means the expected diagnostic family for the controlled fixture intent. It does not mean production root-cause proof.
 
 ## `acceptable_primary`
 `acceptable_primary` defines which primary kinds are acceptable for ambiguous/mixed interpretation and high-confidence-wrong classification. It does not replace `required_top2`.
@@ -43,7 +46,9 @@ The corpus includes insufficient-evidence scenarios to validate conservative fal
 `synthetic_analysis_report` entries are small, hand-readable, report-shaped fixtures used only to cover gaps that real demo fixtures do not cover.
 
 ## Next-check validation status
-Schema supports `must_include_next_checks`, but the current initial corpus has no non-empty next-check requirements, so next-check substrings are not currently part of the deterministic gate.
+The corpus supports `must_include_next_checks`, and selected adversarial cases use it to validate that reports suggest relevant follow-up actions.
+
+Next-check validation is substring-based rather than exact-output based. This keeps the diagnostic contract stable while allowing wording to improve.
 
 ## Future work
 Overhead integration, collector-limit integration, and expanded real-service validation are separate follow-on work.

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -11,13 +11,13 @@ Demos teach; validation measures.
 - `artifact_type`:
   - `analysis_report`: real demo-emitted analyzer report fixture.
   - `synthetic_analysis_report`: hand-written report-shaped synthetic fixture used for coverage gaps.
-- `ground_truth`: expected true diagnosis kind for the fixture intent.
+- `ground_truth`: expected diagnostic family for the controlled fixture intent. It does not mean production root-cause proof.
 - `required_top2`: diagnosis kinds that must appear in primary or first secondary suspect. Usually `[ground_truth]`. Must include `ground_truth`.
 - `acceptable_primary`: diagnosis kinds acceptable as primary for mixed/ambiguous interpretation. Must include `ground_truth`. This does **not** satisfy `required_top2` by itself.
 - `top1_required`: when `true`, primary kind must equal `ground_truth`.
 - `max_primary_confidence`: optional confidence ceiling for primary suspect (`low|medium|high|very_high`).
 - `must_include_evidence`: evidence substrings that must appear in primary or secondary evidence.
-- `must_include_next_checks`: next-check substrings that must appear when required by a case. Schema-supported; current initial corpus has no required next-check cases.
+- `must_include_next_checks`: next-check substrings that must appear when required by a case. Selected adversarial cases use this to validate relevant follow-up guidance.
 - `expected_warnings`: warning substrings that must appear.
 - `allowed_warnings`: warning substrings that may appear in addition to expected warnings (tolerated extras only).
 - `notes`: workload-intent note explaining why labels are set.

--- a/validation/diagnostics/latest/scorecard.md
+++ b/validation/diagnostics/latest/scorecard.md
@@ -18,3 +18,7 @@
 | real service validation | Planned | add curated real-service anonymized artifacts. |
 
 Deterministic synthetic adversarial cases validate benchmark/report contract behavior and humility checks; they are not real-service validation and do not provide root-cause proof.
+
+## Generated metrics snapshot
+
+Latest committed scorecard does not embed benchmark numbers directly. Generate fresh metrics with `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --output target/diagnostic-benchmark.json` and report them alongside machine/workload context when publishing.


### PR DESCRIPTION
### Motivation
- Make validation documentation truthful, stable, and aligned with current scripts/CI/manifest behavior without changing product behavior.
- Remove PR-history phrasing and ensure validation claims are bounded to evidence and clearly labeled as CI/manual/planned.
- Clarify next-check semantics to match the manifest and treat `ground_truth` as fixture intent rather than production proof.

### Description
- Added a new "Validation documentation contract" section to `AGENTS.md` that defines trust-surface rules for validation wording, CI/manual status claims, scorecard expectations, and required cross-file updates when validation semantics change.
- Updated `SPEC.md` to include `validation/` in supporting repo areas and added a high-level "Validation contract" describing deterministic corpus, adversarial fixtures, repeated-run, mitigation, operational, and future real-service validation with explicit non-claims.
- Reworked `IMPLEMENTATION_PLAN.md` active workstreams to prioritize validation truth/presentation and added a "Near-term sequencing" checklist that lists steps 1–8 for pre-release validation alignment.
- Rewrote `VALIDATION.md` to remove PR-history wording, added a present-tense "Current validation status" and an "Evidence levels" table that accurately reflects which tracks run in CI versus manual/local, and updated `docs/diagnostic-validation.md`, `validation/diagnostics/README.md`, and `validation/diagnostics/latest/scorecard.md` to fix next-check and `ground_truth` wording and to add a generated-metrics snapshot note.
- No Rust product behavior or public API was changed, manifest fields were not renamed, and deterministic corpus semantics remain unchanged; the changes are documentation/spec/plan only.

### Testing
- Ran `python3 scripts/validate_docs_contracts.py` and it completed successfully (`docs contracts validated successfully`).
- Ran `python3 -m unittest scripts.tests.test_diagnostic_benchmark` and the validation helper/unit tests passed (`23 tests OK`).
- Ran `cargo fmt --check` which passed, and ran `cargo test --workspace` which completed with all workspace tests passing.
- Deterministic corpus benchmark (`scripts/diagnostic_benchmark.py`) is documented as a manual/local validation path and is not CI-gated by the current `.github/workflows/ci.yml`; CI runs helper/unit checks only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8d6df4e708330bddc9b5a22ddc2bd)