### PR TITLE
Wire operations guide into docs navigation and docs-contract validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ Optimize docs for:
 Docs in `docs/` are user-facing product documentation.
 
 - `docs/` pages are for users of `tailtriage`, not repository development workflow.
+- `docs/operations.md` is the canonical operations guidance page for production rollout and day-2 operation.
 - Do not write contributor-process narration, issue-history context, or roadmap-history wording in `docs/` pages.
 - Keep docs crisp, truthful, present-tense, and aligned with the current product surface.
 - Do not claim behavior that is not supported by the code and current public docs.
@@ -83,6 +84,8 @@ Docs in `docs/` are user-facing product documentation.
   - update the docs to satisfy the existing contract, or
   - update the validator and related tests so they enforce the new truthful contract.
 - When changing the validator, keep checks aligned with code truth and current public guidance, not stale phrasing.
+- Update `docs/operations.md` in the same change set when behavior changes affect rollout guidance, capture-mode choice, controller/lifecycle operation, runtime sampling guidance, artifact sizing, truncation/capture-limit behavior, weak-signal troubleshooting, `evidence_quality` interpretation, or operational validation claims.
+- Keep operations guidance bounded: `tailtriage` provides evidence-ranked suspects and next checks for triage leads, not proof of root cause and not a general observability platform.
 
 
 ## Validation documentation contract

--- a/README.md
+++ b/README.md
@@ -292,6 +292,8 @@ For full report-field interpretation, see [`docs/diagnostics.md`](docs/diagnosti
 
 For validation scope, claims, and current diagnostic scorecard, see [VALIDATION.md](VALIDATION.md).
 
+Use [docs/operations.md](docs/operations.md) as the primary production operations guide for rollout sequencing, capture-mode choice (`light` vs `investigation`), runtime-sampling decisions, artifact sizing/retention expectations, truncation and capture-limit handling, weak-signal troubleshooting, and current operational limits.
+
 `tailtriage` includes repo-local measurement paths for both runtime-overhead attribution and sustained collector-stress behavior. These are based on synthetic, controlled tests in this repository and should be treated as machine- and workload-scoped guidance, not universal production guarantees.
 
 For overhead attribution and measurement workflow, see [`docs/runtime-cost.md`](docs/runtime-cost.md). For sustained-load behavior, truncation onset, artifact-size growth, and memory trends under stress-shaped workloads, see [`docs/collector-limits.md`](docs/collector-limits.md).

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -8,6 +8,7 @@ This repository includes an initial deterministic validation corpus for controll
 
 ## Validation map
 `VALIDATION.md` is the top-level validation map and trust boundary. `docs/diagnostic-validation.md` explains diagnostic validation behavior for users. `validation/diagnostics/README.md` defines the corpus/manifest contract for maintainers. `validation/diagnostics/latest/scorecard.md` is a stable note about committed scorecard status, not a live metrics file. `scripts/validate_all.py` is an orchestration convenience over existing tracks, not the source of truth.
+For production rollout and operation guidance, see `docs/operations.md`; validation claims and non-claims remain anchored here in `VALIDATION.md`.
 
 | File/script/workflow | Role | Normal CI? | Publishes durable artifacts? |
 |---|---|---:|---:|

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ Most users should start with `tailtriage`.
 Use these docs when wiring `tailtriage` into a service or interpreting output.
 
 - [User guide](user-guide.md) — end-to-end adoption path and operational workflow.
+- [Production operations guide](operations.md) — canonical production rollout and operation guidance: rollout path, light vs investigation capture-mode choice, runtime-sampling decisions, artifact sizing/retention expectations, truncation and capture-limit handling, weak-signal troubleshooting, evidence-quality interpretation, and current operational limits.
 - [Diagnostics guide](diagnostics.md) — how to read analyzer output, evidence quality, suspects, confidence, warnings, and field meanings.
 - [Analyzer README (`tailtriage-analyzer`)](../tailtriage-analyzer/README.md) — typed in-process report contract and rendering API.
 - [CLI README (`tailtriage-cli`)](../tailtriage-cli/README.md) — saved-artifact loading, schema validation, and text/JSON output.

--- a/docs/collector-limits.md
+++ b/docs/collector-limits.md
@@ -3,6 +3,7 @@
 This page describes the repository's sustained collector-stress measurement path.
 
 Use this path when you want to understand truncation onset, dropped-category progression, artifact-size growth, and memory trends under stress-shaped synthetic workloads.
+For production rollout and day-2 operating guidance, start with [operations.md](operations.md).
 
 For runtime-overhead attribution across fixed modes, use [runtime-cost.md](runtime-cost.md).
 

--- a/docs/runtime-cost.md
+++ b/docs/runtime-cost.md
@@ -3,6 +3,7 @@
 This page describes the repository's runtime-overhead measurement path.
 
 Use this path when you want overhead attribution across `tailtriage` integration modes on one shared synthetic workload shape.
+For production rollout and operating decisions, start with [operations.md](operations.md).
 
 For sustained stress/limits behavior instead, use [collector-limits.md](collector-limits.md).
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -255,6 +255,7 @@ Semantics notes:
 ## 11) Next docs
 
 - [Documentation index](README.md)
+- [Production operations guide](operations.md) — rollout, capture-mode selection, runtime-sampling choices, artifact sizing, truncation/capture-limit handling, and weak-signal troubleshooting for production use.
 - [Diagnostics guide](diagnostics.md)
 - [Getting started demos](getting-started-demo.md)
 - [Architecture](architecture.md)

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -70,6 +70,42 @@ class ValidateDocsContractsTests(unittest.TestCase):
     def test_user_guide_contract(self) -> None:
         validate_docs_contracts.validate_user_guide_contract()
 
+    def test_operations_guide_contract(self) -> None:
+        validate_docs_contracts.validate_operations_guide_contract()
+
+    def test_operations_guide_contract_fails_when_required_concept_missing(self) -> None:
+        operations_text = """# Production operations guide
+
+Recommended rollout path with light and investigation capture.
+Runtime sampling and controller details are included.
+Artifact growth, truncation, capture limits, and insufficient_evidence are covered.
+VALIDATION.md diagnostics.md runtime-cost.md collector-limits.md
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            operations_path = Path(tmp_dir) / "operations.md"
+            operations_path.write_text(operations_text, encoding="utf-8")
+
+            with mock.patch.object(validate_docs_contracts, "OPERATIONS_PATH", operations_path):
+                with self.assertRaisesRegex(ValueError, r"evidence_quality"):
+                    validate_docs_contracts.validate_operations_guide_contract()
+
+    def test_operations_guide_contract_passes_with_complete_required_tokens(self) -> None:
+        operations_text = """# Production operations guide
+
+This production operations guide includes a recommended rollout path.
+Use light first, then investigation when needed.
+Runtime sampling and controller guidance are included.
+Artifact sizing, truncation, capture limits, insufficient_evidence, and evidence_quality are covered.
+This is not universal production guarantees guidance and not proof of root cause.
+See VALIDATION.md, diagnostics.md, runtime-cost.md, and collector-limits.md.
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            operations_path = Path(tmp_dir) / "operations.md"
+            operations_path.write_text(operations_text, encoding="utf-8")
+
+            with mock.patch.object(validate_docs_contracts, "OPERATIONS_PATH", operations_path):
+                validate_docs_contracts.validate_operations_guide_contract()
+
     def test_user_guide_uses_controller_scoped_toml_shape(self) -> None:
         text = validate_docs_contracts.USER_GUIDE_PATH.read_text(encoding="utf-8")
         self.assertIn("[controller]", text)

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -14,6 +14,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 README_PATH = REPO_ROOT / "README.md"
 DOCS_INDEX_PATH = REPO_ROOT / "docs" / "README.md"
 USER_GUIDE_PATH = REPO_ROOT / "docs" / "user-guide.md"
+OPERATIONS_PATH = REPO_ROOT / "docs" / "operations.md"
 DIAGNOSTICS_PATH = REPO_ROOT / "docs" / "diagnostics.md"
 DIAGNOSTIC_VALIDATION_PATH = REPO_ROOT / "docs" / "diagnostic-validation.md"
 CI_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
@@ -32,6 +33,7 @@ USER_FACING_TERMINOLOGY_PATHS = (
     ARCHITECTURE_PATH,
     REPO_ROOT / "docs" / "runtime-cost.md",
     REPO_ROOT / "docs" / "collector-limits.md",
+    OPERATIONS_PATH,
     REPO_ROOT / "docs" / "getting-started-demo.md",
     REPO_ROOT / "tailtriage" / "README.md",
     REPO_ROOT / "tailtriage-core" / "README.md",
@@ -545,6 +547,41 @@ def validate_user_guide_contract() -> None:
             "user guide TOML example must include non-empty controller.activation.sink.output_path"
         )
 
+def validate_operations_guide_contract() -> None:
+    if not OPERATIONS_PATH.exists():
+        raise ValueError("operations guide missing: docs/operations.md")
+
+    text = OPERATIONS_PATH.read_text(encoding="utf-8")
+    lower_text = text.lower()
+    required_concepts = (
+        "production operations guide",
+        "recommended rollout path",
+        "light",
+        "investigation",
+        "runtime sampling",
+        "artifact",
+        "truncation",
+        "capture limits",
+        "insufficient_evidence",
+        "evidence_quality",
+        "not universal production guarantees",
+        "not proof of root cause",
+        "controller",
+    )
+    for concept in required_concepts:
+        if concept not in lower_text:
+            raise ValueError(f"operations guide missing required concept/token: {concept}")
+
+    required_refs = (
+        "VALIDATION.md",
+        "diagnostics.md",
+        "runtime-cost.md",
+        "collector-limits.md",
+    )
+    for ref in required_refs:
+        if ref not in text:
+            raise ValueError(f"operations guide missing required reference: {ref}")
+
 
 def validate_diagnostics_contract_truthfulness() -> None:
     readme_text = README_PATH.read_text(encoding="utf-8")
@@ -916,6 +953,7 @@ def main() -> int:
     validate_docs_index_contract()
     validate_root_readme_docs_link()
     validate_user_guide_contract()
+    validate_operations_guide_contract()
     validate_diagnostics_contract_truthfulness()
     validate_cli_not_presented_as_library_analyzer_api()
     validate_analyzer_cli_docs_split_contract()


### PR DESCRIPTION
### Motivation
- Make `docs/operations.md` the canonical production operations reference so rollout, capture-mode, sampling, sizing, truncation, and weak-signal troubleshooting are discoverable from the main docs surface. 
- Ensure public docs remain truthful to the code by enforcing operations guidance with the existing docs-contract validator rather than leaving the operations page unreferenced. 
- Tell future agents where to update operational guidance when controller/lifecycle, capture-mode, sampling, sizing, truncation, evidence-quality, or operational validation claims change. 

### Description
- Added references to `docs/operations.md` from the root `README.md`, `docs/README.md`, and `docs/user-guide.md`, and added lightweight backlinks from `docs/runtime-cost.md` and `docs/collector-limits.md`. 
- Updated `AGENTS.md` to name `docs/operations.md` as the canonical operations guidance and to require it be updated when rollout/mode/controller/sampling/sizing/truncation/weak-signal/`evidence_quality` or operational validation guidance changes while preserving triage-not-proof guardrails. 
- Extended `scripts/validate_docs_contracts.py` with `OPERATIONS_PATH`, added it to `USER_FACING_TERMINOLOGY_PATHS`, implemented `validate_operations_guide_contract()` to check required concepts and references, and wired that validator into `main()`. 
- Added tests in `scripts/tests/test_validate_docs_contracts.py` to assert the operations-guide contract passes, fails when a required token is missing, and passes for a complete synthetic example; files changed include: `AGENTS.md`, `README.md`, `VALIDATION.md`, `docs/README.md`, `docs/collector-limits.md`, `docs/runtime-cost.md`, `docs/user-guide.md`, `scripts/validate_docs_contracts.py`, and `scripts/tests/test_validate_docs_contracts.py`. 

### Testing
- Ran `python3 scripts/validate_docs_contracts.py` and it printed success (`docs contracts validated successfully`). 
- Ran formatting/lint/test suite with `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, and `cargo test --workspace --locked`, and all checks passed. 
- Ran the extended Python unit tests with `python3 -m unittest scripts.tests.test_validate_docs_contracts` and the new operations-guide tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fef167cb248330891f8388df5d4cff)