### PR TITLE
Add deterministic `run_artifact` validation path to exercise Run -> analyze_run()

### DIFF
--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -36,6 +36,7 @@ Normal CI keeps deterministic diagnostics and docs contracts as gates but does n
 ## Deterministic corpus validation
 The deterministic benchmark validates:
 - evidence-ranked suspect correctness against corpus labels
+- analyzer-path behavior on selected committed raw run-artifact fixtures (Run -> analyze_run())
 - required top-2 visibility (`required_top2` appears in primary or first secondary)
 - warning expectations (`expected_warnings` required; unexpected warnings rejected unless explicitly allowed)
 - required evidence substrings

--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -3,7 +3,7 @@
 `tailtriage` validation checks diagnosis quality for triage. It does not provide root-cause proof.
 
 ## Methodology
-The benchmark evaluates a deterministic corpus of analyzer reports against workload-grounded labels. It checks suspect ranking behavior, evidence/warning expectations, and bounded failure semantics.
+The benchmark evaluates a deterministic corpus of analyzer reports and selected raw run artifacts against workload-grounded labels. Raw run artifacts are analyzed via Run -> analyze_run() in the CLI path. It checks suspect ranking behavior, evidence/warning expectations, and bounded failure semantics.
 
 ## Deterministic vs repeated-run validation
 Deterministic fixture validation is exercised directly in normal CI against `validation/diagnostics/manifest.json` and referenced fixtures, and is also exercised by the scorecard generator. Durable scorecards are generated only by the versioned/manual snapshot workflow (`validation-snapshot.yml`) on `workflow_dispatch` and `v*` tags. Normal CI does not publish durable diagnostic scorecards.
@@ -32,7 +32,7 @@ The scorecard includes confidence-bucket accuracy summaries (low/medium/high buc
 - observed warnings are allowed only if they match `expected_warnings` or `allowed_warnings`.
 
 ## Negative and adversarial validation
-The corpus includes deterministic synthetic adversarial cases for sparse samples, missing instrumentation, truncated artifacts, and mixed-signal workloads. These cases validate triage humility and evidence-ranked suspect visibility under partial data.
+The corpus includes deterministic synthetic adversarial cases for sparse samples, missing instrumentation, truncated artifacts, and mixed-signal workloads, plus selected deterministic raw run-artifact adversarial cases that exercise analyzer-path behavior on committed fixtures. These cases validate triage humility and evidence-ranked suspect visibility under partial data.
 
 ## Confidence ceilings (`max_primary_confidence`)
 Case-level confidence ceilings enforce conservative confidence behavior for conditions where data is sparse, missing, truncated, noisy, or intentionally ambiguous. A case fails if primary confidence exceeds its configured ceiling.

--- a/scripts/diagnostic_benchmark.py
+++ b/scripts/diagnostic_benchmark.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import argparse
 import json
+import os
+import subprocess
 from collections import Counter, defaultdict
 from pathlib import Path
 
@@ -24,6 +26,33 @@ def load_json(path):
         return json.load(f)
 
 
+def load_case_report(case, root):
+    artifact_path = (root / case["artifact"]).resolve()
+    artifact_type = case["artifact_type"]
+    if artifact_type in {"analysis_report", "synthetic_analysis_report"}:
+        report = load_json(artifact_path)
+        if artifact_type == "analysis_report" and "score" not in report.get("primary_suspect", {}):
+            raise ValueError(f"analysis_report requires report.primary_suspect.score for case {case['id']} ({artifact_path})")
+        return report
+    if artifact_type == "run_artifact":
+        analyze_cmd = os.environ.get("TAILTRIAGE_ANALYZE_CMD", "cargo run --quiet -p tailtriage-cli -- analyze")
+        command = analyze_cmd.split() + [str(artifact_path), "--format", "json"]
+        result = subprocess.run(command, capture_output=True, text=True)
+        if result.returncode != 0:
+            stderr = result.stderr.strip()
+            stdout = result.stdout.strip()
+            detail = stderr or stdout or "no output"
+            raise ValueError(f"run_artifact analyze failed for case {case['id']} ({artifact_path}): {detail}")
+        output = result.stdout.strip()
+        if not output:
+            raise ValueError(f"run_artifact analyze produced empty output for case {case['id']} ({artifact_path})")
+        try:
+            return json.loads(output)
+        except json.JSONDecodeError as err:
+            raise ValueError(f"run_artifact analyze emitted invalid JSON for case {case['id']} ({artifact_path}): {err}") from err
+    raise ValueError(f"unsupported artifact_type {artifact_type} for case {case['id']}")
+
+
 def validate_manifest(manifest):
     if not isinstance(manifest, dict) or "cases" not in manifest or not isinstance(manifest["cases"], list):
         raise ValueError("manifest must be an object containing a cases list")
@@ -42,8 +71,8 @@ def validate_manifest(manifest):
         seen.add(cid)
         if not isinstance(case["artifact"], str) or not case["artifact"].strip():
             raise ValueError(f"artifact must be a non-empty string for {cid}")
-        if case["artifact_type"] not in {"analysis_report", "synthetic_analysis_report"}:
-            raise ValueError(f"artifact_type must be analysis_report or synthetic_analysis_report for {cid}")
+        if case["artifact_type"] not in {"analysis_report", "synthetic_analysis_report", "run_artifact"}:
+            raise ValueError(f"artifact_type must be analysis_report, synthetic_analysis_report, or run_artifact for {cid}")
         gt = case["ground_truth"]
         if gt not in ALLOWED_GROUND_TRUTH:
             raise ValueError(f"unknown ground_truth for {cid}: {gt}")
@@ -258,9 +287,7 @@ def run(manifest_path, min_top1, min_top2, max_high_confidence_wrong):
     temporal_segment_check_passed_cases = 0
 
     for case in manifest["cases"]:
-        report = load_json(root / case["artifact"])
-        if case["artifact_type"] == "analysis_report" and "score" not in report.get("primary_suspect", {}):
-            raise ValueError("analysis_report requires report.primary_suspect.score")
+        report = load_case_report(case, root)
         ext = extract(report)
 
         gt = case["ground_truth"]

--- a/scripts/diagnostic_benchmark.py
+++ b/scripts/diagnostic_benchmark.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import argparse
 import json
-import os
 import subprocess
 from collections import Counter, defaultdict
 from pathlib import Path
@@ -35,8 +34,18 @@ def load_case_report(case, root):
             raise ValueError(f"analysis_report requires report.primary_suspect.score for case {case['id']} ({artifact_path})")
         return report
     if artifact_type == "run_artifact":
-        analyze_cmd = os.environ.get("TAILTRIAGE_ANALYZE_CMD", "cargo run --quiet -p tailtriage-cli -- analyze")
-        command = analyze_cmd.split() + [str(artifact_path), "--format", "json"]
+        command = [
+            "cargo",
+            "run",
+            "--quiet",
+            "-p",
+            "tailtriage-cli",
+            "--",
+            "analyze",
+            str(artifact_path),
+            "--format",
+            "json",
+        ]
         result = subprocess.run(command, capture_output=True, text=True)
         if result.returncode != 0:
             stderr = result.stderr.strip()

--- a/scripts/tests/test_diagnostic_benchmark.py
+++ b/scripts/tests/test_diagnostic_benchmark.py
@@ -98,6 +98,7 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
         bad = self.make_case(artifact_type="anything_else")
         with self.assertRaisesRegex(ValueError, "artifact_type"):
             db.validate_manifest(self.make_manifest(bad))
+        db.validate_manifest(self.make_manifest(self.make_case(artifact_type="run_artifact")))
 
     def test_manifest_ground_truth_and_required_top2_rules(self):
         with self.assertRaisesRegex(ValueError, "unknown ground_truth"):
@@ -148,6 +149,31 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
             db.validate_manifest(self.make_manifest(self.make_case(max_primary_confidence="extreme")))
         with self.assertRaisesRegex(ValueError, "max_primary_confidence must be a string"):
             db.validate_manifest(self.make_manifest(self.make_case(max_primary_confidence=1)))
+
+
+    def test_run_artifact_loads_report_via_cli_json(self):
+        case = self.make_case(artifact_type="run_artifact", artifact="run.json")
+        fake_report = valid_report()
+        with tempfile.TemporaryDirectory() as td:
+            artifact_path = self.write_json(td, case["artifact"], {"schema_version": 1})
+            with mock.patch("scripts.diagnostic_benchmark.subprocess.run") as mocked_run:
+                mocked_run.return_value = mock.Mock(returncode=0, stdout=json.dumps(fake_report), stderr="")
+                loaded = db.load_case_report(case, Path(td))
+        self.assertEqual(loaded["primary_suspect"]["kind"], fake_report["primary_suspect"]["kind"])
+        mocked_run.assert_called_once()
+        cmd = mocked_run.call_args.args[0]
+        self.assertIn(str(artifact_path.resolve()), cmd)
+
+    def test_run_artifact_cli_failure_includes_case_and_path(self):
+        case = self.make_case(artifact_type="run_artifact", artifact="run.json", id="raw-case")
+        with tempfile.TemporaryDirectory() as td:
+            artifact_path = self.write_json(td, case["artifact"], {"schema_version": 1})
+            with mock.patch("scripts.diagnostic_benchmark.subprocess.run") as mocked_run:
+                mocked_run.return_value = mock.Mock(returncode=1, stdout="", stderr="boom")
+                with self.assertRaisesRegex(ValueError, "raw-case"):
+                    db.load_case_report(case, Path(td))
+                with self.assertRaisesRegex(ValueError, str(artifact_path.resolve())):
+                    db.load_case_report(case, Path(td))
 
     # Report validation tests
     def test_report_missing_primary_fails(self):

--- a/scripts/tests/test_diagnostic_benchmark.py
+++ b/scripts/tests/test_diagnostic_benchmark.py
@@ -162,7 +162,11 @@ class DiagnosticBenchmarkTests(unittest.TestCase):
         self.assertEqual(loaded["primary_suspect"]["kind"], fake_report["primary_suspect"]["kind"])
         mocked_run.assert_called_once()
         cmd = mocked_run.call_args.args[0]
+        self.assertEqual(cmd[0], "cargo")
+        self.assertIn("tailtriage-cli", cmd)
+        self.assertIn("analyze", cmd)
         self.assertIn(str(artifact_path.resolve()), cmd)
+        self.assertEqual(cmd[-2:], ["--format", "json"])
 
     def test_run_artifact_cli_failure_includes_case_and_path(self):
         case = self.make_case(artifact_type="run_artifact", artifact="run.json", id="raw-case")

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -13,6 +13,7 @@ Normal CI runs the deterministic corpus benchmark against `validation/diagnostic
 - `artifact_type`:
   - `analysis_report`: real demo-emitted analyzer report fixture.
   - `synthetic_analysis_report`: hand-written report-shaped synthetic fixture used for coverage gaps.
+  - `run_artifact`: raw captured run fixture analyzed through `tailtriage analyze` (Run -> analyze_run()) for analyzer-path validation.
 - `ground_truth`: expected diagnostic family for the controlled fixture intent. It does not mean production root-cause proof.
 - `required_top2`: diagnosis kinds that must appear in primary or first secondary suspect. Usually `[ground_truth]`. Must include `ground_truth`.
 - `acceptable_primary`: diagnosis kinds acceptable as primary for mixed/ambiguous interpretation. Must include `ground_truth`. This does **not** satisfy `required_top2` by itself.
@@ -36,6 +37,7 @@ Normal CI runs the deterministic corpus benchmark against `validation/diagnostic
 - Use `max_primary_confidence` for humility checks in sparse-sample, missing-instrumentation, truncation, noise-only, or close mixed-signal cases.
 - Confidence ceilings validate conservative triage behavior, not truth probabilities.
 - Synthetic fixtures are report-shaped adversarial coverage artifacts, not substitutes for analyzer-generated captures.
+- Raw `run_artifact` fixtures validate analyzer-path behavior on committed captured-shape evidence and remain deterministic fixture checks, not production-accuracy claims or real-service validation.
 
 ## Running the benchmark
 

--- a/validation/diagnostics/corpus/run-artifacts/low-request-insufficient.json
+++ b/validation/diagnostics/corpus/run-artifacts/low-request-insufficient.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "metadata": {
+    "run_id": "insufficient-run",
+    "service_name": "svc",
+    "service_version": null,
+    "started_at_unix_ms": 1,
+    "finished_at_unix_ms": 2,
+    "mode": "light",
+    "host": null,
+    "pid": 7
+  },
+  "requests": [
+    {"request_id":"r1","route":"/a","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":100,"outcome":"ok"},
+    {"request_id":"r2","route":"/a","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":120,"outcome":"ok"},
+    {"request_id":"r3","route":"/a","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":130,"outcome":"ok"}
+  ],
+  "stages": [],
+  "queues": [],
+  "inflight": [],
+  "runtime_snapshots": []
+}

--- a/validation/diagnostics/corpus/run-artifacts/no-queue-events.json
+++ b/validation/diagnostics/corpus/run-artifacts/no-queue-events.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": 1,
+  "metadata": {
+    "run_id": "stage-run",
+    "service_name": "svc",
+    "service_version": null,
+    "started_at_unix_ms": 1,
+    "finished_at_unix_ms": 2,
+    "mode": "light",
+    "host": null,
+    "pid": 7
+  },
+  "requests": [
+    {"request_id":"r1","route":"/a","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":300,"outcome":"ok"},
+    {"request_id":"r2","route":"/a","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":320,"outcome":"ok"},
+    {"request_id":"r3","route":"/a","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":310,"outcome":"ok"}
+  ],
+  "stages": [
+    {"request_id":"r1","stage":"db","started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":180,"success":true},
+    {"request_id":"r2","stage":"db","started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":200,"success":true},
+    {"request_id":"r3","stage":"db","started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":190,"success":true},
+    {"request_id":"r1","stage":"cache","started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":20,"success":true},
+    {"request_id":"r2","stage":"cache","started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":30,"success":true},
+    {"request_id":"r3","stage":"cache","started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":25,"success":true}
+  ],
+  "queues": [],
+  "inflight": [],
+  "runtime_snapshots": []
+}

--- a/validation/diagnostics/corpus/run-artifacts/no-runtime-snapshots.json
+++ b/validation/diagnostics/corpus/run-artifacts/no-runtime-snapshots.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": 1,
+  "metadata": {
+    "run_id": "queue-run",
+    "service_name": "svc",
+    "service_version": null,
+    "started_at_unix_ms": 1,
+    "finished_at_unix_ms": 2,
+    "mode": "light",
+    "host": null,
+    "pid": 7
+  },
+  "requests": [
+    {"request_id":"r1","route":"/a","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":100,"outcome":"ok"},
+    {"request_id":"r2","route":"/a","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":120,"outcome":"ok"},
+    {"request_id":"r3","route":"/a","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":150,"outcome":"ok"}
+  ],
+  "stages": [],
+  "queues": [
+    {"request_id":"r1","queue":"worker","waited_from_unix_ms":1,"waited_until_unix_ms":2,"wait_us":50,"depth_at_start":4},
+    {"request_id":"r2","queue":"worker","waited_from_unix_ms":1,"waited_until_unix_ms":2,"wait_us":75,"depth_at_start":5},
+    {"request_id":"r3","queue":"worker","waited_from_unix_ms":1,"waited_until_unix_ms":2,"wait_us":100,"depth_at_start":6}
+  ],
+  "inflight": [
+    {"gauge":"worker_inflight","at_unix_ms":1,"count":1},
+    {"gauge":"worker_inflight","at_unix_ms":2,"count":3},
+    {"gauge":"worker_inflight","at_unix_ms":3,"count":6}
+  ],
+  "runtime_snapshots": []
+}

--- a/validation/diagnostics/corpus/run-artifacts/no-stage-events.json
+++ b/validation/diagnostics/corpus/run-artifacts/no-stage-events.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": 1,
+  "metadata": {
+    "run_id": "queue-run",
+    "service_name": "svc",
+    "service_version": null,
+    "started_at_unix_ms": 1,
+    "finished_at_unix_ms": 2,
+    "mode": "light",
+    "host": null,
+    "pid": 7
+  },
+  "requests": [
+    {"request_id":"r1","route":"/a","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":100,"outcome":"ok"},
+    {"request_id":"r2","route":"/a","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":120,"outcome":"ok"},
+    {"request_id":"r3","route":"/a","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":150,"outcome":"ok"}
+  ],
+  "stages": [],
+  "queues": [
+    {"request_id":"r1","queue":"worker","waited_from_unix_ms":1,"waited_until_unix_ms":2,"wait_us":50,"depth_at_start":4},
+    {"request_id":"r2","queue":"worker","waited_from_unix_ms":1,"waited_until_unix_ms":2,"wait_us":75,"depth_at_start":5},
+    {"request_id":"r3","queue":"worker","waited_from_unix_ms":1,"waited_until_unix_ms":2,"wait_us":100,"depth_at_start":6}
+  ],
+  "inflight": [
+    {"gauge":"worker_inflight","at_unix_ms":1,"count":1},
+    {"gauge":"worker_inflight","at_unix_ms":2,"count":3},
+    {"gauge":"worker_inflight","at_unix_ms":3,"count":6}
+  ],
+  "runtime_snapshots": []
+}

--- a/validation/diagnostics/corpus/run-artifacts/truncated-queues.json
+++ b/validation/diagnostics/corpus/run-artifacts/truncated-queues.json
@@ -1,0 +1,95 @@
+{
+  "schema_version": 1,
+  "metadata": {
+    "run_id": "truncated-run-artifact",
+    "service_name": "svc",
+    "service_version": null,
+    "started_at_unix_ms": 1,
+    "finished_at_unix_ms": 2,
+    "mode": "light",
+    "host": null,
+    "pid": 7
+  },
+  "requests": [
+    {
+      "request_id": "r1",
+      "route": "/a",
+      "kind": null,
+      "started_at_unix_ms": 1,
+      "finished_at_unix_ms": 2,
+      "latency_us": 100,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "r2",
+      "route": "/a",
+      "kind": null,
+      "started_at_unix_ms": 1,
+      "finished_at_unix_ms": 2,
+      "latency_us": 120,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "r3",
+      "route": "/a",
+      "kind": null,
+      "started_at_unix_ms": 1,
+      "finished_at_unix_ms": 2,
+      "latency_us": 150,
+      "outcome": "ok"
+    }
+  ],
+  "stages": [],
+  "queues": [
+    {
+      "request_id": "r1",
+      "queue": "worker",
+      "waited_from_unix_ms": 1,
+      "waited_until_unix_ms": 2,
+      "wait_us": 50,
+      "depth_at_start": 4
+    },
+    {
+      "request_id": "r2",
+      "queue": "worker",
+      "waited_from_unix_ms": 1,
+      "waited_until_unix_ms": 2,
+      "wait_us": 75,
+      "depth_at_start": 5
+    },
+    {
+      "request_id": "r3",
+      "queue": "worker",
+      "waited_from_unix_ms": 1,
+      "waited_until_unix_ms": 2,
+      "wait_us": 100,
+      "depth_at_start": 6
+    }
+  ],
+  "inflight": [
+    {
+      "gauge": "worker_inflight",
+      "at_unix_ms": 1,
+      "count": 1
+    },
+    {
+      "gauge": "worker_inflight",
+      "at_unix_ms": 2,
+      "count": 3
+    },
+    {
+      "gauge": "worker_inflight",
+      "at_unix_ms": 3,
+      "count": 6
+    }
+  ],
+  "runtime_snapshots": [],
+  "truncation": {
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 2,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "limits_hit": true
+  }
+}

--- a/validation/diagnostics/latest/scorecard.md
+++ b/validation/diagnostics/latest/scorecard.md
@@ -17,7 +17,7 @@
 | mitigation validation | Manual/local mitigation matrix available | baseline/mitigated controlled demos compare latency and evidence movement; generated outputs are not committed by default. |
 | real service validation | Planned | add curated real-service anonymized artifacts. |
 
-Deterministic synthetic adversarial cases validate benchmark/report contract behavior and humility checks; they are not real-service validation and do not provide root-cause proof.
+Deterministic synthetic adversarial cases and selected deterministic raw run-artifact adversarial cases validate benchmark/report contract behavior and humility checks; they are not real-service validation and do not provide root-cause proof.
 
 Normal CI runs the deterministic benchmark against the committed diagnostics manifest and fixtures as a required validation gate. Normal CI still does not publish durable scorecards.
 

--- a/validation/diagnostics/manifest.json
+++ b/validation/diagnostics/manifest.json
@@ -1105,6 +1105,162 @@
         "runtime_snapshots": "partial",
         "inflight_snapshots": "partial"
       }
+    },
+    {
+      "id": "raw_low_request_insufficient",
+      "artifact": "corpus/run-artifacts/low-request-insufficient.json",
+      "artifact_type": "run_artifact",
+      "ground_truth": "insufficient_evidence",
+      "required_top2": [
+        "insufficient_evidence"
+      ],
+      "acceptable_primary": [
+        "insufficient_evidence"
+      ],
+      "tags": [
+        "adversarial",
+        "raw-run",
+        "low-request"
+      ],
+      "must_include_evidence": [],
+      "must_include_next_checks": [],
+      "expected_warnings": [
+        "Low completed-request count"
+      ],
+      "allowed_warnings": [
+        "No queue events captured",
+        "No stage events captured",
+        "No runtime snapshots captured"
+      ],
+      "top1_required": true,
+      "notes": "Raw run fixture with low request count validates analyze_run insufficient-evidence fallback.",
+      "max_primary_confidence": "low"
+    },
+    {
+      "id": "raw_no_queue_events",
+      "artifact": "corpus/run-artifacts/no-queue-events.json",
+      "artifact_type": "run_artifact",
+      "ground_truth": "downstream_stage_dominates",
+      "required_top2": [
+        "downstream_stage_dominates"
+      ],
+      "acceptable_primary": [
+        "downstream_stage_dominates",
+        "insufficient_evidence"
+      ],
+      "tags": [
+        "adversarial",
+        "raw-run",
+        "missing-queue"
+      ],
+      "must_include_evidence": [
+        "Stage"
+      ],
+      "must_include_next_checks": [],
+      "expected_warnings": [
+        "Low completed-request count"
+      ],
+      "allowed_warnings": [
+        "No queue events captured",
+        "No runtime snapshots captured"
+      ],
+      "top1_required": false,
+      "notes": "Raw run fixture without queue events checks missing-queue warning and conservative interpretation.",
+      "max_primary_confidence": "medium"
+    },
+    {
+      "id": "raw_no_stage_events",
+      "artifact": "corpus/run-artifacts/no-stage-events.json",
+      "artifact_type": "run_artifact",
+      "ground_truth": "application_queue_saturation",
+      "required_top2": [
+        "application_queue_saturation"
+      ],
+      "acceptable_primary": [
+        "application_queue_saturation",
+        "insufficient_evidence"
+      ],
+      "tags": [
+        "adversarial",
+        "raw-run",
+        "missing-stage"
+      ],
+      "must_include_evidence": [
+        "Queue wait"
+      ],
+      "must_include_next_checks": [],
+      "expected_warnings": [
+        "Low completed-request count"
+      ],
+      "allowed_warnings": [
+        "No stage events captured",
+        "No runtime snapshots captured"
+      ],
+      "top1_required": false,
+      "notes": "Raw run fixture without stage events checks missing-stage warning and confidence cap.",
+      "max_primary_confidence": "medium"
+    },
+    {
+      "id": "raw_no_runtime_snapshots",
+      "artifact": "corpus/run-artifacts/no-runtime-snapshots.json",
+      "artifact_type": "run_artifact",
+      "ground_truth": "application_queue_saturation",
+      "required_top2": [
+        "application_queue_saturation"
+      ],
+      "acceptable_primary": [
+        "application_queue_saturation"
+      ],
+      "tags": [
+        "adversarial",
+        "raw-run",
+        "missing-runtime"
+      ],
+      "must_include_evidence": [
+        "Queue wait"
+      ],
+      "must_include_next_checks": [],
+      "expected_warnings": [
+        "No runtime snapshots captured"
+      ],
+      "allowed_warnings": [
+        "Low completed-request count"
+      ],
+      "top1_required": true,
+      "notes": "Raw run fixture checks runtime-missing warning from analyzer run path.",
+      "max_primary_confidence": "medium"
+    },
+    {
+      "id": "raw_truncated_partial_evidence",
+      "artifact": "corpus/run-artifacts/truncated-queues.json",
+      "artifact_type": "run_artifact",
+      "ground_truth": "application_queue_saturation",
+      "required_top2": [
+        "application_queue_saturation"
+      ],
+      "acceptable_primary": [
+        "application_queue_saturation"
+      ],
+      "tags": [
+        "adversarial",
+        "raw-run",
+        "truncation"
+      ],
+      "must_include_evidence": [
+        "Queue wait"
+      ],
+      "must_include_next_checks": [],
+      "expected_warnings": [
+        "Capture truncated queues"
+      ],
+      "allowed_warnings": [
+        "Capture limits were hit",
+        "Low completed-request count",
+        "No runtime snapshots captured"
+      ],
+      "top1_required": true,
+      "notes": "Raw run fixture with truncation validates warning propagation and conservative confidence.",
+      "max_primary_confidence": "medium"
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- Ensure deterministic validation covers the actual analyzer path from raw captured runs (`Run -> analyze_run()`), not only report-shaped fixtures, so analyzer-path regressions are caught by the corpus. 
- Keep the change narrow and reviewable: add a small set of adversarial raw-run fixtures that validate humility/warning behavior under missing/truncated/low-evidence conditions. 

### Description
- Add a new manifest `artifact_type` value `run_artifact` and support it in `scripts/diagnostic_benchmark.py` via a new helper `load_case_report()` that either loads a report-shaped fixture or invokes the CLI analyzer to produce JSON.
- Add unit tests in `scripts/tests/test_diagnostic_benchmark.py` to validate manifest acceptance of `run_artifact`, CLI invocation JSON parsing, and clear case/path-aware failure messages on CLI errors.
- Add five small, deterministic raw run-artifact adversarial fixtures under `validation/diagnostics/corpus/run-artifacts/`: `low-request-insufficient.json`, `no-queue-events.json`, `no-stage-events.json`, `no-runtime-snapshots.json`, and `truncated-queues.json`, and add corresponding cases to `validation/diagnostics/manifest.json` preserving existing checks (top1/top2, `acceptable_primary`, evidence substrings, expected/allowed warnings, and `max_primary_confidence`).
- Update validation docs and scorecard notes (`validation/diagnostics/README.md`, `docs/diagnostic-validation.md`, `VALIDATION.md`, and `validation/diagnostics/latest/scorecard.md`) to describe the new deterministic raw run-artifact analyzer-path checks while explicitly preserving the "triage, not root-cause proof" trust boundaries.

### Testing
- Ran unit tests: `python3 -m unittest discover scripts/tests` and all script tests passed (`OK`).
- Ran deterministic benchmark: `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0` and the manifest checks completed successfully against the extended corpus (no failures at the configured thresholds).
- Ran Rust workspace checks: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`, all of which completed successfully.
- Ran docs validator: `python3 scripts/validate_docs_contracts.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc509ba9ec8330bfd3de621d56be5b)