### PR TITLE
Add DiscardSink and MemorySink to tailtriage-core

### DIFF
--- a/tailtriage-core/src/lib.rs
+++ b/tailtriage-core/src/lib.rs
@@ -46,7 +46,7 @@ pub use events::{
     RunEndReason, RunMetadata, RuntimeSnapshot, StageEvent, TruncationSummary,
     UnfinishedRequestSample, UnfinishedRequests, SCHEMA_VERSION,
 };
-pub use sink::{LocalJsonSink, RunSink, SinkError};
+pub use sink::{DiscardSink, LocalJsonSink, MemorySink, RunSink, SinkError};
 pub use time::{system_time_to_unix_ms, unix_time_ms};
 pub use timers::{InflightGuard, QueueTimer, StageTimer};
 

--- a/tailtriage-core/src/sink.rs
+++ b/tailtriage-core/src/sink.rs
@@ -83,6 +83,7 @@ impl MemorySink {
     }
 
     /// Takes the last finalized run and clears the stored value.
+    #[must_use]
     pub fn take_run(&self) -> Option<Run> {
         lock_recover(&self.run).take()
     }

--- a/tailtriage-core/src/sink.rs
+++ b/tailtriage-core/src/sink.rs
@@ -1,6 +1,7 @@
 use std::fs::{self, OpenOptions};
 use std::io::{BufWriter, Error as IoError, Write};
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::Run;
@@ -38,6 +39,72 @@ pub trait RunSink {
     /// Returns [`SinkError`] if the sink cannot write the run output, such as
     /// when file I/O fails or serialization cannot complete.
     fn write(&self, run: &Run) -> Result<(), SinkError>;
+}
+
+/// Sink that finalizes capture lifecycle without writing a run artifact.
+///
+/// [`DiscardSink`] intentionally drops the finalized [`Run`] after shutdown and
+/// does not persist any JSON file artifact.
+///
+/// Use [`MemorySink`] instead when you want to keep the finalized [`Run`] for
+/// in-process analysis.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DiscardSink;
+
+impl RunSink for DiscardSink {
+    fn write(&self, _run: &Run) -> Result<(), SinkError> {
+        Ok(())
+    }
+}
+
+/// In-memory sink that stores only the last finalized run.
+///
+/// [`MemorySink`] writes no file artifact and keeps the most recent finalized
+/// [`Run`] in memory. Later writes replace earlier stored runs.
+///
+/// Storing finalized runs clones captured data and can increase memory use for
+/// large captures.
+#[derive(Debug, Clone, Default)]
+pub struct MemorySink {
+    run: Arc<Mutex<Option<Run>>>,
+}
+
+impl MemorySink {
+    /// Creates a new in-memory sink.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns a cloned copy of the last finalized run, if present.
+    #[must_use]
+    pub fn last_run(&self) -> Option<Run> {
+        lock_recover(&self.run).clone()
+    }
+
+    /// Takes the last finalized run and clears the stored value.
+    pub fn take_run(&self) -> Option<Run> {
+        lock_recover(&self.run).take()
+    }
+
+    /// Clears any stored finalized run.
+    pub fn clear(&self) {
+        *lock_recover(&self.run) = None;
+    }
+}
+
+impl RunSink for MemorySink {
+    fn write(&self, run: &Run) -> Result<(), SinkError> {
+        *lock_recover(&self.run) = Some(run.clone());
+        Ok(())
+    }
+}
+
+fn lock_recover<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    match mutex.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
 }
 
 /// Local file sink that writes one JSON document per run at shutdown.
@@ -151,7 +218,10 @@ impl std::error::Error for SinkError {
 
 #[cfg(test)]
 mod tests {
-    use super::{finalize_temp_file, LocalJsonSink, RunSink, SinkError};
+    use super::{
+        finalize_temp_file, lock_recover, DiscardSink, LocalJsonSink, MemorySink, RunSink,
+        SinkError,
+    };
     use crate::{CaptureMode, Run, RunMetadata, UnfinishedRequests, SCHEMA_VERSION};
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -203,6 +273,58 @@ mod tests {
         assert_eq!(restored.schema_version, SCHEMA_VERSION);
 
         let _ = std::fs::remove_file(output);
+    }
+
+    #[test]
+    fn discard_sink_write_succeeds() {
+        let sink = DiscardSink;
+        sink.write(&sample_run()).expect("discard should succeed");
+    }
+
+    #[test]
+    fn memory_sink_replaces_previous_run() {
+        let sink = MemorySink::new();
+        let mut first = sample_run();
+        first.metadata.run_id = "run-first".to_string();
+        sink.write(&first).expect("first write should succeed");
+        assert_eq!(
+            sink.last_run()
+                .expect("run should be present")
+                .metadata
+                .run_id,
+            "run-first"
+        );
+
+        let mut second = sample_run();
+        second.metadata.run_id = "run-second".to_string();
+        sink.write(&second).expect("second write should succeed");
+        assert_eq!(
+            sink.last_run()
+                .expect("run should be present")
+                .metadata
+                .run_id,
+            "run-second"
+        );
+    }
+
+    #[test]
+    fn memory_sink_recovers_from_poisoned_mutex_operations() {
+        let sink = MemorySink::new();
+        {
+            let sink_clone = sink.clone();
+            let _ = std::thread::spawn(move || {
+                let _guard = lock_recover(&sink_clone.run);
+                panic!("poison mutex");
+            })
+            .join();
+        }
+
+        assert!(sink.last_run().is_none(), "last_run should recover");
+        assert!(sink.take_run().is_none(), "take_run should recover");
+        sink.clear();
+        assert!(sink.last_run().is_none(), "clear should recover");
+        sink.write(&sample_run()).expect("write should recover");
+        assert!(sink.last_run().is_some(), "write should store run");
     }
 
     #[test]

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::{
     BuildError, CaptureLimits, CaptureLimitsOverride, CaptureMode, EffectiveTokioSamplerConfig,
-    Outcome, RequestOptions, RuntimeSamplerRegistrationError, SinkError, Tailtriage,
+    MemorySink, Outcome, RequestOptions, RuntimeSamplerRegistrationError, SinkError, Tailtriage,
 };
 
 #[derive(Debug, Default)]
@@ -198,6 +198,87 @@ fn shutdown_writes_artifact() {
     assert!(
         run.metadata.finalized_at_unix_ms.is_some(),
         "shutdown artifact should include finalized timestamp"
+    );
+}
+
+#[test]
+fn shutdown_with_discard_sink_succeeds() {
+    let tailtriage = Tailtriage::builder("payments")
+        .sink(crate::DiscardSink)
+        .build()
+        .expect("build should succeed");
+    tailtriage.begin_request("/health").completion.finish_ok();
+    tailtriage.shutdown().expect("shutdown should succeed");
+}
+
+#[test]
+fn memory_sink_stores_finalized_run_after_shutdown() {
+    let sink = MemorySink::new();
+    let tailtriage = Tailtriage::builder("payments")
+        .sink(sink.clone())
+        .build()
+        .expect("build should succeed");
+    tailtriage.begin_request("/health").completion.finish_ok();
+    tailtriage.shutdown().expect("shutdown should succeed");
+
+    let run = sink.last_run().expect("run should be stored");
+    assert!(run.metadata.finalized_at_unix_ms.is_some());
+    assert_eq!(run.requests.len(), 1);
+}
+
+#[test]
+fn memory_sink_last_run_returns_clone_without_clearing() {
+    let sink = MemorySink::new();
+    let mut run = Tailtriage::builder("payments")
+        .build()
+        .expect("build should succeed")
+        .snapshot();
+    run.metadata.run_id = "run-1".to_string();
+    crate::RunSink::write(&sink, &run).expect("write should succeed");
+
+    let first = sink.last_run().expect("run should exist");
+    let second = sink.last_run().expect("run should still exist");
+    assert_eq!(first, second);
+}
+
+#[test]
+fn memory_sink_take_run_returns_and_clears() {
+    let sink = MemorySink::new();
+    let run = Tailtriage::builder("payments")
+        .build()
+        .expect("build should succeed")
+        .snapshot();
+    crate::RunSink::write(&sink, &run).expect("write should succeed");
+    assert!(sink.take_run().is_some(), "take should return run");
+    assert!(sink.last_run().is_none(), "take should clear stored run");
+}
+
+#[test]
+fn memory_sink_clear_removes_stored_run() {
+    let sink = MemorySink::new();
+    let run = Tailtriage::builder("payments")
+        .build()
+        .expect("build should succeed")
+        .snapshot();
+    crate::RunSink::write(&sink, &run).expect("write should succeed");
+    sink.clear();
+    assert!(sink.last_run().is_none());
+}
+
+#[test]
+fn memory_sink_clone_handle_observes_builder_write() {
+    let sink = MemorySink::new();
+    let sink_for_builder = sink.clone();
+    let tailtriage = Tailtriage::builder("payments")
+        .sink(sink_for_builder)
+        .build()
+        .expect("build should succeed");
+    tailtriage.begin_request("/health").completion.finish_ok();
+    tailtriage.shutdown().expect("shutdown should succeed");
+
+    assert!(
+        sink.last_run().is_some(),
+        "original handle should observe run"
     );
 }
 


### PR DESCRIPTION
### Motivation
- Provide first-class built-in sinks so users can run without creating a JSON file artifact or keep the finalized `Run` in-process for analysis. 
- Offer an explicit, low-overhead discard path and a cloneable in-memory handle for workflows that need immediate programmatic access to the finalized run.

### Description
- Add `DiscardSink` in `tailtriage-core::sink`: a public zero-sized sink that `#[derive(Debug, Clone, Copy, Default)]` and implements `RunSink` with a no-op `write(&self, _run: &Run) -> Ok(())`, and rustdoc pointing users to `MemorySink` for in-process analysis. 
- Add `MemorySink` in `tailtriage-core::sink`: a public `#[derive(Debug, Clone, Default)]` cloneable handle backed by `Arc<Mutex<Option<Run>>>`, with `pub fn new() -> Self`, `pub fn last_run(&self) -> Option<Run>`, `pub fn take_run(&self) -> Option<Run>`, `pub fn clear(&self)`, and `RunSink::write` that clones and stores the passed `Run`; rustdoc documents that it stores only the last finalized run and may increase memory usage. 
- Implement consistent poisoned-mutex recovery using `into_inner()` via a `lock_recover` helper so `last_run`, `take_run`, `clear`, and `write` recover rather than panic. 
- Re-export `DiscardSink` and `MemorySink` from `tailtriage-core::lib` alongside `LocalJsonSink`, `RunSink`, and `SinkError`, and keep the default sink behavior unchanged (`TailtriageBuilder::new` still defaults to `LocalJsonSink::new("tailtriage-run.json")`). 
- No new dependencies were added; implementation uses only `std`.

### Testing
- Added focused unit tests covering `DiscardSink::write`, builder integration with `DiscardSink`, `MemorySink` store/clone/take/clear semantics, clone-handle sharing, replacement-on-successive-writes, and poisoned-mutex recovery for `last_run`, `take_run`, `clear`, and `write`. 
- Ran `cargo fmt --check` which passed. 
- Ran `cargo test -p tailtriage-core` and all tests passed (unit tests and doc-tests completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcd6036cf48330963d965390958dbb)