### PR TITLE
docs: align controller README crate-boundary guidance

### DIFF
--- a/tailtriage-controller/README.md
+++ b/tailtriage-controller/README.md
@@ -208,5 +208,6 @@ Optional table. If present, `kind` is required.
 - `tailtriage`: default entry point
 - `tailtriage-core`: direct instrumentation lifecycle
 - `tailtriage-tokio`: runtime-pressure sampling
+- `tailtriage-axum`: Axum request-boundary integration
 - `tailtriage-analyzer`: in-process analysis/report generation for completed runs
 - `tailtriage-cli`: command-line analysis of saved run artifacts


### PR DESCRIPTION
### Motivation
- Keep crate README guidance truthful and consistent about crate ownership and related-crates to avoid user confusion about boundaries between capture, analyzer, and integration crates.

### Description
- Add `tailtriage-axum` to the `Related crates` list in `tailtriage-controller/README.md` to align guidance with other READMEs and crate boundaries; this is a docs-only change.

### Testing
- Ran `cargo fmt --check`, `cargo test --doc --workspace`, `cargo doc --workspace --all-features --no-deps`, `python3 scripts/validate_docs_contracts.py`, and `python3 -m unittest scripts.tests.test_validate_docs_contracts`, all of which completed successfully (`cargo doc` emitted a known non-blocking Cargo filename-collision warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fba4f3a4708330b9ce9a0f0fd3a279)