### PR TITLE
CI fixes

### DIFF
--- a/tailtriage-analyzer/src/lib.rs
+++ b/tailtriage-analyzer/src/lib.rs
@@ -306,7 +306,7 @@ pub struct RouteBreakdown {
 /// ```
 #[must_use]
 pub fn analyze_run(run: &Run, options: AnalyzeOptions) -> Report {
-    analyze_run_with_options(run, &options)
+    Analyzer::new(options).analyze_run(run)
 }
 
 /// Options for heuristic run analysis.

--- a/tailtriage-analyzer/src/lib.rs
+++ b/tailtriage-analyzer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Heuristic triage analyzer for completed [`tailtriage_core::Run`] captures.
 //!
-//! This crate analyzes a finished in-memory [`Run`](tailtriage_core::Run) and returns a typed
+//! This crate analyzes a finished in-memory [`Run`] and returns a typed
 //! [`Report`] for in-process diagnosis. It does not load run artifacts from disk and it does not
 //! write capture artifacts.
 //!


### PR DESCRIPTION
## Summary

CI fix

## Why this change

clippy error

## Validation

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`

## Scope check

- [x] This PR stays within MVP triage scope.
- [x] If behavior changed, docs were updated.
- [x] Suspects are still described as evidence-ranked leads, not causal proof.

## Contribution license check

- [x] I have the right to submit this contribution under the MIT License.
- [x] I agree that this contribution is licensed under the repository's MIT License.
