### PR TITLE
Add analyzer route-divergence test coverage (route-level primaries + non‑attribution warning)

### DIFF
--- a/tailtriage-cli/src/analyze/tests.rs
+++ b/tailtriage-cli/src/analyze/tests.rs
@@ -1194,6 +1194,14 @@ fn multi_route_divergence_emits_sorted_breakdowns_and_stable_warning() {
     assert_eq!(report.route_breakdowns.len(), 2);
     assert_eq!(report.route_breakdowns[0].route, "/a");
     assert_eq!(report.route_breakdowns[1].route, "/b");
+    assert_eq!(
+        report.route_breakdowns[0].primary_suspect.kind,
+        DiagnosisKind::ApplicationQueueSaturation
+    );
+    assert_eq!(
+        report.route_breakdowns[1].primary_suspect.kind,
+        DiagnosisKind::DownstreamStageDominates
+    );
     assert!(report
         .warnings
         .iter()
@@ -1219,6 +1227,42 @@ fn multi_route_divergence_emits_sorted_breakdowns_and_stable_warning() {
     {
         assert!(breakdown.get("route_breakdowns").is_none());
     }
+}
+
+#[test]
+fn multi_route_same_primary_keeps_route_breakdowns_empty() {
+    let mut run = test_run();
+    run.requests.clear();
+    run.queues.clear();
+    run.stages.clear();
+    for idx in 1..=3 {
+        let mut req = sample_request(idx);
+        req.route = "/a".into();
+        req.latency_us = 8_000;
+        run.requests.push(req);
+    }
+    for idx in 4..=6 {
+        let mut req = sample_request(idx);
+        req.route = "/b".into();
+        req.latency_us = 8_500;
+        run.requests.push(req);
+    }
+    for req_id in ["req-1", "req-2", "req-3", "req-4", "req-5", "req-6"] {
+        run.queues.push(QueueEvent {
+            request_id: req_id.to_owned(),
+            queue: "ingress".into(),
+            wait_us: 7_400,
+            waited_from_unix_ms: 0,
+            waited_until_unix_ms: 1,
+            depth_at_start: Some(7),
+        });
+    }
+    let report = analyze_run(&run);
+    assert!(report.route_breakdowns.is_empty());
+    assert!(report
+        .warnings
+        .iter()
+        .all(|warning| warning != ROUTE_DIVERGENCE_WARNING));
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Validate actual analyzer-generated route breakdown behavior (route filtering, per-route primary suspects, and route-level warnings) rather than relying only on synthetic report-shaped fixtures.
- Ensure route breakdowns remain supporting context and that runtime/in-flight signals are not falsely attributed to individual routes.

### Description
- Added explicit analyzer assertions to the existing multi-route divergence test in `tailtriage-cli/src/analyze/tests.rs` to check route-level `primary_suspect` kinds for `/a` (queue-dominant) and `/b` (stage/downstream-dominant). 
- Added a new deterministic Rust test `multi_route_same_primary_keeps_route_breakdowns_empty` to assert that eligible routes which share the same primary suspect do not trigger `route_breakdowns` emission or the divergence warning.
- This change is test-only and does not add a generated JSON fixture, modify `validation/diagnostics/manifest.json`, or change analyzer scoring, confidence thresholds, or primary-suspect behavior.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it passed.
- Ran `cargo test --workspace` and all tests passed (`48` tailtriage-cli analyzer tests plus full workspace suites reported OK).
- Ran `python3 scripts/check_demo_fixture_drift.py --profile dev` and it completed with "demo analysis fixtures are up to date".
- Ran `python3 -m unittest scripts.tests.test_diagnostic_benchmark` and it passed (32 tests OK).
- Ran `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0` and it passed with route_breakdown checks reported as passed.
- Ran `python3 scripts/validate_docs_contracts.py` and it passed.
- Ran `python3 -m unittest scripts.tests.test_validate_docs_contracts` and it passed.

Summary: added deterministic analyzer coverage for route-divergence behavior only, no analyzer behavior changes were made, and all validation commands passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb1478b75483309f3a42a6ec2bbfe3)