### PR TITLE
Improve confidence-bucket visibility in diagnostic benchmark stdout

### DIFF
--- a/scripts/diagnostic_benchmark.py
+++ b/scripts/diagnostic_benchmark.py
@@ -13,6 +13,8 @@ ALLOWED_GROUND_TRUTH = {
 }
 CONF_HIGH = {"high"}
 CONFIDENCE_ORDER = {"low": 0, "medium": 1, "high": 2}
+
+CONFIDENCE_BUCKETS = ("low", "medium", "high")
 ALLOWED_EVIDENCE_QUALITY = {"strong", "partial", "weak"}
 ALLOWED_SIGNAL_FAMILIES = {"requests", "queues", "stages", "runtime_snapshots", "inflight_snapshots"}
 ALLOWED_SIGNAL_STATUSES = {"present", "missing", "partial", "truncated"}
@@ -431,6 +433,19 @@ def main():
     print(f"next_check_required_cases={metrics['next_check_required_cases']}")
     print(f"next_check_pass_rate={next_check_pass_rate_text}")
     print(f"next_check_presence_rate={metrics['next_check_presence_rate']:.3f}")
+
+    confidence_bucket_accuracy = metrics.get("confidence_bucket_accuracy", {})
+    for bucket in CONFIDENCE_BUCKETS:
+        bucket_metrics = confidence_bucket_accuracy.get(bucket)
+        if bucket_metrics is None:
+            print(f"confidence_bucket_accuracy.{bucket}=n/a total=0 correct=0")
+            continue
+        total = bucket_metrics.get("total", 0)
+        correct = bucket_metrics.get("correct", 0)
+        if total:
+            print(f"confidence_bucket_accuracy.{bucket}={bucket_metrics.get('accuracy', 0.0):.3f} total={total} correct={correct}")
+        else:
+            print(f"confidence_bucket_accuracy.{bucket}=n/a total=0 correct=0")
     print(
         "evidence_quality_checks="
         f"{metrics['evidence_quality_check_passed_cases']}/{metrics['evidence_quality_check_cases']}"

--- a/scripts/tests/test_diagnostic_benchmark.py
+++ b/scripts/tests/test_diagnostic_benchmark.py
@@ -478,6 +478,35 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
         self.assertIn("route_breakdown_checks=1/1", output)
         self.assertIn("temporal_segment_checks=1/1", output)
 
+    def test_main_prints_confidence_bucket_accuracy_summary_with_missing_bucket(self):
+        case = self.make_case()
+        report = valid_report(confidence="medium")
+        with tempfile.TemporaryDirectory() as td:
+            self.write_json(td, case["artifact"], report)
+            manifest_path = self.write_json(td, "manifest.json", self.make_manifest(case))
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                with mock.patch(
+                    "sys.argv",
+                    [
+                        "diagnostic_benchmark.py",
+                        "--manifest",
+                        str(manifest_path),
+                        "--min-top1",
+                        "0.0",
+                        "--min-top2",
+                        "0.0",
+                        "--max-high-confidence-wrong",
+                        "99",
+                    ],
+                ):
+                    db.main()
+            output = buf.getvalue()
+
+        self.assertIn("confidence_bucket_accuracy.low=n/a total=0 correct=0", output)
+        self.assertIn("confidence_bucket_accuracy.medium=1.000 total=1 correct=1", output)
+        self.assertIn("confidence_bucket_accuracy.high=n/a total=0 correct=0", output)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation
- Make the confidence-bucket calibration surface visible and easy to parse on benchmark stdout without changing analyzer scoring or JSON metrics.
- Ensure missing or zero-count buckets are rendered deterministically and clearly so downstream tooling and humans see a stable summary.
- Add a small unit test to cover the rendered stdout shape so future edits do not regress visibility.

### Description
- Print a compact, deterministic per-bucket summary for `confidence_bucket_accuracy` in `scripts/diagnostic_benchmark.py` in the order `low`, `medium`, `high`, including `accuracy`, `total`, and `correct` counts for each bucket using a new `CONFIDENCE_BUCKETS` tuple and explicit missing-bucket handling (`n/a total=0 correct=0`).
- Handle zero-total buckets deterministically by printing `n/a total=0 correct=0` to avoid ambiguous output.
- Add a unit test in `scripts/tests/test_diagnostic_benchmark.py` that runs the CLI entrypoint and asserts the presence of `confidence_bucket_accuracy` stdout lines, including the `n/a` output for missing buckets.
- Leave the JSON metrics payload shape unchanged and keep the scorecard rendering in `scripts/generate_diagnostic_scorecard.py` intact so downstream JSON consumers and the scorecard generator remain compatible.

### Testing
- Ran Python unit tests: `python3 -m unittest discover scripts/tests` and all tests passed (149 tests ran; OK).
- Exercised the benchmark end-to-end: `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0` and observed stdout including the new per-bucket summary lines; run completed successfully.
- Ran code-quality and repo validation: `cargo fmt --check` (ok), `cargo clippy --workspace --all-targets -- -D warnings` (ok), `cargo test --workspace` (ok), and `python3 scripts/validate_docs_contracts.py` (ok).
- Confirmations: the `confidence_bucket_accuracy` JSON metric structure remained compatible, and the scorecard confidence-bucket section remains available and unchanged in `scripts/generate_diagnostic_scorecard.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc33c2264083309ddb5e3d22422243)