### PR TITLE
Improve diagnostic benchmark confidence bucket stdout reporting

### DIFF
--- a/scripts/diagnostic_benchmark.py
+++ b/scripts/diagnostic_benchmark.py
@@ -16,6 +16,7 @@ CONFIDENCE_ORDER = {"low": 0, "medium": 1, "high": 2}
 ALLOWED_EVIDENCE_QUALITY = {"strong", "partial", "weak"}
 ALLOWED_SIGNAL_FAMILIES = {"requests", "queues", "stages", "runtime_snapshots", "inflight_snapshots"}
 ALLOWED_SIGNAL_STATUSES = {"present", "missing", "partial", "truncated"}
+STDOUT_CONFIDENCE_BUCKET_ORDER = ("low", "medium", "high")
 
 
 def load_json(path):
@@ -431,6 +432,21 @@ def main():
     print(f"next_check_required_cases={metrics['next_check_required_cases']}")
     print(f"next_check_pass_rate={next_check_pass_rate_text}")
     print(f"next_check_presence_rate={metrics['next_check_presence_rate']:.3f}")
+    confidence_bucket_accuracy = metrics.get("confidence_bucket_accuracy", {})
+    for bucket in STDOUT_CONFIDENCE_BUCKET_ORDER:
+        bucket_data = confidence_bucket_accuracy.get(bucket)
+        if not bucket_data:
+            print(f"confidence_bucket_accuracy.{bucket}=n/a total=0 correct=0")
+            continue
+        total = bucket_data.get("total", 0)
+        correct = bucket_data.get("correct", 0)
+        if total:
+            print(
+                f"confidence_bucket_accuracy.{bucket}="
+                f"{bucket_data.get('accuracy', 0.0):.3f} total={total} correct={correct}"
+            )
+        else:
+            print(f"confidence_bucket_accuracy.{bucket}=n/a total=0 correct={correct}")
     print(
         "evidence_quality_checks="
         f"{metrics['evidence_quality_check_passed_cases']}/{metrics['evidence_quality_check_cases']}"

--- a/scripts/tests/test_diagnostic_benchmark.py
+++ b/scripts/tests/test_diagnostic_benchmark.py
@@ -477,6 +477,9 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
         self.assertIn("confidence_note_checks=1/1", output)
         self.assertIn("route_breakdown_checks=1/1", output)
         self.assertIn("temporal_segment_checks=1/1", output)
+        self.assertIn("confidence_bucket_accuracy.low=n/a total=0 correct=0", output)
+        self.assertIn("confidence_bucket_accuracy.medium=n/a total=0 correct=0", output)
+        self.assertIn("confidence_bucket_accuracy.high=1.000 total=1 correct=1", output)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_generate_diagnostic_scorecard.py
+++ b/scripts/tests/test_generate_diagnostic_scorecard.py
@@ -41,6 +41,7 @@ class GenerateScorecardTests(unittest.TestCase):
         text = render_scorecard(metrics, env)
         self.assertIn("failed_case_count", text)
         self.assertIn("not root-cause proof", text)
+        self.assertIn("## Confidence bucket accuracy", text)
 
     def test_failed_case_rendering(self):
         self.assertEqual(render_failed_cases([]).strip(), "None")


### PR DESCRIPTION
### Motivation

- Make the existing `confidence_bucket_accuracy` metric visible and easy to read on `scripts/diagnostic_benchmark.py` stdout for quick local inspection and CI logs. 
- Ensure deterministic, human-friendly rendering and explicit handling when buckets are absent or have zero totals so results are unambiguous. 
- Do this without changing analyzer scoring, adding buckets, or implying probabilistic calibration guarantees.

### Description

- Add `STDOUT_CONFIDENCE_BUCKET_ORDER = ("low", "medium", "high")` and per-bucket stdout rendering in `scripts/diagnostic_benchmark.py` `main()` that prints `accuracy`, `total`, and `correct` for each bucket in a deterministic order. 
- Render missing or zero-total buckets as `n/a total=0 correct=0` to make absent data explicit and repeatable. 
- Keep the existing `metrics["confidence_bucket_accuracy"]` JSON shape unchanged and preserve scorecard rendering in `scripts/generate_diagnostic_scorecard.py`. 
- Add/adjust tests in `scripts/tests/test_diagnostic_benchmark.py` to assert the new stdout lines and add a small assertion in `scripts/tests/test_generate_diagnostic_scorecard.py` to ensure the confidence-bucket section remains in the generated scorecard text.

### Testing

- Ran `python3 -m unittest discover scripts/tests` and all Python unit tests passed. 
- Ran `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0` and observed the compact per-bucket stdout lines (success). 
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` and they all succeeded. 
- Ran `python3 scripts/validate_docs_contracts.py` and the docs contract validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc33c2264083309ddb5e3d22422243)