### PR TITLE
Strengthen docs contract validation for analyzer/CLI split wording

### DIFF
--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -150,6 +150,75 @@ Normal CI does not publish durable diagnostic scorecards.
     def test_cli_not_presented_as_library_analyzer_api_contract(self) -> None:
         validate_docs_contracts.validate_cli_not_presented_as_library_analyzer_api()
 
+    def test_analyzer_and_cli_readme_split_contract_positive(self) -> None:
+        analyzer_text = """
+# tailtriage-analyzer
+in-process analysis for completed Run snapshots with typed Report output.
+Use render_text(report) and serde_json for output serialization.
+Start with AnalyzeOptions::default().
+This is not live streaming analysis.
+For command-line artifact analysis/loading, use tailtriage-cli.
+"""
+        cli_text = """
+# tailtriage-cli
+Loads saved run artifacts with schema validation.
+Loader rule: requests must be non-empty.
+Uses tailtriage-analyzer.
+Provides command-line text and json output.
+Rust in-process users should use tailtriage-analyzer.
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            analyzer_path = repo_root / "tailtriage-analyzer" / "README.md"
+            cli_path = repo_root / "tailtriage-cli" / "README.md"
+            analyzer_path.parent.mkdir(parents=True, exist_ok=True)
+            cli_path.parent.mkdir(parents=True, exist_ok=True)
+            analyzer_path.write_text(analyzer_text, encoding="utf-8")
+            cli_path.write_text(cli_text, encoding="utf-8")
+
+            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root):
+                validate_docs_contracts.validate_analyzer_readme_contract()
+                validate_docs_contracts.validate_cli_readme_contract()
+
+    def test_capture_readme_contract_rejects_stale_cli_only_wording(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "tailtriage" / "README.md"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                "Analysis is still done by `tailtriage-cli` and this crate captures data.",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, r"stale CLI-only analyzer wording"):
+                validate_docs_contracts.validate_capture_readmes_analyzer_cli_split_contract(
+                    paths=(path,)
+                )
+
+    def test_capture_readme_contract_requires_analyzer_and_cli_mentions(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "tailtriage-core" / "README.md"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("Use tailtriage-cli to analyze saved artifacts.", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, r"must mention both tailtriage-analyzer and tailtriage-cli"):
+                validate_docs_contracts.validate_capture_readmes_analyzer_cli_split_contract(
+                    paths=(path,)
+                )
+
+    def test_cli_readme_contract_accepts_cli_invokes_analyzer_wording(self) -> None:
+        cli_text = """
+# tailtriage-cli
+The CLI loads saved run artifacts, validates schema, and enforces non-empty requests.
+It invokes tailtriage-analyzer for analysis and supports command-line text/json output.
+Rust in-process usage should use tailtriage-analyzer directly.
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            cli_path = repo_root / "tailtriage-cli" / "README.md"
+            cli_path.parent.mkdir(parents=True, exist_ok=True)
+            cli_path.write_text(cli_text, encoding="utf-8")
+
+            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root):
+                validate_docs_contracts.validate_cli_readme_contract()
+
     def test_architecture_contract(self) -> None:
         validate_docs_contracts.validate_architecture_contract()
 

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -77,6 +77,13 @@ README_DOC_MAP_REQUIRED_LINKS = (
     "(docs/architecture.md)",
     "(docs/README.md)",
 )
+CAPTURE_INTEGRATION_README_PATHS = (
+    REPO_ROOT / "tailtriage" / "README.md",
+    REPO_ROOT / "tailtriage-core" / "README.md",
+    REPO_ROOT / "tailtriage-controller" / "README.md",
+    REPO_ROOT / "tailtriage-tokio" / "README.md",
+    REPO_ROOT / "tailtriage-axum" / "README.md",
+)
 
 DOCS_DISALLOWED_HISTORY_PATTERNS = (
     r"issue\s*#\d+",
@@ -570,6 +577,113 @@ def validate_cli_not_presented_as_library_analyzer_api() -> None:
     if hits:
         raise ValueError("CLI/library analyzer contract violation:\n" + "\n".join(hits))
 
+
+def validate_analyzer_readme_contract() -> None:
+    path = REPO_ROOT / "tailtriage-analyzer" / "README.md"
+    text = path.read_text(encoding="utf-8")
+    lowered = text.lower()
+
+    required_substrings = (
+        "in-process",
+        "completed",
+        "run",
+        "typed",
+        "report",
+        "render_text",
+        "serde_json",
+        "analyzeoptions::default()",
+        "tailtriage-cli",
+    )
+    missing = [token for token in required_substrings if token not in lowered]
+    if missing:
+        raise ValueError(
+            "tailtriage-analyzer README missing required analyzer contract tokens: "
+            f"{missing}"
+        )
+
+    if "not streaming" not in lowered and "not live streaming" not in lowered:
+        raise ValueError(
+            "tailtriage-analyzer README must state in-process analysis is not streaming/live streaming"
+        )
+
+    has_cli_artifact_guidance = (
+        "tailtriage-cli" in lowered
+        and "artifact" in lowered
+        and (
+            "command-line" in lowered
+            or "command line" in lowered
+            or "load" in lowered
+            or "loading" in lowered
+        )
+    )
+    if not has_cli_artifact_guidance:
+        raise ValueError(
+            "tailtriage-analyzer README must point to tailtriage-cli for command-line artifact analysis"
+        )
+
+
+def validate_cli_readme_contract() -> None:
+    path = REPO_ROOT / "tailtriage-cli" / "README.md"
+    text = path.read_text(encoding="utf-8")
+    lowered = text.lower()
+
+    required_substrings = (
+        "artifact",
+        "schema",
+        "requests",
+        "tailtriage-analyzer",
+        "command-line",
+        "text",
+        "json",
+    )
+    missing = [token for token in required_substrings if token not in lowered]
+    if missing:
+        raise ValueError(f"tailtriage-cli README missing required CLI contract tokens: {missing}")
+
+    has_non_empty_requests_rule = (
+        "requests" in lowered
+        and (
+            "non-empty" in lowered
+            or "nonempty" in lowered
+            or ("empty" in lowered and any(token in lowered for token in ("reject", "error", "invalid", "fail")))
+        )
+    )
+    if not has_non_empty_requests_rule:
+        raise ValueError("tailtriage-cli README must document non-empty requests loader rule")
+
+    if "in-process" not in lowered or "tailtriage-analyzer" not in lowered:
+        raise ValueError(
+            "tailtriage-cli README must point Rust in-process users to tailtriage-analyzer"
+        )
+
+
+def validate_capture_readmes_analyzer_cli_split_contract(
+    *, paths: tuple[Path, ...] = CAPTURE_INTEGRATION_README_PATHS
+) -> None:
+    stale_patterns = (
+        r"analysis\s+is\s+still\s+done\s+by\s+`tailtriage-cli`",
+        r"analysis\s+happens\s+in\s+`tailtriage-cli`",
+        r"artifact\s+produced\s+here\s+is\s+analyzed\s+by\s+`tailtriage-cli`",
+        r"writes\s+artifacts,\s*`tailtriage-cli`\s+analyzes\s+them",
+        r"analysis\s+or\s+report\s+generation.{0,80}`tailtriage-cli`",
+    )
+
+    failures: list[str] = []
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        lowered = text.lower()
+        rel = path.relative_to(REPO_ROOT) if path.is_relative_to(REPO_ROOT) else path
+
+        if "tailtriage-analyzer" not in lowered or "tailtriage-cli" not in lowered:
+            failures.append(f"{rel} must mention both tailtriage-analyzer and tailtriage-cli")
+
+        for pattern in stale_patterns:
+            if re.search(pattern, lowered, flags=re.IGNORECASE):
+                failures.append(f"{rel} contains stale CLI-only analyzer wording matching: {pattern}")
+
+    if failures:
+        raise ValueError("capture/integration README analyzer split contract violation:\n" + "\n".join(failures))
+
 def _active_yaml_lines(text: str) -> str:
     return "\n".join(line for line in text.splitlines() if not line.lstrip().startswith("#"))
 
@@ -760,6 +874,9 @@ def main() -> int:
     validate_user_guide_contract()
     validate_diagnostics_contract_truthfulness()
     validate_cli_not_presented_as_library_analyzer_api()
+    validate_analyzer_readme_contract()
+    validate_cli_readme_contract()
+    validate_capture_readmes_analyzer_cli_split_contract()
     validate_diagnostic_benchmark_ci_contract()
     validate_validation_docs_ci_contract()
     validate_architecture_contract()


### PR DESCRIPTION
### Motivation
- Prevent stale docs that present `tailtriage-cli` as the library analyzer API and ensure public crate docs consistently teach the `tailtriage-analyzer` (in-process analyzer) vs `tailtriage-cli` (CLI artifact analysis) split. 
- This is a docs-validation-only change and does not alter runtime code, analyzer behavior, CLI behavior, fixtures, or JSON output.

### Description
- Added `CAPTURE_INTEGRATION_README_PATHS` to explicitly target capture/integration crate READMEs (`tailtriage`, `tailtriage-core`, `tailtriage-controller`, `tailtriage-tokio`, `tailtriage-axum`).
- Implemented `validate_analyzer_readme_contract()` to require semantic analyzer tokens (e.g. `in-process`, `completed`, `run`, `typed`, `Report`, `render_text`, `serde_json`, `AnalyzeOptions::default()`), non-streaming guidance, and CLI artifact-analysis guidance to `tailtriage-cli`.
- Implemented `validate_cli_readme_contract()` to require CLI README tokens about artifact loading/schema validation, a non-empty `requests` loader rule, reference to `tailtriage-analyzer`, and command-line text/json output guidance.
- Implemented `validate_capture_readmes_analyzer_cli_split_contract()` to require both `tailtriage-analyzer` and `tailtriage-cli` mentions in capture/integration READMEs and to reject stale CLI-only analyzer wording via a set of regex patterns.
- Wired the new validators into `main()` in `scripts/validate_docs_contracts.py` and added unit tests in `scripts/tests/test_validate_docs_contracts.py` covering positive and negative examples for the analyzer/CLI split.

### Testing
- Ran `python3 scripts/validate_docs_contracts.py` and it completed successfully with the new checks reporting "docs contracts validated successfully".
- Ran `python3 -m unittest scripts.tests.test_validate_docs_contracts` and all tests passed (35 tests, OK), including the added positive and negative tests for analyzer/CLI split behavior.
- Ran `cargo fmt --check` and it passed.
- New automated tests added: a positive analyzer/CLI split example, a negative stale CLI-only wording example, a negative capture README that omits `tailtriage-analyzer`, and a positive CLI README that states the CLI invokes `tailtriage-analyzer`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb987fe51c8330bb2f0a1dabca4645)