### PR TITLE
docs: split analyzer and CLI public contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,14 @@ cargo add tailtriage --features tokio
 cargo add tailtriage --features "tokio,axum"
 ```
 
-Install the CLI separately for analysis/report generation:
+Install analyzer and CLI components based on how you analyze:
 
 ```bash
+cargo add tailtriage-analyzer
 cargo install tailtriage-cli
 ```
 
-> Library crates capture data. `tailtriage-cli` analyzes artifacts.
+> `tailtriage` captures data. `tailtriage-analyzer` analyzes completed in-memory runs or stable snapshots in process. `tailtriage-cli` analyzes artifacts from the command line.
 
 ## Why not just tokio-console or tokio-metrics?
 
@@ -135,6 +136,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+```
+
+### In-process analysis (Rust)
+
+```rust
+use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+
+# use tailtriage_core::Run;
+# fn example(run: Run) -> Result<(), serde_json::Error> {
+let report = analyze_run(&run, AnalyzeOptions::default());
+let text = render_text(&report);
+let json = serde_json::to_string_pretty(&report)?;
+# let _ = (text, json);
+# Ok(())
+# }
 ```
 
 ### Analyze artifact (CLI)
@@ -284,7 +300,8 @@ Demo walkthrough and CI coverage details: [`docs/getting-started-demo.md`](docs/
 - User workflow guide: [`docs/user-guide.md`](docs/user-guide.md)
 - Controller docs and config: [`tailtriage-controller/README.md`](tailtriage-controller/README.md)
 - Runtime sampler docs: [`tailtriage-tokio/README.md`](tailtriage-tokio/README.md)
-- Analyzer/report contract: [`tailtriage-cli/README.md`](tailtriage-cli/README.md)
+- In-process analyzer/report contract: [`tailtriage-analyzer/README.md`](tailtriage-analyzer/README.md)
+- CLI artifact loader/report emitter: [`tailtriage-cli/README.md`](tailtriage-cli/README.md)
 - Diagnostics field reference and interpretation: [`docs/diagnostics.md`](docs/diagnostics.md)
 - Demo walkthrough and recommended first demos: [`docs/getting-started-demo.md`](docs/getting-started-demo.md)
 - Runtime-overhead measurement path: [`docs/runtime-cost.md`](docs/runtime-cost.md)

--- a/SPEC.md
+++ b/SPEC.md
@@ -42,6 +42,7 @@ Current workspace members include:
 - `tailtriage-controller`
 - `tailtriage-tokio`
 - `tailtriage-axum`
+- `tailtriage-analyzer`
 - `tailtriage-cli`
 - demos crates under `demos/`
 
@@ -129,9 +130,13 @@ Semantics:
 - middleware starts/finishes request lifecycle at boundary
 - extractor exposes request handle for explicit queue/stage/inflight instrumentation
 
-### 5.8 Analyzer CLI (`tailtriage-cli`)
+### 5.8 In-process analyzer (`tailtriage-analyzer`)
 
-`tailtriage-cli` analyzes artifacts and renders text/JSON reports.
+`tailtriage-analyzer` owns typed report generation for completed in-memory runs or stable snapshots in process. It provides `analyze_run`, `render_text`, and serde-serializable report types.
+
+### 5.9 Analyzer CLI (`tailtriage-cli`)
+
+`tailtriage-cli` owns artifact loading/validation and command-line report emission. It consumes `tailtriage-analyzer` for report generation.
 
 Primary command:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,13 +4,14 @@ This is the canonical user-facing docs index for `tailtriage`.
 
 ## Start here
 
-- [User guide](user-guide.md) — default adoption path (`tailtriage` + `tailtriage-cli`) and the core capture -> analyze -> next check -> re-run workflow.
+- [User guide](user-guide.md) — default adoption path (`tailtriage` + `tailtriage-cli`) plus in-process analysis with `tailtriage-analyzer` and the core capture -> analyze -> next check -> re-run workflow.
 - [Default crate README (`tailtriage`)](../tailtriage/README.md) — fastest way to integrate with one dependency.
 
 ## Core workflow and interpretation
 
 - [Diagnostics guide](diagnostics.md) — quick reading flow plus concise field reference for analyzer output.
-- [CLI README (`tailtriage-cli`)](../tailtriage-cli/README.md) — analyzer/report contract and CLI usage.
+- [Analyzer README (`tailtriage-analyzer`)](../tailtriage-analyzer/README.md) — in-process analyzer/report contract and typed report model.
+- [CLI README (`tailtriage-cli`)](../tailtriage-cli/README.md) — artifact loader and command-line report emission.
 
 ## Capture surfaces
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@ The default user path is:
 1. instrument capture in service code (`tailtriage` default crate)
 2. optionally enrich with runtime sampling (`tailtriage-tokio`)
 3. write local run artifact JSON
-4. analyze artifact with `tailtriage-cli`
+4. analyze in process with `tailtriage-analyzer` or from files with `tailtriage-cli`
 
 The result is a triage report with evidence-ranked suspects and next checks.
 
@@ -49,9 +49,13 @@ Adds optional runtime-pressure snapshots to the same run artifact via `RuntimeSa
 
 Adds optional Axum request-boundary ergonomics (middleware + extractor).
 
+### `tailtriage-analyzer`
+
+Owns analyzer/report logic for completed in-memory runs or stable snapshots in process. Emits typed reports and text rendering.
+
 ### `tailtriage-cli`
 
-Consumes run artifacts and emits diagnosis reports (text/JSON).
+Consumes run artifacts from files, validates artifact schema/loader rules, and emits diagnosis reports (text/JSON) by using `tailtriage-analyzer`.
 
 ## Relationship model
 
@@ -70,3 +74,6 @@ It does not claim:
 - observability backend behavior
 - distributed-system root-cause proof
 - automatic causality certainty
+
+
+Conceptual flow: `tailtriage-core -> tailtriage-analyzer -> tailtriage-cli` for file-based analysis.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,6 +1,6 @@
 # Diagnostics guide
 
-This guide explains how `tailtriage analyze` turns one run artifact into a triage report.
+This guide explains the triage report produced by `tailtriage_analyzer::analyze_run` and `tailtriage analyze`.
 
 ## Read one report quickly
 
@@ -24,7 +24,7 @@ Current supported schema version: `1`.
 
 ## Report contents
 
-`tailtriage analyze <run.json>` outputs:
+`tailtriage_analyzer::analyze_run` and `tailtriage analyze <run.json>` output:
 
 - request count
 - request latency percentiles (`p50`, `p95`, `p99`)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -7,12 +7,14 @@ This guide teaches the default `tailtriage` workflow for end users.
 For most services, use:
 
 - `tailtriage` for capture instrumentation
-- `tailtriage-cli` for analysis/report generation
+- `tailtriage-cli` for artifact analysis/report generation
+- `tailtriage-analyzer` for in-process analysis in Rust code
 
 Install:
 
 ```bash
 cargo add tailtriage
+cargo add tailtriage-analyzer
 cargo install tailtriage-cli
 ```
 
@@ -59,7 +61,26 @@ Read output in this order:
 
 Then run one targeted check, change one thing, and re-run under comparable load.
 
-## 3) Request lifecycle contract (required)
+
+## 3) In-process analysis (embedded Rust users)
+
+If you already have a completed in-memory `Run` (or stable snapshot in process), use `tailtriage-analyzer`:
+
+```rust
+use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+# use tailtriage_core::Run;
+# fn example(run: Run) -> Result<(), serde_json::Error> {
+let report = analyze_run(&run, AnalyzeOptions::default());
+let text = render_text(&report);
+let json = serde_json::to_string_pretty(&report)?;
+# let _ = (text, json);
+# Ok(())
+# }
+```
+
+Current analyzer semantics are batch/snapshot based for one completed run. Live streaming analysis is not part of the current contract.
+
+## 4) Request lifecycle contract (required)
 
 `begin_request(...)` / `begin_request_with(...)` returns `StartedRequest`:
 
@@ -88,7 +109,7 @@ Important semantics:
 - `shutdown()` does not fabricate completion/outcome
 - `strict_lifecycle(true)` can fail shutdown when unfinished requests remain
 
-## 4) Direct capture vs controller
+## 5) Direct capture vs controller
 
 Use **direct capture** (`Tailtriage`) when you want a straightforward run lifecycle in app code.
 
@@ -120,7 +141,7 @@ let _ = controller.disable()?;
 
 Controller details: [tailtriage-controller/README.md](../tailtriage-controller/README.md)
 
-## 5) Controller TOML config and reload semantics
+## 6) Controller TOML config and reload semantics
 
 Controller config is for repeatable operational settings across environments.
 
@@ -149,7 +170,7 @@ At contract level:
 
 See crate README for the full TOML field reference and expanded starter example: [tailtriage-controller/README.md](../tailtriage-controller/README.md)
 
-## 6) Runtime sampler: when and why
+## 7) Runtime sampler: when and why
 
 Add runtime sampling when request timing alone does not clearly separate:
 
@@ -168,7 +189,7 @@ Key constraints:
 
 Sampler details: [tailtriage-tokio/README.md](../tailtriage-tokio/README.md)
 
-## 7) Axum adapter: what it is and is not
+## 8) Axum adapter: what it is and is not
 
 `tailtriage-axum` is a framework-boundary ergonomics layer:
 
@@ -179,7 +200,7 @@ It is not automatic diagnosis. Queue/stage/inflight instrumentation is still exp
 
 Adapter details: [tailtriage-axum/README.md](../tailtriage-axum/README.md)
 
-## 8) What to do when result is `insufficient_evidence`
+## 9) What to do when result is `insufficient_evidence`
 
 When `primary_suspect.kind` is `insufficient_evidence`:
 
@@ -190,7 +211,17 @@ When `primary_suspect.kind` is `insufficient_evidence`:
 
 Use [diagnostics.md](diagnostics.md) for interpretation details.
 
-## 9) Next docs
+## Migration note (library analyzer path)
+
+```rust
+// Old pre-0.1.x API, no longer the supported library analyzer path:
+use tailtriage_cli::analyze::{analyze_run, render_text};
+
+// New:
+use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+```
+
+## 10) Next docs
 
 - [Documentation index](README.md)
 - [Diagnostics guide](diagnostics.md)

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -155,6 +155,9 @@ Normal CI does not publish durable diagnostic scorecards.
     def test_user_facing_wording_has_no_facade_term(self) -> None:
         validate_docs_contracts.validate_no_user_facing_facade_wording()
 
+    def test_docs_do_not_present_cli_as_library_analyzer_api(self) -> None:
+        validate_docs_contracts.validate_cli_not_presented_as_library_analyzer_api()
+
     def test_user_facing_wording_validation_fails_when_facade_present(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             temp_path = Path(tmp_dir) / "README.md"
@@ -167,6 +170,9 @@ Normal CI does not publish durable diagnostic scorecards.
             ):
                 with self.assertRaisesRegex(ValueError, r"stale facade wording"):
                     validate_docs_contracts.validate_no_user_facing_facade_wording()
+
+    def test_docs_do_not_present_cli_as_library_analyzer_api(self) -> None:
+        validate_docs_contracts.validate_cli_not_presented_as_library_analyzer_api()
 
     def test_controller_readme_does_not_use_misleading_dependency_example_flow(self) -> None:
         readme_text = validate_docs_contracts.CONTROLLER_README_PATH.read_text(encoding="utf-8")
@@ -547,6 +553,7 @@ service_name initially_enabled mode strict_lifecycle capture_limits_override max
 - [Diag](diagnostics.md)
 - [Controller crate](../tailtriage-controller/README.md)
 - [Sampler crate](../tailtriage-tokio/README.md)
+- [Analyzer crate](../tailtriage-analyzer/README.md)
 - [CLI crate](../tailtriage-cli/README.md)
 - [Runtime cost notes](runtime-cost.md)
 - [Collector limits notes](collector-limits.md)
@@ -559,6 +566,21 @@ service_name initially_enabled mode strict_lifecycle capture_limits_override max
             with mock.patch.object(validate_docs_contracts, "DOCS_INDEX_PATH", docs_path):
                 validate_docs_contracts.validate_docs_index_contract()
 
+
+    def test_docs_cli_library_api_contract_fails_when_stale_path_used(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            temp_path = Path(tmp_dir) / "README.md"
+            temp_path.write_text("use tailtriage_cli::analyze::analyze_run", encoding="utf-8")
+            cli_readme = Path(tmp_dir) / "tailtriage-cli" / "README.md"
+            cli_readme.parent.mkdir(parents=True, exist_ok=True)
+            cli_readme.write_text("tailtriage-cli docs", encoding="utf-8")
+            with mock.patch.object(validate_docs_contracts, "README_PATH", temp_path), mock.patch.object(
+                validate_docs_contracts, "DOCS_INDEX_PATH", temp_path
+            ), mock.patch.object(validate_docs_contracts, "DIAGNOSTICS_PATH", temp_path), mock.patch.object(
+                validate_docs_contracts, "ARCHITECTURE_PATH", temp_path
+            ), mock.patch.object(validate_docs_contracts, "REPO_ROOT", Path(tmp_dir)):
+                with self.assertRaisesRegex(ValueError, r"library analyzer API"):
+                    validate_docs_contracts.validate_cli_not_presented_as_library_analyzer_api()
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -38,6 +38,7 @@ USER_FACING_TERMINOLOGY_PATHS = (
     REPO_ROOT / "tailtriage-controller" / "README.md",
     REPO_ROOT / "tailtriage-tokio" / "README.md",
     REPO_ROOT / "tailtriage-axum" / "README.md",
+    REPO_ROOT / "tailtriage-analyzer" / "README.md",
     REPO_ROOT / "tailtriage-cli" / "README.md",
     REPO_ROOT / "tailtriage" / "src" / "lib.rs",
     REPO_ROOT / "tailtriage" / "Cargo.toml",
@@ -55,6 +56,7 @@ DOCS_REQUIRED_LINKS = (
     "[Diagnostics guide](diagnostics.md)",
     "[Controller README (`tailtriage-controller`)](../tailtriage-controller/README.md)",
     "[Tokio runtime sampler README (`tailtriage-tokio`)](../tailtriage-tokio/README.md)",
+    "[Analyzer README (`tailtriage-analyzer`)](../tailtriage-analyzer/README.md)",
     "[CLI README (`tailtriage-cli`)](../tailtriage-cli/README.md)",
     "[Runtime cost measurement](runtime-cost.md)",
     "[Collector limits and stress guidance](collector-limits.md)",
@@ -66,6 +68,7 @@ README_DOC_MAP_REQUIRED_LINKS = (
     "(docs/user-guide.md)",
     "(tailtriage-controller/README.md)",
     "(tailtriage-tokio/README.md)",
+    "(tailtriage-analyzer/README.md)",
     "(tailtriage-cli/README.md)",
     "(docs/diagnostics.md)",
     "(docs/runtime-cost.md)",
@@ -696,6 +699,31 @@ def validate_sampler_integration_boundary() -> None:
         )
 
 
+CLI_LIBRARY_API_STALE_PATTERNS = (
+    r"tailtriage_cli::analyze::",
+    r"tailtriage-cli[^\n]{0,80}library analyzer",
+)
+
+def validate_cli_not_presented_as_library_analyzer_api() -> None:
+    paths = (
+        README_PATH,
+        DOCS_INDEX_PATH,
+        DIAGNOSTICS_PATH,
+        ARCHITECTURE_PATH,
+        REPO_ROOT / "tailtriage-cli" / "README.md",
+    )
+    failures: list[str] = []
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        for pattern in CLI_LIBRARY_API_STALE_PATTERNS:
+            if re.search(pattern, text, flags=re.IGNORECASE):
+                failures.append(f"{path.relative_to(REPO_ROOT)} matches disallowed pattern: {pattern}")
+    if failures:
+        raise ValueError(
+            "docs present tailtriage-cli as library analyzer API:\n" + "\n".join(failures)
+        )
+
+
 def main() -> int:
     _ = parse_args()
     validate_readme_analyzer_example()
@@ -710,6 +738,7 @@ def main() -> int:
     validate_architecture_contract()
     validate_docs_no_history_framing()
     validate_no_user_facing_facade_wording()
+    validate_cli_not_presented_as_library_analyzer_api()
     validate_controller_example_usage_contract()
     validate_sampler_integration_boundary()
     print("docs contracts validated successfully")

--- a/tailtriage-analyzer/README.md
+++ b/tailtriage-analyzer/README.md
@@ -1,8 +1,18 @@
 # tailtriage-analyzer
 
-`tailtriage-analyzer` analyzes an already completed `tailtriage_core::Run` and produces a typed triage report.
+`tailtriage-analyzer` is the in-process analyzer/report crate for `tailtriage`.
 
-It is designed for in-process report generation from in-memory runs. It does not load run artifacts from disk, and it does not write run artifacts.
+It analyzes a completed in-memory `tailtriage_core::Run` (or a stable snapshot you already loaded in process) and returns a typed triage report with evidence-ranked suspects and next checks.
+
+Suspects are leads, not proof of root cause.
+
+## Installation
+
+```bash
+cargo add tailtriage-analyzer
+```
+
+## In-process API example
 
 ```rust
 use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
@@ -10,25 +20,41 @@ use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
 # fn example(run: Run) -> Result<(), serde_json::Error> {
 let report = analyze_run(&run, AnalyzeOptions::default());
 let text = render_text(&report);
-let report_json = serde_json::to_string_pretty(&report)?;
-# let _ = (text, report_json);
+let json = serde_json::to_string_pretty(&report)?;
+# let _ = (text, json);
 # Ok(())
 # }
 ```
 
-- `Report` is the primary typed output for analyzer/report logic.
-- `render_text(&Report)` produces human-readable output.
-- `serde_json::to_string_pretty(&report)` produces analysis report JSON.
+## Typed report model
 
-## Run artifact JSON vs analysis report JSON
+`Report` is the analyzer contract for Rust code users.
 
-These are distinct outputs and both remain supported:
+It includes:
 
-1. **Run artifact JSON**: raw captured run data produced by capture/shutdown or artifact-writing workflows. This remains part of capture/core/CLI artifact workflows and can still be analyzed later by the CLI.
-2. **Analysis report JSON**: output from analyzing a `Run`, represented by `tailtriage_analyzer::Report` and serialized with serde.
+- latency percentiles and queue/service share summaries
+- warnings and `evidence_quality`
+- `primary_suspect` and `secondary_suspects`
+- optional `inflight_trend`
+- supporting `route_breakdowns` and `temporal_segments`
 
-Direct analyzer usage does not replace artifact generation and does not require parsing CLI stdout.
+## Text rendering and JSON
 
-## Execution model
+- `render_text(&Report)` emits human-readable triage output.
+- `serde_json::to_string_pretty(&report)` emits structured report JSON.
 
-Current analyzer semantics are batch/snapshot based for one completed run, not streaming.
+JSON is optional for code users; the primary API is typed Rust data.
+
+## Batch/snapshot semantics
+
+Analyzer semantics are currently batch/snapshot based:
+
+- input is one completed run or stable snapshot
+- output is one report for that input
+- this crate does not do streaming analysis
+
+## Scope boundary with CLI
+
+Artifact loading/validation from files is owned by `tailtriage-cli`.
+
+Use `tailtriage-cli` when you want command-line artifact loading and report emission. Use `tailtriage-analyzer` when you want in-process Rust analysis.

--- a/tailtriage-analyzer/src/lib.rs
+++ b/tailtriage-analyzer/src/lib.rs
@@ -1,7 +1,7 @@
 //! Heuristic triage analyzer for completed [`tailtriage_core::Run`] captures.
 //!
 //! This crate analyzes a finished in-memory [`Run`] and returns a typed
-//! [`Report`] for in-process diagnosis. It does not load run artifacts from disk and it does not
+//! [`Report`] for in-process triage diagnosis. It does not load run artifacts from disk and it does not
 //! write capture artifacts.
 //!
 //! Use [`analyze_run`] (or [`Analyzer`]) to produce a [`Report`], then:

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -12,12 +12,12 @@ tailtriage
 
 ## What this tool does
 
-`tailtriage-cli` owns the analysis-side contract:
+`tailtriage-cli` owns the command-line artifact analysis contract:
 
 - load a captured artifact
 - validate schema compatibility
 - produce JSON or human-readable triage output
-- rank likely bottleneck families
+- emit analyzer-ranked bottleneck suspects
 - emit evidence and next checks
 
 The output is intended to guide the next investigation step. It does **not** prove root cause on its own.
@@ -143,10 +143,6 @@ Current contract:
 - `requests` must contain at least one request event
 - artifacts with an empty `requests` array are rejected by the CLI loader
 
-Library note:
-
-- the `tailtriage-analyzer` library API, `tailtriage_analyzer::analyze_run(&Run, AnalyzeOptions)`, can analyze an in-memory `Run` with zero requests
-- the stricter non-empty `requests` rule applies to CLI artifact loading from disk
 
 ## Important interpretation notes
 
@@ -214,3 +210,6 @@ Use capture-side crates for that:
 - `tailtriage-controller`: repeated bounded windows
 - `tailtriage-tokio`: runtime-pressure sampling
 - `tailtriage-axum`: Axum request-boundary integration
+
+
+Rust code users should use `tailtriage-analyzer` for in-process analysis APIs (`analyze_run`, `render_text`, `AnalyzeOptions`).


### PR DESCRIPTION
### Motivation

- Clarify public surface by making `tailtriage-analyzer` the in-process analyzer/report library and `tailtriage-cli` the command-line artifact loader/emitter. 
- Teach correct usage patterns for embedded Rust users vs CLI consumers without changing analyzer behavior or implying streaming analysis. 
- Keep the documentation contract strict and machine-validated so docs remain truthful about crate roles. 

### Description

- Updated top-level `README.md` with install guidance (`cargo add tailtriage-analyzer` / `cargo install tailtriage-cli`), an in-process analysis example using `tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions}`, and clarified capture vs analyze responsibilities. 
- Added `tailtriage-analyzer` to `SPEC.md` and split the analyzer vs CLI contract so the analyzer owns typed reports/rendering and the CLI owns artifact loading/validation and command-line report emission. 
- Revised `docs/*` pages (`docs/README.md`, `docs/user-guide.md`, `docs/diagnostics.md`, `docs/architecture.md`) to document the new split, add an embedded Rust in-process analysis section, state batch/snapshot (non-streaming) semantics, and include a short migration note from `tailtriage_cli::analyze::*` to `tailtriage_analyzer::*`. 
- Reworked crate READMEs: `tailtriage-analyzer/README.md` now documents the analyzer/report contract (purpose, install, typed `Report`, `render_text`, serde JSON, batch semantics), and `tailtriage-cli/README.md` is narrowed to CLI artifact loading/output behavior and points Rust users to `tailtriage-analyzer`. 
- Small rustdoc wording alignment in `tailtriage-analyzer/src/lib.rs` to emphasize in-process triage diagnosis and non-streaming semantics. 
- Strengthened docs-contract validator in `scripts/validate_docs_contracts.py` by adding `tailtriage-analyzer/README.md` to required user-facing links and adding `validate_cli_not_presented_as_library_analyzer_api()` which rejects docs that present `tailtriage-cli` as the library analyzer API; updated `README_DOC_MAP_REQUIRED_LINKS` accordingly. 
- Updated validator unit tests in `scripts/tests/test_validate_docs_contracts.py` to reflect the new required links and to exercise the new CLI-as-library-API detection. 

### Testing

- Ran `cargo fmt --check` and it succeeded. 
- Ran the docs validator `python3 scripts/validate_docs_contracts.py` and it reported success. 
- Ran unit tests `python3 -m unittest scripts.tests.test_validate_docs_contracts` and all tests passed. 
- Ran crate tests `cargo test -p tailtriage-analyzer` and `cargo test -p tailtriage-cli` and both test suites passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb54fcd2508330a29f08944239a887)