### PR TITLE
docs: add tailtriage-analyzer to AGENTS workspace members list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,7 @@ Expected workspace members:
 - `tailtriage-controller`
 - `tailtriage-tokio`
 - `tailtriage-axum`
+- `tailtriage-analyzer`
 - `tailtriage-cli`
 
 Possible directories:


### PR DESCRIPTION
### Motivation
- Ensure the contributor-facing `AGENTS.md` workspace member list reflects the actual crate layout and the intended capture -> analyze -> CLI flow by including `tailtriage-analyzer`.

### Description
- Inserted `- `tailtriage-analyzer`` into the `Expected workspace members` list in `AGENTS.md` immediately before `tailtriage-cli` and performed a quick consistency pass across Markdown docs to confirm other workspace-member lists (e.g., `SPEC.md`) already include the same crate set.

### Testing
- Located workspace-member occurrences with `rg --line-number "workspace members|Expected workspace members|Current workspace members include" --glob "*.md"`, updated `AGENTS.md` with a small scripted edit, and committed the change with `git commit`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fccd3aafa88330bd559dac7cf0cc94)