### PR TITLE
Harden tailtriage-cli boundary after analyzer extraction

### DIFF
--- a/tailtriage-analyzer/README.md
+++ b/tailtriage-analyzer/README.md
@@ -51,7 +51,7 @@ See root docs for interpretation guidance:
 
 ```rust
 // Old pre-0.1.x API, no longer the supported library analyzer path:
-use tailtriage_cli::analyze::{analyze_run, render_text};
+// use old_cli_crate::analyze::{analyze_run, render_text};
 
 // New:
 use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};

--- a/tailtriage-cli/src/artifact.rs
+++ b/tailtriage-cli/src/artifact.rs
@@ -206,6 +206,8 @@ fn parse_error_message(error: &serde_json::Error) -> String {
 #[cfg(test)]
 mod tests {
     use super::load_run_artifact;
+    use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
+    use tailtriage_core::Run;
 
     #[test]
     fn rejects_malformed_json() {
@@ -315,6 +317,21 @@ mod tests {
             .warnings
             .iter()
             .any(|warning| warning.contains("unfinished request")));
+    }
+
+    #[test]
+    fn cli_rejects_empty_requests_but_analyzer_accepts_zero_request_run() {
+        let dir = tempfile::tempdir().expect("tempdir should build");
+        let path = dir.path().join("empty-requests.json");
+        std::fs::write(&path, valid_run_json_with_requests("[]")).expect("fixture should write");
+
+        let load_error = load_run_artifact(&path).expect_err("expected validation failure");
+        assert!(load_error.to_string().contains("requests section is empty"));
+
+        let run: Run =
+            serde_json::from_str(&valid_run_json_with_requests("[]")).expect("valid in-memory run");
+        let report = analyze_run(&run, AnalyzeOptions::default());
+        assert_eq!(report.request_count, 0);
     }
 
     fn valid_run_json_with_requests(requests_json: &str) -> String {


### PR DESCRIPTION
### Motivation
- Protect the CLI/analyzer boundary after extracting `tailtriage-analyzer` by encoding the rule that disk artifact loading is CLI-owned while in-process analysis lives in the analyzer crate.

### Description
- Add a CLI-focused regression test `cli_rejects_empty_requests_but_analyzer_accepts_zero_request_run` in `tailtriage-cli/src/artifact.rs` that asserts disk artifacts with an empty `requests` array are rejected while `analyze_run` accepts an in-memory zero-request `Run`.
- Import analyzer APIs from `tailtriage_analyzer` in the test and construct the in-memory `Run` via `serde_json` to avoid reintroducing analyzer implementation in the CLI crate.
- Remove a stale migration token in `tailtriage-analyzer/README.md` that referenced the deprecated `tailtriage_cli::analyze` path.
- Preserve CLI behavior and outputs: the CLI still loads artifacts, prints loader warnings to stderr, calls `analyze_run(&loaded.run, AnalyzeOptions::default())`, and renders text or JSON without changing output text or JSON contracts.

### Testing
- Ran `cargo fmt --check` which passed.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` which passed.
- Ran `cargo test -p tailtriage-analyzer` which passed (analyzer tests succeeded).
- Ran `cargo test -p tailtriage-cli` which passed (CLI tests including the new regression test succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb5b82073c8330b19318c72725ed0a)