### PR TITLE
Wire docs/operations.md into docs index and enforce operations doc contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ Docs in `docs/` are user-facing product documentation.
 - Keep docs crisp, truthful, present-tense, and aligned with the current product surface.
 - Do not claim behavior that is not supported by the code and current public docs.
 - Keep `docs/README.md` as a complete user-journey index to current docs.
+- Treat `docs/operations.md` as the canonical production operations guidance page.
 - Treat `scripts/validate_docs_contracts.py` and related tests as part of the public documentation contract.
 - If docs structure, required docs links, or enforced public-doc wording changes, update the docs contract validator and related tests in the same change set.
 - Only change docs contract validation when the new docs are more truthful to the code or when the intended public docs contract has actually changed.
@@ -469,6 +470,8 @@ If behavior, scope, or public guidance changes, update as needed:
 Public docs should teach the intended current path first.
 
 Changes to public docs are not complete until the docs contract validator passes, and any validator changes are justified by code truth.
+
+When changes affect rollout guidance, capture-mode choice, controller/lifecycle operation, runtime sampling guidance, artifact sizing, truncation/capture-limit behavior, weak-signal troubleshooting, `evidence_quality` interpretation, or operational validation claims, update `docs/operations.md` in the same change set. Keep wording bounded: evidence-ranked suspects and next checks are triage leads, not proof of root cause, and `tailtriage` is not an observability platform.
 
 Do not leave the repository teaching multiple competing onboarding stories after a change.
 

--- a/README.md
+++ b/README.md
@@ -294,7 +294,9 @@ For validation scope, claims, and current diagnostic scorecard, see [VALIDATION.
 
 `tailtriage` includes repo-local measurement paths for both runtime-overhead attribution and sustained collector-stress behavior. These are based on synthetic, controlled tests in this repository and should be treated as machine- and workload-scoped guidance, not universal production guarantees.
 
-For overhead attribution and measurement workflow, see [`docs/runtime-cost.md`](docs/runtime-cost.md). For sustained-load behavior, truncation onset, artifact-size growth, and memory trends under stress-shaped workloads, see [`docs/collector-limits.md`](docs/collector-limits.md).
+For production operations guidance, start with [`docs/operations.md`](docs/operations.md). It covers recommended rollout path, capture-mode selection (`light` vs `investigation`), runtime-sampling decisions, artifact sizing, truncation handling, weak-signal troubleshooting, and current operational limits.
+
+For supporting validation and measurement detail, see [`docs/runtime-cost.md`](docs/runtime-cost.md) for overhead attribution workflow and [`docs/collector-limits.md`](docs/collector-limits.md) for sustained-load behavior, truncation onset, artifact-size growth, and memory trends under stress-shaped workloads.
 
 ## What this is not
 

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -67,6 +67,7 @@ This workflow is machine/workload scoped and supports triage next checks. Mitiga
 Operational validation has dedicated domain folders under `validation/runtime-cost/` and `validation/collector-limits/`.
 
 `scripts/run_operational_validation.py` adds manual/local operational validation for runtime-cost and collector-limit behavior. It emits raw JSONL records, stable summary JSON, and optional scorecard markdown under `target/operational-validation/`.
+For production rollout and bounded operations interpretation, see `docs/operations.md`. `VALIDATION.md` remains the trust-boundary page for validation claims and non-claims.
 
 Runtime-cost results are machine/workload/profile scoped and are not universal production guarantees.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ Use these docs to understand what the project claims, how those claims are teste
 
 - [Validation overview](../VALIDATION.md) — validation scope, claims, and current diagnostic scorecard entry point.
 - [Diagnostic validation](diagnostic-validation.md) — corpus-driven diagnostic-quality methodology and metrics.
+- [Production operations guide](operations.md) — first-class operations guidance for production rollout, capture-mode selection, runtime-sampling decisions, artifact sizing, truncation handling, weak-signal troubleshooting, and current operational limits.
 - [Runtime cost measurement](runtime-cost.md) — reproducible overhead attribution path for baked-in, core, sampler, and drop-path costs.
 - [Collector limits and stress guidance](collector-limits.md) — sustained-load behavior, truncation onset, artifact-size growth, and memory trend interpretation.
 

--- a/docs/collector-limits.md
+++ b/docs/collector-limits.md
@@ -1,5 +1,7 @@
 # Collector limits and stress guidance
 
+For rollout and capture-mode decisions, runtime-sampling guidance, artifact-sizing policy, and bounded production operations framing, see the [production operations guide](operations.md).
+
 This page describes the repository's sustained collector-stress measurement path.
 
 Use this path when you want to understand truncation onset, dropped-category progression, artifact-size growth, and memory trends under stress-shaped synthetic workloads.

--- a/docs/runtime-cost.md
+++ b/docs/runtime-cost.md
@@ -1,5 +1,7 @@
 # Runtime cost measurement
 
+For rollout, mode selection, runtime-sampling decision flow, artifact-sizing policy, truncation troubleshooting, and bounded production claims, see the [production operations guide](operations.md).
+
 This page describes the repository's runtime-overhead measurement path.
 
 Use this path when you want overhead attribution across `tailtriage` integration modes on one shared synthetic workload shape.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -66,6 +66,7 @@ Read output in this order:
 
 Then run one targeted check, change one thing, and re-run under comparable load.
 
+For production rollout, capture-mode choice, runtime-sampling decisions, artifact sizing, truncation/capture-limit behavior, and weak-signal troubleshooting, use the [operations guide](operations.md).
 
 ## 3) In-process analysis (embedded Rust)
 

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -70,6 +70,52 @@ class ValidateDocsContractsTests(unittest.TestCase):
     def test_user_guide_contract(self) -> None:
         validate_docs_contracts.validate_user_guide_contract()
 
+
+    def test_operations_guide_contract(self) -> None:
+        validate_docs_contracts.validate_operations_guide_contract()
+
+    def test_operations_guide_contract_fails_when_required_concept_missing(self) -> None:
+        operations_text = """# Production operations guide
+
+recommended rollout path
+light investigation runtime sampling artifact truncation capture limits
+insufficient_evidence
+not universal production guarantees
+not proof of root cause
+controller
+See VALIDATION.md diagnostics.md runtime-cost.md collector-limits.md
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            operations_path = Path(tmp_dir) / "operations.md"
+            operations_path.write_text(operations_text, encoding="utf-8")
+            with mock.patch.object(validate_docs_contracts, "OPERATIONS_PATH", operations_path):
+                with self.assertRaisesRegex(ValueError, r"evidence_quality"):
+                    validate_docs_contracts.validate_operations_guide_contract()
+
+    def test_operations_guide_contract_passes_with_complete_minimal_content(self) -> None:
+        operations_text = """# Production operations guide
+
+production operations guide
+recommended rollout path
+light
+investigation
+runtime sampling
+artifact
+truncation
+capture limits
+insufficient_evidence
+evidence_quality
+not universal production guarantees
+not proof of root cause
+controller
+See VALIDATION.md, diagnostics.md, runtime-cost.md, and collector-limits.md.
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            operations_path = Path(tmp_dir) / "operations.md"
+            operations_path.write_text(operations_text, encoding="utf-8")
+            with mock.patch.object(validate_docs_contracts, "OPERATIONS_PATH", operations_path):
+                validate_docs_contracts.validate_operations_guide_contract()
+
     def test_user_guide_uses_controller_scoped_toml_shape(self) -> None:
         text = validate_docs_contracts.USER_GUIDE_PATH.read_text(encoding="utf-8")
         self.assertIn("[controller]", text)

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -15,6 +15,7 @@ README_PATH = REPO_ROOT / "README.md"
 DOCS_INDEX_PATH = REPO_ROOT / "docs" / "README.md"
 USER_GUIDE_PATH = REPO_ROOT / "docs" / "user-guide.md"
 DIAGNOSTICS_PATH = REPO_ROOT / "docs" / "diagnostics.md"
+OPERATIONS_PATH = REPO_ROOT / "docs" / "operations.md"
 DIAGNOSTIC_VALIDATION_PATH = REPO_ROOT / "docs" / "diagnostic-validation.md"
 CI_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 ARCHITECTURE_PATH = REPO_ROOT / "docs" / "architecture.md"
@@ -33,6 +34,7 @@ USER_FACING_TERMINOLOGY_PATHS = (
     REPO_ROOT / "docs" / "runtime-cost.md",
     REPO_ROOT / "docs" / "collector-limits.md",
     REPO_ROOT / "docs" / "getting-started-demo.md",
+    OPERATIONS_PATH,
     REPO_ROOT / "tailtriage" / "README.md",
     REPO_ROOT / "tailtriage-core" / "README.md",
     REPO_ROOT / "tailtriage-controller" / "README.md",
@@ -819,6 +821,43 @@ def validate_architecture_contract() -> None:
             raise ValueError(f"architecture doc missing required product-contract token: {token}")
 
 
+
+def validate_operations_guide_contract() -> None:
+    if not OPERATIONS_PATH.exists():
+        raise ValueError("docs/operations.md is required as the production operations guide")
+
+    text = OPERATIONS_PATH.read_text(encoding="utf-8")
+    required_tokens = (
+        "production operations guide",
+        "recommended rollout path",
+        "light",
+        "investigation",
+        "runtime sampling",
+        "artifact",
+        "truncation",
+        "capture limits",
+        "insufficient_evidence",
+        "evidence_quality",
+        "not universal production guarantees",
+        "not proof of root cause",
+        "controller",
+    )
+    lower_text = text.lower()
+    for token in required_tokens:
+        if token not in lower_text:
+            raise ValueError(f"operations guide missing required concept: {token}")
+
+    required_refs = (
+        "validation.md",
+        "diagnostics.md",
+        "runtime-cost.md",
+        "collector-limits.md",
+    )
+    for ref in required_refs:
+        if ref not in lower_text:
+            raise ValueError(f"operations guide missing required supporting reference: {ref}")
+
+
 def validate_docs_no_history_framing() -> None:
     failures: list[str] = []
     for path in sorted(PUBLIC_DOCS_GLOB):
@@ -916,6 +955,7 @@ def main() -> int:
     validate_docs_index_contract()
     validate_root_readme_docs_link()
     validate_user_guide_contract()
+    validate_operations_guide_contract()
     validate_diagnostics_contract_truthfulness()
     validate_cli_not_presented_as_library_analyzer_api()
     validate_analyzer_cli_docs_split_contract()


### PR DESCRIPTION
### Motivation
- Make `docs/operations.md` the canonical production operations guide and improve discoverability from the root README, docs index, and related pages.  
- Ensure operational guidance is covered by the repository's public-docs contract so rollout, capture-mode, runtime-sampling, artifact-sizing, truncation, weak-signal, and operational-claim surfaces remain consistent and reviewed.  
- Keep product language bounded: `tailtriage` produces evidence-ranked suspects and next checks (triage leads), not root-cause proof or an observability platform.

### Description
- Added navigation and concise pointers to `docs/operations.md` from `README.md`, `docs/README.md`, and `docs/user-guide.md`, and added optional related pointers in `docs/runtime-cost.md`, `docs/collector-limits.md`, and `VALIDATION.md` for discoverability.  
- Updated `AGENTS.md` to name `docs/operations.md` as the canonical production operations guidance and to require updates to it when rollout/mode/controller/runtime-sampling/artifact-sizing/truncation/weak-signal/`evidence_quality`/operational-claim surfaces change, while preserving bounded triage language.  
- Extended `scripts/validate_docs_contracts.py` by adding `OPERATIONS_PATH`, including it in `USER_FACING_TERMINOLOGY_PATHS`, and adding `validate_operations_guide_contract()` which checks that `docs/operations.md` exists and contains required concepts and supporting references (`VALIDATION.md`, `diagnostics.md`, `runtime-cost.md`, `collector-limits.md`), and calling this validator from `main()`.  
- Added focused unit tests in `scripts/tests/test_validate_docs_contracts.py` that assert missing required operations concepts fail and a minimal-complete operations guide passes.  
- Files changed: `README.md`, `docs/README.md`, `docs/user-guide.md`, `docs/runtime-cost.md`, `docs/collector-limits.md`, `VALIDATION.md`, `AGENTS.md`, `scripts/validate_docs_contracts.py`, and `scripts/tests/test_validate_docs_contracts.py`.

### Testing
- Ran `python3 scripts/validate_docs_contracts.py` and it printed `docs contracts validated successfully`.  
- Ran `python3 -m unittest scripts.tests.test_validate_docs_contracts` and all tests passed (`OK`).  
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, and `cargo test --workspace --locked`, and all checks and tests completed successfully.  
- The validator and unit tests exercise both the negative case (missing required concept) and the positive minimal-complete case for the operations guide.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fef167cb248330891f8388df5d4cff)