### PR TITLE
Fix confidence-note truthfulness and ambiguity-cluster capping in analyzer

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -123,6 +123,7 @@ Warnings lower interpretation confidence; they do not automatically invalidate s
   - `strong`: enough request evidence, queue or stage evidence present, no truncation limits active.
 
 Runtime snapshots are optional input. Missing runtime snapshots add a limitation for executor/blocking interpretation, but they do not by themselves force `quality` to `partial` when queue/stage evidence is otherwise strong.
+When runtime snapshots are present but queue-depth fields are absent, confidence notes call this out as partial runtime evidence instead of reporting snapshots as missing.
 
 ## Runtime-pressure caveat
 

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -162,6 +162,7 @@ Suspect ranking uses deterministic, proportional, evidence-aware scoring (0-100)
 
 - Scores rank suspects **inside one report**; they are not probabilities.
 - Confidence is score-derived ranking strength and may be evidence-quality capped; it is not causal certainty.
+- `confidence_notes[]` explain caps, including sparse samples, truncation, missing instrumentation, ambiguous top scores, and partial-vs-missing runtime snapshot limits.
 - Strong downstream tail-stage contribution can outrank weak blocking/runtime signals.
 - Strong queue pressure remains a high-confidence lead when queue share/depth evidence is dominant.
 

--- a/tailtriage-cli/src/analyze.rs
+++ b/tailtriage-cli/src/analyze.rs
@@ -2584,18 +2584,6 @@ mod tests {
                 queue: "q".into(),
                 waited_from_unix_ms: 1,
                 waited_until_unix_ms: 2,
-                wait_us: 990,
-                depth_at_start: Some(15),
-            })
-            .collect();
-        run.queues = run
-            .requests
-            .iter()
-            .map(|r| QueueEvent {
-                request_id: r.request_id.clone(),
-                queue: "q".into(),
-                waited_from_unix_ms: 1,
-                waited_until_unix_ms: 2,
                 wait_us: 985,
                 depth_at_start: Some(15),
             })

--- a/tailtriage-cli/src/analyze.rs
+++ b/tailtriage-cli/src/analyze.rs
@@ -723,20 +723,21 @@ fn apply_evidence_aware_confidence_caps(
     run: &Run,
     evidence_quality: &EvidenceQuality,
 ) {
-    let runtime_missing_key_fields = run.runtime_snapshots.is_empty()
-        || run
+    let runtime_snapshots_missing = run.runtime_snapshots.is_empty();
+    let runtime_partial_key_fields = !runtime_snapshots_missing
+        && (run
             .runtime_snapshots
             .iter()
             .all(|snapshot| snapshot.blocking_queue_depth.is_none())
-        || run
-            .runtime_snapshots
-            .iter()
-            .all(|snapshot| snapshot.local_queue_depth.is_none())
-        || run
-            .runtime_snapshots
-            .iter()
-            .all(|snapshot| snapshot.global_queue_depth.is_none());
-    let ambiguous = ambiguity_warning(suspects).is_some();
+            || run
+                .runtime_snapshots
+                .iter()
+                .all(|snapshot| snapshot.local_queue_depth.is_none())
+            || run
+                .runtime_snapshots
+                .iter()
+                .all(|snapshot| snapshot.global_queue_depth.is_none()));
+    let ambiguous_cluster = ambiguity_cluster_indices(suspects);
     for (i, suspect) in suspects.iter_mut().enumerate() {
         let mut cap = Confidence::High;
         let mut notes = Vec::new();
@@ -766,11 +767,13 @@ fn apply_evidence_aware_confidence_caps(
         apply_family_evidence_caps(
             &suspect.kind,
             run,
-            runtime_missing_key_fields,
+            runtime_snapshots_missing,
+            runtime_partial_key_fields,
             &mut cap,
             &mut notes,
         );
-        if is_primary && ambiguous {
+        let ambiguity_capped = ambiguous_cluster.contains(&i) && !is_insufficient;
+        if ambiguity_capped {
             cap = cap.min(Confidence::Medium);
             notes.push(
                 "Top suspects are close in score; confidence is capped by ambiguity.".to_string(),
@@ -779,7 +782,7 @@ fn apply_evidence_aware_confidence_caps(
         let original = suspect.confidence;
         suspect.confidence = original.min(cap);
         let cap_changed_bucket = suspect.confidence != original;
-        if cap_changed_bucket || (is_primary && ambiguous) {
+        if cap_changed_bucket || ambiguity_capped {
             notes.sort();
             notes.dedup();
             suspect.confidence_notes = notes;
@@ -792,7 +795,8 @@ fn apply_evidence_aware_confidence_caps(
 fn apply_family_evidence_caps(
     kind: &DiagnosisKind,
     run: &Run,
-    runtime_missing_key_fields: bool,
+    runtime_snapshots_missing: bool,
+    runtime_partial_key_fields: bool,
     cap: &mut Confidence,
     notes: &mut Vec<String>,
 ) {
@@ -835,14 +839,47 @@ fn apply_family_evidence_caps(
                         .to_string(),
                 );
             }
-            if runtime_missing_key_fields {
+            if runtime_snapshots_missing {
                 *cap = (*cap).min(Confidence::Medium);
                 notes.push(
                     "Missing runtime snapshots limit executor/blocking confidence.".to_string(),
                 );
+            } else if runtime_partial_key_fields {
+                *cap = (*cap).min(Confidence::Medium);
+                notes.push(
+                    "Runtime snapshots are partial; missing runtime queue-depth fields limit executor/blocking confidence.".to_string(),
+                );
             }
         }
         DiagnosisKind::InsufficientEvidence => {}
+    }
+}
+
+fn ambiguity_cluster_indices(suspects: &[Suspect]) -> Vec<usize> {
+    let mut ranked = suspects
+        .iter()
+        .enumerate()
+        .filter(|(_, s)| s.kind != DiagnosisKind::InsufficientEvidence)
+        .collect::<Vec<_>>();
+    ranked.sort_by_key(|(_, s)| std::cmp::Reverse(s.score));
+    let Some((_, top)) = ranked.first() else {
+        return Vec::new();
+    };
+    if top.score < AMBIGUITY_MIN_SCORE_THRESHOLD {
+        return Vec::new();
+    }
+    let cluster = ranked
+        .iter()
+        .take_while(|(_, s)| {
+            s.score >= AMBIGUITY_MIN_SCORE_THRESHOLD
+                && top.score.abs_diff(s.score) <= AMBIGUITY_SCORE_GAP_THRESHOLD
+        })
+        .map(|(idx, _)| *idx)
+        .collect::<Vec<_>>();
+    if cluster.len() >= 2 {
+        cluster
+    } else {
+        Vec::new()
     }
 }
 
@@ -2547,6 +2584,18 @@ mod tests {
                 queue: "q".into(),
                 waited_from_unix_ms: 1,
                 waited_until_unix_ms: 2,
+                wait_us: 990,
+                depth_at_start: Some(15),
+            })
+            .collect();
+        run.queues = run
+            .requests
+            .iter()
+            .map(|r| QueueEvent {
+                request_id: r.request_id.clone(),
+                queue: "q".into(),
+                waited_from_unix_ms: 1,
+                waited_until_unix_ms: 2,
                 wait_us: 985,
                 depth_at_start: Some(15),
             })
@@ -2710,11 +2759,34 @@ mod tests {
         assert!(suspects[0]
             .confidence_notes
             .iter()
+            .any(|n| n == "Runtime snapshots are partial; missing runtime queue-depth fields limit executor/blocking confidence."));
+        assert!(!suspects[0]
+            .confidence_notes
+            .iter()
             .any(|n| n == "Missing runtime snapshots limit executor/blocking confidence."));
     }
 
     #[test]
-    fn ambiguity_cap_adds_note_to_primary() {
+    fn missing_runtime_snapshots_use_missing_runtime_note() {
+        let mut run = test_run();
+        run.requests = vec![sample_request(1)];
+        run.runtime_snapshots.clear();
+        let eq = evidence_quality(&run);
+        let mut suspects = vec![Suspect::new(
+            DiagnosisKind::ExecutorPressureSuspected,
+            100,
+            vec![],
+            vec![],
+        )];
+        apply_evidence_aware_confidence_caps(&mut suspects, &run, &eq);
+        assert!(suspects[0]
+            .confidence_notes
+            .iter()
+            .any(|n| n == "Missing runtime snapshots limit executor/blocking confidence."));
+    }
+
+    #[test]
+    fn ambiguity_cap_adds_note_to_close_top_suspects() {
         let mut suspects = vec![
             Suspect::new(
                 DiagnosisKind::ApplicationQueueSaturation,
@@ -2728,14 +2800,19 @@ mod tests {
         let eq = evidence_quality(&run);
         apply_evidence_aware_confidence_caps(&mut suspects, &run, &eq);
         assert_eq!(suspects[0].confidence, Confidence::Medium);
+        assert_eq!(suspects[1].confidence, Confidence::Medium);
         assert!(suspects[0]
+            .confidence_notes
+            .iter()
+            .any(|n| n == "Top suspects are close in score; confidence is capped by ambiguity."));
+        assert!(suspects[1]
             .confidence_notes
             .iter()
             .any(|n| n == "Top suspects are close in score; confidence is capped by ambiguity."));
     }
 
     #[test]
-    fn ambiguity_tied_top_scores_only_caps_first_sorted_suspect() {
+    fn ambiguity_capping_preserves_order_and_scores() {
         let mut suspects = vec![
             Suspect::new(
                 DiagnosisKind::ApplicationQueueSaturation,
@@ -2757,10 +2834,52 @@ mod tests {
             .confidence_notes
             .iter()
             .any(|n| n == "Top suspects are close in score; confidence is capped by ambiguity."));
-        assert!(!suspects[1]
+        assert!(suspects[1]
             .confidence_notes
             .iter()
             .any(|n| n == "Top suspects are close in score; confidence is capped by ambiguity."));
+    }
+
+    #[test]
+    fn non_ambiguous_clean_evidence_keeps_high_confidence() {
+        let mut run = test_run();
+        run.requests = (0..45)
+            .map(|i| RequestEvent {
+                request_id: format!("req-{i}"),
+                route: "/q".into(),
+                kind: None,
+                started_at_unix_ms: i,
+                finished_at_unix_ms: i + 1,
+                latency_us: 1_000,
+                outcome: "ok".into(),
+            })
+            .collect();
+        run.queues = run
+            .requests
+            .iter()
+            .map(|r| QueueEvent {
+                request_id: r.request_id.clone(),
+                queue: "q".into(),
+                waited_from_unix_ms: 1,
+                waited_until_unix_ms: 2,
+                wait_us: 990,
+                depth_at_start: Some(15),
+            })
+            .collect();
+        let mut suspects = vec![
+            Suspect::new(
+                DiagnosisKind::ApplicationQueueSaturation,
+                100,
+                vec![],
+                vec![],
+            ),
+            Suspect::new(DiagnosisKind::DownstreamStageDominates, 10, vec![], vec![]),
+        ];
+        suspects[0].confidence = Confidence::High;
+        let eq = evidence_quality(&run);
+        apply_evidence_aware_confidence_caps(&mut suspects, &run, &eq);
+        assert_eq!(suspects[0].confidence, Confidence::High);
+        assert!(suspects[0].confidence_notes.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Make confidence notes truthful and specific for runtime evidence gaps so users are not told snapshots are missing when they exist but lack queue-depth fields. 
- Avoid confusing outputs where ambiguity capping only affected the primary suspect while a close secondary remained at high confidence. 
- Preserve existing scoring, ordering, and diagnosis kinds while improving note discipline and user guidance.

### Description
- Distinguish runtime evidence states by splitting the previous flag into `runtime_snapshots_missing` (no snapshots) and `runtime_partial_key_fields` (snapshots present but important queue-depth fields absent), and use the appropriate note in `apply_family_evidence_caps` so that executor/blocking suspects receive either:
  - `Missing runtime snapshots limit executor/blocking confidence.` when no snapshots exist, or
  - `Runtime snapshots are partial; missing runtime queue-depth fields limit executor/blocking confidence.` when snapshots are present but key fields are missing.
- Implement `ambiguity_cluster_indices` and use it in `apply_evidence_aware_confidence_caps` to identify the ambiguity cluster (non-`insufficient_evidence` suspects meeting the existing ambiguity thresholds) and cap every suspect in that cluster to at most `medium` confidence, adding the note `Top suspects are close in score; confidence is capped by ambiguity.` to each capped suspect without changing scores, ordering, or diagnosis kinds.
- Keep `confidence_notes` empty unless a cap or explicit ambiguity applies, sort/deduplicate notes deterministically, and do not add generic notes to every suspect.
- Add and update unit tests in `tailtriage-cli/src/analyze.rs` to cover partial vs missing runtime notes, ambiguity-cluster capping for multiple close top suspects, preservation of scores/order, and that clean non-ambiguous evidence keeps high confidence.
- Update docs to clarify partial-vs-missing runtime snapshot semantics and expand README wording about what `confidence_notes[]` can explain.

### Testing
- Ran formatting and linting with `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings`, both succeeded. 
- Ran unit and integration tests with `cargo test --workspace`, all test suites passed (repository-wide tests shown as passing). 
- Verified demo fixture stability with `python3 scripts/check_demo_fixture_drift.py --profile dev`, which reported fixtures up to date. 
- Ran diagnostic validation/benchmarks with `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0`, which completed with expected metrics; and `python3 -m unittest scripts.tests.test_diagnostic_benchmark` passed. 
- Validated docs contract with `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts`, both succeeded. 

Notes: scores and suspect ordering were intentionally not changed by this patch; only confidence buckets and confidence notes were adjusted.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa1d694d648330b6512e48a0d14dd0)