### PR TITLE
docs: include crate READMEs in rustdoc and add validator to prevent regressions

### DIFF
--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -156,6 +156,40 @@ Normal CI does not publish durable diagnostic scorecards.
     def test_capture_readmes_analyzer_cli_wording_contract(self) -> None:
         validate_docs_contracts.validate_capture_readmes_analyzer_cli_wording_contract()
 
+    def test_crate_rustdocs_include_readmes_contract(self) -> None:
+        validate_docs_contracts.validate_crate_rustdocs_include_readmes()
+
+    def test_crate_rustdocs_include_readmes_contract_fails_when_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            paths = []
+            for rel in (
+                "tailtriage/src/lib.rs",
+                "tailtriage-core/src/lib.rs",
+                "tailtriage-controller/src/lib.rs",
+                "tailtriage-tokio/src/lib.rs",
+                "tailtriage-axum/src/lib.rs",
+                "tailtriage-analyzer/src/lib.rs",
+                "tailtriage-cli/src/lib.rs",
+            ):
+                path = repo_root / rel
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text('#![doc = include_str!("../README.md")]\n', encoding="utf-8")
+                paths.append(path)
+
+            paths[-1].write_text("// missing include", encoding="utf-8")
+
+            with (
+                mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root),
+                mock.patch.object(
+                    validate_docs_contracts,
+                    "CRATE_RUSTDOC_README_INCLUDE_PATHS",
+                    tuple(paths),
+                ),
+            ):
+                with self.assertRaisesRegex(ValueError, r"tailtriage-cli/src/lib.rs"):
+                    validate_docs_contracts.validate_crate_rustdocs_include_readmes()
+
     def test_capture_readme_wording_rejects_cli_only_stale_phrase(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             repo_root = Path(tmp_dir)

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -110,6 +110,16 @@ STALE_VALIDATION_DOC_PHRASES = (
     "no in normal pr ci",
 )
 
+CRATE_RUSTDOC_README_INCLUDE_PATHS = (
+    REPO_ROOT / "tailtriage" / "src" / "lib.rs",
+    REPO_ROOT / "tailtriage-core" / "src" / "lib.rs",
+    REPO_ROOT / "tailtriage-controller" / "src" / "lib.rs",
+    REPO_ROOT / "tailtriage-tokio" / "src" / "lib.rs",
+    REPO_ROOT / "tailtriage-axum" / "src" / "lib.rs",
+    REPO_ROOT / "tailtriage-analyzer" / "src" / "lib.rs",
+    REPO_ROOT / "tailtriage-cli" / "src" / "lib.rs",
+)
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Validate public docs contracts.")
@@ -882,6 +892,17 @@ def validate_sampler_integration_boundary() -> None:
         )
 
 
+def validate_crate_rustdocs_include_readmes() -> None:
+    expected = '#![doc = include_str!("../README.md")]'
+    for path in CRATE_RUSTDOC_README_INCLUDE_PATHS:
+        text = path.read_text(encoding="utf-8")
+        if expected not in text:
+            relative = path.relative_to(REPO_ROOT)
+            raise ValueError(
+                f"{relative} must include crate README rustdocs via {expected}"
+            )
+
+
 def main() -> int:
     _ = parse_args()
     validate_readme_analyzer_example()
@@ -901,6 +922,7 @@ def main() -> int:
     validate_no_user_facing_facade_wording()
     validate_controller_example_usage_contract()
     validate_sampler_integration_boundary()
+    validate_crate_rustdocs_include_readmes()
     print("docs contracts validated successfully")
     return 0
 

--- a/tailtriage-analyzer/src/lib.rs
+++ b/tailtriage-analyzer/src/lib.rs
@@ -1,22 +1,4 @@
-//! Heuristic triage analyzer for completed [`tailtriage_core::Run`] captures.
-//!
-//! This crate analyzes one completed in-memory [`Run`] and returns a typed
-//! [`Report`] for in-process diagnosis.
-//! It is intended for completed/finalized captures or stable snapshots;
-//! callers that require finalized artifacts should validate that separately.
-//! It does not load run artifacts from disk and it does not
-//! write capture artifacts; CLI artifact loading is owned by `tailtriage-cli`.
-//!
-//! Use [`analyze_run`] (or [`Analyzer`]) to produce a [`Report`], then:
-//!
-//! - call [`render_text`] for human-readable triage output;
-//! - call [`render_json`] for compact analysis report JSON;
-//! - call [`render_json_pretty`] for canonical pretty analysis report JSON.
-//!
-//! The analysis report JSON is distinct from raw run artifact JSON produced by capture/artifact
-//! workflows. Raw run artifacts remain available for later CLI analysis.
-//!
-//! Analyzer semantics are currently batch/snapshot based for one completed run, not streaming.
+#![doc = include_str!("../README.md")]
 
 use std::collections::{BTreeMap, HashMap};
 

--- a/tailtriage/README.md
+++ b/tailtriage/README.md
@@ -23,15 +23,9 @@ The analysis result is triage guidance (evidence-ranked suspects plus next check
 | p95/p99 latency spikes | whether tail latency is dominated by queueing, executor pressure, blocking-pool pressure, or downstream stage latency |
 | intermittent request timeouts | whether slow requests share a common bottleneck family in one captured run |
 | low CPU but high latency | whether requests are waiting in queues, blocked behind constrained resources, or delayed by downstream work |
-| requests appear stuck | whether time is spent before work starts, inside service execution, or in a named downstream stage |
 | suspected blocking in async code | whether blocking-pool pressure is visible and should be investigated with a targeted follow-up |
 | Tokio runtime seems overloaded | whether captured runtime-pressure signals point toward executor contention rather than app-level queueing |
-| queue buildup before work starts | whether application queue wait dominates p95 latency |
 | slow database or external API suspected | whether a downstream stage dominates request latency enough to be the next check |
-| flaky latency in staging or production | which bottleneck family is the strongest lead from a bounded capture window |
-| hard-to-reproduce tail spikes | whether a captured slow window contains enough evidence to choose the next experiment |
-| unclear profiler results | whether queueing, runtime pressure, blocking-pool pressure, or downstream waiting explains the tail before pursuing CPU hot paths |
-| service has partial instrumentation only | whether available request, queue, stage, runtime, or inflight signals are enough for a useful triage lead |
 
 ## Installation
 


### PR DESCRIPTION
### Motivation
- Ensure crates show self-contained, accurate rustdoc on crates.io/docs.rs by making crate-level docs include their `README.md` rather than duplicating or omitting guidance.  
- Prevent regressions by adding an automated validator that enforces the README-included rustdoc pattern across published crates.  
- Reduce noisy repetition in the default crate README to improve the first-time user experience while preserving product positioning and required guidance.

### Description
- Replace the top-level crate doc in `tailtriage-analyzer/src/lib.rs` with `#![doc = include_str!("../README.md")]` so docs.rs and crates.io README remain the single source-of-truth.  
- Add `CRATE_RUSTDOC_README_INCLUDE_PATHS` and `validate_crate_rustdocs_include_readmes()` to `scripts/validate_docs_contracts.py`, and wire the new check into the script `main()` validation flow.  
- Add focused tests in `scripts/tests/test_validate_docs_contracts.py` to cover the new validator for both passing and failing scenarios.  
- Shorten the `tailtriage/README.md` “Common use cases” table from 12 rows to 6 representative rows while preserving installation, quick start, constraints, and crate-selection guidance.  
- Files changed: `tailtriage-analyzer/src/lib.rs`, `scripts/validate_docs_contracts.py`, `scripts/tests/test_validate_docs_contracts.py`, and `tailtriage/README.md`.

### Testing
- Ran `cargo fmt --check` which passed.  
- Ran `cargo clippy --workspace --all-targets -- -D warnings` which passed.  
- Ran `cargo test --workspace` and all unit and doctests passed.  
- Ran `cargo doc --workspace --all-features --no-deps` which completed successfully (Cargo emitted a known docs filename-collision warning for crates sharing the same name).  
- Ran `python3 scripts/validate_docs_contracts.py` and the docs contract validations (including the new README-include check) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd9c4c7e1c8330b3ea32349fee92f8)