### PR TITLE
docs: final crate README/rustdoc consistency pass after analyzer-doc cleanup

### DIFF
--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -42,7 +42,7 @@ Machine-readable JSON output:
 tailtriage analyze tailtriage-run.json --format json
 ```
 
-The CLI artifact loader requires at least one request event in `requests`.
+The CLI artifact loader requires at least one request event in `requests`. This is a CLI artifact-loading rule, not an in-process `tailtriage-analyzer` requirement for already-constructed `Run` values.
 
 ## How to read the result
 


### PR DESCRIPTION
### Motivation
- Finalize a consistency pass across crate README files and crate-level rustdocs after the analyzer documentation cleanup to ensure crate boundaries and analyzer vs CLI responsibilities are clearly stated.

### Description
- Reviewed README and crate docs for `tailtriage`, `tailtriage-core`, `tailtriage-controller`, `tailtriage-tokio`, `tailtriage-axum`, `tailtriage-analyzer`, and `tailtriage-cli`, and applied one narrow wording fix in `tailtriage-cli/README.md` to clarify that the CLI artifact loader’s requirement for at least one `requests` event is a CLI-only artifact-loading rule and not a requirement for in-process `tailtriage-analyzer` when given an already-constructed `Run`.

### Testing
- Ran `cargo fmt --check`, `cargo test --doc --workspace`, `cargo doc --workspace --all-features --no-deps`, `python3 scripts/validate_docs_contracts.py`, and `python3 -m unittest scripts.tests.test_validate_docs_contracts`, all of which completed successfully (note: `cargo doc` emitted a known Cargo filename-collision warning for `tailtriage` doc output but finished successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fba4f3a4708330b9ce9a0f0fd3a279)