### PR TITLE
cli: route JSON output through analyzer renderer and add parity integration test

### DIFF
--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, ValueEnum};
-use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+use tailtriage_analyzer::{analyze_run, render_json_pretty, render_text, AnalyzeOptions};
 use tailtriage_cli::artifact::load_run_artifact;
 
 #[derive(Debug, Parser)]
@@ -47,7 +47,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     println!("{}", render_text(&report));
                 }
                 OutputFormat::Json => {
-                    println!("{}", serde_json::to_string_pretty(&report)?);
+                    println!("{}", render_json_pretty(&report)?);
                 }
             }
         }

--- a/tailtriage-cli/tests/json_parity.rs
+++ b/tailtriage-cli/tests/json_parity.rs
@@ -1,0 +1,46 @@
+use std::process::Command;
+
+use tailtriage_analyzer::{analyze_run, render_json_pretty, AnalyzeOptions};
+use tailtriage_core::{RequestOptions, Tailtriage};
+
+#[test]
+fn cli_json_output_matches_analyzer_pretty_renderer() {
+    let tempdir = tempfile::tempdir().expect("tempdir should build");
+    let artifact_path = tempdir.path().join("run.json");
+
+    let tailtriage = Tailtriage::builder("checkout-service")
+        .output(&artifact_path)
+        .build()
+        .expect("tailtriage should build");
+
+    let started = tailtriage.begin_request_with(
+        "/checkout",
+        RequestOptions::new().request_id("req-1").kind("http"),
+    );
+    started.completion.finish_ok();
+
+    tailtriage.shutdown().expect("shutdown should succeed");
+
+    let loaded =
+        tailtriage_cli::artifact::load_run_artifact(&artifact_path).expect("artifact should load");
+    assert!(loaded.warnings.is_empty());
+
+    let report = analyze_run(&loaded.run, AnalyzeOptions::default());
+    let expected_json = render_json_pretty(&report).expect("expected report JSON should render");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("analyze")
+        .arg(&artifact_path)
+        .arg("--format")
+        .arg("json")
+        .output()
+        .expect("cli should run");
+
+    assert!(output.status.success(), "cli failed: {output:?}");
+
+    let stdout = std::str::from_utf8(&output.stdout).expect("stdout should be utf8");
+    let stderr = std::str::from_utf8(&output.stderr).expect("stderr should be utf8");
+
+    assert_eq!(stderr, "");
+    assert_eq!(stdout, format!("{expected_json}\n"));
+}


### PR DESCRIPTION
### Motivation
- Ensure the CLI emits the canonical pretty JSON produced by the analyzer so CLI JSON output is identical to the analyzer renderer. 
- Add an integration test that proves parity between `tailtriage analyze <run.json> --format json` and the analyzer's `render_json_pretty` to prevent regressions.

### Description
- Import `render_json_pretty` from `tailtriage_analyzer` in `tailtriage-cli/src/main.rs` and replace the direct `serde_json::to_string_pretty(&report)?` call with `render_json_pretty(&report)?`. 
- Keep text output, artifact loading, loader warnings, and error behavior unchanged. 
- Add a new integration test `tailtriage-cli/tests/json_parity.rs` which creates a temporary artifact via `tailtriage_core::Tailtriage` with `.output(...)`, records a completed request using `RequestOptions` (`request_id("req-1")`, `kind("http")`, route `"/checkout"`), calls `shutdown()`, loads the artifact with `tailtriage_cli::artifact::load_run_artifact`, asserts `loaded.warnings.is_empty()`, computes expected JSON with `analyze_run` + `render_json_pretty`, executes the real CLI binary via `env!("CARGO_BIN_EXE_tailtriage")` for `analyze <artifact> --format json`, and asserts success, empty stderr, and exact stdout parity (`expected_json + "\n"`).
- Preserve `serde_json` in `tailtriage-cli/Cargo.toml` for artifact loading usage.

### Testing
- Ran `cargo fmt --check` and it succeeded. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it succeeded with no warnings. 
- Ran `cargo test -p tailtriage-cli --locked` and all CLI tests passed, including the new integration test `cli_json_output_matches_analyzer_pretty_renderer` (tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fced93b9d08330a41ebaceb3696aac)