### PR TITLE
docs: document built-in sinks and canonical report JSON contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ cargo add tailtriage-analyzer
 cargo install tailtriage-cli
 ```
 
-`tailtriage` captures request/runtime evidence. `tailtriage-analyzer` analyzes completed in-memory runs or stable snapshots in process. `tailtriage-cli` analyzes saved run artifacts from the command line.
+`tailtriage` captures request/runtime evidence. Capture sinks produce **Run artifact JSON** for file workflows. `tailtriage-cli` consumes Run artifact JSON from disk. `tailtriage-analyzer` produces typed `Report` values in process and renders **Report JSON** when you call analyzer renderers. Suspects are leads, not proof of root cause, and `tailtriage` is not an observability backend.
 
 ## Why not just tokio-console or tokio-metrics?
 
@@ -168,14 +168,39 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### In-process analysis (library)
 
 ```rust
-use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+use tailtriage_analyzer::{analyze_run, render_json_pretty, render_text, AnalyzeOptions};
 
 # use tailtriage_core::Run;
-# fn example(run: Run) -> Result<(), serde_json::Error> {
+# fn example(run: Run) -> Result<(), Box<dyn std::error::Error>> {
 let report = analyze_run(&run, AnalyzeOptions::default());
 let text = render_text(&report);
-let json = serde_json::to_string_pretty(&report)?;
+let json = render_json_pretty(&report)?;
 # let _ = (text, json);
+# Ok(())
+# }
+```
+
+You can avoid JSON output entirely by using `MemorySink` and the typed `Report`, then call `render_json` / `render_json_pretty` only when you need Report JSON.
+
+```rust,no_run
+use tailtriage_core::{MemorySink, Tailtriage};
+use tailtriage_analyzer::{analyze_run, render_json_pretty, AnalyzeOptions};
+
+# fn example() -> Result<(), Box<dyn std::error::Error>> {
+let sink = MemorySink::new();
+let run = Tailtriage::builder("checkout-service")
+    .sink(sink.clone())
+    .build()?;
+
+let started = run.begin_request("/checkout");
+started.completion.finish_ok();
+run.shutdown()?;
+
+if let Some(finalized_run) = sink.take_run() {
+    let report = analyze_run(&finalized_run, AnalyzeOptions::default());
+    let report_json = render_json_pretty(&report)?;
+    let _ = report_json;
+}
 # Ok(())
 # }
 ```

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ let json = render_json_pretty(&report)?;
 You can avoid JSON output entirely by using `MemorySink` and the typed `Report`, then call `render_json` / `render_json_pretty` only when you need Report JSON.
 
 ```rust,no_run
-use tailtriage_core::{MemorySink, Tailtriage};
+use tailtriage::{MemorySink, Tailtriage};
 use tailtriage_analyzer::{analyze_run, render_json_pretty, AnalyzeOptions};
 
 # fn example() -> Result<(), Box<dyn std::error::Error>> {

--- a/SPEC.md
+++ b/SPEC.md
@@ -136,13 +136,16 @@ Semantics:
 
 - `analyze_run(&Run, AnalyzeOptions) -> Report`
 - `render_text(&Report)` for human-readable output
-- serde-serializable `Report` JSON
+- `render_json(&Report)` for canonical compact Report JSON
+- `render_json_pretty(&Report)` for canonical pretty Report JSON
+- `analyze_run_json(&Run, AnalyzeOptions)` for analyze+compact Report JSON
+- `analyze_run_json_pretty(&Run, AnalyzeOptions)` for analyze+pretty Report JSON
 
 Semantics are batch/snapshot for completed runs, not streaming analysis.
 
 ### 5.9 Analyzer CLI (`tailtriage-cli`)
 
-`tailtriage-cli` owns artifact loading + command-line report emission and uses `tailtriage-analyzer` for analysis logic.
+`tailtriage-cli` owns artifact loading + command-line report emission and uses `tailtriage-analyzer` for analysis logic. CLI JSON output delegates to `tailtriage-analyzer`’s canonical pretty Report JSON renderer.
 
 Primary command:
 
@@ -153,6 +156,12 @@ tailtriage analyze <run.json>
 ## 6. Run artifact, analyzer, and CLI contracts
 
 Run artifacts include request, stage, queue, in-flight, and optional runtime snapshot data plus metadata/truncation context.
+
+Direct capture lifecycle output options:
+
+- default direct capture writes a local run artifact JSON through `LocalJsonSink`
+- choose `MemorySink` when you want a finalized typed `Run` in memory without file output
+- choose `DiscardSink` when you want shutdown/finalization without persisting the finalized `Run`
 
 Analyzer output includes:
 
@@ -166,6 +175,12 @@ Schema contract:
 
 - artifacts require top-level `schema_version`
 - current supported schema version is `1`
+
+Artifact/report contract split:
+
+- **Run artifact JSON**: capture output and CLI input
+- **Report JSON**: analyzer/CLI output and not CLI input
+- **Typed `Report`**: in-process analyzer output for Rust users
 
 ## 7. Suspect taxonomy
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,8 +8,11 @@ The default user path is:
 
 1. instrument capture in service code (`tailtriage` default crate)
 2. optionally enrich with runtime sampling (`tailtriage-tokio`)
-3. write local run artifact JSON
-4. analyze with `tailtriage-analyzer` in process or with `tailtriage-cli` for file artifacts
+3. finalize capture to a sink:
+   - default local run artifact JSON via `LocalJsonSink`
+   - optional finalized typed `Run` in memory via `MemorySink`
+   - optional no persisted finalized run via `DiscardSink`
+4. analyze with `tailtriage-analyzer` in process (typed `Report`, text rendering, Report JSON rendering) or with `tailtriage-cli` for file artifacts
 
 The result is a triage report with evidence-ranked suspects and next checks.
 
@@ -56,11 +59,11 @@ Owns in-process analysis/report generation from completed runs:
 - typed `Report` model
 - `analyze_run` entry point
 - `render_text` human-readable rendering
-- serde-serializable report JSON
+- analyzer-owned Report JSON rendering (`render_json`, `render_json_pretty`)
 
 ### `tailtriage-cli`
 
-Consumes run artifacts from disk, validates schema/loader rules, invokes `tailtriage-analyzer`, and emits text/JSON output.
+Consumes run artifacts from disk, validates schema/loader rules, invokes `tailtriage-analyzer`, and emits text/JSON output. CLI report rendering delegates to analyzer-owned renderers.
 
 ## Relationship model
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -2,6 +2,8 @@
 
 This guide explains analyzer report interpretation for both `tailtriage_analyzer::analyze_run` and `tailtriage analyze`.
 
+Terminology: Run artifact JSON is capture output and CLI input. Report JSON is analyzer/CLI output. Typed `Report` is analyzer in-process output. Text rendering is `render_text`.
+
 ## Read one report quickly
 
 1. Check `primary_suspect.kind`.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -67,16 +67,19 @@ If you want analysis/report generation inside service code or tests, use `tailtr
 
 ```rust
 use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+use tailtriage_analyzer::render_json_pretty;
 
 # use tailtriage_core::Run;
-# fn example(run: Run) -> Result<(), serde_json::Error> {
+# fn example(run: Run) -> Result<(), Box<dyn std::error::Error>> {
 let report = analyze_run(&run, AnalyzeOptions::default());
 let text = render_text(&report);
-let json = serde_json::to_string_pretty(&report)?;
+let json = render_json_pretty(&report)?;
 # let _ = (text, json);
 # Ok(())
 # }
 ```
+
+Run artifact JSON is capture output and CLI input. Report JSON is analyzer/CLI output. Typed `Report` is the in-process analyzer result.
 
 Current analyzer semantics are completed-run or stable-snapshot batch analysis, not live streaming analysis.
 

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -225,14 +225,19 @@ Normal CI does not publish durable diagnostic scorecards.
 
     def test_cli_readme_positive_when_cli_invokes_analyzer(self) -> None:
         analyzer_text = """
-tailtriage-analyzer is in-process for completed Run inputs, typed Report output,
-render_text formatting, serde_json parsing support, AnalyzeOptions::default(),
-not streaming capture, and tailtriage-cli for command-line artifact loading.
+tailtriage-analyzer is in-process analysis for completed Run values and returns a typed Report.
+Use analyze_run(run, AnalyzeOptions::default()) for the standard entry point.
+Use render_text(&report), render_json(&report), and render_json_pretty(&report) for Report rendering.
+Use analyze_run_json(run, AnalyzeOptions::default()) and analyze_run_json_pretty(run, AnalyzeOptions::default()) for helpers.
+This crate is not streaming / not live streaming, and tailtriage-cli owns artifact loading.
 """
         cli_text = """
-tailtriage-cli loads saved run artifacts, performs schema validation, enforces
-non-empty requests loader rules, uses tailtriage-analyzer, and provides command-line
-text or json output. Rust in-process users should use tailtriage-analyzer directly.
+tailtriage-cli loads saved run artifacts from disk, performs schema validation,
+enforces a non-empty requests loader rule, and uses tailtriage-analyzer.
+It provides command-line text/json output and emits Report JSON as output.
+Rust in-process users should use tailtriage-analyzer directly.
+Run artifact JSON is CLI input; Report JSON is CLI/analyzer output.
+CLI does not consume Report JSON as input.
 """
         with tempfile.TemporaryDirectory() as tmp_dir:
             repo_root = Path(tmp_dir)
@@ -245,6 +250,58 @@ text or json output. Rust in-process users should use tailtriage-analyzer direct
 
             with mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root):
                 validate_docs_contracts.validate_analyzer_cli_docs_split_contract()
+
+    def test_analyzer_readme_validation_fails_when_json_renderer_tokens_missing(self) -> None:
+        analyzer_text = """
+tailtriage-analyzer is in-process analysis for completed Run values with typed Report output.
+Use analyze_run(run, AnalyzeOptions::default()) and render_text(&report).
+Use analyze_run_json(run, AnalyzeOptions::default()) and analyze_run_json_pretty(run, AnalyzeOptions::default()).
+This crate is not streaming and references tailtriage-cli for artifact loading.
+"""
+        cli_text = """
+tailtriage-cli loads saved run artifacts from disk, performs schema validation,
+enforces non-empty requests loader rules, uses tailtriage-analyzer, and provides command-line text/json output.
+Rust in-process users should use tailtriage-analyzer.
+Run artifact JSON is input; Report JSON is output; CLI does not consume Report JSON as input.
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            analyzer_readme = repo_root / "tailtriage-analyzer" / "README.md"
+            cli_readme = repo_root / "tailtriage-cli" / "README.md"
+            analyzer_readme.parent.mkdir(parents=True, exist_ok=True)
+            cli_readme.parent.mkdir(parents=True, exist_ok=True)
+            analyzer_readme.write_text(analyzer_text, encoding="utf-8")
+            cli_readme.write_text(cli_text, encoding="utf-8")
+
+            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root):
+                with self.assertRaisesRegex(ValueError, r"render_json"):
+                    validate_docs_contracts.validate_analyzer_cli_docs_split_contract()
+
+    def test_cli_readme_validation_fails_without_report_vs_run_artifact_distinction(self) -> None:
+        analyzer_text = """
+tailtriage-analyzer is in-process analysis for completed Run values and returns a typed Report.
+Use analyze_run(run, AnalyzeOptions::default()) and render_text(&report).
+Use render_json(&report), render_json_pretty(&report), analyze_run_json(run, AnalyzeOptions::default()),
+and analyze_run_json_pretty(run, AnalyzeOptions::default()).
+This crate is not streaming / not live streaming and references tailtriage-cli.
+"""
+        cli_text = """
+tailtriage-cli loads saved run artifacts from disk, performs schema validation,
+enforces non-empty requests loader rules, uses tailtriage-analyzer, and provides command-line text/json output.
+Rust in-process users should use tailtriage-analyzer.
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            analyzer_readme = repo_root / "tailtriage-analyzer" / "README.md"
+            cli_readme = repo_root / "tailtriage-cli" / "README.md"
+            analyzer_readme.parent.mkdir(parents=True, exist_ok=True)
+            cli_readme.parent.mkdir(parents=True, exist_ok=True)
+            analyzer_readme.write_text(analyzer_text, encoding="utf-8")
+            cli_readme.write_text(cli_text, encoding="utf-8")
+
+            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root):
+                with self.assertRaisesRegex(ValueError, r"report vs run artifact json distinction"):
+                    validate_docs_contracts.validate_analyzer_cli_docs_split_contract()
 
     def test_architecture_contract(self) -> None:
         validate_docs_contracts.validate_architecture_contract()

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -613,6 +613,8 @@ def validate_analyzer_cli_docs_split_contract() -> None:
         "render_json",
         "render_json_pretty",
         "analyze_run",
+        "analyze_run_json",
+        "analyze_run_json_pretty",
         "render_text",
         "analyzeoptions::default()",
         "tailtriage-cli",
@@ -634,6 +636,7 @@ def validate_analyzer_cli_docs_split_contract() -> None:
         ("command-line text/json output", r"(command[-\s]?line|cli).{0,160}(text|json|human-readable)"),
         ("in-process pointer for Rust users", r"(rust|in-process).{0,120}tailtriage-analyzer"),
         ("report vs run artifact json distinction", r"(report json).{0,140}(run artifact json|artifact json)|(run artifact json).{0,140}(report json)"),
+        ("cli does not consume report json as input", r"(does\s+not|never|is\s+not).{0,120}(consume|accept|load|read).{0,80}report json.{0,80}(input|artifact)"),
     )
     for label, pattern in cli_required_patterns:
         if re.search(pattern, cli_lower, flags=re.IGNORECASE | re.DOTALL) is None:

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -610,8 +610,10 @@ def validate_analyzer_cli_docs_split_contract() -> None:
         "run",
         "typed",
         "report",
+        "render_json",
+        "render_json_pretty",
+        "analyze_run",
         "render_text",
-        "serde_json",
         "analyzeoptions::default()",
         "tailtriage-cli",
     )
@@ -631,6 +633,7 @@ def validate_analyzer_cli_docs_split_contract() -> None:
         ("tailtriage-analyzer use", r"tailtriage-analyzer"),
         ("command-line text/json output", r"(command[-\s]?line|cli).{0,160}(text|json|human-readable)"),
         ("in-process pointer for Rust users", r"(rust|in-process).{0,120}tailtriage-analyzer"),
+        ("report vs run artifact json distinction", r"(report json).{0,140}(run artifact json|artifact json)|(run artifact json).{0,140}(report json)"),
     )
     for label, pattern in cli_required_patterns:
         if re.search(pattern, cli_lower, flags=re.IGNORECASE | re.DOTALL) is None:

--- a/tailtriage-analyzer/README.md
+++ b/tailtriage-analyzer/README.md
@@ -35,13 +35,13 @@ Typical flow:
 ## In-process API
 
 ```rust
-use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+use tailtriage_analyzer::{analyze_run, render_json_pretty, render_text, AnalyzeOptions};
 use tailtriage_core::Run;
 
-fn render_report(run: &Run) -> Result<String, serde_json::Error> {
+fn render_report(run: &Run) -> Result<String, Box<dyn std::error::Error>> {
     let report = analyze_run(run, AnalyzeOptions::default());
     let text = render_text(&report);
-    let json = tailtriage_analyzer::render_json_pretty(&report)?;
+    let json = render_json_pretty(&report)?;
     Ok(format!("{text}\n\n{json}"))
 }
 ```

--- a/tailtriage-analyzer/README.md
+++ b/tailtriage-analyzer/README.md
@@ -2,14 +2,15 @@
 
 `tailtriage-analyzer` is the in-process analyzer/report crate for `tailtriage`.
 
-Use this crate when you already have a completed `tailtriage_core::Run` in memory (or an equivalent stable snapshot) and want a typed triage report, text rendering, and optional JSON serialization in your Rust process.
+Use this crate when you already have a completed `tailtriage_core::Run` in memory (or an equivalent stable snapshot) and want a typed triage report, text rendering, and canonical Report JSON rendering in your Rust process.
 
 ## What this crate does
 
 - analyzes one completed run/snapshot in batch
 - returns a typed `Report` with evidence-ranked suspects and next checks
 - renders human-readable output with `render_text(&Report)`
-- `Report` implements serde::Serialize; add serde_json or another serde serializer in your application when you want encoded JSON output.
+- renders canonical Report JSON with `render_json(&Report)` and `render_json_pretty(&Report)`
+- provides analyze+render helpers: `analyze_run_json` and `analyze_run_json_pretty`
 
 Suspects are investigation leads, not proof of root cause.
 
@@ -19,12 +20,6 @@ Suspects are investigation leads, not proof of root cause.
 
 ```bash
 cargo add tailtriage-analyzer
-```
-
-If you want JSON serialization output from your Rust code, also add:
-
-```bash
-cargo add serde_json
 ```
 
 ## How to obtain a `Run`
@@ -46,7 +41,7 @@ use tailtriage_core::Run;
 fn render_report(run: &Run) -> Result<String, serde_json::Error> {
     let report = analyze_run(run, AnalyzeOptions::default());
     let text = render_text(&report);
-    let json = serde_json::to_string_pretty(&report)?;
+    let json = tailtriage_analyzer::render_json_pretty(&report)?;
     Ok(format!("{text}\n\n{json}"))
 }
 ```
@@ -57,13 +52,16 @@ fn render_report(run: &Run) -> Result<String, serde_json::Error> {
 - `AnalyzeOptions::default()` is the normal path today and leaves room for future analyzer options
 - `Report` is the typed analyzer output model and should be your primary integration surface
 - `render_text` is for human-readable triage output
-- serde JSON for `Report` is optional and requires user-side `serde_json`
+- `render_json` and `render_json_pretty` are canonical Report JSON renderers
+- `analyze_run_json` and `analyze_run_json_pretty` combine analysis + canonical JSON rendering
+- Report JSON is analyzer output and is distinct from raw Run artifact JSON input
 
 ## Semantics and boundaries
 
 - batch/snapshot analysis of one completed run
 - not streaming analysis
 - artifact loading from disk is CLI-owned (`tailtriage-cli`)
+- CLI `--format json` uses the same canonical pretty Report JSON rendering path
 
 ## Report fields (overview)
 

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -42,7 +42,10 @@ Machine-readable JSON output:
 tailtriage analyze tailtriage-run.json --format json
 ```
 
+`tailtriage analyze <run.json> --format json` emits the same pretty Report JSON as `tailtriage_analyzer::render_json_pretty`.
+
 The CLI artifact loader requires at least one request event in `requests`. This is a CLI artifact-loading rule, not an in-process `tailtriage-analyzer` requirement for already-constructed `Run` values.
+CLI input is Run artifact JSON from disk. CLI does not consume Report JSON as input.
 
 ## How to read the result
 

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -79,6 +79,37 @@ async fn demo() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+## Output sinks
+
+`tailtriage-core` captures run data and finalizes through a sink. It does not perform analysis/report generation.
+
+- `LocalJsonSink` (or builder `.output(...)`) writes Run artifact JSON to disk.
+- `MemorySink` stores finalized typed `Run` values in memory.
+- `DiscardSink` finalizes lifecycle and drops the finalized `Run` without persisting output.
+
+`MemorySink` stores only the last finalized `Run`; each new finalized run replaces the previous stored value.
+
+Use `MemorySink` when you want in-process analysis. `DiscardSink` drops finalized runs; use `MemorySink` instead when the finalized `Run` should be analyzed in process.
+
+```rust,no_run
+use tailtriage_core::{MemorySink, Tailtriage};
+
+# fn example() -> Result<(), Box<dyn std::error::Error>> {
+let sink = MemorySink::new();
+let run = Tailtriage::builder("checkout-service")
+    .sink(sink.clone())
+    .build()?;
+
+let started = run.begin_request("/checkout");
+started.completion.finish_ok();
+run.shutdown()?;
+
+let finalized = sink.last_run();
+# let _ = finalized;
+# Ok(())
+# }
+```
+
 ### Two easy-to-miss helpers
 
 For infallible async work, `StageTimer::await_value(...)` avoids a dummy `Result`:

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -92,7 +92,7 @@ async fn demo() -> Result<(), Box<dyn std::error::Error>> {
 Use `MemorySink` when you want in-process analysis. `DiscardSink` drops finalized runs; use `MemorySink` instead when the finalized `Run` should be analyzed in process.
 
 ```rust,no_run
-use tailtriage_core::{MemorySink, Tailtriage};
+use tailtriage::{MemorySink, Tailtriage};
 
 # fn example() -> Result<(), Box<dyn std::error::Error>> {
 let sink = MemorySink::new();


### PR DESCRIPTION
### Motivation
- Clarify the capture-to-analysis contract by documenting the new built-in sinks and the analyzer-owned canonical Report JSON APIs so users know which JSON is produced and consumed by each component. 
- Make in-process analysis ergonomics explicit (use `MemorySink` and typed `Report`) and remove guidance that encouraged callers to call `serde_json` directly for basic analyzer JSON output.

### Description
- Added explicit sink/docs guidance describing `LocalJsonSink` (default file artifact / `.output(...)`), `MemorySink` (stores the last finalized typed `Run` in memory), and `DiscardSink` (finalize without persisting) in `SPEC.md`, `tailtriage-core/README.md`, and `docs/architecture.md`. 
- Introduced and documented canonical analyzer JSON APIs (`render_json`, `render_json_pretty`, `analyze_run_json`, `analyze_run_json_pretty`) and switched examples to use `render_json_pretty` instead of `serde_json::to_string_pretty` in `tailtriage-analyzer/README.md`, `README.md`, and `docs/*`. 
- Clarified ownership boundaries and contracts: `Run artifact JSON` = capture output and CLI input, `Report JSON` = analyzer/CLI output (not CLI input), and `typed Report` = in-process analyzer output for Rust users, and stated that CLI `--format json` delegates to the analyzer pretty renderer in `tailtriage-cli/README.md` and `SPEC.md`. 
- Updated the docs contract validator `scripts/validate_docs_contracts.py` to require the new analyzer API tokens (`render_json`, `render_json_pretty`, `analyze_run`) and to require a `report vs run artifact json` distinction in CLI docs while removing the stale requirement to mandate direct `serde_json` guidance.

### Testing
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, and `cargo test --workspace --locked`, and all checks and unit tests completed successfully. 
- Ran `python3 scripts/validate_docs_contracts.py` and the docs contract validation passed.

Files changed: `SPEC.md`, `README.md`, `tailtriage-core/README.md`, `tailtriage-analyzer/README.md`, `tailtriage-cli/README.md`, `docs/architecture.md`, `docs/user-guide.md`, `docs/diagnostics.md`, and `scripts/validate_docs_contracts.py`.
Validator changes: updated `validate_analyzer_cli_docs_split_contract()` to require `render_json`, `render_json_pretty`, `analyze_run`, and a `report vs run artifact json` CLI concept and removed the hard `serde_json` requirement.
Commands run: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --locked`, `python3 scripts/validate_docs_contracts.py`.
Remaining limitations: this is documentation-only and does not change runtime behavior, analyzer scoring/shape, sink implementations, CLI loader rules, or dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcf08adec08330a2f851f6f1b31234)