### PR TITLE
Fix downstream demo validator to use downstream-specific mitigation checks

### DIFF
--- a/scripts/demo_tool.py
+++ b/scripts/demo_tool.py
@@ -277,6 +277,32 @@ def _validate_nonworsening_score_or_explainable_saturation(
             f"got queue share {before.get('p95_queue_share_permille')}->{after.get('p95_queue_share_permille')}"
         )
 
+
+def _validate_nonworsening_score_or_expected_primary(
+    *,
+    before: dict,
+    after: dict,
+    expected_primary_kinds: set[str],
+    scenario: str,
+) -> None:
+    before_score = before["primary_suspect"]["score"]
+    after_score = after["primary_suspect"]["score"]
+    if after_score <= before_score:
+        return
+
+    before_p95 = before["p95_latency_us"]
+    after_p95 = after["p95_latency_us"]
+    after_kind = after["primary_suspect"]["kind"]
+    if not _material_p95_improvement(before_p95, after_p95):
+        raise SystemExit(
+            f"expected mitigated {scenario} suspect score to stay flat or drop when p95 does not materially improve, "
+            f"got p95 {before_p95}->{after_p95} and score {before_score}->{after_score}"
+        )
+    if after_kind not in expected_primary_kinds:
+        raise SystemExit(
+            f"expected mitigated {scenario} primary suspect in {sorted(expected_primary_kinds)} when score rises, got {after_kind}"
+        )
+
 def validate_queue(root_dir: Path, *, profile: str = "dev") -> None:
     run_scenario_queue(root_dir, "both", profile=profile)
     artifact_dir = root_dir / "demos/queue_service/artifacts"
@@ -402,11 +428,11 @@ def validate_downstream(root_dir: Path, *, profile: str = "dev") -> None:
 
     before_score = before["primary_suspect"]["score"]
     after_score = after["primary_suspect"]["score"]
-    _validate_nonworsening_score_or_explainable_saturation(
+    _validate_nonworsening_score_or_expected_primary(
         before=before,
         after=after,
-        expected_primary_kinds=EXPECTED_COLD_START_PRIMARY_KINDS,
-        scenario="cold-start",
+        expected_primary_kinds=EXPECTED_DOWNSTREAM_KIND,
+        scenario="downstream",
     )
 
     print(

--- a/scripts/tests/test_demo_scripts.py
+++ b/scripts/tests/test_demo_scripts.py
@@ -209,6 +209,44 @@ class DemoWrapperTests(unittest.TestCase):
             scenario="queue",
         )
 
+    def test_downstream_score_increase_rejected_when_kind_shifts(self) -> None:
+        before = {
+            "primary_suspect": {"kind": "downstream_stage_dominates", "score": 80},
+            "p95_latency_us": 100_000,
+        }
+        after = {
+            "primary_suspect": {"kind": "application_queue_saturation", "score": 85},
+            "p95_latency_us": 40_000,
+        }
+        with self.assertRaisesRegex(SystemExit, "expected mitigated downstream primary suspect"):
+            demo_tool._validate_nonworsening_score_or_expected_primary(
+                before=before,
+                after=after,
+                expected_primary_kinds={"downstream_stage_dominates"},
+                scenario="downstream",
+            )
+
+    @patch("demo_tool.load_report_json")
+    @patch("demo_tool.run_scenario_downstream")
+    def test_validate_downstream_uses_downstream_wording(
+        self,
+        _run_scenario_downstream_mock,
+        load_report_json_mock,
+    ) -> None:
+        before_report = {
+            "primary_suspect": {"kind": "downstream_stage_dominates", "score": 80},
+            "p95_latency_us": 100_000,
+        }
+        after_report = {
+            "primary_suspect": {"kind": "application_queue_saturation", "score": 90},
+            "p95_latency_us": 40_000,
+            "p95_queue_share_permille": 0,
+        }
+        load_report_json_mock.side_effect = [before_report, after_report]
+
+        with self.assertRaisesRegex(SystemExit, "mitigated downstream primary suspect"):
+            demo_tool.validate_downstream(Path("/tmp/tailscope"), profile="dev")
+
 
 class DemoMainRoutingTests(unittest.TestCase):
     @patch("demo_tool.repo_root", return_value=Path("/tmp/tailscope"))


### PR DESCRIPTION
### Motivation
- The downstream demo validator incorrectly used cold-start expectations and wording when validating mitigation outcomes, causing downstream validation messages and allowances to follow cold-start semantics.
- This made downstream validation less precise and risked allowing queue-specific escape logic to apply to downstream scenarios.

### Description
- Updated `validate_downstream()` to call a downstream-appropriate mitigation checker with `expected_primary_kinds=EXPECTED_DOWNSTREAM_KIND` and `scenario="downstream"` instead of the cold-start constants.
- Added a focused helper `_validate_nonworsening_score_or_expected_primary()` that enforces downstream-style expectations for score increases without the queue-evidence escape path.
- Kept the existing `_validate_nonworsening_score_or_explainable_saturation()` unchanged so queue/cold-start semantics remain strict and separate from downstream validation.
- Added focused tests in `scripts/tests/test_demo_scripts.py` to assert downstream helper behavior and that `validate_downstream()` uses downstream-specific wording and logic.

### Testing
- Ran `python3 -m unittest discover scripts/tests` and all script unit tests passed (OK).
- Ran `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings` with no issues (OK).
- Ran `cargo test --workspace` and the full Rust test suite passed (OK).
- Ran `python3 scripts/validate_docs_contracts.py` which validated docs contracts successfully (OK).
- Ran `python3 scripts/demo_tool.py validate downstream --profile dev` and `--profile release` and both validations completed successfully and printed downstream-correct results (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc2c0731e483309d2a7dd51da7b551)