### PR TITLE
Integrate operations guide into docs navigation and docs-contract validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,8 @@ Optimize docs for:
 
 Docs in `docs/` are user-facing product documentation.
 
+`docs/operations.md` is the canonical operations guidance page.
+
 - `docs/` pages are for users of `tailtriage`, not repository development workflow.
 - Do not write contributor-process narration, issue-history context, or roadmap-history wording in `docs/` pages.
 - Keep docs crisp, truthful, present-tense, and aligned with the current product surface.
@@ -83,6 +85,19 @@ Docs in `docs/` are user-facing product documentation.
   - update the docs to satisfy the existing contract, or
   - update the validator and related tests so they enforce the new truthful contract.
 - When changing the validator, keep checks aligned with code truth and current public guidance, not stale phrasing.
+
+When changes affect operational behavior or guidance, update `docs/operations.md` in the same change set, including:
+
+- rollout guidance
+- capture-mode choice (`light` vs `investigation`)
+- controller/lifecycle operation
+- runtime sampling guidance
+- artifact sizing expectations
+- truncation/capture-limit behavior
+- weak-signal troubleshooting (`insufficient_evidence`, `evidence_quality`)
+- operational validation claims and non-claims
+
+Keep operations language bounded: evidence-ranked suspects and next checks are triage leads, not proof of root cause; avoid observability-platform framing.
 
 
 ## Validation documentation contract

--- a/README.md
+++ b/README.md
@@ -292,6 +292,8 @@ For full report-field interpretation, see [`docs/diagnostics.md`](docs/diagnosti
 
 For validation scope, claims, and current diagnostic scorecard, see [VALIDATION.md](VALIDATION.md).
 
+Use [`docs/operations.md`](docs/operations.md) as the primary production operations guide for rollout, capture-mode selection, runtime-sampling decisions, artifact sizing, truncation handling, weak-signal troubleshooting, and current operational limits.
+
 `tailtriage` includes repo-local measurement paths for both runtime-overhead attribution and sustained collector-stress behavior. These are based on synthetic, controlled tests in this repository and should be treated as machine- and workload-scoped guidance, not universal production guarantees.
 
 For overhead attribution and measurement workflow, see [`docs/runtime-cost.md`](docs/runtime-cost.md). For sustained-load behavior, truncation onset, artifact-size growth, and memory trends under stress-shaped workloads, see [`docs/collector-limits.md`](docs/collector-limits.md).

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -3,6 +3,8 @@
 ## Summary
 `tailtriage` is a triage tool, not root-cause proof. It produces evidence-ranked suspects and next checks, where suspects are leads and not causal certainty.
 
+For production rollout and bounded operating guidance, use `docs/operations.md`. `VALIDATION.md` remains the trust-boundary source of truth for validation claims and non-claims.
+
 ## Current validation status
 This repository includes an initial deterministic validation corpus for controlled Tokio workload fixtures. The corpus and benchmark validate bounded diagnostic behavior on committed fixtures, not universal production behavior.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,10 +39,11 @@ Use these docs when running repeated capture windows or adding runtime/framework
 - [Tokio runtime sampler README (`tailtriage-tokio`)](../tailtriage-tokio/README.md) — runtime-pressure enrichment, feature requirements, and sampling constraints.
 - [Axum adapter README (`tailtriage-axum`)](../tailtriage-axum/README.md) — request-boundary wiring for Axum services.
 
-## Validation, cost, and limits
+## Validation, cost, limits, and operations
 
-Use these docs to understand what the project claims, how those claims are tested, and where measurement boundaries are.
+Use these docs to understand rollout/operations guidance, what the project claims, how those claims are tested, and where measurement boundaries are.
 
+- [Production operations guide](operations.md) — first-class production operations guidance for recommended rollout path, light vs investigation mode selection, runtime sampling decisions, artifact sizing, truncation/capture-limit handling, weak-signal troubleshooting (`insufficient_evidence` / `evidence_quality`), and current operational limits.
 - [Validation overview](../VALIDATION.md) — validation scope, claims, and current diagnostic scorecard entry point.
 - [Diagnostic validation](diagnostic-validation.md) — corpus-driven diagnostic-quality methodology and metrics.
 - [Runtime cost measurement](runtime-cost.md) — reproducible overhead attribution path for baked-in, core, sampler, and drop-path costs.

--- a/docs/collector-limits.md
+++ b/docs/collector-limits.md
@@ -4,7 +4,7 @@ This page describes the repository's sustained collector-stress measurement path
 
 Use this path when you want to understand truncation onset, dropped-category progression, artifact-size growth, and memory trends under stress-shaped synthetic workloads.
 
-For runtime-overhead attribution across fixed modes, use [runtime-cost.md](runtime-cost.md).
+For runtime-overhead attribution across fixed modes, use [runtime-cost.md](runtime-cost.md). For production rollout, mode/sampling choice, and weak-signal troubleshooting, use [operations.md](operations.md).
 
 ## What this path measures
 

--- a/docs/runtime-cost.md
+++ b/docs/runtime-cost.md
@@ -4,7 +4,7 @@ This page describes the repository's runtime-overhead measurement path.
 
 Use this path when you want overhead attribution across `tailtriage` integration modes on one shared synthetic workload shape.
 
-For sustained stress/limits behavior instead, use [collector-limits.md](collector-limits.md).
+For sustained stress/limits behavior instead, use [collector-limits.md](collector-limits.md). For production rollout, mode/sampling choice, and truncation/weak-signal operations guidance, use [operations.md](operations.md).
 
 ## What this path measures
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -255,6 +255,7 @@ Semantics notes:
 ## 11) Next docs
 
 - [Documentation index](README.md)
+- [Production operations guide](operations.md) — production rollout, capture-mode choice, runtime-sampling decisions, artifact sizing, truncation/capture-limit behavior, and weak-signal troubleshooting.
 - [Diagnostics guide](diagnostics.md)
 - [Getting started demos](getting-started-demo.md)
 - [Architecture](architecture.md)

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -70,6 +70,42 @@ class ValidateDocsContractsTests(unittest.TestCase):
     def test_user_guide_contract(self) -> None:
         validate_docs_contracts.validate_user_guide_contract()
 
+    def test_operations_guide_contract(self) -> None:
+        validate_docs_contracts.validate_operations_guide_contract()
+
+    def test_operations_guide_contract_fails_when_required_concepts_missing(self) -> None:
+        operations_text = """# Production operations guide
+
+Recommended rollout path.
+Use light mode first.
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            operations_path = Path(tmp_dir) / "operations.md"
+            operations_path.write_text(operations_text, encoding="utf-8")
+
+            with mock.patch.object(validate_docs_contracts, "OPERATIONS_PATH", operations_path):
+                with self.assertRaisesRegex(ValueError, r"missing required concept/token"):
+                    validate_docs_contracts.validate_operations_guide_contract()
+
+    def test_operations_guide_contract_passes_with_complete_content(self) -> None:
+        operations_text = """# Production operations guide
+
+This production operations guide includes a recommended rollout path.
+Use light mode first and investigation mode for active incidents.
+Runtime sampling, artifact sizing, truncation, and capture limits are covered.
+When output is insufficient_evidence, inspect evidence_quality and rerun.
+Results are not universal production guarantees and not proof of root cause.
+Controller guidance is included.
+
+See VALIDATION.md, diagnostics.md, runtime-cost.md, and collector-limits.md.
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            operations_path = Path(tmp_dir) / "operations.md"
+            operations_path.write_text(operations_text, encoding="utf-8")
+
+            with mock.patch.object(validate_docs_contracts, "OPERATIONS_PATH", operations_path):
+                validate_docs_contracts.validate_operations_guide_contract()
+
     def test_user_guide_uses_controller_scoped_toml_shape(self) -> None:
         text = validate_docs_contracts.USER_GUIDE_PATH.read_text(encoding="utf-8")
         self.assertIn("[controller]", text)

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -15,6 +15,7 @@ README_PATH = REPO_ROOT / "README.md"
 DOCS_INDEX_PATH = REPO_ROOT / "docs" / "README.md"
 USER_GUIDE_PATH = REPO_ROOT / "docs" / "user-guide.md"
 DIAGNOSTICS_PATH = REPO_ROOT / "docs" / "diagnostics.md"
+OPERATIONS_PATH = REPO_ROOT / "docs" / "operations.md"
 DIAGNOSTIC_VALIDATION_PATH = REPO_ROOT / "docs" / "diagnostic-validation.md"
 CI_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 ARCHITECTURE_PATH = REPO_ROOT / "docs" / "architecture.md"
@@ -32,6 +33,7 @@ USER_FACING_TERMINOLOGY_PATHS = (
     ARCHITECTURE_PATH,
     REPO_ROOT / "docs" / "runtime-cost.md",
     REPO_ROOT / "docs" / "collector-limits.md",
+    OPERATIONS_PATH,
     REPO_ROOT / "docs" / "getting-started-demo.md",
     REPO_ROOT / "tailtriage" / "README.md",
     REPO_ROOT / "tailtriage-core" / "README.md",
@@ -546,6 +548,42 @@ def validate_user_guide_contract() -> None:
         )
 
 
+def validate_operations_guide_contract() -> None:
+    if not OPERATIONS_PATH.exists():
+        raise ValueError("operations guide missing: docs/operations.md")
+
+    text = OPERATIONS_PATH.read_text(encoding="utf-8")
+    lower_text = text.lower()
+    required_concepts = (
+        "production operations guide",
+        "recommended rollout path",
+        "light",
+        "investigation",
+        "runtime sampling",
+        "artifact",
+        "truncation",
+        "capture limits",
+        "insufficient_evidence",
+        "evidence_quality",
+        "not universal production guarantees",
+        "not proof of root cause",
+        "controller",
+    )
+    for concept in required_concepts:
+        if concept not in lower_text:
+            raise ValueError(f"operations guide missing required concept/token: {concept}")
+
+    required_refs = (
+        "VALIDATION.md",
+        "diagnostics.md",
+        "runtime-cost.md",
+        "collector-limits.md",
+    )
+    for ref in required_refs:
+        if ref not in text:
+            raise ValueError(f"operations guide missing required reference: {ref}")
+
+
 def validate_diagnostics_contract_truthfulness() -> None:
     readme_text = README_PATH.read_text(encoding="utf-8")
     docs_index_text = DOCS_INDEX_PATH.read_text(encoding="utf-8")
@@ -916,6 +954,7 @@ def main() -> int:
     validate_docs_index_contract()
     validate_root_readme_docs_link()
     validate_user_guide_contract()
+    validate_operations_guide_contract()
     validate_diagnostics_contract_truthfulness()
     validate_cli_not_presented_as_library_analyzer_api()
     validate_analyzer_cli_docs_split_contract()


### PR DESCRIPTION
### Motivation
- Make `docs/operations.md` the canonical, discoverable production operations guide for rollout, mode selection, runtime-sampling, artifact sizing, truncation handling, weak-signal troubleshooting, and operational limits. 
- Ensure the public docs contract enforces a minimal operations-guide content shape and cross-references to validation/measurement pages. 
- Teach future contributors/agents to update the operations guide when operational behavior or rollout guidance changes while preserving triage-language guardrails (suspects as leads, not proof).

### Description
- Added `docs/operations.md` as the primary production operations guide in navigation and cross-links from the top-level `README.md`, `docs/README.md`, and `docs/user-guide.md`, and added concise pointers from `docs/runtime-cost.md` and `docs/collector-limits.md` back to the operations guide.
- Updated `AGENTS.md` to explicitly name `docs/operations.md` as the canonical operations page and to instruct future agents to update it when operational behavior/guidance changes, keeping triage/non-proof wording.
- Extended `scripts/validate_docs_contracts.py` with: added `OPERATIONS_PATH`, included it in `USER_FACING_TERMINOLOGY_PATHS`, implemented `validate_operations_guide_contract()` which asserts the operations doc exists, checks for required concept tokens (e.g., `light`, `investigation`, `runtime sampling`, `truncation`, `evidence_quality`, `insufficient_evidence`, `controller`, and non-claim language), and verifies references to supporting docs (`VALIDATION.md`, `diagnostics.md`, `runtime-cost.md`, `collector-limits.md`), and wired the new validator into `main()` without weakening existing checks.
- Added unit tests in `scripts/tests/test_validate_docs_contracts.py` covering: a baseline validator call, a missing-concept failure case, and a complete-content success case following existing test patterns.
- Files changed: `AGENTS.md`, `README.md`, `VALIDATION.md`, `docs/README.md`, `docs/user-guide.md`, `docs/runtime-cost.md`, `docs/collector-limits.md`, `scripts/validate_docs_contracts.py`, `scripts/tests/test_validate_docs_contracts.py`.

### Testing
- Ran `python3 scripts/validate_docs_contracts.py` and it reported: `docs contracts validated successfully`.
- Ran unit tests: `python3 -m unittest scripts.tests.test_validate_docs_contracts` and the test suite passed (tests executed with the new operations-guide tests included).
- Ran workspace quality and verification commands: `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, and `cargo test --workspace --locked`, all of which completed successfully locally.
- No validation or CI checks were skipped in local verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fef167cb248330891f8388df5d4cff)