### PR TITLE
Extend deterministic diagnostic benchmark with optional analyzer-report surface checks

### DIFF
--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -42,7 +42,7 @@ The deterministic benchmark validates:
 - required next-check substrings when required by a case
 - case-level confidence ceilings (`max_primary_confidence`) for sparse/missing/truncated/mixed evidence humility checks
 
-Normal CI enforces this deterministic benchmark directly against `validation/diagnostics/manifest.json` and referenced fixtures. This is a correctness gate for committed corpus/schema drift, not a durable scorecard publication path.
+Normal CI enforces this deterministic benchmark directly against `validation/diagnostics/manifest.json` and referenced fixtures. The manifest includes optional checks for expanded analyzer report surfaces on representative cases; unset optional fields do not affect other cases. This is a correctness gate for committed corpus/schema drift, not a durable scorecard publication path.
 
 The corpus includes deterministic adversarial validation that checks sparse, missing, truncated, or mixed evidence is warned about and does not produce overconfident unsupported classifications.
 

--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -6,7 +6,7 @@
 The benchmark evaluates a deterministic corpus of analyzer reports against workload-grounded labels. It checks suspect ranking behavior, evidence/warning expectations, and bounded failure semantics.
 
 ## Deterministic vs repeated-run validation
-Deterministic fixture validation is exercised directly in normal CI against `validation/diagnostics/manifest.json` and referenced fixtures, and is also exercised by the scorecard generator. Durable scorecards are generated only by the versioned/manual snapshot workflow (`validation-snapshot.yml`) on `workflow_dispatch` and `v*` tags. Normal CI does not publish durable diagnostic scorecards.
+Deterministic fixture validation is exercised directly in normal CI against `validation/diagnostics/manifest.json` and referenced fixtures, and is also exercised by the scorecard generator. Selected cases now also assert optional analyzer report-surface fields (evidence quality, signal statuses, confidence notes, route breakdowns, and temporal segments) without requiring every case to declare every optional field. Durable scorecards are generated only by the versioned/manual snapshot workflow (`validation-snapshot.yml`) on `workflow_dispatch` and `v*` tags. Normal CI does not publish durable diagnostic scorecards.
 
 ## Top-1 vs required top-2
 - **Top-1**: primary suspect matches `ground_truth`.

--- a/scripts/diagnostic_benchmark.py
+++ b/scripts/diagnostic_benchmark.py
@@ -13,12 +13,28 @@ ALLOWED_GROUND_TRUTH = {
 }
 CONF_HIGH = {"high"}
 CONFIDENCE_ORDER = {"low": 0, "medium": 1, "high": 2}
+ALLOWED_EVIDENCE_QUALITY = {"strong", "partial", "weak"}
+ALLOWED_SIGNAL_FAMILIES = {"requests", "queues", "stages", "runtime_snapshots", "inflight_snapshots"}
+ALLOWED_SIGNAL_STATUSES = {"present", "missing", "partial", "truncated"}
 
 
 def load_json(path):
     with path.open("r", encoding="utf-8") as f:
         return json.load(f)
 
+
+
+
+def _validate_string_list(case, cid, field):
+    value = case.get(field)
+    if not isinstance(value, list):
+        raise ValueError(f"{field} must be a list of strings for {cid}")
+    if any(not isinstance(item, str) for item in value):
+        raise ValueError(f"{field} must contain only strings for {cid}")
+
+
+def _has_all_substrings(substrs, haystack):
+    return all(any(req.lower() in item.lower() for item in haystack) for req in substrs)
 
 def validate_manifest(manifest):
     if not isinstance(manifest, dict) or "cases" not in manifest or not isinstance(manifest["cases"], list):
@@ -77,6 +93,27 @@ def validate_manifest(manifest):
                 raise ValueError(f"max_primary_confidence must be a string for {cid}")
             if ceiling not in CONFIDENCE_ORDER:
                 raise ValueError(f"max_primary_confidence must be one of low/medium/high for {cid}")
+        if "expected_evidence_quality" in case:
+            quality = case["expected_evidence_quality"]
+            if quality not in ALLOWED_EVIDENCE_QUALITY:
+                raise ValueError(f"expected_evidence_quality must be one of strong/partial/weak for {cid}")
+        if "expected_signal_statuses" in case:
+            statuses = case["expected_signal_statuses"]
+            if not isinstance(statuses, dict):
+                raise ValueError(f"expected_signal_statuses must be an object for {cid}")
+            for family, status in statuses.items():
+                if family not in ALLOWED_SIGNAL_FAMILIES:
+                    raise ValueError(f"expected_signal_statuses has unknown signal family for {cid}: {family}")
+                if status not in ALLOWED_SIGNAL_STATUSES:
+                    raise ValueError(f"expected_signal_statuses has unknown status for {cid}: {status}")
+        for field in ["must_include_confidence_notes", "must_include_route_warning", "must_include_temporal_warning", "expected_top_level_warnings"]:
+            if field in case:
+                _validate_string_list(case, cid, field)
+                if "*" in case[field]:
+                    raise ValueError(f"wildcard '*' is not allowed in warnings lists for {cid}")
+        for field in ["expected_route_breakdowns", "expected_temporal_segments"]:
+            if field in case and case[field] not in {"empty", "non_empty"}:
+                raise ValueError(f"{field} must be one of empty/non_empty for {cid}")
 
 
 def confidence_bucket(conf):
@@ -140,6 +177,10 @@ def extract(report):
         "evidence": [e for s in all_suspects for e in s.get("evidence", [])],
         "warnings": report["warnings"],
         "next_checks": [n for s in all_suspects for n in s.get("next_checks", [])],
+        "confidence_notes": [n for s in all_suspects for n in s.get("confidence_notes", []) if isinstance(n, str)],
+        "evidence_quality": report.get("evidence_quality"),
+        "route_breakdowns": report.get("route_breakdowns", []),
+        "temporal_segments": report.get("temporal_segments", []),
     }
 
 
@@ -163,6 +204,16 @@ def run(manifest_path, min_top1, min_top2, max_high_confidence_wrong):
     next_check_presence_cases = 0
     confidence_ceiling_cases = 0
     confidence_ceiling_passed_cases = 0
+    evidence_quality_check_cases = 0
+    evidence_quality_check_passed_cases = 0
+    signal_status_check_cases = 0
+    signal_status_check_passed_cases = 0
+    confidence_note_check_cases = 0
+    confidence_note_check_passed_cases = 0
+    route_breakdown_check_cases = 0
+    route_breakdown_check_passed_cases = 0
+    temporal_segment_check_cases = 0
+    temporal_segment_check_passed_cases = 0
 
     for case in manifest["cases"]:
         report = load_json(root / case["artifact"])
@@ -205,11 +256,69 @@ def run(manifest_path, min_top1, min_top2, max_high_confidence_wrong):
 
         unexpected = [w for w in ext["warnings"] if not any(exp.lower() in w.lower() for exp in (case["expected_warnings"] + case["allowed_warnings"]))]
         missing_expected = [exp for exp in case["expected_warnings"] if not any(exp.lower() in w.lower() for w in ext["warnings"])]
+        expected_top_level_warnings = case.get("expected_top_level_warnings", [])
+        missing_top_level = [exp for exp in expected_top_level_warnings if not any(exp.lower() in w.lower() for w in ext["warnings"])]
+
+        evidence_quality_ok = True
+        if "expected_evidence_quality" in case:
+            evidence_quality_check_cases += 1
+            eq = ext["evidence_quality"] or {}
+            evidence_quality_ok = eq.get("quality") == case["expected_evidence_quality"]
+            if evidence_quality_ok:
+                evidence_quality_check_passed_cases += 1
+
+        signal_statuses_ok = True
+        if "expected_signal_statuses" in case:
+            signal_status_check_cases += 1
+            eq = ext["evidence_quality"] or {}
+            signal_statuses_ok = all(eq.get(family) == status for family, status in case["expected_signal_statuses"].items())
+            if signal_statuses_ok:
+                signal_status_check_passed_cases += 1
+
+        confidence_notes_ok = True
+        required_notes = case.get("must_include_confidence_notes", [])
+        if required_notes:
+            confidence_note_check_cases += 1
+            confidence_notes_ok = _has_all_substrings(required_notes, ext["confidence_notes"])
+            if confidence_notes_ok:
+                confidence_note_check_passed_cases += 1
+
+        route_breakdowns_ok = True
+        route_warning_ok = True
+        expected_route = case.get("expected_route_breakdowns")
+        route_warnings = [w for rb in ext["route_breakdowns"] if isinstance(rb, dict) for w in rb.get("warnings", []) if isinstance(w, str)]
+        if expected_route is not None:
+            route_breakdown_check_cases += 1
+            route_breakdowns_ok = (len(ext["route_breakdowns"]) == 0) if expected_route == "empty" else (len(ext["route_breakdowns"]) > 0)
+            if route_breakdowns_ok:
+                route_breakdown_check_passed_cases += 1
+        required_route_warnings = case.get("must_include_route_warning", [])
+        if required_route_warnings:
+            route_breakdown_check_cases += 1
+            route_warning_ok = _has_all_substrings(required_route_warnings, route_warnings)
+            if route_warning_ok:
+                route_breakdown_check_passed_cases += 1
+
+        temporal_segments_ok = True
+        temporal_warning_ok = True
+        expected_temporal = case.get("expected_temporal_segments")
+        temporal_warnings = [w for seg in ext["temporal_segments"] if isinstance(seg, dict) for w in seg.get("warnings", []) if isinstance(w, str)]
+        if expected_temporal is not None:
+            temporal_segment_check_cases += 1
+            temporal_segments_ok = (len(ext["temporal_segments"]) == 0) if expected_temporal == "empty" else (len(ext["temporal_segments"]) > 0)
+            if temporal_segments_ok:
+                temporal_segment_check_passed_cases += 1
+        required_temporal_warnings = case.get("must_include_temporal_warning", [])
+        if required_temporal_warnings:
+            temporal_segment_check_cases += 1
+            temporal_warning_ok = _has_all_substrings(required_temporal_warnings, temporal_warnings)
+            if temporal_warning_ok:
+                temporal_segment_check_passed_cases += 1
         unexpected_warning_count += len(unexpected)
         missing_expected_warning_count += len(missing_expected)
 
-        case_failed = (not top2_ok) or (case["top1_required"] and not top1_ok) or (not ev_ok) or (not next_check_ok) or (not confidence_ceiling_ok) or bool(unexpected) or bool(missing_expected)
-        row = {"id": case["id"], "top1_ok": top1_ok, "top2_ok": top2_ok, "evidence_ok": ev_ok, "next_check_ok": next_check_ok, "confidence_ceiling_ok": confidence_ceiling_ok, "max_primary_confidence": max_primary_confidence, "primary_confidence": ext["primary_confidence"], "unexpected_warnings": unexpected, "missing_expected_warnings": missing_expected}
+        case_failed = (not top2_ok) or (case["top1_required"] and not top1_ok) or (not ev_ok) or (not next_check_ok) or (not confidence_ceiling_ok) or bool(unexpected) or bool(missing_expected) or bool(missing_top_level) or (not evidence_quality_ok) or (not signal_statuses_ok) or (not confidence_notes_ok) or (not route_breakdowns_ok) or (not route_warning_ok) or (not temporal_segments_ok) or (not temporal_warning_ok)
+        row = {"id": case["id"], "top1_ok": top1_ok, "top2_ok": top2_ok, "evidence_ok": ev_ok, "next_check_ok": next_check_ok, "confidence_ceiling_ok": confidence_ceiling_ok, "max_primary_confidence": max_primary_confidence, "primary_confidence": ext["primary_confidence"], "unexpected_warnings": unexpected, "missing_expected_warnings": missing_expected, "missing_top_level_warnings": missing_top_level, "evidence_quality_ok": evidence_quality_ok, "signal_statuses_ok": signal_statuses_ok, "confidence_notes_ok": confidence_notes_ok, "route_breakdowns_ok": route_breakdowns_ok, "route_warning_ok": route_warning_ok, "temporal_segments_ok": temporal_segments_ok, "temporal_warning_ok": temporal_warning_ok}
         results.append(row)
         if case_failed:
             failed_cases.append({**row, "top1_required": case["top1_required"]})
@@ -236,6 +345,16 @@ def run(manifest_path, min_top1, min_top2, max_high_confidence_wrong):
         "confidence_ceiling_pass_rate": (confidence_ceiling_passed_cases / confidence_ceiling_cases) if confidence_ceiling_cases else None,
         "unexpected_warning_count": unexpected_warning_count,
         "missing_expected_warning_count": missing_expected_warning_count,
+        "evidence_quality_check_cases": evidence_quality_check_cases,
+        "evidence_quality_check_passed_cases": evidence_quality_check_passed_cases,
+        "signal_status_check_cases": signal_status_check_cases,
+        "signal_status_check_passed_cases": signal_status_check_passed_cases,
+        "confidence_note_check_cases": confidence_note_check_cases,
+        "confidence_note_check_passed_cases": confidence_note_check_passed_cases,
+        "route_breakdown_check_cases": route_breakdown_check_cases,
+        "route_breakdown_check_passed_cases": route_breakdown_check_passed_cases,
+        "temporal_segment_check_cases": temporal_segment_check_cases,
+        "temporal_segment_check_passed_cases": temporal_segment_check_passed_cases,
         "failed_cases": failed_cases,
     }
 

--- a/scripts/tests/test_diagnostic_benchmark.py
+++ b/scripts/tests/test_diagnostic_benchmark.py
@@ -26,7 +26,7 @@ BASE_CASE = {
 }
 
 
-def valid_report(*, primary_kind="application_queue_saturation", confidence="high", score=1.0, evidence=None, next_checks=None, secondary=None, warnings=None):
+def valid_report(*, primary_kind="application_queue_saturation", confidence="high", score=1.0, evidence=None, next_checks=None, secondary=None, warnings=None, confidence_notes=None, evidence_quality=None, route_breakdowns=None, temporal_segments=None):
     primary = {
         "kind": primary_kind,
         "confidence": confidence,
@@ -35,10 +35,15 @@ def valid_report(*, primary_kind="application_queue_saturation", confidence="hig
     }
     if next_checks is not None:
         primary["next_checks"] = next_checks
+    if confidence_notes is not None:
+        primary["confidence_notes"] = confidence_notes
     return {
         "primary_suspect": primary,
         "secondary_suspects": secondary or [],
         "warnings": warnings or [],
+        "evidence_quality": evidence_quality,
+        "route_breakdowns": route_breakdowns or [],
+        "temporal_segments": temporal_segments or [],
     }
 
 
@@ -285,6 +290,57 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
         self.assertEqual(row["max_primary_confidence"], "medium")
         self.assertEqual(row["primary_confidence"], "high")
 
+
+    def test_optional_manifest_schema_validation(self):
+        db.validate_manifest(self.make_manifest(self.make_case(expected_evidence_quality="strong")))
+        with self.assertRaisesRegex(ValueError, "expected_evidence_quality"):
+            db.validate_manifest(self.make_manifest(self.make_case(expected_evidence_quality="bad")))
+        with self.assertRaisesRegex(ValueError, "expected_signal_statuses has unknown signal family"):
+            db.validate_manifest(self.make_manifest(self.make_case(expected_signal_statuses={"bad":"present"})))
+        with self.assertRaisesRegex(ValueError, "expected_signal_statuses has unknown status"):
+            db.validate_manifest(self.make_manifest(self.make_case(expected_signal_statuses={"queues":"bad"})))
+        with self.assertRaisesRegex(ValueError, "must_include_confidence_notes must be a list"):
+            db.validate_manifest(self.make_manifest(self.make_case(must_include_confidence_notes="bad")))
+
+    def test_optional_checks_pass_and_fail(self):
+        case = self.make_case(
+            expected_evidence_quality="partial",
+            expected_signal_statuses={"runtime_snapshots": "partial"},
+            must_include_confidence_notes=["partial"],
+            expected_route_breakdowns="non_empty",
+            must_include_route_warning=["not route-attributed"],
+            expected_temporal_segments="non_empty",
+            must_include_temporal_warning=["overlap"],
+            expected_top_level_warnings=["p95 shift"],
+            expected_warnings=["p95 shift"],
+        )
+        report = valid_report(
+            confidence_notes=["Runtime snapshots are partial"],
+            warnings=["large p95 shift detected"],
+            evidence_quality={"quality":"partial","runtime_snapshots":"partial"},
+            route_breakdowns=[{"warnings":["runtime signal is not route-attributed"]}],
+            temporal_segments=[{"warnings":["windows overlap"]}],
+        )
+        metrics, failures = self.run_single_case(case, report)
+        self.assertFalse(failures)
+        self.assertEqual(metrics["evidence_quality_check_cases"], 1)
+
+        bad = valid_report(evidence_quality={"quality":"weak","runtime_snapshots":"missing"})
+        metrics, failures = self.run_single_case(case, bad)
+        self.assertTrue(failures)
+        row = metrics["failed_cases"][0]
+        self.assertFalse(row["evidence_quality_ok"])
+        self.assertFalse(row["signal_statuses_ok"])
+        self.assertFalse(row["confidence_notes_ok"])
+        self.assertFalse(row["route_breakdowns_ok"])
+        self.assertFalse(row["temporal_segments_ok"])
+
+    def test_existing_cases_without_optional_fields_still_pass(self):
+        metrics, failures = self.run_single_case(self.make_case(), valid_report())
+        self.assertFalse(failures)
+        self.assertEqual(metrics["evidence_quality_check_cases"], 0)
+        self.assertEqual(metrics["signal_status_check_cases"], 0)
+
     # Threshold and output/path tests
     def test_threshold_failures(self):
         case = self.make_case()
@@ -315,7 +371,7 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
                 "required_evidence_pass_rate", "next_check_required_cases", "next_check_passed_cases",
                 "next_check_presence_rate", "next_check_pass_rate", "confidence_ceiling_cases",
                 "confidence_ceiling_passed_cases", "confidence_ceiling_pass_rate", "unexpected_warning_count",
-                "missing_expected_warning_count", "failed_cases",
+                "missing_expected_warning_count", "evidence_quality_check_cases", "evidence_quality_check_passed_cases", "signal_status_check_cases", "signal_status_check_passed_cases", "confidence_note_check_cases", "confidence_note_check_passed_cases", "route_breakdown_check_cases", "route_breakdown_check_passed_cases", "temporal_segment_check_cases", "temporal_segment_check_passed_cases", "failed_cases",
             }
             self.assertEqual(set(metrics.keys()), expected_keys)
 

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -22,6 +22,7 @@ Normal CI runs the deterministic corpus benchmark against `validation/diagnostic
 - `must_include_next_checks`: next-check substrings that must appear when required by a case. Selected adversarial cases use this to validate relevant follow-up guidance.
 - `expected_warnings`: warning substrings that must appear.
 - `allowed_warnings`: warning substrings that may appear in addition to expected warnings (tolerated extras only).
+- Optional analyzer-surface checks (only on selected cases): `expected_evidence_quality`, `expected_signal_statuses`, `must_include_confidence_notes`, `expected_route_breakdowns`, `expected_temporal_segments`, `must_include_route_warning`, `must_include_temporal_warning`, `expected_top_level_warnings`.
 - `notes`: workload-intent note explaining why labels are set.
 - `tags`: non-empty string tags for grouping/filtering.
 
@@ -31,7 +32,7 @@ Normal CI runs the deterministic corpus benchmark against `validation/diagnostic
 - `required_top2` and `acceptable_primary` are different:
   - `required_top2` = required visibility of true causes.
   - `acceptable_primary` = tolerated primary classification for ambiguity handling/high-confidence-wrong interpretation.
-- Do not use wildcard warning allowlists (`"*"` is invalid).
+- Do not use wildcard warning allowlists (`"*"` is invalid), including optional warning-substring fields.
 - Keep synthetic fixtures small, hand-readable, and explicitly scoped to gaps.
 - Use `max_primary_confidence` for humility checks in sparse-sample, missing-instrumentation, truncation, noise-only, or close mixed-signal cases.
 - Confidence ceilings validate conservative triage behavior, not truth probabilities.

--- a/validation/diagnostics/corpus/low-request-count.json
+++ b/validation/diagnostics/corpus/low-request-count.json
@@ -11,6 +11,9 @@
     "next_checks": [
       "Rerun with enough requests to stabilize tail estimates.",
       "Enable queue and stage instrumentation during the rerun."
+    ],
+    "confidence_notes": [
+      "Low request count limits confidence for stable tail interpretation."
     ]
   },
   "secondary_suspects": [
@@ -24,5 +27,13 @@
         "Collect queue wait and depth over a larger workload window."
       ]
     }
-  ]
+  ],
+  "evidence_quality": {
+    "quality": "weak",
+    "requests": "partial",
+    "queues": "partial",
+    "stages": "partial",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "missing"
+  }
 }

--- a/validation/diagnostics/corpus/route-divergence.json
+++ b/validation/diagnostics/corpus/route-divergence.json
@@ -1,0 +1,41 @@
+{
+  "primary_suspect": {
+    "kind": "downstream_stage_dominates",
+    "confidence": "medium",
+    "evidence": [
+      "Route breakdown shows /search p95 materially worse than /health.",
+      "Route breakdown indicates stage latency concentration on /search."
+    ],
+    "next_checks": [
+      "Compare slow route stage timing with downstream dependency latency."
+    ],
+    "confidence_notes": [
+      "Route-level runtime and in-flight snapshots are not route-attributed in this capture."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "application_queue_saturation",
+      "confidence": "low",
+      "evidence": ["Queue signals are not dominant across routes."]
+    }
+  ],
+  "warnings": [],
+  "evidence_quality": {
+    "quality": "partial",
+    "requests": "present",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "partial",
+    "inflight_snapshots": "partial"
+  },
+  "route_breakdowns": [
+    {
+      "route": "/search",
+      "warnings": [
+        "Runtime and in-flight snapshots are not route-attributed; route conclusions rely on request/queue/stage signals."
+      ]
+    }
+  ],
+  "temporal_segments": []
+}

--- a/validation/diagnostics/manifest.json
+++ b/validation/diagnostics/manifest.json
@@ -27,7 +27,21 @@
       "acceptable_primary": [
         "application_queue_saturation"
       ],
-      "must_include_next_checks": []
+      "must_include_next_checks": [],
+      "expected_evidence_quality": "strong",
+      "expected_signal_statuses": {
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "missing"
+      },
+      "expected_route_breakdowns": "empty",
+      "expected_temporal_segments": "non_empty",
+      "expected_top_level_warnings": [
+        "large p95 latency shift"
+      ],
+      "must_include_temporal_warning": [
+        "overlap under concurrent requests"
+      ]
     },
     {
       "id": "queue_after",
@@ -538,7 +552,14 @@
       "acceptable_primary": [
         "blocking_pool_pressure"
       ],
-      "must_include_next_checks": []
+      "must_include_next_checks": [],
+      "expected_evidence_quality": "partial",
+      "expected_signal_statuses": {
+        "runtime_snapshots": "partial"
+      },
+      "must_include_confidence_notes": [
+        "Runtime snapshots are partial"
+      ]
     },
     {
       "id": "executor_sample",
@@ -754,7 +775,11 @@
         "insufficient_evidence"
       ],
       "max_primary_confidence": "low",
-      "notes": "Synthetic adversarial case for sparse sample humility: too few requests should force insufficient-evidence with low confidence."
+      "notes": "Synthetic adversarial case for sparse sample humility: too few requests should force insufficient-evidence with low confidence.",
+      "expected_evidence_quality": "weak",
+      "must_include_confidence_notes": [
+        "Low request count"
+      ]
     },
     {
       "id": "adversarial_no_queue_events",
@@ -1048,6 +1073,34 @@
       ],
       "max_primary_confidence": "low",
       "notes": "Synthetic adversarial high-latency-without-explanatory-signals case: latency alone should not force a specific high-confidence suspect."
+    },
+    {
+      "id": "synthetic_route_divergence",
+      "artifact": "corpus/route-divergence.json",
+      "artifact_type": "synthetic_analysis_report",
+      "ground_truth": "downstream_stage_dominates",
+      "required_top2": [
+        "downstream_stage_dominates"
+      ],
+      "acceptable_primary": [
+        "downstream_stage_dominates"
+      ],
+      "tags": [
+        "synthetic",
+        "route"
+      ],
+      "must_include_evidence": [
+        "Route breakdown"
+      ],
+      "must_include_next_checks": [],
+      "expected_warnings": [],
+      "allowed_warnings": [],
+      "top1_required": true,
+      "notes": "Synthetic route divergence case for route breakdown contract.",
+      "expected_route_breakdowns": "non_empty",
+      "must_include_route_warning": [
+        "not route-attributed"
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- The analyzer began emitting richer report surface fields (`evidence_quality`, `confidence_notes`, `route_breakdowns`, `temporal_segments`) and the deterministic benchmark needs selective validation for those without making the corpus brittle. 
- Provide maintainers a way to assert representative expectations for the new fields on a few curated cases while preserving existing behavior for cases that do not opt in. 
- Surface clear, actionable failures and counters for the new checks so CI can continue to enforce deterministic contract stability.

### Description
- Add optional manifest fields to `scripts/diagnostic_benchmark.py` supporting `expected_evidence_quality`, `expected_signal_statuses`, `must_include_confidence_notes`, `expected_route_breakdowns`, `expected_temporal_segments`, `must_include_route_warning`, `must_include_temporal_warning`, and `expected_top_level_warnings`. 
- Validate schemas for the new fields in `validate_manifest()` including enum checks (`strong|partial|weak`, `empty|non_empty`), allowed signal families and statuses, list-of-strings checks, and rejection of wildcard (`"*"`) allowances for warning lists. 
- Extend report extraction to include `confidence_notes`, `evidence_quality`, `route_breakdowns`, and `temporal_segments`, add per-check counters and passed-counters (evidence_quality/signal_status/confidence_note/route_breakdown/temporal_segment), and expand `failed_cases` rows with optional-check booleans for debugging. 
- Update the manifest and fixtures narrowly to exercise the new checks: added `expected_*` checks to `queue_before`, `blocking_sample`, `adversarial_low_request_count`, and added a synthetic case `synthetic_route_divergence` plus fixture `validation/diagnostics/corpus/route-divergence.json`; also augmented `low-request-count.json` with `evidence_quality` and a confidence note. 
- Expand Python unit tests (`scripts/tests/test_diagnostic_benchmark.py`) to cover optional-field schema validation, per-check pass/fail behavior, route/temporal warning substring checks, and backward compatibility for cases without optional fields. 
- Update validation docs (`validation/diagnostics/README.md`, `docs/diagnostic-validation.md`, `VALIDATION.md`) to describe the selective optional checks and to emphasize that unset optional fields do not affect other cases.

### Testing
- `python3 -m unittest scripts.tests.test_diagnostic_benchmark` — passed. 
- `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0` — deterministic benchmark completed with no failing cases under the updated manifest (failed_case_count=0). 
- `python3 scripts/validate_docs_contracts.py` — passed. 
- `python3 -m unittest scripts.tests.test_validate_docs_contracts` — passed. 
- `cargo fmt --check` — passed. 
- `cargo clippy --workspace --all-targets -- -D warnings` — passed. 
- `cargo test --workspace` — passed.

Notes: analyzer behavior was not modified; this change only expands validation, fixtures, tests, and docs to assert the analyzer's new report surface on representative cases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad439461c8330b5005ec480b403e6)