### PR TITLE
Fix downstream demo validator to use downstream mitigation semantics

### DIFF
--- a/scripts/demo_tool.py
+++ b/scripts/demo_tool.py
@@ -277,6 +277,32 @@ def _validate_nonworsening_score_or_explainable_saturation(
             f"got queue share {before.get('p95_queue_share_permille')}->{after.get('p95_queue_share_permille')}"
         )
 
+
+def _validate_nonworsening_score_for_downstream(
+    *,
+    before: dict,
+    after: dict,
+    expected_primary_kinds: set[str],
+    scenario: str,
+) -> None:
+    before_score = before["primary_suspect"]["score"]
+    after_score = after["primary_suspect"]["score"]
+    if after_score <= before_score:
+        return
+
+    before_p95 = before["p95_latency_us"]
+    after_p95 = after["p95_latency_us"]
+    after_kind = after["primary_suspect"]["kind"]
+    if not _material_p95_improvement(before_p95, after_p95):
+        raise SystemExit(
+            f"expected mitigated {scenario} suspect score to stay flat or drop when p95 does not materially improve, "
+            f"got p95 {before_p95}->{after_p95} and score {before_score}->{after_score}"
+        )
+    if after_kind not in expected_primary_kinds:
+        raise SystemExit(
+            f"expected mitigated {scenario} primary suspect in {sorted(expected_primary_kinds)} when score rises, got {after_kind}"
+        )
+
 def validate_queue(root_dir: Path, *, profile: str = "dev") -> None:
     run_scenario_queue(root_dir, "both", profile=profile)
     artifact_dir = root_dir / "demos/queue_service/artifacts"
@@ -402,11 +428,11 @@ def validate_downstream(root_dir: Path, *, profile: str = "dev") -> None:
 
     before_score = before["primary_suspect"]["score"]
     after_score = after["primary_suspect"]["score"]
-    _validate_nonworsening_score_or_explainable_saturation(
+    _validate_nonworsening_score_for_downstream(
         before=before,
         after=after,
-        expected_primary_kinds=EXPECTED_COLD_START_PRIMARY_KINDS,
-        scenario="cold-start",
+        expected_primary_kinds=EXPECTED_DOWNSTREAM_KIND,
+        scenario="downstream",
     )
 
     print(

--- a/scripts/tests/test_demo_scripts.py
+++ b/scripts/tests/test_demo_scripts.py
@@ -209,6 +209,42 @@ class DemoWrapperTests(unittest.TestCase):
             scenario="queue",
         )
 
+    def test_downstream_score_increase_rejects_wrong_primary_kind(self) -> None:
+        before = {
+            "primary_suspect": {"kind": "downstream_stage_dominates", "score": 80},
+            "p95_latency_us": 120_000,
+        }
+        after = {
+            "primary_suspect": {"kind": "application_queue_saturation", "score": 90},
+            "p95_latency_us": 40_000,
+        }
+        with self.assertRaisesRegex(SystemExit, "expected mitigated downstream primary suspect"):
+            demo_tool._validate_nonworsening_score_for_downstream(
+                before=before,
+                after=after,
+                expected_primary_kinds={"downstream_stage_dominates"},
+                scenario="downstream",
+            )
+
+    @patch("demo_tool.load_report_json")
+    @patch("demo_tool.run_scenario_downstream")
+    def test_validate_downstream_uses_downstream_scenario_text(
+        self,
+        _run_scenario_downstream_mock,
+        load_report_json_mock,
+    ) -> None:
+        before_report = {
+            "primary_suspect": {"kind": "downstream_stage_dominates", "score": 90},
+            "p95_latency_us": 60_000,
+        }
+        after_report = {
+            "primary_suspect": {"kind": "application_queue_saturation", "score": 95},
+            "p95_latency_us": 30_000,
+        }
+        load_report_json_mock.side_effect = [before_report, after_report]
+        with self.assertRaisesRegex(SystemExit, "expected mitigated downstream primary suspect"):
+            demo_tool.validate_downstream(Path("/tmp/tailscope"), profile="dev")
+
 
 class DemoMainRoutingTests(unittest.TestCase):
     @patch("demo_tool.repo_root", return_value=Path("/tmp/tailscope"))


### PR DESCRIPTION
### Motivation
- The downstream demo validator used cold-start/queue-oriented mitigation semantics when checking mitigations, causing downstream validations to reference `cold-start` text and allow queue-specific evidence escapes incorrectly.
- Keep the change narrowly focused to validation wiring without changing analyzer logic or demo behavior.

### Description
- Updated `validate_downstream()` in `scripts/demo_tool.py` to call the downstream-specific checker with `expected_primary_kinds=EXPECTED_DOWNSTREAM_KIND` and `scenario="downstream"` instead of the incorrect cold-start values.
- Added a small downstream-specific helper ` _validate_nonworsening_score_for_downstream(...)` in `scripts/demo_tool.py` that enforces downstream semantics (score increases allowed only when p95 materially improves and the primary suspect remains downstream), avoiding queue-evidence escape logic.
- Left the existing generic helper `_validate_nonworsening_score_or_explainable_saturation(...)` unchanged so queue-like scenarios retain their current behavior.
- Added focused script tests in `scripts/tests/test_demo_scripts.py`: `test_downstream_score_increase_rejects_wrong_primary_kind` and `test_validate_downstream_uses_downstream_scenario_text` to cover the corrected behavior.

### Testing
- Ran unit tests: `python3 -m unittest discover scripts/tests` (all script tests passed).
- Ran formatting/lint/build/test validations: `cargo fmt --check` (passed), `cargo clippy --workspace --all-targets -- -D warnings` (passed), and `cargo test --workspace` (all Rust tests passed).
- Ran docs contract validation: `python3 scripts/validate_docs_contracts.py` (passed).
- Exercised the downstream demo validator end-to-end: `python3 scripts/demo_tool.py validate downstream --profile dev` and `--profile release` (both succeeded and reported validation passed for the downstream demo).
- All listed validation commands completed successfully; no required validation commands were skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc2c0731e483309d2a7dd51da7b551)