### PR TITLE
Make analyzer confidence evidence-aware with caps and notes

### DIFF
--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -19,7 +19,7 @@ Deterministic fixture validation is exercised directly in normal CI against `val
 `acceptable_primary` defines which primary kinds are acceptable for ambiguous/mixed interpretation and high-confidence-wrong classification. It does not replace `required_top2`.
 
 ## High-confidence-wrong count
-`high_confidence_wrong_count` increments when primary confidence is `high`/`very_high` and primary kind is outside `acceptable_primary`.
+`high_confidence_wrong_count` increments when primary confidence is `high` and primary kind is outside `acceptable_primary`.
 
 ## Confidence calibration
 The scorecard includes confidence-bucket accuracy summaries (low/medium/high buckets) as calibration hints, not probability guarantees.
@@ -76,7 +76,7 @@ This complements deterministic fixture validation:
 Key repeated-run metrics:
 - **Top-1 stability**: fraction of runs where the primary suspect matches the scenario ground truth
 - **Top-2 visibility**: fraction of runs where required causes appear in the top-2 suspects
-- **High-confidence-wrong count**: runs where primary confidence is high/very_high but primary kind is outside acceptable primary kinds
+- **High-confidence-wrong count**: runs where primary confidence is high but primary kind is outside acceptable primary kinds
 - **Confidence bucket accuracy**: top-1 accuracy grouped by confidence bucket
 - **Primary stability**: share of runs captured by the most frequent primary suspect kind
 - **p95 IQR**: interquartile range of p95 latency across repeated runs

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -39,6 +39,7 @@ Each suspect includes:
 - `kind`
 - `score`
 - `confidence`
+- `confidence_notes[]` (empty unless evidence-based capping applied)
 - `evidence[]`
 - `next_checks[]`
 
@@ -81,7 +82,8 @@ The analyzer is deterministic and rule-based. It does not use probabilistic or M
 
 - `score` is a **relative evidence-ranking score within one report**.
 - `score` is **not** a probability and **not** absolute severity across different captures.
-- `confidence` is derived from score bands and reflects ranking strength, not causal certainty.
+- `confidence` is score-derived first, then capped by evidence quality limits when signals are sparse, truncated, missing, or ambiguous.
+- confidence remains triage ranking confidence, not causal certainty or production-accuracy proof.
 
 Signal families used for scoring:
 

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -90,6 +90,7 @@ Then run one targeted check, change one thing, and re-run under comparable load.
     "kind": "application_queue_saturation",
     "score": 90,
     "confidence": "high",
+    "confidence_notes": [],
     "evidence": ["Queue wait at p95 consumes 98.2% of request time."],
     "next_checks": ["Inspect queue admission limits and producer burst patterns."]
   },
@@ -118,6 +119,7 @@ Each suspect includes:
 - `kind`
 - `score`
 - `confidence`
+- `confidence_notes[]` (only present when evidence-based capping applies)
 - `evidence[]`
 - `next_checks[]`
 
@@ -153,7 +155,7 @@ Library note:
 Suspect ranking uses deterministic, proportional, evidence-aware scoring (0-100), not fixed suspect priority.
 
 - Scores rank suspects **inside one report**; they are not probabilities.
-- Confidence is score-derived ranking strength, not causal certainty.
+- Confidence starts score-derived, then may be evidence-quality-capped (weak/sparse/missing/truncated/ambiguous signals); it remains triage ranking confidence, not causal certainty.
 - Strong downstream tail-stage contribution can outrank weak blocking/runtime signals.
 - Strong queue pressure remains a high-confidence lead when queue share/depth evidence is dominant.
 

--- a/tailtriage-cli/src/analyze.rs
+++ b/tailtriage-cli/src/analyze.rs
@@ -161,6 +161,9 @@ pub struct Suspect {
     pub confidence: Confidence,
     /// Supporting evidence strings used to justify this suspect ranking.
     pub evidence: Vec<String>,
+    /// Machine-readable notes explaining evidence-based confidence caps.
+    #[serde(default)]
+    pub confidence_notes: Vec<String>,
     /// Recommended next checks to validate or falsify this suspect.
     pub next_checks: Vec<String>,
 }
@@ -177,6 +180,7 @@ impl Suspect {
             score,
             confidence: Confidence::from_score(score),
             evidence,
+            confidence_notes: Vec::new(),
             next_checks,
         }
     }
@@ -330,8 +334,9 @@ pub fn analyze_run(run: &Run) -> Report {
 
     suspects.sort_by_key(|suspect| std::cmp::Reverse(suspect.score));
 
-    let warnings = analysis_warnings(run, &suspects);
     let evidence_quality = evidence_quality(run);
+    apply_evidence_aware_confidence_caps(&mut suspects, run, &evidence_quality);
+    let warnings = analysis_warnings(run, &suspects);
 
     let mut ranked = suspects.into_iter();
     let primary_suspect = ranked.next().unwrap_or_else(|| {
@@ -355,6 +360,165 @@ pub fn analyze_run(run: &Run) -> Report {
         evidence_quality,
         primary_suspect,
         secondary_suspects: ranked.collect(),
+    }
+}
+
+fn cap_confidence(suspect: &mut Suspect, cap: Confidence, note: &str) {
+    let original = suspect.confidence;
+    suspect.confidence = match (suspect.confidence, cap) {
+        (Confidence::High, Confidence::Medium | Confidence::Low)
+        | (Confidence::Medium, Confidence::Low) => cap,
+        _ => suspect.confidence,
+    };
+    let explicit_ambiguity =
+        note == "Top suspects are close in score; confidence is capped by ambiguity.";
+    if (suspect.confidence != original || explicit_ambiguity)
+        && !suspect.confidence_notes.iter().any(|n| n == note)
+    {
+        suspect.confidence_notes.push(note.to_string());
+    }
+}
+
+fn apply_evidence_aware_confidence_caps(
+    suspects: &mut [Suspect],
+    run: &Run,
+    evidence_quality: &EvidenceQuality,
+) {
+    if suspects.is_empty() {
+        return;
+    }
+    let ambiguity = ambiguity_warning(suspects).is_some();
+    let primary_kind = suspects[0].kind.clone();
+
+    for suspect in suspects
+        .iter_mut()
+        .filter(|s| s.kind != DiagnosisKind::InsufficientEvidence)
+    {
+        apply_base_confidence_caps(suspect, run, evidence_quality);
+        apply_signal_family_caps(suspect, run);
+    }
+
+    if let Some(primary) = suspects.first_mut() {
+        if primary.kind != DiagnosisKind::InsufficientEvidence
+            && run.requests.len() < LOW_COMPLETED_REQUEST_THRESHOLD
+        {
+            cap_confidence(
+                primary,
+                Confidence::Medium,
+                "Low completed-request count caps confidence.",
+            );
+        }
+        if ambiguity && primary.kind != DiagnosisKind::InsufficientEvidence {
+            cap_confidence(
+                primary,
+                Confidence::Medium,
+                "Top suspects are close in score; confidence is capped by ambiguity.",
+            );
+        }
+        if matches!(
+            primary_kind,
+            DiagnosisKind::BlockingPoolPressure | DiagnosisKind::ExecutorPressureSuspected
+        ) && (run.runtime_snapshots.is_empty()
+            || run
+                .runtime_snapshots
+                .iter()
+                .all(|s| s.blocking_queue_depth.is_none())
+            || run
+                .runtime_snapshots
+                .iter()
+                .all(|s| s.local_queue_depth.is_none()))
+        {
+            cap_confidence(
+                primary,
+                Confidence::Medium,
+                "Missing runtime snapshots limit executor/blocking confidence.",
+            );
+        }
+    }
+}
+
+fn apply_base_confidence_caps(
+    suspect: &mut Suspect,
+    run: &Run,
+    evidence_quality: &EvidenceQuality,
+) {
+    if evidence_quality.quality == EvidenceQualityLevel::Weak {
+        cap_confidence(
+            suspect,
+            Confidence::Medium,
+            "Low completed-request count caps confidence.",
+        );
+    }
+    if run.requests.is_empty() {
+        cap_confidence(
+            suspect,
+            Confidence::Low,
+            "Low completed-request count caps confidence.",
+        );
+    } else if run.requests.len() < LOW_COMPLETED_REQUEST_THRESHOLD {
+        cap_confidence(
+            suspect,
+            Confidence::Medium,
+            "Low completed-request count caps confidence.",
+        );
+    }
+    if run.truncation.dropped_requests > 0 {
+        cap_confidence(
+            suspect,
+            Confidence::Medium,
+            "Capture truncation caps confidence because dropped evidence may affect ranking.",
+        );
+    }
+}
+
+fn apply_signal_family_caps(suspect: &mut Suspect, run: &Run) {
+    match suspect.kind {
+        DiagnosisKind::ApplicationQueueSaturation => {
+            if run.truncation.dropped_queues > 0 {
+                cap_confidence(suspect, Confidence::Medium, "Capture truncation caps confidence because dropped evidence may affect ranking.");
+            }
+            if run.queues.is_empty() {
+                cap_confidence(
+                    suspect,
+                    Confidence::Medium,
+                    "Missing queue instrumentation limits queue-saturation confidence.",
+                );
+            }
+        }
+        DiagnosisKind::DownstreamStageDominates => {
+            if run.truncation.dropped_stages > 0 {
+                cap_confidence(suspect, Confidence::Medium, "Capture truncation caps confidence because dropped evidence may affect ranking.");
+            }
+            if run.stages.is_empty() {
+                cap_confidence(
+                    suspect,
+                    Confidence::Medium,
+                    "Missing stage instrumentation limits downstream-stage confidence.",
+                );
+            }
+        }
+        DiagnosisKind::BlockingPoolPressure | DiagnosisKind::ExecutorPressureSuspected => {
+            if run.truncation.dropped_runtime_snapshots > 0 {
+                cap_confidence(suspect, Confidence::Medium, "Capture truncation caps confidence because dropped evidence may affect ranking.");
+            }
+            let missing_runtime = run.runtime_snapshots.is_empty()
+                || run
+                    .runtime_snapshots
+                    .iter()
+                    .all(|s| s.blocking_queue_depth.is_none())
+                || run
+                    .runtime_snapshots
+                    .iter()
+                    .all(|s| s.local_queue_depth.is_none());
+            if missing_runtime {
+                cap_confidence(
+                    suspect,
+                    Confidence::Medium,
+                    "Missing runtime snapshots limit executor/blocking confidence.",
+                );
+            }
+        }
+        DiagnosisKind::InsufficientEvidence => {}
     }
 }
 
@@ -1451,6 +1615,7 @@ mod tests {
                 score: 90,
                 confidence: Confidence::High,
                 evidence: vec!["queue wait high".to_owned()],
+                confidence_notes: vec![],
                 next_checks: vec!["check queue policy".to_owned()],
             },
             secondary_suspects: Vec::new(),
@@ -1501,6 +1666,7 @@ mod tests {
                 score: 50,
                 confidence: Confidence::Low,
                 evidence: vec!["missing signals".to_owned()],
+                confidence_notes: vec![],
                 next_checks: vec!["add instrumentation".to_owned()],
             },
             secondary_suspects: Vec::new(),
@@ -1904,5 +2070,63 @@ mod tests {
             report.evidence_quality.quality,
             EvidenceQualityLevel::Strong
         );
+    }
+
+    #[test]
+    fn confidence_caps_do_not_change_score_ranking_order() {
+        let mut run = test_run();
+        run.requests = (0..40)
+            .map(|i| RequestEvent {
+                request_id: format!("req-{i}"),
+                route: "/t".into(),
+                kind: None,
+                started_at_unix_ms: i,
+                finished_at_unix_ms: i + 1,
+                latency_us: 1_000,
+                outcome: "ok".into(),
+            })
+            .collect();
+        run.queues = run
+            .requests
+            .iter()
+            .map(|r| QueueEvent {
+                request_id: r.request_id.clone(),
+                queue: "q".into(),
+                wait_us: 980,
+                waited_from_unix_ms: 1,
+                waited_until_unix_ms: 2,
+                depth_at_start: Some(10),
+            })
+            .collect();
+        run.stages = run
+            .requests
+            .iter()
+            .map(|r| StageEvent {
+                request_id: r.request_id.clone(),
+                stage: "db".into(),
+                started_at_unix_ms: 1,
+                finished_at_unix_ms: 2,
+                latency_us: 250,
+                success: true,
+            })
+            .collect();
+        let mut clean = run.clone();
+        clean.truncation.dropped_requests = 0;
+        let clean_report = analyze_run(&clean);
+        assert_eq!(clean_report.primary_suspect.confidence, Confidence::High);
+        let mut capped = run;
+        capped.truncation.dropped_requests = 5;
+        let capped_report = analyze_run(&capped);
+        assert_eq!(
+            clean_report.primary_suspect.score,
+            capped_report.primary_suspect.score
+        );
+        assert_eq!(
+            clean_report.primary_suspect.kind,
+            capped_report.primary_suspect.kind
+        );
+        assert_eq!(capped_report.primary_suspect.confidence, Confidence::Medium);
+        assert_eq!(clean_report.primary_suspect.confidence, Confidence::High);
+        assert_eq!(capped_report.primary_suspect.confidence, Confidence::Medium);
     }
 }


### PR DESCRIPTION
### Motivation
- Improve triage humility by making suspect `confidence` reflect evidence quality (sparse/truncated/missing/ambiguous signals) instead of relying purely on score thresholds. 
- Preserve `score` as the deterministic ranking signal so ordering remains score-based and confidence cannot change suspect ordering. 
- Emit machine-readable reasoning when confidence is lowered so downstream automation and validators can make conservative decisions.

### Description
- Added a post-ranking evidence-aware confidence pass `apply_evidence_aware_confidence_caps` that runs after suspects are scored and sorted but before the `Report` is returned; this pass only caps confidence and never changes `score` or suspect ordering. 
- Introduced `confidence_notes: Vec<String>` on `Suspect` (serde defaulted) and populate it only when a cap meaningfully changes the bucket or an explicit ambiguity cap applies. 
- Implemented cap rules covering: overall weak evidence (`evidence_quality.quality == Weak`) capping non-insufficient suspects to at most `Medium`; extremely sparse request counts (empty or below `LOW_COMPLETED_REQUEST_THRESHOLD`) capping `primary` and non-insufficient suspects; dropped request/stage/queue/runtime evidence (truncation) capping relevant suspects to `Medium`; missing signal families (queue/stage/runtime) capping the affected suspects to `Medium`; and ambiguity (top-two close scores) capping the primary suspect to `Medium`. 
- Kept existing `Confidence` buckets (`low`/`medium`/`high`) and existing scoring formulas intact; confidence caps are applied additively and independently per suspect, with priority semantics for the primary suspect. 
- Added a regression test `confidence_caps_do_not_change_score_ranking_order` that verifies suspect scores and ordering are unchanged while confidence may be reduced, and updated sample fixtures/docs to surface `confidence_notes`. 
- Updated CLI and docs (`tailtriage-cli/README.md`, `docs/diagnostics.md`, `docs/diagnostic-validation.md`) to explain new semantics: confidence is score-derived then evidence-capped and `confidence_notes` appears only when capping occurred.

### Testing
- Ran `cargo fmt --check`: passed. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings`: passed. 
- Ran `cargo test` iterations: an analyzer unit test initially failed during development, the assertion was fixed and a focused regression test was added; the regression test for `tailtriage-cli` was verified locally after the fix; recommend running the full workspace test suite in CI to confirm cross-crate effects. 
- Validation scripts not executed in this session and should be run in CI or before merging: `python3 scripts/check_demo_fixture_drift.py --profile dev`, `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json ...`, and `python3 scripts/validate_docs_contracts.py`.

Summary of rule changes: Confidence remains derived from `score` bands but is then capped based on evidence quality and signal-family availability/truncation/ambiguity with concise machine-readable notes when caps apply. Suspect scores and ranking were not changed by this work; only confidence buckets and optional `confidence_notes` were added/updated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f995427764833080053e5793182efe)