### PR TITLE
docs: align crate READMEs and rustdocs with analyzer/CLI split

### DIFF
--- a/tailtriage-analyzer/README.md
+++ b/tailtriage-analyzer/README.md
@@ -1,8 +1,17 @@
 # tailtriage-analyzer
 
-`tailtriage-analyzer` is the in-process analyzer/report crate for `tailtriage`.
+`tailtriage-analyzer` is the in-process analysis/report crate for `tailtriage`.
 
-It analyzes a completed in-memory `tailtriage_core::Run` (or stable snapshot equivalent) and returns a typed triage report with evidence-ranked suspects and next checks.
+Use it when you already have a completed `tailtriage_core::Run` in memory (or a stable snapshot equivalent) and want a typed triage report with evidence-ranked suspects and next checks.
+
+## What this crate does
+
+- analyzes one completed run/snapshot in batch
+- returns a typed `Report`
+- renders human-readable report text with `render_text`
+- supports optional serde JSON serialization of the typed report
+
+Suspects are investigation leads, not proof of root cause.
 
 ## Installation
 
@@ -10,49 +19,62 @@ It analyzes a completed in-memory `tailtriage_core::Run` (or stable snapshot equ
 cargo add tailtriage-analyzer
 ```
 
+If you want JSON serialization in your app, also add:
+
+```bash
+cargo add serde_json
+```
+
+## How to obtain a `Run`
+
+`Run` values come from capture/integration crates such as:
+
+- `tailtriage` (recommended default crate)
+- `tailtriage-core`
+- `tailtriage-controller`
+- `tailtriage-tokio`
+- `tailtriage-axum`
+
+Those crates produce completed runs and optional saved artifacts. This crate analyzes completed in-memory runs/snapshots.
+
 ## In-process API
+
+Use `AnalyzeOptions::default()` as the normal path today; it keeps call sites stable while leaving room for future analyzer options.
+
+`analyze_run` is currently infallible and returns `Report` directly.
 
 ```rust
 use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
-# use tailtriage_core::Run;
-# fn example(run: Run) -> Result<(), serde_json::Error> {
-let report = analyze_run(&run, AnalyzeOptions::default());
-let text = render_text(&report);
-let json = serde_json::to_string_pretty(&report)?;
-# let _ = (text, json);
-# Ok(())
-# }
+use tailtriage_core::Run;
+
+fn render_report(run: &Run) -> Result<String, serde_json::Error> {
+    let report = analyze_run(run, AnalyzeOptions::default());
+    let text = render_text(&report);
+    let json = serde_json::to_string_pretty(&report)?;
+    Ok(format!("{text}\n\n{json}"))
+}
 ```
 
-## Report contract
+## Output model and rendering
 
-- `Report` is the typed analyzer output model.
-- `render_text(&Report)` renders a human-readable triage report.
-- `serde_json::to_string_pretty(&report)` serializes the same typed report as JSON.
-
-Suspects are investigation leads, not proof of root cause.
+- `Report` is the primary typed output for Rust users.
+- `render_text(&Report)` is for human-readable triage output.
+- JSON is optional and uses serde serialization of the same typed `Report`.
 
 ## Semantics and boundaries
 
-- Batch/snapshot analysis of one completed run.
-- Not streaming analysis.
-- Artifact loading from disk is CLI-owned (`tailtriage-cli`).
+- batch/snapshot analysis of one completed run
+- not streaming analysis
+- does not load artifacts from disk
+- artifact loading from disk is CLI-owned (`tailtriage-cli`)
+
+For command-line analysis of saved artifacts, use `tailtriage-cli`.
 
 ## Report fields (overview)
 
 `Report` includes request counts, latency percentiles, queue/service share summaries, warnings, evidence quality, ranked suspects, and optional supporting route/temporal sections.
 
-See root docs for interpretation guidance:
+See interpretation guidance:
 
 - [`docs/diagnostics.md`](../docs/diagnostics.md)
 - [`docs/user-guide.md`](../docs/user-guide.md)
-
-## Migration note
-
-```rust
-// Old pre-0.1.x API was hosted in the CLI crate.
-// Use the analyzer crate directly for in-process analysis/report APIs.
-
-// New:
-use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
-```

--- a/tailtriage-analyzer/src/lib.rs
+++ b/tailtriage-analyzer/src/lib.rs
@@ -163,7 +163,7 @@ pub struct InflightTrend {
     pub growth_per_sec_milli: Option<i64>,
 }
 
-/// Rule-based triage report for one completed run artifact.
+/// Rule-based triage report for one completed [`Run`] or stable snapshot.
 ///
 /// The report ranks evidence-backed suspects and suggests next checks.
 /// It does not prove root cause and should be used as triage guidance.
@@ -255,7 +255,7 @@ pub struct RouteBreakdown {
     pub warnings: Vec<String>,
 }
 
-/// Analyzes one run artifact with rule-based heuristics and returns a triage report.
+/// Analyzes one completed [`Run`] (or stable snapshot equivalent) with rule-based heuristics and returns a triage report.
 ///
 /// The analysis ranks evidence-backed suspects and next checks; it does not
 /// claim causal certainty or proven root cause.
@@ -327,7 +327,7 @@ impl Analyzer {
         Self { options }
     }
 
-    /// Analyzes one completed run artifact and returns a triage report.
+    /// Analyzes one completed [`Run`] (or stable snapshot equivalent) and returns a triage report.
     #[must_use]
     pub fn analyze_run(&self, run: &Run) -> Report {
         analyze_run_with_options(run, &self.options)

--- a/tailtriage-axum/README.md
+++ b/tailtriage-axum/README.md
@@ -93,7 +93,7 @@ That split is important: this crate helps you integrate capture at the framework
 - install `middleware` before using `TailtriageRequest`
 - missing middleware yields `TailtriageExtractorError` with HTTP 500 behavior
 - route labels prefer Axum `MatchedPath`; the fallback is the raw URI path
-- analysis still happens in `tailtriage-cli`
+- for in-process analysis/report generation, use `tailtriage-analyzer`; for command-line analysis of saved artifacts, use `tailtriage-cli`
 
 ## Minimal handler example
 
@@ -119,4 +119,5 @@ If you do not use Axum, this crate is not the right abstraction boundary.
 - `tailtriage`: recommended default entry point
 - `tailtriage-core`: framework-agnostic instrumentation primitives
 - `tailtriage-tokio`: runtime-pressure sampling
-- `tailtriage-cli`: artifact analysis and report generation
+- `tailtriage-analyzer`: in-process analysis/report generation for completed runs
+- `tailtriage-cli`: command-line analysis of saved run artifacts

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -17,7 +17,7 @@ tailtriage
 - load a captured artifact
 - validate schema compatibility
 - produce JSON or human-readable triage output
-- run analyzer logic on loaded artifacts and rank likely bottleneck families
+- invoke `tailtriage-analyzer` on loaded artifacts and rank likely bottleneck families
 - emit evidence and next checks
 
 The output is intended to guide the next investigation step. It does **not** prove root cause on its own.

--- a/tailtriage-controller/README.md
+++ b/tailtriage-controller/README.md
@@ -4,7 +4,7 @@
 
 Use it when you want to turn capture on, collect one generation, turn capture off, and later start a fresh generation without restarting the process.
 
-Analysis is still done by `tailtriage-cli`.
+For in-process analysis/report generation, use `tailtriage-analyzer` on completed runs or stable snapshots. For command-line analysis of saved artifacts, use `tailtriage-cli`.
 
 ## When to use this crate
 
@@ -198,11 +198,12 @@ Optional table. If present, `kind` is required.
 - at most one generation is active at a time
 - active generation settings do not change after activation
 - requests remain bound to the generation that admitted them
-- controller capture and artifact analysis are separate; analysis happens in `tailtriage-cli`
+- controller capture and analysis are separate; for in-process analysis/report generation, use `tailtriage-analyzer`; for command-line analysis of saved artifacts, use `tailtriage-cli`
 
 ## Related crates
 
 - `tailtriage`: default entry point
 - `tailtriage-core`: direct instrumentation lifecycle
 - `tailtriage-tokio`: runtime-pressure sampling
-- `tailtriage-cli`: artifact analysis
+- `tailtriage-analyzer`: in-process analysis/report generation for completed runs
+- `tailtriage-cli`: command-line analysis of saved run artifacts

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -14,7 +14,7 @@ Use it when you want explicit request lifecycle instrumentation and bounded JSON
 - bounded in-memory retention
 - JSON run artifact writing
 
-The artifact produced here is analyzed by `tailtriage-cli`.
+This crate produces completed runs and optional saved artifacts. For in-process analysis/report generation, use `tailtriage-analyzer`. For command-line analysis of saved artifacts, use `tailtriage-cli`.
 
 ## Crate selection
 
@@ -142,4 +142,4 @@ This crate does not provide:
 - Axum middleware/extractors
 - analysis/report generation
 
-Use sibling crates for those surfaces: `tailtriage-controller`, `tailtriage-tokio`, `tailtriage-axum`, and `tailtriage-cli`.
+Use sibling crates for those surfaces: `tailtriage-controller`, `tailtriage-tokio`, `tailtriage-axum`, `tailtriage-analyzer` (in-process analysis/report generation for completed runs), and `tailtriage-cli` (command-line analysis of saved run artifacts).

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -195,13 +195,14 @@ This crate does not provide:
 - request lifecycle instrumentation by itself
 - repeated arm/disarm capture windows
 - framework-boundary integration for Axum
-- analysis or report generation
+- in-process or command-line analysis/report generation
 
 For those surfaces, use:
 
 - `tailtriage-core`
 - `tailtriage-controller`
 - `tailtriage-axum`
+- `tailtriage-analyzer`
 - `tailtriage-cli`
 
 ## Related crates
@@ -209,4 +210,5 @@ For those surfaces, use:
 - `tailtriage`: recommended default entry point
 - `tailtriage-core`: core request instrumentation and artifact writing
 - `tailtriage-controller`: repeated bounded windows
-- `tailtriage-cli`: artifact analysis
+- `tailtriage-analyzer`: in-process analysis/report generation for completed runs
+- `tailtriage-cli`: command-line analysis of saved run artifacts

--- a/tailtriage/README.md
+++ b/tailtriage/README.md
@@ -83,7 +83,7 @@ Docs.rs note: `tailtriage` docs are built with `all-features = true`, so docs.rs
 
 ## Important constraints
 
-- Capture and analysis are separate: this crate writes artifacts, `tailtriage-cli` analyzes them.
+- Capture and analysis are separate: this crate produces completed runs/snapshots and saved artifacts. For in-process analysis/report generation, use `tailtriage-analyzer`. For command-line analysis of saved artifacts, use `tailtriage-cli`.
 - `CaptureMode` selection does not auto-start Tokio runtime sampling.
 - Analysis output is triage guidance, not root-cause proof.
 
@@ -93,4 +93,5 @@ Docs.rs note: `tailtriage` docs are built with `all-features = true`, so docs.rs
 - `tailtriage-controller`: repeated bounded capture windows
 - `tailtriage-tokio`: Tokio runtime-pressure sampling
 - `tailtriage-axum`: Axum request-boundary integration
-- `tailtriage-cli`: artifact analysis and report generation
+- `tailtriage-analyzer`: in-process analysis/report generation for completed runs
+- `tailtriage-cli`: command-line analysis of saved run artifacts


### PR DESCRIPTION
### Motivation

- The analyzer was extracted from the CLI and permanent crate docs still implied CLI-only analysis, which is stale and confusing for in-process Rust users.
- The public analyzer crate needs a stronger, visible README and rustdoc language that teaches the in-process API and batch/snapshot semantics.
- Capture/integration crate docs must consistently show the split: capture crates produce completed runs/snapshots, `tailtriage-analyzer` does in-process analysis, and `tailtriage-cli` does command-line artifact analysis.

### Description

- Rewrote and expanded `tailtriage-analyzer/README.md` to explain crate purpose, installation, how to obtain a `Run`, the in-process API (typed `Report`, `render_text`, optional JSON), `AnalyzeOptions::default()` guidance, and batch/snapshot semantics with a visible example using `analyze_run` (no doctest-hidden lines).
- Updated analyzer rustdoc wording in `tailtriage-analyzer/src/lib.rs` to prefer "completed `Run` / stable snapshot" language for `Report`, `analyze_run`, and `Analyzer::analyze_run` signatures and docs.
- Replaced stale CLI-only analysis wording across capture/integration docs and rustdocs in these files: `tailtriage/README.md`, `tailtriage-core/README.md`, `tailtriage-controller/README.md`, `tailtriage-tokio/README.md`, `tailtriage-axum/README.md`, and `tailtriage-cli/README.md`, and added explicit related-crates lines that mention both `tailtriage-analyzer` (in-process) and `tailtriage-cli` (CLI artifact analysis).
- Changed CLI README wording to state the CLI `invokes tailtriage-analyzer` on loaded artifacts and preserved CLI-owned loader/validation/non-empty-`requests` contract and stderr lifecycle-warning behavior.

### Testing

- Ran `cargo fmt --check` and it passed.
- Ran `cargo test --doc --workspace` and all doc-tests compiled and passed across crates.
- Ran `cargo doc --workspace --all-features --no-deps` and documentation built successfully (note: Cargo emitted a known output-filename collision warning for duplicate crate name paths, but docs generation completed).
- Ran `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts` and both validation suites passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb82ab84ac8330957a8d52dfa9934d)