### PR TITLE
Make analyzer confidence evidence-aware with per-suspect caps

### DIFF
--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -35,7 +35,7 @@ The scorecard includes confidence-bucket accuracy summaries (low/medium/high buc
 The corpus includes deterministic synthetic adversarial cases for sparse samples, missing instrumentation, truncated artifacts, and mixed-signal workloads. These cases validate triage humility and evidence-ranked suspect visibility under partial data.
 
 ## Confidence ceilings (`max_primary_confidence`)
-Case-level confidence ceilings enforce conservative confidence behavior for conditions where data is sparse, missing, truncated, noisy, or intentionally ambiguous. A case fails if primary confidence exceeds its configured ceiling.
+Case-level confidence ceilings enforce conservative confidence behavior for conditions where evidence is sparse, missing, truncated, noisy, or intentionally ambiguous, including evidence-aware confidence caps. A case fails if primary confidence exceeds its configured ceiling.
 
 This check validates humility in diagnosis ranking behavior. It does not claim calibrated truth probability.
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -39,6 +39,7 @@ Each suspect includes:
 - `kind`
 - `score`
 - `confidence`
+- `confidence_notes[]` (only when evidence limitations cap confidence)
 - `evidence[]`
 - `next_checks[]`
 
@@ -81,7 +82,7 @@ The analyzer is deterministic and rule-based. It does not use probabilistic or M
 
 - `score` is a **relative evidence-ranking score within one report**.
 - `score` is **not** a probability and **not** absolute severity across different captures.
-- `confidence` is derived from score bands and reflects ranking strength, not causal certainty.
+- `confidence` is derived from score bands and then evidence-quality capped when evidence is weak/truncated/missing/ambiguous; it reflects ranking strength, not causal certainty.
 
 Signal families used for scoring:
 

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -90,6 +90,7 @@ Then run one targeted check, change one thing, and re-run under comparable load.
     "kind": "application_queue_saturation",
     "score": 90,
     "confidence": "high",
+    "confidence_notes": [],
     "evidence": ["Queue wait at p95 consumes 98.2% of request time."],
     "next_checks": ["Inspect queue admission limits and producer burst patterns."]
   },
@@ -120,6 +121,7 @@ Each suspect includes:
 - `confidence`
 - `evidence[]`
 - `next_checks[]`
+- `confidence_notes[]` (only present when evidence quality caps confidence or ambiguity explicitly caps confidence)
 
 ## Artifact compatibility contract
 
@@ -153,7 +155,7 @@ Library note:
 Suspect ranking uses deterministic, proportional, evidence-aware scoring (0-100), not fixed suspect priority.
 
 - Scores rank suspects **inside one report**; they are not probabilities.
-- Confidence is score-derived ranking strength, not causal certainty.
+- Confidence is score-derived ranking strength and can be evidence-quality-capped, not causal certainty.
 - Strong downstream tail-stage contribution can outrank weak blocking/runtime signals.
 - Strong queue pressure remains a high-confidence lead when queue share/depth evidence is dominant.
 

--- a/tailtriage-cli/src/analyze.rs
+++ b/tailtriage-cli/src/analyze.rs
@@ -159,6 +159,9 @@ pub struct Suspect {
     pub score: u8,
     /// Score-derived confidence bucket for triage prioritization.
     pub confidence: Confidence,
+    /// Evidence-aware confidence-cap notes, present only when a cap applies.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub confidence_notes: Vec<String>,
     /// Supporting evidence strings used to justify this suspect ranking.
     pub evidence: Vec<String>,
     /// Recommended next checks to validate or falsify this suspect.
@@ -176,6 +179,7 @@ impl Suspect {
             kind,
             score,
             confidence: Confidence::from_score(score),
+            confidence_notes: Vec::new(),
             evidence,
             next_checks,
         }
@@ -330,8 +334,9 @@ pub fn analyze_run(run: &Run) -> Report {
 
     suspects.sort_by_key(|suspect| std::cmp::Reverse(suspect.score));
 
-    let warnings = analysis_warnings(run, &suspects);
     let evidence_quality = evidence_quality(run);
+    apply_evidence_aware_confidence_caps(&mut suspects, run, &evidence_quality);
+    let warnings = analysis_warnings(run, &suspects);
 
     let mut ranked = suspects.into_iter();
     let primary_suspect = ranked.next().unwrap_or_else(|| {
@@ -355,6 +360,139 @@ pub fn analyze_run(run: &Run) -> Report {
         evidence_quality,
         primary_suspect,
         secondary_suspects: ranked.collect(),
+    }
+}
+
+fn confidence_min(left: Confidence, right: Confidence) -> Confidence {
+    match (left, right) {
+        (Confidence::Low, _) | (_, Confidence::Low) => Confidence::Low,
+        (Confidence::Medium, _) | (_, Confidence::Medium) => Confidence::Medium,
+        _ => Confidence::High,
+    }
+}
+
+fn caps_from_missing_primary_signal(
+    run: &Run,
+    suspect: &Suspect,
+) -> Vec<(&'static str, Confidence)> {
+    let mut caps = Vec::new();
+    match suspect.kind {
+        DiagnosisKind::ApplicationQueueSaturation if run.queues.is_empty() => caps.push((
+            "Missing queue instrumentation limits queue-saturation confidence.",
+            Confidence::Medium,
+        )),
+        DiagnosisKind::DownstreamStageDominates if run.stages.is_empty() => caps.push((
+            "Missing stage instrumentation limits downstream-stage confidence.",
+            Confidence::Medium,
+        )),
+        DiagnosisKind::BlockingPoolPressure | DiagnosisKind::ExecutorPressureSuspected => {
+            if run.runtime_snapshots.is_empty()
+                || run
+                    .runtime_snapshots
+                    .iter()
+                    .all(|snapshot| snapshot.blocking_queue_depth.is_none())
+                || run
+                    .runtime_snapshots
+                    .iter()
+                    .all(|snapshot| snapshot.local_queue_depth.is_none())
+                || run
+                    .runtime_snapshots
+                    .iter()
+                    .all(|snapshot| snapshot.global_queue_depth.is_none())
+            {
+                caps.push((
+                    "Missing runtime snapshots limit executor/blocking confidence.",
+                    Confidence::Medium,
+                ));
+            }
+        }
+        _ => {}
+    }
+    caps
+}
+
+fn apply_evidence_aware_confidence_caps(
+    suspects: &mut [Suspect],
+    run: &Run,
+    evidence_quality: &EvidenceQuality,
+) {
+    if suspects.is_empty() {
+        return;
+    }
+    let ambiguity_cap_applies = ambiguity_warning(suspects).is_some();
+    for (index, suspect) in suspects.iter_mut().enumerate() {
+        if suspect.kind == DiagnosisKind::InsufficientEvidence {
+            continue;
+        }
+        let mut capped = suspect.confidence;
+        let mut notes = Vec::new();
+        if evidence_quality.quality == EvidenceQualityLevel::Weak {
+            let next = confidence_min(capped, Confidence::Medium);
+            if next != capped {
+                notes.push("Low completed-request count caps confidence.".to_string());
+                capped = next;
+            }
+        }
+        if run.requests.is_empty() {
+            let next = confidence_min(capped, Confidence::Low);
+            if next != capped {
+                notes.push("Low completed-request count caps confidence.".to_string());
+                capped = next;
+            }
+        } else if run.requests.len() < LOW_COMPLETED_REQUEST_THRESHOLD && index == 0 {
+            let next = confidence_min(capped, Confidence::Medium);
+            if next != capped {
+                notes.push("Low completed-request count caps confidence.".to_string());
+                capped = next;
+            }
+        }
+        if run.truncation.dropped_requests > 0 {
+            let next = confidence_min(capped, Confidence::Medium);
+            if next != capped {
+                notes.push(
+                    "Capture truncation caps confidence because dropped evidence may affect ranking."
+                        .to_string(),
+                );
+                capped = next;
+            }
+        }
+        let family_dropped = match suspect.kind {
+            DiagnosisKind::ApplicationQueueSaturation => run.truncation.dropped_queues > 0,
+            DiagnosisKind::DownstreamStageDominates => run.truncation.dropped_stages > 0,
+            DiagnosisKind::BlockingPoolPressure | DiagnosisKind::ExecutorPressureSuspected => {
+                run.truncation.dropped_runtime_snapshots > 0
+            }
+            DiagnosisKind::InsufficientEvidence => false,
+        };
+        if family_dropped {
+            let next = confidence_min(capped, Confidence::Medium);
+            if next != capped {
+                notes.push(
+                    "Capture truncation caps confidence because dropped evidence may affect ranking."
+                        .to_string(),
+                );
+                capped = next;
+            }
+        }
+        for (note, cap) in caps_from_missing_primary_signal(run, suspect) {
+            let next = confidence_min(capped, cap);
+            if next != capped {
+                notes.push(note.to_string());
+                capped = next;
+            }
+        }
+        if ambiguity_cap_applies && index == 0 {
+            let next = confidence_min(capped, Confidence::Medium);
+            if next != capped || suspect.confidence == Confidence::Medium {
+                notes.push(
+                    "Top suspects are close in score; confidence is capped by ambiguity."
+                        .to_string(),
+                );
+                capped = next;
+            }
+        }
+        suspect.confidence = capped;
+        suspect.confidence_notes = notes;
     }
 }
 
@@ -1450,6 +1588,7 @@ mod tests {
                 kind: DiagnosisKind::ApplicationQueueSaturation,
                 score: 90,
                 confidence: Confidence::High,
+                confidence_notes: Vec::new(),
                 evidence: vec!["queue wait high".to_owned()],
                 next_checks: vec!["check queue policy".to_owned()],
             },
@@ -1500,6 +1639,7 @@ mod tests {
                 kind: DiagnosisKind::InsufficientEvidence,
                 score: 50,
                 confidence: Confidence::Low,
+                confidence_notes: Vec::new(),
                 evidence: vec!["missing signals".to_owned()],
                 next_checks: vec!["add instrumentation".to_owned()],
             },
@@ -1904,5 +2044,199 @@ mod tests {
             report.evidence_quality.quality,
             EvidenceQualityLevel::Strong
         );
+    }
+
+    #[test]
+    fn confidence_caps_and_notes_behave_as_expected() {
+        let mut run = test_run();
+        run.queues = vec![
+            QueueEvent {
+                request_id: "req-1".into(),
+                queue: "q".into(),
+                wait_us: 700,
+                waited_from_unix_ms: 0,
+                waited_until_unix_ms: 1,
+                depth_at_start: Some(4),
+            },
+            QueueEvent {
+                request_id: "req-2".into(),
+                queue: "q".into(),
+                wait_us: 720,
+                waited_from_unix_ms: 1,
+                waited_until_unix_ms: 2,
+                depth_at_start: Some(4),
+            },
+            QueueEvent {
+                request_id: "req-3".into(),
+                queue: "q".into(),
+                wait_us: 740,
+                waited_from_unix_ms: 2,
+                waited_until_unix_ms: 3,
+                depth_at_start: Some(4),
+            },
+        ];
+        run.stages = vec![
+            StageEvent {
+                request_id: "req-1".into(),
+                stage: "db".into(),
+                started_at_unix_ms: 0,
+                finished_at_unix_ms: 1,
+                latency_us: 740,
+                success: true,
+            },
+            StageEvent {
+                request_id: "req-2".into(),
+                stage: "db".into(),
+                started_at_unix_ms: 1,
+                finished_at_unix_ms: 2,
+                latency_us: 750,
+                success: true,
+            },
+            StageEvent {
+                request_id: "req-3".into(),
+                stage: "db".into(),
+                started_at_unix_ms: 2,
+                finished_at_unix_ms: 3,
+                latency_us: 760,
+                success: true,
+            },
+        ];
+        run.truncation.dropped_queues = 1;
+        let report = analyze_run(&run);
+        assert_eq!(report.primary_suspect.confidence, Confidence::Medium);
+        assert!(report
+            .primary_suspect
+            .confidence_notes
+            .iter()
+            .any(|n| n == "Low completed-request count caps confidence."));
+        assert!(report.primary_suspect.confidence_notes.iter().all(|n| n
+            != "Capture truncation caps confidence because dropped evidence may affect ranking."));
+    }
+
+    #[test]
+    fn clean_strong_evidence_preserves_high_confidence_and_notes_empty() {
+        let mut run = test_run();
+        run.requests = (0..40)
+            .map(|i| RequestEvent {
+                request_id: format!("req-{i}"),
+                route: "/test".into(),
+                kind: None,
+                started_at_unix_ms: i,
+                finished_at_unix_ms: i + 1,
+                latency_us: 1_000,
+                outcome: "ok".into(),
+            })
+            .collect();
+        run.queues = run
+            .requests
+            .iter()
+            .map(|r| QueueEvent {
+                request_id: r.request_id.clone(),
+                queue: "q".into(),
+                waited_from_unix_ms: 1,
+                waited_until_unix_ms: 2,
+                wait_us: 990,
+                depth_at_start: Some(20),
+            })
+            .collect();
+        let report = analyze_run(&run);
+        assert_eq!(report.primary_suspect.confidence, Confidence::High);
+        assert!(report.primary_suspect.confidence_notes.is_empty());
+    }
+
+    #[test]
+    fn confidence_caps_do_not_change_score_ordering() {
+        let mut run = test_run();
+        run.queues = vec![
+            QueueEvent {
+                request_id: "req-1".into(),
+                queue: "q".into(),
+                wait_us: 700,
+                waited_from_unix_ms: 0,
+                waited_until_unix_ms: 1,
+                depth_at_start: Some(4),
+            },
+            QueueEvent {
+                request_id: "req-2".into(),
+                queue: "q".into(),
+                wait_us: 720,
+                waited_from_unix_ms: 1,
+                waited_until_unix_ms: 2,
+                depth_at_start: Some(4),
+            },
+            QueueEvent {
+                request_id: "req-3".into(),
+                queue: "q".into(),
+                wait_us: 740,
+                waited_from_unix_ms: 2,
+                waited_until_unix_ms: 3,
+                depth_at_start: Some(4),
+            },
+        ];
+        run.stages = vec![
+            StageEvent {
+                request_id: "req-1".into(),
+                stage: "db".into(),
+                started_at_unix_ms: 0,
+                finished_at_unix_ms: 1,
+                latency_us: 740,
+                success: true,
+            },
+            StageEvent {
+                request_id: "req-2".into(),
+                stage: "db".into(),
+                started_at_unix_ms: 1,
+                finished_at_unix_ms: 2,
+                latency_us: 750,
+                success: true,
+            },
+            StageEvent {
+                request_id: "req-3".into(),
+                stage: "db".into(),
+                started_at_unix_ms: 2,
+                finished_at_unix_ms: 3,
+                latency_us: 760,
+                success: true,
+            },
+        ];
+        let report = analyze_run(&run);
+        let mut suspects = vec![report.primary_suspect];
+        suspects.extend(report.secondary_suspects);
+        assert!(suspects
+            .windows(2)
+            .all(|pair| pair[0].score >= pair[1].score));
+    }
+
+    #[test]
+    fn truncation_cap_adds_note_when_it_changes_bucket() {
+        let mut run = test_run();
+        run.requests = (0..40)
+            .map(|i| RequestEvent {
+                request_id: format!("req-{i}"),
+                route: "/test".into(),
+                kind: None,
+                started_at_unix_ms: i,
+                finished_at_unix_ms: i + 1,
+                latency_us: 1_000,
+                outcome: "ok".into(),
+            })
+            .collect();
+        run.queues = run
+            .requests
+            .iter()
+            .map(|r| QueueEvent {
+                request_id: r.request_id.clone(),
+                queue: "q".into(),
+                waited_from_unix_ms: 1,
+                waited_until_unix_ms: 2,
+                wait_us: 990,
+                depth_at_start: Some(20),
+            })
+            .collect();
+        run.truncation.dropped_queues = 5;
+        let report = analyze_run(&run);
+        assert_eq!(report.primary_suspect.confidence, Confidence::Medium);
+        assert!(report.primary_suspect.confidence_notes.iter().any(|n| n
+            == "Capture truncation caps confidence because dropped evidence may affect ranking."));
     }
 }


### PR DESCRIPTION
### Motivation
- Confidence was derived purely from suspect score thresholds and could overstate triage confidence when evidence is sparse, truncated, ambiguous, or missing key signal families. 
- Confidence should remain a triage-priority bucket (not a probability) but reflect evidence quality so users get clearer next-check guidance.

### Description
- Add `confidence_notes: Vec<String>` to `Suspect` and populate it only when an evidence-aware cap actually changes a suspect's confidence bucket or an explicit ambiguity cap applies. 
- Add an evidence-aware capping phase `apply_evidence_aware_confidence_caps(...)` that runs after suspects are generated and sorted by `score` and before the final `Report` is produced, leaving scores and ordering unchanged. 
- Implement per-suspect cap rules driven by `evidence_quality` and truncation/ambiguity logic: weak evidence caps to at most `medium`, very sparse/zero requests can cap to `low`, truncation/dropped events cap to `medium`, missing primary signal families (queues/stages/runtime) cap relevant suspects to `medium`, and primary-ambiguity caps primary suspect to `medium`. 
- Preserve existing score formulas and ranking behavior, add regression/unit tests for confidence-note emission, cap behavior, clean-high-confidence preservation, and ordering invariants, and update CLI/docs to document `confidence_notes` and the score-derived + evidence-quality-capped semantics.

### Testing
- Ran formatting, linting, and unit-test validation: `cargo fmt --check` passed, `cargo clippy --workspace --all-targets -- -D warnings` passed, and `cargo test --workspace` passed (all analyzer tests and new tests passed). 
- Ran fixture/fixture-drift and validation scripts: `python3 scripts/check_demo_fixture_drift.py --profile dev` passed and refreshed demo fixtures as intended. 
- Ran deterministic diagnostic benchmark: `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0` and it passed (top1/top2 thresholds met and `high_confidence_wrong_count == 0`). 
- Ran docs contract checks and related unit tests: `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts` passed.

Suspect scores/ranking change status: suspect scores and ordering were not changed by this change and remain strictly score-based, with confidence now applied only as a post-ranking, per-suspect cap (verified by regression tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f995427764833080053e5793182efe)