### PR TITLE
Fix downstream demo validator to use downstream semantics

### DIFF
--- a/scripts/demo_tool.py
+++ b/scripts/demo_tool.py
@@ -277,6 +277,32 @@ def _validate_nonworsening_score_or_explainable_saturation(
             f"got queue share {before.get('p95_queue_share_permille')}->{after.get('p95_queue_share_permille')}"
         )
 
+
+def _validate_nonworsening_score_for_downstream(
+    *,
+    before: dict,
+    after: dict,
+    expected_primary_kinds: set[str],
+    scenario: str,
+) -> None:
+    before_score = before["primary_suspect"]["score"]
+    after_score = after["primary_suspect"]["score"]
+    if after_score <= before_score:
+        return
+
+    before_p95 = before["p95_latency_us"]
+    after_p95 = after["p95_latency_us"]
+    after_kind = after["primary_suspect"]["kind"]
+    if not _material_p95_improvement(before_p95, after_p95):
+        raise SystemExit(
+            f"expected mitigated {scenario} suspect score to stay flat or drop when p95 does not materially improve, "
+            f"got p95 {before_p95}->{after_p95} and score {before_score}->{after_score}"
+        )
+    if after_kind not in expected_primary_kinds:
+        raise SystemExit(
+            f"expected mitigated {scenario} primary suspect in {sorted(expected_primary_kinds)} when score rises, got {after_kind}"
+        )
+
 def validate_queue(root_dir: Path, *, profile: str = "dev") -> None:
     run_scenario_queue(root_dir, "both", profile=profile)
     artifact_dir = root_dir / "demos/queue_service/artifacts"
@@ -402,11 +428,11 @@ def validate_downstream(root_dir: Path, *, profile: str = "dev") -> None:
 
     before_score = before["primary_suspect"]["score"]
     after_score = after["primary_suspect"]["score"]
-    _validate_nonworsening_score_or_explainable_saturation(
+    _validate_nonworsening_score_for_downstream(
         before=before,
         after=after,
-        expected_primary_kinds=EXPECTED_COLD_START_PRIMARY_KINDS,
-        scenario="cold-start",
+        expected_primary_kinds=EXPECTED_DOWNSTREAM_KIND,
+        scenario="downstream",
     )
 
     print(

--- a/scripts/tests/test_demo_scripts.py
+++ b/scripts/tests/test_demo_scripts.py
@@ -209,6 +209,47 @@ class DemoWrapperTests(unittest.TestCase):
             scenario="queue",
         )
 
+    def test_downstream_score_increase_rejected_when_kind_shifts(self) -> None:
+        before = {
+            "primary_suspect": {"kind": "downstream_stage_dominates", "score": 90},
+            "p95_latency_us": 1_000_000,
+            "p95_queue_share_permille": 980,
+        }
+        after = {
+            "primary_suspect": {"kind": "application_queue_saturation", "score": 95},
+            "p95_latency_us": 100_000,
+            "p95_queue_share_permille": 0,
+        }
+        with self.assertRaisesRegex(SystemExit, "expected mitigated downstream primary suspect"):
+            demo_tool._validate_nonworsening_score_for_downstream(
+                before=before,
+                after=after,
+                expected_primary_kinds={"downstream_stage_dominates"},
+                scenario="downstream",
+            )
+
+    @patch("demo_tool.load_report_json")
+    @patch("demo_tool.run_scenario_downstream")
+    def test_validate_downstream_uses_downstream_context(
+        self,
+        _run_scenario_downstream_mock,
+        load_report_json_mock,
+    ) -> None:
+        before_report = {
+            "primary_suspect": {"kind": "downstream_stage_dominates", "score": 90},
+            "secondary_suspects": [],
+            "p95_latency_us": 100_000,
+        }
+        after_report = {
+            "primary_suspect": {"kind": "application_queue_saturation", "score": 95},
+            "secondary_suspects": [],
+            "p95_latency_us": 20_000,
+        }
+        load_report_json_mock.side_effect = [before_report, after_report]
+
+        with self.assertRaisesRegex(SystemExit, "expected mitigated downstream primary suspect"):
+            demo_tool.validate_downstream(Path("/tmp/tailscope"), profile="dev")
+
 
 class DemoMainRoutingTests(unittest.TestCase):
     @patch("demo_tool.repo_root", return_value=Path("/tmp/tailscope"))


### PR DESCRIPTION
### Motivation
- The downstream demo validator used cold-start mitigation semantics when validating mitigations, causing misleading messages and allowing queue-specific escape logic to apply to downstream scenarios; the intent is to validate downstream mitigations against downstream expectations and wording.

### Description
- Update `validate_downstream()` so mitigation validation uses `EXPECTED_DOWNSTREAM_KIND` and `scenario="downstream"` instead of cold-start values.
- Add a small downstream-specific helper ` _validate_nonworsening_score_for_downstream(...)` that enforces downstream mitigation rules without the queue-evidence escape logic present in ` _validate_nonworsening_score_or_explainable_saturation(...)`.
- Preserve the existing generic helper for queue-like scenarios unchanged so queue-specific allowances remain strict and scoped.
- Add focused unit tests in `scripts/tests/test_demo_scripts.py` that assert downstream-specific validation behavior and error messaging for score/kind shifts.

### Testing
- Ran `python3 -m unittest discover scripts/tests` and all script tests passed (OK).
- Ran `cargo fmt --check` with no changes required (OK).
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and lints passed (OK).
- Ran `cargo test --workspace` and the Rust test suite passed (OK).
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed (OK).
- Exercised the downstream demo validation manually with `python3 scripts/demo_tool.py validate downstream --profile dev` and `--profile release` and observed successful downstream validation messages (OK).

Notes: the mismatch fixed was that `validate_downstream()` previously invoked mitigation validation with `EXPECTED_COLD_START_PRIMARY_KINDS` and `scenario="cold-start"` while its baseline check used `EXPECTED_DOWNSTREAM_KIND`; this patch makes both baseline and mitigation checks downstream-specific. A downstream-specific helper was added because the generic helper includes queue-evidence escape logic that is not appropriate for downstream-only semantics. All requested validation commands were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc2c0731e483309d2a7dd51da7b551)