### PR TITLE
Harden tailtriage-cli boundary around analyzer extraction

### DIFF
--- a/tailtriage-cli/src/artifact.rs
+++ b/tailtriage-cli/src/artifact.rs
@@ -205,6 +205,9 @@ fn parse_error_message(error: &serde_json::Error) -> String {
 
 #[cfg(test)]
 mod tests {
+    use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
+    use tailtriage_core::Run;
+
     use super::load_run_artifact;
 
     #[test]
@@ -244,6 +247,16 @@ mod tests {
         let message = error.to_string();
 
         assert!(message.contains("requests section is empty"));
+    }
+
+    #[test]
+    fn analyzer_accepts_in_memory_zero_request_run() {
+        let run: Run = serde_json::from_str(&valid_run_json_with_requests("[]"))
+            .expect("in-memory run should deserialize");
+
+        let report = analyze_run(&run, AnalyzeOptions::default());
+
+        assert_eq!(report.request_count, 0);
     }
 
     #[test]

--- a/tailtriage-cli/tests/cli_json_output.rs
+++ b/tailtriage-cli/tests/cli_json_output.rs
@@ -1,0 +1,36 @@
+use std::process::Command;
+
+#[test]
+fn analyze_json_output_matches_analyzer_schema() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&run_path, sample_run_json()).expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("analyze")
+        .arg(&run_path)
+        .arg("--format")
+        .arg("json")
+        .output()
+        .expect("cli should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let report: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON report");
+
+    assert_eq!(
+        report["request_count"].as_u64(),
+        Some(1),
+        "unexpected report JSON: {report}"
+    );
+    assert!(report.get("primary_suspect").is_some());
+}
+
+fn sample_run_json() -> &'static str {
+    r#"{"schema_version":1,"metadata":{"run_id":"r1","service_name":"svc","service_version":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"mode":"light","host":null,"pid":null,"lifecycle_warnings":[],"unfinished_requests":{"count":0,"sample":[]}},"requests":[{"request_id":"req1","route":"/","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":10,"outcome":"ok"}],"stages":[],"queues":[],"inflight":[],"runtime_snapshots":[]}"#
+}


### PR DESCRIPTION
### Motivation
- Ensure `tailtriage-cli` remains a thin CLI adapter after extracting the analyzer crate and that the CLI/loader boundary is explicit and well-tested.
- Verify the CLI prints loader warnings to stderr, delegates analysis to `tailtriage_analyzer`, and preserves text/JSON output and exit behavior.
- Add tests that prove the CLI rejects on-disk artifacts with empty `requests` while the analyzer can accept an in-memory zero-request `Run`.

### Description
- Kept `tailtriage-cli` public surface minimal by exposing only CLI-owned helpers (`pub mod artifact`) and not reintroducing an `analyze` module.
- `src/main.rs` uses analyzer APIs imported from `tailtriage_analyzer` and calls `analyze_run(&loaded.run, AnalyzeOptions::default())`, printing loader warnings to `stderr` and emitting text or pretty JSON as before.
- Added a unit test in `tailtriage-cli/src/artifact.rs` (`analyzer_accepts_in_memory_zero_request_run`) that deserializes an in-memory zero-request `Run` and asserts `analyze_run` produces a report with `request_count == 0`.
- Added an integration test `tailtriage-cli/tests/cli_json_output.rs` that runs the CLI binary (`tailtriage analyze --format json`) against a small run fixture and asserts the JSON report shape contains `request_count` and `primary_suspect`.
- Did not reintroduce analyzer implementation into CLI, did not add any `tailtriage_cli::analyze` compatibility layer, did not change CLI text/JSON outputs, and did not refresh fixtures.

### Testing
- Ran `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings`, both succeeded.
- Ran `cargo test -p tailtriage-analyzer`, all analyzer tests passed.
- Ran `cargo test -p tailtriage-cli`, all CLI unit and integration tests passed, including the new JSON output integration test.
- Confirmed dependency direction (`tailtriage-cli -> tailtriage-analyzer`) and that `tailtriage-analyzer` does not depend on `tailtriage-cli` via project checks and `cargo` builds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb5b82073c8330b19318c72725ed0a)