### PR TITLE
Fix Tokio helper laziness and seal TokioRequestHandleExt

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -242,6 +242,12 @@ These helpers are shorthand for explicit `queue(...).await_on(...)`, `stage(...)
 | blocking pool work | `spawn_blocking_stage(...)` | stage |
 | active bounded section | `inflight_guard(...)` | in-flight |
 
+Semantics to keep in mind:
+
+- `spawn_blocking_stage(...)` is lazy: constructing the helper future does not spawn blocking work. Work is spawned when the helper future is polled/awaited, and stage timing covers spawn through join await.
+- `timeout_stage(...)` starts timeout budget when the helper future is polled/awaited, not when it is constructed.
+- `mpsc_recv(...)` queue wait is most useful evidence when the channel reflects real work intake; otherwise it may represent idle-worker time or producer starvation.
+
 ## 11) Next docs
 
 - [Documentation index](README.md)

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -219,6 +219,7 @@ use tailtriage::tokio::TokioRequestHandleExt;
 ```
 
 Helpers map common Tokio primitives to explicit queue/stage/in-flight signals while preserving Tokio return/error types.
+Suspects from analysis remain evidence-ranked leads, not proof of root cause.
 
 | Use case | Helper | Records |
 |---|---|---|
@@ -232,6 +233,12 @@ Helpers map common Tokio primitives to explicit queue/stage/in-flight signals wh
 | timeout-wrapped work | `timeout_stage(...)` | stage |
 | blocking pool work | `spawn_blocking_stage(...)` | stage |
 | active bounded section | `inflight_guard(...)` | in-flight |
+
+Helper timing semantics:
+
+- `spawn_blocking_stage(...)`: constructing the helper future does not spawn blocking work. Work is spawned when the returned future is polled/awaited. Recorded stage time covers spawn through awaiting join completion.
+- `timeout_stage(...)`: timeout budget starts when the returned helper future is polled/awaited, not when helper construction happens.
+- `mpsc_recv(...)`: receive wait is useful queue evidence when the channel represents meaningful work intake; otherwise it may also reflect idle-worker time or producer starvation.
 
 ```rust,no_run
 use std::sync::Arc;

--- a/tailtriage-tokio/src/lib.rs
+++ b/tailtriage-tokio/src/lib.rs
@@ -20,8 +20,15 @@ use tokio::runtime::Handle;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
+mod sealed {
+    pub trait Sealed {}
+
+    impl Sealed for tailtriage_core::RequestHandle<'_> {}
+    impl Sealed for tailtriage_core::OwnedRequestHandle {}
+}
+
 /// Extension helpers that map common Tokio primitives to tailtriage queue/stage/in-flight signals.
-pub trait TokioRequestHandleExt {
+pub trait TokioRequestHandleExt: sealed::Sealed {
     /// Records a queue event while waiting to acquire a semaphore permit.
     ///
     /// Equivalent low-level form: `req.queue(label).await_on(semaphore.acquire())` via [`InstrumentedSemaphore::acquire`].
@@ -48,7 +55,9 @@ pub trait TokioRequestHandleExt {
     ///
     /// Equivalent low-level form: `req.queue(label).await_on(receiver.recv())`.
     ///
-    /// Measures waiting for an item only, not processing after receipt. Returns `Option<T>` unchanged. Request completion remains explicit.
+    /// Measures waiting for an item only, not processing after receipt. This queue evidence is most useful when
+    /// the channel maps to meaningful work intake; otherwise it can also represent idle workers or producer starvation.
+    /// Returns `Option<T>` unchanged. Request completion remains explicit.
     fn mpsc_recv<'a, T>(
         &'a self,
         queue: impl Into<String>,
@@ -110,6 +119,7 @@ pub trait TokioRequestHandleExt {
     ///
     /// Equivalent low-level form: `req.stage(label).await_on(tokio::time::timeout(timeout, future))`.
     ///
+    /// Timeout budget starts when the returned helper future is polled/awaited, not when it is constructed.
     /// Preserves the outer timeout `Result` and any nested inner `Result` exactly (no flattening/remapping).
     /// Timeout elapsed is represented by outer `Err(Elapsed)`. Request completion remains explicit.
     fn timeout_stage<'a, Fut: Future + 'a>(
@@ -122,7 +132,8 @@ pub trait TokioRequestHandleExt {
     ///
     /// Equivalent low-level form: `req.stage(label).await_on(tokio::task::spawn_blocking(f))`.
     ///
-    /// Records stage time from spawning the blocking task through awaiting its join handle.
+    /// Constructing this helper future does not spawn work. Blocking work is spawned when the returned helper future
+    /// is polled/awaited. The recorded stage covers spawning through awaiting the blocking task join handle.
     /// Preserves `Result<R, JoinError>` unchanged. Typical use: blocking pool work. Request completion remains explicit.
     fn spawn_blocking_stage<F, R>(
         &self,
@@ -210,8 +221,8 @@ impl TokioRequestHandleExt for tailtriage_core::RequestHandle<'_> {
         timeout: Duration,
         future: Fut,
     ) -> impl Future<Output = Result<Fut::Output, tokio::time::error::Elapsed>> + 'a {
-        self.stage(stage)
-            .await_on(tokio::time::timeout(timeout, future))
+        let timer = self.stage(stage);
+        async move { timer.await_on(tokio::time::timeout(timeout, future)).await }
     }
     fn spawn_blocking_stage<F, R>(
         &self,
@@ -222,7 +233,8 @@ impl TokioRequestHandleExt for tailtriage_core::RequestHandle<'_> {
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,
     {
-        self.stage(stage).await_on(tokio::task::spawn_blocking(f))
+        let timer = self.stage(stage);
+        async move { timer.await_on(tokio::task::spawn_blocking(f)).await }
     }
     fn inflight_guard(&self, gauge: impl Into<String>) -> tailtriage_core::InflightGuard<'_> {
         self.inflight(gauge)
@@ -299,8 +311,8 @@ impl TokioRequestHandleExt for tailtriage_core::OwnedRequestHandle {
         timeout: Duration,
         future: Fut,
     ) -> impl Future<Output = Result<Fut::Output, tokio::time::error::Elapsed>> + 'a {
-        self.stage(stage)
-            .await_on(tokio::time::timeout(timeout, future))
+        let timer = self.stage(stage);
+        async move { timer.await_on(tokio::time::timeout(timeout, future)).await }
     }
     fn spawn_blocking_stage<F, R>(
         &self,
@@ -311,7 +323,8 @@ impl TokioRequestHandleExt for tailtriage_core::OwnedRequestHandle {
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,
     {
-        self.stage(stage).await_on(tokio::task::spawn_blocking(f))
+        let timer = self.stage(stage);
+        async move { timer.await_on(tokio::task::spawn_blocking(f)).await }
     }
     fn inflight_guard(&self, gauge: impl Into<String>) -> tailtriage_core::InflightGuard<'_> {
         self.inflight(gauge)
@@ -1096,6 +1109,8 @@ mod tests {
 
 #[cfg(test)]
 mod helper_tests {
+    use std::rc::Rc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
 
@@ -1243,6 +1258,7 @@ mod helper_tests {
         started.completion.finish_ok();
         let snap = run.snapshot();
         assert_eq!(snap.requests.len(), 1);
+        assert_eq!(snap.stages.len(), 7);
         let stage = |name: &str| snap.stages.iter().find(|s| s.stage == name).unwrap();
         assert!(stage("join_ok").success);
         assert!(!stage("join_panic").success);
@@ -1272,5 +1288,82 @@ mod helper_tests {
         assert!(run.snapshot().requests.is_empty());
         started.completion.finish_ok();
         assert_eq!(run.snapshot().requests.len(), 1);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn spawn_blocking_stage_is_lazy() {
+        let run = Arc::new(run());
+        let started = run.begin_request("/blocking-lazy");
+        let req = started.handle.clone();
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        let dropped_counter = Arc::clone(&counter);
+        let never_polled = req.spawn_blocking_stage("blocking_lazy", move || {
+            dropped_counter.fetch_add(1, Ordering::SeqCst);
+        });
+        drop(never_polled);
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        assert_eq!(counter.load(Ordering::SeqCst), 0);
+        assert!(run
+            .snapshot()
+            .stages
+            .iter()
+            .all(|stage| stage.stage != "blocking_lazy"));
+
+        let awaited_counter = Arc::clone(&counter);
+        req.spawn_blocking_stage("blocking_lazy", move || {
+            awaited_counter.fetch_add(1, Ordering::SeqCst);
+        })
+        .await
+        .expect("blocking helper should complete");
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+
+        started.completion.finish_ok();
+        let snap = run.snapshot();
+        assert_eq!(
+            snap.stages
+                .iter()
+                .filter(|s| s.stage == "blocking_lazy")
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn timeout_stage_is_lazy_and_accepts_non_send_futures() {
+        let run = Arc::new(run());
+        let started = run.begin_request("/timeout-lazy");
+        let req = started.handle.clone();
+
+        let lazy_ok = req.timeout_stage("timeout_lazy_ok", Duration::from_millis(50), async {});
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(lazy_ok.await.is_ok());
+
+        let rc = Rc::new(7usize);
+        let keep_rc = Rc::clone(&rc);
+        assert_eq!(
+            req.timeout_stage("timeout_non_send", Duration::from_millis(10), async move {
+                *keep_rc
+            })
+            .await,
+            Ok(7usize)
+        );
+
+        started.completion.finish_ok();
+        let snap = run.snapshot();
+        assert_eq!(
+            snap.stages
+                .iter()
+                .filter(|s| s.stage == "timeout_lazy_ok")
+                .count(),
+            1
+        );
+        assert_eq!(
+            snap.stages
+                .iter()
+                .filter(|s| s.stage == "timeout_non_send")
+                .count(),
+            1
+        );
     }
 }

--- a/tailtriage/src/lib.rs
+++ b/tailtriage/src/lib.rs
@@ -47,6 +47,7 @@ mod tests {
 
         fn assert_trait<T: TokioRequestHandleExt>() {}
         assert_trait::<crate::RequestHandle<'_>>();
+        assert_trait::<crate::OwnedRequestHandle>();
     }
 
     #[cfg(feature = "controller")]


### PR DESCRIPTION
### Motivation

- The Tokio helper APIs could start work or timeout budgets at helper-construction time instead of when the returned future is polled, producing incorrect semantics and spurious work/stage events.
- The helper extension trait is intended only for the repo-known handle types and should be sealed to avoid becoming a downstream implementation/growth point.
- Add regression tests to prevent regressions in laziness and tighten existing helper tests for stronger, deterministic assertions.
- Update public docs to accurately describe the lazy semantics and the intended interpretation of `mpsc_recv` evidence.

### Description

- Confirmed the actual branch `codex/add-tokio-helper-api-for-tailtriage` was updated; old head SHA: `9916147edf59ddc2941fb465a686653f576f70ca`, new head SHA: `44cacb402a3419022a55380903d0a6b7c2c7e0b9`.
- Made `spawn_blocking_stage` lazy for both `tailtriage_core::RequestHandle<'_>` and `tailtriage_core::OwnedRequestHandle` by moving `tokio::task::spawn_blocking(f)` into an `async move` returned future so the blocking task is spawned only when the helper future is polled/awaited.
- Made `timeout_stage` lazy for both handle impls by constructing `tokio::time::timeout(timeout, future)` inside the returned `async move` future so the timeout budget begins at poll/await time and the nested `Result` shape is preserved unchanged.
- Sealed the extension trait by adding a private `mod sealed { pub trait Sealed { } ... }` and changing `pub trait TokioRequestHandleExt: sealed::Sealed`, keeping the sealed module private and not exported.

### Testing

- Added and tightened unit tests in `tailtriage-tokio/src/lib.rs`: an exact-stage-count assertion in the stage helper test, a `spawn_blocking_stage_is_lazy` regression (drop-before-await does not run closure and records no stage; await path runs and records exactly one stage), and `timeout_stage_is_lazy_and_accepts_non_send_futures` which verifies laziness and a non-`Send` (`Rc`) inner future.
- Validation commands run: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-features --locked`, `cargo doc --workspace --all-features --no-deps --locked`, and `python3 scripts/validate_docs_contracts.py`, and all completed successfully (note: `cargo doc` emitted the existing doc filename-collision warning for the `tailtriage` lib/bin docs which is pre-existing and not caused by this change).
- Test run summary: `cargo test` passed across the workspace including the new laziness and non-`Send` tests (all tests reported OK).
- Intentional non-changes: did not reintroduce macros, did not add boxed/dynamic futures, did not use `async fn` in traits, added no new dependencies, preserved `tailtriage-core` Tokio-independence, did not add new helper names, and did not change MSRV/workspace metadata.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fded3b4cf0833095a65968cfe41c44)