### PR TITLE
Fix runtime confidence notes and apply ambiguity capping to all close suspects

### DIFF
--- a/tailtriage-cli/src/analyze.rs
+++ b/tailtriage-cli/src/analyze.rs
@@ -736,7 +736,8 @@ fn apply_evidence_aware_confidence_caps(
             .runtime_snapshots
             .iter()
             .all(|snapshot| snapshot.global_queue_depth.is_none());
-    let ambiguous = ambiguity_warning(suspects).is_some();
+    let runtime_note = runtime_confidence_note(run, runtime_missing_key_fields);
+    let ambiguity_cluster = ambiguity_cluster_indexes(suspects);
     for (i, suspect) in suspects.iter_mut().enumerate() {
         let mut cap = Confidence::High;
         let mut notes = Vec::new();
@@ -763,14 +764,9 @@ fn apply_evidence_aware_confidence_caps(
                     .to_string(),
             );
         }
-        apply_family_evidence_caps(
-            &suspect.kind,
-            run,
-            runtime_missing_key_fields,
-            &mut cap,
-            &mut notes,
-        );
-        if is_primary && ambiguous {
+        apply_family_evidence_caps(&suspect.kind, run, runtime_note, &mut cap, &mut notes);
+        let ambiguity_capped = ambiguity_cluster.contains(&i);
+        if ambiguity_capped {
             cap = cap.min(Confidence::Medium);
             notes.push(
                 "Top suspects are close in score; confidence is capped by ambiguity.".to_string(),
@@ -779,7 +775,7 @@ fn apply_evidence_aware_confidence_caps(
         let original = suspect.confidence;
         suspect.confidence = original.min(cap);
         let cap_changed_bucket = suspect.confidence != original;
-        if cap_changed_bucket || (is_primary && ambiguous) {
+        if cap_changed_bucket || ambiguity_capped {
             notes.sort();
             notes.dedup();
             suspect.confidence_notes = notes;
@@ -792,7 +788,7 @@ fn apply_evidence_aware_confidence_caps(
 fn apply_family_evidence_caps(
     kind: &DiagnosisKind,
     run: &Run,
-    runtime_missing_key_fields: bool,
+    runtime_note: Option<&str>,
     cap: &mut Confidence,
     notes: &mut Vec<String>,
 ) {
@@ -835,14 +831,53 @@ fn apply_family_evidence_caps(
                         .to_string(),
                 );
             }
-            if runtime_missing_key_fields {
+            if let Some(runtime_note) = runtime_note {
                 *cap = (*cap).min(Confidence::Medium);
-                notes.push(
-                    "Missing runtime snapshots limit executor/blocking confidence.".to_string(),
-                );
+                notes.push(runtime_note.to_string());
             }
         }
         DiagnosisKind::InsufficientEvidence => {}
+    }
+}
+
+fn runtime_confidence_note(run: &Run, runtime_missing_key_fields: bool) -> Option<&'static str> {
+    if !runtime_missing_key_fields {
+        None
+    } else if run.runtime_snapshots.is_empty() {
+        Some("Missing runtime snapshots limit executor/blocking confidence.")
+    } else {
+        Some(
+            "Runtime snapshots are partial; missing runtime queue-depth fields limit executor/blocking confidence.",
+        )
+    }
+}
+
+fn ambiguity_cluster_indexes(suspects: &[Suspect]) -> Vec<usize> {
+    let mut non_insufficient: Vec<(usize, u8)> = suspects
+        .iter()
+        .enumerate()
+        .filter(|(_, s)| s.kind != DiagnosisKind::InsufficientEvidence)
+        .map(|(i, s)| (i, s.score))
+        .collect();
+    non_insufficient.sort_by_key(|(_, score)| std::cmp::Reverse(*score));
+    let Some((_, top_score)) = non_insufficient.first().copied() else {
+        return Vec::new();
+    };
+    if top_score < AMBIGUITY_MIN_SCORE_THRESHOLD {
+        return Vec::new();
+    }
+    let cluster: Vec<usize> = non_insufficient
+        .into_iter()
+        .filter(|(_, score)| {
+            *score >= AMBIGUITY_MIN_SCORE_THRESHOLD
+                && top_score.abs_diff(*score) <= AMBIGUITY_SCORE_GAP_THRESHOLD
+        })
+        .map(|(idx, _)| idx)
+        .collect();
+    if cluster.len() >= 2 {
+        cluster
+    } else {
+        Vec::new()
     }
 }
 
@@ -2710,11 +2745,34 @@ mod tests {
         assert!(suspects[0]
             .confidence_notes
             .iter()
+            .any(|n| n == "Runtime snapshots are partial; missing runtime queue-depth fields limit executor/blocking confidence."));
+        assert!(!suspects[0]
+            .confidence_notes
+            .iter()
             .any(|n| n == "Missing runtime snapshots limit executor/blocking confidence."));
     }
 
     #[test]
-    fn ambiguity_cap_adds_note_to_primary() {
+    fn missing_runtime_snapshots_use_missing_runtime_note() {
+        let mut run = test_run();
+        run.requests = vec![sample_request(1)];
+        run.runtime_snapshots.clear();
+        let eq = evidence_quality(&run);
+        let mut suspects = vec![Suspect::new(
+            DiagnosisKind::ExecutorPressureSuspected,
+            100,
+            vec![],
+            vec![],
+        )];
+        apply_evidence_aware_confidence_caps(&mut suspects, &run, &eq);
+        assert!(suspects[0]
+            .confidence_notes
+            .iter()
+            .any(|n| n == "Missing runtime snapshots limit executor/blocking confidence."));
+    }
+
+    #[test]
+    fn ambiguity_caps_all_close_top_suspects_and_preserves_order_and_scores() {
         let mut suspects = vec![
             Suspect::new(
                 DiagnosisKind::ApplicationQueueSaturation,
@@ -2724,40 +2782,22 @@ mod tests {
             ),
             Suspect::new(DiagnosisKind::DownstreamStageDominates, 97, vec![], vec![]),
         ];
-        let run = test_run();
-        let eq = evidence_quality(&run);
-        apply_evidence_aware_confidence_caps(&mut suspects, &run, &eq);
-        assert_eq!(suspects[0].confidence, Confidence::Medium);
-        assert!(suspects[0]
-            .confidence_notes
-            .iter()
-            .any(|n| n == "Top suspects are close in score; confidence is capped by ambiguity."));
-    }
-
-    #[test]
-    fn ambiguity_tied_top_scores_only_caps_first_sorted_suspect() {
-        let mut suspects = vec![
-            Suspect::new(
-                DiagnosisKind::ApplicationQueueSaturation,
-                100,
-                vec![],
-                vec![],
-            ),
-            Suspect::new(DiagnosisKind::DownstreamStageDominates, 100, vec![], vec![]),
-        ];
-        let run = test_run();
+        let mut run = test_run();
+        run.requests = (0..30).map(sample_request).collect();
         let eq = evidence_quality(&run);
         apply_evidence_aware_confidence_caps(&mut suspects, &run, &eq);
 
         assert_eq!(suspects[0].score, 100);
-        assert_eq!(suspects[1].score, 100);
+        assert_eq!(suspects[1].score, 97);
         assert_eq!(suspects[0].kind, DiagnosisKind::ApplicationQueueSaturation);
         assert_eq!(suspects[1].kind, DiagnosisKind::DownstreamStageDominates);
+        assert_eq!(suspects[0].confidence, Confidence::Medium);
+        assert_eq!(suspects[1].confidence, Confidence::Medium);
         assert!(suspects[0]
             .confidence_notes
             .iter()
             .any(|n| n == "Top suspects are close in score; confidence is capped by ambiguity."));
-        assert!(!suspects[1]
+        assert!(suspects[1]
             .confidence_notes
             .iter()
             .any(|n| n == "Top suspects are close in score; confidence is capped by ambiguity."));


### PR DESCRIPTION
### Motivation
- Clarify confidence notes so executor/blocking suspects truthfully distinguish between no runtime snapshots and partial runtime snapshots missing queue-depth fields. 
- Make ambiguity capping less confusing by capping every top suspect in a close-score cluster instead of only the primary, while keeping scores and ordering unchanged. 

### Description
- Added `runtime_confidence_note(run, runtime_missing_key_fields)` to return the specific confidence note or `None` and replaced the prior boolean-driven note insertion with the more precise message for partial vs missing runtime snapshots. 
- Added `ambiguity_cluster_indexes(suspects)` to identify the ambiguity cluster of non-`InsufficientEvidence` suspects by the existing score and gap thresholds, and capped every suspect in that cluster to at most `medium`, adding the ambiguity note to each capped suspect. 
- Updated `apply_evidence_aware_confidence_caps` to use the runtime note and ambiguity cluster; notes are sorted and deduplicated deterministically, notes remain empty when no cap or ambiguity applies, and suspect scores/kinds/order are left intact. 
- Updated `apply_family_evidence_caps` signature and logic to accept the runtime note and to preserve prior truncation/coverage caps and messaging. 
- Added and adjusted unit tests to cover partial-runtime vs missing-runtime notes, ambiguity capping of all close top suspects, and that scores and ordering remain unchanged. 

### Testing
- Ran `cargo fmt --check` and it passed. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it passed. 
- Ran `cargo test --workspace` and all Rust tests passed. 
- Ran `python3 scripts/check_demo_fixture_drift.py --profile dev` and fixtures are up to date. 
- Ran `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0` and the benchmark passed. 
- Ran `python3 -m unittest scripts.tests.test_diagnostic_benchmark` and `python3 scripts/validate_docs_contracts.py` and related validation tests and they passed. 

Summary: confidence-note wording now distinguishes missing vs partial runtime snapshots, ambiguity capping is applied to every suspect in a close-score cluster, and suspect scores and ordering remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa1d694d648330b6512e48a0d14dd0)