### PR TITLE
Polish confidence bucket calibration visibility in benchmark stdout

### DIFF
--- a/scripts/diagnostic_benchmark.py
+++ b/scripts/diagnostic_benchmark.py
@@ -396,6 +396,18 @@ def run(manifest_path, min_top1, min_top2, max_high_confidence_wrong):
     return metrics, failures
 
 
+def format_confidence_bucket_accuracy(confidence_bucket_accuracy, bucket):
+    bucket_metrics = confidence_bucket_accuracy.get(bucket)
+    if not bucket_metrics:
+        return "n/a (correct=0 total=0)"
+    total = bucket_metrics.get("total", 0)
+    correct = bucket_metrics.get("correct", 0)
+    if not total:
+        return "n/a (correct=0 total=0)"
+    accuracy = bucket_metrics.get("accuracy", 0.0)
+    return f"{accuracy:.3f} (correct={correct} total={total})"
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--manifest", required=True)
@@ -451,6 +463,11 @@ def main():
         "temporal_segment_checks="
         f"{metrics['temporal_segment_check_passed_cases']}/{metrics['temporal_segment_check_cases']}"
     )
+    for bucket in ("low", "medium", "high"):
+        print(
+            f"confidence_bucket_accuracy.{bucket}="
+            f"{format_confidence_bucket_accuracy(metrics['confidence_bucket_accuracy'], bucket)}"
+        )
     print(f"failed_case_count={len(metrics['failed_cases'])}")
 
     if failures:

--- a/scripts/tests/test_diagnostic_benchmark.py
+++ b/scripts/tests/test_diagnostic_benchmark.py
@@ -477,6 +477,23 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
         self.assertIn("confidence_note_checks=1/1", output)
         self.assertIn("route_breakdown_checks=1/1", output)
         self.assertIn("temporal_segment_checks=1/1", output)
+        self.assertIn("confidence_bucket_accuracy.low=n/a (correct=0 total=0)", output)
+        self.assertIn("confidence_bucket_accuracy.medium=n/a (correct=0 total=0)", output)
+        self.assertIn("confidence_bucket_accuracy.high=1.000 (correct=1 total=1)", output)
+
+    def test_format_confidence_bucket_accuracy_handles_missing_and_zero_totals(self):
+        self.assertEqual(
+            db.format_confidence_bucket_accuracy({}, "low"),
+            "n/a (correct=0 total=0)",
+        )
+        self.assertEqual(
+            db.format_confidence_bucket_accuracy({"low": {"accuracy": 0.0, "correct": 0, "total": 0}}, "low"),
+            "n/a (correct=0 total=0)",
+        )
+        self.assertEqual(
+            db.format_confidence_bucket_accuracy({"low": {"accuracy": 0.5, "correct": 1, "total": 2}}, "low"),
+            "0.500 (correct=1 total=2)",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Improve human-readable visibility of existing `confidence_bucket_accuracy` metrics on the benchmark `stdout` so users can quickly see per-bucket calibration hints without changing analyzer scoring or metric shape.

### Description
- Add `format_confidence_bucket_accuracy()` and emit compact lines `confidence_bucket_accuracy.low|medium|high=` in `scripts/diagnostic_benchmark.py` showing accuracy and `correct/total` counts, with deterministic `n/a (correct=0 total=0)` for missing or zero-total buckets.
- Preserve the existing JSON metrics schema produced by `run(...)` (the `confidence_bucket_accuracy` dictionary is unchanged) and leave `scripts/generate_diagnostic_scorecard.py` scorecard output intact.
- Add tests in `scripts/tests/test_diagnostic_benchmark.py` to assert the new stdout lines appear and to verify the formatting helper handles missing buckets, zero totals, and populated buckets.

### Testing
- Ran `python3 -m unittest discover scripts/tests` and all tests passed (unittest run OK).
- Ran the deterministic benchmark: `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0` and observed the new `confidence_bucket_accuracy.low/medium/high=` lines in stdout.
- Ran repository validation checks: `cargo fmt --check` (OK), `cargo clippy --workspace --all-targets -- -D warnings` (OK), and `cargo test --workspace` (OK).
- Ran docs contract validation: `python3 scripts/validate_docs_contracts.py` (OK).

Validation commands run (successful):
- `python3 -m unittest discover scripts/tests`
- `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0`
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `python3 scripts/validate_docs_contracts.py`

Notes: no analyzer scoring changes, no new buckets added, JSON metric shape compatible, and the scorecard still contains the confidence-bucket section as before.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc33c2264083309ddb5e3d22422243)