### PR TITLE
docs: include README in tailtriage-analyzer rustdoc and add validator

### DIFF
--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -25,6 +25,9 @@ class ValidateDocsContractsTests(unittest.TestCase):
         validate_docs_contracts.validate_readme_analyzer_example()
         validate_docs_contracts.validate_controller_readme_toml()
 
+    def test_crate_rustdocs_include_readmes_contract(self) -> None:
+        validate_docs_contracts.validate_crate_rustdocs_include_readmes()
+
     def test_docs_index_contract(self) -> None:
         validate_docs_contracts.validate_docs_index_contract()
 

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -23,6 +23,15 @@ ANALYSIS_FIXTURE_PATH = REPO_ROOT / "demos" / "queue_service" / "fixtures" / "sa
 CONTROLLER_SOURCE_PATH = REPO_ROOT / "tailtriage-controller" / "src" / "lib.rs"
 CORE_COLLECTOR_SOURCE_PATH = REPO_ROOT / "tailtriage-core" / "src" / "collector.rs"
 CORE_LIB_SOURCE_PATH = REPO_ROOT / "tailtriage-core" / "src" / "lib.rs"
+CRATE_RUSTDOC_INCLUDE_README_PATHS = (
+    REPO_ROOT / "tailtriage" / "src" / "lib.rs",
+    REPO_ROOT / "tailtriage-core" / "src" / "lib.rs",
+    REPO_ROOT / "tailtriage-controller" / "src" / "lib.rs",
+    REPO_ROOT / "tailtriage-tokio" / "src" / "lib.rs",
+    REPO_ROOT / "tailtriage-axum" / "src" / "lib.rs",
+    REPO_ROOT / "tailtriage-analyzer" / "src" / "lib.rs",
+    REPO_ROOT / "tailtriage-cli" / "src" / "lib.rs",
+)
 PUBLIC_DOCS_GLOB = (REPO_ROOT / "docs").glob("*.md")
 USER_FACING_TERMINOLOGY_PATHS = (
     README_PATH,
@@ -421,6 +430,21 @@ def validate_no_stale_controller_policy_names() -> None:
     if hits:
         joined = "\n".join(hits)
         raise ValueError(f"stale controller run_end_policy docs found:\n{joined}")
+
+
+def validate_crate_rustdocs_include_readmes() -> None:
+    required_token = '#![doc = include_str!("../README.md")]'
+    missing: list[str] = []
+    for path in CRATE_RUSTDOC_INCLUDE_README_PATHS:
+        text = path.read_text(encoding="utf-8")
+        if required_token not in text:
+            missing.append(path.relative_to(REPO_ROOT).as_posix())
+
+    if missing:
+        raise ValueError(
+            "crate rustdoc README include contract violation; missing token "
+            f'{required_token!r} in: {missing}'
+        )
 
 
 def normalize_doc_link(link: str) -> str:
@@ -885,6 +909,7 @@ def validate_sampler_integration_boundary() -> None:
 def main() -> int:
     _ = parse_args()
     validate_readme_analyzer_example()
+    validate_crate_rustdocs_include_readmes()
     validate_controller_readme_toml()
     validate_no_stale_controller_policy_names()
     validate_docs_index_contract()

--- a/tailtriage-analyzer/src/lib.rs
+++ b/tailtriage-analyzer/src/lib.rs
@@ -1,22 +1,4 @@
-//! Heuristic triage analyzer for completed [`tailtriage_core::Run`] captures.
-//!
-//! This crate analyzes one completed in-memory [`Run`] and returns a typed
-//! [`Report`] for in-process diagnosis.
-//! It is intended for completed/finalized captures or stable snapshots;
-//! callers that require finalized artifacts should validate that separately.
-//! It does not load run artifacts from disk and it does not
-//! write capture artifacts; CLI artifact loading is owned by `tailtriage-cli`.
-//!
-//! Use [`analyze_run`] (or [`Analyzer`]) to produce a [`Report`], then:
-//!
-//! - call [`render_text`] for human-readable triage output;
-//! - call [`render_json`] for compact analysis report JSON;
-//! - call [`render_json_pretty`] for canonical pretty analysis report JSON.
-//!
-//! The analysis report JSON is distinct from raw run artifact JSON produced by capture/artifact
-//! workflows. Raw run artifacts remain available for later CLI analysis.
-//!
-//! Analyzer semantics are currently batch/snapshot based for one completed run, not streaming.
+#![doc = include_str!("../README.md")]
 
 use std::collections::{BTreeMap, HashMap};
 

--- a/tailtriage/README.md
+++ b/tailtriage/README.md
@@ -23,15 +23,9 @@ The analysis result is triage guidance (evidence-ranked suspects plus next check
 | p95/p99 latency spikes | whether tail latency is dominated by queueing, executor pressure, blocking-pool pressure, or downstream stage latency |
 | intermittent request timeouts | whether slow requests share a common bottleneck family in one captured run |
 | low CPU but high latency | whether requests are waiting in queues, blocked behind constrained resources, or delayed by downstream work |
-| requests appear stuck | whether time is spent before work starts, inside service execution, or in a named downstream stage |
 | suspected blocking in async code | whether blocking-pool pressure is visible and should be investigated with a targeted follow-up |
 | Tokio runtime seems overloaded | whether captured runtime-pressure signals point toward executor contention rather than app-level queueing |
-| queue buildup before work starts | whether application queue wait dominates p95 latency |
 | slow database or external API suspected | whether a downstream stage dominates request latency enough to be the next check |
-| flaky latency in staging or production | which bottleneck family is the strongest lead from a bounded capture window |
-| hard-to-reproduce tail spikes | whether a captured slow window contains enough evidence to choose the next experiment |
-| unclear profiler results | whether queueing, runtime pressure, blocking-pool pressure, or downstream waiting explains the tail before pursuing CPU hot paths |
-| service has partial instrumentation only | whether available request, queue, stage, runtime, or inflight signals are enough for a useful triage lead |
 
 ## Installation
 


### PR DESCRIPTION
### Motivation
- Ensure crates published to crates.io/docs.rs show the same self-contained README rustdoc and prevent regressions. 
- Lock down analyzer vs CLI/docs wording so users see clear triage guidance (evidence-ranked suspects and next checks) without requiring GitHub-only links. 

### Description
- Replace the crate-level rustdoc in `tailtriage-analyzer/src/lib.rs` with `#![doc = include_str!("../README.md")]` so docs.rs renders the README content in rustdoc. 
- Add `validate_crate_rustdocs_include_readmes()` to `scripts/validate_docs_contracts.py` and wire it into the script main flow to require the exact token `#![doc = include_str!("../README.md")]` in these crate roots: `tailtriage`, `tailtriage-core`, `tailtriage-controller`, `tailtriage-tokio`, `tailtriage-axum`, `tailtriage-analyzer`, and `tailtriage-cli`. 
- Add a unit test `test_crate_rustdocs_include_readmes_contract` in `scripts/tests/test_validate_docs_contracts.py` to prevent regression. 
- Shorten `tailtriage/README.md` “Common use cases” table from 12 rows to the requested 6 representative rows while preserving product positioning and triage language. 
- Files changed: `tailtriage-analyzer/src/lib.rs`, `scripts/validate_docs_contracts.py`, `scripts/tests/test_validate_docs_contracts.py`, `tailtriage/README.md`. 

### Testing
- Ran formatting and lint pipelines: `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings` (both passed). 
- Ran unit and integration tests: `cargo test --workspace` (all tests passed). 
- Built documentation: `cargo doc --workspace --all-features --no-deps` (succeeded; noted Cargo doc filename-collision warning only). 
- Ran docs contract validation: `python3 scripts/validate_docs_contracts.py` (succeeded and the new check is exercised by an added unit test).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd9c4c7e1c8330b3ea32349fee92f8)