### PR TITLE
docs: teach tailtriage-analyzer vs tailtriage-cli split

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,16 @@ cargo add tailtriage --features tokio
 cargo add tailtriage --features "tokio,axum"
 ```
 
-Install the CLI separately for analysis/report generation:
+Install analysis/report tools separately:
 
 ```bash
+cargo add tailtriage-analyzer
 cargo install tailtriage-cli
 ```
 
-> Library crates capture data. `tailtriage-cli` analyzes artifacts.
+- `tailtriage` captures run data in your service.
+- `tailtriage-analyzer` analyzes completed in-memory runs or stable snapshots in process.
+- `tailtriage-cli` loads artifacts and emits reports from the command line.
 
 ## Why not just tokio-console or tokio-metrics?
 
@@ -135,6 +138,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+```
+
+### In-process analysis (library)
+
+```rust,no_run
+use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+# use tailtriage_core::Run;
+# fn demo(run: Run) -> Result<(), serde_json::Error> {
+let report = analyze_run(&run, AnalyzeOptions::default());
+let text = render_text(&report);
+let json = serde_json::to_string_pretty(&report)?;
+# let _ = (text, json);
+# Ok(())
+# }
 ```
 
 ### Analyze artifact (CLI)
@@ -284,7 +301,8 @@ Demo walkthrough and CI coverage details: [`docs/getting-started-demo.md`](docs/
 - User workflow guide: [`docs/user-guide.md`](docs/user-guide.md)
 - Controller docs and config: [`tailtriage-controller/README.md`](tailtriage-controller/README.md)
 - Runtime sampler docs: [`tailtriage-tokio/README.md`](tailtriage-tokio/README.md)
-- Analyzer/report contract: [`tailtriage-cli/README.md`](tailtriage-cli/README.md)
+- Analyzer/report contract for Rust code: [`tailtriage-analyzer/README.md`](tailtriage-analyzer/README.md)
+- CLI artifact-loading contract: [`tailtriage-cli/README.md`](tailtriage-cli/README.md)
 - Diagnostics field reference and interpretation: [`docs/diagnostics.md`](docs/diagnostics.md)
 - Demo walkthrough and recommended first demos: [`docs/getting-started-demo.md`](docs/getting-started-demo.md)
 - Runtime-overhead measurement path: [`docs/runtime-cost.md`](docs/runtime-cost.md)

--- a/SPEC.md
+++ b/SPEC.md
@@ -42,6 +42,7 @@ Current workspace members include:
 - `tailtriage-controller`
 - `tailtriage-tokio`
 - `tailtriage-axum`
+- `tailtriage-analyzer`
 - `tailtriage-cli`
 - demos crates under `demos/`
 
@@ -139,7 +140,7 @@ Primary command:
 tailtriage analyze <run.json>
 ```
 
-## 6. Run artifact and analyzer contract
+## 6. Run artifact, analyzer, and CLI contracts
 
 Run artifacts include request, stage, queue, in-flight, and optional runtime snapshot data plus metadata/truncation context.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,13 +4,14 @@ This is the canonical user-facing docs index for `tailtriage`.
 
 ## Start here
 
-- [User guide](user-guide.md) — default adoption path (`tailtriage` + `tailtriage-cli`) and the core capture -> analyze -> next check -> re-run workflow.
+- [User guide](user-guide.md) — default adoption path (`tailtriage` + `tailtriage-cli`) plus in-process analysis with `tailtriage-analyzer` and the core capture -> analyze -> next check -> re-run workflow.
 - [Default crate README (`tailtriage`)](../tailtriage/README.md) — fastest way to integrate with one dependency.
 
 ## Core workflow and interpretation
 
 - [Diagnostics guide](diagnostics.md) — quick reading flow plus concise field reference for analyzer output.
-- [CLI README (`tailtriage-cli`)](../tailtriage-cli/README.md) — analyzer/report contract and CLI usage.
+- [Analyzer README (`tailtriage-analyzer`)](../tailtriage-analyzer/README.md) — in-process analyzer/report contract.
+- [CLI README (`tailtriage-cli`)](../tailtriage-cli/README.md) — artifact loading, validation, and command output usage.
 
 ## Capture surfaces
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@ The default user path is:
 1. instrument capture in service code (`tailtriage` default crate)
 2. optionally enrich with runtime sampling (`tailtriage-tokio`)
 3. write local run artifact JSON
-4. analyze artifact with `tailtriage-cli`
+4. analyze in process with `tailtriage-analyzer` or analyze artifact with `tailtriage-cli`
 
 The result is a triage report with evidence-ranked suspects and next checks.
 
@@ -49,9 +49,13 @@ Adds optional runtime-pressure snapshots to the same run artifact via `RuntimeSa
 
 Adds optional Axum request-boundary ergonomics (middleware + extractor).
 
+### `tailtriage-analyzer`
+
+Owns in-process analyzer/report logic for completed runs and stable snapshots represented as `Run`. It provides typed reports and text rendering; serde enables optional JSON report serialization.
+
 ### `tailtriage-cli`
 
-Consumes run artifacts and emits diagnosis reports (text/JSON).
+Consumes run artifacts from disk, validates artifact schema and loader rules, then emits analyzer reports (text/JSON) by consuming `tailtriage-analyzer`.
 
 ## Relationship model
 
@@ -70,3 +74,10 @@ It does not claim:
 - observability backend behavior
 - distributed-system root-cause proof
 - automatic causality certainty
+
+
+Conceptual dependency flow for analysis:
+
+```text
+tailtriage-core -> tailtriage-analyzer -> tailtriage-cli
+```

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,6 +1,6 @@
 # Diagnostics guide
 
-This guide explains how `tailtriage analyze` turns one run artifact into a triage report.
+This guide explains how both `tailtriage_analyzer::analyze_run` and `tailtriage analyze` turn run data into a triage report.
 
 ## Read one report quickly
 
@@ -11,6 +11,13 @@ This guide explains how `tailtriage analyze` turns one run artifact into a triag
 5. Run one targeted check, then re-run and compare.
 
 Ranking is rule-based triage guidance. Suspects are leads, not proof of root cause.
+
+## Analyzer and CLI entry points
+
+- In-process: `tailtriage_analyzer::analyze_run(&Run, AnalyzeOptions)` for completed runs or stable snapshots represented as `Run`.
+- Command line: `tailtriage analyze <run.json>` for artifact loading + report emission.
+
+Analyzer semantics are batch/snapshot based, not live streaming.
 
 ## Artifact schema contract
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -7,12 +7,14 @@ This guide teaches the default `tailtriage` workflow for end users.
 For most services, use:
 
 - `tailtriage` for capture instrumentation
-- `tailtriage-cli` for analysis/report generation
+- `tailtriage-analyzer` for in-process analysis/report generation in Rust code
+- `tailtriage-cli` for artifact analysis/report generation from the command line
 
 Install:
 
 ```bash
 cargo add tailtriage
+cargo add tailtriage-analyzer
 cargo install tailtriage-cli
 ```
 
@@ -59,7 +61,26 @@ Read output in this order:
 
 Then run one targeted check, change one thing, and re-run under comparable load.
 
-## 3) Request lifecycle contract (required)
+
+## 3) In-process analysis (embedded Rust users)
+
+Use `tailtriage-analyzer` when you already have a completed in-memory `Run` (or a stable snapshot represented as `Run`) and want typed report access in process.
+
+```rust,no_run
+use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+# use tailtriage_core::Run;
+# fn demo(run: Run) -> Result<(), serde_json::Error> {
+let report = analyze_run(&run, AnalyzeOptions::default());
+let text = render_text(&report);
+let json = serde_json::to_string_pretty(&report)?;
+# let _ = (text, json);
+# Ok(())
+# }
+```
+
+Current semantics are batch/snapshot for a completed run, not live streaming analysis. JSON output is optional for code users; use typed `Report` directly when preferred.
+
+## 4) Request lifecycle contract (required)
 
 `begin_request(...)` / `begin_request_with(...)` returns `StartedRequest`:
 
@@ -88,7 +109,7 @@ Important semantics:
 - `shutdown()` does not fabricate completion/outcome
 - `strict_lifecycle(true)` can fail shutdown when unfinished requests remain
 
-## 4) Direct capture vs controller
+## 5) Direct capture vs controller
 
 Use **direct capture** (`Tailtriage`) when you want a straightforward run lifecycle in app code.
 
@@ -120,7 +141,7 @@ let _ = controller.disable()?;
 
 Controller details: [tailtriage-controller/README.md](../tailtriage-controller/README.md)
 
-## 5) Controller TOML config and reload semantics
+## 6) Controller TOML config and reload semantics
 
 Controller config is for repeatable operational settings across environments.
 
@@ -149,7 +170,7 @@ At contract level:
 
 See crate README for the full TOML field reference and expanded starter example: [tailtriage-controller/README.md](../tailtriage-controller/README.md)
 
-## 6) Runtime sampler: when and why
+## 7) Runtime sampler: when and why
 
 Add runtime sampling when request timing alone does not clearly separate:
 
@@ -168,7 +189,7 @@ Key constraints:
 
 Sampler details: [tailtriage-tokio/README.md](../tailtriage-tokio/README.md)
 
-## 7) Axum adapter: what it is and is not
+## 8) Axum adapter: what it is and is not
 
 `tailtriage-axum` is a framework-boundary ergonomics layer:
 
@@ -179,7 +200,7 @@ It is not automatic diagnosis. Queue/stage/inflight instrumentation is still exp
 
 Adapter details: [tailtriage-axum/README.md](../tailtriage-axum/README.md)
 
-## 8) What to do when result is `insufficient_evidence`
+## 9) What to do when result is `insufficient_evidence`
 
 When `primary_suspect.kind` is `insufficient_evidence`:
 
@@ -190,7 +211,7 @@ When `primary_suspect.kind` is `insufficient_evidence`:
 
 Use [diagnostics.md](diagnostics.md) for interpretation details.
 
-## 9) Next docs
+## 10) Next docs
 
 - [Documentation index](README.md)
 - [Diagnostics guide](diagnostics.md)

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -547,6 +547,7 @@ service_name initially_enabled mode strict_lifecycle capture_limits_override max
 - [Diag](diagnostics.md)
 - [Controller crate](../tailtriage-controller/README.md)
 - [Sampler crate](../tailtriage-tokio/README.md)
+- [Analyzer crate](../tailtriage-analyzer/README.md)
 - [CLI crate](../tailtriage-cli/README.md)
 - [Runtime cost notes](runtime-cost.md)
 - [Collector limits notes](collector-limits.md)

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -38,6 +38,7 @@ USER_FACING_TERMINOLOGY_PATHS = (
     REPO_ROOT / "tailtriage-controller" / "README.md",
     REPO_ROOT / "tailtriage-tokio" / "README.md",
     REPO_ROOT / "tailtriage-axum" / "README.md",
+    REPO_ROOT / "tailtriage-analyzer" / "README.md",
     REPO_ROOT / "tailtriage-cli" / "README.md",
     REPO_ROOT / "tailtriage" / "src" / "lib.rs",
     REPO_ROOT / "tailtriage" / "Cargo.toml",
@@ -55,6 +56,7 @@ DOCS_REQUIRED_LINKS = (
     "[Diagnostics guide](diagnostics.md)",
     "[Controller README (`tailtriage-controller`)](../tailtriage-controller/README.md)",
     "[Tokio runtime sampler README (`tailtriage-tokio`)](../tailtriage-tokio/README.md)",
+    "[Analyzer README (`tailtriage-analyzer`)](../tailtriage-analyzer/README.md)",
     "[CLI README (`tailtriage-cli`)](../tailtriage-cli/README.md)",
     "[Runtime cost measurement](runtime-cost.md)",
     "[Collector limits and stress guidance](collector-limits.md)",
@@ -66,6 +68,7 @@ README_DOC_MAP_REQUIRED_LINKS = (
     "(docs/user-guide.md)",
     "(tailtriage-controller/README.md)",
     "(tailtriage-tokio/README.md)",
+    "(tailtriage-analyzer/README.md)",
     "(tailtriage-cli/README.md)",
     "(docs/diagnostics.md)",
     "(docs/runtime-cost.md)",
@@ -696,6 +699,19 @@ def validate_sampler_integration_boundary() -> None:
         )
 
 
+
+def validate_cli_not_presented_as_library_api() -> None:
+    paths = (README_PATH, DOCS_INDEX_PATH, USER_GUIDE_PATH, DIAGNOSTICS_PATH, ARCHITECTURE_PATH, REPO_ROOT / "tailtriage-cli" / "README.md")
+    bad_patterns = (r"tailtriage-cli[^\n]{0,80}library", r"tailtriage_cli::analyze")
+    failures: list[str] = []
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        for pattern in bad_patterns:
+            if re.search(pattern, text, flags=re.IGNORECASE):
+                failures.append(f"{path.relative_to(REPO_ROOT)} contains disallowed CLI-library wording: {pattern}")
+    if failures:
+        raise ValueError("docs present tailtriage-cli as library API:\n" + "\n".join(failures))
+
 def main() -> int:
     _ = parse_args()
     validate_readme_analyzer_example()
@@ -712,6 +728,7 @@ def main() -> int:
     validate_no_user_facing_facade_wording()
     validate_controller_example_usage_contract()
     validate_sampler_integration_boundary()
+    validate_cli_not_presented_as_library_api()
     print("docs contracts validated successfully")
     return 0
 

--- a/tailtriage-analyzer/README.md
+++ b/tailtriage-analyzer/README.md
@@ -4,6 +4,12 @@
 
 It is designed for in-process report generation from in-memory runs. It does not load run artifacts from disk, and it does not write run artifacts.
 
+## Installation
+
+```bash
+cargo add tailtriage-analyzer
+```
+
 ```rust
 use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
 # use tailtriage_core::Run;
@@ -32,3 +38,16 @@ Direct analyzer usage does not replace artifact generation and does not require 
 ## Execution model
 
 Current analyzer semantics are batch/snapshot based for one completed run, not streaming.
+
+
+## Migration note
+
+```rust
+// Old pre-0.1.x API, no longer the supported library analyzer path:
+use tailtriage_cli::analyze::{analyze_run, render_text};
+
+// New:
+use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+```
+
+Artifact loading remains CLI-owned (`tailtriage analyze ...`).

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -12,7 +12,7 @@ tailtriage
 
 ## What this tool does
 
-`tailtriage-cli` owns the analysis-side contract:
+`tailtriage-cli` owns the command-line artifact-analysis contract:
 
 - load a captured artifact
 - validate schema compatibility
@@ -143,10 +143,9 @@ Current contract:
 - `requests` must contain at least one request event
 - artifacts with an empty `requests` array are rejected by the CLI loader
 
-Library note:
+Rust code users should use `tailtriage-analyzer` directly for in-process analysis APIs.
 
-- the `tailtriage-analyzer` library API, `tailtriage_analyzer::analyze_run(&Run, AnalyzeOptions)`, can analyze an in-memory `Run` with zero requests
-- the stricter non-empty `requests` rule applies to CLI artifact loading from disk
+The stricter non-empty `requests` rule applies to CLI artifact loading from disk.
 
 ## Important interpretation notes
 


### PR DESCRIPTION
### Motivation
- Clarify the public surface by teaching that `tailtriage-analyzer` is the in-process analyzer/report library while `tailtriage-cli` is the command-line artifact loader and report emitter. 
- Prevent user confusion and accidental API coupling by ensuring docs do not present the CLI as the library analyzer API or imply streaming analysis. 
- Keep the docs-contract validation honest and enforce the new analyzer README as a first-class user-facing doc.

### Description
- Updated user-facing documentation across `README.md`, `SPEC.md`, `docs/README.md`, `docs/user-guide.md`, `docs/diagnostics.md`, and `docs/architecture.md` to document the split (`tailtriage` captures, `tailtriage-analyzer` analyzes in-process completed runs/snapshots, `tailtriage-cli` analyzes artifacts on the command line) and to add an in-process example using `analyze_run`, `render_text`, and serde JSON. 
- Expanded `tailtriage-analyzer/README.md` into the analyzer/report contract (installation, in-process API example, batch/snapshot semantics, serde JSON note, and migration guidance). 
- Narrowed `tailtriage-cli/README.md` to CLI responsibilities (artifact loading, schema validation, non-empty `requests` loader rule, text/json output, and stderr loader warnings) and removed library-API framing while directing Rust users to `tailtriage-analyzer`. 
- Updated docs-contract validator `scripts/validate_docs_contracts.py` and its unit test `scripts/tests/test_validate_docs_contracts.py` to include the analyzer README in required links and added a new check that prevents docs from presenting `tailtriage-cli` as the library analyzer API.

### Testing
- Ran `cargo fmt --check` and it succeeded. 
- Ran `python3 scripts/validate_docs_contracts.py` and it reported `docs contracts validated successfully`. 
- Ran `python3 -m unittest scripts.tests.test_validate_docs_contracts` and all tests passed. 
- Ran `cargo test -p tailtriage-analyzer` and `cargo test -p tailtriage-cli` and both test suites completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb54fcd2508330a29f08944239a887)