### PR TITLE
Add route-level analyzer breakdowns while keeping global suspect primary

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,10 @@ tailtriage analyze tailtriage-run.json --format json
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
+  "route_breakdowns": [],
   "secondary_suspects": [
     {
       "kind": "downstream_stage_dominates",
@@ -206,7 +208,8 @@ tailtriage analyze tailtriage-run.json --format json
         "Inspect downstream dependency behind stage 'simulated_work'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": ["Top suspects are close in score; confidence is capped by ambiguity."]
     }
   ]
 }

--- a/demos/blocking_service/fixtures/after-analysis.json
+++ b/demos/blocking_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 250,
-  "p50_latency_us": 54509,
-  "p95_latency_us": 87050,
-  "p99_latency_us": 91039,
-  "p95_queue_share_permille": 56,
+  "p50_latency_us": 51669,
+  "p95_latency_us": 88637,
+  "p99_latency_us": 92013,
+  "p95_queue_share_permille": 63,
   "p95_service_share_permille": 993,
   "inflight_trend": {
     "gauge": "blocking_service_inflight",
     "sample_count": 500,
-    "peak_count": 49,
-    "p95_count": 46,
+    "peak_count": 50,
+    "p95_count": 47,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2044
+    "growth_per_sec_milli": -2032
   },
   "warnings": [
     "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited."
@@ -43,15 +43,16 @@
     "score": 100,
     "confidence": "high",
     "evidence": [
-      "Stage 'spawn_blocking_path' has p95 latency 85870 us across 250 samples.",
-      "Stage 'spawn_blocking_path' cumulative latency is 13010681 us (978 permille of request latency).",
+      "Stage 'spawn_blocking_path' has p95 latency 87428 us across 250 samples.",
+      "Stage 'spawn_blocking_path' cumulative latency is 13021115 us (976 permille of request latency).",
       "Stage 'spawn_blocking_path' contributes 986 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -59,12 +60,14 @@
       "score": 82,
       "confidence": "medium",
       "evidence": [
-        "Blocking queue depth p95 is 42, peak is 48, with 98/200 nonzero samples."
+        "Blocking queue depth p95 is 44, peak is 49, with 98/200 nonzero samples."
       ],
       "next_checks": [
         "Audit blocking sections and move avoidable synchronous work out of hot paths.",
         "Inspect spawn_blocking callsites for long-running CPU or I/O work."
-      ]
+      ],
+      "confidence_notes": []
     }
-  ]
+  ],
+  "route_breakdowns": []
 }

--- a/demos/blocking_service/fixtures/before-analysis.json
+++ b/demos/blocking_service/fixtures/before-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 250,
-  "p50_latency_us": 1868185,
-  "p95_latency_us": 3531495,
-  "p99_latency_us": 3680957,
+  "p50_latency_us": 1868543,
+  "p95_latency_us": 3527763,
+  "p99_latency_us": 3677506,
   "p95_queue_share_permille": 6,
   "p95_service_share_permille": 999,
   "inflight_trend": {
@@ -15,7 +15,8 @@
   },
   "warnings": [
     "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited.",
-    "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks."
+    "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks.",
+    "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
   ],
   "evidence_quality": {
     "request_count": 250,
@@ -42,13 +43,17 @@
   "primary_suspect": {
     "kind": "blocking_pool_pressure",
     "score": 88,
-    "confidence": "high",
+    "confidence": "medium",
     "evidence": [
-      "Blocking queue depth p95 is 244, peak is 246, with 200/200 nonzero samples."
+      "Blocking queue depth p95 is 242, peak is 246, with 200/200 nonzero samples."
     ],
     "next_checks": [
       "Audit blocking sections and move avoidable synchronous work out of hot paths.",
       "Inspect spawn_blocking callsites for long-running CPU or I/O work."
+    ],
+    "confidence_notes": [
+      "Missing runtime snapshots limit executor/blocking confidence.",
+      "Top suspects are close in score; confidence is capped by ambiguity."
     ]
   },
   "secondary_suspects": [
@@ -57,8 +62,8 @@
       "score": 86,
       "confidence": "high",
       "evidence": [
-        "Stage 'spawn_blocking_path' has p95 latency 3530254 us across 250 samples.",
-        "Stage 'spawn_blocking_path' cumulative latency is 467061987 us (999 permille of request latency).",
+        "Stage 'spawn_blocking_path' has p95 latency 3526231 us across 250 samples.",
+        "Stage 'spawn_blocking_path' cumulative latency is 466912106 us (999 permille of request latency).",
         "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency.",
         "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
       ],
@@ -66,6 +71,61 @@
         "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
+      ],
+      "confidence_notes": []
+    }
+  ],
+  "route_breakdowns": [
+    {
+      "route": "/blocking-demo",
+      "request_count": 250,
+      "p50_latency_us": 1868543,
+      "p95_latency_us": 3527763,
+      "p99_latency_us": 3677506,
+      "p95_queue_share_permille": 6,
+      "p95_service_share_permille": 999,
+      "evidence_quality": {
+        "request_count": 250,
+        "queue_event_count": 250,
+        "stage_event_count": 250,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 0,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "missing",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation.",
+          "Runtime and in-flight signals are global and are not attributed to this route."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "downstream_stage_dominates",
+        "score": 100,
+        "confidence": "high",
+        "evidence": [
+          "Stage 'spawn_blocking_path' has p95 latency 3526231 us across 250 samples.",
+          "Stage 'spawn_blocking_path' cumulative latency is 466912106 us (999 permille of request latency).",
+          "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency."
+        ],
+        "next_checks": [
+          "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
+          "Collect downstream service timings and retry behavior during tail windows.",
+          "Review downstream SLO/error budget and align retry budget/backoff with it."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [],
+      "warnings": [
+        "Runtime and in-flight signals are global and are not attributed to this route."
       ]
     }
   ]

--- a/demos/blocking_service/fixtures/sample-analysis.json
+++ b/demos/blocking_service/fixtures/sample-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 250,
-  "p50_latency_us": 1868185,
-  "p95_latency_us": 3531495,
-  "p99_latency_us": 3680957,
+  "p50_latency_us": 1868543,
+  "p95_latency_us": 3527763,
+  "p99_latency_us": 3677506,
   "p95_queue_share_permille": 6,
   "p95_service_share_permille": 999,
   "inflight_trend": {
@@ -15,7 +15,8 @@
   },
   "warnings": [
     "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited.",
-    "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks."
+    "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks.",
+    "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
   ],
   "evidence_quality": {
     "request_count": 250,
@@ -42,13 +43,17 @@
   "primary_suspect": {
     "kind": "blocking_pool_pressure",
     "score": 88,
-    "confidence": "high",
+    "confidence": "medium",
     "evidence": [
-      "Blocking queue depth p95 is 244, peak is 246, with 200/200 nonzero samples."
+      "Blocking queue depth p95 is 242, peak is 246, with 200/200 nonzero samples."
     ],
     "next_checks": [
       "Audit blocking sections and move avoidable synchronous work out of hot paths.",
       "Inspect spawn_blocking callsites for long-running CPU or I/O work."
+    ],
+    "confidence_notes": [
+      "Missing runtime snapshots limit executor/blocking confidence.",
+      "Top suspects are close in score; confidence is capped by ambiguity."
     ]
   },
   "secondary_suspects": [
@@ -57,8 +62,8 @@
       "score": 86,
       "confidence": "high",
       "evidence": [
-        "Stage 'spawn_blocking_path' has p95 latency 3530254 us across 250 samples.",
-        "Stage 'spawn_blocking_path' cumulative latency is 467061987 us (999 permille of request latency).",
+        "Stage 'spawn_blocking_path' has p95 latency 3526231 us across 250 samples.",
+        "Stage 'spawn_blocking_path' cumulative latency is 466912106 us (999 permille of request latency).",
         "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency.",
         "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
       ],
@@ -66,6 +71,61 @@
         "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
+      ],
+      "confidence_notes": []
+    }
+  ],
+  "route_breakdowns": [
+    {
+      "route": "/blocking-demo",
+      "request_count": 250,
+      "p50_latency_us": 1868543,
+      "p95_latency_us": 3527763,
+      "p99_latency_us": 3677506,
+      "p95_queue_share_permille": 6,
+      "p95_service_share_permille": 999,
+      "evidence_quality": {
+        "request_count": 250,
+        "queue_event_count": 250,
+        "stage_event_count": 250,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 0,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "missing",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation.",
+          "Runtime and in-flight signals are global and are not attributed to this route."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "downstream_stage_dominates",
+        "score": 100,
+        "confidence": "high",
+        "evidence": [
+          "Stage 'spawn_blocking_path' has p95 latency 3526231 us across 250 samples.",
+          "Stage 'spawn_blocking_path' cumulative latency is 466912106 us (999 permille of request latency).",
+          "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency."
+        ],
+        "next_checks": [
+          "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
+          "Collect downstream service timings and retry behavior during tail windows.",
+          "Review downstream SLO/error budget and align retry budget/backoff with it."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [],
+      "warnings": [
+        "Runtime and in-flight signals are global and are not attributed to this route."
       ]
     }
   ]

--- a/demos/cold_start_burst_service/fixtures/after-analysis.json
+++ b/demos/cold_start_burst_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 8489,
-  "p95_latency_us": 8877,
-  "p99_latency_us": 9039,
+  "p50_latency_us": 8060,
+  "p95_latency_us": 9110,
+  "p99_latency_us": 18246,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 999,
   "inflight_trend": {
@@ -11,7 +11,7 @@
     "peak_count": 4,
     "p95_count": 3,
     "growth_delta": -1,
-    "growth_per_sec_milli": -1064
+    "growth_per_sec_milli": -1011
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,15 +41,17 @@
     "score": 100,
     "confidence": "high",
     "evidence": [
-      "Stage 'cold_start_stage' has p95 latency 8837 us across 220 samples.",
-      "Stage 'cold_start_stage' cumulative latency is 1823038 us (996 permille of request latency).",
-      "Stage 'cold_start_stage' contributes 995 permille of tail request latency."
+      "Stage 'cold_start_stage' has p95 latency 9055 us across 220 samples.",
+      "Stage 'cold_start_stage' cumulative latency is 1816417 us (993 permille of request latency).",
+      "Stage 'cold_start_stage' contributes 970 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'cold_start_stage'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }

--- a/demos/cold_start_burst_service/fixtures/before-analysis.json
+++ b/demos/cold_start_burst_service/fixtures/before-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 993483,
-  "p95_latency_us": 1190031,
-  "p99_latency_us": 1206824,
+  "p50_latency_us": 996817,
+  "p95_latency_us": 1198021,
+  "p99_latency_us": 1214434,
   "p95_queue_share_permille": 993,
-  "p95_service_share_permille": 336,
+  "p95_service_share_permille": 332,
   "inflight_trend": {
     "gauge": "cold_start_burst_inflight",
     "sample_count": 440,
     "peak_count": 220,
     "p95_count": 209,
-    "growth_delta": 0,
-    "growth_per_sec_milli": 0
+    "growth_delta": -1,
+    "growth_per_sec_milli": -809
   },
   "warnings": [],
   "evidence_quality": {
@@ -47,7 +47,8 @@
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -55,15 +56,17 @@
       "score": 32,
       "confidence": "low",
       "evidence": [
-        "Stage 'cold_start_stage' has p95 latency 63617 us across 220 samples.",
-        "Stage 'cold_start_stage' cumulative latency is 4876046 us (24 permille of request latency).",
+        "Stage 'cold_start_stage' has p95 latency 63879 us across 220 samples.",
+        "Stage 'cold_start_stage' cumulative latency is 4911150 us (24 permille of request latency).",
         "Stage 'cold_start_stage' contributes 6 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'cold_start_stage'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
-  ]
+  ],
+  "route_breakdowns": []
 }

--- a/demos/db_pool_saturation_service/fixtures/after-analysis.json
+++ b/demos/db_pool_saturation_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 13254,
-  "p95_latency_us": 14196,
-  "p99_latency_us": 14321,
+  "p50_latency_us": 13491,
+  "p95_latency_us": 15080,
+  "p99_latency_us": 26851,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,7 +11,7 @@
     "peak_count": 10,
     "p95_count": 10,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2710
+    "growth_per_sec_milli": -2506
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,15 +41,17 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'db_query' has p95 latency 11927 us across 220 samples.",
-      "Stage 'db_query' cumulative latency is 2440495 us (833 permille of request latency).",
-      "Stage 'db_query' contributes 841 permille of tail request latency."
+      "Stage 'db_query' has p95 latency 12129 us across 220 samples.",
+      "Stage 'db_query' cumulative latency is 2515951 us (820 permille of request latency).",
+      "Stage 'db_query' contributes 763 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'db_query'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }

--- a/demos/db_pool_saturation_service/fixtures/before-analysis.json
+++ b/demos/db_pool_saturation_service/fixtures/before-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 498135,
-  "p95_latency_us": 927602,
-  "p99_latency_us": 961905,
+  "p50_latency_us": 490685,
+  "p95_latency_us": 932768,
+  "p99_latency_us": 967038,
   "p95_queue_share_permille": 976,
-  "p95_service_share_permille": 368,
+  "p95_service_share_permille": 389,
   "inflight_trend": {
     "gauge": "db_pool_saturation_inflight",
     "sample_count": 440,
     "peak_count": 200,
-    "p95_count": 193,
-    "growth_delta": 2,
-    "growth_per_sec_milli": 1872
+    "p95_count": 189,
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
   },
   "warnings": [],
   "evidence_quality": {
@@ -42,13 +42,13 @@
     "confidence": "high",
     "evidence": [
       "Queue wait at p95 consumes 97.6% of request time.",
-      "Observed queue depth sample up to 196.",
-      "In-flight gauge 'db_pool_saturation_inflight' grew by 2 over the run window (p95=193, peak=200)."
+      "Observed queue depth sample up to 196."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -56,15 +56,17 @@
       "score": 34,
       "confidence": "low",
       "evidence": [
-        "Stage 'db_query' has p95 latency 19752 us across 220 samples.",
-        "Stage 'db_query' cumulative latency is 4247545 us (38 permille of request latency).",
+        "Stage 'db_query' has p95 latency 20068 us across 220 samples.",
+        "Stage 'db_query' cumulative latency is 4260857 us (39 permille of request latency).",
         "Stage 'db_query' contributes 20 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'db_query'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
-  ]
+  ],
+  "route_breakdowns": []
 }

--- a/demos/downstream_service/fixtures/after-analysis.json
+++ b/demos/downstream_service/fixtures/after-analysis.json
@@ -1,15 +1,15 @@
 {
   "request_count": 80,
-  "p50_latency_us": 12294,
-  "p95_latency_us": 13240,
-  "p99_latency_us": 13272,
+  "p50_latency_us": 12655,
+  "p95_latency_us": 13393,
+  "p99_latency_us": 13460,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "downstream_service_inflight",
     "sample_count": 160,
-    "peak_count": 35,
-    "p95_count": 32,
+    "peak_count": 32,
+    "p95_count": 31,
     "growth_delta": 5,
     "growth_per_sec_milli": 108695
   },
@@ -41,15 +41,17 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 10846 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 809068 us (813 permille of request latency).",
-      "Stage 'downstream_call' contributes 804 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 10999 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 833707 us (823 permille of request latency).",
+      "Stage 'downstream_call' contributes 819 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }

--- a/demos/downstream_service/fixtures/before-after-comparison.json
+++ b/demos/downstream_service/fixtures/before-after-comparison.json
@@ -2,19 +2,19 @@
   "before": {
     "primary_suspect_kind": "downstream_stage_dominates",
     "primary_suspect_score": 95,
-    "p95_latency_us": 24448,
+    "p95_latency_us": 23998,
     "p95_service_share_permille": 1000
   },
   "after": {
     "primary_suspect_kind": "downstream_stage_dominates",
     "primary_suspect_score": 95,
-    "p95_latency_us": 13240,
+    "p95_latency_us": 13393,
     "p95_service_share_permille": 1000
   },
   "delta": {
     "primary_suspect_kind": null,
     "primary_suspect_score": 0,
-    "p95_latency_us": -11208,
+    "p95_latency_us": -10605,
     "p95_service_share_permille": 0
   }
 }

--- a/demos/downstream_service/fixtures/before-analysis.json
+++ b/demos/downstream_service/fixtures/before-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 80,
-  "p50_latency_us": 23531,
-  "p95_latency_us": 24448,
-  "p99_latency_us": 24549,
+  "p50_latency_us": 23250,
+  "p95_latency_us": 23998,
+  "p99_latency_us": 24542,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "downstream_service_inflight",
     "sample_count": 160,
-    "peak_count": 57,
-    "p95_count": 55,
-    "growth_delta": 5,
-    "growth_per_sec_milli": 90909
+    "peak_count": 55,
+    "p95_count": 54,
+    "growth_delta": 4,
+    "growth_per_sec_milli": 64516
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,15 +41,17 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 22135 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 1693727 us (903 permille of request latency).",
-      "Stage 'downstream_call' contributes 904 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 21607 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 1675107 us (897 permille of request latency).",
+      "Stage 'downstream_call' contributes 891 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }

--- a/demos/downstream_service/fixtures/sample-analysis.json
+++ b/demos/downstream_service/fixtures/sample-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 80,
-  "p50_latency_us": 23531,
-  "p95_latency_us": 24448,
-  "p99_latency_us": 24549,
+  "p50_latency_us": 23250,
+  "p95_latency_us": 23998,
+  "p99_latency_us": 24542,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "downstream_service_inflight",
     "sample_count": 160,
-    "peak_count": 57,
-    "p95_count": 55,
-    "growth_delta": 5,
-    "growth_per_sec_milli": 90909
+    "peak_count": 55,
+    "p95_count": 54,
+    "growth_delta": 4,
+    "growth_per_sec_milli": 64516
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,15 +41,17 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 22135 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 1693727 us (903 permille of request latency).",
-      "Stage 'downstream_call' contributes 904 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 21607 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 1675107 us (897 permille of request latency).",
+      "Stage 'downstream_call' contributes 891 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }

--- a/demos/executor_pressure_service/fixtures/after-analysis.json
+++ b/demos/executor_pressure_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 240,
-  "p50_latency_us": 7284295,
-  "p95_latency_us": 7413192,
-  "p99_latency_us": 7423728,
+  "p50_latency_us": 12913378,
+  "p95_latency_us": 13009138,
+  "p99_latency_us": 13016402,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,14 +11,16 @@
     "peak_count": 240,
     "p95_count": 228,
     "growth_delta": -1,
-    "growth_per_sec_milli": -134
+    "growth_per_sec_milli": -76
   },
-  "warnings": [],
+  "warnings": [
+    "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
+  ],
   "evidence_quality": {
     "request_count": 240,
     "queue_event_count": 0,
     "stage_event_count": 0,
-    "runtime_snapshot_count": 7433,
+    "runtime_snapshot_count": 13041,
     "inflight_snapshot_count": 480,
     "requests": "present",
     "queues": "missing",
@@ -42,13 +44,67 @@
     "confidence": "high",
     "evidence": [
       "Runtime global queue depth p95 is 720, suggesting scheduler contention.",
-      "Runtime local queue depth p95 is 4656.",
+      "Runtime local queue depth p95 is 4155.",
       "Runtime alive_tasks p95 is 720."
     ],
     "next_checks": [
       "Check for long polls without yielding and uneven task fan-out.",
       "Compare with per-stage timings to isolate overloaded async stages."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": [
+    {
+      "route": "/executor-pressure",
+      "request_count": 240,
+      "p50_latency_us": 12913378,
+      "p95_latency_us": 13009138,
+      "p99_latency_us": 13016402,
+      "p95_queue_share_permille": 0,
+      "p95_service_share_permille": 1000,
+      "evidence_quality": {
+        "request_count": 240,
+        "queue_event_count": 0,
+        "stage_event_count": 0,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 0,
+        "requests": "present",
+        "queues": "missing",
+        "stages": "missing",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "missing",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "weak",
+        "limitations": [
+          "Queue and stage instrumentation are both unavailable, limiting application vs downstream interpretation.",
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation.",
+          "Runtime and in-flight signals are global and are not attributed to this route."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "insufficient_evidence",
+        "score": 50,
+        "confidence": "low",
+        "evidence": [
+          "Not enough queue, stage, or runtime signals to rank a stronger suspect."
+        ],
+        "next_checks": [
+          "Wrap critical awaits with queue(...).await_on(...), and use stage(...).await_on(...) for Result-returning work or stage(...).await_value(...) for infallible work.",
+          "Enable RuntimeSampler during the run to capture runtime pressure signals."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [],
+      "warnings": [
+        "No runtime snapshots captured; executor and blocking-pressure interpretation is limited.",
+        "Runtime and in-flight signals are global and are not attributed to this route."
+      ]
+    }
+  ]
 }

--- a/demos/executor_pressure_service/fixtures/before-analysis.json
+++ b/demos/executor_pressure_service/fixtures/before-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 240,
-  "p50_latency_us": 34531979,
-  "p95_latency_us": 34596797,
-  "p99_latency_us": 34604649,
+  "p50_latency_us": 61590853,
+  "p95_latency_us": 61707325,
+  "p99_latency_us": 61736190,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -10,15 +10,17 @@
     "sample_count": 480,
     "peak_count": 240,
     "p95_count": 228,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -28
+    "growth_delta": 1,
+    "growth_per_sec_milli": 16
   },
-  "warnings": [],
+  "warnings": [
+    "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
+  ],
   "evidence_quality": {
     "request_count": 240,
     "queue_event_count": 0,
     "stage_event_count": 0,
-    "runtime_snapshot_count": 6377,
+    "runtime_snapshot_count": 34397,
     "inflight_snapshot_count": 480,
     "requests": "present",
     "queues": "missing",
@@ -38,17 +40,71 @@
   },
   "primary_suspect": {
     "kind": "executor_pressure_suspected",
-    "score": 99,
+    "score": 100,
     "confidence": "high",
     "evidence": [
       "Runtime global queue depth p95 is 1920, suggesting scheduler contention.",
-      "Runtime local queue depth p95 is 42232.",
+      "Runtime local queue depth p95 is 22912.",
       "Runtime alive_tasks p95 is 1920."
     ],
     "next_checks": [
       "Check for long polls without yielding and uneven task fan-out.",
       "Compare with per-stage timings to isolate overloaded async stages."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": [
+    {
+      "route": "/executor-pressure",
+      "request_count": 240,
+      "p50_latency_us": 61590853,
+      "p95_latency_us": 61707325,
+      "p99_latency_us": 61736190,
+      "p95_queue_share_permille": 0,
+      "p95_service_share_permille": 1000,
+      "evidence_quality": {
+        "request_count": 240,
+        "queue_event_count": 0,
+        "stage_event_count": 0,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 0,
+        "requests": "present",
+        "queues": "missing",
+        "stages": "missing",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "missing",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "weak",
+        "limitations": [
+          "Queue and stage instrumentation are both unavailable, limiting application vs downstream interpretation.",
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation.",
+          "Runtime and in-flight signals are global and are not attributed to this route."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "insufficient_evidence",
+        "score": 50,
+        "confidence": "low",
+        "evidence": [
+          "Not enough queue, stage, or runtime signals to rank a stronger suspect."
+        ],
+        "next_checks": [
+          "Wrap critical awaits with queue(...).await_on(...), and use stage(...).await_on(...) for Result-returning work or stage(...).await_value(...) for infallible work.",
+          "Enable RuntimeSampler during the run to capture runtime pressure signals."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [],
+      "warnings": [
+        "No runtime snapshots captured; executor and blocking-pressure interpretation is limited.",
+        "Runtime and in-flight signals are global and are not attributed to this route."
+      ]
+    }
+  ]
 }

--- a/demos/executor_pressure_service/fixtures/sample-analysis.json
+++ b/demos/executor_pressure_service/fixtures/sample-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 240,
-  "p50_latency_us": 34531979,
-  "p95_latency_us": 34596797,
-  "p99_latency_us": 34604649,
+  "p50_latency_us": 61590853,
+  "p95_latency_us": 61707325,
+  "p99_latency_us": 61736190,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -10,15 +10,17 @@
     "sample_count": 480,
     "peak_count": 240,
     "p95_count": 228,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -28
+    "growth_delta": 1,
+    "growth_per_sec_milli": 16
   },
-  "warnings": [],
+  "warnings": [
+    "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
+  ],
   "evidence_quality": {
     "request_count": 240,
     "queue_event_count": 0,
     "stage_event_count": 0,
-    "runtime_snapshot_count": 6377,
+    "runtime_snapshot_count": 34397,
     "inflight_snapshot_count": 480,
     "requests": "present",
     "queues": "missing",
@@ -38,17 +40,71 @@
   },
   "primary_suspect": {
     "kind": "executor_pressure_suspected",
-    "score": 99,
+    "score": 100,
     "confidence": "high",
     "evidence": [
       "Runtime global queue depth p95 is 1920, suggesting scheduler contention.",
-      "Runtime local queue depth p95 is 42232.",
+      "Runtime local queue depth p95 is 22912.",
       "Runtime alive_tasks p95 is 1920."
     ],
     "next_checks": [
       "Check for long polls without yielding and uneven task fan-out.",
       "Compare with per-stage timings to isolate overloaded async stages."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": [
+    {
+      "route": "/executor-pressure",
+      "request_count": 240,
+      "p50_latency_us": 61590853,
+      "p95_latency_us": 61707325,
+      "p99_latency_us": 61736190,
+      "p95_queue_share_permille": 0,
+      "p95_service_share_permille": 1000,
+      "evidence_quality": {
+        "request_count": 240,
+        "queue_event_count": 0,
+        "stage_event_count": 0,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 0,
+        "requests": "present",
+        "queues": "missing",
+        "stages": "missing",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "missing",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "weak",
+        "limitations": [
+          "Queue and stage instrumentation are both unavailable, limiting application vs downstream interpretation.",
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation.",
+          "Runtime and in-flight signals are global and are not attributed to this route."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "insufficient_evidence",
+        "score": 50,
+        "confidence": "low",
+        "evidence": [
+          "Not enough queue, stage, or runtime signals to rank a stronger suspect."
+        ],
+        "next_checks": [
+          "Wrap critical awaits with queue(...).await_on(...), and use stage(...).await_on(...) for Result-returning work or stage(...).await_value(...) for infallible work.",
+          "Enable RuntimeSampler during the run to capture runtime pressure signals."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [],
+      "warnings": [
+        "No runtime snapshots captured; executor and blocking-pressure interpretation is limited.",
+        "Runtime and in-flight signals are global and are not attributed to this route."
+      ]
+    }
+  ]
 }

--- a/demos/mixed_contention_service/fixtures/baseline-analysis.json
+++ b/demos/mixed_contention_service/fixtures/baseline-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 393750,
-  "p95_latency_us": 738845,
-  "p99_latency_us": 767621,
-  "p95_queue_share_permille": 980,
-  "p95_service_share_permille": 402,
+  "p50_latency_us": 388675,
+  "p95_latency_us": 752024,
+  "p99_latency_us": 784895,
+  "p95_queue_share_permille": 979,
+  "p95_service_share_permille": 393,
   "inflight_trend": {
     "gauge": "mixed_contention_inflight",
     "sample_count": 440,
-    "peak_count": 200,
+    "peak_count": 198,
     "p95_count": 190,
     "growth_delta": -1,
-    "growth_per_sec_milli": -1160
+    "growth_per_sec_milli": -1137
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,13 +41,14 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Queue wait at p95 consumes 98.0% of request time.",
-      "Observed queue depth sample up to 195."
+      "Queue wait at p95 consumes 97.9% of request time.",
+      "Observed queue depth sample up to 193."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -55,15 +56,17 @@
       "score": 35,
       "confidence": "low",
       "evidence": [
-        "Stage 'downstream_call' has p95 latency 32531 us across 220 samples.",
-        "Stage 'downstream_call' cumulative latency is 3775687 us (43 permille of request latency).",
-        "Stage 'downstream_call' contributes 23 permille of tail request latency."
+        "Stage 'downstream_call' has p95 latency 32569 us across 220 samples.",
+        "Stage 'downstream_call' cumulative latency is 3870457 us (44 permille of request latency).",
+        "Stage 'downstream_call' contributes 27 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'downstream_call'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
-  ]
+  ],
+  "route_breakdowns": []
 }

--- a/demos/mixed_contention_service/fixtures/mitigated-analysis.json
+++ b/demos/mixed_contention_service/fixtures/mitigated-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 14399,
-  "p95_latency_us": 34450,
-  "p99_latency_us": 35029,
+  "p50_latency_us": 14630,
+  "p95_latency_us": 35041,
+  "p99_latency_us": 35330,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,7 +11,7 @@
     "peak_count": 14,
     "p95_count": 13,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2631
+    "growth_per_sec_milli": -2525
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,15 +41,17 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 32570 us across 220 samples.",
-      "Stage 'downstream_call' cumulative latency is 3763084 us (889 permille of request latency).",
-      "Stage 'downstream_call' contributes 933 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 32560 us across 220 samples.",
+      "Stage 'downstream_call' cumulative latency is 3778348 us (882 permille of request latency).",
+      "Stage 'downstream_call' contributes 927 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }

--- a/demos/queue_service/fixtures/after-analysis.json
+++ b/demos/queue_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 250,
-  "p50_latency_us": 16086,
-  "p95_latency_us": 17037,
-  "p99_latency_us": 19055,
+  "p50_latency_us": 16251,
+  "p95_latency_us": 16914,
+  "p99_latency_us": 17132,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
-    "peak_count": 16,
-    "p95_count": 12,
+    "peak_count": 12,
+    "p95_count": 11,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2386
+    "growth_per_sec_milli": -2288
   },
   "warnings": [],
   "evidence_quality": {
@@ -38,18 +38,20 @@
   },
   "primary_suspect": {
     "kind": "downstream_stage_dominates",
-    "score": 95,
+    "score": 100,
     "confidence": "high",
     "evidence": [
-      "Stage 'simulated_work' has p95 latency 16919 us across 250 samples.",
-      "Stage 'simulated_work' cumulative latency is 4031794 us (995 permille of request latency).",
-      "Stage 'simulated_work' contributes 955 permille of tail request latency."
+      "Stage 'simulated_work' has p95 latency 16896 us across 250 samples.",
+      "Stage 'simulated_work' cumulative latency is 4052707 us (997 permille of request latency).",
+      "Stage 'simulated_work' contributes 998 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'simulated_work'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }

--- a/demos/queue_service/fixtures/before-analysis.json
+++ b/demos/queue_service/fixtures/before-analysis.json
@@ -1,10 +1,10 @@
 {
   "request_count": 250,
-  "p50_latency_us": 783889,
-  "p95_latency_us": 1463903,
-  "p99_latency_us": 1514094,
-  "p95_queue_share_permille": 982,
-  "p95_service_share_permille": 269,
+  "p50_latency_us": 781757,
+  "p95_latency_us": 1466561,
+  "p99_latency_us": 1515386,
+  "p95_queue_share_permille": 981,
+  "p95_service_share_permille": 266,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
@@ -41,13 +41,14 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Queue wait at p95 consumes 98.2% of request time.",
+      "Queue wait at p95 consumes 98.1% of request time.",
       "Observed queue depth sample up to 230."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -55,15 +56,17 @@
       "score": 33,
       "confidence": "low",
       "evidence": [
-        "Stage 'simulated_work' has p95 latency 26681 us across 250 samples.",
-        "Stage 'simulated_work' cumulative latency is 6548608 us (33 permille of request latency).",
+        "Stage 'simulated_work' has p95 latency 26919 us across 250 samples.",
+        "Stage 'simulated_work' cumulative latency is 6570881 us (33 permille of request latency).",
         "Stage 'simulated_work' contributes 17 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'simulated_work'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
-  ]
+  ],
+  "route_breakdowns": []
 }

--- a/demos/queue_service/fixtures/sample-analysis.json
+++ b/demos/queue_service/fixtures/sample-analysis.json
@@ -1,10 +1,10 @@
 {
   "request_count": 250,
-  "p50_latency_us": 783889,
-  "p95_latency_us": 1463903,
-  "p99_latency_us": 1514094,
-  "p95_queue_share_permille": 982,
-  "p95_service_share_permille": 269,
+  "p50_latency_us": 781757,
+  "p95_latency_us": 1466561,
+  "p99_latency_us": 1515386,
+  "p95_queue_share_permille": 981,
+  "p95_service_share_permille": 266,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
@@ -41,13 +41,14 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Queue wait at p95 consumes 98.2% of request time.",
+      "Queue wait at p95 consumes 98.1% of request time.",
       "Observed queue depth sample up to 230."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -55,15 +56,17 @@
       "score": 33,
       "confidence": "low",
       "evidence": [
-        "Stage 'simulated_work' has p95 latency 26681 us across 250 samples.",
-        "Stage 'simulated_work' cumulative latency is 6548608 us (33 permille of request latency).",
+        "Stage 'simulated_work' has p95 latency 26919 us across 250 samples.",
+        "Stage 'simulated_work' cumulative latency is 6570881 us (33 permille of request latency).",
         "Stage 'simulated_work' contributes 17 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'simulated_work'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
-  ]
+  ],
+  "route_breakdowns": []
 }

--- a/demos/retry_storm_service/fixtures/after-analysis.json
+++ b/demos/retry_storm_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 180,
-  "p50_latency_us": 9513,
-  "p95_latency_us": 29401,
-  "p99_latency_us": 29784,
+  "p50_latency_us": 10045,
+  "p95_latency_us": 29491,
+  "p99_latency_us": 30727,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "retry_storm_inflight",
     "sample_count": 360,
-    "peak_count": 17,
-    "p95_count": 15,
+    "peak_count": 16,
+    "p95_count": 14,
     "growth_delta": -1,
-    "growth_per_sec_milli": -4716
+    "growth_per_sec_milli": -4273
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,15 +41,17 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_total' has p95 latency 27186 us across 180 samples.",
-      "Stage 'downstream_total' cumulative latency is 2154453 us (842 permille of request latency).",
-      "Stage 'downstream_total' contributes 922 permille of tail request latency."
+      "Stage 'downstream_total' has p95 latency 27122 us across 180 samples.",
+      "Stage 'downstream_total' cumulative latency is 2163262 us (833 permille of request latency).",
+      "Stage 'downstream_total' contributes 911 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_total'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }

--- a/demos/retry_storm_service/fixtures/before-analysis.json
+++ b/demos/retry_storm_service/fixtures/before-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 180,
-  "p50_latency_us": 9863,
-  "p95_latency_us": 41148,
-  "p99_latency_us": 42215,
+  "p50_latency_us": 10231,
+  "p95_latency_us": 43062,
+  "p99_latency_us": 44196,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "retry_storm_inflight",
     "sample_count": 360,
-    "peak_count": 57,
-    "p95_count": 54,
+    "peak_count": 50,
+    "p95_count": 46,
     "growth_delta": -1,
-    "growth_per_sec_milli": -9345
+    "growth_per_sec_milli": -8264
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,15 +41,17 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_total' has p95 latency 38902 us across 180 samples.",
-      "Stage 'downstream_total' cumulative latency is 3025771 us (883 permille of request latency).",
-      "Stage 'downstream_total' contributes 945 permille of tail request latency."
+      "Stage 'downstream_total' has p95 latency 40119 us across 180 samples.",
+      "Stage 'downstream_total' cumulative latency is 3056653 us (868 permille of request latency).",
+      "Stage 'downstream_total' contributes 934 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_total'.",
       "Collect downstream service timings and retry behavior during tail windows.",
       "Review downstream SLO/error budget and align retry budget/backoff with it."
-    ]
+    ],
+    "confidence_notes": []
   },
-  "secondary_suspects": []
+  "secondary_suspects": [],
+  "route_breakdowns": []
 }

--- a/demos/shared_state_lock_service/fixtures/after-analysis.json
+++ b/demos/shared_state_lock_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 828874,
-  "p95_latency_us": 1564712,
-  "p99_latency_us": 1623531,
+  "p50_latency_us": 835818,
+  "p95_latency_us": 1589260,
+  "p99_latency_us": 1648726,
   "p95_queue_share_permille": 993,
-  "p95_service_share_permille": 127,
+  "p95_service_share_permille": 120,
   "inflight_trend": {
     "gauge": "shared_state_lock_inflight",
     "sample_count": 440,
-    "peak_count": 201,
+    "peak_count": 200,
     "p95_count": 190,
     "growth_delta": -1,
-    "growth_per_sec_milli": -555
+    "growth_per_sec_milli": -543
   },
   "warnings": [],
   "evidence_quality": {
@@ -42,12 +42,13 @@
     "confidence": "high",
     "evidence": [
       "Queue wait at p95 consumes 99.3% of request time.",
-      "Observed queue depth sample up to 199."
+      "Observed queue depth sample up to 198."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -55,15 +56,17 @@
       "score": 32,
       "confidence": "low",
       "evidence": [
-        "Stage 'shared_state_critical_section' has p95 latency 8269 us across 220 samples.",
-        "Stage 'shared_state_critical_section' cumulative latency is 1787919 us (9 permille of request latency).",
+        "Stage 'shared_state_critical_section' has p95 latency 8600 us across 220 samples.",
+        "Stage 'shared_state_critical_section' cumulative latency is 1818527 us (9 permille of request latency).",
         "Stage 'shared_state_critical_section' contributes 5 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'shared_state_critical_section'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
-  ]
+  ],
+  "route_breakdowns": []
 }

--- a/demos/shared_state_lock_service/fixtures/before-analysis.json
+++ b/demos/shared_state_lock_service/fixtures/before-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 2546348,
-  "p95_latency_us": 4817353,
-  "p99_latency_us": 4999343,
+  "p50_latency_us": 2558638,
+  "p95_latency_us": 4846012,
+  "p99_latency_us": 5028958,
   "p95_queue_share_permille": 994,
-  "p95_service_share_permille": 98,
+  "p95_service_share_permille": 102,
   "inflight_trend": {
     "gauge": "shared_state_lock_inflight",
     "sample_count": 440,
     "peak_count": 217,
     "p95_count": 206,
     "growth_delta": -1,
-    "growth_per_sec_milli": -194
+    "growth_per_sec_milli": -193
   },
   "warnings": [],
   "evidence_quality": {
@@ -42,12 +42,13 @@
     "confidence": "high",
     "evidence": [
       "Queue wait at p95 consumes 99.4% of request time.",
-      "Observed queue depth sample up to 216."
+      "Observed queue depth sample up to 215."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
       "Compare queue wait distribution before and after increasing worker parallelism."
-    ]
+    ],
+    "confidence_notes": []
   },
   "secondary_suspects": [
     {
@@ -55,15 +56,17 @@
       "score": 32,
       "confidence": "low",
       "evidence": [
-        "Stage 'shared_state_critical_section' has p95 latency 23447 us across 220 samples.",
-        "Stage 'shared_state_critical_section' cumulative latency is 5109039 us (9 permille of request latency).",
+        "Stage 'shared_state_critical_section' has p95 latency 23584 us across 220 samples.",
+        "Stage 'shared_state_critical_section' cumulative latency is 5135694 us (9 permille of request latency).",
         "Stage 'shared_state_critical_section' contributes 4 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'shared_state_critical_section'.",
         "Collect downstream service timings and retry behavior during tail windows.",
         "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      ],
+      "confidence_notes": []
     }
-  ]
+  ],
+  "route_breakdowns": []
 }

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -94,6 +94,7 @@ Then run one targeted check, change one thing, and re-run under comparable load.
     "next_checks": ["Inspect queue admission limits and producer burst patterns."],
     "confidence_notes": []
   },
+  "route_breakdowns": [],
   "secondary_suspects": []
 }
 ```

--- a/tailtriage-cli/src/analyze.rs
+++ b/tailtriage-cli/src/analyze.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use serde::{Serialize, Serializer};
 use tailtriage_core::{InFlightSnapshot, Run, RuntimeSnapshot};
@@ -230,6 +230,35 @@ pub struct Report {
     pub primary_suspect: Suspect,
     /// Lower-ranked suspects retained for follow-up triage.
     pub secondary_suspects: Vec<Suspect>,
+    /// Supporting per-route triage summaries when route-level divergence adds signal.
+    pub route_breakdowns: Vec<RouteBreakdown>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+/// Supporting per-route triage summary emitted when route-level divergence adds signal.
+pub struct RouteBreakdown {
+    /// Captured route label from completed request events.
+    pub route: String,
+    /// Completed requests analyzed for this route.
+    pub request_count: usize,
+    /// p50 request latency in microseconds.
+    pub p50_latency_us: Option<u64>,
+    /// p95 request latency in microseconds.
+    pub p95_latency_us: Option<u64>,
+    /// p99 request latency in microseconds.
+    pub p99_latency_us: Option<u64>,
+    /// p95 queue-time share per request in permille (`0..=1000`).
+    pub p95_queue_share_permille: Option<u64>,
+    /// p95 non-queue service-time share per request in permille (`0..=1000`).
+    pub p95_service_share_permille: Option<u64>,
+    /// Structured evidence coverage and interpretation quality summary.
+    pub evidence_quality: EvidenceQuality,
+    /// Highest-ranked suspect for this route-filtered request set.
+    pub primary_suspect: Suspect,
+    /// Lower-ranked route suspects retained for follow-up triage.
+    pub secondary_suspects: Vec<Suspect>,
+    /// Non-fatal route-scoped warnings and attribution limits.
+    pub warnings: Vec<String>,
 }
 
 /// Analyzes one run artifact with rule-based heuristics and returns a triage report.
@@ -283,6 +312,14 @@ pub struct Report {
 /// ```
 #[must_use]
 pub fn analyze_run(run: &Run) -> Report {
+    let mut report = analyze_filtered_run(run);
+    let (route_breakdowns, route_warnings) = build_route_breakdowns(run, &report);
+    report.route_breakdowns = route_breakdowns;
+    report.warnings.extend(route_warnings);
+    report
+}
+
+fn analyze_filtered_run(run: &Run) -> Report {
     let request_latencies = run
         .requests
         .iter()
@@ -360,7 +397,133 @@ pub fn analyze_run(run: &Run) -> Report {
         evidence_quality,
         primary_suspect,
         secondary_suspects: ranked.collect(),
+        route_breakdowns: Vec::new(),
     }
+}
+
+const ROUTE_MIN_REQUESTS: usize = 3;
+const ROUTE_DIVERGENCE_WARNING: &str = "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect.";
+const ROUTE_ATTRIBUTION_WARNING: &str =
+    "Runtime and in-flight signals are global and are not attributed to this route.";
+
+fn build_route_breakdowns(run: &Run, global_report: &Report) -> (Vec<RouteBreakdown>, Vec<String>) {
+    let mut routes: HashMap<&str, Vec<&str>> = HashMap::new();
+    for req in &run.requests {
+        routes
+            .entry(req.route.as_str())
+            .or_default()
+            .push(req.request_id.as_str());
+    }
+    let mut eligible = Vec::new();
+    let mut omitted = 0usize;
+    for (route, request_ids) in routes {
+        if request_ids.len() < ROUTE_MIN_REQUESTS {
+            omitted += 1;
+            continue;
+        }
+        let ids: HashSet<&str> = request_ids.into_iter().collect();
+        let filtered = Run {
+            schema_version: run.schema_version,
+            metadata: run.metadata.clone(),
+            requests: run
+                .requests
+                .iter()
+                .filter(|r| ids.contains(r.request_id.as_str()))
+                .cloned()
+                .collect(),
+            stages: run
+                .stages
+                .iter()
+                .filter(|s| ids.contains(s.request_id.as_str()))
+                .cloned()
+                .collect(),
+            queues: run
+                .queues
+                .iter()
+                .filter(|q| ids.contains(q.request_id.as_str()))
+                .cloned()
+                .collect(),
+            inflight: Vec::new(),
+            runtime_snapshots: Vec::new(),
+            truncation: run.truncation.clone(),
+        };
+        let mut rr = analyze_filtered_run(&filtered);
+        rr.warnings.push(ROUTE_ATTRIBUTION_WARNING.to_string());
+        rr.evidence_quality
+            .limitations
+            .push(ROUTE_ATTRIBUTION_WARNING.to_string());
+        eligible.push(RouteBreakdown {
+            route: route.to_string(),
+            request_count: rr.request_count,
+            p50_latency_us: rr.p50_latency_us,
+            p95_latency_us: rr.p95_latency_us,
+            p99_latency_us: rr.p99_latency_us,
+            p95_queue_share_permille: rr.p95_queue_share_permille,
+            p95_service_share_permille: rr.p95_service_share_permille,
+            evidence_quality: rr.evidence_quality,
+            primary_suspect: rr.primary_suspect,
+            secondary_suspects: rr.secondary_suspects,
+            warnings: rr.warnings,
+        });
+    }
+    if !should_emit_route_breakdowns(&eligible, global_report) {
+        return (Vec::new(), Vec::new());
+    }
+    eligible.sort_by(|a, b| {
+        b.p95_latency_us
+            .cmp(&a.p95_latency_us)
+            .then_with(|| b.request_count.cmp(&a.request_count))
+            .then_with(|| a.route.cmp(&b.route))
+    });
+    eligible.truncate(10);
+    let mut warnings = Vec::new();
+    let kinds: HashSet<&str> = eligible
+        .iter()
+        .map(|r| r.primary_suspect.kind.as_str())
+        .collect();
+    if kinds.len() >= 2
+        || eligible
+            .iter()
+            .any(|r| r.primary_suspect.kind != global_report.primary_suspect.kind)
+    {
+        warnings.push(ROUTE_DIVERGENCE_WARNING.to_string());
+    }
+    if omitted > 0 {
+        warnings.push(format!("Route breakdowns omit {omitted} routes with fewer than {ROUTE_MIN_REQUESTS} completed requests."));
+    }
+    (eligible, warnings)
+}
+
+fn should_emit_route_breakdowns(eligible: &[RouteBreakdown], global_report: &Report) -> bool {
+    if eligible.len() == 1 {
+        return eligible[0].primary_suspect.kind != global_report.primary_suspect.kind;
+    }
+    if eligible.len() < 2 {
+        return false;
+    }
+    let kind_div = eligible
+        .iter()
+        .map(|r| r.primary_suspect.kind.as_str())
+        .collect::<HashSet<_>>()
+        .len()
+        >= 2;
+    let global_div = eligible
+        .iter()
+        .any(|r| r.primary_suspect.kind != global_report.primary_suspect.kind);
+    let p95s: Vec<u64> = eligible.iter().filter_map(|r| r.p95_latency_us).collect();
+    let mut gap_fast = false;
+    let mut gap_global = false;
+    if let (Some(min), Some(max)) = (p95s.iter().min(), p95s.iter().max()) {
+        if *min > 0 {
+            gap_fast = *max >= ((*min * 150) / 100);
+        }
+        if let Some(g) = global_report.p95_latency_us {
+            if g > 0 {
+                gap_global = *max >= ((g * 125) / 100);
+            }
+        }
+    }
+    kind_div || global_div || gap_fast || gap_global
 }
 
 fn apply_evidence_aware_confidence_caps(
@@ -1320,6 +1483,20 @@ pub fn render_text(report: &Report) -> String {
         }
     }
 
+    if !report.route_breakdowns.is_empty() {
+        lines.push("Route breakdowns:".to_string());
+        for rb in &report.route_breakdowns {
+            lines.push(format!(
+                "- {}: requests {}, p95 {}, suspect {} ({} confidence)",
+                rb.route,
+                rb.request_count,
+                fmt_opt_u64(rb.p95_latency_us),
+                rb.primary_suspect.kind.as_str(),
+                fmt_confidence(rb.primary_suspect.confidence)
+            ));
+        }
+    }
+
     if !report.secondary_suspects.is_empty() {
         lines.push("Secondary suspects:".to_string());
         for suspect in &report.secondary_suspects {
@@ -1601,6 +1778,7 @@ mod tests {
                 confidence_notes: Vec::new(),
             },
             secondary_suspects: Vec::new(),
+            route_breakdowns: Vec::new(),
         };
 
         let text = render_text(&report);
@@ -1652,6 +1830,7 @@ mod tests {
                 confidence_notes: Vec::new(),
             },
             secondary_suspects: Vec::new(),
+            route_breakdowns: Vec::new(),
         };
 
         let text = render_text(&report);
@@ -2370,5 +2549,11 @@ mod tests {
             .confidence_notes
             .iter()
             .any(|n| n == "Top suspects are close in score; confidence is capped by ambiguity."));
+    }
+
+    #[test]
+    fn route_breakdowns_field_defaults_empty_for_single_route() {
+        let report = analyze_run(&test_run());
+        assert!(report.route_breakdowns.is_empty());
     }
 }


### PR DESCRIPTION
### Motivation
- Global analyzer output aggregated the whole run and could hide route-specific divergence in dominant suspect kinds or latencies, making triage less actionable for multi-route services.  
- The core run artifact already records `RequestEvent.route`, so add supporting per-route triage summaries that surface meaningful route-level signal without changing global primary suspect semantics.  
- Route-level analysis must avoid falsely attributing global runtime/in-flight signals to individual routes and remain strictly additive to the global report.  

### Description
- Added a new serializable `Report.route_breakdowns: Vec<RouteBreakdown>` field and a `RouteBreakdown` struct with `route`, `request_count`, latency percentiles, p95 queue/service shares, `evidence_quality`, `primary_suspect`, `secondary_suspects`, and `warnings` fields.  
- Refactored analyzer flow with an internal reusable helper `analyze_filtered_run(&Run)` used for global and route-filtered analysis, and added `build_route_breakdowns(run, &global_report)` to produce route summaries without recursing into nested route/temporal segments.  
- Implemented route filtering that includes only requests for the route and stages/queues whose `request_id` belong to that route, and intentionally excludes `runtime_snapshots` and `inflight` from route-scoped runs; route summaries receive a stable attribution warning (`Runtime and in-flight signals are global and are not attributed to this route.`).  
- Emission rules conform to requirements: only routes with >= 3 completed requests are eligible, route breakdowns are emitted only when meaningful (different primary suspect kinds, route vs global primary differs, or p95-based thresholds), results are sorted by descending p95 then request count then route, truncated to top 10, and an omission warning is added when routes were omitted for being below threshold.  
- Kept global semantics unchanged: `Report.primary_suspect` remains the global primary suspect and route breakdowns are supporting context only; a stable divergence warning string is appended to global `warnings` when route divergence is detected.  
- Updated text rendering (`render_text`) to include a compact `Route breakdowns:` section when `route_breakdowns` is non-empty, refreshed demo fixtures and the README JSON sample to reflect the output shape change, and added unit tests covering default empty `route_breakdowns` and attribution warning presence.  

### Testing
- Ran `cargo fmt --check` (passed).  
- Ran `cargo clippy --workspace --all-targets -- -D warnings` (passed).  
- Ran `cargo test --workspace` (passed; unit test additions included).  
- Refreshed and checked demo fixtures with `python3 scripts/check_demo_fixture_drift.py --profile dev --refresh` and `python3 scripts/check_demo_fixture_drift.py --profile dev` (passed).  
- Ran the diagnostic benchmark `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0`; the run completed but reported per-case warning-check failures (some per-case checks flagged — see benchmark summary).  
- Ran `python3 -m unittest scripts.tests.test_diagnostic_benchmark` (passed).  
- Ran `python3 scripts/validate_docs_contracts.py` (after a small README sample adjustment) and it validated successfully; the docs-validator unit test was not re-run after the docs tweak but the validator script itself passes.  

Notes: global ranking/primary suspect semantics were preserved; route breakdowns are deterministic, bounded, and only included when they add meaningful signal per the rules above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9a776be488330bef8d435b4d451ea)