### PR TITLE
Close crates.io README documentation gaps and enforce analyzer contract

### DIFF
--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -303,6 +303,65 @@ Rust in-process users should use tailtriage-analyzer.
                 with self.assertRaisesRegex(ValueError, r"report vs run artifact json distinction"):
                     validate_docs_contracts.validate_analyzer_cli_docs_split_contract()
 
+
+    def test_analyzer_readme_contract_fails_when_repo_relative_docs_link_present(self) -> None:
+        analyzer_text = """
+tailtriage-analyzer is in-process analysis for completed Run values and returns a typed Report.
+Use analyze_run(run, AnalyzeOptions::default()) for the standard entry point.
+Use render_text(&report), render_json(&report), and render_json_pretty(&report) for Report rendering.
+Use analyze_run_json(run, AnalyzeOptions::default()) and analyze_run_json_pretty(run, AnalyzeOptions::default()).
+This crate is not streaming and references tailtriage-cli.
+## How to interpret a report
+primary_suspect secondary_suspects evidence[] next_checks[] score confidence evidence_quality route_breakdowns temporal_segments Report JSON Run artifact JSON
+See ../docs/diagnostics.md
+"""
+        cli_text = """
+tailtriage-cli loads saved run artifacts from disk, performs schema validation,
+enforces non-empty requests loader rules, uses tailtriage-analyzer, and provides command-line text/json output.
+Rust in-process users should use tailtriage-analyzer.
+Run artifact JSON is input; Report JSON is output; CLI does not consume Report JSON as input.
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            analyzer_readme = repo_root / "tailtriage-analyzer" / "README.md"
+            cli_readme = repo_root / "tailtriage-cli" / "README.md"
+            analyzer_readme.parent.mkdir(parents=True, exist_ok=True)
+            cli_readme.parent.mkdir(parents=True, exist_ok=True)
+            analyzer_readme.write_text(analyzer_text, encoding="utf-8")
+            cli_readme.write_text(cli_text, encoding="utf-8")
+
+            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root):
+                with self.assertRaisesRegex(ValueError, r"must not link to ../docs/"):
+                    validate_docs_contracts.validate_analyzer_cli_docs_split_contract()
+
+    def test_analyzer_readme_contract_fails_when_interpret_heading_missing(self) -> None:
+        analyzer_text = """
+tailtriage-analyzer is in-process analysis for completed Run values and returns a typed Report.
+Use analyze_run(run, AnalyzeOptions::default()) for the standard entry point.
+Use render_text(&report), render_json(&report), and render_json_pretty(&report) for Report rendering.
+Use analyze_run_json(run, AnalyzeOptions::default()) and analyze_run_json_pretty(run, AnalyzeOptions::default()).
+This crate is not streaming and references tailtriage-cli.
+primary_suspect secondary_suspects evidence[] next_checks[] score confidence evidence_quality route_breakdowns temporal_segments Report JSON Run artifact JSON
+"""
+        cli_text = """
+tailtriage-cli loads saved run artifacts from disk, performs schema validation,
+enforces non-empty requests loader rules, uses tailtriage-analyzer, and provides command-line text/json output.
+Rust in-process users should use tailtriage-analyzer.
+Run artifact JSON is input; Report JSON is output; CLI does not consume Report JSON as input.
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            analyzer_readme = repo_root / "tailtriage-analyzer" / "README.md"
+            cli_readme = repo_root / "tailtriage-cli" / "README.md"
+            analyzer_readme.parent.mkdir(parents=True, exist_ok=True)
+            cli_readme.parent.mkdir(parents=True, exist_ok=True)
+            analyzer_readme.write_text(analyzer_text, encoding="utf-8")
+            cli_readme.write_text(cli_text, encoding="utf-8")
+
+            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root):
+                with self.assertRaisesRegex(ValueError, r"How to interpret a report"):
+                    validate_docs_contracts.validate_analyzer_cli_docs_split_contract()
+
     def test_architecture_contract(self) -> None:
         validate_docs_contracts.validate_architecture_contract()
 

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -230,6 +230,8 @@ Use analyze_run(run, AnalyzeOptions::default()) for the standard entry point.
 Use render_text(&report), render_json(&report), and render_json_pretty(&report) for Report rendering.
 Use analyze_run_json(run, AnalyzeOptions::default()) and analyze_run_json_pretty(run, AnalyzeOptions::default()) for helpers.
 This crate is not streaming / not live streaming, and tailtriage-cli owns artifact loading.
+## How to interpret a report
+primary_suspect secondary_suspects evidence[] next_checks[] score confidence evidence_quality route_breakdowns temporal_segments Report JSON Run artifact JSON
 """
         cli_text = """
 tailtriage-cli loads saved run artifacts from disk, performs schema validation,
@@ -284,6 +286,8 @@ Use analyze_run(run, AnalyzeOptions::default()) and render_text(&report).
 Use render_json(&report), render_json_pretty(&report), analyze_run_json(run, AnalyzeOptions::default()),
 and analyze_run_json_pretty(run, AnalyzeOptions::default()).
 This crate is not streaming / not live streaming and references tailtriage-cli.
+## How to interpret a report
+primary_suspect secondary_suspects evidence[] next_checks[] score confidence evidence_quality route_breakdowns temporal_segments Report JSON Run artifact JSON
 """
         cli_text = """
 tailtriage-cli loads saved run artifacts from disk, performs schema validation,

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -626,6 +626,32 @@ def validate_analyzer_cli_docs_split_contract() -> None:
     if "not streaming" not in analyzer_lower and "not live streaming" not in analyzer_lower:
         raise ValueError("tailtriage-analyzer README must state it is not streaming/live-streaming")
 
+    if "../docs/" in analyzer_text:
+        raise ValueError("tailtriage-analyzer README must not link to ../docs/ for crates.io interpretation guidance")
+
+    if "## How to interpret a report" not in analyzer_text:
+        raise ValueError("tailtriage-analyzer README must include heading: ## How to interpret a report")
+
+    analyzer_interpretation_tokens = (
+        "primary_suspect",
+        "secondary_suspects",
+        "evidence[]",
+        "next_checks[]",
+        "score",
+        "confidence",
+        "evidence_quality",
+        "route_breakdowns",
+        "temporal_segments",
+        "Report JSON",
+        "Run artifact JSON",
+    )
+    for token in analyzer_interpretation_tokens:
+        if token not in analyzer_text:
+            raise ValueError(
+                "tailtriage-analyzer README interpretation guidance missing required token: "
+                f"{token}"
+            )
+
     cli_text = (REPO_ROOT / "tailtriage-cli" / "README.md").read_text(encoding="utf-8")
     cli_lower = cli_text.lower()
     cli_required_patterns = (

--- a/tailtriage-analyzer/README.md
+++ b/tailtriage-analyzer/README.md
@@ -69,10 +69,17 @@ fn render_report(run: &Run) -> Result<String, Box<dyn std::error::Error>> {
 
 `Report` includes request counts, latency percentiles, queue/service share summaries, warnings, evidence quality, ranked suspects, and optional supporting route/temporal sections.
 
-See root docs for interpretation guidance:
+## How to interpret a report
 
-- [`docs/diagnostics.md`](../docs/diagnostics.md)
-- [`docs/user-guide.md`](../docs/user-guide.md)
+- `primary_suspect` is the strongest triage lead for the analyzed run, not proof of root cause.
+- `secondary_suspects` are lower-ranked leads worth checking when evidence is close or the primary lead does not explain the incident.
+- `evidence[]` explains why a suspect was ranked.
+- `next_checks[]` gives targeted follow-up actions.
+- `score` ranks suspects inside one report; it is not a probability.
+- `confidence` is ranking strength and may be capped by missing, sparse, partial, or truncated evidence.
+- `warnings[]` and `evidence_quality` describe interpretation limits.
+- `route_breakdowns` and `temporal_segments`, when present, are supporting context only and do not override the global `primary_suspect`.
+- Report JSON is analyzer output and is distinct from raw Run artifact JSON.
 
 ## Migration note
 

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -148,6 +148,7 @@ Current contract:
 
 For Rust in-process usage, use `tailtriage-analyzer` directly (`analyze_run`, `render_text`, typed `Report`).
 The stricter non-empty `requests` rule applies to CLI artifact loading from disk.
+Loader, parse, validation, and render errors return a non-zero process exit through the CLI.
 
 ## Important interpretation notes
 

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -54,6 +54,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 - `started.handle` for queue/stage/inflight instrumentation
 - `started.completion` for explicit finish
 
+For `Arc<Tailtriage>` flows that move request handles across spawned tasks or helper layers, use `begin_request_owned(...)` / `begin_request_with_owned(...)`. Owned handles keep the same lifecycle rule: instrumentation does not finish the request, and the completion token must be finished exactly once.
+
 ```rust,no_run
 use tailtriage_core::{RequestOptions, Tailtriage};
 

--- a/tailtriage/README.md
+++ b/tailtriage/README.md
@@ -116,6 +116,8 @@ Choose a focused crate only when you need a narrower boundary:
 
 Docs.rs note: `tailtriage` docs are built with `all-features = true`, so docs.rs may render optional namespaces such as `tailtriage::tokio` and `tailtriage::axum`. In downstream crates, those namespaces are available only when their Cargo features are enabled.
 
+Note: the `tokio` feature controls the public `tailtriage::tokio` namespace. The default `controller` feature enables `tailtriage::controller`; controller-managed runtime sampling uses `tailtriage-tokio` internally, so default controller builds may include Tokio-related dependencies even when the public `tailtriage::tokio` namespace is not enabled.
+
 ## Important constraints
 
 - Capture and analysis are separate. For in-process analysis/report generation, use `tailtriage-analyzer`.


### PR DESCRIPTION
### Motivation
- Make `tailtriage-analyzer` crate README self-contained for crates.io consumption by removing repo-relative `../docs/` links and providing in-place interpretation guidance. 
- Prevent regression by adding validator checks so published analyzer docs cannot rely on repository-local docs and must include the required interpretation tokens and heading. 
- Small clarifications improve user understanding of default feature/dependency nuance, owned-handle lifecycle note, and CLI exit behavior without changing public APIs or runtime behavior. 

### Description
- Update `tailtriage-analyzer/README.md` to remove the two repo-relative `../docs/` links and add a concise `## How to interpret a report` section that explicitly states: `primary_suspect`, `secondary_suspects`, `evidence[]`, `next_checks[]`, `score`, `confidence`, `warnings[]`, `evidence_quality`, `route_breakdowns`, `temporal_segments`, and the distinction between `Report JSON` and `Run artifact JSON`.
- Extend `scripts/validate_docs_contracts.py` in `validate_analyzer_cli_docs_split_contract()` to fail if the analyzer README contains `"../docs/"`, to require the exact heading `## How to interpret a report`, and to require the new interpretation tokens (`primary_suspect`, `secondary_suspects`, `evidence[]`, `next_checks[]`, `score`, `confidence`, `evidence_quality`, `route_breakdowns`, `temporal_segments`, `Report JSON`, `Run artifact JSON`).
- Add focused unit tests in `scripts/tests/test_validate_docs_contracts.py` that assert the validator fails when the analyzer README contains a `../docs/` link and when the `## How to interpret a report` heading is missing.
- Add a short note to `tailtriage/README.md` explaining that the `tokio` feature controls the public `tailtriage::tokio` namespace and that the default `controller` feature enables `tailtriage::controller` and may pull in Tokio-related dependencies internally via `tailtriage-tokio` even when the public `tailtriage::tokio` namespace is not enabled.
- Add a one-line owned-handle note to `tailtriage-core/README.md` describing `begin_request_owned(...)` / `begin_request_with_owned(...)` usage for `Arc<Tailtriage>` flows and reiterating the completion-once lifecycle rule.
- Add one factual CLI behavior sentence to `tailtriage-cli/README.md` stating that loader, parse, validation, and render errors return a non-zero process exit through the CLI.
- Files changed: `tailtriage-analyzer/README.md`, `scripts/validate_docs_contracts.py`, `scripts/tests/test_validate_docs_contracts.py`, `tailtriage/README.md`, `tailtriage-core/README.md`, `tailtriage-cli/README.md`.

### Testing
- Ran `cargo fmt --check` and it passed. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it passed without warnings. 
- Ran `cargo test --workspace` and all unit tests and doctests passed. 
- Ran `python3 scripts/validate_docs_contracts.py` and the docs-contract validation passed, including the new analyzer README checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd7e3626408330af4ff6a90b02b702)