### PR TITLE
docs: include analyzer README in rustdoc & enforce README include contract

### DIFF
--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -25,6 +25,9 @@ class ValidateDocsContractsTests(unittest.TestCase):
         validate_docs_contracts.validate_readme_analyzer_example()
         validate_docs_contracts.validate_controller_readme_toml()
 
+    def test_crate_rustdocs_include_readmes_contract(self) -> None:
+        validate_docs_contracts.validate_crate_rustdocs_include_readmes()
+
     def test_docs_index_contract(self) -> None:
         validate_docs_contracts.validate_docs_index_contract()
 

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -110,6 +110,16 @@ STALE_VALIDATION_DOC_PHRASES = (
     "no in normal pr ci",
 )
 
+RUSTDOC_README_INCLUDE_PATHS = (
+    REPO_ROOT / "tailtriage" / "src" / "lib.rs",
+    REPO_ROOT / "tailtriage-core" / "src" / "lib.rs",
+    REPO_ROOT / "tailtriage-controller" / "src" / "lib.rs",
+    REPO_ROOT / "tailtriage-tokio" / "src" / "lib.rs",
+    REPO_ROOT / "tailtriage-axum" / "src" / "lib.rs",
+    REPO_ROOT / "tailtriage-analyzer" / "src" / "lib.rs",
+    REPO_ROOT / "tailtriage-cli" / "src" / "lib.rs",
+)
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Validate public docs contracts.")
@@ -185,6 +195,21 @@ def assert_same_object_shape(*, name: str, actual: dict[str, Any], expected: dic
         if actual_kind != expected_kind:
             raise ValueError(f"{name}.{key} type drift: expected {expected_kind}, got {actual_kind}")
 
+
+
+def validate_crate_rustdocs_include_readmes() -> None:
+    required = '#![doc = include_str!("../README.md")]'
+    missing: list[str] = []
+    for path in RUSTDOC_README_INCLUDE_PATHS:
+        source = path.read_text(encoding="utf-8")
+        if required not in source:
+            missing.append(str(path.relative_to(REPO_ROOT)))
+
+    if missing:
+        raise ValueError(
+            "crate rustdoc include_str README contract failed for: "
+            + ", ".join(sorted(missing))
+        )
 
 def validate_readme_analyzer_example() -> None:
     readme_text = README_PATH.read_text(encoding="utf-8")
@@ -901,6 +926,7 @@ def main() -> int:
     validate_no_user_facing_facade_wording()
     validate_controller_example_usage_contract()
     validate_sampler_integration_boundary()
+    validate_crate_rustdocs_include_readmes()
     print("docs contracts validated successfully")
     return 0
 

--- a/tailtriage-analyzer/src/lib.rs
+++ b/tailtriage-analyzer/src/lib.rs
@@ -1,22 +1,5 @@
-//! Heuristic triage analyzer for completed [`tailtriage_core::Run`] captures.
-//!
-//! This crate analyzes one completed in-memory [`Run`] and returns a typed
-//! [`Report`] for in-process diagnosis.
-//! It is intended for completed/finalized captures or stable snapshots;
-//! callers that require finalized artifacts should validate that separately.
-//! It does not load run artifacts from disk and it does not
-//! write capture artifacts; CLI artifact loading is owned by `tailtriage-cli`.
-//!
-//! Use [`analyze_run`] (or [`Analyzer`]) to produce a [`Report`], then:
-//!
-//! - call [`render_text`] for human-readable triage output;
-//! - call [`render_json`] for compact analysis report JSON;
-//! - call [`render_json_pretty`] for canonical pretty analysis report JSON.
-//!
-//! The analysis report JSON is distinct from raw run artifact JSON produced by capture/artifact
-//! workflows. Raw run artifacts remain available for later CLI analysis.
-//!
-//! Analyzer semantics are currently batch/snapshot based for one completed run, not streaming.
+#![doc = include_str!("../README.md")]
+#![warn(missing_docs)]
 
 use std::collections::{BTreeMap, HashMap};
 

--- a/tailtriage/README.md
+++ b/tailtriage/README.md
@@ -23,15 +23,9 @@ The analysis result is triage guidance (evidence-ranked suspects plus next check
 | p95/p99 latency spikes | whether tail latency is dominated by queueing, executor pressure, blocking-pool pressure, or downstream stage latency |
 | intermittent request timeouts | whether slow requests share a common bottleneck family in one captured run |
 | low CPU but high latency | whether requests are waiting in queues, blocked behind constrained resources, or delayed by downstream work |
-| requests appear stuck | whether time is spent before work starts, inside service execution, or in a named downstream stage |
 | suspected blocking in async code | whether blocking-pool pressure is visible and should be investigated with a targeted follow-up |
 | Tokio runtime seems overloaded | whether captured runtime-pressure signals point toward executor contention rather than app-level queueing |
-| queue buildup before work starts | whether application queue wait dominates p95 latency |
 | slow database or external API suspected | whether a downstream stage dominates request latency enough to be the next check |
-| flaky latency in staging or production | which bottleneck family is the strongest lead from a bounded capture window |
-| hard-to-reproduce tail spikes | whether a captured slow window contains enough evidence to choose the next experiment |
-| unclear profiler results | whether queueing, runtime pressure, blocking-pool pressure, or downstream waiting explains the tail before pursuing CPU hot paths |
-| service has partial instrumentation only | whether available request, queue, stage, runtime, or inflight signals are enough for a useful triage lead |
 
 ## Installation
 


### PR DESCRIPTION
### Motivation
- The `tailtriage-analyzer` crate had crate-level rustdocs that duplicated or diverged from its README, causing crates.io/docs.rs inconsistency and a publication-readiness gap.
- Add an automated docs-contract check to prevent regressions where crate lib rustdocs must include the crate README, ensuring docs.rs renders the standalone README content.
- Reduce repetitive rows in the default `tailtriage` README to keep the crate README concise and focused for crates.io while preserving product positioning.

### Description
- Replaced the top crate-level documentation in `tailtriage-analyzer/src/lib.rs` with `#![doc = include_str!("../README.md")]` and retained `#![warn(missing_docs)]` so docs.rs renders the README content without duplicating text in `src/lib.rs`.
- Added `RUSTDOC_README_INCLUDE_PATHS` and a new `validate_crate_rustdocs_include_readmes()` validator to `scripts/validate_docs_contracts.py` and wired it into the script's main validation flow to enforce the include_str README contract across the published crates.
- Added a focused unit test `test_crate_rustdocs_include_readmes_contract` in `scripts/tests/test_validate_docs_contracts.py` covering the new validator.
- Shortened the “Common use cases” table in `tailtriage/README.md` from 12 rows to the requested 6 representative rows while preserving installation, feature flags, quick start, constraints, and related-crates guidance.
- No dependencies were added, no `Cargo.toml` changes were made, and no public API or product-scope changes were introduced.

### Testing
- Files changed: `tailtriage-analyzer/src/lib.rs`, `scripts/validate_docs_contracts.py`, `scripts/tests/test_validate_docs_contracts.py`, and `tailtriage/README.md`.
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, and `cargo doc --workspace --all-features --no-deps`, and all commands completed successfully in this environment.
- Ran `python3 scripts/validate_docs_contracts.py` and the script reported "docs contracts validated successfully" indicating the new validator passed.
- Publication blockers: none identified within the scope of these doc/validator changes; validation commands passed and no further changes are required for the specific gaps addressed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd9c4c7e1c8330b3ea32349fee92f8)