### PR TITLE
tokio: add inflight_guard extension trait alias

### DIFF
--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -70,6 +70,20 @@ async fn demo() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+
+## Request-handle helper trait
+
+This crate also exports `TokioRequestHandleExt` for a discoverable in-flight helper alias:
+
+```rust
+use tailtriage_tokio::TokioRequestHandleExt;
+
+# fn demo(req: &tailtriage_core::RequestHandle<'_>) {
+let _guard = req.inflight_guard("db_pool_active");
+# }
+```
+
+`inflight_guard(...)` is equivalent to `inflight(...)` and keeps request completion explicit.
 ## Important constraints
 
 - `RuntimeSampler::start()` must run inside an active Tokio runtime

--- a/tailtriage-tokio/src/lib.rs
+++ b/tailtriage-tokio/src/lib.rs
@@ -19,6 +19,25 @@ use tokio::runtime::Handle;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
+/// Extension helper methods for request handles used with Tokio integrations.
+pub trait TokioRequestHandleExt {
+    /// Alias for [`tailtriage_core::RequestHandle::inflight`] and
+    /// [`tailtriage_core::OwnedRequestHandle::inflight`] for clearer RAII naming.
+    fn inflight_guard(&self, gauge: impl Into<String>) -> tailtriage_core::InflightGuard<'_>;
+}
+
+impl TokioRequestHandleExt for tailtriage_core::RequestHandle<'_> {
+    fn inflight_guard(&self, gauge: impl Into<String>) -> tailtriage_core::InflightGuard<'_> {
+        self.inflight(gauge)
+    }
+}
+
+impl TokioRequestHandleExt for tailtriage_core::OwnedRequestHandle {
+    fn inflight_guard(&self, gauge: impl Into<String>) -> tailtriage_core::InflightGuard<'_> {
+        self.inflight(gauge)
+    }
+}
+
 /// Returns the crate name for smoke-testing workspace wiring.
 #[must_use]
 pub const fn crate_name() -> &'static str {


### PR DESCRIPTION
### Motivation
- Provide a small, discoverable RAII-named alias for in-flight gauges in the Tokio integration so users can more easily find the guard-style API without changing existing semantics.

### Description
- Add `TokioRequestHandleExt` with `inflight_guard(...)` implemented for `tailtriage_core::RequestHandle<'_>` and `tailtriage_core::OwnedRequestHandle` in `tailtriage-tokio/src/lib.rs`, and document the helper in `tailtriage-tokio/README.md`.

### Testing
- Ran `cargo fmt --all` and `cargo test -p tailtriage-tokio`, both succeeded (unit tests and doc-tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdaa636aa48330b977b61543b66799)