### PR TITLE
Add TokioRequestHandleExt helpers for common Tokio primitives

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -219,7 +219,31 @@ When `primary_suspect.kind` is `insufficient_evidence`:
 
 Use [diagnostics.md](diagnostics.md) for interpretation details.
 
-## 10) Next docs
+
+## 10) Tokio primitive helpers
+
+```rust
+use tailtriage::tokio::TokioRequestHandleExt;
+```
+
+These helpers are shorthand for explicit `queue(...).await_on(...)`, `stage(...).await_on(...)`, and `inflight(...)`; they do not finish requests.
+
+| Use case                     | Helper                                   | Records   |
+| ---------------------------- | ---------------------------------------- | --------- |
+| DB pool / capacity wait      | `semaphore(...).acquire()`               | queue     |
+| owned permit wait            | `owned_semaphore(...).acquire_owned()`   | queue     |
+| worker queue receive         | `mpsc_recv(...)`                         | queue     |
+| bounded channel backpressure | `mpsc_send(...)`                         | queue     |
+| async mutex contention       | `mutex_lock(...)`                        | queue     |
+| async rwlock contention      | `rwlock_read(...)` / `rwlock_write(...)` | queue     |
+| spawned task result          | `join_task(...)`                         | stage     |
+| timeout-wrapped work         | `timeout_stage(...)`                     | stage     |
+| blocking pool work           | `spawn_blocking_stage(...)`              | stage     |
+| active bounded section       | `inflight_guard(...)`                    | in-flight |
+
+See `tailtriage-tokio/README.md` for a detailed example.
+
+## 11) Next docs
 
 - [Documentation index](README.md)
 - [Diagnostics guide](diagnostics.md)

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -27,6 +27,7 @@ Choose `tailtriage-tokio` when:
 - you already use `tailtriage-core` and want runtime snapshots in the same artifact
 - you want stronger evidence for runtime-related bottlenecks
 - you want direct control over sampler cadence and runtime snapshot retention
+- you want Tokio primitive helpers (`TokioRequestHandleExt`) for queue/stage/in-flight instrumentation around common Tokio waits
 
 Choose `tailtriage` instead when you want the default entry point and feature-gated access to this crate.
 
@@ -212,3 +213,55 @@ For those surfaces, use:
 - `tailtriage-controller`: repeated bounded windows
 - `tailtriage-analyzer`: in-process analysis/report generation for completed runs
 - `tailtriage-cli`: command-line analysis of saved run artifacts
+
+## Tokio primitive helper trait
+
+```rust
+use tailtriage_tokio::TokioRequestHandleExt;
+```
+
+```rust,ignore
+use tailtriage::tokio::TokioRequestHandleExt;
+```
+
+| Use case                     | Helper                                   | Records   |
+| ---------------------------- | ---------------------------------------- | --------- |
+| DB pool / capacity wait      | `semaphore(...).acquire()`               | queue     |
+| owned permit wait            | `owned_semaphore(...).acquire_owned()`   | queue     |
+| worker queue receive         | `mpsc_recv(...)`                         | queue     |
+| bounded channel backpressure | `mpsc_send(...)`                         | queue     |
+| async mutex contention       | `mutex_lock(...)`                        | queue     |
+| async rwlock contention      | `rwlock_read(...)` / `rwlock_write(...)` | queue     |
+| spawned task result          | `join_task(...)`                         | stage     |
+| timeout-wrapped work         | `timeout_stage(...)`                     | stage     |
+| blocking pool work           | `spawn_blocking_stage(...)`              | stage     |
+| active bounded section       | `inflight_guard(...)`                    | in-flight |
+
+```rust,no_run
+use std::sync::Arc;
+use std::time::Duration;
+use tailtriage_core::Tailtriage;
+use tailtriage_tokio::TokioRequestHandleExt;
+
+# async fn demo() -> Result<(), Box<dyn std::error::Error>> {
+let run = Arc::new(Tailtriage::builder("checkout-service").build()?);
+let started = run.begin_request("/checkout");
+let req = started.handle.clone();
+let db_pool = tokio::sync::Semaphore::new(8);
+let (tx, _rx) = tokio::sync::mpsc::channel::<u64>(64);
+
+{
+    let _permit = req.semaphore("db_pool_wait", &db_pool).acquire().await?;
+    let _: Result<Result<(), ()>, tokio::time::error::Elapsed> = req
+        .timeout_stage("downstream_http", Duration::from_millis(200), async {
+            Ok::<(), ()>(())
+        })
+        .await;
+}
+
+req.mpsc_send("worker_backpressure", &tx, 42_u64).await?;
+started.completion.finish_ok();
+run.shutdown()?;
+# Ok(())
+# }
+```

--- a/tailtriage-tokio/src/lib.rs
+++ b/tailtriage-tokio/src/lib.rs
@@ -25,6 +25,135 @@ pub const fn crate_name() -> &'static str {
     "tailtriage-tokio"
 }
 
+/// Tokio primitive helpers for `tailtriage` request handles.
+///
+/// These helpers are shorthand over explicit `queue(...).await_on(...)`,
+/// `stage(...).await_on(...)`, and `inflight(...)` instrumentation calls.
+/// They do not finish request lifecycles; completion remains explicit via the
+/// request completion token.
+pub trait TokioRequestHandleExt {
+    /// Returns a borrowed semaphore wrapper that records a queue wait when acquired.
+    ///
+    /// Records queue timing only for permit acquisition, not work performed while
+    /// holding the permit. Equivalent to
+    /// `req.queue(label).await_on(semaphore.acquire()).await` and preserves
+    /// `Result<SemaphorePermit<'_>, AcquireError>` exactly.
+    fn semaphore<'a>(
+        &'a self,
+        queue: impl Into<String>,
+        semaphore: &'a tokio::sync::Semaphore,
+    ) -> InstrumentedSemaphore<'a>;
+
+    /// Returns an owned semaphore wrapper that records a queue wait when acquired.
+    ///
+    /// Records queue timing only for permit acquisition, not protected work.
+    /// Equivalent to `req.queue(label).await_on(semaphore.acquire_owned()).await`
+    /// and preserves `Result<OwnedSemaphorePermit, AcquireError>` exactly.
+    fn owned_semaphore(
+        &self,
+        queue: impl Into<String>,
+        semaphore: std::sync::Arc<tokio::sync::Semaphore>,
+    ) -> InstrumentedOwnedSemaphore<'_>;
+
+    /// Awaits one mpsc receive as queue timing instrumentation.
+    fn mpsc_recv<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        receiver: &'a mut tokio::sync::mpsc::Receiver<T>,
+    ) -> impl std::future::Future<Output = Option<T>> + 'a;
+    /// Awaits one mpsc send as queue timing instrumentation.
+    fn mpsc_send<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        sender: &'a tokio::sync::mpsc::Sender<T>,
+        value: T,
+    ) -> impl std::future::Future<Output = Result<(), tokio::sync::mpsc::error::SendError<T>>> + 'a;
+    /// Awaits async mutex acquisition as queue timing instrumentation.
+    fn mutex_lock<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        mutex: &'a tokio::sync::Mutex<T>,
+    ) -> impl std::future::Future<Output = tokio::sync::MutexGuard<'a, T>> + 'a;
+    /// Awaits async read-lock acquisition as queue timing instrumentation.
+    fn rwlock_read<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        lock: &'a tokio::sync::RwLock<T>,
+    ) -> impl std::future::Future<Output = tokio::sync::RwLockReadGuard<'a, T>> + 'a;
+    /// Awaits async write-lock acquisition as queue timing instrumentation.
+    fn rwlock_write<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        lock: &'a tokio::sync::RwLock<T>,
+    ) -> impl std::future::Future<Output = tokio::sync::RwLockWriteGuard<'a, T>> + 'a;
+    /// Awaits a `JoinHandle` as stage timing instrumentation.
+    fn join_task<T>(
+        &self,
+        stage: impl Into<String>,
+        handle: tokio::task::JoinHandle<T>,
+    ) -> impl std::future::Future<Output = Result<T, tokio::task::JoinError>>;
+    /// Wraps `tokio::time::timeout` as stage timing instrumentation.
+    fn timeout_stage<'a, Fut>(
+        &'a self,
+        stage: impl Into<String>,
+        timeout: std::time::Duration,
+        future: Fut,
+    ) -> impl std::future::Future<Output = Result<Fut::Output, tokio::time::error::Elapsed>> + 'a
+    where
+        Fut: std::future::Future + 'a;
+    /// Spawns blocking work and awaits it as stage timing instrumentation.
+    fn spawn_blocking_stage<F, R>(
+        &self,
+        stage: impl Into<String>,
+        f: F,
+    ) -> impl std::future::Future<Output = Result<R, tokio::task::JoinError>>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static;
+    /// Alias for `req.inflight(label)` for in-flight gauge discoverability.
+    fn inflight_guard(&self, gauge: impl Into<String>) -> tailtriage_core::InflightGuard<'_>;
+}
+
+/// Borrowed semaphore helper that defers queue recording until `acquire()` is awaited.
+#[must_use = "constructing the wrapper records nothing until acquire() is awaited"]
+pub struct InstrumentedSemaphore<'a> {
+    timer: tailtriage_core::QueueTimer<'a>,
+    semaphore: &'a tokio::sync::Semaphore,
+}
+
+impl<'a> InstrumentedSemaphore<'a> {
+    /// Acquires one borrowed semaphore permit and records queue wait timing.
+    ///
+    /// # Errors
+    ///
+    /// Returns the original `AcquireError` from Tokio when the semaphore is closed.
+    pub async fn acquire(
+        self,
+    ) -> Result<tokio::sync::SemaphorePermit<'a>, tokio::sync::AcquireError> {
+        self.timer.await_on(self.semaphore.acquire()).await
+    }
+}
+
+/// Owned semaphore helper that defers queue recording until `acquire_owned()` is awaited.
+#[must_use = "constructing the wrapper records nothing until acquire_owned() is awaited"]
+pub struct InstrumentedOwnedSemaphore<'a> {
+    timer: tailtriage_core::QueueTimer<'a>,
+    semaphore: std::sync::Arc<tokio::sync::Semaphore>,
+}
+
+impl InstrumentedOwnedSemaphore<'_> {
+    /// Acquires one owned semaphore permit and records queue wait timing.
+    ///
+    /// # Errors
+    ///
+    /// Returns the original `AcquireError` from Tokio when the semaphore is closed.
+    pub async fn acquire_owned(
+        self,
+    ) -> Result<tokio::sync::OwnedSemaphorePermit, tokio::sync::AcquireError> {
+        self.timer.await_on(self.semaphore.acquire_owned()).await
+    }
+}
+
 /// Errors produced while starting runtime sampling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SamplerStartError {
@@ -293,6 +422,216 @@ impl ResolvedRuntimeSamplerConfig {
     }
 }
 
+impl TokioRequestHandleExt for tailtriage_core::RequestHandle<'_> {
+    fn semaphore<'a>(
+        &'a self,
+        queue: impl Into<String>,
+        semaphore: &'a tokio::sync::Semaphore,
+    ) -> InstrumentedSemaphore<'a> {
+        InstrumentedSemaphore {
+            timer: self.queue(queue),
+            semaphore,
+        }
+    }
+
+    fn owned_semaphore(
+        &self,
+        queue: impl Into<String>,
+        semaphore: Arc<tokio::sync::Semaphore>,
+    ) -> InstrumentedOwnedSemaphore<'_> {
+        InstrumentedOwnedSemaphore {
+            timer: self.queue(queue),
+            semaphore,
+        }
+    }
+
+    fn mpsc_recv<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        receiver: &'a mut tokio::sync::mpsc::Receiver<T>,
+    ) -> impl std::future::Future<Output = Option<T>> + 'a {
+        let timer = self.queue(queue);
+        async move { timer.await_on(receiver.recv()).await }
+    }
+
+    fn mpsc_send<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        sender: &'a tokio::sync::mpsc::Sender<T>,
+        value: T,
+    ) -> impl std::future::Future<Output = Result<(), tokio::sync::mpsc::error::SendError<T>>> + 'a
+    {
+        let timer = self.queue(queue);
+        async move { timer.await_on(sender.send(value)).await }
+    }
+
+    fn mutex_lock<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        mutex: &'a tokio::sync::Mutex<T>,
+    ) -> impl std::future::Future<Output = tokio::sync::MutexGuard<'a, T>> + 'a {
+        let timer = self.queue(queue);
+        async move { timer.await_on(mutex.lock()).await }
+    }
+
+    fn rwlock_read<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        lock: &'a tokio::sync::RwLock<T>,
+    ) -> impl std::future::Future<Output = tokio::sync::RwLockReadGuard<'a, T>> + 'a {
+        let timer = self.queue(queue);
+        async move { timer.await_on(lock.read()).await }
+    }
+
+    fn rwlock_write<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        lock: &'a tokio::sync::RwLock<T>,
+    ) -> impl std::future::Future<Output = tokio::sync::RwLockWriteGuard<'a, T>> + 'a {
+        let timer = self.queue(queue);
+        async move { timer.await_on(lock.write()).await }
+    }
+
+    fn join_task<T>(
+        &self,
+        stage: impl Into<String>,
+        handle: tokio::task::JoinHandle<T>,
+    ) -> impl std::future::Future<Output = Result<T, tokio::task::JoinError>> {
+        let timer = self.stage(stage);
+        async move { timer.await_on(handle).await }
+    }
+
+    fn timeout_stage<'a, Fut>(
+        &'a self,
+        stage: impl Into<String>,
+        timeout: Duration,
+        future: Fut,
+    ) -> impl std::future::Future<Output = Result<Fut::Output, tokio::time::error::Elapsed>> + 'a
+    where
+        Fut: std::future::Future + 'a,
+    {
+        let timer = self.stage(stage);
+        async move { timer.await_on(tokio::time::timeout(timeout, future)).await }
+    }
+
+    fn spawn_blocking_stage<F, R>(
+        &self,
+        stage: impl Into<String>,
+        f: F,
+    ) -> impl std::future::Future<Output = Result<R, tokio::task::JoinError>>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        let timer = self.stage(stage);
+        async move { timer.await_on(tokio::task::spawn_blocking(f)).await }
+    }
+
+    fn inflight_guard(&self, gauge: impl Into<String>) -> tailtriage_core::InflightGuard<'_> {
+        self.inflight(gauge)
+    }
+}
+
+impl TokioRequestHandleExt for tailtriage_core::OwnedRequestHandle {
+    fn semaphore<'a>(
+        &'a self,
+        queue: impl Into<String>,
+        semaphore: &'a tokio::sync::Semaphore,
+    ) -> InstrumentedSemaphore<'a> {
+        InstrumentedSemaphore {
+            timer: self.queue(queue),
+            semaphore,
+        }
+    }
+    fn owned_semaphore(
+        &self,
+        queue: impl Into<String>,
+        semaphore: Arc<tokio::sync::Semaphore>,
+    ) -> InstrumentedOwnedSemaphore<'_> {
+        InstrumentedOwnedSemaphore {
+            timer: self.queue(queue),
+            semaphore,
+        }
+    }
+    fn mpsc_recv<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        receiver: &'a mut tokio::sync::mpsc::Receiver<T>,
+    ) -> impl std::future::Future<Output = Option<T>> + 'a {
+        let timer = self.queue(queue);
+        async move { timer.await_on(receiver.recv()).await }
+    }
+    fn mpsc_send<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        sender: &'a tokio::sync::mpsc::Sender<T>,
+        value: T,
+    ) -> impl std::future::Future<Output = Result<(), tokio::sync::mpsc::error::SendError<T>>> + 'a
+    {
+        let timer = self.queue(queue);
+        async move { timer.await_on(sender.send(value)).await }
+    }
+    fn mutex_lock<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        mutex: &'a tokio::sync::Mutex<T>,
+    ) -> impl std::future::Future<Output = tokio::sync::MutexGuard<'a, T>> + 'a {
+        let timer = self.queue(queue);
+        async move { timer.await_on(mutex.lock()).await }
+    }
+    fn rwlock_read<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        lock: &'a tokio::sync::RwLock<T>,
+    ) -> impl std::future::Future<Output = tokio::sync::RwLockReadGuard<'a, T>> + 'a {
+        let timer = self.queue(queue);
+        async move { timer.await_on(lock.read()).await }
+    }
+    fn rwlock_write<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        lock: &'a tokio::sync::RwLock<T>,
+    ) -> impl std::future::Future<Output = tokio::sync::RwLockWriteGuard<'a, T>> + 'a {
+        let timer = self.queue(queue);
+        async move { timer.await_on(lock.write()).await }
+    }
+    fn join_task<T>(
+        &self,
+        stage: impl Into<String>,
+        handle: tokio::task::JoinHandle<T>,
+    ) -> impl std::future::Future<Output = Result<T, tokio::task::JoinError>> {
+        let timer = self.stage(stage);
+        async move { timer.await_on(handle).await }
+    }
+    fn timeout_stage<'a, Fut>(
+        &'a self,
+        stage: impl Into<String>,
+        timeout: Duration,
+        future: Fut,
+    ) -> impl std::future::Future<Output = Result<Fut::Output, tokio::time::error::Elapsed>> + 'a
+    where
+        Fut: std::future::Future + 'a,
+    {
+        let timer = self.stage(stage);
+        async move { timer.await_on(tokio::time::timeout(timeout, future)).await }
+    }
+    fn spawn_blocking_stage<F, R>(
+        &self,
+        stage: impl Into<String>,
+        f: F,
+    ) -> impl std::future::Future<Output = Result<R, tokio::task::JoinError>>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        let timer = self.stage(stage);
+        async move { timer.await_on(tokio::task::spawn_blocking(f)).await }
+    }
+    fn inflight_guard(&self, gauge: impl Into<String>) -> tailtriage_core::InflightGuard<'_> {
+        self.inflight(gauge)
+    }
+}
+
 /// Captures one point-in-time runtime metrics snapshot from `handle`.
 #[must_use]
 pub fn capture_runtime_snapshot(handle: &Handle) -> RuntimeSnapshot {
@@ -340,7 +679,7 @@ mod tests {
     use tailtriage_core::{CaptureMode, Tailtriage};
 
     use super::crate_name;
-    use super::{RuntimeSampler, SamplerStartError};
+    use super::{RuntimeSampler, SamplerStartError, TokioRequestHandleExt};
 
     async fn wait_until(
         timeout: Duration,
@@ -357,6 +696,51 @@ mod tests {
         }
 
         assert!(condition(), "{failure_message}");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tokio_helpers_record_queue_stage_and_inflight() {
+        let run = Tailtriage::builder("helper-test").build().expect("build");
+        let started = run.begin_request("/h");
+        let req = started.handle.clone();
+
+        let sem = Arc::new(tokio::sync::Semaphore::new(1));
+        let permit = req
+            .owned_semaphore("db_wait", Arc::clone(&sem))
+            .acquire_owned()
+            .await
+            .expect("permit");
+        drop(permit);
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        req.mpsc_send("send_wait", &tx, 7_u8).await.expect("send");
+        let v = req.mpsc_recv("recv_wait", &mut rx).await;
+        assert_eq!(v, Some(7));
+
+        let lock = tokio::sync::Mutex::new(3_u8);
+        let guard = req.mutex_lock("mu_wait", &lock).await;
+        assert_eq!(*guard, 3);
+        drop(guard);
+
+        let out = req
+            .timeout_stage("tmo_stage", Duration::from_millis(20), async {
+                Ok::<u8, ()>(1)
+            })
+            .await;
+        assert_eq!(out.expect("outer").expect("inner"), 1);
+
+        let inflight_guard = req.inflight_guard("inflight_requests");
+        drop(inflight_guard);
+
+        let snap = run.snapshot();
+        assert_eq!(snap.requests.len(), 0);
+        assert!(snap.queues.len() >= 4);
+        assert_eq!(snap.stages.len(), 1);
+        assert!(snap.stages[0].success);
+        assert_eq!(snap.inflight.len(), 2);
+
+        started.completion.finish_ok();
+        assert_eq!(run.snapshot().requests.len(), 1);
     }
 
     #[test]

--- a/tailtriage/README.md
+++ b/tailtriage/README.md
@@ -98,7 +98,7 @@ Choose a focused crate only when you need a narrower boundary:
 
 - `tailtriage-core`: framework-agnostic instrumentation primitives
 - `tailtriage-controller`: repeated bounded windows
-- `tailtriage-tokio`: runtime-pressure sampling
+- `tailtriage-tokio`: runtime-pressure sampling plus `TokioRequestHandleExt` helpers for common Tokio primitive queue/stage/in-flight instrumentation
 - `tailtriage-axum`: Axum request-boundary wiring
 
 ## Feature flags

--- a/tailtriage/src/lib.rs
+++ b/tailtriage/src/lib.rs
@@ -37,7 +37,10 @@ mod tests {
     #[cfg(feature = "tokio")]
     #[test]
     fn tokio_namespace_reexport_compiles() {
+        use crate::tokio::TokioRequestHandleExt;
+
         let _name = crate::tokio::crate_name();
+        let _uses_trait = |req: &crate::RequestHandle<'_>| req.inflight_guard("smoke");
     }
 
     #[cfg(feature = "controller")]


### PR DESCRIPTION
### Motivation

- Make common Tokio awaits (semaphores, mpsc, mutex/rwlock, join/timeout/spawn_blocking, inflight gauges) ergonomic to record as queue/stage/in-flight events without changing the core request model. 

### Description

- Add `TokioRequestHandleExt` in `tailtriage-tokio` providing helpers that are explicit sugar over existing `RequestHandle` APIs (`queue(...).await_on(...)`, `stage(...).await_on(...)`, `inflight(...)`).
- Add `InstrumentedSemaphore` and `InstrumentedOwnedSemaphore` wrapper types with `#[must_use]` semantics and explicit `acquire()` / `acquire_owned()` methods that record only acquisition queue wait timing and preserve Tokio return/error types.
- Implement `TokioRequestHandleExt` explicitly (no macros) for `tailtriage_core::RequestHandle<'_>` and `tailtriage_core::OwnedRequestHandle` using borrowed futures (no boxed dyn futures) and limiting `Send + 'static` bounds only where required by `spawn_blocking_stage`.
- Update documentation to advertise the helper trait and include the helper table and a compact example in `tailtriage-tokio/README.md`, add a concise “Tokio primitive helpers” section to `docs/user-guide.md`, and mention the helper surface in `tailtriage/README.md`.

### Testing

- Ran formatting, lints, tests, and docs validation: `cargo fmt --check` succeeded; `cargo clippy --workspace --all-targets -- -D warnings` succeeded; `cargo test --workspace` succeeded; `python3 scripts/validate_docs_contracts.py` succeeded. 
- Added a focused Tokio test `tokio_helpers_record_queue_stage_and_inflight` (in `tailtriage-tokio` tests) that exercises semaphore, mpsc send/recv, mutex lock, timeout stage, and inflight guard behavior; it passed as part of the workspace test run. 
- Notes/limitations: the change implements the helper surface and a behavioral smoke test; additional targeted edge-case tests from the full matrix (e.g., exhaustive panic/cancel/closed-channel value round-trips) can be added in follow-ups if desired.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdde8e367883308d2029a08b89596c)