### PR TITLE
docs: teach analyzer/CLI split and enforce docs contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,14 @@ cargo add tailtriage --features tokio
 cargo add tailtriage --features "tokio,axum"
 ```
 
-Install the CLI separately for analysis/report generation:
+Install analyzer/report tooling based on how you work:
 
 ```bash
+cargo add tailtriage-analyzer
 cargo install tailtriage-cli
 ```
 
-> Library crates capture data. `tailtriage-cli` analyzes artifacts.
+`tailtriage` captures request/runtime evidence. `tailtriage-analyzer` analyzes completed in-memory runs or stable snapshots in process. `tailtriage-cli` analyzes saved run artifacts from the command line.
 
 ## Why not just tokio-console or tokio-metrics?
 
@@ -135,6 +136,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+```
+
+### In-process analysis (library)
+
+```rust
+use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+
+# use tailtriage_core::Run;
+# fn example(run: Run) -> Result<(), serde_json::Error> {
+let report = analyze_run(&run, AnalyzeOptions::default());
+let text = render_text(&report);
+let json = serde_json::to_string_pretty(&report)?;
+# let _ = (text, json);
+# Ok(())
+# }
 ```
 
 ### Analyze artifact (CLI)
@@ -284,7 +300,8 @@ Demo walkthrough and CI coverage details: [`docs/getting-started-demo.md`](docs/
 - User workflow guide: [`docs/user-guide.md`](docs/user-guide.md)
 - Controller docs and config: [`tailtriage-controller/README.md`](tailtriage-controller/README.md)
 - Runtime sampler docs: [`tailtriage-tokio/README.md`](tailtriage-tokio/README.md)
-- Analyzer/report contract: [`tailtriage-cli/README.md`](tailtriage-cli/README.md)
+- In-process analyzer/report contract: [`tailtriage-analyzer/README.md`](tailtriage-analyzer/README.md)
+- CLI artifact loader/report emitter: [`tailtriage-cli/README.md`](tailtriage-cli/README.md)
 - Diagnostics field reference and interpretation: [`docs/diagnostics.md`](docs/diagnostics.md)
 - Demo walkthrough and recommended first demos: [`docs/getting-started-demo.md`](docs/getting-started-demo.md)
 - Runtime-overhead measurement path: [`docs/runtime-cost.md`](docs/runtime-cost.md)

--- a/SPEC.md
+++ b/SPEC.md
@@ -42,6 +42,7 @@ Current workspace members include:
 - `tailtriage-controller`
 - `tailtriage-tokio`
 - `tailtriage-axum`
+- `tailtriage-analyzer`
 - `tailtriage-cli`
 - demos crates under `demos/`
 
@@ -129,9 +130,19 @@ Semantics:
 - middleware starts/finishes request lifecycle at boundary
 - extractor exposes request handle for explicit queue/stage/inflight instrumentation
 
-### 5.8 Analyzer CLI (`tailtriage-cli`)
+### 5.8 In-process analyzer (`tailtriage-analyzer`)
 
-`tailtriage-cli` analyzes artifacts and renders text/JSON reports.
+`tailtriage-analyzer` owns typed report generation from completed runs:
+
+- `analyze_run(&Run, AnalyzeOptions) -> Report`
+- `render_text(&Report)` for human-readable output
+- serde-serializable `Report` JSON
+
+Semantics are batch/snapshot for completed runs, not streaming analysis.
+
+### 5.9 Analyzer CLI (`tailtriage-cli`)
+
+`tailtriage-cli` owns artifact loading + command-line report emission and uses `tailtriage-analyzer` for analysis logic.
 
 Primary command:
 
@@ -139,7 +150,7 @@ Primary command:
 tailtriage analyze <run.json>
 ```
 
-## 6. Run artifact and analyzer contract
+## 6. Run artifact, analyzer, and CLI contracts
 
 Run artifacts include request, stage, queue, in-flight, and optional runtime snapshot data plus metadata/truncation context.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,8 +22,6 @@ This is the canonical user-facing docs index for `tailtriage`.
 ## Practical measurement guidance
 
 - [Diagnostic validation](diagnostic-validation.md) — corpus-driven diagnostic quality validation methodology and metrics.
-
-
 - [Runtime cost measurement](runtime-cost.md) — reproducible overhead attribution path (baked-in, core, sampler, post-limit/drop-path).
 - [Collector limits and stress guidance](collector-limits.md) — sustained-load truncation onset, artifact-size growth, and memory trend interpretation.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,13 +4,15 @@ This is the canonical user-facing docs index for `tailtriage`.
 
 ## Start here
 
-- [User guide](user-guide.md) — default adoption path (`tailtriage` + `tailtriage-cli`) and the core capture -> analyze -> next check -> re-run workflow.
+- [User guide](user-guide.md) — default CLI workflow plus concise in-process analysis guidance for Rust users.
 - [Default crate README (`tailtriage`)](../tailtriage/README.md) — fastest way to integrate with one dependency.
 
 ## Core workflow and interpretation
 
 - [Diagnostics guide](diagnostics.md) — quick reading flow plus concise field reference for analyzer output.
-- [CLI README (`tailtriage-cli`)](../tailtriage-cli/README.md) — analyzer/report contract and CLI usage.
+- [Analyzer README (`tailtriage-analyzer`)](../tailtriage-analyzer/README.md) — in-process analyzer/report contract.
+
+- [CLI README (`tailtriage-cli`)](../tailtriage-cli/README.md) — artifact loader and report-emitter CLI contract.
 
 ## Capture surfaces
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,6 @@ This is the canonical user-facing docs index for `tailtriage`.
 
 - [Diagnostics guide](diagnostics.md) — quick reading flow plus concise field reference for analyzer output.
 - [Analyzer README (`tailtriage-analyzer`)](../tailtriage-analyzer/README.md) — in-process analyzer/report contract.
-
 - [CLI README (`tailtriage-cli`)](../tailtriage-cli/README.md) — artifact loader and report-emitter CLI contract.
 
 ## Capture surfaces

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@ The default user path is:
 1. instrument capture in service code (`tailtriage` default crate)
 2. optionally enrich with runtime sampling (`tailtriage-tokio`)
 3. write local run artifact JSON
-4. analyze artifact with `tailtriage-cli`
+4. analyze with `tailtriage-analyzer` in process or with `tailtriage-cli` for file artifacts
 
 The result is a triage report with evidence-ranked suspects and next checks.
 
@@ -49,9 +49,18 @@ Adds optional runtime-pressure snapshots to the same run artifact via `RuntimeSa
 
 Adds optional Axum request-boundary ergonomics (middleware + extractor).
 
+### `tailtriage-analyzer`
+
+Owns in-process analysis/report generation from completed runs:
+
+- typed `Report` model
+- `analyze_run` entry point
+- `render_text` human-readable rendering
+- serde-serializable report JSON
+
 ### `tailtriage-cli`
 
-Consumes run artifacts and emits diagnosis reports (text/JSON).
+Consumes run artifacts from disk, validates schema/loader rules, invokes `tailtriage-analyzer`, and emits text/JSON output.
 
 ## Relationship model
 
@@ -70,3 +79,10 @@ It does not claim:
 - observability backend behavior
 - distributed-system root-cause proof
 - automatic causality certainty
+
+
+## Conceptual dependency flow
+
+`tailtriage-core -> tailtriage-analyzer -> tailtriage-cli`
+
+The CLI performs file-based analysis by loading artifacts, then consuming the analyzer crate for triage/report generation.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,6 +1,6 @@
 # Diagnostics guide
 
-This guide explains how `tailtriage analyze` turns one run artifact into a triage report.
+This guide explains analyzer report interpretation for both `tailtriage_analyzer::analyze_run` and `tailtriage analyze`.
 
 ## Read one report quickly
 
@@ -24,7 +24,7 @@ Current supported schema version: `1`.
 
 ## Report contents
 
-`tailtriage analyze <run.json>` outputs:
+Analyzer reports (from `analyze_run` or `tailtriage analyze <run.json>`) include:
 
 - request count
 - request latency percentiles (`p50`, `p95`, `p99`)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -7,12 +7,13 @@ This guide teaches the default `tailtriage` workflow for end users.
 For most services, use:
 
 - `tailtriage` for capture instrumentation
-- `tailtriage-cli` for analysis/report generation
+- `tailtriage-cli` for artifact analysis/report generation
 
 Install:
 
 ```bash
 cargo add tailtriage
+cargo add tailtriage-analyzer
 cargo install tailtriage-cli
 ```
 
@@ -59,7 +60,27 @@ Read output in this order:
 
 Then run one targeted check, change one thing, and re-run under comparable load.
 
-## 3) Request lifecycle contract (required)
+
+## 3) In-process analysis (embedded Rust)
+
+If you want analysis/report generation inside service code or tests, use `tailtriage-analyzer`:
+
+```rust
+use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+
+# use tailtriage_core::Run;
+# fn example(run: Run) -> Result<(), serde_json::Error> {
+let report = analyze_run(&run, AnalyzeOptions::default());
+let text = render_text(&report);
+let json = serde_json::to_string_pretty(&report)?;
+# let _ = (text, json);
+# Ok(())
+# }
+```
+
+Current analyzer semantics are completed-run or stable-snapshot batch analysis, not live streaming analysis.
+
+## 4) Request lifecycle contract (required)
 
 `begin_request(...)` / `begin_request_with(...)` returns `StartedRequest`:
 
@@ -88,7 +109,7 @@ Important semantics:
 - `shutdown()` does not fabricate completion/outcome
 - `strict_lifecycle(true)` can fail shutdown when unfinished requests remain
 
-## 4) Direct capture vs controller
+## 5) Direct capture vs controller
 
 Use **direct capture** (`Tailtriage`) when you want a straightforward run lifecycle in app code.
 
@@ -120,7 +141,7 @@ let _ = controller.disable()?;
 
 Controller details: [tailtriage-controller/README.md](../tailtriage-controller/README.md)
 
-## 5) Controller TOML config and reload semantics
+## 6) Controller TOML config and reload semantics
 
 Controller config is for repeatable operational settings across environments.
 
@@ -149,7 +170,7 @@ At contract level:
 
 See crate README for the full TOML field reference and expanded starter example: [tailtriage-controller/README.md](../tailtriage-controller/README.md)
 
-## 6) Runtime sampler: when and why
+## 7) Runtime sampler: when and why
 
 Add runtime sampling when request timing alone does not clearly separate:
 
@@ -168,7 +189,7 @@ Key constraints:
 
 Sampler details: [tailtriage-tokio/README.md](../tailtriage-tokio/README.md)
 
-## 7) Axum adapter: what it is and is not
+## 8) Axum adapter: what it is and is not
 
 `tailtriage-axum` is a framework-boundary ergonomics layer:
 
@@ -179,7 +200,7 @@ It is not automatic diagnosis. Queue/stage/inflight instrumentation is still exp
 
 Adapter details: [tailtriage-axum/README.md](../tailtriage-axum/README.md)
 
-## 8) What to do when result is `insufficient_evidence`
+## 9) What to do when result is `insufficient_evidence`
 
 When `primary_suspect.kind` is `insufficient_evidence`:
 
@@ -190,7 +211,7 @@ When `primary_suspect.kind` is `insufficient_evidence`:
 
 Use [diagnostics.md](diagnostics.md) for interpretation details.
 
-## 9) Next docs
+## 10) Next docs
 
 - [Documentation index](README.md)
 - [Diagnostics guide](diagnostics.md)

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -182,6 +182,60 @@ Normal CI does not publish durable diagnostic scorecards.
                 with self.assertRaisesRegex(ValueError, r"tailtriage_cli::analyze"):
                     validate_docs_contracts.validate_cli_not_presented_as_library_analyzer_api()
 
+    def test_analyzer_readme_migration_note_allows_old_token_only_in_migration_block(self) -> None:
+        readme_text = """# tailtriage-analyzer
+
+## Migration note
+
+```rust
+use tailtriage_cli::analyze::{analyze_run, render_text};
+```
+"""
+        stripped = validate_docs_contracts._strip_allowed_analyzer_migration_note(readme_text)
+        self.assertNotIn("tailtriage_cli::analyze", stripped)
+
+    def test_analyzer_readme_contract_fails_on_old_token_outside_migration_note(self) -> None:
+        analyzer_text = """# tailtriage-analyzer
+
+Use `tailtriage_cli::analyze` in this section.
+
+## Migration note
+
+```rust
+use tailtriage_cli::analyze::{analyze_run, render_text};
+```
+"""
+        clean_text = "# tailtriage docs"
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            root_readme = repo_root / "README.md"
+            docs_index = repo_root / "docs" / "README.md"
+            user_guide = repo_root / "docs" / "user-guide.md"
+            diagnostics = repo_root / "docs" / "diagnostics.md"
+            architecture = repo_root / "docs" / "architecture.md"
+            cli_readme = repo_root / "tailtriage-cli" / "README.md"
+            analyzer_readme = repo_root / "tailtriage-analyzer" / "README.md"
+            for path in (docs_index, user_guide, diagnostics, architecture, cli_readme, analyzer_readme):
+                path.parent.mkdir(parents=True, exist_ok=True)
+            root_readme.write_text(clean_text, encoding="utf-8")
+            docs_index.write_text(clean_text, encoding="utf-8")
+            user_guide.write_text(clean_text, encoding="utf-8")
+            diagnostics.write_text(clean_text, encoding="utf-8")
+            architecture.write_text(clean_text, encoding="utf-8")
+            cli_readme.write_text(clean_text, encoding="utf-8")
+            analyzer_readme.write_text(analyzer_text, encoding="utf-8")
+
+            with (
+                mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root),
+                mock.patch.object(validate_docs_contracts, "README_PATH", root_readme),
+                mock.patch.object(validate_docs_contracts, "DOCS_INDEX_PATH", docs_index),
+                mock.patch.object(validate_docs_contracts, "USER_GUIDE_PATH", user_guide),
+                mock.patch.object(validate_docs_contracts, "DIAGNOSTICS_PATH", diagnostics),
+                mock.patch.object(validate_docs_contracts, "ARCHITECTURE_PATH", architecture),
+            ):
+                with self.assertRaisesRegex(ValueError, r"tailtriage_cli::analyze"):
+                    validate_docs_contracts.validate_cli_not_presented_as_library_analyzer_api()
+
     def test_controller_readme_does_not_use_misleading_dependency_example_flow(self) -> None:
         readme_text = validate_docs_contracts.CONTROLLER_README_PATH.read_text(encoding="utf-8")
         self.assertFalse(validate_docs_contracts.is_misleading_controller_example_flow(readme_text))

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -146,6 +146,10 @@ Normal CI does not publish durable diagnostic scorecards.
                     doc_paths=(doc_path,)
                 )
 
+
+    def test_cli_not_presented_as_library_analyzer_api_contract(self) -> None:
+        validate_docs_contracts.validate_cli_not_presented_as_library_analyzer_api()
+
     def test_architecture_contract(self) -> None:
         validate_docs_contracts.validate_architecture_contract()
 
@@ -167,6 +171,16 @@ Normal CI does not publish durable diagnostic scorecards.
             ):
                 with self.assertRaisesRegex(ValueError, r"stale facade wording"):
                     validate_docs_contracts.validate_no_user_facing_facade_wording()
+
+
+    def test_cli_library_analyzer_api_contract_fails_on_banned_token(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            temp_path = Path(tmp_dir) / "README.md"
+            temp_path.write_text("use tailtriage_cli::analyze::{analyze_run, render_text};", encoding="utf-8")
+
+            with mock.patch.object(validate_docs_contracts, "README_PATH", temp_path):
+                with self.assertRaisesRegex(ValueError, r"tailtriage_cli::analyze"):
+                    validate_docs_contracts.validate_cli_not_presented_as_library_analyzer_api()
 
     def test_controller_readme_does_not_use_misleading_dependency_example_flow(self) -> None:
         readme_text = validate_docs_contracts.CONTROLLER_README_PATH.read_text(encoding="utf-8")
@@ -547,6 +561,7 @@ service_name initially_enabled mode strict_lifecycle capture_limits_override max
 - [Diag](diagnostics.md)
 - [Controller crate](../tailtriage-controller/README.md)
 - [Sampler crate](../tailtriage-tokio/README.md)
+- [Analyzer crate](../tailtriage-analyzer/README.md)
 - [CLI crate](../tailtriage-cli/README.md)
 - [Runtime cost notes](runtime-cost.md)
 - [Collector limits notes](collector-limits.md)

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -520,18 +520,51 @@ def validate_diagnostics_contract_truthfulness() -> None:
 
 
 
+def _strip_allowed_analyzer_migration_note(text: str) -> str:
+    """Allow old API token only in the dedicated migration-note example block."""
+    marker = "## Migration note"
+    marker_index = text.find(marker)
+    if marker_index < 0:
+        return text
+
+    migration_section = text[marker_index:]
+    migration_block_pattern = re.compile(r"```rust\n(.*?)\n```", re.DOTALL)
+    block_match = migration_block_pattern.search(migration_section)
+    if block_match is None:
+        return text
+
+    block = block_match.group(1)
+    if "tailtriage_cli::analyze" not in block:
+        return text
+
+    start = marker_index + block_match.start(1)
+    end = marker_index + block_match.end(1)
+    return text[:start] + text[end:]
+
+
 def validate_cli_not_presented_as_library_analyzer_api() -> None:
-    paths = (README_PATH, DOCS_INDEX_PATH, USER_GUIDE_PATH, DIAGNOSTICS_PATH, ARCHITECTURE_PATH, REPO_ROOT / "tailtriage-cli" / "README.md")
+    paths = (
+        README_PATH,
+        DOCS_INDEX_PATH,
+        USER_GUIDE_PATH,
+        DIAGNOSTICS_PATH,
+        ARCHITECTURE_PATH,
+        REPO_ROOT / "tailtriage-cli" / "README.md",
+        REPO_ROOT / "tailtriage-analyzer" / "README.md",
+    )
     banned_tokens = ("tailtriage_cli::analyze",)
     hits: list[str] = []
     for path in paths:
         text = path.read_text(encoding="utf-8")
+        scan_text = text
+        if path == REPO_ROOT / "tailtriage-analyzer" / "README.md":
+            scan_text = _strip_allowed_analyzer_migration_note(text)
         lowered = text.lower()
         if "tailtriage-cli" in lowered and "library analyzer api" in lowered:
             rel = path.relative_to(REPO_ROOT) if path.is_relative_to(REPO_ROOT) else path
             hits.append(f"{rel} presents tailtriage-cli as library analyzer API")
         for token in banned_tokens:
-            if token in text:
+            if token in scan_text:
                 rel = path.relative_to(REPO_ROOT) if path.is_relative_to(REPO_ROOT) else path
                 hits.append(f"{rel} contains banned token: {token}")
     if hits:

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -38,6 +38,7 @@ USER_FACING_TERMINOLOGY_PATHS = (
     REPO_ROOT / "tailtriage-controller" / "README.md",
     REPO_ROOT / "tailtriage-tokio" / "README.md",
     REPO_ROOT / "tailtriage-axum" / "README.md",
+    REPO_ROOT / "tailtriage-analyzer" / "README.md",
     REPO_ROOT / "tailtriage-cli" / "README.md",
     REPO_ROOT / "tailtriage" / "src" / "lib.rs",
     REPO_ROOT / "tailtriage" / "Cargo.toml",
@@ -55,6 +56,7 @@ DOCS_REQUIRED_LINKS = (
     "[Diagnostics guide](diagnostics.md)",
     "[Controller README (`tailtriage-controller`)](../tailtriage-controller/README.md)",
     "[Tokio runtime sampler README (`tailtriage-tokio`)](../tailtriage-tokio/README.md)",
+    "[Analyzer README (`tailtriage-analyzer`)](../tailtriage-analyzer/README.md)",
     "[CLI README (`tailtriage-cli`)](../tailtriage-cli/README.md)",
     "[Runtime cost measurement](runtime-cost.md)",
     "[Collector limits and stress guidance](collector-limits.md)",
@@ -66,6 +68,7 @@ README_DOC_MAP_REQUIRED_LINKS = (
     "(docs/user-guide.md)",
     "(tailtriage-controller/README.md)",
     "(tailtriage-tokio/README.md)",
+    "(tailtriage-analyzer/README.md)",
     "(tailtriage-cli/README.md)",
     "(docs/diagnostics.md)",
     "(docs/runtime-cost.md)",
@@ -516,6 +519,24 @@ def validate_diagnostics_contract_truthfulness() -> None:
         )
 
 
+
+def validate_cli_not_presented_as_library_analyzer_api() -> None:
+    paths = (README_PATH, DOCS_INDEX_PATH, USER_GUIDE_PATH, DIAGNOSTICS_PATH, ARCHITECTURE_PATH, REPO_ROOT / "tailtriage-cli" / "README.md")
+    banned_tokens = ("tailtriage_cli::analyze",)
+    hits: list[str] = []
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        lowered = text.lower()
+        if "tailtriage-cli" in lowered and "library analyzer api" in lowered:
+            rel = path.relative_to(REPO_ROOT) if path.is_relative_to(REPO_ROOT) else path
+            hits.append(f"{rel} presents tailtriage-cli as library analyzer API")
+        for token in banned_tokens:
+            if token in text:
+                rel = path.relative_to(REPO_ROOT) if path.is_relative_to(REPO_ROOT) else path
+                hits.append(f"{rel} contains banned token: {token}")
+    if hits:
+        raise ValueError("CLI/library analyzer contract violation:\n" + "\n".join(hits))
+
 def _active_yaml_lines(text: str) -> str:
     return "\n".join(line for line in text.splitlines() if not line.lstrip().startswith("#"))
 
@@ -705,6 +726,7 @@ def main() -> int:
     validate_root_readme_docs_map_parity()
     validate_user_guide_contract()
     validate_diagnostics_contract_truthfulness()
+    validate_cli_not_presented_as_library_analyzer_api()
     validate_diagnostic_benchmark_ci_contract()
     validate_validation_docs_ci_contract()
     validate_architecture_contract()

--- a/tailtriage-analyzer/README.md
+++ b/tailtriage-analyzer/README.md
@@ -1,8 +1,16 @@
 # tailtriage-analyzer
 
-`tailtriage-analyzer` analyzes an already completed `tailtriage_core::Run` and produces a typed triage report.
+`tailtriage-analyzer` is the in-process analyzer/report crate for `tailtriage`.
 
-It is designed for in-process report generation from in-memory runs. It does not load run artifacts from disk, and it does not write run artifacts.
+It analyzes a completed in-memory `tailtriage_core::Run` (or stable snapshot equivalent) and returns a typed triage report with evidence-ranked suspects and next checks.
+
+## Installation
+
+```bash
+cargo add tailtriage-analyzer
+```
+
+## In-process API
 
 ```rust
 use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
@@ -10,25 +18,41 @@ use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
 # fn example(run: Run) -> Result<(), serde_json::Error> {
 let report = analyze_run(&run, AnalyzeOptions::default());
 let text = render_text(&report);
-let report_json = serde_json::to_string_pretty(&report)?;
-# let _ = (text, report_json);
+let json = serde_json::to_string_pretty(&report)?;
+# let _ = (text, json);
 # Ok(())
 # }
 ```
 
-- `Report` is the primary typed output for analyzer/report logic.
-- `render_text(&Report)` produces human-readable output.
-- `serde_json::to_string_pretty(&report)` produces analysis report JSON.
+## Report contract
 
-## Run artifact JSON vs analysis report JSON
+- `Report` is the typed analyzer output model.
+- `render_text(&Report)` renders a human-readable triage report.
+- `serde_json::to_string_pretty(&report)` serializes the same typed report as JSON.
 
-These are distinct outputs and both remain supported:
+Suspects are investigation leads, not proof of root cause.
 
-1. **Run artifact JSON**: raw captured run data produced by capture/shutdown or artifact-writing workflows. This remains part of capture/core/CLI artifact workflows and can still be analyzed later by the CLI.
-2. **Analysis report JSON**: output from analyzing a `Run`, represented by `tailtriage_analyzer::Report` and serialized with serde.
+## Semantics and boundaries
 
-Direct analyzer usage does not replace artifact generation and does not require parsing CLI stdout.
+- Batch/snapshot analysis of one completed run.
+- Not streaming analysis.
+- Artifact loading from disk is CLI-owned (`tailtriage-cli`).
 
-## Execution model
+## Report fields (overview)
 
-Current analyzer semantics are batch/snapshot based for one completed run, not streaming.
+`Report` includes request counts, latency percentiles, queue/service share summaries, warnings, evidence quality, ranked suspects, and optional supporting route/temporal sections.
+
+See root docs for interpretation guidance:
+
+- [`docs/diagnostics.md`](../docs/diagnostics.md)
+- [`docs/user-guide.md`](../docs/user-guide.md)
+
+## Migration note
+
+```rust
+// Old pre-0.1.x API, no longer the supported library analyzer path:
+use tailtriage_cli::analyze::{analyze_run, render_text};
+
+// New:
+use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+```

--- a/tailtriage-analyzer/src/lib.rs
+++ b/tailtriage-analyzer/src/lib.rs
@@ -1,8 +1,8 @@
 //! Heuristic triage analyzer for completed [`tailtriage_core::Run`] captures.
 //!
-//! This crate analyzes a finished in-memory [`Run`] and returns a typed
+//! This crate analyzes a finished in-memory [`Run`] (or stable snapshot equivalent) and returns a typed
 //! [`Report`] for in-process diagnosis. It does not load run artifacts from disk and it does not
-//! write capture artifacts.
+//! write capture artifacts; CLI artifact loading is owned by `tailtriage-cli`.
 //!
 //! Use [`analyze_run`] (or [`Analyzer`]) to produce a [`Report`], then:
 //!

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -12,12 +12,12 @@ tailtriage
 
 ## What this tool does
 
-`tailtriage-cli` owns the analysis-side contract:
+`tailtriage-cli` owns the command-line artifact-analysis contract:
 
 - load a captured artifact
 - validate schema compatibility
 - produce JSON or human-readable triage output
-- rank likely bottleneck families
+- run analyzer logic on loaded artifacts and rank likely bottleneck families
 - emit evidence and next checks
 
 The output is intended to guide the next investigation step. It does **not** prove root cause on its own.
@@ -143,10 +143,8 @@ Current contract:
 - `requests` must contain at least one request event
 - artifacts with an empty `requests` array are rejected by the CLI loader
 
-Library note:
-
-- the `tailtriage-analyzer` library API, `tailtriage_analyzer::analyze_run(&Run, AnalyzeOptions)`, can analyze an in-memory `Run` with zero requests
-- the stricter non-empty `requests` rule applies to CLI artifact loading from disk
+For Rust in-process usage, use `tailtriage-analyzer` directly (`analyze_run`, `render_text`, typed `Report`).
+The stricter non-empty `requests` rule applies to CLI artifact loading from disk.
 
 ## Important interpretation notes
 

--- a/tailtriage-cli/src/lib.rs
+++ b/tailtriage-cli/src/lib.rs
@@ -1,5 +1,8 @@
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
 
+//! `tailtriage-cli` is the command-line artifact loader and report emitter.
+//! For in-process Rust analysis/report APIs, use `tailtriage-analyzer`.
+
 /// Artifact loading and validation helpers for CLI workflows.
 pub mod artifact;


### PR DESCRIPTION
### Motivation
- Clarify the public surface: capture is provided by `tailtriage`, analysis/reporting is split between an in-process library `tailtriage-analyzer` and a CLI `tailtriage-cli` that loads artifacts and emits reports.  This keeps the product story narrow and avoids implying the CLI is a library analyzer API or that analysis is streaming. 
- Keep the docs contract truthful and enforceable by extending the validator to reflect the new crate split so user-facing docs remain consistent.

### Description
- Updated root and docs pages (`README.md`, `docs/README.md`, `docs/user-guide.md`, `docs/diagnostics.md`, `docs/architecture.md`, `SPEC.md`) to teach: `tailtriage` captures, `tailtriage-analyzer` is the in-process analyzer for completed runs/snapshots, and `tailtriage-cli` is the artifact-loading CLI that invokes analyzer logic for file artifacts; added install snippets and an in-process API example. 
- Created/rewrote analyzer-focused docs (`tailtriage-analyzer/README.md`) to document purpose, install, in-process API example, typed `Report` model, `render_text`, serde JSON, batch/snapshot (non-streaming) semantics, and a migration note from the old `tailtriage_cli::analyze` usage. 
- Narrowed CLI docs (`tailtriage-cli/README.md`) and crate rustdoc to present `tailtriage-cli` as the command-line artifact loader/report-emitter and direct Rust library users to `tailtriage-analyzer`. 
- Adjusted analyzer crate rustdoc to explicitly note that CLI-owned artifact loading is separate. 
- Extended the docs validator (`scripts/validate_docs_contracts.py`) and its unit tests to: include `tailtriage-analyzer/README.md` in required doc links, enforce that docs do not present `tailtriage-cli` as the library analyzer API, and ban occurrences of the old `tailtriage_cli::analyze` library token in user-facing docs; added test coverage (`scripts/tests/test_validate_docs_contracts.py`) for the new checks. 
- Small text and index fixes across the docs to keep the default CLI workflow while adding concise in-process guidance; no analyzer or CLI runtime behavior code was changed.

### Testing
- Ran `cargo fmt --check` and it succeeded. 
- Ran the docs validator `python3 scripts/validate_docs_contracts.py` and it reported: `docs contracts validated successfully`. 
- Ran unit tests `python3 -m unittest scripts.tests.test_validate_docs_contracts` and all tests passed. 
- Ran crate tests `cargo test -p tailtriage-analyzer` and `cargo test -p tailtriage-cli` and both test suites passed. 

All automated checks listed in the task were executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb54fcd2508330a29f08944239a887)