### PR TITLE
Strengthen analyzer-backed route-divergence validation coverage

### DIFF
--- a/tailtriage-cli/src/analyze/tests.rs
+++ b/tailtriage-cli/src/analyze/tests.rs
@@ -1194,6 +1194,18 @@ fn multi_route_divergence_emits_sorted_breakdowns_and_stable_warning() {
     assert_eq!(report.route_breakdowns.len(), 2);
     assert_eq!(report.route_breakdowns[0].route, "/a");
     assert_eq!(report.route_breakdowns[1].route, "/b");
+    assert_eq!(
+        report.route_breakdowns[0].primary_suspect.kind,
+        DiagnosisKind::ApplicationQueueSaturation
+    );
+    assert_eq!(
+        report.route_breakdowns[1].primary_suspect.kind,
+        DiagnosisKind::DownstreamStageDominates
+    );
+    assert_ne!(
+        report.route_breakdowns[0].primary_suspect.kind,
+        report.route_breakdowns[1].primary_suspect.kind
+    );
     assert!(report
         .warnings
         .iter()


### PR DESCRIPTION
### Motivation
- Ensure route-breakdown validation covers actual analyzer behavior by asserting analyzer-generated per-route primary suspects in a deterministic multi-route in-memory run, so route breakdowns validate route filtering and route-level diagnosis caveats rather than only synthetic report-shaped plumbing.

### Description
- Tightened the existing Rust analyzer test `multi_route_divergence_emits_sorted_breakdowns_and_stable_warning` to assert that `route_breakdowns` is non-empty and that route `/a` is `ApplicationQueueSaturation` while route `/b` is `DownstreamStageDominates`, and kept existing checks for the global `ROUTE_DIVERGENCE_WARNING`, route-level runtime/in-flight attribution caveat, and the absence of falsely route-attributed executor/blocking suspects; no new JSON fixture or manifest entry was added and analyzer scoring/behavior was not changed.

### Testing
- Ran Rust and workspace checks: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, and they succeeded.
- Ran fixture/benchmark validation: `python3 scripts/check_demo_fixture_drift.py --profile dev` which reported a pre-existing demo fixture drift (stale `demos/blocking_service/fixtures/after-analysis.json`) and failed as expected against the current demo fixtures.
- Ran the diagnostic benchmark and docs validation: `python3 -m unittest scripts.tests.test_diagnostic_benchmark`, `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0`, `python3 scripts/validate_docs_contracts.py`, and `python3 -m unittest scripts.tests.test_validate_docs_contracts`, and they all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb1478b75483309f3a42a6ec2bbfe3)