### PR TITLE
Clarify validation hierarchy

### DIFF
--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -6,6 +6,21 @@
 ## Current validation status
 This repository includes an initial deterministic validation corpus for controlled Tokio workload fixtures. The corpus and benchmark validate bounded diagnostic behavior on committed fixtures, not universal production behavior.
 
+## Validation map
+`VALIDATION.md` is the top-level validation map and trust boundary. `docs/diagnostic-validation.md` explains diagnostic validation behavior for users. `validation/diagnostics/README.md` defines the corpus/manifest contract for maintainers. `validation/diagnostics/latest/scorecard.md` is a stable note about committed scorecard status, not a live metrics file. `scripts/validate_all.py` is an orchestration convenience over existing tracks, not the source of truth.
+
+| File/script/workflow | Role | Normal CI? | Publishes durable artifacts? |
+|---|---|---:|---:|
+| `scripts/diagnostic_benchmark.py` | Deterministic diagnostics corpus gate for committed manifest/fixtures | Yes | No |
+| `scripts/validate_docs_contracts.py` | Public-doc and validation-doc truth contract | Yes | No |
+| `.github/workflows/validation-snapshot.yml` | Versioned/manual diagnostic scorecard snapshot | Manual/tag | Yes |
+| `scripts/run_diagnostic_matrix.py` | Repeated controlled demo runs | No, local/manual | No |
+| `scripts/run_mitigation_matrix.py` | Baseline vs mitigated evidence-movement checks | No, local/manual | No |
+| `scripts/run_operational_validation.py` | Runtime-cost and collector-limit operational validation | Manual/local; some narrower smoke checks exist elsewhere | No |
+| `scripts/validate_all.py` | Optional orchestration wrapper over existing validation tracks | No single source of truth; local/manual wrapper | Local outputs only |
+
+Normal CI keeps deterministic diagnostics and docs contracts as gates but does not publish durable scorecards. Durable scorecard publication remains limited to the manual/tag snapshot workflow.
+
 ## Evidence levels
 
 | Level | Runs in CI? | What it supports | What it does not prove |

--- a/scripts/tests/test_validate_all.py
+++ b/scripts/tests/test_validate_all.py
@@ -30,6 +30,30 @@ class ValidateAllTests(unittest.TestCase):
         self.assertIn("scripts.tests.test_run_operational_validation", joined)
         self.assertIn("scripts.tests.test_validate_docs_contracts", joined)
 
+    def test_ci_plan_deterministic_benchmark_uses_ci_thresholds(self):
+        plan = va.build_plan(self.args("ci"))
+        benchmark = next(
+            c
+            for c in plan
+            if c.name == "deterministic benchmark"
+            and "scripts/diagnostic_benchmark.py" in c.argv
+        )
+
+        self.assertIn("--manifest", benchmark.argv)
+        self.assertEqual(
+            benchmark.argv[benchmark.argv.index("--manifest") + 1],
+            "validation/diagnostics/manifest.json",
+        )
+        self.assertIn("--min-top1", benchmark.argv)
+        self.assertEqual(benchmark.argv[benchmark.argv.index("--min-top1") + 1], "0.75")
+        self.assertIn("--min-top2", benchmark.argv)
+        self.assertEqual(benchmark.argv[benchmark.argv.index("--min-top2") + 1], "0.90")
+        self.assertIn("--max-high-confidence-wrong", benchmark.argv)
+        self.assertEqual(
+            benchmark.argv[benchmark.argv.index("--max-high-confidence-wrong") + 1],
+            "0",
+        )
+
     def test_full_includes_live_tracks(self):
         a = self.args("full"); a.runs = 7
         plan = va.build_plan(a)

--- a/scripts/validate_all.py
+++ b/scripts/validate_all.py
@@ -56,8 +56,21 @@ def _py(args: argparse.Namespace, *extra: str) -> list[str]:
 def build_plan(args: argparse.Namespace) -> list[CommandSpec]:
     out = Path(args.out)
     operational_artifact_root = out / "operational" / "artifacts"
+    deterministic_benchmark_args = [
+        "scripts/diagnostic_benchmark.py",
+        "--manifest",
+        "validation/diagnostics/manifest.json",
+        "--min-top1",
+        "0.75",
+        "--min-top2",
+        "0.90",
+        "--max-high-confidence-wrong",
+        "0",
+        "--output",
+        str(out / "diagnostics/benchmark-summary.json"),
+    ]
     cmds: list[CommandSpec] = [
-        CommandSpec("deterministic benchmark", "diagnostics", _py(args, "scripts/diagnostic_benchmark.py", "--manifest", "validation/diagnostics/manifest.json", "--output", str(out / "diagnostics/benchmark-summary.json"))),
+        CommandSpec("deterministic benchmark", "diagnostics", _py(args, *deterministic_benchmark_args)),
         CommandSpec("docs contract", "docs", _py(args, "scripts/validate_docs_contracts.py")),
     ]
     nfts = ["--no-fail-thresholds"] if args.no_fail_thresholds else []


### PR DESCRIPTION
### Motivation
- Improve maintainability and reviewability of the validation surface by making the hierarchy and roles of validation artifacts/scripts explicit. 
- Make the deterministic benchmark threshold usage easier to audit by surfacing the same explicit CI thresholds in the `validate_all` orchestration plan. 
- Keep the change narrow: clarify docs and plan generation only, without changing benchmark semantics or validation tracks.

### Description
- Add a concise “Validation map” to `VALIDATION.md` that maps concrete files/scripts/workflows to their roles, CI status, and durable-artifact publication boundaries, and explicitly states trust boundaries and non-claims.  (file changed: `VALIDATION.md`)
- Update `scripts/validate_all.py` so the deterministic benchmark `CommandSpec` is built with explicit CI-matching threshold arguments: `--min-top1 0.75`, `--min-top2 0.90`, and `--max-high-confidence-wrong 0`, for reviewability only. (file changed: `scripts/validate_all.py`)
- Add a focused unit test to `scripts/tests/test_validate_all.py` that asserts the `ci` profile plan includes the deterministic benchmark command with `scripts/diagnostic_benchmark.py`, `--manifest validation/diagnostics/manifest.json`, and the explicit threshold arguments. (file changed: `scripts/tests/test_validate_all.py`)
- Files changed: `VALIDATION.md`, `scripts/validate_all.py`, `scripts/tests/test_validate_all.py`.

### Testing
- Ran `python3 -m unittest scripts.tests.test_validate_all` and the suite passed (11 tests, `OK`).
- Ran `python3 -m unittest scripts.tests.test_validate_docs_contracts` and `python3 scripts/validate_docs_contracts.py`, both succeeded (`OK` and "docs contracts validated successfully").
- Executed the deterministic benchmark with the explicit thresholds via `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0` and it completed successfully (reported `top1_accuracy=0.946`, `top2_recall=1.000`, `high_confidence_wrong_count=0`, `failed_case_count=0`).
- Ran repository checks: `cargo fmt --check` (passed), `cargo clippy --workspace --all-targets -- -D warnings` (passed), and `cargo test --workspace` (passed).

Confirmation: durable diagnostic scorecard publication remains manual/tag-only via `.github/workflows/validation-snapshot.yml`, and no generated validation artifacts (scorecards or runtime outputs) were added or committed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f90859cbb483308426c45afcb5f3c7)