### PR TITLE
Expand README with tailtriage usage and comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,20 @@ tailtriage is useful for:
 
 ## When to use tailtriage
 
-Use tailtriage when a Rust/Tokio service has:
-- intermittent request timeouts
-- p95/p99 latency spikes
-- requests or background work that appear stuck during latency spikes
-- low CPU but high latency
-- suspected blocking work inside async code
-- queue buildup before work starts
-- unclear difference between Tokio scheduler pressure and slow downstream dependencies
+| Symptom | tailtriage helps check |
+| --- | --- |
+| p95/p99 latency spikes | whether tail latency is dominated by queueing, executor pressure, blocking-pool pressure, or downstream stage latency |
+| intermittent request timeouts | whether slow requests share a common bottleneck family in one captured run |
+| low CPU but high latency | whether requests are waiting in queues, blocked behind constrained resources, or delayed by downstream work |
+| requests appear stuck | whether time is spent before work starts, inside service execution, or in a named downstream stage |
+| suspected blocking in async code | whether blocking-pool pressure is visible and should be investigated with a targeted follow-up |
+| Tokio runtime seems overloaded | whether runtime-pressure signals point toward executor contention rather than app-level queueing |
+| queue buildup before work starts | whether application queue wait dominates p95 latency |
+| slow database or external API suspected | whether a downstream stage dominates request latency enough to be the next check |
+| flaky latency in staging or production | which bottleneck family is the strongest lead from a bounded capture window |
+| hard-to-reproduce tail spikes | whether a captured slow window contains enough evidence to choose the next experiment |
+| unclear profiler results | whether the latency problem is actually CPU-bound work, queueing, runtime pressure, or downstream waiting |
+| service has partial instrumentation only | whether available request, queue, stage, runtime, or inflight signals are enough for a useful triage lead |
 
 ## Quick start (crates.io)
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ tailtriage is useful for:
 Use tailtriage when a Rust/Tokio service has:
 - intermittent request timeouts
 - p95/p99 latency spikes
-- tasks that appear stuck
+- requests or background work that appear stuck during latency spikes
 - low CPU but high latency
 - suspected blocking work inside async code
 - queue buildup before work starts

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ In short:
 
 | Tool                 | Best for                                              | tailtriage relationship                         |
 | -------------------- | ----------------------------------------------------- | ----------------------------------------------- |
-| `tracing`            | structured logs/spans                                 | complementary input layer                       |
+| `tracing` | structured logs/spans | complementary operational context |
 | `tokio-console`      | live task/runtime inspection                          | use after tailtriage points to runtime pressure |
 | `tokio-metrics`      | runtime/task metrics                                  | complementary signal source                     |
 | `pprof` / flamegraph | CPU hot paths                                         | use when suspect is CPU-bound work              |

--- a/README.md
+++ b/README.md
@@ -13,18 +13,6 @@ It produces a triage report with **evidence-ranked suspects** and **next checks*
 - Not an observability backend.
 - Not root-cause proof on its own.
 
-## Problems tailtriage helps diagnose
-
-tailtriage is useful for:
-- Tokio latency debugging
-- Rust async performance triage
-- debugging flaky Tokio services
-- investigating p95/p99 latency spikes
-- finding executor pressure
-- identifying blocking-pool pressure
-- distinguishing queueing from downstream latency
-- lightweight production/staging diagnostics for async Rust
-
 ## When to use tailtriage
 
 | Symptom | tailtriage helps check |
@@ -34,12 +22,12 @@ tailtriage is useful for:
 | low CPU but high latency | whether requests are waiting in queues, blocked behind constrained resources, or delayed by downstream work |
 | requests appear stuck | whether time is spent before work starts, inside service execution, or in a named downstream stage |
 | suspected blocking in async code | whether blocking-pool pressure is visible and should be investigated with a targeted follow-up |
-| Tokio runtime seems overloaded | whether runtime-pressure signals point toward executor contention rather than app-level queueing |
+| Tokio runtime seems overloaded | whether captured runtime-pressure signals point toward executor contention rather than app-level queueing |
 | queue buildup before work starts | whether application queue wait dominates p95 latency |
 | slow database or external API suspected | whether a downstream stage dominates request latency enough to be the next check |
 | flaky latency in staging or production | which bottleneck family is the strongest lead from a bounded capture window |
 | hard-to-reproduce tail spikes | whether a captured slow window contains enough evidence to choose the next experiment |
-| unclear profiler results | whether the latency problem is actually CPU-bound work, queueing, runtime pressure, or downstream waiting |
+| unclear profiler results | whether queueing, runtime pressure, blocking-pool pressure, or downstream waiting explains the tail before pursuing CPU hot paths |
 | service has partial instrumentation only | whether available request, queue, stage, runtime, or inflight signals are enough for a useful triage lead |
 
 ## Quick start (crates.io)
@@ -80,13 +68,13 @@ In short:
 
 ## Tool comparison
 
-| Tool                 | Best for                                              | tailtriage relationship                         |
-| -------------------- | ----------------------------------------------------- | ----------------------------------------------- |
-| `tracing` | structured logs/spans | complementary operational context |
-| `tokio-console`      | live task/runtime inspection                          | use after tailtriage points to runtime pressure |
-| `tokio-metrics`      | runtime/task metrics                                  | complementary signal source                     |
-| `pprof` / flamegraph | CPU hot paths                                         | use when suspect is CPU-bound work              |
-| `tailtriage`         | ranking likely latency bottleneck family from one run | first-pass triage loop                          |
+| Tool | Best for | Use with tailtriage when |
+| --- | --- | --- |
+| `tracing` | structured logs and spans | you need operational context around the captured slow window |
+| `tokio-console` | live Tokio task/runtime inspection | tailtriage points toward runtime or task pressure and you need live inspection |
+| `tokio-metrics` | runtime and task metrics | you want runtime signals to strengthen or explain tailtriage evidence |
+| `pprof` / flamegraph | CPU hot paths | tailtriage does not show queueing, runtime, blocking-pool, or downstream waiting as the likely lead |
+| `tailtriage` | first-pass ranking of likely latency bottleneck families from one run | you need a focused next-check loop rather than continuous observability |
 
 ## What you get from the output
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,29 @@ It produces a triage report with **evidence-ranked suspects** and **next checks*
 - Not an observability backend.
 - Not root-cause proof on its own.
 
+## Problems tailtriage helps diagnose
+
+tailtriage is useful for:
+- Tokio latency debugging
+- Rust async performance triage
+- debugging flaky Tokio services
+- investigating p95/p99 latency spikes
+- finding executor pressure
+- identifying blocking-pool pressure
+- distinguishing queueing from downstream latency
+- lightweight production/staging diagnostics for async Rust
+
+## When to use tailtriage
+
+Use tailtriage when a Rust/Tokio service has:
+- intermittent request timeouts
+- p95/p99 latency spikes
+- tasks that appear stuck
+- low CPU but high latency
+- suspected blocking work inside async code
+- queue buildup before work starts
+- unclear difference between Tokio scheduler pressure and slow downstream dependencies
+
 ## Quick start (crates.io)
 
 For most users, start with the default crate:
@@ -48,6 +71,16 @@ In short:
 - `tokio-console` helps you inspect live runtime/task behavior.
 - `tokio-metrics` gives you runtime/task metrics signals.
 - `tailtriage` helps you rank likely bottleneck families and choose the next targeted check from one captured run.
+
+## Tool comparison
+
+| Tool                 | Best for                                              | tailtriage relationship                         |
+| -------------------- | ----------------------------------------------------- | ----------------------------------------------- |
+| `tracing`            | structured logs/spans                                 | complementary input layer                       |
+| `tokio-console`      | live task/runtime inspection                          | use after tailtriage points to runtime pressure |
+| `tokio-metrics`      | runtime/task metrics                                  | complementary signal source                     |
+| `pprof` / flamegraph | CPU hot paths                                         | use when suspect is CPU-bound work              |
+| `tailtriage`         | ranking likely latency bottleneck family from one run | first-pass triage loop                          |
 
 ## What you get from the output
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ In short:
 | Tool | Best for | Use with tailtriage when |
 | --- | --- | --- |
 | `tracing` | structured logs and spans | you need operational context around the captured slow window |
-| `tokio-console` | live Tokio task/runtime inspection | tailtriage points toward runtime or task pressure and you need live inspection |
+| `tokio-console` | live Tokio task/runtime inspection | tailtriage points toward executor/runtime pressure and you need live inspection |
 | `tokio-metrics` | runtime and task metrics | you want runtime signals to strengthen or explain tailtriage evidence |
 | `pprof` / flamegraph | CPU hot paths | tailtriage does not show queueing, runtime, blocking-pool, or downstream waiting as the likely lead |
 | `tailtriage` | first-pass ranking of likely latency bottleneck families from one run | you need a focused next-check loop rather than continuous observability |

--- a/tailtriage/README.md
+++ b/tailtriage/README.md
@@ -16,6 +16,16 @@ When a Tokio service slows down, the first triage question is often:
 
 The analysis result is triage guidance (evidence-ranked suspects plus next checks), not proof of root cause.
 
+## Common use cases
+
+| Symptom | tailtriage helps check |
+| --- | --- |
+| p95/p99 latency spikes | whether tail time is dominated by queueing, executor pressure, blocking-pool pressure, or downstream stages |
+| low CPU but high latency | whether work is waiting before execution or blocked behind constrained resources |
+| suspected blocking in async code | whether blocking-pool pressure or runtime pressure is visible in captured evidence |
+| requests appear stuck | whether queue wait, service time, or downstream stage latency dominates |
+| flaky Tokio service latency | which bottleneck family is the best next diagnostic lead |
+
 ## Installation
 
 ```bash

--- a/tailtriage/README.md
+++ b/tailtriage/README.md
@@ -20,11 +20,18 @@ The analysis result is triage guidance (evidence-ranked suspects plus next check
 
 | Symptom | tailtriage helps check |
 | --- | --- |
-| p95/p99 latency spikes | whether tail time is dominated by queueing, executor pressure, blocking-pool pressure, or downstream stages |
-| low CPU but high latency | whether work is waiting before execution or blocked behind constrained resources |
-| suspected blocking in async code | whether blocking-pool pressure or runtime pressure is visible in captured evidence |
-| requests appear stuck | whether queue wait, service time, or downstream stage latency dominates |
-| flaky Tokio service latency | which bottleneck family is the best next diagnostic lead |
+| p95/p99 latency spikes | whether tail latency is dominated by queueing, executor pressure, blocking-pool pressure, or downstream stage latency |
+| intermittent request timeouts | whether slow requests share a common bottleneck family in one captured run |
+| low CPU but high latency | whether requests are waiting in queues, blocked behind constrained resources, or delayed by downstream work |
+| requests appear stuck | whether time is spent before work starts, inside service execution, or in a named downstream stage |
+| suspected blocking in async code | whether blocking-pool pressure is visible and should be investigated with a targeted follow-up |
+| Tokio runtime seems overloaded | whether runtime-pressure signals point toward executor contention rather than app-level queueing |
+| queue buildup before work starts | whether application queue wait dominates p95 latency |
+| slow database or external API suspected | whether a downstream stage dominates request latency enough to be the next check |
+| flaky latency in staging or production | which bottleneck family is the strongest lead from a bounded capture window |
+| hard-to-reproduce tail spikes | whether a captured slow window contains enough evidence to choose the next experiment |
+| unclear profiler results | whether the latency problem is actually CPU-bound work, queueing, runtime pressure, or downstream waiting |
+| service has partial instrumentation only | whether available request, queue, stage, runtime, or inflight signals are enough for a useful triage lead |
 
 ## Installation
 

--- a/tailtriage/README.md
+++ b/tailtriage/README.md
@@ -25,12 +25,12 @@ The analysis result is triage guidance (evidence-ranked suspects plus next check
 | low CPU but high latency | whether requests are waiting in queues, blocked behind constrained resources, or delayed by downstream work |
 | requests appear stuck | whether time is spent before work starts, inside service execution, or in a named downstream stage |
 | suspected blocking in async code | whether blocking-pool pressure is visible and should be investigated with a targeted follow-up |
-| Tokio runtime seems overloaded | whether runtime-pressure signals point toward executor contention rather than app-level queueing |
+| Tokio runtime seems overloaded | whether captured runtime-pressure signals point toward executor contention rather than app-level queueing |
 | queue buildup before work starts | whether application queue wait dominates p95 latency |
 | slow database or external API suspected | whether a downstream stage dominates request latency enough to be the next check |
 | flaky latency in staging or production | which bottleneck family is the strongest lead from a bounded capture window |
 | hard-to-reproduce tail spikes | whether a captured slow window contains enough evidence to choose the next experiment |
-| unclear profiler results | whether the latency problem is actually CPU-bound work, queueing, runtime pressure, or downstream waiting |
+| unclear profiler results | whether queueing, runtime pressure, blocking-pool pressure, or downstream waiting explains the tail before pursuing CPU hot paths |
 | service has partial instrumentation only | whether available request, queue, stage, runtime, or inflight signals are enough for a useful triage lead |
 
 ## Installation


### PR DESCRIPTION
Added sections on problems tailtriage helps diagnose, when to use tailtriage, and tool comparison.

## Summary

seo and ai friendliness

## Contribution license check

- [x] I have the right to submit this contribution under the MIT License.
- [x] I agree that this contribution is licensed under the repository's MIT License.
