### PR TITLE
Use analyzer JSON renderer in CLI and add JSON-parity integration test

### DIFF
--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, ValueEnum};
-use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+use tailtriage_analyzer::{analyze_run, render_json_pretty, render_text, AnalyzeOptions};
 use tailtriage_cli::artifact::load_run_artifact;
 
 #[derive(Debug, Parser)]
@@ -47,7 +47,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     println!("{}", render_text(&report));
                 }
                 OutputFormat::Json => {
-                    println!("{}", serde_json::to_string_pretty(&report)?);
+                    println!("{}", render_json_pretty(&report)?);
                 }
             }
         }

--- a/tailtriage-cli/tests/json_parity.rs
+++ b/tailtriage-cli/tests/json_parity.rs
@@ -1,0 +1,49 @@
+use std::process::Command;
+
+use tailtriage_core::{RequestOptions, Tailtriage};
+
+#[test]
+fn cli_json_matches_analyzer_renderer_output() {
+    let tempdir = tempfile::tempdir().expect("tempdir should build");
+    let artifact_path = tempdir.path().join("run.json");
+
+    let tailtriage = Tailtriage::builder("checkout-service")
+        .output(&artifact_path)
+        .build()
+        .expect("tailtriage should build");
+
+    let started = tailtriage.begin_request_with(
+        "/checkout",
+        RequestOptions::new().request_id("req-1").kind("http"),
+    );
+    started.completion.finish_ok();
+
+    tailtriage.shutdown().expect("shutdown should succeed");
+
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&artifact_path)
+        .expect("artifact should load successfully");
+    assert!(loaded.warnings.is_empty());
+
+    let report = tailtriage_analyzer::analyze_run(
+        &loaded.run,
+        tailtriage_analyzer::AnalyzeOptions::default(),
+    );
+    let expected_json = tailtriage_analyzer::render_json_pretty(&report)
+        .expect("expected report JSON should render");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("analyze")
+        .arg(&artifact_path)
+        .arg("--format")
+        .arg("json")
+        .output()
+        .expect("cli should run");
+
+    assert!(output.status.success(), "cli failed: {output:?}");
+
+    let stdout = std::str::from_utf8(&output.stdout).expect("stdout should be utf8");
+    let stderr = std::str::from_utf8(&output.stderr).expect("stderr should be utf8");
+
+    assert_eq!(stderr, "");
+    assert_eq!(stdout, format!("{expected_json}\n"));
+}


### PR DESCRIPTION
### Motivation
- Ensure the CLI emits the canonical pretty JSON produced by the analyzer so CLI JSON output is identical to the analyzer renderer.
- Provide an integration test proving exact parity between the analyzer-rendered JSON and the CLI `--format json` output.

### Description
- Imported `render_json_pretty` from `tailtriage_analyzer` and replaced the `serde_json::to_string_pretty(&report)?` call with `render_json_pretty(&report)?` in `tailtriage-cli/src/main.rs` while leaving text output, artifact loading, warning emission, and error behavior unchanged.
- Added `tailtriage-cli/tests/json_parity.rs` which builds a temporary run artifact via `tailtriage_core::Tailtriage` with stable `RequestOptions` metadata, shuts down, reloads the artifact with `tailtriage_cli::artifact::load_run_artifact`, asserts no loader warnings, computes the expected JSON using `analyze_run` + `render_json_pretty`, runs the CLI binary via `std::process::Command`, and asserts success, empty stderr, and exact stdout parity including a trailing newline.
- Kept `serde_json` in `tailtriage-cli/Cargo.toml` because the crate still uses it for artifact loading.

### Testing
- Ran `cargo fmt --check` which succeeded.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which succeeded.
- Ran `cargo test -p tailtriage-cli --locked` and all tailtriage-cli unit and integration tests passed, including the new `json_parity` test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fced93b9d08330a41ebaceb3696aac)