### PR TITLE
Add meaningful route-level analyzer breakdowns while preserving global suspect semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,8 @@ tailtriage analyze tailtriage-run.json --format json
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -206,9 +207,11 @@ tailtriage analyze tailtriage-run.json --format json
         "Inspect downstream dependency behind stage 'simulated_work'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
-  ]
+  ],
+  "route_breakdowns": []
 }
 ```
 

--- a/demos/blocking_service/fixtures/after-analysis.json
+++ b/demos/blocking_service/fixtures/after-analysis.json
@@ -1,10 +1,10 @@
 {
   "request_count": 250,
-  "p50_latency_us": 54509,
-  "p95_latency_us": 87050,
-  "p99_latency_us": 91039,
-  "p95_queue_share_permille": 56,
-  "p95_service_share_permille": 993,
+  "p50_latency_us": 56069,
+  "p95_latency_us": 87332,
+  "p99_latency_us": 90939,
+  "p95_queue_share_permille": 64,
+  "p95_service_share_permille": 992,
   "inflight_trend": {
     "gauge": "blocking_service_inflight",
     "sample_count": 500,
@@ -43,15 +43,16 @@
     "score": 100,
     "confidence": "high",
     "evidence": [
-      "Stage 'spawn_blocking_path' has p95 latency 85870 us across 250 samples.",
-      "Stage 'spawn_blocking_path' cumulative latency is 13010681 us (978 permille of request latency).",
+      "Stage 'spawn_blocking_path' has p95 latency 86405 us across 250 samples.",
+      "Stage 'spawn_blocking_path' cumulative latency is 13149746 us (977 permille of request latency).",
       "Stage 'spawn_blocking_path' contributes 986 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -59,12 +60,14 @@
       "score": 82,
       "confidence": "medium",
       "evidence": [
-        "Blocking queue depth p95 is 42, peak is 48, with 98/200 nonzero samples."
+        "Blocking queue depth p95 is 42, peak is 49, with 98/200 nonzero samples."
       ],
       "next_checks": [
         "Audit blocking sections and move avoidable synchronous work out of hot paths.",
         "Inspect spawn_blocking callsites for long-running CPU or I/O work."
-      ]
+      ],
+      "confidence_notes": []
     }
-  ]
+  ],
+  "route_breakdowns": []
 }

--- a/demos/blocking_service/fixtures/before-analysis.json
+++ b/demos/blocking_service/fixtures/before-analysis.json
@@ -1,9 +1,9 @@
 {
   "request_count": 250,
-  "p50_latency_us": 1868185,
-  "p95_latency_us": 3531495,
-  "p99_latency_us": 3680957,
-  "p95_queue_share_permille": 6,
+  "p50_latency_us": 1867940,
+  "p95_latency_us": 3530827,
+  "p99_latency_us": 3679038,
+  "p95_queue_share_permille": 3,
   "p95_service_share_permille": 999,
   "inflight_trend": {
     "gauge": "blocking_service_inflight",
@@ -15,7 +15,8 @@
   },
   "warnings": [
     "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited.",
-    "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks."
+    "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks.",
+    "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
   ],
   "evidence_quality": {
     "request_count": 250,
@@ -42,13 +43,17 @@
   "primary_suspect": {
     "kind": "blocking_pool_pressure",
     "score": 88,
-    "confidence": "high",
+    "confidence": "medium",
     "evidence": [
       "Blocking queue depth p95 is 244, peak is 246, with 200/200 nonzero samples."
     ],
     "next_checks": [
       "Audit blocking sections and move avoidable synchronous work out of hot paths.",
       "Inspect spawn_blocking callsites for long-running CPU or I/O work."
+    ],
+    "confidence_notes": [
+      "Missing runtime snapshots limit executor/blocking confidence.",
+      "Top suspects are close in score; confidence is capped by ambiguity."
     ]
   },
   "secondary_suspects": [
@@ -57,8 +62,8 @@
       "score": 86,
       "confidence": "high",
       "evidence": [
-        "Stage 'spawn_blocking_path' has p95 latency 3530254 us across 250 samples.",
-        "Stage 'spawn_blocking_path' cumulative latency is 467061987 us (999 permille of request latency).",
+        "Stage 'spawn_blocking_path' has p95 latency 3529606 us across 250 samples.",
+        "Stage 'spawn_blocking_path' cumulative latency is 467199533 us (999 permille of request latency).",
         "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency.",
         "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
       ],
@@ -66,6 +71,61 @@
         "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
+      ],
+      "confidence_notes": []
+    }
+  ],
+  "route_breakdowns": [
+    {
+      "route": "/blocking-demo",
+      "request_count": 250,
+      "p50_latency_us": 1867940,
+      "p95_latency_us": 3530827,
+      "p99_latency_us": 3679038,
+      "p95_queue_share_permille": 3,
+      "p95_service_share_permille": 999,
+      "evidence_quality": {
+        "request_count": 250,
+        "queue_event_count": 250,
+        "stage_event_count": 250,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 0,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "missing",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime and in-flight signals are global and are not attributed to this route.",
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "downstream_stage_dominates",
+        "score": 100,
+        "confidence": "high",
+        "evidence": [
+          "Stage 'spawn_blocking_path' has p95 latency 3529606 us across 250 samples.",
+          "Stage 'spawn_blocking_path' cumulative latency is 467199533 us (999 permille of request latency).",
+          "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency."
+        ],
+        "next_checks": [
+          "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
+          "Collect downstream service timings and retry behavior during tail windows.",
+          "Review downstream SLO/error budget and align retry budget/backoff with it."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [],
+      "warnings": [
+        "Runtime and in-flight signals are global and are not attributed to this route."
       ]
     }
   ]

--- a/demos/blocking_service/fixtures/sample-analysis.json
+++ b/demos/blocking_service/fixtures/sample-analysis.json
@@ -1,9 +1,9 @@
 {
   "request_count": 250,
-  "p50_latency_us": 1868185,
-  "p95_latency_us": 3531495,
-  "p99_latency_us": 3680957,
-  "p95_queue_share_permille": 6,
+  "p50_latency_us": 1867940,
+  "p95_latency_us": 3530827,
+  "p99_latency_us": 3679038,
+  "p95_queue_share_permille": 3,
   "p95_service_share_permille": 999,
   "inflight_trend": {
     "gauge": "blocking_service_inflight",
@@ -15,7 +15,8 @@
   },
   "warnings": [
     "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited.",
-    "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks."
+    "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks.",
+    "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
   ],
   "evidence_quality": {
     "request_count": 250,
@@ -42,13 +43,17 @@
   "primary_suspect": {
     "kind": "blocking_pool_pressure",
     "score": 88,
-    "confidence": "high",
+    "confidence": "medium",
     "evidence": [
       "Blocking queue depth p95 is 244, peak is 246, with 200/200 nonzero samples."
     ],
     "next_checks": [
       "Audit blocking sections and move avoidable synchronous work out of hot paths.",
       "Inspect spawn_blocking callsites for long-running CPU or I/O work."
+    ],
+    "confidence_notes": [
+      "Missing runtime snapshots limit executor/blocking confidence.",
+      "Top suspects are close in score; confidence is capped by ambiguity."
     ]
   },
   "secondary_suspects": [
@@ -57,8 +62,8 @@
       "score": 86,
       "confidence": "high",
       "evidence": [
-        "Stage 'spawn_blocking_path' has p95 latency 3530254 us across 250 samples.",
-        "Stage 'spawn_blocking_path' cumulative latency is 467061987 us (999 permille of request latency).",
+        "Stage 'spawn_blocking_path' has p95 latency 3529606 us across 250 samples.",
+        "Stage 'spawn_blocking_path' cumulative latency is 467199533 us (999 permille of request latency).",
         "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency.",
         "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
       ],
@@ -66,6 +71,61 @@
         "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
+      ],
+      "confidence_notes": []
+    }
+  ],
+  "route_breakdowns": [
+    {
+      "route": "/blocking-demo",
+      "request_count": 250,
+      "p50_latency_us": 1867940,
+      "p95_latency_us": 3530827,
+      "p99_latency_us": 3679038,
+      "p95_queue_share_permille": 3,
+      "p95_service_share_permille": 999,
+      "evidence_quality": {
+        "request_count": 250,
+        "queue_event_count": 250,
+        "stage_event_count": 250,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 0,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "missing",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime and in-flight signals are global and are not attributed to this route.",
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "downstream_stage_dominates",
+        "score": 100,
+        "confidence": "high",
+        "evidence": [
+          "Stage 'spawn_blocking_path' has p95 latency 3529606 us across 250 samples.",
+          "Stage 'spawn_blocking_path' cumulative latency is 467199533 us (999 permille of request latency).",
+          "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency."
+        ],
+        "next_checks": [
+          "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
+          "Collect downstream service timings and retry behavior during tail windows.",
+          "Review downstream SLO/error budget and align retry budget/backoff with it."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [],
+      "warnings": [
+        "Runtime and in-flight signals are global and are not attributed to this route."
       ]
     }
   ]

--- a/demos/cold_start_burst_service/fixtures/after-analysis.json
+++ b/demos/cold_start_burst_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 8489,
-  "p95_latency_us": 8877,
-  "p99_latency_us": 9039,
+  "p50_latency_us": 8378,
+  "p95_latency_us": 8895,
+  "p99_latency_us": 9116,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 999,
   "inflight_trend": {
@@ -11,7 +11,7 @@
     "peak_count": 4,
     "p95_count": 3,
     "growth_delta": -1,
-    "growth_per_sec_milli": -1064
+    "growth_per_sec_milli": -1071
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,15 +41,17 @@
     "score": 100,
     "confidence": "high",
     "evidence": [
-      "Stage 'cold_start_stage' has p95 latency 8837 us across 220 samples.",
-      "Stage 'cold_start_stage' cumulative latency is 1823038 us (996 permille of request latency).",
-      "Stage 'cold_start_stage' contributes 995 permille of tail request latency."
+      "Stage 'cold_start_stage' has p95 latency 8869 us across 220 samples.",
+      "Stage 'cold_start_stage' cumulative latency is 1811817 us (996 permille of request latency).",
+      "Stage 'cold_start_stage' contributes 996 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'cold_start_stage'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }

--- a/demos/cold_start_burst_service/fixtures/before-analysis.json
+++ b/demos/cold_start_burst_service/fixtures/before-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 993483,
-  "p95_latency_us": 1190031,
-  "p99_latency_us": 1206824,
+  "p50_latency_us": 992479,
+  "p95_latency_us": 1191060,
+  "p99_latency_us": 1207907,
   "p95_queue_share_permille": 993,
-  "p95_service_share_permille": 336,
+  "p95_service_share_permille": 337,
   "inflight_trend": {
     "gauge": "cold_start_burst_inflight",
     "sample_count": 440,
     "peak_count": 220,
     "p95_count": 209,
-    "growth_delta": 0,
-    "growth_per_sec_milli": 0
+    "growth_delta": 1,
+    "growth_per_sec_milli": 816
   },
   "warnings": [],
   "evidence_quality": {
@@ -38,16 +38,18 @@
   },
   "primary_suspect": {
     "kind": "application_queue_saturation",
-    "score": 95,
+    "score": 100,
     "confidence": "high",
     "evidence": [
       "Queue wait at p95 consumes 99.3% of request time.",
-      "Observed queue depth sample up to 216."
+      "Observed queue depth sample up to 216.",
+      "In-flight gauge 'cold_start_burst_inflight' grew by 1 over the run window (p95=209, peak=220)."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -55,15 +57,17 @@
       "score": 32,
       "confidence": "low",
       "evidence": [
-        "Stage 'cold_start_stage' has p95 latency 63617 us across 220 samples.",
-        "Stage 'cold_start_stage' cumulative latency is 4876046 us (24 permille of request latency).",
+        "Stage 'cold_start_stage' has p95 latency 63740 us across 220 samples.",
+        "Stage 'cold_start_stage' cumulative latency is 4882950 us (24 permille of request latency).",
         "Stage 'cold_start_stage' contributes 6 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'cold_start_stage'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
-  ]
+  ],
+  "route_breakdowns": []
 }

--- a/demos/db_pool_saturation_service/fixtures/after-analysis.json
+++ b/demos/db_pool_saturation_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 13254,
-  "p95_latency_us": 14196,
-  "p99_latency_us": 14321,
+  "p50_latency_us": 13422,
+  "p95_latency_us": 14144,
+  "p99_latency_us": 14343,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "db_pool_saturation_inflight",
     "sample_count": 440,
-    "peak_count": 10,
+    "peak_count": 12,
     "p95_count": 10,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2710
+    "growth_per_sec_milli": -2702
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,15 +41,17 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'db_query' has p95 latency 11927 us across 220 samples.",
-      "Stage 'db_query' cumulative latency is 2440495 us (833 permille of request latency).",
-      "Stage 'db_query' contributes 841 permille of tail request latency."
+      "Stage 'db_query' has p95 latency 11820 us across 220 samples.",
+      "Stage 'db_query' cumulative latency is 2452885 us (832 permille of request latency).",
+      "Stage 'db_query' contributes 819 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'db_query'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }

--- a/demos/db_pool_saturation_service/fixtures/before-analysis.json
+++ b/demos/db_pool_saturation_service/fixtures/before-analysis.json
@@ -1,10 +1,10 @@
 {
   "request_count": 220,
-  "p50_latency_us": 498135,
-  "p95_latency_us": 927602,
-  "p99_latency_us": 961905,
-  "p95_queue_share_permille": 976,
-  "p95_service_share_permille": 368,
+  "p50_latency_us": 492563,
+  "p95_latency_us": 931643,
+  "p99_latency_us": 966460,
+  "p95_queue_share_permille": 977,
+  "p95_service_share_permille": 378,
   "inflight_trend": {
     "gauge": "db_pool_saturation_inflight",
     "sample_count": 440,
@@ -41,14 +41,15 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Queue wait at p95 consumes 97.6% of request time.",
+      "Queue wait at p95 consumes 97.7% of request time.",
       "Observed queue depth sample up to 196.",
       "In-flight gauge 'db_pool_saturation_inflight' grew by 2 over the run window (p95=193, peak=200)."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -56,15 +57,17 @@
       "score": 34,
       "confidence": "low",
       "evidence": [
-        "Stage 'db_query' has p95 latency 19752 us across 220 samples.",
-        "Stage 'db_query' cumulative latency is 4247545 us (38 permille of request latency).",
+        "Stage 'db_query' has p95 latency 19775 us across 220 samples.",
+        "Stage 'db_query' cumulative latency is 4247000 us (39 permille of request latency).",
         "Stage 'db_query' contributes 20 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'db_query'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
-  ]
+  ],
+  "route_breakdowns": []
 }

--- a/demos/downstream_service/fixtures/after-analysis.json
+++ b/demos/downstream_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 80,
-  "p50_latency_us": 12294,
-  "p95_latency_us": 13240,
-  "p99_latency_us": 13272,
+  "p50_latency_us": 12752,
+  "p95_latency_us": 13488,
+  "p99_latency_us": 13555,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "downstream_service_inflight",
     "sample_count": 160,
     "peak_count": 35,
-    "p95_count": 32,
+    "p95_count": 33,
     "growth_delta": 5,
-    "growth_per_sec_milli": 108695
+    "growth_per_sec_milli": 116279
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,15 +41,17 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 10846 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 809068 us (813 permille of request latency).",
-      "Stage 'downstream_call' contributes 804 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 11035 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 816669 us (817 permille of request latency).",
+      "Stage 'downstream_call' contributes 815 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }

--- a/demos/downstream_service/fixtures/before-after-comparison.json
+++ b/demos/downstream_service/fixtures/before-after-comparison.json
@@ -2,19 +2,19 @@
   "before": {
     "primary_suspect_kind": "downstream_stage_dominates",
     "primary_suspect_score": 95,
-    "p95_latency_us": 24448,
+    "p95_latency_us": 23881,
     "p95_service_share_permille": 1000
   },
   "after": {
     "primary_suspect_kind": "downstream_stage_dominates",
     "primary_suspect_score": 95,
-    "p95_latency_us": 13240,
+    "p95_latency_us": 13488,
     "p95_service_share_permille": 1000
   },
   "delta": {
     "primary_suspect_kind": null,
     "primary_suspect_score": 0,
-    "p95_latency_us": -11208,
+    "p95_latency_us": -10393,
     "p95_service_share_permille": 0
   }
 }

--- a/demos/downstream_service/fixtures/before-analysis.json
+++ b/demos/downstream_service/fixtures/before-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 80,
-  "p50_latency_us": 23531,
-  "p95_latency_us": 24448,
-  "p99_latency_us": 24549,
+  "p50_latency_us": 23330,
+  "p95_latency_us": 23881,
+  "p99_latency_us": 23893,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "downstream_service_inflight",
     "sample_count": 160,
-    "peak_count": 57,
+    "peak_count": 56,
     "p95_count": 55,
     "growth_delta": 5,
-    "growth_per_sec_milli": 90909
+    "growth_per_sec_milli": 87719
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,15 +41,17 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 22135 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 1693727 us (903 permille of request latency).",
-      "Stage 'downstream_call' contributes 904 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 21708 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 1681052 us (902 permille of request latency).",
+      "Stage 'downstream_call' contributes 908 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }

--- a/demos/downstream_service/fixtures/sample-analysis.json
+++ b/demos/downstream_service/fixtures/sample-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 80,
-  "p50_latency_us": 23531,
-  "p95_latency_us": 24448,
-  "p99_latency_us": 24549,
+  "p50_latency_us": 23330,
+  "p95_latency_us": 23881,
+  "p99_latency_us": 23893,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "downstream_service_inflight",
     "sample_count": 160,
-    "peak_count": 57,
+    "peak_count": 56,
     "p95_count": 55,
     "growth_delta": 5,
-    "growth_per_sec_milli": 90909
+    "growth_per_sec_milli": 87719
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,15 +41,17 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 22135 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 1693727 us (903 permille of request latency).",
-      "Stage 'downstream_call' contributes 904 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 21708 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 1681052 us (902 permille of request latency).",
+      "Stage 'downstream_call' contributes 908 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }

--- a/demos/executor_pressure_service/fixtures/after-analysis.json
+++ b/demos/executor_pressure_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 240,
-  "p50_latency_us": 7284295,
-  "p95_latency_us": 7413192,
-  "p99_latency_us": 7423728,
+  "p50_latency_us": 7196166,
+  "p95_latency_us": 7283015,
+  "p99_latency_us": 7290936,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,14 +11,16 @@
     "peak_count": 240,
     "p95_count": 228,
     "growth_delta": -1,
-    "growth_per_sec_milli": -134
+    "growth_per_sec_milli": -136
   },
-  "warnings": [],
+  "warnings": [
+    "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
+  ],
   "evidence_quality": {
     "request_count": 240,
     "queue_event_count": 0,
     "stage_event_count": 0,
-    "runtime_snapshot_count": 7433,
+    "runtime_snapshot_count": 7305,
     "inflight_snapshot_count": 480,
     "requests": "present",
     "queues": "missing",
@@ -41,14 +43,68 @@
     "score": 99,
     "confidence": "high",
     "evidence": [
-      "Runtime global queue depth p95 is 720, suggesting scheduler contention.",
-      "Runtime local queue depth p95 is 4656.",
-      "Runtime alive_tasks p95 is 720."
+      "Runtime global queue depth p95 is 711, suggesting scheduler contention.",
+      "Runtime local queue depth p95 is 4794.",
+      "Runtime alive_tasks p95 is 711."
     ],
     "next_checks": [
       "Check for long polls without yielding and uneven task fan-out.",
       "Compare with per-stage timings to isolate overloaded async stages."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": [
+    {
+      "route": "/executor-pressure",
+      "request_count": 240,
+      "p50_latency_us": 7196166,
+      "p95_latency_us": 7283015,
+      "p99_latency_us": 7290936,
+      "p95_queue_share_permille": 0,
+      "p95_service_share_permille": 1000,
+      "evidence_quality": {
+        "request_count": 240,
+        "queue_event_count": 0,
+        "stage_event_count": 0,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 0,
+        "requests": "present",
+        "queues": "missing",
+        "stages": "missing",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "missing",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "weak",
+        "limitations": [
+          "Queue and stage instrumentation are both unavailable, limiting application vs downstream interpretation.",
+          "Runtime and in-flight signals are global and are not attributed to this route.",
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "insufficient_evidence",
+        "score": 50,
+        "confidence": "low",
+        "evidence": [
+          "Not enough queue, stage, or runtime signals to rank a stronger suspect."
+        ],
+        "next_checks": [
+          "Wrap critical awaits with queue(...).await_on(...), and use stage(...).await_on(...) for Result-returning work or stage(...).await_value(...) for infallible work.",
+          "Enable RuntimeSampler during the run to capture runtime pressure signals."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [],
+      "warnings": [
+        "No runtime snapshots captured; executor and blocking-pressure interpretation is limited.",
+        "Runtime and in-flight signals are global and are not attributed to this route."
+      ]
+    }
+  ]
 }

--- a/demos/executor_pressure_service/fixtures/before-analysis.json
+++ b/demos/executor_pressure_service/fixtures/before-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 240,
-  "p50_latency_us": 34531979,
-  "p95_latency_us": 34596797,
-  "p99_latency_us": 34604649,
+  "p50_latency_us": 34986526,
+  "p95_latency_us": 35037320,
+  "p99_latency_us": 35043235,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -13,12 +13,14 @@
     "growth_delta": -1,
     "growth_per_sec_milli": -28
   },
-  "warnings": [],
+  "warnings": [
+    "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
+  ],
   "evidence_quality": {
     "request_count": 240,
     "queue_event_count": 0,
     "stage_event_count": 0,
-    "runtime_snapshot_count": 6377,
+    "runtime_snapshot_count": 7653,
     "inflight_snapshot_count": 480,
     "requests": "present",
     "queues": "missing",
@@ -42,13 +44,67 @@
     "confidence": "high",
     "evidence": [
       "Runtime global queue depth p95 is 1920, suggesting scheduler contention.",
-      "Runtime local queue depth p95 is 42232.",
+      "Runtime local queue depth p95 is 41288.",
       "Runtime alive_tasks p95 is 1920."
     ],
     "next_checks": [
       "Check for long polls without yielding and uneven task fan-out.",
       "Compare with per-stage timings to isolate overloaded async stages."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": [
+    {
+      "route": "/executor-pressure",
+      "request_count": 240,
+      "p50_latency_us": 34986526,
+      "p95_latency_us": 35037320,
+      "p99_latency_us": 35043235,
+      "p95_queue_share_permille": 0,
+      "p95_service_share_permille": 1000,
+      "evidence_quality": {
+        "request_count": 240,
+        "queue_event_count": 0,
+        "stage_event_count": 0,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 0,
+        "requests": "present",
+        "queues": "missing",
+        "stages": "missing",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "missing",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "weak",
+        "limitations": [
+          "Queue and stage instrumentation are both unavailable, limiting application vs downstream interpretation.",
+          "Runtime and in-flight signals are global and are not attributed to this route.",
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "insufficient_evidence",
+        "score": 50,
+        "confidence": "low",
+        "evidence": [
+          "Not enough queue, stage, or runtime signals to rank a stronger suspect."
+        ],
+        "next_checks": [
+          "Wrap critical awaits with queue(...).await_on(...), and use stage(...).await_on(...) for Result-returning work or stage(...).await_value(...) for infallible work.",
+          "Enable RuntimeSampler during the run to capture runtime pressure signals."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [],
+      "warnings": [
+        "No runtime snapshots captured; executor and blocking-pressure interpretation is limited.",
+        "Runtime and in-flight signals are global and are not attributed to this route."
+      ]
+    }
+  ]
 }

--- a/demos/executor_pressure_service/fixtures/sample-analysis.json
+++ b/demos/executor_pressure_service/fixtures/sample-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 240,
-  "p50_latency_us": 34531979,
-  "p95_latency_us": 34596797,
-  "p99_latency_us": 34604649,
+  "p50_latency_us": 34986526,
+  "p95_latency_us": 35037320,
+  "p99_latency_us": 35043235,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -13,12 +13,14 @@
     "growth_delta": -1,
     "growth_per_sec_milli": -28
   },
-  "warnings": [],
+  "warnings": [
+    "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
+  ],
   "evidence_quality": {
     "request_count": 240,
     "queue_event_count": 0,
     "stage_event_count": 0,
-    "runtime_snapshot_count": 6377,
+    "runtime_snapshot_count": 7653,
     "inflight_snapshot_count": 480,
     "requests": "present",
     "queues": "missing",
@@ -42,13 +44,67 @@
     "confidence": "high",
     "evidence": [
       "Runtime global queue depth p95 is 1920, suggesting scheduler contention.",
-      "Runtime local queue depth p95 is 42232.",
+      "Runtime local queue depth p95 is 41288.",
       "Runtime alive_tasks p95 is 1920."
     ],
     "next_checks": [
       "Check for long polls without yielding and uneven task fan-out.",
       "Compare with per-stage timings to isolate overloaded async stages."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": [
+    {
+      "route": "/executor-pressure",
+      "request_count": 240,
+      "p50_latency_us": 34986526,
+      "p95_latency_us": 35037320,
+      "p99_latency_us": 35043235,
+      "p95_queue_share_permille": 0,
+      "p95_service_share_permille": 1000,
+      "evidence_quality": {
+        "request_count": 240,
+        "queue_event_count": 0,
+        "stage_event_count": 0,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 0,
+        "requests": "present",
+        "queues": "missing",
+        "stages": "missing",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "missing",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "weak",
+        "limitations": [
+          "Queue and stage instrumentation are both unavailable, limiting application vs downstream interpretation.",
+          "Runtime and in-flight signals are global and are not attributed to this route.",
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "insufficient_evidence",
+        "score": 50,
+        "confidence": "low",
+        "evidence": [
+          "Not enough queue, stage, or runtime signals to rank a stronger suspect."
+        ],
+        "next_checks": [
+          "Wrap critical awaits with queue(...).await_on(...), and use stage(...).await_on(...) for Result-returning work or stage(...).await_value(...) for infallible work.",
+          "Enable RuntimeSampler during the run to capture runtime pressure signals."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [],
+      "warnings": [
+        "No runtime snapshots captured; executor and blocking-pressure interpretation is limited.",
+        "Runtime and in-flight signals are global and are not attributed to this route."
+      ]
+    }
+  ]
 }

--- a/demos/mixed_contention_service/fixtures/baseline-analysis.json
+++ b/demos/mixed_contention_service/fixtures/baseline-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 393750,
-  "p95_latency_us": 738845,
-  "p99_latency_us": 767621,
-  "p95_queue_share_permille": 980,
-  "p95_service_share_permille": 402,
+  "p50_latency_us": 397216,
+  "p95_latency_us": 754808,
+  "p99_latency_us": 784193,
+  "p95_queue_share_permille": 979,
+  "p95_service_share_permille": 392,
   "inflight_trend": {
     "gauge": "mixed_contention_inflight",
     "sample_count": 440,
     "peak_count": 200,
     "p95_count": 190,
     "growth_delta": -1,
-    "growth_per_sec_milli": -1160
+    "growth_per_sec_milli": -1135
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,13 +41,14 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Queue wait at p95 consumes 98.0% of request time.",
+      "Queue wait at p95 consumes 97.9% of request time.",
       "Observed queue depth sample up to 195."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -55,15 +56,17 @@
       "score": 35,
       "confidence": "low",
       "evidence": [
-        "Stage 'downstream_call' has p95 latency 32531 us across 220 samples.",
-        "Stage 'downstream_call' cumulative latency is 3775687 us (43 permille of request latency).",
-        "Stage 'downstream_call' contributes 23 permille of tail request latency."
+        "Stage 'downstream_call' has p95 latency 32585 us across 220 samples.",
+        "Stage 'downstream_call' cumulative latency is 3800594 us (43 permille of request latency).",
+        "Stage 'downstream_call' contributes 24 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'downstream_call'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
-  ]
+  ],
+  "route_breakdowns": []
 }

--- a/demos/mixed_contention_service/fixtures/mitigated-analysis.json
+++ b/demos/mixed_contention_service/fixtures/mitigated-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 14399,
-  "p95_latency_us": 34450,
-  "p99_latency_us": 35029,
+  "p50_latency_us": 14566,
+  "p95_latency_us": 34893,
+  "p99_latency_us": 35068,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,7 +11,7 @@
     "peak_count": 14,
     "p95_count": 13,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2631
+    "growth_per_sec_milli": -2638
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,15 +41,17 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 32570 us across 220 samples.",
-      "Stage 'downstream_call' cumulative latency is 3763084 us (889 permille of request latency).",
-      "Stage 'downstream_call' contributes 933 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 32558 us across 220 samples.",
+      "Stage 'downstream_call' cumulative latency is 3774260 us (887 permille of request latency).",
+      "Stage 'downstream_call' contributes 931 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }

--- a/demos/queue_service/fixtures/after-analysis.json
+++ b/demos/queue_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 250,
-  "p50_latency_us": 16086,
-  "p95_latency_us": 17037,
-  "p99_latency_us": 19055,
+  "p50_latency_us": 16154,
+  "p95_latency_us": 16906,
+  "p99_latency_us": 17150,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
-    "peak_count": 16,
+    "peak_count": 12,
     "p95_count": 12,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2386
+    "growth_per_sec_milli": -2341
   },
   "warnings": [],
   "evidence_quality": {
@@ -38,18 +38,20 @@
   },
   "primary_suspect": {
     "kind": "downstream_stage_dominates",
-    "score": 95,
+    "score": 100,
     "confidence": "high",
     "evidence": [
-      "Stage 'simulated_work' has p95 latency 16919 us across 250 samples.",
-      "Stage 'simulated_work' cumulative latency is 4031794 us (995 permille of request latency).",
-      "Stage 'simulated_work' contributes 955 permille of tail request latency."
+      "Stage 'simulated_work' has p95 latency 16885 us across 250 samples.",
+      "Stage 'simulated_work' cumulative latency is 4035408 us (998 permille of request latency).",
+      "Stage 'simulated_work' contributes 998 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'simulated_work'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }

--- a/demos/queue_service/fixtures/before-analysis.json
+++ b/demos/queue_service/fixtures/before-analysis.json
@@ -1,10 +1,10 @@
 {
   "request_count": 250,
-  "p50_latency_us": 783889,
-  "p95_latency_us": 1463903,
-  "p99_latency_us": 1514094,
+  "p50_latency_us": 782506,
+  "p95_latency_us": 1470239,
+  "p99_latency_us": 1520678,
   "p95_queue_share_permille": 982,
-  "p95_service_share_permille": 269,
+  "p95_service_share_permille": 265,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
@@ -47,7 +47,8 @@
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -55,15 +56,17 @@
       "score": 33,
       "confidence": "low",
       "evidence": [
-        "Stage 'simulated_work' has p95 latency 26681 us across 250 samples.",
-        "Stage 'simulated_work' cumulative latency is 6548608 us (33 permille of request latency).",
+        "Stage 'simulated_work' has p95 latency 26806 us across 250 samples.",
+        "Stage 'simulated_work' cumulative latency is 6561094 us (33 permille of request latency).",
         "Stage 'simulated_work' contributes 17 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'simulated_work'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
-  ]
+  ],
+  "route_breakdowns": []
 }

--- a/demos/queue_service/fixtures/sample-analysis.json
+++ b/demos/queue_service/fixtures/sample-analysis.json
@@ -1,10 +1,10 @@
 {
   "request_count": 250,
-  "p50_latency_us": 783889,
-  "p95_latency_us": 1463903,
-  "p99_latency_us": 1514094,
+  "p50_latency_us": 782506,
+  "p95_latency_us": 1470239,
+  "p99_latency_us": 1520678,
   "p95_queue_share_permille": 982,
-  "p95_service_share_permille": 269,
+  "p95_service_share_permille": 265,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
@@ -47,7 +47,8 @@
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -55,15 +56,17 @@
       "score": 33,
       "confidence": "low",
       "evidence": [
-        "Stage 'simulated_work' has p95 latency 26681 us across 250 samples.",
-        "Stage 'simulated_work' cumulative latency is 6548608 us (33 permille of request latency).",
+        "Stage 'simulated_work' has p95 latency 26806 us across 250 samples.",
+        "Stage 'simulated_work' cumulative latency is 6561094 us (33 permille of request latency).",
         "Stage 'simulated_work' contributes 17 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'simulated_work'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
-  ]
+  ],
+  "route_breakdowns": []
 }

--- a/demos/retry_storm_service/fixtures/after-analysis.json
+++ b/demos/retry_storm_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 180,
-  "p50_latency_us": 9513,
-  "p95_latency_us": 29401,
-  "p99_latency_us": 29784,
+  "p50_latency_us": 9848,
+  "p95_latency_us": 29680,
+  "p99_latency_us": 29866,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,7 +11,7 @@
     "peak_count": 17,
     "p95_count": 15,
     "growth_delta": -1,
-    "growth_per_sec_milli": -4716
+    "growth_per_sec_milli": -4587
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,15 +41,17 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_total' has p95 latency 27186 us across 180 samples.",
-      "Stage 'downstream_total' cumulative latency is 2154453 us (842 permille of request latency).",
+      "Stage 'downstream_total' has p95 latency 27395 us across 180 samples.",
+      "Stage 'downstream_total' cumulative latency is 2178633 us (840 permille of request latency).",
       "Stage 'downstream_total' contributes 922 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_total'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }

--- a/demos/retry_storm_service/fixtures/before-analysis.json
+++ b/demos/retry_storm_service/fixtures/before-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 180,
-  "p50_latency_us": 9863,
-  "p95_latency_us": 41148,
-  "p99_latency_us": 42215,
+  "p50_latency_us": 9791,
+  "p95_latency_us": 42053,
+  "p99_latency_us": 43654,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "retry_storm_inflight",
     "sample_count": 360,
-    "peak_count": 57,
-    "p95_count": 54,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -9345
+    "peak_count": 54,
+    "p95_count": 51,
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,15 +41,17 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_total' has p95 latency 38902 us across 180 samples.",
-      "Stage 'downstream_total' cumulative latency is 3025771 us (883 permille of request latency).",
-      "Stage 'downstream_total' contributes 945 permille of tail request latency."
+      "Stage 'downstream_total' has p95 latency 39932 us across 180 samples.",
+      "Stage 'downstream_total' cumulative latency is 3047769 us (879 permille of request latency).",
+      "Stage 'downstream_total' contributes 938 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_total'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }

--- a/demos/shared_state_lock_service/fixtures/after-analysis.json
+++ b/demos/shared_state_lock_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 828874,
-  "p95_latency_us": 1564712,
-  "p99_latency_us": 1623531,
+  "p50_latency_us": 847996,
+  "p95_latency_us": 1593978,
+  "p99_latency_us": 1651094,
   "p95_queue_share_permille": 993,
-  "p95_service_share_permille": 127,
+  "p95_service_share_permille": 126,
   "inflight_trend": {
     "gauge": "shared_state_lock_inflight",
     "sample_count": 440,
-    "peak_count": 201,
+    "peak_count": 200,
     "p95_count": 190,
     "growth_delta": -1,
-    "growth_per_sec_milli": -555
+    "growth_per_sec_milli": -543
   },
   "warnings": [],
   "evidence_quality": {
@@ -47,7 +47,8 @@
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -55,15 +56,17 @@
       "score": 32,
       "confidence": "low",
       "evidence": [
-        "Stage 'shared_state_critical_section' has p95 latency 8269 us across 220 samples.",
-        "Stage 'shared_state_critical_section' cumulative latency is 1787919 us (9 permille of request latency).",
-        "Stage 'shared_state_critical_section' contributes 5 permille of tail request latency."
+        "Stage 'shared_state_critical_section' has p95 latency 8525 us across 220 samples.",
+        "Stage 'shared_state_critical_section' cumulative latency is 1820496 us (9 permille of request latency).",
+        "Stage 'shared_state_critical_section' contributes 4 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'shared_state_critical_section'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
-  ]
+  ],
+  "route_breakdowns": []
 }

--- a/demos/shared_state_lock_service/fixtures/before-analysis.json
+++ b/demos/shared_state_lock_service/fixtures/before-analysis.json
@@ -1,10 +1,10 @@
 {
   "request_count": 220,
-  "p50_latency_us": 2546348,
-  "p95_latency_us": 4817353,
-  "p99_latency_us": 4999343,
+  "p50_latency_us": 2554054,
+  "p95_latency_us": 4825169,
+  "p99_latency_us": 5007481,
   "p95_queue_share_permille": 994,
-  "p95_service_share_permille": 98,
+  "p95_service_share_permille": 100,
   "inflight_trend": {
     "gauge": "shared_state_lock_inflight",
     "sample_count": 440,
@@ -47,7 +47,8 @@
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -55,15 +56,17 @@
       "score": 32,
       "confidence": "low",
       "evidence": [
-        "Stage 'shared_state_critical_section' has p95 latency 23447 us across 220 samples.",
-        "Stage 'shared_state_critical_section' cumulative latency is 5109039 us (9 permille of request latency).",
+        "Stage 'shared_state_critical_section' has p95 latency 23545 us across 220 samples.",
+        "Stage 'shared_state_critical_section' cumulative latency is 5118202 us (9 permille of request latency).",
         "Stage 'shared_state_critical_section' contributes 4 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'shared_state_critical_section'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
-  ]
+  ],
+  "route_breakdowns": []
 }

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -33,6 +33,7 @@ Current supported schema version: `1`.
 - warnings (analyzer/report warnings, especially truncation-related)
 - evidence_quality (structured coverage/completeness/interpretability summary)
 - ranked suspects (primary + secondary)
+- optional `route_breakdowns[]` supporting context when route-level divergence or latency spread adds meaningful triage signal
 
 Each suspect includes:
 
@@ -55,6 +56,7 @@ Each suspect includes:
 - `evidence_quality`: structured signal coverage status, truncation counters, and overall evidence quality (`strong`/`partial`/`weak`).
 - `primary_suspect`: highest-ranked suspect with evidence and next checks.
 - `secondary_suspects[]`: additional ranked suspects.
+- `route_breakdowns[]`: supporting route-level summaries (bounded and only emitted when meaningful). Global `primary_suspect` remains the primary output.
 - `inflight_trend` (optional): dominant in-flight gauge trend summary when snapshots exist.
 
 ## Suspect kinds
@@ -141,3 +143,10 @@ If truncation counters are non-zero, treat the diagnosis as partial-data triage.
 4. Change one thing.
 5. Re-run under comparable load.
 6. Compare suspect movement and p95 shares.
+
+
+## Route breakdown interpretation
+
+When emitted, `route_breakdowns[]` helps compare evidence-ranked suspects by route label. This is supporting context, not replacement global ranking. Route summaries are based on route-attributed request/queue/stage signals. Runtime and in-flight snapshots remain global and are intentionally not attributed per route in current analysis.
+
+Treat route suspects as leads for next checks, not proof of per-route root cause.

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -94,7 +94,8 @@ Then run one targeted check, change one thing, and re-run under comparable load.
     "next_checks": ["Inspect queue admission limits and producer burst patterns."],
     "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }
 ```
 
@@ -111,6 +112,7 @@ A report can include:
 - report warnings from analysis/report generation (for example truncation-related)
 - structured evidence quality coverage/status summary
 - primary and secondary suspects
+- optional `route_breakdowns[]` supporting context when route-level divergence/latency spread is meaningful
 
 `tailtriage analyze` also prints loader/lifecycle warnings to stderr before the report. Those warnings are surfaced separately; they are not merged into the report `warnings` field.
 
@@ -148,6 +150,10 @@ Library note:
 - truncation warnings mean the diagnosis is based on partial retained data
 - unfinished lifecycle warnings printed by the CLI indicate some requests were not completed cleanly
 - `p95_queue_share_permille` and `p95_service_share_permille` are independent percentile summaries and do not need to sum to `1000`
+- `route_breakdowns[]` is supporting context only; global `primary_suspect` remains the primary triage output
+- route-level summaries use captured route labels and route-attributed request/queue/stage evidence
+- runtime and in-flight signals are global today and are intentionally not attributed to individual routes in route breakdowns
+- route-level suspects are leads for next checks, not per-route causal proof
 
 
 ## Scoring and warning behavior

--- a/tailtriage-cli/src/analyze.rs
+++ b/tailtriage-cli/src/analyze.rs
@@ -230,6 +230,35 @@ pub struct Report {
     pub primary_suspect: Suspect,
     /// Lower-ranked suspects retained for follow-up triage.
     pub secondary_suspects: Vec<Suspect>,
+    /// Supporting per-route triage summaries when route-level divergence is meaningful.
+    pub route_breakdowns: Vec<RouteBreakdown>,
+}
+
+/// Supporting route-scoped triage summary.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct RouteBreakdown {
+    /// Route label from captured request events.
+    pub route: String,
+    /// Number of completed requests analyzed for this route.
+    pub request_count: usize,
+    /// p50 route latency in microseconds.
+    pub p50_latency_us: Option<u64>,
+    /// p95 route latency in microseconds.
+    pub p95_latency_us: Option<u64>,
+    /// p99 route latency in microseconds.
+    pub p99_latency_us: Option<u64>,
+    /// p95 queue-time share for this route in permille.
+    pub p95_queue_share_permille: Option<u64>,
+    /// p95 non-queue service-time share for this route in permille.
+    pub p95_service_share_permille: Option<u64>,
+    /// Structured evidence coverage summary for this route analysis.
+    pub evidence_quality: EvidenceQuality,
+    /// Highest-ranked suspect for this route subset.
+    pub primary_suspect: Suspect,
+    /// Lower-ranked route suspects retained for follow-up checks.
+    pub secondary_suspects: Vec<Suspect>,
+    /// Route-scoped warnings and limitations.
+    pub warnings: Vec<String>,
 }
 
 /// Analyzes one run artifact with rule-based heuristics and returns a triage report.
@@ -283,6 +312,15 @@ pub struct Report {
 /// ```
 #[must_use]
 pub fn analyze_run(run: &Run) -> Report {
+    let mut report = analyze_run_core(run);
+    report.route_breakdowns = build_route_breakdowns(run, &report);
+    if route_divergence_exists(&report.route_breakdowns, &report.primary_suspect.kind) {
+        report.warnings.push("Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect.".to_string());
+    }
+    report
+}
+
+fn analyze_run_core(run: &Run) -> Report {
     let request_latencies = run
         .requests
         .iter()
@@ -360,7 +398,156 @@ pub fn analyze_run(run: &Run) -> Report {
         evidence_quality,
         primary_suspect,
         secondary_suspects: ranked.collect(),
+        route_breakdowns: Vec::new(),
     }
+}
+
+fn build_route_breakdowns(run: &Run, global: &Report) -> Vec<RouteBreakdown> {
+    const MIN_ROUTE_REQUESTS: usize = 3;
+    const MAX_ROUTE_BREAKDOWNS: usize = 10;
+    let mut grouped: std::collections::BTreeMap<String, Vec<String>> =
+        std::collections::BTreeMap::new();
+    for req in &run.requests {
+        grouped
+            .entry(req.route.clone())
+            .or_default()
+            .push(req.request_id.clone());
+    }
+    let mut eligible = Vec::new();
+    let mut omitted = 0usize;
+    for (route, ids) in grouped {
+        if ids.len() < MIN_ROUTE_REQUESTS {
+            omitted += 1;
+            continue;
+        }
+        let route_run = filter_run_by_request_ids(run, &ids, false);
+        let mut route_report = analyze_run_core(&route_run);
+        route_report.warnings.push(
+            "Runtime and in-flight signals are global and are not attributed to this route."
+                .to_string(),
+        );
+        route_report.evidence_quality.limitations.push(
+            "Runtime and in-flight signals are global and are not attributed to this route."
+                .to_string(),
+        );
+        route_report.evidence_quality.limitations.sort();
+        route_report.evidence_quality.limitations.dedup();
+        eligible.push(RouteBreakdown {
+            route,
+            request_count: route_report.request_count,
+            p50_latency_us: route_report.p50_latency_us,
+            p95_latency_us: route_report.p95_latency_us,
+            p99_latency_us: route_report.p99_latency_us,
+            p95_queue_share_permille: route_report.p95_queue_share_permille,
+            p95_service_share_permille: route_report.p95_service_share_permille,
+            evidence_quality: route_report.evidence_quality,
+            primary_suspect: route_report.primary_suspect,
+            secondary_suspects: route_report.secondary_suspects,
+            warnings: route_report.warnings,
+        });
+    }
+    if !route_breakdowns_meaningful(&eligible, global) {
+        return Vec::new();
+    }
+    if omitted > 0 {
+        // note is carried on each route line to keep report additive and avoid changing report schema
+        for item in &mut eligible {
+            item.warnings.push(format!(
+                "Some routes were omitted from route breakdowns because they had fewer than {MIN_ROUTE_REQUESTS} completed requests."
+            ));
+        }
+    }
+    eligible.sort_by(|a, b| {
+        b.p95_latency_us
+            .cmp(&a.p95_latency_us)
+            .then_with(|| b.request_count.cmp(&a.request_count))
+            .then_with(|| a.route.cmp(&b.route))
+    });
+    eligible.truncate(MAX_ROUTE_BREAKDOWNS);
+    eligible
+}
+
+fn filter_run_by_request_ids(
+    run: &Run,
+    request_ids: &[String],
+    include_global_signals: bool,
+) -> Run {
+    let ids: std::collections::HashSet<String> = request_ids.iter().cloned().collect();
+    Run {
+        schema_version: run.schema_version,
+        metadata: run.metadata.clone(),
+        requests: run
+            .requests
+            .iter()
+            .filter(|r| ids.contains(&r.request_id))
+            .cloned()
+            .collect(),
+        stages: run
+            .stages
+            .iter()
+            .filter(|s| ids.contains(&s.request_id))
+            .cloned()
+            .collect(),
+        queues: run
+            .queues
+            .iter()
+            .filter(|q| ids.contains(&q.request_id))
+            .cloned()
+            .collect(),
+        inflight: if include_global_signals {
+            run.inflight.clone()
+        } else {
+            Vec::new()
+        },
+        runtime_snapshots: if include_global_signals {
+            run.runtime_snapshots.clone()
+        } else {
+            Vec::new()
+        },
+        truncation: run.truncation.clone(),
+    }
+}
+
+fn route_breakdowns_meaningful(routes: &[RouteBreakdown], global: &Report) -> bool {
+    if routes.is_empty() {
+        return false;
+    }
+    if routes.len() == 1 && routes[0].primary_suspect.kind == global.primary_suspect.kind {
+        return false;
+    }
+    let different_route_kinds = routes.iter().any(|r| {
+        routes
+            .iter()
+            .any(|o| o.primary_suspect.kind.as_str() != r.primary_suspect.kind.as_str())
+    });
+    let differs_from_global = routes
+        .iter()
+        .any(|r| r.primary_suspect.kind != global.primary_suspect.kind);
+    let (slowest, fastest) = routes.iter().fold((None, None), |acc, r| {
+        let p95 = r.p95_latency_us;
+        (acc.0.max(p95), acc.1.min(p95))
+    });
+    let slow_vs_fast = routes.len() >= 2 && ratio_at_least(slowest, fastest, 150);
+    let slow_vs_global = routes.len() >= 2 && ratio_at_least(slowest, global.p95_latency_us, 125);
+    different_route_kinds || differs_from_global || slow_vs_fast || slow_vs_global
+}
+
+fn ratio_at_least(numerator: Option<u64>, denominator: Option<u64>, pct: u64) -> bool {
+    match (numerator, denominator) {
+        (Some(n), Some(d)) if d > 0 => u128::from(n) * 100 >= u128::from(d) * u128::from(pct),
+        _ => false,
+    }
+}
+
+fn route_divergence_exists(routes: &[RouteBreakdown], global_kind: &DiagnosisKind) -> bool {
+    routes
+        .iter()
+        .any(|r| &r.primary_suspect.kind != global_kind)
+        || routes.iter().any(|r| {
+            routes
+                .iter()
+                .any(|o| o.primary_suspect.kind.as_str() != r.primary_suspect.kind.as_str())
+        })
 }
 
 fn apply_evidence_aware_confidence_caps(
@@ -1331,6 +1518,19 @@ pub fn render_text(report: &Report) -> String {
             ));
         }
     }
+    if !report.route_breakdowns.is_empty() {
+        lines.push("Route breakdowns:".to_string());
+        for route in &report.route_breakdowns {
+            lines.push(format!(
+                "- {} (requests {}, p95 {}us): {} ({} confidence)",
+                route.route,
+                route.request_count,
+                fmt_opt_u64(route.p95_latency_us),
+                route.primary_suspect.kind.as_str(),
+                fmt_confidence(route.primary_suspect.confidence)
+            ));
+        }
+    }
 
     lines.join("\n")
 }
@@ -1601,6 +1801,7 @@ mod tests {
                 confidence_notes: Vec::new(),
             },
             secondary_suspects: Vec::new(),
+            route_breakdowns: Vec::new(),
         };
 
         let text = render_text(&report);
@@ -1652,6 +1853,7 @@ mod tests {
                 confidence_notes: Vec::new(),
             },
             secondary_suspects: Vec::new(),
+            route_breakdowns: Vec::new(),
         };
 
         let text = render_text(&report);
@@ -1680,6 +1882,57 @@ mod tests {
             .warnings
             .iter()
             .any(|warning| warning.contains("dropped 1 entries")));
+    }
+
+    #[test]
+    fn route_breakdowns_empty_for_single_route_matching_global() {
+        let report = analyze_run(&test_run());
+        assert!(report.route_breakdowns.is_empty());
+    }
+
+    #[test]
+    fn route_breakdowns_emit_for_divergent_route_suspects() {
+        let mut run = test_run();
+        run.requests = (0..3)
+            .map(|i| RequestEvent {
+                request_id: format!("q-{i}"),
+                route: "/queue".to_string(),
+                latency_us: 2_000,
+                ..sample_request(i)
+            })
+            .chain((0..3).map(|i| RequestEvent {
+                request_id: format!("d-{i}"),
+                route: "/db".to_string(),
+                latency_us: 3_000,
+                ..sample_request(100 + i)
+            }))
+            .collect();
+        run.queues = (0..3)
+            .map(|i| QueueEvent {
+                request_id: format!("q-{i}"),
+                queue: "q".into(),
+                wait_us: 1_500,
+                depth_at_start: None,
+                waited_from_unix_ms: 1,
+                waited_until_unix_ms: 2,
+            })
+            .collect();
+        run.stages = (0..3)
+            .map(|i| StageEvent {
+                request_id: format!("d-{i}"),
+                stage: "db".into(),
+                started_at_unix_ms: 1,
+                finished_at_unix_ms: 3,
+                latency_us: 2_500,
+                success: true,
+            })
+            .collect();
+        let report = analyze_run(&run);
+        assert!(!report.route_breakdowns.is_empty());
+        assert!(report
+            .warnings
+            .iter()
+            .any(|w| w.contains("Different routes show different primary suspects")));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The analyzer aggregated evidence across all requests which can hide route-specific bottlenecks when different routes show different suspect families or latency spreads.
- Provide bounded, deterministic, supporting context per route so operators can inspect per-route suspects without changing the global primary suspect semantics.
- Avoid false precision by not attributing global runtime/in-flight snapshots to routes, and surface that limitation explicitly.

### Description
- Added a new serializable `route_breakdowns: Vec<RouteBreakdown>` field to `Report` and introduced the `RouteBreakdown` struct with the required fields and docs. 
- Refactored analysis into a reusable `analyze_run_core` and implemented `build_route_breakdowns` which filters a `Run` by request IDs (including request-scoped `stages` and `queues`) and analyzes each route without attaching global runtime/in-flight snapshots.
- Route breakdown emission is gated and bounded: only routes with >=3 completed requests are considered; breakdowns are emitted only when divergence or latency-spread rules are met; results are sorted (p95 desc, request count desc, route) and capped to 10; omitted-route note is added when applicable.
- Route-level analysis intentionally omits global `runtime_snapshots` and `inflight` unless explicitly included, and each route breakdown includes a warning/limitation: `Runtime and in-flight signals are global and are not attributed to this route.`
- Kept global semantics unchanged: `Report.primary_suspect` remains the authoritative global lead, and route analysis does not re-rank the global suspect; a stable global warning is added when route divergence exists: `Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect.`
- Added compact text rendering for route breakdowns when present, updated docs (`tailtriage-cli/README.md`, `docs/diagnostics.md`, `README.md`) to document semantics and limitations, refreshed demo analysis fixtures to reflect the additive report shape, and added unit tests for route emission and behavior.

### Testing
- Ran formatting and lints: `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings` (both passed).
- Ran full test suite: `cargo test --workspace` (all tests passed: unit and integration tests including new route-breakdown tests).
- Refreshed and validated demo fixtures: `python3 scripts/check_demo_fixture_drift.py --profile dev --refresh` and then non-refresh check (fixtures refreshed and validated).
- Docs contract validation: `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts` (passed).
- Diagnostic benchmark: `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0` was executed but reported failing per-case checks in this environment (`failed_case_count=5`); other benchmark/unit checks (`python3 -m unittest scripts.tests.test_diagnostic_benchmark`) passed.
- Summary: analysis, docs validation, format, lint, and unit/integration tests passed; diagnostic benchmark run produced some failing per-case checks (environment-specific details captured in run output).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9a776be488330bef8d435b4d451ea)