### PR TITLE
docs: clarify user docs index, onboarding, and README report example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [] - Unreleased
+## [Unreleased]
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -263,11 +263,8 @@ tailtriage analyze tailtriage-run.json --format json
     "kind": "application_queue_saturation",
     "score": 90,
     "confidence": "high",
-    "evidence": ["Queue wait at p95 consumes 98.2% of request time.", "Observed queue depth sample up to 230."],
-    "next_checks": [
-      "Inspect queue admission limits and producer burst patterns.",
-      "Compare queue wait distribution before and after increasing worker parallelism."
-    ],
+    "evidence": ["Queue wait at p95 consumes 98.2% of request time."],
+    "next_checks": ["Inspect queue admission limits and producer burst patterns."],
     "confidence_notes": []
   },
   "secondary_suspects": [
@@ -275,22 +272,15 @@ tailtriage analyze tailtriage-run.json --format json
       "kind": "downstream_stage_dominates",
       "score": 55,
       "confidence": "low",
-      "evidence": [
-        "Stage 'simulated_work' has p95 latency 26566 us across 250 samples.",
-        "Stage 'simulated_work' cumulative latency is 6546159 us.",
-        "Stage 'simulated_work' contributes 33 permille of cumulative request latency."
-      ],
-      "next_checks": [
-        "Inspect downstream dependency behind stage 'simulated_work'.",
-        "Collect downstream service timings and retry behavior during tail windows.",
-        "Review downstream SLO/error budget and align retry budget/backoff with it."
-      ]
+      "evidence": ["Stage 'simulated_work' has p95 latency 26566 us across 250 samples."],
+      "next_checks": ["Inspect downstream dependency behind stage 'simulated_work'."]
     }
   ],
   "route_breakdowns": [],
   "temporal_segments": []
 }
 ```
+See [`docs/diagnostics.md`](docs/diagnostics.md) and [`tailtriage-cli/README.md`](tailtriage-cli/README.md) for full report-field interpretation details.
 
 `temporal_segments` is always present in JSON output and is usually an empty array. It is populated only when conservative within-run early/late checks find material signal movement (for example, different early/late primary suspects or a large early/late p95 shift). The global `primary_suspect` remains the primary full-run triage lead. Temporal segments are supporting within-run hints only and do not prove a phase-specific root cause. A temporal p95 warning means early/late latency changed materially in that run. Runtime and in-flight phase attribution is timestamp-filtered to each segment window and can be limited when those segment-filtered samples are sparse; with overlapping early/late request windows under concurrency, timestamp-filtered runtime/in-flight attribution is approximate.
 
@@ -356,6 +346,6 @@ Demo walkthrough and CI coverage details: [`docs/getting-started-demo.md`](docs/
 
 ## Documentation
 
-The complete documentation index lives in [`docs/README.md`](docs/README.md).
+The canonical user documentation index lives in [`docs/README.md`](docs/README.md).
 
 Start there for the user workflow, crate selection, controller configuration, analyzer and CLI contracts, diagnostics interpretation, demos, validation, runtime-cost measurement, collector limits, and architecture.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # tailtriage documentation
 
-This is the canonical documentation index for `tailtriage`.
+This is the canonical user documentation index for `tailtriage`.
 
 `tailtriage` is a Rust toolkit for Tokio tail-latency triage. It helps turn one captured run into evidence-ranked suspects and targeted next checks. Suspects are triage leads, not proof of root cause.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -9,12 +9,17 @@ For most services, use:
 - `tailtriage` for capture instrumentation
 - `tailtriage-cli` for artifact analysis/report generation
 
-Install:
+Install (default CLI path):
 
 ```bash
 cargo add tailtriage
-cargo add tailtriage-analyzer
 cargo install tailtriage-cli
+```
+
+For embedded in-process Rust analysis/report generation only, also add:
+
+```bash
+cargo add tailtriage-analyzer
 ```
 
 Optional integrations:


### PR DESCRIPTION
### Motivation
- Reduce user confusion about which Markdown files are intended as product-facing docs versus repository/maintenance artifacts.  
- Make the default installation path and crate roles explicit for first-time users to avoid ambiguous `tailtriage-analyzer` vs CLI guidance.  
- Shorten the representative CLI JSON in the root `README` to reduce first-time reader cognitive load while preserving the report shape needed by the docs contract validator.

### Description
- Update `docs/README.md` to say "This is the canonical user documentation index for `tailtriage`." instead of implying every Markdown file is part of user docs.  
- Update `README.md` to use the same user-docs wording, shorten the representative `Report` JSON sample while preserving top-level object shape and primary suspect fields, and add a pointer to `docs/diagnostics.md` and `tailtriage-cli/README.md` for full field interpretation.  
- Update `docs/user-guide.md` install instructions so the default CLI path shows `cargo add tailtriage` and `cargo install tailtriage-cli`, and add a short explicit note plus code block that `cargo add tailtriage-analyzer` is only for embedded/in-process Rust analysis.  
- Fix `CHANGELOG.md` heading from `## [] - Unreleased` to `## [Unreleased]`.  
- No changes to Rust code, public APIs, dependencies, or validator logic were required.

### Testing
- Ran `python3 scripts/validate_docs_contracts.py` and it passed with: `docs contracts validated successfully`.  
- Ran `cargo fmt --check` and it passed.  
- Not run: `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace` because the requested task was limited to documentation edits and the docs-contract validator plus formatting checks were the required validations for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd96205c8083309179c95a6aa87646)