### PR TITLE
Add analyzer-generated route-divergence validation coverage

### DIFF
--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -45,6 +45,10 @@ The corpus includes insufficient-evidence scenarios to validate conservative fal
 ## Synthetic corpus fixture type
 `synthetic_analysis_report` entries are small, hand-readable, report-shaped fixtures used only to cover gaps that real demo fixtures do not cover.
 
+Route-breakdown validation is not synthetic-only: the corpus includes analyzer-generated route-divergence fixtures so checks exercise actual analyzer route filtering, route-breakdown generation, and warning behavior.
+
+Route-level output remains supporting context. Route suspects are evidence-ranked triage leads, not per-route root-cause proof, and runtime/in-flight signals are not route-attributed unless reliable attribution exists.
+
 ## Next-check validation status
 The corpus supports `must_include_next_checks`, and selected adversarial cases use it to validate that reports suggest relevant follow-up actions.
 

--- a/tailtriage-cli/src/analyze/tests.rs
+++ b/tailtriage-cli/src/analyze/tests.rs
@@ -1194,6 +1194,14 @@ fn multi_route_divergence_emits_sorted_breakdowns_and_stable_warning() {
     assert_eq!(report.route_breakdowns.len(), 2);
     assert_eq!(report.route_breakdowns[0].route, "/a");
     assert_eq!(report.route_breakdowns[1].route, "/b");
+    assert_eq!(
+        report.route_breakdowns[0].primary_suspect.kind,
+        DiagnosisKind::ApplicationQueueSaturation
+    );
+    assert_eq!(
+        report.route_breakdowns[1].primary_suspect.kind,
+        DiagnosisKind::DownstreamStageDominates
+    );
     assert!(report
         .warnings
         .iter()

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -36,6 +36,9 @@ Normal CI runs the deterministic corpus benchmark against `validation/diagnostic
 - Use `max_primary_confidence` for humility checks in sparse-sample, missing-instrumentation, truncation, noise-only, or close mixed-signal cases.
 - Confidence ceilings validate conservative triage behavior, not truth probabilities.
 - Synthetic fixtures are report-shaped adversarial coverage artifacts, not substitutes for analyzer-generated captures.
+- Route-breakdown coverage includes analyzer-generated fixtures alongside synthetic fixtures so validation exercises actual analyzer route filtering and warning behavior.
+- Route breakdowns remain supporting triage context; route-level suspects are evidence-ranked leads, not per-route root-cause proof.
+- Runtime snapshots and in-flight gauges are global signals and are not route-attributed unless reliable attribution exists.
 
 ## Running the benchmark
 

--- a/validation/diagnostics/corpus/route-divergence-generated.json
+++ b/validation/diagnostics/corpus/route-divergence-generated.json
@@ -1,0 +1,195 @@
+{
+  "request_count": 7,
+  "p50_latency_us": 10000,
+  "p95_latency_us": 10000,
+  "p99_latency_us": 10000,
+  "p95_queue_share_permille": 900,
+  "p95_service_share_permille": 1000,
+  "inflight_trend": null,
+  "warnings": [
+    "Low completed-request count; diagnosis ranking may be unstable for this run window.",
+    "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited.",
+    "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
+  ],
+  "evidence_quality": {
+    "request_count": 7,
+    "queue_event_count": 4,
+    "stage_event_count": 3,
+    "runtime_snapshot_count": 1,
+    "inflight_snapshot_count": 0,
+    "requests": "partial",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "partial",
+    "inflight_snapshots": "missing",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "weak",
+    "limitations": [
+      "Low completed-request count can make suspect ranking unstable.",
+      "Runtime snapshots have missing queue-depth fields, limiting executor vs blocking differentiation."
+    ]
+  },
+  "primary_suspect": {
+    "kind": "application_queue_saturation",
+    "score": 92,
+    "confidence": "medium",
+    "evidence": [
+      "Queue wait at p95 consumes 90.0% of request time.",
+      "Observed queue depth sample up to 9."
+    ],
+    "next_checks": [
+      "Inspect queue admission limits and producer burst patterns.",
+      "Compare queue wait distribution before and after increasing worker parallelism."
+    ],
+    "confidence_notes": [
+      "Low completed-request count caps confidence."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "executor_pressure_suspected",
+      "score": 71,
+      "confidence": "medium",
+      "evidence": [
+        "Runtime global queue depth p95 is 200, suggesting scheduler contention."
+      ],
+      "next_checks": [
+        "Check for long polls without yielding and uneven task fan-out.",
+        "Compare with per-stage timings to isolate overloaded async stages."
+      ],
+      "confidence_notes": []
+    },
+    {
+      "kind": "downstream_stage_dominates",
+      "score": 27,
+      "confidence": "low",
+      "evidence": [
+        "Stage 'db' has p95 latency 1900 us across 3 samples.",
+        "Stage 'db' cumulative latency is 5700 us (123 permille of request latency).",
+        "Stage 'db' contributes 0 permille of tail request latency."
+      ],
+      "next_checks": [
+        "Inspect downstream dependency behind stage 'db'.",
+        "Collect downstream service timings and retry behavior during tail windows.",
+        "Review downstream SLO/error budget and align retry budget/backoff with it."
+      ],
+      "confidence_notes": []
+    }
+  ],
+  "route_breakdowns": [
+    {
+      "route": "/a",
+      "request_count": 4,
+      "p50_latency_us": 10000,
+      "p95_latency_us": 10000,
+      "p99_latency_us": 10000,
+      "p95_queue_share_permille": 900,
+      "p95_service_share_permille": 100,
+      "evidence_quality": {
+        "request_count": 4,
+        "queue_event_count": 4,
+        "stage_event_count": 0,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 0,
+        "requests": "partial",
+        "queues": "present",
+        "stages": "missing",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "missing",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "weak",
+        "limitations": [
+          "Low completed-request count can make suspect ranking unstable.",
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 92,
+        "confidence": "medium",
+        "evidence": [
+          "Queue wait at p95 consumes 90.0% of request time.",
+          "Observed queue depth sample up to 9."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": [
+          "Low completed-request count caps confidence."
+        ]
+      },
+      "secondary_suspects": [],
+      "warnings": [
+        "Low completed-request count; diagnosis ranking may be unstable for this run window.",
+        "Runtime and in-flight signals are global and are not attributed to this route."
+      ]
+    },
+    {
+      "route": "/b",
+      "request_count": 3,
+      "p50_latency_us": 2000,
+      "p95_latency_us": 2000,
+      "p99_latency_us": 2000,
+      "p95_queue_share_permille": 0,
+      "p95_service_share_permille": 1000,
+      "evidence_quality": {
+        "request_count": 3,
+        "queue_event_count": 0,
+        "stage_event_count": 3,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 0,
+        "requests": "partial",
+        "queues": "missing",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "missing",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "weak",
+        "limitations": [
+          "Low completed-request count can make suspect ranking unstable.",
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "downstream_stage_dominates",
+        "score": 95,
+        "confidence": "medium",
+        "evidence": [
+          "Stage 'db' has p95 latency 1900 us across 3 samples.",
+          "Stage 'db' cumulative latency is 5700 us (950 permille of request latency).",
+          "Stage 'db' contributes 950 permille of tail request latency."
+        ],
+        "next_checks": [
+          "Inspect downstream dependency behind stage 'db'.",
+          "Collect downstream service timings and retry behavior during tail windows.",
+          "Review downstream SLO/error budget and align retry budget/backoff with it."
+        ],
+        "confidence_notes": [
+          "Low completed-request count caps confidence."
+        ]
+      },
+      "secondary_suspects": [],
+      "warnings": [
+        "Low completed-request count; diagnosis ranking may be unstable for this run window.",
+        "Runtime and in-flight signals are global and are not attributed to this route."
+      ]
+    }
+  ],
+  "temporal_segments": []
+}

--- a/validation/diagnostics/manifest.json
+++ b/validation/diagnostics/manifest.json
@@ -1105,6 +1105,53 @@
         "runtime_snapshots": "partial",
         "inflight_snapshots": "partial"
       }
+    },
+    {
+      "id": "generated_route_divergence",
+      "artifact": "corpus/route-divergence-generated.json",
+      "artifact_type": "analysis_report",
+      "ground_truth": "application_queue_saturation",
+      "tags": [
+        "generated",
+        "route"
+      ],
+      "must_include_evidence": [
+        "Queue wait at p95 consumes 90.0% of request time."
+      ],
+      "notes": "Analyzer-generated route divergence case validating route filtering, route-level caveats, and top-level divergence warning.",
+      "expected_warnings": [
+        "Low completed-request count"
+      ],
+      "top1_required": true,
+      "allowed_warnings": [],
+      "required_top2": [
+        "application_queue_saturation"
+      ],
+      "acceptable_primary": [
+        "application_queue_saturation"
+      ],
+      "must_include_next_checks": [
+        "Inspect queue admission limits"
+      ],
+      "expected_route_breakdowns": "non_empty",
+      "must_include_route_warning": [
+        "not attributed to this route"
+      ],
+      "expected_top_level_warnings": [
+        "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
+      ],
+      "allowed_warnings": [
+        "Runtime snapshots are missing blocking_queue_depth or local_queue_depth",
+        "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
+      ],
+      "expected_evidence_quality": "weak",
+      "expected_signal_statuses": {
+        "requests": "partial",
+        "queues": "present",
+        "stages": "present",
+        "runtime_snapshots": "partial",
+        "inflight_snapshots": "missing"
+      }
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- Close a validation gap where route-breakdown checks relied only on synthetic report-shaped fixtures by adding an analyzer-generated route-divergence artifact so validation exercises real analyzer route filtering and warning behavior.
- Ensure route-level output is tested as supporting triage context (evidence-ranked suspects and explicit caveats) and does not change global scoring/ranking semantics.

### Description
- Add an analyzer-generated JSON report at `validation/diagnostics/corpus/route-divergence-generated.json` produced from a deterministic two-route run that yields non-empty `route_breakdowns` with different per-route primary suspects (`/a` queue-dominant, `/b` downstream-stage-dominant) and includes runtime/in-flight non-attribution caveats and the top-level route-divergence warning.
- Add a manifest case `generated_route_divergence` in `validation/diagnostics/manifest.json` (now `artifact_type: "analysis_report"`) that narrowly checks `expected_route_breakdowns`, route-warning substrings, `expected_top_level_warnings`, evidence expectations, and signal-status expectations.
- Strengthen analyzer unit coverage in `tailtriage-cli/src/analyze/tests.rs` by asserting the divergent per-route `primary_suspect.kind` values for the multi-route divergence test without changing scoring logic.
- Update validation docs (`validation/diagnostics/README.md` and `docs/diagnostic-validation.md`) to state that route-breakdown validation includes analyzer-generated fixtures and to reinforce that route-level suspects are supporting triage leads, not per-route root-cause proof, and that runtime/in-flight signals are not route-attributed.

### Testing
- Ran `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings`, both succeeded.
- Ran `cargo test --workspace`, and the workspace unit tests completed successfully (all relevant analyzer tests passed, including the updated multi-route divergence assertions).
- Ran `python3 -m unittest scripts.tests.test_diagnostic_benchmark` and `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0`, and the deterministic diagnostic benchmark passed with the new generated case included.
- Ran `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts`, both succeeded.
- `python3 scripts/check_demo_fixture_drift.py --profile dev` failed due to pre-existing demo fixture drift in the tree (`demos/blocking_service/fixtures/after-analysis.json`) and is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb1478b75483309f3a42a6ec2bbfe3)