### PR TITLE
Make analyzer README self-contained for crates.io and tighten docs-contract validation

### DIFF
--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -277,6 +277,64 @@ Run artifact JSON is input; Report JSON is output; CLI does not consume Report J
                 with self.assertRaisesRegex(ValueError, r"render_json"):
                     validate_docs_contracts.validate_analyzer_cli_docs_split_contract()
 
+    def test_analyzer_readme_validation_fails_when_repo_relative_docs_links_present(self) -> None:
+        analyzer_text = """
+tailtriage-analyzer is in-process analysis for completed Run values and returns a typed Report.
+Use analyze_run(run, AnalyzeOptions::default()) and render_text(&report).
+Use render_json(&report), render_json_pretty(&report), analyze_run_json(run, AnalyzeOptions::default()),
+and analyze_run_json_pretty(run, AnalyzeOptions::default()).
+This crate is not streaming / not live streaming and references tailtriage-cli.
+## How to interpret a report
+primary_suspect secondary_suspects evidence[] next_checks[] score confidence evidence_quality route_breakdowns temporal_segments Report JSON Run artifact JSON
+See ../docs/diagnostics.md
+"""
+        cli_text = """
+tailtriage-cli loads saved run artifacts from disk, performs schema validation,
+enforces non-empty requests loader rules, uses tailtriage-analyzer, and provides command-line text/json output.
+Rust in-process users should use tailtriage-analyzer.
+Run artifact JSON is input; Report JSON is output; CLI does not consume Report JSON as input.
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            analyzer_readme = repo_root / "tailtriage-analyzer" / "README.md"
+            cli_readme = repo_root / "tailtriage-cli" / "README.md"
+            analyzer_readme.parent.mkdir(parents=True, exist_ok=True)
+            cli_readme.parent.mkdir(parents=True, exist_ok=True)
+            analyzer_readme.write_text(analyzer_text, encoding="utf-8")
+            cli_readme.write_text(cli_text, encoding="utf-8")
+
+            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root):
+                with self.assertRaisesRegex(ValueError, r"must not contain ../docs/ links"):
+                    validate_docs_contracts.validate_analyzer_cli_docs_split_contract()
+
+    def test_analyzer_readme_validation_fails_when_interpret_heading_missing(self) -> None:
+        analyzer_text = """
+tailtriage-analyzer is in-process analysis for completed Run values and returns a typed Report.
+Use analyze_run(run, AnalyzeOptions::default()) and render_text(&report).
+Use render_json(&report), render_json_pretty(&report), analyze_run_json(run, AnalyzeOptions::default()),
+and analyze_run_json_pretty(run, AnalyzeOptions::default()).
+This crate is not streaming / not live streaming and references tailtriage-cli.
+primary_suspect secondary_suspects evidence[] next_checks[] score confidence evidence_quality route_breakdowns temporal_segments Report JSON Run artifact JSON
+"""
+        cli_text = """
+tailtriage-cli loads saved run artifacts from disk, performs schema validation,
+enforces non-empty requests loader rules, uses tailtriage-analyzer, and provides command-line text/json output.
+Rust in-process users should use tailtriage-analyzer.
+Run artifact JSON is input; Report JSON is output; CLI does not consume Report JSON as input.
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            analyzer_readme = repo_root / "tailtriage-analyzer" / "README.md"
+            cli_readme = repo_root / "tailtriage-cli" / "README.md"
+            analyzer_readme.parent.mkdir(parents=True, exist_ok=True)
+            cli_readme.parent.mkdir(parents=True, exist_ok=True)
+            analyzer_readme.write_text(analyzer_text, encoding="utf-8")
+            cli_readme.write_text(cli_text, encoding="utf-8")
+
+            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root):
+                with self.assertRaisesRegex(ValueError, r"How to interpret a report"):
+                    validate_docs_contracts.validate_analyzer_cli_docs_split_contract()
+
     def test_cli_readme_validation_fails_without_report_vs_run_artifact_distinction(self) -> None:
         analyzer_text = """
 tailtriage-analyzer is in-process analysis for completed Run values and returns a typed Report.

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -623,6 +623,33 @@ def validate_analyzer_cli_docs_split_contract() -> None:
         if token not in analyzer_lower:
             raise ValueError(f"tailtriage-analyzer README missing required concept/token: {token}")
 
+    if "../docs/" in analyzer_text:
+        raise ValueError("tailtriage-analyzer README must not contain ../docs/ links")
+
+    if "## How to interpret a report" not in analyzer_text:
+        raise ValueError(
+            "tailtriage-analyzer README must include exact heading: ## How to interpret a report"
+        )
+
+    analyzer_interpretation_required = (
+        "primary_suspect",
+        "secondary_suspects",
+        "evidence[]",
+        "next_checks[]",
+        "score",
+        "confidence",
+        "evidence_quality",
+        "route_breakdowns",
+        "temporal_segments",
+        "Report JSON",
+        "Run artifact JSON",
+    )
+    for token in analyzer_interpretation_required:
+        if token not in analyzer_text:
+            raise ValueError(
+                f"tailtriage-analyzer README interpretation section missing required token: {token}"
+            )
+
     if "not streaming" not in analyzer_lower and "not live streaming" not in analyzer_lower:
         raise ValueError("tailtriage-analyzer README must state it is not streaming/live-streaming")
 

--- a/tailtriage-analyzer/README.md
+++ b/tailtriage-analyzer/README.md
@@ -69,10 +69,17 @@ fn render_report(run: &Run) -> Result<String, Box<dyn std::error::Error>> {
 
 `Report` includes request counts, latency percentiles, queue/service share summaries, warnings, evidence quality, ranked suspects, and optional supporting route/temporal sections.
 
-See root docs for interpretation guidance:
+## How to interpret a report
 
-- [`docs/diagnostics.md`](../docs/diagnostics.md)
-- [`docs/user-guide.md`](../docs/user-guide.md)
+- `primary_suspect` is the strongest triage lead for the analyzed run, not proof of root cause.
+- `secondary_suspects` are lower-ranked leads worth checking when evidence is close or the primary lead does not explain the incident.
+- `evidence[]` explains why a suspect was ranked.
+- `next_checks[]` gives targeted follow-up actions.
+- `score` ranks suspects inside one report; it is not a probability.
+- `confidence` is ranking strength and may be capped by missing, sparse, partial, or truncated evidence.
+- `warnings[]` and `evidence_quality` describe interpretation limits.
+- `route_breakdowns` and `temporal_segments`, when present, are supporting context only and do not override the global `primary_suspect`.
+- Report JSON is analyzer output and is distinct from raw Run artifact JSON.
 
 ## Migration note
 

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -146,6 +146,8 @@ Current contract:
 - `requests` must contain at least one request event
 - artifacts with an empty `requests` array are rejected by the CLI loader
 
+Loader, parse, validation, and render failures return a non-zero process exit through the CLI.
+
 For Rust in-process usage, use `tailtriage-analyzer` directly (`analyze_run`, `render_text`, typed `Report`).
 The stricter non-empty `requests` rule applies to CLI artifact loading from disk.
 

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -54,6 +54,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 - `started.handle` for queue/stage/inflight instrumentation
 - `started.completion` for explicit finish
 
+When handles must move across spawned tasks or helper layers with `Arc<Tailtriage>`, use `begin_request_owned(...)` / `begin_request_with_owned(...)`. Owned handles keep the same lifecycle rule: instrumentation does not finish the request, and the completion token must still be finished exactly once.
+
 ```rust,no_run
 use tailtriage_core::{RequestOptions, Tailtriage};
 

--- a/tailtriage/README.md
+++ b/tailtriage/README.md
@@ -115,6 +115,7 @@ Choose a focused crate only when you need a narrower boundary:
 - `full`: enables `controller`, `tokio`, and `axum`
 
 Docs.rs note: `tailtriage` docs are built with `all-features = true`, so docs.rs may render optional namespaces such as `tailtriage::tokio` and `tailtriage::axum`. In downstream crates, those namespaces are available only when their Cargo features are enabled.
+Note: the `tokio` feature controls the public `tailtriage::tokio` namespace. The default `controller` feature enables `tailtriage::controller`; controller-managed runtime sampling uses `tailtriage-tokio` internally, so default controller builds may include Tokio-related dependencies even when the public `tailtriage::tokio` namespace is not enabled.
 
 ## Important constraints
 


### PR DESCRIPTION
### Motivation

- The analyzer crate README linked repository-local docs that are not packaged to crates.io, causing an incomplete crates.io README and potential user confusion.  
- Enforceable checks are needed so this regression does not reappear when editing docs.  
- Clarify a small feature/dep nuance and a couple of short UX notes so crate READMEs match the repo truth without changing behavior or APIs.

### Description

- Replace repo-relative links in `tailtriage-analyzer/README.md` with a self-contained section titled exactly `## How to interpret a report` that describes `primary_suspect`, `secondary_suspects`, `evidence[]`, `next_checks[]`, `score`, `confidence`, `warnings[]`, `evidence_quality`, `route_breakdowns`, `temporal_segments`, and the distinction between Report JSON and Run artifact JSON.  (file changed: `tailtriage-analyzer/README.md`)
- Extend `scripts/validate_docs_contracts.py` to fail when `tailtriage-analyzer/README.md` contains `../docs/`, to require the exact heading `## How to interpret a report`, and to require the presence of the interpretation tokens `primary_suspect`, `secondary_suspects`, `evidence[]`, `next_checks[]`, `score`, `confidence`, `evidence_quality`, `route_breakdowns`, `temporal_segments`, `Report JSON`, and `Run artifact JSON`.  (file changed: `scripts/validate_docs_contracts.py`)
- Add focused unit tests exercising the new validator rules: one test fails when analyzer README contains `../docs/`, and one fails when the `## How to interpret a report` heading is missing; tests follow the style of existing validator tests.  (file changed: `scripts/tests/test_validate_docs_contracts.py`)
- Add a short note to `tailtriage/README.md` clarifying that the `tokio` feature controls the public `tailtriage::tokio` namespace and that the default `controller` feature enables `tailtriage::controller` and may pull Tokio-related dependencies internally via controller-managed runtime sampling.  (file changed: `tailtriage/README.md`)
- Add a one-line lifecycle note to `tailtriage-core/README.md` about `begin_request_owned(...)` / `begin_request_with_owned(...)` for `Arc<Tailtriage>` use and confirm the same exactly-once completion rule.  (file changed: `tailtriage-core/README.md`)
- Add one CLI behavior sentence to `tailtriage-cli/README.md` that loader/parse/validation/render failures return a non-zero process exit.  (file changed: `tailtriage-cli/README.md`)
- No public APIs, runtime behavior, Cargo dependencies, examples, demos, or version numbers were changed.

### Testing

- Ran `cargo fmt --check` which succeeded.  
- Ran `cargo clippy --workspace --all-targets -- -D warnings` which completed with no warnings (success).  
- Ran `cargo test --workspace` and all tests passed (unit tests and doc-tests completed successfully).  
- Ran `python3 scripts/validate_docs_contracts.py` and the docs validator passed, verifying the new analyzer README constraints and other existing doc contracts.

Files changed: `tailtriage-analyzer/README.md`, `scripts/validate_docs_contracts.py`, `scripts/tests/test_validate_docs_contracts.py`, `tailtriage/README.md`, `tailtriage-core/README.md`, `tailtriage-cli/README.md`.

Remaining limitations: these are documentation and validator updates only and do not change analyzer logic, CLI runtime behavior, or public APIs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd7e3626408330af4ff6a90b02b702)