### PR TITLE
Add route-level triage breakdowns to analyzer report

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,8 @@ tailtriage analyze tailtriage-run.json --format json
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -208,7 +209,8 @@ tailtriage analyze tailtriage-run.json --format json
         "Review downstream SLO/error budget and align retry budget/backoff with it."
       ]
     }
-  ]
+  ],
+  "route_breakdowns": []
 }
 ```
 

--- a/demos/blocking_service/fixtures/after-analysis.json
+++ b/demos/blocking_service/fixtures/after-analysis.json
@@ -1,15 +1,15 @@
 {
   "request_count": 250,
-  "p50_latency_us": 54509,
-  "p95_latency_us": 87050,
-  "p99_latency_us": 91039,
-  "p95_queue_share_permille": 56,
-  "p95_service_share_permille": 993,
+  "p50_latency_us": 57344,
+  "p95_latency_us": 97423,
+  "p99_latency_us": 101371,
+  "p95_queue_share_permille": 62,
+  "p95_service_share_permille": 994,
   "inflight_trend": {
     "gauge": "blocking_service_inflight",
     "sample_count": 500,
-    "peak_count": 49,
-    "p95_count": 46,
+    "peak_count": 56,
+    "p95_count": 52,
     "growth_delta": -1,
     "growth_per_sec_milli": -2044
   },
@@ -43,15 +43,16 @@
     "score": 100,
     "confidence": "high",
     "evidence": [
-      "Stage 'spawn_blocking_path' has p95 latency 85870 us across 250 samples.",
-      "Stage 'spawn_blocking_path' cumulative latency is 13010681 us (978 permille of request latency).",
-      "Stage 'spawn_blocking_path' contributes 986 permille of tail request latency."
+      "Stage 'spawn_blocking_path' has p95 latency 96474 us across 250 samples.",
+      "Stage 'spawn_blocking_path' cumulative latency is 14120757 us (980 permille of request latency).",
+      "Stage 'spawn_blocking_path' contributes 989 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -59,12 +60,14 @@
       "score": 82,
       "confidence": "medium",
       "evidence": [
-        "Blocking queue depth p95 is 42, peak is 48, with 98/200 nonzero samples."
+        "Blocking queue depth p95 is 48, peak is 54, with 98/200 nonzero samples."
       ],
       "next_checks": [
         "Audit blocking sections and move avoidable synchronous work out of hot paths.",
         "Inspect spawn_blocking callsites for long-running CPU or I/O work."
-      ]
+      ],
+      "confidence_notes": []
     }
-  ]
+  ],
+  "route_breakdowns": []
 }

--- a/demos/blocking_service/fixtures/after-analysis.json
+++ b/demos/blocking_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 250,
-  "p50_latency_us": 57344,
-  "p95_latency_us": 97423,
-  "p99_latency_us": 101371,
-  "p95_queue_share_permille": 62,
-  "p95_service_share_permille": 994,
+  "p50_latency_us": 52104,
+  "p95_latency_us": 85732,
+  "p99_latency_us": 89330,
+  "p95_queue_share_permille": 66,
+  "p95_service_share_permille": 990,
   "inflight_trend": {
     "gauge": "blocking_service_inflight",
     "sample_count": 500,
-    "peak_count": 56,
-    "p95_count": 52,
+    "peak_count": 48,
+    "p95_count": 45,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2044
+    "growth_per_sec_milli": -2053
   },
   "warnings": [
     "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited."
@@ -43,9 +43,9 @@
     "score": 100,
     "confidence": "high",
     "evidence": [
-      "Stage 'spawn_blocking_path' has p95 latency 96474 us across 250 samples.",
-      "Stage 'spawn_blocking_path' cumulative latency is 14120757 us (980 permille of request latency).",
-      "Stage 'spawn_blocking_path' contributes 989 permille of tail request latency."
+      "Stage 'spawn_blocking_path' has p95 latency 84718 us across 250 samples.",
+      "Stage 'spawn_blocking_path' cumulative latency is 13035850 us (978 permille of request latency).",
+      "Stage 'spawn_blocking_path' contributes 988 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
@@ -60,7 +60,7 @@
       "score": 82,
       "confidence": "medium",
       "evidence": [
-        "Blocking queue depth p95 is 48, peak is 54, with 98/200 nonzero samples."
+        "Blocking queue depth p95 is 43, peak is 47, with 97/200 nonzero samples."
       ],
       "next_checks": [
         "Audit blocking sections and move avoidable synchronous work out of hot paths.",

--- a/demos/blocking_service/fixtures/before-analysis.json
+++ b/demos/blocking_service/fixtures/before-analysis.json
@@ -1,21 +1,22 @@
 {
   "request_count": 250,
-  "p50_latency_us": 1868185,
-  "p95_latency_us": 3531495,
-  "p99_latency_us": 3680957,
-  "p95_queue_share_permille": 6,
+  "p50_latency_us": 1872673,
+  "p95_latency_us": 3541194,
+  "p99_latency_us": 3689612,
+  "p95_queue_share_permille": 5,
   "p95_service_share_permille": 999,
   "inflight_trend": {
     "gauge": "blocking_service_inflight",
     "sample_count": 500,
     "peak_count": 246,
-    "p95_count": 234,
-    "growth_delta": 0,
-    "growth_per_sec_milli": 0
+    "p95_count": 235,
+    "growth_delta": -1,
+    "growth_per_sec_milli": -264
   },
   "warnings": [
     "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited.",
-    "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks."
+    "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks.",
+    "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
   ],
   "evidence_quality": {
     "request_count": 250,
@@ -42,13 +43,17 @@
   "primary_suspect": {
     "kind": "blocking_pool_pressure",
     "score": 88,
-    "confidence": "high",
+    "confidence": "medium",
     "evidence": [
       "Blocking queue depth p95 is 244, peak is 246, with 200/200 nonzero samples."
     ],
     "next_checks": [
       "Audit blocking sections and move avoidable synchronous work out of hot paths.",
       "Inspect spawn_blocking callsites for long-running CPU or I/O work."
+    ],
+    "confidence_notes": [
+      "Missing runtime snapshots limit executor/blocking confidence.",
+      "Top suspects are close in score; confidence is capped by ambiguity."
     ]
   },
   "secondary_suspects": [
@@ -57,8 +62,8 @@
       "score": 86,
       "confidence": "high",
       "evidence": [
-        "Stage 'spawn_blocking_path' has p95 latency 3530254 us across 250 samples.",
-        "Stage 'spawn_blocking_path' cumulative latency is 467061987 us (999 permille of request latency).",
+        "Stage 'spawn_blocking_path' has p95 latency 3540002 us across 250 samples.",
+        "Stage 'spawn_blocking_path' cumulative latency is 467722801 us (999 permille of request latency).",
         "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency.",
         "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
       ],
@@ -66,6 +71,60 @@
         "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
+      ],
+      "confidence_notes": []
+    }
+  ],
+  "route_breakdowns": [
+    {
+      "route": "/blocking-demo",
+      "request_count": 250,
+      "p50_latency_us": 1872673,
+      "p95_latency_us": 3541194,
+      "p99_latency_us": 3689612,
+      "p95_queue_share_permille": 5,
+      "p95_service_share_permille": 999,
+      "evidence_quality": {
+        "request_count": 250,
+        "queue_event_count": 250,
+        "stage_event_count": 250,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 0,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "missing",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "downstream_stage_dominates",
+        "score": 100,
+        "confidence": "high",
+        "evidence": [
+          "Stage 'spawn_blocking_path' has p95 latency 3540002 us across 250 samples.",
+          "Stage 'spawn_blocking_path' cumulative latency is 467722801 us (999 permille of request latency).",
+          "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency."
+        ],
+        "next_checks": [
+          "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
+          "Collect downstream service timings and retry behavior during tail windows.",
+          "Review downstream SLO/error budget and align retry budget/backoff with it."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [],
+      "warnings": [
+        "Runtime and in-flight signals are global and are not attributed to this route."
       ]
     }
   ]

--- a/demos/blocking_service/fixtures/before-analysis.json
+++ b/demos/blocking_service/fixtures/before-analysis.json
@@ -1,22 +1,21 @@
 {
   "request_count": 250,
-  "p50_latency_us": 1872673,
-  "p95_latency_us": 3541194,
-  "p99_latency_us": 3689612,
-  "p95_queue_share_permille": 5,
+  "p50_latency_us": 1866475,
+  "p95_latency_us": 3524603,
+  "p99_latency_us": 3673375,
+  "p95_queue_share_permille": 3,
   "p95_service_share_permille": 999,
   "inflight_trend": {
     "gauge": "blocking_service_inflight",
     "sample_count": 500,
     "peak_count": 246,
     "p95_count": 235,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -264
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
   },
   "warnings": [
     "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited.",
-    "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks.",
-    "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
+    "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks."
   ],
   "evidence_quality": {
     "request_count": 250,
@@ -62,8 +61,8 @@
       "score": 86,
       "confidence": "high",
       "evidence": [
-        "Stage 'spawn_blocking_path' has p95 latency 3540002 us across 250 samples.",
-        "Stage 'spawn_blocking_path' cumulative latency is 467722801 us (999 permille of request latency).",
+        "Stage 'spawn_blocking_path' has p95 latency 3523850 us across 250 samples.",
+        "Stage 'spawn_blocking_path' cumulative latency is 466288754 us (999 permille of request latency).",
         "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency.",
         "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
       ],
@@ -75,57 +74,5 @@
       "confidence_notes": []
     }
   ],
-  "route_breakdowns": [
-    {
-      "route": "/blocking-demo",
-      "request_count": 250,
-      "p50_latency_us": 1872673,
-      "p95_latency_us": 3541194,
-      "p99_latency_us": 3689612,
-      "p95_queue_share_permille": 5,
-      "p95_service_share_permille": 999,
-      "evidence_quality": {
-        "request_count": 250,
-        "queue_event_count": 250,
-        "stage_event_count": 250,
-        "runtime_snapshot_count": 0,
-        "inflight_snapshot_count": 0,
-        "requests": "present",
-        "queues": "present",
-        "stages": "present",
-        "runtime_snapshots": "missing",
-        "inflight_snapshots": "missing",
-        "truncated": false,
-        "dropped_requests": 0,
-        "dropped_stages": 0,
-        "dropped_queues": 0,
-        "dropped_inflight_snapshots": 0,
-        "dropped_runtime_snapshots": 0,
-        "quality": "strong",
-        "limitations": [
-          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
-        ]
-      },
-      "primary_suspect": {
-        "kind": "downstream_stage_dominates",
-        "score": 100,
-        "confidence": "high",
-        "evidence": [
-          "Stage 'spawn_blocking_path' has p95 latency 3540002 us across 250 samples.",
-          "Stage 'spawn_blocking_path' cumulative latency is 467722801 us (999 permille of request latency).",
-          "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency."
-        ],
-        "next_checks": [
-          "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
-          "Collect downstream service timings and retry behavior during tail windows.",
-          "Review downstream SLO/error budget and align retry budget/backoff with it."
-        ],
-        "confidence_notes": []
-      },
-      "secondary_suspects": [],
-      "warnings": [
-        "Runtime and in-flight signals are global and are not attributed to this route."
-      ]
-    }
-  ]
+  "route_breakdowns": []
 }

--- a/demos/blocking_service/fixtures/sample-analysis.json
+++ b/demos/blocking_service/fixtures/sample-analysis.json
@@ -1,21 +1,22 @@
 {
   "request_count": 250,
-  "p50_latency_us": 1868185,
-  "p95_latency_us": 3531495,
-  "p99_latency_us": 3680957,
-  "p95_queue_share_permille": 6,
+  "p50_latency_us": 1872673,
+  "p95_latency_us": 3541194,
+  "p99_latency_us": 3689612,
+  "p95_queue_share_permille": 5,
   "p95_service_share_permille": 999,
   "inflight_trend": {
     "gauge": "blocking_service_inflight",
     "sample_count": 500,
     "peak_count": 246,
-    "p95_count": 234,
-    "growth_delta": 0,
-    "growth_per_sec_milli": 0
+    "p95_count": 235,
+    "growth_delta": -1,
+    "growth_per_sec_milli": -264
   },
   "warnings": [
     "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited.",
-    "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks."
+    "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks.",
+    "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
   ],
   "evidence_quality": {
     "request_count": 250,
@@ -42,13 +43,17 @@
   "primary_suspect": {
     "kind": "blocking_pool_pressure",
     "score": 88,
-    "confidence": "high",
+    "confidence": "medium",
     "evidence": [
       "Blocking queue depth p95 is 244, peak is 246, with 200/200 nonzero samples."
     ],
     "next_checks": [
       "Audit blocking sections and move avoidable synchronous work out of hot paths.",
       "Inspect spawn_blocking callsites for long-running CPU or I/O work."
+    ],
+    "confidence_notes": [
+      "Missing runtime snapshots limit executor/blocking confidence.",
+      "Top suspects are close in score; confidence is capped by ambiguity."
     ]
   },
   "secondary_suspects": [
@@ -57,8 +62,8 @@
       "score": 86,
       "confidence": "high",
       "evidence": [
-        "Stage 'spawn_blocking_path' has p95 latency 3530254 us across 250 samples.",
-        "Stage 'spawn_blocking_path' cumulative latency is 467061987 us (999 permille of request latency).",
+        "Stage 'spawn_blocking_path' has p95 latency 3540002 us across 250 samples.",
+        "Stage 'spawn_blocking_path' cumulative latency is 467722801 us (999 permille of request latency).",
         "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency.",
         "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
       ],
@@ -66,6 +71,60 @@
         "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
+      ],
+      "confidence_notes": []
+    }
+  ],
+  "route_breakdowns": [
+    {
+      "route": "/blocking-demo",
+      "request_count": 250,
+      "p50_latency_us": 1872673,
+      "p95_latency_us": 3541194,
+      "p99_latency_us": 3689612,
+      "p95_queue_share_permille": 5,
+      "p95_service_share_permille": 999,
+      "evidence_quality": {
+        "request_count": 250,
+        "queue_event_count": 250,
+        "stage_event_count": 250,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 0,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "missing",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "downstream_stage_dominates",
+        "score": 100,
+        "confidence": "high",
+        "evidence": [
+          "Stage 'spawn_blocking_path' has p95 latency 3540002 us across 250 samples.",
+          "Stage 'spawn_blocking_path' cumulative latency is 467722801 us (999 permille of request latency).",
+          "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency."
+        ],
+        "next_checks": [
+          "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
+          "Collect downstream service timings and retry behavior during tail windows.",
+          "Review downstream SLO/error budget and align retry budget/backoff with it."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [],
+      "warnings": [
+        "Runtime and in-flight signals are global and are not attributed to this route."
       ]
     }
   ]

--- a/demos/blocking_service/fixtures/sample-analysis.json
+++ b/demos/blocking_service/fixtures/sample-analysis.json
@@ -1,22 +1,21 @@
 {
   "request_count": 250,
-  "p50_latency_us": 1872673,
-  "p95_latency_us": 3541194,
-  "p99_latency_us": 3689612,
-  "p95_queue_share_permille": 5,
+  "p50_latency_us": 1866475,
+  "p95_latency_us": 3524603,
+  "p99_latency_us": 3673375,
+  "p95_queue_share_permille": 3,
   "p95_service_share_permille": 999,
   "inflight_trend": {
     "gauge": "blocking_service_inflight",
     "sample_count": 500,
     "peak_count": 246,
     "p95_count": 235,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -264
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
   },
   "warnings": [
     "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited.",
-    "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks.",
-    "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
+    "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks."
   ],
   "evidence_quality": {
     "request_count": 250,
@@ -62,8 +61,8 @@
       "score": 86,
       "confidence": "high",
       "evidence": [
-        "Stage 'spawn_blocking_path' has p95 latency 3540002 us across 250 samples.",
-        "Stage 'spawn_blocking_path' cumulative latency is 467722801 us (999 permille of request latency).",
+        "Stage 'spawn_blocking_path' has p95 latency 3523850 us across 250 samples.",
+        "Stage 'spawn_blocking_path' cumulative latency is 466288754 us (999 permille of request latency).",
         "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency.",
         "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
       ],
@@ -75,57 +74,5 @@
       "confidence_notes": []
     }
   ],
-  "route_breakdowns": [
-    {
-      "route": "/blocking-demo",
-      "request_count": 250,
-      "p50_latency_us": 1872673,
-      "p95_latency_us": 3541194,
-      "p99_latency_us": 3689612,
-      "p95_queue_share_permille": 5,
-      "p95_service_share_permille": 999,
-      "evidence_quality": {
-        "request_count": 250,
-        "queue_event_count": 250,
-        "stage_event_count": 250,
-        "runtime_snapshot_count": 0,
-        "inflight_snapshot_count": 0,
-        "requests": "present",
-        "queues": "present",
-        "stages": "present",
-        "runtime_snapshots": "missing",
-        "inflight_snapshots": "missing",
-        "truncated": false,
-        "dropped_requests": 0,
-        "dropped_stages": 0,
-        "dropped_queues": 0,
-        "dropped_inflight_snapshots": 0,
-        "dropped_runtime_snapshots": 0,
-        "quality": "strong",
-        "limitations": [
-          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
-        ]
-      },
-      "primary_suspect": {
-        "kind": "downstream_stage_dominates",
-        "score": 100,
-        "confidence": "high",
-        "evidence": [
-          "Stage 'spawn_blocking_path' has p95 latency 3540002 us across 250 samples.",
-          "Stage 'spawn_blocking_path' cumulative latency is 467722801 us (999 permille of request latency).",
-          "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency."
-        ],
-        "next_checks": [
-          "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
-          "Collect downstream service timings and retry behavior during tail windows.",
-          "Review downstream SLO/error budget and align retry budget/backoff with it."
-        ],
-        "confidence_notes": []
-      },
-      "secondary_suspects": [],
-      "warnings": [
-        "Runtime and in-flight signals are global and are not attributed to this route."
-      ]
-    }
-  ]
+  "route_breakdowns": []
 }

--- a/demos/cold_start_burst_service/fixtures/after-analysis.json
+++ b/demos/cold_start_burst_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 8449,
-  "p95_latency_us": 8749,
-  "p99_latency_us": 8847,
+  "p50_latency_us": 8382,
+  "p95_latency_us": 8642,
+  "p99_latency_us": 13879,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 999,
   "inflight_trend": {
     "gauge": "cold_start_burst_inflight",
     "sample_count": 440,
     "peak_count": 4,
-    "p95_count": 2,
+    "p95_count": 3,
     "growth_delta": -1,
-    "growth_per_sec_milli": -1054
+    "growth_per_sec_milli": -1071
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,9 +41,9 @@
     "score": 100,
     "confidence": "high",
     "evidence": [
-      "Stage 'cold_start_stage' has p95 latency 8698 us across 220 samples.",
-      "Stage 'cold_start_stage' cumulative latency is 1815135 us (996 permille of request latency).",
-      "Stage 'cold_start_stage' contributes 995 permille of tail request latency."
+      "Stage 'cold_start_stage' has p95 latency 8627 us across 220 samples.",
+      "Stage 'cold_start_stage' cumulative latency is 1813450 us (997 permille of request latency).",
+      "Stage 'cold_start_stage' contributes 997 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'cold_start_stage'.",

--- a/demos/cold_start_burst_service/fixtures/after-analysis.json
+++ b/demos/cold_start_burst_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 8489,
-  "p95_latency_us": 8877,
-  "p99_latency_us": 9039,
+  "p50_latency_us": 8449,
+  "p95_latency_us": 8749,
+  "p99_latency_us": 8847,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 999,
   "inflight_trend": {
     "gauge": "cold_start_burst_inflight",
     "sample_count": 440,
     "peak_count": 4,
-    "p95_count": 3,
+    "p95_count": 2,
     "growth_delta": -1,
-    "growth_per_sec_milli": -1064
+    "growth_per_sec_milli": -1054
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,15 +41,17 @@
     "score": 100,
     "confidence": "high",
     "evidence": [
-      "Stage 'cold_start_stage' has p95 latency 8837 us across 220 samples.",
-      "Stage 'cold_start_stage' cumulative latency is 1823038 us (996 permille of request latency).",
+      "Stage 'cold_start_stage' has p95 latency 8698 us across 220 samples.",
+      "Stage 'cold_start_stage' cumulative latency is 1815135 us (996 permille of request latency).",
       "Stage 'cold_start_stage' contributes 995 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'cold_start_stage'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }

--- a/demos/cold_start_burst_service/fixtures/before-analysis.json
+++ b/demos/cold_start_burst_service/fixtures/before-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 991955,
-  "p95_latency_us": 1190243,
-  "p99_latency_us": 1206689,
+  "p50_latency_us": 990199,
+  "p95_latency_us": 1183880,
+  "p99_latency_us": 1200371,
   "p95_queue_share_permille": 993,
-  "p95_service_share_permille": 330,
+  "p95_service_share_permille": 334,
   "inflight_trend": {
     "gauge": "cold_start_burst_inflight",
     "sample_count": 440,
     "peak_count": 220,
     "p95_count": 209,
-    "growth_delta": 2,
-    "growth_per_sec_milli": 1633
+    "growth_delta": -1,
+    "growth_per_sec_milli": -816
   },
   "warnings": [],
   "evidence_quality": {
@@ -38,12 +38,11 @@
   },
   "primary_suspect": {
     "kind": "application_queue_saturation",
-    "score": 100,
+    "score": 95,
     "confidence": "high",
     "evidence": [
       "Queue wait at p95 consumes 99.3% of request time.",
-      "Observed queue depth sample up to 216.",
-      "In-flight gauge 'cold_start_burst_inflight' grew by 2 over the run window (p95=209, peak=220)."
+      "Observed queue depth sample up to 216."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -57,8 +56,8 @@
       "score": 32,
       "confidence": "low",
       "evidence": [
-        "Stage 'cold_start_stage' has p95 latency 63656 us across 220 samples.",
-        "Stage 'cold_start_stage' cumulative latency is 4881615 us (24 permille of request latency).",
+        "Stage 'cold_start_stage' has p95 latency 63550 us across 220 samples.",
+        "Stage 'cold_start_stage' cumulative latency is 4862350 us (24 permille of request latency).",
         "Stage 'cold_start_stage' contributes 6 permille of tail request latency."
       ],
       "next_checks": [

--- a/demos/cold_start_burst_service/fixtures/before-analysis.json
+++ b/demos/cold_start_burst_service/fixtures/before-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 993483,
-  "p95_latency_us": 1190031,
-  "p99_latency_us": 1206824,
+  "p50_latency_us": 991955,
+  "p95_latency_us": 1190243,
+  "p99_latency_us": 1206689,
   "p95_queue_share_permille": 993,
-  "p95_service_share_permille": 336,
+  "p95_service_share_permille": 330,
   "inflight_trend": {
     "gauge": "cold_start_burst_inflight",
     "sample_count": 440,
     "peak_count": 220,
     "p95_count": 209,
-    "growth_delta": 0,
-    "growth_per_sec_milli": 0
+    "growth_delta": 2,
+    "growth_per_sec_milli": 1633
   },
   "warnings": [],
   "evidence_quality": {
@@ -38,16 +38,18 @@
   },
   "primary_suspect": {
     "kind": "application_queue_saturation",
-    "score": 95,
+    "score": 100,
     "confidence": "high",
     "evidence": [
       "Queue wait at p95 consumes 99.3% of request time.",
-      "Observed queue depth sample up to 216."
+      "Observed queue depth sample up to 216.",
+      "In-flight gauge 'cold_start_burst_inflight' grew by 2 over the run window (p95=209, peak=220)."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -55,15 +57,17 @@
       "score": 32,
       "confidence": "low",
       "evidence": [
-        "Stage 'cold_start_stage' has p95 latency 63617 us across 220 samples.",
-        "Stage 'cold_start_stage' cumulative latency is 4876046 us (24 permille of request latency).",
+        "Stage 'cold_start_stage' has p95 latency 63656 us across 220 samples.",
+        "Stage 'cold_start_stage' cumulative latency is 4881615 us (24 permille of request latency).",
         "Stage 'cold_start_stage' contributes 6 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'cold_start_stage'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
-  ]
+  ],
+  "route_breakdowns": []
 }

--- a/demos/db_pool_saturation_service/fixtures/after-analysis.json
+++ b/demos/db_pool_saturation_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 13187,
-  "p95_latency_us": 14046,
-  "p99_latency_us": 14355,
+  "p50_latency_us": 13407,
+  "p95_latency_us": 13884,
+  "p99_latency_us": 13940,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,7 +11,7 @@
     "peak_count": 10,
     "p95_count": 10,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2702
+    "growth_per_sec_milli": -2770
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,9 +41,9 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'db_query' has p95 latency 11927 us across 220 samples.",
-      "Stage 'db_query' cumulative latency is 2445545 us (838 permille of request latency).",
-      "Stage 'db_query' contributes 839 permille of tail request latency."
+      "Stage 'db_query' has p95 latency 11690 us across 220 samples.",
+      "Stage 'db_query' cumulative latency is 2431825 us (836 permille of request latency).",
+      "Stage 'db_query' contributes 840 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'db_query'.",

--- a/demos/db_pool_saturation_service/fixtures/after-analysis.json
+++ b/demos/db_pool_saturation_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 13254,
-  "p95_latency_us": 14196,
-  "p99_latency_us": 14321,
+  "p50_latency_us": 13187,
+  "p95_latency_us": 14046,
+  "p99_latency_us": 14355,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,7 +11,7 @@
     "peak_count": 10,
     "p95_count": 10,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2710
+    "growth_per_sec_milli": -2702
   },
   "warnings": [],
   "evidence_quality": {
@@ -42,14 +42,16 @@
     "confidence": "high",
     "evidence": [
       "Stage 'db_query' has p95 latency 11927 us across 220 samples.",
-      "Stage 'db_query' cumulative latency is 2440495 us (833 permille of request latency).",
-      "Stage 'db_query' contributes 841 permille of tail request latency."
+      "Stage 'db_query' cumulative latency is 2445545 us (838 permille of request latency).",
+      "Stage 'db_query' contributes 839 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'db_query'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }

--- a/demos/db_pool_saturation_service/fixtures/before-analysis.json
+++ b/demos/db_pool_saturation_service/fixtures/before-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 498135,
-  "p95_latency_us": 927602,
-  "p99_latency_us": 961905,
+  "p50_latency_us": 495001,
+  "p95_latency_us": 931554,
+  "p99_latency_us": 966885,
   "p95_queue_share_permille": 976,
-  "p95_service_share_permille": 368,
+  "p95_service_share_permille": 379,
   "inflight_trend": {
     "gauge": "db_pool_saturation_inflight",
     "sample_count": 440,
     "peak_count": 200,
     "p95_count": 193,
-    "growth_delta": 2,
-    "growth_per_sec_milli": 1872
+    "growth_delta": -1,
+    "growth_per_sec_milli": -936
   },
   "warnings": [],
   "evidence_quality": {
@@ -42,13 +42,13 @@
     "confidence": "high",
     "evidence": [
       "Queue wait at p95 consumes 97.6% of request time.",
-      "Observed queue depth sample up to 196.",
-      "In-flight gauge 'db_pool_saturation_inflight' grew by 2 over the run window (p95=193, peak=200)."
+      "Observed queue depth sample up to 196."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -56,15 +56,17 @@
       "score": 34,
       "confidence": "low",
       "evidence": [
-        "Stage 'db_query' has p95 latency 19752 us across 220 samples.",
-        "Stage 'db_query' cumulative latency is 4247545 us (38 permille of request latency).",
+        "Stage 'db_query' has p95 latency 19588 us across 220 samples.",
+        "Stage 'db_query' cumulative latency is 4243946 us (39 permille of request latency).",
         "Stage 'db_query' contributes 20 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'db_query'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
-  ]
+  ],
+  "route_breakdowns": []
 }

--- a/demos/db_pool_saturation_service/fixtures/before-analysis.json
+++ b/demos/db_pool_saturation_service/fixtures/before-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 495001,
-  "p95_latency_us": 931554,
-  "p99_latency_us": 966885,
+  "p50_latency_us": 495974,
+  "p95_latency_us": 930473,
+  "p99_latency_us": 964158,
   "p95_queue_share_permille": 976,
-  "p95_service_share_permille": 379,
+  "p95_service_share_permille": 367,
   "inflight_trend": {
     "gauge": "db_pool_saturation_inflight",
     "sample_count": 440,
-    "peak_count": 200,
+    "peak_count": 204,
     "p95_count": 193,
     "growth_delta": -1,
-    "growth_per_sec_milli": -936
+    "growth_per_sec_milli": -940
   },
   "warnings": [],
   "evidence_quality": {
@@ -42,7 +42,7 @@
     "confidence": "high",
     "evidence": [
       "Queue wait at p95 consumes 97.6% of request time.",
-      "Observed queue depth sample up to 196."
+      "Observed queue depth sample up to 199."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -56,8 +56,8 @@
       "score": 34,
       "confidence": "low",
       "evidence": [
-        "Stage 'db_query' has p95 latency 19588 us across 220 samples.",
-        "Stage 'db_query' cumulative latency is 4243946 us (39 permille of request latency).",
+        "Stage 'db_query' has p95 latency 19560 us across 220 samples.",
+        "Stage 'db_query' cumulative latency is 4214847 us (38 permille of request latency).",
         "Stage 'db_query' contributes 20 permille of tail request latency."
       ],
       "next_checks": [

--- a/demos/downstream_service/fixtures/after-analysis.json
+++ b/demos/downstream_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 80,
-  "p50_latency_us": 12294,
-  "p95_latency_us": 13240,
-  "p99_latency_us": 13272,
+  "p50_latency_us": 12633,
+  "p95_latency_us": 13029,
+  "p99_latency_us": 13033,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "downstream_service_inflight",
     "sample_count": 160,
-    "peak_count": 35,
+    "peak_count": 33,
     "p95_count": 32,
     "growth_delta": 5,
-    "growth_per_sec_milli": 108695
+    "growth_per_sec_milli": 111111
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,15 +41,17 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 10846 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 809068 us (813 permille of request latency).",
-      "Stage 'downstream_call' contributes 804 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 10703 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 811346 us (817 permille of request latency).",
+      "Stage 'downstream_call' contributes 822 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }

--- a/demos/downstream_service/fixtures/after-analysis.json
+++ b/demos/downstream_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 80,
-  "p50_latency_us": 12633,
-  "p95_latency_us": 13029,
-  "p99_latency_us": 13033,
+  "p50_latency_us": 12499,
+  "p95_latency_us": 12626,
+  "p99_latency_us": 13358,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,7 +11,7 @@
     "peak_count": 33,
     "p95_count": 32,
     "growth_delta": 5,
-    "growth_per_sec_milli": 111111
+    "growth_per_sec_milli": 113636
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,9 +41,9 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 10703 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 811346 us (817 permille of request latency).",
-      "Stage 'downstream_call' contributes 822 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 10422 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 809061 us (825 permille of request latency).",
+      "Stage 'downstream_call' contributes 799 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",

--- a/demos/downstream_service/fixtures/before-after-comparison.json
+++ b/demos/downstream_service/fixtures/before-after-comparison.json
@@ -2,19 +2,19 @@
   "before": {
     "primary_suspect_kind": "downstream_stage_dominates",
     "primary_suspect_score": 95,
-    "p95_latency_us": 24067,
+    "p95_latency_us": 23960,
     "p95_service_share_permille": 1000
   },
   "after": {
     "primary_suspect_kind": "downstream_stage_dominates",
     "primary_suspect_score": 95,
-    "p95_latency_us": 13029,
+    "p95_latency_us": 12626,
     "p95_service_share_permille": 1000
   },
   "delta": {
     "primary_suspect_kind": null,
     "primary_suspect_score": 0,
-    "p95_latency_us": -11038,
+    "p95_latency_us": -11334,
     "p95_service_share_permille": 0
   }
 }

--- a/demos/downstream_service/fixtures/before-after-comparison.json
+++ b/demos/downstream_service/fixtures/before-after-comparison.json
@@ -2,19 +2,19 @@
   "before": {
     "primary_suspect_kind": "downstream_stage_dominates",
     "primary_suspect_score": 95,
-    "p95_latency_us": 24448,
+    "p95_latency_us": 24067,
     "p95_service_share_permille": 1000
   },
   "after": {
     "primary_suspect_kind": "downstream_stage_dominates",
     "primary_suspect_score": 95,
-    "p95_latency_us": 13240,
+    "p95_latency_us": 13029,
     "p95_service_share_permille": 1000
   },
   "delta": {
     "primary_suspect_kind": null,
     "primary_suspect_score": 0,
-    "p95_latency_us": -11208,
+    "p95_latency_us": -11038,
     "p95_service_share_permille": 0
   }
 }

--- a/demos/downstream_service/fixtures/before-analysis.json
+++ b/demos/downstream_service/fixtures/before-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 80,
-  "p50_latency_us": 23416,
-  "p95_latency_us": 24067,
-  "p99_latency_us": 24124,
+  "p50_latency_us": 23490,
+  "p95_latency_us": 23960,
+  "p99_latency_us": 24038,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "downstream_service_inflight",
     "sample_count": 160,
-    "peak_count": 63,
-    "p95_count": 59,
-    "growth_delta": 5,
-    "growth_per_sec_milli": 90909
+    "peak_count": 64,
+    "p95_count": 62,
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,8 +41,8 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 21801 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 1697265 us (907 permille of request latency).",
+      "Stage 'downstream_call' has p95 latency 21745 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 1696247 us (907 permille of request latency).",
       "Stage 'downstream_call' contributes 904 permille of tail request latency."
     ],
     "next_checks": [

--- a/demos/downstream_service/fixtures/before-analysis.json
+++ b/demos/downstream_service/fixtures/before-analysis.json
@@ -1,15 +1,15 @@
 {
   "request_count": 80,
-  "p50_latency_us": 23531,
-  "p95_latency_us": 24448,
-  "p99_latency_us": 24549,
+  "p50_latency_us": 23416,
+  "p95_latency_us": 24067,
+  "p99_latency_us": 24124,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "downstream_service_inflight",
     "sample_count": 160,
-    "peak_count": 57,
-    "p95_count": 55,
+    "peak_count": 63,
+    "p95_count": 59,
     "growth_delta": 5,
     "growth_per_sec_milli": 90909
   },
@@ -41,15 +41,17 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 22135 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 1693727 us (903 permille of request latency).",
+      "Stage 'downstream_call' has p95 latency 21801 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 1697265 us (907 permille of request latency).",
       "Stage 'downstream_call' contributes 904 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }

--- a/demos/downstream_service/fixtures/sample-analysis.json
+++ b/demos/downstream_service/fixtures/sample-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 80,
-  "p50_latency_us": 23416,
-  "p95_latency_us": 24067,
-  "p99_latency_us": 24124,
+  "p50_latency_us": 23490,
+  "p95_latency_us": 23960,
+  "p99_latency_us": 24038,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "downstream_service_inflight",
     "sample_count": 160,
-    "peak_count": 63,
-    "p95_count": 59,
-    "growth_delta": 5,
-    "growth_per_sec_milli": 90909
+    "peak_count": 64,
+    "p95_count": 62,
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,8 +41,8 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 21801 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 1697265 us (907 permille of request latency).",
+      "Stage 'downstream_call' has p95 latency 21745 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 1696247 us (907 permille of request latency).",
       "Stage 'downstream_call' contributes 904 permille of tail request latency."
     ],
     "next_checks": [

--- a/demos/downstream_service/fixtures/sample-analysis.json
+++ b/demos/downstream_service/fixtures/sample-analysis.json
@@ -1,15 +1,15 @@
 {
   "request_count": 80,
-  "p50_latency_us": 23531,
-  "p95_latency_us": 24448,
-  "p99_latency_us": 24549,
+  "p50_latency_us": 23416,
+  "p95_latency_us": 24067,
+  "p99_latency_us": 24124,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "downstream_service_inflight",
     "sample_count": 160,
-    "peak_count": 57,
-    "p95_count": 55,
+    "peak_count": 63,
+    "p95_count": 59,
     "growth_delta": 5,
     "growth_per_sec_milli": 90909
   },
@@ -41,15 +41,17 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 22135 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 1693727 us (903 permille of request latency).",
+      "Stage 'downstream_call' has p95 latency 21801 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 1697265 us (907 permille of request latency).",
       "Stage 'downstream_call' contributes 904 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }

--- a/demos/executor_pressure_service/fixtures/after-analysis.json
+++ b/demos/executor_pressure_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 240,
-  "p50_latency_us": 7106134,
-  "p95_latency_us": 7161651,
-  "p99_latency_us": 7162753,
+  "p50_latency_us": 5031245,
+  "p95_latency_us": 5100556,
+  "p99_latency_us": 5104772,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -10,17 +10,15 @@
     "sample_count": 480,
     "peak_count": 240,
     "p95_count": 228,
-    "growth_delta": 0,
-    "growth_per_sec_milli": 0
+    "growth_delta": -1,
+    "growth_per_sec_milli": -195
   },
-  "warnings": [
-    "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
-  ],
+  "warnings": [],
   "evidence_quality": {
     "request_count": 240,
     "queue_event_count": 0,
     "stage_event_count": 0,
-    "runtime_snapshot_count": 7178,
+    "runtime_snapshot_count": 5116,
     "inflight_snapshot_count": 480,
     "requests": "present",
     "queues": "missing",
@@ -44,7 +42,7 @@
     "confidence": "high",
     "evidence": [
       "Runtime global queue depth p95 is 720, suggesting scheduler contention.",
-      "Runtime local queue depth p95 is 6966.",
+      "Runtime local queue depth p95 is 4833.",
       "Runtime alive_tasks p95 is 720."
     ],
     "next_checks": [
@@ -54,56 +52,5 @@
     "confidence_notes": []
   },
   "secondary_suspects": [],
-  "route_breakdowns": [
-    {
-      "route": "/executor-pressure",
-      "request_count": 240,
-      "p50_latency_us": 7106134,
-      "p95_latency_us": 7161651,
-      "p99_latency_us": 7162753,
-      "p95_queue_share_permille": 0,
-      "p95_service_share_permille": 1000,
-      "evidence_quality": {
-        "request_count": 240,
-        "queue_event_count": 0,
-        "stage_event_count": 0,
-        "runtime_snapshot_count": 0,
-        "inflight_snapshot_count": 0,
-        "requests": "present",
-        "queues": "missing",
-        "stages": "missing",
-        "runtime_snapshots": "missing",
-        "inflight_snapshots": "missing",
-        "truncated": false,
-        "dropped_requests": 0,
-        "dropped_stages": 0,
-        "dropped_queues": 0,
-        "dropped_inflight_snapshots": 0,
-        "dropped_runtime_snapshots": 0,
-        "quality": "weak",
-        "limitations": [
-          "Queue and stage instrumentation are both unavailable, limiting application vs downstream interpretation.",
-          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
-        ]
-      },
-      "primary_suspect": {
-        "kind": "insufficient_evidence",
-        "score": 50,
-        "confidence": "low",
-        "evidence": [
-          "Not enough queue, stage, or runtime signals to rank a stronger suspect."
-        ],
-        "next_checks": [
-          "Wrap critical awaits with queue(...).await_on(...), and use stage(...).await_on(...) for Result-returning work or stage(...).await_value(...) for infallible work.",
-          "Enable RuntimeSampler during the run to capture runtime pressure signals."
-        ],
-        "confidence_notes": []
-      },
-      "secondary_suspects": [],
-      "warnings": [
-        "No runtime snapshots captured; executor and blocking-pressure interpretation is limited.",
-        "Runtime and in-flight signals are global and are not attributed to this route."
-      ]
-    }
-  ]
+  "route_breakdowns": []
 }

--- a/demos/executor_pressure_service/fixtures/after-analysis.json
+++ b/demos/executor_pressure_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 240,
-  "p50_latency_us": 7284295,
-  "p95_latency_us": 7413192,
-  "p99_latency_us": 7423728,
+  "p50_latency_us": 7106134,
+  "p95_latency_us": 7161651,
+  "p99_latency_us": 7162753,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -10,15 +10,17 @@
     "sample_count": 480,
     "peak_count": 240,
     "p95_count": 228,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -134
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
   },
-  "warnings": [],
+  "warnings": [
+    "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
+  ],
   "evidence_quality": {
     "request_count": 240,
     "queue_event_count": 0,
     "stage_event_count": 0,
-    "runtime_snapshot_count": 7433,
+    "runtime_snapshot_count": 7178,
     "inflight_snapshot_count": 480,
     "requests": "present",
     "queues": "missing",
@@ -42,13 +44,66 @@
     "confidence": "high",
     "evidence": [
       "Runtime global queue depth p95 is 720, suggesting scheduler contention.",
-      "Runtime local queue depth p95 is 4656.",
+      "Runtime local queue depth p95 is 6966.",
       "Runtime alive_tasks p95 is 720."
     ],
     "next_checks": [
       "Check for long polls without yielding and uneven task fan-out.",
       "Compare with per-stage timings to isolate overloaded async stages."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": [
+    {
+      "route": "/executor-pressure",
+      "request_count": 240,
+      "p50_latency_us": 7106134,
+      "p95_latency_us": 7161651,
+      "p99_latency_us": 7162753,
+      "p95_queue_share_permille": 0,
+      "p95_service_share_permille": 1000,
+      "evidence_quality": {
+        "request_count": 240,
+        "queue_event_count": 0,
+        "stage_event_count": 0,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 0,
+        "requests": "present",
+        "queues": "missing",
+        "stages": "missing",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "missing",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "weak",
+        "limitations": [
+          "Queue and stage instrumentation are both unavailable, limiting application vs downstream interpretation.",
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "insufficient_evidence",
+        "score": 50,
+        "confidence": "low",
+        "evidence": [
+          "Not enough queue, stage, or runtime signals to rank a stronger suspect."
+        ],
+        "next_checks": [
+          "Wrap critical awaits with queue(...).await_on(...), and use stage(...).await_on(...) for Result-returning work or stage(...).await_value(...) for infallible work.",
+          "Enable RuntimeSampler during the run to capture runtime pressure signals."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [],
+      "warnings": [
+        "No runtime snapshots captured; executor and blocking-pressure interpretation is limited.",
+        "Runtime and in-flight signals are global and are not attributed to this route."
+      ]
+    }
+  ]
 }

--- a/demos/executor_pressure_service/fixtures/before-analysis.json
+++ b/demos/executor_pressure_service/fixtures/before-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 240,
-  "p50_latency_us": 33526374,
-  "p95_latency_us": 33677816,
-  "p99_latency_us": 33687600,
+  "p50_latency_us": 24445238,
+  "p95_latency_us": 24529057,
+  "p99_latency_us": 24533220,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -13,14 +13,12 @@
     "growth_delta": 0,
     "growth_per_sec_milli": 0
   },
-  "warnings": [
-    "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
-  ],
+  "warnings": [],
   "evidence_quality": {
     "request_count": 240,
     "queue_event_count": 0,
     "stage_event_count": 0,
-    "runtime_snapshot_count": 33715,
+    "runtime_snapshot_count": 24540,
     "inflight_snapshot_count": 480,
     "requests": "present",
     "queues": "missing",
@@ -44,7 +42,7 @@
     "confidence": "high",
     "evidence": [
       "Runtime global queue depth p95 is 1920, suggesting scheduler contention.",
-      "Runtime local queue depth p95 is 27720.",
+      "Runtime local queue depth p95 is 9896.",
       "Runtime alive_tasks p95 is 1920."
     ],
     "next_checks": [
@@ -54,56 +52,5 @@
     "confidence_notes": []
   },
   "secondary_suspects": [],
-  "route_breakdowns": [
-    {
-      "route": "/executor-pressure",
-      "request_count": 240,
-      "p50_latency_us": 33526374,
-      "p95_latency_us": 33677816,
-      "p99_latency_us": 33687600,
-      "p95_queue_share_permille": 0,
-      "p95_service_share_permille": 1000,
-      "evidence_quality": {
-        "request_count": 240,
-        "queue_event_count": 0,
-        "stage_event_count": 0,
-        "runtime_snapshot_count": 0,
-        "inflight_snapshot_count": 0,
-        "requests": "present",
-        "queues": "missing",
-        "stages": "missing",
-        "runtime_snapshots": "missing",
-        "inflight_snapshots": "missing",
-        "truncated": false,
-        "dropped_requests": 0,
-        "dropped_stages": 0,
-        "dropped_queues": 0,
-        "dropped_inflight_snapshots": 0,
-        "dropped_runtime_snapshots": 0,
-        "quality": "weak",
-        "limitations": [
-          "Queue and stage instrumentation are both unavailable, limiting application vs downstream interpretation.",
-          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
-        ]
-      },
-      "primary_suspect": {
-        "kind": "insufficient_evidence",
-        "score": 50,
-        "confidence": "low",
-        "evidence": [
-          "Not enough queue, stage, or runtime signals to rank a stronger suspect."
-        ],
-        "next_checks": [
-          "Wrap critical awaits with queue(...).await_on(...), and use stage(...).await_on(...) for Result-returning work or stage(...).await_value(...) for infallible work.",
-          "Enable RuntimeSampler during the run to capture runtime pressure signals."
-        ],
-        "confidence_notes": []
-      },
-      "secondary_suspects": [],
-      "warnings": [
-        "No runtime snapshots captured; executor and blocking-pressure interpretation is limited.",
-        "Runtime and in-flight signals are global and are not attributed to this route."
-      ]
-    }
-  ]
+  "route_breakdowns": []
 }

--- a/demos/executor_pressure_service/fixtures/before-analysis.json
+++ b/demos/executor_pressure_service/fixtures/before-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 240,
-  "p50_latency_us": 34531979,
-  "p95_latency_us": 34596797,
-  "p99_latency_us": 34604649,
+  "p50_latency_us": 33526374,
+  "p95_latency_us": 33677816,
+  "p99_latency_us": 33687600,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -10,15 +10,17 @@
     "sample_count": 480,
     "peak_count": 240,
     "p95_count": 228,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -28
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
   },
-  "warnings": [],
+  "warnings": [
+    "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
+  ],
   "evidence_quality": {
     "request_count": 240,
     "queue_event_count": 0,
     "stage_event_count": 0,
-    "runtime_snapshot_count": 6377,
+    "runtime_snapshot_count": 33715,
     "inflight_snapshot_count": 480,
     "requests": "present",
     "queues": "missing",
@@ -42,13 +44,66 @@
     "confidence": "high",
     "evidence": [
       "Runtime global queue depth p95 is 1920, suggesting scheduler contention.",
-      "Runtime local queue depth p95 is 42232.",
+      "Runtime local queue depth p95 is 27720.",
       "Runtime alive_tasks p95 is 1920."
     ],
     "next_checks": [
       "Check for long polls without yielding and uneven task fan-out.",
       "Compare with per-stage timings to isolate overloaded async stages."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": [
+    {
+      "route": "/executor-pressure",
+      "request_count": 240,
+      "p50_latency_us": 33526374,
+      "p95_latency_us": 33677816,
+      "p99_latency_us": 33687600,
+      "p95_queue_share_permille": 0,
+      "p95_service_share_permille": 1000,
+      "evidence_quality": {
+        "request_count": 240,
+        "queue_event_count": 0,
+        "stage_event_count": 0,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 0,
+        "requests": "present",
+        "queues": "missing",
+        "stages": "missing",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "missing",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "weak",
+        "limitations": [
+          "Queue and stage instrumentation are both unavailable, limiting application vs downstream interpretation.",
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "insufficient_evidence",
+        "score": 50,
+        "confidence": "low",
+        "evidence": [
+          "Not enough queue, stage, or runtime signals to rank a stronger suspect."
+        ],
+        "next_checks": [
+          "Wrap critical awaits with queue(...).await_on(...), and use stage(...).await_on(...) for Result-returning work or stage(...).await_value(...) for infallible work.",
+          "Enable RuntimeSampler during the run to capture runtime pressure signals."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [],
+      "warnings": [
+        "No runtime snapshots captured; executor and blocking-pressure interpretation is limited.",
+        "Runtime and in-flight signals are global and are not attributed to this route."
+      ]
+    }
+  ]
 }

--- a/demos/executor_pressure_service/fixtures/sample-analysis.json
+++ b/demos/executor_pressure_service/fixtures/sample-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 240,
-  "p50_latency_us": 33526374,
-  "p95_latency_us": 33677816,
-  "p99_latency_us": 33687600,
+  "p50_latency_us": 24445238,
+  "p95_latency_us": 24529057,
+  "p99_latency_us": 24533220,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -13,14 +13,12 @@
     "growth_delta": 0,
     "growth_per_sec_milli": 0
   },
-  "warnings": [
-    "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
-  ],
+  "warnings": [],
   "evidence_quality": {
     "request_count": 240,
     "queue_event_count": 0,
     "stage_event_count": 0,
-    "runtime_snapshot_count": 33715,
+    "runtime_snapshot_count": 24540,
     "inflight_snapshot_count": 480,
     "requests": "present",
     "queues": "missing",
@@ -44,7 +42,7 @@
     "confidence": "high",
     "evidence": [
       "Runtime global queue depth p95 is 1920, suggesting scheduler contention.",
-      "Runtime local queue depth p95 is 27720.",
+      "Runtime local queue depth p95 is 9896.",
       "Runtime alive_tasks p95 is 1920."
     ],
     "next_checks": [
@@ -54,56 +52,5 @@
     "confidence_notes": []
   },
   "secondary_suspects": [],
-  "route_breakdowns": [
-    {
-      "route": "/executor-pressure",
-      "request_count": 240,
-      "p50_latency_us": 33526374,
-      "p95_latency_us": 33677816,
-      "p99_latency_us": 33687600,
-      "p95_queue_share_permille": 0,
-      "p95_service_share_permille": 1000,
-      "evidence_quality": {
-        "request_count": 240,
-        "queue_event_count": 0,
-        "stage_event_count": 0,
-        "runtime_snapshot_count": 0,
-        "inflight_snapshot_count": 0,
-        "requests": "present",
-        "queues": "missing",
-        "stages": "missing",
-        "runtime_snapshots": "missing",
-        "inflight_snapshots": "missing",
-        "truncated": false,
-        "dropped_requests": 0,
-        "dropped_stages": 0,
-        "dropped_queues": 0,
-        "dropped_inflight_snapshots": 0,
-        "dropped_runtime_snapshots": 0,
-        "quality": "weak",
-        "limitations": [
-          "Queue and stage instrumentation are both unavailable, limiting application vs downstream interpretation.",
-          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
-        ]
-      },
-      "primary_suspect": {
-        "kind": "insufficient_evidence",
-        "score": 50,
-        "confidence": "low",
-        "evidence": [
-          "Not enough queue, stage, or runtime signals to rank a stronger suspect."
-        ],
-        "next_checks": [
-          "Wrap critical awaits with queue(...).await_on(...), and use stage(...).await_on(...) for Result-returning work or stage(...).await_value(...) for infallible work.",
-          "Enable RuntimeSampler during the run to capture runtime pressure signals."
-        ],
-        "confidence_notes": []
-      },
-      "secondary_suspects": [],
-      "warnings": [
-        "No runtime snapshots captured; executor and blocking-pressure interpretation is limited.",
-        "Runtime and in-flight signals are global and are not attributed to this route."
-      ]
-    }
-  ]
+  "route_breakdowns": []
 }

--- a/demos/executor_pressure_service/fixtures/sample-analysis.json
+++ b/demos/executor_pressure_service/fixtures/sample-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 240,
-  "p50_latency_us": 34531979,
-  "p95_latency_us": 34596797,
-  "p99_latency_us": 34604649,
+  "p50_latency_us": 33526374,
+  "p95_latency_us": 33677816,
+  "p99_latency_us": 33687600,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -10,15 +10,17 @@
     "sample_count": 480,
     "peak_count": 240,
     "p95_count": 228,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -28
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
   },
-  "warnings": [],
+  "warnings": [
+    "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
+  ],
   "evidence_quality": {
     "request_count": 240,
     "queue_event_count": 0,
     "stage_event_count": 0,
-    "runtime_snapshot_count": 6377,
+    "runtime_snapshot_count": 33715,
     "inflight_snapshot_count": 480,
     "requests": "present",
     "queues": "missing",
@@ -42,13 +44,66 @@
     "confidence": "high",
     "evidence": [
       "Runtime global queue depth p95 is 1920, suggesting scheduler contention.",
-      "Runtime local queue depth p95 is 42232.",
+      "Runtime local queue depth p95 is 27720.",
       "Runtime alive_tasks p95 is 1920."
     ],
     "next_checks": [
       "Check for long polls without yielding and uneven task fan-out.",
       "Compare with per-stage timings to isolate overloaded async stages."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": [
+    {
+      "route": "/executor-pressure",
+      "request_count": 240,
+      "p50_latency_us": 33526374,
+      "p95_latency_us": 33677816,
+      "p99_latency_us": 33687600,
+      "p95_queue_share_permille": 0,
+      "p95_service_share_permille": 1000,
+      "evidence_quality": {
+        "request_count": 240,
+        "queue_event_count": 0,
+        "stage_event_count": 0,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 0,
+        "requests": "present",
+        "queues": "missing",
+        "stages": "missing",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "missing",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "weak",
+        "limitations": [
+          "Queue and stage instrumentation are both unavailable, limiting application vs downstream interpretation.",
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "insufficient_evidence",
+        "score": 50,
+        "confidence": "low",
+        "evidence": [
+          "Not enough queue, stage, or runtime signals to rank a stronger suspect."
+        ],
+        "next_checks": [
+          "Wrap critical awaits with queue(...).await_on(...), and use stage(...).await_on(...) for Result-returning work or stage(...).await_value(...) for infallible work.",
+          "Enable RuntimeSampler during the run to capture runtime pressure signals."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [],
+      "warnings": [
+        "No runtime snapshots captured; executor and blocking-pressure interpretation is limited.",
+        "Runtime and in-flight signals are global and are not attributed to this route."
+      ]
+    }
+  ]
 }

--- a/demos/mixed_contention_service/fixtures/baseline-analysis.json
+++ b/demos/mixed_contention_service/fixtures/baseline-analysis.json
@@ -1,15 +1,15 @@
 {
   "request_count": 220,
-  "p50_latency_us": 393750,
-  "p95_latency_us": 738845,
-  "p99_latency_us": 767621,
+  "p50_latency_us": 403826,
+  "p95_latency_us": 743254,
+  "p99_latency_us": 772473,
   "p95_queue_share_permille": 980,
   "p95_service_share_permille": 402,
   "inflight_trend": {
     "gauge": "mixed_contention_inflight",
     "sample_count": 440,
-    "peak_count": 200,
-    "p95_count": 190,
+    "peak_count": 201,
+    "p95_count": 192,
     "growth_delta": -1,
     "growth_per_sec_milli": -1160
   },
@@ -42,12 +42,13 @@
     "confidence": "high",
     "evidence": [
       "Queue wait at p95 consumes 98.0% of request time.",
-      "Observed queue depth sample up to 195."
+      "Observed queue depth sample up to 196."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -55,15 +56,17 @@
       "score": 35,
       "confidence": "low",
       "evidence": [
-        "Stage 'downstream_call' has p95 latency 32531 us across 220 samples.",
-        "Stage 'downstream_call' cumulative latency is 3775687 us (43 permille of request latency).",
-        "Stage 'downstream_call' contributes 23 permille of tail request latency."
+        "Stage 'downstream_call' has p95 latency 32545 us across 220 samples.",
+        "Stage 'downstream_call' cumulative latency is 3770888 us (43 permille of request latency).",
+        "Stage 'downstream_call' contributes 25 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'downstream_call'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
-  ]
+  ],
+  "route_breakdowns": []
 }

--- a/demos/mixed_contention_service/fixtures/baseline-analysis.json
+++ b/demos/mixed_contention_service/fixtures/baseline-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 403826,
-  "p95_latency_us": 743254,
-  "p99_latency_us": 772473,
+  "p50_latency_us": 390695,
+  "p95_latency_us": 736242,
+  "p99_latency_us": 762947,
   "p95_queue_share_permille": 980,
-  "p95_service_share_permille": 402,
+  "p95_service_share_permille": 393,
   "inflight_trend": {
     "gauge": "mixed_contention_inflight",
     "sample_count": 440,
     "peak_count": 201,
-    "p95_count": 192,
+    "p95_count": 190,
     "growth_delta": -1,
-    "growth_per_sec_milli": -1160
+    "growth_per_sec_milli": -1161
   },
   "warnings": [],
   "evidence_quality": {
@@ -56,8 +56,8 @@
       "score": 35,
       "confidence": "low",
       "evidence": [
-        "Stage 'downstream_call' has p95 latency 32545 us across 220 samples.",
-        "Stage 'downstream_call' cumulative latency is 3770888 us (43 permille of request latency).",
+        "Stage 'downstream_call' has p95 latency 32487 us across 220 samples.",
+        "Stage 'downstream_call' cumulative latency is 3767713 us (43 permille of request latency).",
         "Stage 'downstream_call' contributes 25 permille of tail request latency."
       ],
       "next_checks": [

--- a/demos/mixed_contention_service/fixtures/mitigated-analysis.json
+++ b/demos/mixed_contention_service/fixtures/mitigated-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 14481,
-  "p95_latency_us": 34796,
-  "p99_latency_us": 35247,
+  "p50_latency_us": 14604,
+  "p95_latency_us": 34367,
+  "p99_latency_us": 34982,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,7 +11,7 @@
     "peak_count": 14,
     "p95_count": 13,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2481
+    "growth_per_sec_milli": -2652
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,9 +41,9 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 32561 us across 220 samples.",
-      "Stage 'downstream_call' cumulative latency is 3771440 us (886 permille of request latency).",
-      "Stage 'downstream_call' contributes 935 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 32237 us across 220 samples.",
+      "Stage 'downstream_call' cumulative latency is 3757963 us (889 permille of request latency).",
+      "Stage 'downstream_call' contributes 933 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",

--- a/demos/mixed_contention_service/fixtures/mitigated-analysis.json
+++ b/demos/mixed_contention_service/fixtures/mitigated-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 14399,
-  "p95_latency_us": 34450,
-  "p99_latency_us": 35029,
+  "p50_latency_us": 14481,
+  "p95_latency_us": 34796,
+  "p99_latency_us": 35247,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,7 +11,7 @@
     "peak_count": 14,
     "p95_count": 13,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2631
+    "growth_per_sec_milli": -2481
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,15 +41,17 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 32570 us across 220 samples.",
-      "Stage 'downstream_call' cumulative latency is 3763084 us (889 permille of request latency).",
-      "Stage 'downstream_call' contributes 933 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 32561 us across 220 samples.",
+      "Stage 'downstream_call' cumulative latency is 3771440 us (886 permille of request latency).",
+      "Stage 'downstream_call' contributes 935 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }

--- a/demos/queue_service/fixtures/after-analysis.json
+++ b/demos/queue_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 250,
-  "p50_latency_us": 16166,
-  "p95_latency_us": 16880,
-  "p99_latency_us": 17344,
+  "p50_latency_us": 16028,
+  "p95_latency_us": 16827,
+  "p99_latency_us": 16953,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
-    "peak_count": 14,
+    "peak_count": 12,
     "p95_count": 12,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2352
+    "growth_per_sec_milli": -2450
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,9 +41,9 @@
     "score": 100,
     "confidence": "high",
     "evidence": [
-      "Stage 'simulated_work' has p95 latency 16860 us across 250 samples.",
-      "Stage 'simulated_work' cumulative latency is 4034383 us (997 permille of request latency).",
-      "Stage 'simulated_work' contributes 987 permille of tail request latency."
+      "Stage 'simulated_work' has p95 latency 16817 us across 250 samples.",
+      "Stage 'simulated_work' cumulative latency is 4019716 us (999 permille of request latency).",
+      "Stage 'simulated_work' contributes 998 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'simulated_work'.",

--- a/demos/queue_service/fixtures/after-analysis.json
+++ b/demos/queue_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 250,
-  "p50_latency_us": 16086,
-  "p95_latency_us": 17037,
-  "p99_latency_us": 19055,
+  "p50_latency_us": 16166,
+  "p95_latency_us": 16880,
+  "p99_latency_us": 17344,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
-    "peak_count": 16,
+    "peak_count": 14,
     "p95_count": 12,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2386
+    "growth_per_sec_milli": -2352
   },
   "warnings": [],
   "evidence_quality": {
@@ -38,18 +38,20 @@
   },
   "primary_suspect": {
     "kind": "downstream_stage_dominates",
-    "score": 95,
+    "score": 100,
     "confidence": "high",
     "evidence": [
-      "Stage 'simulated_work' has p95 latency 16919 us across 250 samples.",
-      "Stage 'simulated_work' cumulative latency is 4031794 us (995 permille of request latency).",
-      "Stage 'simulated_work' contributes 955 permille of tail request latency."
+      "Stage 'simulated_work' has p95 latency 16860 us across 250 samples.",
+      "Stage 'simulated_work' cumulative latency is 4034383 us (997 permille of request latency).",
+      "Stage 'simulated_work' contributes 987 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'simulated_work'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }

--- a/demos/queue_service/fixtures/before-analysis.json
+++ b/demos/queue_service/fixtures/before-analysis.json
@@ -1,10 +1,10 @@
 {
   "request_count": 250,
-  "p50_latency_us": 783889,
-  "p95_latency_us": 1463903,
-  "p99_latency_us": 1514094,
+  "p50_latency_us": 785735,
+  "p95_latency_us": 1466620,
+  "p99_latency_us": 1526049,
   "p95_queue_share_permille": 982,
-  "p95_service_share_permille": 269,
+  "p95_service_share_permille": 270,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
@@ -47,7 +47,8 @@
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -55,15 +56,17 @@
       "score": 33,
       "confidence": "low",
       "evidence": [
-        "Stage 'simulated_work' has p95 latency 26681 us across 250 samples.",
-        "Stage 'simulated_work' cumulative latency is 6548608 us (33 permille of request latency).",
+        "Stage 'simulated_work' has p95 latency 26777 us across 250 samples.",
+        "Stage 'simulated_work' cumulative latency is 6550998 us (33 permille of request latency).",
         "Stage 'simulated_work' contributes 17 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'simulated_work'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
-  ]
+  ],
+  "route_breakdowns": []
 }

--- a/demos/queue_service/fixtures/before-analysis.json
+++ b/demos/queue_service/fixtures/before-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 250,
-  "p50_latency_us": 785735,
-  "p95_latency_us": 1466620,
-  "p99_latency_us": 1526049,
+  "p50_latency_us": 783739,
+  "p95_latency_us": 1472369,
+  "p99_latency_us": 1521948,
   "p95_queue_share_permille": 982,
-  "p95_service_share_permille": 270,
+  "p95_service_share_permille": 265,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
     "peak_count": 234,
-    "p95_count": 222,
-    "growth_delta": 0,
-    "growth_per_sec_milli": 0
+    "p95_count": 226,
+    "growth_delta": -1,
+    "growth_per_sec_milli": -604
   },
   "warnings": [],
   "evidence_quality": {
@@ -56,8 +56,8 @@
       "score": 33,
       "confidence": "low",
       "evidence": [
-        "Stage 'simulated_work' has p95 latency 26777 us across 250 samples.",
-        "Stage 'simulated_work' cumulative latency is 6550998 us (33 permille of request latency).",
+        "Stage 'simulated_work' has p95 latency 26571 us across 250 samples.",
+        "Stage 'simulated_work' cumulative latency is 6535903 us (33 permille of request latency).",
         "Stage 'simulated_work' contributes 17 permille of tail request latency."
       ],
       "next_checks": [

--- a/demos/queue_service/fixtures/sample-analysis.json
+++ b/demos/queue_service/fixtures/sample-analysis.json
@@ -1,10 +1,10 @@
 {
   "request_count": 250,
-  "p50_latency_us": 783889,
-  "p95_latency_us": 1463903,
-  "p99_latency_us": 1514094,
+  "p50_latency_us": 785735,
+  "p95_latency_us": 1466620,
+  "p99_latency_us": 1526049,
   "p95_queue_share_permille": 982,
-  "p95_service_share_permille": 269,
+  "p95_service_share_permille": 270,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
@@ -47,7 +47,8 @@
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -55,15 +56,17 @@
       "score": 33,
       "confidence": "low",
       "evidence": [
-        "Stage 'simulated_work' has p95 latency 26681 us across 250 samples.",
-        "Stage 'simulated_work' cumulative latency is 6548608 us (33 permille of request latency).",
+        "Stage 'simulated_work' has p95 latency 26777 us across 250 samples.",
+        "Stage 'simulated_work' cumulative latency is 6550998 us (33 permille of request latency).",
         "Stage 'simulated_work' contributes 17 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'simulated_work'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
-  ]
+  ],
+  "route_breakdowns": []
 }

--- a/demos/queue_service/fixtures/sample-analysis.json
+++ b/demos/queue_service/fixtures/sample-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 250,
-  "p50_latency_us": 785735,
-  "p95_latency_us": 1466620,
-  "p99_latency_us": 1526049,
+  "p50_latency_us": 783739,
+  "p95_latency_us": 1472369,
+  "p99_latency_us": 1521948,
   "p95_queue_share_permille": 982,
-  "p95_service_share_permille": 270,
+  "p95_service_share_permille": 265,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
     "peak_count": 234,
-    "p95_count": 222,
-    "growth_delta": 0,
-    "growth_per_sec_milli": 0
+    "p95_count": 226,
+    "growth_delta": -1,
+    "growth_per_sec_milli": -604
   },
   "warnings": [],
   "evidence_quality": {
@@ -56,8 +56,8 @@
       "score": 33,
       "confidence": "low",
       "evidence": [
-        "Stage 'simulated_work' has p95 latency 26777 us across 250 samples.",
-        "Stage 'simulated_work' cumulative latency is 6550998 us (33 permille of request latency).",
+        "Stage 'simulated_work' has p95 latency 26571 us across 250 samples.",
+        "Stage 'simulated_work' cumulative latency is 6535903 us (33 permille of request latency).",
         "Stage 'simulated_work' contributes 17 permille of tail request latency."
       ],
       "next_checks": [

--- a/demos/retry_storm_service/fixtures/after-analysis.json
+++ b/demos/retry_storm_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 180,
-  "p50_latency_us": 9513,
-  "p95_latency_us": 29401,
-  "p99_latency_us": 29784,
+  "p50_latency_us": 9673,
+  "p95_latency_us": 29454,
+  "p99_latency_us": 29779,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -41,15 +41,17 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_total' has p95 latency 27186 us across 180 samples.",
-      "Stage 'downstream_total' cumulative latency is 2154453 us (842 permille of request latency).",
-      "Stage 'downstream_total' contributes 922 permille of tail request latency."
+      "Stage 'downstream_total' has p95 latency 27240 us across 180 samples.",
+      "Stage 'downstream_total' cumulative latency is 2159443 us (842 permille of request latency).",
+      "Stage 'downstream_total' contributes 923 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_total'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }

--- a/demos/retry_storm_service/fixtures/after-analysis.json
+++ b/demos/retry_storm_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 180,
-  "p50_latency_us": 9673,
-  "p95_latency_us": 29454,
-  "p99_latency_us": 29779,
+  "p50_latency_us": 9536,
+  "p95_latency_us": 29293,
+  "p99_latency_us": 30041,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,7 +11,7 @@
     "peak_count": 17,
     "p95_count": 15,
     "growth_delta": -1,
-    "growth_per_sec_milli": -4716
+    "growth_per_sec_milli": -4608
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,9 +41,9 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_total' has p95 latency 27240 us across 180 samples.",
-      "Stage 'downstream_total' cumulative latency is 2159443 us (842 permille of request latency).",
-      "Stage 'downstream_total' contributes 923 permille of tail request latency."
+      "Stage 'downstream_total' has p95 latency 27264 us across 180 samples.",
+      "Stage 'downstream_total' cumulative latency is 2154010 us (848 permille of request latency).",
+      "Stage 'downstream_total' contributes 924 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_total'.",

--- a/demos/retry_storm_service/fixtures/before-analysis.json
+++ b/demos/retry_storm_service/fixtures/before-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 180,
-  "p50_latency_us": 9977,
-  "p95_latency_us": 41817,
-  "p99_latency_us": 42856,
+  "p50_latency_us": 9559,
+  "p95_latency_us": 41567,
+  "p99_latency_us": 41781,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "retry_storm_inflight",
     "sample_count": 360,
-    "peak_count": 54,
-    "p95_count": 51,
+    "peak_count": 57,
+    "p95_count": 55,
     "growth_delta": -1,
-    "growth_per_sec_milli": -8849
+    "growth_per_sec_milli": -9523
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,9 +41,9 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_total' has p95 latency 39461 us across 180 samples.",
-      "Stage 'downstream_total' cumulative latency is 3054613 us (875 permille of request latency).",
-      "Stage 'downstream_total' contributes 942 permille of tail request latency."
+      "Stage 'downstream_total' has p95 latency 39310 us across 180 samples.",
+      "Stage 'downstream_total' cumulative latency is 3026286 us (887 permille of request latency).",
+      "Stage 'downstream_total' contributes 945 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_total'.",

--- a/demos/retry_storm_service/fixtures/before-analysis.json
+++ b/demos/retry_storm_service/fixtures/before-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 180,
-  "p50_latency_us": 9863,
-  "p95_latency_us": 41148,
-  "p99_latency_us": 42215,
+  "p50_latency_us": 9977,
+  "p95_latency_us": 41817,
+  "p99_latency_us": 42856,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "retry_storm_inflight",
     "sample_count": 360,
-    "peak_count": 57,
-    "p95_count": 54,
+    "peak_count": 54,
+    "p95_count": 51,
     "growth_delta": -1,
-    "growth_per_sec_milli": -9345
+    "growth_per_sec_milli": -8849
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,15 +41,17 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_total' has p95 latency 38902 us across 180 samples.",
-      "Stage 'downstream_total' cumulative latency is 3025771 us (883 permille of request latency).",
-      "Stage 'downstream_total' contributes 945 permille of tail request latency."
+      "Stage 'downstream_total' has p95 latency 39461 us across 180 samples.",
+      "Stage 'downstream_total' cumulative latency is 3054613 us (875 permille of request latency).",
+      "Stage 'downstream_total' contributes 942 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_total'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }

--- a/demos/shared_state_lock_service/fixtures/after-analysis.json
+++ b/demos/shared_state_lock_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 828874,
-  "p95_latency_us": 1564712,
-  "p99_latency_us": 1623531,
+  "p50_latency_us": 829608,
+  "p95_latency_us": 1562567,
+  "p99_latency_us": 1621277,
   "p95_queue_share_permille": 993,
-  "p95_service_share_permille": 127,
+  "p95_service_share_permille": 130,
   "inflight_trend": {
     "gauge": "shared_state_lock_inflight",
     "sample_count": 440,
-    "peak_count": 201,
+    "peak_count": 200,
     "p95_count": 190,
     "growth_delta": -1,
-    "growth_per_sec_milli": -555
+    "growth_per_sec_milli": -553
   },
   "warnings": [],
   "evidence_quality": {
@@ -47,7 +47,8 @@
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -55,15 +56,17 @@
       "score": 32,
       "confidence": "low",
       "evidence": [
-        "Stage 'shared_state_critical_section' has p95 latency 8269 us across 220 samples.",
-        "Stage 'shared_state_critical_section' cumulative latency is 1787919 us (9 permille of request latency).",
+        "Stage 'shared_state_critical_section' has p95 latency 8395 us across 220 samples.",
+        "Stage 'shared_state_critical_section' cumulative latency is 1792942 us (9 permille of request latency).",
         "Stage 'shared_state_critical_section' contributes 5 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'shared_state_critical_section'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
-  ]
+  ],
+  "route_breakdowns": []
 }

--- a/demos/shared_state_lock_service/fixtures/after-analysis.json
+++ b/demos/shared_state_lock_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 829608,
-  "p95_latency_us": 1562567,
-  "p99_latency_us": 1621277,
+  "p50_latency_us": 828543,
+  "p95_latency_us": 1565357,
+  "p99_latency_us": 1626849,
   "p95_queue_share_permille": 993,
-  "p95_service_share_permille": 130,
+  "p95_service_share_permille": 124,
   "inflight_trend": {
     "gauge": "shared_state_lock_inflight",
     "sample_count": 440,
-    "peak_count": 200,
-    "p95_count": 190,
+    "peak_count": 201,
+    "p95_count": 191,
     "growth_delta": -1,
-    "growth_per_sec_milli": -553
+    "growth_per_sec_milli": -554
   },
   "warnings": [],
   "evidence_quality": {
@@ -42,7 +42,7 @@
     "confidence": "high",
     "evidence": [
       "Queue wait at p95 consumes 99.3% of request time.",
-      "Observed queue depth sample up to 199."
+      "Observed queue depth sample up to 200."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -56,8 +56,8 @@
       "score": 32,
       "confidence": "low",
       "evidence": [
-        "Stage 'shared_state_critical_section' has p95 latency 8395 us across 220 samples.",
-        "Stage 'shared_state_critical_section' cumulative latency is 1792942 us (9 permille of request latency).",
+        "Stage 'shared_state_critical_section' has p95 latency 8246 us across 220 samples.",
+        "Stage 'shared_state_critical_section' cumulative latency is 1791550 us (9 permille of request latency).",
         "Stage 'shared_state_critical_section' contributes 5 permille of tail request latency."
       ],
       "next_checks": [

--- a/demos/shared_state_lock_service/fixtures/before-analysis.json
+++ b/demos/shared_state_lock_service/fixtures/before-analysis.json
@@ -1,10 +1,10 @@
 {
   "request_count": 220,
-  "p50_latency_us": 2546348,
-  "p95_latency_us": 4817353,
-  "p99_latency_us": 4999343,
+  "p50_latency_us": 2551706,
+  "p95_latency_us": 4829656,
+  "p99_latency_us": 5011711,
   "p95_queue_share_permille": 994,
-  "p95_service_share_permille": 98,
+  "p95_service_share_permille": 97,
   "inflight_trend": {
     "gauge": "shared_state_lock_inflight",
     "sample_count": 440,
@@ -47,7 +47,8 @@
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -55,15 +56,17 @@
       "score": 32,
       "confidence": "low",
       "evidence": [
-        "Stage 'shared_state_critical_section' has p95 latency 23447 us across 220 samples.",
-        "Stage 'shared_state_critical_section' cumulative latency is 5109039 us (9 permille of request latency).",
+        "Stage 'shared_state_critical_section' has p95 latency 23376 us across 220 samples.",
+        "Stage 'shared_state_critical_section' cumulative latency is 5122119 us (9 permille of request latency).",
         "Stage 'shared_state_critical_section' contributes 4 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'shared_state_critical_section'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
-  ]
+  ],
+  "route_breakdowns": []
 }

--- a/demos/shared_state_lock_service/fixtures/before-analysis.json
+++ b/demos/shared_state_lock_service/fixtures/before-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 2551706,
-  "p95_latency_us": 4829656,
-  "p99_latency_us": 5011711,
+  "p50_latency_us": 2533261,
+  "p95_latency_us": 4794306,
+  "p99_latency_us": 4975959,
   "p95_queue_share_permille": 994,
-  "p95_service_share_permille": 97,
+  "p95_service_share_permille": 100,
   "inflight_trend": {
     "gauge": "shared_state_lock_inflight",
     "sample_count": 440,
     "peak_count": 217,
     "p95_count": 206,
     "growth_delta": -1,
-    "growth_per_sec_milli": -194
+    "growth_per_sec_milli": -196
   },
   "warnings": [],
   "evidence_quality": {
@@ -56,8 +56,8 @@
       "score": 32,
       "confidence": "low",
       "evidence": [
-        "Stage 'shared_state_critical_section' has p95 latency 23376 us across 220 samples.",
-        "Stage 'shared_state_critical_section' cumulative latency is 5122119 us (9 permille of request latency).",
+        "Stage 'shared_state_critical_section' has p95 latency 23290 us across 220 samples.",
+        "Stage 'shared_state_critical_section' cumulative latency is 5087992 us (9 permille of request latency).",
         "Stage 'shared_state_critical_section' contributes 4 permille of tail request latency."
       ],
       "next_checks": [

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -56,6 +56,7 @@ Each suspect includes:
 - `primary_suspect`: highest-ranked suspect with evidence and next checks.
 - `secondary_suspects[]`: additional ranked suspects.
 - `inflight_trend` (optional): dominant in-flight gauge trend summary when snapshots exist.
+- `route_breakdowns`: always present and usually empty. It is populated only when at least two captured routes have enough completed requests and route-level context adds signal (for example, different route-level primary suspects or a large route p95 latency spread). Route breakdowns are supporting context only; global `primary_suspect` remains the primary full-run triage lead. Route breakdowns use route-attributed request, queue, and stage events. Runtime snapshots and in-flight gauges are global signals and are intentionally not attributed to individual routes. Route-level summaries do not prove per-route root cause.
 
 ## Suspect kinds
 
@@ -141,6 +142,3 @@ If truncation counters are non-zero, treat the diagnosis as partial-data triage.
 4. Change one thing.
 5. Re-run under comparable load.
 6. Compare suspect movement and p95 shares.
-
-
-- `route_breakdowns`: supporting per-route triage summaries when route-level differences are meaningful; empty otherwise. Global `primary_suspect` remains the primary output. Route summaries are scoped to captured route labels and do not attribute global runtime/in-flight signals to a route.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -141,3 +141,6 @@ If truncation counters are non-zero, treat the diagnosis as partial-data triage.
 4. Change one thing.
 5. Re-run under comparable load.
 6. Compare suspect movement and p95 shares.
+
+
+- `route_breakdowns`: supporting per-route triage summaries when route-level differences are meaningful; empty otherwise. Global `primary_suspect` remains the primary output. Route summaries are scoped to captured route labels and do not attribute global runtime/in-flight signals to a route.

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -101,6 +101,8 @@ Then run one targeted check, change one thing, and re-run under comparable load.
 
 `inflight_trend` may be `null` when no in-flight gauges were captured.
 
+`route_breakdowns` is always present in JSON output and is usually an empty array. It is populated only when at least two captured routes have enough completed requests and route-level context adds signal, such as different route-level primary suspects or a large route p95 latency spread. The global `primary_suspect` remains the primary full-run triage lead. Route breakdowns are supporting context only. They use route-attributed request, queue, and stage events. Runtime snapshots and in-flight gauges are global signals, so they are intentionally not attributed to individual routes. Route-level summaries do not prove per-route root cause.
+
 ## What the report contains
 
 A report can include:
@@ -208,6 +210,3 @@ Use capture-side crates for that:
 - `tailtriage-controller`: repeated bounded windows
 - `tailtriage-tokio`: runtime-pressure sampling
 - `tailtriage-axum`: Axum request-boundary integration
-
-
-- `route_breakdowns`: supporting per-route triage summaries when route-level differences are meaningful; empty otherwise. Global `primary_suspect` remains the primary output. Route summaries are scoped to captured route labels and do not attribute global runtime/in-flight signals to a route.

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -94,7 +94,8 @@ Then run one targeted check, change one thing, and re-run under comparable load.
     "next_checks": ["Inspect queue admission limits and producer burst patterns."],
     "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }
 ```
 
@@ -207,3 +208,6 @@ Use capture-side crates for that:
 - `tailtriage-controller`: repeated bounded windows
 - `tailtriage-tokio`: runtime-pressure sampling
 - `tailtriage-axum`: Axum request-boundary integration
+
+
+- `route_breakdowns`: supporting per-route triage summaries when route-level differences are meaningful; empty otherwise. Global `primary_suspect` remains the primary output. Route summaries are scoped to captured route labels and do not attribute global runtime/in-flight signals to a route.

--- a/tailtriage-cli/src/analyze.rs
+++ b/tailtriage-cli/src/analyze.rs
@@ -14,6 +14,12 @@ const SAMPLE_QUALITY_HIGH_SAMPLE_COUNT: usize = 100;
 const SAMPLE_QUALITY_MEDIUM_SAMPLE_COUNT: usize = 40;
 const SAMPLE_QUALITY_LOW_SAMPLE_COUNT: usize = 20;
 const SAMPLE_QUALITY_MIN_NONZERO_SAMPLE_COUNT: usize = 8;
+const ROUTE_MIN_REQUEST_COUNT: usize = 3;
+const ROUTE_BREAKDOWN_LIMIT: usize = 10;
+const ROUTE_DIVERGENCE_WARNING: &str =
+    "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect.";
+const ROUTE_RUNTIME_ATTRIBUTION_WARNING: &str =
+    "Runtime and in-flight signals are global and are not attributed to this route.";
 
 /// Evidence-ranked diagnosis categories produced by heuristic triage.
 ///
@@ -230,6 +236,35 @@ pub struct Report {
     pub primary_suspect: Suspect,
     /// Lower-ranked suspects retained for follow-up triage.
     pub secondary_suspects: Vec<Suspect>,
+    /// Supporting per-route triage summaries when route-level signal adds value.
+    pub route_breakdowns: Vec<RouteBreakdown>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+/// Supporting per-route triage summary derived from captured request route labels.
+pub struct RouteBreakdown {
+    /// Route or operation label from request capture.
+    pub route: String,
+    /// Completed request count included for this route.
+    pub request_count: usize,
+    /// p50 request latency for this route in microseconds.
+    pub p50_latency_us: Option<u64>,
+    /// p95 request latency for this route in microseconds.
+    pub p95_latency_us: Option<u64>,
+    /// p99 request latency for this route in microseconds.
+    pub p99_latency_us: Option<u64>,
+    /// p95 queue-time share for this route in permille.
+    pub p95_queue_share_permille: Option<u64>,
+    /// p95 non-queue service-time share for this route in permille.
+    pub p95_service_share_permille: Option<u64>,
+    /// Evidence coverage summary for this route-filtered analysis.
+    pub evidence_quality: EvidenceQuality,
+    /// Highest-ranked route-level suspect.
+    pub primary_suspect: Suspect,
+    /// Lower-ranked route-level suspects for follow-up.
+    pub secondary_suspects: Vec<Suspect>,
+    /// Route-scoped warnings and interpretation limits.
+    pub warnings: Vec<String>,
 }
 
 /// Analyzes one run artifact with rule-based heuristics and returns a triage report.
@@ -283,6 +318,16 @@ pub struct Report {
 /// ```
 #[must_use]
 pub fn analyze_run(run: &Run) -> Report {
+    let mut report = analyze_run_internal(run);
+    let route_context = route_breakdowns(run, &report);
+    if route_context.divergent {
+        report.warnings.push(ROUTE_DIVERGENCE_WARNING.to_string());
+    }
+    report.route_breakdowns = route_context.breakdowns;
+    report
+}
+
+fn analyze_run_internal(run: &Run) -> Report {
     let request_latencies = run
         .requests
         .iter()
@@ -360,7 +405,157 @@ pub fn analyze_run(run: &Run) -> Report {
         evidence_quality,
         primary_suspect,
         secondary_suspects: ranked.collect(),
+        route_breakdowns: Vec::new(),
     }
+}
+
+struct RouteBreakdownContext {
+    breakdowns: Vec<RouteBreakdown>,
+    divergent: bool,
+}
+
+fn route_breakdowns(run: &Run, global: &Report) -> RouteBreakdownContext {
+    let mut ids_by_route: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for request in &run.requests {
+        ids_by_route
+            .entry(request.route.clone())
+            .or_default()
+            .push(request.request_id.clone());
+    }
+    let eligible: Vec<(String, Vec<String>)> = ids_by_route
+        .into_iter()
+        .filter(|(_, ids)| ids.len() >= ROUTE_MIN_REQUEST_COUNT)
+        .collect();
+    if eligible.is_empty() {
+        return RouteBreakdownContext {
+            breakdowns: vec![],
+            divergent: false,
+        };
+    }
+
+    let omitted_routes = run
+        .requests
+        .iter()
+        .fold(BTreeMap::<String, usize>::new(), |mut acc, request| {
+            *acc.entry(request.route.clone()).or_default() += 1;
+            acc
+        })
+        .into_values()
+        .filter(|count| *count < ROUTE_MIN_REQUEST_COUNT)
+        .count();
+
+    let mut candidates = Vec::new();
+    for (route, request_ids) in eligible {
+        let filtered = filtered_run_for_route(run, &request_ids);
+        let mut analyzed = analyze_run_internal(&filtered);
+        analyzed
+            .warnings
+            .push(ROUTE_RUNTIME_ATTRIBUTION_WARNING.to_string());
+        candidates.push(RouteBreakdown {
+            route,
+            request_count: analyzed.request_count,
+            p50_latency_us: analyzed.p50_latency_us,
+            p95_latency_us: analyzed.p95_latency_us,
+            p99_latency_us: analyzed.p99_latency_us,
+            p95_queue_share_permille: analyzed.p95_queue_share_permille,
+            p95_service_share_permille: analyzed.p95_service_share_permille,
+            evidence_quality: analyzed.evidence_quality,
+            primary_suspect: analyzed.primary_suspect,
+            secondary_suspects: analyzed.secondary_suspects,
+            warnings: analyzed.warnings,
+        });
+    }
+    if !should_emit_route_breakdowns(global, &candidates) {
+        return RouteBreakdownContext {
+            breakdowns: vec![],
+            divergent: false,
+        };
+    }
+    let divergent = route_divergence(global, &candidates);
+    let mut emitted = candidates;
+    emitted.sort_by(|a, b| {
+        b.p95_latency_us
+            .cmp(&a.p95_latency_us)
+            .then_with(|| b.request_count.cmp(&a.request_count))
+            .then_with(|| a.route.cmp(&b.route))
+    });
+    emitted.truncate(ROUTE_BREAKDOWN_LIMIT);
+    if omitted_routes > 0 {
+        let note = format!(
+            "Some routes are omitted from route_breakdowns because they have fewer than {ROUTE_MIN_REQUEST_COUNT} completed requests."
+        );
+        for breakdown in &mut emitted {
+            breakdown.warnings.push(note.clone());
+        }
+    }
+    RouteBreakdownContext {
+        breakdowns: emitted,
+        divergent,
+    }
+}
+
+fn route_divergence(global: &Report, candidates: &[RouteBreakdown]) -> bool {
+    let distinct = candidates
+        .iter()
+        .map(|c| c.primary_suspect.kind.as_str())
+        .collect::<std::collections::BTreeSet<_>>()
+        .len();
+    distinct >= 2
+        || candidates
+            .iter()
+            .any(|c| c.primary_suspect.kind != global.primary_suspect.kind)
+}
+
+fn should_emit_route_breakdowns(global: &Report, candidates: &[RouteBreakdown]) -> bool {
+    if candidates.len() == 1 && candidates[0].primary_suspect.kind == global.primary_suspect.kind {
+        return false;
+    }
+    if route_divergence(global, candidates) {
+        return true;
+    }
+    if candidates.len() < 2 {
+        return false;
+    }
+    let p95s: Vec<u64> = candidates.iter().filter_map(|c| c.p95_latency_us).collect();
+    if p95s.len() < 2 {
+        return false;
+    }
+    let slowest = *p95s.iter().max().unwrap_or(&0);
+    let fastest = *p95s.iter().min().unwrap_or(&0);
+    (fastest > 0 && slowest.saturating_mul(2) >= fastest.saturating_mul(3))
+        || match global.p95_latency_us {
+            Some(global_p95) if global_p95 > 0 => {
+                slowest.saturating_mul(4) >= global_p95.saturating_mul(5)
+            }
+            _ => false,
+        }
+}
+
+fn filtered_run_for_route(run: &Run, request_ids: &[String]) -> Run {
+    let request_ids: std::collections::HashSet<&str> =
+        request_ids.iter().map(String::as_str).collect();
+    let mut filtered = run.clone();
+    filtered.requests = run
+        .requests
+        .iter()
+        .filter(|r| request_ids.contains(r.request_id.as_str()))
+        .cloned()
+        .collect();
+    filtered.stages = run
+        .stages
+        .iter()
+        .filter(|s| request_ids.contains(s.request_id.as_str()))
+        .cloned()
+        .collect();
+    filtered.queues = run
+        .queues
+        .iter()
+        .filter(|q| request_ids.contains(q.request_id.as_str()))
+        .cloned()
+        .collect();
+    filtered.runtime_snapshots = Vec::new();
+    filtered.inflight = Vec::new();
+    filtered
 }
 
 fn apply_evidence_aware_confidence_caps(
@@ -1331,6 +1526,19 @@ pub fn render_text(report: &Report) -> String {
             ));
         }
     }
+    if !report.route_breakdowns.is_empty() {
+        lines.push("Route breakdowns:".to_string());
+        for route in &report.route_breakdowns {
+            lines.push(format!(
+                "- {}: requests {}, p95 {}us, suspect {} ({} confidence)",
+                route.route,
+                route.request_count,
+                fmt_opt_u64(route.p95_latency_us),
+                route.primary_suspect.kind.as_str(),
+                fmt_confidence(route.primary_suspect.confidence),
+            ));
+        }
+    }
 
     lines.join("\n")
 }
@@ -1601,6 +1809,7 @@ mod tests {
                 confidence_notes: Vec::new(),
             },
             secondary_suspects: Vec::new(),
+            route_breakdowns: Vec::new(),
         };
 
         let text = render_text(&report);
@@ -1652,6 +1861,7 @@ mod tests {
                 confidence_notes: Vec::new(),
             },
             secondary_suspects: Vec::new(),
+            route_breakdowns: Vec::new(),
         };
 
         let text = render_text(&report);
@@ -2370,5 +2580,29 @@ mod tests {
             .confidence_notes
             .iter()
             .any(|n| n == "Top suspects are close in score; confidence is capped by ambiguity."));
+    }
+
+    #[test]
+    fn route_breakdowns_empty_for_single_route() {
+        let report = analyze_run(&test_run());
+        assert!(report.route_breakdowns.is_empty());
+    }
+
+    #[test]
+    fn route_breakdowns_include_runtime_attribution_warning_when_emitted() {
+        let mut run = test_run();
+        for idx in 4..=6 {
+            let mut req = sample_request(idx);
+            req.route = "/slow".to_owned();
+            req.latency_us = 9_000;
+            run.requests.push(req);
+        }
+        let report = analyze_run(&run);
+        if !report.route_breakdowns.is_empty() {
+            assert!(report.route_breakdowns.iter().all(|route| route
+                .warnings
+                .iter()
+                .any(|warning| warning == super::ROUTE_RUNTIME_ATTRIBUTION_WARNING)));
+        }
     }
 }

--- a/tailtriage-cli/src/analyze.rs
+++ b/tailtriage-cli/src/analyze.rs
@@ -426,7 +426,7 @@ fn route_breakdowns(run: &Run, global: &Report) -> RouteBreakdownContext {
         .into_iter()
         .filter(|(_, ids)| ids.len() >= ROUTE_MIN_REQUEST_COUNT)
         .collect();
-    if eligible.is_empty() {
+    if eligible.len() < 2 {
         return RouteBreakdownContext {
             breakdowns: vec![],
             divergent: false,
@@ -471,7 +471,6 @@ fn route_breakdowns(run: &Run, global: &Report) -> RouteBreakdownContext {
             divergent: false,
         };
     }
-    let divergent = route_divergence(global, &candidates);
     let mut emitted = candidates;
     emitted.sort_by(|a, b| {
         b.p95_latency_us
@@ -480,6 +479,7 @@ fn route_breakdowns(run: &Run, global: &Report) -> RouteBreakdownContext {
             .then_with(|| a.route.cmp(&b.route))
     });
     emitted.truncate(ROUTE_BREAKDOWN_LIMIT);
+    let divergent = route_divergence(&emitted);
     if omitted_routes > 0 {
         let note = format!(
             "Some routes are omitted from route_breakdowns because they have fewer than {ROUTE_MIN_REQUEST_COUNT} completed requests."
@@ -494,27 +494,21 @@ fn route_breakdowns(run: &Run, global: &Report) -> RouteBreakdownContext {
     }
 }
 
-fn route_divergence(global: &Report, candidates: &[RouteBreakdown]) -> bool {
-    let distinct = candidates
+fn route_divergence(candidates: &[RouteBreakdown]) -> bool {
+    candidates
         .iter()
         .map(|c| c.primary_suspect.kind.as_str())
         .collect::<std::collections::BTreeSet<_>>()
-        .len();
-    distinct >= 2
-        || candidates
-            .iter()
-            .any(|c| c.primary_suspect.kind != global.primary_suspect.kind)
+        .len()
+        >= 2
 }
 
 fn should_emit_route_breakdowns(global: &Report, candidates: &[RouteBreakdown]) -> bool {
-    if candidates.len() == 1 && candidates[0].primary_suspect.kind == global.primary_suspect.kind {
-        return false;
-    }
-    if route_divergence(global, candidates) {
-        return true;
-    }
     if candidates.len() < 2 {
         return false;
+    }
+    if route_divergence(candidates) {
+        return true;
     }
     let p95s: Vec<u64> = candidates.iter().filter_map(|c| c.p95_latency_us).collect();
     if p95s.len() < 2 {
@@ -1551,9 +1545,10 @@ mod tests {
     };
 
     use crate::analyze::{
-        analyze_run, apply_evidence_aware_confidence_caps, evidence_quality, render_text,
-        Confidence, DiagnosisKind, EvidenceQuality, EvidenceQualityLevel, InflightTrend, Report,
-        SignalCoverageStatus, Suspect,
+        analyze_run, analyze_run_internal, apply_evidence_aware_confidence_caps, evidence_quality,
+        render_text, Confidence, DiagnosisKind, EvidenceQuality, EvidenceQualityLevel,
+        InflightTrend, Report, SignalCoverageStatus, Suspect, ROUTE_DIVERGENCE_WARNING,
+        ROUTE_RUNTIME_ATTRIBUTION_WARNING,
     };
 
     fn test_run() -> Run {
@@ -2586,23 +2581,106 @@ mod tests {
     fn route_breakdowns_empty_for_single_route() {
         let report = analyze_run(&test_run());
         assert!(report.route_breakdowns.is_empty());
+        assert!(report
+            .warnings
+            .iter()
+            .all(|warning| warning != ROUTE_DIVERGENCE_WARNING));
     }
 
     #[test]
-    fn route_breakdowns_include_runtime_attribution_warning_when_emitted() {
+    fn single_route_executor_signals_do_not_emit_route_breakdowns_or_divergence_warning() {
         let mut run = test_run();
-        for idx in 4..=6 {
+        run.runtime_snapshots = vec![runtime_snapshot(Some(150), Some(120), Some(2))];
+        let report = analyze_run(&run);
+        assert!(report.route_breakdowns.is_empty());
+        assert!(report
+            .warnings
+            .iter()
+            .all(|warning| warning != ROUTE_DIVERGENCE_WARNING));
+    }
+
+    #[test]
+    fn multi_route_divergence_emits_sorted_breakdowns_and_stable_warning() {
+        let mut run = test_run();
+        run.requests.clear();
+        for idx in 1..=4 {
             let mut req = sample_request(idx);
-            req.route = "/slow".to_owned();
-            req.latency_us = 9_000;
+            req.route = "/a".into();
+            req.latency_us = 10_000;
             run.requests.push(req);
         }
-        let report = analyze_run(&run);
-        if !report.route_breakdowns.is_empty() {
-            assert!(report.route_breakdowns.iter().all(|route| route
-                .warnings
-                .iter()
-                .any(|warning| warning == super::ROUTE_RUNTIME_ATTRIBUTION_WARNING)));
+        for idx in 5..=7 {
+            let mut req = sample_request(idx);
+            req.route = "/b".into();
+            req.latency_us = 2_000;
+            run.requests.push(req);
         }
+        // Below threshold route must be omitted.
+        for idx in 8..=9 {
+            let mut req = sample_request(idx);
+            req.route = "/c".into();
+            req.latency_us = 50_000;
+            run.requests.push(req);
+        }
+        for req_id in ["req-1", "req-2", "req-3", "req-4"] {
+            run.queues.push(QueueEvent {
+                request_id: req_id.to_owned(),
+                queue: "ingress".into(),
+                wait_us: 9_000,
+                waited_from_unix_ms: 0,
+                waited_until_unix_ms: 1,
+                depth_at_start: Some(9),
+            });
+        }
+        for req_id in ["req-5", "req-6", "req-7"] {
+            run.stages.push(StageEvent {
+                request_id: req_id.to_owned(),
+                stage: "db".into(),
+                started_at_unix_ms: 1,
+                finished_at_unix_ms: 2,
+                latency_us: 1_900,
+                success: true,
+            });
+        }
+        run.runtime_snapshots = vec![runtime_snapshot(Some(200), Some(140), Some(180))];
+        let report = analyze_run(&run);
+        assert_eq!(report.route_breakdowns.len(), 2);
+        assert_eq!(report.route_breakdowns[0].route, "/a");
+        assert_eq!(report.route_breakdowns[1].route, "/b");
+        assert!(report
+            .warnings
+            .iter()
+            .any(|warning| warning == ROUTE_DIVERGENCE_WARNING));
+        assert!(report.route_breakdowns.iter().all(|rb| rb
+            .warnings
+            .iter()
+            .any(|warning| warning == ROUTE_RUNTIME_ATTRIBUTION_WARNING)));
+        assert!(report.route_breakdowns.iter().all(|rb| rb
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("fewer than 3 completed requests"))));
+        assert!(report.route_breakdowns.iter().all(|rb| rb
+            .secondary_suspects
+            .iter()
+            .all(|s| s.kind != DiagnosisKind::ExecutorPressureSuspected
+                && s.kind != DiagnosisKind::BlockingPoolPressure)));
+        let value = serde_json::to_value(&report).expect("serialize report");
+        for breakdown in value
+            .get("route_breakdowns")
+            .and_then(serde_json::Value::as_array)
+            .expect("route_breakdowns array")
+        {
+            assert!(breakdown.get("route_breakdowns").is_none());
+        }
+    }
+
+    #[test]
+    fn route_breakdowns_do_not_change_global_primary_suspect() {
+        let mut run = test_run();
+        run.runtime_snapshots = vec![runtime_snapshot(Some(300), Some(250), Some(200))];
+        let global = analyze_run_internal(&run);
+        let report = analyze_run(&run);
+        assert_eq!(report.primary_suspect.kind, global.primary_suspect.kind);
+        assert_eq!(report.primary_suspect.score, global.primary_suspect.score);
     }
 }

--- a/validation/diagnostics/manifest.json
+++ b/validation/diagnostics/manifest.json
@@ -69,8 +69,7 @@
       "notes": "Blocking pool backlog is intentional pre-fix condition.",
       "expected_warnings": [
         "Runtime snapshots are missing",
-        "Top suspects are close in score",
-        "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
+        "Top suspects are close in score"
       ],
       "top1_required": true,
       "allowed_warnings": [],
@@ -126,9 +125,7 @@
         "Global queue depth"
       ],
       "notes": "Executor-pressure demo before mitigation should prioritize executor suspect.",
-      "expected_warnings": [
-        "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
-      ],
+      "expected_warnings": [],
       "top1_required": true,
       "allowed_warnings": [],
       "required_top2": [
@@ -153,9 +150,7 @@
         "Runtime global queue depth"
       ],
       "notes": "Post-mitigation executor pressure reduces, but executor remains the expected true cause in this fixture; downstream may appear as an acceptable alternate primary.",
-      "expected_warnings": [
-        "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
-      ],
+      "expected_warnings": [],
       "top1_required": false,
       "allowed_warnings": [],
       "required_top2": [
@@ -518,8 +513,7 @@
       "notes": "Blocking sample is canonical blocking saturation evidence.",
       "expected_warnings": [
         "Runtime snapshots are missing",
-        "Top suspects are close in score",
-        "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
+        "Top suspects are close in score"
       ],
       "top1_required": true,
       "allowed_warnings": [],
@@ -545,9 +539,7 @@
         "Global queue depth"
       ],
       "notes": "Executor sample has clear runtime queue pressure cues.",
-      "expected_warnings": [
-        "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
-      ],
+      "expected_warnings": [],
       "top1_required": true,
       "allowed_warnings": [],
       "required_top2": [

--- a/validation/diagnostics/manifest.json
+++ b/validation/diagnostics/manifest.json
@@ -69,7 +69,8 @@
       "notes": "Blocking pool backlog is intentional pre-fix condition.",
       "expected_warnings": [
         "Runtime snapshots are missing",
-        "Top suspects are close in score"
+        "Top suspects are close in score",
+        "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
       ],
       "top1_required": true,
       "allowed_warnings": [],
@@ -125,7 +126,9 @@
         "Global queue depth"
       ],
       "notes": "Executor-pressure demo before mitigation should prioritize executor suspect.",
-      "expected_warnings": [],
+      "expected_warnings": [
+        "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
+      ],
       "top1_required": true,
       "allowed_warnings": [],
       "required_top2": [
@@ -150,7 +153,9 @@
         "Runtime global queue depth"
       ],
       "notes": "Post-mitigation executor pressure reduces, but executor remains the expected true cause in this fixture; downstream may appear as an acceptable alternate primary.",
-      "expected_warnings": [],
+      "expected_warnings": [
+        "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
+      ],
       "top1_required": false,
       "allowed_warnings": [],
       "required_top2": [
@@ -513,7 +518,8 @@
       "notes": "Blocking sample is canonical blocking saturation evidence.",
       "expected_warnings": [
         "Runtime snapshots are missing",
-        "Top suspects are close in score"
+        "Top suspects are close in score",
+        "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
       ],
       "top1_required": true,
       "allowed_warnings": [],
@@ -539,7 +545,9 @@
         "Global queue depth"
       ],
       "notes": "Executor sample has clear runtime queue pressure cues.",
-      "expected_warnings": [],
+      "expected_warnings": [
+        "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
+      ],
       "top1_required": true,
       "allowed_warnings": [],
       "required_top2": [


### PR DESCRIPTION
### Motivation
- Improve diagnosis signal by surfacing per-route triage summaries when routes show different bottleneck families that the global aggregation can hide.
- Preserve the existing global report and suspect-ranking semantics while providing supporting route-level context, and avoid attributing global runtime/in-flight signals to individual routes.

### Description
- Add a new always-present `route_breakdowns: Vec<RouteBreakdown>` field on `Report` and a serializable `RouteBreakdown` struct with the requested fields including `evidence_quality`, `primary_suspect`, `secondary_suspects`, and `warnings`.
- Refactor analysis into a reusable `analyze_run_internal(&Run)` function and implement `analyze_run(&Run)` as the global flow that layers route breakdown generation on top, with `filtered_run_for_route` producing a route-filtered `Run` (requests, stages, queues) that explicitly clears runtime and in-flight snapshots.
- Implement deterministic, bounded route-emission rules (min 3 completed requests, divergence/latency gates, top-10 cap, sorting by p95 desc/request_count desc/route), add omission notes for under-threshold routes, and add the stable divergence warning text `Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect.` when appropriate.
- Ensure truthful attribution by omitting runtime/in-flight snapshots from route-filtered analyses and adding the route-level warning `Runtime and in-flight signals are global and are not attributed to this route.`, update compact text rendering to include a minimal route-breakdown section only when non-empty, and refresh demo fixtures and docs to reflect the new field and its interpretation limits.

### Testing
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` and all checks/tests passed successfully.
- Refreshed and re-validated demo fixtures with `python3 scripts/check_demo_fixture_drift.py --profile dev --refresh` and re-ran the non-refresh check; fixture updates were intentional and the checks passed.
- Ran the diagnostic benchmark and validation suite (`python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json ...`, `python3 -m unittest scripts.tests.test_diagnostic_benchmark`, `python3 scripts/validate_docs_contracts.py`, and `python3 -m unittest scripts.tests.test_validate_docs_contracts`); after updating expected warnings in the validation manifest to account for the stable divergence warning all per-case checks and validation tests passed.
- Confirmed global suspect ranking logic remained unchanged and only an additive divergence warning and supporting route context were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9a776be488330bef8d435b4d451ea)