### PR TITLE
analyzer: add canonical Report JSON rendering API

### DIFF
--- a/tailtriage-analyzer/Cargo.toml
+++ b/tailtriage-analyzer/Cargo.toml
@@ -13,6 +13,7 @@ include = ["Cargo.toml", "README.md", "LICENSE", "src/**"]
 
 [dependencies]
 serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
 tailtriage-core.workspace = true
 
 [package.metadata.docs.rs]
@@ -22,5 +23,4 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dev-dependencies]
-serde_json = "1.0.145"
 tokio = { version = "1.48.0", features = ["macros", "rt", "time"] }

--- a/tailtriage-analyzer/src/lib.rs
+++ b/tailtriage-analyzer/src/lib.rs
@@ -10,7 +10,7 @@
 //! Use [`analyze_run`] (or [`Analyzer`]) to produce a [`Report`], then:
 //!
 //! - call [`render_text`] for human-readable triage output;
-//! - call `serde_json::to_string_pretty(&report)` for analysis report JSON.
+//! - call [`render_json`] or [`render_json_pretty`] for analysis report JSON.
 //!
 //! The analysis report JSON is distinct from raw run artifact JSON produced by capture/artifact
 //! workflows. Raw run artifacts remain available for later CLI analysis.
@@ -310,6 +310,65 @@ pub struct RouteBreakdown {
 #[must_use]
 pub fn analyze_run(run: &Run, options: AnalyzeOptions) -> Report {
     Analyzer::new(options).analyze_run(run)
+}
+
+/// Renders analyzer [`Report`] JSON in compact form.
+///
+/// This serializes analyzer report data, not raw run artifact JSON produced by
+/// capture/artifact workflows.
+///
+/// # Errors
+///
+/// Returns any serialization error produced by [`serde_json::to_string`].
+#[must_use = "Use the returned JSON string or handle the serialization error."]
+pub fn render_json(report: &Report) -> Result<String, serde_json::Error> {
+    serde_json::to_string(report)
+}
+
+/// Renders analyzer [`Report`] JSON in canonical pretty-printed form.
+///
+/// This is intended as the canonical renderer for CLI JSON output. It
+/// serializes analyzer report data, not raw run artifact JSON produced by
+/// capture/artifact workflows.
+///
+/// # Errors
+///
+/// Returns any serialization error produced by [`serde_json::to_string`].
+#[must_use = "Use the returned JSON string or handle the serialization error."]
+pub fn render_json_pretty(report: &Report) -> Result<String, serde_json::Error> {
+    serde_json::to_string_pretty(report)
+}
+
+/// Analyzes an in-memory [`Run`] and returns compact analyzer [`Report`] JSON.
+///
+/// This analyzes run data first and then serializes the resulting report. The
+/// returned JSON is analyzer report JSON, not raw run artifact JSON.
+///
+/// # Errors
+///
+/// Returns any serialization error produced while rendering the report JSON.
+#[must_use = "Use the returned JSON string or handle the serialization error."]
+pub fn analyze_run_json(run: &Run, options: AnalyzeOptions) -> Result<String, serde_json::Error> {
+    let report = analyze_run(run, options);
+    render_json(&report)
+}
+
+/// Analyzes an in-memory [`Run`] and returns canonical pretty analyzer [`Report`] JSON.
+///
+/// This analyzes run data first and then serializes the resulting report. The
+/// returned JSON is analyzer report JSON intended for CLI JSON output, not raw
+/// run artifact JSON.
+///
+/// # Errors
+///
+/// Returns any serialization error produced while rendering the report JSON.
+#[must_use = "Use the returned JSON string or handle the serialization error."]
+pub fn analyze_run_json_pretty(
+    run: &Run,
+    options: AnalyzeOptions,
+) -> Result<String, serde_json::Error> {
+    let report = analyze_run(run, options);
+    render_json_pretty(&report)
 }
 
 /// Options for heuristic run analysis.

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -9,9 +9,10 @@ use super::temporal::{
     TEMPORAL_SUSPECT_SHIFT_WARNING,
 };
 use crate::{
-    analyze_run, analyze_run_internal, evidence, render_text, AnalyzeOptions, Confidence,
-    DiagnosisKind, EvidenceQuality, EvidenceQualityLevel, InflightTrend, Report,
-    SignalCoverageStatus, Suspect, ROUTE_DIVERGENCE_WARNING, ROUTE_RUNTIME_ATTRIBUTION_WARNING,
+    analyze_run, analyze_run_internal, analyze_run_json_pretty, evidence, render_json,
+    render_json_pretty, render_text, AnalyzeOptions, Confidence, DiagnosisKind, EvidenceQuality,
+    EvidenceQualityLevel, InflightTrend, Report, SignalCoverageStatus, Suspect,
+    ROUTE_DIVERGENCE_WARNING, ROUTE_RUNTIME_ATTRIBUTION_WARNING,
 };
 
 fn test_run() -> Run {
@@ -278,6 +279,46 @@ fn render_text_formats_inflight_trend_fields() {
     assert!(text.contains("p95 7"));
     assert!(text.contains("net growth +5"));
     assert!(text.contains("Request time at p95: queue 10.0%, non-queue service 90.0%"));
+}
+
+#[test]
+fn render_json_matches_serde_compact_for_report() {
+    let report = analyze_run(&test_run(), AnalyzeOptions::default());
+    let rendered = render_json(&report).expect("compact render should succeed");
+    let expected = serde_json::to_string(&report).expect("serde compact render should succeed");
+    assert_eq!(rendered, expected);
+}
+
+#[test]
+fn render_json_pretty_matches_serde_pretty_for_report() {
+    let report = analyze_run(&test_run(), AnalyzeOptions::default());
+    let rendered = render_json_pretty(&report).expect("pretty render should succeed");
+    let expected =
+        serde_json::to_string_pretty(&report).expect("serde pretty render should succeed");
+    assert_eq!(rendered, expected);
+}
+
+#[test]
+fn analyze_run_json_pretty_matches_analyze_then_render_json_pretty() {
+    let run = test_run();
+    let rendered = analyze_run_json_pretty(&run, AnalyzeOptions::default())
+        .expect("analyze+pretty render should succeed");
+    let report = analyze_run(&run, AnalyzeOptions::default());
+    let expected = render_json_pretty(&report).expect("pretty render should succeed");
+    assert_eq!(rendered, expected);
+}
+
+#[test]
+fn compact_and_pretty_report_json_have_same_value() {
+    let report = analyze_run(&test_run(), AnalyzeOptions::default());
+    let compact = render_json(&report).expect("compact render should succeed");
+    let pretty = render_json_pretty(&report).expect("pretty render should succeed");
+
+    let compact_value: serde_json::Value =
+        serde_json::from_str(&compact).expect("compact should parse as json");
+    let pretty_value: serde_json::Value =
+        serde_json::from_str(&pretty).expect("pretty should parse as json");
+    assert_eq!(compact_value, pretty_value);
 }
 
 #[test]


### PR DESCRIPTION
### Motivation

- Make `tailtriage-analyzer` the canonical owner of analyzer `Report` JSON rendering so the library and CLI can share a single renderer.

### Description

- Move `serde_json = "1.0.145"` from `[dev-dependencies]` to `[dependencies]` in `tailtriage-analyzer/Cargo.toml` with no other dependency changes.
- Add public crate-root JSON rendering helpers: `render_json`, `render_json_pretty`, `analyze_run_json`, and `analyze_run_json_pretty`, each documented and `#[must_use]` as required.
- Implement `render_json` via `serde_json::to_string(report)` and `render_json_pretty` via `serde_json::to_string_pretty(report)`; implement `analyze_run_json*` as `analyze_run(...)` followed by the corresponding renderer.
- Update crate-level rustdoc to recommend `render_json` / `render_json_pretty` (and preserve the distinction between analyzer Report JSON and raw run artifact JSON and that artifact loading belongs to the CLI).

### Testing

- Ran `cargo fmt --check`, which succeeded.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, which succeeded after adding `# Errors` doc and improving `#[must_use]` messages.
- Ran `cargo test -p tailtriage-analyzer --locked`, which succeeded; added focused tests asserting parity with `serde_json::to_string` / `to_string_pretty`, parity of `analyze_run_json_pretty` with `analyze_run` + renderer, and that compact output parses to the same `serde_json::Value` as pretty output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce010b9248330bbd5e4609b61baf1)