### PR TITLE
Use canonical analyzer JSON renderer for CLI analyze output

### DIFF
--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, ValueEnum};
-use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+use tailtriage_analyzer::{analyze_run, render_json_pretty, render_text, AnalyzeOptions};
 use tailtriage_cli::artifact::load_run_artifact;
 
 #[derive(Debug, Parser)]
@@ -47,7 +47,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     println!("{}", render_text(&report));
                 }
                 OutputFormat::Json => {
-                    println!("{}", serde_json::to_string_pretty(&report)?);
+                    println!("{}", render_json_pretty(&report)?);
                 }
             }
         }

--- a/tailtriage-cli/tests/json_parity.rs
+++ b/tailtriage-cli/tests/json_parity.rs
@@ -1,0 +1,36 @@
+use std::process::Command;
+
+use tailtriage_analyzer::{analyze_run, render_json_pretty, AnalyzeOptions};
+use tailtriage_cli::artifact::load_run_artifact;
+
+#[test]
+fn cli_json_output_matches_analyzer_renderer() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let artifact_path = dir.path().join("run.json");
+
+    std::fs::write(&artifact_path, valid_cli_artifact_with_requests())
+        .expect("fixture should write");
+
+    let loaded = load_run_artifact(&artifact_path).expect("artifact should load");
+    let report = analyze_run(&loaded.run, AnalyzeOptions::default());
+    let expected = render_json_pretty(&report).expect("analyzer should render JSON");
+
+    let exe = env!("CARGO_BIN_EXE_tailtriage");
+    let output = Command::new(exe)
+        .arg("analyze")
+        .arg(&artifact_path)
+        .arg("--format")
+        .arg("json")
+        .output()
+        .expect("cli should run");
+
+    assert!(output.status.success(), "cli failed: {output:?}");
+    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    assert_eq!(stdout.trim_end(), expected);
+}
+
+fn valid_cli_artifact_with_requests() -> &'static str {
+    r#"{"schema_version":1,"metadata":{"run_id":"r1","service_name":"svc","service_version":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"mode":"light","host":null,"pid":null,"lifecycle_warnings":[],"unfinished_requests":{"count":0,"sample":[]}},"requests":[{"request_id":"req1","route":"/","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":10,"outcome":"ok"}],"stages":[],"queues":[],"inflight":[],"runtime_snapshots":[]}"#
+}


### PR DESCRIPTION
### Motivation
- Ensure the CLI `tailtriage analyze <run.json> --format json` emits the canonical pretty JSON produced by the analyzer so CLI consumers and analyzer fixtures remain byte-for-byte consistent.

### Description
- Import `render_json_pretty` from `tailtriage_analyzer` in `tailtriage-cli/src/main.rs` and replace the JSON branch `serde_json::to_string_pretty(&report)?` with `render_json_pretty(&report)?` while leaving text output and error/warning behavior unchanged.
- Add an integration test `tailtriage-cli/tests/json_parity.rs` that loads a fixture artifact, produces a report with `analyze_run`, renders expected JSON with `render_json_pretty`, runs the CLI `analyze --format json`, and asserts parity between CLI stdout and the analyzer renderer.
- Keep `serde_json` in `tailtriage-cli` unchanged because it is still required by `tailtriage-cli/src/artifact.rs` for artifact loading.

### Testing
- Ran `cargo fmt --check` and it passed without changes required.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and the workspace passed with no warnings.
- Ran `cargo test --workspace` and all tests including the new `json_parity` integration test passed.
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce8cd5ff48330b4b366e88e43a3c7)