### PR TITLE
Strengthen docs-contract validation for analyzer/CLI split wording

### DIFF
--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -150,6 +150,102 @@ Normal CI does not publish durable diagnostic scorecards.
     def test_cli_not_presented_as_library_analyzer_api_contract(self) -> None:
         validate_docs_contracts.validate_cli_not_presented_as_library_analyzer_api()
 
+    def test_analyzer_cli_docs_split_contract(self) -> None:
+        validate_docs_contracts.validate_analyzer_cli_docs_split_contract()
+
+    def test_capture_readmes_analyzer_cli_wording_contract(self) -> None:
+        validate_docs_contracts.validate_capture_readmes_analyzer_cli_wording_contract()
+
+    def test_capture_readme_wording_rejects_cli_only_stale_phrase(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            paths = []
+            for rel in (
+                "tailtriage/README.md",
+                "tailtriage-core/README.md",
+                "tailtriage-controller/README.md",
+                "tailtriage-tokio/README.md",
+                "tailtriage-axum/README.md",
+            ):
+                path = repo_root / rel
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(
+                    "Use tailtriage-analyzer in-process and tailtriage-cli for saved artifacts.",
+                    encoding="utf-8",
+                )
+                paths.append(path)
+
+            paths[0].write_text(
+                "Analysis is still done by `tailtriage-cli` for this crate.\n"
+                "Also references tailtriage-analyzer and tailtriage-cli.",
+                encoding="utf-8",
+            )
+
+            with (
+                mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root),
+                mock.patch.object(
+                    validate_docs_contracts,
+                    "CAPTURE_INTEGRATION_README_PATHS",
+                    tuple(paths),
+                ),
+            ):
+                with self.assertRaisesRegex(ValueError, r"stale CLI-only analyzer wording"):
+                    validate_docs_contracts.validate_capture_readmes_analyzer_cli_wording_contract()
+
+    def test_capture_readme_requires_analyzer_and_cli_mentions(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            paths = []
+            for rel in (
+                "tailtriage/README.md",
+                "tailtriage-core/README.md",
+                "tailtriage-controller/README.md",
+                "tailtriage-tokio/README.md",
+                "tailtriage-axum/README.md",
+            ):
+                path = repo_root / rel
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(
+                    "Use tailtriage-analyzer in-process and tailtriage-cli for saved artifacts.",
+                    encoding="utf-8",
+                )
+                paths.append(path)
+            paths[1].write_text("Use tailtriage-cli for saved artifacts only.", encoding="utf-8")
+
+            with (
+                mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root),
+                mock.patch.object(
+                    validate_docs_contracts,
+                    "CAPTURE_INTEGRATION_README_PATHS",
+                    tuple(paths),
+                ),
+            ):
+                with self.assertRaisesRegex(ValueError, r"must mention tailtriage-analyzer"):
+                    validate_docs_contracts.validate_capture_readmes_analyzer_cli_wording_contract()
+
+    def test_cli_readme_positive_when_cli_invokes_analyzer(self) -> None:
+        analyzer_text = """
+tailtriage-analyzer is in-process for completed Run inputs, typed Report output,
+render_text formatting, serde_json parsing support, AnalyzeOptions::default(),
+not streaming capture, and tailtriage-cli for command-line artifact loading.
+"""
+        cli_text = """
+tailtriage-cli loads saved run artifacts, performs schema validation, enforces
+non-empty requests loader rules, uses tailtriage-analyzer, and provides command-line
+text or json output. Rust in-process users should use tailtriage-analyzer directly.
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            analyzer_readme = repo_root / "tailtriage-analyzer" / "README.md"
+            cli_readme = repo_root / "tailtriage-cli" / "README.md"
+            analyzer_readme.parent.mkdir(parents=True, exist_ok=True)
+            cli_readme.parent.mkdir(parents=True, exist_ok=True)
+            analyzer_readme.write_text(analyzer_text, encoding="utf-8")
+            cli_readme.write_text(cli_text, encoding="utf-8")
+
+            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root):
+                validate_docs_contracts.validate_analyzer_cli_docs_split_contract()
+
     def test_architecture_contract(self) -> None:
         validate_docs_contracts.validate_architecture_contract()
 

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -83,6 +83,14 @@ DOCS_DISALLOWED_HISTORY_PATTERNS = (
     r"PR\s*#\d+",
 )
 
+CAPTURE_INTEGRATION_README_PATHS = (
+    REPO_ROOT / "tailtriage" / "README.md",
+    REPO_ROOT / "tailtriage-core" / "README.md",
+    REPO_ROOT / "tailtriage-controller" / "README.md",
+    REPO_ROOT / "tailtriage-tokio" / "README.md",
+    REPO_ROOT / "tailtriage-axum" / "README.md",
+)
+
 DIAGNOSTICS_FIELD_REFERENCE_LABELS = (
     "field reference",
     "field-reference",
@@ -570,6 +578,76 @@ def validate_cli_not_presented_as_library_analyzer_api() -> None:
     if hits:
         raise ValueError("CLI/library analyzer contract violation:\n" + "\n".join(hits))
 
+
+def validate_analyzer_cli_docs_split_contract() -> None:
+    analyzer_text = (REPO_ROOT / "tailtriage-analyzer" / "README.md").read_text(encoding="utf-8")
+    analyzer_lower = analyzer_text.lower()
+    analyzer_required = (
+        "in-process",
+        "completed",
+        "run",
+        "typed",
+        "report",
+        "render_text",
+        "serde_json",
+        "analyzeoptions::default()",
+        "tailtriage-cli",
+    )
+    for token in analyzer_required:
+        if token not in analyzer_lower:
+            raise ValueError(f"tailtriage-analyzer README missing required concept/token: {token}")
+
+    if "not streaming" not in analyzer_lower and "not live streaming" not in analyzer_lower:
+        raise ValueError("tailtriage-analyzer README must state it is not streaming/live-streaming")
+
+    cli_text = (REPO_ROOT / "tailtriage-cli" / "README.md").read_text(encoding="utf-8")
+    cli_lower = cli_text.lower()
+    cli_required_patterns = (
+        ("saved/run artifact loading", r"(saved|captured|on-disk|persisted|run).{0,120}artifact"),
+        ("schema validation", r"(schema.{0,80}validat|validat.{0,80}schema)"),
+        ("non-empty requests loader rule", r"non[-\s]?empty.{0,80}requests"),
+        ("tailtriage-analyzer use", r"tailtriage-analyzer"),
+        ("command-line text/json output", r"(command[-\s]?line|cli).{0,160}(text|json|human-readable)"),
+        ("in-process pointer for Rust users", r"(rust|in-process).{0,120}tailtriage-analyzer"),
+    )
+    for label, pattern in cli_required_patterns:
+        if re.search(pattern, cli_lower, flags=re.IGNORECASE | re.DOTALL) is None:
+            raise ValueError(f"tailtriage-cli README missing required concept: {label}")
+
+
+def validate_capture_readmes_analyzer_cli_wording_contract() -> None:
+    stale_patterns = (
+        r"analysis\s+is\s+still\s+done\s+by\s+`?tailtriage-cli`?",
+        r"analysis\s+happens\s+in\s+`?tailtriage-cli`?",
+        r"artifact\s+produced\s+here.{0,80}analy[sz]ed\s+by\s+`?tailtriage-cli`?",
+        r"this\s+crate\s+writes\s+artifacts?.{0,80}`?tailtriage-cli`?\s+analy[sz]es",
+        r"analysis\s+or\s+report\s+generation.{0,120}`?tailtriage-cli`?",
+    )
+
+    failures: list[str] = []
+    for path in CAPTURE_INTEGRATION_README_PATHS:
+        text = path.read_text(encoding="utf-8")
+        lower = text.lower()
+        if "tailtriage-analyzer" not in lower:
+            failures.append(
+                f"{path.relative_to(REPO_ROOT)} must mention tailtriage-analyzer for in-process analysis"
+            )
+        if "tailtriage-cli" not in lower:
+            failures.append(
+                f"{path.relative_to(REPO_ROOT)} must mention tailtriage-cli for command-line artifact analysis"
+            )
+
+        for pattern in stale_patterns:
+            if re.search(pattern, lower, flags=re.IGNORECASE | re.DOTALL):
+                failures.append(
+                    f"{path.relative_to(REPO_ROOT)} contains stale CLI-only analyzer wording: {pattern}"
+                )
+
+    if failures:
+        raise ValueError(
+            "capture/integration README analyzer wording contract violation:\n" + "\n".join(failures)
+        )
+
 def _active_yaml_lines(text: str) -> str:
     return "\n".join(line for line in text.splitlines() if not line.lstrip().startswith("#"))
 
@@ -760,6 +838,8 @@ def main() -> int:
     validate_user_guide_contract()
     validate_diagnostics_contract_truthfulness()
     validate_cli_not_presented_as_library_analyzer_api()
+    validate_analyzer_cli_docs_split_contract()
+    validate_capture_readmes_analyzer_cli_wording_contract()
     validate_diagnostic_benchmark_ci_contract()
     validate_validation_docs_ci_contract()
     validate_architecture_contract()


### PR DESCRIPTION
### Motivation
- Ensure public docs consistently teach the post-extraction split between `tailtriage-analyzer` (in-process analysis) and `tailtriage-cli` (command-line artifact analysis) so stale CLI-only analyzer wording cannot return.
- Catch accidental regressions in capture/integration README phrasing that could mislead users about the recommended in-process library API.

### Description
- Added `CAPTURE_INTEGRATION_README_PATHS` and implemented `validate_analyzer_cli_docs_split_contract()` to semantically check `tailtriage-analyzer/README.md` for in-process/completed-run/report API tokens and `tailtriage-cli/README.md` for artifact-loading, schema validation, non-empty `requests` rule, CLI output formats, and pointer to `tailtriage-analyzer` for Rust in-process users.
- Added `validate_capture_readmes_analyzer_cli_wording_contract()` to require both `tailtriage-analyzer` and `tailtriage-cli` mentions in capture/integration crate README files and to reject a set of stale CLI-only analyzer wording patterns while allowing legitimate CLI artifact-analysis statements.
- Kept existing docs-index/root parity checks intact and wired the new validators into `main()` so they run with the rest of the docs-contract checks.
- Added unit tests in `scripts/tests/test_validate_docs_contracts.py` covering positive analyzer/CLI split cases and negative cases for stale CLI-only wording and missing analyzer mention in capture readmes.

### Testing
- Ran `python3 scripts/validate_docs_contracts.py` and it completed successfully with "docs contracts validated successfully".
- Ran the test suite with `python3 -m unittest scripts.tests.test_validate_docs_contracts` and all tests passed (`OK`).
- Ran `cargo fmt --check` and it reported no formatting issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb987fe51c8330bb2f0a1dabca4645)