### PR TITLE
Expand Tokio helper impls/docs and add non-Send tests

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -227,7 +227,7 @@ Import via default crate path:
 use tailtriage::tokio::TokioRequestHandleExt;
 ```
 
-These helpers are shorthand for explicit `queue(...).await_on(...)`, `stage(...).await_on(...)`, and `inflight(...)` instrumentation; they do not finish requests.
+These helpers are shorthand for explicit `queue(...).await_on(...)`, `stage(...).await_on(...)`, and `inflight(...)` instrumentation; they do not finish requests. For a compact end-to-end helper example, see the Tokio helper example in [`tailtriage-tokio/README.md`](../tailtriage-tokio/README.md).
 
 | Use case | Helper | Records |
 |---|---|---|

--- a/tailtriage-tokio/src/lib.rs
+++ b/tailtriage-tokio/src/lib.rs
@@ -99,6 +99,7 @@ pub trait TokioRequestHandleExt {
     ///
     /// Equivalent low-level form: `req.stage(label).await_on(handle)`.
     ///
+    /// Records time spent awaiting the supplied join handle. If the task started earlier, this may not represent the full task lifetime.
     /// Preserves `Result<T, JoinError>` unchanged, including panic/cancel join errors. Request completion remains explicit.
     fn join_task<T>(
         &self,
@@ -110,7 +111,8 @@ pub trait TokioRequestHandleExt {
     /// Equivalent low-level form: `req.stage(label).await_on(tokio::time::timeout(timeout, future))`.
     ///
     /// Preserves the outer timeout `Result` and any nested inner `Result` exactly (no flattening/remapping).
-    /// Timeout elapsed is represented by outer `Err(Elapsed)`. Request completion remains explicit.
+    /// Timeout elapsed is represented by outer `Err(Elapsed)` and records a failed stage because success derives from the outer `Result`.
+    /// Request completion remains explicit.
     fn timeout_stage<'a, Fut: Future + 'a>(
         &'a self,
         stage: impl Into<String>,
@@ -121,6 +123,7 @@ pub trait TokioRequestHandleExt {
     ///
     /// Equivalent low-level form: `req.stage(label).await_on(tokio::task::spawn_blocking(f))`.
     ///
+    /// Records stage time from spawning the blocking task through awaiting its join handle.
     /// Preserves `Result<R, JoinError>` unchanged. Typical use: blocking pool work. Request completion remains explicit.
     fn spawn_blocking_stage<F, R>(
         &self,
@@ -138,103 +141,183 @@ pub trait TokioRequestHandleExt {
     fn inflight_guard(&self, gauge: impl Into<String>) -> tailtriage_core::InflightGuard<'_>;
 }
 
-macro_rules! impl_tokio_ext {
-    ($ty:ty) => {
-        impl TokioRequestHandleExt for $ty {
-            fn semaphore<'a>(
-                &'a self,
-                queue: impl Into<String>,
-                semaphore: &'a tokio::sync::Semaphore,
-            ) -> InstrumentedSemaphore<'a> {
-                InstrumentedSemaphore {
-                    timer: self.queue(queue),
-                    semaphore,
-                }
-            }
-            fn owned_semaphore(
-                &self,
-                queue: impl Into<String>,
-                semaphore: Arc<tokio::sync::Semaphore>,
-            ) -> InstrumentedOwnedSemaphore<'_> {
-                InstrumentedOwnedSemaphore {
-                    timer: self.queue(queue),
-                    semaphore,
-                }
-            }
-            fn mpsc_recv<'a, T>(
-                &'a self,
-                queue: impl Into<String>,
-                receiver: &'a mut tokio::sync::mpsc::Receiver<T>,
-            ) -> impl Future<Output = Option<T>> + 'a {
-                self.queue(queue).await_on(receiver.recv())
-            }
-            fn mpsc_send<'a, T>(
-                &'a self,
-                queue: impl Into<String>,
-                sender: &'a tokio::sync::mpsc::Sender<T>,
-                value: T,
-            ) -> impl Future<Output = Result<(), tokio::sync::mpsc::error::SendError<T>>> + 'a {
-                self.queue(queue).await_on(sender.send(value))
-            }
-            fn mutex_lock<'a, T>(
-                &'a self,
-                queue: impl Into<String>,
-                mutex: &'a tokio::sync::Mutex<T>,
-            ) -> impl Future<Output = tokio::sync::MutexGuard<'a, T>> + 'a {
-                self.queue(queue).await_on(mutex.lock())
-            }
-            fn rwlock_read<'a, T>(
-                &'a self,
-                queue: impl Into<String>,
-                lock: &'a tokio::sync::RwLock<T>,
-            ) -> impl Future<Output = tokio::sync::RwLockReadGuard<'a, T>> + 'a {
-                self.queue(queue).await_on(lock.read())
-            }
-            fn rwlock_write<'a, T>(
-                &'a self,
-                queue: impl Into<String>,
-                lock: &'a tokio::sync::RwLock<T>,
-            ) -> impl Future<Output = tokio::sync::RwLockWriteGuard<'a, T>> + 'a {
-                self.queue(queue).await_on(lock.write())
-            }
-            fn join_task<T>(
-                &self,
-                stage: impl Into<String>,
-                handle: tokio::task::JoinHandle<T>,
-            ) -> impl Future<Output = Result<T, tokio::task::JoinError>> {
-                self.stage(stage).await_on(handle)
-            }
-            fn timeout_stage<'a, Fut: Future + 'a>(
-                &'a self,
-                stage: impl Into<String>,
-                timeout: Duration,
-                future: Fut,
-            ) -> impl Future<Output = Result<Fut::Output, tokio::time::error::Elapsed>> + 'a {
-                self.stage(stage)
-                    .await_on(tokio::time::timeout(timeout, future))
-            }
-            fn spawn_blocking_stage<F, R>(
-                &self,
-                stage: impl Into<String>,
-                f: F,
-            ) -> impl Future<Output = Result<R, tokio::task::JoinError>>
-            where
-                F: FnOnce() -> R + Send + 'static,
-                R: Send + 'static,
-            {
-                self.stage(stage).await_on(tokio::task::spawn_blocking(f))
-            }
-            fn inflight_guard(
-                &self,
-                gauge: impl Into<String>,
-            ) -> tailtriage_core::InflightGuard<'_> {
-                self.inflight(gauge)
-            }
+impl TokioRequestHandleExt for tailtriage_core::RequestHandle<'_> {
+    fn semaphore<'a>(
+        &'a self,
+        queue: impl Into<String>,
+        semaphore: &'a tokio::sync::Semaphore,
+    ) -> InstrumentedSemaphore<'a> {
+        InstrumentedSemaphore {
+            timer: self.queue(queue),
+            semaphore,
         }
-    };
+    }
+    fn owned_semaphore(
+        &self,
+        queue: impl Into<String>,
+        semaphore: Arc<tokio::sync::Semaphore>,
+    ) -> InstrumentedOwnedSemaphore<'_> {
+        InstrumentedOwnedSemaphore {
+            timer: self.queue(queue),
+            semaphore,
+        }
+    }
+    fn mpsc_recv<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        receiver: &'a mut tokio::sync::mpsc::Receiver<T>,
+    ) -> impl Future<Output = Option<T>> + 'a {
+        self.queue(queue).await_on(receiver.recv())
+    }
+    fn mpsc_send<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        sender: &'a tokio::sync::mpsc::Sender<T>,
+        value: T,
+    ) -> impl Future<Output = Result<(), tokio::sync::mpsc::error::SendError<T>>> + 'a {
+        self.queue(queue).await_on(sender.send(value))
+    }
+    fn mutex_lock<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        mutex: &'a tokio::sync::Mutex<T>,
+    ) -> impl Future<Output = tokio::sync::MutexGuard<'a, T>> + 'a {
+        self.queue(queue).await_on(mutex.lock())
+    }
+    fn rwlock_read<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        lock: &'a tokio::sync::RwLock<T>,
+    ) -> impl Future<Output = tokio::sync::RwLockReadGuard<'a, T>> + 'a {
+        self.queue(queue).await_on(lock.read())
+    }
+    fn rwlock_write<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        lock: &'a tokio::sync::RwLock<T>,
+    ) -> impl Future<Output = tokio::sync::RwLockWriteGuard<'a, T>> + 'a {
+        self.queue(queue).await_on(lock.write())
+    }
+    fn join_task<T>(
+        &self,
+        stage: impl Into<String>,
+        handle: tokio::task::JoinHandle<T>,
+    ) -> impl Future<Output = Result<T, tokio::task::JoinError>> {
+        self.stage(stage).await_on(handle)
+    }
+    fn timeout_stage<'a, Fut: Future + 'a>(
+        &'a self,
+        stage: impl Into<String>,
+        timeout: Duration,
+        future: Fut,
+    ) -> impl Future<Output = Result<Fut::Output, tokio::time::error::Elapsed>> + 'a {
+        self.stage(stage)
+            .await_on(tokio::time::timeout(timeout, future))
+    }
+    fn spawn_blocking_stage<F, R>(
+        &self,
+        stage: impl Into<String>,
+        f: F,
+    ) -> impl Future<Output = Result<R, tokio::task::JoinError>>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        self.stage(stage).await_on(tokio::task::spawn_blocking(f))
+    }
+    fn inflight_guard(&self, gauge: impl Into<String>) -> tailtriage_core::InflightGuard<'_> {
+        self.inflight(gauge)
+    }
 }
-impl_tokio_ext!(tailtriage_core::RequestHandle<'_>);
-impl_tokio_ext!(tailtriage_core::OwnedRequestHandle);
+
+impl TokioRequestHandleExt for tailtriage_core::OwnedRequestHandle {
+    fn semaphore<'a>(
+        &'a self,
+        queue: impl Into<String>,
+        semaphore: &'a tokio::sync::Semaphore,
+    ) -> InstrumentedSemaphore<'a> {
+        InstrumentedSemaphore {
+            timer: self.queue(queue),
+            semaphore,
+        }
+    }
+    fn owned_semaphore(
+        &self,
+        queue: impl Into<String>,
+        semaphore: Arc<tokio::sync::Semaphore>,
+    ) -> InstrumentedOwnedSemaphore<'_> {
+        InstrumentedOwnedSemaphore {
+            timer: self.queue(queue),
+            semaphore,
+        }
+    }
+    fn mpsc_recv<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        receiver: &'a mut tokio::sync::mpsc::Receiver<T>,
+    ) -> impl Future<Output = Option<T>> + 'a {
+        self.queue(queue).await_on(receiver.recv())
+    }
+    fn mpsc_send<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        sender: &'a tokio::sync::mpsc::Sender<T>,
+        value: T,
+    ) -> impl Future<Output = Result<(), tokio::sync::mpsc::error::SendError<T>>> + 'a {
+        self.queue(queue).await_on(sender.send(value))
+    }
+    fn mutex_lock<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        mutex: &'a tokio::sync::Mutex<T>,
+    ) -> impl Future<Output = tokio::sync::MutexGuard<'a, T>> + 'a {
+        self.queue(queue).await_on(mutex.lock())
+    }
+    fn rwlock_read<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        lock: &'a tokio::sync::RwLock<T>,
+    ) -> impl Future<Output = tokio::sync::RwLockReadGuard<'a, T>> + 'a {
+        self.queue(queue).await_on(lock.read())
+    }
+    fn rwlock_write<'a, T>(
+        &'a self,
+        queue: impl Into<String>,
+        lock: &'a tokio::sync::RwLock<T>,
+    ) -> impl Future<Output = tokio::sync::RwLockWriteGuard<'a, T>> + 'a {
+        self.queue(queue).await_on(lock.write())
+    }
+    fn join_task<T>(
+        &self,
+        stage: impl Into<String>,
+        handle: tokio::task::JoinHandle<T>,
+    ) -> impl Future<Output = Result<T, tokio::task::JoinError>> {
+        self.stage(stage).await_on(handle)
+    }
+    fn timeout_stage<'a, Fut: Future + 'a>(
+        &'a self,
+        stage: impl Into<String>,
+        timeout: Duration,
+        future: Fut,
+    ) -> impl Future<Output = Result<Fut::Output, tokio::time::error::Elapsed>> + 'a {
+        self.stage(stage)
+            .await_on(tokio::time::timeout(timeout, future))
+    }
+    fn spawn_blocking_stage<F, R>(
+        &self,
+        stage: impl Into<String>,
+        f: F,
+    ) -> impl Future<Output = Result<R, tokio::task::JoinError>>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        self.stage(stage).await_on(tokio::task::spawn_blocking(f))
+    }
+    fn inflight_guard(&self, gauge: impl Into<String>) -> tailtriage_core::InflightGuard<'_> {
+        self.inflight(gauge)
+    }
+}
 
 /// Queue-instrumented semaphore acquisition helper.
 #[must_use = "constructing the wrapper records nothing until acquire() is awaited"]
@@ -1161,6 +1244,7 @@ mod helper_tests {
         started.completion.finish_ok();
         let snap = run.snapshot();
         assert_eq!(snap.requests.len(), 1);
+        assert_eq!(snap.stages.len(), 7);
         let stage = |name: &str| snap.stages.iter().find(|s| s.stage == name).unwrap();
         assert!(stage("join_ok").success);
         assert!(!stage("join_panic").success);
@@ -1169,6 +1253,43 @@ mod helper_tests {
         assert!(stage("timeout_nested").success);
         assert!(stage("blocking_ok").success);
         assert!(!stage("blocking_panic").success);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn non_send_values_work_for_timeout_stage_and_queue_helpers() {
+        use std::rc::Rc;
+
+        let run = run();
+        let started = run.begin_request("/nonsend");
+        let req = started.handle.clone();
+
+        let value = Rc::new(String::from("payload"));
+        let timeout_value = req
+            .timeout_stage("timeout_non_send", Duration::from_millis(50), async {
+                Rc::clone(&value)
+            })
+            .await
+            .expect("timeout ok");
+        assert_eq!(&*timeout_value, "payload");
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        req.mpsc_send("send_non_send", &tx, Rc::clone(&value))
+            .await
+            .expect("send ok");
+        let recv = req.mpsc_recv("recv_non_send", &mut rx).await.expect("recv");
+        assert_eq!(&*recv, "payload");
+
+        started.completion.finish_ok();
+        let snap = run.snapshot();
+        assert_eq!(snap.requests.len(), 1);
+        assert_eq!(snap.queues.len(), 2);
+        assert!(snap.queues.iter().any(|q| q.queue == "send_non_send"));
+        assert!(snap.queues.iter().any(|q| q.queue == "recv_non_send"));
+        assert_eq!(snap.stages.len(), 1);
+        assert!(snap
+            .stages
+            .iter()
+            .any(|s| s.stage == "timeout_non_send" && s.success));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/tailtriage/src/lib.rs
+++ b/tailtriage/src/lib.rs
@@ -40,6 +40,15 @@ mod tests {
         let _name = crate::tokio::crate_name();
     }
 
+    #[cfg(feature = "tokio")]
+    #[test]
+    fn tokio_helper_trait_reexport_path_compiles() {
+        use crate::tokio::TokioRequestHandleExt;
+
+        fn _assert_trait<T: TokioRequestHandleExt>() {}
+        _assert_trait::<crate::RequestHandle<'_>>();
+    }
+
     #[cfg(feature = "controller")]
     #[test]
     fn controller_namespace_reexport_compiles() {


### PR DESCRIPTION
### Motivation

- Provide concrete implementations of the Tokio helper trait for both borrowed and owned request handles instead of relying on a macro, and clarify helper semantics in docs.  
- Ensure helper helpers (`timeout_stage`, mpsc helpers, queue helpers) correctly handle non-`Send` values on the current-thread runtime.  
- Add a small compile-time reexport check so the Tokio helper trait path is verified by tests.

### Description

- Replaced the `impl_tokio_ext!` macro with explicit `impl TokioRequestHandleExt` blocks for `tailtriage_core::RequestHandle<'_]` and `tailtriage_core::OwnedRequestHandle`.  
- Updated inline docs on `join_task`, `timeout_stage`, and `spawn_blocking_stage` to clarify timing and failure semantics.  
- Added a link in `docs/user-guide.md` to the Tokio helper end-to-end example in `tailtriage-tokio/README.md`.  
- Added tests: `non_send_values_work_for_timeout_stage_and_queue_helpers` and a compile-time reexport test `tokio_helper_trait_reexport_path_compiles`, and adjusted some existing helper assertions.

### Testing

- Ran the unit test suite with the Tokio feature enabled using `cargo test --features tokio`, and all tests passed.  
- The new async test `non_send_values_work_for_timeout_stage_and_queue_helpers` passed under the `current_thread` Tokio flavor.  
- The compile-time reexport test `tokio_helper_trait_reexport_path_compiles` also compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdde13773c83309aec25afeef9222b)