### PR TITLE
Improve diagnostic benchmark confidence-bucket stdout visibility

### DIFF
--- a/scripts/diagnostic_benchmark.py
+++ b/scripts/diagnostic_benchmark.py
@@ -13,6 +13,7 @@ ALLOWED_GROUND_TRUTH = {
 }
 CONF_HIGH = {"high"}
 CONFIDENCE_ORDER = {"low": 0, "medium": 1, "high": 2}
+CONFIDENCE_BUCKETS = ("low", "medium", "high")
 ALLOWED_EVIDENCE_QUALITY = {"strong", "partial", "weak"}
 ALLOWED_SIGNAL_FAMILIES = {"requests", "queues", "stages", "runtime_snapshots", "inflight_snapshots"}
 ALLOWED_SIGNAL_STATUSES = {"present", "missing", "partial", "truncated"}
@@ -148,6 +149,18 @@ def confidence_bucket(conf):
     if conf == "low":
         return "low"
     raise ValueError("report.primary_suspect.confidence must be one of low/medium/high")
+
+
+def format_confidence_bucket_summary(metrics, bucket):
+    bucket_stats = metrics.get("confidence_bucket_accuracy", {}).get(bucket)
+    if not bucket_stats:
+        return f"confidence_bucket_accuracy.{bucket}=n/a total=0 correct=0"
+    total = bucket_stats.get("total", 0)
+    correct = bucket_stats.get("correct", 0)
+    if total == 0:
+        return f"confidence_bucket_accuracy.{bucket}=n/a total=0 correct=0"
+    accuracy = bucket_stats.get("accuracy", 0.0)
+    return f"confidence_bucket_accuracy.{bucket}={accuracy:.3f} total={total} correct={correct}"
 
 
 def extract(report):
@@ -451,6 +464,8 @@ def main():
         "temporal_segment_checks="
         f"{metrics['temporal_segment_check_passed_cases']}/{metrics['temporal_segment_check_cases']}"
     )
+    for bucket in CONFIDENCE_BUCKETS:
+        print(format_confidence_bucket_summary(metrics, bucket))
     print(f"failed_case_count={len(metrics['failed_cases'])}")
 
     if failures:

--- a/scripts/tests/test_diagnostic_benchmark.py
+++ b/scripts/tests/test_diagnostic_benchmark.py
@@ -477,6 +477,40 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
         self.assertIn("confidence_note_checks=1/1", output)
         self.assertIn("route_breakdown_checks=1/1", output)
         self.assertIn("temporal_segment_checks=1/1", output)
+        self.assertIn("confidence_bucket_accuracy.low=n/a total=0 correct=0", output)
+        self.assertIn("confidence_bucket_accuracy.medium=n/a total=0 correct=0", output)
+        self.assertIn("confidence_bucket_accuracy.high=1.000 total=1 correct=1", output)
+
+    def test_main_prints_confidence_bucket_accuracy_for_missing_and_present_buckets(self):
+        low_case = self.make_case(id="low-case", artifact="low-case.json")
+        medium_case = self.make_case(id="medium-case", artifact="medium-case.json")
+        low_report = valid_report(confidence="low")
+        medium_report = valid_report(confidence="medium")
+        with tempfile.TemporaryDirectory() as td:
+            self.write_json(td, low_case["artifact"], low_report)
+            self.write_json(td, medium_case["artifact"], medium_report)
+            manifest_path = self.write_json(td, "manifest.json", self.make_manifest(low_case, medium_case))
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                with mock.patch(
+                    "sys.argv",
+                    [
+                        "diagnostic_benchmark.py",
+                        "--manifest",
+                        str(manifest_path),
+                        "--min-top1",
+                        "0.0",
+                        "--min-top2",
+                        "0.0",
+                        "--max-high-confidence-wrong",
+                        "99",
+                    ],
+                ):
+                    db.main()
+            output = buf.getvalue()
+        self.assertIn("confidence_bucket_accuracy.low=1.000 total=1 correct=1", output)
+        self.assertIn("confidence_bucket_accuracy.medium=1.000 total=1 correct=1", output)
+        self.assertIn("confidence_bucket_accuracy.high=n/a total=0 correct=0", output)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_generate_diagnostic_scorecard.py
+++ b/scripts/tests/test_generate_diagnostic_scorecard.py
@@ -41,6 +41,15 @@ class GenerateScorecardTests(unittest.TestCase):
         text = render_scorecard(metrics, env)
         self.assertIn("failed_case_count", text)
         self.assertIn("not root-cause proof", text)
+        self.assertIn("## Confidence bucket accuracy", text)
+
+    def test_render_includes_confidence_bucket_accuracy_rows(self):
+        env = {"generated_at_utc": "t", "snapshot_label": "s", "git": {"sha": "a", "tag": "v1", "describe": "d"}, "tailtriage": {"workspace_package_version": "1", "packages": {"tailtriage": "1"}}, "github_actions": {"run_id": None, "ref": None, "runner_os": None, "runner_arch": None, "image_version": None}, "software": {"python": "3", "rustc": "r", "cargo": "c"}, "hardware": {"cpu_model": "cpu", "logical_cores": 1, "memory_total_kib": 2}, "inputs": {"manifest_sha256": "m", "referenced_artifacts_sha256": "a", "thresholds": {"min_top1": 0.75}}}
+        metrics = {"failed_cases": [], "per_ground_truth_counts": {}, "confidence_bucket_accuracy": {"low": {"accuracy": 0.5, "total": 2, "correct": 1}}}
+        for k in ["total_cases", "top1_accuracy", "top2_recall", "high_confidence_wrong_count", "required_evidence_pass_rate", "next_check_required_cases", "next_check_passed_cases", "next_check_pass_rate", "next_check_presence_rate", "confidence_ceiling_cases", "confidence_ceiling_passed_cases", "confidence_ceiling_pass_rate", "unexpected_warning_count", "missing_expected_warning_count"]:
+            metrics[k] = 0
+        text = render_scorecard(metrics, env)
+        self.assertIn("- low: accuracy=0.5 total=2 correct=1", text)
 
     def test_failed_case_rendering(self):
         self.assertEqual(render_failed_cases([]).strip(), "None")


### PR DESCRIPTION
### Motivation
- Make confidence-bucket calibration hints visible and easy to consume from the deterministic benchmark `stdout` so reviewers and CI users can quickly inspect bucketed accuracy without opening JSON files. 
- Add deterministic handling and test coverage for missing/empty buckets so the rendered calibration surface is stable and unambiguous.

### Description
- Added `CONFIDENCE_BUCKETS` and `format_confidence_bucket_summary()` to `scripts/diagnostic_benchmark.py` and print one compact line per canonical bucket (`low`, `medium`, `high`) in the main `stdout` output, including `accuracy`, `total`, and `correct` or `n/a total=0 correct=0` when absent. 
- Kept `run()` metrics unchanged: the `confidence_bucket_accuracy` JSON shape and analyzer scoring logic were not modified. 
- Updated `scripts/tests/test_diagnostic_benchmark.py` to assert the new confidence-bucket stdout lines for both present and missing buckets. 
- Added a small assertion in `scripts/tests/test_generate_diagnostic_scorecard.py` to ensure the scorecard renderer still includes the “## Confidence bucket accuracy” section (no scorecard rendering framework changes). 

### Testing
- Ran the Python unit tests with `python3 -m unittest discover scripts/tests` and they all passed. 
- Executed the deterministic benchmark `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0` and observed per-bucket stdout lines (successful run). 
- Verified formatting/linting with `cargo fmt --check` (OK) and `cargo clippy --workspace --all-targets -- -D warnings` (OK). 
- Ran Rust tests with `cargo test --workspace` and they all passed. 
- Ran docs contract validation with `python3 scripts/validate_docs_contracts.py` and it succeeded. 

Validation notes: benchmark stdout now prints deterministic lines like `confidence_bucket_accuracy.low=n/a total=0 correct=0` or `confidence_bucket_accuracy.medium=1.000 total=1 correct=1`; the JSON metric `confidence_bucket_accuracy` and the scorecard confidence-bucket section remain compatible and unchanged in shape.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc33c2264083309ddb5e3d22422243)