### PR TITLE
docs: document built-in sinks and canonical analyzer Report JSON contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,11 @@ cargo add tailtriage-analyzer
 cargo install tailtriage-cli
 ```
 
-`tailtriage` captures request/runtime evidence. `tailtriage-analyzer` analyzes completed in-memory runs or stable snapshots in process. `tailtriage-cli` analyzes saved run artifacts from the command line.
+`tailtriage` captures request/runtime evidence.
+
+- Run artifact JSON: produced by capture sinks and consumed by `tailtriage-cli`.
+- Report JSON: produced by `tailtriage-analyzer` and emitted by `tailtriage analyze ... --format json`.
+- typed `Report`: in-process analyzer output for Rust users.
 
 ## Why not just tokio-console or tokio-metrics?
 
@@ -168,17 +172,45 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### In-process analysis (library)
 
 ```rust
-use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+use tailtriage_analyzer::{analyze_run, render_json_pretty, render_text, AnalyzeOptions};
 
 # use tailtriage_core::Run;
-# fn example(run: Run) -> Result<(), serde_json::Error> {
+# fn example(run: Run) {
 let report = analyze_run(&run, AnalyzeOptions::default());
 let text = render_text(&report);
-let json = serde_json::to_string_pretty(&report)?;
+let json = render_json_pretty(&report);
 # let _ = (text, json);
-# Ok(())
 # }
 ```
+
+
+### In-process capture + analysis with `MemorySink`
+
+```rust
+use tailtriage::{MemorySink, Tailtriage};
+use tailtriage_analyzer::{analyze_run, render_json_pretty, AnalyzeOptions};
+
+fn example() -> Result<(), Box<dyn std::error::Error>> {
+    let sink = MemorySink::default();
+    let run = Tailtriage::builder("checkout-service")
+        .sink(sink.clone())
+        .build()?;
+
+    let started = run.begin_request("/checkout");
+    started.completion.finish_ok();
+    run.shutdown()?;
+
+    if let Some(finalized_run) = sink.take_run() {
+        let report = analyze_run(&finalized_run, AnalyzeOptions::default());
+        let report_json = render_json_pretty(&report);
+        let _ = report_json;
+    }
+
+    Ok(())
+}
+```
+
+You can avoid JSON output entirely by using `MemorySink` with the typed `Report`, and call `render_json`/`render_json_pretty` only when you want Report JSON.
 
 ### Analyze artifact (CLI)
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -71,6 +71,13 @@ Single-run shape:
 2. capture request lifecycle data
 3. `shutdown()` to finalize artifact
 
+Default direct capture writes a local run artifact JSON file through `LocalJsonSink` (for example via `.output(...)`).
+
+Alternative sinks:
+
+- `MemorySink`: keep the finalized typed `Run` in memory without file output
+- `DiscardSink`: run full shutdown/finalization without persisting the finalized `Run`
+
 ### 5.3 Request lifecycle contract
 
 `begin_request(...)` / `begin_request_with(...)` returns `StartedRequest { handle, completion }`.
@@ -136,13 +143,17 @@ Semantics:
 
 - `analyze_run(&Run, AnalyzeOptions) -> Report`
 - `render_text(&Report)` for human-readable output
-- serde-serializable `Report` JSON
+- canonical report JSON functions:
+  - `render_json`
+  - `render_json_pretty`
+  - `analyze_run_json`
+  - `analyze_run_json_pretty`
 
 Semantics are batch/snapshot for completed runs, not streaming analysis.
 
 ### 5.9 Analyzer CLI (`tailtriage-cli`)
 
-`tailtriage-cli` owns artifact loading + command-line report emission and uses `tailtriage-analyzer` for analysis logic.
+`tailtriage-cli` owns artifact loading + command-line report emission and uses `tailtriage-analyzer` for analysis logic. CLI JSON output delegates to `tailtriage-analyzer`'s canonical pretty Report JSON renderer.
 
 Primary command:
 
@@ -151,6 +162,12 @@ tailtriage analyze <run.json>
 ```
 
 ## 6. Run artifact, analyzer, and CLI contracts
+
+Contract boundary:
+
+- Run artifact JSON: capture output and CLI input
+- Report JSON: analyzer/CLI output and not CLI input
+- typed `Report`: in-process analyzer output for Rust users
 
 Run artifacts include request, stage, queue, in-flight, and optional runtime snapshot data plus metadata/truncation context.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,8 +8,13 @@ The default user path is:
 
 1. instrument capture in service code (`tailtriage` default crate)
 2. optionally enrich with runtime sampling (`tailtriage-tokio`)
-3. write local run artifact JSON
-4. analyze with `tailtriage-analyzer` in process or with `tailtriage-cli` for file artifacts
+3. finalize through sink choice:
+   - default local run artifact JSON path via `LocalJsonSink`
+   - optional in-memory finalized typed `Run` via `MemorySink`
+   - optional no-persist finalization via `DiscardSink`
+4. analyze finalized `Run` values with `tailtriage-analyzer` to produce typed `Report`
+5. render report text or Report JSON through analyzer-owned rendering
+6. use `tailtriage-cli` for disk artifact loading, then delegate report rendering to `tailtriage-analyzer`
 
 The result is a triage report with evidence-ranked suspects and next checks.
 
@@ -56,7 +61,7 @@ Owns in-process analysis/report generation from completed runs:
 - typed `Report` model
 - `analyze_run` entry point
 - `render_text` human-readable rendering
-- serde-serializable report JSON
+- analyzer-owned Report JSON rendering (`render_json`, `render_json_pretty`)
 
 ### `tailtriage-cli`
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -72,7 +72,7 @@ use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
 # fn example(run: Run) -> Result<(), serde_json::Error> {
 let report = analyze_run(&run, AnalyzeOptions::default());
 let text = render_text(&report);
-let json = serde_json::to_string_pretty(&report)?;
+let json = tailtriage_analyzer::render_json_pretty(&report);
 # let _ = (text, json);
 # Ok(())
 # }

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -611,7 +611,9 @@ def validate_analyzer_cli_docs_split_contract() -> None:
         "typed",
         "report",
         "render_text",
-        "serde_json",
+        "render_json",
+        "render_json_pretty",
+        "analyze_run",
         "analyzeoptions::default()",
         "tailtriage-cli",
     )
@@ -629,6 +631,7 @@ def validate_analyzer_cli_docs_split_contract() -> None:
         ("schema validation", r"(schema.{0,80}validat|validat.{0,80}schema)"),
         ("non-empty requests loader rule", r"non[-\s]?empty.{0,80}requests"),
         ("tailtriage-analyzer use", r"tailtriage-analyzer"),
+        ("report json vs run artifact json distinction", r"(report\s+json).{0,160}(run\s+artifact\s+json)|(run\s+artifact\s+json).{0,160}(report\s+json)"),
         ("command-line text/json output", r"(command[-\s]?line|cli).{0,160}(text|json|human-readable)"),
         ("in-process pointer for Rust users", r"(rust|in-process).{0,120}tailtriage-analyzer"),
     )

--- a/tailtriage-analyzer/README.md
+++ b/tailtriage-analyzer/README.md
@@ -2,14 +2,15 @@
 
 `tailtriage-analyzer` is the in-process analyzer/report crate for `tailtriage`.
 
-Use this crate when you already have a completed `tailtriage_core::Run` in memory (or an equivalent stable snapshot) and want a typed triage report, text rendering, and optional JSON serialization in your Rust process.
+Use this crate when you already have a completed `tailtriage_core::Run` in memory (or an equivalent stable snapshot) and want a typed triage report, text rendering, and canonical text/JSON rendering in your Rust process.
 
 ## What this crate does
 
 - analyzes one completed run/snapshot in batch
 - returns a typed `Report` with evidence-ranked suspects and next checks
 - renders human-readable output with `render_text(&Report)`
-- `Report` implements serde::Serialize; add serde_json or another serde serializer in your application when you want encoded JSON output.
+- renders canonical Report JSON with `render_json(&Report)` / `render_json_pretty(&Report)`
+- provides one-shot helpers `analyze_run_json` / `analyze_run_json_pretty`
 
 Suspects are investigation leads, not proof of root cause.
 
@@ -19,12 +20,6 @@ Suspects are investigation leads, not proof of root cause.
 
 ```bash
 cargo add tailtriage-analyzer
-```
-
-If you want JSON serialization output from your Rust code, also add:
-
-```bash
-cargo add serde_json
 ```
 
 ## How to obtain a `Run`
@@ -40,14 +35,20 @@ Typical flow:
 ## In-process API
 
 ```rust
-use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+use tailtriage_analyzer::{
+    analyze_run, analyze_run_json, analyze_run_json_pretty, render_json, render_json_pretty,
+    render_text, AnalyzeOptions,
+};
 use tailtriage_core::Run;
 
-fn render_report(run: &Run) -> Result<String, serde_json::Error> {
+fn render_report(run: &Run) -> String {
     let report = analyze_run(run, AnalyzeOptions::default());
     let text = render_text(&report);
-    let json = serde_json::to_string_pretty(&report)?;
-    Ok(format!("{text}\n\n{json}"))
+    let json = render_json_pretty(&report);
+    let _compact_json = render_json(&report);
+    let _json_from_run = analyze_run_json(run, AnalyzeOptions::default());
+    let _pretty_json_from_run = analyze_run_json_pretty(run, AnalyzeOptions::default());
+    format!("{text}\n\n{json}")
 }
 ```
 
@@ -57,7 +58,9 @@ fn render_report(run: &Run) -> Result<String, serde_json::Error> {
 - `AnalyzeOptions::default()` is the normal path today and leaves room for future analyzer options
 - `Report` is the typed analyzer output model and should be your primary integration surface
 - `render_text` is for human-readable triage output
-- serde JSON for `Report` is optional and requires user-side `serde_json`
+- `render_json` / `render_json_pretty` are the canonical Report JSON renderers
+- `analyze_run_json` / `analyze_run_json_pretty` run analysis and return Report JSON directly
+- Report JSON is distinct from raw run artifact JSON
 
 ## Semantics and boundaries
 
@@ -82,3 +85,6 @@ See root docs for interpretation guidance:
 
 use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
 ```
+
+
+CLI `--format json` uses the same canonical pretty Report JSON rendering path from `tailtriage-analyzer`.

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -42,6 +42,8 @@ Machine-readable JSON output:
 tailtriage analyze tailtriage-run.json --format json
 ```
 
+`tailtriage analyze <run.json> --format json` emits the same pretty Report JSON as `tailtriage_analyzer::render_json_pretty`.
+
 The CLI artifact loader requires at least one request event in `requests`. This is a CLI artifact-loading rule, not an in-process `tailtriage-analyzer` requirement for already-constructed `Run` values.
 
 ## How to read the result
@@ -145,6 +147,7 @@ Current contract:
 
 For Rust in-process usage, use `tailtriage-analyzer` directly (`analyze_run`, `render_text`, typed `Report`).
 The stricter non-empty `requests` rule applies to CLI artifact loading from disk.
+CLI input is run artifact JSON from disk; CLI does not consume Report JSON as input.
 
 ## Important interpretation notes
 

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -47,6 +47,37 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+
+## Output sinks
+
+`tailtriage-core` captures run data and finalizes a typed `Run`. It does not perform analysis or report generation.
+
+- `LocalJsonSink` (or builder `.output(...)`) writes run artifact JSON files.
+- `MemorySink` keeps finalized typed `Run` values in memory.
+- `DiscardSink` finalizes the run and persists nothing.
+
+`MemorySink` stores the last finalized `Run` and replaces earlier stored runs.
+
+```rust,no_run
+use tailtriage_core::{MemorySink, Tailtriage};
+
+# fn demo() -> Result<(), Box<dyn std::error::Error>> {
+let sink = MemorySink::default();
+let run = Tailtriage::builder("checkout-service")
+    .sink(sink.clone())
+    .build()?;
+
+let started = run.begin_request("/checkout");
+started.completion.finish_ok();
+run.shutdown()?;
+
+let _last_run = sink.take_run();
+# Ok(())
+# }
+```
+
+`DiscardSink` drops the finalized `Run`. Use `MemorySink` when the finalized `Run` should be analyzed in process.
+
 ## Request lifecycle
 
 `begin_request(...)` / `begin_request_with(...)` returns `StartedRequest` with:


### PR DESCRIPTION
### Motivation

- Make the capture -> analyze -> CLI workflow explicit by documenting the new built-in sink choices and the analyzer-owned canonical Report JSON rendering contract. 
- Clarify distinctions between run artifact JSON (capture/CLI input), Report JSON (analyzer/CLI output), and the typed `Report` (in-process analyzer value) so users pick the right path and examples.

### Description

- Update `SPEC.md` to state that the default direct capture writes a local run artifact JSON via `LocalJsonSink`, and list `MemorySink` and `DiscardSink` as alternative sink choices, and add the analyzer JSON functions: `render_json`, `render_json_pretty`, `analyze_run_json`, `analyze_run_json_pretty`, and note CLI JSON delegates to the analyzer renderer. 
- Update the root `README.md` to distinguish run artifact JSON vs Report JSON vs typed `Report`, replace examples that used `serde_json::to_string_pretty(&report)` with `render_json_pretty(&report)`, and add a compact `MemorySink` in-process capture+analysis example showing `analyze_run` + `render_json_pretty`. 
- Add an “Output sinks” section to `tailtriage-core/README.md` documenting `LocalJsonSink`/`.output(...)`, `MemorySink` (stores last finalized `Run` and replaces earlier runs) and `DiscardSink` (drops finalized `Run`), and include a small `MemorySink` example. 
- Update `tailtriage-analyzer/README.md` to remove guidance that users must call `serde_json` for basic JSON output, add and document the canonical renderers (`render_json`, `render_json_pretty`) and helpers (`analyze_run_json`, `analyze_run_json_pretty`), and state Report JSON is distinct from raw run artifact JSON and that CLI `--format json` uses the same pretty renderer. 
- Update `tailtriage-cli/README.md` to state `tailtriage analyze <run.json> --format json` emits the same pretty Report JSON as `tailtriage_analyzer::render_json_pretty`, preserve loader/schema/non-empty-requests rules, and explicitly state CLI input is run artifact JSON (not Report JSON). 
- Update product docs (`docs/architecture.md`, `docs/user-guide.md`, `docs/diagnostics.md`) to reflect the sink paths, analyzer-owned typed `Report`, and analyzer-owned Report JSON rendering; replace inline `serde_json` report examples with analyzer renderers where present. 
- Update `scripts/validate_docs_contracts.py` to remove the stale requirement that analyzer README must recommend direct `serde_json` use, and to require analyzer README tokens for `render_json`, `render_json_pretty`, `analyze_run`, `AnalyzeOptions::default()`, `render_text`, typed `Report`, in-process semantics, and non-streaming notes, and to require CLI README to explicitly mention the Report JSON vs run-artifact JSON distinction while preserving existing loader/split checks.

Files changed: `SPEC.md`, `README.md`, `docs/architecture.md`, `docs/user-guide.md`, `docs/diagnostics.md`, `tailtriage-core/README.md`, `tailtriage-analyzer/README.md`, `tailtriage-cli/README.md`, `scripts/validate_docs_contracts.py`.

### Testing

- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed.
- Ran `cargo test --workspace --locked` and the full test suite passed.
- Ran the docs contract validator via `python3 scripts/validate_docs_contracts.py` and it validated successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcf08adec08330a2f851f6f1b31234)