### PR TITLE
docs: align crate READMEs and rustdocs with analyzer / CLI split

### DIFF
--- a/tailtriage-analyzer/README.md
+++ b/tailtriage-analyzer/README.md
@@ -2,7 +2,16 @@
 
 `tailtriage-analyzer` is the in-process analyzer/report crate for `tailtriage`.
 
-It analyzes a completed in-memory `tailtriage_core::Run` (or stable snapshot equivalent) and returns a typed triage report with evidence-ranked suspects and next checks.
+Use this crate when you already have a completed `tailtriage_core::Run` in memory (or an equivalent stable snapshot) and want a typed triage report, text rendering, and optional JSON serialization in your Rust process.
+
+## What this crate does
+
+- analyzes one completed run/snapshot in batch
+- returns a typed `Report` with evidence-ranked suspects and next checks
+- renders human-readable output with `render_text(&Report)`
+- supports optional serde-based JSON serialization of `Report`
+
+Suspects are investigation leads, not proof of root cause.
 
 ## Installation
 
@@ -10,33 +19,49 @@ It analyzes a completed in-memory `tailtriage_core::Run` (or stable snapshot equ
 cargo add tailtriage-analyzer
 ```
 
+If you want JSON serialization output from your Rust code, also add:
+
+```bash
+cargo add serde_json
+```
+
+## How to obtain a `Run`
+
+`tailtriage-analyzer` does not capture requests and does not load artifacts from disk.
+
+Typical flow:
+
+- capture/integration crates (`tailtriage`, `tailtriage-core`, `tailtriage-controller`, `tailtriage-tokio`, `tailtriage-axum`) produce completed runs or saved artifacts
+- `tailtriage-analyzer` analyzes completed in-memory runs or stable snapshots in process
+- `tailtriage-cli` loads saved artifacts from disk and invokes `tailtriage-analyzer`
+
 ## In-process API
 
 ```rust
 use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
-# use tailtriage_core::Run;
-# fn example(run: Run) -> Result<(), serde_json::Error> {
-let report = analyze_run(&run, AnalyzeOptions::default());
-let text = render_text(&report);
-let json = serde_json::to_string_pretty(&report)?;
-# let _ = (text, json);
-# Ok(())
-# }
+use tailtriage_core::Run;
+
+fn render_report(run: &Run) -> Result<String, serde_json::Error> {
+    let report = analyze_run(run, AnalyzeOptions::default());
+    let text = render_text(&report);
+    let json = serde_json::to_string_pretty(&report)?;
+    Ok(format!("{text}\n\n{json}"))
+}
 ```
 
 ## Report contract
 
-- `Report` is the typed analyzer output model.
-- `render_text(&Report)` renders a human-readable triage report.
-- `serde_json::to_string_pretty(&report)` serializes the same typed report as JSON.
-
-Suspects are investigation leads, not proof of root cause.
+- `analyze_run` currently returns `Report` directly and is currently infallible
+- `AnalyzeOptions::default()` is the normal path today and leaves room for future analyzer options
+- `Report` is the typed analyzer output model and should be your primary integration surface
+- `render_text` is for human-readable triage output
+- serde JSON for `Report` is optional and requires user-side `serde_json`
 
 ## Semantics and boundaries
 
-- Batch/snapshot analysis of one completed run.
-- Not streaming analysis.
-- Artifact loading from disk is CLI-owned (`tailtriage-cli`).
+- batch/snapshot analysis of one completed run
+- not streaming analysis
+- artifact loading from disk is CLI-owned (`tailtriage-cli`)
 
 ## Report fields (overview)
 
@@ -53,6 +78,5 @@ See root docs for interpretation guidance:
 // Old pre-0.1.x API was hosted in the CLI crate.
 // Use the analyzer crate directly for in-process analysis/report APIs.
 
-// New:
 use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
 ```

--- a/tailtriage-analyzer/src/lib.rs
+++ b/tailtriage-analyzer/src/lib.rs
@@ -163,7 +163,7 @@ pub struct InflightTrend {
     pub growth_per_sec_milli: Option<i64>,
 }
 
-/// Rule-based triage report for one completed run artifact.
+/// Rule-based triage report for one completed [`Run`] snapshot.
 ///
 /// The report ranks evidence-backed suspects and suggests next checks.
 /// It does not prove root cause and should be used as triage guidance.
@@ -255,7 +255,7 @@ pub struct RouteBreakdown {
     pub warnings: Vec<String>,
 }
 
-/// Analyzes one run artifact with rule-based heuristics and returns a triage report.
+/// Analyzes one completed [`Run`] with rule-based heuristics and returns a triage report.
 ///
 /// The analysis ranks evidence-backed suspects and next checks; it does not
 /// claim causal certainty or proven root cause.
@@ -327,7 +327,7 @@ impl Analyzer {
         Self { options }
     }
 
-    /// Analyzes one completed run artifact and returns a triage report.
+    /// Analyzes one completed [`Run`] (or stable snapshot equivalent) and returns a triage report.
     #[must_use]
     pub fn analyze_run(&self, run: &Run) -> Report {
         analyze_run_with_options(run, &self.options)

--- a/tailtriage-axum/README.md
+++ b/tailtriage-axum/README.md
@@ -93,7 +93,9 @@ That split is important: this crate helps you integrate capture at the framework
 - install `middleware` before using `TailtriageRequest`
 - missing middleware yields `TailtriageExtractorError` with HTTP 500 behavior
 - route labels prefer Axum `MatchedPath`; the fallback is the raw URI path
-- analysis still happens in `tailtriage-cli`
+- analysis is separate from capture integration
+- for in-process analysis/report generation, use `tailtriage-analyzer`
+- for command-line analysis of saved artifacts, use `tailtriage-cli`
 
 ## Minimal handler example
 
@@ -119,4 +121,5 @@ If you do not use Axum, this crate is not the right abstraction boundary.
 - `tailtriage`: recommended default entry point
 - `tailtriage-core`: framework-agnostic instrumentation primitives
 - `tailtriage-tokio`: runtime-pressure sampling
-- `tailtriage-cli`: artifact analysis and report generation
+- `tailtriage-analyzer`: in-process analysis/report generation for completed runs
+- `tailtriage-cli`: command-line analysis of saved run artifacts

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -17,7 +17,7 @@ tailtriage
 - load a captured artifact
 - validate schema compatibility
 - produce JSON or human-readable triage output
-- run analyzer logic on loaded artifacts and rank likely bottleneck families
+- invoke `tailtriage-analyzer` on loaded artifacts and rank likely bottleneck families
 - emit evidence and next checks
 
 The output is intended to guide the next investigation step. It does **not** prove root cause on its own.

--- a/tailtriage-controller/README.md
+++ b/tailtriage-controller/README.md
@@ -4,7 +4,8 @@
 
 Use it when you want to turn capture on, collect one generation, turn capture off, and later start a fresh generation without restarting the process.
 
-Analysis is still done by `tailtriage-cli`.
+For in-process analysis/report generation, use `tailtriage-analyzer`.
+For command-line analysis of saved artifacts, use `tailtriage-cli`.
 
 ## When to use this crate
 
@@ -198,11 +199,14 @@ Optional table. If present, `kind` is required.
 - at most one generation is active at a time
 - active generation settings do not change after activation
 - requests remain bound to the generation that admitted them
-- controller capture and artifact analysis are separate; analysis happens in `tailtriage-cli`
+- controller capture and analysis are separate
+- for in-process analysis/report generation, use `tailtriage-analyzer`
+- for command-line analysis of saved artifacts, use `tailtriage-cli`
 
 ## Related crates
 
 - `tailtriage`: default entry point
 - `tailtriage-core`: direct instrumentation lifecycle
 - `tailtriage-tokio`: runtime-pressure sampling
-- `tailtriage-cli`: artifact analysis
+- `tailtriage-analyzer`: in-process analysis/report generation for completed runs
+- `tailtriage-cli`: command-line analysis of saved run artifacts

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -14,7 +14,8 @@ Use it when you want explicit request lifecycle instrumentation and bounded JSON
 - bounded in-memory retention
 - JSON run artifact writing
 
-The artifact produced here is analyzed by `tailtriage-cli`.
+For in-process analysis/report generation, use `tailtriage-analyzer`.
+For command-line analysis of saved artifacts, use `tailtriage-cli`.
 
 ## Crate selection
 
@@ -142,4 +143,4 @@ This crate does not provide:
 - Axum middleware/extractors
 - analysis/report generation
 
-Use sibling crates for those surfaces: `tailtriage-controller`, `tailtriage-tokio`, `tailtriage-axum`, and `tailtriage-cli`.
+Use sibling crates for those surfaces: `tailtriage-controller`, `tailtriage-tokio`, `tailtriage-axum`, `tailtriage-analyzer`, and `tailtriage-cli`.

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -202,11 +202,13 @@ For those surfaces, use:
 - `tailtriage-core`
 - `tailtriage-controller`
 - `tailtriage-axum`
-- `tailtriage-cli`
+- `tailtriage-analyzer` (in-process analysis/report generation)
+- `tailtriage-cli` (command-line analysis of saved artifacts)
 
 ## Related crates
 
 - `tailtriage`: recommended default entry point
 - `tailtriage-core`: core request instrumentation and artifact writing
 - `tailtriage-controller`: repeated bounded windows
-- `tailtriage-cli`: artifact analysis
+- `tailtriage-analyzer`: in-process analysis/report generation for completed runs
+- `tailtriage-cli`: command-line analysis of saved run artifacts

--- a/tailtriage/README.md
+++ b/tailtriage/README.md
@@ -55,7 +55,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-### 2) Analyze the artifact
+### 2) Analyze the captured run
+
+In process (typed `Report` + optional text/JSON rendering), use `tailtriage-analyzer`.
+
+From the command line for saved artifacts, use `tailtriage-cli`:
 
 ```bash
 tailtriage analyze tailtriage-run.json
@@ -83,7 +87,8 @@ Docs.rs note: `tailtriage` docs are built with `all-features = true`, so docs.rs
 
 ## Important constraints
 
-- Capture and analysis are separate: this crate writes artifacts, `tailtriage-cli` analyzes them.
+- Capture and analysis are separate. For in-process analysis/report generation, use `tailtriage-analyzer`.
+- For command-line analysis of saved artifacts, use `tailtriage-cli`.
 - `CaptureMode` selection does not auto-start Tokio runtime sampling.
 - Analysis output is triage guidance, not root-cause proof.
 
@@ -93,4 +98,5 @@ Docs.rs note: `tailtriage` docs are built with `all-features = true`, so docs.rs
 - `tailtriage-controller`: repeated bounded capture windows
 - `tailtriage-tokio`: Tokio runtime-pressure sampling
 - `tailtriage-axum`: Axum request-boundary integration
-- `tailtriage-cli`: artifact analysis and report generation
+- `tailtriage-analyzer`: in-process analysis/report generation for completed runs
+- `tailtriage-cli`: command-line analysis of saved run artifacts


### PR DESCRIPTION
### Motivation
- After extracting the analyzer into `tailtriage-analyzer`, several crate READMEs and rustdoc comments still described analysis as CLI-only, which is stale and misleading. 
- The public docs should clearly teach the split: capture/integration crates produce runs or artifacts, `tailtriage-analyzer` performs in-process analysis on a completed `Run`, and `tailtriage-cli` analyzes saved artifacts from the command line. 
- Keep the public guidance tight and consistent so Rust in-process users know to call the analyzer crate directly rather than treating the CLI as the library API. 

### Description
- Replaced CLI-only analysis wording across permanent crate READMEs: `tailtriage`, `tailtriage-core`, `tailtriage-controller`, `tailtriage-tokio`, `tailtriage-axum`, and `tailtriage-cli`. 
- Updated `Related crates` lists to include both `tailtriage-analyzer` (in-process analysis/report generation) and `tailtriage-cli` (command-line analysis of saved run artifacts). 
- Introduced a strengthened `tailtriage-analyzer/README.md` with crate purpose, installation notes (including optional `serde_json`), how to obtain a `Run`, a visible complete example, guidance that `AnalyzeOptions::default()` is the normal path, the current infallible `analyze_run` contract, batch/snapshot semantics (not streaming), and the reminder that suspects are leads not proof. 
- Adjusted analyzer crate rustdocs to prefer "completed `Run`" / "stable snapshot" phrasing instead of ambiguous "run artifact" language, and made `Analyzer::analyze_run` and `analyze_run` wording consistent. 
- Clarified `tailtriage-cli` README to state it `invoke`s `tailtriage-analyzer` on loaded artifacts (keeping CLI loader/validation and stderr warning behavior intact). 
- This is a docs-only change and does not modify runtime code, public APIs, JSON outputs, fixtures, tests, or analyzer behavior. 

### Testing
- Ran `cargo fmt --check` and it completed successfully. 
- Ran `cargo test --doc --workspace` and all doctests passed. 
- Ran `cargo doc --workspace --all-features --no-deps` and documentation built successfully with a known doc filename collision warning for the `tailtriage` target; the build completed. 
- Ran `python3 scripts/validate_docs_contracts.py` and it passed. 
- Ran `python3 -m unittest scripts.tests.test_validate_docs_contracts` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb82ab84ac8330957a8d52dfa9934d)