### PR TITLE
Strengthen analyzer JSON schema-contract coverage

### DIFF
--- a/tailtriage-analyzer/tests/report_schema_contract.rs
+++ b/tailtriage-analyzer/tests/report_schema_contract.rs
@@ -26,13 +26,41 @@ fn documented_report_keys_exist_in_json_output() {
         ["primary_suspect", "kind"].as_slice(),
         ["p95_queue_share_permille"].as_slice(),
         ["p95_service_share_permille"].as_slice(),
+        ["evidence_quality"].as_slice(),
         ["primary_suspect", "evidence"].as_slice(),
+        ["primary_suspect", "confidence_notes"].as_slice(),
+        ["route_breakdowns"].as_slice(),
+        ["temporal_segments"].as_slice(),
     ] {
         assert!(
             json_path_exists(&json, path).is_some(),
             "expected documented JSON path {path:?}",
         );
     }
+
+    assert!(
+        json_path_exists(&json, &["evidence_quality"])
+            .is_some_and(Value::is_object),
+        "evidence_quality should be an object"
+    );
+
+    assert!(
+        json_path_exists(&json, &["primary_suspect", "confidence_notes"])
+            .is_some_and(Value::is_array),
+        "primary_suspect.confidence_notes should be an array"
+    );
+
+    assert!(
+        json_path_exists(&json, &["route_breakdowns"])
+            .is_some_and(Value::is_array),
+        "route_breakdowns should be an array"
+    );
+
+    assert!(
+        json_path_exists(&json, &["temporal_segments"])
+            .is_some_and(Value::is_array),
+        "temporal_segments should be an array"
+    );
 
     let evidence = json_path_exists(&json, &["primary_suspect", "evidence"])
         .and_then(Value::as_array)


### PR DESCRIPTION
### Motivation
- Make the dedicated analyzer JSON schema-contract test cover all documented report-shape fields so report-shape drift is caught in one place.
- The analyzer was already validating some of these fields elsewhere; the goal is to consolidate explicit shape checks into the schema-contract test without changing behavior.

### Description
- Extended `tailtriage-analyzer/tests/report_schema_contract.rs` to assert presence of `/evidence_quality`, `/primary_suspect/confidence_notes`, `/route_breakdowns`, and `/temporal_segments` in `documented_report_keys_exist_in_json_output`.
- Added non-brittle type assertions that `evidence_quality` is an object and that `primary_suspect.confidence_notes`, `route_breakdowns`, and `temporal_segments` are arrays, while preserving the existing `primary_suspect.evidence` check as a non-empty array of strings.
- Did not change analyzer logic, JSON field names, serialization, text rendering, fixtures, dependencies, or `public_api_contract.rs`.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo test -p tailtriage-analyzer` and `cargo test -p tailtriage-cli`, and the test suites passed.
- Ran `cargo clippy --workspace --all-targets -- -D warnings`; an initial clippy warning (`clippy::map_unwrap_or`) was triggered by the new test code, the test was updated to use `Option::is_some_and`, and a subsequent clippy run passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb68dcd8808330bbd34f6368cc421d)