### PR TITLE
Strengthen analyzer-generated route-divergence validation coverage

### DIFF
--- a/tailtriage-cli/src/analyze/tests.rs
+++ b/tailtriage-cli/src/analyze/tests.rs
@@ -1194,6 +1194,18 @@ fn multi_route_divergence_emits_sorted_breakdowns_and_stable_warning() {
     assert_eq!(report.route_breakdowns.len(), 2);
     assert_eq!(report.route_breakdowns[0].route, "/a");
     assert_eq!(report.route_breakdowns[1].route, "/b");
+    assert_eq!(
+        report.route_breakdowns[0].primary_suspect.kind,
+        DiagnosisKind::ApplicationQueueSaturation
+    );
+    assert_eq!(
+        report.route_breakdowns[1].primary_suspect.kind,
+        DiagnosisKind::DownstreamStageDominates
+    );
+    assert_ne!(
+        report.route_breakdowns[0].primary_suspect.kind,
+        report.route_breakdowns[1].primary_suspect.kind
+    );
     assert!(report
         .warnings
         .iter()
@@ -1229,6 +1241,56 @@ fn route_breakdowns_do_not_change_global_primary_suspect() {
     let report = analyze_run(&run);
     assert_eq!(report.primary_suspect.kind, global.primary_suspect.kind);
     assert_eq!(report.primary_suspect.score, global.primary_suspect.score);
+}
+
+#[test]
+fn route_breakdowns_empty_when_routes_repeat_global_primary() {
+    let mut run = test_run();
+    run.requests.clear();
+    run.queues.clear();
+    run.stages.clear();
+
+    for idx in 1..=6 {
+        let mut req = sample_request(idx);
+        req.route = "/a".into();
+        req.latency_us = 8_000;
+        run.requests.push(req);
+        run.queues.push(QueueEvent {
+            request_id: format!("req-{idx}"),
+            queue: "ingress".into(),
+            wait_us: 7_000,
+            waited_from_unix_ms: 0,
+            waited_until_unix_ms: 1,
+            depth_at_start: Some(10),
+        });
+    }
+    for idx in 7..=12 {
+        let mut req = sample_request(idx);
+        req.route = "/b".into();
+        req.latency_us = 9_000;
+        run.requests.push(req);
+        run.queues.push(QueueEvent {
+            request_id: format!("req-{idx}"),
+            queue: "ingress".into(),
+            wait_us: 8_000,
+            waited_from_unix_ms: 0,
+            waited_until_unix_ms: 1,
+            depth_at_start: Some(11),
+        });
+    }
+
+    let global = analyze_run_internal(&run);
+    assert_eq!(
+        global.primary_suspect.kind,
+        DiagnosisKind::ApplicationQueueSaturation
+    );
+
+    let report = analyze_run(&run);
+    assert!(report.route_breakdowns.is_empty());
+    assert!(report
+        .warnings
+        .iter()
+        .all(|warning| warning != ROUTE_DIVERGENCE_WARNING));
 }
 
 #[test]


### PR DESCRIPTION
### Motivation

- Ensure route-breakdown validation covers actual analyzer behavior (route filtering, per-route primary suspect selection, and route-level attribution caveats) instead of relying only on synthetic report-shaped fixtures.

### Description

- Extended the existing multi-route divergence analyzer test in `tailtriage-cli/src/analyze/tests.rs` to assert that route `/a` is queue-dominant and route `/b` is downstream-stage-dominant, and that their `primary_suspect.kind` values differ.
- Added a deterministic analyzer test `route_breakdowns_empty_when_routes_repeat_global_primary` that builds an in-memory `Run` with two eligible routes that both reproduce the same global primary suspect and asserts `route_breakdowns` remains empty and no route-divergence warning is emitted.
- Preserved and asserted route-level runtime/in-flight non-attribution warnings and the top-level route-divergence warning so route breakdowns remain supporting context and do not change global ranking behavior.
- Did not add a generated JSON fixture; this change hardens validation via deterministic Rust analyzer tests only.

### Testing

- Ran `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings` which completed successfully.
- Ran `cargo test --workspace` and all Rust unit tests passed (`58` tests in `tailtriage-cli` + full workspace test suite reported success).
- Ran the validation and docs checks: `python3 scripts/check_demo_fixture_drift.py --profile dev`, `python3 -m unittest scripts.tests.test_diagnostic_benchmark`, `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0`, `python3 scripts/validate_docs_contracts.py`, and `python3 -m unittest scripts.tests.test_validate_docs_contracts`, all of which completed successfully with no failed cases.

- Analyzer behavior changed: No; this PR only strengthens test coverage and assertions and does not alter scoring, confidence, or global ranking logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb1478b75483309f3a42a6ec2bbfe3)