### PR TITLE
Add bounded early/late temporal segments to analyzer output

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ tailtriage analyze tailtriage-run.json --format json
       ]
     }
   ],
+  "temporal_segments": [],
   "route_breakdowns": []
 }
 ```

--- a/demos/blocking_service/fixtures/after-analysis.json
+++ b/demos/blocking_service/fixtures/after-analysis.json
@@ -1,20 +1,21 @@
 {
   "request_count": 250,
-  "p50_latency_us": 52104,
-  "p95_latency_us": 85732,
-  "p99_latency_us": 89330,
-  "p95_queue_share_permille": 66,
-  "p95_service_share_permille": 990,
+  "p50_latency_us": 60172,
+  "p95_latency_us": 84908,
+  "p99_latency_us": 90687,
+  "p95_queue_share_permille": 58,
+  "p95_service_share_permille": 993,
   "inflight_trend": {
     "gauge": "blocking_service_inflight",
     "sample_count": 500,
-    "peak_count": 48,
-    "p95_count": 45,
+    "peak_count": 47,
+    "p95_count": 43,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2053
+    "growth_per_sec_milli": -2012
   },
   "warnings": [
-    "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited."
+    "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited.",
+    "Temporal segments show a large p95 latency shift between early and late requests."
   ],
   "evidence_quality": {
     "request_count": 250,
@@ -43,9 +44,9 @@
     "score": 100,
     "confidence": "high",
     "evidence": [
-      "Stage 'spawn_blocking_path' has p95 latency 84718 us across 250 samples.",
-      "Stage 'spawn_blocking_path' cumulative latency is 13035850 us (978 permille of request latency).",
-      "Stage 'spawn_blocking_path' contributes 988 permille of tail request latency."
+      "Stage 'spawn_blocking_path' has p95 latency 84116 us across 250 samples.",
+      "Stage 'spawn_blocking_path' cumulative latency is 13204646 us (979 permille of request latency).",
+      "Stage 'spawn_blocking_path' contributes 987 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
@@ -60,13 +61,161 @@
       "score": 82,
       "confidence": "medium",
       "evidence": [
-        "Blocking queue depth p95 is 43, peak is 47, with 97/200 nonzero samples."
+        "Blocking queue depth p95 is 41, peak is 46, with 100/200 nonzero samples."
       ],
       "next_checks": [
         "Audit blocking sections and move avoidable synchronous work out of hot paths.",
         "Inspect spawn_blocking callsites for long-running CPU or I/O work."
       ],
       "confidence_notes": []
+    }
+  ],
+  "temporal_segments": [
+    {
+      "name": "early",
+      "request_count": 125,
+      "started_at_unix_ms": 1777977998973,
+      "finished_at_unix_ms": 1777977999228,
+      "p50_latency_us": 36353,
+      "p95_latency_us": 54903,
+      "p99_latency_us": 66594,
+      "p95_queue_share_permille": 65,
+      "p95_service_share_permille": 992,
+      "evidence_quality": {
+        "request_count": 125,
+        "queue_event_count": 125,
+        "stage_event_count": 125,
+        "runtime_snapshot_count": 52,
+        "inflight_snapshot_count": 287,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "partial",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "partial",
+        "limitations": [
+          "Runtime snapshots have missing queue-depth fields, limiting executor vs blocking differentiation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "blocking_pool_pressure",
+        "score": 85,
+        "confidence": "medium",
+        "evidence": [
+          "Blocking queue depth p95 is 35, peak is 36, with 52/52 nonzero samples."
+        ],
+        "next_checks": [
+          "Audit blocking sections and move avoidable synchronous work out of hot paths.",
+          "Inspect spawn_blocking callsites for long-running CPU or I/O work."
+        ],
+        "confidence_notes": [
+          "Missing runtime snapshots limit executor/blocking confidence.",
+          "Top suspects are close in score; confidence is capped by ambiguity."
+        ]
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 83,
+          "confidence": "medium",
+          "evidence": [
+            "Stage 'spawn_blocking_path' has p95 latency 53834 us across 125 samples.",
+            "Stage 'spawn_blocking_path' cumulative latency is 4477920 us (969 permille of request latency).",
+            "Stage 'spawn_blocking_path' contributes 980 permille of tail request latency.",
+            "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": [
+        "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited.",
+        "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks.",
+        "Runtime and in-flight temporal attribution is limited to timestamp-filtered samples in the segment window."
+      ]
+    },
+    {
+      "name": "late",
+      "request_count": 125,
+      "started_at_unix_ms": 1777977999168,
+      "finished_at_unix_ms": 1777977999461,
+      "p50_latency_us": 68474,
+      "p95_latency_us": 87716,
+      "p99_latency_us": 90737,
+      "p95_queue_share_permille": 22,
+      "p95_service_share_permille": 997,
+      "evidence_quality": {
+        "request_count": 125,
+        "queue_event_count": 125,
+        "stage_event_count": 125,
+        "runtime_snapshot_count": 59,
+        "inflight_snapshot_count": 279,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "partial",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "partial",
+        "limitations": [
+          "Runtime snapshots have missing queue-depth fields, limiting executor vs blocking differentiation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "blocking_pool_pressure",
+        "score": 85,
+        "confidence": "medium",
+        "evidence": [
+          "Blocking queue depth p95 is 44, peak is 46, with 59/59 nonzero samples."
+        ],
+        "next_checks": [
+          "Audit blocking sections and move avoidable synchronous work out of hot paths.",
+          "Inspect spawn_blocking callsites for long-running CPU or I/O work."
+        ],
+        "confidence_notes": [
+          "Missing runtime snapshots limit executor/blocking confidence.",
+          "Top suspects are close in score; confidence is capped by ambiguity."
+        ]
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 83,
+          "confidence": "medium",
+          "evidence": [
+            "Stage 'spawn_blocking_path' has p95 latency 86543 us across 125 samples.",
+            "Stage 'spawn_blocking_path' cumulative latency is 8726726 us (983 permille of request latency).",
+            "Stage 'spawn_blocking_path' contributes 986 permille of tail request latency.",
+            "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": [
+        "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited.",
+        "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks.",
+        "Runtime and in-flight temporal attribution is limited to timestamp-filtered samples in the segment window."
+      ]
     }
   ],
   "route_breakdowns": []

--- a/demos/blocking_service/fixtures/before-analysis.json
+++ b/demos/blocking_service/fixtures/before-analysis.json
@@ -1,21 +1,22 @@
 {
   "request_count": 250,
-  "p50_latency_us": 1866475,
-  "p95_latency_us": 3524603,
-  "p99_latency_us": 3673375,
-  "p95_queue_share_permille": 3,
+  "p50_latency_us": 1852509,
+  "p95_latency_us": 3512660,
+  "p99_latency_us": 3661027,
+  "p95_queue_share_permille": 9,
   "p95_service_share_permille": 999,
   "inflight_trend": {
     "gauge": "blocking_service_inflight",
     "sample_count": 500,
     "peak_count": 246,
-    "p95_count": 235,
+    "p95_count": 234,
     "growth_delta": 0,
     "growth_per_sec_milli": 0
   },
   "warnings": [
     "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited.",
-    "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks."
+    "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks.",
+    "Temporal segments show a large p95 latency shift between early and late requests."
   ],
   "evidence_quality": {
     "request_count": 250,
@@ -44,7 +45,7 @@
     "score": 88,
     "confidence": "medium",
     "evidence": [
-      "Blocking queue depth p95 is 244, peak is 246, with 200/200 nonzero samples."
+      "Blocking queue depth p95 is 242, peak is 246, with 200/200 nonzero samples."
     ],
     "next_checks": [
       "Audit blocking sections and move avoidable synchronous work out of hot paths.",
@@ -61,8 +62,8 @@
       "score": 86,
       "confidence": "high",
       "evidence": [
-        "Stage 'spawn_blocking_path' has p95 latency 3523850 us across 250 samples.",
-        "Stage 'spawn_blocking_path' cumulative latency is 466288754 us (999 permille of request latency).",
+        "Stage 'spawn_blocking_path' has p95 latency 3511501 us across 250 samples.",
+        "Stage 'spawn_blocking_path' cumulative latency is 464688915 us (999 permille of request latency).",
         "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency.",
         "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
       ],
@@ -72,6 +73,154 @@
         "Review downstream SLO/error budget and align retry budget/backoff with it."
       ],
       "confidence_notes": []
+    }
+  ],
+  "temporal_segments": [
+    {
+      "name": "early",
+      "request_count": 125,
+      "started_at_unix_ms": 1777977994714,
+      "finished_at_unix_ms": 1777977996616,
+      "p50_latency_us": 949071,
+      "p95_latency_us": 1778779,
+      "p99_latency_us": 1852501,
+      "p95_queue_share_permille": 12,
+      "p95_service_share_permille": 999,
+      "evidence_quality": {
+        "request_count": 125,
+        "queue_event_count": 125,
+        "stage_event_count": 125,
+        "runtime_snapshot_count": 200,
+        "inflight_snapshot_count": 376,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "partial",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "partial",
+        "limitations": [
+          "Runtime snapshots have missing queue-depth fields, limiting executor vs blocking differentiation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "blocking_pool_pressure",
+        "score": 88,
+        "confidence": "medium",
+        "evidence": [
+          "Blocking queue depth p95 is 242, peak is 246, with 200/200 nonzero samples."
+        ],
+        "next_checks": [
+          "Audit blocking sections and move avoidable synchronous work out of hot paths.",
+          "Inspect spawn_blocking callsites for long-running CPU or I/O work."
+        ],
+        "confidence_notes": [
+          "Missing runtime snapshots limit executor/blocking confidence.",
+          "Top suspects are close in score; confidence is capped by ambiguity."
+        ]
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 86,
+          "confidence": "high",
+          "evidence": [
+            "Stage 'spawn_blocking_path' has p95 latency 1761779 us across 125 samples.",
+            "Stage 'spawn_blocking_path' cumulative latency is 117429849 us (997 permille of request latency).",
+            "Stage 'spawn_blocking_path' contributes 995 permille of tail request latency.",
+            "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": [
+        "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited.",
+        "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks.",
+        "Runtime and in-flight temporal attribution is limited to timestamp-filtered samples in the segment window."
+      ]
+    },
+    {
+      "name": "late",
+      "request_count": 125,
+      "started_at_unix_ms": 1777977994764,
+      "finished_at_unix_ms": 1777977998488,
+      "p50_latency_us": 2771968,
+      "p95_latency_us": 3600692,
+      "p99_latency_us": 3688865,
+      "p95_queue_share_permille": 0,
+      "p95_service_share_permille": 999,
+      "evidence_quality": {
+        "request_count": 125,
+        "queue_event_count": 125,
+        "stage_event_count": 125,
+        "runtime_snapshot_count": 193,
+        "inflight_snapshot_count": 377,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "partial",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "partial",
+        "limitations": [
+          "Runtime snapshots have missing queue-depth fields, limiting executor vs blocking differentiation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "blocking_pool_pressure",
+        "score": 88,
+        "confidence": "medium",
+        "evidence": [
+          "Blocking queue depth p95 is 242, peak is 246, with 193/193 nonzero samples."
+        ],
+        "next_checks": [
+          "Audit blocking sections and move avoidable synchronous work out of hot paths.",
+          "Inspect spawn_blocking callsites for long-running CPU or I/O work."
+        ],
+        "confidence_notes": [
+          "Missing runtime snapshots limit executor/blocking confidence.",
+          "Top suspects are close in score; confidence is capped by ambiguity."
+        ]
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 86,
+          "confidence": "high",
+          "evidence": [
+            "Stage 'spawn_blocking_path' has p95 latency 3599512 us across 125 samples.",
+            "Stage 'spawn_blocking_path' cumulative latency is 347259066 us (999 permille of request latency).",
+            "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency.",
+            "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": [
+        "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited.",
+        "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks.",
+        "Runtime and in-flight temporal attribution is limited to timestamp-filtered samples in the segment window."
+      ]
     }
   ],
   "route_breakdowns": []

--- a/demos/blocking_service/fixtures/sample-analysis.json
+++ b/demos/blocking_service/fixtures/sample-analysis.json
@@ -1,21 +1,22 @@
 {
   "request_count": 250,
-  "p50_latency_us": 1866475,
-  "p95_latency_us": 3524603,
-  "p99_latency_us": 3673375,
-  "p95_queue_share_permille": 3,
+  "p50_latency_us": 1852509,
+  "p95_latency_us": 3512660,
+  "p99_latency_us": 3661027,
+  "p95_queue_share_permille": 9,
   "p95_service_share_permille": 999,
   "inflight_trend": {
     "gauge": "blocking_service_inflight",
     "sample_count": 500,
     "peak_count": 246,
-    "p95_count": 235,
+    "p95_count": 234,
     "growth_delta": 0,
     "growth_per_sec_milli": 0
   },
   "warnings": [
     "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited.",
-    "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks."
+    "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks.",
+    "Temporal segments show a large p95 latency shift between early and late requests."
   ],
   "evidence_quality": {
     "request_count": 250,
@@ -44,7 +45,7 @@
     "score": 88,
     "confidence": "medium",
     "evidence": [
-      "Blocking queue depth p95 is 244, peak is 246, with 200/200 nonzero samples."
+      "Blocking queue depth p95 is 242, peak is 246, with 200/200 nonzero samples."
     ],
     "next_checks": [
       "Audit blocking sections and move avoidable synchronous work out of hot paths.",
@@ -61,8 +62,8 @@
       "score": 86,
       "confidence": "high",
       "evidence": [
-        "Stage 'spawn_blocking_path' has p95 latency 3523850 us across 250 samples.",
-        "Stage 'spawn_blocking_path' cumulative latency is 466288754 us (999 permille of request latency).",
+        "Stage 'spawn_blocking_path' has p95 latency 3511501 us across 250 samples.",
+        "Stage 'spawn_blocking_path' cumulative latency is 464688915 us (999 permille of request latency).",
         "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency.",
         "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
       ],
@@ -72,6 +73,154 @@
         "Review downstream SLO/error budget and align retry budget/backoff with it."
       ],
       "confidence_notes": []
+    }
+  ],
+  "temporal_segments": [
+    {
+      "name": "early",
+      "request_count": 125,
+      "started_at_unix_ms": 1777977994714,
+      "finished_at_unix_ms": 1777977996616,
+      "p50_latency_us": 949071,
+      "p95_latency_us": 1778779,
+      "p99_latency_us": 1852501,
+      "p95_queue_share_permille": 12,
+      "p95_service_share_permille": 999,
+      "evidence_quality": {
+        "request_count": 125,
+        "queue_event_count": 125,
+        "stage_event_count": 125,
+        "runtime_snapshot_count": 200,
+        "inflight_snapshot_count": 376,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "partial",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "partial",
+        "limitations": [
+          "Runtime snapshots have missing queue-depth fields, limiting executor vs blocking differentiation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "blocking_pool_pressure",
+        "score": 88,
+        "confidence": "medium",
+        "evidence": [
+          "Blocking queue depth p95 is 242, peak is 246, with 200/200 nonzero samples."
+        ],
+        "next_checks": [
+          "Audit blocking sections and move avoidable synchronous work out of hot paths.",
+          "Inspect spawn_blocking callsites for long-running CPU or I/O work."
+        ],
+        "confidence_notes": [
+          "Missing runtime snapshots limit executor/blocking confidence.",
+          "Top suspects are close in score; confidence is capped by ambiguity."
+        ]
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 86,
+          "confidence": "high",
+          "evidence": [
+            "Stage 'spawn_blocking_path' has p95 latency 1761779 us across 125 samples.",
+            "Stage 'spawn_blocking_path' cumulative latency is 117429849 us (997 permille of request latency).",
+            "Stage 'spawn_blocking_path' contributes 995 permille of tail request latency.",
+            "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": [
+        "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited.",
+        "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks.",
+        "Runtime and in-flight temporal attribution is limited to timestamp-filtered samples in the segment window."
+      ]
+    },
+    {
+      "name": "late",
+      "request_count": 125,
+      "started_at_unix_ms": 1777977994764,
+      "finished_at_unix_ms": 1777977998488,
+      "p50_latency_us": 2771968,
+      "p95_latency_us": 3600692,
+      "p99_latency_us": 3688865,
+      "p95_queue_share_permille": 0,
+      "p95_service_share_permille": 999,
+      "evidence_quality": {
+        "request_count": 125,
+        "queue_event_count": 125,
+        "stage_event_count": 125,
+        "runtime_snapshot_count": 193,
+        "inflight_snapshot_count": 377,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "partial",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "partial",
+        "limitations": [
+          "Runtime snapshots have missing queue-depth fields, limiting executor vs blocking differentiation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "blocking_pool_pressure",
+        "score": 88,
+        "confidence": "medium",
+        "evidence": [
+          "Blocking queue depth p95 is 242, peak is 246, with 193/193 nonzero samples."
+        ],
+        "next_checks": [
+          "Audit blocking sections and move avoidable synchronous work out of hot paths.",
+          "Inspect spawn_blocking callsites for long-running CPU or I/O work."
+        ],
+        "confidence_notes": [
+          "Missing runtime snapshots limit executor/blocking confidence.",
+          "Top suspects are close in score; confidence is capped by ambiguity."
+        ]
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 86,
+          "confidence": "high",
+          "evidence": [
+            "Stage 'spawn_blocking_path' has p95 latency 3599512 us across 125 samples.",
+            "Stage 'spawn_blocking_path' cumulative latency is 347259066 us (999 permille of request latency).",
+            "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency.",
+            "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": [
+        "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited.",
+        "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks.",
+        "Runtime and in-flight temporal attribution is limited to timestamp-filtered samples in the segment window."
+      ]
     }
   ],
   "route_breakdowns": []

--- a/demos/cold_start_burst_service/fixtures/after-analysis.json
+++ b/demos/cold_start_burst_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 8382,
-  "p95_latency_us": 8642,
-  "p99_latency_us": 13879,
+  "p50_latency_us": 8411,
+  "p95_latency_us": 8727,
+  "p99_latency_us": 9000,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 999,
   "inflight_trend": {
     "gauge": "cold_start_burst_inflight",
     "sample_count": 440,
     "peak_count": 4,
-    "p95_count": 3,
+    "p95_count": 2,
     "growth_delta": -1,
-    "growth_per_sec_milli": -1071
+    "growth_per_sec_milli": -1070
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,8 +41,8 @@
     "score": 100,
     "confidence": "high",
     "evidence": [
-      "Stage 'cold_start_stage' has p95 latency 8627 us across 220 samples.",
-      "Stage 'cold_start_stage' cumulative latency is 1813450 us (997 permille of request latency).",
+      "Stage 'cold_start_stage' has p95 latency 8707 us across 220 samples.",
+      "Stage 'cold_start_stage' cumulative latency is 1810642 us (997 permille of request latency).",
       "Stage 'cold_start_stage' contributes 997 permille of tail request latency."
     ],
     "next_checks": [
@@ -53,5 +53,6 @@
     "confidence_notes": []
   },
   "secondary_suspects": [],
+  "temporal_segments": [],
   "route_breakdowns": []
 }

--- a/demos/cold_start_burst_service/fixtures/before-analysis.json
+++ b/demos/cold_start_burst_service/fixtures/before-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 990199,
-  "p95_latency_us": 1183880,
-  "p99_latency_us": 1200371,
+  "p50_latency_us": 995594,
+  "p95_latency_us": 1194364,
+  "p99_latency_us": 1210228,
   "p95_queue_share_permille": 993,
-  "p95_service_share_permille": 334,
+  "p95_service_share_permille": 329,
   "inflight_trend": {
     "gauge": "cold_start_burst_inflight",
     "sample_count": 440,
     "peak_count": 220,
     "p95_count": 209,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -816
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
   },
   "warnings": [],
   "evidence_quality": {
@@ -56,8 +56,8 @@
       "score": 32,
       "confidence": "low",
       "evidence": [
-        "Stage 'cold_start_stage' has p95 latency 63550 us across 220 samples.",
-        "Stage 'cold_start_stage' cumulative latency is 4862350 us (24 permille of request latency).",
+        "Stage 'cold_start_stage' has p95 latency 63633 us across 220 samples.",
+        "Stage 'cold_start_stage' cumulative latency is 4895276 us (24 permille of request latency).",
         "Stage 'cold_start_stage' contributes 6 permille of tail request latency."
       ],
       "next_checks": [
@@ -66,6 +66,145 @@
         "Review downstream SLO/error budget and align retry budget/backoff with it."
       ],
       "confidence_notes": []
+    }
+  ],
+  "temporal_segments": [
+    {
+      "name": "early",
+      "request_count": 110,
+      "started_at_unix_ms": 1777978045769,
+      "finished_at_unix_ms": 1777978046781,
+      "p50_latency_us": 882968,
+      "p95_latency_us": 988061,
+      "p99_latency_us": 1002713,
+      "p95_queue_share_permille": 992,
+      "p95_service_share_permille": 501,
+      "evidence_quality": {
+        "request_count": 110,
+        "queue_event_count": 110,
+        "stage_event_count": 110,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 333,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 100,
+        "confidence": "high",
+        "evidence": [
+          "Queue wait at p95 consumes 99.2% of request time.",
+          "Observed queue depth sample up to 113.",
+          "In-flight gauge 'cold_start_burst_inflight' grew by 106 over the run window (p95=212, peak=220)."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 33,
+          "confidence": "low",
+          "evidence": [
+            "Stage 'cold_start_stage' has p95 latency 63691 us across 110 samples.",
+            "Stage 'cold_start_stage' cumulative latency is 3990577 us (51 permille of request latency).",
+            "Stage 'cold_start_stage' contributes 8 permille of tail request latency."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'cold_start_stage'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": [
+        "Runtime and in-flight temporal attribution is limited to timestamp-filtered samples in the segment window."
+      ]
+    },
+    {
+      "name": "late",
+      "request_count": 110,
+      "started_at_unix_ms": 1777978045779,
+      "finished_at_unix_ms": 1777978046995,
+      "p50_latency_us": 1108030,
+      "p95_latency_us": 1204030,
+      "p99_latency_us": 1212377,
+      "p95_queue_share_permille": 993,
+      "p95_service_share_permille": 8,
+      "evidence_quality": {
+        "request_count": 110,
+        "queue_event_count": 110,
+        "stage_event_count": 110,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 341,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 95,
+        "confidence": "high",
+        "evidence": [
+          "Queue wait at p95 consumes 99.3% of request time.",
+          "Observed queue depth sample up to 216."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 32,
+          "confidence": "low",
+          "evidence": [
+            "Stage 'cold_start_stage' has p95 latency 8726 us across 110 samples.",
+            "Stage 'cold_start_stage' cumulative latency is 904699 us (7 permille of request latency).",
+            "Stage 'cold_start_stage' contributes 6 permille of tail request latency."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'cold_start_stage'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": [
+        "Runtime and in-flight temporal attribution is limited to timestamp-filtered samples in the segment window."
+      ]
     }
   ],
   "route_breakdowns": []

--- a/demos/db_pool_saturation_service/fixtures/after-analysis.json
+++ b/demos/db_pool_saturation_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 13407,
-  "p95_latency_us": 13884,
-  "p99_latency_us": 13940,
+  "p50_latency_us": 13246,
+  "p95_latency_us": 14256,
+  "p99_latency_us": 16135,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,7 +11,7 @@
     "peak_count": 10,
     "p95_count": 10,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2770
+    "growth_per_sec_milli": -2724
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,9 +41,9 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'db_query' has p95 latency 11690 us across 220 samples.",
-      "Stage 'db_query' cumulative latency is 2431825 us (836 permille of request latency).",
-      "Stage 'db_query' contributes 840 permille of tail request latency."
+      "Stage 'db_query' has p95 latency 11899 us across 220 samples.",
+      "Stage 'db_query' cumulative latency is 2448781 us (833 permille of request latency).",
+      "Stage 'db_query' contributes 805 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'db_query'.",
@@ -53,5 +53,6 @@
     "confidence_notes": []
   },
   "secondary_suspects": [],
+  "temporal_segments": [],
   "route_breakdowns": []
 }

--- a/demos/db_pool_saturation_service/fixtures/before-analysis.json
+++ b/demos/db_pool_saturation_service/fixtures/before-analysis.json
@@ -1,19 +1,21 @@
 {
   "request_count": 220,
-  "p50_latency_us": 495974,
-  "p95_latency_us": 930473,
-  "p99_latency_us": 964158,
-  "p95_queue_share_permille": 976,
-  "p95_service_share_permille": 367,
+  "p50_latency_us": 495837,
+  "p95_latency_us": 933537,
+  "p99_latency_us": 968454,
+  "p95_queue_share_permille": 977,
+  "p95_service_share_permille": 370,
   "inflight_trend": {
     "gauge": "db_pool_saturation_inflight",
     "sample_count": 440,
     "peak_count": 204,
     "p95_count": 193,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -940
+    "growth_delta": 2,
+    "growth_per_sec_milli": 1879
   },
-  "warnings": [],
+  "warnings": [
+    "Temporal segments show a large p95 latency shift between early and late requests."
+  ],
   "evidence_quality": {
     "request_count": 220,
     "queue_event_count": 220,
@@ -41,8 +43,9 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Queue wait at p95 consumes 97.6% of request time.",
-      "Observed queue depth sample up to 199."
+      "Queue wait at p95 consumes 97.7% of request time.",
+      "Observed queue depth sample up to 200.",
+      "In-flight gauge 'db_pool_saturation_inflight' grew by 2 over the run window (p95=193, peak=204)."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -56,8 +59,8 @@
       "score": 34,
       "confidence": "low",
       "evidence": [
-        "Stage 'db_query' has p95 latency 19560 us across 220 samples.",
-        "Stage 'db_query' cumulative latency is 4214847 us (38 permille of request latency).",
+        "Stage 'db_query' has p95 latency 19532 us across 220 samples.",
+        "Stage 'db_query' cumulative latency is 4234123 us (38 permille of request latency).",
         "Stage 'db_query' contributes 20 permille of tail request latency."
       ],
       "next_checks": [
@@ -66,6 +69,145 @@
         "Review downstream SLO/error budget and align retry budget/backoff with it."
       ],
       "confidence_notes": []
+    }
+  ],
+  "temporal_segments": [
+    {
+      "name": "early",
+      "request_count": 110,
+      "started_at_unix_ms": 1777978050773,
+      "finished_at_unix_ms": 1777978051298,
+      "p50_latency_us": 247807,
+      "p95_latency_us": 476560,
+      "p99_latency_us": 495837,
+      "p95_queue_share_permille": 954,
+      "p95_service_share_permille": 559,
+      "evidence_quality": {
+        "request_count": 110,
+        "queue_event_count": 110,
+        "stage_event_count": 220,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 328,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 95,
+        "confidence": "high",
+        "evidence": [
+          "Queue wait at p95 consumes 95.4% of request time.",
+          "Observed queue depth sample up to 99.",
+          "In-flight gauge 'db_pool_saturation_inflight' grew by 114 over the run window (p95=196, peak=204)."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 37,
+          "confidence": "low",
+          "evidence": [
+            "Stage 'db_query' has p95 latency 19931 us across 110 samples.",
+            "Stage 'db_query' cumulative latency is 2117823 us (75 permille of request latency).",
+            "Stage 'db_query' contributes 39 permille of tail request latency."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'db_query'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": [
+        "Runtime and in-flight temporal attribution is limited to timestamp-filtered samples in the segment window."
+      ]
+    },
+    {
+      "name": "late",
+      "request_count": 110,
+      "started_at_unix_ms": 1777978050821,
+      "finished_at_unix_ms": 1777978051837,
+      "p50_latency_us": 737856,
+      "p95_latency_us": 951580,
+      "p99_latency_us": 968458,
+      "p95_queue_share_permille": 977,
+      "p95_service_share_permille": 41,
+      "evidence_quality": {
+        "request_count": 110,
+        "queue_event_count": 110,
+        "stage_event_count": 220,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 326,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 95,
+        "confidence": "high",
+        "evidence": [
+          "Queue wait at p95 consumes 97.7% of request time.",
+          "Observed queue depth sample up to 200."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 33,
+          "confidence": "low",
+          "evidence": [
+            "Stage 'db_query' has p95 latency 19438 us across 110 samples.",
+            "Stage 'db_query' cumulative latency is 2116300 us (26 permille of request latency).",
+            "Stage 'db_query' contributes 19 permille of tail request latency."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'db_query'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": [
+        "Runtime and in-flight temporal attribution is limited to timestamp-filtered samples in the segment window."
+      ]
     }
   ],
   "route_breakdowns": []

--- a/demos/downstream_service/fixtures/after-analysis.json
+++ b/demos/downstream_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 80,
-  "p50_latency_us": 12499,
-  "p95_latency_us": 12626,
-  "p99_latency_us": 13358,
+  "p50_latency_us": 12372,
+  "p95_latency_us": 12755,
+  "p99_latency_us": 12763,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "downstream_service_inflight",
     "sample_count": 160,
-    "peak_count": 33,
-    "p95_count": 32,
+    "peak_count": 32,
+    "p95_count": 31,
     "growth_delta": 5,
-    "growth_per_sec_milli": 113636
+    "growth_per_sec_milli": 111111
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,9 +41,9 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 10422 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 809061 us (825 permille of request latency).",
-      "Stage 'downstream_call' contributes 799 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 10525 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 807261 us (821 permille of request latency).",
+      "Stage 'downstream_call' contributes 825 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",
@@ -53,5 +53,6 @@
     "confidence_notes": []
   },
   "secondary_suspects": [],
+  "temporal_segments": [],
   "route_breakdowns": []
 }

--- a/demos/downstream_service/fixtures/before-after-comparison.json
+++ b/demos/downstream_service/fixtures/before-after-comparison.json
@@ -2,19 +2,19 @@
   "before": {
     "primary_suspect_kind": "downstream_stage_dominates",
     "primary_suspect_score": 95,
-    "p95_latency_us": 23960,
+    "p95_latency_us": 23865,
     "p95_service_share_permille": 1000
   },
   "after": {
     "primary_suspect_kind": "downstream_stage_dominates",
     "primary_suspect_score": 95,
-    "p95_latency_us": 12626,
+    "p95_latency_us": 12755,
     "p95_service_share_permille": 1000
   },
   "delta": {
     "primary_suspect_kind": null,
     "primary_suspect_score": 0,
-    "p95_latency_us": -11334,
+    "p95_latency_us": -11110,
     "p95_service_share_permille": 0
   }
 }

--- a/demos/downstream_service/fixtures/before-analysis.json
+++ b/demos/downstream_service/fixtures/before-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 80,
-  "p50_latency_us": 23490,
-  "p95_latency_us": 23960,
-  "p99_latency_us": 24038,
+  "p50_latency_us": 23083,
+  "p95_latency_us": 23865,
+  "p99_latency_us": 23973,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -10,8 +10,8 @@
     "sample_count": 160,
     "peak_count": 64,
     "p95_count": 62,
-    "growth_delta": 0,
-    "growth_per_sec_milli": 0
+    "growth_delta": 5,
+    "growth_per_sec_milli": 90909
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,9 +41,9 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 21745 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 1696247 us (907 permille of request latency).",
-      "Stage 'downstream_call' contributes 904 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 21665 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 1681004 us (905 permille of request latency).",
+      "Stage 'downstream_call' contributes 907 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",
@@ -53,5 +53,6 @@
     "confidence_notes": []
   },
   "secondary_suspects": [],
+  "temporal_segments": [],
   "route_breakdowns": []
 }

--- a/demos/downstream_service/fixtures/sample-analysis.json
+++ b/demos/downstream_service/fixtures/sample-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 80,
-  "p50_latency_us": 23490,
-  "p95_latency_us": 23960,
-  "p99_latency_us": 24038,
+  "p50_latency_us": 23083,
+  "p95_latency_us": 23865,
+  "p99_latency_us": 23973,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -10,8 +10,8 @@
     "sample_count": 160,
     "peak_count": 64,
     "p95_count": 62,
-    "growth_delta": 0,
-    "growth_per_sec_milli": 0
+    "growth_delta": 5,
+    "growth_per_sec_milli": 90909
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,9 +41,9 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 21745 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 1696247 us (907 permille of request latency).",
-      "Stage 'downstream_call' contributes 904 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 21665 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 1681004 us (905 permille of request latency).",
+      "Stage 'downstream_call' contributes 907 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",
@@ -53,5 +53,6 @@
     "confidence_notes": []
   },
   "secondary_suspects": [],
+  "temporal_segments": [],
   "route_breakdowns": []
 }

--- a/demos/executor_pressure_service/fixtures/after-analysis.json
+++ b/demos/executor_pressure_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 240,
-  "p50_latency_us": 5031245,
-  "p95_latency_us": 5100556,
-  "p99_latency_us": 5104772,
+  "p50_latency_us": 5122690,
+  "p95_latency_us": 5168982,
+  "p99_latency_us": 5170976,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,14 +11,14 @@
     "peak_count": 240,
     "p95_count": 228,
     "growth_delta": -1,
-    "growth_per_sec_milli": -195
+    "growth_per_sec_milli": -193
   },
   "warnings": [],
   "evidence_quality": {
     "request_count": 240,
     "queue_event_count": 0,
     "stage_event_count": 0,
-    "runtime_snapshot_count": 5116,
+    "runtime_snapshot_count": 5179,
     "inflight_snapshot_count": 480,
     "requests": "present",
     "queues": "missing",
@@ -42,7 +42,7 @@
     "confidence": "high",
     "evidence": [
       "Runtime global queue depth p95 is 720, suggesting scheduler contention.",
-      "Runtime local queue depth p95 is 4833.",
+      "Runtime local queue depth p95 is 5763.",
       "Runtime alive_tasks p95 is 720."
     ],
     "next_checks": [
@@ -52,5 +52,6 @@
     "confidence_notes": []
   },
   "secondary_suspects": [],
+  "temporal_segments": [],
   "route_breakdowns": []
 }

--- a/demos/executor_pressure_service/fixtures/before-analysis.json
+++ b/demos/executor_pressure_service/fixtures/before-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 240,
-  "p50_latency_us": 24445238,
-  "p95_latency_us": 24529057,
-  "p99_latency_us": 24533220,
+  "p50_latency_us": 25098980,
+  "p95_latency_us": 25169510,
+  "p99_latency_us": 25174028,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -10,15 +10,15 @@
     "sample_count": 480,
     "peak_count": 240,
     "p95_count": 228,
-    "growth_delta": 0,
-    "growth_per_sec_milli": 0
+    "growth_delta": 1,
+    "growth_per_sec_milli": 39
   },
   "warnings": [],
   "evidence_quality": {
     "request_count": 240,
     "queue_event_count": 0,
     "stage_event_count": 0,
-    "runtime_snapshot_count": 24540,
+    "runtime_snapshot_count": 25185,
     "inflight_snapshot_count": 480,
     "requests": "present",
     "queues": "missing",
@@ -38,11 +38,11 @@
   },
   "primary_suspect": {
     "kind": "executor_pressure_suspected",
-    "score": 99,
+    "score": 100,
     "confidence": "high",
     "evidence": [
       "Runtime global queue depth p95 is 1920, suggesting scheduler contention.",
-      "Runtime local queue depth p95 is 9896.",
+      "Runtime local queue depth p95 is 15296.",
       "Runtime alive_tasks p95 is 1920."
     ],
     "next_checks": [
@@ -52,5 +52,6 @@
     "confidence_notes": []
   },
   "secondary_suspects": [],
+  "temporal_segments": [],
   "route_breakdowns": []
 }

--- a/demos/executor_pressure_service/fixtures/sample-analysis.json
+++ b/demos/executor_pressure_service/fixtures/sample-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 240,
-  "p50_latency_us": 24445238,
-  "p95_latency_us": 24529057,
-  "p99_latency_us": 24533220,
+  "p50_latency_us": 25098980,
+  "p95_latency_us": 25169510,
+  "p99_latency_us": 25174028,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -10,15 +10,15 @@
     "sample_count": 480,
     "peak_count": 240,
     "p95_count": 228,
-    "growth_delta": 0,
-    "growth_per_sec_milli": 0
+    "growth_delta": 1,
+    "growth_per_sec_milli": 39
   },
   "warnings": [],
   "evidence_quality": {
     "request_count": 240,
     "queue_event_count": 0,
     "stage_event_count": 0,
-    "runtime_snapshot_count": 24540,
+    "runtime_snapshot_count": 25185,
     "inflight_snapshot_count": 480,
     "requests": "present",
     "queues": "missing",
@@ -38,11 +38,11 @@
   },
   "primary_suspect": {
     "kind": "executor_pressure_suspected",
-    "score": 99,
+    "score": 100,
     "confidence": "high",
     "evidence": [
       "Runtime global queue depth p95 is 1920, suggesting scheduler contention.",
-      "Runtime local queue depth p95 is 9896.",
+      "Runtime local queue depth p95 is 15296.",
       "Runtime alive_tasks p95 is 1920."
     ],
     "next_checks": [
@@ -52,5 +52,6 @@
     "confidence_notes": []
   },
   "secondary_suspects": [],
+  "temporal_segments": [],
   "route_breakdowns": []
 }

--- a/demos/mixed_contention_service/fixtures/baseline-analysis.json
+++ b/demos/mixed_contention_service/fixtures/baseline-analysis.json
@@ -1,19 +1,21 @@
 {
   "request_count": 220,
-  "p50_latency_us": 390695,
-  "p95_latency_us": 736242,
-  "p99_latency_us": 762947,
+  "p50_latency_us": 397214,
+  "p95_latency_us": 741034,
+  "p99_latency_us": 770505,
   "p95_queue_share_permille": 980,
-  "p95_service_share_permille": 393,
+  "p95_service_share_permille": 380,
   "inflight_trend": {
     "gauge": "mixed_contention_inflight",
     "sample_count": 440,
     "peak_count": 201,
-    "p95_count": 190,
+    "p95_count": 191,
     "growth_delta": -1,
-    "growth_per_sec_milli": -1161
+    "growth_per_sec_milli": -1154
   },
-  "warnings": [],
+  "warnings": [
+    "Temporal segments show a large p95 latency shift between early and late requests."
+  ],
   "evidence_quality": {
     "request_count": 220,
     "queue_event_count": 220,
@@ -56,8 +58,8 @@
       "score": 35,
       "confidence": "low",
       "evidence": [
-        "Stage 'downstream_call' has p95 latency 32487 us across 220 samples.",
-        "Stage 'downstream_call' cumulative latency is 3767713 us (43 permille of request latency).",
+        "Stage 'downstream_call' has p95 latency 32440 us across 220 samples.",
+        "Stage 'downstream_call' cumulative latency is 3778373 us (43 permille of request latency).",
         "Stage 'downstream_call' contributes 25 permille of tail request latency."
       ],
       "next_checks": [
@@ -66,6 +68,145 @@
         "Review downstream SLO/error budget and align retry budget/backoff with it."
       ],
       "confidence_notes": []
+    }
+  ],
+  "temporal_segments": [
+    {
+      "name": "early",
+      "request_count": 110,
+      "started_at_unix_ms": 1777978041695,
+      "finished_at_unix_ms": 1777978042127,
+      "p50_latency_us": 202735,
+      "p95_latency_us": 377155,
+      "p99_latency_us": 392917,
+      "p95_queue_share_permille": 960,
+      "p95_service_share_permille": 567,
+      "evidence_quality": {
+        "request_count": 110,
+        "queue_event_count": 110,
+        "stage_event_count": 220,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 328,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 95,
+        "confidence": "high",
+        "evidence": [
+          "Queue wait at p95 consumes 96.0% of request time.",
+          "Observed queue depth sample up to 97.",
+          "In-flight gauge 'mixed_contention_inflight' grew by 111 over the run window (p95=193, peak=201)."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 39,
+          "confidence": "low",
+          "evidence": [
+            "Stage 'downstream_call' has p95 latency 32440 us across 110 samples.",
+            "Stage 'downstream_call' cumulative latency is 1902953 us (85 permille of request latency).",
+            "Stage 'downstream_call' contributes 56 permille of tail request latency."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'downstream_call'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": [
+        "Runtime and in-flight temporal attribution is limited to timestamp-filtered samples in the segment window."
+      ]
+    },
+    {
+      "name": "late",
+      "request_count": 110,
+      "started_at_unix_ms": 1777978041738,
+      "finished_at_unix_ms": 1777978042550,
+      "p50_latency_us": 585269,
+      "p95_latency_us": 762121,
+      "p99_latency_us": 772296,
+      "p95_queue_share_permille": 981,
+      "p95_service_share_permille": 69,
+      "evidence_quality": {
+        "request_count": 110,
+        "queue_event_count": 110,
+        "stage_event_count": 220,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 322,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 95,
+        "confidence": "high",
+        "evidence": [
+          "Queue wait at p95 consumes 98.1% of request time.",
+          "Observed queue depth sample up to 196."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 34,
+          "confidence": "low",
+          "evidence": [
+            "Stage 'downstream_call' has p95 latency 32431 us across 110 samples.",
+            "Stage 'downstream_call' cumulative latency is 1875420 us (28 permille of request latency).",
+            "Stage 'downstream_call' contributes 28 permille of tail request latency."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'downstream_call'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": [
+        "Runtime and in-flight temporal attribution is limited to timestamp-filtered samples in the segment window."
+      ]
     }
   ],
   "route_breakdowns": []

--- a/demos/mixed_contention_service/fixtures/mitigated-analysis.json
+++ b/demos/mixed_contention_service/fixtures/mitigated-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 14604,
-  "p95_latency_us": 34367,
-  "p99_latency_us": 34982,
+  "p50_latency_us": 14682,
+  "p95_latency_us": 34604,
+  "p99_latency_us": 34883,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -41,9 +41,9 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 32237 us across 220 samples.",
-      "Stage 'downstream_call' cumulative latency is 3757963 us (889 permille of request latency).",
-      "Stage 'downstream_call' contributes 933 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 32376 us across 220 samples.",
+      "Stage 'downstream_call' cumulative latency is 3748840 us (886 permille of request latency).",
+      "Stage 'downstream_call' contributes 934 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",
@@ -53,5 +53,6 @@
     "confidence_notes": []
   },
   "secondary_suspects": [],
+  "temporal_segments": [],
   "route_breakdowns": []
 }

--- a/demos/queue_service/fixtures/after-analysis.json
+++ b/demos/queue_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 250,
-  "p50_latency_us": 16028,
-  "p95_latency_us": 16827,
-  "p99_latency_us": 16953,
+  "p50_latency_us": 16124,
+  "p95_latency_us": 16621,
+  "p99_latency_us": 16894,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
     "peak_count": 12,
-    "p95_count": 12,
+    "p95_count": 11,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2450
+    "growth_per_sec_milli": -2398
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,9 +41,9 @@
     "score": 100,
     "confidence": "high",
     "evidence": [
-      "Stage 'simulated_work' has p95 latency 16817 us across 250 samples.",
-      "Stage 'simulated_work' cumulative latency is 4019716 us (999 permille of request latency).",
-      "Stage 'simulated_work' contributes 998 permille of tail request latency."
+      "Stage 'simulated_work' has p95 latency 16610 us across 250 samples.",
+      "Stage 'simulated_work' cumulative latency is 4020499 us (998 permille of request latency).",
+      "Stage 'simulated_work' contributes 999 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'simulated_work'.",
@@ -53,5 +53,6 @@
     "confidence_notes": []
   },
   "secondary_suspects": [],
+  "temporal_segments": [],
   "route_breakdowns": []
 }

--- a/demos/queue_service/fixtures/before-analysis.json
+++ b/demos/queue_service/fixtures/before-analysis.json
@@ -1,19 +1,21 @@
 {
   "request_count": 250,
-  "p50_latency_us": 783739,
-  "p95_latency_us": 1472369,
-  "p99_latency_us": 1521948,
+  "p50_latency_us": 784557,
+  "p95_latency_us": 1476514,
+  "p99_latency_us": 1527537,
   "p95_queue_share_permille": 982,
-  "p95_service_share_permille": 265,
+  "p95_service_share_permille": 270,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
     "peak_count": 234,
-    "p95_count": 226,
+    "p95_count": 225,
     "growth_delta": -1,
-    "growth_per_sec_milli": -604
+    "growth_per_sec_milli": -602
   },
-  "warnings": [],
+  "warnings": [
+    "Temporal segments show a large p95 latency shift between early and late requests."
+  ],
   "evidence_quality": {
     "request_count": 250,
     "queue_event_count": 250,
@@ -56,8 +58,8 @@
       "score": 33,
       "confidence": "low",
       "evidence": [
-        "Stage 'simulated_work' has p95 latency 26571 us across 250 samples.",
-        "Stage 'simulated_work' cumulative latency is 6535903 us (33 permille of request latency).",
+        "Stage 'simulated_work' has p95 latency 26737 us across 250 samples.",
+        "Stage 'simulated_work' cumulative latency is 6567084 us (33 permille of request latency).",
         "Stage 'simulated_work' contributes 17 permille of tail request latency."
       ],
       "next_checks": [
@@ -66,6 +68,145 @@
         "Review downstream SLO/error budget and align retry budget/backoff with it."
       ],
       "confidence_notes": []
+    }
+  ],
+  "temporal_segments": [
+    {
+      "name": "early",
+      "request_count": 125,
+      "started_at_unix_ms": 1777977974310,
+      "finished_at_unix_ms": 1777977975151,
+      "p50_latency_us": 393546,
+      "p95_latency_us": 737240,
+      "p99_latency_us": 762515,
+      "p95_queue_share_permille": 964,
+      "p95_service_share_permille": 514,
+      "evidence_quality": {
+        "request_count": 125,
+        "queue_event_count": 125,
+        "stage_event_count": 125,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 378,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 95,
+        "confidence": "high",
+        "evidence": [
+          "Queue wait at p95 consumes 96.4% of request time.",
+          "Observed queue depth sample up to 113.",
+          "In-flight gauge 'queue_service_inflight' grew by 124 over the run window (p95=226, peak=234)."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 36,
+          "confidence": "low",
+          "evidence": [
+            "Stage 'simulated_work' has p95 latency 26723 us across 125 samples.",
+            "Stage 'simulated_work' cumulative latency is 3274597 us (66 permille of request latency).",
+            "Stage 'simulated_work' contributes 34 permille of tail request latency."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'simulated_work'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": [
+        "Runtime and in-flight temporal attribution is limited to timestamp-filtered samples in the segment window."
+      ]
+    },
+    {
+      "name": "late",
+      "request_count": 125,
+      "started_at_unix_ms": 1777977974365,
+      "finished_at_unix_ms": 1777977975970,
+      "p50_latency_us": 1157002,
+      "p95_latency_us": 1502057,
+      "p99_latency_us": 1543716,
+      "p95_queue_share_permille": 982,
+      "p95_service_share_permille": 32,
+      "evidence_quality": {
+        "request_count": 125,
+        "queue_event_count": 125,
+        "stage_event_count": 125,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 371,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 95,
+        "confidence": "high",
+        "evidence": [
+          "Queue wait at p95 consumes 98.2% of request time.",
+          "Observed queue depth sample up to 230."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 33,
+          "confidence": "low",
+          "evidence": [
+            "Stage 'simulated_work' has p95 latency 26737 us across 125 samples.",
+            "Stage 'simulated_work' cumulative latency is 3292487 us (22 permille of request latency).",
+            "Stage 'simulated_work' contributes 17 permille of tail request latency."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'simulated_work'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": [
+        "Runtime and in-flight temporal attribution is limited to timestamp-filtered samples in the segment window."
+      ]
     }
   ],
   "route_breakdowns": []

--- a/demos/queue_service/fixtures/sample-analysis.json
+++ b/demos/queue_service/fixtures/sample-analysis.json
@@ -1,19 +1,21 @@
 {
   "request_count": 250,
-  "p50_latency_us": 783739,
-  "p95_latency_us": 1472369,
-  "p99_latency_us": 1521948,
+  "p50_latency_us": 784557,
+  "p95_latency_us": 1476514,
+  "p99_latency_us": 1527537,
   "p95_queue_share_permille": 982,
-  "p95_service_share_permille": 265,
+  "p95_service_share_permille": 270,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
     "peak_count": 234,
-    "p95_count": 226,
+    "p95_count": 225,
     "growth_delta": -1,
-    "growth_per_sec_milli": -604
+    "growth_per_sec_milli": -602
   },
-  "warnings": [],
+  "warnings": [
+    "Temporal segments show a large p95 latency shift between early and late requests."
+  ],
   "evidence_quality": {
     "request_count": 250,
     "queue_event_count": 250,
@@ -56,8 +58,8 @@
       "score": 33,
       "confidence": "low",
       "evidence": [
-        "Stage 'simulated_work' has p95 latency 26571 us across 250 samples.",
-        "Stage 'simulated_work' cumulative latency is 6535903 us (33 permille of request latency).",
+        "Stage 'simulated_work' has p95 latency 26737 us across 250 samples.",
+        "Stage 'simulated_work' cumulative latency is 6567084 us (33 permille of request latency).",
         "Stage 'simulated_work' contributes 17 permille of tail request latency."
       ],
       "next_checks": [
@@ -66,6 +68,145 @@
         "Review downstream SLO/error budget and align retry budget/backoff with it."
       ],
       "confidence_notes": []
+    }
+  ],
+  "temporal_segments": [
+    {
+      "name": "early",
+      "request_count": 125,
+      "started_at_unix_ms": 1777977974310,
+      "finished_at_unix_ms": 1777977975151,
+      "p50_latency_us": 393546,
+      "p95_latency_us": 737240,
+      "p99_latency_us": 762515,
+      "p95_queue_share_permille": 964,
+      "p95_service_share_permille": 514,
+      "evidence_quality": {
+        "request_count": 125,
+        "queue_event_count": 125,
+        "stage_event_count": 125,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 378,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 95,
+        "confidence": "high",
+        "evidence": [
+          "Queue wait at p95 consumes 96.4% of request time.",
+          "Observed queue depth sample up to 113.",
+          "In-flight gauge 'queue_service_inflight' grew by 124 over the run window (p95=226, peak=234)."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 36,
+          "confidence": "low",
+          "evidence": [
+            "Stage 'simulated_work' has p95 latency 26723 us across 125 samples.",
+            "Stage 'simulated_work' cumulative latency is 3274597 us (66 permille of request latency).",
+            "Stage 'simulated_work' contributes 34 permille of tail request latency."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'simulated_work'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": [
+        "Runtime and in-flight temporal attribution is limited to timestamp-filtered samples in the segment window."
+      ]
+    },
+    {
+      "name": "late",
+      "request_count": 125,
+      "started_at_unix_ms": 1777977974365,
+      "finished_at_unix_ms": 1777977975970,
+      "p50_latency_us": 1157002,
+      "p95_latency_us": 1502057,
+      "p99_latency_us": 1543716,
+      "p95_queue_share_permille": 982,
+      "p95_service_share_permille": 32,
+      "evidence_quality": {
+        "request_count": 125,
+        "queue_event_count": 125,
+        "stage_event_count": 125,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 371,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 95,
+        "confidence": "high",
+        "evidence": [
+          "Queue wait at p95 consumes 98.2% of request time.",
+          "Observed queue depth sample up to 230."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 33,
+          "confidence": "low",
+          "evidence": [
+            "Stage 'simulated_work' has p95 latency 26737 us across 125 samples.",
+            "Stage 'simulated_work' cumulative latency is 3292487 us (22 permille of request latency).",
+            "Stage 'simulated_work' contributes 17 permille of tail request latency."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'simulated_work'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": [
+        "Runtime and in-flight temporal attribution is limited to timestamp-filtered samples in the segment window."
+      ]
     }
   ],
   "route_breakdowns": []

--- a/demos/retry_storm_service/fixtures/after-analysis.json
+++ b/demos/retry_storm_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 180,
-  "p50_latency_us": 9536,
-  "p95_latency_us": 29293,
-  "p99_latency_us": 30041,
+  "p50_latency_us": 9573,
+  "p95_latency_us": 29275,
+  "p99_latency_us": 29875,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "retry_storm_inflight",
     "sample_count": 360,
-    "peak_count": 17,
+    "peak_count": 16,
     "p95_count": 15,
     "growth_delta": -1,
-    "growth_per_sec_milli": -4608
+    "growth_per_sec_milli": -4672
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,9 +41,9 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_total' has p95 latency 27264 us across 180 samples.",
-      "Stage 'downstream_total' cumulative latency is 2154010 us (848 permille of request latency).",
-      "Stage 'downstream_total' contributes 924 permille of tail request latency."
+      "Stage 'downstream_total' has p95 latency 27096 us across 180 samples.",
+      "Stage 'downstream_total' cumulative latency is 2151675 us (843 permille of request latency).",
+      "Stage 'downstream_total' contributes 922 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_total'.",
@@ -53,5 +53,6 @@
     "confidence_notes": []
   },
   "secondary_suspects": [],
+  "temporal_segments": [],
   "route_breakdowns": []
 }

--- a/demos/retry_storm_service/fixtures/before-analysis.json
+++ b/demos/retry_storm_service/fixtures/before-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 180,
-  "p50_latency_us": 9559,
-  "p95_latency_us": 41567,
-  "p99_latency_us": 41781,
+  "p50_latency_us": 9990,
+  "p95_latency_us": 41229,
+  "p99_latency_us": 42372,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "retry_storm_inflight",
     "sample_count": 360,
-    "peak_count": 57,
-    "p95_count": 55,
+    "peak_count": 55,
+    "p95_count": 53,
     "growth_delta": -1,
-    "growth_per_sec_milli": -9523
+    "growth_per_sec_milli": -9345
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,9 +41,9 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_total' has p95 latency 39310 us across 180 samples.",
-      "Stage 'downstream_total' cumulative latency is 3026286 us (887 permille of request latency).",
-      "Stage 'downstream_total' contributes 945 permille of tail request latency."
+      "Stage 'downstream_total' has p95 latency 39253 us across 180 samples.",
+      "Stage 'downstream_total' cumulative latency is 3046095 us (883 permille of request latency).",
+      "Stage 'downstream_total' contributes 943 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_total'.",
@@ -53,5 +53,6 @@
     "confidence_notes": []
   },
   "secondary_suspects": [],
+  "temporal_segments": [],
   "route_breakdowns": []
 }

--- a/demos/shared_state_lock_service/fixtures/after-analysis.json
+++ b/demos/shared_state_lock_service/fixtures/after-analysis.json
@@ -1,19 +1,21 @@
 {
   "request_count": 220,
-  "p50_latency_us": 828543,
-  "p95_latency_us": 1565357,
-  "p99_latency_us": 1626849,
+  "p50_latency_us": 847430,
+  "p95_latency_us": 1592196,
+  "p99_latency_us": 1651610,
   "p95_queue_share_permille": 993,
-  "p95_service_share_permille": 124,
+  "p95_service_share_permille": 138,
   "inflight_trend": {
     "gauge": "shared_state_lock_inflight",
     "sample_count": 440,
     "peak_count": 201,
     "p95_count": 191,
     "growth_delta": -1,
-    "growth_per_sec_milli": -554
+    "growth_per_sec_milli": -544
   },
-  "warnings": [],
+  "warnings": [
+    "Temporal segments show a large p95 latency shift between early and late requests."
+  ],
   "evidence_quality": {
     "request_count": 220,
     "queue_event_count": 220,
@@ -56,8 +58,8 @@
       "score": 32,
       "confidence": "low",
       "evidence": [
-        "Stage 'shared_state_critical_section' has p95 latency 8246 us across 220 samples.",
-        "Stage 'shared_state_critical_section' cumulative latency is 1791550 us (9 permille of request latency).",
+        "Stage 'shared_state_critical_section' has p95 latency 8571 us across 220 samples.",
+        "Stage 'shared_state_critical_section' cumulative latency is 1819289 us (9 permille of request latency).",
         "Stage 'shared_state_critical_section' contributes 5 permille of tail request latency."
       ],
       "next_checks": [
@@ -66,6 +68,145 @@
         "Review downstream SLO/error budget and align retry budget/backoff with it."
       ],
       "confidence_notes": []
+    }
+  ],
+  "temporal_segments": [
+    {
+      "name": "early",
+      "request_count": 110,
+      "started_at_unix_ms": 1777978060514,
+      "finished_at_unix_ms": 1777978061445,
+      "p50_latency_us": 429755,
+      "p95_latency_us": 800943,
+      "p99_latency_us": 833047,
+      "p95_queue_share_permille": 987,
+      "p95_service_share_permille": 207,
+      "evidence_quality": {
+        "request_count": 110,
+        "queue_event_count": 110,
+        "stage_event_count": 220,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 331,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 100,
+        "confidence": "high",
+        "evidence": [
+          "Queue wait at p95 consumes 98.7% of request time.",
+          "Observed queue depth sample up to 100.",
+          "In-flight gauge 'shared_state_lock_inflight' grew by 108 over the run window (p95=193, peak=201)."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 32,
+          "confidence": "low",
+          "evidence": [
+            "Stage 'shared_state_critical_section' has p95 latency 8826 us across 110 samples.",
+            "Stage 'shared_state_critical_section' cumulative latency is 912551 us (19 permille of request latency).",
+            "Stage 'shared_state_critical_section' contributes 10 permille of tail request latency."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'shared_state_critical_section'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": [
+        "Runtime and in-flight temporal attribution is limited to timestamp-filtered samples in the segment window."
+      ]
+    },
+    {
+      "name": "late",
+      "request_count": 110,
+      "started_at_unix_ms": 1777978060598,
+      "finished_at_unix_ms": 1777978062351,
+      "p50_latency_us": 1264089,
+      "p95_latency_us": 1629192,
+      "p99_latency_us": 1659905,
+      "p95_queue_share_permille": 993,
+      "p95_service_share_permille": 12,
+      "evidence_quality": {
+        "request_count": 110,
+        "queue_event_count": 110,
+        "stage_event_count": 220,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 322,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 95,
+        "confidence": "high",
+        "evidence": [
+          "Queue wait at p95 consumes 99.3% of request time.",
+          "Observed queue depth sample up to 200."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 32,
+          "confidence": "low",
+          "evidence": [
+            "Stage 'shared_state_critical_section' has p95 latency 8351 us across 110 samples.",
+            "Stage 'shared_state_critical_section' cumulative latency is 906738 us (6 permille of request latency).",
+            "Stage 'shared_state_critical_section' contributes 4 permille of tail request latency."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'shared_state_critical_section'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": [
+        "Runtime and in-flight temporal attribution is limited to timestamp-filtered samples in the segment window."
+      ]
     }
   ],
   "route_breakdowns": []

--- a/demos/shared_state_lock_service/fixtures/before-analysis.json
+++ b/demos/shared_state_lock_service/fixtures/before-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 2533261,
-  "p95_latency_us": 4794306,
-  "p99_latency_us": 4975959,
+  "p50_latency_us": 2539152,
+  "p95_latency_us": 4806236,
+  "p99_latency_us": 4987331,
   "p95_queue_share_permille": 994,
   "p95_service_share_permille": 100,
   "inflight_trend": {
@@ -11,9 +11,11 @@
     "peak_count": 217,
     "p95_count": 206,
     "growth_delta": -1,
-    "growth_per_sec_milli": -196
+    "growth_per_sec_milli": -195
   },
-  "warnings": [],
+  "warnings": [
+    "Temporal segments show a large p95 latency shift between early and late requests."
+  ],
   "evidence_quality": {
     "request_count": 220,
     "queue_event_count": 220,
@@ -56,8 +58,8 @@
       "score": 32,
       "confidence": "low",
       "evidence": [
-        "Stage 'shared_state_critical_section' has p95 latency 23290 us across 220 samples.",
-        "Stage 'shared_state_critical_section' cumulative latency is 5087992 us (9 permille of request latency).",
+        "Stage 'shared_state_critical_section' has p95 latency 23397 us across 220 samples.",
+        "Stage 'shared_state_critical_section' cumulative latency is 5098012 us (9 permille of request latency).",
         "Stage 'shared_state_critical_section' contributes 4 permille of tail request latency."
       ],
       "next_checks": [
@@ -66,6 +68,145 @@
         "Review downstream SLO/error budget and align retry budget/backoff with it."
       ],
       "confidence_notes": []
+    }
+  ],
+  "temporal_segments": [
+    {
+      "name": "early",
+      "request_count": 110,
+      "started_at_unix_ms": 1777978054903,
+      "finished_at_unix_ms": 1777978057483,
+      "p50_latency_us": 1283618,
+      "p95_latency_us": 2401528,
+      "p99_latency_us": 2494788,
+      "p95_queue_share_permille": 989,
+      "p95_service_share_permille": 184,
+      "evidence_quality": {
+        "request_count": 110,
+        "queue_event_count": 110,
+        "stage_event_count": 220,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 331,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 100,
+        "confidence": "high",
+        "evidence": [
+          "Queue wait at p95 consumes 98.9% of request time.",
+          "Observed queue depth sample up to 109.",
+          "In-flight gauge 'shared_state_lock_inflight' grew by 108 over the run window (p95=209, peak=217)."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 32,
+          "confidence": "low",
+          "evidence": [
+            "Stage 'shared_state_critical_section' has p95 latency 23397 us across 110 samples.",
+            "Stage 'shared_state_critical_section' cumulative latency is 2547850 us (18 permille of request latency).",
+            "Stage 'shared_state_critical_section' contributes 9 permille of tail request latency."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'shared_state_critical_section'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": [
+        "Runtime and in-flight temporal attribution is limited to timestamp-filtered samples in the segment window."
+      ]
+    },
+    {
+      "name": "late",
+      "request_count": 110,
+      "started_at_unix_ms": 1777978054944,
+      "finished_at_unix_ms": 1777978059972,
+      "p50_latency_us": 3796259,
+      "p95_latency_us": 4920570,
+      "p99_latency_us": 5010589,
+      "p95_queue_share_permille": 994,
+      "p95_service_share_permille": 9,
+      "evidence_quality": {
+        "request_count": 110,
+        "queue_event_count": 110,
+        "stage_event_count": 220,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 328,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 95,
+        "confidence": "high",
+        "evidence": [
+          "Queue wait at p95 consumes 99.4% of request time.",
+          "Observed queue depth sample up to 216."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 32,
+          "confidence": "low",
+          "evidence": [
+            "Stage 'shared_state_critical_section' has p95 latency 23394 us across 110 samples.",
+            "Stage 'shared_state_critical_section' cumulative latency is 2550162 us (6 permille of request latency).",
+            "Stage 'shared_state_critical_section' contributes 4 permille of tail request latency."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'shared_state_critical_section'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": [
+        "Runtime and in-flight temporal attribution is limited to timestamp-filtered samples in the segment window."
+      ]
     }
   ],
   "route_breakdowns": []

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -142,3 +142,6 @@ If truncation counters are non-zero, treat the diagnosis as partial-data triage.
 4. Change one thing.
 5. Re-run under comparable load.
 6. Compare suspect movement and p95 shares.
+
+
+`temporal_segments` is always present in JSON output and is usually an empty array. It is populated only when early/late within-run analysis adds signal, such as different segment primary suspects or a large p95 shift. Temporal segments are supporting context only: global `primary_suspect` remains the primary full-run triage lead. Temporal segments are hints, not proof of phase-specific root cause. Runtime and in-flight evidence is included only when timestamp-filtered samples in a segment window are reliable.

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -95,6 +95,7 @@ Then run one targeted check, change one thing, and re-run under comparable load.
     "confidence_notes": []
   },
   "secondary_suspects": [],
+  "temporal_segments": [],
   "route_breakdowns": []
 }
 ```
@@ -210,3 +211,6 @@ Use capture-side crates for that:
 - `tailtriage-controller`: repeated bounded windows
 - `tailtriage-tokio`: runtime-pressure sampling
 - `tailtriage-axum`: Axum request-boundary integration
+
+
+`temporal_segments` is always present in JSON output and is usually an empty array. It is populated only when early/late within-run analysis adds signal, such as different segment primary suspects or a large p95 shift. Temporal segments are supporting context only: global `primary_suspect` remains the primary full-run triage lead. Temporal segments are hints, not proof of phase-specific root cause. Runtime and in-flight evidence is included only when timestamp-filtered samples in a segment window are reliable.

--- a/tailtriage-cli/src/analyze.rs
+++ b/tailtriage-cli/src/analyze.rs
@@ -18,6 +18,7 @@ const ROUTE_MIN_REQUEST_COUNT: usize = 3;
 const ROUTE_BREAKDOWN_LIMIT: usize = 10;
 const TEMPORAL_MIN_REQUEST_COUNT: usize = 20;
 const TEMPORAL_MIN_SEGMENT_REQUEST_COUNT: usize = 8;
+const TEMPORAL_MIN_RUNTIME_ATTRIBUTION_SAMPLES: usize = 2;
 const TEMPORAL_SHARE_SHIFT_PERMILLE_THRESHOLD: u64 = 200;
 const ROUTE_DIVERGENCE_WARNING: &str =
     "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect.";
@@ -531,13 +532,18 @@ fn build_temporal_segment(
     requests: &[tailtriage_core::RequestEvent],
 ) -> TemporalSegment {
     let ids: Vec<String> = requests.iter().map(|r| r.request_id.clone()).collect();
-    let window = requests
-        .first()
-        .zip(requests.last())
-        .map(|(first, last)| (first.started_at_unix_ms, last.finished_at_unix_ms));
+    let segment_start = requests.first().map(|r| r.started_at_unix_ms);
+    let segment_finish = requests.iter().map(|r| r.finished_at_unix_ms).max();
+    let window = segment_start.zip(segment_finish);
+    let runtime_present_full = !run.runtime_snapshots.is_empty();
+    let inflight_present_full = !run.inflight.is_empty();
     let filtered = filtered_run_for_request_ids_and_time(run, &ids, window);
     let mut analyzed = analyze_run_internal(&filtered);
-    if !filtered.runtime_snapshots.is_empty() || !filtered.inflight.is_empty() {
+    let runtime_limited = runtime_present_full
+        && filtered.runtime_snapshots.len() < TEMPORAL_MIN_RUNTIME_ATTRIBUTION_SAMPLES;
+    let inflight_limited =
+        inflight_present_full && filtered.inflight.len() < TEMPORAL_MIN_RUNTIME_ATTRIBUTION_SAMPLES;
+    if runtime_limited || inflight_limited {
         analyzed
             .warnings
             .push(TEMPORAL_RUNTIME_FILTER_WARNING.to_string());
@@ -545,8 +551,8 @@ fn build_temporal_segment(
     TemporalSegment {
         name: name.to_string(),
         request_count: analyzed.request_count,
-        started_at_unix_ms: requests.first().map(|r| r.started_at_unix_ms),
-        finished_at_unix_ms: requests.last().map(|r| r.finished_at_unix_ms),
+        started_at_unix_ms: segment_start,
+        finished_at_unix_ms: segment_finish,
         p50_latency_us: analyzed.p50_latency_us,
         p95_latency_us: analyzed.p95_latency_us,
         p99_latency_us: analyzed.p99_latency_us,
@@ -2897,7 +2903,7 @@ mod tests {
     #[test]
     fn temporal_segments_emit_and_are_deterministic() {
         let mut run = test_run();
-        run.requests = (0..20)
+        run.requests = (0_u64..20)
             .map(|i| RequestEvent {
                 request_id: format!("req-{i:02}"),
                 route: "/test".to_string(),
@@ -2916,5 +2922,75 @@ mod tests {
             .warnings
             .iter()
             .any(|w| w == TEMPORAL_LATENCY_SHIFT_WARNING));
+    }
+
+    #[test]
+    fn temporal_segments_empty_when_not_meaningfully_different() {
+        let mut run = test_run();
+        run.requests = (0_u64..20)
+            .map(|i| RequestEvent {
+                request_id: format!("req-{i:02}"),
+                route: "/test".to_string(),
+                kind: None,
+                started_at_unix_ms: 10 + i,
+                finished_at_unix_ms: 11 + i,
+                latency_us: 5_000,
+                outcome: "ok".to_string(),
+            })
+            .collect();
+        let report = analyze_run(&run);
+        assert!(report.temporal_segments.is_empty());
+    }
+
+    #[test]
+    fn temporal_segment_window_uses_max_finish_timestamp() {
+        let mut run = test_run();
+        run.requests = (0_u64..20)
+            .map(|i| RequestEvent {
+                request_id: format!("req-{i:02}"),
+                route: "/test".to_string(),
+                kind: None,
+                started_at_unix_ms: i,
+                finished_at_unix_ms: i + 2,
+                latency_us: if i < 10 { 1_000 } else { 10_000 },
+                outcome: "ok".to_string(),
+            })
+            .collect();
+        run.requests[0].finished_at_unix_ms = 100;
+        run.requests[9].finished_at_unix_ms = 11;
+        let report = analyze_run(&run);
+        let early = report
+            .temporal_segments
+            .iter()
+            .find(|s| s.name == "early")
+            .unwrap();
+        assert_eq!(early.finished_at_unix_ms, Some(100));
+    }
+
+    #[test]
+    fn temporal_runtime_warning_only_when_attribution_is_limited() {
+        let mut run = test_run();
+        run.requests = (0_u64..20)
+            .map(|i| RequestEvent {
+                request_id: format!("req-{i:02}"),
+                route: "/test".to_string(),
+                kind: None,
+                started_at_unix_ms: i,
+                finished_at_unix_ms: i + 1,
+                latency_us: if i < 10 { 1_000 } else { 8_000 },
+                outcome: "ok".to_string(),
+            })
+            .collect();
+        run.runtime_snapshots = vec![
+            runtime_snapshot(Some(1), Some(1), Some(1)),
+            runtime_snapshot(Some(2), Some(2), Some(2)),
+        ];
+        run.runtime_snapshots[0].at_unix_ms = 2;
+        run.runtime_snapshots[1].at_unix_ms = 17;
+        let report = analyze_run(&run);
+        assert!(report.temporal_segments.iter().any(|s| s
+            .warnings
+            .iter()
+            .any(|w| w == super::TEMPORAL_RUNTIME_FILTER_WARNING)));
     }
 }

--- a/tailtriage-cli/src/analyze.rs
+++ b/tailtriage-cli/src/analyze.rs
@@ -16,10 +16,19 @@ const SAMPLE_QUALITY_LOW_SAMPLE_COUNT: usize = 20;
 const SAMPLE_QUALITY_MIN_NONZERO_SAMPLE_COUNT: usize = 8;
 const ROUTE_MIN_REQUEST_COUNT: usize = 3;
 const ROUTE_BREAKDOWN_LIMIT: usize = 10;
+const TEMPORAL_MIN_REQUEST_COUNT: usize = 20;
+const TEMPORAL_MIN_SEGMENT_REQUEST_COUNT: usize = 8;
+const TEMPORAL_SHARE_SHIFT_PERMILLE_THRESHOLD: u64 = 200;
 const ROUTE_DIVERGENCE_WARNING: &str =
     "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect.";
 const ROUTE_RUNTIME_ATTRIBUTION_WARNING: &str =
     "Runtime and in-flight signals are global and are not attributed to this route.";
+const TEMPORAL_DIVERGENCE_WARNING: &str =
+    "Temporal segments show different primary suspects; inspect temporal_segments before acting on the global suspect.";
+const TEMPORAL_LATENCY_SHIFT_WARNING: &str =
+    "Temporal segments show a large p95 latency shift between early and late requests.";
+const TEMPORAL_RUNTIME_FILTER_WARNING: &str =
+    "Runtime and in-flight temporal attribution is limited to timestamp-filtered samples in the segment window.";
 
 /// Evidence-ranked diagnosis categories produced by heuristic triage.
 ///
@@ -236,8 +245,41 @@ pub struct Report {
     pub primary_suspect: Suspect,
     /// Lower-ranked suspects retained for follow-up triage.
     pub secondary_suspects: Vec<Suspect>,
+    /// Supporting early/late temporal summaries when within-run phase shift signal adds value.
+    pub temporal_segments: Vec<TemporalSegment>,
     /// Supporting per-route triage summaries when route-level signal adds value.
     pub route_breakdowns: Vec<RouteBreakdown>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+/// Supporting early/late temporal triage summary for within-run shifts.
+pub struct TemporalSegment {
+    /// Stable segment name (`early` or `late`).
+    pub name: String,
+    /// Completed request count included in this segment.
+    pub request_count: usize,
+    /// Earliest request start timestamp in this segment, if available.
+    pub started_at_unix_ms: Option<u64>,
+    /// Latest request finish timestamp in this segment, if available.
+    pub finished_at_unix_ms: Option<u64>,
+    /// p50 request latency in microseconds for this segment.
+    pub p50_latency_us: Option<u64>,
+    /// p95 request latency in microseconds for this segment.
+    pub p95_latency_us: Option<u64>,
+    /// p99 request latency in microseconds for this segment.
+    pub p99_latency_us: Option<u64>,
+    /// p95 queue-time share per request in permille for this segment.
+    pub p95_queue_share_permille: Option<u64>,
+    /// p95 non-queue service-time share per request in permille for this segment.
+    pub p95_service_share_permille: Option<u64>,
+    /// Evidence coverage summary for this segment analysis.
+    pub evidence_quality: EvidenceQuality,
+    /// Highest-ranked suspect for this segment.
+    pub primary_suspect: Suspect,
+    /// Lower-ranked segment suspects retained for follow-up.
+    pub secondary_suspects: Vec<Suspect>,
+    /// Segment-scoped warnings and interpretation limits.
+    pub warnings: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -319,6 +361,18 @@ pub struct RouteBreakdown {
 #[must_use]
 pub fn analyze_run(run: &Run) -> Report {
     let mut report = analyze_run_internal(run);
+    let temporal_context = temporal_segments(run);
+    if temporal_context.divergent {
+        report
+            .warnings
+            .push(TEMPORAL_DIVERGENCE_WARNING.to_string());
+    }
+    if temporal_context.latency_shift {
+        report
+            .warnings
+            .push(TEMPORAL_LATENCY_SHIFT_WARNING.to_string());
+    }
+    report.temporal_segments = temporal_context.segments;
     let route_context = route_breakdowns(run, &report);
     if route_context.divergent {
         report.warnings.push(ROUTE_DIVERGENCE_WARNING.to_string());
@@ -405,13 +459,121 @@ fn analyze_run_internal(run: &Run) -> Report {
         evidence_quality,
         primary_suspect,
         secondary_suspects: ranked.collect(),
+        temporal_segments: Vec::new(),
         route_breakdowns: Vec::new(),
     }
+}
+
+struct TemporalSegmentContext {
+    segments: Vec<TemporalSegment>,
+    divergent: bool,
+    latency_shift: bool,
 }
 
 struct RouteBreakdownContext {
     breakdowns: Vec<RouteBreakdown>,
     divergent: bool,
+}
+
+fn temporal_segments(run: &Run) -> TemporalSegmentContext {
+    if run.requests.len() < TEMPORAL_MIN_REQUEST_COUNT {
+        return TemporalSegmentContext {
+            segments: vec![],
+            divergent: false,
+            latency_shift: false,
+        };
+    }
+    let mut ordered = run.requests.clone();
+    ordered.sort_by(|a, b| {
+        a.started_at_unix_ms
+            .cmp(&b.started_at_unix_ms)
+            .then_with(|| a.request_id.cmp(&b.request_id))
+    });
+    let split = ordered.len() / 2;
+    let (early, late) = ordered.split_at(split);
+    if early.len() < TEMPORAL_MIN_SEGMENT_REQUEST_COUNT
+        || late.len() < TEMPORAL_MIN_SEGMENT_REQUEST_COUNT
+    {
+        return TemporalSegmentContext {
+            segments: vec![],
+            divergent: false,
+            latency_shift: false,
+        };
+    }
+    let early_segment = build_temporal_segment(run, "early", early);
+    let late_segment = build_temporal_segment(run, "late", late);
+    let divergent = early_segment.primary_suspect.kind != late_segment.primary_suspect.kind;
+    let latency_shift = large_p95_shift(early_segment.p95_latency_us, late_segment.p95_latency_us);
+    let share_shift = share_shift(
+        early_segment.p95_queue_share_permille,
+        late_segment.p95_queue_share_permille,
+    ) || share_shift(
+        early_segment.p95_service_share_permille,
+        late_segment.p95_service_share_permille,
+    );
+    let evidence_shift =
+        early_segment.evidence_quality.quality != late_segment.evidence_quality.quality;
+    let meaningful = divergent || latency_shift || share_shift || evidence_shift;
+    TemporalSegmentContext {
+        segments: if meaningful {
+            vec![early_segment, late_segment]
+        } else {
+            vec![]
+        },
+        divergent,
+        latency_shift,
+    }
+}
+
+fn build_temporal_segment(
+    run: &Run,
+    name: &str,
+    requests: &[tailtriage_core::RequestEvent],
+) -> TemporalSegment {
+    let ids: Vec<String> = requests.iter().map(|r| r.request_id.clone()).collect();
+    let window = requests
+        .first()
+        .zip(requests.last())
+        .map(|(first, last)| (first.started_at_unix_ms, last.finished_at_unix_ms));
+    let filtered = filtered_run_for_request_ids_and_time(run, &ids, window);
+    let mut analyzed = analyze_run_internal(&filtered);
+    if !filtered.runtime_snapshots.is_empty() || !filtered.inflight.is_empty() {
+        analyzed
+            .warnings
+            .push(TEMPORAL_RUNTIME_FILTER_WARNING.to_string());
+    }
+    TemporalSegment {
+        name: name.to_string(),
+        request_count: analyzed.request_count,
+        started_at_unix_ms: requests.first().map(|r| r.started_at_unix_ms),
+        finished_at_unix_ms: requests.last().map(|r| r.finished_at_unix_ms),
+        p50_latency_us: analyzed.p50_latency_us,
+        p95_latency_us: analyzed.p95_latency_us,
+        p99_latency_us: analyzed.p99_latency_us,
+        p95_queue_share_permille: analyzed.p95_queue_share_permille,
+        p95_service_share_permille: analyzed.p95_service_share_permille,
+        evidence_quality: analyzed.evidence_quality,
+        primary_suspect: analyzed.primary_suspect,
+        secondary_suspects: analyzed.secondary_suspects,
+        warnings: analyzed.warnings,
+    }
+}
+
+fn large_p95_shift(early: Option<u64>, late: Option<u64>) -> bool {
+    match (early, late) {
+        (Some(a), Some(b)) if a > 0 && b > 0 => {
+            let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+            hi.saturating_mul(2) >= lo.saturating_mul(3)
+        }
+        _ => false,
+    }
+}
+
+fn share_shift(early: Option<u64>, late: Option<u64>) -> bool {
+    match (early, late) {
+        (Some(a), Some(b)) => a.abs_diff(b) >= TEMPORAL_SHARE_SHIFT_PERMILLE_THRESHOLD,
+        _ => false,
+    }
 }
 
 fn route_breakdowns(run: &Run, global: &Report) -> RouteBreakdownContext {
@@ -446,7 +608,7 @@ fn route_breakdowns(run: &Run, global: &Report) -> RouteBreakdownContext {
 
     let mut candidates = Vec::new();
     for (route, request_ids) in eligible {
-        let filtered = filtered_run_for_route(run, &request_ids);
+        let filtered = filtered_run_for_request_ids_and_time(run, &request_ids, None);
         let mut analyzed = analyze_run_internal(&filtered);
         analyzed
             .warnings
@@ -525,7 +687,11 @@ fn should_emit_route_breakdowns(global: &Report, candidates: &[RouteBreakdown]) 
         }
 }
 
-fn filtered_run_for_route(run: &Run, request_ids: &[String]) -> Run {
+fn filtered_run_for_request_ids_and_time(
+    run: &Run,
+    request_ids: &[String],
+    time_window: Option<(u64, u64)>,
+) -> Run {
     let request_ids: std::collections::HashSet<&str> =
         request_ids.iter().map(String::as_str).collect();
     let mut filtered = run.clone();
@@ -547,8 +713,24 @@ fn filtered_run_for_route(run: &Run, request_ids: &[String]) -> Run {
         .filter(|q| request_ids.contains(q.request_id.as_str()))
         .cloned()
         .collect();
-    filtered.runtime_snapshots = Vec::new();
-    filtered.inflight = Vec::new();
+    filtered.runtime_snapshots = run
+        .runtime_snapshots
+        .iter()
+        .filter(|snapshot| match time_window {
+            Some((start, end)) => snapshot.at_unix_ms >= start && snapshot.at_unix_ms <= end,
+            None => false,
+        })
+        .cloned()
+        .collect();
+    filtered.inflight = run
+        .inflight
+        .iter()
+        .filter(|snapshot| match time_window {
+            Some((start, end)) => snapshot.at_unix_ms >= start && snapshot.at_unix_ms <= end,
+            None => false,
+        })
+        .cloned()
+        .collect();
     filtered
 }
 
@@ -1520,6 +1702,7 @@ pub fn render_text(report: &Report) -> String {
             ));
         }
     }
+    render_temporal_section(report, &mut lines);
     if !report.route_breakdowns.is_empty() {
         lines.push("Route breakdowns:".to_string());
         for route in &report.route_breakdowns {
@@ -1537,6 +1720,23 @@ pub fn render_text(report: &Report) -> String {
     lines.join("\n")
 }
 
+fn render_temporal_section(report: &Report, lines: &mut Vec<String>) {
+    if report.temporal_segments.is_empty() {
+        return;
+    }
+    lines.push("Temporal segments:".to_string());
+    for segment in &report.temporal_segments {
+        lines.push(format!(
+            "- {}: requests {}, p95 {}us, suspect {} ({} confidence)",
+            segment.name,
+            segment.request_count,
+            fmt_opt_u64(segment.p95_latency_us),
+            segment.primary_suspect.kind.as_str(),
+            fmt_confidence(segment.primary_suspect.confidence),
+        ));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use tailtriage_core::{
@@ -1548,7 +1748,7 @@ mod tests {
         analyze_run, analyze_run_internal, apply_evidence_aware_confidence_caps, evidence_quality,
         render_text, Confidence, DiagnosisKind, EvidenceQuality, EvidenceQualityLevel,
         InflightTrend, Report, SignalCoverageStatus, Suspect, ROUTE_DIVERGENCE_WARNING,
-        ROUTE_RUNTIME_ATTRIBUTION_WARNING,
+        ROUTE_RUNTIME_ATTRIBUTION_WARNING, TEMPORAL_LATENCY_SHIFT_WARNING,
     };
 
     fn test_run() -> Run {
@@ -1804,6 +2004,7 @@ mod tests {
                 confidence_notes: Vec::new(),
             },
             secondary_suspects: Vec::new(),
+            temporal_segments: Vec::new(),
             route_breakdowns: Vec::new(),
         };
 
@@ -1856,6 +2057,7 @@ mod tests {
                 confidence_notes: Vec::new(),
             },
             secondary_suspects: Vec::new(),
+            temporal_segments: Vec::new(),
             route_breakdowns: Vec::new(),
         };
 
@@ -2682,5 +2884,37 @@ mod tests {
         let report = analyze_run(&run);
         assert_eq!(report.primary_suspect.kind, global.primary_suspect.kind);
         assert_eq!(report.primary_suspect.score, global.primary_suspect.score);
+    }
+
+    #[test]
+    fn temporal_segments_present_and_empty_below_threshold() {
+        let report = analyze_run(&test_run());
+        let value = serde_json::to_value(&report).expect("serialize report");
+        assert!(value.get("temporal_segments").is_some());
+        assert!(report.temporal_segments.is_empty());
+    }
+
+    #[test]
+    fn temporal_segments_emit_and_are_deterministic() {
+        let mut run = test_run();
+        run.requests = (0..20)
+            .map(|i| RequestEvent {
+                request_id: format!("req-{i:02}"),
+                route: "/test".to_string(),
+                kind: None,
+                started_at_unix_ms: 10 + i,
+                finished_at_unix_ms: 11 + i,
+                latency_us: if i < 10 { 1_000 } else { 8_000 },
+                outcome: "ok".to_string(),
+            })
+            .collect();
+        let report = analyze_run(&run);
+        assert_eq!(report.temporal_segments.len(), 2);
+        assert_eq!(report.temporal_segments[0].name, "early");
+        assert_eq!(report.temporal_segments[1].name, "late");
+        assert!(report
+            .warnings
+            .iter()
+            .any(|w| w == TEMPORAL_LATENCY_SHIFT_WARNING));
     }
 }

--- a/validation/diagnostics/manifest.json
+++ b/validation/diagnostics/manifest.json
@@ -16,7 +16,9 @@
         "Queue wait"
       ],
       "notes": "Queue scenario before mitigation is queue-dominant.",
-      "expected_warnings": [],
+      "expected_warnings": [
+        "Temporal segments show a large p95 latency shift between early and late requests."
+      ],
       "top1_required": true,
       "allowed_warnings": [],
       "required_top2": [
@@ -69,7 +71,8 @@
       "notes": "Blocking pool backlog is intentional pre-fix condition.",
       "expected_warnings": [
         "Runtime snapshots are missing",
-        "Top suspects are close in score"
+        "Top suspects are close in score",
+        "Temporal segments show a large p95 latency shift between early and late requests."
       ],
       "top1_required": true,
       "allowed_warnings": [],
@@ -96,7 +99,8 @@
       ],
       "notes": "After blocking mitigation, downstream work can dominate residual tail.",
       "expected_warnings": [
-        "Runtime snapshots are missing"
+        "Runtime snapshots are missing",
+        "Temporal segments show a large p95 latency shift between early and late requests."
       ],
       "top1_required": false,
       "allowed_warnings": [
@@ -227,7 +231,9 @@
         "Queue wait"
       ],
       "notes": "Mixed baseline intentionally keeps queue and executor signals close.",
-      "expected_warnings": [],
+      "expected_warnings": [
+        "Temporal segments show a large p95 latency shift between early and late requests."
+      ],
       "top1_required": false,
       "allowed_warnings": [],
       "required_top2": [
@@ -331,7 +337,9 @@
         "Queue wait"
       ],
       "notes": "Before pool tuning queueing from limited DB pool appears strongly.",
-      "expected_warnings": [],
+      "expected_warnings": [
+        "Temporal segments show a large p95 latency shift between early and late requests."
+      ],
       "top1_required": false,
       "allowed_warnings": [],
       "required_top2": [
@@ -383,7 +391,9 @@
         "Stage"
       ],
       "notes": "Shared lock contention manifests through stage latency dominance.",
-      "expected_warnings": [],
+      "expected_warnings": [
+        "Temporal segments show a large p95 latency shift between early and late requests."
+      ],
       "top1_required": false,
       "allowed_warnings": [],
       "required_top2": [
@@ -409,7 +419,9 @@
         "Stage"
       ],
       "notes": "After mitigation remaining time is still mostly stage work.",
-      "expected_warnings": [],
+      "expected_warnings": [
+        "Temporal segments show a large p95 latency shift between early and late requests."
+      ],
       "top1_required": false,
       "allowed_warnings": [],
       "required_top2": [
@@ -486,7 +498,9 @@
         "Queue wait"
       ],
       "notes": "Queue sample is canonical queue saturation evidence.",
-      "expected_warnings": [],
+      "expected_warnings": [
+        "Temporal segments show a large p95 latency shift between early and late requests."
+      ],
       "top1_required": true,
       "allowed_warnings": [],
       "required_top2": [
@@ -513,7 +527,8 @@
       "notes": "Blocking sample is canonical blocking saturation evidence.",
       "expected_warnings": [
         "Runtime snapshots are missing",
-        "Top suspects are close in score"
+        "Top suspects are close in score",
+        "Temporal segments show a large p95 latency shift between early and late requests."
       ],
       "top1_required": true,
       "allowed_warnings": [],


### PR DESCRIPTION
### Motivation
- Improve within-run signal visibility by adding a compact bounded temporal summary that highlights meaningful early/late phase shifts such as cold-start bursts or late saturation. 
- Keep the change additive and non-disruptive to existing run artifacts and global triage semantics. 
- Avoid noisy output by only emitting segments when simple, conservative rules indicate useful phase-differentiating signal.

### Description
- Added a new always-present `Report.temporal_segments: Vec<TemporalSegment>` field and a serializable `TemporalSegment` type with the requested fields (names, counts, timestamps, p50/p95/p99, p95 queue/service shares, `evidence_quality`, `primary_suspect`, `secondary_suspects`, and `warnings`).
- Implemented a deterministic two-way split by `started_at_unix_ms` then `request_id` into `early` / `late` segments with bounded eligibility: at least `TEMPORAL_MIN_REQUEST_COUNT` (20) total and at least `TEMPORAL_MIN_SEGMENT_REQUEST_COUNT` (8) per segment.
- Emission gating: `early`/`late` segments are emitted only when at least one meaningful condition holds (primary-suspect kind divergence, large p95 shift >=50% using a guarded comparison, large queue/service share movement using a permille threshold, or evidence-quality movement); otherwise `temporal_segments` is an empty array to avoid noise.
- Reused and extended existing analyzer helpers safely: added `filtered_run_for_request_ids_and_time` to filter requests/stages/queues and timestamp-filter runtime/in-flight snapshots for segment windows, and built per-segment analysis via `analyze_run_internal` without recursive nested temporal/route breakdowns; added stable runtime-attribution warning when timestamp filtering yields segment-limited runtime/in-flight evidence.
- Added stable global warnings when temporal segments are emitted for divergence or large p95 shifts and a compact CLI text section rendering `early`/`late` (name, request count, p95, primary suspect, confidence) only when non-empty; updated docs and JSON README/example to include `temporal_segments` and clarified semantics (hints, not proof).
- Updated demo fixtures and added unit tests validating presence/emptiness of `temporal_segments` below thresholds, deterministic split and emission, warning behavior, and that global ranking remains unchanged by segment generation.

### Testing
- Ran `cargo fmt --check`: passed. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings`: passed. 
- Ran `cargo test --workspace`: all Rust unit tests passed (45 tests in CLI analyzers plus workspace tests). 
- Refreshed and checked demo fixtures with `python3 scripts/check_demo_fixture_drift.py --profile dev --refresh` and `--profile dev`: fixtures refreshed and validations completed (demo fixtures updated to include `temporal_segments`).
- Ran the full diagnostic benchmark `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0`: aggregate thresholds met but the run reported `failed_case_count=9` due to per-case warning expectation mismatches (this is a targeted discrepancy in per-case warnings after adding temporal warnings). 
- Ran `python3 -m unittest scripts.tests.test_diagnostic_benchmark`: passed. 
- Ran docs contract validation `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts`: both passed after updating README/docs JSON examples.

Temporal segmentation behavior summary: the analyzer deterministically splits completed requests into `early` and `late` halves (by start-time then id), analyzes each segment with timestamp-filtered runtime/in-flight where available, and emits two `TemporalSegment` entries only when they add meaningful signal (suspect divergence, large p95 shift, large share movement, or evidence-quality change). The `temporal_segments` field is always present in JSON but is an empty array unless the gating rules are satisfied.

Global ranking change status: global `Report.primary_suspect` and global suspect scores were not changed by this feature; temporal segments are supporting context only and only add stable temporal warnings (they do not re-rank the global suspect).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c92cdd4c83309b62f252b580942d)