### PR TITLE
Harden docs-contract validation for analyzer vs CLI split

### DIFF
--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -150,6 +150,93 @@ Normal CI does not publish durable diagnostic scorecards.
     def test_cli_not_presented_as_library_analyzer_api_contract(self) -> None:
         validate_docs_contracts.validate_cli_not_presented_as_library_analyzer_api()
 
+    def test_analyzer_readme_contract(self) -> None:
+        validate_docs_contracts.validate_analyzer_readme_contract()
+
+    def test_cli_readme_contract(self) -> None:
+        validate_docs_contracts.validate_cli_readme_contract()
+
+    def test_capture_readmes_analyzer_cli_split_contract(self) -> None:
+        validate_docs_contracts.validate_capture_readmes_analyzer_cli_split()
+
+    def test_analyzer_readme_contract_positive_split_example(self) -> None:
+        analyzer_text = """# tailtriage-analyzer
+In-process analysis for completed Run captures.
+Produces typed Report values.
+Use AnalyzeOptions::default() and render_text for text output.
+Use serde_json for JSON serialization.
+This is not live streaming.
+For command-line artifact loading and analysis, use tailtriage-cli.
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            readme_path = Path(tmp_dir) / "README.md"
+            readme_path.write_text(analyzer_text, encoding="utf-8")
+            with mock.patch.object(validate_docs_contracts, "ANALYZER_README_PATH", readme_path):
+                validate_docs_contracts.validate_analyzer_readme_contract()
+
+    def test_capture_readme_contract_rejects_stale_cli_only_wording(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            paths = []
+            for rel in (
+                "tailtriage/README.md",
+                "tailtriage-core/README.md",
+                "tailtriage-controller/README.md",
+                "tailtriage-tokio/README.md",
+                "tailtriage-axum/README.md",
+            ):
+                path = repo_root / rel
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(
+                    "Uses `tailtriage-analyzer` and `tailtriage-cli`.\nAnalysis happens in `tailtriage-cli`.\n",
+                    encoding="utf-8",
+                )
+                paths.append(path)
+
+            with (
+                mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root),
+                mock.patch.object(validate_docs_contracts, "CAPTURE_INTEGRATION_README_PATHS", tuple(paths)),
+            ):
+                with self.assertRaisesRegex(ValueError, r"stale CLI-only analyzer wording"):
+                    validate_docs_contracts.validate_capture_readmes_analyzer_cli_split()
+
+    def test_capture_readme_contract_rejects_cli_without_analyzer(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            paths = []
+            for rel in (
+                "tailtriage/README.md",
+                "tailtriage-core/README.md",
+                "tailtriage-controller/README.md",
+                "tailtriage-tokio/README.md",
+                "tailtriage-axum/README.md",
+            ):
+                path = repo_root / rel
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("Use `tailtriage-cli` for saved artifacts.\n", encoding="utf-8")
+                paths.append(path)
+
+            with (
+                mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root),
+                mock.patch.object(validate_docs_contracts, "CAPTURE_INTEGRATION_README_PATHS", tuple(paths)),
+            ):
+                with self.assertRaisesRegex(ValueError, r"must mention `tailtriage-analyzer`"):
+                    validate_docs_contracts.validate_capture_readmes_analyzer_cli_split()
+
+    def test_cli_readme_contract_positive_cli_invokes_analyzer(self) -> None:
+        cli_text = """# tailtriage-cli
+Command-line analysis of saved run artifacts with schema validation.
+Loader requires non-empty requests.
+The CLI invokes tailtriage-analyzer.
+Produces command-line text and JSON output.
+Rust in-process integrations should use tailtriage-analyzer directly.
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            readme_path = Path(tmp_dir) / "README.md"
+            readme_path.write_text(cli_text, encoding="utf-8")
+            with mock.patch.object(validate_docs_contracts, "CLI_README_PATH", readme_path):
+                validate_docs_contracts.validate_cli_readme_contract()
+
     def test_architecture_contract(self) -> None:
         validate_docs_contracts.validate_architecture_contract()
 

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -19,6 +19,8 @@ DIAGNOSTIC_VALIDATION_PATH = REPO_ROOT / "docs" / "diagnostic-validation.md"
 CI_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 ARCHITECTURE_PATH = REPO_ROOT / "docs" / "architecture.md"
 CONTROLLER_README_PATH = REPO_ROOT / "tailtriage-controller" / "README.md"
+ANALYZER_README_PATH = REPO_ROOT / "tailtriage-analyzer" / "README.md"
+CLI_README_PATH = REPO_ROOT / "tailtriage-cli" / "README.md"
 ANALYSIS_FIXTURE_PATH = REPO_ROOT / "demos" / "queue_service" / "fixtures" / "sample-analysis.json"
 CONTROLLER_SOURCE_PATH = REPO_ROOT / "tailtriage-controller" / "src" / "lib.rs"
 CORE_COLLECTOR_SOURCE_PATH = REPO_ROOT / "tailtriage-core" / "src" / "collector.rs"
@@ -104,6 +106,14 @@ DIAGNOSTIC_BENCHMARK_CI_ARGS = (
 
 STALE_VALIDATION_DOC_PHRASES = (
     "no in normal pr ci",
+)
+
+CAPTURE_INTEGRATION_README_PATHS = (
+    REPO_ROOT / "tailtriage" / "README.md",
+    REPO_ROOT / "tailtriage-core" / "README.md",
+    REPO_ROOT / "tailtriage-controller" / "README.md",
+    REPO_ROOT / "tailtriage-tokio" / "README.md",
+    REPO_ROOT / "tailtriage-axum" / "README.md",
 )
 
 
@@ -570,6 +580,78 @@ def validate_cli_not_presented_as_library_analyzer_api() -> None:
     if hits:
         raise ValueError("CLI/library analyzer contract violation:\n" + "\n".join(hits))
 
+
+def _contains_any(text: str, patterns: tuple[str, ...]) -> bool:
+    return any(re.search(pattern, text, flags=re.IGNORECASE) for pattern in patterns)
+
+
+def validate_analyzer_readme_contract() -> None:
+    text = ANALYZER_README_PATH.read_text(encoding="utf-8")
+    checks: tuple[tuple[str, tuple[str, ...]], ...] = (
+        ("in-process analyzer wording", (r"\bin[\s-]?process\b",)),
+        ("completed run/snapshot wording", (r"\bcompleted\b",)),
+        ("Run type mention", (r"\brun\b",)),
+        ("typed report wording", (r"\btyped\b",)),
+        ("Report type mention", (r"\breport\b",)),
+        ("render_text mention", (r"\brender_text\b",)),
+        ("serde_json mention", (r"\bserde_json\b",)),
+        ("AnalyzeOptions::default mention", (r"analyzeoptions::default\(\)",)),
+        ("not streaming wording", (r"\bnot\s+(?:live\s+)?streaming\b",)),
+        (
+            "tailtriage-cli artifact-analysis mention",
+            (r"\btailtriage-cli\b", r"\bartifact", r"\bcommand[\s-]?line\b"),
+        ),
+    )
+    lower = text.lower()
+    failures: list[str] = []
+    for label, patterns in checks:
+        if not _contains_any(lower, patterns):
+            failures.append(label)
+    if failures:
+        raise ValueError("tailtriage-analyzer README missing required contract concepts: " + ", ".join(failures))
+
+
+def validate_cli_readme_contract() -> None:
+    lower = CLI_README_PATH.read_text(encoding="utf-8").lower()
+    checks: tuple[tuple[str, tuple[str, ...]], ...] = (
+        ("saved/run artifact loading", (r"(saved|run).{0,40}artifact", r"\bartifact.{0,40}(load|read)")),
+        ("schema validation mention", (r"\bschema\b.{0,50}\bvalidat", r"\bvalidat.{0,50}\bschema\b")),
+        ("non-empty requests loader rule", (r"\bnon[\s-]?empty\b.{0,50}\brequests\b",)),
+        ("tailtriage-analyzer mention", (r"\btailtriage-analyzer\b",)),
+        ("command-line text/json output mention", (r"\bcommand[\s-]?line\b", r"\btext\b.{0,30}\bjson\b")),
+        ("in-process Rust users should use tailtriage-analyzer", (r"\bin[\s-]?process\b", r"\brust\b",)),
+    )
+    failures: list[str] = []
+    for label, patterns in checks:
+        if not _contains_any(lower, patterns):
+            failures.append(label)
+    if failures:
+        raise ValueError("tailtriage-cli README missing required contract concepts: " + ", ".join(failures))
+
+
+def validate_capture_readmes_analyzer_cli_split() -> None:
+    stale_patterns = (
+        r"analysis\s+is\s+still\s+done\s+by\s+`tailtriage-cli`",
+        r"analysis\s+happens\s+in\s+`tailtriage-cli`",
+        r"artifact\s+produced\s+here\s+is\s+analyzed\s+by\s+`tailtriage-cli`",
+        r"writes?\s+artifacts?,\s*`tailtriage-cli`\s+analyzes?\s+them",
+        r"analysis\s+or\s+report\s+generation[\s\S]{0,80}`tailtriage-cli`",
+    )
+    failures: list[str] = []
+    for path in CAPTURE_INTEGRATION_README_PATHS:
+        text = path.read_text(encoding="utf-8")
+        lower = text.lower()
+        rel = path.relative_to(REPO_ROOT)
+        if "`tailtriage-analyzer`" not in text:
+            failures.append(f"{rel} must mention `tailtriage-analyzer`")
+        if "`tailtriage-cli`" not in text:
+            failures.append(f"{rel} must mention `tailtriage-cli`")
+        for pattern in stale_patterns:
+            if re.search(pattern, lower, flags=re.IGNORECASE):
+                failures.append(f"{rel} contains stale CLI-only analyzer wording: {pattern}")
+    if failures:
+        raise ValueError("capture/integration README analyzer split violations:\n" + "\n".join(failures))
+
 def _active_yaml_lines(text: str) -> str:
     return "\n".join(line for line in text.splitlines() if not line.lstrip().startswith("#"))
 
@@ -760,6 +842,9 @@ def main() -> int:
     validate_user_guide_contract()
     validate_diagnostics_contract_truthfulness()
     validate_cli_not_presented_as_library_analyzer_api()
+    validate_analyzer_readme_contract()
+    validate_cli_readme_contract()
+    validate_capture_readmes_analyzer_cli_split()
     validate_diagnostic_benchmark_ci_contract()
     validate_validation_docs_ci_contract()
     validate_architecture_contract()


### PR DESCRIPTION
### Motivation
- Prevent stale docs that describe `tailtriage-cli` as the sole or library analyzer path after extracting `tailtriage-analyzer` into a separate crate.
- Ensure public crate docs consistently teach the intended split: `tailtriage-analyzer = in-process analysis/report generation` and `tailtriage-cli = command-line analysis of saved artifacts`.

### Description
- Added `ANALYZER_README_PATH` and `CLI_README_PATH` constants and a `CAPTURE_INTEGRATION_README_PATHS` list for targeted capture/integration READMEs in `scripts/validate_docs_contracts.py`.
- Implemented `validate_analyzer_readme_contract`, `validate_cli_readme_contract`, and `validate_capture_readmes_analyzer_cli_split` to semantically check required tokens (for example `in-process`, `Run`, `Report`, `render_text`, `serde_json`, `AnalyzeOptions::default()`, schema validation, non-empty `requests`, and explicit pointers between CLI and analyzer) and to reject stale CLI-only analyzer wording patterns.
- Added a helper `_contains_any` and extended an existing CLI README schema regex for more robust matching, and wired the new validators into the main validation run.
- Added unit tests in `scripts/tests/test_validate_docs_contracts.py` covering positive/negative examples: correct analyzer/CLI split, stale CLI-only wording rejection, capture README missing analyzer mention, and CLI README that correctly states the CLI invokes `tailtriage-analyzer`.

### Testing
- Ran `python3 scripts/validate_docs_contracts.py` and it completed with "docs contracts validated successfully".
- Ran `python3 -m unittest scripts.tests.test_validate_docs_contracts` and all tests passed (`Ran 38 tests ... OK`).
- Ran `cargo fmt --check` which completed without formatting errors.
- No runtime code, analyzer behavior, CLI behavior, fixtures, or JSON output were modified by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb987fe51c8330bb2f0a1dabca4645)