### PR TITLE
analyzer: add canonical Report JSON rendering API

### DIFF
--- a/tailtriage-analyzer/Cargo.toml
+++ b/tailtriage-analyzer/Cargo.toml
@@ -13,6 +13,7 @@ include = ["Cargo.toml", "README.md", "LICENSE", "src/**"]
 
 [dependencies]
 serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
 tailtriage-core.workspace = true
 
 [package.metadata.docs.rs]
@@ -22,5 +23,4 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dev-dependencies]
-serde_json = "1.0.145"
 tokio = { version = "1.48.0", features = ["macros", "rt", "time"] }

--- a/tailtriage-analyzer/src/lib.rs
+++ b/tailtriage-analyzer/src/lib.rs
@@ -10,7 +10,7 @@
 //! Use [`analyze_run`] (or [`Analyzer`]) to produce a [`Report`], then:
 //!
 //! - call [`render_text`] for human-readable triage output;
-//! - call `serde_json::to_string_pretty(&report)` for analysis report JSON.
+//! - call [`render_json`] or [`render_json_pretty`] for analysis report JSON.
 //!
 //! The analysis report JSON is distinct from raw run artifact JSON produced by capture/artifact
 //! workflows. Raw run artifacts remain available for later CLI analysis.
@@ -310,6 +310,64 @@ pub struct RouteBreakdown {
 #[must_use]
 pub fn analyze_run(run: &Run, options: AnalyzeOptions) -> Report {
     Analyzer::new(options).analyze_run(run)
+}
+
+/// Renders analyzer [`Report`] output as compact JSON.
+///
+/// This renders analyzer report JSON (suspects/evidence/next checks), not raw run artifact JSON.
+#[must_use = "rendered analyzer Report JSON should be used"]
+///
+/// # Errors
+///
+/// Returns an error if report serialization fails.
+pub fn render_json(report: &Report) -> Result<String, serde_json::Error> {
+    serde_json::to_string(report)
+}
+
+/// Renders analyzer [`Report`] output as canonical pretty JSON.
+///
+/// This emits analyzer report JSON, not raw run artifact JSON, and is intended as the canonical
+/// renderer for CLI JSON output.
+#[must_use = "rendered analyzer Report JSON should be used"]
+///
+/// # Errors
+///
+/// Returns an error if report serialization fails.
+pub fn render_json_pretty(report: &Report) -> Result<String, serde_json::Error> {
+    serde_json::to_string_pretty(report)
+}
+
+/// Analyzes an in-memory [`Run`] and renders compact analyzer [`Report`] JSON.
+///
+/// The returned JSON is analyzer report JSON, not raw run artifact JSON.
+#[must_use = "rendered analyzer Report JSON should be used"]
+///
+/// # Errors
+///
+/// Returns an error if report serialization fails.
+pub fn analyze_run_json(
+    run: &tailtriage_core::Run,
+    options: AnalyzeOptions,
+) -> Result<String, serde_json::Error> {
+    let report = analyze_run(run, options);
+    render_json(&report)
+}
+
+/// Analyzes an in-memory [`Run`] and renders canonical pretty analyzer [`Report`] JSON.
+///
+/// The returned JSON is analyzer report JSON (not raw run artifact JSON) and is intended for CLI
+/// JSON output.
+#[must_use = "rendered analyzer Report JSON should be used"]
+///
+/// # Errors
+///
+/// Returns an error if report serialization fails.
+pub fn analyze_run_json_pretty(
+    run: &tailtriage_core::Run,
+    options: AnalyzeOptions,
+) -> Result<String, serde_json::Error> {
+    let report = analyze_run(run, options);
+    render_json_pretty(&report)
 }
 
 /// Options for heuristic run analysis.

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -9,9 +9,10 @@ use super::temporal::{
     TEMPORAL_SUSPECT_SHIFT_WARNING,
 };
 use crate::{
-    analyze_run, analyze_run_internal, evidence, render_text, AnalyzeOptions, Confidence,
-    DiagnosisKind, EvidenceQuality, EvidenceQualityLevel, InflightTrend, Report,
-    SignalCoverageStatus, Suspect, ROUTE_DIVERGENCE_WARNING, ROUTE_RUNTIME_ATTRIBUTION_WARNING,
+    analyze_run, analyze_run_internal, analyze_run_json_pretty, evidence, render_json,
+    render_json_pretty, render_text, AnalyzeOptions, Confidence, DiagnosisKind, EvidenceQuality,
+    EvidenceQualityLevel, InflightTrend, Report, SignalCoverageStatus, Suspect,
+    ROUTE_DIVERGENCE_WARNING, ROUTE_RUNTIME_ATTRIBUTION_WARNING,
 };
 
 fn test_run() -> Run {
@@ -278,6 +279,44 @@ fn render_text_formats_inflight_trend_fields() {
     assert!(text.contains("p95 7"));
     assert!(text.contains("net growth +5"));
     assert!(text.contains("Request time at p95: queue 10.0%, non-queue service 90.0%"));
+}
+
+#[test]
+fn render_json_pretty_matches_serde_for_deterministic_report() {
+    let report = analyze_run(&test_run(), AnalyzeOptions::default());
+    let expected = serde_json::to_string_pretty(&report).expect("report should serialize");
+    let actual = render_json_pretty(&report).expect("report should serialize");
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn render_json_matches_serde_for_deterministic_report() {
+    let report = analyze_run(&test_run(), AnalyzeOptions::default());
+    let expected = serde_json::to_string(&report).expect("report should serialize");
+    let actual = render_json(&report).expect("report should serialize");
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn analyze_run_json_pretty_matches_analyze_then_render() {
+    let run = test_run();
+    let expected_report = analyze_run(&run, AnalyzeOptions::default());
+    let expected = render_json_pretty(&expected_report).expect("report should serialize");
+    let actual =
+        analyze_run_json_pretty(&run, AnalyzeOptions::default()).expect("report should serialize");
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn compact_and_pretty_render_have_equal_json_values() {
+    let report = analyze_run(&test_run(), AnalyzeOptions::default());
+    let compact = render_json(&report).expect("report should serialize");
+    let pretty = render_json_pretty(&report).expect("report should serialize");
+    let compact_value: serde_json::Value =
+        serde_json::from_str(&compact).expect("compact output should be valid json");
+    let pretty_value: serde_json::Value =
+        serde_json::from_str(&pretty).expect("pretty output should be valid json");
+    assert_eq!(compact_value, pretty_value);
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Make `tailtriage-analyzer` the canonical owner of analyzer `Report` JSON rendering so library callers and the CLI can share the same rendering path.
- Provide ergonomic, documented functions for compact and pretty JSON output without changing analyzer semantics or report schema.

### Description
- Moved `serde_json = "1.0.145"` from `[dev-dependencies]` to `[dependencies]` in `tailtriage-analyzer/Cargo.toml` and removed the duplicate dev entry.
- Added crate-root public rendering functions: `render_json`, `render_json_pretty`, `analyze_run_json`, and `analyze_run_json_pretty`, implemented to call `serde_json::to_string`, `serde_json::to_string_pretty`, `analyze_run(...)+render_json(...)`, and `analyze_run(...)+render_json_pretty(...)` respectively, with `#[must_use]` and rustdoc describing analyzer `Report` JSON vs raw run artifact JSON.
- Updated crate-level rustdoc in `src/lib.rs` to teach `render_json`/`render_json_pretty` instead of suggesting callers directly call `serde_json::to_string_pretty(&report)` and preserved statements that CLI artifact loading is owned by `tailtriage-cli`.
- Added focused deterministic tests exercising compact/pretty parity and `analyze_run_json_pretty` equivalence without asserting broad report text or changing analyzer behavior.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed with no warnings.
- Ran `cargo test -p tailtriage-analyzer --locked` and all analyzer tests passed (including the new deterministic JSON parity tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce010b9248330bbd5e4609b61baf1)