### PR TITLE
cli: use canonical analyzer pretty JSON renderer for analyze output

### DIFF
--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, ValueEnum};
-use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+use tailtriage_analyzer::{analyze_run, render_json_pretty, render_text, AnalyzeOptions};
 use tailtriage_cli::artifact::load_run_artifact;
 
 #[derive(Debug, Parser)]
@@ -47,7 +47,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     println!("{}", render_text(&report));
                 }
                 OutputFormat::Json => {
-                    println!("{}", serde_json::to_string_pretty(&report)?);
+                    println!("{}", render_json_pretty(&report)?);
                 }
             }
         }

--- a/tailtriage-cli/tests/json_parity.rs
+++ b/tailtriage-cli/tests/json_parity.rs
@@ -1,0 +1,37 @@
+use std::process::Command;
+
+use tailtriage_analyzer::{analyze_run, render_json_pretty, AnalyzeOptions};
+use tailtriage_core::Run;
+
+#[test]
+fn cli_json_output_matches_analyzer_pretty_renderer() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let artifact_path = dir.path().join("run.json");
+
+    std::fs::write(&artifact_path, valid_cli_artifact_with_requests())
+        .expect("fixture should write");
+
+    let run: Run = serde_json::from_str(valid_cli_artifact_with_requests())
+        .expect("fixture should decode to run");
+    let report = analyze_run(&run, AnalyzeOptions::default());
+    let expected = render_json_pretty(&report).expect("pretty report json should render");
+
+    let exe = env!("CARGO_BIN_EXE_tailtriage");
+    let output = Command::new(exe)
+        .arg("analyze")
+        .arg(&artifact_path)
+        .arg("--format")
+        .arg("json")
+        .output()
+        .expect("cli should run");
+
+    assert!(output.status.success(), "cli failed: {output:?}");
+    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    assert_eq!(stdout.trim_end_matches('\n'), expected);
+}
+
+fn valid_cli_artifact_with_requests() -> &'static str {
+    r#"{"schema_version":1,"metadata":{"run_id":"r1","service_name":"svc","service_version":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"mode":"light","host":null,"pid":null,"lifecycle_warnings":[],"unfinished_requests":{"count":0,"sample":[]}},"requests":[{"request_id":"req1","route":"/","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":10,"outcome":"ok"}],"stages":[],"queues":[],"inflight":[],"runtime_snapshots":[]}"#
+}


### PR DESCRIPTION
### Motivation

- Ensure the CLI emits analyzer report JSON in the same canonical pretty form as the analyzer library so CLI consumers get a stable, canonical JSON layout for machine consumption.
- Add an integration test that proves the CLI output exactly matches the analyzer's canonical pretty renderer to prevent regressions.

### Description

- Import `render_json_pretty` from `tailtriage_analyzer` and replace the `--format json` branch call from `serde_json::to_string_pretty(&report)?` to `render_json_pretty(&report)?` in `tailtriage-cli/src/main.rs`.
- Add an integration test `tailtriage-cli/tests/json_parity.rs` that builds a small run fixture, computes the expected JSON via `analyze_run` + `render_json_pretty`, runs the CLI with `analyze ... --format json`, and asserts byte-for-byte parity (ignoring a trailing newline).
- Preserve the text output path, artifact loading, loader warning behavior, and error propagation exactly as before.
- Leave `serde_json` in `tailtriage-cli/Cargo.toml` because the crate still uses it for artifact loading in `tailtriage-cli/src/artifact.rs`.

### Testing

- Ran `cargo test -p tailtriage-cli --tests` and all package tests passed, including the new `cli_json_output_matches_analyzer_pretty_renderer` integration test.
- Existing CLI and artifact unit tests under `tailtriage-cli/tests/` also passed with no regressions.
- The change was validated by comparing CLI stdout against `tailtriage_analyzer::render_json_pretty` output for the fixture and the assertion succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce8cd5ff48330b4b366e88e43a3c7)