### PR TITLE
Use analyzer canonical JSON renderer for CLI and add JSON-parity integration test

### DIFF
--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, ValueEnum};
-use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+use tailtriage_analyzer::{analyze_run, render_json_pretty, render_text, AnalyzeOptions};
 use tailtriage_cli::artifact::load_run_artifact;
 
 #[derive(Debug, Parser)]
@@ -47,7 +47,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     println!("{}", render_text(&report));
                 }
                 OutputFormat::Json => {
-                    println!("{}", serde_json::to_string_pretty(&report)?);
+                    println!("{}", render_json_pretty(&report)?);
                 }
             }
         }

--- a/tailtriage-cli/tests/json_parity.rs
+++ b/tailtriage-cli/tests/json_parity.rs
@@ -1,0 +1,48 @@
+use std::process::Command;
+
+use tailtriage_analyzer::{analyze_run, render_json_pretty, AnalyzeOptions};
+use tailtriage_core::{RequestOptions, Tailtriage};
+
+#[test]
+fn cli_json_matches_analyzer_renderer() {
+    let tempdir = tempfile::tempdir().expect("tempdir should build");
+    let artifact_path = tempdir.path().join("run.json");
+
+    let run = Tailtriage::builder("checkout-service")
+        .output(&artifact_path)
+        .build()
+        .expect("tailtriage should build");
+
+    let started = run.begin_request_with(
+        "/checkout",
+        RequestOptions::new().request_id("req-1").kind("http"),
+    );
+    started.completion.finish_ok();
+    run.shutdown().expect("shutdown should write artifact");
+
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&artifact_path)
+        .expect("cli loader should load generated artifact");
+    assert!(
+        loaded.warnings.is_empty(),
+        "expected generated fixture to have no loader warnings"
+    );
+
+    let report = analyze_run(&loaded.run, AnalyzeOptions::default());
+    let expected_json = render_json_pretty(&report).expect("expected report JSON should render");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("analyze")
+        .arg(&artifact_path)
+        .arg("--format")
+        .arg("json")
+        .output()
+        .expect("cli should run");
+
+    assert!(output.status.success(), "cli failed: {output:?}");
+
+    let stdout = std::str::from_utf8(&output.stdout).expect("stdout should be utf8");
+    let stderr = std::str::from_utf8(&output.stderr).expect("stderr should be utf8");
+
+    assert_eq!(stderr, "");
+    assert_eq!(stdout, format!("{expected_json}\n"));
+}


### PR DESCRIPTION
### Motivation
- Ensure the CLI emits the same canonical pretty JSON that the analyzer library produces so CLI output is authoritative and stable for downstream consumers. 
- Provide an automated integration test that proves byte-for-byte parity between the CLI JSON output and the analyzer renderer.

### Description
- In `tailtriage-cli/src/main.rs` import `render_json_pretty` from `tailtriage_analyzer` and replace the JSON branch call from `serde_json::to_string_pretty(&report)?` to `render_json_pretty(&report)?`, leaving text output, artifact loading, warnings, and error behavior unchanged. 
- Added an integration test `tailtriage-cli/tests/json_parity.rs` which builds a temporary run artifact via `tailtriage_core::Tailtriage` using stable `RequestOptions` (`request_id("req-1")`, `kind("http")`, route `"/checkout"`), calls `shutdown()`, loads the artifact with `tailtriage_cli::artifact::load_run_artifact`, asserts no loader warnings, computes expected JSON with `analyze_run` + `render_json_pretty`, executes the CLI binary via `std::process::Command::new(env!("CARGO_BIN_EXE_tailtriage"))` for `tailtriage analyze <artifact> --format json`, and asserts success, empty stderr, and exact stdout equality including the trailing newline. 
- Kept `serde_json` in `tailtriage-cli/Cargo.toml` unchanged because it is still used by the artifact loader.

### Testing
- Ran `cargo fmt --check` which succeeded. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which completed without warnings. 
- Ran `cargo test -p tailtriage-cli --locked` and all tests passed, including the new `cli_json_matches_analyzer_renderer` integration test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fced93b9d08330a41ebaceb3696aac)