### PR TITLE
Extend diagnostic benchmark with optional analyzer-report validations

### DIFF
--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -97,3 +97,6 @@ Demos teach scenarios; validation measures bounded diagnostic behavior.
 Durable diagnostic validation scorecards are generated only by `.github/workflows/validation-snapshot.yml` on `workflow_dispatch` and `v*` tags. Normal CI does not publish durable diagnostic scorecards and does not auto-overwrite `validation/diagnostics/latest/scorecard.md`.
 
 Snapshot artifacts include deterministic benchmark metrics, thresholds, git/ref metadata, `tailtriage` workspace/package version metadata, GitHub Actions metadata when available, software/hardware metadata, and manifest/referenced-artifact hashes.
+
+
+Optional manifest fields can validate expanded analyzer report surface on selected cases only: `expected_evidence_quality`, `expected_signal_statuses`, `must_include_confidence_notes`, `expected_route_breakdowns`, `expected_temporal_segments`, `must_include_route_warning`, `must_include_temporal_warning`, and `expected_top_level_warnings`. These checks are fixture-scoped and optional; cases that omit them continue to validate under the existing suspect/evidence/warning contract.

--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -104,3 +104,6 @@ Use `.github/workflows/validation-snapshot.yml` for auditable snapshots. It gene
 The snapshot captures deterministic benchmark metrics, thresholds, `tailtriage` workspace and per-crate versions, git metadata, GitHub Actions runner metadata (when available), software metadata, hardware metadata, and manifest/referenced-artifact hashes.
 
 Deterministic fixture metrics validate committed fixture behavior only. They do not prove production root cause, universal production accuracy, universal production overhead, or real-service behavior. Repeated-run, runtime-cost, and collector-limit results are more hardware-sensitive than deterministic fixture validation.
+
+
+Optional manifest fields can validate expanded analyzer report surface on selected cases only: `expected_evidence_quality`, `expected_signal_statuses`, `must_include_confidence_notes`, `expected_route_breakdowns`, `expected_temporal_segments`, `must_include_route_warning`, `must_include_temporal_warning`, and `expected_top_level_warnings`. These checks are fixture-scoped and optional; cases that omit them continue to validate under the existing suspect/evidence/warning contract.

--- a/scripts/diagnostic_benchmark.py
+++ b/scripts/diagnostic_benchmark.py
@@ -13,6 +13,9 @@ ALLOWED_GROUND_TRUTH = {
 }
 CONF_HIGH = {"high"}
 CONFIDENCE_ORDER = {"low": 0, "medium": 1, "high": 2}
+ALLOWED_EVIDENCE_QUALITY = {"strong", "partial", "weak"}
+ALLOWED_SIGNAL_FAMILIES = {"requests", "queues", "stages", "runtime_snapshots", "inflight_snapshots"}
+ALLOWED_SIGNAL_STATUSES = {"present", "missing", "partial", "truncated"}
 
 
 def load_json(path):
@@ -57,16 +60,34 @@ def validate_manifest(manifest):
             raise ValueError(f"acceptable_primary must include ground_truth for {cid}")
         if not isinstance(case["tags"], list) or any((not isinstance(t, str) or not t.strip()) for t in case["tags"]):
             raise ValueError(f"tags must be a list of non-empty strings for {cid}")
-        if not isinstance(case["must_include_evidence"], list) or any(not isinstance(e, str) for e in case["must_include_evidence"]):
-            raise ValueError(f"must_include_evidence must be a list of strings for {cid}")
-        if not isinstance(case["must_include_next_checks"], list) or any(not isinstance(e, str) for e in case["must_include_next_checks"]):
-            raise ValueError(f"must_include_next_checks must be a list of strings for {cid}")
-        if not isinstance(case["expected_warnings"], list) or any(not isinstance(w, str) for w in case["expected_warnings"]):
-            raise ValueError(f"expected_warnings must be a list of strings for {cid}")
-        if not isinstance(case["allowed_warnings"], list) or any(not isinstance(w, str) for w in case["allowed_warnings"]):
-            raise ValueError(f"allowed_warnings must be a list of strings for {cid}")
+        validate_string_list(case["must_include_evidence"], "must_include_evidence", cid)
+        validate_string_list(case["must_include_next_checks"], "must_include_next_checks", cid)
+        validate_string_list(case["expected_warnings"], "expected_warnings", cid)
+        validate_string_list(case["allowed_warnings"], "allowed_warnings", cid)
         if "*" in case["expected_warnings"] or "*" in case["allowed_warnings"]:
             raise ValueError(f"wildcard '*' is not allowed in warnings lists for {cid}")
+        if "expected_evidence_quality" in case:
+            quality = case["expected_evidence_quality"]
+            if quality not in ALLOWED_EVIDENCE_QUALITY:
+                raise ValueError(f"expected_evidence_quality must be one of strong/partial/weak for {cid}")
+        if "expected_signal_statuses" in case:
+            statuses = case["expected_signal_statuses"]
+            if not isinstance(statuses, dict):
+                raise ValueError(f"expected_signal_statuses must be an object for {cid}")
+            for family, status in statuses.items():
+                if family not in ALLOWED_SIGNAL_FAMILIES:
+                    raise ValueError(f"unknown signal family in expected_signal_statuses for {cid}: {family}")
+                if status not in ALLOWED_SIGNAL_STATUSES:
+                    raise ValueError(f"unknown signal status in expected_signal_statuses for {cid}: {status}")
+        for field in ["must_include_confidence_notes", "must_include_route_warning", "must_include_temporal_warning", "expected_top_level_warnings"]:
+            if field in case:
+                validate_string_list(case[field], field, cid)
+                if "*" in case[field]:
+                    raise ValueError(f"wildcard '*' is not allowed in warnings lists for {cid}")
+        if "expected_route_breakdowns" in case and case["expected_route_breakdowns"] not in {"empty", "non_empty"}:
+            raise ValueError(f"expected_route_breakdowns must be one of empty/non_empty for {cid}")
+        if "expected_temporal_segments" in case and case["expected_temporal_segments"] not in {"empty", "non_empty"}:
+            raise ValueError(f"expected_temporal_segments must be one of empty/non_empty for {cid}")
         if not isinstance(case["top1_required"], bool):
             raise ValueError(f"top1_required must be a bool for {cid}")
         if not isinstance(case["notes"], str) or not case["notes"].strip():
@@ -78,6 +99,32 @@ def validate_manifest(manifest):
             if ceiling not in CONFIDENCE_ORDER:
                 raise ValueError(f"max_primary_confidence must be one of low/medium/high for {cid}")
 
+
+
+def validate_string_list(value, field_name, cid):
+    if not isinstance(value, list):
+        raise ValueError(f"{field_name} must be a list of strings for {cid}")
+    for item in value:
+        if not isinstance(item, str):
+            raise ValueError(f"{field_name} must be a list of strings for {cid}")
+
+
+def collect_confidence_notes(suspects):
+    notes = []
+    for suspect in suspects:
+        entries = suspect.get("confidence_notes", [])
+        if isinstance(entries, list):
+            notes.extend([n for n in entries if isinstance(n, str)])
+    return notes
+
+
+def collect_nested_warnings(items):
+    warnings = []
+    for item in items:
+        entries = item.get("warnings", [])
+        if isinstance(entries, list):
+            warnings.extend([w for w in entries if isinstance(w, str)])
+    return warnings
 
 def confidence_bucket(conf):
     if conf == "high":
@@ -133,6 +180,9 @@ def extract(report):
         raise ValueError("report.warnings must be a list of strings")
 
     all_suspects = [primary] + secondary
+    route_breakdowns = report.get("route_breakdowns", [])
+    temporal_segments = report.get("temporal_segments", [])
+    evidence_quality = report.get("evidence_quality", {})
     return {
         "top1": kind,
         "top2": [s.get("kind") for s in all_suspects[:2] if s.get("kind")],
@@ -140,6 +190,12 @@ def extract(report):
         "evidence": [e for s in all_suspects for e in s.get("evidence", [])],
         "warnings": report["warnings"],
         "next_checks": [n for s in all_suspects for n in s.get("next_checks", [])],
+        "confidence_notes": collect_confidence_notes(all_suspects),
+        "route_breakdowns": route_breakdowns if isinstance(route_breakdowns, list) else [],
+        "temporal_segments": temporal_segments if isinstance(temporal_segments, list) else [],
+        "route_warnings": collect_nested_warnings(route_breakdowns if isinstance(route_breakdowns, list) else []),
+        "temporal_warnings": collect_nested_warnings(temporal_segments if isinstance(temporal_segments, list) else []),
+        "evidence_quality": evidence_quality if isinstance(evidence_quality, dict) else {},
     }
 
 
@@ -163,6 +219,16 @@ def run(manifest_path, min_top1, min_top2, max_high_confidence_wrong):
     next_check_presence_cases = 0
     confidence_ceiling_cases = 0
     confidence_ceiling_passed_cases = 0
+    evidence_quality_check_cases = 0
+    evidence_quality_check_passed_cases = 0
+    signal_status_check_cases = 0
+    signal_status_check_passed_cases = 0
+    confidence_note_check_cases = 0
+    confidence_note_check_passed_cases = 0
+    route_breakdown_check_cases = 0
+    route_breakdown_check_passed_cases = 0
+    temporal_segment_check_cases = 0
+    temporal_segment_check_passed_cases = 0
 
     for case in manifest["cases"]:
         report = load_json(root / case["artifact"])
@@ -205,11 +271,51 @@ def run(manifest_path, min_top1, min_top2, max_high_confidence_wrong):
 
         unexpected = [w for w in ext["warnings"] if not any(exp.lower() in w.lower() for exp in (case["expected_warnings"] + case["allowed_warnings"]))]
         missing_expected = [exp for exp in case["expected_warnings"] if not any(exp.lower() in w.lower() for w in ext["warnings"])]
+        expected_top_level = case.get("expected_top_level_warnings", [])
+        missing_top_level = [exp for exp in expected_top_level if not any(exp.lower() in w.lower() for w in ext["warnings"])]
+
+        evidence_quality_ok = True
+        if "expected_evidence_quality" in case:
+            evidence_quality_check_cases += 1
+            evidence_quality_ok = ext["evidence_quality"].get("quality") == case["expected_evidence_quality"]
+            if evidence_quality_ok:
+                evidence_quality_check_passed_cases += 1
+
+        signal_status_ok = True
+        if "expected_signal_statuses" in case:
+            signal_status_check_cases += 1
+            signal_status_ok = all(ext["evidence_quality"].get(k) == v for k, v in case["expected_signal_statuses"].items())
+            if signal_status_ok:
+                signal_status_check_passed_cases += 1
+
+        confidence_note_ok = True
+        required_notes = case.get("must_include_confidence_notes", [])
+        if required_notes:
+            confidence_note_check_cases += 1
+            confidence_note_ok = all(any(req.lower() in n.lower() for n in ext["confidence_notes"]) for req in required_notes)
+            if confidence_note_ok:
+                confidence_note_check_passed_cases += 1
+
+        route_breakdown_ok = True
+        if "expected_route_breakdowns" in case:
+            route_breakdown_check_cases += 1
+            route_breakdown_ok = (len(ext["route_breakdowns"]) == 0) if case["expected_route_breakdowns"] == "empty" else (len(ext["route_breakdowns"]) > 0)
+            if route_breakdown_ok:
+                route_breakdown_check_passed_cases += 1
+        route_warning_ok = all(any(req.lower() in w.lower() for w in ext["route_warnings"]) for req in case.get("must_include_route_warning", []))
+
+        temporal_segment_ok = True
+        if "expected_temporal_segments" in case:
+            temporal_segment_check_cases += 1
+            temporal_segment_ok = (len(ext["temporal_segments"]) == 0) if case["expected_temporal_segments"] == "empty" else (len(ext["temporal_segments"]) > 0)
+            if temporal_segment_ok:
+                temporal_segment_check_passed_cases += 1
+        temporal_warning_ok = all(any(req.lower() in w.lower() for w in ext["temporal_warnings"]) for req in case.get("must_include_temporal_warning", []))
         unexpected_warning_count += len(unexpected)
         missing_expected_warning_count += len(missing_expected)
 
-        case_failed = (not top2_ok) or (case["top1_required"] and not top1_ok) or (not ev_ok) or (not next_check_ok) or (not confidence_ceiling_ok) or bool(unexpected) or bool(missing_expected)
-        row = {"id": case["id"], "top1_ok": top1_ok, "top2_ok": top2_ok, "evidence_ok": ev_ok, "next_check_ok": next_check_ok, "confidence_ceiling_ok": confidence_ceiling_ok, "max_primary_confidence": max_primary_confidence, "primary_confidence": ext["primary_confidence"], "unexpected_warnings": unexpected, "missing_expected_warnings": missing_expected}
+        case_failed = (not top2_ok) or (case["top1_required"] and not top1_ok) or (not ev_ok) or (not next_check_ok) or (not confidence_ceiling_ok) or bool(unexpected) or bool(missing_expected) or bool(missing_top_level) or (not evidence_quality_ok) or (not signal_status_ok) or (not confidence_note_ok) or (not route_breakdown_ok) or (not route_warning_ok) or (not temporal_segment_ok) or (not temporal_warning_ok)
+        row = {"id": case["id"], "top1_ok": top1_ok, "top2_ok": top2_ok, "evidence_ok": ev_ok, "next_check_ok": next_check_ok, "confidence_ceiling_ok": confidence_ceiling_ok, "max_primary_confidence": max_primary_confidence, "primary_confidence": ext["primary_confidence"], "unexpected_warnings": unexpected, "missing_expected_warnings": missing_expected, "missing_expected_top_level_warnings": missing_top_level, "evidence_quality_ok": evidence_quality_ok, "signal_status_ok": signal_status_ok, "confidence_note_ok": confidence_note_ok, "route_breakdown_ok": route_breakdown_ok, "route_warning_ok": route_warning_ok, "temporal_segment_ok": temporal_segment_ok, "temporal_warning_ok": temporal_warning_ok}
         results.append(row)
         if case_failed:
             failed_cases.append({**row, "top1_required": case["top1_required"]})
@@ -236,6 +342,16 @@ def run(manifest_path, min_top1, min_top2, max_high_confidence_wrong):
         "confidence_ceiling_pass_rate": (confidence_ceiling_passed_cases / confidence_ceiling_cases) if confidence_ceiling_cases else None,
         "unexpected_warning_count": unexpected_warning_count,
         "missing_expected_warning_count": missing_expected_warning_count,
+        "evidence_quality_check_cases": evidence_quality_check_cases,
+        "evidence_quality_check_passed_cases": evidence_quality_check_passed_cases,
+        "signal_status_check_cases": signal_status_check_cases,
+        "signal_status_check_passed_cases": signal_status_check_passed_cases,
+        "confidence_note_check_cases": confidence_note_check_cases,
+        "confidence_note_check_passed_cases": confidence_note_check_passed_cases,
+        "route_breakdown_check_cases": route_breakdown_check_cases,
+        "route_breakdown_check_passed_cases": route_breakdown_check_passed_cases,
+        "temporal_segment_check_cases": temporal_segment_check_cases,
+        "temporal_segment_check_passed_cases": temporal_segment_check_passed_cases,
         "failed_cases": failed_cases,
     }
 

--- a/scripts/diagnostic_benchmark.py
+++ b/scripts/diagnostic_benchmark.py
@@ -68,6 +68,8 @@ def validate_manifest(manifest):
             raise ValueError(f"wildcard '*' is not allowed in warnings lists for {cid}")
         if "expected_evidence_quality" in case:
             quality = case["expected_evidence_quality"]
+            if not isinstance(quality, str):
+                raise ValueError(f"expected_evidence_quality must be a string for {cid}")
             if quality not in ALLOWED_EVIDENCE_QUALITY:
                 raise ValueError(f"expected_evidence_quality must be one of strong/partial/weak for {cid}")
         if "expected_signal_statuses" in case:
@@ -75,8 +77,12 @@ def validate_manifest(manifest):
             if not isinstance(statuses, dict):
                 raise ValueError(f"expected_signal_statuses must be an object for {cid}")
             for family, status in statuses.items():
+                if not isinstance(family, str):
+                    raise ValueError(f"expected_signal_statuses keys must be strings for {cid}")
                 if family not in ALLOWED_SIGNAL_FAMILIES:
                     raise ValueError(f"unknown signal family in expected_signal_statuses for {cid}: {family}")
+                if not isinstance(status, str):
+                    raise ValueError(f"expected_signal_statuses values must be strings for {cid}")
                 if status not in ALLOWED_SIGNAL_STATUSES:
                     raise ValueError(f"unknown signal status in expected_signal_statuses for {cid}: {status}")
         for field in ["must_include_confidence_notes", "must_include_route_warning", "must_include_temporal_warning", "expected_top_level_warnings"]:
@@ -84,10 +90,18 @@ def validate_manifest(manifest):
                 validate_string_list(case[field], field, cid)
                 if "*" in case[field]:
                     raise ValueError(f"wildcard '*' is not allowed in warnings lists for {cid}")
-        if "expected_route_breakdowns" in case and case["expected_route_breakdowns"] not in {"empty", "non_empty"}:
-            raise ValueError(f"expected_route_breakdowns must be one of empty/non_empty for {cid}")
-        if "expected_temporal_segments" in case and case["expected_temporal_segments"] not in {"empty", "non_empty"}:
-            raise ValueError(f"expected_temporal_segments must be one of empty/non_empty for {cid}")
+        if "expected_route_breakdowns" in case:
+            expected_route_breakdowns = case["expected_route_breakdowns"]
+            if not isinstance(expected_route_breakdowns, str):
+                raise ValueError(f"expected_route_breakdowns must be a string for {cid}")
+            if expected_route_breakdowns not in {"empty", "non_empty"}:
+                raise ValueError(f"expected_route_breakdowns must be one of empty/non_empty for {cid}")
+        if "expected_temporal_segments" in case:
+            expected_temporal_segments = case["expected_temporal_segments"]
+            if not isinstance(expected_temporal_segments, str):
+                raise ValueError(f"expected_temporal_segments must be a string for {cid}")
+            if expected_temporal_segments not in {"empty", "non_empty"}:
+                raise ValueError(f"expected_temporal_segments must be one of empty/non_empty for {cid}")
         if not isinstance(case["top1_required"], bool):
             raise ValueError(f"top1_required must be a bool for {cid}")
         if not isinstance(case["notes"], str) or not case["notes"].strip():
@@ -282,40 +296,55 @@ def run(manifest_path, min_top1, min_top2, max_high_confidence_wrong):
                 evidence_quality_check_passed_cases += 1
 
         signal_status_ok = True
+        signal_status_mismatches = []
         if "expected_signal_statuses" in case:
             signal_status_check_cases += 1
-            signal_status_ok = all(ext["evidence_quality"].get(k) == v for k, v in case["expected_signal_statuses"].items())
+            for family, expected_status in case["expected_signal_statuses"].items():
+                actual_status = ext["evidence_quality"].get(family)
+                if actual_status != expected_status:
+                    signal_status_mismatches.append({"family": family, "expected": expected_status, "actual": actual_status})
+            signal_status_ok = len(signal_status_mismatches) == 0
             if signal_status_ok:
                 signal_status_check_passed_cases += 1
 
         confidence_note_ok = True
         required_notes = case.get("must_include_confidence_notes", [])
+        missing_confidence_notes = []
         if required_notes:
             confidence_note_check_cases += 1
-            confidence_note_ok = all(any(req.lower() in n.lower() for n in ext["confidence_notes"]) for req in required_notes)
+            missing_confidence_notes = [req for req in required_notes if not any(req.lower() in n.lower() for n in ext["confidence_notes"])]
+            confidence_note_ok = len(missing_confidence_notes) == 0
             if confidence_note_ok:
                 confidence_note_check_passed_cases += 1
 
         route_breakdown_ok = True
+        has_route_checks = ("expected_route_breakdowns" in case) or bool(case.get("must_include_route_warning", []))
         if "expected_route_breakdowns" in case:
-            route_breakdown_check_cases += 1
             route_breakdown_ok = (len(ext["route_breakdowns"]) == 0) if case["expected_route_breakdowns"] == "empty" else (len(ext["route_breakdowns"]) > 0)
-            if route_breakdown_ok:
+        required_route_warnings = case.get("must_include_route_warning", [])
+        missing_route_warnings = [req for req in required_route_warnings if not any(req.lower() in w.lower() for w in ext["route_warnings"])]
+        route_warning_ok = len(missing_route_warnings) == 0
+        if has_route_checks:
+            route_breakdown_check_cases += 1
+            if route_breakdown_ok and route_warning_ok:
                 route_breakdown_check_passed_cases += 1
-        route_warning_ok = all(any(req.lower() in w.lower() for w in ext["route_warnings"]) for req in case.get("must_include_route_warning", []))
 
         temporal_segment_ok = True
+        has_temporal_checks = ("expected_temporal_segments" in case) or bool(case.get("must_include_temporal_warning", []))
         if "expected_temporal_segments" in case:
-            temporal_segment_check_cases += 1
             temporal_segment_ok = (len(ext["temporal_segments"]) == 0) if case["expected_temporal_segments"] == "empty" else (len(ext["temporal_segments"]) > 0)
-            if temporal_segment_ok:
+        required_temporal_warnings = case.get("must_include_temporal_warning", [])
+        missing_temporal_warnings = [req for req in required_temporal_warnings if not any(req.lower() in w.lower() for w in ext["temporal_warnings"])]
+        temporal_warning_ok = len(missing_temporal_warnings) == 0
+        if has_temporal_checks:
+            temporal_segment_check_cases += 1
+            if temporal_segment_ok and temporal_warning_ok:
                 temporal_segment_check_passed_cases += 1
-        temporal_warning_ok = all(any(req.lower() in w.lower() for w in ext["temporal_warnings"]) for req in case.get("must_include_temporal_warning", []))
         unexpected_warning_count += len(unexpected)
         missing_expected_warning_count += len(missing_expected)
 
         case_failed = (not top2_ok) or (case["top1_required"] and not top1_ok) or (not ev_ok) or (not next_check_ok) or (not confidence_ceiling_ok) or bool(unexpected) or bool(missing_expected) or bool(missing_top_level) or (not evidence_quality_ok) or (not signal_status_ok) or (not confidence_note_ok) or (not route_breakdown_ok) or (not route_warning_ok) or (not temporal_segment_ok) or (not temporal_warning_ok)
-        row = {"id": case["id"], "top1_ok": top1_ok, "top2_ok": top2_ok, "evidence_ok": ev_ok, "next_check_ok": next_check_ok, "confidence_ceiling_ok": confidence_ceiling_ok, "max_primary_confidence": max_primary_confidence, "primary_confidence": ext["primary_confidence"], "unexpected_warnings": unexpected, "missing_expected_warnings": missing_expected, "missing_expected_top_level_warnings": missing_top_level, "evidence_quality_ok": evidence_quality_ok, "signal_status_ok": signal_status_ok, "confidence_note_ok": confidence_note_ok, "route_breakdown_ok": route_breakdown_ok, "route_warning_ok": route_warning_ok, "temporal_segment_ok": temporal_segment_ok, "temporal_warning_ok": temporal_warning_ok}
+        row = {"id": case["id"], "top1_ok": top1_ok, "top2_ok": top2_ok, "evidence_ok": ev_ok, "next_check_ok": next_check_ok, "confidence_ceiling_ok": confidence_ceiling_ok, "max_primary_confidence": max_primary_confidence, "primary_confidence": ext["primary_confidence"], "unexpected_warnings": unexpected, "missing_expected_warnings": missing_expected, "missing_expected_top_level_warnings": missing_top_level, "evidence_quality_ok": evidence_quality_ok, "expected_evidence_quality": case.get("expected_evidence_quality"), "actual_evidence_quality": ext["evidence_quality"].get("quality"), "signal_status_ok": signal_status_ok, "signal_status_mismatches": signal_status_mismatches, "confidence_note_ok": confidence_note_ok, "missing_confidence_notes": missing_confidence_notes, "route_breakdown_ok": route_breakdown_ok, "route_warning_ok": route_warning_ok, "missing_route_warnings": missing_route_warnings, "temporal_segment_ok": temporal_segment_ok, "temporal_warning_ok": temporal_warning_ok, "missing_temporal_warnings": missing_temporal_warnings}
         results.append(row)
         if case_failed:
             failed_cases.append({**row, "top1_required": case["top1_required"]})

--- a/scripts/tests/test_diagnostic_benchmark.py
+++ b/scripts/tests/test_diagnostic_benchmark.py
@@ -292,12 +292,20 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
 
 
     def test_optional_manifest_field_validation(self):
+        with self.assertRaisesRegex(ValueError, "expected_evidence_quality must be a string"):
+            db.validate_manifest(self.make_manifest(self.make_case(expected_evidence_quality=1)))
         with self.assertRaisesRegex(ValueError, "expected_evidence_quality"):
             db.validate_manifest(self.make_manifest(self.make_case(expected_evidence_quality="bad")))
         with self.assertRaisesRegex(ValueError, "unknown signal family"):
             db.validate_manifest(self.make_manifest(self.make_case(expected_signal_statuses={"bad":"present"})))
+        with self.assertRaisesRegex(ValueError, "expected_signal_statuses values must be strings"):
+            db.validate_manifest(self.make_manifest(self.make_case(expected_signal_statuses={"queues": 1})))
         with self.assertRaisesRegex(ValueError, "unknown signal status"):
             db.validate_manifest(self.make_manifest(self.make_case(expected_signal_statuses={"queues":"bad"})))
+        with self.assertRaisesRegex(ValueError, "expected_route_breakdowns must be a string"):
+            db.validate_manifest(self.make_manifest(self.make_case(expected_route_breakdowns=1)))
+        with self.assertRaisesRegex(ValueError, "expected_temporal_segments must be a string"):
+            db.validate_manifest(self.make_manifest(self.make_case(expected_temporal_segments=1)))
         with self.assertRaisesRegex(ValueError, "must_include_confidence_notes"):
             db.validate_manifest(self.make_manifest(self.make_case(must_include_confidence_notes="x")))
 
@@ -326,6 +334,69 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
         metrics, failures = self.run_single_case(case, valid_report())
         self.assertFalse(failures)
         self.assertEqual(metrics["evidence_quality_check_cases"], 0)
+
+    def test_route_temporal_warning_only_checks_count_cases(self):
+        route_case = self.make_case(must_include_route_warning=["route caveat"])
+        route_report = valid_report(route_breakdowns=[{"warnings": ["route caveat noted"]}])
+        metrics, failures = self.run_single_case(route_case, route_report)
+        self.assertFalse(failures)
+        self.assertEqual(metrics["route_breakdown_check_cases"], 1)
+        self.assertEqual(metrics["route_breakdown_check_passed_cases"], 1)
+
+        temporal_case = self.make_case(must_include_temporal_warning=["segment overlap"])
+        temporal_report = valid_report(temporal_segments=[{"warnings": ["segment overlap warning"]}])
+        metrics, failures = self.run_single_case(temporal_case, temporal_report)
+        self.assertFalse(failures)
+        self.assertEqual(metrics["temporal_segment_check_cases"], 1)
+        self.assertEqual(metrics["temporal_segment_check_passed_cases"], 1)
+
+    def test_route_temporal_shape_and_warning_do_not_double_count(self):
+        route_case = self.make_case(expected_route_breakdowns="non_empty", must_include_route_warning=["route caveat"])
+        route_report = valid_report(route_breakdowns=[{"warnings": ["route caveat"]}])
+        metrics, failures = self.run_single_case(route_case, route_report)
+        self.assertFalse(failures)
+        self.assertEqual(metrics["route_breakdown_check_cases"], 1)
+
+        temporal_case = self.make_case(expected_temporal_segments="non_empty", must_include_temporal_warning=["overlap"])
+        temporal_report = valid_report(temporal_segments=[{"warnings": ["overlap"]}])
+        metrics, failures = self.run_single_case(temporal_case, temporal_report)
+        self.assertFalse(failures)
+        self.assertEqual(metrics["temporal_segment_check_cases"], 1)
+
+    def test_failed_rows_include_optional_mismatch_details(self):
+        case = self.make_case(
+            expected_evidence_quality="strong",
+            expected_signal_statuses={"queues": "present"},
+            must_include_confidence_notes=["queue confidence"],
+            must_include_route_warning=["route caveat"],
+            must_include_temporal_warning=["segment overlap"],
+        )
+        report = valid_report(
+            confidence_notes=["other note"],
+            evidence_quality={"quality": "weak", "queues": "missing"},
+            route_breakdowns=[{"warnings": ["different route warning"]}],
+            temporal_segments=[{"warnings": ["different segment warning"]}],
+        )
+        metrics, failures = self.run_single_case(case, report)
+        self.assertTrue(failures)
+        row = metrics["failed_cases"][0]
+        self.assertEqual(row["expected_evidence_quality"], "strong")
+        self.assertEqual(row["actual_evidence_quality"], "weak")
+        self.assertEqual(row["signal_status_mismatches"], [{"family": "queues", "expected": "present", "actual": "missing"}])
+        self.assertEqual(row["missing_confidence_notes"], ["queue confidence"])
+        self.assertEqual(row["missing_route_warnings"], ["route caveat"])
+        self.assertEqual(row["missing_temporal_warnings"], ["segment overlap"])
+
+    def test_malformed_optional_fields_do_not_satisfy_non_empty_checks(self):
+        case = self.make_case(expected_route_breakdowns="non_empty", expected_temporal_segments="non_empty")
+        report = valid_report(route_breakdowns=[], temporal_segments=[])
+        report["route_breakdowns"] = "not-a-list"
+        report["temporal_segments"] = "not-a-list"
+        metrics, failures = self.run_single_case(case, report)
+        self.assertTrue(failures)
+        row = metrics["failed_cases"][0]
+        self.assertFalse(row["route_breakdown_ok"])
+        self.assertFalse(row["temporal_segment_ok"])
     # Threshold and output/path tests
     def test_threshold_failures(self):
         case = self.make_case()

--- a/scripts/tests/test_diagnostic_benchmark.py
+++ b/scripts/tests/test_diagnostic_benchmark.py
@@ -26,7 +26,7 @@ BASE_CASE = {
 }
 
 
-def valid_report(*, primary_kind="application_queue_saturation", confidence="high", score=1.0, evidence=None, next_checks=None, secondary=None, warnings=None):
+def valid_report(*, primary_kind="application_queue_saturation", confidence="high", score=1.0, evidence=None, next_checks=None, secondary=None, warnings=None, confidence_notes=None, evidence_quality=None, route_breakdowns=None, temporal_segments=None):
     primary = {
         "kind": primary_kind,
         "confidence": confidence,
@@ -35,10 +35,15 @@ def valid_report(*, primary_kind="application_queue_saturation", confidence="hig
     }
     if next_checks is not None:
         primary["next_checks"] = next_checks
+    if confidence_notes is not None:
+        primary["confidence_notes"] = confidence_notes
     return {
         "primary_suspect": primary,
         "secondary_suspects": secondary or [],
         "warnings": warnings or [],
+        "evidence_quality": evidence_quality or {},
+        "route_breakdowns": route_breakdowns or [],
+        "temporal_segments": temporal_segments or [],
     }
 
 
@@ -285,6 +290,42 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
         self.assertEqual(row["max_primary_confidence"], "medium")
         self.assertEqual(row["primary_confidence"], "high")
 
+
+    def test_optional_manifest_field_validation(self):
+        with self.assertRaisesRegex(ValueError, "expected_evidence_quality"):
+            db.validate_manifest(self.make_manifest(self.make_case(expected_evidence_quality="bad")))
+        with self.assertRaisesRegex(ValueError, "unknown signal family"):
+            db.validate_manifest(self.make_manifest(self.make_case(expected_signal_statuses={"bad":"present"})))
+        with self.assertRaisesRegex(ValueError, "unknown signal status"):
+            db.validate_manifest(self.make_manifest(self.make_case(expected_signal_statuses={"queues":"bad"})))
+        with self.assertRaisesRegex(ValueError, "must_include_confidence_notes"):
+            db.validate_manifest(self.make_manifest(self.make_case(must_include_confidence_notes="x")))
+
+    def test_optional_checks_pass_and_fail(self):
+        case = self.make_case(expected_evidence_quality="strong", expected_signal_statuses={"queues":"present"}, must_include_confidence_notes=["queue"], expected_route_breakdowns="non_empty", expected_temporal_segments="non_empty", must_include_route_warning=["route caveat"], must_include_temporal_warning=["overlap"], expected_top_level_warnings=["top warning"], allowed_warnings=["top warning"])
+        report = valid_report(confidence_notes=["Queue confidence note"], warnings=["top warning"], evidence_quality={"quality":"strong","queues":"present"}, route_breakdowns=[{"warnings":["route caveat"]}], temporal_segments=[{"warnings":["overlap"]}])
+        metrics, failures = self.run_single_case(case, report)
+        self.assertFalse(failures)
+        self.assertEqual(metrics["evidence_quality_check_passed_cases"], 1)
+
+        bad = valid_report(confidence_notes=["other"], warnings=[], evidence_quality={"quality":"weak","queues":"missing"}, route_breakdowns=[], temporal_segments=[])
+        metrics, failures = self.run_single_case(case, bad)
+        self.assertTrue(failures)
+        row = metrics["failed_cases"][0]
+        self.assertFalse(row["evidence_quality_ok"])
+        self.assertFalse(row["signal_status_ok"])
+        self.assertFalse(row["confidence_note_ok"])
+        self.assertFalse(row["route_breakdown_ok"])
+        self.assertFalse(row["temporal_segment_ok"])
+        self.assertFalse(row["route_warning_ok"])
+        self.assertFalse(row["temporal_warning_ok"])
+        self.assertEqual(row["missing_expected_top_level_warnings"], ["top warning"])
+
+    def test_existing_cases_without_optional_fields_still_pass(self):
+        case = self.make_case()
+        metrics, failures = self.run_single_case(case, valid_report())
+        self.assertFalse(failures)
+        self.assertEqual(metrics["evidence_quality_check_cases"], 0)
     # Threshold and output/path tests
     def test_threshold_failures(self):
         case = self.make_case()
@@ -315,7 +356,10 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
                 "required_evidence_pass_rate", "next_check_required_cases", "next_check_passed_cases",
                 "next_check_presence_rate", "next_check_pass_rate", "confidence_ceiling_cases",
                 "confidence_ceiling_passed_cases", "confidence_ceiling_pass_rate", "unexpected_warning_count",
-                "missing_expected_warning_count", "failed_cases",
+                "missing_expected_warning_count", "evidence_quality_check_cases", "evidence_quality_check_passed_cases",
+                "signal_status_check_cases", "signal_status_check_passed_cases", "confidence_note_check_cases",
+                "confidence_note_check_passed_cases", "route_breakdown_check_cases", "route_breakdown_check_passed_cases",
+                "temporal_segment_check_cases", "temporal_segment_check_passed_cases", "failed_cases",
             }
             self.assertEqual(set(metrics.keys()), expected_keys)
 

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -83,3 +83,6 @@ Snapshot output directory: `target/validation/diagnostics/`
 `environment.json` includes `tailtriage` workspace version and per-crate versions, git metadata, GitHub Actions metadata when available, software/hardware metadata, manifest hash, referenced-artifact hash, and benchmark thresholds.
 
 Deterministic fixture metrics validate committed fixtures only; they are not root-cause proof, universal production accuracy, universal production overhead, or real-service validation.
+
+
+Optional manifest fields can validate expanded analyzer report surface on selected cases only: `expected_evidence_quality`, `expected_signal_statuses`, `must_include_confidence_notes`, `expected_route_breakdowns`, `expected_temporal_segments`, `must_include_route_warning`, `must_include_temporal_warning`, and `expected_top_level_warnings`. These checks are fixture-scoped and optional; cases that omit them continue to validate under the existing suspect/evidence/warning contract.

--- a/validation/diagnostics/corpus/low-request-count.json
+++ b/validation/diagnostics/corpus/low-request-count.json
@@ -11,6 +11,9 @@
     "next_checks": [
       "Rerun with enough requests to stabilize tail estimates.",
       "Enable queue and stage instrumentation during the rerun."
+    ],
+    "confidence_notes": [
+      "Low request count limits confidence in tail estimates."
     ]
   },
   "secondary_suspects": [
@@ -24,5 +27,13 @@
         "Collect queue wait and depth over a larger workload window."
       ]
     }
-  ]
+  ],
+  "evidence_quality": {
+    "quality": "weak",
+    "requests": "partial",
+    "queues": "missing",
+    "stages": "missing",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "missing"
+  }
 }

--- a/validation/diagnostics/corpus/route-divergence.json
+++ b/validation/diagnostics/corpus/route-divergence.json
@@ -1,0 +1,37 @@
+{
+  "warnings": [],
+  "evidence_quality": {
+    "quality": "partial",
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "partial",
+    "inflight_snapshots": "partial"
+  },
+  "primary_suspect": {
+    "kind": "downstream_stage_dominates",
+    "confidence": "medium",
+    "evidence": [
+      "Route /slow has dominant stage latency"
+    ],
+    "confidence_notes": [
+      "Route runtime and inflight context is partial."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "application_queue_saturation",
+      "confidence": "low",
+      "confidence_notes": []
+    }
+  ],
+  "route_breakdowns": [
+    {
+      "route": "/slow",
+      "warnings": [
+        "Runtime and in-flight snapshots are not route-attributed; route ranking uses request and stage evidence."
+      ]
+    }
+  ],
+  "temporal_segments": []
+}

--- a/validation/diagnostics/manifest.json
+++ b/validation/diagnostics/manifest.json
@@ -27,7 +27,14 @@
       "acceptable_primary": [
         "application_queue_saturation"
       ],
-      "must_include_next_checks": []
+      "must_include_next_checks": [],
+      "expected_evidence_quality": "strong",
+      "expected_signal_statuses": {
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing"
+      },
+      "expected_route_breakdowns": "empty"
     },
     {
       "id": "queue_after",
@@ -82,7 +89,14 @@
       "acceptable_primary": [
         "blocking_pool_pressure"
       ],
-      "must_include_next_checks": []
+      "must_include_next_checks": [],
+      "expected_evidence_quality": "partial",
+      "expected_signal_statuses": {
+        "runtime_snapshots": "partial"
+      },
+      "must_include_confidence_notes": [
+        "missing runtime queue-depth fields"
+      ]
     },
     {
       "id": "blocking_after",
@@ -243,7 +257,14 @@
         "application_queue_saturation",
         "executor_pressure_suspected"
       ],
-      "must_include_next_checks": []
+      "must_include_next_checks": [],
+      "expected_temporal_segments": "non_empty",
+      "expected_top_level_warnings": [
+        "large p95 latency shift"
+      ],
+      "must_include_temporal_warning": [
+        "windows overlap under concurrent requests"
+      ]
     },
     {
       "id": "mixed_mitigated",
@@ -754,7 +775,11 @@
         "insufficient_evidence"
       ],
       "max_primary_confidence": "low",
-      "notes": "Synthetic adversarial case for sparse sample humility: too few requests should force insufficient-evidence with low confidence."
+      "notes": "Synthetic adversarial case for sparse sample humility: too few requests should force insufficient-evidence with low confidence.",
+      "expected_evidence_quality": "weak",
+      "must_include_confidence_notes": [
+        "Low request count"
+      ]
     },
     {
       "id": "adversarial_no_queue_events",
@@ -1048,6 +1073,38 @@
       ],
       "max_primary_confidence": "low",
       "notes": "Synthetic adversarial high-latency-without-explanatory-signals case: latency alone should not force a specific high-confidence suspect."
+    },
+    {
+      "id": "synthetic_route_divergence",
+      "artifact": "corpus/route-divergence.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "downstream_stage_dominates",
+      "tags": [
+        "synthetic",
+        "route"
+      ],
+      "must_include_evidence": [
+        "Route /slow"
+      ],
+      "notes": "Synthetic route divergence case for route breakdown validation.",
+      "expected_warnings": [],
+      "top1_required": true,
+      "allowed_warnings": [],
+      "required_top2": [
+        "downstream_stage_dominates"
+      ],
+      "acceptable_primary": [
+        "downstream_stage_dominates"
+      ],
+      "must_include_next_checks": [],
+      "expected_route_breakdowns": "non_empty",
+      "must_include_route_warning": [
+        "not route-attributed"
+      ],
+      "expected_signal_statuses": {
+        "runtime_snapshots": "partial",
+        "inflight_snapshots": "partial"
+      }
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- Add fixture-scoped, non-brittle validation for the expanded analyzer report surface (`evidence_quality`, `confidence_notes`, `route_breakdowns`, `temporal_segments`) so deterministic corpus cases can assert richer report fields without forcing every case to opt in. 
- Keep the deterministic benchmark focused and narrow: optional checks only for representative cases, no analyzer behavior, scoring, thresholds, or dependencies changed.

### Description
- Added optional manifest fields and schema checks in `scripts/diagnostic_benchmark.py`: `expected_evidence_quality`, `expected_signal_statuses`, `must_include_confidence_notes`, `expected_route_breakdowns`, `expected_temporal_segments`, `must_include_route_warning`, `must_include_temporal_warning`, and `expected_top_level_warnings`; enums and allowed names/statuses are validated and wildcard warning allowlists remain forbidden.  
- Extended `extract()` to surface `evidence_quality`, `confidence_notes`, `route_breakdowns`, `temporal_segments`, and nested route/temporal warnings, and implemented per-case checks that set boolean flags on failures.  
- Added summary counters/metrics for the new checks (`*_check_cases` / `*_check_passed_cases`) and surface rich failure rows in `failed_cases` for easier triage.  
- Updated a small set of manifest cases and fixtures to exercise the new checks only where useful: `queue_before`, `blocking_before`, `adversarial_low_request_count`, `mixed_baseline`, and added `synthetic_route_divergence` (new fixture `validation/diagnostics/corpus/route-divergence.json`); updated `low-request-count.json` to include `evidence_quality` + `confidence_notes`.  
- Expanded Python unit tests in `scripts/tests/test_diagnostic_benchmark.py` to cover optional-schema validation, successful optional checks, failing optional checks (with useful failure rows), route/temporal warning substring checks, and backward compatibility for existing cases.  
- Updated validation docs (`validation/diagnostics/README.md`, `docs/diagnostic-validation.md`, `VALIDATION.md`) to document the optional, fixture-scoped nature of these checks.

### Testing
- `python3 -m unittest scripts.tests.test_diagnostic_benchmark` — passed.  
- `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0` — ran against committed manifest; metrics reported and deterministic benchmark passed (no failing cases for the configured thresholds).  
- `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts` — passed.  
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` — all passed.  

Notes: analyzer implementation, ranking, scoring, and public thresholds were not modified; this PR only extends deterministic validation coverage and fixtures/tests/docs to assert the expanded report surface where appropriate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad439461c8330b5005ec480b403e6)