### PR TITLE
Polish validation warning wording and print optional-check counters in benchmark

### DIFF
--- a/scripts/diagnostic_benchmark.py
+++ b/scripts/diagnostic_benchmark.py
@@ -431,6 +431,26 @@ def main():
     print(f"next_check_required_cases={metrics['next_check_required_cases']}")
     print(f"next_check_pass_rate={next_check_pass_rate_text}")
     print(f"next_check_presence_rate={metrics['next_check_presence_rate']:.3f}")
+    print(
+        "evidence_quality_checks="
+        f"{metrics['evidence_quality_check_passed_cases']}/{metrics['evidence_quality_check_cases']}"
+    )
+    print(
+        "signal_status_checks="
+        f"{metrics['signal_status_check_passed_cases']}/{metrics['signal_status_check_cases']}"
+    )
+    print(
+        "confidence_note_checks="
+        f"{metrics['confidence_note_check_passed_cases']}/{metrics['confidence_note_check_cases']}"
+    )
+    print(
+        "route_breakdown_checks="
+        f"{metrics['route_breakdown_check_passed_cases']}/{metrics['route_breakdown_check_cases']}"
+    )
+    print(
+        "temporal_segment_checks="
+        f"{metrics['temporal_segment_check_passed_cases']}/{metrics['temporal_segment_check_cases']}"
+    )
     print(f"failed_case_count={len(metrics['failed_cases'])}")
 
     if failures:

--- a/scripts/tests/test_diagnostic_benchmark.py
+++ b/scripts/tests/test_diagnostic_benchmark.py
@@ -1,9 +1,12 @@
 import copy
+import contextlib
+import io
 import json
 import os
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from scripts import diagnostic_benchmark as db
 
@@ -433,6 +436,47 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
                 "temporal_segment_check_cases", "temporal_segment_check_passed_cases", "failed_cases",
             }
             self.assertEqual(set(metrics.keys()), expected_keys)
+
+    def test_main_prints_optional_check_counters(self):
+        case = self.make_case(
+            expected_evidence_quality="strong",
+            expected_signal_statuses={"queues": "present"},
+            must_include_confidence_notes=["queue"],
+            expected_route_breakdowns="non_empty",
+            expected_temporal_segments="non_empty",
+        )
+        report = valid_report(
+            confidence_notes=["queue note"],
+            evidence_quality={"quality": "strong", "queues": "present"},
+            route_breakdowns=[{"warnings": []}],
+            temporal_segments=[{"warnings": []}],
+        )
+        with tempfile.TemporaryDirectory() as td:
+            self.write_json(td, case["artifact"], report)
+            manifest_path = self.write_json(td, "manifest.json", self.make_manifest(case))
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                with mock.patch(
+                    "sys.argv",
+                    [
+                        "diagnostic_benchmark.py",
+                        "--manifest",
+                        str(manifest_path),
+                        "--min-top1",
+                        "0.0",
+                        "--min-top2",
+                        "0.0",
+                        "--max-high-confidence-wrong",
+                        "99",
+                    ],
+                ):
+                    db.main()
+            output = buf.getvalue()
+        self.assertIn("evidence_quality_checks=1/1", output)
+        self.assertIn("signal_status_checks=1/1", output)
+        self.assertIn("confidence_note_checks=1/1", output)
+        self.assertIn("route_breakdown_checks=1/1", output)
+        self.assertIn("temporal_segment_checks=1/1", output)
 
 
 if __name__ == "__main__":

--- a/validation/diagnostics/manifest.json
+++ b/validation/diagnostics/manifest.json
@@ -77,7 +77,7 @@
       ],
       "notes": "Blocking pool backlog is intentional pre-fix condition.",
       "expected_warnings": [
-        "Runtime snapshots are missing",
+        "missing blocking_queue_depth or local_queue_depth",
         "Top suspects are close in score",
         "Temporal segments show a large p95 latency shift between early and late requests."
       ],
@@ -113,7 +113,7 @@
       ],
       "notes": "After blocking mitigation, downstream work can dominate residual tail.",
       "expected_warnings": [
-        "Runtime snapshots are missing",
+        "missing blocking_queue_depth or local_queue_depth",
         "Temporal segments show a large p95 latency shift between early and late requests."
       ],
       "top1_required": false,
@@ -547,7 +547,7 @@
       ],
       "notes": "Blocking sample is canonical blocking saturation evidence.",
       "expected_warnings": [
-        "Runtime snapshots are missing",
+        "missing blocking_queue_depth or local_queue_depth",
         "Top suspects are close in score",
         "Temporal segments show a large p95 latency shift between early and late requests."
       ],


### PR DESCRIPTION
### Motivation
- Make validation wording semantically precise so manifest warnings do not imply runtime snapshots are absent when the actual issue is missing optional runtime queue-depth fields. 
- Make the deterministic diagnostic benchmark CLI easier to audit by surfacing optional-check pass/total counters for newly-emitted optional fields. 
- Keep analyzer behavior, JSON report shape, scoring, ranking, and thresholds unchanged.

### Description
- Tightened expected-warning substrings in `validation/diagnostics/manifest.json` by replacing the imprecise `Runtime snapshots are missing` with the narrower `missing blocking_queue_depth or local_queue_depth` in the blocking fixtures (`blocking_before`, `blocking_after`, `blocking_sample`).
- Added compact optional-check summary lines to `scripts/diagnostic_benchmark.py` after existing metrics, printing `evidence_quality_checks=passed/total`, `signal_status_checks=passed/total`, `confidence_note_checks=passed/total`, `route_breakdown_checks=passed/total`, and `temporal_segment_checks=passed/total` without changing existing printed metrics.
- Added a deterministic unit test in `scripts/tests/test_diagnostic_benchmark.py` (`test_main_prints_optional_check_counters`) that captures `main()` stdout and asserts the new optional-check summary lines are present, and adjusted the test imports to use `unittest.mock` via `from unittest import mock`.
- No analyzer code, scoring, ranking, confidence buckets, route/temporal generation, or report JSON shape were modified.

### Testing
- Ran `python3 -m unittest scripts.tests.test_diagnostic_benchmark` and the test suite passed (32 tests; all OK). 
- Ran the deterministic benchmark CLI: `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0` and it printed the new summary lines; sample output snippet includes: 
  - `evidence_quality_checks=3/3` 
  - `signal_status_checks=3/3` 
  - `confidence_note_checks=2/2` 
  - `route_breakdown_checks=2/2` 
  - `temporal_segment_checks=1/1` 
- Ran `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts`, both passed. 
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, all succeeded.
- Analyzer behavior unchanged by this PR; changes are limited to validation wording, benchmark CLI output, and test coverage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb103fe38c8330994b87d66beb4252)