### PR TITLE
test: strengthen analyzer report schema contract coverage

### DIFF
--- a/tailtriage-analyzer/tests/report_schema_contract.rs
+++ b/tailtriage-analyzer/tests/report_schema_contract.rs
@@ -26,13 +26,38 @@ fn documented_report_keys_exist_in_json_output() {
         ["primary_suspect", "kind"].as_slice(),
         ["p95_queue_share_permille"].as_slice(),
         ["p95_service_share_permille"].as_slice(),
+        ["evidence_quality"].as_slice(),
         ["primary_suspect", "evidence"].as_slice(),
+        ["primary_suspect", "confidence_notes"].as_slice(),
+        ["route_breakdowns"].as_slice(),
+        ["temporal_segments"].as_slice(),
     ] {
         assert!(
             json_path_exists(&json, path).is_some(),
             "expected documented JSON path {path:?}",
         );
     }
+
+    assert!(
+        json_path_exists(&json, &["evidence_quality"]).is_some_and(Value::is_object),
+        "evidence_quality should be an object"
+    );
+
+    assert!(
+        json_path_exists(&json, &["primary_suspect", "confidence_notes"])
+            .is_some_and(Value::is_array),
+        "primary_suspect.confidence_notes should be an array"
+    );
+
+    assert!(
+        json_path_exists(&json, &["route_breakdowns"]).is_some_and(Value::is_array),
+        "route_breakdowns should be an array"
+    );
+
+    assert!(
+        json_path_exists(&json, &["temporal_segments"]).is_some_and(Value::is_array),
+        "temporal_segments should be an array"
+    );
 
     let evidence = json_path_exists(&json, &["primary_suspect", "evidence"])
         .and_then(Value::as_array)


### PR DESCRIPTION
### Motivation
- Make the dedicated analyzer JSON schema-contract test the primary guard for report shape by explicitly covering a few required fields that were only asserted elsewhere.

### Description
- Extend `tailtriage-analyzer/tests/report_schema_contract.rs` so `documented_report_keys_exist_in_json_output` asserts `/evidence_quality`, `/primary_suspect/confidence_notes`, `/route_breakdowns`, and `/temporal_segments`, add non-brittle type checks for those paths (object/array), and keep the existing `primary_suspect.evidence` check as a non-empty array of strings; no analyzer behavior, JSON key, serialization, fixture, rendering, dependency, or CLI/integration logic was changed and `public_api_contract.rs` was left unchanged.

### Testing
- Ran `cargo fmt --check` (passed), `cargo test -p tailtriage-analyzer` (passed), `cargo test -p tailtriage-cli` (passed), and `cargo clippy --workspace --all-targets -- -D warnings` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb68dcd8808330bbd34f6368cc421d)