### PR TITLE
Add conservative early/late temporal segments to analyzer output

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,8 @@ tailtriage analyze tailtriage-run.json --format json
       ]
     }
   ],
-  "route_breakdowns": []
+  "route_breakdowns": [],
+  "temporal_segments": []
 }
 ```
 
@@ -288,3 +289,6 @@ Demo walkthrough and CI coverage details: [`docs/getting-started-demo.md`](docs/
 - Collector-stress, truncation, artifact-size, and memory guidance: [`docs/collector-limits.md`](docs/collector-limits.md)
 - Architecture and crate responsibilities: [`docs/architecture.md`](docs/architecture.md)
 - Full docs index: [`docs/README.md`](docs/README.md)
+
+
+`temporal_segments` is always present in JSON output and usually empty. It is emitted only when conservative early/late comparison finds a material within-run shift (for example primary suspect shift or large p95 shift). These are triage hints only; global `primary_suspect` and ranking remain the full-run source of truth.

--- a/demos/blocking_service/fixtures/after-analysis.json
+++ b/demos/blocking_service/fixtures/after-analysis.json
@@ -1,20 +1,21 @@
 {
   "request_count": 250,
-  "p50_latency_us": 52104,
-  "p95_latency_us": 85732,
-  "p99_latency_us": 89330,
-  "p95_queue_share_permille": 66,
-  "p95_service_share_permille": 990,
+  "p50_latency_us": 54923,
+  "p95_latency_us": 89624,
+  "p99_latency_us": 92129,
+  "p95_queue_share_permille": 62,
+  "p95_service_share_permille": 995,
   "inflight_trend": {
     "gauge": "blocking_service_inflight",
     "sample_count": 500,
-    "peak_count": 48,
-    "p95_count": 45,
+    "peak_count": 50,
+    "p95_count": 47,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2053
+    "growth_per_sec_milli": -2040
   },
   "warnings": [
-    "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited."
+    "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited.",
+    "Temporal segments show a large p95 latency shift between early and late requests."
   ],
   "evidence_quality": {
     "request_count": 250,
@@ -43,8 +44,8 @@
     "score": 100,
     "confidence": "high",
     "evidence": [
-      "Stage 'spawn_blocking_path' has p95 latency 84718 us across 250 samples.",
-      "Stage 'spawn_blocking_path' cumulative latency is 13035850 us (978 permille of request latency).",
+      "Stage 'spawn_blocking_path' has p95 latency 88284 us across 250 samples.",
+      "Stage 'spawn_blocking_path' cumulative latency is 13515839 us (978 permille of request latency).",
       "Stage 'spawn_blocking_path' contributes 988 permille of tail request latency."
     ],
     "next_checks": [
@@ -60,7 +61,7 @@
       "score": 82,
       "confidence": "medium",
       "evidence": [
-        "Blocking queue depth p95 is 43, peak is 47, with 97/200 nonzero samples."
+        "Blocking queue depth p95 is 44, peak is 48, with 98/200 nonzero samples."
       ],
       "next_checks": [
         "Audit blocking sections and move avoidable synchronous work out of hot paths.",
@@ -69,5 +70,145 @@
       "confidence_notes": []
     }
   ],
-  "route_breakdowns": []
+  "route_breakdowns": [],
+  "temporal_segments": [
+    {
+      "name": "early",
+      "request_count": 125,
+      "started_at_unix_ms": 1777982579443,
+      "finished_at_unix_ms": 1777982579694,
+      "p50_latency_us": 34467,
+      "p95_latency_us": 52659,
+      "p99_latency_us": 54923,
+      "p95_queue_share_permille": 68,
+      "p95_service_share_permille": 995,
+      "evidence_quality": {
+        "request_count": 125,
+        "queue_event_count": 125,
+        "stage_event_count": 125,
+        "runtime_snapshot_count": 51,
+        "inflight_snapshot_count": 284,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "partial",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "partial",
+        "limitations": [
+          "Runtime snapshots have missing queue-depth fields, limiting executor vs blocking differentiation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "blocking_pool_pressure",
+        "score": 85,
+        "confidence": "medium",
+        "evidence": [
+          "Blocking queue depth p95 is 34, peak is 34, with 51/51 nonzero samples."
+        ],
+        "next_checks": [
+          "Audit blocking sections and move avoidable synchronous work out of hot paths.",
+          "Inspect spawn_blocking callsites for long-running CPU or I/O work."
+        ],
+        "confidence_notes": [
+          "Missing runtime snapshots limit executor/blocking confidence.",
+          "Top suspects are close in score; confidence is capped by ambiguity."
+        ]
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 83,
+          "confidence": "medium",
+          "evidence": [
+            "Stage 'spawn_blocking_path' has p95 latency 52329 us across 125 samples.",
+            "Stage 'spawn_blocking_path' cumulative latency is 4285430 us (967 permille of request latency).",
+            "Stage 'spawn_blocking_path' contributes 978 permille of tail request latency.",
+            "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": []
+    },
+    {
+      "name": "late",
+      "request_count": 125,
+      "started_at_unix_ms": 1777982579642,
+      "finished_at_unix_ms": 1777982579933,
+      "p50_latency_us": 75628,
+      "p95_latency_us": 91537,
+      "p99_latency_us": 94283,
+      "p95_queue_share_permille": 25,
+      "p95_service_share_permille": 993,
+      "evidence_quality": {
+        "request_count": 125,
+        "queue_event_count": 125,
+        "stage_event_count": 125,
+        "runtime_snapshot_count": 58,
+        "inflight_snapshot_count": 279,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "partial",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "partial",
+        "limitations": [
+          "Runtime snapshots have missing queue-depth fields, limiting executor vs blocking differentiation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "blocking_pool_pressure",
+        "score": 85,
+        "confidence": "medium",
+        "evidence": [
+          "Blocking queue depth p95 is 48, peak is 48, with 58/58 nonzero samples."
+        ],
+        "next_checks": [
+          "Audit blocking sections and move avoidable synchronous work out of hot paths.",
+          "Inspect spawn_blocking callsites for long-running CPU or I/O work."
+        ],
+        "confidence_notes": [
+          "Missing runtime snapshots limit executor/blocking confidence.",
+          "Top suspects are close in score; confidence is capped by ambiguity."
+        ]
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 83,
+          "confidence": "medium",
+          "evidence": [
+            "Stage 'spawn_blocking_path' has p95 latency 90852 us across 125 samples.",
+            "Stage 'spawn_blocking_path' cumulative latency is 9230409 us (983 permille of request latency).",
+            "Stage 'spawn_blocking_path' contributes 987 permille of tail request latency.",
+            "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": []
+    }
+  ]
 }

--- a/demos/blocking_service/fixtures/before-analysis.json
+++ b/demos/blocking_service/fixtures/before-analysis.json
@@ -1,21 +1,22 @@
 {
   "request_count": 250,
-  "p50_latency_us": 1866475,
-  "p95_latency_us": 3524603,
-  "p99_latency_us": 3673375,
-  "p95_queue_share_permille": 3,
+  "p50_latency_us": 1872732,
+  "p95_latency_us": 3536828,
+  "p99_latency_us": 3686672,
+  "p95_queue_share_permille": 6,
   "p95_service_share_permille": 999,
   "inflight_trend": {
     "gauge": "blocking_service_inflight",
     "sample_count": 500,
     "peak_count": 246,
-    "p95_count": 235,
+    "p95_count": 234,
     "growth_delta": 0,
     "growth_per_sec_milli": 0
   },
   "warnings": [
     "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited.",
-    "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks."
+    "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks.",
+    "Temporal segments show a large p95 latency shift between early and late requests."
   ],
   "evidence_quality": {
     "request_count": 250,
@@ -44,7 +45,7 @@
     "score": 88,
     "confidence": "medium",
     "evidence": [
-      "Blocking queue depth p95 is 244, peak is 246, with 200/200 nonzero samples."
+      "Blocking queue depth p95 is 244, peak is 246, with 199/200 nonzero samples."
     ],
     "next_checks": [
       "Audit blocking sections and move avoidable synchronous work out of hot paths.",
@@ -61,8 +62,8 @@
       "score": 86,
       "confidence": "high",
       "evidence": [
-        "Stage 'spawn_blocking_path' has p95 latency 3523850 us across 250 samples.",
-        "Stage 'spawn_blocking_path' cumulative latency is 466288754 us (999 permille of request latency).",
+        "Stage 'spawn_blocking_path' has p95 latency 3535561 us across 250 samples.",
+        "Stage 'spawn_blocking_path' cumulative latency is 467850111 us (999 permille of request latency).",
         "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency.",
         "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
       ],
@@ -74,5 +75,145 @@
       "confidence_notes": []
     }
   ],
-  "route_breakdowns": []
+  "route_breakdowns": [],
+  "temporal_segments": [
+    {
+      "name": "early",
+      "request_count": 125,
+      "started_at_unix_ms": 1777982574986,
+      "finished_at_unix_ms": 1777982576952,
+      "p50_latency_us": 952189,
+      "p95_latency_us": 1783274,
+      "p99_latency_us": 1903039,
+      "p95_queue_share_permille": 11,
+      "p95_service_share_permille": 999,
+      "evidence_quality": {
+        "request_count": 125,
+        "queue_event_count": 125,
+        "stage_event_count": 125,
+        "runtime_snapshot_count": 200,
+        "inflight_snapshot_count": 379,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "partial",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "partial",
+        "limitations": [
+          "Runtime snapshots have missing queue-depth fields, limiting executor vs blocking differentiation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "blocking_pool_pressure",
+        "score": 88,
+        "confidence": "medium",
+        "evidence": [
+          "Blocking queue depth p95 is 244, peak is 246, with 199/200 nonzero samples."
+        ],
+        "next_checks": [
+          "Audit blocking sections and move avoidable synchronous work out of hot paths.",
+          "Inspect spawn_blocking callsites for long-running CPU or I/O work."
+        ],
+        "confidence_notes": [
+          "Missing runtime snapshots limit executor/blocking confidence.",
+          "Top suspects are close in score; confidence is capped by ambiguity."
+        ]
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 86,
+          "confidence": "high",
+          "evidence": [
+            "Stage 'spawn_blocking_path' has p95 latency 1782007 us across 125 samples.",
+            "Stage 'spawn_blocking_path' cumulative latency is 118136034 us (998 permille of request latency).",
+            "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency.",
+            "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": []
+    },
+    {
+      "name": "late",
+      "request_count": 125,
+      "started_at_unix_ms": 1777982575020,
+      "finished_at_unix_ms": 1777982578769,
+      "p50_latency_us": 2792076,
+      "p95_latency_us": 3626269,
+      "p99_latency_us": 3714446,
+      "p95_queue_share_permille": 0,
+      "p95_service_share_permille": 999,
+      "evidence_quality": {
+        "request_count": 125,
+        "queue_event_count": 125,
+        "stage_event_count": 125,
+        "runtime_snapshot_count": 193,
+        "inflight_snapshot_count": 378,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "partial",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "partial",
+        "limitations": [
+          "Runtime snapshots have missing queue-depth fields, limiting executor vs blocking differentiation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "blocking_pool_pressure",
+        "score": 88,
+        "confidence": "medium",
+        "evidence": [
+          "Blocking queue depth p95 is 244, peak is 246, with 193/193 nonzero samples."
+        ],
+        "next_checks": [
+          "Audit blocking sections and move avoidable synchronous work out of hot paths.",
+          "Inspect spawn_blocking callsites for long-running CPU or I/O work."
+        ],
+        "confidence_notes": [
+          "Missing runtime snapshots limit executor/blocking confidence.",
+          "Top suspects are close in score; confidence is capped by ambiguity."
+        ]
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 86,
+          "confidence": "high",
+          "evidence": [
+            "Stage 'spawn_blocking_path' has p95 latency 3625024 us across 125 samples.",
+            "Stage 'spawn_blocking_path' cumulative latency is 349714077 us (999 permille of request latency).",
+            "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency.",
+            "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": []
+    }
+  ]
 }

--- a/demos/blocking_service/fixtures/sample-analysis.json
+++ b/demos/blocking_service/fixtures/sample-analysis.json
@@ -1,21 +1,22 @@
 {
   "request_count": 250,
-  "p50_latency_us": 1866475,
-  "p95_latency_us": 3524603,
-  "p99_latency_us": 3673375,
-  "p95_queue_share_permille": 3,
+  "p50_latency_us": 1872732,
+  "p95_latency_us": 3536828,
+  "p99_latency_us": 3686672,
+  "p95_queue_share_permille": 6,
   "p95_service_share_permille": 999,
   "inflight_trend": {
     "gauge": "blocking_service_inflight",
     "sample_count": 500,
     "peak_count": 246,
-    "p95_count": 235,
+    "p95_count": 234,
     "growth_delta": 0,
     "growth_per_sec_milli": 0
   },
   "warnings": [
     "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited.",
-    "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks."
+    "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks.",
+    "Temporal segments show a large p95 latency shift between early and late requests."
   ],
   "evidence_quality": {
     "request_count": 250,
@@ -44,7 +45,7 @@
     "score": 88,
     "confidence": "medium",
     "evidence": [
-      "Blocking queue depth p95 is 244, peak is 246, with 200/200 nonzero samples."
+      "Blocking queue depth p95 is 244, peak is 246, with 199/200 nonzero samples."
     ],
     "next_checks": [
       "Audit blocking sections and move avoidable synchronous work out of hot paths.",
@@ -61,8 +62,8 @@
       "score": 86,
       "confidence": "high",
       "evidence": [
-        "Stage 'spawn_blocking_path' has p95 latency 3523850 us across 250 samples.",
-        "Stage 'spawn_blocking_path' cumulative latency is 466288754 us (999 permille of request latency).",
+        "Stage 'spawn_blocking_path' has p95 latency 3535561 us across 250 samples.",
+        "Stage 'spawn_blocking_path' cumulative latency is 467850111 us (999 permille of request latency).",
         "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency.",
         "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
       ],
@@ -74,5 +75,145 @@
       "confidence_notes": []
     }
   ],
-  "route_breakdowns": []
+  "route_breakdowns": [],
+  "temporal_segments": [
+    {
+      "name": "early",
+      "request_count": 125,
+      "started_at_unix_ms": 1777982574986,
+      "finished_at_unix_ms": 1777982576952,
+      "p50_latency_us": 952189,
+      "p95_latency_us": 1783274,
+      "p99_latency_us": 1903039,
+      "p95_queue_share_permille": 11,
+      "p95_service_share_permille": 999,
+      "evidence_quality": {
+        "request_count": 125,
+        "queue_event_count": 125,
+        "stage_event_count": 125,
+        "runtime_snapshot_count": 200,
+        "inflight_snapshot_count": 379,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "partial",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "partial",
+        "limitations": [
+          "Runtime snapshots have missing queue-depth fields, limiting executor vs blocking differentiation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "blocking_pool_pressure",
+        "score": 88,
+        "confidence": "medium",
+        "evidence": [
+          "Blocking queue depth p95 is 244, peak is 246, with 199/200 nonzero samples."
+        ],
+        "next_checks": [
+          "Audit blocking sections and move avoidable synchronous work out of hot paths.",
+          "Inspect spawn_blocking callsites for long-running CPU or I/O work."
+        ],
+        "confidence_notes": [
+          "Missing runtime snapshots limit executor/blocking confidence.",
+          "Top suspects are close in score; confidence is capped by ambiguity."
+        ]
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 86,
+          "confidence": "high",
+          "evidence": [
+            "Stage 'spawn_blocking_path' has p95 latency 1782007 us across 125 samples.",
+            "Stage 'spawn_blocking_path' cumulative latency is 118136034 us (998 permille of request latency).",
+            "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency.",
+            "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": []
+    },
+    {
+      "name": "late",
+      "request_count": 125,
+      "started_at_unix_ms": 1777982575020,
+      "finished_at_unix_ms": 1777982578769,
+      "p50_latency_us": 2792076,
+      "p95_latency_us": 3626269,
+      "p99_latency_us": 3714446,
+      "p95_queue_share_permille": 0,
+      "p95_service_share_permille": 999,
+      "evidence_quality": {
+        "request_count": 125,
+        "queue_event_count": 125,
+        "stage_event_count": 125,
+        "runtime_snapshot_count": 193,
+        "inflight_snapshot_count": 378,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "partial",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "partial",
+        "limitations": [
+          "Runtime snapshots have missing queue-depth fields, limiting executor vs blocking differentiation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "blocking_pool_pressure",
+        "score": 88,
+        "confidence": "medium",
+        "evidence": [
+          "Blocking queue depth p95 is 244, peak is 246, with 193/193 nonzero samples."
+        ],
+        "next_checks": [
+          "Audit blocking sections and move avoidable synchronous work out of hot paths.",
+          "Inspect spawn_blocking callsites for long-running CPU or I/O work."
+        ],
+        "confidence_notes": [
+          "Missing runtime snapshots limit executor/blocking confidence.",
+          "Top suspects are close in score; confidence is capped by ambiguity."
+        ]
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 86,
+          "confidence": "high",
+          "evidence": [
+            "Stage 'spawn_blocking_path' has p95 latency 3625024 us across 125 samples.",
+            "Stage 'spawn_blocking_path' cumulative latency is 349714077 us (999 permille of request latency).",
+            "Stage 'spawn_blocking_path' contributes 999 permille of tail request latency.",
+            "Stage 'spawn_blocking_path' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'spawn_blocking_path'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": []
+    }
+  ]
 }

--- a/demos/cold_start_burst_service/fixtures/after-analysis.json
+++ b/demos/cold_start_burst_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 8382,
-  "p95_latency_us": 8642,
-  "p99_latency_us": 13879,
+  "p50_latency_us": 8026,
+  "p95_latency_us": 9063,
+  "p99_latency_us": 10762,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 999,
   "inflight_trend": {
@@ -11,7 +11,7 @@
     "peak_count": 4,
     "p95_count": 3,
     "growth_delta": -1,
-    "growth_per_sec_milli": -1071
+    "growth_per_sec_milli": -1042
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,9 +41,9 @@
     "score": 100,
     "confidence": "high",
     "evidence": [
-      "Stage 'cold_start_stage' has p95 latency 8627 us across 220 samples.",
-      "Stage 'cold_start_stage' cumulative latency is 1813450 us (997 permille of request latency).",
-      "Stage 'cold_start_stage' contributes 997 permille of tail request latency."
+      "Stage 'cold_start_stage' has p95 latency 9018 us across 220 samples.",
+      "Stage 'cold_start_stage' cumulative latency is 1825136 us (996 permille of request latency).",
+      "Stage 'cold_start_stage' contributes 995 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'cold_start_stage'.",
@@ -53,5 +53,6 @@
     "confidence_notes": []
   },
   "secondary_suspects": [],
-  "route_breakdowns": []
+  "route_breakdowns": [],
+  "temporal_segments": []
 }

--- a/demos/cold_start_burst_service/fixtures/before-analysis.json
+++ b/demos/cold_start_burst_service/fixtures/before-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 220,
-  "p50_latency_us": 990199,
-  "p95_latency_us": 1183880,
-  "p99_latency_us": 1200371,
+  "p50_latency_us": 997087,
+  "p95_latency_us": 1195871,
+  "p99_latency_us": 1212636,
   "p95_queue_share_permille": 993,
-  "p95_service_share_permille": 334,
+  "p95_service_share_permille": 335,
   "inflight_trend": {
     "gauge": "cold_start_burst_inflight",
     "sample_count": 440,
     "peak_count": 220,
     "p95_count": 209,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -816
+    "growth_delta": 2,
+    "growth_per_sec_milli": 1626
   },
   "warnings": [],
   "evidence_quality": {
@@ -38,11 +38,12 @@
   },
   "primary_suspect": {
     "kind": "application_queue_saturation",
-    "score": 95,
+    "score": 100,
     "confidence": "high",
     "evidence": [
       "Queue wait at p95 consumes 99.3% of request time.",
-      "Observed queue depth sample up to 216."
+      "Observed queue depth sample up to 216.",
+      "In-flight gauge 'cold_start_burst_inflight' grew by 2 over the run window (p95=209, peak=220)."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -56,8 +57,8 @@
       "score": 32,
       "confidence": "low",
       "evidence": [
-        "Stage 'cold_start_stage' has p95 latency 63550 us across 220 samples.",
-        "Stage 'cold_start_stage' cumulative latency is 4862350 us (24 permille of request latency).",
+        "Stage 'cold_start_stage' has p95 latency 63643 us across 220 samples.",
+        "Stage 'cold_start_stage' cumulative latency is 4903878 us (24 permille of request latency).",
         "Stage 'cold_start_stage' contributes 6 permille of tail request latency."
       ],
       "next_checks": [
@@ -68,5 +69,140 @@
       "confidence_notes": []
     }
   ],
-  "route_breakdowns": []
+  "route_breakdowns": [],
+  "temporal_segments": [
+    {
+      "name": "early",
+      "request_count": 110,
+      "started_at_unix_ms": 1777982635689,
+      "finished_at_unix_ms": 1777982636704,
+      "p50_latency_us": 886164,
+      "p95_latency_us": 988785,
+      "p99_latency_us": 1005273,
+      "p95_queue_share_permille": 992,
+      "p95_service_share_permille": 504,
+      "evidence_quality": {
+        "request_count": 110,
+        "queue_event_count": 110,
+        "stage_event_count": 110,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 336,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 100,
+        "confidence": "high",
+        "evidence": [
+          "Queue wait at p95 consumes 99.2% of request time.",
+          "Observed queue depth sample up to 110.",
+          "In-flight gauge 'cold_start_burst_inflight' grew by 106 over the run window (p95=212, peak=220)."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 33,
+          "confidence": "low",
+          "evidence": [
+            "Stage 'cold_start_stage' has p95 latency 63829 us across 110 samples.",
+            "Stage 'cold_start_stage' cumulative latency is 3996647 us (51 permille of request latency).",
+            "Stage 'cold_start_stage' contributes 8 permille of tail request latency."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'cold_start_stage'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": []
+    },
+    {
+      "name": "late",
+      "request_count": 110,
+      "started_at_unix_ms": 1777982635698,
+      "finished_at_unix_ms": 1777982636919,
+      "p50_latency_us": 1107231,
+      "p95_latency_us": 1204352,
+      "p99_latency_us": 1212664,
+      "p95_queue_share_permille": 993,
+      "p95_service_share_permille": 8,
+      "evidence_quality": {
+        "request_count": 110,
+        "queue_event_count": 110,
+        "stage_event_count": 110,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 343,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 95,
+        "confidence": "high",
+        "evidence": [
+          "Queue wait at p95 consumes 99.3% of request time.",
+          "Observed queue depth sample up to 216."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 32,
+          "confidence": "low",
+          "evidence": [
+            "Stage 'cold_start_stage' has p95 latency 8583 us across 110 samples.",
+            "Stage 'cold_start_stage' cumulative latency is 907231 us (7 permille of request latency).",
+            "Stage 'cold_start_stage' contributes 6 permille of tail request latency."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'cold_start_stage'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": []
+    }
+  ]
 }

--- a/demos/db_pool_saturation_service/fixtures/after-analysis.json
+++ b/demos/db_pool_saturation_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 13407,
-  "p95_latency_us": 13884,
-  "p99_latency_us": 13940,
+  "p50_latency_us": 13456,
+  "p95_latency_us": 14059,
+  "p99_latency_us": 14353,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,7 +11,7 @@
     "peak_count": 10,
     "p95_count": 10,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2770
+    "growth_per_sec_milli": -2695
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,9 +41,9 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'db_query' has p95 latency 11690 us across 220 samples.",
-      "Stage 'db_query' cumulative latency is 2431825 us (836 permille of request latency).",
-      "Stage 'db_query' contributes 840 permille of tail request latency."
+      "Stage 'db_query' has p95 latency 11793 us across 220 samples.",
+      "Stage 'db_query' cumulative latency is 2450435 us (830 permille of request latency).",
+      "Stage 'db_query' contributes 820 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'db_query'.",
@@ -53,5 +53,6 @@
     "confidence_notes": []
   },
   "secondary_suspects": [],
-  "route_breakdowns": []
+  "route_breakdowns": [],
+  "temporal_segments": []
 }

--- a/demos/db_pool_saturation_service/fixtures/before-analysis.json
+++ b/demos/db_pool_saturation_service/fixtures/before-analysis.json
@@ -1,19 +1,21 @@
 {
   "request_count": 220,
-  "p50_latency_us": 495974,
-  "p95_latency_us": 930473,
-  "p99_latency_us": 964158,
+  "p50_latency_us": 493724,
+  "p95_latency_us": 937554,
+  "p99_latency_us": 972925,
   "p95_queue_share_permille": 976,
-  "p95_service_share_permille": 367,
+  "p95_service_share_permille": 398,
   "inflight_trend": {
     "gauge": "db_pool_saturation_inflight",
     "sample_count": 440,
-    "peak_count": 204,
+    "peak_count": 203,
     "p95_count": 193,
     "growth_delta": -1,
-    "growth_per_sec_milli": -940
+    "growth_per_sec_milli": -917
   },
-  "warnings": [],
+  "warnings": [
+    "Temporal segments show a large p95 latency shift between early and late requests."
+  ],
   "evidence_quality": {
     "request_count": 220,
     "queue_event_count": 220,
@@ -42,7 +44,7 @@
     "confidence": "high",
     "evidence": [
       "Queue wait at p95 consumes 97.6% of request time.",
-      "Observed queue depth sample up to 199."
+      "Observed queue depth sample up to 197."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -56,9 +58,9 @@
       "score": 34,
       "confidence": "low",
       "evidence": [
-        "Stage 'db_query' has p95 latency 19560 us across 220 samples.",
-        "Stage 'db_query' cumulative latency is 4214847 us (38 permille of request latency).",
-        "Stage 'db_query' contributes 20 permille of tail request latency."
+        "Stage 'db_query' has p95 latency 19877 us across 220 samples.",
+        "Stage 'db_query' cumulative latency is 4294543 us (39 permille of request latency).",
+        "Stage 'db_query' contributes 19 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'db_query'.",
@@ -68,5 +70,140 @@
       "confidence_notes": []
     }
   ],
-  "route_breakdowns": []
+  "route_breakdowns": [],
+  "temporal_segments": [
+    {
+      "name": "early",
+      "request_count": 110,
+      "started_at_unix_ms": 1777982639190,
+      "finished_at_unix_ms": 1777982639735,
+      "p50_latency_us": 249994,
+      "p95_latency_us": 474418,
+      "p99_latency_us": 493724,
+      "p95_queue_share_permille": 955,
+      "p95_service_share_permille": 564,
+      "evidence_quality": {
+        "request_count": 110,
+        "queue_event_count": 110,
+        "stage_event_count": 220,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 332,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 95,
+        "confidence": "high",
+        "evidence": [
+          "Queue wait at p95 consumes 95.5% of request time.",
+          "Observed queue depth sample up to 99.",
+          "In-flight gauge 'db_pool_saturation_inflight' grew by 110 over the run window (p95=196, peak=203)."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 37,
+          "confidence": "low",
+          "evidence": [
+            "Stage 'db_query' has p95 latency 19764 us across 110 samples.",
+            "Stage 'db_query' cumulative latency is 2117686 us (75 permille of request latency).",
+            "Stage 'db_query' contributes 39 permille of tail request latency."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'db_query'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": []
+    },
+    {
+      "name": "late",
+      "request_count": 110,
+      "started_at_unix_ms": 1777982639241,
+      "finished_at_unix_ms": 1777982640280,
+      "p50_latency_us": 741336,
+      "p95_latency_us": 971629,
+      "p99_latency_us": 990121,
+      "p95_queue_share_permille": 978,
+      "p95_service_share_permille": 44,
+      "evidence_quality": {
+        "request_count": 110,
+        "queue_event_count": 110,
+        "stage_event_count": 220,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 326,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 95,
+        "confidence": "high",
+        "evidence": [
+          "Queue wait at p95 consumes 97.8% of request time.",
+          "Observed queue depth sample up to 197."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 33,
+          "confidence": "low",
+          "evidence": [
+            "Stage 'db_query' has p95 latency 23390 us across 110 samples.",
+            "Stage 'db_query' cumulative latency is 2176857 us (26 permille of request latency).",
+            "Stage 'db_query' contributes 19 permille of tail request latency."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'db_query'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": []
+    }
+  ]
 }

--- a/demos/downstream_service/fixtures/after-analysis.json
+++ b/demos/downstream_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 80,
-  "p50_latency_us": 12499,
-  "p95_latency_us": 12626,
-  "p99_latency_us": 13358,
+  "p50_latency_us": 12328,
+  "p95_latency_us": 13001,
+  "p99_latency_us": 13186,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,7 +11,7 @@
     "peak_count": 33,
     "p95_count": 32,
     "growth_delta": 5,
-    "growth_per_sec_milli": 113636
+    "growth_per_sec_milli": 108695
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,9 +41,9 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 10422 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 809061 us (825 permille of request latency).",
-      "Stage 'downstream_call' contributes 799 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 10285 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 801832 us (808 permille of request latency).",
+      "Stage 'downstream_call' contributes 776 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",
@@ -53,5 +53,6 @@
     "confidence_notes": []
   },
   "secondary_suspects": [],
-  "route_breakdowns": []
+  "route_breakdowns": [],
+  "temporal_segments": []
 }

--- a/demos/downstream_service/fixtures/before-after-comparison.json
+++ b/demos/downstream_service/fixtures/before-after-comparison.json
@@ -2,19 +2,19 @@
   "before": {
     "primary_suspect_kind": "downstream_stage_dominates",
     "primary_suspect_score": 95,
-    "p95_latency_us": 23960,
+    "p95_latency_us": 24395,
     "p95_service_share_permille": 1000
   },
   "after": {
     "primary_suspect_kind": "downstream_stage_dominates",
     "primary_suspect_score": 95,
-    "p95_latency_us": 12626,
+    "p95_latency_us": 13001,
     "p95_service_share_permille": 1000
   },
   "delta": {
     "primary_suspect_kind": null,
     "primary_suspect_score": 0,
-    "p95_latency_us": -11334,
+    "p95_latency_us": -11394,
     "p95_service_share_permille": 0
   }
 }

--- a/demos/downstream_service/fixtures/before-analysis.json
+++ b/demos/downstream_service/fixtures/before-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 80,
-  "p50_latency_us": 23490,
-  "p95_latency_us": 23960,
-  "p99_latency_us": 24038,
+  "p50_latency_us": 23431,
+  "p95_latency_us": 24395,
+  "p99_latency_us": 24421,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -10,8 +10,8 @@
     "sample_count": 160,
     "peak_count": 64,
     "p95_count": 62,
-    "growth_delta": 0,
-    "growth_per_sec_milli": 0
+    "growth_delta": 5,
+    "growth_per_sec_milli": 90909
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,8 +41,8 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 21745 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 1696247 us (907 permille of request latency).",
+      "Stage 'downstream_call' has p95 latency 22061 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 1689125 us (898 permille of request latency).",
       "Stage 'downstream_call' contributes 904 permille of tail request latency."
     ],
     "next_checks": [
@@ -53,5 +53,6 @@
     "confidence_notes": []
   },
   "secondary_suspects": [],
-  "route_breakdowns": []
+  "route_breakdowns": [],
+  "temporal_segments": []
 }

--- a/demos/downstream_service/fixtures/sample-analysis.json
+++ b/demos/downstream_service/fixtures/sample-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 80,
-  "p50_latency_us": 23490,
-  "p95_latency_us": 23960,
-  "p99_latency_us": 24038,
+  "p50_latency_us": 23431,
+  "p95_latency_us": 24395,
+  "p99_latency_us": 24421,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -10,8 +10,8 @@
     "sample_count": 160,
     "peak_count": 64,
     "p95_count": 62,
-    "growth_delta": 0,
-    "growth_per_sec_milli": 0
+    "growth_delta": 5,
+    "growth_per_sec_milli": 90909
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,8 +41,8 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 21745 us across 80 samples.",
-      "Stage 'downstream_call' cumulative latency is 1696247 us (907 permille of request latency).",
+      "Stage 'downstream_call' has p95 latency 22061 us across 80 samples.",
+      "Stage 'downstream_call' cumulative latency is 1689125 us (898 permille of request latency).",
       "Stage 'downstream_call' contributes 904 permille of tail request latency."
     ],
     "next_checks": [
@@ -53,5 +53,6 @@
     "confidence_notes": []
   },
   "secondary_suspects": [],
-  "route_breakdowns": []
+  "route_breakdowns": [],
+  "temporal_segments": []
 }

--- a/demos/executor_pressure_service/fixtures/after-analysis.json
+++ b/demos/executor_pressure_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 240,
-  "p50_latency_us": 5031245,
-  "p95_latency_us": 5100556,
-  "p99_latency_us": 5104772,
+  "p50_latency_us": 7687986,
+  "p95_latency_us": 7757328,
+  "p99_latency_us": 7760923,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,14 +11,14 @@
     "peak_count": 240,
     "p95_count": 228,
     "growth_delta": -1,
-    "growth_per_sec_milli": -195
+    "growth_per_sec_milli": -128
   },
   "warnings": [],
   "evidence_quality": {
     "request_count": 240,
     "queue_event_count": 0,
     "stage_event_count": 0,
-    "runtime_snapshot_count": 5116,
+    "runtime_snapshot_count": 7772,
     "inflight_snapshot_count": 480,
     "requests": "present",
     "queues": "missing",
@@ -42,7 +42,7 @@
     "confidence": "high",
     "evidence": [
       "Runtime global queue depth p95 is 720, suggesting scheduler contention.",
-      "Runtime local queue depth p95 is 4833.",
+      "Runtime local queue depth p95 is 4284.",
       "Runtime alive_tasks p95 is 720."
     ],
     "next_checks": [
@@ -52,5 +52,6 @@
     "confidence_notes": []
   },
   "secondary_suspects": [],
-  "route_breakdowns": []
+  "route_breakdowns": [],
+  "temporal_segments": []
 }

--- a/demos/executor_pressure_service/fixtures/before-analysis.json
+++ b/demos/executor_pressure_service/fixtures/before-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 240,
-  "p50_latency_us": 24445238,
-  "p95_latency_us": 24529057,
-  "p99_latency_us": 24533220,
+  "p50_latency_us": 37128610,
+  "p95_latency_us": 37209087,
+  "p99_latency_us": 37214593,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -10,15 +10,15 @@
     "sample_count": 480,
     "peak_count": 240,
     "p95_count": 228,
-    "growth_delta": 0,
-    "growth_per_sec_milli": 0
+    "growth_delta": -1,
+    "growth_per_sec_milli": -26
   },
   "warnings": [],
   "evidence_quality": {
     "request_count": 240,
     "queue_event_count": 0,
     "stage_event_count": 0,
-    "runtime_snapshot_count": 24540,
+    "runtime_snapshot_count": 11654,
     "inflight_snapshot_count": 480,
     "requests": "present",
     "queues": "missing",
@@ -42,7 +42,7 @@
     "confidence": "high",
     "evidence": [
       "Runtime global queue depth p95 is 1920, suggesting scheduler contention.",
-      "Runtime local queue depth p95 is 9896.",
+      "Runtime local queue depth p95 is 40896.",
       "Runtime alive_tasks p95 is 1920."
     ],
     "next_checks": [
@@ -52,5 +52,6 @@
     "confidence_notes": []
   },
   "secondary_suspects": [],
-  "route_breakdowns": []
+  "route_breakdowns": [],
+  "temporal_segments": []
 }

--- a/demos/executor_pressure_service/fixtures/sample-analysis.json
+++ b/demos/executor_pressure_service/fixtures/sample-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 240,
-  "p50_latency_us": 24445238,
-  "p95_latency_us": 24529057,
-  "p99_latency_us": 24533220,
+  "p50_latency_us": 37128610,
+  "p95_latency_us": 37209087,
+  "p99_latency_us": 37214593,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -10,15 +10,15 @@
     "sample_count": 480,
     "peak_count": 240,
     "p95_count": 228,
-    "growth_delta": 0,
-    "growth_per_sec_milli": 0
+    "growth_delta": -1,
+    "growth_per_sec_milli": -26
   },
   "warnings": [],
   "evidence_quality": {
     "request_count": 240,
     "queue_event_count": 0,
     "stage_event_count": 0,
-    "runtime_snapshot_count": 24540,
+    "runtime_snapshot_count": 11654,
     "inflight_snapshot_count": 480,
     "requests": "present",
     "queues": "missing",
@@ -42,7 +42,7 @@
     "confidence": "high",
     "evidence": [
       "Runtime global queue depth p95 is 1920, suggesting scheduler contention.",
-      "Runtime local queue depth p95 is 9896.",
+      "Runtime local queue depth p95 is 40896.",
       "Runtime alive_tasks p95 is 1920."
     ],
     "next_checks": [
@@ -52,5 +52,6 @@
     "confidence_notes": []
   },
   "secondary_suspects": [],
-  "route_breakdowns": []
+  "route_breakdowns": [],
+  "temporal_segments": []
 }

--- a/demos/mixed_contention_service/fixtures/baseline-analysis.json
+++ b/demos/mixed_contention_service/fixtures/baseline-analysis.json
@@ -1,19 +1,21 @@
 {
   "request_count": 220,
-  "p50_latency_us": 390695,
-  "p95_latency_us": 736242,
-  "p99_latency_us": 762947,
-  "p95_queue_share_permille": 980,
-  "p95_service_share_permille": 393,
+  "p50_latency_us": 393648,
+  "p95_latency_us": 740162,
+  "p99_latency_us": 765646,
+  "p95_queue_share_permille": 979,
+  "p95_service_share_permille": 395,
   "inflight_trend": {
     "gauge": "mixed_contention_inflight",
     "sample_count": 440,
-    "peak_count": 201,
-    "p95_count": 190,
+    "peak_count": 199,
+    "p95_count": 189,
     "growth_delta": -1,
-    "growth_per_sec_milli": -1161
+    "growth_per_sec_milli": -1148
   },
-  "warnings": [],
+  "warnings": [
+    "Temporal segments show a large p95 latency shift between early and late requests."
+  ],
   "evidence_quality": {
     "request_count": 220,
     "queue_event_count": 220,
@@ -41,8 +43,8 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Queue wait at p95 consumes 98.0% of request time.",
-      "Observed queue depth sample up to 196."
+      "Queue wait at p95 consumes 97.9% of request time.",
+      "Observed queue depth sample up to 194."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -56,8 +58,8 @@
       "score": 35,
       "confidence": "low",
       "evidence": [
-        "Stage 'downstream_call' has p95 latency 32487 us across 220 samples.",
-        "Stage 'downstream_call' cumulative latency is 3767713 us (43 permille of request latency).",
+        "Stage 'downstream_call' has p95 latency 32539 us across 220 samples.",
+        "Stage 'downstream_call' cumulative latency is 3796006 us (44 permille of request latency).",
         "Stage 'downstream_call' contributes 25 permille of tail request latency."
       ],
       "next_checks": [
@@ -68,5 +70,140 @@
       "confidence_notes": []
     }
   ],
-  "route_breakdowns": []
+  "route_breakdowns": [],
+  "temporal_segments": [
+    {
+      "name": "early",
+      "request_count": 110,
+      "started_at_unix_ms": 1777982633092,
+      "finished_at_unix_ms": 1777982633530,
+      "p50_latency_us": 201095,
+      "p95_latency_us": 372369,
+      "p99_latency_us": 390145,
+      "p95_queue_share_permille": 959,
+      "p95_service_share_permille": 591,
+      "evidence_quality": {
+        "request_count": 110,
+        "queue_event_count": 110,
+        "stage_event_count": 220,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 331,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 95,
+        "confidence": "high",
+        "evidence": [
+          "Queue wait at p95 consumes 95.9% of request time.",
+          "Observed queue depth sample up to 96.",
+          "In-flight gauge 'mixed_contention_inflight' grew by 108 over the run window (p95=192, peak=199)."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 39,
+          "confidence": "low",
+          "evidence": [
+            "Stage 'downstream_call' has p95 latency 32573 us across 110 samples.",
+            "Stage 'downstream_call' cumulative latency is 1907016 us (87 permille of request latency).",
+            "Stage 'downstream_call' contributes 58 permille of tail request latency."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'downstream_call'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": []
+    },
+    {
+      "name": "late",
+      "request_count": 110,
+      "started_at_unix_ms": 1777982633138,
+      "finished_at_unix_ms": 1777982633963,
+      "p50_latency_us": 584884,
+      "p95_latency_us": 755874,
+      "p99_latency_us": 770430,
+      "p95_queue_share_permille": 980,
+      "p95_service_share_permille": 68,
+      "evidence_quality": {
+        "request_count": 110,
+        "queue_event_count": 110,
+        "stage_event_count": 220,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 323,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 95,
+        "confidence": "high",
+        "evidence": [
+          "Queue wait at p95 consumes 98.0% of request time.",
+          "Observed queue depth sample up to 194."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 34,
+          "confidence": "low",
+          "evidence": [
+            "Stage 'downstream_call' has p95 latency 32480 us across 110 samples.",
+            "Stage 'downstream_call' cumulative latency is 1888990 us (29 permille of request latency).",
+            "Stage 'downstream_call' contributes 28 permille of tail request latency."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'downstream_call'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": []
+    }
+  ]
 }

--- a/demos/mixed_contention_service/fixtures/mitigated-analysis.json
+++ b/demos/mixed_contention_service/fixtures/mitigated-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 220,
-  "p50_latency_us": 14604,
-  "p95_latency_us": 34367,
-  "p99_latency_us": 34982,
+  "p50_latency_us": 14596,
+  "p95_latency_us": 34813,
+  "p99_latency_us": 38064,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,7 +11,7 @@
     "peak_count": 14,
     "p95_count": 13,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2652
+    "growth_per_sec_milli": -2500
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,9 +41,9 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_call' has p95 latency 32237 us across 220 samples.",
-      "Stage 'downstream_call' cumulative latency is 3757963 us (889 permille of request latency).",
-      "Stage 'downstream_call' contributes 933 permille of tail request latency."
+      "Stage 'downstream_call' has p95 latency 32434 us across 220 samples.",
+      "Stage 'downstream_call' cumulative latency is 3786475 us (879 permille of request latency).",
+      "Stage 'downstream_call' contributes 907 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_call'.",
@@ -53,5 +53,6 @@
     "confidence_notes": []
   },
   "secondary_suspects": [],
-  "route_breakdowns": []
+  "route_breakdowns": [],
+  "temporal_segments": []
 }

--- a/demos/queue_service/fixtures/after-analysis.json
+++ b/demos/queue_service/fixtures/after-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 250,
-  "p50_latency_us": 16028,
-  "p95_latency_us": 16827,
-  "p99_latency_us": 16953,
+  "p50_latency_us": 16113,
+  "p95_latency_us": 16902,
+  "p99_latency_us": 17093,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
     "peak_count": 12,
-    "p95_count": 12,
+    "p95_count": 11,
     "growth_delta": -1,
-    "growth_per_sec_milli": -2450
+    "growth_per_sec_milli": -2341
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,8 +41,8 @@
     "score": 100,
     "confidence": "high",
     "evidence": [
-      "Stage 'simulated_work' has p95 latency 16817 us across 250 samples.",
-      "Stage 'simulated_work' cumulative latency is 4019716 us (999 permille of request latency).",
+      "Stage 'simulated_work' has p95 latency 16876 us across 250 samples.",
+      "Stage 'simulated_work' cumulative latency is 4031510 us (998 permille of request latency).",
       "Stage 'simulated_work' contributes 998 permille of tail request latency."
     ],
     "next_checks": [
@@ -53,5 +53,6 @@
     "confidence_notes": []
   },
   "secondary_suspects": [],
-  "route_breakdowns": []
+  "route_breakdowns": [],
+  "temporal_segments": []
 }

--- a/demos/queue_service/fixtures/before-analysis.json
+++ b/demos/queue_service/fixtures/before-analysis.json
@@ -1,19 +1,21 @@
 {
   "request_count": 250,
-  "p50_latency_us": 783739,
-  "p95_latency_us": 1472369,
-  "p99_latency_us": 1521948,
-  "p95_queue_share_permille": 982,
-  "p95_service_share_permille": 265,
+  "p50_latency_us": 790337,
+  "p95_latency_us": 1480939,
+  "p99_latency_us": 1531218,
+  "p95_queue_share_permille": 981,
+  "p95_service_share_permille": 268,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
     "peak_count": 234,
-    "p95_count": 226,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -604
+    "p95_count": 222,
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
   },
-  "warnings": [],
+  "warnings": [
+    "Temporal segments show a large p95 latency shift between early and late requests."
+  ],
   "evidence_quality": {
     "request_count": 250,
     "queue_event_count": 250,
@@ -41,7 +43,7 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Queue wait at p95 consumes 98.2% of request time.",
+      "Queue wait at p95 consumes 98.1% of request time.",
       "Observed queue depth sample up to 230."
     ],
     "next_checks": [
@@ -56,8 +58,8 @@
       "score": 33,
       "confidence": "low",
       "evidence": [
-        "Stage 'simulated_work' has p95 latency 26571 us across 250 samples.",
-        "Stage 'simulated_work' cumulative latency is 6535903 us (33 permille of request latency).",
+        "Stage 'simulated_work' has p95 latency 27018 us across 250 samples.",
+        "Stage 'simulated_work' cumulative latency is 6607905 us (33 permille of request latency).",
         "Stage 'simulated_work' contributes 17 permille of tail request latency."
       ],
       "next_checks": [
@@ -68,5 +70,140 @@
       "confidence_notes": []
     }
   ],
-  "route_breakdowns": []
+  "route_breakdowns": [],
+  "temporal_segments": [
+    {
+      "name": "early",
+      "request_count": 125,
+      "started_at_unix_ms": 1777982571540,
+      "finished_at_unix_ms": 1777982572381,
+      "p50_latency_us": 399850,
+      "p95_latency_us": 740310,
+      "p99_latency_us": 767763,
+      "p95_queue_share_permille": 964,
+      "p95_service_share_permille": 518,
+      "evidence_quality": {
+        "request_count": 125,
+        "queue_event_count": 125,
+        "stage_event_count": 125,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 375,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 95,
+        "confidence": "high",
+        "evidence": [
+          "Queue wait at p95 consumes 96.4% of request time.",
+          "Observed queue depth sample up to 113.",
+          "In-flight gauge 'queue_service_inflight' grew by 124 over the run window (p95=225, peak=234)."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 36,
+          "confidence": "low",
+          "evidence": [
+            "Stage 'simulated_work' has p95 latency 26969 us across 125 samples.",
+            "Stage 'simulated_work' cumulative latency is 3293663 us (65 permille of request latency).",
+            "Stage 'simulated_work' contributes 34 permille of tail request latency."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'simulated_work'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": []
+    },
+    {
+      "name": "late",
+      "request_count": 125,
+      "started_at_unix_ms": 1777982571596,
+      "finished_at_unix_ms": 1777982573211,
+      "p50_latency_us": 1154697,
+      "p95_latency_us": 1507552,
+      "p99_latency_us": 1556489,
+      "p95_queue_share_permille": 982,
+      "p95_service_share_permille": 32,
+      "evidence_quality": {
+        "request_count": 125,
+        "queue_event_count": 125,
+        "stage_event_count": 125,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 371,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 95,
+        "confidence": "high",
+        "evidence": [
+          "Queue wait at p95 consumes 98.2% of request time.",
+          "Observed queue depth sample up to 230."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 33,
+          "confidence": "low",
+          "evidence": [
+            "Stage 'simulated_work' has p95 latency 27079 us across 125 samples.",
+            "Stage 'simulated_work' cumulative latency is 3314242 us (22 permille of request latency).",
+            "Stage 'simulated_work' contributes 17 permille of tail request latency."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'simulated_work'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": []
+    }
+  ]
 }

--- a/demos/queue_service/fixtures/sample-analysis.json
+++ b/demos/queue_service/fixtures/sample-analysis.json
@@ -1,19 +1,21 @@
 {
   "request_count": 250,
-  "p50_latency_us": 783739,
-  "p95_latency_us": 1472369,
-  "p99_latency_us": 1521948,
-  "p95_queue_share_permille": 982,
-  "p95_service_share_permille": 265,
+  "p50_latency_us": 790337,
+  "p95_latency_us": 1480939,
+  "p99_latency_us": 1531218,
+  "p95_queue_share_permille": 981,
+  "p95_service_share_permille": 268,
   "inflight_trend": {
     "gauge": "queue_service_inflight",
     "sample_count": 500,
     "peak_count": 234,
-    "p95_count": 226,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -604
+    "p95_count": 222,
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
   },
-  "warnings": [],
+  "warnings": [
+    "Temporal segments show a large p95 latency shift between early and late requests."
+  ],
   "evidence_quality": {
     "request_count": 250,
     "queue_event_count": 250,
@@ -41,7 +43,7 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Queue wait at p95 consumes 98.2% of request time.",
+      "Queue wait at p95 consumes 98.1% of request time.",
       "Observed queue depth sample up to 230."
     ],
     "next_checks": [
@@ -56,8 +58,8 @@
       "score": 33,
       "confidence": "low",
       "evidence": [
-        "Stage 'simulated_work' has p95 latency 26571 us across 250 samples.",
-        "Stage 'simulated_work' cumulative latency is 6535903 us (33 permille of request latency).",
+        "Stage 'simulated_work' has p95 latency 27018 us across 250 samples.",
+        "Stage 'simulated_work' cumulative latency is 6607905 us (33 permille of request latency).",
         "Stage 'simulated_work' contributes 17 permille of tail request latency."
       ],
       "next_checks": [
@@ -68,5 +70,140 @@
       "confidence_notes": []
     }
   ],
-  "route_breakdowns": []
+  "route_breakdowns": [],
+  "temporal_segments": [
+    {
+      "name": "early",
+      "request_count": 125,
+      "started_at_unix_ms": 1777982571540,
+      "finished_at_unix_ms": 1777982572381,
+      "p50_latency_us": 399850,
+      "p95_latency_us": 740310,
+      "p99_latency_us": 767763,
+      "p95_queue_share_permille": 964,
+      "p95_service_share_permille": 518,
+      "evidence_quality": {
+        "request_count": 125,
+        "queue_event_count": 125,
+        "stage_event_count": 125,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 375,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 95,
+        "confidence": "high",
+        "evidence": [
+          "Queue wait at p95 consumes 96.4% of request time.",
+          "Observed queue depth sample up to 113.",
+          "In-flight gauge 'queue_service_inflight' grew by 124 over the run window (p95=225, peak=234)."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 36,
+          "confidence": "low",
+          "evidence": [
+            "Stage 'simulated_work' has p95 latency 26969 us across 125 samples.",
+            "Stage 'simulated_work' cumulative latency is 3293663 us (65 permille of request latency).",
+            "Stage 'simulated_work' contributes 34 permille of tail request latency."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'simulated_work'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": []
+    },
+    {
+      "name": "late",
+      "request_count": 125,
+      "started_at_unix_ms": 1777982571596,
+      "finished_at_unix_ms": 1777982573211,
+      "p50_latency_us": 1154697,
+      "p95_latency_us": 1507552,
+      "p99_latency_us": 1556489,
+      "p95_queue_share_permille": 982,
+      "p95_service_share_permille": 32,
+      "evidence_quality": {
+        "request_count": 125,
+        "queue_event_count": 125,
+        "stage_event_count": 125,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 371,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 95,
+        "confidence": "high",
+        "evidence": [
+          "Queue wait at p95 consumes 98.2% of request time.",
+          "Observed queue depth sample up to 230."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 33,
+          "confidence": "low",
+          "evidence": [
+            "Stage 'simulated_work' has p95 latency 27079 us across 125 samples.",
+            "Stage 'simulated_work' cumulative latency is 3314242 us (22 permille of request latency).",
+            "Stage 'simulated_work' contributes 17 permille of tail request latency."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'simulated_work'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": []
+    }
+  ]
 }

--- a/demos/retry_storm_service/fixtures/after-analysis.json
+++ b/demos/retry_storm_service/fixtures/after-analysis.json
@@ -1,8 +1,8 @@
 {
   "request_count": 180,
-  "p50_latency_us": 9536,
-  "p95_latency_us": 29293,
-  "p99_latency_us": 30041,
+  "p50_latency_us": 9814,
+  "p95_latency_us": 29419,
+  "p99_latency_us": 30121,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
@@ -11,7 +11,7 @@
     "peak_count": 17,
     "p95_count": 15,
     "growth_delta": -1,
-    "growth_per_sec_milli": -4608
+    "growth_per_sec_milli": -4545
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,9 +41,9 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_total' has p95 latency 27264 us across 180 samples.",
-      "Stage 'downstream_total' cumulative latency is 2154010 us (848 permille of request latency).",
-      "Stage 'downstream_total' contributes 924 permille of tail request latency."
+      "Stage 'downstream_total' has p95 latency 27190 us across 180 samples.",
+      "Stage 'downstream_total' cumulative latency is 2173204 us (842 permille of request latency).",
+      "Stage 'downstream_total' contributes 920 permille of tail request latency."
     ],
     "next_checks": [
       "Inspect downstream dependency behind stage 'downstream_total'.",
@@ -53,5 +53,6 @@
     "confidence_notes": []
   },
   "secondary_suspects": [],
-  "route_breakdowns": []
+  "route_breakdowns": [],
+  "temporal_segments": []
 }

--- a/demos/retry_storm_service/fixtures/before-analysis.json
+++ b/demos/retry_storm_service/fixtures/before-analysis.json
@@ -1,17 +1,17 @@
 {
   "request_count": 180,
-  "p50_latency_us": 9559,
-  "p95_latency_us": 41567,
-  "p99_latency_us": 41781,
+  "p50_latency_us": 9993,
+  "p95_latency_us": 42173,
+  "p99_latency_us": 42957,
   "p95_queue_share_permille": 0,
   "p95_service_share_permille": 1000,
   "inflight_trend": {
     "gauge": "retry_storm_inflight",
     "sample_count": 360,
-    "peak_count": 57,
-    "p95_count": 55,
-    "growth_delta": -1,
-    "growth_per_sec_milli": -9523
+    "peak_count": 55,
+    "p95_count": 52,
+    "growth_delta": 0,
+    "growth_per_sec_milli": 0
   },
   "warnings": [],
   "evidence_quality": {
@@ -41,8 +41,8 @@
     "score": 95,
     "confidence": "high",
     "evidence": [
-      "Stage 'downstream_total' has p95 latency 39310 us across 180 samples.",
-      "Stage 'downstream_total' cumulative latency is 3026286 us (887 permille of request latency).",
+      "Stage 'downstream_total' has p95 latency 39696 us across 180 samples.",
+      "Stage 'downstream_total' cumulative latency is 3052069 us (881 permille of request latency).",
       "Stage 'downstream_total' contributes 945 permille of tail request latency."
     ],
     "next_checks": [
@@ -53,5 +53,6 @@
     "confidence_notes": []
   },
   "secondary_suspects": [],
-  "route_breakdowns": []
+  "route_breakdowns": [],
+  "temporal_segments": []
 }

--- a/demos/shared_state_lock_service/fixtures/after-analysis.json
+++ b/demos/shared_state_lock_service/fixtures/after-analysis.json
@@ -1,19 +1,21 @@
 {
   "request_count": 220,
-  "p50_latency_us": 828543,
-  "p95_latency_us": 1565357,
-  "p99_latency_us": 1626849,
+  "p50_latency_us": 834157,
+  "p95_latency_us": 1576374,
+  "p99_latency_us": 1633415,
   "p95_queue_share_permille": 993,
-  "p95_service_share_permille": 124,
+  "p95_service_share_permille": 121,
   "inflight_trend": {
     "gauge": "shared_state_lock_inflight",
     "sample_count": 440,
-    "peak_count": 201,
-    "p95_count": 191,
+    "peak_count": 200,
+    "p95_count": 190,
     "growth_delta": -1,
-    "growth_per_sec_milli": -554
+    "growth_per_sec_milli": -548
   },
-  "warnings": [],
+  "warnings": [
+    "Temporal segments show a large p95 latency shift between early and late requests."
+  ],
   "evidence_quality": {
     "request_count": 220,
     "queue_event_count": 220,
@@ -42,7 +44,7 @@
     "confidence": "high",
     "evidence": [
       "Queue wait at p95 consumes 99.3% of request time.",
-      "Observed queue depth sample up to 200."
+      "Observed queue depth sample up to 199."
     ],
     "next_checks": [
       "Inspect queue admission limits and producer burst patterns.",
@@ -56,9 +58,9 @@
       "score": 32,
       "confidence": "low",
       "evidence": [
-        "Stage 'shared_state_critical_section' has p95 latency 8246 us across 220 samples.",
-        "Stage 'shared_state_critical_section' cumulative latency is 1791550 us (9 permille of request latency).",
-        "Stage 'shared_state_critical_section' contributes 5 permille of tail request latency."
+        "Stage 'shared_state_critical_section' has p95 latency 8451 us across 220 samples.",
+        "Stage 'shared_state_critical_section' cumulative latency is 1803410 us (9 permille of request latency).",
+        "Stage 'shared_state_critical_section' contributes 4 permille of tail request latency."
       ],
       "next_checks": [
         "Inspect downstream dependency behind stage 'shared_state_critical_section'.",
@@ -68,5 +70,140 @@
       "confidence_notes": []
     }
   ],
-  "route_breakdowns": []
+  "route_breakdowns": [],
+  "temporal_segments": [
+    {
+      "name": "early",
+      "request_count": 110,
+      "started_at_unix_ms": 1777982647845,
+      "finished_at_unix_ms": 1777982648766,
+      "p50_latency_us": 422194,
+      "p95_latency_us": 789031,
+      "p99_latency_us": 819954,
+      "p95_queue_share_permille": 986,
+      "p95_service_share_permille": 226,
+      "evidence_quality": {
+        "request_count": 110,
+        "queue_event_count": 110,
+        "stage_event_count": 220,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 331,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 100,
+        "confidence": "high",
+        "evidence": [
+          "Queue wait at p95 consumes 98.6% of request time.",
+          "Observed queue depth sample up to 100.",
+          "In-flight gauge 'shared_state_lock_inflight' grew by 108 over the run window (p95=193, peak=200)."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 32,
+          "confidence": "low",
+          "evidence": [
+            "Stage 'shared_state_critical_section' has p95 latency 8486 us across 110 samples.",
+            "Stage 'shared_state_critical_section' cumulative latency is 901750 us (19 permille of request latency).",
+            "Stage 'shared_state_critical_section' contributes 10 permille of tail request latency."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'shared_state_critical_section'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": []
+    },
+    {
+      "name": "late",
+      "request_count": 110,
+      "started_at_unix_ms": 1777982647932,
+      "finished_at_unix_ms": 1777982649667,
+      "p50_latency_us": 1247760,
+      "p95_latency_us": 1612174,
+      "p99_latency_us": 1641692,
+      "p95_queue_share_permille": 993,
+      "p95_service_share_permille": 12,
+      "evidence_quality": {
+        "request_count": 110,
+        "queue_event_count": 110,
+        "stage_event_count": 220,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 322,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 95,
+        "confidence": "high",
+        "evidence": [
+          "Queue wait at p95 consumes 99.3% of request time.",
+          "Observed queue depth sample up to 199."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 32,
+          "confidence": "low",
+          "evidence": [
+            "Stage 'shared_state_critical_section' has p95 latency 8389 us across 110 samples.",
+            "Stage 'shared_state_critical_section' cumulative latency is 901660 us (6 permille of request latency).",
+            "Stage 'shared_state_critical_section' contributes 4 permille of tail request latency."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'shared_state_critical_section'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": []
+    }
+  ]
 }

--- a/demos/shared_state_lock_service/fixtures/before-analysis.json
+++ b/demos/shared_state_lock_service/fixtures/before-analysis.json
@@ -1,19 +1,21 @@
 {
   "request_count": 220,
-  "p50_latency_us": 2533261,
-  "p95_latency_us": 4794306,
-  "p99_latency_us": 4975959,
+  "p50_latency_us": 2553518,
+  "p95_latency_us": 4828276,
+  "p99_latency_us": 5010737,
   "p95_queue_share_permille": 994,
-  "p95_service_share_permille": 100,
+  "p95_service_share_permille": 102,
   "inflight_trend": {
     "gauge": "shared_state_lock_inflight",
     "sample_count": 440,
     "peak_count": 217,
     "p95_count": 206,
     "growth_delta": -1,
-    "growth_per_sec_milli": -196
+    "growth_per_sec_milli": -194
   },
-  "warnings": [],
+  "warnings": [
+    "Temporal segments show a large p95 latency shift between early and late requests."
+  ],
   "evidence_quality": {
     "request_count": 220,
     "queue_event_count": 220,
@@ -56,8 +58,8 @@
       "score": 32,
       "confidence": "low",
       "evidence": [
-        "Stage 'shared_state_critical_section' has p95 latency 23290 us across 220 samples.",
-        "Stage 'shared_state_critical_section' cumulative latency is 5087992 us (9 permille of request latency).",
+        "Stage 'shared_state_critical_section' has p95 latency 23580 us across 220 samples.",
+        "Stage 'shared_state_critical_section' cumulative latency is 5122867 us (9 permille of request latency).",
         "Stage 'shared_state_critical_section' contributes 4 permille of tail request latency."
       ],
       "next_checks": [
@@ -68,5 +70,140 @@
       "confidence_notes": []
     }
   ],
-  "route_breakdowns": []
+  "route_breakdowns": [],
+  "temporal_segments": [
+    {
+      "name": "early",
+      "request_count": 110,
+      "started_at_unix_ms": 1777982642017,
+      "finished_at_unix_ms": 1777982644615,
+      "p50_latency_us": 1291094,
+      "p95_latency_us": 2416445,
+      "p99_latency_us": 2510001,
+      "p95_queue_share_permille": 989,
+      "p95_service_share_permille": 183,
+      "evidence_quality": {
+        "request_count": 110,
+        "queue_event_count": 110,
+        "stage_event_count": 220,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 331,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 100,
+        "confidence": "high",
+        "evidence": [
+          "Queue wait at p95 consumes 98.9% of request time.",
+          "Observed queue depth sample up to 109.",
+          "In-flight gauge 'shared_state_lock_inflight' grew by 108 over the run window (p95=209, peak=217)."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 32,
+          "confidence": "low",
+          "evidence": [
+            "Stage 'shared_state_critical_section' has p95 latency 23588 us across 110 samples.",
+            "Stage 'shared_state_critical_section' cumulative latency is 2565033 us (18 permille of request latency).",
+            "Stage 'shared_state_critical_section' contributes 9 permille of tail request latency."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'shared_state_critical_section'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": []
+    },
+    {
+      "name": "late",
+      "request_count": 110,
+      "started_at_unix_ms": 1777982642061,
+      "finished_at_unix_ms": 1777982647160,
+      "p50_latency_us": 3816624,
+      "p95_latency_us": 4944149,
+      "p99_latency_us": 5034157,
+      "p95_queue_share_permille": 994,
+      "p95_service_share_permille": 9,
+      "evidence_quality": {
+        "request_count": 110,
+        "queue_event_count": 110,
+        "stage_event_count": 220,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 330,
+        "requests": "present",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "strong",
+        "limitations": [
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 95,
+        "confidence": "high",
+        "evidence": [
+          "Queue wait at p95 consumes 99.4% of request time.",
+          "Observed queue depth sample up to 216."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [
+        {
+          "kind": "downstream_stage_dominates",
+          "score": 32,
+          "confidence": "low",
+          "evidence": [
+            "Stage 'shared_state_critical_section' has p95 latency 23494 us across 110 samples.",
+            "Stage 'shared_state_critical_section' cumulative latency is 2557834 us (6 permille of request latency).",
+            "Stage 'shared_state_critical_section' contributes 4 permille of tail request latency."
+          ],
+          "next_checks": [
+            "Inspect downstream dependency behind stage 'shared_state_critical_section'.",
+            "Collect downstream service timings and retry behavior during tail windows.",
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+          ],
+          "confidence_notes": []
+        }
+      ],
+      "warnings": []
+    }
+  ]
 }

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -142,3 +142,6 @@ If truncation counters are non-zero, treat the diagnosis as partial-data triage.
 4. Change one thing.
 5. Re-run under comparable load.
 6. Compare suspect movement and p95 shares.
+
+
+`temporal_segments` is always present in JSON output and usually empty. It is emitted only when conservative early/late comparison finds a material within-run shift (for example primary suspect shift or large p95 shift). These are triage hints only; global `primary_suspect` and ranking remain the full-run source of truth.

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -95,7 +95,8 @@ Then run one targeted check, change one thing, and re-run under comparable load.
     "confidence_notes": []
   },
   "secondary_suspects": [],
-  "route_breakdowns": []
+  "route_breakdowns": [],
+  "temporal_segments": []
 }
 ```
 
@@ -210,3 +211,6 @@ Use capture-side crates for that:
 - `tailtriage-controller`: repeated bounded windows
 - `tailtriage-tokio`: runtime-pressure sampling
 - `tailtriage-axum`: Axum request-boundary integration
+
+
+`temporal_segments` is always present in JSON output and usually empty. It is emitted only when conservative early/late comparison finds a material within-run shift (for example primary suspect shift or large p95 shift). These are triage hints only; global `primary_suspect` and ranking remain the full-run source of truth.

--- a/tailtriage-cli/src/analyze.rs
+++ b/tailtriage-cli/src/analyze.rs
@@ -20,6 +20,12 @@ const ROUTE_DIVERGENCE_WARNING: &str =
     "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect.";
 const ROUTE_RUNTIME_ATTRIBUTION_WARNING: &str =
     "Runtime and in-flight signals are global and are not attributed to this route.";
+const TEMPORAL_MIN_REQUEST_COUNT: usize = 20;
+const TEMPORAL_MIN_SEGMENT_REQUEST_COUNT: usize = 8;
+const TEMPORAL_PRIMARY_SHIFT_WARNING: &str =
+    "Temporal segments show different primary suspects; inspect temporal_segments before acting on the global suspect.";
+const TEMPORAL_P95_SHIFT_WARNING: &str =
+    "Temporal segments show a large p95 latency shift between early and late requests.";
 
 /// Evidence-ranked diagnosis categories produced by heuristic triage.
 ///
@@ -238,6 +244,39 @@ pub struct Report {
     pub secondary_suspects: Vec<Suspect>,
     /// Supporting per-route triage summaries when route-level signal adds value.
     pub route_breakdowns: Vec<RouteBreakdown>,
+    /// Supporting early/late temporal triage summaries when within-run shift adds value.
+    pub temporal_segments: Vec<TemporalSegment>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+/// Supporting early/late temporal triage summary for one run.
+pub struct TemporalSegment {
+    /// Segment label (`early` or `late`).
+    pub name: String,
+    /// Completed request count in this segment.
+    pub request_count: usize,
+    /// Earliest request start timestamp in this segment.
+    pub started_at_unix_ms: Option<u64>,
+    /// Latest request finish timestamp in this segment.
+    pub finished_at_unix_ms: Option<u64>,
+    /// Segment p50 request latency in microseconds.
+    pub p50_latency_us: Option<u64>,
+    /// Segment p95 request latency in microseconds.
+    pub p95_latency_us: Option<u64>,
+    /// Segment p99 request latency in microseconds.
+    pub p99_latency_us: Option<u64>,
+    /// Segment p95 queue-time share in permille.
+    pub p95_queue_share_permille: Option<u64>,
+    /// Segment p95 non-queue service-time share in permille.
+    pub p95_service_share_permille: Option<u64>,
+    /// Coverage summary for segment-scoped evidence.
+    pub evidence_quality: EvidenceQuality,
+    /// Highest-ranked segment-level suspect.
+    pub primary_suspect: Suspect,
+    /// Lower-ranked segment-level suspects.
+    pub secondary_suspects: Vec<Suspect>,
+    /// Segment-scoped warnings and interpretation limits.
+    pub warnings: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -324,6 +363,16 @@ pub fn analyze_run(run: &Run) -> Report {
         report.warnings.push(ROUTE_DIVERGENCE_WARNING.to_string());
     }
     report.route_breakdowns = route_context.breakdowns;
+    let temporal = temporal_segments(run, &report);
+    if temporal.primary_shift {
+        report
+            .warnings
+            .push(TEMPORAL_PRIMARY_SHIFT_WARNING.to_string());
+    }
+    if temporal.p95_shift {
+        report.warnings.push(TEMPORAL_P95_SHIFT_WARNING.to_string());
+    }
+    report.temporal_segments = temporal.segments;
     report
 }
 
@@ -406,7 +455,14 @@ fn analyze_run_internal(run: &Run) -> Report {
         primary_suspect,
         secondary_suspects: ranked.collect(),
         route_breakdowns: Vec::new(),
+        temporal_segments: Vec::new(),
     }
+}
+
+struct TemporalContext {
+    segments: Vec<TemporalSegment>,
+    primary_shift: bool,
+    p95_shift: bool,
 }
 
 struct RouteBreakdownContext {
@@ -550,6 +606,115 @@ fn filtered_run_for_route(run: &Run, request_ids: &[String]) -> Run {
     filtered.runtime_snapshots = Vec::new();
     filtered.inflight = Vec::new();
     filtered
+}
+
+fn temporal_segments(run: &Run, global: &Report) -> TemporalContext {
+    if run.requests.len() < TEMPORAL_MIN_REQUEST_COUNT {
+        return TemporalContext {
+            segments: vec![],
+            primary_shift: false,
+            p95_shift: false,
+        };
+    }
+    let mut sorted = run.requests.clone();
+    sorted.sort_by(|a, b| {
+        a.started_at_unix_ms
+            .cmp(&b.started_at_unix_ms)
+            .then_with(|| a.request_id.cmp(&b.request_id))
+    });
+    let split = sorted.len() / 2;
+    let (early, late) = sorted.split_at(split);
+    if early.len() < TEMPORAL_MIN_SEGMENT_REQUEST_COUNT
+        || late.len() < TEMPORAL_MIN_SEGMENT_REQUEST_COUNT
+    {
+        return TemporalContext {
+            segments: vec![],
+            primary_shift: false,
+            p95_shift: false,
+        };
+    }
+    let early_seg = build_temporal_segment("early", run, early);
+    let late_seg = build_temporal_segment("late", run, late);
+    let primary_shift = early_seg.primary_suspect.kind != late_seg.primary_suspect.kind;
+    let p95_shift = match (early_seg.p95_latency_us, late_seg.p95_latency_us) {
+        (Some(a), Some(b)) => {
+            let low = a.min(b);
+            let high = a.max(b);
+            low > 0 && high.saturating_mul(2) >= low.saturating_mul(3)
+        }
+        _ => false,
+    };
+    let emit = primary_shift || p95_shift;
+    let segments = if emit {
+        vec![early_seg, late_seg]
+    } else {
+        vec![]
+    };
+    let _ = global;
+    TemporalContext {
+        segments,
+        primary_shift: emit && primary_shift,
+        p95_shift: emit && p95_shift,
+    }
+}
+
+fn build_temporal_segment(
+    name: &str,
+    run: &Run,
+    requests: &[tailtriage_core::RequestEvent],
+) -> TemporalSegment {
+    let ids: std::collections::HashSet<&str> =
+        requests.iter().map(|r| r.request_id.as_str()).collect();
+    let started_at_unix_ms = requests.iter().map(|r| r.started_at_unix_ms).min();
+    let finished_at_unix_ms = requests.iter().map(|r| r.finished_at_unix_ms).max();
+    let mut filtered = run.clone();
+    filtered.requests = requests.to_vec();
+    filtered.stages = run
+        .stages
+        .iter()
+        .filter(|s| ids.contains(s.request_id.as_str()))
+        .cloned()
+        .collect();
+    filtered.queues = run
+        .queues
+        .iter()
+        .filter(|q| ids.contains(q.request_id.as_str()))
+        .cloned()
+        .collect();
+    filtered.runtime_snapshots = run
+        .runtime_snapshots
+        .iter()
+        .filter(|s| {
+            started_at_unix_ms.is_some_and(|start| s.at_unix_ms >= start)
+                && finished_at_unix_ms.is_some_and(|end| s.at_unix_ms <= end)
+        })
+        .cloned()
+        .collect();
+    filtered.inflight = run
+        .inflight
+        .iter()
+        .filter(|s| {
+            started_at_unix_ms.is_some_and(|start| s.at_unix_ms >= start)
+                && finished_at_unix_ms.is_some_and(|end| s.at_unix_ms <= end)
+        })
+        .cloned()
+        .collect();
+    let analyzed = analyze_run_internal(&filtered);
+    TemporalSegment {
+        name: name.to_string(),
+        request_count: analyzed.request_count,
+        started_at_unix_ms,
+        finished_at_unix_ms,
+        p50_latency_us: analyzed.p50_latency_us,
+        p95_latency_us: analyzed.p95_latency_us,
+        p99_latency_us: analyzed.p99_latency_us,
+        p95_queue_share_permille: analyzed.p95_queue_share_permille,
+        p95_service_share_permille: analyzed.p95_service_share_permille,
+        evidence_quality: analyzed.evidence_quality,
+        primary_suspect: analyzed.primary_suspect,
+        secondary_suspects: analyzed.secondary_suspects,
+        warnings: Vec::new(),
+    }
 }
 
 fn apply_evidence_aware_confidence_caps(
@@ -1431,6 +1596,21 @@ fn fmt_confidence(confidence: Confidence) -> &'static str {
     }
 }
 
+fn temporal_text_lines(segments: &[TemporalSegment]) -> Vec<String> {
+    let mut lines = vec!["Temporal segments:".to_string()];
+    for segment in segments {
+        lines.push(format!(
+            "- {}: requests {}, p95 {}us, suspect {} ({} confidence)",
+            segment.name,
+            segment.request_count,
+            fmt_opt_u64(segment.p95_latency_us),
+            segment.primary_suspect.kind.as_str(),
+            fmt_confidence(segment.primary_suspect.confidence),
+        ));
+    }
+    lines
+}
+
 #[must_use]
 /// Renders a compact text triage summary from a [`Report`].
 ///
@@ -1532,6 +1712,9 @@ pub fn render_text(report: &Report) -> String {
                 fmt_confidence(route.primary_suspect.confidence),
             ));
         }
+    }
+    if !report.temporal_segments.is_empty() {
+        lines.extend(temporal_text_lines(&report.temporal_segments));
     }
 
     lines.join("\n")
@@ -1805,6 +1988,7 @@ mod tests {
             },
             secondary_suspects: Vec::new(),
             route_breakdowns: Vec::new(),
+            temporal_segments: Vec::new(),
         };
 
         let text = render_text(&report);
@@ -1857,6 +2041,7 @@ mod tests {
             },
             secondary_suspects: Vec::new(),
             route_breakdowns: Vec::new(),
+            temporal_segments: Vec::new(),
         };
 
         let text = render_text(&report);
@@ -2682,5 +2867,11 @@ mod tests {
         let report = analyze_run(&run);
         assert_eq!(report.primary_suspect.kind, global.primary_suspect.kind);
         assert_eq!(report.primary_suspect.score, global.primary_suspect.score);
+    }
+
+    #[test]
+    fn temporal_segments_empty_below_threshold() {
+        let report = analyze_run(&test_run());
+        assert!(report.temporal_segments.is_empty());
     }
 }

--- a/tailtriage-cli/tests/report_schema_contract.rs
+++ b/tailtriage-cli/tests/report_schema_contract.rs
@@ -27,6 +27,7 @@ fn documented_report_keys_exist_in_json_output() {
         ["p95_queue_share_permille"].as_slice(),
         ["p95_service_share_permille"].as_slice(),
         ["primary_suspect", "evidence"].as_slice(),
+        ["temporal_segments"].as_slice(),
     ] {
         assert!(
             json_path_exists(&json, path).is_some(),


### PR DESCRIPTION
### Motivation
- The analyzer currently treats a run as a single aggregate window which can hide within-run phase changes (cold-start bursts, late saturation, etc.), so add low-noise early/late hints to surface material temporal shifts without changing global diagnosis semantics.
- Temporal segments are supporting context only and must not alter full-run primary suspect ranking, scores, or kinds.

### Description
- Added a stable `temporal_segments: Vec<TemporalSegment>` field to `Report` and introduced `TemporalSegment` with the requested fields (`name`, `request_count`, `started_at_unix_ms`, `finished_at_unix_ms`, percentile fields, p95 queue/service shares, `evidence_quality`, `primary_suspect`, `secondary_suspects`, and `warnings`).
- Implemented deterministic early/late split logic (sort by `(started_at_unix_ms, request_id)`, split in half) with emission gating: total completed requests >= 20, each half >= 8, and segments emitted only when a material shift is detected (primary-suspect kind change or large p95 shift >=50% plus conservative handling).
- Segment analysis filters requests, stages, and queues by request_id and timestamp-filters runtime/inflight samples to the segment window when available; segment scoring reuses analyzer helpers (`analyze_run_internal`) but avoids recursive nested `route_breakdowns`/`temporal_segments` and keeps global analysis as source-of-truth for primary suspects and ranking.
- Added stable temporal warning strings and only add global temporal warnings when temporal segments are emitted for the corresponding material reason; added compact text rendering for temporal segments that appears only when `temporal_segments` is non-empty.
- Updated JSON schema contract test to expect `temporal_segments` key, refreshed demo analysis fixtures and docs (`README.md`, `tailtriage-cli/README.md`, `docs/diagnostics.md`) to document the new field and semantics.

### Testing
- `cargo fmt --check`: passed.
- `cargo clippy --workspace --all-targets -- -D warnings`: passed.
- `cargo test --workspace`: all unit and integration tests passed (`44` analyzer tests plus workspace tests passed).
- `python3 scripts/check_demo_fixture_drift.py --profile dev --refresh` then `python3 scripts/check_demo_fixture_drift.py --profile dev`: demo analysis fixtures were refreshed and the fixture check passed.
- `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0`: failed with `failed_case_count=9` due to unexpected warning drift (manifest expectations were not changed in this change set).

Notes: global primary suspect kind, scores, and ordering were not changed by this work — temporal output is additive supporting context only. Demo fixtures were refreshed to reflect the new temporal output, but `validation/diagnostics/manifest.json` was not edited; the deterministic benchmark indicates per-case warning/next-check expectations need review (currently 9 failed cases).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9da80c64483308e505d1d94b66e77)