### PR TITLE
Align diagnostic benchmark confidence schema with analyzer buckets

### DIFF
--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -76,7 +76,7 @@ This complements deterministic fixture validation:
 Key repeated-run metrics:
 - **Top-1 stability**: fraction of runs where the primary suspect matches the scenario ground truth
 - **Top-2 visibility**: fraction of runs where required causes appear in the top-2 suspects
-- **High-confidence-wrong count**: runs where primary confidence is high/very_high but primary kind is outside acceptable primary kinds
+- **High-confidence-wrong count**: runs where primary confidence is high but primary kind is outside acceptable primary kinds
 - **Confidence bucket accuracy**: top-1 accuracy grouped by confidence bucket
 - **Primary stability**: share of runs captured by the most frequent primary suspect kind
 - **p95 IQR**: interquartile range of p95 latency across repeated runs

--- a/scripts/diagnostic_benchmark.py
+++ b/scripts/diagnostic_benchmark.py
@@ -11,8 +11,8 @@ ALLOWED_GROUND_TRUTH = {
     "downstream_stage_dominates",
     "insufficient_evidence",
 }
-CONF_HIGH = {"high", "very_high"}
-CONFIDENCE_ORDER = {"low": 0, "medium": 1, "high": 2, "very_high": 3}
+CONF_HIGH = {"high"}
+CONFIDENCE_ORDER = {"low": 0, "medium": 1, "high": 2}
 
 
 def load_json(path):
@@ -76,17 +76,17 @@ def validate_manifest(manifest):
             if not isinstance(ceiling, str):
                 raise ValueError(f"max_primary_confidence must be a string for {cid}")
             if ceiling not in CONFIDENCE_ORDER:
-                raise ValueError(f"max_primary_confidence must be one of low/medium/high/very_high for {cid}")
+                raise ValueError(f"max_primary_confidence must be one of low/medium/high for {cid}")
 
 
 def confidence_bucket(conf):
-    if conf in ("high", "very_high"):
+    if conf == "high":
         return "high"
     if conf == "medium":
         return "medium"
     if conf == "low":
         return "low"
-    raise ValueError("report.primary_suspect.confidence must be one of low/medium/high/very_high")
+    raise ValueError("report.primary_suspect.confidence must be one of low/medium/high")
 
 
 def extract(report):
@@ -121,8 +121,8 @@ def extract(report):
         if "kind" in s and s["kind"] not in ALLOWED_GROUND_TRUTH:
             raise ValueError("report.secondary_suspects.kind must be an allowed diagnosis kind when present")
         if "confidence" in s:
-            if not isinstance(s["confidence"], str) or s["confidence"] not in {"low", "medium", "high", "very_high"}:
-                raise ValueError("report.secondary_suspects.confidence must be one of low/medium/high/very_high when present")
+            if not isinstance(s["confidence"], str) or s["confidence"] not in {"low", "medium", "high"}:
+                raise ValueError("report.secondary_suspects.confidence must be one of low/medium/high when present")
         if "score" in s and not isinstance(s["score"], (int, float)):
             raise ValueError("report.secondary_suspects.score must be numeric when present")
         if "evidence" in s and (not isinstance(s["evidence"], list) or not all(isinstance(e, str) for e in s["evidence"])):

--- a/scripts/tests/test_diagnostic_benchmark.py
+++ b/scripts/tests/test_diagnostic_benchmark.py
@@ -132,8 +132,10 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
             db.validate_manifest(self.make_manifest(self.make_case(notes="")))
     def test_manifest_max_primary_confidence_rules(self):
         db.validate_manifest(self.make_manifest(self.make_case()))
-        for allowed in ["low", "medium", "high", "very_high"]:
+        for allowed in ["low", "medium", "high"]:
             db.validate_manifest(self.make_manifest(self.make_case(max_primary_confidence=allowed)))
+        with self.assertRaisesRegex(ValueError, "max_primary_confidence must be one of"):
+            db.validate_manifest(self.make_manifest(self.make_case(max_primary_confidence="very_high")))
         with self.assertRaisesRegex(ValueError, "max_primary_confidence must be one of"):
             db.validate_manifest(self.make_manifest(self.make_case(max_primary_confidence="extreme")))
         with self.assertRaisesRegex(ValueError, "max_primary_confidence must be a string"):
@@ -149,6 +151,8 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
             db.extract({"primary_suspect": {"kind": "bad", "confidence": "high", "evidence": []}, "secondary_suspects": [], "warnings": []})
         with self.assertRaisesRegex(ValueError, "confidence"):
             db.extract({"primary_suspect": {"kind": ALLOWED[0], "confidence": "bad", "evidence": []}, "secondary_suspects": [], "warnings": []})
+        with self.assertRaisesRegex(ValueError, "low/medium/high"):
+            db.extract({"primary_suspect": {"kind": ALLOWED[0], "confidence": "very_high", "evidence": []}, "secondary_suspects": [], "warnings": []})
         with self.assertRaisesRegex(ValueError, "score"):
             db.extract({"primary_suspect": {"kind": ALLOWED[0], "confidence": "high", "score": "x", "evidence": []}, "secondary_suspects": [], "warnings": []})
         with self.assertRaisesRegex(ValueError, "evidence"):
@@ -162,6 +166,8 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
             db.extract({"primary_suspect": primary, "secondary_suspects": [{"kind": "bad"}], "warnings": []})
         with self.assertRaisesRegex(ValueError, "secondary_suspects.confidence"):
             db.extract({"primary_suspect": primary, "secondary_suspects": [{"confidence": "bad"}], "warnings": []})
+        with self.assertRaisesRegex(ValueError, "low/medium/high"):
+            db.extract({"primary_suspect": primary, "secondary_suspects": [{"confidence": "very_high"}], "warnings": []})
         with self.assertRaisesRegex(ValueError, "secondary_suspects.score"):
             db.extract({"primary_suspect": primary, "secondary_suspects": [{"score": "bad"}], "warnings": []})
         with self.assertRaisesRegex(ValueError, "secondary_suspects.evidence"):

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -17,7 +17,7 @@ Normal CI runs the deterministic corpus benchmark against `validation/diagnostic
 - `required_top2`: diagnosis kinds that must appear in primary or first secondary suspect. Usually `[ground_truth]`. Must include `ground_truth`.
 - `acceptable_primary`: diagnosis kinds acceptable as primary for mixed/ambiguous interpretation. Must include `ground_truth`. This does **not** satisfy `required_top2` by itself.
 - `top1_required`: when `true`, primary kind must equal `ground_truth`.
-- `max_primary_confidence`: optional confidence ceiling for primary suspect (`low|medium|high|very_high`).
+- `max_primary_confidence`: optional confidence ceiling for primary suspect (`low|medium|high`).
 - `must_include_evidence`: evidence substrings that must appear in primary or secondary evidence.
 - `must_include_next_checks`: next-check substrings that must appear when required by a case. Selected adversarial cases use this to validate relevant follow-up guidance.
 - `expected_warnings`: warning substrings that must appear.


### PR DESCRIPTION
### Motivation
- The Rust analyzer only uses three confidence buckets (`low`, `medium`, `high`) while the Python benchmark still accepted the stale `very_high` bucket, which allowed invalid committed reports to pass validation.
- This change removes schema drift by making the Python benchmark and docs enforce the same three-bucket contract as the analyzer.

### Description
- Updated `scripts/diagnostic_benchmark.py` to remove `very_high` from `CONF_HIGH`, to restrict `CONFIDENCE_ORDER` to `low/medium/high`, to update error messages to say `low/medium/high`, and to make `confidence_bucket()` and secondary/manifest validations reject `very_high`.
- Updated unit tests in `scripts/tests/test_diagnostic_benchmark.py` to assert that `very_high` is rejected for primary suspect confidence, secondary suspect confidence, and `max_primary_confidence`, while preserving `low`, `medium`, and `high` behavior.
- Cleared stale references to `very_high` in `docs/diagnostic-validation.md` and `validation/diagnostics/README.md` so documentation matches the validated schema.
- No analyzer scoring, ranking, or Rust output behavior was changed; this is validation/schema and docs alignment only.

### Testing
- Ran `python3 -m unittest scripts.tests.test_diagnostic_benchmark` and all tests passed (24 tests, OK).
- Ran the deterministic benchmark `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0` and it completed with expected metrics and `high_confidence_wrong_count=0`.
- Ran docs validation `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts`, both passed.
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fac933942483309b4287dfca838616)