### PR TITLE
Strengthen analyzer report schema contract assertions

### DIFF
--- a/tailtriage-analyzer/tests/report_schema_contract.rs
+++ b/tailtriage-analyzer/tests/report_schema_contract.rs
@@ -26,6 +26,10 @@ fn documented_report_keys_exist_in_json_output() {
         ["primary_suspect", "kind"].as_slice(),
         ["p95_queue_share_permille"].as_slice(),
         ["p95_service_share_permille"].as_slice(),
+        ["evidence_quality"].as_slice(),
+        ["primary_suspect", "confidence_notes"].as_slice(),
+        ["route_breakdowns"].as_slice(),
+        ["temporal_segments"].as_slice(),
         ["primary_suspect", "evidence"].as_slice(),
     ] {
         assert!(
@@ -33,6 +37,24 @@ fn documented_report_keys_exist_in_json_output() {
             "expected documented JSON path {path:?}",
         );
     }
+
+    assert!(
+        json_path_exists(&json, &["evidence_quality"]).is_some_and(Value::is_object),
+        "evidence_quality should be an object"
+    );
+    assert!(
+        json_path_exists(&json, &["primary_suspect", "confidence_notes"])
+            .is_some_and(Value::is_array),
+        "primary_suspect.confidence_notes should be an array"
+    );
+    assert!(
+        json_path_exists(&json, &["route_breakdowns"]).is_some_and(Value::is_array),
+        "route_breakdowns should be an array"
+    );
+    assert!(
+        json_path_exists(&json, &["temporal_segments"]).is_some_and(Value::is_array),
+        "temporal_segments should be an array"
+    );
 
     let evidence = json_path_exists(&json, &["primary_suspect", "evidence"])
         .and_then(Value::as_array)


### PR DESCRIPTION
### Motivation
- Make the dedicated analyzer JSON schema-contract test the single clear guard for required report-shape fields that were previously only partially covered elsewhere.
- Reduce future drift by explicitly asserting the documented JSON paths and basic types in the `tailtriage-analyzer` test suite.

### Description
- Updated `tailtriage-analyzer/tests/report_schema_contract.rs` to assert presence of the documented JSON paths: `/evidence_quality`, `/primary_suspect/confidence_notes`, `/route_breakdowns`, and `/temporal_segments`.
- Added lightweight, non-brittle type assertions that `evidence_quality` is an object and that `primary_suspect.confidence_notes`, `route_breakdowns`, and `temporal_segments` are arrays.
- Retained the existing `primary_suspect.evidence` check that it is a non-empty array of strings.
- Did not change analyzer behavior, JSON field names, JSON serialization, text rendering, fixtures, dependencies, or `public_api_contract.rs` (left unchanged and still focused on typed API/text/serde checks).

### Testing
- Ran `cargo fmt --check` and `cargo fmt` as needed and formatting now passes.
- Ran `cargo test -p tailtriage-analyzer` and all analyzer tests passed.
- Ran `cargo test -p tailtriage-cli` and all CLI tests passed.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and lints passed with no warnings.
- Validation confirms the change only tightens schema assertions and does not alter runtime behavior or serialized JSON shape.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb68dcd8808330bbd34f6368cc421d)