### PR TITLE
docs: align crate READMEs/rustdocs with analyzer/cli split

### DIFF
--- a/tailtriage-analyzer/README.md
+++ b/tailtriage-analyzer/README.md
@@ -1,8 +1,10 @@
 # tailtriage-analyzer
 
-`tailtriage-analyzer` is the in-process analyzer/report crate for `tailtriage`.
+`tailtriage-analyzer` is the in-process analysis/report crate for `tailtriage`.
 
-It analyzes a completed in-memory `tailtriage_core::Run` (or stable snapshot equivalent) and returns a typed triage report with evidence-ranked suspects and next checks.
+It analyzes a completed in-memory `tailtriage_core::Run` (or a stable snapshot equivalent) and returns a typed triage report with evidence-ranked suspects and next checks.
+
+Suspects are investigation leads, not proof of root cause.
 
 ## Installation
 
@@ -10,33 +12,49 @@ It analyzes a completed in-memory `tailtriage_core::Run` (or stable snapshot equ
 cargo add tailtriage-analyzer
 ```
 
+If you also want JSON serialization of reports, add `serde_json` in your own crate:
+
+```bash
+cargo add serde_json
+```
+
+## How to obtain a `Run`
+
+`tailtriage-analyzer` analyzes completed run data. Typical sources are:
+
+- a completed `Run` captured in process with `tailtriage-core` (or the default `tailtriage` crate)
+- a stable in-memory snapshot equivalent produced by your own flow
+
+Artifact loading from disk is CLI-owned. Use `tailtriage-cli` when you want command-line analysis of saved artifacts.
+
 ## In-process API
+
+- `analyze_run(&Run, AnalyzeOptions) -> Report`
+- `Report` is the primary typed output
+- `render_text(&Report)` renders human-readable triage output
+- `serde_json` serialization is optional and user-provided
+
+`AnalyzeOptions::default()` is the normal path today and leaves room for future analyzer options.
+`analyze_run` is currently infallible and returns `Report` directly.
 
 ```rust
 use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
-# use tailtriage_core::Run;
-# fn example(run: Run) -> Result<(), serde_json::Error> {
-let report = analyze_run(&run, AnalyzeOptions::default());
-let text = render_text(&report);
-let json = serde_json::to_string_pretty(&report)?;
-# let _ = (text, json);
-# Ok(())
-# }
+use tailtriage_core::Run;
+
+fn render_report(run: &Run) -> Result<String, serde_json::Error> {
+    let report = analyze_run(run, AnalyzeOptions::default());
+    let text = render_text(&report);
+    let json = serde_json::to_string_pretty(&report)?;
+    Ok(format!("{text}\n\n{json}"))
+}
 ```
-
-## Report contract
-
-- `Report` is the typed analyzer output model.
-- `render_text(&Report)` renders a human-readable triage report.
-- `serde_json::to_string_pretty(&report)` serializes the same typed report as JSON.
-
-Suspects are investigation leads, not proof of root cause.
 
 ## Semantics and boundaries
 
-- Batch/snapshot analysis of one completed run.
-- Not streaming analysis.
-- Artifact loading from disk is CLI-owned (`tailtriage-cli`).
+- Analysis is batch/snapshot oriented over completed run data, not streaming.
+- This crate does not capture instrumentation data.
+- This crate does not load artifacts from disk.
+- CLI artifact loading/validation is owned by `tailtriage-cli`.
 
 ## Report fields (overview)
 
@@ -46,13 +64,3 @@ See root docs for interpretation guidance:
 
 - [`docs/diagnostics.md`](../docs/diagnostics.md)
 - [`docs/user-guide.md`](../docs/user-guide.md)
-
-## Migration note
-
-```rust
-// Old pre-0.1.x API was hosted in the CLI crate.
-// Use the analyzer crate directly for in-process analysis/report APIs.
-
-// New:
-use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
-```

--- a/tailtriage-analyzer/src/lib.rs
+++ b/tailtriage-analyzer/src/lib.rs
@@ -1,4 +1,4 @@
-//! Heuristic triage analyzer for completed [`tailtriage_core::Run`] captures.
+//! Heuristic triage analyzer for completed [`tailtriage_core::Run`] data.
 //!
 //! This crate analyzes a finished in-memory [`Run`] (or stable snapshot equivalent) and returns a typed
 //! [`Report`] for in-process diagnosis. It does not load run artifacts from disk and it does not
@@ -163,7 +163,7 @@ pub struct InflightTrend {
     pub growth_per_sec_milli: Option<i64>,
 }
 
-/// Rule-based triage report for one completed run artifact.
+/// Rule-based triage report for one completed run.
 ///
 /// The report ranks evidence-backed suspects and suggests next checks.
 /// It does not prove root cause and should be used as triage guidance.
@@ -255,7 +255,7 @@ pub struct RouteBreakdown {
     pub warnings: Vec<String>,
 }
 
-/// Analyzes one run artifact with rule-based heuristics and returns a triage report.
+/// Analyzes one completed [`Run`] with rule-based heuristics and returns a triage report.
 ///
 /// The analysis ranks evidence-backed suspects and next checks; it does not
 /// claim causal certainty or proven root cause.
@@ -327,7 +327,7 @@ impl Analyzer {
         Self { options }
     }
 
-    /// Analyzes one completed run artifact and returns a triage report.
+    /// Analyzes one completed [`Run`] and returns a triage report.
     #[must_use]
     pub fn analyze_run(&self, run: &Run) -> Report {
         analyze_run_with_options(run, &self.options)

--- a/tailtriage-axum/README.md
+++ b/tailtriage-axum/README.md
@@ -93,7 +93,7 @@ That split is important: this crate helps you integrate capture at the framework
 - install `middleware` before using `TailtriageRequest`
 - missing middleware yields `TailtriageExtractorError` with HTTP 500 behavior
 - route labels prefer Axum `MatchedPath`; the fallback is the raw URI path
-- analysis still happens in `tailtriage-cli`
+- analysis uses `tailtriage-analyzer` in process or `tailtriage-cli` from saved artifacts
 
 ## Minimal handler example
 
@@ -119,4 +119,5 @@ If you do not use Axum, this crate is not the right abstraction boundary.
 - `tailtriage`: recommended default entry point
 - `tailtriage-core`: framework-agnostic instrumentation primitives
 - `tailtriage-tokio`: runtime-pressure sampling
-- `tailtriage-cli`: artifact analysis and report generation
+- `tailtriage-analyzer`: in-process analysis/report generation for completed runs
+- `tailtriage-cli`: command-line analysis of saved run artifacts

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -17,7 +17,7 @@ tailtriage
 - load a captured artifact
 - validate schema compatibility
 - produce JSON or human-readable triage output
-- run analyzer logic on loaded artifacts and rank likely bottleneck families
+- invoke `tailtriage-analyzer` on loaded artifacts and rank likely bottleneck families
 - emit evidence and next checks
 
 The output is intended to guide the next investigation step. It does **not** prove root cause on its own.

--- a/tailtriage-controller/README.md
+++ b/tailtriage-controller/README.md
@@ -4,7 +4,8 @@
 
 Use it when you want to turn capture on, collect one generation, turn capture off, and later start a fresh generation without restarting the process.
 
-Analysis is still done by `tailtriage-cli`.
+For in-process analysis/report generation, use `tailtriage-analyzer`.
+For command-line analysis of saved artifacts, use `tailtriage-cli`.
 
 ## When to use this crate
 
@@ -198,11 +199,12 @@ Optional table. If present, `kind` is required.
 - at most one generation is active at a time
 - active generation settings do not change after activation
 - requests remain bound to the generation that admitted them
-- controller capture and artifact analysis are separate; analysis happens in `tailtriage-cli`
+- controller capture and analysis are separate; use `tailtriage-analyzer` for in-process analysis/report generation and `tailtriage-cli` for command-line analysis of saved artifacts
 
 ## Related crates
 
 - `tailtriage`: default entry point
 - `tailtriage-core`: direct instrumentation lifecycle
 - `tailtriage-tokio`: runtime-pressure sampling
-- `tailtriage-cli`: artifact analysis
+- `tailtriage-analyzer`: in-process analysis/report generation for completed runs
+- `tailtriage-cli`: command-line analysis of saved run artifacts

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -14,7 +14,8 @@ Use it when you want explicit request lifecycle instrumentation and bounded JSON
 - bounded in-memory retention
 - JSON run artifact writing
 
-The artifact produced here is analyzed by `tailtriage-cli`.
+For in-process analysis/report generation, use `tailtriage-analyzer`.
+For command-line analysis of saved artifacts, use `tailtriage-cli`.
 
 ## Crate selection
 

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -195,18 +195,20 @@ This crate does not provide:
 - request lifecycle instrumentation by itself
 - repeated arm/disarm capture windows
 - framework-boundary integration for Axum
-- analysis or report generation
+- in-process analysis/report generation or command-line artifact analysis
 
 For those surfaces, use:
 
 - `tailtriage-core`
 - `tailtriage-controller`
 - `tailtriage-axum`
-- `tailtriage-cli`
+- `tailtriage-analyzer`: in-process analysis/report generation for completed runs
+- `tailtriage-cli`: command-line analysis of saved run artifacts
 
 ## Related crates
 
 - `tailtriage`: recommended default entry point
 - `tailtriage-core`: core request instrumentation and artifact writing
 - `tailtriage-controller`: repeated bounded windows
-- `tailtriage-cli`: artifact analysis
+- `tailtriage-analyzer`: in-process analysis/report generation for completed runs
+- `tailtriage-cli`: command-line analysis of saved run artifacts

--- a/tailtriage/README.md
+++ b/tailtriage/README.md
@@ -83,7 +83,7 @@ Docs.rs note: `tailtriage` docs are built with `all-features = true`, so docs.rs
 
 ## Important constraints
 
-- Capture and analysis are separate: this crate writes artifacts, `tailtriage-cli` analyzes them.
+- Capture and analysis are separate: use `tailtriage-analyzer` for in-process analysis/report generation from completed `Run` data or stable snapshots, and `tailtriage-cli` for command-line analysis of saved artifacts.
 - `CaptureMode` selection does not auto-start Tokio runtime sampling.
 - Analysis output is triage guidance, not root-cause proof.
 
@@ -93,4 +93,5 @@ Docs.rs note: `tailtriage` docs are built with `all-features = true`, so docs.rs
 - `tailtriage-controller`: repeated bounded capture windows
 - `tailtriage-tokio`: Tokio runtime-pressure sampling
 - `tailtriage-axum`: Axum request-boundary integration
-- `tailtriage-cli`: artifact analysis and report generation
+- `tailtriage-analyzer`: in-process analysis/report generation for completed runs
+- `tailtriage-cli`: command-line analysis of saved run artifacts


### PR DESCRIPTION
### Motivation

- The analyzer extraction left several crate READMEs and rustdocs implying analysis is CLI-only, which is stale and confusing for in-process Rust users. 
- The public crate docs must teach the intended split: capture/integration crates produce completed runs or saved artifacts; `tailtriage-analyzer` performs in-process analysis/report generation on completed `Run` data or stable snapshots; `tailtriage-cli` performs command-line analysis of saved artifacts.

### Description

- Rewrote and expanded `tailtriage-analyzer/README.md` into a permanent public README that explains crate purpose, installation, how to obtain a `Run`, the in-process API (typed `Report`, `render_text`, `analyze_run`, and `AnalyzeOptions::default()` guidance), optional `serde_json` usage, batch/snapshot semantics, and the CLI-owned artifact-loading boundary.
- Replaced stale CLI-only analysis wording in capture/integration crate READMEs and rustdocs (`tailtriage`, `tailtriage-core`, `tailtriage-controller`, `tailtriage-tokio`, `tailtriage-axum`) to point readers to `tailtriage-analyzer` for in-process analysis and to `tailtriage-cli` for command-line artifact analysis, and updated their “Related crates” sections accordingly.
- Updated `tailtriage-cli/README.md` to explicitly state the CLI invokes `tailtriage-analyzer` on validated, loaded artifacts while preserving CLI-owned loader/validation semantics (including the non-empty `requests` rule).
- Adjusted analyzer rustdoc wording in `tailtriage-analyzer/src/lib.rs` to prefer “completed `Run`” / “stable snapshot” phrasing (including `analyze_run` and `Analyzer::analyze_run`) and removed misleading "run artifact" phrasing for in-process APIs.

### Testing

- Ran `cargo fmt --check` and it succeeded.
- Ran `cargo test --doc --workspace` and all doc-tests passed.
- Ran `cargo doc --workspace --all-features --no-deps` and documentation built successfully (Cargo emitted a known docs filename-collision warning but the build completed).
- Ran `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts` and the docs contract validation tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb82ab84ac8330957a8d52dfa9934d)