### PR TITLE
Use analyzer JSON renderer in CLI and add JSON parity integration test

### DIFF
--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, ValueEnum};
-use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+use tailtriage_analyzer::{analyze_run, render_json_pretty, render_text, AnalyzeOptions};
 use tailtriage_cli::artifact::load_run_artifact;
 
 #[derive(Debug, Parser)]
@@ -47,7 +47,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     println!("{}", render_text(&report));
                 }
                 OutputFormat::Json => {
-                    println!("{}", serde_json::to_string_pretty(&report)?);
+                    println!("{}", render_json_pretty(&report)?);
                 }
             }
         }

--- a/tailtriage-cli/tests/json_parity.rs
+++ b/tailtriage-cli/tests/json_parity.rs
@@ -1,0 +1,56 @@
+use std::process::Command;
+
+use tailtriage_cli::artifact::load_run_artifact;
+use tailtriage_core::{RequestOptions, Tailtriage};
+
+#[test]
+fn cli_json_matches_analyzer_pretty_json() {
+    let tempdir = tempfile::tempdir().expect("tempdir should build");
+    let artifact_path = tempdir.path().join("run.json");
+
+    let run = Tailtriage::builder("checkout-service")
+        .output(&artifact_path)
+        .build()
+        .expect("tailtriage run should build");
+
+    let started = run.begin_request_with(
+        "/checkout",
+        RequestOptions::new().request_id("req-1").kind("http"),
+    );
+    started.completion.finish_ok();
+
+    run.shutdown().expect("shutdown should succeed");
+
+    let loaded = load_run_artifact(&artifact_path).expect("artifact should load");
+    assert!(
+        loaded.warnings.is_empty(),
+        "fixture should produce no loader warnings"
+    );
+
+    let report = tailtriage_analyzer::analyze_run(
+        &loaded.run,
+        tailtriage_analyzer::AnalyzeOptions::default(),
+    );
+    let expected_json = tailtriage_analyzer::render_json_pretty(&report)
+        .expect("expected report JSON should render");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .args([
+            "analyze",
+            artifact_path
+                .to_str()
+                .expect("artifact path should be valid UTF-8"),
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("CLI should execute");
+
+    assert!(output.status.success(), "CLI should exit successfully");
+
+    let stdout = std::str::from_utf8(&output.stdout).expect("stdout should be valid UTF-8");
+    let stderr = std::str::from_utf8(&output.stderr).expect("stderr should be valid UTF-8");
+
+    assert_eq!(stderr, "");
+    assert_eq!(stdout, format!("{expected_json}\n"));
+}


### PR DESCRIPTION
### Motivation
- Ensure the CLI emits the canonical pretty JSON produced by the analyzer so the `--format json` output matches the analyzer’s official renderer and avoids divergence between CLI and analyzer JSON formatting.

### Description
- Import `render_json_pretty` from `tailtriage_analyzer` and replace `serde_json::to_string_pretty(&report)?` with `render_json_pretty(&report)?` in `tailtriage-cli/src/main.rs` so JSON output uses the analyzer renderer.
- Added an integration test `tailtriage-cli/tests/json_parity.rs` that builds a real run artifact, records a completed request with stable metadata, loads the artifact via `tailtriage_cli::artifact::load_run_artifact`, computes expected JSON via `analyze_run` + `render_json_pretty`, invokes the CLI (`tailtriage analyze <run.json> --format json`) with `std::process::Command`, and asserts exact stdout/stderr parity.
- Kept text output, artifact loading, warning emission, error propagation, and `serde_json` dependency usage (for artifact loading) unchanged.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed with zero warnings.
- Ran `cargo test -p tailtriage-cli --locked` and the `tailtriage-cli` test-suite including the new `json_parity` integration test passed (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fced93b9d08330a41ebaceb3696aac)