### PR TITLE
Add built-in DiscardSink and MemorySink to tailtriage-core

### DIFF
--- a/tailtriage-core/src/lib.rs
+++ b/tailtriage-core/src/lib.rs
@@ -46,7 +46,7 @@ pub use events::{
     RunEndReason, RunMetadata, RuntimeSnapshot, StageEvent, TruncationSummary,
     UnfinishedRequestSample, UnfinishedRequests, SCHEMA_VERSION,
 };
-pub use sink::{LocalJsonSink, RunSink, SinkError};
+pub use sink::{DiscardSink, LocalJsonSink, MemorySink, RunSink, SinkError};
 pub use time::{system_time_to_unix_ms, unix_time_ms};
 pub use timers::{InflightGuard, QueueTimer, StageTimer};
 

--- a/tailtriage-core/src/sink.rs
+++ b/tailtriage-core/src/sink.rs
@@ -1,6 +1,7 @@
 use std::fs::{self, OpenOptions};
 use std::io::{BufWriter, Error as IoError, Write};
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::Run;
@@ -38,6 +39,82 @@ pub trait RunSink {
     /// Returns [`SinkError`] if the sink cannot write the run output, such as
     /// when file I/O fails or serialization cannot complete.
     fn write(&self, run: &Run) -> Result<(), SinkError>;
+}
+
+/// Sink that finalizes the capture lifecycle and intentionally drops the
+/// finalized run.
+///
+/// This sink writes no run artifact file. Use it when you want shutdown to
+/// complete without persisting output.
+///
+/// If you need in-process analysis of the finalized [`Run`], use
+/// [`MemorySink`] instead.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DiscardSink;
+
+impl RunSink for DiscardSink {
+    fn write(&self, _run: &Run) -> Result<(), SinkError> {
+        Ok(())
+    }
+}
+
+/// Sink that stores finalized runs in memory and writes no file artifact.
+///
+/// This sink stores only the last finalized [`Run`]. Later writes replace any
+/// previously stored run.
+///
+/// Storing finalized runs clones captured data, which can increase memory use
+/// for large captures.
+#[derive(Debug, Clone, Default)]
+pub struct MemorySink {
+    last_run: Arc<Mutex<Option<Run>>>,
+}
+
+impl MemorySink {
+    /// Creates a new in-memory sink.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns a clone of the last stored run, if present.
+    #[must_use]
+    pub fn last_run(&self) -> Option<Run> {
+        let guard = self
+            .last_run
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.clone()
+    }
+
+    /// Takes and clears the last stored run.
+    pub fn take_run(&self) -> Option<Run> {
+        let mut guard = self
+            .last_run
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.take()
+    }
+
+    /// Clears any stored run.
+    pub fn clear(&self) {
+        let mut guard = self
+            .last_run
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *guard = None;
+    }
+}
+
+impl RunSink for MemorySink {
+    fn write(&self, run: &Run) -> Result<(), SinkError> {
+        let mut guard = self
+            .last_run
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *guard = Some(run.clone());
+        Ok(())
+    }
 }
 
 /// Local file sink that writes one JSON document per run at shutdown.
@@ -151,9 +228,10 @@ impl std::error::Error for SinkError {
 
 #[cfg(test)]
 mod tests {
-    use super::{finalize_temp_file, LocalJsonSink, RunSink, SinkError};
+    use super::{finalize_temp_file, DiscardSink, LocalJsonSink, MemorySink, RunSink, SinkError};
     use crate::{CaptureMode, Run, RunMetadata, UnfinishedRequests, SCHEMA_VERSION};
     use std::path::PathBuf;
+    use std::sync::{Arc, Mutex};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn unique_path(suffix: &str) -> PathBuf {
@@ -203,6 +281,90 @@ mod tests {
         assert_eq!(restored.schema_version, SCHEMA_VERSION);
 
         let _ = std::fs::remove_file(output);
+    }
+
+    #[test]
+    fn discard_sink_write_succeeds() {
+        let sink = DiscardSink;
+        sink.write(&sample_run())
+            .expect("discard sink should succeed");
+    }
+
+    #[test]
+    fn memory_sink_last_run_returns_clone_without_clearing() {
+        let sink = MemorySink::new();
+        let run = sample_run();
+        sink.write(&run).expect("memory sink write should succeed");
+
+        let first = sink.last_run().expect("run should be stored");
+        let second = sink.last_run().expect("run should remain stored");
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn memory_sink_take_run_returns_and_clears() {
+        let sink = MemorySink::new();
+        let run = sample_run();
+        sink.write(&run).expect("memory sink write should succeed");
+
+        let taken = sink.take_run().expect("run should be returned");
+        assert_eq!(taken, run);
+        assert!(sink.last_run().is_none(), "take should clear stored run");
+    }
+
+    #[test]
+    fn memory_sink_clear_removes_stored_run() {
+        let sink = MemorySink::new();
+        sink.write(&sample_run())
+            .expect("memory sink write should succeed");
+        sink.clear();
+        assert!(sink.last_run().is_none(), "clear should remove stored run");
+    }
+
+    #[test]
+    fn memory_sink_write_replaces_previous_run() {
+        let sink = MemorySink::new();
+        let mut first = sample_run();
+        first.metadata.run_id = "first".to_string();
+        sink.write(&first).expect("first write should succeed");
+        let mut second = sample_run();
+        second.metadata.run_id = "second".to_string();
+        sink.write(&second).expect("second write should succeed");
+        assert_eq!(
+            sink.last_run().expect("latest run should be present"),
+            second
+        );
+    }
+
+    #[test]
+    fn memory_sink_recovers_from_poisoned_mutex() {
+        let poisonable = Arc::new(Mutex::new(Some(sample_run())));
+        let poisoned = Arc::clone(&poisonable);
+        let _ = std::thread::spawn(move || {
+            let _guard = poisoned.lock().expect("poisoning lock should succeed");
+            panic!("intentional panic to poison mutex");
+        })
+        .join();
+
+        let poisoned_sink = MemorySink {
+            last_run: poisonable,
+        };
+        assert!(
+            poisoned_sink.last_run().is_some(),
+            "last_run should recover from poison"
+        );
+        assert!(
+            poisoned_sink.take_run().is_some(),
+            "take_run should recover from poison"
+        );
+        poisoned_sink.clear();
+        assert!(
+            poisoned_sink.last_run().is_none(),
+            "clear should recover from poison and clear state"
+        );
+        poisoned_sink
+            .write(&sample_run())
+            .expect("write should recover from poison");
     }
 
     #[test]

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::{
     BuildError, CaptureLimits, CaptureLimitsOverride, CaptureMode, EffectiveTokioSamplerConfig,
-    Outcome, RequestOptions, RuntimeSamplerRegistrationError, SinkError, Tailtriage,
+    MemorySink, Outcome, RequestOptions, RuntimeSamplerRegistrationError, SinkError, Tailtriage,
 };
 
 #[derive(Debug, Default)]
@@ -198,6 +198,50 @@ fn shutdown_writes_artifact() {
     assert!(
         run.metadata.finalized_at_unix_ms.is_some(),
         "shutdown artifact should include finalized timestamp"
+    );
+}
+
+#[test]
+fn builder_with_discard_sink_builds_and_shutdown_succeeds() {
+    let tailtriage = Tailtriage::builder("payments")
+        .sink(crate::DiscardSink)
+        .build()
+        .expect("build should succeed");
+    tailtriage.begin_request("/health").completion.finish_ok();
+    tailtriage.shutdown().expect("shutdown should succeed");
+}
+
+#[test]
+fn memory_sink_stores_finalized_run_after_shutdown() {
+    let sink = MemorySink::new();
+    let tailtriage = Tailtriage::builder("payments")
+        .sink(sink.clone())
+        .build()
+        .expect("build should succeed");
+    tailtriage.begin_request("/health").completion.finish_ok();
+    tailtriage.shutdown().expect("shutdown should succeed");
+
+    let run = sink.last_run().expect("finalized run should be stored");
+    assert!(
+        run.metadata.finalized_at_unix_ms.is_some(),
+        "run should be finalized at shutdown"
+    );
+}
+
+#[test]
+fn memory_sink_can_be_cloned_before_builder_and_read_after_shutdown() {
+    let sink = MemorySink::new();
+    let sink_for_builder = sink.clone();
+    let tailtriage = Tailtriage::builder("payments")
+        .sink(sink_for_builder)
+        .build()
+        .expect("build should succeed");
+    tailtriage.begin_request("/health").completion.finish_ok();
+    tailtriage.shutdown().expect("shutdown should succeed");
+
+    assert!(
+        sink.last_run().is_some(),
+        "original handle should retrieve finalized run"
     );
 }
 


### PR DESCRIPTION
### Motivation
- Provide first-class, std-only sinks so users can run without writing JSON artifacts or keep the finalized `Run` in-process for analysis.
- Offer a zero-cost discard path for callers that only need the capture lifecycle to complete without persisting output.
- Offer a simple in-memory handle for test and interactive workflows that must inspect the finalized `Run` without file I/O.

### Description
- Added `DiscardSink` (`Debug`, `Clone`, `Copy`, `Default`) as a zero-sized `RunSink` that finalizes shutdown and intentionally drops the finalized `Run` and writes no artifact; rustdoc points users at `MemorySink` for in-process analysis.
- Added `MemorySink` (`Debug`, `Clone`, `Default`) backed by `Arc<Mutex<Option<Run>>>` with `pub fn new()`, `pub fn last_run(&self) -> Option<Run>`, `pub fn take_run(&self) -> Option<Run>`, and `pub fn clear(&self)`; `write()` clones and stores the passed `Run` and only retains the latest run.
- `MemorySink` and `DiscardSink` recover from poisoned mutexes using `PoisonError::into_inner()` (consistent with crate behavior) rather than panicking.
- Re-exported `DiscardSink` and `MemorySink` from the crate root alongside `LocalJsonSink`, `RunSink`, and `SinkError` without changing the default sink behavior (`TailtriageBuilder::new` still defaults to `LocalJsonSink::new("tailtriage-run.json")`).
- Added focused unit and integration tests exercising `DiscardSink`, `MemorySink` semantics (last/take/clear, replacement, cloning handle usage, and poisoned mutex recovery) and a builder test using `DiscardSink` to ensure shutdown completes.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo test -p tailtriage-core` and all tests passed (new and existing tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcd6036cf48330963d965390958dbb)