### PR TITLE
test: tighten analyzer JSON schema contract assertions

### DIFF
--- a/tailtriage-analyzer/tests/report_schema_contract.rs
+++ b/tailtriage-analyzer/tests/report_schema_contract.rs
@@ -26,13 +26,30 @@ fn documented_report_keys_exist_in_json_output() {
         ["primary_suspect", "kind"].as_slice(),
         ["p95_queue_share_permille"].as_slice(),
         ["p95_service_share_permille"].as_slice(),
+        ["evidence_quality"].as_slice(),
+        ["primary_suspect", "confidence_notes"].as_slice(),
         ["primary_suspect", "evidence"].as_slice(),
+        ["route_breakdowns"].as_slice(),
+        ["temporal_segments"].as_slice(),
     ] {
         assert!(
             json_path_exists(&json, path).is_some(),
             "expected documented JSON path {path:?}",
         );
     }
+
+    let evidence_quality =
+        json_path_exists(&json, &["evidence_quality"]).expect("evidence_quality should exist");
+    assert!(
+        evidence_quality.is_object(),
+        "evidence_quality should be an object"
+    );
+
+    assert!(
+        json_path_exists(&json, &["primary_suspect", "confidence_notes"])
+            .is_some_and(Value::is_array),
+        "primary_suspect.confidence_notes should be an array"
+    );
 
     let evidence = json_path_exists(&json, &["primary_suspect", "evidence"])
         .and_then(Value::as_array)
@@ -41,5 +58,14 @@ fn documented_report_keys_exist_in_json_output() {
     assert!(
         evidence.iter().all(Value::is_string),
         "primary_suspect.evidence should contain strings"
+    );
+
+    assert!(
+        json_path_exists(&json, &["route_breakdowns"]).is_some_and(Value::is_array),
+        "route_breakdowns should be an array"
+    );
+    assert!(
+        json_path_exists(&json, &["temporal_segments"]).is_some_and(Value::is_array),
+        "temporal_segments should be an array"
     );
 }


### PR DESCRIPTION
### Motivation
- Ensure the dedicated analyzer JSON schema contract test covers all required report-shape fields that were left checked only in `public_api_contract.rs` after the `tailtriage-analyzer` extraction so drift is easier to catch in one place.

### Description
- Updated `tailtriage-analyzer/tests/report_schema_contract.rs` to assert presence of `/evidence_quality`, `/primary_suspect/confidence_notes`, `/route_breakdowns`, and `/temporal_segments` in the serialized report JSON.
- Added non-brittle type checks asserting `evidence_quality` is an object and `primary_suspect.confidence_notes`, `route_breakdowns`, and `temporal_segments` are arrays.
- Kept the existing `primary_suspect.evidence` assertion and its checks that it is a non-empty array of strings.
- Did not change analyzer behavior, JSON field names, serialization, fixtures, or `public_api_contract.rs` semantics.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo test -p tailtriage-analyzer` and all tests passed (including the updated schema test).
- Ran `cargo test -p tailtriage-cli` and all tests passed.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it passed with no warnings.

All changes are limited to test assertions in the schema-contract file and do not alter runtime behavior or output shape.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb68dcd8808330bbd34f6368cc421d)