### PR TITLE
Add analyzer-owned Report JSON rendering APIs

### DIFF
--- a/tailtriage-analyzer/Cargo.toml
+++ b/tailtriage-analyzer/Cargo.toml
@@ -13,6 +13,7 @@ include = ["Cargo.toml", "README.md", "LICENSE", "src/**"]
 
 [dependencies]
 serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
 tailtriage-core.workspace = true
 
 [package.metadata.docs.rs]
@@ -22,5 +23,4 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dev-dependencies]
-serde_json = "1.0.145"
 tokio = { version = "1.48.0", features = ["macros", "rt", "time"] }

--- a/tailtriage-analyzer/src/lib.rs
+++ b/tailtriage-analyzer/src/lib.rs
@@ -10,7 +10,7 @@
 //! Use [`analyze_run`] (or [`Analyzer`]) to produce a [`Report`], then:
 //!
 //! - call [`render_text`] for human-readable triage output;
-//! - call `serde_json::to_string_pretty(&report)` for analysis report JSON.
+//! - call [`render_json`] or [`render_json_pretty`] for analysis report JSON.
 //!
 //! The analysis report JSON is distinct from raw run artifact JSON produced by capture/artifact
 //! workflows. Raw run artifacts remain available for later CLI analysis.
@@ -310,6 +310,63 @@ pub struct RouteBreakdown {
 #[must_use]
 pub fn analyze_run(run: &Run, options: AnalyzeOptions) -> Report {
     Analyzer::new(options).analyze_run(run)
+}
+
+/// Renders analyzer [`Report`] output as compact JSON.
+///
+/// This renders analyzer report JSON, not raw run artifact JSON.
+///
+/// # Errors
+///
+/// Returns `serde_json::Error` if the report cannot be serialized to JSON.
+#[must_use = "use the rendered compact report JSON or handle serialization failure"]
+pub fn render_json(report: &Report) -> Result<String, serde_json::Error> {
+    serde_json::to_string(report)
+}
+
+/// Renders analyzer [`Report`] output as canonical pretty JSON intended for CLI JSON output.
+///
+/// This renders analyzer report JSON, not raw run artifact JSON.
+///
+/// # Errors
+///
+/// Returns `serde_json::Error` if the report cannot be serialized to JSON.
+#[must_use = "use the rendered pretty report JSON or handle serialization failure"]
+pub fn render_json_pretty(report: &Report) -> Result<String, serde_json::Error> {
+    serde_json::to_string_pretty(report)
+}
+
+/// Analyzes an in-memory [`Run`] and returns compact analyzer report JSON.
+///
+/// This returns analyzer report JSON, not raw run artifact JSON.
+///
+/// # Errors
+///
+/// Returns `serde_json::Error` if the analyzed report cannot be serialized to JSON.
+#[must_use = "use the rendered compact report JSON or handle serialization failure"]
+pub fn analyze_run_json(
+    run: &tailtriage_core::Run,
+    options: AnalyzeOptions,
+) -> Result<String, serde_json::Error> {
+    let report = analyze_run(run, options);
+    render_json(&report)
+}
+
+/// Analyzes an in-memory [`Run`] and returns canonical pretty analyzer report JSON.
+///
+/// This is the canonical renderer intended for CLI JSON output, and it returns analyzer
+/// report JSON, not raw run artifact JSON.
+///
+/// # Errors
+///
+/// Returns `serde_json::Error` if the analyzed report cannot be serialized to JSON.
+#[must_use = "use the rendered pretty report JSON or handle serialization failure"]
+pub fn analyze_run_json_pretty(
+    run: &tailtriage_core::Run,
+    options: AnalyzeOptions,
+) -> Result<String, serde_json::Error> {
+    let report = analyze_run(run, options);
+    render_json_pretty(&report)
 }
 
 /// Options for heuristic run analysis.

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -1603,3 +1603,45 @@ fn public_api_supports_report_text_and_json_contract_fields() {
     assert!(report_json.contains("\"route_breakdowns\""));
     assert!(report_json.contains("\"temporal_segments\""));
 }
+
+#[test]
+fn render_json_pretty_matches_serde_json() {
+    let report = analyze_run(&test_run(), AnalyzeOptions::default());
+    assert_eq!(
+        crate::render_json_pretty(&report).expect("render_json_pretty should serialize"),
+        serde_json::to_string_pretty(&report).expect("serde pretty serialization should succeed")
+    );
+}
+
+#[test]
+fn render_json_matches_serde_json() {
+    let report = analyze_run(&test_run(), AnalyzeOptions::default());
+    assert_eq!(
+        crate::render_json(&report).expect("render_json should serialize"),
+        serde_json::to_string(&report).expect("serde compact serialization should succeed")
+    );
+}
+
+#[test]
+fn analyze_run_json_pretty_matches_analyze_then_render() {
+    let run = test_run();
+    let expected = crate::render_json_pretty(&analyze_run(&run, AnalyzeOptions::default()))
+        .expect("render_json_pretty should serialize");
+    let actual = crate::analyze_run_json_pretty(&run, AnalyzeOptions::default())
+        .expect("analyze_run_json_pretty should serialize");
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn compact_json_matches_pretty_json_value() {
+    let report = analyze_run(&test_run(), AnalyzeOptions::default());
+    let compact = crate::render_json(&report).expect("render_json should serialize");
+    let pretty = crate::render_json_pretty(&report).expect("render_json_pretty should serialize");
+
+    let compact_value: serde_json::Value =
+        serde_json::from_str(&compact).expect("compact output should parse as valid JSON");
+    let pretty_value: serde_json::Value =
+        serde_json::from_str(&pretty).expect("pretty output should parse as valid JSON");
+
+    assert_eq!(compact_value, pretty_value);
+}


### PR DESCRIPTION
### Motivation
- Make `tailtriage-analyzer` the canonical place to render analyzer `Report` JSON so library callers and the CLI can share a single renderer API.
- Preserve existing analysis semantics while providing a stable, documented JSON rendering surface for compact and pretty output.

### Description
- Moved `serde_json = "1.0.145"` from `[dev-dependencies]` into `[dependencies]` in `tailtriage-analyzer/Cargo.toml` and removed the duplicate dev-dependency entry, without adding any other dependencies.
- Added public crate-root JSON rendering functions in `tailtriage-analyzer/src/lib.rs`: `render_json`, `render_json_pretty`, `analyze_run_json`, and `analyze_run_json_pretty` with exact wiring to `serde_json::to_string` / `to_string_pretty` and `analyze_run(...)` as specified, and added rustdoc clarifying these produce analyzer `Report` JSON (not raw run artifact JSON) and that pretty output is the canonical renderer intended for CLI JSON output.
- Replaced the previous crate-level rustdoc guidance that told callers to call `serde_json::to_string_pretty(&report)` with guidance to use `render_json` / `render_json_pretty`, while keeping the distinction between Report JSON and raw run artifact JSON and retaining that CLI artifact loading is owned by `tailtriage-cli`.
- Added focused tests in `tailtriage-analyzer/src/tests.rs` that assert parity with `serde_json::to_string`/`to_string_pretty`, parity of `analyze_run_json_pretty` with the analyze-then-render flow, and semantic equality of compact vs pretty JSON via `serde_json::Value` parsing; no analyzer behavior or report fields were changed.

### Testing
- Ran `cargo fmt --check` (succeeded).
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (succeeded with zero warnings/errors).
- Ran `cargo test -p tailtriage-analyzer --locked` (all analyzer tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce010b9248330bbd5e4609b61baf1)