### PR TITLE
Align diagnostic benchmark confidence schema with Rust analyzer

### DIFF
--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -76,7 +76,7 @@ This complements deterministic fixture validation:
 Key repeated-run metrics:
 - **Top-1 stability**: fraction of runs where the primary suspect matches the scenario ground truth
 - **Top-2 visibility**: fraction of runs where required causes appear in the top-2 suspects
-- **High-confidence-wrong count**: runs where primary confidence is high/very_high but primary kind is outside acceptable primary kinds
+- **High-confidence-wrong count**: runs where primary confidence is high but primary kind is outside acceptable primary kinds
 - **Confidence bucket accuracy**: top-1 accuracy grouped by confidence bucket
 - **Primary stability**: share of runs captured by the most frequent primary suspect kind
 - **p95 IQR**: interquartile range of p95 latency across repeated runs

--- a/scripts/diagnostic_benchmark.py
+++ b/scripts/diagnostic_benchmark.py
@@ -11,8 +11,8 @@ ALLOWED_GROUND_TRUTH = {
     "downstream_stage_dominates",
     "insufficient_evidence",
 }
-CONF_HIGH = {"high", "very_high"}
-CONFIDENCE_ORDER = {"low": 0, "medium": 1, "high": 2, "very_high": 3}
+CONF_HIGH = {"high"}
+CONFIDENCE_ORDER = {"low": 0, "medium": 1, "high": 2}
 
 
 def load_json(path):
@@ -76,17 +76,17 @@ def validate_manifest(manifest):
             if not isinstance(ceiling, str):
                 raise ValueError(f"max_primary_confidence must be a string for {cid}")
             if ceiling not in CONFIDENCE_ORDER:
-                raise ValueError(f"max_primary_confidence must be one of low/medium/high/very_high for {cid}")
+                raise ValueError(f"max_primary_confidence must be one of low/medium/high for {cid}")
 
 
 def confidence_bucket(conf):
-    if conf in ("high", "very_high"):
+    if conf == "high":
         return "high"
     if conf == "medium":
         return "medium"
     if conf == "low":
         return "low"
-    raise ValueError("report.primary_suspect.confidence must be one of low/medium/high/very_high")
+    raise ValueError("report.primary_suspect.confidence must be one of low/medium/high")
 
 
 def extract(report):
@@ -121,8 +121,8 @@ def extract(report):
         if "kind" in s and s["kind"] not in ALLOWED_GROUND_TRUTH:
             raise ValueError("report.secondary_suspects.kind must be an allowed diagnosis kind when present")
         if "confidence" in s:
-            if not isinstance(s["confidence"], str) or s["confidence"] not in {"low", "medium", "high", "very_high"}:
-                raise ValueError("report.secondary_suspects.confidence must be one of low/medium/high/very_high when present")
+            if not isinstance(s["confidence"], str) or s["confidence"] not in {"low", "medium", "high"}:
+                raise ValueError("report.secondary_suspects.confidence must be one of low/medium/high when present")
         if "score" in s and not isinstance(s["score"], (int, float)):
             raise ValueError("report.secondary_suspects.score must be numeric when present")
         if "evidence" in s and (not isinstance(s["evidence"], list) or not all(isinstance(e, str) for e in s["evidence"])):

--- a/scripts/tests/test_diagnostic_benchmark.py
+++ b/scripts/tests/test_diagnostic_benchmark.py
@@ -132,7 +132,7 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
             db.validate_manifest(self.make_manifest(self.make_case(notes="")))
     def test_manifest_max_primary_confidence_rules(self):
         db.validate_manifest(self.make_manifest(self.make_case()))
-        for allowed in ["low", "medium", "high", "very_high"]:
+        for allowed in ["low", "medium", "high"]:
             db.validate_manifest(self.make_manifest(self.make_case(max_primary_confidence=allowed)))
         with self.assertRaisesRegex(ValueError, "max_primary_confidence must be one of"):
             db.validate_manifest(self.make_manifest(self.make_case(max_primary_confidence="extreme")))
@@ -140,6 +140,12 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
             db.validate_manifest(self.make_manifest(self.make_case(max_primary_confidence=1)))
 
     # Report validation tests
+
+
+    def test_manifest_rejects_very_high_max_primary_confidence(self):
+        with self.assertRaisesRegex(ValueError, "low/medium/high"):
+            db.validate_manifest(self.make_manifest(self.make_case(max_primary_confidence="very_high")))
+
     def test_report_missing_primary_fails(self):
         with self.assertRaisesRegex(ValueError, "primary_suspect"):
             db.extract({"secondary_suspects": [], "warnings": []})
@@ -170,6 +176,17 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
             db.extract({"primary_suspect": primary, "secondary_suspects": [{"next_checks": "bad"}], "warnings": []})
         with self.assertRaisesRegex(ValueError, "warnings"):
             db.extract({"primary_suspect": primary, "secondary_suspects": [], "warnings": [1]})
+
+
+
+    def test_primary_confidence_rejects_very_high(self):
+        with self.assertRaisesRegex(ValueError, "low/medium/high"):
+            db.extract({"primary_suspect": {"kind": ALLOWED[0], "confidence": "very_high", "evidence": []}, "secondary_suspects": [], "warnings": []})
+
+    def test_secondary_confidence_rejects_very_high(self):
+        primary = {"kind": ALLOWED[0], "confidence": "high", "evidence": []}
+        with self.assertRaisesRegex(ValueError, "low/medium/high"):
+            db.extract({"primary_suspect": primary, "secondary_suspects": [{"confidence": "very_high"}], "warnings": []})
 
     def test_analysis_report_requires_primary_score_but_synthetic_may_omit(self):
         case = self.make_case(artifact_type="analysis_report")

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -17,7 +17,7 @@ Normal CI runs the deterministic corpus benchmark against `validation/diagnostic
 - `required_top2`: diagnosis kinds that must appear in primary or first secondary suspect. Usually `[ground_truth]`. Must include `ground_truth`.
 - `acceptable_primary`: diagnosis kinds acceptable as primary for mixed/ambiguous interpretation. Must include `ground_truth`. This does **not** satisfy `required_top2` by itself.
 - `top1_required`: when `true`, primary kind must equal `ground_truth`.
-- `max_primary_confidence`: optional confidence ceiling for primary suspect (`low|medium|high|very_high`).
+- `max_primary_confidence`: optional confidence ceiling for primary suspect (`low|medium|high`).
 - `must_include_evidence`: evidence substrings that must appear in primary or secondary evidence.
 - `must_include_next_checks`: next-check substrings that must appear when required by a case. Selected adversarial cases use this to validate relevant follow-up guidance.
 - `expected_warnings`: warning substrings that must appear.


### PR DESCRIPTION
### Motivation
- Prevent stale schema drift by aligning the Python diagnostic benchmark with the Rust analyzer’s supported confidence buckets (`low`, `medium`, `high`) so committed analysis reports cannot include the deprecated `very_high` bucket.
- Keep this change strictly validation/schema-focused so analyzer scoring, ranking, and output behavior remain unchanged.

### Description
- Remove `very_high` from `CONF_HIGH` and `CONFIDENCE_ORDER` and restrict `CONF_HIGH` to only `{"high"}` in `scripts/diagnostic_benchmark.py`.
- Update `confidence_bucket()` and all error messages to require one of `low/medium/high`, and make secondary-suspect and `max_primary_confidence` manifest validation reject `very_high`.
- Add unit tests in `scripts/tests/test_diagnostic_benchmark.py` that assert rejection of `very_high` for primary suspect confidence, secondary suspect confidence, and manifest `max_primary_confidence`, and keep `low`/`medium`/`high` behavior unchanged.
- Remove references to `very_high` from validation docs (`docs/diagnostic-validation.md` and `validation/diagnostics/README.md`).

### Testing
- Ran `python3 -m unittest scripts.tests.test_diagnostic_benchmark` and the benchmark unit tests passed (no failures).
- Ran the deterministic benchmark with `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0` and it completed with no failures and expected metrics printed.
- Ran `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts` and docs contract validation passed.
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` and the Rust formatting, linting, and tests completed successfully.
- Analyzer behavior changed? No — this is a validation/schema cleanup only and does not modify analyzer scoring, ranking, or outputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fac933942483309b4287dfca838616)