### PR TITLE
docs: align crate READMEs/rustdocs with analyzer extraction

### DIFF
--- a/tailtriage-analyzer/README.md
+++ b/tailtriage-analyzer/README.md
@@ -1,8 +1,16 @@
 # tailtriage-analyzer
 
-`tailtriage-analyzer` is the in-process analyzer/report crate for `tailtriage`.
+`tailtriage-analyzer` is the in-process analysis/report crate for `tailtriage`.
 
-It analyzes a completed in-memory `tailtriage_core::Run` (or stable snapshot equivalent) and returns a typed triage report with evidence-ranked suspects and next checks.
+It analyzes a completed in-memory `tailtriage_core::Run` (or stable snapshot equivalent) and returns a typed triage `Report` with evidence-ranked suspects and next checks.
+
+Suspects are investigation leads, not proof of root cause.
+
+## When to use this crate
+
+Use `tailtriage-analyzer` when you already have a completed `Run` in Rust code and want to analyze it in process.
+
+Use `tailtriage-cli` when you want command-line analysis of saved run artifacts from disk.
 
 ## Installation
 
@@ -10,27 +18,53 @@ It analyzes a completed in-memory `tailtriage_core::Run` (or stable snapshot equ
 cargo add tailtriage-analyzer
 ```
 
+If you also want JSON serialization in your application, add `serde_json` in your own crate:
+
+```bash
+cargo add serde_json
+```
+
+## How to obtain a `Run`
+
+Capture/integration crates produce completed runs or saved artifacts:
+
+- `tailtriage` (default entry point)
+- `tailtriage-core`
+- `tailtriage-controller`
+- `tailtriage-tokio`
+- `tailtriage-axum`
+
+Typical in-process flow:
+
+1. capture one bounded run in memory;
+2. finish lifecycle and obtain a stable snapshot/completed run;
+3. call `tailtriage-analyzer` on that completed data.
+
 ## In-process API
+
+`AnalyzeOptions::default()` is the normal path today and leaves room for future analyzer options.
+
+`analyze_run` is currently infallible and returns `Report` directly.
 
 ```rust
 use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
-# use tailtriage_core::Run;
-# fn example(run: Run) -> Result<(), serde_json::Error> {
-let report = analyze_run(&run, AnalyzeOptions::default());
-let text = render_text(&report);
-let json = serde_json::to_string_pretty(&report)?;
-# let _ = (text, json);
-# Ok(())
-# }
+use tailtriage_core::Run;
+
+fn render_report(run: &Run) -> Result<String, serde_json::Error> {
+    let report = analyze_run(run, AnalyzeOptions::default());
+    let text = render_text(&report);
+    let json = serde_json::to_string_pretty(&report)?;
+    Ok(format!("{text}\n\n{json}"))
+}
 ```
 
-## Report contract
+## Report outputs
 
-- `Report` is the typed analyzer output model.
+- `Report` is the typed analyzer output model and should be your first integration target.
 - `render_text(&Report)` renders a human-readable triage report.
-- `serde_json::to_string_pretty(&report)` serializes the same typed report as JSON.
+- `serde_json::to_string_pretty(&report)` can serialize the same typed report as JSON when your app needs it.
 
-Suspects are investigation leads, not proof of root cause.
+JSON is optional for in-process code users.
 
 ## Semantics and boundaries
 
@@ -46,13 +80,3 @@ See root docs for interpretation guidance:
 
 - [`docs/diagnostics.md`](../docs/diagnostics.md)
 - [`docs/user-guide.md`](../docs/user-guide.md)
-
-## Migration note
-
-```rust
-// Old pre-0.1.x API was hosted in the CLI crate.
-// Use the analyzer crate directly for in-process analysis/report APIs.
-
-// New:
-use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
-```

--- a/tailtriage-analyzer/src/lib.rs
+++ b/tailtriage-analyzer/src/lib.rs
@@ -163,7 +163,7 @@ pub struct InflightTrend {
     pub growth_per_sec_milli: Option<i64>,
 }
 
-/// Rule-based triage report for one completed run artifact.
+/// Rule-based triage report for one completed run.
 ///
 /// The report ranks evidence-backed suspects and suggests next checks.
 /// It does not prove root cause and should be used as triage guidance.
@@ -255,7 +255,7 @@ pub struct RouteBreakdown {
     pub warnings: Vec<String>,
 }
 
-/// Analyzes one run artifact with rule-based heuristics and returns a triage report.
+/// Analyzes one completed [`Run`] with rule-based heuristics and returns a triage report.
 ///
 /// The analysis ranks evidence-backed suspects and next checks; it does not
 /// claim causal certainty or proven root cause.
@@ -327,7 +327,7 @@ impl Analyzer {
         Self { options }
     }
 
-    /// Analyzes one completed run artifact and returns a triage report.
+    /// Analyzes one completed [`Run`] (or stable snapshot equivalent) and returns a triage report.
     #[must_use]
     pub fn analyze_run(&self, run: &Run) -> Report {
         analyze_run_with_options(run, &self.options)

--- a/tailtriage-axum/README.md
+++ b/tailtriage-axum/README.md
@@ -93,7 +93,8 @@ That split is important: this crate helps you integrate capture at the framework
 - install `middleware` before using `TailtriageRequest`
 - missing middleware yields `TailtriageExtractorError` with HTTP 500 behavior
 - route labels prefer Axum `MatchedPath`; the fallback is the raw URI path
-- analysis still happens in `tailtriage-cli`
+- for in-process analysis/report generation, use `tailtriage-analyzer`
+- for command-line analysis of saved artifacts, use `tailtriage-cli`
 
 ## Minimal handler example
 
@@ -119,4 +120,5 @@ If you do not use Axum, this crate is not the right abstraction boundary.
 - `tailtriage`: recommended default entry point
 - `tailtriage-core`: framework-agnostic instrumentation primitives
 - `tailtriage-tokio`: runtime-pressure sampling
-- `tailtriage-cli`: artifact analysis and report generation
+- `tailtriage-analyzer`: in-process analysis/report generation for completed runs
+- `tailtriage-cli`: command-line analysis of saved run artifacts

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -17,7 +17,7 @@ tailtriage
 - load a captured artifact
 - validate schema compatibility
 - produce JSON or human-readable triage output
-- run analyzer logic on loaded artifacts and rank likely bottleneck families
+- invoke `tailtriage-analyzer` on loaded artifacts and rank likely bottleneck families
 - emit evidence and next checks
 
 The output is intended to guide the next investigation step. It does **not** prove root cause on its own.

--- a/tailtriage-controller/README.md
+++ b/tailtriage-controller/README.md
@@ -4,7 +4,7 @@
 
 Use it when you want to turn capture on, collect one generation, turn capture off, and later start a fresh generation without restarting the process.
 
-Analysis is still done by `tailtriage-cli`.
+For in-process analysis/report generation, use `tailtriage-analyzer`. For command-line analysis of saved artifacts, use `tailtriage-cli`.
 
 ## When to use this crate
 
@@ -198,11 +198,12 @@ Optional table. If present, `kind` is required.
 - at most one generation is active at a time
 - active generation settings do not change after activation
 - requests remain bound to the generation that admitted them
-- controller capture and artifact analysis are separate; analysis happens in `tailtriage-cli`
+- controller capture and artifact analysis are separate; analysis can happen in process via `tailtriage-analyzer` or from saved artifacts via `tailtriage-cli`
 
 ## Related crates
 
 - `tailtriage`: default entry point
 - `tailtriage-core`: direct instrumentation lifecycle
 - `tailtriage-tokio`: runtime-pressure sampling
-- `tailtriage-cli`: artifact analysis
+- `tailtriage-analyzer`: in-process analysis/report generation for completed runs
+- `tailtriage-cli`: command-line analysis of saved run artifacts

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -14,7 +14,7 @@ Use it when you want explicit request lifecycle instrumentation and bounded JSON
 - bounded in-memory retention
 - JSON run artifact writing
 
-The artifact produced here is analyzed by `tailtriage-cli`.
+Captured data from this crate can be analyzed in process with `tailtriage-analyzer` or from saved artifacts with `tailtriage-cli`.
 
 ## Crate selection
 
@@ -142,4 +142,4 @@ This crate does not provide:
 - Axum middleware/extractors
 - analysis/report generation
 
-Use sibling crates for those surfaces: `tailtriage-controller`, `tailtriage-tokio`, `tailtriage-axum`, and `tailtriage-cli`.
+Use sibling crates for those surfaces: `tailtriage-controller`, `tailtriage-tokio`, `tailtriage-axum`, `tailtriage-analyzer`, and `tailtriage-cli`.

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -202,6 +202,7 @@ For those surfaces, use:
 - `tailtriage-core`
 - `tailtriage-controller`
 - `tailtriage-axum`
+- `tailtriage-analyzer`
 - `tailtriage-cli`
 
 ## Related crates
@@ -209,4 +210,5 @@ For those surfaces, use:
 - `tailtriage`: recommended default entry point
 - `tailtriage-core`: core request instrumentation and artifact writing
 - `tailtriage-controller`: repeated bounded windows
-- `tailtriage-cli`: artifact analysis
+- `tailtriage-analyzer`: in-process analysis/report generation for completed runs
+- `tailtriage-cli`: command-line analysis of saved run artifacts

--- a/tailtriage/README.md
+++ b/tailtriage/README.md
@@ -83,7 +83,7 @@ Docs.rs note: `tailtriage` docs are built with `all-features = true`, so docs.rs
 
 ## Important constraints
 
-- Capture and analysis are separate: this crate writes artifacts, `tailtriage-cli` analyzes them.
+- Capture and analysis are separate: capture and integration crates produce completed runs or saved artifacts. For in-process analysis/report generation, use `tailtriage-analyzer`. For command-line analysis of saved artifacts, use `tailtriage-cli`.
 - `CaptureMode` selection does not auto-start Tokio runtime sampling.
 - Analysis output is triage guidance, not root-cause proof.
 
@@ -93,4 +93,5 @@ Docs.rs note: `tailtriage` docs are built with `all-features = true`, so docs.rs
 - `tailtriage-controller`: repeated bounded capture windows
 - `tailtriage-tokio`: Tokio runtime-pressure sampling
 - `tailtriage-axum`: Axum request-boundary integration
-- `tailtriage-cli`: artifact analysis and report generation
+- `tailtriage-analyzer`: in-process analysis/report generation for completed runs
+- `tailtriage-cli`: command-line analysis of saved run artifacts


### PR DESCRIPTION
### Motivation
- The analyzer extraction left several crate READMEs and rustdocs implying analysis is CLI-only, which is stale and confusing for in-process Rust users.
- Crate-level documentation should clearly teach the split: capture/integration crates produce completed runs or artifacts; `tailtriage-analyzer` performs in-process analysis; `tailtriage-cli` performs command-line analysis of saved artifacts.
- `tailtriage-analyzer` needed a permanent public-facing README that explains the typed `Report` API, `render_text`, optional JSON, and how to obtain a `Run` in process.

### Description
- Rewrote and polished README text across crates to remove CLI-only wording and present the consistent pattern: "capture/integration crates produce completed runs or saved artifacts; For in-process analysis/report generation, use `tailtriage-analyzer`. For command-line analysis of saved artifacts, use `tailtriage-cli`." (updated files: `tailtriage/README.md`, `tailtriage-core/README.md`, `tailtriage-controller/README.md`, `tailtriage-tokio/README.md`, `tailtriage-axum/README.md`, `tailtriage-cli/README.md`).
- Reworked `tailtriage-analyzer/README.md` into a full public crate README that includes: purpose, when to use it, installation note, how to obtain a `Run`, in-process API guidance (including `AnalyzeOptions::default()` and that `analyze_run` is currently infallible), a visible non-hidden example using `analyze_run` + `render_text` + `serde_json`, and batch/snapshot semantics and boundaries.
- Updated analyzer rustdocs in `tailtriage-analyzer/src/lib.rs` to prefer "completed `Run` / stable snapshot equivalent" (and adjusted `Report` wording) rather than saying "run artifact"; updated `Analyzer::analyze_run` docs similarly.
- Updated "Related crates" sections in capture/integration READMEs to list both `tailtriage-analyzer` (in-process) and `tailtriage-cli` (CLI), and changed CLI README to state it `invoke`s `tailtriage-analyzer` on loaded artifacts while preserving loader/validation notes.
- Kept changes docs-only: no runtime code, public API, JSON output, tests, fixtures, or behavior were modified, and no analyzer/CLI code surface was restored or removed.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo test --doc --workspace` and all doc-tests passed.
- Ran `cargo doc --workspace --all-features --no-deps` which completed successfully but emitted an existing Cargo filename-collision warning for the `tailtriage` binary vs library name (pre-existing, informational only).
- Ran `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts` and both validations passed.
- Docs validation logic/tests were not changed and remain enforced and passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb82ab84ac8330957a8d52dfa9934d)