### PR TITLE
analyzer: add canonical Report JSON rendering surface

### DIFF
--- a/tailtriage-analyzer/Cargo.toml
+++ b/tailtriage-analyzer/Cargo.toml
@@ -13,6 +13,7 @@ include = ["Cargo.toml", "README.md", "LICENSE", "src/**"]
 
 [dependencies]
 serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
 tailtriage-core.workspace = true
 
 [package.metadata.docs.rs]
@@ -22,5 +23,4 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dev-dependencies]
-serde_json = "1.0.145"
 tokio = { version = "1.48.0", features = ["macros", "rt", "time"] }

--- a/tailtriage-analyzer/src/lib.rs
+++ b/tailtriage-analyzer/src/lib.rs
@@ -10,7 +10,8 @@
 //! Use [`analyze_run`] (or [`Analyzer`]) to produce a [`Report`], then:
 //!
 //! - call [`render_text`] for human-readable triage output;
-//! - call `serde_json::to_string_pretty(&report)` for analysis report JSON.
+//! - call [`render_json`] for compact analysis report JSON;
+//! - call [`render_json_pretty`] for canonical pretty analysis report JSON.
 //!
 //! The analysis report JSON is distinct from raw run artifact JSON produced by capture/artifact
 //! workflows. Raw run artifacts remain available for later CLI analysis.
@@ -310,6 +311,65 @@ pub struct RouteBreakdown {
 #[must_use]
 pub fn analyze_run(run: &Run, options: AnalyzeOptions) -> Report {
     Analyzer::new(options).analyze_run(run)
+}
+
+/// Renders analyzer [`Report`] JSON in compact form.
+///
+/// This renders analyzer report JSON (the diagnosis output), not raw run artifact JSON.
+///
+/// # Errors
+///
+/// Returns any serialization error from `serde_json::to_string`.
+#[must_use = "The rendered JSON string should be used for output or transport."]
+pub fn render_json(report: &Report) -> Result<String, serde_json::Error> {
+    serde_json::to_string(report)
+}
+
+/// Renders analyzer [`Report`] JSON in canonical pretty form.
+///
+/// This renders analyzer report JSON (the diagnosis output), not raw run artifact JSON.
+/// The pretty output is intended as the canonical renderer for CLI JSON output.
+///
+/// # Errors
+///
+/// Returns any serialization error from `serde_json::to_string_pretty`.
+#[must_use = "The rendered JSON string should be used for output or transport."]
+pub fn render_json_pretty(report: &Report) -> Result<String, serde_json::Error> {
+    serde_json::to_string_pretty(report)
+}
+
+/// Analyzes one in-memory [`Run`] and returns compact analyzer [`Report`] JSON.
+///
+/// This analyzes a run artifact already loaded in memory and returns analyzer report JSON,
+/// not raw run artifact JSON.
+///
+/// # Errors
+///
+/// Returns any serialization error from [`render_json`].
+#[must_use = "The rendered JSON string should be used for output or transport."]
+pub fn analyze_run_json(
+    run: &tailtriage_core::Run,
+    options: AnalyzeOptions,
+) -> Result<String, serde_json::Error> {
+    let report = analyze_run(run, options);
+    render_json(&report)
+}
+
+/// Analyzes one in-memory [`Run`] and returns canonical pretty analyzer [`Report`] JSON.
+///
+/// This analyzes a run artifact already loaded in memory and returns analyzer report JSON,
+/// not raw run artifact JSON. The pretty output is intended for CLI JSON output.
+///
+/// # Errors
+///
+/// Returns any serialization error from [`render_json_pretty`].
+#[must_use = "The rendered JSON string should be used for output or transport."]
+pub fn analyze_run_json_pretty(
+    run: &tailtriage_core::Run,
+    options: AnalyzeOptions,
+) -> Result<String, serde_json::Error> {
+    let report = analyze_run(run, options);
+    render_json_pretty(&report)
 }
 
 /// Options for heuristic run analysis.

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -9,9 +9,10 @@ use super::temporal::{
     TEMPORAL_SUSPECT_SHIFT_WARNING,
 };
 use crate::{
-    analyze_run, analyze_run_internal, evidence, render_text, AnalyzeOptions, Confidence,
-    DiagnosisKind, EvidenceQuality, EvidenceQualityLevel, InflightTrend, Report,
-    SignalCoverageStatus, Suspect, ROUTE_DIVERGENCE_WARNING, ROUTE_RUNTIME_ATTRIBUTION_WARNING,
+    analyze_run, analyze_run_internal, analyze_run_json_pretty, evidence, render_json,
+    render_json_pretty, render_text, AnalyzeOptions, Confidence, DiagnosisKind, EvidenceQuality,
+    EvidenceQualityLevel, InflightTrend, Report, SignalCoverageStatus, Suspect,
+    ROUTE_DIVERGENCE_WARNING, ROUTE_RUNTIME_ATTRIBUTION_WARNING,
 };
 
 fn test_run() -> Run {
@@ -1602,4 +1603,42 @@ fn public_api_supports_report_text_and_json_contract_fields() {
     assert!(report_json.contains("\"confidence_notes\""));
     assert!(report_json.contains("\"route_breakdowns\""));
     assert!(report_json.contains("\"temporal_segments\""));
+}
+
+#[test]
+fn render_json_pretty_matches_serde_json_pretty() {
+    let report = analyze_run(&test_run(), AnalyzeOptions::default());
+    let actual = render_json_pretty(&report).expect("report json should render");
+    let expected = serde_json::to_string_pretty(&report).expect("report json should render");
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn render_json_matches_serde_json_compact() {
+    let report = analyze_run(&test_run(), AnalyzeOptions::default());
+    let actual = render_json(&report).expect("report json should render");
+    let expected = serde_json::to_string(&report).expect("report json should render");
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn analyze_run_json_pretty_matches_analyze_then_render_json_pretty() {
+    let run = test_run();
+    let actual = analyze_run_json_pretty(&run, AnalyzeOptions::default())
+        .expect("analyze+json should render");
+    let expected_report = analyze_run(&run, AnalyzeOptions::default());
+    let expected = render_json_pretty(&expected_report).expect("report json should render");
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn compact_and_pretty_report_json_are_value_equivalent() {
+    let report = analyze_run(&test_run(), AnalyzeOptions::default());
+    let compact = render_json(&report).expect("compact report json should render");
+    let pretty = render_json_pretty(&report).expect("pretty report json should render");
+    let compact_value: serde_json::Value =
+        serde_json::from_str(&compact).expect("compact report json should parse");
+    let pretty_value: serde_json::Value =
+        serde_json::from_str(&pretty).expect("pretty report json should parse");
+    assert_eq!(compact_value, pretty_value);
 }


### PR DESCRIPTION
### Motivation

- Expose a canonical analyzer-owned JSON rendering API so the analyzer and future CLI can share the same code path for producing Report JSON.
- Make `serde_json` a runtime dependency of `tailtriage-analyzer` so the crate can serialize `Report` values directly.

### Description

- Move `serde_json = "1.0.145"` from `[dev-dependencies]` into `[dependencies]` in `tailtriage-analyzer/Cargo.toml` and remove the duplicate dev entry.
- Add public crate-root functions `render_json`, `render_json_pretty`, `analyze_run_json`, and `analyze_run_json_pretty` that call `serde_json::to_string`, `serde_json::to_string_pretty`, and `analyze_run(...)` as required.
- Add rustdoc for each new function clarifying these produce analyzer `Report` JSON (not raw run artifact JSON) and that pretty output is intended as the canonical renderer for CLI JSON output.
- Update crate-level rustdoc in `src/lib.rs` to recommend `render_json`/`render_json_pretty` instead of calling `serde_json::to_string_pretty(&report)` directly, while preserving the distinction between Report JSON and raw run artifact JSON and keeping CLI artifact loading as `tailtriage-cli` responsibility.
- Add focused deterministic tests verifying parity between the new renderers and `serde_json` (`render_json_pretty` matches `serde_json::to_string_pretty`, `render_json` matches `serde_json::to_string`), that `analyze_run_json_pretty` matches analyze-then-render flow, and that compact/pretty outputs are value-equivalent JSON.
- No analyzer scoring, warnings, route breakdowns, temporal segments, confidence, or `Report` field semantics were changed.

### Testing

- Ran `cargo fmt --check` which succeeded.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which succeeded with no warnings.
- Ran `cargo test -p tailtriage-analyzer --locked` which passed all analyzer tests (all tests in `tailtriage-analyzer` succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce010b9248330bbd5e4609b61baf1)