### PR TITLE
Make analyzer confidence evidence-aware with cap notes

### DIFF
--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -19,7 +19,7 @@ Deterministic fixture validation is exercised directly in normal CI against `val
 `acceptable_primary` defines which primary kinds are acceptable for ambiguous/mixed interpretation and high-confidence-wrong classification. It does not replace `required_top2`.
 
 ## High-confidence-wrong count
-`high_confidence_wrong_count` increments when primary confidence is `high`/`very_high` and primary kind is outside `acceptable_primary`.
+`high_confidence_wrong_count` increments when primary confidence is `high` and primary kind is outside `acceptable_primary`.
 
 ## Confidence calibration
 The scorecard includes confidence-bucket accuracy summaries (low/medium/high buckets) as calibration hints, not probability guarantees.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -41,7 +41,7 @@ Each suspect includes:
 - `confidence`
 - `evidence[]`
 - `next_checks[]`
-- `confidence_notes[]` (present only when confidence is capped by evidence limits or explicit ambiguity)
+- `confidence_notes[]` (present and empty unless confidence is capped by evidence limits or explicit ambiguity applies)
 
 `p95_queue_share_permille` and `p95_service_share_permille` are independent percentile summaries and do not need to sum to `1000`.
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -41,6 +41,7 @@ Each suspect includes:
 - `confidence`
 - `evidence[]`
 - `next_checks[]`
+- `confidence_notes[]` (present only when confidence is capped by evidence limits or explicit ambiguity)
 
 `p95_queue_share_permille` and `p95_service_share_permille` are independent percentile summaries and do not need to sum to `1000`.
 
@@ -81,7 +82,7 @@ The analyzer is deterministic and rule-based. It does not use probabilistic or M
 
 - `score` is a **relative evidence-ranking score within one report**.
 - `score` is **not** a probability and **not** absolute severity across different captures.
-- `confidence` is derived from score bands and reflects ranking strength, not causal certainty.
+- `confidence` starts from score bands and is then capped by evidence quality limits (sparse/missing/truncated/ambiguous evidence); it reflects triage ranking confidence, not causal certainty.
 
 Signal families used for scoring:
 

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -121,7 +121,7 @@ Each suspect includes:
 - `confidence`
 - `evidence[]`
 - `next_checks[]`
-- `confidence_notes[]` (only when evidence-aware caps/ambiguity affect confidence)
+- `confidence_notes[]` (present and empty unless evidence-aware caps affect confidence, or explicit ambiguity applies)
 
 ## Artifact compatibility contract
 

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -91,7 +91,8 @@ Then run one targeted check, change one thing, and re-run under comparable load.
     "score": 90,
     "confidence": "high",
     "evidence": ["Queue wait at p95 consumes 98.2% of request time."],
-    "next_checks": ["Inspect queue admission limits and producer burst patterns."]
+    "next_checks": ["Inspect queue admission limits and producer burst patterns."],
+    "confidence_notes": []
   },
   "secondary_suspects": []
 }
@@ -120,6 +121,7 @@ Each suspect includes:
 - `confidence`
 - `evidence[]`
 - `next_checks[]`
+- `confidence_notes[]` (only when evidence-aware caps/ambiguity affect confidence)
 
 ## Artifact compatibility contract
 
@@ -153,7 +155,7 @@ Library note:
 Suspect ranking uses deterministic, proportional, evidence-aware scoring (0-100), not fixed suspect priority.
 
 - Scores rank suspects **inside one report**; they are not probabilities.
-- Confidence is score-derived ranking strength, not causal certainty.
+- Confidence is score-derived ranking strength and may be evidence-quality capped; it is not causal certainty.
 - Strong downstream tail-stage contribution can outrank weak blocking/runtime signals.
 - Strong queue pressure remains a high-confidence lead when queue share/depth evidence is dominant.
 

--- a/tailtriage-cli/src/analyze.rs
+++ b/tailtriage-cli/src/analyze.rs
@@ -368,6 +368,19 @@ fn apply_evidence_aware_confidence_caps(
     run: &Run,
     evidence_quality: &EvidenceQuality,
 ) {
+    let runtime_missing_key_fields = run.runtime_snapshots.is_empty()
+        || run
+            .runtime_snapshots
+            .iter()
+            .all(|snapshot| snapshot.blocking_queue_depth.is_none())
+        || run
+            .runtime_snapshots
+            .iter()
+            .all(|snapshot| snapshot.local_queue_depth.is_none())
+        || run
+            .runtime_snapshots
+            .iter()
+            .all(|snapshot| snapshot.global_queue_depth.is_none());
     let ambiguous = ambiguity_warning(suspects).is_some();
     let primary_index = suspects
         .iter()
@@ -400,36 +413,13 @@ fn apply_evidence_aware_confidence_caps(
                     .to_string(),
             );
         }
-        match suspect.kind {
-            DiagnosisKind::ApplicationQueueSaturation => {
-                if run.truncation.dropped_queues > 0 || run.queues.is_empty() {
-                    cap = cap.min(Confidence::Medium);
-                    notes.push(
-                        "Missing queue instrumentation limits queue-saturation confidence."
-                            .to_string(),
-                    );
-                }
-            }
-            DiagnosisKind::DownstreamStageDominates => {
-                if run.truncation.dropped_stages > 0 || run.stages.is_empty() {
-                    cap = cap.min(Confidence::Medium);
-                    notes.push(
-                        "Missing stage instrumentation limits downstream-stage confidence."
-                            .to_string(),
-                    );
-                }
-            }
-            DiagnosisKind::BlockingPoolPressure | DiagnosisKind::ExecutorPressureSuspected => {
-                if run.truncation.dropped_runtime_snapshots > 0 || run.runtime_snapshots.is_empty()
-                {
-                    cap = cap.min(Confidence::Medium);
-                    notes.push(
-                        "Missing runtime snapshots limit executor/blocking confidence.".to_string(),
-                    );
-                }
-            }
-            DiagnosisKind::InsufficientEvidence => {}
-        }
+        apply_family_evidence_caps(
+            &suspect.kind,
+            run,
+            runtime_missing_key_fields,
+            &mut cap,
+            &mut notes,
+        );
         if is_primary && ambiguous {
             cap = cap.min(Confidence::Medium);
             notes.push(
@@ -438,13 +428,71 @@ fn apply_evidence_aware_confidence_caps(
         }
         let original = suspect.confidence;
         suspect.confidence = original.min(cap);
-        if suspect.confidence != original || (is_primary && ambiguous) {
+        let cap_changed_bucket = suspect.confidence != original;
+        if cap_changed_bucket || (is_primary && ambiguous) {
             notes.sort();
             notes.dedup();
             suspect.confidence_notes = notes;
         } else {
             suspect.confidence_notes.clear();
         }
+    }
+}
+
+fn apply_family_evidence_caps(
+    kind: &DiagnosisKind,
+    run: &Run,
+    runtime_missing_key_fields: bool,
+    cap: &mut Confidence,
+    notes: &mut Vec<String>,
+) {
+    match kind {
+        DiagnosisKind::ApplicationQueueSaturation => {
+            if run.truncation.dropped_queues > 0 {
+                *cap = (*cap).min(Confidence::Medium);
+                notes.push(
+                    "Capture truncation caps confidence because dropped evidence may affect ranking."
+                        .to_string(),
+                );
+            }
+            if run.queues.is_empty() {
+                *cap = (*cap).min(Confidence::Medium);
+                notes.push(
+                    "Missing queue instrumentation limits queue-saturation confidence.".to_string(),
+                );
+            }
+        }
+        DiagnosisKind::DownstreamStageDominates => {
+            if run.truncation.dropped_stages > 0 {
+                *cap = (*cap).min(Confidence::Medium);
+                notes.push(
+                    "Capture truncation caps confidence because dropped evidence may affect ranking."
+                        .to_string(),
+                );
+            }
+            if run.stages.is_empty() {
+                *cap = (*cap).min(Confidence::Medium);
+                notes.push(
+                    "Missing stage instrumentation limits downstream-stage confidence.".to_string(),
+                );
+            }
+        }
+        DiagnosisKind::BlockingPoolPressure | DiagnosisKind::ExecutorPressureSuspected => {
+            if run.truncation.dropped_runtime_snapshots > 0 {
+                *cap = (*cap).min(Confidence::Medium);
+                notes.push(
+                    "Capture truncation caps confidence because dropped evidence may affect ranking."
+                        .to_string(),
+                );
+            }
+            if runtime_missing_key_fields {
+                *cap = (*cap).min(Confidence::Medium);
+                notes.push(
+                    "Missing runtime snapshots limit executor/blocking confidence.".to_string(),
+                );
+            }
+        }
+        DiagnosisKind::InsufficientEvidence => {}
     }
 }
 
@@ -1300,8 +1348,9 @@ mod tests {
     };
 
     use crate::analyze::{
-        analyze_run, render_text, Confidence, DiagnosisKind, EvidenceQuality, EvidenceQualityLevel,
-        InflightTrend, Report, SignalCoverageStatus, Suspect,
+        analyze_run, apply_evidence_aware_confidence_caps, evidence_quality, render_text,
+        Confidence, DiagnosisKind, EvidenceQuality, EvidenceQualityLevel, InflightTrend, Report,
+        SignalCoverageStatus, Suspect,
     };
 
     fn test_run() -> Run {
@@ -1361,6 +1410,18 @@ mod tests {
             inflight: Vec::new(),
             runtime_snapshots: Vec::new(),
             truncation: tailtriage_core::TruncationSummary::default(),
+        }
+    }
+
+    fn sample_request(id: u64) -> RequestEvent {
+        RequestEvent {
+            request_id: format!("req-{id}"),
+            route: "/t".into(),
+            kind: None,
+            started_at_unix_ms: id,
+            finished_at_unix_ms: id + 1,
+            latency_us: 1_000,
+            outcome: "ok".into(),
         }
     }
 
@@ -2123,5 +2184,167 @@ mod tests {
         );
         assert_eq!(report.primary_suspect.confidence, Confidence::High);
         assert!(report.primary_suspect.confidence_notes.is_empty());
+    }
+
+    #[test]
+    fn queue_truncation_uses_truncation_note_not_missing_queue_note() {
+        let mut run = test_run();
+        run.requests = (0..45)
+            .map(|i| RequestEvent {
+                request_id: format!("req-{i}"),
+                route: "/q".into(),
+                kind: None,
+                started_at_unix_ms: i,
+                finished_at_unix_ms: i + 1,
+                latency_us: 1_000,
+                outcome: "ok".into(),
+            })
+            .collect();
+        run.queues = run
+            .requests
+            .iter()
+            .map(|r| QueueEvent {
+                request_id: r.request_id.clone(),
+                queue: "q".into(),
+                waited_from_unix_ms: 1,
+                waited_until_unix_ms: 2,
+                wait_us: 990,
+                depth_at_start: Some(15),
+            })
+            .collect();
+        run.truncation.dropped_queues = 1;
+        let report = analyze_run(&run);
+        assert!(report.primary_suspect.confidence_notes.iter().any(|n| n
+            == "Capture truncation caps confidence because dropped evidence may affect ranking."));
+        assert!(!report
+            .primary_suspect
+            .confidence_notes
+            .iter()
+            .any(|n| n == "Missing queue instrumentation limits queue-saturation confidence."));
+    }
+
+    #[test]
+    fn missing_queue_instrumentation_uses_missing_queue_note() {
+        let mut run = test_run();
+        run.requests = vec![sample_request(1)];
+        run.queues.clear();
+        let eq = evidence_quality(&run);
+        let mut suspects = vec![Suspect::new(
+            DiagnosisKind::ApplicationQueueSaturation,
+            100,
+            vec![],
+            vec![],
+        )];
+        apply_evidence_aware_confidence_caps(&mut suspects, &run, &eq);
+        assert!(suspects[0]
+            .confidence_notes
+            .iter()
+            .any(|n| n == "Missing queue instrumentation limits queue-saturation confidence."));
+    }
+
+    #[test]
+    fn stage_truncation_uses_truncation_note_not_missing_stage_note() {
+        let mut run = test_run();
+        run.requests = (0..45)
+            .map(|i| RequestEvent {
+                request_id: format!("req-{i}"),
+                route: "/s".into(),
+                kind: None,
+                started_at_unix_ms: i,
+                finished_at_unix_ms: i + 1,
+                latency_us: 5_000,
+                outcome: "ok".into(),
+            })
+            .collect();
+        run.stages = run
+            .requests
+            .iter()
+            .map(|r| StageEvent {
+                request_id: r.request_id.clone(),
+                stage: "db".into(),
+                started_at_unix_ms: 1,
+                finished_at_unix_ms: 10,
+                latency_us: 4_800,
+                success: true,
+            })
+            .collect();
+        run.truncation.dropped_stages = 1;
+        let report = analyze_run(&run);
+        assert!(report.primary_suspect.confidence_notes.iter().any(|n| n
+            == "Capture truncation caps confidence because dropped evidence may affect ranking."));
+        assert!(!report
+            .primary_suspect
+            .confidence_notes
+            .iter()
+            .any(|n| n == "Missing stage instrumentation limits downstream-stage confidence."));
+    }
+
+    #[test]
+    fn missing_stage_instrumentation_uses_missing_stage_note() {
+        let mut run = test_run();
+        run.requests = vec![sample_request(1)];
+        run.stages.clear();
+        let eq = evidence_quality(&run);
+        let mut suspects = vec![Suspect::new(
+            DiagnosisKind::DownstreamStageDominates,
+            100,
+            vec![],
+            vec![],
+        )];
+        apply_evidence_aware_confidence_caps(&mut suspects, &run, &eq);
+        assert!(suspects[0]
+            .confidence_notes
+            .iter()
+            .any(|n| n == "Missing stage instrumentation limits downstream-stage confidence."));
+    }
+
+    #[test]
+    fn runtime_partial_fields_cap_executor_or_blocking_confidence() {
+        let mut run = test_run();
+        run.requests = vec![sample_request(1)];
+        run.runtime_snapshots = (0..10)
+            .map(|i| RuntimeSnapshot {
+                at_unix_ms: i,
+                alive_tasks: Some(1),
+                global_queue_depth: Some(5),
+                local_queue_depth: Some(2),
+                blocking_queue_depth: None,
+                remote_schedule_count: Some(0),
+            })
+            .collect();
+        let eq = evidence_quality(&run);
+        let mut suspects = vec![Suspect::new(
+            DiagnosisKind::BlockingPoolPressure,
+            100,
+            vec![],
+            vec![],
+        )];
+        apply_evidence_aware_confidence_caps(&mut suspects, &run, &eq);
+        assert_eq!(suspects[0].confidence, Confidence::Medium);
+        assert!(suspects[0]
+            .confidence_notes
+            .iter()
+            .any(|n| n == "Missing runtime snapshots limit executor/blocking confidence."));
+    }
+
+    #[test]
+    fn ambiguity_cap_adds_note_to_primary() {
+        let mut suspects = vec![
+            Suspect::new(
+                DiagnosisKind::ApplicationQueueSaturation,
+                100,
+                vec![],
+                vec![],
+            ),
+            Suspect::new(DiagnosisKind::DownstreamStageDominates, 97, vec![], vec![]),
+        ];
+        let run = test_run();
+        let eq = evidence_quality(&run);
+        apply_evidence_aware_confidence_caps(&mut suspects, &run, &eq);
+        assert_eq!(suspects[0].confidence, Confidence::Medium);
+        assert!(suspects[0]
+            .confidence_notes
+            .iter()
+            .any(|n| n == "Top suspects are close in score; confidence is capped by ambiguity."));
     }
 }

--- a/tailtriage-cli/src/analyze.rs
+++ b/tailtriage-cli/src/analyze.rs
@@ -55,7 +55,7 @@ impl Serialize for DiagnosisKind {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(rename_all = "snake_case")]
 /// Confidence bucket derived from suspect score thresholds.
 ///
@@ -163,6 +163,8 @@ pub struct Suspect {
     pub evidence: Vec<String>,
     /// Recommended next checks to validate or falsify this suspect.
     pub next_checks: Vec<String>,
+    /// Machine-readable notes explaining confidence caps due to evidence limitations.
+    pub confidence_notes: Vec<String>,
 }
 
 impl Suspect {
@@ -178,6 +180,7 @@ impl Suspect {
             confidence: Confidence::from_score(score),
             evidence,
             next_checks,
+            confidence_notes: Vec::new(),
         }
     }
 }
@@ -333,6 +336,8 @@ pub fn analyze_run(run: &Run) -> Report {
     let warnings = analysis_warnings(run, &suspects);
     let evidence_quality = evidence_quality(run);
 
+    apply_evidence_aware_confidence_caps(&mut suspects, run, &evidence_quality);
+
     let mut ranked = suspects.into_iter();
     let primary_suspect = ranked.next().unwrap_or_else(|| {
         Suspect::new(
@@ -355,6 +360,91 @@ pub fn analyze_run(run: &Run) -> Report {
         evidence_quality,
         primary_suspect,
         secondary_suspects: ranked.collect(),
+    }
+}
+
+fn apply_evidence_aware_confidence_caps(
+    suspects: &mut [Suspect],
+    run: &Run,
+    evidence_quality: &EvidenceQuality,
+) {
+    let ambiguous = ambiguity_warning(suspects).is_some();
+    let primary_index = suspects
+        .iter()
+        .enumerate()
+        .max_by_key(|(_, s)| s.score)
+        .map(|(i, _)| i);
+    for (i, suspect) in suspects.iter_mut().enumerate() {
+        let mut cap = Confidence::High;
+        let mut notes = Vec::new();
+        let is_primary = Some(i) == primary_index;
+        let is_insufficient = suspect.kind == DiagnosisKind::InsufficientEvidence;
+        if !is_insufficient && evidence_quality.quality == EvidenceQualityLevel::Weak {
+            cap = cap.min(Confidence::Medium);
+        }
+        if !is_insufficient && run.requests.is_empty() {
+            cap = Confidence::Low;
+            notes.push("Low completed-request count caps confidence.".to_string());
+        } else if run.requests.len() < LOW_COMPLETED_REQUEST_THRESHOLD {
+            if !is_insufficient {
+                cap = cap.min(Confidence::Medium);
+            }
+            if is_primary {
+                notes.push("Low completed-request count caps confidence.".to_string());
+            }
+        }
+        if run.truncation.dropped_requests > 0 && !is_insufficient {
+            cap = cap.min(Confidence::Medium);
+            notes.push(
+                "Capture truncation caps confidence because dropped evidence may affect ranking."
+                    .to_string(),
+            );
+        }
+        match suspect.kind {
+            DiagnosisKind::ApplicationQueueSaturation => {
+                if run.truncation.dropped_queues > 0 || run.queues.is_empty() {
+                    cap = cap.min(Confidence::Medium);
+                    notes.push(
+                        "Missing queue instrumentation limits queue-saturation confidence."
+                            .to_string(),
+                    );
+                }
+            }
+            DiagnosisKind::DownstreamStageDominates => {
+                if run.truncation.dropped_stages > 0 || run.stages.is_empty() {
+                    cap = cap.min(Confidence::Medium);
+                    notes.push(
+                        "Missing stage instrumentation limits downstream-stage confidence."
+                            .to_string(),
+                    );
+                }
+            }
+            DiagnosisKind::BlockingPoolPressure | DiagnosisKind::ExecutorPressureSuspected => {
+                if run.truncation.dropped_runtime_snapshots > 0 || run.runtime_snapshots.is_empty()
+                {
+                    cap = cap.min(Confidence::Medium);
+                    notes.push(
+                        "Missing runtime snapshots limit executor/blocking confidence.".to_string(),
+                    );
+                }
+            }
+            DiagnosisKind::InsufficientEvidence => {}
+        }
+        if is_primary && ambiguous {
+            cap = cap.min(Confidence::Medium);
+            notes.push(
+                "Top suspects are close in score; confidence is capped by ambiguity.".to_string(),
+            );
+        }
+        let original = suspect.confidence;
+        suspect.confidence = original.min(cap);
+        if suspect.confidence != original || (is_primary && ambiguous) {
+            notes.sort();
+            notes.dedup();
+            suspect.confidence_notes = notes;
+        } else {
+            suspect.confidence_notes.clear();
+        }
     }
 }
 
@@ -1452,6 +1542,7 @@ mod tests {
                 confidence: Confidence::High,
                 evidence: vec!["queue wait high".to_owned()],
                 next_checks: vec!["check queue policy".to_owned()],
+                confidence_notes: Vec::new(),
             },
             secondary_suspects: Vec::new(),
         };
@@ -1502,6 +1593,7 @@ mod tests {
                 confidence: Confidence::Low,
                 evidence: vec!["missing signals".to_owned()],
                 next_checks: vec!["add instrumentation".to_owned()],
+                confidence_notes: Vec::new(),
             },
             secondary_suspects: Vec::new(),
         };
@@ -1904,5 +1996,132 @@ mod tests {
             report.evidence_quality.quality,
             EvidenceQualityLevel::Strong
         );
+    }
+
+    #[test]
+    fn confidence_caps_do_not_change_score_ordering() {
+        let mut run = test_run();
+        run.requests = (0..40)
+            .map(|i| RequestEvent {
+                request_id: format!("req-{i}"),
+                route: "/t".into(),
+                kind: None,
+                started_at_unix_ms: i,
+                finished_at_unix_ms: i + 1,
+                latency_us: 1_000,
+                outcome: "ok".into(),
+            })
+            .collect();
+        run.queues = run
+            .requests
+            .iter()
+            .map(|r| QueueEvent {
+                request_id: r.request_id.clone(),
+                queue: "q".into(),
+                wait_us: 900,
+                waited_from_unix_ms: 1,
+                waited_until_unix_ms: 2,
+                depth_at_start: Some(8),
+            })
+            .collect();
+        run.stages = run
+            .requests
+            .iter()
+            .map(|r| StageEvent {
+                request_id: r.request_id.clone(),
+                stage: "db".into(),
+                started_at_unix_ms: 1,
+                finished_at_unix_ms: 2,
+                latency_us: 800,
+                success: true,
+            })
+            .collect();
+        run.truncation.dropped_requests = 1;
+        let report = analyze_run(&run);
+        let mut scores = vec![report.primary_suspect.score];
+        scores.extend(report.secondary_suspects.iter().map(|s| s.score));
+        assert!(scores.windows(2).all(|w| w[0] >= w[1]));
+    }
+
+    #[test]
+    fn low_request_count_caps_primary_confidence_and_adds_note() {
+        let mut run = test_run();
+        run.requests = (0..15)
+            .map(|i| RequestEvent {
+                request_id: format!("req-{i}"),
+                route: "/t".into(),
+                kind: None,
+                started_at_unix_ms: i,
+                finished_at_unix_ms: i + 1,
+                latency_us: 1_000,
+                outcome: "ok".into(),
+            })
+            .collect();
+        run.queues = run
+            .requests
+            .iter()
+            .map(|r| QueueEvent {
+                request_id: r.request_id.clone(),
+                queue: "q".into(),
+                waited_from_unix_ms: 1,
+                waited_until_unix_ms: 2,
+                wait_us: 990,
+                depth_at_start: Some(18),
+            })
+            .collect();
+        let report = analyze_run(&run);
+        assert_eq!(report.primary_suspect.confidence, Confidence::Medium);
+        assert!(report
+            .primary_suspect
+            .confidence_notes
+            .iter()
+            .any(|n| n == "Low completed-request count caps confidence."));
+    }
+
+    #[test]
+    fn clean_strong_queue_evidence_keeps_high_confidence_without_notes() {
+        let mut run = test_run();
+        run.requests = (0..45)
+            .map(|i| RequestEvent {
+                request_id: format!("req-{i}"),
+                route: "/test".into(),
+                kind: None,
+                started_at_unix_ms: i,
+                finished_at_unix_ms: i + 1,
+                latency_us: 1_000,
+                outcome: "ok".into(),
+            })
+            .collect();
+        run.queues = run
+            .requests
+            .iter()
+            .map(|r| QueueEvent {
+                request_id: r.request_id.clone(),
+                queue: "q".into(),
+                waited_from_unix_ms: 1,
+                waited_until_unix_ms: 2,
+                wait_us: 985,
+                depth_at_start: Some(15),
+            })
+            .collect();
+        run.inflight = vec![
+            tailtriage_core::InFlightSnapshot {
+                gauge: "http".into(),
+                at_unix_ms: 1,
+                count: 1,
+            },
+            tailtriage_core::InFlightSnapshot {
+                gauge: "http".into(),
+                at_unix_ms: 2,
+                count: 10,
+            },
+        ];
+        let report = analyze_run(&run);
+        assert_eq!(
+            report.primary_suspect.kind,
+            DiagnosisKind::ApplicationQueueSaturation
+        );
+        assert_eq!(report.primary_suspect.confidence, Confidence::High);
+        assert!(report.primary_suspect.confidence_notes.is_empty());
     }
 }

--- a/tailtriage-cli/src/analyze.rs
+++ b/tailtriage-cli/src/analyze.rs
@@ -382,15 +382,10 @@ fn apply_evidence_aware_confidence_caps(
             .iter()
             .all(|snapshot| snapshot.global_queue_depth.is_none());
     let ambiguous = ambiguity_warning(suspects).is_some();
-    let primary_index = suspects
-        .iter()
-        .enumerate()
-        .max_by_key(|(_, s)| s.score)
-        .map(|(i, _)| i);
     for (i, suspect) in suspects.iter_mut().enumerate() {
         let mut cap = Confidence::High;
         let mut notes = Vec::new();
-        let is_primary = Some(i) == primary_index;
+        let is_primary = i == 0;
         let is_insufficient = suspect.kind == DiagnosisKind::InsufficientEvidence;
         if !is_insufficient && evidence_quality.quality == EvidenceQualityLevel::Weak {
             cap = cap.min(Confidence::Medium);
@@ -2343,6 +2338,35 @@ mod tests {
         apply_evidence_aware_confidence_caps(&mut suspects, &run, &eq);
         assert_eq!(suspects[0].confidence, Confidence::Medium);
         assert!(suspects[0]
+            .confidence_notes
+            .iter()
+            .any(|n| n == "Top suspects are close in score; confidence is capped by ambiguity."));
+    }
+
+    #[test]
+    fn ambiguity_tied_top_scores_only_caps_first_sorted_suspect() {
+        let mut suspects = vec![
+            Suspect::new(
+                DiagnosisKind::ApplicationQueueSaturation,
+                100,
+                vec![],
+                vec![],
+            ),
+            Suspect::new(DiagnosisKind::DownstreamStageDominates, 100, vec![], vec![]),
+        ];
+        let run = test_run();
+        let eq = evidence_quality(&run);
+        apply_evidence_aware_confidence_caps(&mut suspects, &run, &eq);
+
+        assert_eq!(suspects[0].score, 100);
+        assert_eq!(suspects[1].score, 100);
+        assert_eq!(suspects[0].kind, DiagnosisKind::ApplicationQueueSaturation);
+        assert_eq!(suspects[1].kind, DiagnosisKind::DownstreamStageDominates);
+        assert!(suspects[0]
+            .confidence_notes
+            .iter()
+            .any(|n| n == "Top suspects are close in score; confidence is capped by ambiguity."));
+        assert!(!suspects[1]
             .confidence_notes
             .iter()
             .any(|n| n == "Top suspects are close in score; confidence is capped by ambiguity."));


### PR DESCRIPTION
### Motivation
- Confidence was previously derived only from suspect score thresholds and could overstate triage confidence when evidence was sparse, truncated, ambiguous, or missing key signal families.  The change aims to keep confidence as a triage-priority bucket while making it reflect evidence quality.

### Description
- Add `confidence_notes: Vec<String>` to `Suspect` and populate it only when evidence-aware caps or explicit ambiguity caps change the confidence bucket.
- Introduce `apply_evidence_aware_confidence_caps(...)` and invoke it after suspects are generated and sorted so ranking remains score-based and ordering is unchanged.
- Implement per-suspect cap rules that enforce the required behavior: weak `evidence_quality` limits, low-completed-request caps, dropped-request/truncation caps, missing/truncated family-specific caps (queues/stages/runtime/requests), and an ambiguity cap when top suspects are close in score; primary-suspect caps are applied with priority for validation cases.
- Preserve existing `score` calculations and suspect ordering; only `confidence` (Low/Medium/High) can be reduced by caps and `confidence_notes` explains caps in machine-readable form.
- Add regression/unit tests validating ranking invariants, low-request primary cap + note behavior, and that clean/strong evidence keeps high confidence without notes; update demo fixtures/docs to document `confidence_notes` and the evidence-aware semantics.
- Files changed: `tailtriage-cli/src/analyze.rs`, `tailtriage-cli/README.md`, `docs/diagnostics.md`, `docs/diagnostic-validation.md`.

### Testing
- Ran formatting/lint/test and validation pipeline; all checks passed.
  - `cargo fmt --check`: passed
  - `cargo clippy --workspace --all-targets -- -D warnings`: passed
  - `cargo test --workspace`: passed (new analyzer tests included; unit test suite passed)
  - `python3 scripts/check_demo_fixture_drift.py --profile dev`: passed (fixtures up to date)
  - `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0`: passed (benchmark thresholds met)
  - `python3 -m unittest scripts.tests.test_diagnostic_benchmark`: passed
  - `python3 scripts/validate_docs_contracts.py`: passed
  - `python3 -m unittest scripts.tests.test_validate_docs_contracts`: passed
- Summary of confidence rule changes: weak evidence forces at-most `medium` for non-insufficient suspects; extremely sparse/few completed requests can cap primary to `medium` (or `low` when zero requests); dropped requests/truncation caps at `medium`; missing/truncated per-signal-family caps at `medium` for suspects that depend on that family; ambiguity between top two suspects caps primary at `medium`; machine-readable notes added when a cap changes the bucket or ambiguity applies.
- Suspect scores and ordering remain unchanged and remain the canonical ranking signal; confidence capping does not reorder suspects.  Tests explicitly assert that scores and ordering are preserved under caps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f995427764833080053e5793182efe)