### PR TITLE
Add optional analyzer-report checks to deterministic diagnostic benchmark

### DIFF
--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -41,6 +41,7 @@ The deterministic benchmark validates:
 - required evidence substrings
 - required next-check substrings when required by a case
 - case-level confidence ceilings (`max_primary_confidence`) for sparse/missing/truncated/mixed evidence humility checks
+- optional expanded-report checks on selected cases (`evidence_quality`, signal-family statuses, confidence-note substrings, route/temporal section presence, and route/temporal warning substrings)
 
 Normal CI enforces this deterministic benchmark directly against `validation/diagnostics/manifest.json` and referenced fixtures. This is a correctness gate for committed corpus/schema drift, not a durable scorecard publication path.
 

--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -3,7 +3,7 @@
 `tailtriage` validation checks diagnosis quality for triage. It does not provide root-cause proof.
 
 ## Methodology
-The benchmark evaluates a deterministic corpus of analyzer reports against workload-grounded labels. It checks suspect ranking behavior, evidence/warning expectations, and bounded failure semantics.
+The benchmark evaluates a deterministic corpus of analyzer reports against workload-grounded labels. It checks suspect ranking behavior, evidence/warning expectations, and bounded failure semantics. Selected corpus cases can also opt into checks for expanded report surface (`evidence_quality`, confidence notes, route breakdowns, temporal segments) without requiring every case to pin every field.
 
 ## Deterministic vs repeated-run validation
 Deterministic fixture validation is exercised directly in normal CI against `validation/diagnostics/manifest.json` and referenced fixtures, and is also exercised by the scorecard generator. Durable scorecards are generated only by the versioned/manual snapshot workflow (`validation-snapshot.yml`) on `workflow_dispatch` and `v*` tags. Normal CI does not publish durable diagnostic scorecards.
@@ -30,6 +30,7 @@ The scorecard includes confidence-bucket accuracy summaries (low/medium/high buc
 ## Warning validation
 - `expected_warnings` substrings are required.
 - observed warnings are allowed only if they match `expected_warnings` or `allowed_warnings`.
+- optional case-level checks can assert evidence-quality classification and signal-family statuses, confidence-note substrings, route/temporal section presence (`empty|non_empty`), route/temporal warning substrings, and optional top-level warning substrings.
 
 ## Negative and adversarial validation
 The corpus includes deterministic synthetic adversarial cases for sparse samples, missing instrumentation, truncated artifacts, and mixed-signal workloads. These cases validate triage humility and evidence-ranked suspect visibility under partial data.

--- a/scripts/diagnostic_benchmark.py
+++ b/scripts/diagnostic_benchmark.py
@@ -13,6 +13,9 @@ ALLOWED_GROUND_TRUTH = {
 }
 CONF_HIGH = {"high"}
 CONFIDENCE_ORDER = {"low": 0, "medium": 1, "high": 2}
+ALLOWED_EVIDENCE_QUALITY = {"strong", "partial", "weak"}
+ALLOWED_SIGNAL_FAMILIES = {"requests", "queues", "stages", "runtime_snapshots", "inflight_snapshots"}
+ALLOWED_SIGNAL_STATUSES = {"present", "missing", "partial", "truncated"}
 
 
 def load_json(path):
@@ -21,6 +24,13 @@ def load_json(path):
 
 
 def validate_manifest(manifest):
+    def validate_substring_list(case, field):
+        value = case[field]
+        if not isinstance(value, list):
+            raise ValueError(f"{field} must be a list of strings for {cid}")
+        if any(not isinstance(item, str) for item in value):
+            raise ValueError(f"{field} must be a list of strings for {cid}")
+
     if not isinstance(manifest, dict) or "cases" not in manifest or not isinstance(manifest["cases"], list):
         raise ValueError("manifest must be an object containing a cases list")
     if manifest.get("schema_version") != 1:
@@ -77,6 +87,29 @@ def validate_manifest(manifest):
                 raise ValueError(f"max_primary_confidence must be a string for {cid}")
             if ceiling not in CONFIDENCE_ORDER:
                 raise ValueError(f"max_primary_confidence must be one of low/medium/high for {cid}")
+        if "expected_evidence_quality" in case:
+            value = case["expected_evidence_quality"]
+            if not isinstance(value, str) or value not in ALLOWED_EVIDENCE_QUALITY:
+                raise ValueError(f"expected_evidence_quality must be one of strong/partial/weak for {cid}")
+        if "expected_signal_statuses" in case:
+            value = case["expected_signal_statuses"]
+            if not isinstance(value, dict):
+                raise ValueError(f"expected_signal_statuses must be an object for {cid}")
+            for family, status in value.items():
+                if family not in ALLOWED_SIGNAL_FAMILIES:
+                    raise ValueError(f"expected_signal_statuses contains unknown signal family for {cid}: {family}")
+                if not isinstance(status, str) or status not in ALLOWED_SIGNAL_STATUSES:
+                    raise ValueError(f"expected_signal_statuses contains unknown status for {cid}: {status}")
+        for field in ["must_include_confidence_notes", "must_include_route_warning", "must_include_temporal_warning", "expected_top_level_warnings"]:
+            if field in case:
+                validate_substring_list(case, field)
+                if "*" in case[field]:
+                    raise ValueError(f"wildcard '*' is not allowed in warnings lists for {cid}")
+        for field in ["expected_route_breakdowns", "expected_temporal_segments"]:
+            if field in case:
+                value = case[field]
+                if not isinstance(value, str) or value not in {"empty", "non_empty"}:
+                    raise ValueError(f"{field} must be one of empty/non_empty for {cid}")
 
 
 def confidence_bucket(conf):
@@ -163,6 +196,16 @@ def run(manifest_path, min_top1, min_top2, max_high_confidence_wrong):
     next_check_presence_cases = 0
     confidence_ceiling_cases = 0
     confidence_ceiling_passed_cases = 0
+    evidence_quality_check_cases = 0
+    evidence_quality_check_passed_cases = 0
+    signal_status_check_cases = 0
+    signal_status_check_passed_cases = 0
+    confidence_note_check_cases = 0
+    confidence_note_check_passed_cases = 0
+    route_breakdown_check_cases = 0
+    route_breakdown_check_passed_cases = 0
+    temporal_segment_check_cases = 0
+    temporal_segment_check_passed_cases = 0
 
     for case in manifest["cases"]:
         report = load_json(root / case["artifact"])
@@ -205,11 +248,79 @@ def run(manifest_path, min_top1, min_top2, max_high_confidence_wrong):
 
         unexpected = [w for w in ext["warnings"] if not any(exp.lower() in w.lower() for exp in (case["expected_warnings"] + case["allowed_warnings"]))]
         missing_expected = [exp for exp in case["expected_warnings"] if not any(exp.lower() in w.lower() for w in ext["warnings"])]
+        expected_top_level = case.get("expected_top_level_warnings", [])
+        missing_top_level = [exp for exp in expected_top_level if not any(exp.lower() in w.lower() for w in ext["warnings"])]
         unexpected_warning_count += len(unexpected)
         missing_expected_warning_count += len(missing_expected)
+        evidence_quality_ok = True
+        expected_evidence_quality = case.get("expected_evidence_quality")
+        actual_evidence_quality = report.get("evidence_quality", {}).get("quality")
+        if expected_evidence_quality is not None:
+            evidence_quality_check_cases += 1
+            evidence_quality_ok = actual_evidence_quality == expected_evidence_quality
+            if evidence_quality_ok:
+                evidence_quality_check_passed_cases += 1
 
-        case_failed = (not top2_ok) or (case["top1_required"] and not top1_ok) or (not ev_ok) or (not next_check_ok) or (not confidence_ceiling_ok) or bool(unexpected) or bool(missing_expected)
-        row = {"id": case["id"], "top1_ok": top1_ok, "top2_ok": top2_ok, "evidence_ok": ev_ok, "next_check_ok": next_check_ok, "confidence_ceiling_ok": confidence_ceiling_ok, "max_primary_confidence": max_primary_confidence, "primary_confidence": ext["primary_confidence"], "unexpected_warnings": unexpected, "missing_expected_warnings": missing_expected}
+        signal_status_ok = True
+        expected_signal_statuses = case.get("expected_signal_statuses")
+        signal_status_mismatches = []
+        if expected_signal_statuses is not None:
+            signal_status_check_cases += 1
+            evidence_quality = report.get("evidence_quality", {})
+            for family, expected in expected_signal_statuses.items():
+                actual = evidence_quality.get(family)
+                if actual != expected:
+                    signal_status_mismatches.append({"family": family, "expected": expected, "actual": actual})
+            signal_status_ok = not signal_status_mismatches
+            if signal_status_ok:
+                signal_status_check_passed_cases += 1
+        notes = []
+        for suspect in [report.get("primary_suspect", {})] + report.get("secondary_suspects", []):
+            notes.extend(suspect.get("confidence_notes") or [])
+        confidence_note_ok = True
+        missing_confidence_notes = []
+        required_confidence_notes = case.get("must_include_confidence_notes")
+        if required_confidence_notes is not None:
+            confidence_note_check_cases += 1
+            missing_confidence_notes = [needle for needle in required_confidence_notes if not any(needle.lower() in note.lower() for note in notes)]
+            confidence_note_ok = not missing_confidence_notes
+            if confidence_note_ok:
+                confidence_note_check_passed_cases += 1
+
+        route_breakdown_ok = True
+        missing_route_warnings = []
+        expected_route_breakdowns = case.get("expected_route_breakdowns")
+        route_breakdowns = report.get("route_breakdowns") or []
+        if expected_route_breakdowns is not None or "must_include_route_warning" in case:
+            route_breakdown_check_cases += 1
+            if expected_route_breakdowns == "empty":
+                route_breakdown_ok = len(route_breakdowns) == 0
+            elif expected_route_breakdowns == "non_empty":
+                route_breakdown_ok = len(route_breakdowns) > 0
+            route_warnings = [w for rb in route_breakdowns for w in rb.get("warnings", [])]
+            missing_route_warnings = [needle for needle in case.get("must_include_route_warning", []) if not any(needle.lower() in w.lower() for w in route_warnings)]
+            route_breakdown_ok = route_breakdown_ok and not missing_route_warnings
+            if route_breakdown_ok:
+                route_breakdown_check_passed_cases += 1
+
+        temporal_segment_ok = True
+        missing_temporal_warnings = []
+        expected_temporal_segments = case.get("expected_temporal_segments")
+        temporal_segments = report.get("temporal_segments") or []
+        if expected_temporal_segments is not None or "must_include_temporal_warning" in case:
+            temporal_segment_check_cases += 1
+            if expected_temporal_segments == "empty":
+                temporal_segment_ok = len(temporal_segments) == 0
+            elif expected_temporal_segments == "non_empty":
+                temporal_segment_ok = len(temporal_segments) > 0
+            temporal_warnings = [w for ts in temporal_segments for w in ts.get("warnings", [])]
+            missing_temporal_warnings = [needle for needle in case.get("must_include_temporal_warning", []) if not any(needle.lower() in w.lower() for w in temporal_warnings)]
+            temporal_segment_ok = temporal_segment_ok and not missing_temporal_warnings
+            if temporal_segment_ok:
+                temporal_segment_check_passed_cases += 1
+
+        case_failed = (not top2_ok) or (case["top1_required"] and not top1_ok) or (not ev_ok) or (not next_check_ok) or (not confidence_ceiling_ok) or (not evidence_quality_ok) or (not signal_status_ok) or (not confidence_note_ok) or (not route_breakdown_ok) or (not temporal_segment_ok) or bool(unexpected) or bool(missing_expected) or bool(missing_top_level)
+        row = {"id": case["id"], "top1_ok": top1_ok, "top2_ok": top2_ok, "evidence_ok": ev_ok, "next_check_ok": next_check_ok, "confidence_ceiling_ok": confidence_ceiling_ok, "max_primary_confidence": max_primary_confidence, "primary_confidence": ext["primary_confidence"], "unexpected_warnings": unexpected, "missing_expected_warnings": missing_expected, "missing_top_level_warnings": missing_top_level, "evidence_quality_ok": evidence_quality_ok, "expected_evidence_quality": expected_evidence_quality, "actual_evidence_quality": actual_evidence_quality, "signal_status_ok": signal_status_ok, "signal_status_mismatches": signal_status_mismatches, "confidence_note_ok": confidence_note_ok, "missing_confidence_notes": missing_confidence_notes, "route_breakdown_ok": route_breakdown_ok, "missing_route_warnings": missing_route_warnings, "temporal_segment_ok": temporal_segment_ok, "missing_temporal_warnings": missing_temporal_warnings}
         results.append(row)
         if case_failed:
             failed_cases.append({**row, "top1_required": case["top1_required"]})
@@ -237,6 +348,16 @@ def run(manifest_path, min_top1, min_top2, max_high_confidence_wrong):
         "unexpected_warning_count": unexpected_warning_count,
         "missing_expected_warning_count": missing_expected_warning_count,
         "failed_cases": failed_cases,
+        "evidence_quality_check_cases": evidence_quality_check_cases,
+        "evidence_quality_check_passed_cases": evidence_quality_check_passed_cases,
+        "signal_status_check_cases": signal_status_check_cases,
+        "signal_status_check_passed_cases": signal_status_check_passed_cases,
+        "confidence_note_check_cases": confidence_note_check_cases,
+        "confidence_note_check_passed_cases": confidence_note_check_passed_cases,
+        "route_breakdown_check_cases": route_breakdown_check_cases,
+        "route_breakdown_check_passed_cases": route_breakdown_check_passed_cases,
+        "temporal_segment_check_cases": temporal_segment_check_cases,
+        "temporal_segment_check_passed_cases": temporal_segment_check_passed_cases,
     }
 
     failures = []

--- a/scripts/tests/test_diagnostic_benchmark.py
+++ b/scripts/tests/test_diagnostic_benchmark.py
@@ -140,6 +140,18 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
             db.validate_manifest(self.make_manifest(self.make_case(max_primary_confidence="extreme")))
         with self.assertRaisesRegex(ValueError, "max_primary_confidence must be a string"):
             db.validate_manifest(self.make_manifest(self.make_case(max_primary_confidence=1)))
+    def test_manifest_optional_field_validation(self):
+        db.validate_manifest(self.make_manifest(self.make_case(expected_evidence_quality="strong")))
+        with self.assertRaisesRegex(ValueError, "expected_evidence_quality"):
+            db.validate_manifest(self.make_manifest(self.make_case(expected_evidence_quality="great")))
+        with self.assertRaisesRegex(ValueError, "expected_signal_statuses contains unknown signal family"):
+            db.validate_manifest(self.make_manifest(self.make_case(expected_signal_statuses={"bad": "present"})))
+        with self.assertRaisesRegex(ValueError, "expected_signal_statuses contains unknown status"):
+            db.validate_manifest(self.make_manifest(self.make_case(expected_signal_statuses={"queues": "ok"})))
+        with self.assertRaisesRegex(ValueError, "must_include_confidence_notes"):
+            db.validate_manifest(self.make_manifest(self.make_case(must_include_confidence_notes="not-a-list")))
+        with self.assertRaisesRegex(ValueError, "must_include_route_warning"):
+            db.validate_manifest(self.make_manifest(self.make_case(must_include_route_warning=[1])))
 
     # Report validation tests
     def test_report_missing_primary_fails(self):
@@ -284,6 +296,52 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
         self.assertFalse(row["confidence_ceiling_ok"])
         self.assertEqual(row["max_primary_confidence"], "medium")
         self.assertEqual(row["primary_confidence"], "high")
+    def test_optional_checks_pass(self):
+        case = self.make_case(
+            expected_evidence_quality="partial",
+            expected_signal_statuses={"queues": "present", "runtime_snapshots": "partial"},
+            must_include_confidence_notes=["partial runtime"],
+            expected_route_breakdowns="non_empty",
+            must_include_route_warning=["not route-attributed"],
+            expected_temporal_segments="non_empty",
+            must_include_temporal_warning=["overlap"],
+            expected_top_level_warnings=["large p95 shift"],
+            allowed_warnings=["large p95 shift"],
+        )
+        report = valid_report(warnings=["large p95 shift"])
+        report["evidence_quality"] = {"quality": "partial", "queues": "present", "runtime_snapshots": "partial"}
+        report["primary_suspect"]["confidence_notes"] = ["partial runtime data observed"]
+        report["route_breakdowns"] = [{"warnings": ["runtime evidence is not route-attributed"]}]
+        report["temporal_segments"] = [{"warnings": ["windows overlap under concurrency"]}]
+        metrics, failures = self.run_single_case(case, report)
+        self.assertFalse(failures)
+        self.assertEqual(metrics["evidence_quality_check_passed_cases"], 1)
+        self.assertEqual(metrics["signal_status_check_passed_cases"], 1)
+
+    def test_optional_checks_fail_with_useful_fields(self):
+        case = self.make_case(
+            expected_evidence_quality="strong",
+            expected_signal_statuses={"queues": "present"},
+            must_include_confidence_notes=["needle"],
+            expected_route_breakdowns="non_empty",
+            must_include_route_warning=["route warn"],
+            expected_temporal_segments="non_empty",
+            must_include_temporal_warning=["temporal warn"],
+            expected_top_level_warnings=["top warn"],
+        )
+        report = valid_report(warnings=[])
+        report["evidence_quality"] = {"quality": "weak", "queues": "missing"}
+        report["route_breakdowns"] = []
+        report["temporal_segments"] = []
+        metrics, failures = self.run_single_case(case, report)
+        self.assertTrue(failures)
+        row = metrics["failed_cases"][0]
+        self.assertFalse(row["evidence_quality_ok"])
+        self.assertFalse(row["signal_status_ok"])
+        self.assertFalse(row["confidence_note_ok"])
+        self.assertFalse(row["route_breakdown_ok"])
+        self.assertFalse(row["temporal_segment_ok"])
+        self.assertTrue(row["missing_top_level_warnings"])
 
     # Threshold and output/path tests
     def test_threshold_failures(self):
@@ -315,7 +373,10 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
                 "required_evidence_pass_rate", "next_check_required_cases", "next_check_passed_cases",
                 "next_check_presence_rate", "next_check_pass_rate", "confidence_ceiling_cases",
                 "confidence_ceiling_passed_cases", "confidence_ceiling_pass_rate", "unexpected_warning_count",
-                "missing_expected_warning_count", "failed_cases",
+                "missing_expected_warning_count", "failed_cases", "evidence_quality_check_cases",
+                "evidence_quality_check_passed_cases", "signal_status_check_cases", "signal_status_check_passed_cases",
+                "confidence_note_check_cases", "confidence_note_check_passed_cases", "route_breakdown_check_cases",
+                "route_breakdown_check_passed_cases", "temporal_segment_check_cases", "temporal_segment_check_passed_cases",
             }
             self.assertEqual(set(metrics.keys()), expected_keys)
 

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -22,6 +22,7 @@ Normal CI runs the deterministic corpus benchmark against `validation/diagnostic
 - `must_include_next_checks`: next-check substrings that must appear when required by a case. Selected adversarial cases use this to validate relevant follow-up guidance.
 - `expected_warnings`: warning substrings that must appear.
 - `allowed_warnings`: warning substrings that may appear in addition to expected warnings (tolerated extras only).
+- Optional expanded-report checks (opt-in per case): `expected_evidence_quality`, `expected_signal_statuses`, `must_include_confidence_notes`, `expected_route_breakdowns`, `expected_temporal_segments`, `must_include_route_warning`, `must_include_temporal_warning`, and `expected_top_level_warnings`.
 - `notes`: workload-intent note explaining why labels are set.
 - `tags`: non-empty string tags for grouping/filtering.
 
@@ -63,7 +64,7 @@ python3 scripts/diagnostic_benchmark.py \
 - repeated-run controlled matrix runner: `scripts/run_diagnostic_matrix.py`
 - mitigation matrix runner: `scripts/run_mitigation_matrix.py`
 
-The deterministic corpus checks fixture-labeled contract behavior. The repeated-run runner checks repeated-run stability for selected controlled demo workloads.
+The deterministic corpus checks fixture-labeled contract behavior. Optional expanded-report checks are intentionally per-case so representative fixtures can validate newer analyzer report surface without making every corpus case brittle. The repeated-run runner checks repeated-run stability for selected controlled demo workloads.
 
 Validation tracks currently include deterministic corpus benchmark, adversarial synthetic coverage (inside the corpus), repeated-run diagnostic matrix, mitigation matrix workflows, and operational validation for runtime cost and collector limits. Operational validation now has dedicated domain folders under `validation/runtime-cost/` and `validation/collector-limits/`; diagnostics references them but is not the only operational validation location. Generated operational outputs remain under `target/operational-validation/` and are not committed by default.
 

--- a/validation/diagnostics/corpus/low-request-quality.json
+++ b/validation/diagnostics/corpus/low-request-quality.json
@@ -1,0 +1,29 @@
+{
+  "primary_suspect": {
+    "kind": "insufficient_evidence",
+    "confidence": "low",
+    "evidence": [
+      "Low request count limits stable tail interpretation."
+    ],
+    "next_checks": [
+      "Increase request volume and re-run capture."
+    ],
+    "confidence_notes": [
+      "Low request count reduces confidence in ranking."
+    ]
+  },
+  "secondary_suspects": [],
+  "warnings": [
+    "Low request count: tail estimates may be unstable."
+  ],
+  "evidence_quality": {
+    "quality": "weak",
+    "requests": "partial",
+    "queues": "missing",
+    "stages": "missing",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "missing"
+  },
+  "route_breakdowns": [],
+  "temporal_segments": []
+}

--- a/validation/diagnostics/corpus/route-divergence.json
+++ b/validation/diagnostics/corpus/route-divergence.json
@@ -1,0 +1,23 @@
+{
+  "primary_suspect": {
+    "kind": "application_queue_saturation",
+    "confidence": "medium",
+    "evidence": [
+      "Queue wait dominates route /slow"
+    ],
+    "confidence_notes": [
+      "Route breakdown is available for one route."
+    ]
+  },
+  "secondary_suspects": [],
+  "warnings": [],
+  "route_breakdowns": [
+    {
+      "route": "/slow",
+      "warnings": [
+        "Runtime and in-flight snapshots are not route-attributed; route diagnosis is not route-attributed for executor/blocking evidence."
+      ]
+    }
+  ],
+  "temporal_segments": []
+}

--- a/validation/diagnostics/manifest.json
+++ b/validation/diagnostics/manifest.json
@@ -27,7 +27,14 @@
       "acceptable_primary": [
         "application_queue_saturation"
       ],
-      "must_include_next_checks": []
+      "must_include_next_checks": [],
+      "expected_evidence_quality": "strong",
+      "expected_signal_statuses": {
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing"
+      },
+      "expected_route_breakdowns": "empty"
     },
     {
       "id": "queue_after",
@@ -82,7 +89,14 @@
       "acceptable_primary": [
         "blocking_pool_pressure"
       ],
-      "must_include_next_checks": []
+      "must_include_next_checks": [],
+      "expected_evidence_quality": "partial",
+      "expected_signal_statuses": {
+        "runtime_snapshots": "partial"
+      },
+      "must_include_confidence_notes": [
+        "Runtime snapshots are partial"
+      ]
     },
     {
       "id": "blocking_after",
@@ -509,7 +523,14 @@
       "acceptable_primary": [
         "application_queue_saturation"
       ],
-      "must_include_next_checks": []
+      "must_include_next_checks": [],
+      "expected_temporal_segments": "non_empty",
+      "expected_top_level_warnings": [
+        "large p95 latency shift"
+      ],
+      "must_include_temporal_warning": [
+        "Segment windows overlap under concurrent requests"
+      ]
     },
     {
       "id": "blocking_sample",
@@ -1048,6 +1069,67 @@
       ],
       "max_primary_confidence": "low",
       "notes": "Synthetic adversarial high-latency-without-explanatory-signals case: latency alone should not force a specific high-confidence suspect."
+    },
+    {
+      "id": "synthetic_route_divergence",
+      "artifact": "corpus/route-divergence.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "application_queue_saturation",
+      "required_top2": [
+        "application_queue_saturation"
+      ],
+      "acceptable_primary": [
+        "application_queue_saturation"
+      ],
+      "tags": [
+        "synthetic",
+        "route"
+      ],
+      "must_include_evidence": [
+        "Queue wait dominates"
+      ],
+      "must_include_next_checks": [],
+      "expected_warnings": [],
+      "allowed_warnings": [],
+      "top1_required": false,
+      "notes": "Synthetic route divergence case for optional route breakdown validation coverage.",
+      "expected_route_breakdowns": "non_empty",
+      "must_include_route_warning": [
+        "not route-attributed"
+      ]
+    },
+    {
+      "id": "synthetic_low_request_quality",
+      "artifact": "corpus/low-request-quality.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "insufficient_evidence",
+      "required_top2": [
+        "insufficient_evidence"
+      ],
+      "acceptable_primary": [
+        "insufficient_evidence"
+      ],
+      "tags": [
+        "synthetic",
+        "low-request"
+      ],
+      "must_include_evidence": [
+        "Low request count"
+      ],
+      "must_include_next_checks": [
+        "Increase request volume"
+      ],
+      "expected_warnings": [
+        "Low request count"
+      ],
+      "allowed_warnings": [],
+      "top1_required": true,
+      "notes": "Synthetic low-request case with weak evidence quality and explicit confidence notes.",
+      "max_primary_confidence": "low",
+      "expected_evidence_quality": "weak",
+      "must_include_confidence_notes": [
+        "Low request count"
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- Expand deterministic validation to cover the analyzer's newer report surface (`evidence_quality`, signal-status flags, `confidence_notes`, `route_breakdowns`, and `temporal_segments`) while keeping the corpus non-brittle by making these checks opt-in per-case. 
- Provide stricter manifest/schema validation for these optional assertions so representative fixtures can assert richer report fields safely.

### Description
- Extended `scripts/diagnostic_benchmark.py` to accept the following optional per-case manifest fields: `expected_evidence_quality` (enum `strong|partial|weak`), `expected_signal_statuses` (map of families `requests|queues|stages|runtime_snapshots|inflight_snapshots` to statuses `present|missing|partial|truncated`), `must_include_confidence_notes` (list of substrings), `expected_route_breakdowns`/`expected_temporal_segments` (each `empty|non_empty`), `must_include_route_warning`, `must_include_temporal_warning`, and `expected_top_level_warnings` (list of substrings). 
- Added schema validation in `validate_manifest()` to reject unknown enum values, non-list/non-string substring fields, unknown signal families/statuses, and preserved the prohibition on wildcard (`*`) warning allowlists. 
- Implemented runtime checks and per-check counters/metrics (`evidence_quality_check_*`, `signal_status_check_*`, `confidence_note_check_*`, `route_breakdown_check_*`, `temporal_segment_check_*`) and included richer failure payloads in `failed_cases` for useful debugging. 
- Updated `validation/diagnostics/manifest.json` with narrow, representative opt-in coverage (no mass changes): `queue_before`, `blocking_before`, `queue_sample`, and added two synthetic fixtures `synthetic_route_divergence` and `synthetic_low_request_quality` to exercise route/temporal and weak-evidence cases respectively. 
- Added/updated unit tests in `scripts/tests/test_diagnostic_benchmark.py` to validate optional-field schema handling, passing/failing behaviors, and metrics shape compatibility; updated docs (`validation/diagnostics/README.md`, `docs/diagnostic-validation.md`, `VALIDATION.md`) to describe the opt-in contract. 
- Analyzer implementation, scoring, and ranking were not changed by this PR. 

### Testing
- Ran `python3 -m unittest scripts.tests.test_diagnostic_benchmark` and all tests passed. 
- Ran the deterministic benchmark: `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0` and it completed with zero failed cases. 
- Ran doc validations: `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts` and they passed. 
- Ran Rust checks: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` and they all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad439461c8330b5005ec480b403e6)