### PR TITLE
Harden tailtriage-cli boundary after analyzer extraction

### DIFF
--- a/tailtriage-analyzer/README.md
+++ b/tailtriage-analyzer/README.md
@@ -50,8 +50,8 @@ See root docs for interpretation guidance:
 ## Migration note
 
 ```rust
-// Old pre-0.1.x API, no longer the supported library analyzer path:
-use tailtriage_cli::analyze::{analyze_run, render_text};
+// Old pre-0.1.x API was hosted in the CLI crate.
+// Use the analyzer crate directly for in-process analysis/report APIs.
 
 // New:
 use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -26,7 +26,7 @@ fn cli_json_output_is_valid_report_json() {
     let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
     let report: serde_json::Value =
         serde_json::from_str(&stdout).expect("stdout should be valid json");
-    assert!(report.get("request_count").is_some());
+    assert_eq!(report["request_count"].as_u64(), Some(1));
     assert!(report.get("primary_suspect").is_some());
 }
 

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -1,0 +1,58 @@
+use std::process::Command;
+
+use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
+use tailtriage_core::Run;
+
+#[test]
+fn cli_json_output_is_valid_report_json() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let artifact_path = dir.path().join("run.json");
+
+    std::fs::write(&artifact_path, valid_cli_artifact_with_requests())
+        .expect("fixture should write");
+
+    let exe = env!("CARGO_BIN_EXE_tailtriage");
+    let output = Command::new(exe)
+        .arg("analyze")
+        .arg(&artifact_path)
+        .arg("--format")
+        .arg("json")
+        .output()
+        .expect("cli should run");
+
+    assert!(output.status.success(), "cli failed: {output:?}");
+    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    let report: serde_json::Value =
+        serde_json::from_str(&stdout).expect("stdout should be valid json");
+    assert!(report.get("request_count").is_some());
+    assert!(report.get("primary_suspect").is_some());
+}
+
+#[test]
+fn cli_loader_rejects_empty_requests_but_analyzer_accepts_zero_request_run() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let artifact_path = dir.path().join("empty-requests.json");
+
+    std::fs::write(&artifact_path, valid_cli_artifact_with_empty_requests())
+        .expect("fixture should write");
+
+    let err = tailtriage_cli::artifact::load_run_artifact(&artifact_path)
+        .expect_err("cli loader should reject empty requests artifacts");
+    assert!(err.to_string().contains("requests section is empty"));
+
+    let run: Run = serde_json::from_str(valid_cli_artifact_with_empty_requests())
+        .expect("fixture should decode to run");
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+    assert_eq!(report.request_count, 0);
+}
+
+fn valid_cli_artifact_with_requests() -> &'static str {
+    r#"{"schema_version":1,"metadata":{"run_id":"r1","service_name":"svc","service_version":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"mode":"light","host":null,"pid":null,"lifecycle_warnings":[],"unfinished_requests":{"count":0,"sample":[]}},"requests":[{"request_id":"req1","route":"/","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":10,"outcome":"ok"}],"stages":[],"queues":[],"inflight":[],"runtime_snapshots":[]}"#
+}
+
+fn valid_cli_artifact_with_empty_requests() -> &'static str {
+    r#"{"schema_version":1,"metadata":{"run_id":"r1","service_name":"svc","service_version":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"mode":"light","host":null,"pid":null,"lifecycle_warnings":[],"unfinished_requests":{"count":0,"sample":[]}},"requests":[],"stages":[],"queues":[],"inflight":[],"runtime_snapshots":[]}"#
+}


### PR DESCRIPTION
### Motivation
- Ensure the command-line boundary remains a thin adapter after the analyzer was extracted into `tailtriage-analyzer` so the CLI only parses args, loads artifacts, prints loader warnings to stderr, calls the analyzer, and renders text/JSON without re-introducing analyzer code into the CLI.
- Add regression coverage that the CLI emits the same analyzer report JSON and that artifact loading policy (reject empty `requests`) remains a CLI-owned responsibility.

### Description
- Added an integration test `tailtriage-cli/tests/cli_boundary.rs` that runs the `tailtriage` binary in JSON mode and validates the stdout is valid analyzer report JSON and contains core report keys (`request_count`, `primary_suspect`).
- Added a test in the same file proving the CLI artifact loader (`tailtriage_cli::artifact::load_run_artifact`) rejects artifacts with empty `requests` while `tailtriage_analyzer::analyze_run` still accepts an in-memory zero-request `Run` and produces a `request_count == 0` report.
- Updated `tailtriage-analyzer/README.md` to remove a stale pre-extraction migration snippet that suggested importing `analyze` from the CLI crate and clarified the analyzer crate is the in-process API surface.
- Verified the CLI imports analyzer APIs from `tailtriage_analyzer` and calls `analyze_run(&loaded.run, AnalyzeOptions::default())`, and that `tailtriage-cli` exposes only its `artifact` helpers and not any `analyze` compatibility module.

### Testing
- Ran `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings`, which passed.
- Ran `cargo test -p tailtriage-analyzer` and `cargo test -p tailtriage-cli`, and all tests (analyzer unit tests, analyzer fixtures, CLI artifact tests, and the new CLI boundary tests) passed.
- Verified dependency/direction checks: `tailtriage-analyzer` does not depend on `tailtriage-cli`, and code searches for `tailtriage_cli::analyze` / `pub mod analyze` show only docs-validator/test fixtures (no public CLI analyze module in the product surface).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb5b82073c8330b19318c72725ed0a)