### PR TITLE
docs: clarify user docs index & install path; shorten README example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [] - Unreleased
+## [Unreleased]
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -263,11 +263,8 @@ tailtriage analyze tailtriage-run.json --format json
     "kind": "application_queue_saturation",
     "score": 90,
     "confidence": "high",
-    "evidence": ["Queue wait at p95 consumes 98.2% of request time.", "Observed queue depth sample up to 230."],
-    "next_checks": [
-      "Inspect queue admission limits and producer burst patterns.",
-      "Compare queue wait distribution before and after increasing worker parallelism."
-    ],
+    "evidence": ["Queue wait at p95 consumes 98.2% of request time."],
+    "next_checks": ["Inspect queue admission limits and producer burst patterns."],
     "confidence_notes": []
   },
   "secondary_suspects": [
@@ -275,22 +272,16 @@ tailtriage analyze tailtriage-run.json --format json
       "kind": "downstream_stage_dominates",
       "score": 55,
       "confidence": "low",
-      "evidence": [
-        "Stage 'simulated_work' has p95 latency 26566 us across 250 samples.",
-        "Stage 'simulated_work' cumulative latency is 6546159 us.",
-        "Stage 'simulated_work' contributes 33 permille of cumulative request latency."
-      ],
-      "next_checks": [
-        "Inspect downstream dependency behind stage 'simulated_work'.",
-        "Collect downstream service timings and retry behavior during tail windows.",
-        "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      "evidence": ["Stage 'simulated_work' has p95 latency 26566 us across 250 samples."],
+      "next_checks": ["Inspect downstream dependency behind stage 'simulated_work'."]
     }
   ],
   "route_breakdowns": [],
   "temporal_segments": []
 }
 ```
+
+For full report-field interpretation, see [`docs/diagnostics.md`](docs/diagnostics.md) and [`tailtriage-cli/README.md`](tailtriage-cli/README.md).
 
 `temporal_segments` is always present in JSON output and is usually an empty array. It is populated only when conservative within-run early/late checks find material signal movement (for example, different early/late primary suspects or a large early/late p95 shift). The global `primary_suspect` remains the primary full-run triage lead. Temporal segments are supporting within-run hints only and do not prove a phase-specific root cause. A temporal p95 warning means early/late latency changed materially in that run. Runtime and in-flight phase attribution is timestamp-filtered to each segment window and can be limited when those segment-filtered samples are sparse; with overlapping early/late request windows under concurrency, timestamp-filtered runtime/in-flight attribution is approximate.
 
@@ -356,6 +347,6 @@ Demo walkthrough and CI coverage details: [`docs/getting-started-demo.md`](docs/
 
 ## Documentation
 
-The complete documentation index lives in [`docs/README.md`](docs/README.md).
+The canonical user documentation index lives in [`docs/README.md`](docs/README.md).
 
 Start there for the user workflow, crate selection, controller configuration, analyzer and CLI contracts, diagnostics interpretation, demos, validation, runtime-cost measurement, collector limits, and architecture.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # tailtriage documentation
 
-This is the canonical documentation index for `tailtriage`.
+This is the canonical user documentation index for `tailtriage`.
 
 `tailtriage` is a Rust toolkit for Tokio tail-latency triage. It helps turn one captured run into evidence-ranked suspects and targeted next checks. Suspects are triage leads, not proof of root cause.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -9,12 +9,17 @@ For most services, use:
 - `tailtriage` for capture instrumentation
 - `tailtriage-cli` for artifact analysis/report generation
 
-Install:
+Install (default CLI path):
 
 ```bash
 cargo add tailtriage
-cargo add tailtriage-analyzer
 cargo install tailtriage-cli
+```
+
+For embedded/in-process Rust analysis and report generation, add `tailtriage-analyzer`:
+
+```bash
+cargo add tailtriage-analyzer
 ```
 
 Optional integrations:


### PR DESCRIPTION
### Motivation
- Clarify that the docs index is the canonical user documentation index and avoid implying every repo Markdown file is user-facing.
- Make the default installation guidance explicit for first-time users by favoring the CLI-first adoption path while still documenting the in-process analyzer option.
- Reduce cognitive load for first-time readers by shortening the representative JSON example in the root `README.md` while preserving the expected top-level report shape.
- Fix a minor formatting issue in `CHANGELOG.md` (unreleased heading) to match repository conventions.

### Description
- Updated `docs/README.md` to replace “This is the canonical documentation index for `tailtriage`.” with “This is the canonical user documentation index for `tailtriage`.” without changing any links.
- Updated `README.md` to use the matching user-doc wording, shorten the representative JSON example (preserving top-level keys and `primary_suspect` shape) and add a pointer to `docs/diagnostics.md` and `tailtriage-cli/README.md` for full field interpretation.
- Updated `docs/user-guide.md` to make the default CLI install path explicitly show the recommended CLI-first flow with `cargo add tailtriage` + `cargo install tailtriage-cli`, and added a short note immediately after for in-process Rust analysis showing `cargo add tailtriage-analyzer` with wording that it is only needed for in-process analysis/report generation.
- Fixed the `CHANGELOG.md` header from `## [] - Unreleased` to `## [Unreleased]`.
- The docs contract validator (`scripts/validate_docs_contracts.py`) did not require changes because the shortened example still satisfies the existing shape validation.

### Testing
- Ran `python3 scripts/validate_docs_contracts.py` and it completed successfully (`docs contracts validated successfully`).
- Ran `cargo fmt --check` and it passed.
- Did not run `cargo clippy --workspace --all-targets -- -D warnings` or `cargo test --workspace` because this change is docs-only and those checks were not requested for this task.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd96205c8083309179c95a6aa87646)