### PR TITLE
Make analyzer confidence evidence-aware with capping notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ tailtriage analyze tailtriage-run.json --format json
     "kind": "application_queue_saturation",
     "score": 90,
     "confidence": "high",
+    "confidence_notes": [],
     "evidence": ["Queue wait at p95 consumes 98.2% of request time.", "Observed queue depth sample up to 230."],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -197,6 +198,7 @@ tailtriage analyze tailtriage-run.json --format json
       "kind": "downstream_stage_dominates",
       "score": 55,
       "confidence": "low",
+      "confidence_notes": [],
       "evidence": [
         "Stage 'simulated_work' has p95 latency 26566 us across 250 samples.",
         "Stage 'simulated_work' cumulative latency is 6546159 us.",

--- a/demos/blocking_service/fixtures/after-analysis.json
+++ b/demos/blocking_service/fixtures/after-analysis.json
@@ -1,15 +1,15 @@
 {
   "request_count": 250,
-  "p50_latency_us": 54509,
-  "p95_latency_us": 87050,
-  "p99_latency_us": 91039,
-  "p95_queue_share_permille": 56,
-  "p95_service_share_permille": 993,
+  "p50_latency_us": 53862,
+  "p95_latency_us": 85266,
+  "p99_latency_us": 87969,
+  "p95_queue_share_permille": 60,
+  "p95_service_share_permille": 995,
   "inflight_trend": {
     "gauge": "blocking_service_inflight",
     "sample_count": 500,
-    "peak_count": 49,
-    "p95_count": 46,
+    "peak_count": 48,
+    "p95_count": 45,
     "growth_delta": -1,
     "growth_per_sec_milli": -2044
   },
@@ -43,15 +43,16 @@
     "score": 100,
     "confidence": "high",
     "evidence": [
-      "Stage 'spawn_blocking_path' has p95 latency 85870 us across 250 samples.",
-      "Stage 'spawn_blocking_path' cumulative latency is 13010681 us (978 permille of request latency).",
+      "Stage 'spawn_blocking_path' has p95 latency 84352 us across 250 samples.",
+      "Stage 'spawn_blocking_path' cumulative latency is 12980797 us (978 permille of request latency).",
       "Stage 'spawn_blocking_path' contributes 986 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -59,12 +60,13 @@
       "score": 82,
       "confidence": "medium",
       "evidence": [
-        "Blocking queue depth p95 is 42, peak is 48, with 98/200 nonzero samples."
+        "Blocking queue depth p95 is 42, peak is 47, with 98/200 nonzero samples."
       ],
       "next_checks": [
         "Audit blocking sections and move avoidable synchronous work out of hot paths.",
         "Inspect spawn_blocking callsites for long-running CPU or I/O work."
-      ]
+      ],
+      "confidence_notes": []
     }
   ]
 }

--- a/demos/blocking_service/fixtures/before-analysis.json
+++ b/demos/blocking_service/fixtures/before-analysis.json
@@ -1,15 +1,15 @@
 {
   "request_count": 250,
-  "p50_latency_us": 1868185,
-  "p95_latency_us": 3531495,
-  "p99_latency_us": 3680957,
+  "p50_latency_us": 1870110,
+  "p95_latency_us": 3529784,
+  "p99_latency_us": 3678293,
   "p95_queue_share_permille": 6,
   "p95_service_share_permille": 999,
   "inflight_trend": {
     "gauge": "blocking_service_inflight",
     "sample_count": 500,
     "peak_count": 246,
-    "p95_count": 234,
+    "p95_count": 235,
     "growth_delta": 0,
     "growth_per_sec_milli": 0
   },
@@ -42,13 +42,17 @@
   "primary_suspect": {
     "kind": "blocking_pool_pressure",
     "score": 88,
-    "confidence": "high",
+    "confidence": "medium",
     "evidence": [
       "Blocking queue depth p95 is 244, peak is 246, with 200/200 nonzero samples."
     ],
     "next_checks": [
       "Audit blocking sections and move avoidable synchronous work out of hot paths.",
       "Inspect spawn_blocking callsites for long-running CPU or I/O work."
+    ],
+    "confidence_notes": [
+      "Missing runtime snapshots limit executor/blocking confidence.",
+      "Top suspects are close in score; confidence is capped by ambiguity."
     ]
   },
   "secondary_suspects": [
@@ -57,8 +61,8 @@
       "score": 86,
       "confidence": "high",
       "evidence": [
-        "Stage 'spawn_blocking_path' has p95 latency 3530254 us across 250 samples.",
-        "Stage 'spawn_blocking_path' cumulative latency is 467061987 us (999 permille of request latency).",
+        "Stage 'spawn_blocking_path' has p95 latency 3528530 us across 250 samples.",
+        "Stage 'spawn_blocking_path' cumulative latency is 467055190 us (999 permille of request latency).",
         "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency.",
         "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
       ],
@@ -66,7 +70,8 @@
         "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
   ]
 }

--- a/demos/blocking_service/fixtures/sample-analysis.json
+++ b/demos/blocking_service/fixtures/sample-analysis.json
@@ -1,15 +1,15 @@
 {
   "request_count": 250,
-  "p50_latency_us": 1868185,
-  "p95_latency_us": 3531495,
-  "p99_latency_us": 3680957,
+  "p50_latency_us": 1870110,
+  "p95_latency_us": 3529784,
+  "p99_latency_us": 3678293,
   "p95_queue_share_permille": 6,
   "p95_service_share_permille": 999,
   "inflight_trend": {
     "gauge": "blocking_service_inflight",
     "sample_count": 500,
     "peak_count": 246,
-    "p95_count": 234,
+    "p95_count": 235,
     "growth_delta": 0,
     "growth_per_sec_milli": 0
   },
@@ -42,13 +42,17 @@
   "primary_suspect": {
     "kind": "blocking_pool_pressure",
     "score": 88,
-    "confidence": "high",
+    "confidence": "medium",
     "evidence": [
       "Blocking queue depth p95 is 244, peak is 246, with 200/200 nonzero samples."
     ],
     "next_checks": [
       "Audit blocking sections and move avoidable synchronous work out of hot paths.",
       "Inspect spawn_blocking callsites for long-running CPU or I/O work."
+    ],
+    "confidence_notes": [
+      "Missing runtime snapshots limit executor/blocking confidence.",
+      "Top suspects are close in score; confidence is capped by ambiguity."
     ]
   },
   "secondary_suspects": [
@@ -57,8 +61,8 @@
       "score": 86,
       "confidence": "high",
       "evidence": [
-        "Stage 'spawn_blocking_path' has p95 latency 3530254 us across 250 samples.",
-        "Stage 'spawn_blocking_path' cumulative latency is 467061987 us (999 permille of request latency).",
+        "Stage 'spawn_blocking_path' has p95 latency 3528530 us across 250 samples.",
+        "Stage 'spawn_blocking_path' cumulative latency is 467055190 us (999 permille of request latency).",
         "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency.",
         "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
       ],
@@ -66,7 +70,8 @@
         "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
   ]
 }

--- a/demos/cold_start_burst_service/fixtures/after-analysis.json
+++ b/demos/cold_start_burst_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 8489,
-  "p95_latency_us": 8877,
-  "p99_latency_us": 9039,
+  "p50_latency_us": 8468,
+  "p95_latency_us": 8764,
+  "p99_latency_us": 8906,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 999,
   "inflight_trend": {
     "gauge": "cold_start_burst_inflight",
     "sample_count": 440,
     "peak_count": 4,
-    "p95_count": 3,
+    "p95_count": 2,
     "growth_delta": -1,
-    "growth_per_sec_milli": -1064
+    "growth_per_sec_milli": -1050
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,15 +41,16 @@
     "score": 100,
     "confidence": "high",
     "evidence": [
-      "Stage 'cold_start_stage' has p95 latency 8837 us across 220 samples.",
-      "Stage 'cold_start_stage' cumulative latency is 1823038 us (996 permille of request latency).",
-      "Stage 'cold_start_stage' contributes 995 permille of tail request latency."
+      "Stage 'cold_start_stage' has p95 latency 8721 us across 220 samples.",
+      "Stage 'cold_start_stage' cumulative latency is 1812221 us (996 permille of request latency).",
+      "Stage 'cold_start_stage' contributes 994 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'cold_start_stage'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": []
 }

--- a/demos/cold_start_burst_service/fixtures/before-analysis.json
+++ b/demos/cold_start_burst_service/fixtures/before-analysis.json
@@ -1,10 +1,10 @@
 {
   "request_count": 220,
-  "p50_latency_us": 993483,
-  "p95_latency_us": 1190031,
-  "p99_latency_us": 1206824,
+  "p50_latency_us": 992104,
+  "p95_latency_us": 1187152,
+  "p99_latency_us": 1204130,
   "p95_queue_share_permille": 993,
-  "p95_service_share_permille": 336,
+  "p95_service_share_permille": 330,
   "inflight_trend": {
     "gauge": "cold_start_burst_inflight",
     "sample_count": 440,
@@ -47,7 +47,8 @@
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -55,15 +56,16 @@
       "score": 32,
       "confidence": "low",
       "evidence": [
-        "Stage 'cold_start_stage' has p95 latency 63617 us across 220 samples.",
-        "Stage 'cold_start_stage' cumulative latency is 4876046 us (24 permille of request latency).",
+        "Stage 'cold_start_stage' has p95 latency 63724 us across 220 samples.",
+        "Stage 'cold_start_stage' cumulative latency is 4877474 us (24 permille of request latency).",
         "Stage 'cold_start_stage' contributes 6 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'cold_start_stage'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
   ]
 }

--- a/demos/db_pool_saturation_service/fixtures/after-analysis.json
+++ b/demos/db_pool_saturation_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 13254,
-  "p95_latency_us": 14196,
-  "p99_latency_us": 14321,
+  "p50_latency_us": 13180,
+  "p95_latency_us": 14272,
+  "p99_latency_us": 15456,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -41,15 +41,16 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'db_query' has p95 latency 11927 us across 220 samples.",
-      "Stage 'db_query' cumulative latency is 2440495 us (833 permille of request latency).",
-      "Stage 'db_query' contributes 841 permille of tail request latency."
+      "Stage 'db_query' has p95 latency 12043 us across 220 samples.",
+      "Stage 'db_query' cumulative latency is 2448461 us (834 permille of request latency).",
+      "Stage 'db_query' contributes 846 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'db_query'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": []
 }

--- a/demos/db_pool_saturation_service/fixtures/before-analysis.json
+++ b/demos/db_pool_saturation_service/fixtures/before-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 498135,
-  "p95_latency_us": 927602,
-  "p99_latency_us": 961905,
+  "p50_latency_us": 489909,
+  "p95_latency_us": 928485,
+  "p99_latency_us": 963058,
   "p95_queue_share_permille": 976,
-  "p95_service_share_permille": 368,
+  "p95_service_share_permille": 374,
   "inflight_trend": {
     "gauge": "db_pool_saturation_inflight",
     "sample_count": 440,
-    "peak_count": 200,
+    "peak_count": 203,
     "p95_count": 193,
     "growth_delta": 2,
-    "growth_per_sec_milli": 1872
+    "growth_per_sec_milli": 1885
   },
   "warnings": [],
   "evidence_quality": {
@@ -42,13 +42,14 @@
     "confidence": "high",
     "evidence": [
       "Queue wait at p95 consumes 97.6% of request time.",
-      "Observed queue depth sample up to 196.",
-      "In-flight gauge 'db_pool_saturation_inflight' grew by 2 over the run window (p95=193, peak=200)."
+      "Observed queue depth sample up to 197.",
+      "In-flight gauge 'db_pool_saturation_inflight' grew by 2 over the run window (p95=193, peak=203)."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -56,15 +57,16 @@
       "score": 34,
       "confidence": "low",
       "evidence": [
-        "Stage 'db_query' has p95 latency 19752 us across 220 samples.",
-        "Stage 'db_query' cumulative latency is 4247545 us (38 permille of request latency).",
+        "Stage 'db_query' has p95 latency 19651 us across 220 samples.",
+        "Stage 'db_query' cumulative latency is 4223425 us (39 permille of request latency).",
         "Stage 'db_query' contributes 20 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'db_query'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
   ]
 }

--- a/demos/downstream_service/fixtures/after-analysis.json
+++ b/demos/downstream_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 80,
-  "p50_latency_us": 12294,
-  "p95_latency_us": 13240,
-  "p99_latency_us": 13272,
+  "p50_latency_us": 12310,
+  "p95_latency_us": 13027,
+  "p99_latency_us": 13053,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "downstream_service_inflight",
     "sample_count": 160,
-    "peak_count": 35,
-    "p95_count": 32,
+    "peak_count": 37,
+    "p95_count": 34,
     "growth_delta": 5,
-    "growth_per_sec_milli": 108695
+    "growth_per_sec_milli": 119047
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,15 +41,16 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 10846 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 809068 us (813 permille of request latency).",
-      "Stage 'downstream_call' contributes 804 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 10965 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 813414 us (821 permille of request latency).",
+      "Stage 'downstream_call' contributes 823 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": []
 }

--- a/demos/downstream_service/fixtures/before-after-comparison.json
+++ b/demos/downstream_service/fixtures/before-after-comparison.json
@@ -2,19 +2,19 @@
   "before": {
     "primary_suspect_kind": "downstream_stage_dominates",
     "primary_suspect_score": 95,
-    "p95_latency_us": 24448,
+    "p95_latency_us": 23897,
     "p95_service_share_permille": 1000
   },
   "after": {
     "primary_suspect_kind": "downstream_stage_dominates",
     "primary_suspect_score": 95,
-    "p95_latency_us": 13240,
+    "p95_latency_us": 13027,
     "p95_service_share_permille": 1000
   },
   "delta": {
     "primary_suspect_kind": null,
     "primary_suspect_score": 0,
-    "p95_latency_us": -11208,
+    "p95_latency_us": -10870,
     "p95_service_share_permille": 0
   }
 }

--- a/demos/downstream_service/fixtures/before-analysis.json
+++ b/demos/downstream_service/fixtures/before-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 80,
-  "p50_latency_us": 23531,
-  "p95_latency_us": 24448,
-  "p99_latency_us": 24549,
+  "p50_latency_us": 23260,
+  "p95_latency_us": 23897,
+  "p99_latency_us": 23984,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "downstream_service_inflight",
     "sample_count": 160,
-    "peak_count": 57,
+    "peak_count": 56,
     "p95_count": 55,
     "growth_delta": 5,
-    "growth_per_sec_milli": 90909
+    "growth_per_sec_milli": 87719
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,15 +41,16 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 22135 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 1693727 us (903 permille of request latency).",
-      "Stage 'downstream_call' contributes 904 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 21642 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 1685650 us (903 permille of request latency).",
+      "Stage 'downstream_call' contributes 896 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": []
 }

--- a/demos/downstream_service/fixtures/sample-analysis.json
+++ b/demos/downstream_service/fixtures/sample-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 80,
-  "p50_latency_us": 23531,
-  "p95_latency_us": 24448,
-  "p99_latency_us": 24549,
+  "p50_latency_us": 23260,
+  "p95_latency_us": 23897,
+  "p99_latency_us": 23984,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "downstream_service_inflight",
     "sample_count": 160,
-    "peak_count": 57,
+    "peak_count": 56,
     "p95_count": 55,
     "growth_delta": 5,
-    "growth_per_sec_milli": 90909
+    "growth_per_sec_milli": 87719
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,15 +41,16 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 22135 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 1693727 us (903 permille of request latency).",
-      "Stage 'downstream_call' contributes 904 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 21642 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 1685650 us (903 permille of request latency).",
+      "Stage 'downstream_call' contributes 896 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": []
 }

--- a/demos/executor_pressure_service/fixtures/after-analysis.json
+++ b/demos/executor_pressure_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 240,
-  "p50_latency_us": 7284295,
-  "p95_latency_us": 7413192,
-  "p99_latency_us": 7423728,
+  "p50_latency_us": 7156036,
+  "p95_latency_us": 7190132,
+  "p99_latency_us": 7197977,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,14 +11,14 @@
     "peak_count": 240,
     "p95_count": 228,
     "growth_delta": -1,
-    "growth_per_sec_milli": -134
+    "growth_per_sec_milli": -138
   },
   "warnings": [],
   "evidence_quality": {
     "request_count": 240,
     "queue_event_count": 0,
     "stage_event_count": 0,
-    "runtime_snapshot_count": 7433,
+    "runtime_snapshot_count": 7213,
     "inflight_snapshot_count": 480,
     "requests": "present",
     "queues": "missing",
@@ -42,13 +42,14 @@
     "confidence": "high",
     "evidence": [
       "Runtime global queue depth p95 is 720, suggesting scheduler contention.",
-      "Runtime local queue depth p95 is 4656.",
+      "Runtime local queue depth p95 is 4866.",
       "Runtime alive_tasks p95 is 720."
     ],
     "next_checks": [
       "Check for long polls without yielding and uneven task fan-out.",
       "Compare with per-stage timings to isolate overloaded async stages."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": []
 }

--- a/demos/executor_pressure_service/fixtures/before-analysis.json
+++ b/demos/executor_pressure_service/fixtures/before-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 240,
-  "p50_latency_us": 34531979,
-  "p95_latency_us": 34596797,
-  "p99_latency_us": 34604649,
+  "p50_latency_us": 35076349,
+  "p95_latency_us": 35151672,
+  "p99_latency_us": 35160262,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -18,7 +18,7 @@
     "request_count": 240,
     "queue_event_count": 0,
     "stage_event_count": 0,
-    "runtime_snapshot_count": 6377,
+    "runtime_snapshot_count": 35168,
     "inflight_snapshot_count": 480,
     "requests": "present",
     "queues": "missing",
@@ -42,13 +42,14 @@
     "confidence": "high",
     "evidence": [
       "Runtime global queue depth p95 is 1920, suggesting scheduler contention.",
-      "Runtime local queue depth p95 is 42232.",
+      "Runtime local queue depth p95 is 26256.",
       "Runtime alive_tasks p95 is 1920."
     ],
     "next_checks": [
       "Check for long polls without yielding and uneven task fan-out.",
       "Compare with per-stage timings to isolate overloaded async stages."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": []
 }

--- a/demos/executor_pressure_service/fixtures/sample-analysis.json
+++ b/demos/executor_pressure_service/fixtures/sample-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 240,
-  "p50_latency_us": 34531979,
-  "p95_latency_us": 34596797,
-  "p99_latency_us": 34604649,
+  "p50_latency_us": 35076349,
+  "p95_latency_us": 35151672,
+  "p99_latency_us": 35160262,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -18,7 +18,7 @@
     "request_count": 240,
     "queue_event_count": 0,
     "stage_event_count": 0,
-    "runtime_snapshot_count": 6377,
+    "runtime_snapshot_count": 35168,
     "inflight_snapshot_count": 480,
     "requests": "present",
     "queues": "missing",
@@ -42,13 +42,14 @@
     "confidence": "high",
     "evidence": [
       "Runtime global queue depth p95 is 1920, suggesting scheduler contention.",
-      "Runtime local queue depth p95 is 42232.",
+      "Runtime local queue depth p95 is 26256.",
       "Runtime alive_tasks p95 is 1920."
     ],
     "next_checks": [
       "Check for long polls without yielding and uneven task fan-out.",
       "Compare with per-stage timings to isolate overloaded async stages."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": []
 }

--- a/demos/mixed_contention_service/fixtures/baseline-analysis.json
+++ b/demos/mixed_contention_service/fixtures/baseline-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 393750,
-  "p95_latency_us": 738845,
-  "p99_latency_us": 767621,
-  "p95_queue_share_permille": 980,
-  "p95_service_share_permille": 402,
+  "p50_latency_us": 391310,
+  "p95_latency_us": 738721,
+  "p99_latency_us": 764569,
+  "p95_queue_share_permille": 979,
+  "p95_service_share_permille": 399,
   "inflight_trend": {
     "gauge": "mixed_contention_inflight",
     "sample_count": 440,
-    "peak_count": 200,
+    "peak_count": 201,
     "p95_count": 190,
     "growth_delta": -1,
-    "growth_per_sec_milli": -1160
+    "growth_per_sec_milli": -1166
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,13 +41,14 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Queue wait at p95 consumes 98.0% of request time.",
-      "Observed queue depth sample up to 195."
+      "Queue wait at p95 consumes 97.9% of request time.",
+      "Observed queue depth sample up to 196."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -55,15 +56,16 @@
       "score": 35,
       "confidence": "low",
       "evidence": [
-        "Stage 'downstream_call' has p95 latency 32531 us across 220 samples.",
-        "Stage 'downstream_call' cumulative latency is 3775687 us (43 permille of request latency).",
+        "Stage 'downstream_call' has p95 latency 32631 us across 220 samples.",
+        "Stage 'downstream_call' cumulative latency is 3761869 us (43 permille of request latency).",
         "Stage 'downstream_call' contributes 23 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'downstream_call'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
   ]
 }

--- a/demos/mixed_contention_service/fixtures/mitigated-analysis.json
+++ b/demos/mixed_contention_service/fixtures/mitigated-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 14399,
-  "p95_latency_us": 34450,
-  "p99_latency_us": 35029,
+  "p50_latency_us": 14374,
+  "p95_latency_us": 34754,
+  "p99_latency_us": 34989,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,7 +11,7 @@
     "peak_count": 14,
     "p95_count": 13,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2631
+    "growth_per_sec_milli": -2610
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,15 +41,16 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 32570 us across 220 samples.",
-      "Stage 'downstream_call' cumulative latency is 3763084 us (889 permille of request latency).",
-      "Stage 'downstream_call' contributes 933 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 32579 us across 220 samples.",
+      "Stage 'downstream_call' cumulative latency is 3766493 us (889 permille of request latency).",
+      "Stage 'downstream_call' contributes 934 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": []
 }

--- a/demos/queue_service/fixtures/after-analysis.json
+++ b/demos/queue_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 250,
-  "p50_latency_us": 16086,
-  "p95_latency_us": 17037,
-  "p99_latency_us": 19055,
+  "p50_latency_us": 16103,
+  "p95_latency_us": 16887,
+  "p99_latency_us": 16950,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
-    "peak_count": 16,
-    "p95_count": 12,
+    "peak_count": 12,
+    "p95_count": 11,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2386
+    "growth_per_sec_milli": -2364
   },
   "warnings": [],
   "evidence_quality": {
@@ -38,18 +38,19 @@
   },
   "primary_suspect": {
     "kind": "downstream_stage_dominates",
-    "score": 95,
+    "score": 100,
     "confidence": "high",
     "evidence": [
-      "Stage 'simulated_work' has p95 latency 16919 us across 250 samples.",
-      "Stage 'simulated_work' cumulative latency is 4031794 us (995 permille of request latency).",
-      "Stage 'simulated_work' contributes 955 permille of tail request latency."
+      "Stage 'simulated_work' has p95 latency 16867 us across 250 samples.",
+      "Stage 'simulated_work' cumulative latency is 4029576 us (998 permille of request latency).",
+      "Stage 'simulated_work' contributes 998 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'simulated_work'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": []
 }

--- a/demos/queue_service/fixtures/before-analysis.json
+++ b/demos/queue_service/fixtures/before-analysis.json
@@ -1,10 +1,10 @@
 {
   "request_count": 250,
-  "p50_latency_us": 783889,
-  "p95_latency_us": 1463903,
-  "p99_latency_us": 1514094,
+  "p50_latency_us": 781675,
+  "p95_latency_us": 1463123,
+  "p99_latency_us": 1513368,
   "p95_queue_share_permille": 982,
-  "p95_service_share_permille": 269,
+  "p95_service_share_permille": 272,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
@@ -47,7 +47,8 @@
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -55,15 +56,16 @@
       "score": 33,
       "confidence": "low",
       "evidence": [
-        "Stage 'simulated_work' has p95 latency 26681 us across 250 samples.",
-        "Stage 'simulated_work' cumulative latency is 6548608 us (33 permille of request latency).",
+        "Stage 'simulated_work' has p95 latency 26804 us across 250 samples.",
+        "Stage 'simulated_work' cumulative latency is 6560349 us (33 permille of request latency).",
         "Stage 'simulated_work' contributes 17 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'simulated_work'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
   ]
 }

--- a/demos/queue_service/fixtures/sample-analysis.json
+++ b/demos/queue_service/fixtures/sample-analysis.json
@@ -1,10 +1,10 @@
 {
   "request_count": 250,
-  "p50_latency_us": 783889,
-  "p95_latency_us": 1463903,
-  "p99_latency_us": 1514094,
+  "p50_latency_us": 781675,
+  "p95_latency_us": 1463123,
+  "p99_latency_us": 1513368,
   "p95_queue_share_permille": 982,
-  "p95_service_share_permille": 269,
+  "p95_service_share_permille": 272,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
@@ -47,7 +47,8 @@
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -55,15 +56,16 @@
       "score": 33,
       "confidence": "low",
       "evidence": [
-        "Stage 'simulated_work' has p95 latency 26681 us across 250 samples.",
-        "Stage 'simulated_work' cumulative latency is 6548608 us (33 permille of request latency).",
+        "Stage 'simulated_work' has p95 latency 26804 us across 250 samples.",
+        "Stage 'simulated_work' cumulative latency is 6560349 us (33 permille of request latency).",
         "Stage 'simulated_work' contributes 17 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'simulated_work'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
   ]
 }

--- a/demos/retry_storm_service/fixtures/after-analysis.json
+++ b/demos/retry_storm_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 180,
-  "p50_latency_us": 9513,
-  "p95_latency_us": 29401,
-  "p99_latency_us": 29784,
+  "p50_latency_us": 9668,
+  "p95_latency_us": 29221,
+  "p99_latency_us": 29880,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,7 +11,7 @@
     "peak_count": 17,
     "p95_count": 15,
     "growth_delta": -1,
-    "growth_per_sec_milli": -4716
+    "growth_per_sec_milli": -4739
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,15 +41,16 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_total' has p95 latency 27186 us across 180 samples.",
-      "Stage 'downstream_total' cumulative latency is 2154453 us (842 permille of request latency).",
-      "Stage 'downstream_total' contributes 922 permille of tail request latency."
+      "Stage 'downstream_total' has p95 latency 27065 us across 180 samples.",
+      "Stage 'downstream_total' cumulative latency is 2163347 us (842 permille of request latency).",
+      "Stage 'downstream_total' contributes 921 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_total'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": []
 }

--- a/demos/retry_storm_service/fixtures/before-analysis.json
+++ b/demos/retry_storm_service/fixtures/before-analysis.json
@@ -1,15 +1,15 @@
 {
   "request_count": 180,
-  "p50_latency_us": 9863,
-  "p95_latency_us": 41148,
-  "p99_latency_us": 42215,
+  "p50_latency_us": 9591,
+  "p95_latency_us": 41485,
+  "p99_latency_us": 42289,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "retry_storm_inflight",
     "sample_count": 360,
-    "peak_count": 57,
-    "p95_count": 54,
+    "peak_count": 58,
+    "p95_count": 56,
     "growth_delta": -1,
     "growth_per_sec_milli": -9345
   },
@@ -41,15 +41,16 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_total' has p95 latency 38902 us across 180 samples.",
-      "Stage 'downstream_total' cumulative latency is 3025771 us (883 permille of request latency).",
-      "Stage 'downstream_total' contributes 945 permille of tail request latency."
+      "Stage 'downstream_total' has p95 latency 39492 us across 180 samples.",
+      "Stage 'downstream_total' cumulative latency is 3023311 us (885 permille of request latency).",
+      "Stage 'downstream_total' contributes 942 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_total'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": []
 }

--- a/demos/shared_state_lock_service/fixtures/after-analysis.json
+++ b/demos/shared_state_lock_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 828874,
-  "p95_latency_us": 1564712,
-  "p99_latency_us": 1623531,
+  "p50_latency_us": 833806,
+  "p95_latency_us": 1573417,
+  "p99_latency_us": 1632234,
   "p95_queue_share_permille": 993,
-  "p95_service_share_permille": 127,
+  "p95_service_share_permille": 131,
   "inflight_trend": {
     "gauge": "shared_state_lock_inflight",
     "sample_count": 440,
     "peak_count": 201,
-    "p95_count": 190,
+    "p95_count": 191,
     "growth_delta": -1,
-    "growth_per_sec_milli": -555
+    "growth_per_sec_milli": -551
   },
   "warnings": [],
   "evidence_quality": {
@@ -42,12 +42,13 @@
     "confidence": "high",
     "evidence": [
       "Queue wait at p95 consumes 99.3% of request time.",
-      "Observed queue depth sample up to 199."
+      "Observed queue depth sample up to 200."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -55,15 +56,16 @@
       "score": 32,
       "confidence": "low",
       "evidence": [
-        "Stage 'shared_state_critical_section' has p95 latency 8269 us across 220 samples.",
-        "Stage 'shared_state_critical_section' cumulative latency is 1787919 us (9 permille of request latency).",
+        "Stage 'shared_state_critical_section' has p95 latency 8359 us across 220 samples.",
+        "Stage 'shared_state_critical_section' cumulative latency is 1798265 us (9 permille of request latency).",
         "Stage 'shared_state_critical_section' contributes 5 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'shared_state_critical_section'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
   ]
 }

--- a/demos/shared_state_lock_service/fixtures/before-analysis.json
+++ b/demos/shared_state_lock_service/fixtures/before-analysis.json
@@ -1,10 +1,10 @@
 {
   "request_count": 220,
-  "p50_latency_us": 2546348,
-  "p95_latency_us": 4817353,
-  "p99_latency_us": 4999343,
+  "p50_latency_us": 2541704,
+  "p95_latency_us": 4818681,
+  "p99_latency_us": 4999289,
   "p95_queue_share_permille": 994,
-  "p95_service_share_permille": 98,
+  "p95_service_share_permille": 101,
   "inflight_trend": {
     "gauge": "shared_state_lock_inflight",
     "sample_count": 440,
@@ -47,7 +47,8 @@
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -55,15 +56,16 @@
       "score": 32,
       "confidence": "low",
       "evidence": [
-        "Stage 'shared_state_critical_section' has p95 latency 23447 us across 220 samples.",
-        "Stage 'shared_state_critical_section' cumulative latency is 5109039 us (9 permille of request latency).",
+        "Stage 'shared_state_critical_section' has p95 latency 23390 us across 220 samples.",
+        "Stage 'shared_state_critical_section' cumulative latency is 5111344 us (9 permille of request latency).",
         "Stage 'shared_state_critical_section' contributes 4 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'shared_state_critical_section'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
   ]
 }

--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -19,7 +19,7 @@ Deterministic fixture validation is exercised directly in normal CI against `val
 `acceptable_primary` defines which primary kinds are acceptable for ambiguous/mixed interpretation and high-confidence-wrong classification. It does not replace `required_top2`.
 
 ## High-confidence-wrong count
-`high_confidence_wrong_count` increments when primary confidence is `high`/`very_high` and primary kind is outside `acceptable_primary`.
+`high_confidence_wrong_count` increments when primary confidence is `high` and primary kind is outside `acceptable_primary`.
 
 ## Confidence calibration
 The scorecard includes confidence-bucket accuracy summaries (low/medium/high buckets) as calibration hints, not probability guarantees.
@@ -76,7 +76,7 @@ This complements deterministic fixture validation:
 Key repeated-run metrics:
 - **Top-1 stability**: fraction of runs where the primary suspect matches the scenario ground truth
 - **Top-2 visibility**: fraction of runs where required causes appear in the top-2 suspects
-- **High-confidence-wrong count**: runs where primary confidence is high/very_high but primary kind is outside acceptable primary kinds
+- **High-confidence-wrong count**: runs where primary confidence is high but primary kind is outside acceptable primary kinds
 - **Confidence bucket accuracy**: top-1 accuracy grouped by confidence bucket
 - **Primary stability**: share of runs captured by the most frequent primary suspect kind
 - **p95 IQR**: interquartile range of p95 latency across repeated runs

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -39,6 +39,7 @@ Each suspect includes:
 - `kind`
 - `score`
 - `confidence`
+- `confidence_notes[]` (only when confidence is capped by evidence limits or explicit ambiguity)
 - `evidence[]`
 - `next_checks[]`
 
@@ -81,7 +82,7 @@ The analyzer is deterministic and rule-based. It does not use probabilistic or M
 
 - `score` is a **relative evidence-ranking score within one report**.
 - `score` is **not** a probability and **not** absolute severity across different captures.
-- `confidence` is derived from score bands and reflects ranking strength, not causal certainty.
+- `confidence` is derived from score bands and then capped by evidence quality/coverage limits; it remains ranking confidence, not causal certainty.
 
 Signal families used for scoring:
 

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -90,6 +90,7 @@ Then run one targeted check, change one thing, and re-run under comparable load.
     "kind": "application_queue_saturation",
     "score": 90,
     "confidence": "high",
+    "confidence_notes": [],
     "evidence": ["Queue wait at p95 consumes 98.2% of request time."],
     "next_checks": ["Inspect queue admission limits and producer burst patterns."]
   },
@@ -118,6 +119,7 @@ Each suspect includes:
 - `kind`
 - `score`
 - `confidence`
+- `confidence_notes[]` (present only when confidence is capped by evidence limits or explicit ambiguity)
 - `evidence[]`
 - `next_checks[]`
 
@@ -153,7 +155,7 @@ Library note:
 Suspect ranking uses deterministic, proportional, evidence-aware scoring (0-100), not fixed suspect priority.
 
 - Scores rank suspects **inside one report**; they are not probabilities.
-- Confidence is score-derived ranking strength, not causal certainty.
+- Confidence is score-derived ranking strength, then evidence-quality capped when data is sparse, truncated, missing, or ambiguous.
 - Strong downstream tail-stage contribution can outrank weak blocking/runtime signals.
 - Strong queue pressure remains a high-confidence lead when queue share/depth evidence is dominant.
 

--- a/tailtriage-cli/src/analyze.rs
+++ b/tailtriage-cli/src/analyze.rs
@@ -55,7 +55,7 @@ impl Serialize for DiagnosisKind {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(rename_all = "snake_case")]
 /// Confidence bucket derived from suspect score thresholds.
 ///
@@ -163,6 +163,8 @@ pub struct Suspect {
     pub evidence: Vec<String>,
     /// Recommended next checks to validate or falsify this suspect.
     pub next_checks: Vec<String>,
+    /// Evidence-aware confidence capping notes when confidence is reduced or ambiguity applies.
+    pub confidence_notes: Vec<String>,
 }
 
 impl Suspect {
@@ -178,6 +180,7 @@ impl Suspect {
             confidence: Confidence::from_score(score),
             evidence,
             next_checks,
+            confidence_notes: Vec::new(),
         }
     }
 }
@@ -330,8 +333,9 @@ pub fn analyze_run(run: &Run) -> Report {
 
     suspects.sort_by_key(|suspect| std::cmp::Reverse(suspect.score));
 
-    let warnings = analysis_warnings(run, &suspects);
     let evidence_quality = evidence_quality(run);
+    apply_evidence_aware_confidence_caps(&mut suspects, run, &evidence_quality);
+    let warnings = analysis_warnings(run, &suspects);
 
     let mut ranked = suspects.into_iter();
     let primary_suspect = ranked.next().unwrap_or_else(|| {
@@ -355,6 +359,108 @@ pub fn analyze_run(run: &Run) -> Report {
         evidence_quality,
         primary_suspect,
         secondary_suspects: ranked.collect(),
+    }
+}
+
+fn apply_evidence_aware_confidence_caps(
+    suspects: &mut [Suspect],
+    run: &Run,
+    evidence_quality: &EvidenceQuality,
+) {
+    let ambiguous_top = ambiguity_warning(suspects).is_some();
+    for (index, suspect) in suspects.iter_mut().enumerate() {
+        if suspect.kind == DiagnosisKind::InsufficientEvidence {
+            continue;
+        }
+        let mut cap = Confidence::High;
+        let mut notes = Vec::new();
+        let is_primary = index == 0;
+        if evidence_quality.quality == EvidenceQualityLevel::Weak {
+            cap = cap.min(Confidence::Medium);
+        }
+        if run.requests.is_empty() {
+            cap = Confidence::Low;
+            notes.push("Low completed-request count caps confidence.".to_string());
+        } else if run.requests.len() < LOW_COMPLETED_REQUEST_THRESHOLD {
+            cap = cap.min(Confidence::Medium);
+            if is_primary {
+                notes.push("Low completed-request count caps confidence.".to_string());
+            }
+        }
+        if run.truncation.dropped_requests > 0 {
+            cap = cap.min(Confidence::Medium);
+            notes.push(
+                "Capture truncation caps confidence because dropped evidence may affect ranking."
+                    .to_string(),
+            );
+        }
+        if is_primary && ambiguous_top {
+            cap = cap.min(Confidence::Medium);
+            notes.push(
+                "Top suspects are close in score; confidence is capped by ambiguity.".to_string(),
+            );
+        }
+        match suspect.kind {
+            DiagnosisKind::ApplicationQueueSaturation => {
+                if run.queues.is_empty() {
+                    cap = cap.min(Confidence::Medium);
+                    notes.push(
+                        "Missing queue instrumentation limits queue-saturation confidence."
+                            .to_string(),
+                    );
+                }
+                if run.truncation.dropped_queues > 0 {
+                    cap = cap.min(Confidence::Medium);
+                    notes.push("Capture truncation caps confidence because dropped evidence may affect ranking.".to_string());
+                }
+            }
+            DiagnosisKind::DownstreamStageDominates => {
+                if run.stages.is_empty() {
+                    cap = cap.min(Confidence::Medium);
+                    notes.push(
+                        "Missing stage instrumentation limits downstream-stage confidence."
+                            .to_string(),
+                    );
+                }
+                if run.truncation.dropped_stages > 0 {
+                    cap = cap.min(Confidence::Medium);
+                    notes.push("Capture truncation caps confidence because dropped evidence may affect ranking.".to_string());
+                }
+            }
+            DiagnosisKind::BlockingPoolPressure | DiagnosisKind::ExecutorPressureSuspected => {
+                let runtime_missing_or_partial = run.runtime_snapshots.is_empty()
+                    || run
+                        .runtime_snapshots
+                        .iter()
+                        .all(|snapshot| snapshot.blocking_queue_depth.is_none())
+                    || run
+                        .runtime_snapshots
+                        .iter()
+                        .all(|snapshot| snapshot.local_queue_depth.is_none())
+                    || run
+                        .runtime_snapshots
+                        .iter()
+                        .all(|snapshot| snapshot.global_queue_depth.is_none());
+                if runtime_missing_or_partial {
+                    cap = cap.min(Confidence::Medium);
+                    notes.push(
+                        "Missing runtime snapshots limit executor/blocking confidence.".to_string(),
+                    );
+                }
+                if run.truncation.dropped_runtime_snapshots > 0 {
+                    cap = cap.min(Confidence::Medium);
+                    notes.push("Capture truncation caps confidence because dropped evidence may affect ranking.".to_string());
+                }
+            }
+            DiagnosisKind::InsufficientEvidence => {}
+        }
+        let original = suspect.confidence;
+        suspect.confidence = original.min(cap);
+        if suspect.confidence != original || (is_primary && ambiguous_top) {
+            notes.sort();
+            notes.dedup();
+            suspect.confidence_notes = notes;
+        }
     }
 }
 
@@ -1452,6 +1558,7 @@ mod tests {
                 confidence: Confidence::High,
                 evidence: vec!["queue wait high".to_owned()],
                 next_checks: vec!["check queue policy".to_owned()],
+                confidence_notes: vec![],
             },
             secondary_suspects: Vec::new(),
         };
@@ -1502,6 +1609,7 @@ mod tests {
                 confidence: Confidence::Low,
                 evidence: vec!["missing signals".to_owned()],
                 next_checks: vec!["add instrumentation".to_owned()],
+                confidence_notes: vec![],
             },
             secondary_suspects: Vec::new(),
         };
@@ -1904,5 +2012,106 @@ mod tests {
             report.evidence_quality.quality,
             EvidenceQualityLevel::Strong
         );
+    }
+
+    #[test]
+    fn confidence_cap_low_request_count_applies_with_note() {
+        let mut run = test_run();
+        run.queues = run
+            .requests
+            .iter()
+            .map(|r| QueueEvent {
+                request_id: r.request_id.clone(),
+                queue: "q".into(),
+                wait_us: 990,
+                waited_from_unix_ms: 1,
+                waited_until_unix_ms: 2,
+                depth_at_start: Some(20),
+            })
+            .collect();
+        let report = analyze_run(&run);
+        assert_eq!(report.primary_suspect.confidence, Confidence::Medium);
+        assert!(report
+            .primary_suspect
+            .confidence_notes
+            .iter()
+            .any(|note| note == "Low completed-request count caps confidence."));
+    }
+
+    #[test]
+    fn confidence_cap_truncation_adds_note() {
+        let mut run = test_run();
+        run.requests = (0..40)
+            .map(|i| RequestEvent {
+                request_id: format!("req-{i}"),
+                route: "/test".into(),
+                kind: None,
+                started_at_unix_ms: i,
+                finished_at_unix_ms: i + 1,
+                latency_us: 1_000,
+                outcome: "ok".into(),
+            })
+            .collect();
+        run.queues = run
+            .requests
+            .iter()
+            .map(|r| QueueEvent {
+                request_id: r.request_id.clone(),
+                queue: "q".into(),
+                wait_us: 980,
+                waited_from_unix_ms: 1,
+                waited_until_unix_ms: 2,
+                depth_at_start: Some(18),
+            })
+            .collect();
+        run.truncation.dropped_queues = 1;
+        let report = analyze_run(&run);
+        assert_eq!(report.primary_suspect.confidence, Confidence::Medium);
+        assert!(report.primary_suspect.confidence_notes.iter().any(|note| {
+            note == "Capture truncation caps confidence because dropped evidence may affect ranking."
+        }));
+    }
+
+    #[test]
+    fn confidence_capping_does_not_change_score_ordering() {
+        let mut run = test_run();
+        run.requests = (0..40)
+            .map(|i| RequestEvent {
+                request_id: format!("req-{i}"),
+                route: "/test".into(),
+                kind: None,
+                started_at_unix_ms: i,
+                finished_at_unix_ms: i + 1,
+                latency_us: 4_000_000,
+                outcome: "ok".into(),
+            })
+            .collect();
+        run.stages = run
+            .requests
+            .iter()
+            .map(|r| StageEvent {
+                request_id: r.request_id.clone(),
+                stage: "spawn_blocking_path".into(),
+                started_at_unix_ms: 1,
+                finished_at_unix_ms: 2,
+                latency_us: 3_900_000,
+                success: true,
+            })
+            .collect();
+        run.runtime_snapshots = vec![runtime_snapshot(Some(1), Some(1), Some(240)); 80];
+        let report = analyze_run(&run);
+        let ranked = std::iter::once(&report.primary_suspect)
+            .chain(report.secondary_suspects.iter())
+            .collect::<Vec<_>>();
+        let mut sorted_by_score = ranked.clone();
+        sorted_by_score.sort_by_key(|suspect| std::cmp::Reverse(suspect.score));
+        assert_eq!(
+            ranked.iter().map(|s| s.kind.as_str()).collect::<Vec<_>>(),
+            sorted_by_score
+                .iter()
+                .map(|s| s.kind.as_str())
+                .collect::<Vec<_>>()
+        );
+        assert!(ranked.windows(2).all(|pair| pair[0].score >= pair[1].score));
     }
 }


### PR DESCRIPTION
### Motivation
- Confidence previously came directly from score thresholds and could overstate triage certainty when evidence was sparse, truncated, ambiguous, or missing a signal family. The analyzer should keep score-based ranking but reflect evidence quality in reported confidence. 
- The change adds machine-readable explanation when confidence is reduced so downstream tooling and validation can reason about capped confidence.

### Description
- Added `confidence_notes: Vec<String>` to `Suspect` and initialized it empty by default so notes appear only when caps/ambiguity apply. 
- Introduced `apply_evidence_aware_confidence_caps(&mut suspects, run, &evidence_quality)` which runs after suspects are scored and sorted and applies per-suspect and primary-suspect caps based on `evidence_quality`, truncation, missing signal families, runtime-field gaps, low/zero completed requests, and top-suspect ambiguity; notes are added only when a cap changes the bucket or ambiguity cap applies. 
- Preserved existing score formulas and score-based sorting (`Reverse(score)`); the capping pass only adjusts `confidence` and `confidence_notes` and never affects ordering. 
- Added unit tests that cover low-request caps (with note), truncation caps (with note), and a regression test proving suspect scores and ordering are unchanged by confidence capping; updated and refreshed demo analysis fixtures and docs (CLI README, docs/diagnostics.md, docs/diagnostic-validation.md, root README) to include `confidence_notes` and explain new semantics.

### Testing
- Ran formatting, linting, and unit tests: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`; all passed. 
- Refreshed and re-checked demo fixtures: `python3 scripts/check_demo_fixture_drift.py --profile dev --refresh` and `python3 scripts/check_demo_fixture_drift.py --profile dev`; fixtures refreshed and the non-refresh check reported fixtures are up to date. 
- Executed analyzer validation and benchmark: `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0` and `python3 -m unittest scripts.tests.test_diagnostic_benchmark`; benchmark completed and passed its checks (top1/top2 thresholds and confidence-ceiling cases passed). 
- Validated docs contract: `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts`; all checks passed.

Summary: confidence is still derived from score bands for ranking, then evidence-quality caps are applied; suspect ordering and score values are unchanged by this change; automated formatting, linting, unit tests, benchmark, fixture drift checks, and docs-contract validation all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f995427764833080053e5793182efe)