### PR TITLE
Add structured evidence_quality coverage to analyzer output and extract thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,26 @@ tailtriage analyze tailtriage-run.json --format json
     "growth_per_sec_milli": 0
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 250,
+    "queue_event_count": 250,
+    "stage_event_count": 250,
+    "runtime_snapshot_count": 500,
+    "inflight_snapshot_count": 500,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "present",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": []
+  },
   "primary_suspect": {
     "kind": "application_queue_saturation",
     "score": 90,

--- a/demos/blocking_service/fixtures/after-analysis.json
+++ b/demos/blocking_service/fixtures/after-analysis.json
@@ -1,29 +1,51 @@
 {
   "request_count": 250,
-  "p50_latency_us": 47452,
-  "p95_latency_us": 73489,
-  "p99_latency_us": 75963,
-  "p95_queue_share_permille": 78,
+  "p50_latency_us": 54509,
+  "p95_latency_us": 87050,
+  "p99_latency_us": 91039,
+  "p95_queue_share_permille": 56,
   "p95_service_share_permille": 993,
   "inflight_trend": {
     "gauge": "blocking_service_inflight",
     "sample_count": 500,
-    "peak_count": 42,
-    "p95_count": 38,
+    "peak_count": 49,
+    "p95_count": 46,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2020
+    "growth_per_sec_milli": -2044
   },
   "warnings": [
     "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited."
   ],
+  "evidence_quality": {
+    "request_count": 250,
+    "queue_event_count": 250,
+    "stage_event_count": 250,
+    "runtime_snapshot_count": 200,
+    "inflight_snapshot_count": 500,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "partial",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "partial",
+    "limitations": [
+      "Runtime snapshots have missing queue-depth fields, limiting executor vs blocking differentiation."
+    ]
+  },
   "primary_suspect": {
     "kind": "downstream_stage_dominates",
     "score": 100,
     "confidence": "high",
     "evidence": [
-      "Stage 'spawn_blocking_path' has p95 latency 72080 us across 250 samples.",
-      "Stage 'spawn_blocking_path' cumulative latency is 11518403 us (971 permille of request latency).",
-      "Stage 'spawn_blocking_path' contributes 981 permille of tail request latency."
+      "Stage 'spawn_blocking_path' has p95 latency 85870 us across 250 samples.",
+      "Stage 'spawn_blocking_path' cumulative latency is 13010681 us (978 permille of request latency).",
+      "Stage 'spawn_blocking_path' contributes 986 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
@@ -37,7 +59,7 @@
       "score": 82,
       "confidence": "medium",
       "evidence": [
-        "Blocking queue depth p95 is 36, peak is 40, with 98/200 nonzero samples."
+        "Blocking queue depth p95 is 42, peak is 48, with 98/200 nonzero samples."
       ],
       "next_checks": [
         "Audit blocking sections and move avoidable synchronous work out of hot paths.",

--- a/demos/blocking_service/fixtures/before-analysis.json
+++ b/demos/blocking_service/fixtures/before-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 250,
-  "p50_latency_us": 1872360,
-  "p95_latency_us": 3548117,
-  "p99_latency_us": 3696181,
+  "p50_latency_us": 1868185,
+  "p95_latency_us": 3531495,
+  "p99_latency_us": 3680957,
   "p95_queue_share_permille": 6,
   "p95_service_share_permille": 999,
   "inflight_trend": {
@@ -10,13 +10,35 @@
     "sample_count": 500,
     "peak_count": 246,
     "p95_count": 234,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -263
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
   },
   "warnings": [
     "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited.",
     "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks."
   ],
+  "evidence_quality": {
+    "request_count": 250,
+    "queue_event_count": 250,
+    "stage_event_count": 250,
+    "runtime_snapshot_count": 200,
+    "inflight_snapshot_count": 500,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "partial",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "partial",
+    "limitations": [
+      "Runtime snapshots have missing queue-depth fields, limiting executor vs blocking differentiation."
+    ]
+  },
   "primary_suspect": {
     "kind": "blocking_pool_pressure",
     "score": 88,
@@ -35,8 +57,8 @@
       "score": 86,
       "confidence": "high",
       "evidence": [
-        "Stage 'spawn_blocking_path' has p95 latency 3546732 us across 250 samples.",
-        "Stage 'spawn_blocking_path' cumulative latency is 468587693 us (999 permille of request latency).",
+        "Stage 'spawn_blocking_path' has p95 latency 3530254 us across 250 samples.",
+        "Stage 'spawn_blocking_path' cumulative latency is 467061987 us (999 permille of request latency).",
         "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency.",
         "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
       ],

--- a/demos/blocking_service/fixtures/sample-analysis.json
+++ b/demos/blocking_service/fixtures/sample-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 250,
-  "p50_latency_us": 1872360,
-  "p95_latency_us": 3548117,
-  "p99_latency_us": 3696181,
+  "p50_latency_us": 1868185,
+  "p95_latency_us": 3531495,
+  "p99_latency_us": 3680957,
   "p95_queue_share_permille": 6,
   "p95_service_share_permille": 999,
   "inflight_trend": {
@@ -10,13 +10,35 @@
     "sample_count": 500,
     "peak_count": 246,
     "p95_count": 234,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -263
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
   },
   "warnings": [
     "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited.",
     "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks."
   ],
+  "evidence_quality": {
+    "request_count": 250,
+    "queue_event_count": 250,
+    "stage_event_count": 250,
+    "runtime_snapshot_count": 200,
+    "inflight_snapshot_count": 500,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "partial",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "partial",
+    "limitations": [
+      "Runtime snapshots have missing queue-depth fields, limiting executor vs blocking differentiation."
+    ]
+  },
   "primary_suspect": {
     "kind": "blocking_pool_pressure",
     "score": 88,
@@ -35,8 +57,8 @@
       "score": 86,
       "confidence": "high",
       "evidence": [
-        "Stage 'spawn_blocking_path' has p95 latency 3546732 us across 250 samples.",
-        "Stage 'spawn_blocking_path' cumulative latency is 468587693 us (999 permille of request latency).",
+        "Stage 'spawn_blocking_path' has p95 latency 3530254 us across 250 samples.",
+        "Stage 'spawn_blocking_path' cumulative latency is 467061987 us (999 permille of request latency).",
         "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency.",
         "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
       ],

--- a/demos/cold_start_burst_service/fixtures/after-analysis.json
+++ b/demos/cold_start_burst_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 8253,
-  "p95_latency_us": 9028,
-  "p99_latency_us": 12979,
+  "p50_latency_us": 8489,
+  "p95_latency_us": 8877,
+  "p99_latency_us": 9039,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 999,
   "inflight_trend": {
@@ -11,16 +11,38 @@
     "peak_count": 4,
     "p95_count": 3,
     "growth_delta": -1,
-    "growth_per_sec_milli": -971
+    "growth_per_sec_milli": -1064
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 220,
+    "queue_event_count": 220,
+    "stage_event_count": 220,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 440,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": [
+      "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+    ]
+  },
   "primary_suspect": {
     "kind": "downstream_stage_dominates",
     "score": 100,
     "confidence": "high",
     "evidence": [
-      "Stage 'cold_start_stage' has p95 latency 8986 us across 220 samples.",
-      "Stage 'cold_start_stage' cumulative latency is 1834129 us (993 permille of request latency).",
+      "Stage 'cold_start_stage' has p95 latency 8837 us across 220 samples.",
+      "Stage 'cold_start_stage' cumulative latency is 1823038 us (996 permille of request latency).",
       "Stage 'cold_start_stage' contributes 995 permille of tail request latency."
     ],
     "next_checks": [

--- a/demos/cold_start_burst_service/fixtures/before-analysis.json
+++ b/demos/cold_start_burst_service/fixtures/before-analysis.json
@@ -1,10 +1,10 @@
 {
   "request_count": 220,
-  "p50_latency_us": 995604,
-  "p95_latency_us": 1191696,
-  "p99_latency_us": 1207786,
+  "p50_latency_us": 993483,
+  "p95_latency_us": 1190031,
+  "p99_latency_us": 1206824,
   "p95_queue_share_permille": 993,
-  "p95_service_share_permille": 334,
+  "p95_service_share_permille": 336,
   "inflight_trend": {
     "gauge": "cold_start_burst_inflight",
     "sample_count": 440,
@@ -14,6 +14,28 @@
     "growth_per_sec_milli": 0
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 220,
+    "queue_event_count": 220,
+    "stage_event_count": 220,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 440,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": [
+      "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+    ]
+  },
   "primary_suspect": {
     "kind": "application_queue_saturation",
     "score": 95,
@@ -33,8 +55,8 @@
       "score": 32,
       "confidence": "low",
       "evidence": [
-        "Stage 'cold_start_stage' has p95 latency 63897 us across 220 samples.",
-        "Stage 'cold_start_stage' cumulative latency is 4885791 us (24 permille of request latency).",
+        "Stage 'cold_start_stage' has p95 latency 63617 us across 220 samples.",
+        "Stage 'cold_start_stage' cumulative latency is 4876046 us (24 permille of request latency).",
         "Stage 'cold_start_stage' contributes 6 permille of tail request latency."
       ],
       "next_checks": [

--- a/demos/db_pool_saturation_service/fixtures/after-analysis.json
+++ b/demos/db_pool_saturation_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 13425,
-  "p95_latency_us": 13964,
-  "p99_latency_us": 14227,
+  "p50_latency_us": 13254,
+  "p95_latency_us": 14196,
+  "p99_latency_us": 14321,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,17 +11,39 @@
     "peak_count": 10,
     "p95_count": 10,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2652
+    "growth_per_sec_milli": -2710
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 220,
+    "queue_event_count": 220,
+    "stage_event_count": 440,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 440,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": [
+      "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+    ]
+  },
   "primary_suspect": {
     "kind": "downstream_stage_dominates",
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'db_query' has p95 latency 11701 us across 220 samples.",
-      "Stage 'db_query' cumulative latency is 2450346 us (832 permille of request latency).",
-      "Stage 'db_query' contributes 829 permille of tail request latency."
+      "Stage 'db_query' has p95 latency 11927 us across 220 samples.",
+      "Stage 'db_query' cumulative latency is 2440495 us (833 permille of request latency).",
+      "Stage 'db_query' contributes 841 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'db_query'.",

--- a/demos/db_pool_saturation_service/fixtures/before-analysis.json
+++ b/demos/db_pool_saturation_service/fixtures/before-analysis.json
@@ -1,19 +1,41 @@
 {
   "request_count": 220,
-  "p50_latency_us": 495267,
-  "p95_latency_us": 928790,
-  "p99_latency_us": 963868,
+  "p50_latency_us": 498135,
+  "p95_latency_us": 927602,
+  "p99_latency_us": 961905,
   "p95_queue_share_permille": 976,
-  "p95_service_share_permille": 385,
+  "p95_service_share_permille": 368,
   "inflight_trend": {
     "gauge": "db_pool_saturation_inflight",
     "sample_count": 440,
     "peak_count": 200,
-    "p95_count": 190,
+    "p95_count": 193,
     "growth_delta": 2,
-    "growth_per_sec_milli": 1876
+    "growth_per_sec_milli": 1872
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 220,
+    "queue_event_count": 220,
+    "stage_event_count": 440,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 440,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": [
+      "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+    ]
+  },
   "primary_suspect": {
     "kind": "application_queue_saturation",
     "score": 95,
@@ -21,7 +43,7 @@
     "evidence": [
       "Queue wait at p95 consumes 97.6% of request time.",
       "Observed queue depth sample up to 196.",
-      "In-flight gauge 'db_pool_saturation_inflight' grew by 2 over the run window (p95=190, peak=200)."
+      "In-flight gauge 'db_pool_saturation_inflight' grew by 2 over the run window (p95=193, peak=200)."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -34,8 +56,8 @@
       "score": 34,
       "confidence": "low",
       "evidence": [
-        "Stage 'db_query' has p95 latency 19762 us across 220 samples.",
-        "Stage 'db_query' cumulative latency is 4240358 us (39 permille of request latency).",
+        "Stage 'db_query' has p95 latency 19752 us across 220 samples.",
+        "Stage 'db_query' cumulative latency is 4247545 us (38 permille of request latency).",
         "Stage 'db_query' contributes 20 permille of tail request latency."
       ],
       "next_checks": [

--- a/demos/downstream_service/fixtures/after-analysis.json
+++ b/demos/downstream_service/fixtures/after-analysis.json
@@ -1,27 +1,49 @@
 {
   "request_count": 80,
-  "p50_latency_us": 12476,
-  "p95_latency_us": 13110,
-  "p99_latency_us": 13158,
+  "p50_latency_us": 12294,
+  "p95_latency_us": 13240,
+  "p99_latency_us": 13272,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "downstream_service_inflight",
     "sample_count": 160,
-    "peak_count": 33,
+    "peak_count": 35,
     "p95_count": 32,
     "growth_delta": 5,
-    "growth_per_sec_milli": 111111
+    "growth_per_sec_milli": 108695
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 80,
+    "queue_event_count": 0,
+    "stage_event_count": 160,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 160,
+    "requests": "present",
+    "queues": "missing",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": [
+      "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+    ]
+  },
   "primary_suspect": {
     "kind": "downstream_stage_dominates",
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 10629 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 811602 us (817 permille of request latency).",
-      "Stage 'downstream_call' contributes 802 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 10846 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 809068 us (813 permille of request latency).",
+      "Stage 'downstream_call' contributes 804 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",

--- a/demos/downstream_service/fixtures/before-after-comparison.json
+++ b/demos/downstream_service/fixtures/before-after-comparison.json
@@ -2,19 +2,19 @@
   "before": {
     "primary_suspect_kind": "downstream_stage_dominates",
     "primary_suspect_score": 95,
-    "p95_latency_us": 24819,
+    "p95_latency_us": 24448,
     "p95_service_share_permille": 1000
   },
   "after": {
     "primary_suspect_kind": "downstream_stage_dominates",
     "primary_suspect_score": 95,
-    "p95_latency_us": 13110,
+    "p95_latency_us": 13240,
     "p95_service_share_permille": 1000
   },
   "delta": {
     "primary_suspect_kind": null,
     "primary_suspect_score": 0,
-    "p95_latency_us": -11709,
+    "p95_latency_us": -11208,
     "p95_service_share_permille": 0
   }
 }

--- a/demos/downstream_service/fixtures/before-analysis.json
+++ b/demos/downstream_service/fixtures/before-analysis.json
@@ -1,27 +1,49 @@
 {
   "request_count": 80,
-  "p50_latency_us": 23508,
-  "p95_latency_us": 24819,
-  "p99_latency_us": 24838,
+  "p50_latency_us": 23531,
+  "p95_latency_us": 24448,
+  "p99_latency_us": 24549,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "downstream_service_inflight",
     "sample_count": 160,
-    "peak_count": 56,
+    "peak_count": 57,
     "p95_count": 55,
     "growth_delta": 5,
-    "growth_per_sec_milli": 84745
+    "growth_per_sec_milli": 90909
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 80,
+    "queue_event_count": 0,
+    "stage_event_count": 160,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 160,
+    "requests": "present",
+    "queues": "missing",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": [
+      "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+    ]
+  },
   "primary_suspect": {
     "kind": "downstream_stage_dominates",
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 21980 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 1697504 us (897 permille of request latency).",
-      "Stage 'downstream_call' contributes 885 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 22135 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 1693727 us (903 permille of request latency).",
+      "Stage 'downstream_call' contributes 904 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",

--- a/demos/downstream_service/fixtures/sample-analysis.json
+++ b/demos/downstream_service/fixtures/sample-analysis.json
@@ -1,27 +1,49 @@
 {
   "request_count": 80,
-  "p50_latency_us": 23508,
-  "p95_latency_us": 24819,
-  "p99_latency_us": 24838,
+  "p50_latency_us": 23531,
+  "p95_latency_us": 24448,
+  "p99_latency_us": 24549,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "downstream_service_inflight",
     "sample_count": 160,
-    "peak_count": 56,
+    "peak_count": 57,
     "p95_count": 55,
     "growth_delta": 5,
-    "growth_per_sec_milli": 84745
+    "growth_per_sec_milli": 90909
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 80,
+    "queue_event_count": 0,
+    "stage_event_count": 160,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 160,
+    "requests": "present",
+    "queues": "missing",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": [
+      "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+    ]
+  },
   "primary_suspect": {
     "kind": "downstream_stage_dominates",
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 21980 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 1697504 us (897 permille of request latency).",
-      "Stage 'downstream_call' contributes 885 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 22135 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 1693727 us (903 permille of request latency).",
+      "Stage 'downstream_call' contributes 904 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",

--- a/demos/executor_pressure_service/fixtures/after-analysis.json
+++ b/demos/executor_pressure_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 240,
-  "p50_latency_us": 16236717,
-  "p95_latency_us": 16412208,
-  "p99_latency_us": 16423914,
+  "p50_latency_us": 7284295,
+  "p95_latency_us": 7413192,
+  "p99_latency_us": 7423728,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,17 +11,39 @@
     "peak_count": 240,
     "p95_count": 228,
     "growth_delta": -1,
-    "growth_per_sec_milli": -60
+    "growth_per_sec_milli": -134
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 240,
+    "queue_event_count": 0,
+    "stage_event_count": 0,
+    "runtime_snapshot_count": 7433,
+    "inflight_snapshot_count": 480,
+    "requests": "present",
+    "queues": "missing",
+    "stages": "missing",
+    "runtime_snapshots": "present",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "partial",
+    "limitations": [
+      "Queue and stage instrumentation are both unavailable, limiting application vs downstream interpretation."
+    ]
+  },
   "primary_suspect": {
     "kind": "executor_pressure_suspected",
     "score": 99,
     "confidence": "high",
     "evidence": [
-      "Runtime global queue depth p95 is 717, suggesting scheduler contention.",
-      "Runtime local queue depth p95 is 1674.",
-      "Runtime alive_tasks p95 is 717."
+      "Runtime global queue depth p95 is 720, suggesting scheduler contention.",
+      "Runtime local queue depth p95 is 4656.",
+      "Runtime alive_tasks p95 is 720."
     ],
     "next_checks": [
       "Check for long polls without yielding and uneven task fan-out.",

--- a/demos/executor_pressure_service/fixtures/before-analysis.json
+++ b/demos/executor_pressure_service/fixtures/before-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 240,
-  "p50_latency_us": 84085499,
-  "p95_latency_us": 84319683,
-  "p99_latency_us": 84346000,
+  "p50_latency_us": 34531979,
+  "p95_latency_us": 34596797,
+  "p99_latency_us": 34604649,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,17 +11,39 @@
     "peak_count": 240,
     "p95_count": 228,
     "growth_delta": -1,
-    "growth_per_sec_milli": -11
+    "growth_per_sec_milli": -28
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 240,
+    "queue_event_count": 0,
+    "stage_event_count": 0,
+    "runtime_snapshot_count": 6377,
+    "inflight_snapshot_count": 480,
+    "requests": "present",
+    "queues": "missing",
+    "stages": "missing",
+    "runtime_snapshots": "present",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "partial",
+    "limitations": [
+      "Queue and stage instrumentation are both unavailable, limiting application vs downstream interpretation."
+    ]
+  },
   "primary_suspect": {
     "kind": "executor_pressure_suspected",
     "score": 99,
     "confidence": "high",
     "evidence": [
-      "Runtime global queue depth p95 is 712, suggesting scheduler contention.",
-      "Runtime local queue depth p95 is 488.",
-      "Runtime alive_tasks p95 is 712."
+      "Runtime global queue depth p95 is 1920, suggesting scheduler contention.",
+      "Runtime local queue depth p95 is 42232.",
+      "Runtime alive_tasks p95 is 1920."
     ],
     "next_checks": [
       "Check for long polls without yielding and uneven task fan-out.",

--- a/demos/executor_pressure_service/fixtures/sample-analysis.json
+++ b/demos/executor_pressure_service/fixtures/sample-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 240,
-  "p50_latency_us": 84085499,
-  "p95_latency_us": 84319683,
-  "p99_latency_us": 84346000,
+  "p50_latency_us": 34531979,
+  "p95_latency_us": 34596797,
+  "p99_latency_us": 34604649,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,17 +11,39 @@
     "peak_count": 240,
     "p95_count": 228,
     "growth_delta": -1,
-    "growth_per_sec_milli": -11
+    "growth_per_sec_milli": -28
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 240,
+    "queue_event_count": 0,
+    "stage_event_count": 0,
+    "runtime_snapshot_count": 6377,
+    "inflight_snapshot_count": 480,
+    "requests": "present",
+    "queues": "missing",
+    "stages": "missing",
+    "runtime_snapshots": "present",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "partial",
+    "limitations": [
+      "Queue and stage instrumentation are both unavailable, limiting application vs downstream interpretation."
+    ]
+  },
   "primary_suspect": {
     "kind": "executor_pressure_suspected",
     "score": 99,
     "confidence": "high",
     "evidence": [
-      "Runtime global queue depth p95 is 712, suggesting scheduler contention.",
-      "Runtime local queue depth p95 is 488.",
-      "Runtime alive_tasks p95 is 712."
+      "Runtime global queue depth p95 is 1920, suggesting scheduler contention.",
+      "Runtime local queue depth p95 is 42232.",
+      "Runtime alive_tasks p95 is 1920."
     ],
     "next_checks": [
       "Check for long polls without yielding and uneven task fan-out.",

--- a/demos/mixed_contention_service/fixtures/baseline-analysis.json
+++ b/demos/mixed_contention_service/fixtures/baseline-analysis.json
@@ -1,26 +1,48 @@
 {
   "request_count": 220,
-  "p50_latency_us": 393714,
-  "p95_latency_us": 743315,
-  "p99_latency_us": 771767,
+  "p50_latency_us": 393750,
+  "p95_latency_us": 738845,
+  "p99_latency_us": 767621,
   "p95_queue_share_permille": 980,
-  "p95_service_share_permille": 392,
+  "p95_service_share_permille": 402,
   "inflight_trend": {
     "gauge": "mixed_contention_inflight",
     "sample_count": 440,
-    "peak_count": 201,
-    "p95_count": 191,
+    "peak_count": 200,
+    "p95_count": 190,
     "growth_delta": -1,
-    "growth_per_sec_milli": -1156
+    "growth_per_sec_milli": -1160
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 220,
+    "queue_event_count": 220,
+    "stage_event_count": 440,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 440,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": [
+      "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+    ]
+  },
   "primary_suspect": {
     "kind": "application_queue_saturation",
     "score": 95,
     "confidence": "high",
     "evidence": [
       "Queue wait at p95 consumes 98.0% of request time.",
-      "Observed queue depth sample up to 196."
+      "Observed queue depth sample up to 195."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -33,9 +55,9 @@
       "score": 35,
       "confidence": "low",
       "evidence": [
-        "Stage 'downstream_call' has p95 latency 32407 us across 220 samples.",
-        "Stage 'downstream_call' cumulative latency is 3782929 us (43 permille of request latency).",
-        "Stage 'downstream_call' contributes 25 permille of tail request latency."
+        "Stage 'downstream_call' has p95 latency 32531 us across 220 samples.",
+        "Stage 'downstream_call' cumulative latency is 3775687 us (43 permille of request latency).",
+        "Stage 'downstream_call' contributes 23 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'downstream_call'.",

--- a/demos/mixed_contention_service/fixtures/mitigated-analysis.json
+++ b/demos/mixed_contention_service/fixtures/mitigated-analysis.json
@@ -1,27 +1,49 @@
 {
   "request_count": 220,
-  "p50_latency_us": 14492,
-  "p95_latency_us": 34767,
-  "p99_latency_us": 35164,
+  "p50_latency_us": 14399,
+  "p95_latency_us": 34450,
+  "p99_latency_us": 35029,
   "p95_queue_share_permille": 0,
-  "p95_service_share_permille": 999,
+  "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "mixed_contention_inflight",
     "sample_count": 440,
-    "peak_count": 13,
+    "peak_count": 14,
     "p95_count": 13,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2380
+    "growth_per_sec_milli": -2631
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 220,
+    "queue_event_count": 220,
+    "stage_event_count": 440,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 440,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": [
+      "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+    ]
+  },
   "primary_suspect": {
     "kind": "downstream_stage_dominates",
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 32473 us across 220 samples.",
-      "Stage 'downstream_call' cumulative latency is 3739540 us (876 permille of request latency).",
-      "Stage 'downstream_call' contributes 932 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 32570 us across 220 samples.",
+      "Stage 'downstream_call' cumulative latency is 3763084 us (889 permille of request latency).",
+      "Stage 'downstream_call' contributes 933 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",

--- a/demos/queue_service/fixtures/after-analysis.json
+++ b/demos/queue_service/fixtures/after-analysis.json
@@ -1,27 +1,49 @@
 {
   "request_count": 250,
-  "p50_latency_us": 16153,
-  "p95_latency_us": 17033,
-  "p99_latency_us": 18572,
+  "p50_latency_us": 16086,
+  "p95_latency_us": 17037,
+  "p99_latency_us": 19055,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
-    "peak_count": 12,
-    "p95_count": 11,
+    "peak_count": 16,
+    "p95_count": 12,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2283
+    "growth_per_sec_milli": -2386
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 250,
+    "queue_event_count": 250,
+    "stage_event_count": 250,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 500,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": [
+      "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+    ]
+  },
   "primary_suspect": {
     "kind": "downstream_stage_dominates",
-    "score": 100,
+    "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'simulated_work' has p95 latency 16978 us across 250 samples.",
-      "Stage 'simulated_work' cumulative latency is 4051036 us (996 permille of request latency).",
-      "Stage 'simulated_work' contributes 975 permille of tail request latency."
+      "Stage 'simulated_work' has p95 latency 16919 us across 250 samples.",
+      "Stage 'simulated_work' cumulative latency is 4031794 us (995 permille of request latency).",
+      "Stage 'simulated_work' contributes 955 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'simulated_work'.",

--- a/demos/queue_service/fixtures/before-analysis.json
+++ b/demos/queue_service/fixtures/before-analysis.json
@@ -1,25 +1,47 @@
 {
   "request_count": 250,
-  "p50_latency_us": 787254,
-  "p95_latency_us": 1472731,
-  "p99_latency_us": 1524462,
-  "p95_queue_share_permille": 981,
-  "p95_service_share_permille": 271,
+  "p50_latency_us": 783889,
+  "p95_latency_us": 1463903,
+  "p99_latency_us": 1514094,
+  "p95_queue_share_permille": 982,
+  "p95_service_share_permille": 269,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
     "peak_count": 234,
     "p95_count": 222,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -598
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 250,
+    "queue_event_count": 250,
+    "stage_event_count": 250,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 500,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": [
+      "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+    ]
+  },
   "primary_suspect": {
     "kind": "application_queue_saturation",
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Queue wait at p95 consumes 98.1% of request time.",
+      "Queue wait at p95 consumes 98.2% of request time.",
       "Observed queue depth sample up to 230."
     ],
     "next_checks": [
@@ -33,8 +55,8 @@
       "score": 33,
       "confidence": "low",
       "evidence": [
-        "Stage 'simulated_work' has p95 latency 27170 us across 250 samples.",
-        "Stage 'simulated_work' cumulative latency is 6609298 us (33 permille of request latency).",
+        "Stage 'simulated_work' has p95 latency 26681 us across 250 samples.",
+        "Stage 'simulated_work' cumulative latency is 6548608 us (33 permille of request latency).",
         "Stage 'simulated_work' contributes 17 permille of tail request latency."
       ],
       "next_checks": [

--- a/demos/queue_service/fixtures/sample-analysis.json
+++ b/demos/queue_service/fixtures/sample-analysis.json
@@ -1,25 +1,47 @@
 {
   "request_count": 250,
-  "p50_latency_us": 787254,
-  "p95_latency_us": 1472731,
-  "p99_latency_us": 1524462,
-  "p95_queue_share_permille": 981,
-  "p95_service_share_permille": 271,
+  "p50_latency_us": 783889,
+  "p95_latency_us": 1463903,
+  "p99_latency_us": 1514094,
+  "p95_queue_share_permille": 982,
+  "p95_service_share_permille": 269,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
     "peak_count": 234,
     "p95_count": 222,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -598
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 250,
+    "queue_event_count": 250,
+    "stage_event_count": 250,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 500,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": [
+      "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+    ]
+  },
   "primary_suspect": {
     "kind": "application_queue_saturation",
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Queue wait at p95 consumes 98.1% of request time.",
+      "Queue wait at p95 consumes 98.2% of request time.",
       "Observed queue depth sample up to 230."
     ],
     "next_checks": [
@@ -33,8 +55,8 @@
       "score": 33,
       "confidence": "low",
       "evidence": [
-        "Stage 'simulated_work' has p95 latency 27170 us across 250 samples.",
-        "Stage 'simulated_work' cumulative latency is 6609298 us (33 permille of request latency).",
+        "Stage 'simulated_work' has p95 latency 26681 us across 250 samples.",
+        "Stage 'simulated_work' cumulative latency is 6548608 us (33 permille of request latency).",
         "Stage 'simulated_work' contributes 17 permille of tail request latency."
       ],
       "next_checks": [

--- a/demos/retry_storm_service/fixtures/after-analysis.json
+++ b/demos/retry_storm_service/fixtures/after-analysis.json
@@ -1,27 +1,49 @@
 {
   "request_count": 180,
-  "p50_latency_us": 9867,
-  "p95_latency_us": 29695,
-  "p99_latency_us": 30241,
+  "p50_latency_us": 9513,
+  "p95_latency_us": 29401,
+  "p99_latency_us": 29784,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "retry_storm_inflight",
     "sample_count": 360,
-    "peak_count": 16,
-    "p95_count": 14,
+    "peak_count": 17,
+    "p95_count": 15,
     "growth_delta": -1,
-    "growth_per_sec_milli": -4098
+    "growth_per_sec_milli": -4716
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 180,
+    "queue_event_count": 0,
+    "stage_event_count": 587,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 360,
+    "requests": "present",
+    "queues": "missing",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": [
+      "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+    ]
+  },
   "primary_suspect": {
     "kind": "downstream_stage_dominates",
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_total' has p95 latency 27307 us across 180 samples.",
-      "Stage 'downstream_total' cumulative latency is 2161657 us (829 permille of request latency).",
-      "Stage 'downstream_total' contributes 914 permille of tail request latency."
+      "Stage 'downstream_total' has p95 latency 27186 us across 180 samples.",
+      "Stage 'downstream_total' cumulative latency is 2154453 us (842 permille of request latency).",
+      "Stage 'downstream_total' contributes 922 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_total'.",

--- a/demos/retry_storm_service/fixtures/before-analysis.json
+++ b/demos/retry_storm_service/fixtures/before-analysis.json
@@ -1,27 +1,49 @@
 {
   "request_count": 180,
-  "p50_latency_us": 10540,
-  "p95_latency_us": 42303,
-  "p99_latency_us": 44006,
+  "p50_latency_us": 9863,
+  "p95_latency_us": 41148,
+  "p99_latency_us": 42215,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "retry_storm_inflight",
     "sample_count": 360,
-    "peak_count": 49,
-    "p95_count": 47,
+    "peak_count": 57,
+    "p95_count": 54,
     "growth_delta": -1,
-    "growth_per_sec_milli": -8264
+    "growth_per_sec_milli": -9345
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 180,
+    "queue_event_count": 0,
+    "stage_event_count": 706,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 360,
+    "requests": "present",
+    "queues": "missing",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": [
+      "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+    ]
+  },
   "primary_suspect": {
     "kind": "downstream_stage_dominates",
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_total' has p95 latency 39555 us across 180 samples.",
-      "Stage 'downstream_total' cumulative latency is 3061237 us (869 permille of request latency).",
-      "Stage 'downstream_total' contributes 933 permille of tail request latency."
+      "Stage 'downstream_total' has p95 latency 38902 us across 180 samples.",
+      "Stage 'downstream_total' cumulative latency is 3025771 us (883 permille of request latency).",
+      "Stage 'downstream_total' contributes 945 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_total'.",

--- a/demos/shared_state_lock_service/fixtures/after-analysis.json
+++ b/demos/shared_state_lock_service/fixtures/after-analysis.json
@@ -1,26 +1,48 @@
 {
   "request_count": 220,
-  "p50_latency_us": 839822,
-  "p95_latency_us": 1592823,
-  "p99_latency_us": 1652940,
+  "p50_latency_us": 828874,
+  "p95_latency_us": 1564712,
+  "p99_latency_us": 1623531,
   "p95_queue_share_permille": 993,
-  "p95_service_share_permille": 111,
+  "p95_service_share_permille": 127,
   "inflight_trend": {
     "gauge": "shared_state_lock_inflight",
     "sample_count": 440,
-    "peak_count": 200,
+    "peak_count": 201,
     "p95_count": 190,
     "growth_delta": -1,
-    "growth_per_sec_milli": -541
+    "growth_per_sec_milli": -555
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 220,
+    "queue_event_count": 220,
+    "stage_event_count": 440,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 440,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": [
+      "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+    ]
+  },
   "primary_suspect": {
     "kind": "application_queue_saturation",
     "score": 95,
     "confidence": "high",
     "evidence": [
       "Queue wait at p95 consumes 99.3% of request time.",
-      "Observed queue depth sample up to 198."
+      "Observed queue depth sample up to 199."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -33,8 +55,8 @@
       "score": 32,
       "confidence": "low",
       "evidence": [
-        "Stage 'shared_state_critical_section' has p95 latency 8601 us across 220 samples.",
-        "Stage 'shared_state_critical_section' cumulative latency is 1822487 us (9 permille of request latency).",
+        "Stage 'shared_state_critical_section' has p95 latency 8269 us across 220 samples.",
+        "Stage 'shared_state_critical_section' cumulative latency is 1787919 us (9 permille of request latency).",
         "Stage 'shared_state_critical_section' contributes 5 permille of tail request latency."
       ],
       "next_checks": [

--- a/demos/shared_state_lock_service/fixtures/before-analysis.json
+++ b/demos/shared_state_lock_service/fixtures/before-analysis.json
@@ -1,26 +1,48 @@
 {
   "request_count": 220,
-  "p50_latency_us": 2569298,
-  "p95_latency_us": 4858829,
-  "p99_latency_us": 5042007,
+  "p50_latency_us": 2546348,
+  "p95_latency_us": 4817353,
+  "p99_latency_us": 4999343,
   "p95_queue_share_permille": 994,
-  "p95_service_share_permille": 101,
+  "p95_service_share_permille": 98,
   "inflight_trend": {
     "gauge": "shared_state_lock_inflight",
     "sample_count": 440,
     "peak_count": 217,
     "p95_count": 206,
     "growth_delta": -1,
-    "growth_per_sec_milli": -193
+    "growth_per_sec_milli": -194
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 220,
+    "queue_event_count": 220,
+    "stage_event_count": 440,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 440,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": [
+      "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+    ]
+  },
   "primary_suspect": {
     "kind": "application_queue_saturation",
     "score": 95,
     "confidence": "high",
     "evidence": [
       "Queue wait at p95 consumes 99.4% of request time.",
-      "Observed queue depth sample up to 215."
+      "Observed queue depth sample up to 216."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -33,8 +55,8 @@
       "score": 32,
       "confidence": "low",
       "evidence": [
-        "Stage 'shared_state_critical_section' has p95 latency 23767 us across 220 samples.",
-        "Stage 'shared_state_critical_section' cumulative latency is 5148216 us (9 permille of request latency).",
+        "Stage 'shared_state_critical_section' has p95 latency 23447 us across 220 samples.",
+        "Stage 'shared_state_critical_section' cumulative latency is 5109039 us (9 permille of request latency).",
         "Stage 'shared_state_critical_section' contributes 4 permille of tail request latency."
       ],
       "next_checks": [

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -31,6 +31,7 @@ Current supported schema version: `1`.
 - p95 queue/service share summaries
 - optional in-flight trend summary
 - warnings (analyzer/report warnings, especially truncation-related)
+- evidence_quality (structured coverage/completeness/interpretability summary)
 - ranked suspects (primary + secondary)
 
 Each suspect includes:
@@ -50,6 +51,7 @@ Each suspect includes:
 - `p95_queue_share_permille`: p95 queue-time share per request (0..1000 scale).
 - `p95_service_share_permille`: p95 service-time share per request (0..1000 scale).
 - `warnings[]`: analyzer/report warnings, especially truncation-related warnings from captured-data limits. Loader/lifecycle warnings (including unfinished-request warnings) are emitted separately by the CLI loader to stderr before the report output.
+- `evidence_quality`: structured signal coverage status, truncation counters, and overall evidence quality (`strong`/`partial`/`weak`).
 - `primary_suspect`: highest-ranked suspect with evidence and next checks.
 - `secondary_suspects[]`: additional ranked suspects.
 - `inflight_trend` (optional): dominant in-flight gauge trend summary when snapshots exist.
@@ -105,6 +107,19 @@ As always: suspects are leads for next checks, not proof.
 - truncation warnings when capture limits dropped events
 
 Warnings lower interpretation confidence; they do not automatically invalidate suspect ranking.
+
+## Evidence quality semantics
+
+`evidence_quality` describes capture completeness and interpretation limits. It does **not** claim causal certainty, and suspects remain evidence-ranked leads, not proof.
+
+- `requests`: `missing`, `partial`, `truncated`, or `present` based on completed-request count and request drops.
+- `queues`, `stages`, `runtime_snapshots`, `inflight_snapshots`: per-family coverage status.
+- `quality`:
+  - `weak`: sparse/missing request evidence, request truncation, or no explanatory evidence families.
+  - `partial`: non-request truncation or major evidence-family limitations.
+  - `strong`: enough request evidence, queue or stage evidence present, no truncation limits active.
+
+Runtime snapshots are optional input. Missing runtime snapshots add a limitation for executor/blocking interpretation, but they do not by themselves force `quality` to `partial` when queue/stage evidence is otherwise strong.
 
 ## Runtime-pressure caveat
 

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -66,6 +66,26 @@ Then run one targeted check, change one thing, and re-run under comparable load.
   "p95_service_share_permille": 267,
   "inflight_trend": null,
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 250,
+    "queue_event_count": 250,
+    "stage_event_count": 250,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 0,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "missing",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": ["Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."]
+  },
   "primary_suspect": {
     "kind": "application_queue_saturation",
     "score": 90,
@@ -88,6 +108,7 @@ A report can include:
 - p95 queue/service share summaries
 - optional in-flight trend summary
 - report warnings from analysis/report generation (for example truncation-related)
+- structured evidence quality coverage/status summary
 - primary and secondary suspects
 
 `tailtriage analyze` also prints loader/lifecycle warnings to stderr before the report. Those warnings are surfaced separately; they are not merged into the report `warnings` field.

--- a/tailtriage-cli/src/analyze.rs
+++ b/tailtriage-cli/src/analyze.rs
@@ -1854,4 +1854,55 @@ mod tests {
             EvidenceQualityLevel::Strong
         );
     }
+
+    #[test]
+    fn evidence_quality_marks_queue_signal_truncated_and_not_strong() {
+        let mut run = test_run();
+        run.requests = (0..30)
+            .map(|i| RequestEvent {
+                request_id: format!("req-{i}"),
+                route: "/t".into(),
+                kind: None,
+                started_at_unix_ms: i,
+                finished_at_unix_ms: i + 1,
+                latency_us: 1_000,
+                outcome: "ok".into(),
+            })
+            .collect();
+        run.queues = run
+            .requests
+            .iter()
+            .map(|r| QueueEvent {
+                request_id: r.request_id.clone(),
+                queue: "q".into(),
+                wait_us: 500,
+                waited_from_unix_ms: 1,
+                waited_until_unix_ms: 2,
+                depth_at_start: Some(2),
+            })
+            .collect();
+        run.stages = run
+            .requests
+            .iter()
+            .map(|r| StageEvent {
+                request_id: r.request_id.clone(),
+                stage: "db".into(),
+                started_at_unix_ms: 1,
+                finished_at_unix_ms: 2,
+                latency_us: 400,
+                success: true,
+            })
+            .collect();
+        run.truncation.dropped_queues = 2;
+
+        let report = analyze_run(&run);
+        assert_eq!(
+            report.evidence_quality.queues,
+            SignalCoverageStatus::Truncated
+        );
+        assert_ne!(
+            report.evidence_quality.quality,
+            EvidenceQualityLevel::Strong
+        );
+    }
 }

--- a/tailtriage-cli/src/analyze.rs
+++ b/tailtriage-cli/src/analyze.rs
@@ -3,6 +3,18 @@ use std::collections::{BTreeMap, HashMap};
 use serde::{Serialize, Serializer};
 use tailtriage_core::{InFlightSnapshot, Run, RuntimeSnapshot};
 
+const LOW_COMPLETED_REQUEST_THRESHOLD: usize = 20;
+const QUEUE_SHARE_TRIGGER_PERMILLE: u64 = 300;
+const MEDIUM_CONFIDENCE_SCORE_THRESHOLD: u8 = 65;
+const HIGH_CONFIDENCE_SCORE_THRESHOLD: u8 = 85;
+const DOWNSTREAM_MIN_STAGE_SAMPLES: usize = 3;
+const AMBIGUITY_MIN_SCORE_THRESHOLD: u8 = 60;
+const AMBIGUITY_SCORE_GAP_THRESHOLD: u8 = 4;
+const SAMPLE_QUALITY_HIGH_SAMPLE_COUNT: usize = 100;
+const SAMPLE_QUALITY_MEDIUM_SAMPLE_COUNT: usize = 40;
+const SAMPLE_QUALITY_LOW_SAMPLE_COUNT: usize = 20;
+const SAMPLE_QUALITY_MIN_NONZERO_SAMPLE_COUNT: usize = 8;
+
 /// Evidence-ranked diagnosis categories produced by heuristic triage.
 ///
 /// These categories are leads for investigation and are not proof of root cause.
@@ -59,14 +71,81 @@ pub enum Confidence {
 
 impl Confidence {
     fn from_score(score: u8) -> Self {
-        if score >= 85 {
+        if score >= HIGH_CONFIDENCE_SCORE_THRESHOLD {
             Self::High
-        } else if score >= 65 {
+        } else if score >= MEDIUM_CONFIDENCE_SCORE_THRESHOLD {
             Self::Medium
         } else {
             Self::Low
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+/// Overall evidence-quality level for this capture.
+pub enum EvidenceQualityLevel {
+    /// Evidence coverage is sufficient for a strong triage interpretation.
+    Strong,
+    /// Evidence coverage has important limitations.
+    Partial,
+    /// Evidence coverage is too sparse/truncated for stable interpretation.
+    Weak,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+/// Coverage status for one signal family.
+pub enum SignalCoverageStatus {
+    /// Signal family has usable data.
+    Present,
+    /// Signal family is absent.
+    Missing,
+    /// Signal family exists but has limited interpretability.
+    Partial,
+    /// Signal family had capture drops due to truncation.
+    Truncated,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+/// Structured capture-coverage and interpretation-quality summary.
+pub struct EvidenceQuality {
+    /// Number of completed request events captured.
+    pub request_count: usize,
+    /// Number of queue events captured.
+    pub queue_event_count: usize,
+    /// Number of stage events captured.
+    pub stage_event_count: usize,
+    /// Number of runtime snapshots captured.
+    pub runtime_snapshot_count: usize,
+    /// Number of in-flight snapshots captured.
+    pub inflight_snapshot_count: usize,
+    /// Coverage status for request events.
+    pub requests: SignalCoverageStatus,
+    /// Coverage status for queue events.
+    pub queues: SignalCoverageStatus,
+    /// Coverage status for stage events.
+    pub stages: SignalCoverageStatus,
+    /// Coverage status for runtime snapshots.
+    pub runtime_snapshots: SignalCoverageStatus,
+    /// Coverage status for in-flight snapshots.
+    pub inflight_snapshots: SignalCoverageStatus,
+    /// Whether any capture truncation limit was hit.
+    pub truncated: bool,
+    /// Number of dropped request events.
+    pub dropped_requests: u64,
+    /// Number of dropped stage events.
+    pub dropped_stages: u64,
+    /// Number of dropped queue events.
+    pub dropped_queues: u64,
+    /// Number of dropped in-flight snapshots.
+    pub dropped_inflight_snapshots: u64,
+    /// Number of dropped runtime snapshots.
+    pub dropped_runtime_snapshots: u64,
+    /// Overall quality level for this report's evidence coverage.
+    pub quality: EvidenceQualityLevel,
+    /// Interpretation limitations inferred from coverage/truncation.
+    pub limitations: Vec<String>,
 }
 
 /// Evidence-ranked suspect produced by heuristic analysis.
@@ -142,6 +221,8 @@ pub struct Report {
     pub inflight_trend: Option<InflightTrend>,
     /// Non-fatal analysis warnings (for example, capture truncation notices).
     pub warnings: Vec<String>,
+    /// Structured evidence coverage and interpretation quality summary.
+    pub evidence_quality: EvidenceQuality,
     /// Highest-ranked suspect from this run.
     pub primary_suspect: Suspect,
     /// Lower-ranked suspects retained for follow-up triage.
@@ -250,6 +331,7 @@ pub fn analyze_run(run: &Run) -> Report {
     suspects.sort_by_key(|suspect| std::cmp::Reverse(suspect.score));
 
     let warnings = analysis_warnings(run, &suspects);
+    let evidence_quality = evidence_quality(run, &suspects);
 
     let mut ranked = suspects.into_iter();
     let primary_suspect = ranked.next().unwrap_or_else(|| {
@@ -270,9 +352,147 @@ pub fn analyze_run(run: &Run) -> Report {
         p95_service_share_permille,
         inflight_trend,
         warnings,
+        evidence_quality,
         primary_suspect,
         secondary_suspects: ranked.collect(),
     }
+}
+
+fn evidence_quality(run: &Run, suspects: &[Suspect]) -> EvidenceQuality {
+    let requests = request_status(run);
+    let queues = family_status(run.queues.is_empty(), run.truncation.dropped_queues);
+    let stages = family_status(run.stages.is_empty(), run.truncation.dropped_stages);
+    let runtime_snapshots = runtime_status(run);
+    let inflight_snapshots = family_status(
+        run.inflight.is_empty(),
+        run.truncation.dropped_inflight_snapshots,
+    );
+    let limitations = evidence_limitations(run, queues, stages, runtime_snapshots);
+    let non_request_truncated = matches!(queues, SignalCoverageStatus::Truncated)
+        || matches!(stages, SignalCoverageStatus::Truncated)
+        || matches!(runtime_snapshots, SignalCoverageStatus::Truncated)
+        || matches!(inflight_snapshots, SignalCoverageStatus::Truncated);
+    let explanatory_present =
+        !run.queues.is_empty() || !run.stages.is_empty() || !run.runtime_snapshots.is_empty();
+    let quality = if run.requests.is_empty()
+        || run.requests.len() < LOW_COMPLETED_REQUEST_THRESHOLD
+        || run.truncation.dropped_requests > 0
+        || !explanatory_present
+    {
+        EvidenceQualityLevel::Weak
+    } else if non_request_truncated
+        || (run.queues.is_empty() && run.stages.is_empty())
+        || runtime_snapshots == SignalCoverageStatus::Partial
+    {
+        EvidenceQualityLevel::Partial
+    } else {
+        let _primary_runtime_dependent = suspects.first().is_some_and(|s| {
+            s.kind == DiagnosisKind::BlockingPoolPressure
+                || s.kind == DiagnosisKind::ExecutorPressureSuspected
+        });
+        EvidenceQualityLevel::Strong
+    };
+
+    EvidenceQuality {
+        request_count: run.requests.len(),
+        queue_event_count: run.queues.len(),
+        stage_event_count: run.stages.len(),
+        runtime_snapshot_count: run.runtime_snapshots.len(),
+        inflight_snapshot_count: run.inflight.len(),
+        requests,
+        queues,
+        stages,
+        runtime_snapshots,
+        inflight_snapshots,
+        truncated: run.truncation.is_truncated() || run.truncation.limits_hit,
+        dropped_requests: run.truncation.dropped_requests,
+        dropped_stages: run.truncation.dropped_stages,
+        dropped_queues: run.truncation.dropped_queues,
+        dropped_inflight_snapshots: run.truncation.dropped_inflight_snapshots,
+        dropped_runtime_snapshots: run.truncation.dropped_runtime_snapshots,
+        quality,
+        limitations,
+    }
+}
+
+fn request_status(run: &Run) -> SignalCoverageStatus {
+    if run.truncation.dropped_requests > 0 {
+        SignalCoverageStatus::Truncated
+    } else if run.requests.is_empty() {
+        SignalCoverageStatus::Missing
+    } else if run.requests.len() < LOW_COMPLETED_REQUEST_THRESHOLD {
+        SignalCoverageStatus::Partial
+    } else {
+        SignalCoverageStatus::Present
+    }
+}
+
+fn family_status(is_empty: bool, dropped: u64) -> SignalCoverageStatus {
+    if dropped > 0 {
+        SignalCoverageStatus::Truncated
+    } else if is_empty {
+        SignalCoverageStatus::Missing
+    } else {
+        SignalCoverageStatus::Present
+    }
+}
+
+fn runtime_status(run: &Run) -> SignalCoverageStatus {
+    if run.truncation.dropped_runtime_snapshots > 0 {
+        SignalCoverageStatus::Truncated
+    } else if run.runtime_snapshots.is_empty() {
+        SignalCoverageStatus::Missing
+    } else if run
+        .runtime_snapshots
+        .iter()
+        .all(|snapshot| snapshot.blocking_queue_depth.is_none())
+        || run
+            .runtime_snapshots
+            .iter()
+            .all(|snapshot| snapshot.local_queue_depth.is_none())
+        || run
+            .runtime_snapshots
+            .iter()
+            .all(|snapshot| snapshot.global_queue_depth.is_none())
+    {
+        SignalCoverageStatus::Partial
+    } else {
+        SignalCoverageStatus::Present
+    }
+}
+
+fn evidence_limitations(
+    run: &Run,
+    queues: SignalCoverageStatus,
+    stages: SignalCoverageStatus,
+    runtime_snapshots: SignalCoverageStatus,
+) -> Vec<String> {
+    let mut limitations = Vec::new();
+    if run.requests.len() < LOW_COMPLETED_REQUEST_THRESHOLD {
+        limitations
+            .push("Low completed-request count can make suspect ranking unstable.".to_string());
+    }
+    if matches!(
+        queues,
+        SignalCoverageStatus::Missing | SignalCoverageStatus::Truncated
+    ) && matches!(
+        stages,
+        SignalCoverageStatus::Missing | SignalCoverageStatus::Truncated
+    ) {
+        limitations.push("Queue and stage instrumentation are both unavailable, limiting application vs downstream interpretation.".to_string());
+    }
+    if run.runtime_snapshots.is_empty() {
+        limitations.push("Runtime snapshots are missing, limiting executor and blocking-pressure interpretation.".to_string());
+    } else if runtime_snapshots == SignalCoverageStatus::Partial {
+        limitations.push("Runtime snapshots have missing queue-depth fields, limiting executor vs blocking differentiation.".to_string());
+    }
+    if run.truncation.is_truncated() || run.truncation.limits_hit {
+        limitations.push(
+            "Capture truncation dropped evidence and can reduce diagnosis completeness."
+                .to_string(),
+        );
+    }
+    limitations
 }
 
 fn truncation_warnings(run: &Run) -> Vec<String> {
@@ -329,14 +549,14 @@ fn max_or_zero(values: &[u64]) -> u64 {
 }
 
 fn score_sample_quality(sample_count: usize) -> u8 {
-    if sample_count >= 100 {
+    if sample_count >= SAMPLE_QUALITY_HIGH_SAMPLE_COUNT {
         8
-    } else if sample_count >= 40 {
+    } else if sample_count >= SAMPLE_QUALITY_MEDIUM_SAMPLE_COUNT {
         5
-    } else if sample_count >= 20 {
+    } else if sample_count >= SAMPLE_QUALITY_LOW_SAMPLE_COUNT {
         3
     } else {
-        u8::from(sample_count >= 8)
+        u8::from(sample_count >= SAMPLE_QUALITY_MIN_NONZERO_SAMPLE_COUNT)
     }
 }
 
@@ -355,7 +575,7 @@ fn cap_unless_clean_evidence(score: u64, clean: bool, soft_cap: u8) -> u8 {
 fn queue_saturation_suspect(run: &Run, inflight_trend: Option<&InflightTrend>) -> Option<Suspect> {
     let (queue_shares, _) = request_time_shares(run);
     let p95_queue_share_permille = percentile(&queue_shares, 95, 100)?;
-    if p95_queue_share_permille < 300 {
+    if p95_queue_share_permille < QUEUE_SHARE_TRIGGER_PERMILLE {
         return None;
     }
     let queue_depths = run
@@ -538,7 +758,7 @@ fn downstream_stage_candidates(run: &Run, p95_req: u64, total_req: u64) -> Vec<S
     }
     let mut cands = Vec::new();
     for (name, ss) in by {
-        if ss.len() < 3 {
+        if ss.len() < DOWNSTREAM_MIN_STAGE_SAMPLES {
             continue;
         }
         let lats = ss.iter().map(|s| s.latency_us).collect::<Vec<_>>();
@@ -668,9 +888,9 @@ fn ambiguity_warning(suspects: &[Suspect]) -> Option<String> {
         .collect::<Vec<_>>();
     ranked.sort_by_key(|s| std::cmp::Reverse(s.score));
     if ranked.len() >= 2
-        && ranked[0].score >= 60
-        && ranked[1].score >= 60
-        && ranked[0].score.abs_diff(ranked[1].score) <= 4
+        && ranked[0].score >= AMBIGUITY_MIN_SCORE_THRESHOLD
+        && ranked[1].score >= AMBIGUITY_MIN_SCORE_THRESHOLD
+        && ranked[0].score.abs_diff(ranked[1].score) <= AMBIGUITY_SCORE_GAP_THRESHOLD
     {
         Some("Top suspects are close in score; treat ranking as ambiguous and validate both with next checks.".to_string())
     } else {
@@ -680,7 +900,7 @@ fn ambiguity_warning(suspects: &[Suspect]) -> Option<String> {
 
 fn analysis_warnings(run: &Run, suspects: &[Suspect]) -> Vec<String> {
     let mut warnings = truncation_warnings(run);
-    if run.requests.len() < 20 {
+    if run.requests.len() < LOW_COMPLETED_REQUEST_THRESHOLD {
         warnings.push(
             "Low completed-request count; diagnosis ranking may be unstable for this run window."
                 .to_string(),
@@ -934,6 +1154,19 @@ pub fn render_text(report: &Report) -> String {
         fmt_confidence(report.primary_suspect.confidence),
         report.primary_suspect.score,
     ));
+    lines.push(format!(
+        "Evidence quality: {}{}",
+        match report.evidence_quality.quality {
+            EvidenceQualityLevel::Strong => "strong",
+            EvidenceQualityLevel::Partial => "partial",
+            EvidenceQualityLevel::Weak => "weak",
+        },
+        report
+            .evidence_quality
+            .limitations
+            .first()
+            .map_or_else(String::new, |l| format!(" ({l})"))
+    ));
 
     if !report.warnings.is_empty() {
         lines.push("Warnings:".to_string());
@@ -979,7 +1212,8 @@ mod tests {
     };
 
     use crate::analyze::{
-        analyze_run, render_text, Confidence, DiagnosisKind, InflightTrend, Report, Suspect,
+        analyze_run, render_text, Confidence, DiagnosisKind, EvidenceQuality, EvidenceQualityLevel,
+        InflightTrend, Report, SignalCoverageStatus, Suspect,
     };
 
     fn test_run() -> Run {
@@ -1194,6 +1428,26 @@ mod tests {
                 growth_per_sec_milli: Some(2_500),
             }),
             warnings: Vec::new(),
+            evidence_quality: EvidenceQuality {
+                request_count: 2,
+                queue_event_count: 0,
+                stage_event_count: 0,
+                runtime_snapshot_count: 0,
+                inflight_snapshot_count: 0,
+                requests: SignalCoverageStatus::Present,
+                queues: SignalCoverageStatus::Missing,
+                stages: SignalCoverageStatus::Missing,
+                runtime_snapshots: SignalCoverageStatus::Missing,
+                inflight_snapshots: SignalCoverageStatus::Missing,
+                truncated: false,
+                dropped_requests: 0,
+                dropped_stages: 0,
+                dropped_queues: 0,
+                dropped_inflight_snapshots: 0,
+                dropped_runtime_snapshots: 0,
+                quality: EvidenceQualityLevel::Strong,
+                limitations: vec![],
+            },
             primary_suspect: Suspect {
                 kind: DiagnosisKind::ApplicationQueueSaturation,
                 score: 90,
@@ -1224,6 +1478,26 @@ mod tests {
             p95_service_share_permille: None,
             inflight_trend: None,
             warnings: vec!["Capture truncated requests.".to_owned()],
+            evidence_quality: EvidenceQuality {
+                request_count: 0,
+                queue_event_count: 0,
+                stage_event_count: 0,
+                runtime_snapshot_count: 0,
+                inflight_snapshot_count: 0,
+                requests: SignalCoverageStatus::Missing,
+                queues: SignalCoverageStatus::Missing,
+                stages: SignalCoverageStatus::Missing,
+                runtime_snapshots: SignalCoverageStatus::Missing,
+                inflight_snapshots: SignalCoverageStatus::Missing,
+                truncated: true,
+                dropped_requests: 1,
+                dropped_stages: 0,
+                dropped_queues: 0,
+                dropped_inflight_snapshots: 0,
+                dropped_runtime_snapshots: 0,
+                quality: EvidenceQualityLevel::Weak,
+                limitations: vec!["capture limited".to_owned()],
+            },
             primary_suspect: Suspect {
                 kind: DiagnosisKind::InsufficientEvidence,
                 score: 50,
@@ -1476,5 +1750,98 @@ mod tests {
             .warnings
             .iter()
             .any(|w| w.contains("dropped 1 entries after reaching max_runtime_snapshots")));
+    }
+
+    #[test]
+    fn evidence_quality_weak_for_low_requests() {
+        let report = analyze_run(&test_run());
+        assert_eq!(report.evidence_quality.quality, EvidenceQualityLevel::Weak);
+        assert_eq!(
+            report.evidence_quality.requests,
+            SignalCoverageStatus::Partial
+        );
+    }
+
+    #[test]
+    fn evidence_quality_partial_for_runtime_partial_fields() {
+        let mut run = test_run();
+        run.requests = (0..25)
+            .map(|i| RequestEvent {
+                request_id: format!("req-{i}"),
+                route: "/t".into(),
+                kind: None,
+                started_at_unix_ms: i,
+                finished_at_unix_ms: i + 1,
+                latency_us: 1_000,
+                outcome: "ok".into(),
+            })
+            .collect();
+        run.queues = run
+            .requests
+            .iter()
+            .map(|r| QueueEvent {
+                request_id: r.request_id.clone(),
+                queue: "q".into(),
+                wait_us: 600,
+                waited_from_unix_ms: 1,
+                waited_until_unix_ms: 2,
+                depth_at_start: Some(2),
+            })
+            .collect();
+        run.runtime_snapshots = vec![runtime_snapshot(Some(1), None, Some(1)); 10];
+        let report = analyze_run(&run);
+        assert_eq!(
+            report.evidence_quality.runtime_snapshots,
+            SignalCoverageStatus::Partial
+        );
+        assert_eq!(
+            report.evidence_quality.quality,
+            EvidenceQualityLevel::Partial
+        );
+    }
+
+    #[test]
+    fn evidence_quality_strong_without_runtime_snapshots_when_queue_stage_present() {
+        let mut run = test_run();
+        run.requests = (0..30)
+            .map(|i| RequestEvent {
+                request_id: format!("req-{i}"),
+                route: "/t".into(),
+                kind: None,
+                started_at_unix_ms: i,
+                finished_at_unix_ms: i + 1,
+                latency_us: 1_000,
+                outcome: "ok".into(),
+            })
+            .collect();
+        run.queues = run
+            .requests
+            .iter()
+            .map(|r| QueueEvent {
+                request_id: r.request_id.clone(),
+                queue: "q".into(),
+                wait_us: 500,
+                waited_from_unix_ms: 1,
+                waited_until_unix_ms: 2,
+                depth_at_start: Some(2),
+            })
+            .collect();
+        run.stages = run
+            .requests
+            .iter()
+            .map(|r| StageEvent {
+                request_id: r.request_id.clone(),
+                stage: "db".into(),
+                started_at_unix_ms: 1,
+                finished_at_unix_ms: 2,
+                latency_us: 400,
+                success: true,
+            })
+            .collect();
+        let report = analyze_run(&run);
+        assert_eq!(
+            report.evidence_quality.quality,
+            EvidenceQualityLevel::Strong
+        );
     }
 }

--- a/tailtriage-cli/src/analyze.rs
+++ b/tailtriage-cli/src/analyze.rs
@@ -331,7 +331,7 @@ pub fn analyze_run(run: &Run) -> Report {
     suspects.sort_by_key(|suspect| std::cmp::Reverse(suspect.score));
 
     let warnings = analysis_warnings(run, &suspects);
-    let evidence_quality = evidence_quality(run, &suspects);
+    let evidence_quality = evidence_quality(run);
 
     let mut ranked = suspects.into_iter();
     let primary_suspect = ranked.next().unwrap_or_else(|| {
@@ -358,7 +358,7 @@ pub fn analyze_run(run: &Run) -> Report {
     }
 }
 
-fn evidence_quality(run: &Run, _suspects: &[Suspect]) -> EvidenceQuality {
+fn evidence_quality(run: &Run) -> EvidenceQuality {
     let requests = request_status(run);
     let queues = family_status(run.queues.is_empty(), run.truncation.dropped_queues);
     let stages = family_status(run.stages.is_empty(), run.truncation.dropped_stages);

--- a/tailtriage-cli/src/analyze.rs
+++ b/tailtriage-cli/src/analyze.rs
@@ -358,7 +358,7 @@ pub fn analyze_run(run: &Run) -> Report {
     }
 }
 
-fn evidence_quality(run: &Run, suspects: &[Suspect]) -> EvidenceQuality {
+fn evidence_quality(run: &Run, _suspects: &[Suspect]) -> EvidenceQuality {
     let requests = request_status(run);
     let queues = family_status(run.queues.is_empty(), run.truncation.dropped_queues);
     let stages = family_status(run.stages.is_empty(), run.truncation.dropped_stages);
@@ -386,10 +386,8 @@ fn evidence_quality(run: &Run, suspects: &[Suspect]) -> EvidenceQuality {
     {
         EvidenceQualityLevel::Partial
     } else {
-        let _primary_runtime_dependent = suspects.first().is_some_and(|s| {
-            s.kind == DiagnosisKind::BlockingPoolPressure
-                || s.kind == DiagnosisKind::ExecutorPressureSuspected
-        });
+        // Runtime snapshots are optional; when queue/stage evidence is otherwise strong,
+        // missing runtime is represented as a limitation, not an automatic downgrade.
         EvidenceQualityLevel::Strong
     };
 
@@ -416,10 +414,10 @@ fn evidence_quality(run: &Run, suspects: &[Suspect]) -> EvidenceQuality {
 }
 
 fn request_status(run: &Run) -> SignalCoverageStatus {
-    if run.truncation.dropped_requests > 0 {
-        SignalCoverageStatus::Truncated
-    } else if run.requests.is_empty() {
+    if run.requests.is_empty() {
         SignalCoverageStatus::Missing
+    } else if run.truncation.dropped_requests > 0 {
+        SignalCoverageStatus::Truncated
     } else if run.requests.len() < LOW_COMPLETED_REQUEST_THRESHOLD {
         SignalCoverageStatus::Partial
     } else {
@@ -1434,7 +1432,7 @@ mod tests {
                 stage_event_count: 0,
                 runtime_snapshot_count: 0,
                 inflight_snapshot_count: 0,
-                requests: SignalCoverageStatus::Present,
+                requests: SignalCoverageStatus::Partial,
                 queues: SignalCoverageStatus::Missing,
                 stages: SignalCoverageStatus::Missing,
                 runtime_snapshots: SignalCoverageStatus::Missing,
@@ -1445,7 +1443,7 @@ mod tests {
                 dropped_queues: 0,
                 dropped_inflight_snapshots: 0,
                 dropped_runtime_snapshots: 0,
-                quality: EvidenceQualityLevel::Strong,
+                quality: EvidenceQualityLevel::Weak,
                 limitations: vec![],
             },
             primary_suspect: Suspect {
@@ -1759,6 +1757,18 @@ mod tests {
         assert_eq!(
             report.evidence_quality.requests,
             SignalCoverageStatus::Partial
+        );
+    }
+
+    #[test]
+    fn evidence_quality_requests_missing_when_zero_requests_even_if_dropped() {
+        let mut run = test_run();
+        run.requests.clear();
+        run.truncation.dropped_requests = 3;
+        let report = analyze_run(&run);
+        assert_eq!(
+            report.evidence_quality.requests,
+            SignalCoverageStatus::Missing
         );
     }
 


### PR DESCRIPTION
### Motivation
- Make evidence completeness and signal coverage first-class in machine-readable analyzer reports so users and validation tooling can deterministically understand data quality instead of inferring it from warnings.
- Keep analyzer behavior identical while improving observability of capture limitations and making thresholds reusable and named for clarity and tests.

### Description
- Added named constants for existing thresholds and sample-quality cutoffs (low completed-request threshold, queue-share trigger, medium/high confidence thresholds, downstream minimum stage samples, ambiguity gap, and sample-quality thresholds) and wired them into the existing heuristics without changing scoring formulas or confidence bands (`tailtriage-cli/src/analyze.rs`).
- Introduced a serializable `evidence_quality` section with `EvidenceQuality`, `EvidenceQualityLevel`, and `SignalCoverageStatus` types that record per-family counts/statuses, truncation/drop counters, `quality` (`strong`/`partial`/`weak`), and concise `limitations` inferred from coverage (`tailtriage-cli/src/analyze.rs`).
- Implemented deterministic semantics for per-family coverage and overall quality (requests, queues, stages, runtime_snapshots, inflight_snapshots) respecting runtime-snapshot optionality and truncation rules, and populated `limitations` while preserving existing warnings.
- Rendered a compact evidence-quality line in human text output and added the new field to JSON sample shapes and public docs; refreshed demo analysis fixtures to include the new field (`README.md`, `tailtriage-cli/README.md`, `docs/diagnostics.md`, demos/*/fixtures/*).
- Added analyzer unit tests covering `strong`/`partial`/`weak` evidence-quality outcomes and signal-family statuses and a preservation test verifying existing suspect ordering behavior remains unchanged (`tailtriage-cli/src/analyze.rs` tests).

### Testing
- Ran formatting and linting: `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings` (passed after minor refactor to satisfy clippy limits).
- Ran full test suite: `cargo test --workspace` (all tests passed; analyzer unit tests exercising evidence-quality logic passed).
- Refreshed and validated demo fixture drift: `python3 scripts/check_demo_fixture_drift.py --profile dev --refresh` and re-ran non-refresh check (fixtures refreshed intentionally and validation passed).
- Ran diagnostic corpus benchmark: `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0` (report: top1_accuracy=0.946, top2_recall=1.000, high_confidence_wrong_count=0; passed thresholds).
- Ran Python validation/unit checks: `python3 -m unittest scripts.tests.test_diagnostic_benchmark` and `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts` (all passed).

Files changed (high level): `tailtriage-cli/src/analyze.rs` (constants, types, logic, tests), `tailtriage-cli/README.md`, `docs/diagnostics.md`, `README.md`, and refreshed demo fixture analysis JSON files under `demos/*/fixtures/`.

Scoring/ranking/confidence behavior changed? No — no new diagnosis kinds, no scoring formula changes, and no confidence-bucket behavior changes were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97dbed2bc8330972fd86fa20868ba)