### PR TITLE
Strengthen docs-contract validation for analyzer vs CLI docs split

### DIFF
--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -150,6 +150,84 @@ Normal CI does not publish durable diagnostic scorecards.
     def test_cli_not_presented_as_library_analyzer_api_contract(self) -> None:
         validate_docs_contracts.validate_cli_not_presented_as_library_analyzer_api()
 
+
+    def test_analyzer_and_cli_docs_split_contract(self) -> None:
+        validate_docs_contracts.validate_analyzer_and_cli_docs_split_contract()
+
+    def test_capture_readmes_contract_rejects_stale_cli_only_wording(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            capture_paths = [
+                repo_root / "tailtriage" / "README.md",
+                repo_root / "tailtriage-core" / "README.md",
+                repo_root / "tailtriage-controller" / "README.md",
+                repo_root / "tailtriage-tokio" / "README.md",
+                repo_root / "tailtriage-axum" / "README.md",
+            ]
+            for path in capture_paths:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(
+                    "Use tailtriage-analyzer and tailtriage-cli. Analysis is still done by `tailtriage-cli`.",
+                    encoding="utf-8",
+                )
+
+            with (
+                mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root),
+                mock.patch.object(validate_docs_contracts, "CAPTURE_INTEGRATION_README_PATHS", tuple(capture_paths)),
+            ):
+                with self.assertRaisesRegex(ValueError, r"stale CLI-only"):
+                    validate_docs_contracts.validate_capture_readmes_analyzer_cli_wording_contract()
+
+    def test_capture_readmes_contract_rejects_cli_without_analyzer(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            capture_paths = [
+                repo_root / "tailtriage" / "README.md",
+                repo_root / "tailtriage-core" / "README.md",
+                repo_root / "tailtriage-controller" / "README.md",
+                repo_root / "tailtriage-tokio" / "README.md",
+                repo_root / "tailtriage-axum" / "README.md",
+            ]
+            for path in capture_paths:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("Use tailtriage-cli for saved artifact analysis.", encoding="utf-8")
+
+            with (
+                mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root),
+                mock.patch.object(validate_docs_contracts, "CAPTURE_INTEGRATION_README_PATHS", tuple(capture_paths)),
+            ):
+                with self.assertRaisesRegex(ValueError, r"must mention both"):
+                    validate_docs_contracts.validate_capture_readmes_analyzer_cli_wording_contract()
+
+    def test_cli_readme_positive_split_mentions_analyzer(self) -> None:
+        analyzer_text = """
+# tailtriage-analyzer
+in-process completed Run typed Report render_text serde_json AnalyzeOptions::default()
+not live streaming
+Use tailtriage-cli for artifact loading from command line.
+"""
+        cli_text = """
+# tailtriage-cli
+Loads saved run artifacts with schema validation and enforces non-empty requests.
+Invokes tailtriage-analyzer for analysis.
+Supports command-line text and json output.
+Rust in-process users should use tailtriage-analyzer.
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            analyzer_path = repo_root / "tailtriage-analyzer" / "README.md"
+            cli_path = repo_root / "tailtriage-cli" / "README.md"
+            analyzer_path.parent.mkdir(parents=True, exist_ok=True)
+            cli_path.parent.mkdir(parents=True, exist_ok=True)
+            analyzer_path.write_text(analyzer_text, encoding="utf-8")
+            cli_path.write_text(cli_text, encoding="utf-8")
+
+            with (
+                mock.patch.object(validate_docs_contracts, "ANALYZER_README_PATH", analyzer_path),
+                mock.patch.object(validate_docs_contracts, "CLI_README_PATH", cli_path),
+            ):
+                validate_docs_contracts.validate_analyzer_and_cli_docs_split_contract()
+
     def test_architecture_contract(self) -> None:
         validate_docs_contracts.validate_architecture_contract()
 

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -20,6 +20,24 @@ CI_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 ARCHITECTURE_PATH = REPO_ROOT / "docs" / "architecture.md"
 CONTROLLER_README_PATH = REPO_ROOT / "tailtriage-controller" / "README.md"
 ANALYSIS_FIXTURE_PATH = REPO_ROOT / "demos" / "queue_service" / "fixtures" / "sample-analysis.json"
+
+ANALYZER_README_PATH = REPO_ROOT / "tailtriage-analyzer" / "README.md"
+CLI_README_PATH = REPO_ROOT / "tailtriage-cli" / "README.md"
+CAPTURE_INTEGRATION_README_PATHS = (
+    REPO_ROOT / "tailtriage" / "README.md",
+    REPO_ROOT / "tailtriage-core" / "README.md",
+    REPO_ROOT / "tailtriage-controller" / "README.md",
+    REPO_ROOT / "tailtriage-tokio" / "README.md",
+    REPO_ROOT / "tailtriage-axum" / "README.md",
+)
+
+STALE_CLI_ONLY_ANALYZER_PATTERNS = (
+    r"analysis\s+is\s+still\s+done\s+by\s+`?tailtriage-cli`?",
+    r"analysis\s+happens\s+in\s+`?tailtriage-cli`?",
+    r"artifact\s+produced\s+here\s+is\s+analy(?:s|z)ed\s+by\s+`?tailtriage-cli`?",
+    r"this\s+crate\s+writes\s+artifacts?,\s*`?tailtriage-cli`?\s+analy(?:s|z)es\s+them",
+    r"analysis\s+or\s+report\s+generation[^\n]*`?tailtriage-cli`?",
+)
 CONTROLLER_SOURCE_PATH = REPO_ROOT / "tailtriage-controller" / "src" / "lib.rs"
 CORE_COLLECTOR_SOURCE_PATH = REPO_ROOT / "tailtriage-core" / "src" / "collector.rs"
 CORE_LIB_SOURCE_PATH = REPO_ROOT / "tailtriage-core" / "src" / "lib.rs"
@@ -570,6 +588,72 @@ def validate_cli_not_presented_as_library_analyzer_api() -> None:
     if hits:
         raise ValueError("CLI/library analyzer contract violation:\n" + "\n".join(hits))
 
+
+
+def _has_all_tokens(text: str, tokens: tuple[str, ...]) -> bool:
+    lowered = text.lower()
+    return all(token.lower() in lowered for token in tokens)
+
+
+def validate_analyzer_and_cli_docs_split_contract() -> None:
+    analyzer_text = ANALYZER_README_PATH.read_text(encoding="utf-8")
+    cli_text = CLI_README_PATH.read_text(encoding="utf-8")
+
+    analyzer_token_groups = (
+        ("in-process",),
+        ("completed",),
+        ("run",),
+        ("typed",),
+        ("report",),
+        ("render_text",),
+        ("serde_json",),
+        ("analyzeoptions::default()",),
+        ("not streaming", "not live streaming"),
+        ("tailtriage-cli",),
+    )
+    for group in analyzer_token_groups:
+        if not any(token.lower() in analyzer_text.lower() for token in group):
+            raise ValueError(
+                "tailtriage-analyzer README is missing analyzer/CLI split concept token(s): "
+                + " or ".join(group)
+            )
+
+    cli_required = (
+        "artifact",
+        "schema",
+        "requests",
+        "tailtriage-analyzer",
+        "json",
+        "text",
+        "in-process",
+    )
+    missing_cli = [token for token in cli_required if token not in cli_text.lower()]
+    if missing_cli:
+        raise ValueError(
+            "tailtriage-cli README is missing analyzer split concept token(s): "
+            + ", ".join(missing_cli)
+        )
+
+
+def validate_capture_readmes_analyzer_cli_wording_contract() -> None:
+    failures: list[str] = []
+    for path in CAPTURE_INTEGRATION_README_PATHS:
+        text = path.read_text(encoding="utf-8")
+        lowered = text.lower()
+        rel = path.relative_to(REPO_ROOT) if path.is_relative_to(REPO_ROOT) else path
+
+        if "tailtriage-analyzer" not in lowered or "tailtriage-cli" not in lowered:
+            failures.append(
+                f"{rel} must mention both tailtriage-analyzer and tailtriage-cli"
+            )
+
+        for pattern in STALE_CLI_ONLY_ANALYZER_PATTERNS:
+            if re.search(pattern, lowered):
+                failures.append(f"{rel} contains stale CLI-only analyzer wording matching: {pattern}")
+
+    if failures:
+        raise ValueError("capture/integration README analyzer wording contract violation:\n" + "\n".join(failures))
+
 def _active_yaml_lines(text: str) -> str:
     return "\n".join(line for line in text.splitlines() if not line.lstrip().startswith("#"))
 
@@ -760,6 +844,8 @@ def main() -> int:
     validate_user_guide_contract()
     validate_diagnostics_contract_truthfulness()
     validate_cli_not_presented_as_library_analyzer_api()
+    validate_analyzer_and_cli_docs_split_contract()
+    validate_capture_readmes_analyzer_cli_wording_contract()
     validate_diagnostic_benchmark_ci_contract()
     validate_validation_docs_ci_contract()
     validate_architecture_contract()


### PR DESCRIPTION
### Motivation
- Prevent stale docs that present `tailtriage-cli` as the only analyzer/report-generation path after extracting `tailtriage-analyzer` into a separate crate.
- Ensure public docs consistently teach the split: `tailtriage-analyzer` is the in-process analyzer for completed runs/snapshots and `tailtriage-cli` is the command-line artifact analyzer.

### Description
- Added README path constants `ANALYZER_README_PATH`, `CLI_README_PATH`, and `CAPTURE_INTEGRATION_README_PATHS` and new stale-phrase patterns in `scripts/validate_docs_contracts.py`.
- Implemented `validate_analyzer_and_cli_docs_split_contract()` to semantically check `tailtriage-analyzer/README.md` for analyzer tokens (e.g., `in-process`, `completed`, `Run`, `Report`, `render_text`, `serde_json`, `AnalyzeOptions::default()`, `not streaming`) and `tailtriage-cli/README.md` for artifact/schema/requests/analyzer linkage and output modes.
- Implemented `validate_capture_readmes_analyzer_cli_wording_contract()` to require capture/integration crate READMEs mention both `tailtriage-analyzer` and `tailtriage-cli` and to reject stale CLI-only analyzer phrasing patterns while allowing legitimate CLI artifact-analysis statements.
- Wired the new validations into the main validator run in `scripts/validate_docs_contracts.py` and added unit tests in `scripts/tests/test_validate_docs_contracts.py` covering positive and negative cases.
- No runtime code, analyzer behavior, CLI behavior, fixtures, or JSON output were changed.

### Testing
- Ran `python3 scripts/validate_docs_contracts.py` and observed: `docs contracts validated successfully`.
- Ran `python3 -m unittest scripts.tests.test_validate_docs_contracts` and observed: `Ran 35 tests` with `OK`.
- Ran `cargo fmt --check` which completed with no formatting errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb987fe51c8330bb2f0a1dabca4645)