### PR TITLE
Add production operations guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,9 @@ Docs in `docs/` are user-facing product documentation.
 - Do not write contributor-process narration, issue-history context, or roadmap-history wording in `docs/` pages.
 - Keep docs crisp, truthful, present-tense, and aligned with the current product surface.
 - Do not claim behavior that is not supported by the code and current public docs.
+- Treat `docs/operations.md` as the canonical production operations guidance page.
+- Update `docs/operations.md` when behavior or guidance changes for rollout path, capture-mode choice, controller/lifecycle operation, runtime sampling guidance, artifact sizing, truncation/capture-limit behavior, weak-signal troubleshooting, `evidence_quality` interpretation, or operational validation claims.
+- Keep operations guidance bounded: evidence-ranked suspects and next checks are triage leads, not proof of root cause, and not observability-platform claims.
 - Keep `docs/README.md` as a complete user-journey index to current docs.
 - Treat `scripts/validate_docs_contracts.py` and related tests as part of the public documentation contract.
 - If docs structure, required docs links, or enforced public-doc wording changes, update the docs contract validator and related tests in the same change set.

--- a/README.md
+++ b/README.md
@@ -292,6 +292,8 @@ For full report-field interpretation, see [`docs/diagnostics.md`](docs/diagnosti
 
 For validation scope, claims, and current diagnostic scorecard, see [VALIDATION.md](VALIDATION.md).
 
+For production rollout, capture-mode selection, runtime-sampling decisions, artifact sizing, truncation handling, weak-signal troubleshooting, and current operational limits, start with [`docs/operations.md`](docs/operations.md).
+
 `tailtriage` includes repo-local measurement paths for both runtime-overhead attribution and sustained collector-stress behavior. These are based on synthetic, controlled tests in this repository and should be treated as machine- and workload-scoped guidance, not universal production guarantees.
 
 For overhead attribution and measurement workflow, see [`docs/runtime-cost.md`](docs/runtime-cost.md). For sustained-load behavior, truncation onset, artifact-size growth, and memory trends under stress-shaped workloads, see [`docs/collector-limits.md`](docs/collector-limits.md).

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -3,6 +3,8 @@
 ## Summary
 `tailtriage` is a triage tool, not root-cause proof. It produces evidence-ranked suspects and next checks, where suspects are leads and not causal certainty.
 
+For production rollout and operational guidance that applies these bounded claims, see `docs/operations.md`.
+
 ## Current validation status
 This repository includes an initial deterministic validation corpus for controlled Tokio workload fixtures. The corpus and benchmark validate bounded diagnostic behavior on committed fixtures, not universal production behavior.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ Most users should start with `tailtriage`.
 Use these docs when wiring `tailtriage` into a service or interpreting output.
 
 - [User guide](user-guide.md) — end-to-end adoption path and operational workflow.
+- [Operations guide](operations.md) — primary production operations guidance for rollout path, capture-mode selection, runtime sampling decisions, artifact sizing, truncation/capture-limit handling, weak-signal troubleshooting, and current operational limits.
 - [Diagnostics guide](diagnostics.md) — how to read analyzer output, evidence quality, suspects, confidence, warnings, and field meanings.
 - [Analyzer README (`tailtriage-analyzer`)](../tailtriage-analyzer/README.md) — typed in-process report contract and rendering API.
 - [CLI README (`tailtriage-cli`)](../tailtriage-cli/README.md) — saved-artifact loading, schema validation, and text/JSON output.

--- a/docs/collector-limits.md
+++ b/docs/collector-limits.md
@@ -5,6 +5,7 @@ This page describes the repository's sustained collector-stress measurement path
 Use this path when you want to understand truncation onset, dropped-category progression, artifact-size growth, and memory trends under stress-shaped synthetic workloads.
 
 For runtime-overhead attribution across fixed modes, use [runtime-cost.md](runtime-cost.md).
+For production rollout and operations decisions that combine limits behavior with capture-mode and troubleshooting guidance, see [operations.md](operations.md).
 
 ## What this path measures
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -162,9 +162,9 @@ The repository intentionally does not claim universal production artifact sizing
 
 Use:
 
-* `docs/runtime-cost.md`
-* `docs/collector-limits.md`
-* `scripts/measure_collector_limits.py`
+* [runtime cost measurement](runtime-cost.md)
+* [collector limits and stress guidance](collector-limits.md)
+* [`scripts/measure_collector_limits.py`](../scripts/measure_collector_limits.py)
 
 when establishing local operational expectations.
 
@@ -412,11 +412,11 @@ Use these when evaluating:
 
 Primary references:
 
-* `VALIDATION.md`
-* `docs/runtime-cost.md`
-* `docs/collector-limits.md`
-* `scripts/run_operational_validation.py`
-* `scripts/measure_collector_limits.py`
+* [validation overview](../VALIDATION.md)
+* [runtime cost measurement](runtime-cost.md)
+* [collector limits and stress guidance](collector-limits.md)
+* [`scripts/run_operational_validation.py`](../scripts/run_operational_validation.py)
+* [`scripts/measure_collector_limits.py`](../scripts/measure_collector_limits.py)
 
 These measurements are:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -18,10 +18,10 @@ This guide explains:
 
 For API-level usage and request lifecycle contracts, see:
 
-* `docs/user-guide.md`
-* `docs/diagnostics.md`
-* `tailtriage-controller/README.md`
-* `VALIDATION.md`
+- [user guide](user-guide.md)
+- [diagnostics guide](diagnostics.md)
+- [controller README](../tailtriage-controller/README.md)
+- [validation overview](../VALIDATION.md)
 
 ## Recommended rollout path
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,466 @@
+# Production operations guide
+
+This guide focuses on operating `tailtriage` in real services.
+
+It is intentionally operational rather than API-centric.
+
+`tailtriage` is a bounded tail-latency triage tool. It produces evidence-ranked suspects and next checks from one captured run. Suspects are triage leads, not proof of root cause.
+
+This guide explains:
+
+* when to enable capture
+* how to roll out safely
+* when to use light versus investigation capture
+* when runtime sampling helps
+* how to reason about artifact growth and truncation
+* how to interpret weak or ambiguous output
+* what the current operational limits and non-fits are
+
+For API-level usage and request lifecycle contracts, see:
+
+* `docs/user-guide.md`
+* `docs/diagnostics.md`
+* `tailtriage-controller/README.md`
+* `VALIDATION.md`
+
+## Recommended rollout path
+
+Use a staged rollout.
+
+Do not begin with dense runtime sampling and maximum capture limits in production.
+
+Recommended progression:
+
+1. start with direct capture or controller-managed bounded windows
+2. use `light` mode first
+3. add queue and stage instrumentation around suspected waits
+4. validate that artifacts analyze cleanly
+5. enable runtime sampling only when request timing alone is insufficient
+6. increase capture density only when the existing evidence is not enough
+
+A conservative rollout usually gives better operational signal than enabling every feature immediately.
+
+## Choosing direct capture vs controller capture
+
+### Direct capture
+
+Use `Tailtriage` directly when:
+
+* you want one explicit bounded run
+* capture lifetime naturally matches process lifetime
+* you are validating instrumentation locally or in staging
+* you do not need repeated arm/disarm windows
+
+This model is:
+
+```text
+build -> capture -> shutdown
+```
+
+### Controller capture
+
+Use `TailtriageController` when:
+
+* the service stays up continuously
+* you need repeated bounded capture windows
+* you want runtime arm/disarm control
+* you want TOML-backed operational configuration
+* you want future generations to pick up reloaded config
+
+This model is:
+
+```text
+enable -> capture -> disable -> re-enable later
+```
+
+Controller capture is usually the better production operational model.
+
+## Capture mode guidance
+
+### `light`
+
+Use `light` mode first.
+
+Recommended for:
+
+* initial production rollout
+* lower-risk bounded captures
+* validating instrumentation quality
+* broad environment coverage
+* services where artifact growth must stay conservative
+
+Prefer `light` when:
+
+* you are still deciding where instrumentation belongs
+* you only need directional evidence
+* you expect many repeated capture windows
+* you are operating under tight retention constraints
+
+### `investigation`
+
+Use `investigation` mode when:
+
+* a real tail-latency incident is active
+* `light` mode produced ambiguous evidence
+* runtime pressure needs deeper separation
+* you need more complete stage/queue visibility
+* you are intentionally running a denser bounded capture
+
+`investigation` mode is not intended as a permanent always-on telemetry configuration.
+
+## Runtime sampling guidance
+
+Runtime sampling is optional enrichment.
+
+It is most useful when request timing alone cannot clearly separate:
+
+* application queue saturation
+* executor pressure
+* blocking-pool pressure
+
+Runtime sampling is usually worth enabling when:
+
+* executor pressure is suspected
+* blocking-pool contention is suspected
+* queue wait alone does not explain the tail
+* request timing evidence is ambiguous
+* the service already uses Tokio heavily
+
+Runtime sampling is usually unnecessary when:
+
+* downstream stage latency clearly dominates
+* queue saturation is already obvious
+* the run already produces strong evidence quality
+* you only need high-level directional triage
+
+Important operational constraints:
+
+* runtime sampling must start inside an active Tokio runtime
+* runtime snapshots are bounded by capture limits
+* some runtime fields require `tokio_unstable`
+* runtime sampling increases event volume and artifact growth
+
+Start conservatively.
+
+Prefer moderate intervals and bounded runs before increasing density.
+
+## Artifact sizing and retention expectations
+
+Artifact size depends on:
+
+* request count
+* queue event count
+* stage event count
+* runtime snapshot density
+* in-flight snapshot density
+* capture duration
+* truncation state
+
+Artifact growth is workload-shaped and machine-scoped.
+
+The repository intentionally does not claim universal production artifact sizing.
+
+Use:
+
+* `docs/runtime-cost.md`
+* `docs/collector-limits.md`
+* `scripts/measure_collector_limits.py`
+
+when establishing local operational expectations.
+
+## Capture limits and truncation
+
+Capture limits are expected operational controls, not exceptional failures.
+
+When limits are hit:
+
+* retained data becomes partial
+* dropped counters become non-zero
+* evidence quality can downgrade
+* warnings can appear
+* interpretation confidence should become more conservative
+
+Treat truncation as a signal that:
+
+* the capture window was too dense
+* the run duration was too large
+* limits were too small for the workload
+* runtime sampling density may be too aggressive
+
+Do not treat truncation as proof the analyzer is wrong.
+
+Instead:
+
+1. inspect dropped counters
+2. inspect warnings
+3. reduce capture scope or increase limits
+4. rerun under comparable load
+
+For controller-managed runs, consider:
+
+* `continue_after_limits_hit`
+* `auto_seal_on_limits_hit`
+
+based on whether bounded retention or uninterrupted capture matters more operationally.
+
+## Operational guidance for bounded runs
+
+Prefer bounded investigative windows over continuous long-lived capture.
+
+Good operational patterns:
+
+* arm during a suspected incident window
+* collect enough traffic to produce stable evidence
+* disarm and analyze
+* compare before/after mitigation runs
+* rerun with one changed variable
+
+Avoid:
+
+* indefinite always-recording operation
+* continuously increasing limits without understanding growth
+* treating one run as causal proof
+* enabling every instrumentation surface immediately
+
+## How to interpret common output patterns
+
+### `application_queue_saturation`
+
+Usually indicates:
+
+* queue residence time dominates tail latency
+* work is delayed before execution begins
+* admission pressure or producer burst behavior is likely relevant
+
+Next checks often include:
+
+* queue limits
+* concurrency limits
+* worker availability
+* producer burst patterns
+* request fan-in
+
+### `blocking_pool_pressure`
+
+Usually indicates:
+
+* `spawn_blocking` backlog pressure
+* blocking work saturation
+* blocking pool queue growth
+
+Next checks often include:
+
+* blocking pool sizing
+* synchronous I/O paths
+* CPU-heavy blocking sections
+* accidental blocking in async code
+
+### `executor_pressure_suspected`
+
+Usually indicates:
+
+* runtime scheduling contention
+* runnable-task pressure
+* executor queue growth
+
+Next checks often include:
+
+* task fan-out
+* task explosion
+* runtime saturation
+* busy-loop or starvation behavior
+* over-fragmented async work
+
+### `downstream_stage_dominates`
+
+Usually indicates:
+
+* one downstream stage materially dominates request latency
+* queue pressure is not the strongest lead in that run
+
+Next checks often include:
+
+* database latency
+* external API latency
+* cache misses
+* retry amplification
+* downstream concurrency constraints
+
+### `insufficient_evidence`
+
+This usually means the run lacks enough explanatory signal.
+
+It does not necessarily mean nothing is wrong.
+
+Most common causes:
+
+* too little instrumentation
+* missing queue wrappers
+* missing stage wrappers
+* insufficient runtime visibility
+* very small request sample count
+* heavily truncated capture
+
+Recommended progression:
+
+1. add queue instrumentation around waits
+2. add stage instrumentation around downstream work
+3. optionally add runtime sampling
+4. rerun under comparable load
+
+## Evidence quality and operational trust
+
+Use `evidence_quality` as an operational interpretation boundary.
+
+### `strong`
+
+Usually means:
+
+* enough requests were captured
+* important evidence families are present
+* truncation is not active
+
+This supports stronger next-check confidence.
+
+### `partial`
+
+Usually means:
+
+* some evidence families are missing
+* truncation occurred
+* runtime visibility is incomplete
+* interpretation limits are material
+
+Treat conclusions more conservatively.
+
+### `weak`
+
+Usually means:
+
+* request evidence is sparse
+* critical evidence families are absent
+* request retention was truncated heavily
+
+Use the run mainly to decide what instrumentation or capture shape to improve next.
+
+## Operational troubleshooting
+
+### Analyzer output feels ambiguous
+
+Most common causes:
+
+* multiple bottleneck families overlap
+* runtime evidence is incomplete
+* queue/stage instrumentation coverage is sparse
+* the workload is phase-changing during capture
+
+Recommended actions:
+
+* add one more instrumentation surface
+* shorten the capture window
+* compare multiple bounded runs
+* rerun after one targeted mitigation
+
+### Artifacts are too large
+
+Reduce:
+
+* runtime sampling density
+* capture duration
+* request volume per run
+* unnecessary instrumentation breadth
+
+Or:
+
+* lower capture concurrency
+* split captures into smaller bounded windows
+* use controller-managed operational windows
+
+### Runtime sampling overwhelms the run
+
+Use:
+
+* longer sample intervals
+* lower runtime snapshot limits
+* shorter capture windows
+* `light` mode instead of `investigation`
+
+### Strict lifecycle shutdown fails
+
+This usually means requests were started but not completed.
+
+Common causes:
+
+* missing completion calls
+* early returns
+* canceled tasks
+* dropped completion handles
+
+Use stricter request lifecycle review before increasing capture density.
+
+## Operational validation workflow
+
+The repository includes local operational validation paths.
+
+Use these when evaluating:
+
+* runtime overhead
+* collector stress behavior
+* truncation onset
+* artifact growth
+* memory trends
+
+Primary references:
+
+* `VALIDATION.md`
+* `docs/runtime-cost.md`
+* `docs/collector-limits.md`
+* `scripts/run_operational_validation.py`
+* `scripts/measure_collector_limits.py`
+
+These measurements are:
+
+* synthetic
+* workload-scoped
+* machine-scoped
+* intentionally conservative
+
+They are not universal production guarantees.
+
+## Current known limits and non-fits
+
+`tailtriage` is intentionally not:
+
+* a distributed tracing backend
+* a metrics platform
+* a permanent telemetry pipeline
+* a root-cause proof engine
+* a replacement for profiling
+* a replacement for `tokio-console`
+* a universal observability system
+
+Current operational limits include:
+
+* runtime sampling density can materially increase event volume
+* truncation can reduce evidence quality under heavy load
+* runtime-field visibility varies depending on Tokio capabilities
+* diagnosis quality depends heavily on instrumentation quality
+* one run provides bounded triage guidance, not certainty
+* repeated comparative runs are often more useful than one dense run
+
+## Recommended operational workflow
+
+A practical production loop:
+
+1. identify a slow window
+2. arm a bounded capture
+3. collect one representative run
+4. analyze the report
+5. choose one next check
+6. apply one targeted mitigation or instrumentation improvement
+7. rerun under comparable load
+8. compare suspect movement and p95 share movement
+
+Treat the workflow as iterative triage.
+
+Do not treat one report as final proof.

--- a/docs/runtime-cost.md
+++ b/docs/runtime-cost.md
@@ -5,6 +5,7 @@ This page describes the repository's runtime-overhead measurement path.
 Use this path when you want overhead attribution across `tailtriage` integration modes on one shared synthetic workload shape.
 
 For sustained stress/limits behavior instead, use [collector-limits.md](collector-limits.md).
+For production rollout and operations decisions that combine this data with capture-mode and troubleshooting guidance, see [operations.md](operations.md).
 
 ## What this path measures
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2,6 +2,8 @@
 
 This guide teaches the default `tailtriage` workflow for end users.
 
+For production rollout, capture mode choice, runtime-sampling decisions, artifact sizing, truncation/capture-limit behavior, and weak-signal troubleshooting, see [operations.md](operations.md).
+
 ## 1) Default adoption path
 
 For most services, use:

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -70,6 +70,40 @@ class ValidateDocsContractsTests(unittest.TestCase):
     def test_user_guide_contract(self) -> None:
         validate_docs_contracts.validate_user_guide_contract()
 
+    def test_operations_guide_contract(self) -> None:
+        validate_docs_contracts.validate_operations_guide_contract()
+
+    def test_operations_guide_contract_fails_when_required_concepts_missing(self) -> None:
+        incomplete = """# Production operations guide
+
+Minimal text that references VALIDATION.md, diagnostics.md, runtime-cost.md, and collector-limits.md,
+but intentionally omits required operational concepts.
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            operations_path = Path(tmp_dir) / "operations.md"
+            operations_path.write_text(incomplete, encoding="utf-8")
+            with mock.patch.object(validate_docs_contracts, "OPERATIONS_PATH", operations_path):
+                with self.assertRaisesRegex(ValueError, r"missing required concept/token"):
+                    validate_docs_contracts.validate_operations_guide_contract()
+
+    def test_operations_guide_contract_passes_with_complete_content(self) -> None:
+        complete = """# Production operations guide
+
+This is a production operations guide with a recommended rollout path.
+Use light first, escalate to investigation when needed.
+Runtime sampling may help.
+Artifact sizing and truncation behavior depend on capture limits.
+If results are insufficient_evidence, inspect evidence_quality and controller choices.
+These suspects are not proof of root cause and not universal production guarantees.
+
+See VALIDATION.md, diagnostics.md, runtime-cost.md, and collector-limits.md.
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            operations_path = Path(tmp_dir) / "operations.md"
+            operations_path.write_text(complete, encoding="utf-8")
+            with mock.patch.object(validate_docs_contracts, "OPERATIONS_PATH", operations_path):
+                validate_docs_contracts.validate_operations_guide_contract()
+
     def test_user_guide_uses_controller_scoped_toml_shape(self) -> None:
         text = validate_docs_contracts.USER_GUIDE_PATH.read_text(encoding="utf-8")
         self.assertIn("[controller]", text)

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -15,6 +15,7 @@ README_PATH = REPO_ROOT / "README.md"
 DOCS_INDEX_PATH = REPO_ROOT / "docs" / "README.md"
 USER_GUIDE_PATH = REPO_ROOT / "docs" / "user-guide.md"
 DIAGNOSTICS_PATH = REPO_ROOT / "docs" / "diagnostics.md"
+OPERATIONS_PATH = REPO_ROOT / "docs" / "operations.md"
 DIAGNOSTIC_VALIDATION_PATH = REPO_ROOT / "docs" / "diagnostic-validation.md"
 CI_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 ARCHITECTURE_PATH = REPO_ROOT / "docs" / "architecture.md"
@@ -29,6 +30,7 @@ USER_FACING_TERMINOLOGY_PATHS = (
     DOCS_INDEX_PATH,
     USER_GUIDE_PATH,
     DIAGNOSTICS_PATH,
+    OPERATIONS_PATH,
     ARCHITECTURE_PATH,
     REPO_ROOT / "docs" / "runtime-cost.md",
     REPO_ROOT / "docs" / "collector-limits.md",
@@ -546,6 +548,37 @@ def validate_user_guide_contract() -> None:
         )
 
 
+def validate_operations_guide_contract() -> None:
+    if not OPERATIONS_PATH.exists():
+        raise ValueError("operations guide is missing: docs/operations.md")
+
+    text = OPERATIONS_PATH.read_text(encoding="utf-8")
+    lower_text = text.lower()
+    required_concepts = (
+        "production operations guide",
+        "recommended rollout path",
+        "light",
+        "investigation",
+        "runtime sampling",
+        "artifact",
+        "truncation",
+        "capture limits",
+        "insufficient_evidence",
+        "evidence_quality",
+        "not universal production guarantees",
+        "not proof of root cause",
+        "controller",
+    )
+    for concept in required_concepts:
+        if concept not in lower_text:
+            raise ValueError(f"operations guide missing required concept/token: {concept}")
+
+    required_refs = ("validation.md", "diagnostics.md", "runtime-cost.md", "collector-limits.md")
+    for ref in required_refs:
+        if ref not in lower_text:
+            raise ValueError(f"operations guide missing required reference: {ref}")
+
+
 def validate_diagnostics_contract_truthfulness() -> None:
     readme_text = README_PATH.read_text(encoding="utf-8")
     docs_index_text = DOCS_INDEX_PATH.read_text(encoding="utf-8")
@@ -916,6 +949,7 @@ def main() -> int:
     validate_docs_index_contract()
     validate_root_readme_docs_link()
     validate_user_guide_contract()
+    validate_operations_guide_contract()
     validate_diagnostics_contract_truthfulness()
     validate_cli_not_presented_as_library_analyzer_api()
     validate_analyzer_cli_docs_split_contract()


### PR DESCRIPTION
Adds `docs/operations.md` as the production operations guide and wires it into the public documentation surface.

Also updates:
- `README.md`
- `docs/README.md`
- `docs/user-guide.md`
- runtime-cost / collector-limits navigation
- `VALIDATION.md`
- `AGENTS.md`
- docs contract validation
- docs contract tests

Validation:
- `python3 scripts/validate_docs_contracts.py`
- `python3 -m unittest scripts.tests.test_validate_docs_contracts`
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`