### PR TITLE
Add versioned/manual diagnostic validation snapshot generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,10 @@ jobs:
         if: matrix.extended && matrix.profile == 'dev'
         run: python3 -m unittest scripts.tests.test_diagnostic_benchmark
 
+      - name: Validate diagnostic scorecard generator unit tests
+        if: matrix.extended && matrix.profile == 'dev'
+        run: python3 -m unittest scripts.tests.test_generate_diagnostic_scorecard
+
       - name: Check demo fixture drift
         if: matrix.extended && matrix.profile == 'dev'
         run: python3 scripts/check_demo_fixture_drift.py --profile ${{ matrix.profile }}

--- a/.github/workflows/validation-snapshot.yml
+++ b/.github/workflows/validation-snapshot.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -37,6 +39,16 @@ jobs:
             echo "SNAPSHOT_LABEL=${{ inputs.snapshot_label }}" >> "$GITHUB_ENV"
           fi
 
+      - name: Sanitize snapshot label for artifact name
+        run: |
+          SAFE_SNAPSHOT_LABEL="$(printf %s "$SNAPSHOT_LABEL" | tr -c "A-Za-z0-9._-" "-")"
+          SAFE_SNAPSHOT_LABEL="${SAFE_SNAPSHOT_LABEL#-}"
+          SAFE_SNAPSHOT_LABEL="${SAFE_SNAPSHOT_LABEL%-}"
+          if [ -z "$SAFE_SNAPSHOT_LABEL" ]; then
+            SAFE_SNAPSHOT_LABEL="snapshot"
+          fi
+          echo "SAFE_SNAPSHOT_LABEL=$SAFE_SNAPSHOT_LABEL" >> "$GITHUB_ENV"
+
       - name: Generate scorecard snapshot
         run: |
           python3 scripts/generate_diagnostic_scorecard.py \
@@ -50,7 +62,7 @@ jobs:
       - name: Upload snapshot artifact
         uses: actions/upload-artifact@v4
         with:
-          name: diagnostic-validation-${{ env.SNAPSHOT_LABEL }}-${{ env.SHORT_SHA }}
+          name: diagnostic-validation-${{ env.SAFE_SNAPSHOT_LABEL }}-${{ env.SHORT_SHA }}
           path: target/validation/diagnostics
           retention-days: 90
 

--- a/.github/workflows/validation-snapshot.yml
+++ b/.github/workflows/validation-snapshot.yml
@@ -1,0 +1,58 @@
+name: Validation Snapshot
+
+on:
+  workflow_dispatch:
+    inputs:
+      snapshot_label:
+        description: "Snapshot label, for example v0.3.0, pre-release, or validation-check"
+        required: true
+        type: string
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set snapshot label
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "SNAPSHOT_LABEL=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"
+          else
+            echo "SNAPSHOT_LABEL=${{ inputs.snapshot_label }}" >> "$GITHUB_ENV"
+          fi
+
+      - name: Generate scorecard snapshot
+        run: |
+          python3 scripts/generate_diagnostic_scorecard.py \
+            --manifest validation/diagnostics/manifest.json \
+            --out-dir target/validation/diagnostics \
+            --snapshot-label "${SNAPSHOT_LABEL}"
+
+      - name: Compute short sha
+        run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+
+      - name: Upload snapshot artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: diagnostic-validation-${{ env.SNAPSHOT_LABEL }}-${{ env.SHORT_SHA }}
+          path: target/validation/diagnostics
+          retention-days: 90
+
+      - name: TODO release attach
+        run: echo "TODO: optionally attach snapshot artifact to GitHub Releases in a follow-up task."

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -11,7 +11,7 @@ This repository includes an initial deterministic validation corpus for controll
 | Level | Runs in CI? | What it supports | What it does not prove |
 |---|---|---|---|
 | Unit/helper tests | Yes | script/helper correctness checks for validation tooling | end-to-end diagnostic behavior by itself |
-| Deterministic corpus | No (manual/local) | bounded analyzer/report behavior on committed fixtures | production root cause certainty or universal accuracy |
+| Deterministic corpus | Yes (correctness checks only) | bounded analyzer/report behavior on committed fixtures | production root cause certainty or universal accuracy |
 | Repeated-run matrix | No (manual/local) | stability metrics across repeated controlled runs on one machine/workload profile | universal stability across production environments |
 | Mitigation matrix | No (manual/local) | baseline vs mitigated movement checks for next-check usefulness | formal causal proof |
 | Runtime-cost measurement | Partially (non-blocking measure in CI) | overhead measurement under documented synthetic workloads | universal production overhead guarantees |
@@ -74,3 +74,9 @@ Validation does not claim:
 - mitigation movement as formal causal proof
 
 Demos teach scenarios; validation measures bounded diagnostic behavior.
+
+
+## Versioned/manual diagnostic snapshots
+Durable diagnostic validation scorecards are generated only by `.github/workflows/validation-snapshot.yml` on `workflow_dispatch` and `v*` tags. Normal CI does not publish durable diagnostic scorecards and does not auto-overwrite `validation/diagnostics/latest/scorecard.md`.
+
+Snapshot artifacts include deterministic benchmark metrics, thresholds, git/ref metadata, `tailtriage` workspace/package version metadata, GitHub Actions metadata when available, software/hardware metadata, and manifest/referenced-artifact hashes.

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -11,7 +11,7 @@ This repository includes an initial deterministic validation corpus for controll
 | Level | Runs in CI? | What it supports | What it does not prove |
 |---|---|---|---|
 | Unit/helper tests | Yes | script/helper correctness checks for validation tooling | end-to-end diagnostic behavior by itself |
-| Deterministic corpus | Yes (correctness checks only) | bounded analyzer/report behavior on committed fixtures | production root cause certainty or universal accuracy |
+| Deterministic corpus | Yes in `validation-snapshot.yml`; no in normal PR CI | bounded analyzer/report behavior on committed fixtures | production root cause certainty or universal accuracy |
 | Repeated-run matrix | No (manual/local) | stability metrics across repeated controlled runs on one machine/workload profile | universal stability across production environments |
 | Mitigation matrix | No (manual/local) | baseline vs mitigated movement checks for next-check usefulness | formal causal proof |
 | Runtime-cost measurement | Partially (non-blocking measure in CI) | overhead measurement under documented synthetic workloads | universal production overhead guarantees |

--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -6,7 +6,7 @@
 The benchmark evaluates a deterministic corpus of analyzer reports against workload-grounded labels. It checks suspect ranking behavior, evidence/warning expectations, and bounded failure semantics.
 
 ## Deterministic vs repeated-run validation
-Deterministic fixture validation is a manual/local validation path. Repeated-run variance validation is also manual/local. CI currently runs helper/unit checks for validation scripts, not the full deterministic corpus benchmark.
+Deterministic fixture validation is exercised by the scorecard generator and can be used as a correctness gate. Durable scorecards are generated only by the versioned/manual snapshot workflow (`validation-snapshot.yml`) on `workflow_dispatch` and `v*` tags. Normal CI runs helper/unit checks for validation scripts and does not publish durable diagnostic scorecards.
 
 ## Top-1 vs required top-2
 - **Top-1**: primary suspect matches `ground_truth`.
@@ -96,3 +96,11 @@ Operational validation has dedicated domain folders under `validation/runtime-co
 You can run diagnostic validation directly with domain scripts or orchestrate tracks with `scripts/validate_all.py` profiles.
 
 The unified runner coordinates existing validation scripts and outputs; it does not replace or redefine diagnostics-specific validation semantics.
+
+
+## Versioned/manual snapshot workflow
+Use `.github/workflows/validation-snapshot.yml` for auditable snapshots. It generates `benchmark-summary.json`, `environment.json`, and `scorecard.md` under `target/validation/diagnostics` and uploads them as an artifact.
+
+The snapshot captures deterministic benchmark metrics, thresholds, `tailtriage` workspace and per-crate versions, git metadata, GitHub Actions runner metadata (when available), software metadata, hardware metadata, and manifest/referenced-artifact hashes.
+
+Deterministic fixture metrics validate committed fixture behavior only. They do not prove production root cause, universal production accuracy, universal production overhead, or real-service behavior. Repeated-run, runtime-cost, and collector-limit results are more hardware-sensitive than deterministic fixture validation.

--- a/scripts/generate_diagnostic_scorecard.py
+++ b/scripts/generate_diagnostic_scorecard.py
@@ -54,7 +54,6 @@ def get_tailtriage_versions(repo_root: Path):
     workspace_version = data.get("workspace", {}).get("package", {}).get("version")
     members = data.get("workspace", {}).get("members", [])
     versions = {name: None for name in EXPECTED_PACKAGES}
-
     for member in members:
         manifest_path = repo_root / member / "Cargo.toml"
         if not manifest_path.exists():
@@ -71,11 +70,7 @@ def get_tailtriage_versions(repo_root: Path):
             versions[name] = version
         elif isinstance(version, dict) and version.get("workspace") is True:
             versions[name] = workspace_version
-
-    return {
-        "workspace_package_version": workspace_version,
-        "packages": versions,
-    }
+    return {"workspace_package_version": workspace_version, "packages": versions}
 
 
 def manifest_and_artifact_hashes(manifest_path: Path):
@@ -84,7 +79,6 @@ def manifest_and_artifact_hashes(manifest_path: Path):
     manifest = json.loads(manifest_bytes)
     root = manifest_path.parent
     artifacts = sorted({case["artifact"] for case in manifest.get("cases", [])})
-
     hasher = hashlib.sha256()
     for rel in artifacts:
         artifact_path = (root / rel).resolve()
@@ -119,7 +113,6 @@ def _linux_mem_kib():
 
 def collect_environment(repo_root: Path, manifest_path: Path, snapshot_label, thresholds):
     manifest_sha, artifacts_sha = manifest_and_artifact_hashes(manifest_path)
-    os_release = _read_text(Path("/etc/os-release"))
     return {
         "schema_version": 1,
         "generated_at_utc": dt.datetime.now(dt.timezone.utc).isoformat(),
@@ -153,7 +146,7 @@ def collect_environment(repo_root: Path, manifest_path: Path, snapshot_label, th
             "cargo": _cmd_output(["cargo", "--version"]),
             "platform": platform.platform(),
             "kernel": platform.release(),
-            "os_release": os_release,
+            "os_release": _read_text(Path("/etc/os-release")),
         },
         "hardware": {
             "machine": platform.machine(),
@@ -176,48 +169,19 @@ def render_failed_cases(failed_cases):
         return "None\n"
     lines = ["| id | top1_ok | top2_ok | evidence_ok | next_check_ok | confidence_ceiling_ok |", "|---|---:|---:|---:|---:|---:|"]
     for case in failed_cases:
-        lines.append(
-            f"| {case['id']} | {case['top1_ok']} | {case['top2_ok']} | {case['evidence_ok']} | {case['next_check_ok']} | {case['confidence_ceiling_ok']} |"
-        )
+        lines.append(f"| {case['id']} | {case['top1_ok']} | {case['top2_ok']} | {case['evidence_ok']} | {case['next_check_ok']} | {case['confidence_ceiling_ok']} |")
     return "\n".join(lines) + "\n"
 
 
 def render_scorecard(metrics, env):
     metric_keys = ["total_cases", "top1_accuracy", "top2_recall", "high_confidence_wrong_count", "required_evidence_pass_rate", "next_check_required_cases", "next_check_passed_cases", "next_check_pass_rate", "next_check_presence_rate", "confidence_ceiling_cases", "confidence_ceiling_passed_cases", "confidence_ceiling_pass_rate", "unexpected_warning_count", "missing_expected_warning_count"]
-    failed_count = len(metrics.get("failed_cases", []))
-    parts = [
-        "# Diagnostic validation scorecard\n",
-        "## Snapshot\n",
-        f"- Generated at (UTC): {env['generated_at_utc']}",
-        f"- Snapshot label: {env.get('snapshot_label')}",
-        f"- Git SHA: {env['git'].get('sha')}",
-        f"- Git tag: {env['git'].get('tag')}",
-        f"- Git describe: {env['git'].get('describe')}\n",
-        "## Environment\n",
-        f"- tailtriage workspace package version: {env['tailtriage'].get('workspace_package_version')}",
-    ]
+    parts = ["# Diagnostic validation scorecard\n", "## Snapshot\n", f"- Generated at (UTC): {env['generated_at_utc']}", f"- Snapshot label: {env.get('snapshot_label')}", f"- Git SHA: {env['git'].get('sha')}", f"- Git tag: {env['git'].get('tag')}", f"- Git describe: {env['git'].get('describe')}\n", "## Environment\n", f"- tailtriage workspace package version: {env['tailtriage'].get('workspace_package_version')}"]
     for k, v in env["tailtriage"]["packages"].items():
         parts.append(f"- {k}: {v}")
-    parts.extend([
-        f"- GitHub run: {env['github_actions'].get('run_id')} ({env['github_actions'].get('ref')})",
-        f"- Runner: {env['github_actions'].get('runner_os')} {env['github_actions'].get('runner_arch')} / {env['github_actions'].get('image_version')}",
-        f"- Python: {env['software'].get('python')}",
-        f"- rustc: {env['software'].get('rustc')}",
-        f"- cargo: {env['software'].get('cargo')}",
-        f"- CPU model: {env['hardware'].get('cpu_model')}",
-        f"- Logical cores: {env['hardware'].get('logical_cores')}",
-        f"- Memory KiB: {env['hardware'].get('memory_total_kib')}\n",
-        "## Inputs\n",
-        f"- Manifest SHA256: {env['inputs']['manifest_sha256']}",
-        f"- Referenced artifacts SHA256: {env['inputs']['referenced_artifacts_sha256']}",
-        f"- Thresholds: {json.dumps(env['inputs']['thresholds'], sort_keys=True)}\n",
-        "## Metrics\n",
-        "| metric | value |",
-        "|---|---:|",
-    ])
+    parts.extend([f"- GitHub run: {env['github_actions'].get('run_id')} ({env['github_actions'].get('ref')})", f"- Runner: {env['github_actions'].get('runner_os')} {env['github_actions'].get('runner_arch')} / {env['github_actions'].get('image_version')}", f"- Python: {env['software'].get('python')}", f"- rustc: {env['software'].get('rustc')}", f"- cargo: {env['software'].get('cargo')}", f"- CPU model: {env['hardware'].get('cpu_model')}", f"- Logical cores: {env['hardware'].get('logical_cores')}", f"- Memory KiB: {env['hardware'].get('memory_total_kib')}\n", "## Inputs\n", f"- Manifest SHA256: {env['inputs']['manifest_sha256']}", f"- Referenced artifacts SHA256: {env['inputs']['referenced_artifacts_sha256']}", f"- Thresholds: {json.dumps(env['inputs']['thresholds'], sort_keys=True)}\n", "## Metrics\n", "| metric | value |", "|---|---:|"])
     for k in metric_keys:
         parts.append(f"| {k} | {metrics.get(k)} |")
-    parts.append(f"| failed_case_count | {failed_count} |\n")
+    parts.append(f"| failed_case_count | {len(metrics.get('failed_cases', []))} |\n")
     parts.append("## Per-ground-truth case counts\n")
     for k, v in sorted(metrics.get("per_ground_truth_counts", {}).items()):
         parts.append(f"- {k}: {v}")
@@ -227,14 +191,21 @@ def render_scorecard(metrics, env):
     parts.append("\n## Failed cases\n")
     parts.append(render_failed_cases(metrics.get("failed_cases", [])))
     parts.append("## Non-claims\n")
-    parts.extend([
-        "- This is not root-cause proof.",
-        "- This is not universal production accuracy.",
-        "- This is not universal production overhead.",
-        "- This is not real-service validation.",
-        "- `ground_truth` labels are controlled fixture intent, not production truth.",
-    ])
+    parts.extend(["- This is not root-cause proof.", "- This is not universal production accuracy.", "- This is not universal production overhead.", "- This is not real-service validation.", "- `ground_truth` labels are controlled fixture intent, not production truth."])
     return "\n".join(parts) + "\n"
+
+
+def generate_scorecard(repo_root: Path, manifest_rel: str, out_dir_rel: str, min_top1: float, min_top2: float, max_high_confidence_wrong: int, snapshot_label):
+    manifest_path = (repo_root / manifest_rel).resolve()
+    out_dir = (repo_root / out_dir_rel).resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    metrics, failures = run_diagnostic_benchmark(manifest_path, min_top1, min_top2, max_high_confidence_wrong)
+    thresholds = {"min_top1": min_top1, "min_top2": min_top2, "max_high_confidence_wrong": max_high_confidence_wrong}
+    environment = collect_environment(repo_root, manifest_path, snapshot_label, thresholds)
+    (out_dir / "benchmark-summary.json").write_text(json.dumps(metrics, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    (out_dir / "environment.json").write_text(json.dumps(environment, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    (out_dir / "scorecard.md").write_text(render_scorecard(metrics, environment), encoding="utf-8")
+    return failures
 
 
 def main():
@@ -246,20 +217,7 @@ def main():
     ap.add_argument("--max-high-confidence-wrong", type=int, default=0)
     ap.add_argument("--snapshot-label")
     args = ap.parse_args()
-
-    repo_root = REPO_ROOT
-    manifest_path = (repo_root / args.manifest).resolve()
-    out_dir = (repo_root / args.out_dir).resolve()
-    out_dir.mkdir(parents=True, exist_ok=True)
-
-    metrics, failures = run_diagnostic_benchmark(manifest_path, args.min_top1, args.min_top2, args.max_high_confidence_wrong)
-    thresholds = {"min_top1": args.min_top1, "min_top2": args.min_top2, "max_high_confidence_wrong": args.max_high_confidence_wrong}
-    environment = collect_environment(repo_root, manifest_path, args.snapshot_label, thresholds)
-
-    (out_dir / "benchmark-summary.json").write_text(json.dumps(metrics, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    (out_dir / "environment.json").write_text(json.dumps(environment, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    (out_dir / "scorecard.md").write_text(render_scorecard(metrics, environment), encoding="utf-8")
-
+    failures = generate_scorecard(REPO_ROOT, args.manifest, args.out_dir, args.min_top1, args.min_top2, args.max_high_confidence_wrong, args.snapshot_label)
     if failures:
         for failure in failures:
             print(f"FAIL: {failure}")

--- a/scripts/generate_diagnostic_scorecard.py
+++ b/scripts/generate_diagnostic_scorecard.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import platform
+import subprocess
+from pathlib import Path
+import tomllib
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.diagnostic_benchmark import run as run_diagnostic_benchmark
+
+EXPECTED_PACKAGES = [
+    "tailtriage",
+    "tailtriage-core",
+    "tailtriage-cli",
+    "tailtriage-tokio",
+    "tailtriage-axum",
+    "tailtriage-controller",
+]
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _cmd_output(argv):
+    try:
+        result = subprocess.run(argv, capture_output=True, text=True, check=False)
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    text = result.stdout.strip()
+    return text or None
+
+
+def _read_text(path: Path):
+    try:
+        return path.read_text(encoding="utf-8")
+    except Exception:
+        return None
+
+
+def get_tailtriage_versions(repo_root: Path):
+    root_manifest = repo_root / "Cargo.toml"
+    data = tomllib.loads(root_manifest.read_text(encoding="utf-8"))
+    workspace_version = data.get("workspace", {}).get("package", {}).get("version")
+    members = data.get("workspace", {}).get("members", [])
+    versions = {name: None for name in EXPECTED_PACKAGES}
+
+    for member in members:
+        manifest_path = repo_root / member / "Cargo.toml"
+        if not manifest_path.exists():
+            continue
+        try:
+            package = tomllib.loads(manifest_path.read_text(encoding="utf-8")).get("package", {})
+        except Exception:
+            continue
+        name = package.get("name")
+        if name not in versions:
+            continue
+        version = package.get("version")
+        if isinstance(version, str):
+            versions[name] = version
+        elif isinstance(version, dict) and version.get("workspace") is True:
+            versions[name] = workspace_version
+
+    return {
+        "workspace_package_version": workspace_version,
+        "packages": versions,
+    }
+
+
+def manifest_and_artifact_hashes(manifest_path: Path):
+    manifest_bytes = manifest_path.read_bytes()
+    manifest_sha = sha256_bytes(manifest_bytes)
+    manifest = json.loads(manifest_bytes)
+    root = manifest_path.parent
+    artifacts = sorted({case["artifact"] for case in manifest.get("cases", [])})
+
+    hasher = hashlib.sha256()
+    for rel in artifacts:
+        artifact_path = (root / rel).resolve()
+        rel_norm = str(Path(rel).as_posix())
+        hasher.update(rel_norm.encode("utf-8"))
+        hasher.update(b"\0")
+        hasher.update(artifact_path.read_bytes())
+        hasher.update(b"\0")
+    return manifest_sha, hasher.hexdigest()
+
+
+def _linux_cpu_model():
+    cpuinfo = _read_text(Path("/proc/cpuinfo"))
+    if not cpuinfo:
+        return None
+    for line in cpuinfo.splitlines():
+        if line.lower().startswith("model name"):
+            return line.split(":", 1)[1].strip()
+    return None
+
+
+def _linux_mem_kib():
+    meminfo = _read_text(Path("/proc/meminfo"))
+    if not meminfo:
+        return None
+    for line in meminfo.splitlines():
+        if line.startswith("MemTotal:"):
+            parts = line.split()
+            return int(parts[1]) if len(parts) > 1 and parts[1].isdigit() else None
+    return None
+
+
+def collect_environment(repo_root: Path, manifest_path: Path, snapshot_label, thresholds):
+    manifest_sha, artifacts_sha = manifest_and_artifact_hashes(manifest_path)
+    os_release = _read_text(Path("/etc/os-release"))
+    return {
+        "schema_version": 1,
+        "generated_at_utc": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "snapshot_label": snapshot_label,
+        "git": {
+            "sha": _cmd_output(["git", "rev-parse", "HEAD"]),
+            "short_sha": _cmd_output(["git", "rev-parse", "--short", "HEAD"]),
+            "branch": _cmd_output(["git", "branch", "--show-current"]),
+            "tag": _cmd_output(["git", "describe", "--tags", "--exact-match"]),
+            "describe": _cmd_output(["git", "describe", "--tags", "--always", "--dirty"]),
+            "dirty": _cmd_output(["git", "status", "--porcelain"]) not in (None, ""),
+        },
+        "tailtriage": get_tailtriage_versions(repo_root),
+        "github_actions": {
+            "enabled": os.getenv("GITHUB_ACTIONS") == "true",
+            "workflow": os.getenv("GITHUB_WORKFLOW"),
+            "run_id": os.getenv("GITHUB_RUN_ID"),
+            "run_attempt": os.getenv("GITHUB_RUN_ATTEMPT"),
+            "event_name": os.getenv("GITHUB_EVENT_NAME"),
+            "ref": os.getenv("GITHUB_REF"),
+            "sha": os.getenv("GITHUB_SHA"),
+            "runner_os": os.getenv("RUNNER_OS"),
+            "runner_arch": os.getenv("RUNNER_ARCH"),
+            "runner_name": os.getenv("RUNNER_NAME"),
+            "image_os": os.getenv("ImageOS"),
+            "image_version": os.getenv("ImageVersion"),
+        },
+        "software": {
+            "python": platform.python_version(),
+            "rustc": _cmd_output(["rustc", "--version"]),
+            "cargo": _cmd_output(["cargo", "--version"]),
+            "platform": platform.platform(),
+            "kernel": platform.release(),
+            "os_release": os_release,
+        },
+        "hardware": {
+            "machine": platform.machine(),
+            "processor": platform.processor() or None,
+            "cpu_model": _linux_cpu_model(),
+            "logical_cores": os.cpu_count(),
+            "memory_total_kib": _linux_mem_kib(),
+        },
+        "inputs": {
+            "manifest": str(manifest_path.relative_to(repo_root)),
+            "manifest_sha256": manifest_sha,
+            "referenced_artifacts_sha256": artifacts_sha,
+            "thresholds": thresholds,
+        },
+    }
+
+
+def render_failed_cases(failed_cases):
+    if not failed_cases:
+        return "None\n"
+    lines = ["| id | top1_ok | top2_ok | evidence_ok | next_check_ok | confidence_ceiling_ok |", "|---|---:|---:|---:|---:|---:|"]
+    for case in failed_cases:
+        lines.append(
+            f"| {case['id']} | {case['top1_ok']} | {case['top2_ok']} | {case['evidence_ok']} | {case['next_check_ok']} | {case['confidence_ceiling_ok']} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def render_scorecard(metrics, env):
+    metric_keys = ["total_cases", "top1_accuracy", "top2_recall", "high_confidence_wrong_count", "required_evidence_pass_rate", "next_check_required_cases", "next_check_passed_cases", "next_check_pass_rate", "next_check_presence_rate", "confidence_ceiling_cases", "confidence_ceiling_passed_cases", "confidence_ceiling_pass_rate", "unexpected_warning_count", "missing_expected_warning_count"]
+    failed_count = len(metrics.get("failed_cases", []))
+    parts = [
+        "# Diagnostic validation scorecard\n",
+        "## Snapshot\n",
+        f"- Generated at (UTC): {env['generated_at_utc']}",
+        f"- Snapshot label: {env.get('snapshot_label')}",
+        f"- Git SHA: {env['git'].get('sha')}",
+        f"- Git tag: {env['git'].get('tag')}",
+        f"- Git describe: {env['git'].get('describe')}\n",
+        "## Environment\n",
+        f"- tailtriage workspace package version: {env['tailtriage'].get('workspace_package_version')}",
+    ]
+    for k, v in env["tailtriage"]["packages"].items():
+        parts.append(f"- {k}: {v}")
+    parts.extend([
+        f"- GitHub run: {env['github_actions'].get('run_id')} ({env['github_actions'].get('ref')})",
+        f"- Runner: {env['github_actions'].get('runner_os')} {env['github_actions'].get('runner_arch')} / {env['github_actions'].get('image_version')}",
+        f"- Python: {env['software'].get('python')}",
+        f"- rustc: {env['software'].get('rustc')}",
+        f"- cargo: {env['software'].get('cargo')}",
+        f"- CPU model: {env['hardware'].get('cpu_model')}",
+        f"- Logical cores: {env['hardware'].get('logical_cores')}",
+        f"- Memory KiB: {env['hardware'].get('memory_total_kib')}\n",
+        "## Inputs\n",
+        f"- Manifest SHA256: {env['inputs']['manifest_sha256']}",
+        f"- Referenced artifacts SHA256: {env['inputs']['referenced_artifacts_sha256']}",
+        f"- Thresholds: {json.dumps(env['inputs']['thresholds'], sort_keys=True)}\n",
+        "## Metrics\n",
+        "| metric | value |",
+        "|---|---:|",
+    ])
+    for k in metric_keys:
+        parts.append(f"| {k} | {metrics.get(k)} |")
+    parts.append(f"| failed_case_count | {failed_count} |\n")
+    parts.append("## Per-ground-truth case counts\n")
+    for k, v in sorted(metrics.get("per_ground_truth_counts", {}).items()):
+        parts.append(f"- {k}: {v}")
+    parts.append("\n## Confidence bucket accuracy\n")
+    for k, v in sorted(metrics.get("confidence_bucket_accuracy", {}).items()):
+        parts.append(f"- {k}: accuracy={v.get('accuracy')} total={v.get('total')} correct={v.get('correct')}")
+    parts.append("\n## Failed cases\n")
+    parts.append(render_failed_cases(metrics.get("failed_cases", [])))
+    parts.append("## Non-claims\n")
+    parts.extend([
+        "- This is not root-cause proof.",
+        "- This is not universal production accuracy.",
+        "- This is not universal production overhead.",
+        "- This is not real-service validation.",
+        "- `ground_truth` labels are controlled fixture intent, not production truth.",
+    ])
+    return "\n".join(parts) + "\n"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--manifest", default="validation/diagnostics/manifest.json")
+    ap.add_argument("--out-dir", default="target/validation/diagnostics")
+    ap.add_argument("--min-top1", type=float, default=0.75)
+    ap.add_argument("--min-top2", type=float, default=0.90)
+    ap.add_argument("--max-high-confidence-wrong", type=int, default=0)
+    ap.add_argument("--snapshot-label")
+    args = ap.parse_args()
+
+    repo_root = REPO_ROOT
+    manifest_path = (repo_root / args.manifest).resolve()
+    out_dir = (repo_root / args.out_dir).resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    metrics, failures = run_diagnostic_benchmark(manifest_path, args.min_top1, args.min_top2, args.max_high_confidence_wrong)
+    thresholds = {"min_top1": args.min_top1, "min_top2": args.min_top2, "max_high_confidence_wrong": args.max_high_confidence_wrong}
+    environment = collect_environment(repo_root, manifest_path, args.snapshot_label, thresholds)
+
+    (out_dir / "benchmark-summary.json").write_text(json.dumps(metrics, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    (out_dir / "environment.json").write_text(json.dumps(environment, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    (out_dir / "scorecard.md").write_text(render_scorecard(metrics, environment), encoding="utf-8")
+
+    if failures:
+        for failure in failures:
+            print(f"FAIL: {failure}")
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_generate_diagnostic_scorecard.py
+++ b/scripts/tests/test_generate_diagnostic_scorecard.py
@@ -3,14 +3,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from scripts.generate_diagnostic_scorecard import (
-    collect_environment,
-    get_tailtriage_versions,
-    manifest_and_artifact_hashes,
-    render_failed_cases,
-    render_scorecard,
-    sha256_bytes,
-)
+from scripts.generate_diagnostic_scorecard import collect_environment, generate_scorecard, get_tailtriage_versions, manifest_and_artifact_hashes, render_failed_cases, render_scorecard, sha256_bytes
 
 
 class GenerateScorecardTests(unittest.TestCase):
@@ -20,15 +13,7 @@ class GenerateScorecardTests(unittest.TestCase):
     def test_versions_workspace_and_explicit(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
-            (root / "Cargo.toml").write_text(
-                """
-[workspace]
-members = ["a", "b"]
-[workspace.package]
-version = "1.2.3"
-""",
-                encoding="utf-8",
-            )
+            (root / "Cargo.toml").write_text('[workspace]\nmembers=["a","b"]\n[workspace.package]\nversion="1.2.3"\n', encoding="utf-8")
             (root / "a").mkdir()
             (root / "a/Cargo.toml").write_text('[package]\nname="tailtriage"\nversion={ workspace = true }\n', encoding="utf-8")
             (root / "b").mkdir()
@@ -49,16 +34,7 @@ version = "1.2.3"
             self.assertNotEqual(h1, h2)
 
     def test_render_contains_non_claims_and_metrics(self):
-        env = {
-            "generated_at_utc": "t",
-            "snapshot_label": "s",
-            "git": {"sha": "a", "tag": "v1", "describe": "d"},
-            "tailtriage": {"workspace_package_version": "1", "packages": {"tailtriage": "1"}},
-            "github_actions": {"run_id": None, "ref": None, "runner_os": None, "runner_arch": None, "image_version": None},
-            "software": {"python": "3", "rustc": "r", "cargo": "c"},
-            "hardware": {"cpu_model": "cpu", "logical_cores": 1, "memory_total_kib": 2},
-            "inputs": {"manifest_sha256": "m", "referenced_artifacts_sha256": "a", "thresholds": {"min_top1": 0.75}},
-        }
+        env = {"generated_at_utc": "t", "snapshot_label": "s", "git": {"sha": "a", "tag": "v1", "describe": "d"}, "tailtriage": {"workspace_package_version": "1", "packages": {"tailtriage": "1"}}, "github_actions": {"run_id": None, "ref": None, "runner_os": None, "runner_arch": None, "image_version": None}, "software": {"python": "3", "rustc": "r", "cargo": "c"}, "hardware": {"cpu_model": "cpu", "logical_cores": 1, "memory_total_kib": 2}, "inputs": {"manifest_sha256": "m", "referenced_artifacts_sha256": "a", "thresholds": {"min_top1": 0.75}}}
         metrics = {"failed_cases": [], "per_ground_truth_counts": {}, "confidence_bucket_accuracy": {}}
         for k in ["total_cases", "top1_accuracy", "top2_recall", "high_confidence_wrong_count", "required_evidence_pass_rate", "next_check_required_cases", "next_check_passed_cases", "next_check_pass_rate", "next_check_presence_rate", "confidence_ceiling_cases", "confidence_ceiling_passed_cases", "confidence_ceiling_pass_rate", "unexpected_warning_count", "missing_expected_warning_count"]:
             metrics[k] = 0
@@ -76,6 +52,27 @@ version = "1.2.3"
         env = collect_environment(repo, repo / "validation/diagnostics/manifest.json", "x", {"min_top1": 0.75, "min_top2": 0.9, "max_high_confidence_wrong": 0})
         for key in ["schema_version", "generated_at_utc", "git", "tailtriage", "github_actions", "software", "hardware", "inputs"]:
             self.assertIn(key, env)
+
+    def test_generate_scorecard_end_to_end_tiny_fixture(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "Cargo.toml").write_text('[workspace]\nmembers=["tailtriage"]\n[workspace.package]\nversion="1.2.3"\n', encoding="utf-8")
+            (root / "tailtriage").mkdir()
+            (root / "tailtriage/Cargo.toml").write_text('[package]\nname="tailtriage"\nversion={ workspace = true }\n', encoding="utf-8")
+            manifest_dir = root / "validation/diagnostics"
+            manifest_dir.mkdir(parents=True)
+            (manifest_dir / "tiny.json").write_text(json.dumps({"primary_suspect": {"kind": "insufficient_evidence", "confidence": "low", "score": 0, "evidence": ["not enough requests"], "next_checks": ["rerun with enough requests"]}, "secondary_suspects": [], "warnings": ["not enough requests"]}), encoding="utf-8")
+            (manifest_dir / "manifest.json").write_text(json.dumps({"schema_version": 1, "cases": [{"id": "tiny_insufficient", "artifact": "tiny.json", "artifact_type": "analysis_report", "ground_truth": "insufficient_evidence", "required_top2": ["insufficient_evidence"], "acceptable_primary": ["insufficient_evidence"], "tags": ["tiny"], "must_include_evidence": ["not enough requests"], "must_include_next_checks": ["rerun"], "expected_warnings": ["not enough requests"], "allowed_warnings": [], "top1_required": True, "notes": "tiny generator smoke fixture"}]}, indent=2), encoding="utf-8")
+            failures = generate_scorecard(root, "validation/diagnostics/manifest.json", "target/validation/diagnostics", 1.0, 1.0, 0, "tiny")
+            self.assertEqual(failures, [])
+            out_dir = root / "target/validation/diagnostics"
+            self.assertTrue((out_dir / "benchmark-summary.json").exists())
+            self.assertTrue((out_dir / "environment.json").exists())
+            self.assertTrue((out_dir / "scorecard.md").exists())
+            summary = json.loads((out_dir / "benchmark-summary.json").read_text(encoding="utf-8"))
+            environment = json.loads((out_dir / "environment.json").read_text(encoding="utf-8"))
+            self.assertEqual(summary["total_cases"], 1)
+            self.assertEqual(environment["tailtriage"]["workspace_package_version"], "1.2.3")
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_generate_diagnostic_scorecard.py
+++ b/scripts/tests/test_generate_diagnostic_scorecard.py
@@ -1,0 +1,82 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.generate_diagnostic_scorecard import (
+    collect_environment,
+    get_tailtriage_versions,
+    manifest_and_artifact_hashes,
+    render_failed_cases,
+    render_scorecard,
+    sha256_bytes,
+)
+
+
+class GenerateScorecardTests(unittest.TestCase):
+    def test_sha256_stable(self):
+        self.assertEqual(sha256_bytes(b"abc"), sha256_bytes(b"abc"))
+
+    def test_versions_workspace_and_explicit(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "Cargo.toml").write_text(
+                """
+[workspace]
+members = ["a", "b"]
+[workspace.package]
+version = "1.2.3"
+""",
+                encoding="utf-8",
+            )
+            (root / "a").mkdir()
+            (root / "a/Cargo.toml").write_text('[package]\nname="tailtriage"\nversion={ workspace = true }\n', encoding="utf-8")
+            (root / "b").mkdir()
+            (root / "b/Cargo.toml").write_text('[package]\nname="tailtriage-core"\nversion="9.9.9"\n', encoding="utf-8")
+            versions = get_tailtriage_versions(root)
+            self.assertEqual(versions["workspace_package_version"], "1.2.3")
+            self.assertEqual(versions["packages"]["tailtriage"], "1.2.3")
+            self.assertEqual(versions["packages"]["tailtriage-core"], "9.9.9")
+
+    def test_artifact_hash_changes(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "a.json").write_text('{"x":1}', encoding="utf-8")
+            (root / "manifest.json").write_text(json.dumps({"cases": [{"artifact": "a.json"}]}), encoding="utf-8")
+            h1 = manifest_and_artifact_hashes(root / "manifest.json")[1]
+            (root / "a.json").write_text('{"x":2}', encoding="utf-8")
+            h2 = manifest_and_artifact_hashes(root / "manifest.json")[1]
+            self.assertNotEqual(h1, h2)
+
+    def test_render_contains_non_claims_and_metrics(self):
+        env = {
+            "generated_at_utc": "t",
+            "snapshot_label": "s",
+            "git": {"sha": "a", "tag": "v1", "describe": "d"},
+            "tailtriage": {"workspace_package_version": "1", "packages": {"tailtriage": "1"}},
+            "github_actions": {"run_id": None, "ref": None, "runner_os": None, "runner_arch": None, "image_version": None},
+            "software": {"python": "3", "rustc": "r", "cargo": "c"},
+            "hardware": {"cpu_model": "cpu", "logical_cores": 1, "memory_total_kib": 2},
+            "inputs": {"manifest_sha256": "m", "referenced_artifacts_sha256": "a", "thresholds": {"min_top1": 0.75}},
+        }
+        metrics = {"failed_cases": [], "per_ground_truth_counts": {}, "confidence_bucket_accuracy": {}}
+        for k in ["total_cases", "top1_accuracy", "top2_recall", "high_confidence_wrong_count", "required_evidence_pass_rate", "next_check_required_cases", "next_check_passed_cases", "next_check_pass_rate", "next_check_presence_rate", "confidence_ceiling_cases", "confidence_ceiling_passed_cases", "confidence_ceiling_pass_rate", "unexpected_warning_count", "missing_expected_warning_count"]:
+            metrics[k] = 0
+        text = render_scorecard(metrics, env)
+        self.assertIn("failed_case_count", text)
+        self.assertIn("not root-cause proof", text)
+
+    def test_failed_case_rendering(self):
+        self.assertEqual(render_failed_cases([]).strip(), "None")
+        table = render_failed_cases([{"id": "a", "top1_ok": False, "top2_ok": True, "evidence_ok": True, "next_check_ok": True, "confidence_ceiling_ok": True}])
+        self.assertIn("| a |", table)
+
+    def test_environment_keys(self):
+        repo = Path(__file__).resolve().parents[2]
+        env = collect_environment(repo, repo / "validation/diagnostics/manifest.json", "x", {"min_top1": 0.75, "min_top2": 0.9, "max_high_confidence_wrong": 0})
+        for key in ["schema_version", "generated_at_utc", "git", "tailtriage", "github_actions", "software", "hardware", "inputs"]:
+            self.assertIn(key, env)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -68,3 +68,16 @@ Validation tracks currently include deterministic corpus benchmark, adversarial 
 ## Unified runner orchestration
 
 For profile-based orchestration across validation tracks, use `scripts/validate_all.py` (`smoke`, `ci`, `full`, `publish`). Keep using this diagnostics runner directly for diagnostics-specific validation workflows.
+
+
+## Versioned/manual scorecard generation
+Use `.github/workflows/validation-snapshot.yml` to generate durable diagnostic snapshots on manual dispatch or `v*` tag pushes. Normal CI does not upload durable diagnostic scorecards.
+
+Snapshot output directory: `target/validation/diagnostics/`
+- `benchmark-summary.json`
+- `environment.json`
+- `scorecard.md`
+
+`environment.json` includes `tailtriage` workspace version and per-crate versions, git metadata, GitHub Actions metadata when available, software/hardware metadata, manifest hash, referenced-artifact hash, and benchmark thresholds.
+
+Deterministic fixture metrics validate committed fixtures only; they are not root-cause proof, universal production accuracy, universal production overhead, or real-service validation.

--- a/validation/diagnostics/latest/scorecard.md
+++ b/validation/diagnostics/latest/scorecard.md
@@ -22,3 +22,11 @@ Deterministic synthetic adversarial cases validate benchmark/report contract beh
 ## Generated metrics snapshot
 
 Latest committed scorecard does not embed benchmark numbers directly. Generate fresh metrics with `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --output target/diagnostic-benchmark.json` and report them alongside machine/workload context when publishing.
+
+## Versioned/manual scorecards
+
+The committed scorecard is a stable repository note, not an automatically updated latest-run file.
+
+For a versioned or manually requested snapshot, run the `validation-snapshot.yml` workflow. It uploads a generated scorecard plus `benchmark-summary.json` and `environment.json` as a GitHub Actions artifact. Snapshot artifacts include the `tailtriage` package version, git metadata, runner metadata, software/hardware metadata, manifest hash, referenced-artifact hash, thresholds, and deterministic benchmark metrics.
+
+Normal CI does not publish durable diagnostic scorecards and does not auto-overwrite this committed file.


### PR DESCRIPTION
### Motivation
- Provide an auditable, reproducible way to generate durable diagnostic validation snapshots for a specific `tailtriage` version without publishing scorecards on every CI run.
- Capture enough environment, version, git, and input-hash metadata to make deterministic benchmark outputs reproducible and auditable.
- Keep normal CI behavior unchanged so durable scorecards are produced only via explicit snapshot requests (manual dispatch or version/tag workflows).

### Description
- Add `scripts/generate_diagnostic_scorecard.py`, a stdlib-only generator that reuses `scripts.diagnostic_benchmark.run(...)`, computes manifest and referenced-artifact SHA256s, resolves `tailtriage` workspace and per-crate versions via `tomllib`, captures git/GitHub Actions/software/hardware metadata, writes `benchmark-summary.json`, `environment.json`, and `scorecard.md`, and exits nonzero when thresholds fail.
- Add unit tests at `scripts/tests/test_generate_diagnostic_scorecard.py` that validate version extraction, SHA256 stability and sensitivity, environment keys, scorecard rendering, and failed-case rendering.
- Add a manual/versioned GitHub Actions workflow `.github/workflows/validation-snapshot.yml` that triggers on `workflow_dispatch` (requires `snapshot_label`) and `push` tags `v*`, runs the generator, and uploads `target/validation/diagnostics` as an artifact named `diagnostic-validation-${snapshot_label}-${short_sha}` with 90-day retention.
- Update docs (`VALIDATION.md`, `docs/diagnostic-validation.md`, `validation/diagnostics/README.md`, and `validation/diagnostics/latest/scorecard.md`) to state that durable diagnostic scorecards are generated only by the new snapshot workflow, list the generated outputs and captured metadata, and reiterate the non-claims (not root-cause proof, not universal accuracy/overhead, not real-service validation).

### Testing
- Ran the generator locally with `python3 scripts/generate_diagnostic_scorecard.py --manifest validation/diagnostics/manifest.json --out-dir target/validation/diagnostics --snapshot-label local-test` and it produced `benchmark-summary.json`, `environment.json`, and `scorecard.md` (run succeeded when thresholds passed).
- Ran unit tests `python3 -m unittest scripts.tests.test_generate_diagnostic_scorecard` and `python3 -m unittest scripts.tests.test_diagnostic_benchmark` and both test suites passed.
- Validated docs contract with `python3 scripts/validate_docs_contracts.py` which succeeded and kept public-doc non-claims intact.
- Ran repository validations `cargo fmt --check` and `cargo test --workspace` which completed successfully and showed no product-behavior changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8e8aac05c8330871b5d600f755f6f)