### PR TITLE
Add Tokio primitive helper trait (TokioRequestHandleExt) and semaphore wrappers

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -219,6 +219,32 @@ When `primary_suspect.kind` is `insufficient_evidence`:
 
 Use [diagnostics.md](diagnostics.md) for interpretation details.
 
+
+## Tokio primitive helpers
+
+Import path:
+
+```rust
+use tailtriage::tokio::TokioRequestHandleExt;
+```
+
+These helpers are shorthand for explicit `queue(...).await_on(...)`, `stage(...).await_on(...)`, and `inflight(...)`; they do not finish requests.
+
+| Use case                     | Helper                                   | Records   |
+| ---------------------------- | ---------------------------------------- | --------- |
+| DB pool / capacity wait      | `semaphore(...).acquire()`               | queue     |
+| owned permit wait            | `owned_semaphore(...).acquire_owned()`   | queue     |
+| worker queue receive         | `mpsc_recv(...)`                         | queue     |
+| bounded channel backpressure | `mpsc_send(...)`                         | queue     |
+| async mutex contention       | `mutex_lock(...)`                        | queue     |
+| async rwlock contention      | `rwlock_read(...)` / `rwlock_write(...)` | queue     |
+| spawned task result          | `join_task(...)`                         | stage     |
+| timeout-wrapped work         | `timeout_stage(...)`                     | stage     |
+| blocking pool work           | `spawn_blocking_stage(...)`              | stage     |
+| active bounded section       | `inflight_guard(...)`                    | in-flight |
+
+See [tailtriage-tokio/README.md](../tailtriage-tokio/README.md) for a full example.
+
 ## 10) Next docs
 
 - [Documentation index](README.md)

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -212,3 +212,64 @@ For those surfaces, use:
 - `tailtriage-controller`: repeated bounded windows
 - `tailtriage-analyzer`: in-process analysis/report generation for completed runs
 - `tailtriage-cli`: command-line analysis of saved run artifacts
+
+## Tokio primitive helper trait
+
+`tailtriage-tokio` also provides `TokioRequestHandleExt` for Tokio primitive helper shorthand, in addition to runtime-pressure sampling.
+
+```rust
+use tailtriage_tokio::TokioRequestHandleExt;
+```
+
+From the default crate with feature:
+
+```rust,ignore
+use tailtriage::tokio::TokioRequestHandleExt;
+```
+
+| Use case                     | Helper                                   | Records   |
+| ---------------------------- | ---------------------------------------- | --------- |
+| DB pool / capacity wait      | `semaphore(...).acquire()`               | queue     |
+| owned permit wait            | `owned_semaphore(...).acquire_owned()`   | queue     |
+| worker queue receive         | `mpsc_recv(...)`                         | queue     |
+| bounded channel backpressure | `mpsc_send(...)`                         | queue     |
+| async mutex contention       | `mutex_lock(...)`                        | queue     |
+| async rwlock contention      | `rwlock_read(...)` / `rwlock_write(...)` | queue     |
+| spawned task result          | `join_task(...)`                         | stage     |
+| timeout-wrapped work         | `timeout_stage(...)`                     | stage     |
+| blocking pool work           | `spawn_blocking_stage(...)`              | stage     |
+| active bounded section       | `inflight_guard(...)`                    | in-flight |
+
+```rust,no_run
+use std::sync::Arc;
+use std::time::Duration;
+
+use tailtriage_core::Tailtriage;
+use tailtriage_tokio::TokioRequestHandleExt;
+
+# async fn demo() -> Result<(), Box<dyn std::error::Error>> {
+let run = Tailtriage::builder("checkout-service")
+    .output("tailtriage-run.json")
+    .build()?;
+
+let started = run.begin_request("/checkout");
+let req = started.handle.clone();
+let db_pool = tokio::sync::Semaphore::new(8);
+let (tx, _rx) = tokio::sync::mpsc::channel::<u64>(64);
+let value = 7_u64;
+
+{
+    let _permit = req.semaphore("db_pool_wait", &db_pool).acquire().await?;
+    let _: Result<Result<(), ()>, tokio::time::error::Elapsed> = req
+        .timeout_stage("downstream_http", Duration::from_millis(200), async {
+            Ok::<(), ()>(())
+        })
+        .await;
+}
+
+req.mpsc_send("worker_backpressure", &tx, value).await?;
+started.completion.finish_ok();
+run.shutdown()?;
+# Ok(())
+# }
+```

--- a/tailtriage-tokio/src/lib.rs
+++ b/tailtriage-tokio/src/lib.rs
@@ -19,6 +19,211 @@ use tokio::runtime::Handle;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
+/// Queue-instrumented wrapper for borrowed semaphore acquisition.
+///
+/// Constructing this wrapper does not record anything. Recording starts only
+/// when [`Self::acquire`] is awaited.
+#[must_use = "constructing the wrapper records nothing until acquire() is awaited"]
+pub struct InstrumentedSemaphore<'a> {
+    request: RequestHandleRef<'a>,
+    queue: String,
+    semaphore: &'a tokio::sync::Semaphore,
+}
+
+impl<'a> InstrumentedSemaphore<'a> {
+    /// Acquires one semaphore permit while recording a queue wait event.
+    ///
+    /// Records only queue wait time for permit acquisition. It does not record
+    /// work performed after the permit is acquired.
+    ///
+    /// Equivalent low-level API:
+    /// `req.queue(label).await_on(semaphore.acquire()).await`.
+    ///
+    /// Returns the exact `Result<SemaphorePermit<'_>, AcquireError>` from
+    /// Tokio unchanged.
+    ///
+    /// Request completion remains explicit and must be finished separately.
+    ///
+    /// # Errors
+    ///
+    /// Returns Tokio `AcquireError` unchanged when the semaphore is closed.
+    pub async fn acquire(
+        self,
+    ) -> Result<tokio::sync::SemaphorePermit<'a>, tokio::sync::AcquireError> {
+        self.request
+            .queue(self.queue)
+            .await_on(self.semaphore.acquire())
+            .await
+    }
+}
+
+/// Queue-instrumented wrapper for owned semaphore acquisition.
+///
+/// Constructing this wrapper does not record anything. Recording starts only
+/// when [`Self::acquire_owned`] is awaited.
+#[must_use = "constructing the wrapper records nothing until acquire_owned() is awaited"]
+pub struct InstrumentedOwnedSemaphore<'a> {
+    request: RequestHandleRef<'a>,
+    queue: String,
+    semaphore: Arc<tokio::sync::Semaphore>,
+}
+
+impl InstrumentedOwnedSemaphore<'_> {
+    /// Acquires one owned semaphore permit while recording a queue wait event.
+    ///
+    /// Records only queue wait time for permit acquisition. It does not record
+    /// work performed after the permit is acquired.
+    ///
+    /// Equivalent low-level API:
+    /// `req.queue(label).await_on(semaphore.acquire_owned()).await`.
+    ///
+    /// Returns the exact `Result<OwnedSemaphorePermit, AcquireError>` from
+    /// Tokio unchanged.
+    ///
+    /// Request completion remains explicit and must be finished separately.
+    ///
+    /// # Errors
+    ///
+    /// Returns Tokio `AcquireError` unchanged when the semaphore is closed.
+    pub async fn acquire_owned(
+        self,
+    ) -> Result<tokio::sync::OwnedSemaphorePermit, tokio::sync::AcquireError> {
+        self.request
+            .queue(self.queue)
+            .await_on(self.semaphore.acquire_owned())
+            .await
+    }
+}
+
+#[derive(Clone, Copy)]
+enum RequestHandleRef<'a> {
+    Borrowed(&'a tailtriage_core::RequestHandle<'a>),
+    Owned(&'a tailtriage_core::OwnedRequestHandle),
+}
+
+impl RequestHandleRef<'_> {
+    fn queue(&self, queue: impl Into<String>) -> tailtriage_core::QueueTimer<'_> {
+        match self {
+            Self::Borrowed(req) => req.queue(queue),
+            Self::Owned(req) => req.queue(queue),
+        }
+    }
+}
+
+/// Tokio-specific helper methods for request-handle instrumentation.
+pub trait TokioRequestHandleExt {
+    /// Creates a queue-instrumented wrapper for borrowed semaphore acquisition.
+    ///
+    /// Records queue wait time only when `.acquire().await` is performed.
+    /// Equivalent to `req.queue(label).await_on(semaphore.acquire()).await`.
+    /// Request completion remains explicit.
+    fn semaphore<'a>(
+        &'a self,
+        queue: impl Into<String>,
+        semaphore: &'a tokio::sync::Semaphore,
+    ) -> InstrumentedSemaphore<'a>;
+    /// Creates a queue-instrumented wrapper for owned semaphore acquisition.
+    ///
+    /// Records queue wait time only when `.acquire_owned().await` is performed.
+    /// Equivalent to `req.queue(label).await_on(semaphore.acquire_owned()).await`.
+    /// Request completion remains explicit.
+    fn owned_semaphore(
+        &self,
+        queue: impl Into<String>,
+        semaphore: Arc<tokio::sync::Semaphore>,
+    ) -> InstrumentedOwnedSemaphore<'_>;
+    /// Records a queue wait around `mpsc::Receiver::recv`.
+    ///
+    /// Measures waiting for an item only, not subsequent processing.
+    /// Equivalent to `req.queue(label).await_on(receiver.recv()).await`.
+    /// Preserves `Option<T>` exactly. Request completion remains explicit.
+    fn mpsc_recv<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        receiver: &'a mut tokio::sync::mpsc::Receiver<T>,
+    ) -> impl std::future::Future<Output = Option<T>> + 'a;
+    /// Records a queue wait around `mpsc::Sender::send`.
+    ///
+    /// Measures backpressure wait only, not downstream processing.
+    /// Equivalent to `req.queue(label).await_on(sender.send(value)).await`.
+    /// Preserves `Result<(), SendError<T>>` unchanged. Request completion remains explicit.
+    fn mpsc_send<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        sender: &'a tokio::sync::mpsc::Sender<T>,
+        value: T,
+    ) -> impl std::future::Future<Output = Result<(), tokio::sync::mpsc::error::SendError<T>>> + 'a;
+    /// Records queue wait around `Mutex::lock`.
+    ///
+    /// Measures acquisition only, not guard-held work.
+    /// Equivalent to `req.queue(label).await_on(mutex.lock()).await`.
+    /// Request completion remains explicit.
+    fn mutex_lock<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        mutex: &'a tokio::sync::Mutex<T>,
+    ) -> impl std::future::Future<Output = tokio::sync::MutexGuard<'a, T>> + 'a;
+    /// Records queue wait around `RwLock::read`.
+    ///
+    /// Measures acquisition only, not guard-held work.
+    /// Equivalent to `req.queue(label).await_on(lock.read()).await`.
+    /// Request completion remains explicit.
+    fn rwlock_read<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        lock: &'a tokio::sync::RwLock<T>,
+    ) -> impl std::future::Future<Output = tokio::sync::RwLockReadGuard<'a, T>> + 'a;
+    /// Records queue wait around `RwLock::write`.
+    ///
+    /// Measures acquisition only, not guard-held work.
+    /// Equivalent to `req.queue(label).await_on(lock.write()).await`.
+    /// Request completion remains explicit.
+    fn rwlock_write<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        lock: &'a tokio::sync::RwLock<T>,
+    ) -> impl std::future::Future<Output = tokio::sync::RwLockWriteGuard<'a, T>> + 'a;
+    /// Records a stage wait around awaiting a `JoinHandle`.
+    ///
+    /// Equivalent to `req.stage(label).await_on(handle).await`.
+    /// Preserves `Result<T, JoinError>` unchanged. Request completion remains explicit.
+    fn join_task<T>(
+        &self,
+        stage: impl Into<String>,
+        handle: tokio::task::JoinHandle<T>,
+    ) -> impl std::future::Future<Output = Result<T, tokio::task::JoinError>>;
+    /// Records a stage around `tokio::time::timeout(timeout, future)`.
+    ///
+    /// Equivalent to `req.stage(label).await_on(tokio::time::timeout(...)).await`.
+    /// Preserves the outer timeout result and nested inner results unchanged.
+    /// Request completion remains explicit.
+    fn timeout_stage<'a, Fut>(
+        &'a self,
+        stage: impl Into<String>,
+        timeout: Duration,
+        future: Fut,
+    ) -> impl std::future::Future<Output = Result<Fut::Output, tokio::time::error::Elapsed>> + 'a
+    where
+        Fut: std::future::Future + 'a;
+    /// Records a stage around `tokio::task::spawn_blocking(f)` and awaiting it.
+    ///
+    /// Intended for blocking-pool work. Preserves `Result<R, JoinError>`
+    /// unchanged. Request completion remains explicit.
+    fn spawn_blocking_stage<F, R>(
+        &self,
+        stage: impl Into<String>,
+        f: F,
+    ) -> impl std::future::Future<Output = Result<R, tokio::task::JoinError>>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static;
+    /// Alias for `req.inflight(label)` for RAII discoverability.
+    ///
+    /// Records in-flight increment/decrement only, not queue or stage timing.
+    /// Request completion remains explicit.
+    fn inflight_guard(&self, gauge: impl Into<String>) -> tailtriage_core::InflightGuard<'_>;
+}
+
 /// Returns the crate name for smoke-testing workspace wiring.
 #[must_use]
 pub const fn crate_name() -> &'static str {
@@ -293,6 +498,196 @@ impl ResolvedRuntimeSamplerConfig {
     }
 }
 
+impl TokioRequestHandleExt for tailtriage_core::RequestHandle<'_> {
+    fn semaphore<'a>(
+        &'a self,
+        queue: impl Into<String>,
+        semaphore: &'a tokio::sync::Semaphore,
+    ) -> InstrumentedSemaphore<'a> {
+        InstrumentedSemaphore {
+            request: RequestHandleRef::Borrowed(self),
+            queue: queue.into(),
+            semaphore,
+        }
+    }
+    fn owned_semaphore(
+        &self,
+        queue: impl Into<String>,
+        semaphore: Arc<tokio::sync::Semaphore>,
+    ) -> InstrumentedOwnedSemaphore<'_> {
+        InstrumentedOwnedSemaphore {
+            request: RequestHandleRef::Borrowed(self),
+            queue: queue.into(),
+            semaphore,
+        }
+    }
+    fn mpsc_recv<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        receiver: &'a mut tokio::sync::mpsc::Receiver<T>,
+    ) -> impl std::future::Future<Output = Option<T>> + 'a {
+        self.queue(queue).await_on(receiver.recv())
+    }
+    fn mpsc_send<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        sender: &'a tokio::sync::mpsc::Sender<T>,
+        value: T,
+    ) -> impl std::future::Future<Output = Result<(), tokio::sync::mpsc::error::SendError<T>>> + 'a
+    {
+        self.queue(queue).await_on(sender.send(value))
+    }
+    fn mutex_lock<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        mutex: &'a tokio::sync::Mutex<T>,
+    ) -> impl std::future::Future<Output = tokio::sync::MutexGuard<'a, T>> + 'a {
+        self.queue(queue).await_on(mutex.lock())
+    }
+    fn rwlock_read<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        lock: &'a tokio::sync::RwLock<T>,
+    ) -> impl std::future::Future<Output = tokio::sync::RwLockReadGuard<'a, T>> + 'a {
+        self.queue(queue).await_on(lock.read())
+    }
+    fn rwlock_write<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        lock: &'a tokio::sync::RwLock<T>,
+    ) -> impl std::future::Future<Output = tokio::sync::RwLockWriteGuard<'a, T>> + 'a {
+        self.queue(queue).await_on(lock.write())
+    }
+    fn join_task<T>(
+        &self,
+        stage: impl Into<String>,
+        handle: tokio::task::JoinHandle<T>,
+    ) -> impl std::future::Future<Output = Result<T, tokio::task::JoinError>> {
+        self.stage(stage).await_on(handle)
+    }
+    fn timeout_stage<'a, Fut>(
+        &'a self,
+        stage: impl Into<String>,
+        timeout: Duration,
+        future: Fut,
+    ) -> impl std::future::Future<Output = Result<Fut::Output, tokio::time::error::Elapsed>> + 'a
+    where
+        Fut: std::future::Future + 'a,
+    {
+        self.stage(stage)
+            .await_on(tokio::time::timeout(timeout, future))
+    }
+    fn spawn_blocking_stage<F, R>(
+        &self,
+        stage: impl Into<String>,
+        f: F,
+    ) -> impl std::future::Future<Output = Result<R, tokio::task::JoinError>>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        self.stage(stage).await_on(tokio::task::spawn_blocking(f))
+    }
+    fn inflight_guard(&self, gauge: impl Into<String>) -> tailtriage_core::InflightGuard<'_> {
+        self.inflight(gauge)
+    }
+}
+
+impl TokioRequestHandleExt for tailtriage_core::OwnedRequestHandle {
+    fn semaphore<'a>(
+        &'a self,
+        queue: impl Into<String>,
+        semaphore: &'a tokio::sync::Semaphore,
+    ) -> InstrumentedSemaphore<'a> {
+        InstrumentedSemaphore {
+            request: RequestHandleRef::Owned(self),
+            queue: queue.into(),
+            semaphore,
+        }
+    }
+    fn owned_semaphore(
+        &self,
+        queue: impl Into<String>,
+        semaphore: Arc<tokio::sync::Semaphore>,
+    ) -> InstrumentedOwnedSemaphore<'_> {
+        InstrumentedOwnedSemaphore {
+            request: RequestHandleRef::Owned(self),
+            queue: queue.into(),
+            semaphore,
+        }
+    }
+    fn mpsc_recv<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        receiver: &'a mut tokio::sync::mpsc::Receiver<T>,
+    ) -> impl std::future::Future<Output = Option<T>> + 'a {
+        self.queue(queue).await_on(receiver.recv())
+    }
+    fn mpsc_send<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        sender: &'a tokio::sync::mpsc::Sender<T>,
+        value: T,
+    ) -> impl std::future::Future<Output = Result<(), tokio::sync::mpsc::error::SendError<T>>> + 'a
+    {
+        self.queue(queue).await_on(sender.send(value))
+    }
+    fn mutex_lock<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        mutex: &'a tokio::sync::Mutex<T>,
+    ) -> impl std::future::Future<Output = tokio::sync::MutexGuard<'a, T>> + 'a {
+        self.queue(queue).await_on(mutex.lock())
+    }
+    fn rwlock_read<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        lock: &'a tokio::sync::RwLock<T>,
+    ) -> impl std::future::Future<Output = tokio::sync::RwLockReadGuard<'a, T>> + 'a {
+        self.queue(queue).await_on(lock.read())
+    }
+    fn rwlock_write<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        lock: &'a tokio::sync::RwLock<T>,
+    ) -> impl std::future::Future<Output = tokio::sync::RwLockWriteGuard<'a, T>> + 'a {
+        self.queue(queue).await_on(lock.write())
+    }
+    fn join_task<T>(
+        &self,
+        stage: impl Into<String>,
+        handle: tokio::task::JoinHandle<T>,
+    ) -> impl std::future::Future<Output = Result<T, tokio::task::JoinError>> {
+        self.stage(stage).await_on(handle)
+    }
+    fn timeout_stage<'a, Fut>(
+        &'a self,
+        stage: impl Into<String>,
+        timeout: Duration,
+        future: Fut,
+    ) -> impl std::future::Future<Output = Result<Fut::Output, tokio::time::error::Elapsed>> + 'a
+    where
+        Fut: std::future::Future + 'a,
+    {
+        self.stage(stage)
+            .await_on(tokio::time::timeout(timeout, future))
+    }
+    fn spawn_blocking_stage<F, R>(
+        &self,
+        stage: impl Into<String>,
+        f: F,
+    ) -> impl std::future::Future<Output = Result<R, tokio::task::JoinError>>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        self.stage(stage).await_on(tokio::task::spawn_blocking(f))
+    }
+    fn inflight_guard(&self, gauge: impl Into<String>) -> tailtriage_core::InflightGuard<'_> {
+        self.inflight(gauge)
+    }
+}
+
 /// Captures one point-in-time runtime metrics snapshot from `handle`.
 #[must_use]
 pub fn capture_runtime_snapshot(handle: &Handle) -> RuntimeSnapshot {
@@ -340,7 +735,7 @@ mod tests {
     use tailtriage_core::{CaptureMode, Tailtriage};
 
     use super::crate_name;
-    use super::{RuntimeSampler, SamplerStartError};
+    use super::{RuntimeSampler, SamplerStartError, TokioRequestHandleExt};
 
     async fn wait_until(
         timeout: Duration,
@@ -755,5 +1150,95 @@ mod tests {
             metadata.resolved_sampler_cadence_ms, 11,
             "duplicate start must not overwrite prior metadata"
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tokio_helpers_record_queue_stage_and_inflight() {
+        let run = Tailtriage::builder("helpers")
+            .output(std::env::temp_dir().join("tailtriage_tokio_helpers.json"))
+            .build()
+            .expect("build");
+        let started = run.begin_request("route");
+        let req = started.handle.clone();
+
+        let sem = tokio::sync::Semaphore::new(1);
+        let _permit = req
+            .semaphore("db_pool_wait", &sem)
+            .acquire()
+            .await
+            .expect("permit");
+
+        let sem_owned = Arc::new(tokio::sync::Semaphore::new(1));
+        let _owned_permit = req
+            .owned_semaphore("owned_wait", Arc::clone(&sem_owned))
+            .acquire_owned()
+            .await
+            .expect("owned permit");
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        req.mpsc_send("worker_backpressure", &tx, 1)
+            .await
+            .expect("send");
+        assert_eq!(req.mpsc_recv("worker_recv", &mut rx).await, Some(1));
+        drop(tx);
+        assert_eq!(req.mpsc_recv("worker_closed", &mut rx).await, None);
+
+        let mutex = tokio::sync::Mutex::new(3);
+        let guard = req.mutex_lock("mutex_wait", &mutex).await;
+        assert_eq!(*guard, 3);
+        drop(guard);
+
+        let rw = tokio::sync::RwLock::new(4);
+        let rg = req.rwlock_read("rw_read", &rw).await;
+        assert_eq!(*rg, 4);
+        drop(rg);
+        let mut wg = req.rwlock_write("rw_write", &rw).await;
+        *wg = 7;
+        drop(wg);
+
+        let join_ok = req
+            .join_task("join_ok", tokio::spawn(async { 9_u8 }))
+            .await
+            .expect("join");
+        assert_eq!(join_ok, 9);
+        let join_err = req
+            .join_task("join_err", tokio::spawn(async move { panic!("boom") }))
+            .await;
+        assert!(join_err.is_err());
+
+        let timeout_ok = req
+            .timeout_stage("downstream_http", Duration::from_millis(50), async {
+                Ok::<_, &str>(())
+            })
+            .await
+            .expect("not elapsed");
+        assert_eq!(timeout_ok, Ok(()));
+
+        let timeout_err = req
+            .timeout_stage("downstream_timeout", Duration::from_millis(1), async {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            })
+            .await;
+        assert!(timeout_err.is_err());
+
+        let block_ok = req
+            .spawn_blocking_stage("block_ok", || 11_i32)
+            .await
+            .expect("join blocking");
+        assert_eq!(block_ok, 11);
+        let block_err = req
+            .spawn_blocking_stage("block_err", || -> i32 { panic!("nope") })
+            .await;
+        assert!(block_err.is_err());
+
+        {
+            let _g = req.inflight_guard("critical");
+            assert_eq!(run.snapshot().inflight.last().expect("inflight").count, 1);
+        }
+        assert_eq!(run.snapshot().inflight.last().expect("inflight").count, 0);
+
+        assert!(run.snapshot().requests.is_empty());
+        started.completion.finish_ok();
+        assert_eq!(run.snapshot().requests.len(), 1);
     }
 }

--- a/tailtriage/README.md
+++ b/tailtriage/README.md
@@ -98,7 +98,7 @@ Choose a focused crate only when you need a narrower boundary:
 
 - `tailtriage-core`: framework-agnostic instrumentation primitives
 - `tailtriage-controller`: repeated bounded windows
-- `tailtriage-tokio`: runtime-pressure sampling
+- `tailtriage-tokio`: runtime-pressure sampling plus the `TokioRequestHandleExt` Tokio primitive helper trait
 - `tailtriage-axum`: Axum request-boundary wiring
 
 ## Feature flags

--- a/tailtriage/src/lib.rs
+++ b/tailtriage/src/lib.rs
@@ -37,7 +37,10 @@ mod tests {
     #[cfg(feature = "tokio")]
     #[test]
     fn tokio_namespace_reexport_compiles() {
+        use crate::tokio::TokioRequestHandleExt;
         let _name = crate::tokio::crate_name();
+        fn _uses_trait<T: TokioRequestHandleExt>() {}
+        _uses_trait::<crate::OwnedRequestHandle>();
     }
 
     #[cfg(feature = "controller")]


### PR DESCRIPTION
### Motivation
- Reduce repetition and improve adoption by providing small, clear Tokio-specific helpers that map common Tokio waits to the existing `queue`, `stage`, and `inflight` request signals.
- Provide ergonomic, explicit sugar over the current request-handle model without changing core semantics, capture schema, or analyzer behavior.
- Keep the helper layer Tokio-specific (live in `tailtriage-tokio`) so `tailtriage-core` remains runtime-independent.
- Preserve safety and predictability: explicit labels required, no automatic request completion, no new dependencies, and no public macros or boxed futures.

### Description
- Added a public extension trait `TokioRequestHandleExt` in `tailtriage-tokio/src/lib.rs` that provides helpers for common Tokio primitives: `semaphore`, `owned_semaphore`, `mpsc_recv`, `mpsc_send`, `mutex_lock`, `rwlock_read`, `rwlock_write`, `join_task`, `timeout_stage`, `spawn_blocking_stage`, and `inflight_guard`.
- Implemented the trait explicitly for `tailtriage_core::RequestHandle<'_>` and `tailtriage_core::OwnedRequestHandle` (no macros), using a small internal `RequestHandleRef` enum to dispatch to the underlying low-level `queue`/`stage`/`inflight` APIs.
- Added two public wrapper types: `InstrumentedSemaphore::acquire()` and `InstrumentedOwnedSemaphore::acquire_owned()` that record queue wait time only and preserve Tokio return/error types exactly.
- Updated exports and docs: re-export path `tailtriage::tokio::TokioRequestHandleExt` is supported, `tailtriage-tokio/README.md` now documents the helper trait with a helper table and example, `docs/user-guide.md` contains a concise “Tokio primitive helpers” section, and `tailtriage/README.md` notes the trait in crate selection.

### Testing
- Ran formatter and linting: `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings` (both passed).
- Ran full workspace tests: `cargo test --workspace` and all test suites passed, including the new Tokio helper tests in `tailtriage-tokio`.
- Ran docs contract validation: `python3 scripts/validate_docs_contracts.py` and it passed.
- All validation commands above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdde8e367883308d2029a08b89596c)