### PR TITLE
Gate deterministic diagnostics benchmark and manifest schema in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,10 @@ jobs:
         if: matrix.extended && matrix.profile == 'dev'
         run: python3 -m unittest scripts.tests.test_diagnostic_benchmark
 
+      - name: Validate deterministic diagnostics benchmark manifest
+        if: matrix.extended && matrix.profile == 'dev'
+        run: python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0
+
       - name: Validate diagnostic scorecard generator unit tests
         if: matrix.extended && matrix.profile == 'dev'
         run: python3 -m unittest scripts.tests.test_generate_diagnostic_scorecard

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -11,7 +11,7 @@ This repository includes an initial deterministic validation corpus for controll
 | Level | Runs in CI? | What it supports | What it does not prove |
 |---|---|---|---|
 | Unit/helper tests | Yes | script/helper correctness checks for validation tooling | end-to-end diagnostic behavior by itself |
-| Deterministic corpus | Yes in `validation-snapshot.yml`; no in normal PR CI | bounded analyzer/report behavior on committed fixtures | production root cause certainty or universal accuracy |
+| Deterministic corpus | Yes in normal CI and `validation-snapshot.yml` | bounded analyzer/report behavior on committed fixtures | production root cause certainty or universal accuracy |
 | Repeated-run matrix | No (manual/local) | stability metrics across repeated controlled runs on one machine/workload profile | universal stability across production environments |
 | Mitigation matrix | No (manual/local) | baseline vs mitigated movement checks for next-check usefulness | formal causal proof |
 | Runtime-cost measurement | Partially (non-blocking measure in CI) | overhead measurement under documented synthetic workloads | universal production overhead guarantees |

--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -6,7 +6,7 @@
 The benchmark evaluates a deterministic corpus of analyzer reports against workload-grounded labels. It checks suspect ranking behavior, evidence/warning expectations, and bounded failure semantics.
 
 ## Deterministic vs repeated-run validation
-Deterministic fixture validation is exercised by the scorecard generator and can be used as a correctness gate. Durable scorecards are generated only by the versioned/manual snapshot workflow (`validation-snapshot.yml`) on `workflow_dispatch` and `v*` tags. Normal CI runs helper/unit checks for validation scripts and does not publish durable diagnostic scorecards.
+Deterministic fixture validation is exercised as a normal CI correctness gate via `scripts/diagnostic_benchmark.py` against `validation/diagnostics/manifest.json`, and it is also exercised by the scorecard generator. Durable scorecards are generated only by the versioned/manual snapshot workflow (`validation-snapshot.yml`) on `workflow_dispatch` and `v*` tags. Normal CI does not publish durable diagnostic scorecards.
 
 ## Top-1 vs required top-2
 - **Top-1**: primary suspect matches `ground_truth`.

--- a/scripts/tests/test_diagnostic_benchmark.py
+++ b/scripts/tests/test_diagnostic_benchmark.py
@@ -133,6 +133,14 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "max_primary_confidence must be a string"):
             db.validate_manifest(self.make_manifest(self.make_case(max_primary_confidence=1)))
 
+
+
+    def test_committed_manifest_requires_schema_version_one(self):
+        manifest_path = Path(__file__).resolve().parents[2] / "validation" / "diagnostics" / "manifest.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        self.assertEqual(manifest.get("schema_version"), 1)
+        db.validate_manifest(manifest)
+
     # Report validation tests
     def test_report_missing_primary_fails(self):
         with self.assertRaisesRegex(ValueError, "primary_suspect"):

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -70,6 +70,14 @@ Validation tracks currently include deterministic corpus benchmark, adversarial 
 For profile-based orchestration across validation tracks, use `scripts/validate_all.py` (`smoke`, `ci`, `full`, `publish`). Keep using this diagnostics runner directly for diagnostics-specific validation workflows.
 
 
+
+
+## CI gating and scorecard publication boundaries
+- Normal CI runs the deterministic diagnostics benchmark against `validation/diagnostics/manifest.json` as a required gate.
+- Normal CI validates fixture/schema drift and fails on invalid manifests or fixture contract breaks.
+- Durable/versioned diagnostic scorecards are generated only by `.github/workflows/validation-snapshot.yml` on manual dispatch or `v*` tags.
+- Normal CI does not publish durable diagnostic scorecards.
+
 ## Versioned/manual scorecard generation
 Use `.github/workflows/validation-snapshot.yml` to generate durable diagnostic snapshots on manual dispatch or `v*` tag pushes. Normal CI does not upload durable diagnostic scorecards.
 

--- a/validation/diagnostics/latest/scorecard.md
+++ b/validation/diagnostics/latest/scorecard.md
@@ -19,6 +19,8 @@
 
 Deterministic synthetic adversarial cases validate benchmark/report contract behavior and humility checks; they are not real-service validation and do not provide root-cause proof.
 
+Normal CI runs deterministic diagnostics corpus validation as a required gate against the committed manifest/fixtures, but normal CI does not publish durable diagnostic scorecards.
+
 ## Generated metrics snapshot
 
 Latest committed scorecard does not embed benchmark numbers directly. Generate fresh metrics with `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --output target/diagnostic-benchmark.json` and report them alongside machine/workload context when publishing.


### PR DESCRIPTION
### Motivation
- Prevent validation trust drift by ensuring the deterministic diagnostics manifest has a top-level `schema_version: 1` and by exercising the committed manifest/fixtures in normal CI so manifest/schema or fixture drift fails fast.

### Description
- Add a required CI step in `.github/workflows/ci.yml` (Ubuntu/dev extended leg) to run `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0` as a non-optional gate.
- Add `test_committed_manifest_requires_schema_version_one` to `scripts/tests/test_diagnostic_benchmark.py` which loads `validation/diagnostics/manifest.json`, asserts `schema_version == 1`, and calls `db.validate_manifest(manifest)` to detect committed manifest schema drift.
- Update validation documentation (`VALIDATION.md`, `docs/diagnostic-validation.md`, `validation/diagnostics/README.md`, `validation/diagnostics/latest/scorecard.md`) to state that the deterministic corpus benchmark is a required normal CI gate while durable/versioned scorecards remain produced only by the manual/tagged `validation-snapshot.yml` workflow.
- Preserve manifest cases, thresholds, fixture paths, diagnosis expectations, validation logic, and not introduce new dependencies or loosen validation rules.

### Testing
- Ran `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0`, which completed with `total_cases=37`, `top1_accuracy=0.946`, `top2_recall=1.000`, and `failed_case_count=0`.
- Ran `python3 -m unittest scripts.tests.test_diagnostic_benchmark`, which ran 24 tests and reported `OK`.
- Ran `python3 -m unittest scripts.tests.test_generate_diagnostic_scorecard`, which ran 7 tests and reported `OK`.
- Ran `python3 scripts/validate_docs_contracts.py`, which reported `docs contracts validated successfully`.
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, and all succeeded.
- No remaining limitations within the scoped fix; CI will now fail for missing `schema_version: 1` or if the deterministic benchmark thresholds are not met.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8f9658534833092dab0ee31396de9)