### PR TITLE
Make Tokio helper futures lazy, seal TokioRequestHandleExt, add regressions and docs

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -242,6 +242,12 @@ These helpers are shorthand for explicit `queue(...).await_on(...)`, `stage(...)
 | blocking pool work | `spawn_blocking_stage(...)` | stage |
 | active bounded section | `inflight_guard(...)` | in-flight |
 
+Semantic notes:
+
+- `spawn_blocking_stage(...)` is lazy: constructing the helper future does not spawn blocking work. Spawning starts when the helper future is polled/awaited, and recorded stage time covers spawn through join wait.
+- `timeout_stage(...)` is lazy: timeout budget starts when the helper future is polled/awaited, not when constructed.
+- `mpsc_recv(...)` is useful queue evidence when the channel is meaningful work intake; otherwise it may reflect idle-worker time or producer starvation.
+
 ## 11) Next docs
 
 - [Documentation index](README.md)

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -233,6 +233,12 @@ Helpers map common Tokio primitives to explicit queue/stage/in-flight signals wh
 | blocking pool work | `spawn_blocking_stage(...)` | stage |
 | active bounded section | `inflight_guard(...)` | in-flight |
 
+Semantic notes:
+
+- `spawn_blocking_stage(...)` is lazy: constructing the helper future does not spawn blocking work. Spawning happens when the helper future is polled/awaited, and recorded stage time covers spawn through join wait.
+- `timeout_stage(...)` is lazy: timeout budget starts when the helper future is polled/awaited, not when constructed.
+- `mpsc_recv(...)` is queue evidence when the channel represents meaningful work intake; otherwise it can reflect idle-worker time or producer starvation.
+
 ```rust,no_run
 use std::sync::Arc;
 use std::time::Duration;

--- a/tailtriage-tokio/src/lib.rs
+++ b/tailtriage-tokio/src/lib.rs
@@ -20,8 +20,15 @@ use tokio::runtime::Handle;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
+mod sealed {
+    pub trait Sealed {}
+
+    impl Sealed for tailtriage_core::RequestHandle<'_> {}
+    impl Sealed for tailtriage_core::OwnedRequestHandle {}
+}
+
 /// Extension helpers that map common Tokio primitives to tailtriage queue/stage/in-flight signals.
-pub trait TokioRequestHandleExt {
+pub trait TokioRequestHandleExt: sealed::Sealed {
     /// Records a queue event while waiting to acquire a semaphore permit.
     ///
     /// Equivalent low-level form: `req.queue(label).await_on(semaphore.acquire())` via [`InstrumentedSemaphore::acquire`].
@@ -48,7 +55,9 @@ pub trait TokioRequestHandleExt {
     ///
     /// Equivalent low-level form: `req.queue(label).await_on(receiver.recv())`.
     ///
-    /// Measures waiting for an item only, not processing after receipt. Returns `Option<T>` unchanged. Request completion remains explicit.
+    /// Measures waiting for an item only, not processing after receipt.
+    /// This queue signal is most useful when the channel represents real work intake; otherwise it can reflect idle-worker time or producer starvation.
+    /// Returns `Option<T>` unchanged. Request completion remains explicit.
     fn mpsc_recv<'a, T>(
         &'a self,
         queue: impl Into<String>,
@@ -111,7 +120,9 @@ pub trait TokioRequestHandleExt {
     /// Equivalent low-level form: `req.stage(label).await_on(tokio::time::timeout(timeout, future))`.
     ///
     /// Preserves the outer timeout `Result` and any nested inner `Result` exactly (no flattening/remapping).
-    /// Timeout elapsed is represented by outer `Err(Elapsed)`. Request completion remains explicit.
+    /// Timeout elapsed is represented by outer `Err(Elapsed)`.
+    /// Timeout budget begins when the returned helper future is polled/awaited, not when constructed.
+    /// Request completion remains explicit.
     fn timeout_stage<'a, Fut: Future + 'a>(
         &'a self,
         stage: impl Into<String>,
@@ -122,7 +133,8 @@ pub trait TokioRequestHandleExt {
     ///
     /// Equivalent low-level form: `req.stage(label).await_on(tokio::task::spawn_blocking(f))`.
     ///
-    /// Records stage time from spawning the blocking task through awaiting its join handle.
+    /// Constructing the helper future does not spawn work.
+    /// Work is spawned when the returned helper future is polled/awaited, and stage timing covers spawning through awaiting the join handle.
     /// Preserves `Result<R, JoinError>` unchanged. Typical use: blocking pool work. Request completion remains explicit.
     fn spawn_blocking_stage<F, R>(
         &self,
@@ -210,8 +222,8 @@ impl TokioRequestHandleExt for tailtriage_core::RequestHandle<'_> {
         timeout: Duration,
         future: Fut,
     ) -> impl Future<Output = Result<Fut::Output, tokio::time::error::Elapsed>> + 'a {
-        self.stage(stage)
-            .await_on(tokio::time::timeout(timeout, future))
+        let timer = self.stage(stage);
+        async move { timer.await_on(tokio::time::timeout(timeout, future)).await }
     }
     fn spawn_blocking_stage<F, R>(
         &self,
@@ -222,7 +234,8 @@ impl TokioRequestHandleExt for tailtriage_core::RequestHandle<'_> {
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,
     {
-        self.stage(stage).await_on(tokio::task::spawn_blocking(f))
+        let timer = self.stage(stage);
+        async move { timer.await_on(tokio::task::spawn_blocking(f)).await }
     }
     fn inflight_guard(&self, gauge: impl Into<String>) -> tailtriage_core::InflightGuard<'_> {
         self.inflight(gauge)
@@ -299,8 +312,8 @@ impl TokioRequestHandleExt for tailtriage_core::OwnedRequestHandle {
         timeout: Duration,
         future: Fut,
     ) -> impl Future<Output = Result<Fut::Output, tokio::time::error::Elapsed>> + 'a {
-        self.stage(stage)
-            .await_on(tokio::time::timeout(timeout, future))
+        let timer = self.stage(stage);
+        async move { timer.await_on(tokio::time::timeout(timeout, future)).await }
     }
     fn spawn_blocking_stage<F, R>(
         &self,
@@ -311,7 +324,8 @@ impl TokioRequestHandleExt for tailtriage_core::OwnedRequestHandle {
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,
     {
-        self.stage(stage).await_on(tokio::task::spawn_blocking(f))
+        let timer = self.stage(stage);
+        async move { timer.await_on(tokio::task::spawn_blocking(f)).await }
     }
     fn inflight_guard(&self, gauge: impl Into<String>) -> tailtriage_core::InflightGuard<'_> {
         self.inflight(gauge)
@@ -1096,6 +1110,8 @@ mod tests {
 
 #[cfg(test)]
 mod helper_tests {
+    use std::rc::Rc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
 
@@ -1243,6 +1259,7 @@ mod helper_tests {
         started.completion.finish_ok();
         let snap = run.snapshot();
         assert_eq!(snap.requests.len(), 1);
+        assert_eq!(snap.stages.len(), 7);
         let stage = |name: &str| snap.stages.iter().find(|s| s.stage == name).unwrap();
         assert!(stage("join_ok").success);
         assert!(!stage("join_panic").success);
@@ -1251,6 +1268,78 @@ mod helper_tests {
         assert!(stage("timeout_nested").success);
         assert!(stage("blocking_ok").success);
         assert!(!stage("blocking_panic").success);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn spawn_blocking_stage_is_lazy_until_polled() {
+        let run = run();
+        let started = run.begin_request("/lazy-blocking");
+        let req = started.handle.clone();
+        let counter = Arc::new(AtomicUsize::new(0));
+        {
+            let c = Arc::clone(&counter);
+            let fut = req.spawn_blocking_stage("lazy_blocking", move || {
+                c.fetch_add(1, Ordering::SeqCst);
+            });
+            drop(fut);
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert_eq!(counter.load(Ordering::SeqCst), 0);
+        assert!(run.snapshot().stages.is_empty());
+
+        {
+            let c = Arc::clone(&counter);
+            req.spawn_blocking_stage("lazy_blocking", move || {
+                c.fetch_add(1, Ordering::SeqCst);
+            })
+            .await
+            .expect("spawn_blocking join should succeed");
+        }
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+        let snap = run.snapshot();
+        let matching: Vec<_> = snap
+            .stages
+            .iter()
+            .filter(|s| s.stage == "lazy_blocking")
+            .collect();
+        assert_eq!(matching.len(), 1);
+        started.completion.finish_ok();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn timeout_stage_is_lazy_until_polled() {
+        let run = run();
+        let started = run.begin_request("/lazy-timeout");
+        let req = started.handle.clone();
+        let fut = req.timeout_stage("lazy_timeout", Duration::from_millis(10), async { 5usize });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let out = fut.await;
+        assert_eq!(out, Ok(5usize));
+        let snap = run.snapshot();
+        let matching: Vec<_> = snap
+            .stages
+            .iter()
+            .filter(|s| s.stage == "lazy_timeout")
+            .collect();
+        assert_eq!(matching.len(), 1);
+        assert!(matching[0].success);
+        started.completion.finish_ok();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn timeout_stage_does_not_require_send() {
+        let run = run();
+        let started = run.begin_request("/non-send-timeout");
+        let req = started.handle.clone();
+        let rc = Rc::new(String::from("ok"));
+        let out = req
+            .timeout_stage("non_send_timeout", Duration::from_millis(20), {
+                let rc = Rc::clone(&rc);
+                async move { rc.len() }
+            })
+            .await;
+        assert_eq!(out, Ok(2usize));
+        started.completion.finish_ok();
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -1272,5 +1361,12 @@ mod helper_tests {
         assert!(run.snapshot().requests.is_empty());
         started.completion.finish_ok();
         assert_eq!(run.snapshot().requests.len(), 1);
+    }
+
+    #[test]
+    fn ext_trait_is_available_from_crate_re_exports() {
+        fn assert_ext<T: crate::TokioRequestHandleExt>() {}
+        assert_ext::<tailtriage_core::RequestHandle<'_>>();
+        assert_ext::<tailtriage_core::OwnedRequestHandle>();
     }
 }


### PR DESCRIPTION
### Motivation

- Fix incorrect eager behavior where `spawn_blocking_stage` and `timeout_stage` could start blocking work or a timeout budget at helper construction time instead of when the returned future is polled/awaited.
- Prevent downstream crates from implementing the extension trait as a customization point by sealing `TokioRequestHandleExt` so future helper additions remain non-breaking.
- Add focused, deterministic regression tests and update docs so public helper semantics match the implementation and the repo documentation contract.

### Description

- Make `spawn_blocking_stage` lazy for both `tailtriage_core::RequestHandle<'_>` and `tailtriage_core::OwnedRequestHandle` by creating the stage timer and calling `tokio::task::spawn_blocking(f)` inside an `async move` returned future so spawning occurs at poll/await time.
- Make `timeout_stage` lazy for both handle impls by constructing `tokio::time::timeout(timeout, future)` inside the returned `async move` future, preserving the nested `Result` types exactly.
- Seal `TokioRequestHandleExt` via a private `mod sealed` with `trait Sealed` and implement it only for `tailtriage_core::RequestHandle<'_>` and `tailtriage_core::OwnedRequestHandle`, then require `TokioRequestHandleExt: sealed::Sealed`.
- Add and tighten tests in `tailtriage-tokio/src/lib.rs` for `spawn_blocking_stage` laziness, `timeout_stage` laziness, non-`Send` helper usage (`Rc` capture), exact stage-count assertions, and a compile-check that both core handle types implement the helper trait; update README and `docs/user-guide.md` to document the lazy semantics and `mpsc_recv` caveat.
- Branch/commit note: the requested branch `codex/add-tokio-helper-api-for-tailtriage` was not present in the environment so the fixes were applied and committed to the current working branch `work`; old HEAD was `9916147edf59ddc2941fb465a686653f576f70ca` and new HEAD is `ccea2a92fd3b5ca78da30ae7648dcbbb05e042d0`.
- Intentional non-changes: no macros reintroduced, no boxed dynamic futures, no public async-fn-in-trait, no new dependencies, no new helper names, and `tailtriage-core` remains Tokio-independent.

### Testing

- Ran `cargo fmt --check` and it succeeded without changes required.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it completed with no warnings.
- Ran `cargo test --workspace --all-features --locked` and the full test matrix passed (the added tokio helper tests exercised laziness and non-`Send` behavior successfully).
- Ran `cargo doc --workspace --all-features --no-deps --locked` which completed successfully (a Cargo doc filename-collision warning about duplicate crate names was emitted but documentation generation succeeded).
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fded3b4cf0833095a65968cfe41c44)