### PR TITLE
Support optional analyzer-report checks in diagnostic benchmark

### DIFF
--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -39,6 +39,7 @@ The deterministic benchmark validates:
 - required top-2 visibility (`required_top2` appears in primary or first secondary)
 - warning expectations (`expected_warnings` required; unexpected warnings rejected unless explicitly allowed)
 - required evidence substrings
+- optional expanded report-surface checks on selected cases (evidence-quality bucket, signal-family statuses, suspect confidence-note substrings, route-breakdown/temporal-segment presence, and route/temporal warning substrings)
 - required next-check substrings when required by a case
 - case-level confidence ceilings (`max_primary_confidence`) for sparse/missing/truncated/mixed evidence humility checks
 

--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -26,6 +26,7 @@ The scorecard includes confidence-bucket accuracy summaries (low/medium/high buc
 
 ## Evidence validation
 `must_include_evidence` substrings must appear in primary or secondary evidence.
+Selected cases can also validate expanded report surface fields (`expected_evidence_quality`, `expected_signal_statuses`, `must_include_confidence_notes`, `expected_route_breakdowns`, `expected_temporal_segments`, and warning substrings inside route/temporal sections). These checks are optional and fixture-scoped; not every case uses every field.
 
 ## Warning validation
 - `expected_warnings` substrings are required.

--- a/scripts/diagnostic_benchmark.py
+++ b/scripts/diagnostic_benchmark.py
@@ -13,6 +13,10 @@ ALLOWED_GROUND_TRUTH = {
 }
 CONF_HIGH = {"high"}
 CONFIDENCE_ORDER = {"low": 0, "medium": 1, "high": 2}
+EVIDENCE_QUALITY_VALUES = {"strong", "partial", "weak"}
+SIGNAL_FAMILIES = {"requests", "queues", "stages", "runtime_snapshots", "inflight_snapshots"}
+SIGNAL_STATUSES = {"present", "missing", "partial", "truncated"}
+BREAKDOWN_EXPECTATIONS = {"empty", "non_empty"}
 
 
 def load_json(path):
@@ -21,6 +25,13 @@ def load_json(path):
 
 
 def validate_manifest(manifest):
+    def require_string_list(case, field, cid):
+        values = case.get(field)
+        if not isinstance(values, list):
+            raise ValueError(f"{field} must be a list of strings for {cid}")
+        if any(not isinstance(v, str) for v in values):
+            raise ValueError(f"{field} must be a list of strings for {cid}")
+
     if not isinstance(manifest, dict) or "cases" not in manifest or not isinstance(manifest["cases"], list):
         raise ValueError("manifest must be an object containing a cases list")
     if manifest.get("schema_version") != 1:
@@ -77,6 +88,27 @@ def validate_manifest(manifest):
                 raise ValueError(f"max_primary_confidence must be a string for {cid}")
             if ceiling not in CONFIDENCE_ORDER:
                 raise ValueError(f"max_primary_confidence must be one of low/medium/high for {cid}")
+        if "expected_evidence_quality" in case:
+            quality = case["expected_evidence_quality"]
+            if quality not in EVIDENCE_QUALITY_VALUES:
+                raise ValueError(f"expected_evidence_quality must be one of strong/partial/weak for {cid}")
+        if "expected_signal_statuses" in case:
+            statuses = case["expected_signal_statuses"]
+            if not isinstance(statuses, dict):
+                raise ValueError(f"expected_signal_statuses must be an object for {cid}")
+            for family, status in statuses.items():
+                if family not in SIGNAL_FAMILIES:
+                    raise ValueError(f"expected_signal_statuses contains unknown signal family for {cid}: {family}")
+                if status not in SIGNAL_STATUSES:
+                    raise ValueError(f"expected_signal_statuses contains unknown signal status for {cid}: {status}")
+        for field in ["must_include_confidence_notes", "must_include_route_warning", "must_include_temporal_warning", "expected_top_level_warnings"]:
+            if field in case:
+                require_string_list(case, field, cid)
+                if "*" in case[field]:
+                    raise ValueError(f"wildcard '*' is not allowed in {field} for {cid}")
+        for field in ["expected_route_breakdowns", "expected_temporal_segments"]:
+            if field in case and case[field] not in BREAKDOWN_EXPECTATIONS:
+                raise ValueError(f"{field} must be one of empty/non_empty for {cid}")
 
 
 def confidence_bucket(conf):
@@ -133,6 +165,11 @@ def extract(report):
         raise ValueError("report.warnings must be a list of strings")
 
     all_suspects = [primary] + secondary
+    confidence_notes = [note for s in all_suspects for note in s.get("confidence_notes", []) if isinstance(note, str)]
+    route_breakdowns = report.get("route_breakdowns", [])
+    temporal_segments = report.get("temporal_segments", [])
+    route_warnings = [w for r in route_breakdowns for w in r.get("warnings", []) if isinstance(w, str)] if isinstance(route_breakdowns, list) else []
+    temporal_warnings = [w for r in temporal_segments for w in r.get("warnings", []) if isinstance(w, str)] if isinstance(temporal_segments, list) else []
     return {
         "top1": kind,
         "top2": [s.get("kind") for s in all_suspects[:2] if s.get("kind")],
@@ -140,6 +177,12 @@ def extract(report):
         "evidence": [e for s in all_suspects for e in s.get("evidence", [])],
         "warnings": report["warnings"],
         "next_checks": [n for s in all_suspects for n in s.get("next_checks", [])],
+        "confidence_notes": confidence_notes,
+        "evidence_quality": report.get("evidence_quality", {}),
+        "route_breakdowns": route_breakdowns if isinstance(route_breakdowns, list) else [],
+        "temporal_segments": temporal_segments if isinstance(temporal_segments, list) else [],
+        "route_warnings": route_warnings,
+        "temporal_warnings": temporal_warnings,
     }
 
 
@@ -163,6 +206,16 @@ def run(manifest_path, min_top1, min_top2, max_high_confidence_wrong):
     next_check_presence_cases = 0
     confidence_ceiling_cases = 0
     confidence_ceiling_passed_cases = 0
+    evidence_quality_check_cases = 0
+    evidence_quality_check_passed_cases = 0
+    signal_status_check_cases = 0
+    signal_status_check_passed_cases = 0
+    confidence_note_check_cases = 0
+    confidence_note_check_passed_cases = 0
+    route_breakdown_check_cases = 0
+    route_breakdown_check_passed_cases = 0
+    temporal_segment_check_cases = 0
+    temporal_segment_check_passed_cases = 0
 
     for case in manifest["cases"]:
         report = load_json(root / case["artifact"])
@@ -205,11 +258,47 @@ def run(manifest_path, min_top1, min_top2, max_high_confidence_wrong):
 
         unexpected = [w for w in ext["warnings"] if not any(exp.lower() in w.lower() for exp in (case["expected_warnings"] + case["allowed_warnings"]))]
         missing_expected = [exp for exp in case["expected_warnings"] if not any(exp.lower() in w.lower() for w in ext["warnings"])]
+        expected_top_level_warnings = case.get("expected_top_level_warnings", [])
+        missing_top_level = [exp for exp in expected_top_level_warnings if not any(exp.lower() in w.lower() for w in ext["warnings"])]
+        evidence_quality_ok = True
+        if "expected_evidence_quality" in case:
+            evidence_quality_check_cases += 1
+            evidence_quality_ok = ext["evidence_quality"].get("quality") == case["expected_evidence_quality"]
+            if evidence_quality_ok:
+                evidence_quality_check_passed_cases += 1
+        signal_status_ok = True
+        expected_signal_statuses = case.get("expected_signal_statuses")
+        if expected_signal_statuses is not None:
+            signal_status_check_cases += 1
+            signal_status_ok = all(ext["evidence_quality"].get(k) == v for k, v in expected_signal_statuses.items())
+            if signal_status_ok:
+                signal_status_check_passed_cases += 1
+        confidence_note_ok = True
+        required_notes = case.get("must_include_confidence_notes", [])
+        if required_notes:
+            confidence_note_check_cases += 1
+            confidence_note_ok = all(any(req.lower() in note.lower() for note in ext["confidence_notes"]) for req in required_notes)
+            if confidence_note_ok:
+                confidence_note_check_passed_cases += 1
+        route_breakdown_ok = True
+        if "expected_route_breakdowns" in case:
+            route_breakdown_check_cases += 1
+            route_breakdown_ok = (len(ext["route_breakdowns"]) == 0) if case["expected_route_breakdowns"] == "empty" else (len(ext["route_breakdowns"]) > 0)
+            if route_breakdown_ok:
+                route_breakdown_check_passed_cases += 1
+        route_warning_ok = all(any(req.lower() in w.lower() for w in ext["route_warnings"]) for req in case.get("must_include_route_warning", []))
+        temporal_segment_ok = True
+        if "expected_temporal_segments" in case:
+            temporal_segment_check_cases += 1
+            temporal_segment_ok = (len(ext["temporal_segments"]) == 0) if case["expected_temporal_segments"] == "empty" else (len(ext["temporal_segments"]) > 0)
+            if temporal_segment_ok:
+                temporal_segment_check_passed_cases += 1
+        temporal_warning_ok = all(any(req.lower() in w.lower() for w in ext["temporal_warnings"]) for req in case.get("must_include_temporal_warning", []))
         unexpected_warning_count += len(unexpected)
         missing_expected_warning_count += len(missing_expected)
 
-        case_failed = (not top2_ok) or (case["top1_required"] and not top1_ok) or (not ev_ok) or (not next_check_ok) or (not confidence_ceiling_ok) or bool(unexpected) or bool(missing_expected)
-        row = {"id": case["id"], "top1_ok": top1_ok, "top2_ok": top2_ok, "evidence_ok": ev_ok, "next_check_ok": next_check_ok, "confidence_ceiling_ok": confidence_ceiling_ok, "max_primary_confidence": max_primary_confidence, "primary_confidence": ext["primary_confidence"], "unexpected_warnings": unexpected, "missing_expected_warnings": missing_expected}
+        case_failed = (not top2_ok) or (case["top1_required"] and not top1_ok) or (not ev_ok) or (not next_check_ok) or (not confidence_ceiling_ok) or bool(unexpected) or bool(missing_expected) or bool(missing_top_level) or (not evidence_quality_ok) or (not signal_status_ok) or (not confidence_note_ok) or (not route_breakdown_ok) or (not route_warning_ok) or (not temporal_segment_ok) or (not temporal_warning_ok)
+        row = {"id": case["id"], "top1_ok": top1_ok, "top2_ok": top2_ok, "evidence_ok": ev_ok, "next_check_ok": next_check_ok, "confidence_ceiling_ok": confidence_ceiling_ok, "max_primary_confidence": max_primary_confidence, "primary_confidence": ext["primary_confidence"], "unexpected_warnings": unexpected, "missing_expected_warnings": missing_expected, "missing_expected_top_level_warnings": missing_top_level, "evidence_quality_ok": evidence_quality_ok, "signal_status_ok": signal_status_ok, "confidence_note_ok": confidence_note_ok, "route_breakdown_ok": route_breakdown_ok, "route_warning_ok": route_warning_ok, "temporal_segment_ok": temporal_segment_ok, "temporal_warning_ok": temporal_warning_ok}
         results.append(row)
         if case_failed:
             failed_cases.append({**row, "top1_required": case["top1_required"]})
@@ -234,6 +323,16 @@ def run(manifest_path, min_top1, min_top2, max_high_confidence_wrong):
         "confidence_ceiling_cases": confidence_ceiling_cases,
         "confidence_ceiling_passed_cases": confidence_ceiling_passed_cases,
         "confidence_ceiling_pass_rate": (confidence_ceiling_passed_cases / confidence_ceiling_cases) if confidence_ceiling_cases else None,
+        "evidence_quality_check_cases": evidence_quality_check_cases,
+        "evidence_quality_check_passed_cases": evidence_quality_check_passed_cases,
+        "signal_status_check_cases": signal_status_check_cases,
+        "signal_status_check_passed_cases": signal_status_check_passed_cases,
+        "confidence_note_check_cases": confidence_note_check_cases,
+        "confidence_note_check_passed_cases": confidence_note_check_passed_cases,
+        "route_breakdown_check_cases": route_breakdown_check_cases,
+        "route_breakdown_check_passed_cases": route_breakdown_check_passed_cases,
+        "temporal_segment_check_cases": temporal_segment_check_cases,
+        "temporal_segment_check_passed_cases": temporal_segment_check_passed_cases,
         "unexpected_warning_count": unexpected_warning_count,
         "missing_expected_warning_count": missing_expected_warning_count,
         "failed_cases": failed_cases,

--- a/scripts/tests/test_diagnostic_benchmark.py
+++ b/scripts/tests/test_diagnostic_benchmark.py
@@ -39,6 +39,16 @@ def valid_report(*, primary_kind="application_queue_saturation", confidence="hig
         "primary_suspect": primary,
         "secondary_suspects": secondary or [],
         "warnings": warnings or [],
+        "evidence_quality": {
+            "quality": "strong",
+            "requests": "present",
+            "queues": "present",
+            "stages": "present",
+            "runtime_snapshots": "present",
+            "inflight_snapshots": "present",
+        },
+        "route_breakdowns": [],
+        "temporal_segments": [],
     }
 
 
@@ -140,6 +150,18 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
             db.validate_manifest(self.make_manifest(self.make_case(max_primary_confidence="extreme")))
         with self.assertRaisesRegex(ValueError, "max_primary_confidence must be a string"):
             db.validate_manifest(self.make_manifest(self.make_case(max_primary_confidence=1)))
+    def test_manifest_optional_field_validation(self):
+        db.validate_manifest(self.make_manifest(self.make_case(expected_evidence_quality="strong")))
+        with self.assertRaisesRegex(ValueError, "expected_evidence_quality"):
+            db.validate_manifest(self.make_manifest(self.make_case(expected_evidence_quality="excellent")))
+        with self.assertRaisesRegex(ValueError, "unknown signal family"):
+            db.validate_manifest(self.make_manifest(self.make_case(expected_signal_statuses={"bad_family": "present"})))
+        with self.assertRaisesRegex(ValueError, "unknown signal status"):
+            db.validate_manifest(self.make_manifest(self.make_case(expected_signal_statuses={"queues": "mostly"})))
+        with self.assertRaisesRegex(ValueError, "must_include_confidence_notes"):
+            db.validate_manifest(self.make_manifest(self.make_case(must_include_confidence_notes="note")))
+        with self.assertRaisesRegex(ValueError, "must be one of empty/non_empty"):
+            db.validate_manifest(self.make_manifest(self.make_case(expected_route_breakdowns="sometimes")))
 
     # Report validation tests
     def test_report_missing_primary_fails(self):
@@ -263,8 +285,48 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
         metrics, _ = self.run_single_case(case, valid_report(primary_kind="blocking_pool_pressure", warnings=[]))
         self.assertEqual(len(metrics["failed_cases"]), 1)
         row = metrics["failed_cases"][0]
-        for field in ["id", "top1_ok", "top2_ok", "evidence_ok", "next_check_ok", "confidence_ceiling_ok", "max_primary_confidence", "primary_confidence", "unexpected_warnings", "missing_expected_warnings", "top1_required"]:
+        for field in ["id", "top1_ok", "top2_ok", "evidence_ok", "next_check_ok", "confidence_ceiling_ok", "max_primary_confidence", "primary_confidence", "unexpected_warnings", "missing_expected_warnings", "missing_expected_top_level_warnings", "evidence_quality_ok", "signal_status_ok", "confidence_note_ok", "route_breakdown_ok", "route_warning_ok", "temporal_segment_ok", "temporal_warning_ok", "top1_required"]:
             self.assertIn(field, row)
+    def test_optional_checks_pass(self):
+        case = self.make_case(
+            expected_warnings=["large p95 shift"],
+            expected_evidence_quality="strong",
+            expected_signal_statuses={"queues": "present", "runtime_snapshots": "present"},
+            must_include_confidence_notes=["partial runtime"],
+            expected_route_breakdowns="non_empty",
+            expected_temporal_segments="non_empty",
+            must_include_route_warning=["not route-attributed"],
+            must_include_temporal_warning=["overlap"],
+            expected_top_level_warnings=["large p95 shift"],
+        )
+        report = valid_report(warnings=["large p95 shift"])
+        report["primary_suspect"]["confidence_notes"] = ["partial runtime fields observed"]
+        report["route_breakdowns"] = [{"warnings": ["Runtime/in-flight metrics are not route-attributed."]}]
+        report["temporal_segments"] = [{"warnings": ["Segment windows overlap under concurrent requests."]}]
+        metrics, failures = self.run_single_case(case, report)
+        self.assertFalse(failures)
+        self.assertEqual(metrics["evidence_quality_check_passed_cases"], 1)
+    def test_optional_checks_fail_with_useful_fields(self):
+        case = self.make_case(
+            expected_warnings=[],
+            expected_evidence_quality="weak",
+            expected_signal_statuses={"queues": "missing"},
+            must_include_confidence_notes=["low request count"],
+            expected_route_breakdowns="non_empty",
+            expected_temporal_segments="non_empty",
+            must_include_route_warning=["not route-attributed"],
+            must_include_temporal_warning=["overlap"],
+            expected_top_level_warnings=["large p95 shift"],
+        )
+        metrics, failures = self.run_single_case(case, valid_report())
+        self.assertTrue(failures)
+        row = metrics["failed_cases"][0]
+        self.assertFalse(row["evidence_quality_ok"])
+        self.assertFalse(row["signal_status_ok"])
+        self.assertFalse(row["confidence_note_ok"])
+        self.assertFalse(row["route_breakdown_ok"])
+        self.assertFalse(row["temporal_segment_ok"])
+        self.assertTrue(row["missing_expected_top_level_warnings"])
     def test_confidence_ceiling_semantics_and_metrics(self):
         base_case = self.make_case(max_primary_confidence="medium")
         metrics, failures = self.run_single_case(base_case, valid_report(confidence="medium"))
@@ -314,8 +376,11 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
                 "per_ground_truth_counts", "confusion_matrix", "confidence_bucket_accuracy",
                 "required_evidence_pass_rate", "next_check_required_cases", "next_check_passed_cases",
                 "next_check_presence_rate", "next_check_pass_rate", "confidence_ceiling_cases",
-                "confidence_ceiling_passed_cases", "confidence_ceiling_pass_rate", "unexpected_warning_count",
-                "missing_expected_warning_count", "failed_cases",
+                "confidence_ceiling_passed_cases", "confidence_ceiling_pass_rate", "evidence_quality_check_cases",
+                "evidence_quality_check_passed_cases", "signal_status_check_cases", "signal_status_check_passed_cases",
+                "confidence_note_check_cases", "confidence_note_check_passed_cases", "route_breakdown_check_cases",
+                "route_breakdown_check_passed_cases", "temporal_segment_check_cases", "temporal_segment_check_passed_cases",
+                "unexpected_warning_count", "missing_expected_warning_count", "failed_cases",
             }
             self.assertEqual(set(metrics.keys()), expected_keys)
 

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -22,6 +22,13 @@ Normal CI runs the deterministic corpus benchmark against `validation/diagnostic
 - `must_include_next_checks`: next-check substrings that must appear when required by a case. Selected adversarial cases use this to validate relevant follow-up guidance.
 - `expected_warnings`: warning substrings that must appear.
 - `allowed_warnings`: warning substrings that may appear in addition to expected warnings (tolerated extras only).
+- `expected_top_level_warnings` (optional): additional required top-level warning substrings; can be used as a stricter supplement to `expected_warnings` for selected cases.
+- `expected_evidence_quality` (optional): expected evidence quality bucket (`strong|partial|weak`) from `report.evidence_quality.quality`.
+- `expected_signal_statuses` (optional): expected signal-family status map (`requests|queues|stages|runtime_snapshots|inflight_snapshots` -> `present|missing|partial|truncated`).
+- `must_include_confidence_notes` (optional): confidence-note substrings that must appear across primary + secondary suspects.
+- `expected_route_breakdowns` (optional): route-breakdown presence check (`empty|non_empty`).
+- `expected_temporal_segments` (optional): temporal-segment presence check (`empty|non_empty`).
+- `must_include_route_warning` / `must_include_temporal_warning` (optional): substring checks across route-breakdown warnings and temporal-segment warnings.
 - `notes`: workload-intent note explaining why labels are set.
 - `tags`: non-empty string tags for grouping/filtering.
 
@@ -32,6 +39,7 @@ Normal CI runs the deterministic corpus benchmark against `validation/diagnostic
   - `required_top2` = required visibility of true causes.
   - `acceptable_primary` = tolerated primary classification for ambiguity handling/high-confidence-wrong interpretation.
 - Do not use wildcard warning allowlists (`"*"` is invalid).
+- Optional report-surface checks are case-scoped. Do not require every corpus case to assert every optional field.
 - Keep synthetic fixtures small, hand-readable, and explicitly scoped to gaps.
 - Use `max_primary_confidence` for humility checks in sparse-sample, missing-instrumentation, truncation, noise-only, or close mixed-signal cases.
 - Confidence ceilings validate conservative triage behavior, not truth probabilities.

--- a/validation/diagnostics/corpus/low-request-count.json
+++ b/validation/diagnostics/corpus/low-request-count.json
@@ -11,6 +11,9 @@
     "next_checks": [
       "Rerun with enough requests to stabilize tail estimates.",
       "Enable queue and stage instrumentation during the rerun."
+    ],
+    "confidence_notes": [
+      "Low request count limits confidence and evidence quality."
     ]
   },
   "secondary_suspects": [
@@ -22,7 +25,18 @@
       ],
       "next_checks": [
         "Collect queue wait and depth over a larger workload window."
+      ],
+      "confidence_notes": [
+        "Low request count limits confidence and evidence quality."
       ]
     }
-  ]
+  ],
+  "evidence_quality": {
+    "quality": "weak",
+    "requests": "partial",
+    "queues": "missing",
+    "stages": "missing",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "missing"
+  }
 }

--- a/validation/diagnostics/corpus/route-divergence.json
+++ b/validation/diagnostics/corpus/route-divergence.json
@@ -1,0 +1,36 @@
+{
+  "warnings": [],
+  "primary_suspect": {
+    "kind": "application_queue_saturation",
+    "confidence": "medium",
+    "evidence": [
+      "Queue wait is elevated on /checkout route."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "downstream_stage_dominates",
+      "confidence": "low",
+      "evidence": [
+        "Stage contributes on /status route."
+      ]
+    }
+  ],
+  "evidence_quality": {
+    "quality": "partial",
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "missing"
+  },
+  "route_breakdowns": [
+    {
+      "route": "/checkout",
+      "warnings": [
+        "Runtime/in-flight metrics are not route-attributed; treat route-level executor/blocking attribution as directional."
+      ]
+    }
+  ],
+  "temporal_segments": []
+}

--- a/validation/diagnostics/manifest.json
+++ b/validation/diagnostics/manifest.json
@@ -27,7 +27,21 @@
       "acceptable_primary": [
         "application_queue_saturation"
       ],
-      "must_include_next_checks": []
+      "must_include_next_checks": [],
+      "expected_evidence_quality": "strong",
+      "expected_signal_statuses": {
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing"
+      },
+      "expected_route_breakdowns": "empty",
+      "expected_temporal_segments": "non_empty",
+      "expected_top_level_warnings": [
+        "large p95 latency shift"
+      ],
+      "must_include_temporal_warning": [
+        "overlap under concurrent requests"
+      ]
     },
     {
       "id": "queue_after",
@@ -82,7 +96,14 @@
       "acceptable_primary": [
         "blocking_pool_pressure"
       ],
-      "must_include_next_checks": []
+      "must_include_next_checks": [],
+      "expected_evidence_quality": "partial",
+      "expected_signal_statuses": {
+        "runtime_snapshots": "partial"
+      },
+      "must_include_confidence_notes": [
+        "Runtime snapshots are partial"
+      ]
     },
     {
       "id": "blocking_after",
@@ -754,7 +775,11 @@
         "insufficient_evidence"
       ],
       "max_primary_confidence": "low",
-      "notes": "Synthetic adversarial case for sparse sample humility: too few requests should force insufficient-evidence with low confidence."
+      "notes": "Synthetic adversarial case for sparse sample humility: too few requests should force insufficient-evidence with low confidence.",
+      "expected_evidence_quality": "weak",
+      "must_include_confidence_notes": [
+        "Low request count"
+      ]
     },
     {
       "id": "adversarial_no_queue_events",
@@ -1048,6 +1073,34 @@
       ],
       "max_primary_confidence": "low",
       "notes": "Synthetic adversarial high-latency-without-explanatory-signals case: latency alone should not force a specific high-confidence suspect."
+    },
+    {
+      "id": "synthetic_route_divergence",
+      "artifact": "corpus/route-divergence.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "application_queue_saturation",
+      "tags": [
+        "synthetic",
+        "route-divergence"
+      ],
+      "must_include_evidence": [
+        "Queue wait"
+      ],
+      "notes": "Synthetic route-divergence case validates route breakdown checks and route warning expectations.",
+      "expected_warnings": [],
+      "top1_required": false,
+      "allowed_warnings": [],
+      "required_top2": [
+        "application_queue_saturation"
+      ],
+      "acceptable_primary": [
+        "application_queue_saturation"
+      ],
+      "must_include_next_checks": [],
+      "expected_route_breakdowns": "non_empty",
+      "must_include_route_warning": [
+        "not route-attributed"
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- Validate the analyzer's expanded report surface (`evidence_quality`, `confidence_notes`, `route_breakdowns`, `temporal_segments`) in a targeted, non-brittle way so selected corpus cases can assert new signals without forcing every case to change. 
- Keep deterministic validation fixture-scoped and optional so existing manifest entries remain valid and the analyzer scoring/behavior is unchanged. 
- Surface actionable CI-level metrics for the new checks so failures are easy to inspect and fix for representative cases.

### Description
- Extended `scripts/diagnostic_benchmark.py` to extract `evidence_quality`, `confidence_notes`, `route_breakdowns`, and `temporal_segments` and to accept optional manifest fields: `expected_evidence_quality`, `expected_signal_statuses`, `must_include_confidence_notes`, `expected_route_breakdowns`, `expected_temporal_segments`, `must_include_route_warning`, `must_include_temporal_warning`, and `expected_top_level_warnings` (all optional). 
- Added schema validation in `validate_manifest()` to reject unknown enum values, non-list/string shapes, unknown signal family names or statuses, and wildcard warning allowlists for the new optional fields. 
- Added per-check counters and summary metrics (`evidence_quality_check_cases`, `evidence_quality_check_passed_cases`, `signal_status_check_cases`, `signal_status_check_passed_cases`, `confidence_note_check_cases`, `confidence_note_check_passed_cases`, `route_breakdown_check_cases`, `route_breakdown_check_passed_cases`, `temporal_segment_check_cases`, `temporal_segment_check_passed_cases`) and included useful per-case booleans in `failed_cases` for debugging. 
- Updated representative manifest cases only and added a synthetic route-divergence fixture: updated `queue_before`, `blocking_before`, `adversarial_low_request_count`, and added `synthetic_route_divergence`; also updated validation docs (`VALIDATION.md`, `docs/diagnostic-validation.md`, `validation/diagnostics/README.md`) and extended Python unit tests under `scripts/tests` to cover schema validation and pass/fail behavior for the optional checks.

### Testing
- Ran Python unit tests: `python3 -m unittest scripts.tests.test_diagnostic_benchmark` and `python3 -m unittest scripts.tests.test_validate_docs_contracts`, and both test suites passed. 
- Ran the deterministic benchmark: `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0`, which reported `total_cases=38`, `top1_accuracy=0.947`, `top2_recall=1.000`, `high_confidence_wrong_count=0`, and `failed_case_count=0`. 
- Validated doc contracts with `python3 scripts/validate_docs_contracts.py`, which passed. 
- Ran Rust checks `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, and they all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad439461c8330b5005ec480b403e6)