### PR TITLE
Integrate docs/operations.md into docs surface and docs-contract validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,9 @@ Docs in `docs/` are user-facing product documentation.
 - Do not write contributor-process narration, issue-history context, or roadmap-history wording in `docs/` pages.
 - Keep docs crisp, truthful, present-tense, and aligned with the current product surface.
 - Do not claim behavior that is not supported by the code and current public docs.
+- Treat `docs/operations.md` as the canonical production operations guidance page.
+- Update `docs/operations.md` when behavior or guidance changes for rollout path, capture-mode choice, controller/lifecycle operation, runtime sampling guidance, artifact sizing, truncation/capture-limit behavior, weak-signal troubleshooting, `evidence_quality` interpretation, or operational validation claims.
+- Keep operations guidance bounded: evidence-ranked suspects and next checks are triage leads, not proof of root cause, and not observability-platform claims.
 - Keep `docs/README.md` as a complete user-journey index to current docs.
 - Treat `scripts/validate_docs_contracts.py` and related tests as part of the public documentation contract.
 - If docs structure, required docs links, or enforced public-doc wording changes, update the docs contract validator and related tests in the same change set.

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ For full report-field interpretation, see [`docs/diagnostics.md`](docs/diagnosti
 
 For validation scope, claims, and current diagnostic scorecard, see [VALIDATION.md](VALIDATION.md).
 
-For production rollout and day-2 operation guidance, start with [`docs/operations.md`](docs/operations.md).
+For production rollout, capture-mode selection, runtime-sampling decisions, artifact sizing, truncation handling, weak-signal troubleshooting, and current operational limits, start with [`docs/operations.md`](docs/operations.md).
 
 `tailtriage` includes repo-local measurement paths for both runtime-overhead attribution and sustained collector-stress behavior. These are based on synthetic, controlled tests in this repository and should be treated as machine- and workload-scoped guidance, not universal production guarantees.
 

--- a/README.md
+++ b/README.md
@@ -292,6 +292,8 @@ For full report-field interpretation, see [`docs/diagnostics.md`](docs/diagnosti
 
 For validation scope, claims, and current diagnostic scorecard, see [VALIDATION.md](VALIDATION.md).
 
+For production rollout and day-2 operation guidance, start with [`docs/operations.md`](docs/operations.md).
+
 `tailtriage` includes repo-local measurement paths for both runtime-overhead attribution and sustained collector-stress behavior. These are based on synthetic, controlled tests in this repository and should be treated as machine- and workload-scoped guidance, not universal production guarantees.
 
 For overhead attribution and measurement workflow, see [`docs/runtime-cost.md`](docs/runtime-cost.md). For sustained-load behavior, truncation onset, artifact-size growth, and memory trends under stress-shaped workloads, see [`docs/collector-limits.md`](docs/collector-limits.md).

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -3,6 +3,8 @@
 ## Summary
 `tailtriage` is a triage tool, not root-cause proof. It produces evidence-ranked suspects and next checks, where suspects are leads and not causal certainty.
 
+For production rollout and day-2 operational guidance that applies these bounded claims, see `docs/operations.md`.
+
 ## Current validation status
 This repository includes an initial deterministic validation corpus for controlled Tokio workload fixtures. The corpus and benchmark validate bounded diagnostic behavior on committed fixtures, not universal production behavior.
 

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -3,7 +3,7 @@
 ## Summary
 `tailtriage` is a triage tool, not root-cause proof. It produces evidence-ranked suspects and next checks, where suspects are leads and not causal certainty.
 
-For production rollout and day-2 operational guidance that applies these bounded claims, see `docs/operations.md`.
+For production rollout and operational guidance that applies these bounded claims, see `docs/operations.md`.
 
 ## Current validation status
 This repository includes an initial deterministic validation corpus for controlled Tokio workload fixtures. The corpus and benchmark validate bounded diagnostic behavior on committed fixtures, not universal production behavior.

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ Most users should start with `tailtriage`.
 Use these docs when wiring `tailtriage` into a service or interpreting output.
 
 - [User guide](user-guide.md) — end-to-end adoption path and operational workflow.
+- [Operations guide](operations.md) — primary production operations guidance for rollout path, capture-mode selection, runtime sampling decisions, artifact sizing, truncation/capture-limit handling, weak-signal troubleshooting, and current operational limits.
 - [Diagnostics guide](diagnostics.md) — how to read analyzer output, evidence quality, suspects, confidence, warnings, and field meanings.
 - [Analyzer README (`tailtriage-analyzer`)](../tailtriage-analyzer/README.md) — typed in-process report contract and rendering API.
 - [CLI README (`tailtriage-cli`)](../tailtriage-cli/README.md) — saved-artifact loading, schema validation, and text/JSON output.

--- a/docs/collector-limits.md
+++ b/docs/collector-limits.md
@@ -5,6 +5,7 @@ This page describes the repository's sustained collector-stress measurement path
 Use this path when you want to understand truncation onset, dropped-category progression, artifact-size growth, and memory trends under stress-shaped synthetic workloads.
 
 For runtime-overhead attribution across fixed modes, use [runtime-cost.md](runtime-cost.md).
+For production rollout and operations decisions that combine limits behavior with capture-mode and troubleshooting guidance, see [operations.md](operations.md).
 
 ## What this path measures
 

--- a/docs/runtime-cost.md
+++ b/docs/runtime-cost.md
@@ -5,6 +5,7 @@ This page describes the repository's runtime-overhead measurement path.
 Use this path when you want overhead attribution across `tailtriage` integration modes on one shared synthetic workload shape.
 
 For sustained stress/limits behavior instead, use [collector-limits.md](collector-limits.md).
+For production rollout and operations decisions that combine this data with capture-mode and troubleshooting guidance, see [operations.md](operations.md).
 
 ## What this path measures
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2,6 +2,8 @@
 
 This guide teaches the default `tailtriage` workflow for end users.
 
+For production rollout, capture mode choice, runtime-sampling decisions, artifact sizing, truncation/capture-limit behavior, and weak-signal troubleshooting, see [operations.md](operations.md).
+
 ## 1) Default adoption path
 
 For most services, use:

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -70,6 +70,40 @@ class ValidateDocsContractsTests(unittest.TestCase):
     def test_user_guide_contract(self) -> None:
         validate_docs_contracts.validate_user_guide_contract()
 
+    def test_operations_guide_contract(self) -> None:
+        validate_docs_contracts.validate_operations_guide_contract()
+
+    def test_operations_guide_contract_fails_when_required_concepts_missing(self) -> None:
+        incomplete = """# Production operations guide
+
+Minimal text that references VALIDATION.md, diagnostics.md, runtime-cost.md, and collector-limits.md,
+but intentionally omits required operational concepts.
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            operations_path = Path(tmp_dir) / "operations.md"
+            operations_path.write_text(incomplete, encoding="utf-8")
+            with mock.patch.object(validate_docs_contracts, "OPERATIONS_PATH", operations_path):
+                with self.assertRaisesRegex(ValueError, r"missing required concept/token"):
+                    validate_docs_contracts.validate_operations_guide_contract()
+
+    def test_operations_guide_contract_passes_with_complete_content(self) -> None:
+        complete = """# Production operations guide
+
+This is a production operations guide with a recommended rollout path.
+Use light first, escalate to investigation when needed.
+Runtime sampling may help.
+Artifact sizing and truncation behavior depend on capture limits.
+If results are insufficient_evidence, inspect evidence_quality and controller choices.
+These suspects are not proof of root cause and not universal production guarantees.
+
+See VALIDATION.md, diagnostics.md, runtime-cost.md, and collector-limits.md.
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            operations_path = Path(tmp_dir) / "operations.md"
+            operations_path.write_text(complete, encoding="utf-8")
+            with mock.patch.object(validate_docs_contracts, "OPERATIONS_PATH", operations_path):
+                validate_docs_contracts.validate_operations_guide_contract()
+
     def test_user_guide_uses_controller_scoped_toml_shape(self) -> None:
         text = validate_docs_contracts.USER_GUIDE_PATH.read_text(encoding="utf-8")
         self.assertIn("[controller]", text)

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -15,6 +15,7 @@ README_PATH = REPO_ROOT / "README.md"
 DOCS_INDEX_PATH = REPO_ROOT / "docs" / "README.md"
 USER_GUIDE_PATH = REPO_ROOT / "docs" / "user-guide.md"
 DIAGNOSTICS_PATH = REPO_ROOT / "docs" / "diagnostics.md"
+OPERATIONS_PATH = REPO_ROOT / "docs" / "operations.md"
 DIAGNOSTIC_VALIDATION_PATH = REPO_ROOT / "docs" / "diagnostic-validation.md"
 CI_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 ARCHITECTURE_PATH = REPO_ROOT / "docs" / "architecture.md"
@@ -29,6 +30,7 @@ USER_FACING_TERMINOLOGY_PATHS = (
     DOCS_INDEX_PATH,
     USER_GUIDE_PATH,
     DIAGNOSTICS_PATH,
+    OPERATIONS_PATH,
     ARCHITECTURE_PATH,
     REPO_ROOT / "docs" / "runtime-cost.md",
     REPO_ROOT / "docs" / "collector-limits.md",
@@ -546,6 +548,37 @@ def validate_user_guide_contract() -> None:
         )
 
 
+def validate_operations_guide_contract() -> None:
+    if not OPERATIONS_PATH.exists():
+        raise ValueError("operations guide is missing: docs/operations.md")
+
+    text = OPERATIONS_PATH.read_text(encoding="utf-8")
+    lower_text = text.lower()
+    required_concepts = (
+        "production operations guide",
+        "recommended rollout path",
+        "light",
+        "investigation",
+        "runtime sampling",
+        "artifact",
+        "truncation",
+        "capture limits",
+        "insufficient_evidence",
+        "evidence_quality",
+        "not universal production guarantees",
+        "not proof of root cause",
+        "controller",
+    )
+    for concept in required_concepts:
+        if concept not in lower_text:
+            raise ValueError(f"operations guide missing required concept/token: {concept}")
+
+    required_refs = ("validation.md", "diagnostics.md", "runtime-cost.md", "collector-limits.md")
+    for ref in required_refs:
+        if ref not in lower_text:
+            raise ValueError(f"operations guide missing required reference: {ref}")
+
+
 def validate_diagnostics_contract_truthfulness() -> None:
     readme_text = README_PATH.read_text(encoding="utf-8")
     docs_index_text = DOCS_INDEX_PATH.read_text(encoding="utf-8")
@@ -916,6 +949,7 @@ def main() -> int:
     validate_docs_index_contract()
     validate_root_readme_docs_link()
     validate_user_guide_contract()
+    validate_operations_guide_contract()
     validate_diagnostics_contract_truthfulness()
     validate_cli_not_presented_as_library_analyzer_api()
     validate_analyzer_cli_docs_split_contract()


### PR DESCRIPTION
### Motivation
- Make the new `docs/operations.md` discoverable from top-level docs and enforce it in the public docs contract so operational rollout and day-2 guidance cannot drift undocumented. 
- Ensure operations guidance remains the canonical place for rollout, capture-mode, runtime-sampling, artifact sizing, truncation, weak-signal troubleshooting, and operational-limit guidance while preserving the repository's bounded triage claims (evidence-ranked suspects and next checks, not root-cause proof).

### Description
- Wired `docs/operations.md` into user discovery paths by adding pointers from `README.md`, `docs/README.md`, and `docs/user-guide.md`, and by adding related-navigation pointers from `docs/runtime-cost.md` and `docs/collector-limits.md` without duplicating content. 
- Added a bounded pointer to `docs/operations.md` from `VALIDATION.md` while preserving `VALIDATION.md` as the trust-boundary source for validation claims. 
- Updated `AGENTS.md` to treat `docs/operations.md` as the canonical operations guidance page and to instruct future agents to update it when rollout/capture-mode/controller/runtime-sampling/artifact-sizing/truncation/weak-signal/`evidence_quality`/operational-validation guidance changes, keeping wording consistent with triage-not-proof guardrails. 
- Extended `scripts/validate_docs_contracts.py`: added `OPERATIONS_PATH`, included it in `USER_FACING_TERMINOLOGY_PATHS`, implemented `validate_operations_guide_contract()` to assert presence of required operational concepts and required references (`VALIDATION.md`, `diagnostics.md`, `runtime-cost.md`, `collector-limits.md`), and invoked the new validation from `main()`. 
- Extended `scripts/tests/test_validate_docs_contracts.py` with focused tests that assert the operations guide validation passes for a complete document and fails when required concepts are missing. 
- Files changed: `README.md`, `docs/README.md`, `docs/user-guide.md`, `docs/runtime-cost.md`, `docs/collector-limits.md`, `VALIDATION.md`, `AGENTS.md`, `docs/operations.md` (present), `scripts/validate_docs_contracts.py`, `scripts/tests/test_validate_docs_contracts.py`.

### Testing
- Ran `python3 scripts/validate_docs_contracts.py` and it printed `docs contracts validated successfully`; the new operations check executed and passed against the repository docs. 
- Ran formatting/lint/test suite: `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, and `cargo test --workspace --locked`; all completed successfully. 
- Ran Python unit tests for docs contract helpers: `python3 -m unittest scripts.tests.test_validate_docs_contracts` and the new operations-guide unit tests passed. 

All automated validation and test steps requested in the task were executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fef167cb248330891f8388df5d4cff)