### PR TITLE
docs: document built-in sinks and canonical analyzer Report JSON flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ cargo add tailtriage-analyzer
 cargo install tailtriage-cli
 ```
 
-`tailtriage` captures request/runtime evidence. `tailtriage-analyzer` analyzes completed in-memory runs or stable snapshots in process. `tailtriage-cli` analyzes saved run artifacts from the command line.
+`tailtriage` captures request/runtime evidence into run artifact JSON via capture sinks. `tailtriage-cli` consumes run artifact JSON from disk. `tailtriage-analyzer` produces typed `Report` values in process and renders Report JSON when needed.
 
 ## Why not just tokio-console or tokio-metrics?
 
@@ -168,17 +168,46 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### In-process analysis (library)
 
 ```rust
-use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+use tailtriage_analyzer::{analyze_run, render_json_pretty, render_text, AnalyzeOptions};
 
 # use tailtriage_core::Run;
-# fn example(run: Run) -> Result<(), serde_json::Error> {
+# fn example(run: Run) {
 let report = analyze_run(&run, AnalyzeOptions::default());
 let text = render_text(&report);
-let json = serde_json::to_string_pretty(&report)?;
+let json = render_json_pretty(&report);
 # let _ = (text, json);
-# Ok(())
 # }
 ```
+
+
+
+### In-process capture + analysis with `MemorySink`
+
+```rust,no_run
+use tailtriage_core::{MemorySink, Tailtriage};
+use tailtriage_analyzer::{analyze_run, render_json_pretty, AnalyzeOptions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let sink = MemorySink::new();
+    let run = Tailtriage::builder("checkout-service")
+        .sink(sink.clone())
+        .build()?;
+
+    let started = run.begin_request("/checkout");
+    started.completion.finish_ok();
+    run.shutdown()?;
+
+    if let Some(finalized_run) = sink.take_run() {
+        let report = analyze_run(&finalized_run, AnalyzeOptions::default());
+        let report_json = render_json_pretty(&report);
+        let _ = report_json;
+    }
+
+    Ok(())
+}
+```
+
+You can avoid JSON output entirely by using `MemorySink` plus typed `Report` values in process, and call `render_json` or `render_json_pretty` only when you want Report JSON.
 
 ### Analyze artifact (CLI)
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -69,7 +69,14 @@ Single-run shape:
 
 1. build
 2. capture request lifecycle data
-3. `shutdown()` to finalize artifact
+3. `shutdown()` to finalize artifact output
+
+
+Direct capture output sinks:
+
+- default direct capture writes a local run artifact JSON through `LocalJsonSink`
+- use `MemorySink` when you want the finalized typed `Run` in memory without file output
+- use `DiscardSink` when you want shutdown/finalization without persisting the finalized `Run`
 
 ### 5.3 Request lifecycle contract
 
@@ -136,13 +143,16 @@ Semantics:
 
 - `analyze_run(&Run, AnalyzeOptions) -> Report`
 - `render_text(&Report)` for human-readable output
-- serde-serializable `Report` JSON
+- `render_json(&Report)`
+- `render_json_pretty(&Report)`
+- `analyze_run_json(&Run, AnalyzeOptions)`
+- `analyze_run_json_pretty(&Run, AnalyzeOptions)`
 
 Semantics are batch/snapshot for completed runs, not streaming analysis.
 
 ### 5.9 Analyzer CLI (`tailtriage-cli`)
 
-`tailtriage-cli` owns artifact loading + command-line report emission and uses `tailtriage-analyzer` for analysis logic.
+`tailtriage-cli` owns run artifact loading + command-line report emission and uses `tailtriage-analyzer` for analysis logic. CLI JSON output delegates to `tailtriage-analyzer`'s canonical pretty Report JSON renderer.
 
 Primary command:
 
@@ -151,6 +161,18 @@ tailtriage analyze <run.json>
 ```
 
 ## 6. Run artifact, analyzer, and CLI contracts
+
+Run artifact JSON is capture output and CLI input.
+
+- Produced by capture surfaces and sinks (`LocalJsonSink`, `MemorySink`, `DiscardSink` contract context).
+- Consumed by `tailtriage-cli` loader from disk.
+
+Report JSON is analyzer/CLI output and is not CLI input.
+
+- Produced by `tailtriage-analyzer` rendering (`render_json`, `render_json_pretty`, `analyze_run_json`, `analyze_run_json_pretty`).
+- Emitted by `tailtriage-cli --format json` via analyzer-owned canonical pretty rendering.
+
+Typed `Report` is in-process analyzer output for Rust users.
 
 Run artifacts include request, stage, queue, in-flight, and optional runtime snapshot data plus metadata/truncation context.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,8 +8,11 @@ The default user path is:
 
 1. instrument capture in service code (`tailtriage` default crate)
 2. optionally enrich with runtime sampling (`tailtriage-tokio`)
-3. write local run artifact JSON
-4. analyze with `tailtriage-analyzer` in process or with `tailtriage-cli` for file artifacts
+3. default capture writes local run artifact JSON through `LocalJsonSink`
+4. optional capture uses `MemorySink` for in-memory finalized typed `Run` values
+5. optional capture uses `DiscardSink` for finalization with no persisted finalized `Run`
+6. analyze typed `Run` in process with `tailtriage-analyzer` to get a typed `Report`
+7. render text or Report JSON with analyzer-owned renderers; `tailtriage-cli` delegates to analyzer rendering for `--format json`
 
 The result is a triage report with evidence-ranked suspects and next checks.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -72,7 +72,7 @@ use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
 # fn example(run: Run) -> Result<(), serde_json::Error> {
 let report = analyze_run(&run, AnalyzeOptions::default());
 let text = render_text(&report);
-let json = serde_json::to_string_pretty(&report)?;
+let json = tailtriage_analyzer::render_json_pretty(&report);
 # let _ = (text, json);
 # Ok(())
 # }

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -611,7 +611,9 @@ def validate_analyzer_cli_docs_split_contract() -> None:
         "typed",
         "report",
         "render_text",
-        "serde_json",
+        "render_json",
+        "render_json_pretty",
+        "analyze_run",
         "analyzeoptions::default()",
         "tailtriage-cli",
     )
@@ -625,6 +627,7 @@ def validate_analyzer_cli_docs_split_contract() -> None:
     cli_text = (REPO_ROOT / "tailtriage-cli" / "README.md").read_text(encoding="utf-8")
     cli_lower = cli_text.lower()
     cli_required_patterns = (
+        ("report json vs run artifact json distinction", r"report.{0,80}json.{0,120}(distinct|separate|not).{0,120}run artifact"),
         ("saved/run artifact loading", r"(saved|captured|on-disk|persisted|run).{0,120}artifact"),
         ("schema validation", r"(schema.{0,80}validat|validat.{0,80}schema)"),
         ("non-empty requests loader rule", r"non[-\s]?empty.{0,80}requests"),

--- a/tailtriage-analyzer/README.md
+++ b/tailtriage-analyzer/README.md
@@ -2,14 +2,14 @@
 
 `tailtriage-analyzer` is the in-process analyzer/report crate for `tailtriage`.
 
-Use this crate when you already have a completed `tailtriage_core::Run` in memory (or an equivalent stable snapshot) and want a typed triage report, text rendering, and optional JSON serialization in your Rust process.
+Use this crate when you already have a completed `tailtriage_core::Run` in memory (or an equivalent stable snapshot) and want a typed triage report, text rendering, and canonical Report JSON rendering in your Rust process.
 
 ## What this crate does
 
 - analyzes one completed run/snapshot in batch
 - returns a typed `Report` with evidence-ranked suspects and next checks
 - renders human-readable output with `render_text(&Report)`
-- `Report` implements serde::Serialize; add serde_json or another serde serializer in your application when you want encoded JSON output.
+- renders canonical Report JSON with `render_json`, `render_json_pretty`, `analyze_run_json`, and `analyze_run_json_pretty`
 
 Suspects are investigation leads, not proof of root cause.
 
@@ -19,12 +19,6 @@ Suspects are investigation leads, not proof of root cause.
 
 ```bash
 cargo add tailtriage-analyzer
-```
-
-If you want JSON serialization output from your Rust code, also add:
-
-```bash
-cargo add serde_json
 ```
 
 ## How to obtain a `Run`
@@ -40,14 +34,17 @@ Typical flow:
 ## In-process API
 
 ```rust
-use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+use tailtriage_analyzer::{
+    analyze_run, analyze_run_json, analyze_run_json_pretty, render_json, render_json_pretty,
+    render_text, AnalyzeOptions,
+};
 use tailtriage_core::Run;
 
-fn render_report(run: &Run) -> Result<String, serde_json::Error> {
+fn render_report(run: &Run) -> String {
     let report = analyze_run(run, AnalyzeOptions::default());
     let text = render_text(&report);
-    let json = serde_json::to_string_pretty(&report)?;
-    Ok(format!("{text}\n\n{json}"))
+    let json = render_json_pretty(&report);
+    format!("{text}\n\n{json}")
 }
 ```
 
@@ -57,7 +54,9 @@ fn render_report(run: &Run) -> Result<String, serde_json::Error> {
 - `AnalyzeOptions::default()` is the normal path today and leaves room for future analyzer options
 - `Report` is the typed analyzer output model and should be your primary integration surface
 - `render_text` is for human-readable triage output
-- serde JSON for `Report` is optional and requires user-side `serde_json`
+- `render_json` and `render_json_pretty` encode canonical Report JSON from a typed `Report`
+- `analyze_run_json` and `analyze_run_json_pretty` analyze and render canonical Report JSON in one call
+- Report JSON is distinct from run artifact JSON
 
 ## Semantics and boundaries
 
@@ -80,5 +79,11 @@ See root docs for interpretation guidance:
 // Old pre-0.1.x API was hosted in the CLI crate.
 // Use the analyzer crate directly for in-process analysis/report APIs.
 
-use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+use tailtriage_analyzer::{
+    analyze_run, analyze_run_json, analyze_run_json_pretty, render_json, render_json_pretty,
+    render_text, AnalyzeOptions,
+};
 ```
+
+
+CLI `--format json` uses the same canonical pretty Report JSON renderer (`render_json_pretty`) through `tailtriage-analyzer`.

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -12,7 +12,8 @@ tailtriage
 
 ## What this tool does
 
-`tailtriage-cli` owns the command-line artifact-analysis contract:
+`tailtriage-cli` owns the command-line artifact-analysis contract. It consumes run artifact JSON from disk and does not consume Report JSON as input:
+
 
 - load a captured artifact
 - validate schema compatibility
@@ -36,13 +37,14 @@ Default text output:
 tailtriage analyze tailtriage-run.json
 ```
 
-Machine-readable JSON output:
+Machine-readable JSON output (same pretty Report JSON as `tailtriage_analyzer::render_json_pretty`):
 
 ```bash
 tailtriage analyze tailtriage-run.json --format json
 ```
 
 The CLI artifact loader requires at least one request event in `requests`. This is a CLI artifact-loading rule, not an in-process `tailtriage-analyzer` requirement for already-constructed `Run` values.
+Report JSON output is separate from run artifact JSON input: the CLI reads run artifact JSON and emits Report JSON.
 
 ## How to read the result
 

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -47,6 +47,36 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+
+## Output sinks
+
+`tailtriage-core` capture surfaces can finalize runs to different sinks:
+
+- `LocalJsonSink` (or builder `.output(...)`) writes run artifact JSON files.
+- `MemorySink` keeps the last finalized typed `Run` value in memory.
+- `DiscardSink` finalizes lifecycle state and drops the finalized `Run` without persisting output.
+
+`MemorySink` stores only the last finalized `Run` and replaces any earlier stored run.
+`DiscardSink` drops finalized data; use `MemorySink` when you want to analyze the finalized `Run` in process.
+
+```rust,no_run
+use tailtriage_core::{MemorySink, Tailtriage};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let sink = MemorySink::new();
+    let run = Tailtriage::builder("checkout-service")
+        .sink(sink.clone())
+        .build()?;
+
+    let started = run.begin_request("/checkout");
+    started.completion.finish_ok();
+    run.shutdown()?;
+
+    let _finalized_run = sink.take_run();
+    Ok(())
+}
+```
+
 ## Request lifecycle
 
 `begin_request(...)` / `begin_request_with(...)` returns `StartedRequest` with:


### PR DESCRIPTION
### Motivation

- Make the capture -> analyze -> render contract explicit by documenting built-in output sinks and the distinction between run artifact JSON, analyzer-owned Report JSON, and the typed `Report` used in-process. 
- Surface the analyzer's canonical JSON rendering APIs so Rust users and the CLI delegate to a single, stable renderer instead of calling `serde_json` directly. 
- Keep docs- and validator-level expectations truthful to the code without changing runtime or analyzer behavior.

### Description

- Document direct-capture sinks in `SPEC.md` and `tailtriage-core/README.md`: default `LocalJsonSink`, `MemorySink` for an in-memory finalized typed `Run`, and `DiscardSink` for finalization without persisting output, and add a compact `MemorySink` example. 
- Add analyzer JSON APIs to docs (`render_json`, `render_json_pretty`, `analyze_run_json`, `analyze_run_json_pretty`) and replace examples that previously used `serde_json::to_string_pretty(&report)` with `render_json_pretty(&report)` in `README.md`, `tailtriage-analyzer/README.md`, and `docs/user-guide.md`. 
- Clarify the contract in `SPEC.md`, `README.md`, `docs/architecture.md`, and `tailtriage-cli/README.md` that: run artifact JSON is capture output / CLI input, Report JSON is analyzer/CLI output (not CLI input), and typed `Report` is the in-process analyzer output for Rust integrations; also state that `tailtriage-cli --format json` delegates to the analyzer's pretty renderer. 
- Update docs validation (`scripts/validate_docs_contracts.py`) to require the new analyzer renderer tokens and the Report JSON vs run artifact JSON distinction while removing the stale requirement that the analyzer README instruct users to call `serde_json` directly.

### Testing

- Commands run: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --locked`, and `python3 scripts/validate_docs_contracts.py`. 
- Results: all checks passed (format, clippy, unit/doc tests, and the docs contract validator). 
- Docs files changed: `SPEC.md`, `README.md`, `tailtriage-core/README.md`, `tailtriage-analyzer/README.md`, `tailtriage-cli/README.md`, `docs/architecture.md`, and `docs/user-guide.md`. 
- Validator changes: `scripts/validate_docs_contracts.py` updated to require `render_json`/`render_json_pretty`/`analyze_run` tokens and to check the Report JSON vs run artifact JSON distinction; this was adjusted to match the new truthful docs contract. 
- Remaining limitation: this PR only updates documentation and validator checks; no runtime, CLI behavior, analyzer scoring, sink implementations, or dependencies were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcf08adec08330a2f851f6f1b31234)