### PR TITLE
Add `evidence_quality` to analyzer reports and extract analyzer thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,26 @@ tailtriage analyze tailtriage-run.json --format json
     "growth_per_sec_milli": 0
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 250,
+    "queue_event_count": 250,
+    "stage_event_count": 250,
+    "runtime_snapshot_count": 500,
+    "inflight_snapshot_count": 500,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "present",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": []
+  },
   "primary_suspect": {
     "kind": "application_queue_saturation",
     "score": 90,

--- a/demos/blocking_service/fixtures/after-analysis.json
+++ b/demos/blocking_service/fixtures/after-analysis.json
@@ -1,29 +1,51 @@
 {
   "request_count": 250,
-  "p50_latency_us": 47452,
-  "p95_latency_us": 73489,
-  "p99_latency_us": 75963,
-  "p95_queue_share_permille": 78,
-  "p95_service_share_permille": 993,
+  "p50_latency_us": 60107,
+  "p95_latency_us": 98828,
+  "p99_latency_us": 103345,
+  "p95_queue_share_permille": 62,
+  "p95_service_share_permille": 990,
   "inflight_trend": {
     "gauge": "blocking_service_inflight",
     "sample_count": 500,
-    "peak_count": 42,
-    "p95_count": 38,
+    "peak_count": 56,
+    "p95_count": 52,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2020
+    "growth_per_sec_milli": -2036
   },
   "warnings": [
     "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited."
   ],
+  "evidence_quality": {
+    "request_count": 250,
+    "queue_event_count": 250,
+    "stage_event_count": 250,
+    "runtime_snapshot_count": 200,
+    "inflight_snapshot_count": 500,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "partial",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "partial",
+    "limitations": [
+      "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited."
+    ]
+  },
   "primary_suspect": {
     "kind": "downstream_stage_dominates",
     "score": 100,
     "confidence": "high",
     "evidence": [
-      "Stage 'spawn_blocking_path' has p95 latency 72080 us across 250 samples.",
-      "Stage 'spawn_blocking_path' cumulative latency is 11518403 us (971 permille of request latency).",
-      "Stage 'spawn_blocking_path' contributes 981 permille of tail request latency."
+      "Stage 'spawn_blocking_path' has p95 latency 97546 us across 250 samples.",
+      "Stage 'spawn_blocking_path' cumulative latency is 14444526 us (980 permille of request latency).",
+      "Stage 'spawn_blocking_path' contributes 988 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
@@ -37,7 +59,7 @@
       "score": 82,
       "confidence": "medium",
       "evidence": [
-        "Blocking queue depth p95 is 36, peak is 40, with 98/200 nonzero samples."
+        "Blocking queue depth p95 is 49, peak is 54, with 97/200 nonzero samples."
       ],
       "next_checks": [
         "Audit blocking sections and move avoidable synchronous work out of hot paths.",

--- a/demos/blocking_service/fixtures/before-analysis.json
+++ b/demos/blocking_service/fixtures/before-analysis.json
@@ -1,22 +1,45 @@
 {
   "request_count": 250,
-  "p50_latency_us": 1872360,
-  "p95_latency_us": 3548117,
-  "p99_latency_us": 3696181,
-  "p95_queue_share_permille": 6,
+  "p50_latency_us": 1864985,
+  "p95_latency_us": 3525604,
+  "p99_latency_us": 3673870,
+  "p95_queue_share_permille": 5,
   "p95_service_share_permille": 999,
   "inflight_trend": {
     "gauge": "blocking_service_inflight",
     "sample_count": 500,
     "peak_count": 246,
     "p95_count": 234,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -263
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
   },
   "warnings": [
     "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited.",
     "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks."
   ],
+  "evidence_quality": {
+    "request_count": 250,
+    "queue_event_count": 250,
+    "stage_event_count": 250,
+    "runtime_snapshot_count": 200,
+    "inflight_snapshot_count": 500,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "partial",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "partial",
+    "limitations": [
+      "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited.",
+      "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks."
+    ]
+  },
   "primary_suspect": {
     "kind": "blocking_pool_pressure",
     "score": 88,
@@ -35,8 +58,8 @@
       "score": 86,
       "confidence": "high",
       "evidence": [
-        "Stage 'spawn_blocking_path' has p95 latency 3546732 us across 250 samples.",
-        "Stage 'spawn_blocking_path' cumulative latency is 468587693 us (999 permille of request latency).",
+        "Stage 'spawn_blocking_path' has p95 latency 3524396 us across 250 samples.",
+        "Stage 'spawn_blocking_path' cumulative latency is 466074362 us (999 permille of request latency).",
         "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency.",
         "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
       ],

--- a/demos/blocking_service/fixtures/sample-analysis.json
+++ b/demos/blocking_service/fixtures/sample-analysis.json
@@ -1,22 +1,45 @@
 {
   "request_count": 250,
-  "p50_latency_us": 1872360,
-  "p95_latency_us": 3548117,
-  "p99_latency_us": 3696181,
-  "p95_queue_share_permille": 6,
+  "p50_latency_us": 1864985,
+  "p95_latency_us": 3525604,
+  "p99_latency_us": 3673870,
+  "p95_queue_share_permille": 5,
   "p95_service_share_permille": 999,
   "inflight_trend": {
     "gauge": "blocking_service_inflight",
     "sample_count": 500,
     "peak_count": 246,
     "p95_count": 234,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -263
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
   },
   "warnings": [
     "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited.",
     "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks."
   ],
+  "evidence_quality": {
+    "request_count": 250,
+    "queue_event_count": 250,
+    "stage_event_count": 250,
+    "runtime_snapshot_count": 200,
+    "inflight_snapshot_count": 500,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "partial",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "partial",
+    "limitations": [
+      "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited.",
+      "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks."
+    ]
+  },
   "primary_suspect": {
     "kind": "blocking_pool_pressure",
     "score": 88,
@@ -35,8 +58,8 @@
       "score": 86,
       "confidence": "high",
       "evidence": [
-        "Stage 'spawn_blocking_path' has p95 latency 3546732 us across 250 samples.",
-        "Stage 'spawn_blocking_path' cumulative latency is 468587693 us (999 permille of request latency).",
+        "Stage 'spawn_blocking_path' has p95 latency 3524396 us across 250 samples.",
+        "Stage 'spawn_blocking_path' cumulative latency is 466074362 us (999 permille of request latency).",
         "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency.",
         "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
       ],

--- a/demos/cold_start_burst_service/fixtures/after-analysis.json
+++ b/demos/cold_start_burst_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 8253,
-  "p95_latency_us": 9028,
-  "p99_latency_us": 12979,
+  "p50_latency_us": 8495,
+  "p95_latency_us": 8898,
+  "p99_latency_us": 10251,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 999,
   "inflight_trend": {
@@ -11,16 +11,36 @@
     "peak_count": 4,
     "p95_count": 3,
     "growth_delta": -1,
-    "growth_per_sec_milli": -971
+    "growth_per_sec_milli": -1067
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 220,
+    "queue_event_count": 220,
+    "stage_event_count": 220,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 440,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": []
+  },
   "primary_suspect": {
     "kind": "downstream_stage_dominates",
     "score": 100,
     "confidence": "high",
     "evidence": [
-      "Stage 'cold_start_stage' has p95 latency 8986 us across 220 samples.",
-      "Stage 'cold_start_stage' cumulative latency is 1834129 us (993 permille of request latency).",
+      "Stage 'cold_start_stage' has p95 latency 8874 us across 220 samples.",
+      "Stage 'cold_start_stage' cumulative latency is 1823215 us (996 permille of request latency).",
       "Stage 'cold_start_stage' contributes 995 permille of tail request latency."
     ],
     "next_checks": [

--- a/demos/cold_start_burst_service/fixtures/before-analysis.json
+++ b/demos/cold_start_burst_service/fixtures/before-analysis.json
@@ -1,26 +1,47 @@
 {
   "request_count": 220,
-  "p50_latency_us": 995604,
-  "p95_latency_us": 1191696,
-  "p99_latency_us": 1207786,
+  "p50_latency_us": 993119,
+  "p95_latency_us": 1193493,
+  "p99_latency_us": 1209061,
   "p95_queue_share_permille": 993,
-  "p95_service_share_permille": 334,
+  "p95_service_share_permille": 335,
   "inflight_trend": {
     "gauge": "cold_start_burst_inflight",
     "sample_count": 440,
     "peak_count": 220,
     "p95_count": 209,
-    "growth_delta": 0,
-    "growth_per_sec_milli": 0
+    "growth_delta": 1,
+    "growth_per_sec_milli": 815
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 220,
+    "queue_event_count": 220,
+    "stage_event_count": 220,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 440,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": []
+  },
   "primary_suspect": {
     "kind": "application_queue_saturation",
-    "score": 95,
+    "score": 100,
     "confidence": "high",
     "evidence": [
       "Queue wait at p95 consumes 99.3% of request time.",
-      "Observed queue depth sample up to 216."
+      "Observed queue depth sample up to 216.",
+      "In-flight gauge 'cold_start_burst_inflight' grew by 1 over the run window (p95=209, peak=220)."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -33,8 +54,8 @@
       "score": 32,
       "confidence": "low",
       "evidence": [
-        "Stage 'cold_start_stage' has p95 latency 63897 us across 220 samples.",
-        "Stage 'cold_start_stage' cumulative latency is 4885791 us (24 permille of request latency).",
+        "Stage 'cold_start_stage' has p95 latency 63592 us across 220 samples.",
+        "Stage 'cold_start_stage' cumulative latency is 4881612 us (24 permille of request latency).",
         "Stage 'cold_start_stage' contributes 6 permille of tail request latency."
       ],
       "next_checks": [

--- a/demos/db_pool_saturation_service/fixtures/after-analysis.json
+++ b/demos/db_pool_saturation_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 13425,
-  "p95_latency_us": 13964,
-  "p99_latency_us": 14227,
+  "p50_latency_us": 13168,
+  "p95_latency_us": 14032,
+  "p99_latency_us": 14135,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,17 +11,37 @@
     "peak_count": 10,
     "p95_count": 10,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2652
+    "growth_per_sec_milli": -2659
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 220,
+    "queue_event_count": 220,
+    "stage_event_count": 440,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 440,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": []
+  },
   "primary_suspect": {
     "kind": "downstream_stage_dominates",
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'db_query' has p95 latency 11701 us across 220 samples.",
-      "Stage 'db_query' cumulative latency is 2450346 us (832 permille of request latency).",
-      "Stage 'db_query' contributes 829 permille of tail request latency."
+      "Stage 'db_query' has p95 latency 11823 us across 220 samples.",
+      "Stage 'db_query' cumulative latency is 2426876 us (833 permille of request latency).",
+      "Stage 'db_query' contributes 835 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'db_query'.",

--- a/demos/db_pool_saturation_service/fixtures/before-analysis.json
+++ b/demos/db_pool_saturation_service/fixtures/before-analysis.json
@@ -1,27 +1,46 @@
 {
   "request_count": 220,
-  "p50_latency_us": 495267,
-  "p95_latency_us": 928790,
-  "p99_latency_us": 963868,
-  "p95_queue_share_permille": 976,
-  "p95_service_share_permille": 385,
+  "p50_latency_us": 495606,
+  "p95_latency_us": 930132,
+  "p99_latency_us": 965329,
+  "p95_queue_share_permille": 977,
+  "p95_service_share_permille": 371,
   "inflight_trend": {
     "gauge": "db_pool_saturation_inflight",
     "sample_count": 440,
-    "peak_count": 200,
-    "p95_count": 190,
-    "growth_delta": 2,
-    "growth_per_sec_milli": 1876
+    "peak_count": 204,
+    "p95_count": 193,
+    "growth_delta": -1,
+    "growth_per_sec_milli": -941
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 220,
+    "queue_event_count": 220,
+    "stage_event_count": 440,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 440,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": []
+  },
   "primary_suspect": {
     "kind": "application_queue_saturation",
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Queue wait at p95 consumes 97.6% of request time.",
-      "Observed queue depth sample up to 196.",
-      "In-flight gauge 'db_pool_saturation_inflight' grew by 2 over the run window (p95=190, peak=200)."
+      "Queue wait at p95 consumes 97.7% of request time.",
+      "Observed queue depth sample up to 200."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -34,8 +53,8 @@
       "score": 34,
       "confidence": "low",
       "evidence": [
-        "Stage 'db_query' has p95 latency 19762 us across 220 samples.",
-        "Stage 'db_query' cumulative latency is 4240358 us (39 permille of request latency).",
+        "Stage 'db_query' has p95 latency 19618 us across 220 samples.",
+        "Stage 'db_query' cumulative latency is 4221148 us (38 permille of request latency).",
         "Stage 'db_query' contributes 20 permille of tail request latency."
       ],
       "next_checks": [

--- a/demos/downstream_service/fixtures/after-analysis.json
+++ b/demos/downstream_service/fixtures/after-analysis.json
@@ -1,27 +1,47 @@
 {
   "request_count": 80,
-  "p50_latency_us": 12476,
-  "p95_latency_us": 13110,
-  "p99_latency_us": 13158,
+  "p50_latency_us": 12154,
+  "p95_latency_us": 13250,
+  "p99_latency_us": 13290,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "downstream_service_inflight",
     "sample_count": 160,
-    "peak_count": 33,
-    "p95_count": 32,
+    "peak_count": 40,
+    "p95_count": 36,
     "growth_delta": 5,
-    "growth_per_sec_milli": 111111
+    "growth_per_sec_milli": 113636
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 80,
+    "queue_event_count": 0,
+    "stage_event_count": 160,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 160,
+    "requests": "present",
+    "queues": "missing",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": []
+  },
   "primary_suspect": {
     "kind": "downstream_stage_dominates",
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 10629 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 811602 us (817 permille of request latency).",
-      "Stage 'downstream_call' contributes 802 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 11005 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 813468 us (824 permille of request latency).",
+      "Stage 'downstream_call' contributes 832 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",

--- a/demos/downstream_service/fixtures/before-after-comparison.json
+++ b/demos/downstream_service/fixtures/before-after-comparison.json
@@ -2,19 +2,19 @@
   "before": {
     "primary_suspect_kind": "downstream_stage_dominates",
     "primary_suspect_score": 95,
-    "p95_latency_us": 24819,
+    "p95_latency_us": 24151,
     "p95_service_share_permille": 1000
   },
   "after": {
     "primary_suspect_kind": "downstream_stage_dominates",
     "primary_suspect_score": 95,
-    "p95_latency_us": 13110,
+    "p95_latency_us": 13250,
     "p95_service_share_permille": 1000
   },
   "delta": {
     "primary_suspect_kind": null,
     "primary_suspect_score": 0,
-    "p95_latency_us": -11709,
+    "p95_latency_us": -10901,
     "p95_service_share_permille": 0
   }
 }

--- a/demos/downstream_service/fixtures/before-analysis.json
+++ b/demos/downstream_service/fixtures/before-analysis.json
@@ -1,27 +1,47 @@
 {
   "request_count": 80,
-  "p50_latency_us": 23508,
-  "p95_latency_us": 24819,
-  "p99_latency_us": 24838,
+  "p50_latency_us": 23752,
+  "p95_latency_us": 24151,
+  "p99_latency_us": 24169,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "downstream_service_inflight",
     "sample_count": 160,
-    "peak_count": 56,
-    "p95_count": 55,
+    "peak_count": 64,
+    "p95_count": 63,
     "growth_delta": 5,
-    "growth_per_sec_milli": 84745
+    "growth_per_sec_milli": 94339
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 80,
+    "queue_event_count": 0,
+    "stage_event_count": 160,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 160,
+    "requests": "present",
+    "queues": "missing",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": []
+  },
   "primary_suspect": {
     "kind": "downstream_stage_dominates",
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 21980 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 1697504 us (897 permille of request latency).",
-      "Stage 'downstream_call' contributes 885 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 21903 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 1716135 us (905 permille of request latency).",
+      "Stage 'downstream_call' contributes 906 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",

--- a/demos/downstream_service/fixtures/sample-analysis.json
+++ b/demos/downstream_service/fixtures/sample-analysis.json
@@ -1,27 +1,47 @@
 {
   "request_count": 80,
-  "p50_latency_us": 23508,
-  "p95_latency_us": 24819,
-  "p99_latency_us": 24838,
+  "p50_latency_us": 23752,
+  "p95_latency_us": 24151,
+  "p99_latency_us": 24169,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "downstream_service_inflight",
     "sample_count": 160,
-    "peak_count": 56,
-    "p95_count": 55,
+    "peak_count": 64,
+    "p95_count": 63,
     "growth_delta": 5,
-    "growth_per_sec_milli": 84745
+    "growth_per_sec_milli": 94339
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 80,
+    "queue_event_count": 0,
+    "stage_event_count": 160,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 160,
+    "requests": "present",
+    "queues": "missing",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": []
+  },
   "primary_suspect": {
     "kind": "downstream_stage_dominates",
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 21980 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 1697504 us (897 permille of request latency).",
-      "Stage 'downstream_call' contributes 885 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 21903 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 1716135 us (905 permille of request latency).",
+      "Stage 'downstream_call' contributes 906 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",

--- a/demos/executor_pressure_service/fixtures/after-analysis.json
+++ b/demos/executor_pressure_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 240,
-  "p50_latency_us": 16236717,
-  "p95_latency_us": 16412208,
-  "p99_latency_us": 16423914,
+  "p50_latency_us": 6974749,
+  "p95_latency_us": 7045080,
+  "p99_latency_us": 7055393,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,17 +11,37 @@
     "peak_count": 240,
     "p95_count": 228,
     "growth_delta": -1,
-    "growth_per_sec_milli": -60
+    "growth_per_sec_milli": -141
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 240,
+    "queue_event_count": 0,
+    "stage_event_count": 0,
+    "runtime_snapshot_count": 7063,
+    "inflight_snapshot_count": 480,
+    "requests": "present",
+    "queues": "missing",
+    "stages": "missing",
+    "runtime_snapshots": "present",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "partial",
+    "limitations": []
+  },
   "primary_suspect": {
     "kind": "executor_pressure_suspected",
     "score": 99,
     "confidence": "high",
     "evidence": [
-      "Runtime global queue depth p95 is 717, suggesting scheduler contention.",
-      "Runtime local queue depth p95 is 1674.",
-      "Runtime alive_tasks p95 is 717."
+      "Runtime global queue depth p95 is 720, suggesting scheduler contention.",
+      "Runtime local queue depth p95 is 6621.",
+      "Runtime alive_tasks p95 is 720."
     ],
     "next_checks": [
       "Check for long polls without yielding and uneven task fan-out.",

--- a/demos/executor_pressure_service/fixtures/before-analysis.json
+++ b/demos/executor_pressure_service/fixtures/before-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 240,
-  "p50_latency_us": 84085499,
-  "p95_latency_us": 84319683,
-  "p99_latency_us": 84346000,
+  "p50_latency_us": 34088406,
+  "p95_latency_us": 34148682,
+  "p99_latency_us": 34153840,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,17 +11,37 @@
     "peak_count": 240,
     "p95_count": 228,
     "growth_delta": -1,
-    "growth_per_sec_milli": -11
+    "growth_per_sec_milli": -29
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 240,
+    "queue_event_count": 0,
+    "stage_event_count": 0,
+    "runtime_snapshot_count": 5539,
+    "inflight_snapshot_count": 480,
+    "requests": "present",
+    "queues": "missing",
+    "stages": "missing",
+    "runtime_snapshots": "present",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "partial",
+    "limitations": []
+  },
   "primary_suspect": {
     "kind": "executor_pressure_suspected",
     "score": 99,
     "confidence": "high",
     "evidence": [
-      "Runtime global queue depth p95 is 712, suggesting scheduler contention.",
-      "Runtime local queue depth p95 is 488.",
-      "Runtime alive_tasks p95 is 712."
+      "Runtime global queue depth p95 is 1920, suggesting scheduler contention.",
+      "Runtime local queue depth p95 is 41296.",
+      "Runtime alive_tasks p95 is 1920."
     ],
     "next_checks": [
       "Check for long polls without yielding and uneven task fan-out.",

--- a/demos/executor_pressure_service/fixtures/sample-analysis.json
+++ b/demos/executor_pressure_service/fixtures/sample-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 240,
-  "p50_latency_us": 84085499,
-  "p95_latency_us": 84319683,
-  "p99_latency_us": 84346000,
+  "p50_latency_us": 34088406,
+  "p95_latency_us": 34148682,
+  "p99_latency_us": 34153840,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,17 +11,37 @@
     "peak_count": 240,
     "p95_count": 228,
     "growth_delta": -1,
-    "growth_per_sec_milli": -11
+    "growth_per_sec_milli": -29
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 240,
+    "queue_event_count": 0,
+    "stage_event_count": 0,
+    "runtime_snapshot_count": 5539,
+    "inflight_snapshot_count": 480,
+    "requests": "present",
+    "queues": "missing",
+    "stages": "missing",
+    "runtime_snapshots": "present",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "partial",
+    "limitations": []
+  },
   "primary_suspect": {
     "kind": "executor_pressure_suspected",
     "score": 99,
     "confidence": "high",
     "evidence": [
-      "Runtime global queue depth p95 is 712, suggesting scheduler contention.",
-      "Runtime local queue depth p95 is 488.",
-      "Runtime alive_tasks p95 is 712."
+      "Runtime global queue depth p95 is 1920, suggesting scheduler contention.",
+      "Runtime local queue depth p95 is 41296.",
+      "Runtime alive_tasks p95 is 1920."
     ],
     "next_checks": [
       "Check for long polls without yielding and uneven task fan-out.",

--- a/demos/mixed_contention_service/fixtures/baseline-analysis.json
+++ b/demos/mixed_contention_service/fixtures/baseline-analysis.json
@@ -1,19 +1,39 @@
 {
   "request_count": 220,
-  "p50_latency_us": 393714,
-  "p95_latency_us": 743315,
-  "p99_latency_us": 771767,
+  "p50_latency_us": 395353,
+  "p95_latency_us": 738319,
+  "p99_latency_us": 764454,
   "p95_queue_share_permille": 980,
-  "p95_service_share_permille": 392,
+  "p95_service_share_permille": 508,
   "inflight_trend": {
     "gauge": "mixed_contention_inflight",
     "sample_count": 440,
     "peak_count": 201,
-    "p95_count": 191,
+    "p95_count": 190,
     "growth_delta": -1,
-    "growth_per_sec_milli": -1156
+    "growth_per_sec_milli": -1153
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 220,
+    "queue_event_count": 220,
+    "stage_event_count": 440,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 440,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": []
+  },
   "primary_suspect": {
     "kind": "application_queue_saturation",
     "score": 95,
@@ -33,9 +53,9 @@
       "score": 35,
       "confidence": "low",
       "evidence": [
-        "Stage 'downstream_call' has p95 latency 32407 us across 220 samples.",
-        "Stage 'downstream_call' cumulative latency is 3782929 us (43 permille of request latency).",
-        "Stage 'downstream_call' contributes 25 permille of tail request latency."
+        "Stage 'downstream_call' has p95 latency 32671 us across 220 samples.",
+        "Stage 'downstream_call' cumulative latency is 3763131 us (43 permille of request latency).",
+        "Stage 'downstream_call' contributes 23 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'downstream_call'.",

--- a/demos/mixed_contention_service/fixtures/mitigated-analysis.json
+++ b/demos/mixed_contention_service/fixtures/mitigated-analysis.json
@@ -1,27 +1,47 @@
 {
   "request_count": 220,
-  "p50_latency_us": 14492,
-  "p95_latency_us": 34767,
-  "p99_latency_us": 35164,
+  "p50_latency_us": 14377,
+  "p95_latency_us": 34751,
+  "p99_latency_us": 35043,
   "p95_queue_share_permille": 0,
-  "p95_service_share_permille": 999,
+  "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "mixed_contention_inflight",
     "sample_count": 440,
-    "peak_count": 13,
+    "peak_count": 14,
     "p95_count": 13,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2380
+    "growth_per_sec_milli": -2638
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 220,
+    "queue_event_count": 220,
+    "stage_event_count": 440,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 440,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": []
+  },
   "primary_suspect": {
     "kind": "downstream_stage_dominates",
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 32473 us across 220 samples.",
-      "Stage 'downstream_call' cumulative latency is 3739540 us (876 permille of request latency).",
-      "Stage 'downstream_call' contributes 932 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 32527 us across 220 samples.",
+      "Stage 'downstream_call' cumulative latency is 3767093 us (888 permille of request latency).",
+      "Stage 'downstream_call' contributes 935 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",

--- a/demos/queue_service/fixtures/after-analysis.json
+++ b/demos/queue_service/fixtures/after-analysis.json
@@ -1,27 +1,47 @@
 {
   "request_count": 250,
-  "p50_latency_us": 16153,
-  "p95_latency_us": 17033,
-  "p99_latency_us": 18572,
+  "p50_latency_us": 16204,
+  "p95_latency_us": 16873,
+  "p99_latency_us": 17028,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
     "peak_count": 12,
-    "p95_count": 11,
+    "p95_count": 12,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2283
+    "growth_per_sec_milli": -2403
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 250,
+    "queue_event_count": 250,
+    "stage_event_count": 250,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 500,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": []
+  },
   "primary_suspect": {
     "kind": "downstream_stage_dominates",
     "score": 100,
     "confidence": "high",
     "evidence": [
-      "Stage 'simulated_work' has p95 latency 16978 us across 250 samples.",
-      "Stage 'simulated_work' cumulative latency is 4051036 us (996 permille of request latency).",
-      "Stage 'simulated_work' contributes 975 permille of tail request latency."
+      "Stage 'simulated_work' has p95 latency 16859 us across 250 samples.",
+      "Stage 'simulated_work' cumulative latency is 4032487 us (998 permille of request latency).",
+      "Stage 'simulated_work' contributes 999 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'simulated_work'.",

--- a/demos/queue_service/fixtures/before-analysis.json
+++ b/demos/queue_service/fixtures/before-analysis.json
@@ -1,25 +1,45 @@
 {
   "request_count": 250,
-  "p50_latency_us": 787254,
-  "p95_latency_us": 1472731,
-  "p99_latency_us": 1524462,
-  "p95_queue_share_permille": 981,
-  "p95_service_share_permille": 271,
+  "p50_latency_us": 782920,
+  "p95_latency_us": 1464265,
+  "p99_latency_us": 1516042,
+  "p95_queue_share_permille": 982,
+  "p95_service_share_permille": 270,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
     "peak_count": 234,
     "p95_count": 222,
     "growth_delta": -1,
-    "growth_per_sec_milli": -598
+    "growth_per_sec_milli": -603
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 250,
+    "queue_event_count": 250,
+    "stage_event_count": 250,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 500,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": []
+  },
   "primary_suspect": {
     "kind": "application_queue_saturation",
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Queue wait at p95 consumes 98.1% of request time.",
+      "Queue wait at p95 consumes 98.2% of request time.",
       "Observed queue depth sample up to 230."
     ],
     "next_checks": [
@@ -33,8 +53,8 @@
       "score": 33,
       "confidence": "low",
       "evidence": [
-        "Stage 'simulated_work' has p95 latency 27170 us across 250 samples.",
-        "Stage 'simulated_work' cumulative latency is 6609298 us (33 permille of request latency).",
+        "Stage 'simulated_work' has p95 latency 26635 us across 250 samples.",
+        "Stage 'simulated_work' cumulative latency is 6551172 us (33 permille of request latency).",
         "Stage 'simulated_work' contributes 17 permille of tail request latency."
       ],
       "next_checks": [

--- a/demos/queue_service/fixtures/sample-analysis.json
+++ b/demos/queue_service/fixtures/sample-analysis.json
@@ -1,25 +1,45 @@
 {
   "request_count": 250,
-  "p50_latency_us": 787254,
-  "p95_latency_us": 1472731,
-  "p99_latency_us": 1524462,
-  "p95_queue_share_permille": 981,
-  "p95_service_share_permille": 271,
+  "p50_latency_us": 782920,
+  "p95_latency_us": 1464265,
+  "p99_latency_us": 1516042,
+  "p95_queue_share_permille": 982,
+  "p95_service_share_permille": 270,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
     "peak_count": 234,
     "p95_count": 222,
     "growth_delta": -1,
-    "growth_per_sec_milli": -598
+    "growth_per_sec_milli": -603
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 250,
+    "queue_event_count": 250,
+    "stage_event_count": 250,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 500,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": []
+  },
   "primary_suspect": {
     "kind": "application_queue_saturation",
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Queue wait at p95 consumes 98.1% of request time.",
+      "Queue wait at p95 consumes 98.2% of request time.",
       "Observed queue depth sample up to 230."
     ],
     "next_checks": [
@@ -33,8 +53,8 @@
       "score": 33,
       "confidence": "low",
       "evidence": [
-        "Stage 'simulated_work' has p95 latency 27170 us across 250 samples.",
-        "Stage 'simulated_work' cumulative latency is 6609298 us (33 permille of request latency).",
+        "Stage 'simulated_work' has p95 latency 26635 us across 250 samples.",
+        "Stage 'simulated_work' cumulative latency is 6551172 us (33 permille of request latency).",
         "Stage 'simulated_work' contributes 17 permille of tail request latency."
       ],
       "next_checks": [

--- a/demos/retry_storm_service/fixtures/after-analysis.json
+++ b/demos/retry_storm_service/fixtures/after-analysis.json
@@ -1,27 +1,47 @@
 {
   "request_count": 180,
-  "p50_latency_us": 9867,
-  "p95_latency_us": 29695,
-  "p99_latency_us": 30241,
+  "p50_latency_us": 9569,
+  "p95_latency_us": 29378,
+  "p99_latency_us": 30038,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "retry_storm_inflight",
     "sample_count": 360,
-    "peak_count": 16,
-    "p95_count": 14,
+    "peak_count": 17,
+    "p95_count": 15,
     "growth_delta": -1,
-    "growth_per_sec_milli": -4098
+    "growth_per_sec_milli": -4672
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 180,
+    "queue_event_count": 0,
+    "stage_event_count": 587,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 360,
+    "requests": "present",
+    "queues": "missing",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": []
+  },
   "primary_suspect": {
     "kind": "downstream_stage_dominates",
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_total' has p95 latency 27307 us across 180 samples.",
-      "Stage 'downstream_total' cumulative latency is 2161657 us (829 permille of request latency).",
-      "Stage 'downstream_total' contributes 914 permille of tail request latency."
+      "Stage 'downstream_total' has p95 latency 27163 us across 180 samples.",
+      "Stage 'downstream_total' cumulative latency is 2159975 us (848 permille of request latency).",
+      "Stage 'downstream_total' contributes 923 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_total'.",

--- a/demos/retry_storm_service/fixtures/before-analysis.json
+++ b/demos/retry_storm_service/fixtures/before-analysis.json
@@ -1,27 +1,47 @@
 {
   "request_count": 180,
-  "p50_latency_us": 10540,
-  "p95_latency_us": 42303,
-  "p99_latency_us": 44006,
+  "p50_latency_us": 9909,
+  "p95_latency_us": 41557,
+  "p99_latency_us": 42572,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "retry_storm_inflight",
     "sample_count": 360,
-    "peak_count": 49,
-    "p95_count": 47,
+    "peak_count": 57,
+    "p95_count": 53,
     "growth_delta": -1,
-    "growth_per_sec_milli": -8264
+    "growth_per_sec_milli": -9174
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 180,
+    "queue_event_count": 0,
+    "stage_event_count": 706,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 360,
+    "requests": "present",
+    "queues": "missing",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": []
+  },
   "primary_suspect": {
     "kind": "downstream_stage_dominates",
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_total' has p95 latency 39555 us across 180 samples.",
-      "Stage 'downstream_total' cumulative latency is 3061237 us (869 permille of request latency).",
-      "Stage 'downstream_total' contributes 933 permille of tail request latency."
+      "Stage 'downstream_total' has p95 latency 39222 us across 180 samples.",
+      "Stage 'downstream_total' cumulative latency is 3035376 us (881 permille of request latency).",
+      "Stage 'downstream_total' contributes 943 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_total'.",

--- a/demos/shared_state_lock_service/fixtures/after-analysis.json
+++ b/demos/shared_state_lock_service/fixtures/after-analysis.json
@@ -1,26 +1,46 @@
 {
   "request_count": 220,
-  "p50_latency_us": 839822,
-  "p95_latency_us": 1592823,
-  "p99_latency_us": 1652940,
+  "p50_latency_us": 830274,
+  "p95_latency_us": 1572815,
+  "p99_latency_us": 1631887,
   "p95_queue_share_permille": 993,
-  "p95_service_share_permille": 111,
+  "p95_service_share_permille": 125,
   "inflight_trend": {
     "gauge": "shared_state_lock_inflight",
     "sample_count": 440,
-    "peak_count": 200,
-    "p95_count": 190,
+    "peak_count": 201,
+    "p95_count": 191,
     "growth_delta": -1,
-    "growth_per_sec_milli": -541
+    "growth_per_sec_milli": -552
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 220,
+    "queue_event_count": 220,
+    "stage_event_count": 440,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 440,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": []
+  },
   "primary_suspect": {
     "kind": "application_queue_saturation",
     "score": 95,
     "confidence": "high",
     "evidence": [
       "Queue wait at p95 consumes 99.3% of request time.",
-      "Observed queue depth sample up to 198."
+      "Observed queue depth sample up to 200."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -33,8 +53,8 @@
       "score": 32,
       "confidence": "low",
       "evidence": [
-        "Stage 'shared_state_critical_section' has p95 latency 8601 us across 220 samples.",
-        "Stage 'shared_state_critical_section' cumulative latency is 1822487 us (9 permille of request latency).",
+        "Stage 'shared_state_critical_section' has p95 latency 8300 us across 220 samples.",
+        "Stage 'shared_state_critical_section' cumulative latency is 1796102 us (9 permille of request latency).",
         "Stage 'shared_state_critical_section' contributes 5 permille of tail request latency."
       ],
       "next_checks": [

--- a/demos/shared_state_lock_service/fixtures/before-analysis.json
+++ b/demos/shared_state_lock_service/fixtures/before-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 2569298,
-  "p95_latency_us": 4858829,
-  "p99_latency_us": 5042007,
+  "p50_latency_us": 2546551,
+  "p95_latency_us": 4808723,
+  "p99_latency_us": 4990460,
   "p95_queue_share_permille": 994,
   "p95_service_share_permille": 101,
   "inflight_trend": {
@@ -11,16 +11,36 @@
     "peak_count": 217,
     "p95_count": 206,
     "growth_delta": -1,
-    "growth_per_sec_milli": -193
+    "growth_per_sec_milli": -195
   },
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 220,
+    "queue_event_count": 220,
+    "stage_event_count": 440,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 440,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": []
+  },
   "primary_suspect": {
     "kind": "application_queue_saturation",
     "score": 95,
     "confidence": "high",
     "evidence": [
       "Queue wait at p95 consumes 99.4% of request time.",
-      "Observed queue depth sample up to 215."
+      "Observed queue depth sample up to 216."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -33,8 +53,8 @@
       "score": 32,
       "confidence": "low",
       "evidence": [
-        "Stage 'shared_state_critical_section' has p95 latency 23767 us across 220 samples.",
-        "Stage 'shared_state_critical_section' cumulative latency is 5148216 us (9 permille of request latency).",
+        "Stage 'shared_state_critical_section' has p95 latency 23348 us across 220 samples.",
+        "Stage 'shared_state_critical_section' cumulative latency is 5103200 us (9 permille of request latency).",
         "Stage 'shared_state_critical_section' contributes 4 permille of tail request latency."
       ],
       "next_checks": [

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -50,6 +50,7 @@ Each suspect includes:
 - `p95_queue_share_permille`: p95 queue-time share per request (0..1000 scale).
 - `p95_service_share_permille`: p95 service-time share per request (0..1000 scale).
 - `warnings[]`: analyzer/report warnings, especially truncation-related warnings from captured-data limits. Loader/lifecycle warnings (including unfinished-request warnings) are emitted separately by the CLI loader to stderr before the report output.
+- `evidence_quality`: machine-readable capture completeness and interpretability summary. Includes per-signal-family coverage (`present`/`missing`/`partial`/`truncated`), truncation counters, an overall quality level (`strong`/`partial`/`weak`), and compact limitations. This quality is not causal certainty.
 - `primary_suspect`: highest-ranked suspect with evidence and next checks.
 - `secondary_suspects[]`: additional ranked suspects.
 - `inflight_trend` (optional): dominant in-flight gauge trend summary when snapshots exist.

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -66,6 +66,26 @@ Then run one targeted check, change one thing, and re-run under comparable load.
   "p95_service_share_permille": 267,
   "inflight_trend": null,
   "warnings": [],
+  "evidence_quality": {
+    "request_count": 250,
+    "queue_event_count": 250,
+    "stage_event_count": 250,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 0,
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "missing",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "strong",
+    "limitations": ["No runtime snapshots captured; executor and blocking-pressure interpretation is limited."]
+  },
   "primary_suspect": {
     "kind": "application_queue_saturation",
     "score": 90,
@@ -88,6 +108,7 @@ A report can include:
 - p95 queue/service share summaries
 - optional in-flight trend summary
 - report warnings from analysis/report generation (for example truncation-related)
+- evidence quality coverage summary for capture completeness and interpretability
 - primary and secondary suspects
 
 `tailtriage analyze` also prints loader/lifecycle warnings to stderr before the report. Those warnings are surfaced separately; they are not merged into the report `warnings` field.

--- a/tailtriage-cli/src/analyze.rs
+++ b/tailtriage-cli/src/analyze.rs
@@ -59,14 +59,93 @@ pub enum Confidence {
 
 impl Confidence {
     fn from_score(score: u8) -> Self {
-        if score >= 85 {
+        if score >= HIGH_CONFIDENCE_MIN_SCORE {
             Self::High
-        } else if score >= 65 {
+        } else if score >= MEDIUM_CONFIDENCE_MIN_SCORE {
             Self::Medium
         } else {
             Self::Low
         }
     }
+}
+
+const LOW_COMPLETED_REQUEST_WARNING_THRESHOLD: usize = 20;
+const QUEUE_SHARE_TRIGGER_PERMILLE: u64 = 300;
+const MEDIUM_CONFIDENCE_MIN_SCORE: u8 = 65;
+const HIGH_CONFIDENCE_MIN_SCORE: u8 = 85;
+const DOWNSTREAM_MIN_STAGE_SAMPLES: usize = 3;
+const AMBIGUITY_MIN_SCORE: u8 = 60;
+const AMBIGUITY_MAX_SCORE_GAP: u8 = 4;
+const SAMPLE_QUALITY_HIGH_SAMPLE_THRESHOLD: usize = 100;
+const SAMPLE_QUALITY_MEDIUM_SAMPLE_THRESHOLD: usize = 40;
+const SAMPLE_QUALITY_LOW_SAMPLE_THRESHOLD: usize = 20;
+const SAMPLE_QUALITY_MIN_SIGNAL_SAMPLE_THRESHOLD: usize = 8;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+/// Overall capture completeness and interpretability level.
+pub enum EvidenceQualityLevel {
+    /// Evidence is sufficiently complete for strong triage interpretation.
+    Strong,
+    /// Evidence has meaningful limitations that should guide cautious interpretation.
+    Partial,
+    /// Evidence is too sparse or truncated for strong interpretation.
+    Weak,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+/// Coverage status for one signal family.
+pub enum SignalCoverageStatus {
+    /// Signal family is present without detected partial/truncated limitations.
+    Present,
+    /// Signal family is absent.
+    Missing,
+    /// Signal family exists but is incomplete for interpretation.
+    Partial,
+    /// Signal family had dropped events due to capture truncation.
+    Truncated,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+/// Structured evidence-completeness summary for one report.
+pub struct EvidenceQuality {
+    /// Number of completed requests seen.
+    pub request_count: usize,
+    /// Number of queue events seen.
+    pub queue_event_count: usize,
+    /// Number of stage events seen.
+    pub stage_event_count: usize,
+    /// Number of runtime snapshots seen.
+    pub runtime_snapshot_count: usize,
+    /// Number of in-flight snapshots seen.
+    pub inflight_snapshot_count: usize,
+    /// Coverage status for request completion signals.
+    pub requests: SignalCoverageStatus,
+    /// Coverage status for queue instrumentation signals.
+    pub queues: SignalCoverageStatus,
+    /// Coverage status for stage instrumentation signals.
+    pub stages: SignalCoverageStatus,
+    /// Coverage status for runtime snapshot signals.
+    pub runtime_snapshots: SignalCoverageStatus,
+    /// Coverage status for in-flight snapshot signals.
+    pub inflight_snapshots: SignalCoverageStatus,
+    /// Whether any capture truncation was reported.
+    pub truncated: bool,
+    /// Dropped request event count.
+    pub dropped_requests: u64,
+    /// Dropped stage event count.
+    pub dropped_stages: u64,
+    /// Dropped queue event count.
+    pub dropped_queues: u64,
+    /// Dropped in-flight snapshot count.
+    pub dropped_inflight_snapshots: u64,
+    /// Dropped runtime snapshot count.
+    pub dropped_runtime_snapshots: u64,
+    /// Overall evidence quality level.
+    pub quality: EvidenceQualityLevel,
+    /// Concise interpretation limits for this capture.
+    pub limitations: Vec<String>,
 }
 
 /// Evidence-ranked suspect produced by heuristic analysis.
@@ -142,6 +221,8 @@ pub struct Report {
     pub inflight_trend: Option<InflightTrend>,
     /// Non-fatal analysis warnings (for example, capture truncation notices).
     pub warnings: Vec<String>,
+    /// Structured capture completeness and interpretability signals for this run.
+    pub evidence_quality: EvidenceQuality,
     /// Highest-ranked suspect from this run.
     pub primary_suspect: Suspect,
     /// Lower-ranked suspects retained for follow-up triage.
@@ -250,6 +331,7 @@ pub fn analyze_run(run: &Run) -> Report {
     suspects.sort_by_key(|suspect| std::cmp::Reverse(suspect.score));
 
     let warnings = analysis_warnings(run, &suspects);
+    let evidence_quality = evidence_quality(run, &suspects, &warnings);
 
     let mut ranked = suspects.into_iter();
     let primary_suspect = ranked.next().unwrap_or_else(|| {
@@ -270,6 +352,7 @@ pub fn analyze_run(run: &Run) -> Report {
         p95_service_share_permille,
         inflight_trend,
         warnings,
+        evidence_quality,
         primary_suspect,
         secondary_suspects: ranked.collect(),
     }
@@ -329,14 +412,14 @@ fn max_or_zero(values: &[u64]) -> u64 {
 }
 
 fn score_sample_quality(sample_count: usize) -> u8 {
-    if sample_count >= 100 {
+    if sample_count >= SAMPLE_QUALITY_HIGH_SAMPLE_THRESHOLD {
         8
-    } else if sample_count >= 40 {
+    } else if sample_count >= SAMPLE_QUALITY_MEDIUM_SAMPLE_THRESHOLD {
         5
-    } else if sample_count >= 20 {
+    } else if sample_count >= SAMPLE_QUALITY_LOW_SAMPLE_THRESHOLD {
         3
     } else {
-        u8::from(sample_count >= 8)
+        u8::from(sample_count >= SAMPLE_QUALITY_MIN_SIGNAL_SAMPLE_THRESHOLD)
     }
 }
 
@@ -355,7 +438,7 @@ fn cap_unless_clean_evidence(score: u64, clean: bool, soft_cap: u8) -> u8 {
 fn queue_saturation_suspect(run: &Run, inflight_trend: Option<&InflightTrend>) -> Option<Suspect> {
     let (queue_shares, _) = request_time_shares(run);
     let p95_queue_share_permille = percentile(&queue_shares, 95, 100)?;
-    if p95_queue_share_permille < 300 {
+    if p95_queue_share_permille < QUEUE_SHARE_TRIGGER_PERMILLE {
         return None;
     }
     let queue_depths = run
@@ -538,7 +621,7 @@ fn downstream_stage_candidates(run: &Run, p95_req: u64, total_req: u64) -> Vec<S
     }
     let mut cands = Vec::new();
     for (name, ss) in by {
-        if ss.len() < 3 {
+        if ss.len() < DOWNSTREAM_MIN_STAGE_SAMPLES {
             continue;
         }
         let lats = ss.iter().map(|s| s.latency_us).collect::<Vec<_>>();
@@ -668,9 +751,9 @@ fn ambiguity_warning(suspects: &[Suspect]) -> Option<String> {
         .collect::<Vec<_>>();
     ranked.sort_by_key(|s| std::cmp::Reverse(s.score));
     if ranked.len() >= 2
-        && ranked[0].score >= 60
-        && ranked[1].score >= 60
-        && ranked[0].score.abs_diff(ranked[1].score) <= 4
+        && ranked[0].score >= AMBIGUITY_MIN_SCORE
+        && ranked[1].score >= AMBIGUITY_MIN_SCORE
+        && ranked[0].score.abs_diff(ranked[1].score) <= AMBIGUITY_MAX_SCORE_GAP
     {
         Some("Top suspects are close in score; treat ranking as ambiguous and validate both with next checks.".to_string())
     } else {
@@ -680,7 +763,7 @@ fn ambiguity_warning(suspects: &[Suspect]) -> Option<String> {
 
 fn analysis_warnings(run: &Run, suspects: &[Suspect]) -> Vec<String> {
     let mut warnings = truncation_warnings(run);
-    if run.requests.len() < 20 {
+    if run.requests.len() < LOW_COMPLETED_REQUEST_WARNING_THRESHOLD {
         warnings.push(
             "Low completed-request count; diagnosis ranking may be unstable for this run window."
                 .to_string(),
@@ -731,6 +814,116 @@ fn analysis_warnings(run: &Run, suspects: &[Suspect]) -> Vec<String> {
         warnings.push(w);
     }
     warnings
+}
+
+fn runtime_snapshots_partial(snapshots: &[RuntimeSnapshot]) -> bool {
+    !snapshots.is_empty()
+        && (snapshots.iter().all(|s| s.blocking_queue_depth.is_none())
+            || snapshots.iter().all(|s| s.local_queue_depth.is_none())
+            || snapshots.iter().all(|s| s.global_queue_depth.is_none()))
+}
+
+fn evidence_quality(run: &Run, suspects: &[Suspect], warnings: &[String]) -> EvidenceQuality {
+    let request_count = run.requests.len();
+    let queue_event_count = run.queues.len();
+    let stage_event_count = run.stages.len();
+    let runtime_snapshot_count = run.runtime_snapshots.len();
+    let inflight_snapshot_count = run.inflight.len();
+    let runtime_partial = runtime_snapshots_partial(&run.runtime_snapshots);
+
+    let requests = if request_count == 0 {
+        SignalCoverageStatus::Missing
+    } else if run.truncation.dropped_requests > 0 {
+        SignalCoverageStatus::Truncated
+    } else if request_count < LOW_COMPLETED_REQUEST_WARNING_THRESHOLD {
+        SignalCoverageStatus::Partial
+    } else {
+        SignalCoverageStatus::Present
+    };
+    let queues = if queue_event_count == 0 {
+        SignalCoverageStatus::Missing
+    } else if run.truncation.dropped_queues > 0 {
+        SignalCoverageStatus::Truncated
+    } else {
+        SignalCoverageStatus::Present
+    };
+    let stages = if stage_event_count == 0 {
+        SignalCoverageStatus::Missing
+    } else if run.truncation.dropped_stages > 0 {
+        SignalCoverageStatus::Truncated
+    } else {
+        SignalCoverageStatus::Present
+    };
+    let runtime_snapshots = if runtime_snapshot_count == 0 {
+        SignalCoverageStatus::Missing
+    } else if run.truncation.dropped_runtime_snapshots > 0 {
+        SignalCoverageStatus::Truncated
+    } else if runtime_partial {
+        SignalCoverageStatus::Partial
+    } else {
+        SignalCoverageStatus::Present
+    };
+    let inflight_snapshots = if inflight_snapshot_count == 0 {
+        SignalCoverageStatus::Missing
+    } else if run.truncation.dropped_inflight_snapshots > 0 {
+        SignalCoverageStatus::Truncated
+    } else {
+        SignalCoverageStatus::Present
+    };
+
+    let no_explanatory_signal_family =
+        queue_event_count == 0 && stage_event_count == 0 && runtime_snapshot_count == 0;
+    let non_request_truncation = run.truncation.dropped_queues > 0
+        || run.truncation.dropped_stages > 0
+        || run.truncation.dropped_runtime_snapshots > 0
+        || run.truncation.dropped_inflight_snapshots > 0;
+
+    let strong_non_runtime_primary = suspects.first().is_some_and(|s| {
+        (s.kind == DiagnosisKind::ApplicationQueueSaturation
+            || s.kind == DiagnosisKind::DownstreamStageDominates)
+            && s.score >= HIGH_CONFIDENCE_MIN_SCORE
+    });
+
+    let quality = if request_count == 0
+        || request_count < LOW_COMPLETED_REQUEST_WARNING_THRESHOLD
+        || run.truncation.dropped_requests > 0
+        || no_explanatory_signal_family
+    {
+        EvidenceQualityLevel::Weak
+    } else if non_request_truncation
+        || (queue_event_count == 0 && stage_event_count == 0)
+        || runtime_partial
+    {
+        EvidenceQualityLevel::Partial
+    } else if (queue_event_count > 0 || stage_event_count > 0)
+        && (runtime_snapshot_count > 0 || strong_non_runtime_primary)
+    {
+        EvidenceQualityLevel::Strong
+    } else {
+        EvidenceQualityLevel::Partial
+    };
+
+    let limitations = warnings.to_vec();
+    EvidenceQuality {
+        request_count,
+        queue_event_count,
+        stage_event_count,
+        runtime_snapshot_count,
+        inflight_snapshot_count,
+        requests,
+        queues,
+        stages,
+        runtime_snapshots,
+        inflight_snapshots,
+        truncated: run.truncation.limits_hit || run.truncation.is_truncated(),
+        dropped_requests: run.truncation.dropped_requests,
+        dropped_stages: run.truncation.dropped_stages,
+        dropped_queues: run.truncation.dropped_queues,
+        dropped_inflight_snapshots: run.truncation.dropped_inflight_snapshots,
+        dropped_runtime_snapshots: run.truncation.dropped_runtime_snapshots,
+        quality,
+        limitations,
+    }
 }
 
 fn request_time_shares(run: &Run) -> (Vec<u64>, Vec<u64>) {
@@ -891,6 +1084,14 @@ fn fmt_confidence(confidence: Confidence) -> &'static str {
     }
 }
 
+fn fmt_evidence_quality(quality: EvidenceQualityLevel) -> &'static str {
+    match quality {
+        EvidenceQualityLevel::Strong => "strong",
+        EvidenceQualityLevel::Partial => "partial",
+        EvidenceQualityLevel::Weak => "weak",
+    }
+}
+
 #[must_use]
 /// Renders a compact text triage summary from a [`Report`].
 ///
@@ -933,6 +1134,16 @@ pub fn render_text(report: &Report) -> String {
         report.primary_suspect.kind.as_str(),
         fmt_confidence(report.primary_suspect.confidence),
         report.primary_suspect.score,
+    ));
+    let evidence_summary = report
+        .evidence_quality
+        .limitations
+        .first()
+        .map_or_else(String::new, |l| format!(" ({l})"));
+    lines.push(format!(
+        "Evidence quality: {}{}",
+        fmt_evidence_quality(report.evidence_quality.quality),
+        evidence_summary
     ));
 
     if !report.warnings.is_empty() {
@@ -979,7 +1190,8 @@ mod tests {
     };
 
     use crate::analyze::{
-        analyze_run, render_text, Confidence, DiagnosisKind, InflightTrend, Report, Suspect,
+        analyze_run, render_text, Confidence, DiagnosisKind, EvidenceQuality, EvidenceQualityLevel,
+        InflightTrend, Report, SignalCoverageStatus, Suspect,
     };
 
     fn test_run() -> Run {
@@ -1194,6 +1406,26 @@ mod tests {
                 growth_per_sec_milli: Some(2_500),
             }),
             warnings: Vec::new(),
+            evidence_quality: EvidenceQuality {
+                request_count: 2,
+                queue_event_count: 0,
+                stage_event_count: 0,
+                runtime_snapshot_count: 0,
+                inflight_snapshot_count: 0,
+                requests: SignalCoverageStatus::Present,
+                queues: SignalCoverageStatus::Missing,
+                stages: SignalCoverageStatus::Missing,
+                runtime_snapshots: SignalCoverageStatus::Missing,
+                inflight_snapshots: SignalCoverageStatus::Missing,
+                truncated: false,
+                dropped_requests: 0,
+                dropped_stages: 0,
+                dropped_queues: 0,
+                dropped_inflight_snapshots: 0,
+                dropped_runtime_snapshots: 0,
+                quality: EvidenceQualityLevel::Strong,
+                limitations: Vec::new(),
+            },
             primary_suspect: Suspect {
                 kind: DiagnosisKind::ApplicationQueueSaturation,
                 score: 90,
@@ -1224,6 +1456,26 @@ mod tests {
             p95_service_share_permille: None,
             inflight_trend: None,
             warnings: vec!["Capture truncated requests.".to_owned()],
+            evidence_quality: EvidenceQuality {
+                request_count: 0,
+                queue_event_count: 0,
+                stage_event_count: 0,
+                runtime_snapshot_count: 0,
+                inflight_snapshot_count: 0,
+                requests: SignalCoverageStatus::Missing,
+                queues: SignalCoverageStatus::Missing,
+                stages: SignalCoverageStatus::Missing,
+                runtime_snapshots: SignalCoverageStatus::Missing,
+                inflight_snapshots: SignalCoverageStatus::Missing,
+                truncated: true,
+                dropped_requests: 1,
+                dropped_stages: 0,
+                dropped_queues: 0,
+                dropped_inflight_snapshots: 0,
+                dropped_runtime_snapshots: 0,
+                quality: EvidenceQualityLevel::Weak,
+                limitations: vec!["Capture truncated requests.".to_owned()],
+            },
             primary_suspect: Suspect {
                 kind: DiagnosisKind::InsufficientEvidence,
                 score: 50,
@@ -1476,5 +1728,102 @@ mod tests {
             .warnings
             .iter()
             .any(|w| w.contains("dropped 1 entries after reaching max_runtime_snapshots")));
+    }
+
+    #[test]
+    fn evidence_quality_weak_with_low_requests_and_missing_signals() {
+        let report = analyze_run(&test_run());
+        assert_eq!(report.evidence_quality.quality, EvidenceQualityLevel::Weak);
+        assert_eq!(
+            report.evidence_quality.requests,
+            SignalCoverageStatus::Partial
+        );
+        assert_eq!(
+            report.evidence_quality.queues,
+            SignalCoverageStatus::Missing
+        );
+        assert_eq!(
+            report.evidence_quality.stages,
+            SignalCoverageStatus::Missing
+        );
+        assert_eq!(
+            report.evidence_quality.runtime_snapshots,
+            SignalCoverageStatus::Missing
+        );
+    }
+
+    #[test]
+    fn evidence_quality_partial_for_runtime_partial_or_truncation() {
+        let mut run = test_run();
+        run.requests = (0..30)
+            .map(|i| RequestEvent {
+                request_id: format!("req-{i}"),
+                route: "/test".into(),
+                kind: None,
+                started_at_unix_ms: i,
+                finished_at_unix_ms: i + 1,
+                latency_us: 1_000,
+                outcome: "ok".into(),
+            })
+            .collect();
+        run.queues = run
+            .requests
+            .iter()
+            .map(|r| QueueEvent {
+                request_id: r.request_id.clone(),
+                queue: "q".into(),
+                wait_us: 100,
+                waited_from_unix_ms: 0,
+                waited_until_unix_ms: 1,
+                depth_at_start: Some(1),
+            })
+            .collect();
+        run.runtime_snapshots = vec![runtime_snapshot(Some(1), Some(1), None); 20];
+        let report = analyze_run(&run);
+        assert_eq!(
+            report.evidence_quality.quality,
+            EvidenceQualityLevel::Partial
+        );
+        assert_eq!(
+            report.evidence_quality.runtime_snapshots,
+            SignalCoverageStatus::Partial
+        );
+    }
+
+    #[test]
+    fn evidence_quality_strong_without_runtime_snapshots_when_non_runtime_evidence_is_clear() {
+        let mut run = test_run();
+        run.requests = (0..40)
+            .map(|i| RequestEvent {
+                request_id: format!("req-{i}"),
+                route: "/test".into(),
+                kind: None,
+                started_at_unix_ms: i,
+                finished_at_unix_ms: i + 1,
+                latency_us: 1_000,
+                outcome: "ok".into(),
+            })
+            .collect();
+        run.queues = run
+            .requests
+            .iter()
+            .map(|r| QueueEvent {
+                request_id: r.request_id.clone(),
+                queue: "q".into(),
+                waited_from_unix_ms: 1,
+                waited_until_unix_ms: 2,
+                wait_us: 990,
+                depth_at_start: Some(20),
+            })
+            .collect();
+        let report = analyze_run(&run);
+        assert_eq!(
+            report.primary_suspect.kind,
+            DiagnosisKind::ApplicationQueueSaturation
+        );
+        assert_eq!(
+            report.evidence_quality.quality,
+            EvidenceQualityLevel::Strong
+        );
     }
 }


### PR DESCRIPTION
### Motivation
- Make evidence completeness explicit in machine-readable analyzer output so consumers and validation can deterministically understand which signal families are present, missing, partial, or truncated instead of inferring from free-form warnings. 
- Promote maintainability and testability by extracting existing analyzer literal thresholds and limits into named constants (behavior-preserving). 
- Preserve the analyzer’s narrow triage scope: report capture completeness/interpretability (not causal claims) and do not change scoring, ranking, or confidence behavior.

### Description
- Added a new serializable report field `evidence_quality: EvidenceQuality` containing counts, per-family `SignalCoverageStatus` (`present`/`missing`/`partial`/`truncated`), truncation counters, overall `EvidenceQualityLevel` (`strong`/`partial`/`weak`), and `limitations: Vec<String>` populated from existing warnings; implemented deterministic semantics in `evidence_quality(...)` and `runtime_snapshots_partial(...)` (see `tailtriage-cli/src/analyze.rs`).
- Extracted analyzer literals into named constants and wired existing logic to use them, including `LOW_COMPLETED_REQUEST_WARNING_THRESHOLD`, `QUEUE_SHARE_TRIGGER_PERMILLE`, `MEDIUM_CONFIDENCE_MIN_SCORE`, `HIGH_CONFIDENCE_MIN_SCORE`, `DOWNSTREAM_MIN_STAGE_SAMPLES`, `AMBIGUITY_MIN_SCORE`, `AMBIGUITY_MAX_SCORE_GAP`, and sample-quality thresholds such as `SAMPLE_QUALITY_HIGH_SAMPLE_THRESHOLD` (behavior preserved).
- Kept existing warnings additive and reused them as concise `evidence_quality.limitations`; added a compact text rendering line in `render_text` (e.g. `Evidence quality: partial (missing runtime snapshots)`).
- Added unit tests that cover `strong`/`partial`/`weak` evidence-quality outcomes and per-signal coverage statuses, plus a behavior-preservation test asserting primary suspect/ranking behavior for an existing fixture; refreshed demo analysis fixtures and updated relevant docs and README JSON examples to include the new field.

### Testing
- Ran formatting/lint/build/test and validation suites; all automated checks passed: `cargo fmt --check` (pass), `cargo clippy --workspace --all-targets -- -D warnings` (pass), `cargo test --workspace` (pass).
- Ran demo fixture drift and benchmark/validation scripts; all passed: `python3 scripts/check_demo_fixture_drift.py --profile dev --refresh` (refreshed fixtures) and subsequent `--profile dev` check (pass), `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0` (pass), `python3 -m unittest scripts.tests.test_diagnostic_benchmark` (pass), `python3 scripts/validate_docs_contracts.py` (pass), and `python3 -m unittest scripts.tests.test_validate_docs_contracts` (pass).

Notes: No diagnosis kinds, scoring formulas, ranking logic, or confidence-bucket behavior were changed; this PR is additive to the report shape and extracts constants only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97dbed2bc8330972fd86fa20868ba)