### PR TITLE
Polish validation wording and print optional-check counts in benchmark

### DIFF
--- a/scripts/diagnostic_benchmark.py
+++ b/scripts/diagnostic_benchmark.py
@@ -431,6 +431,11 @@ def main():
     print(f"next_check_required_cases={metrics['next_check_required_cases']}")
     print(f"next_check_pass_rate={next_check_pass_rate_text}")
     print(f"next_check_presence_rate={metrics['next_check_presence_rate']:.3f}")
+    print(f"evidence_quality_checks={metrics['evidence_quality_check_passed_cases']}/{metrics['evidence_quality_check_cases']}")
+    print(f"signal_status_checks={metrics['signal_status_check_passed_cases']}/{metrics['signal_status_check_cases']}")
+    print(f"confidence_note_checks={metrics['confidence_note_check_passed_cases']}/{metrics['confidence_note_check_cases']}")
+    print(f"route_breakdown_checks={metrics['route_breakdown_check_passed_cases']}/{metrics['route_breakdown_check_cases']}")
+    print(f"temporal_segment_checks={metrics['temporal_segment_check_passed_cases']}/{metrics['temporal_segment_check_cases']}")
     print(f"failed_case_count={len(metrics['failed_cases'])}")
 
     if failures:

--- a/scripts/tests/test_diagnostic_benchmark.py
+++ b/scripts/tests/test_diagnostic_benchmark.py
@@ -1,8 +1,11 @@
 import copy
+import io
 import json
 import os
+import sys
 import tempfile
 import unittest
+from contextlib import redirect_stdout
 from pathlib import Path
 
 from scripts import diagnostic_benchmark as db
@@ -433,6 +436,39 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
                 "temporal_segment_check_cases", "temporal_segment_check_passed_cases", "failed_cases",
             }
             self.assertEqual(set(metrics.keys()), expected_keys)
+
+    def test_main_prints_optional_check_summary_lines(self):
+        case = self.make_case(
+            expected_evidence_quality="strong",
+            expected_signal_statuses={"queues": "present"},
+            must_include_confidence_notes=["queue confidence"],
+            expected_route_breakdowns="non_empty",
+            expected_temporal_segments="non_empty",
+        )
+        report = valid_report(
+            confidence_notes=["queue confidence note"],
+            evidence_quality={"quality": "strong", "queues": "present"},
+            route_breakdowns=[{"warnings": []}],
+            temporal_segments=[{"warnings": []}],
+        )
+        with tempfile.TemporaryDirectory() as td:
+            self.write_json(td, case["artifact"], report)
+            manifest_path = self.write_json(td, "manifest.json", self.make_manifest(case))
+            argv = sys.argv
+            stdout = io.StringIO()
+            try:
+                sys.argv = ["diagnostic_benchmark.py", "--manifest", str(manifest_path), "--min-top1", "0.0", "--min-top2", "0.0", "--max-high-confidence-wrong", "99"]
+                with redirect_stdout(stdout):
+                    db.main()
+            finally:
+                sys.argv = argv
+            output = stdout.getvalue()
+
+        self.assertIn("evidence_quality_checks=1/1", output)
+        self.assertIn("signal_status_checks=1/1", output)
+        self.assertIn("confidence_note_checks=1/1", output)
+        self.assertIn("route_breakdown_checks=1/1", output)
+        self.assertIn("temporal_segment_checks=1/1", output)
 
 
 if __name__ == "__main__":

--- a/validation/diagnostics/manifest.json
+++ b/validation/diagnostics/manifest.json
@@ -77,7 +77,7 @@
       ],
       "notes": "Blocking pool backlog is intentional pre-fix condition.",
       "expected_warnings": [
-        "Runtime snapshots are missing",
+        "missing blocking_queue_depth or local_queue_depth",
         "Top suspects are close in score",
         "Temporal segments show a large p95 latency shift between early and late requests."
       ],
@@ -113,7 +113,7 @@
       ],
       "notes": "After blocking mitigation, downstream work can dominate residual tail.",
       "expected_warnings": [
-        "Runtime snapshots are missing",
+        "missing blocking_queue_depth or local_queue_depth",
         "Temporal segments show a large p95 latency shift between early and late requests."
       ],
       "top1_required": false,
@@ -547,7 +547,7 @@
       ],
       "notes": "Blocking sample is canonical blocking saturation evidence.",
       "expected_warnings": [
-        "Runtime snapshots are missing",
+        "missing blocking_queue_depth or local_queue_depth",
         "Top suspects are close in score",
         "Temporal segments show a large p95 latency shift between early and late requests."
       ],


### PR DESCRIPTION
### Motivation
- Make deterministic validation wording semantically precise so expected-warning substrings do not imply absent runtime snapshots when the real issue is only missing optional runtime fields. 
- Improve CLI benchmark auditability by surface-printing optional-check coverage (passed/total) so reviewers can quickly confirm which optional checks ran and passed. 
- Keep the change narrowly focused on validation/reporting polish and tests without touching analyzer logic, scoring, ranking, or JSON report shapes. 

### Description
- Tightened imprecise warning substrings in `validation/diagnostics/manifest.json` by replacing occurrences of `"Runtime snapshots are missing"` in blocking-case entries with the narrower `"missing blocking_queue_depth or local_queue_depth"` so warnings truthfully reflect missing optional runtime queue-depth fields. 
- Added compact optional-check summary lines to the benchmark CLI in `scripts/diagnostic_benchmark.py` that print passed/total counters for: `evidence_quality_checks`, `signal_status_checks`, `confidence_note_checks`, `route_breakdown_checks`, and `temporal_segment_checks`. 
- Added a deterministic unit test in `scripts/tests/test_diagnostic_benchmark.py` that invokes `db.main()` against a temporary manifest/report and asserts the new optional-check summary lines are present in stdout. 
- No analyzer behavior, scoring, ranking, confidence, route, temporal generation, or JSON report-shape changes were made. 

### Testing
- `python3 -m unittest scripts.tests.test_diagnostic_benchmark` — all tests passed (32 tests, OK). 
- `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0` — benchmark ran and exited cleanly with `failed_case_count=0`. 
- `python3 scripts/validate_docs_contracts.py` — docs contract validation passed. 
- `python3 -m unittest scripts.tests.test_validate_docs_contracts` — all tests passed (27 tests, OK). 
- `cargo fmt --check` — passed. 
- `cargo clippy --workspace --all-targets -- -D warnings` — passed. 
- `cargo test --workspace` — all workspace tests passed. 

New benchmark CLI lines now emitted (examples from a deterministic run):
- `evidence_quality_checks=3/3`
- `signal_status_checks=3/3`
- `confidence_note_checks=2/2`
- `route_breakdown_checks=2/2`
- `temporal_segment_checks=1/1`

Analyzer behavior unchanged: no functional changes to analyzer scoring, ranking, confidence, route or temporal logic, or report JSON shape.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb103fe38c8330994b87d66beb4252)