### PR TITLE
Use analyzer canonical pretty JSON renderer in CLI output

### DIFF
--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, ValueEnum};
-use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+use tailtriage_analyzer::{analyze_run, render_json_pretty, render_text, AnalyzeOptions};
 use tailtriage_cli::artifact::load_run_artifact;
 
 #[derive(Debug, Parser)]
@@ -47,7 +47,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     println!("{}", render_text(&report));
                 }
                 OutputFormat::Json => {
-                    println!("{}", serde_json::to_string_pretty(&report)?);
+                    println!("{}", render_json_pretty(&report)?);
                 }
             }
         }

--- a/tailtriage-cli/tests/json_parity.rs
+++ b/tailtriage-cli/tests/json_parity.rs
@@ -1,0 +1,38 @@
+use std::process::Command;
+
+use tailtriage_analyzer::{analyze_run, render_json_pretty, AnalyzeOptions};
+use tailtriage_core::Run;
+
+#[test]
+fn analyze_json_matches_analyzer_renderer_output() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let artifact_path = dir.path().join("run.json");
+
+    std::fs::write(&artifact_path, valid_cli_artifact_with_requests())
+        .expect("fixture should write");
+
+    let exe = env!("CARGO_BIN_EXE_tailtriage");
+    let output = Command::new(exe)
+        .arg("analyze")
+        .arg(&artifact_path)
+        .arg("--format")
+        .arg("json")
+        .output()
+        .expect("cli should run");
+
+    assert!(output.status.success(), "cli failed: {output:?}");
+    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+
+    let cli_stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+
+    let run: Run =
+        serde_json::from_str(valid_cli_artifact_with_requests()).expect("fixture should decode");
+    let report = analyze_run(&run, AnalyzeOptions::default());
+    let expected = render_json_pretty(&report).expect("renderer should succeed");
+
+    assert_eq!(cli_stdout.trim_end(), expected);
+}
+
+fn valid_cli_artifact_with_requests() -> &'static str {
+    r#"{"schema_version":1,"metadata":{"run_id":"r1","service_name":"svc","service_version":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"mode":"light","host":null,"pid":null,"lifecycle_warnings":[],"unfinished_requests":{"count":0,"sample":[]}},"requests":[{"request_id":"req1","route":"/","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":10,"outcome":"ok"}],"stages":[],"queues":[],"inflight":[],"runtime_snapshots":[]}"#
+}


### PR DESCRIPTION
### Motivation
- Ensure `tailtriage analyze <run.json> --format json` emits the canonical, pretty-printed Report JSON produced by the analyzer so CLI output exactly matches the analyzer's renderer and avoids subtle serializer discrepancies.

### Description
- Import `render_json_pretty` from `tailtriage_analyzer` into `tailtriage-cli/src/main.rs` and use `render_json_pretty(&report)?` for the JSON output branch instead of `serde_json::to_string_pretty(&report)?`.
- Keep text rendering, artifact loading, loader warnings, and existing error behavior unchanged.
- Add an integration test `tailtriage-cli/tests/json_parity.rs` that runs the `tailtriage` binary with `analyze ... --format json`, computes the expected output with `tailtriage_analyzer::render_json_pretty`, and asserts exact parity between CLI stdout and the analyzer renderer.
- Leave `serde_json` in `tailtriage-cli/Cargo.toml` intact because artifact loading still depends on it.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it passed.
- Ran `cargo test --workspace` and all tests (including the new `tests/json_parity.rs`) passed.
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce8cd5ff48330b4b366e88e43a3c7)