### PR TITLE
docs(analyzer): clarify analyzer consumes a completed in-memory Run

### DIFF
--- a/tailtriage-analyzer/src/lib.rs
+++ b/tailtriage-analyzer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Heuristic triage analyzer for completed [`tailtriage_core::Run`] captures.
 //!
-//! This crate analyzes a finished in-memory [`Run`] (or stable snapshot equivalent) and returns a typed
+//! This crate analyzes one completed in-memory [`Run`] and returns a typed
 //! [`Report`] for in-process diagnosis. It does not load run artifacts from disk and it does not
 //! write capture artifacts; CLI artifact loading is owned by `tailtriage-cli`.
 //!


### PR DESCRIPTION
### Motivation
- Make crate-level documentation explicit that the analyzer operates on a single completed in-memory `Run` (not file artifacts or streaming) to preserve clear crate boundaries between capture, analyzer, and CLI.

### Description
- Small docs-only change: updated the rustdoc in `tailtriage-analyzer/src/lib.rs` to state it "analyzes one completed in-memory `Run`" and reaffirm that artifact loading is owned by `tailtriage-cli`.

### Testing
- Ran `cargo fmt --check`, `cargo test --doc --workspace`, `cargo doc --workspace --all-features --no-deps`, `python3 scripts/validate_docs_contracts.py`, and `python3 -m unittest scripts.tests.test_validate_docs_contracts`, and all commands completed successfully (`cargo doc` emitted a known Cargo output-filename collision warning but finished).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fba4f3a4708330b9ce9a0f0fd3a279)