### PR TITLE
docs: teach analyzer crate vs CLI artifact-loader split

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,16 @@ cargo add tailtriage --features tokio
 cargo add tailtriage --features "tokio,axum"
 ```
 
-Install the CLI separately for analysis/report generation:
+Install the analyzer crate and CLI separately:
 
 ```bash
+cargo add tailtriage-analyzer
 cargo install tailtriage-cli
 ```
 
-> Library crates capture data. `tailtriage-cli` analyzes artifacts.
+- `tailtriage` captures run data in-process.
+- `tailtriage-analyzer` analyzes completed in-memory runs or stable snapshots in process.
+- `tailtriage-cli` loads run artifacts and emits reports from the command line.
 
 ## Why not just tokio-console or tokio-metrics?
 
@@ -135,6 +138,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+```
+
+### In-process analysis (Rust library)
+
+```rust
+use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+
+# use tailtriage_core::Run;
+# fn example(run: Run) -> Result<(), serde_json::Error> {
+let report = analyze_run(&run, AnalyzeOptions::default());
+let text = render_text(&report);
+let json = serde_json::to_string_pretty(&report)?;
+# let _ = (text, json);
+# Ok(())
+# }
 ```
 
 ### Analyze artifact (CLI)
@@ -284,7 +302,8 @@ Demo walkthrough and CI coverage details: [`docs/getting-started-demo.md`](docs/
 - User workflow guide: [`docs/user-guide.md`](docs/user-guide.md)
 - Controller docs and config: [`tailtriage-controller/README.md`](tailtriage-controller/README.md)
 - Runtime sampler docs: [`tailtriage-tokio/README.md`](tailtriage-tokio/README.md)
-- Analyzer/report contract: [`tailtriage-cli/README.md`](tailtriage-cli/README.md)
+- In-process analyzer/report contract: [`tailtriage-analyzer/README.md`](tailtriage-analyzer/README.md)
+- CLI artifact loading/report emission: [`tailtriage-cli/README.md`](tailtriage-cli/README.md)
 - Diagnostics field reference and interpretation: [`docs/diagnostics.md`](docs/diagnostics.md)
 - Demo walkthrough and recommended first demos: [`docs/getting-started-demo.md`](docs/getting-started-demo.md)
 - Runtime-overhead measurement path: [`docs/runtime-cost.md`](docs/runtime-cost.md)

--- a/SPEC.md
+++ b/SPEC.md
@@ -286,3 +286,13 @@ When behavior or public guidance changes, update relevant public docs together:
 - `docs/architecture.md`
 - relevant crate READMEs
 - relevant examples, demos, and tests
+
+
+## Analyzer and CLI split
+
+Workspace surface includes `tailtriage-analyzer` as the in-process analyzer/report crate and `tailtriage-cli` as the command-line artifact loader/report emitter.
+
+- `tailtriage-analyzer` owns typed `Report` generation, suspect ranking, interpretation warnings, and `render_text`.
+- `tailtriage-cli` owns artifact loading, schema validation, CLI UX, and output format selection.
+
+This split does not change product non-claims: suspects remain evidence-ranked leads, not proof of root cause.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,13 +4,14 @@ This is the canonical user-facing docs index for `tailtriage`.
 
 ## Start here
 
-- [User guide](user-guide.md) — default adoption path (`tailtriage` + `tailtriage-cli`) and the core capture -> analyze -> next check -> re-run workflow.
+- [User guide](user-guide.md) — default adoption path (`tailtriage` + `tailtriage-cli`) and in-process analyzer usage and the core capture -> analyze -> next check -> re-run workflow.
 - [Default crate README (`tailtriage`)](../tailtriage/README.md) — fastest way to integrate with one dependency.
 
 ## Core workflow and interpretation
 
 - [Diagnostics guide](diagnostics.md) — quick reading flow plus concise field reference for analyzer output.
-- [CLI README (`tailtriage-cli`)](../tailtriage-cli/README.md) — analyzer/report contract and CLI usage.
+- [Analyzer README (`tailtriage-analyzer`)](../tailtriage-analyzer/README.md) — in-process analyzer/report contract for Rust code.
+- [CLI README (`tailtriage-cli`)](../tailtriage-cli/README.md) — artifact loading and command-line report emission.
 
 ## Capture surfaces
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,3 +70,14 @@ It does not claim:
 - observability backend behavior
 - distributed-system root-cause proof
 - automatic causality certainty
+
+
+## Analysis crate split
+
+Conceptually, the analysis side flows as:
+
+```text
+tailtriage-core -> tailtriage-analyzer -> tailtriage-cli
+```
+
+`tailtriage-analyzer` owns typed report generation and text rendering for in-process usage. `tailtriage-cli` consumes that analyzer crate and performs file-based analysis by loading artifacts from disk, validating schema, then emitting text or JSON output for command-line workflows.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,6 +1,6 @@
 # Diagnostics guide
 
-This guide explains how `tailtriage analyze` turns one run artifact into a triage report.
+This guide explains how `tailtriage_analyzer::analyze_run` and `tailtriage analyze` both produce one triage report per run input (in-memory run for the library, artifact file for the CLI).
 
 ## Read one report quickly
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -7,12 +7,14 @@ This guide teaches the default `tailtriage` workflow for end users.
 For most services, use:
 
 - `tailtriage` for capture instrumentation
-- `tailtriage-cli` for analysis/report generation
+- `tailtriage-cli` for artifact analysis/report generation
+- `tailtriage-analyzer` for in-process analysis in Rust code
 
 Install:
 
 ```bash
 cargo add tailtriage
+cargo add tailtriage-analyzer
 cargo install tailtriage-cli
 ```
 
@@ -58,6 +60,25 @@ Read output in this order:
 3. `primary_suspect.next_checks[]`
 
 Then run one targeted check, change one thing, and re-run under comparable load.
+
+## 3) In-process analysis (embedded Rust users)
+
+For code-local analysis, use `tailtriage-analyzer` on a completed run (or stable snapshot):
+
+```rust
+use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+
+# use tailtriage_core::Run;
+# fn example(run: Run) -> Result<(), serde_json::Error> {
+let report = analyze_run(&run, AnalyzeOptions::default());
+let text = render_text(&report);
+let json = serde_json::to_string_pretty(&report)?;
+# let _ = (text, json);
+# Ok(())
+# }
+```
+
+Current semantics are batch/snapshot based: completed run or stable snapshot, not live streaming analysis.
 
 ## 3) Request lifecycle contract (required)
 

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -149,6 +149,9 @@ Normal CI does not publish durable diagnostic scorecards.
     def test_architecture_contract(self) -> None:
         validate_docs_contracts.validate_architecture_contract()
 
+    def test_cli_not_presented_as_library_api(self) -> None:
+        validate_docs_contracts.validate_cli_not_presented_as_library_api()
+
     def test_docs_no_history_framing(self) -> None:
         validate_docs_contracts.validate_docs_no_history_framing()
 
@@ -547,6 +550,7 @@ service_name initially_enabled mode strict_lifecycle capture_limits_override max
 - [Diag](diagnostics.md)
 - [Controller crate](../tailtriage-controller/README.md)
 - [Sampler crate](../tailtriage-tokio/README.md)
+- [Analyzer crate](../tailtriage-analyzer/README.md)
 - [CLI crate](../tailtriage-cli/README.md)
 - [Runtime cost notes](runtime-cost.md)
 - [Collector limits notes](collector-limits.md)

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -39,6 +39,7 @@ USER_FACING_TERMINOLOGY_PATHS = (
     REPO_ROOT / "tailtriage-tokio" / "README.md",
     REPO_ROOT / "tailtriage-axum" / "README.md",
     REPO_ROOT / "tailtriage-cli" / "README.md",
+    REPO_ROOT / "tailtriage-analyzer" / "README.md",
     REPO_ROOT / "tailtriage" / "src" / "lib.rs",
     REPO_ROOT / "tailtriage" / "Cargo.toml",
 )
@@ -55,6 +56,7 @@ DOCS_REQUIRED_LINKS = (
     "[Diagnostics guide](diagnostics.md)",
     "[Controller README (`tailtriage-controller`)](../tailtriage-controller/README.md)",
     "[Tokio runtime sampler README (`tailtriage-tokio`)](../tailtriage-tokio/README.md)",
+    "[Analyzer README (`tailtriage-analyzer`)](../tailtriage-analyzer/README.md)",
     "[CLI README (`tailtriage-cli`)](../tailtriage-cli/README.md)",
     "[Runtime cost measurement](runtime-cost.md)",
     "[Collector limits and stress guidance](collector-limits.md)",
@@ -66,6 +68,7 @@ README_DOC_MAP_REQUIRED_LINKS = (
     "(docs/user-guide.md)",
     "(tailtriage-controller/README.md)",
     "(tailtriage-tokio/README.md)",
+    "(tailtriage-analyzer/README.md)",
     "(tailtriage-cli/README.md)",
     "(docs/diagnostics.md)",
     "(docs/runtime-cost.md)",
@@ -622,6 +625,20 @@ def validate_architecture_contract() -> None:
             raise ValueError(f"architecture doc missing required product-contract token: {token}")
 
 
+
+
+def validate_cli_not_presented_as_library_api() -> None:
+    cli_text = (REPO_ROOT / "tailtriage-cli" / "README.md").read_text(encoding="utf-8")
+    disallowed = (
+        "tailtriage_cli::analyze",
+        "Library note",
+        "library analyzer api",
+    )
+    for token in disallowed:
+        if token.lower() in cli_text.lower():
+            raise ValueError(f"tailtriage-cli README contains stale library-analyzer wording: {token}")
+
+
 def validate_docs_no_history_framing() -> None:
     failures: list[str] = []
     for path in sorted(PUBLIC_DOCS_GLOB):
@@ -708,6 +725,7 @@ def main() -> int:
     validate_diagnostic_benchmark_ci_contract()
     validate_validation_docs_ci_contract()
     validate_architecture_contract()
+    validate_cli_not_presented_as_library_api()
     validate_docs_no_history_framing()
     validate_no_user_facing_facade_wording()
     validate_controller_example_usage_contract()

--- a/tailtriage-analyzer/README.md
+++ b/tailtriage-analyzer/README.md
@@ -1,8 +1,18 @@
 # tailtriage-analyzer
 
-`tailtriage-analyzer` analyzes an already completed `tailtriage_core::Run` and produces a typed triage report.
+`tailtriage-analyzer` is the in-process analyzer/report library for `tailtriage`.
 
-It is designed for in-process report generation from in-memory runs. It does not load run artifacts from disk, and it does not write run artifacts.
+Use it to analyze a completed `tailtriage_core::Run` (or a stable in-memory snapshot of one) and produce a typed triage report with evidence-ranked suspects and next checks.
+
+Suspects are leads, not proof of root cause.
+
+## Installation
+
+```bash
+cargo add tailtriage-analyzer
+```
+
+## In-process API
 
 ```rust
 use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
@@ -16,19 +26,42 @@ let report_json = serde_json::to_string_pretty(&report)?;
 # }
 ```
 
-- `Report` is the primary typed output for analyzer/report logic.
-- `render_text(&Report)` produces human-readable output.
-- `serde_json::to_string_pretty(&report)` produces analysis report JSON.
+## Typed report model
 
-## Run artifact JSON vs analysis report JSON
+`Report` is the analyzer contract for downstream Rust code:
 
-These are distinct outputs and both remain supported:
+- latency and share summaries
+- evidence-quality summary
+- primary and secondary suspects
+- optional route breakdowns
+- optional temporal segments
+- warnings and interpretation limits
 
-1. **Run artifact JSON**: raw captured run data produced by capture/shutdown or artifact-writing workflows. This remains part of capture/core/CLI artifact workflows and can still be analyzed later by the CLI.
-2. **Analysis report JSON**: output from analyzing a `Run`, represented by `tailtriage_analyzer::Report` and serialized with serde.
+Use `Report` directly for typed integration and tooling.
 
-Direct analyzer usage does not replace artifact generation and does not require parsing CLI stdout.
+## Rendering and JSON
 
-## Execution model
+- `render_text(&Report)` emits human-readable report text.
+- `serde_json::to_string_pretty(&report)` emits structured report JSON.
 
-Current analyzer semantics are batch/snapshot based for one completed run, not streaming.
+JSON is optional for Rust code users; the typed `Report` model is the primary in-process API.
+
+## Batch/snapshot semantics
+
+Analyzer execution is batch/snapshot based for one completed run (or stable snapshot). It is not live streaming analysis.
+
+## Artifact loading ownership
+
+Artifact loading/validation is CLI-owned. `tailtriage-analyzer` does not load run artifacts from disk.
+
+For file-based analysis from artifacts, use `tailtriage-cli`.
+
+## Migration note
+
+```rust
+// Old pre-0.1.x API, no longer the supported library analyzer path:
+use tailtriage_cli::analyze::{analyze_run, render_text};
+
+// New:
+use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+```

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -1,26 +1,8 @@
 # tailtriage-cli
 
-`tailtriage-cli` loads `tailtriage` run artifacts and turns them into a triage report.
+`tailtriage-cli` is the command-line artifact loader and report emitter for `tailtriage`.
 
-Install it after capture instrumentation is in place.
-
-The binary name is:
-
-```bash
-tailtriage
-```
-
-## What this tool does
-
-`tailtriage-cli` owns the analysis-side contract:
-
-- load a captured artifact
-- validate schema compatibility
-- produce JSON or human-readable triage output
-- rank likely bottleneck families
-- emit evidence and next checks
-
-The output is intended to guide the next investigation step. It does **not** prove root cause on its own.
+It loads captured run artifacts, validates schema compatibility, runs analysis, and emits triage reports as text or JSON.
 
 ## Installation
 
@@ -28,189 +10,43 @@ The output is intended to guide the next investigation step. It does **not** pro
 cargo install tailtriage-cli
 ```
 
-## Minimal usage
+Binary name:
 
-Default text output:
+```bash
+tailtriage
+```
+
+## Minimal usage
 
 ```bash
 tailtriage analyze tailtriage-run.json
-```
-
-Machine-readable JSON output:
-
-```bash
 tailtriage analyze tailtriage-run.json --format json
 ```
 
-The CLI artifact loader requires at least one request event in `requests`.
+## CLI-owned artifact contract
 
-## How to read the result
+The CLI loader validates artifact shape before analysis:
 
-Read output in this order:
+- top-level `schema_version` is required and must be a supported integer
+- `requests` must exist and be non-empty
+- unsupported schema versions are rejected
 
-1. `primary_suspect.kind`
-2. `primary_suspect.evidence[]`
-3. `primary_suspect.next_checks[]`
+The non-empty `requests` rule applies to CLI artifact loading.
 
-Then run one targeted check, change one thing, and re-run under comparable load.
+## Output selection
 
-## Representative output shape
+- default output is human-readable text
+- `--format json` emits the structured report JSON
 
-```json
-{
-  "request_count": 250,
-  "p50_latency_us": 782227,
-  "p95_latency_us": 1468239,
-  "p99_latency_us": 1518551,
-  "p95_queue_share_permille": 982,
-  "p95_service_share_permille": 267,
-  "inflight_trend": null,
-  "warnings": [],
-  "evidence_quality": {
-    "request_count": 250,
-    "queue_event_count": 250,
-    "stage_event_count": 250,
-    "runtime_snapshot_count": 0,
-    "inflight_snapshot_count": 0,
-    "requests": "present",
-    "queues": "present",
-    "stages": "present",
-    "runtime_snapshots": "missing",
-    "inflight_snapshots": "missing",
-    "truncated": false,
-    "dropped_requests": 0,
-    "dropped_stages": 0,
-    "dropped_queues": 0,
-    "dropped_inflight_snapshots": 0,
-    "dropped_runtime_snapshots": 0,
-    "quality": "strong",
-    "limitations": ["Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."]
-  },
-  "primary_suspect": {
-    "kind": "application_queue_saturation",
-    "score": 90,
-    "confidence": "high",
-    "evidence": ["Queue wait at p95 consumes 98.2% of request time."],
-    "next_checks": ["Inspect queue admission limits and producer burst patterns."],
-    "confidence_notes": []
-  },
-  "secondary_suspects": [],
-  "route_breakdowns": [],
-  "temporal_segments": []
-}
-```
+## Loader and lifecycle warnings
 
-`inflight_trend` may be `null` when no in-flight gauges were captured.
+`tailtriage analyze` may emit loader/lifecycle warnings to stderr before report output.
 
-`route_breakdowns` is always present in JSON output and is usually an empty array. It is populated only when at least two captured routes have enough completed requests and route-level context adds signal, such as different route-level primary suspects or a large route p95 latency spread. The global `primary_suspect` remains the primary full-run triage lead. Route breakdowns are supporting context only. They use route-attributed request, queue, and stage events. Runtime snapshots and in-flight gauges are global signals, so they are intentionally not attributed to individual routes. Route-level summaries do not prove per-route root cause.
+These warnings are separate from report `warnings[]` and help explain input/collection limitations.
 
-`temporal_segments` is always present in JSON output and is usually an empty array. It is populated only when conservative within-run early/late checks detect material signal movement. The global `primary_suspect` remains global and unchanged by segment generation. Temporal segments are within-run hints, not proof of phase-specific root cause. Report warnings can explicitly call out large early/late p95 movement. Runtime and in-flight phase attribution uses timestamp-filtered segment windows and is limited when segment-filtered samples are sparse; when early/late windows overlap under concurrency, that timestamp-filtered runtime/in-flight attribution is approximate.
+## Rust library users
 
-## What the report contains
+If you need in-process analysis in Rust code, use `tailtriage-analyzer`:
 
-A report can include:
-
-- request count
-- request latency percentiles (`p50`, `p95`, `p99`)
-- p95 queue/service share summaries
-- optional in-flight trend summary
-- report warnings from analysis/report generation (for example truncation-related)
-- structured evidence quality coverage/status summary
-- primary and secondary suspects
-
-`tailtriage analyze` also prints loader/lifecycle warnings to stderr before the report. Those warnings are surfaced separately; they are not merged into the report `warnings` field.
-
-Each suspect includes:
-
-- `kind`
-- `score`
-- `confidence`
-- `evidence[]`
-- `next_checks[]`
-- `confidence_notes[]` (present and empty unless evidence-aware caps affect confidence, or explicit ambiguity applies)
-
-## Artifact compatibility contract
-
-The `tailtriage analyze` workflow expects a supported `tailtriage` run artifact with minimum required content.
-
-Current contract:
-
-- top-level `schema_version` is required
-- missing `schema_version` is rejected
-- non-integer `schema_version` is rejected
-- unsupported `schema_version` is rejected
-- current supported schema version is `1`
-- `requests` must contain at least one request event
-- artifacts with an empty `requests` array are rejected by the CLI loader
-
-Library note:
-
-- the `tailtriage-analyzer` library API, `tailtriage_analyzer::analyze_run(&Run, AnalyzeOptions)`, can analyze an in-memory `Run` with zero requests
-- the stricter non-empty `requests` rule applies to CLI artifact loading from disk
-
-## Important interpretation notes
-
-- suspects are investigation leads, not proof of root cause
-- truncation warnings mean the diagnosis is based on partial retained data
-- unfinished lifecycle warnings printed by the CLI indicate some requests were not completed cleanly
-- `p95_queue_share_permille` and `p95_service_share_permille` are independent percentile summaries and do not need to sum to `1000`
-
-
-## Scoring and warning behavior
-
-Suspect ranking uses deterministic, proportional, evidence-aware scoring (0-100), not fixed suspect priority.
-
-- Scores rank suspects **inside one report**; they are not probabilities.
-- Confidence is score-derived ranking strength and may be evidence-quality capped; it is not causal certainty.
-- `confidence_notes[]` explain caps, including sparse samples, truncation, missing instrumentation, ambiguous top scores, and partial-vs-missing runtime snapshot limits.
-- Strong downstream tail-stage contribution can outrank weak blocking/runtime signals.
-- Strong queue pressure remains a high-confidence lead when queue share/depth evidence is dominant.
-
-How to read before/after runs:
-
-- Compare p95 latency movement first.
-- Confirm primary suspect kind/rank and evidence direction.
-- Use score movement as supporting context, not a standalone pass/fail rule.
-
-Why a score can stay flat or rise after mitigation:
-
-- Scores are relative to the evidence mix in each capture.
-- If total latency drops but the remaining tail is still dominated by one suspect family, that suspect score can remain high or increase.
-- This does not by itself mean mitigation failed when p95 and relevant evidence improve.
-
-`warnings[]` may include:
-
-- evidence-quality warnings (for example low request counts or missing signal families)
-- ambiguity warnings when top suspects are genuinely close after calibration
-- additive truncation warnings when capture limits drop events
-
-## Suspect kinds
-
-The current report surface includes these suspect kinds:
-
-- `application_queue_saturation`
-- `blocking_pool_pressure`
-- `executor_pressure_suspected`
-- `downstream_stage_dominates`
-- `insufficient_evidence`
-
-## When the result is `insufficient_evidence`
-
-Usually the next step is to add more structure to capture:
-
-- add queue wrappers around suspected waits
-- add stage wrappers around suspected downstream work
-- optionally add runtime sampling if runtime pressure is unclear
-- re-run under comparable load
-
-## What this tool does not do
-
-`tailtriage-cli` does not capture instrumentation data.
-
-Use capture-side crates for that:
-
-- `tailtriage`: recommended capture-side entry point
-- `tailtriage-core`: direct instrumentation primitives
-- `tailtriage-controller`: repeated bounded windows
-- `tailtriage-tokio`: runtime-pressure sampling
-- `tailtriage-axum`: Axum request-boundary integration
+- `tailtriage_analyzer::analyze_run(&Run, AnalyzeOptions)`
+- `tailtriage_analyzer::render_text(&Report)`


### PR DESCRIPTION
### Motivation
- Clarify public guidance that analysis is provided by a new in-process crate (`tailtriage-analyzer`) while the CLI (`tailtriage-cli`) is a file/artifact loader and report emitter.  
- Prevent accidental framing of the CLI as the library analyzer API and avoid implying streaming analysis or that JSON output is required for code users.  
- Keep the documentation contract strict and machine-checked so docs remain truthful to the new crate split and public API surface.  

### Description
- Updated the root `README.md` to document the split, add install guidance (`cargo add tailtriage-analyzer` and `cargo install tailtriage-cli`), and include a concise in-process analyzer example using `analyze_run`, `render_text`, and `AnalyzeOptions`.  
- Added a full `tailtriage-analyzer/README.md` that documents purpose, installation, typed `Report` contract, `render_text`, serde JSON usage (optional), batch/snapshot semantics (no streaming), and a migration note away from the old `tailtriage_cli::analyze::*` usage.  
- Narrowed `tailtriage-cli/README.md` to CLI responsibilities (artifact loading, schema validation, non-empty `requests` rule, output selection, and stderr loader/lifecycle warnings) and explicitly point Rust code users to `tailtriage-analyzer`.  
- Updated user-facing docs (`docs/README.md`, `docs/user-guide.md`, `docs/diagnostics.md`, `docs/architecture.md`, `SPEC.md`) to reflect crate roles, the conceptual flow (`tailtriage-core -> tailtriage-analyzer -> tailtriage-cli`), and the in-process analysis example.  
- Extended the docs-contract validator (`scripts/validate_docs_contracts.py`) and its tests (`scripts/tests/test_validate_docs_contracts.py`) to include the new analyzer README in required links and terminology scans and to add a check that the CLI README does not present the CLI as the library analyzer API.  

### Testing
- Ran `cargo fmt --check` and it passed.  
- Ran `python3 scripts/validate_docs_contracts.py` and it reported: `docs contracts validated successfully`.  
- Ran `python3 -m unittest scripts.tests.test_validate_docs_contracts` and all tests passed.  
- Ran `cargo test -p tailtriage-analyzer` and `cargo test -p tailtriage-cli` and both test suites succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb54fcd2508330a29f08944239a887)