### PR TITLE
docs: make operations guide internal references clickable

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -162,9 +162,9 @@ The repository intentionally does not claim universal production artifact sizing
 
 Use:
 
-* `docs/runtime-cost.md`
-* `docs/collector-limits.md`
-* `scripts/measure_collector_limits.py`
+* [runtime cost measurement](runtime-cost.md)
+* [collector limits and stress guidance](collector-limits.md)
+* [`scripts/measure_collector_limits.py`](../scripts/measure_collector_limits.py)
 
 when establishing local operational expectations.
 
@@ -412,11 +412,11 @@ Use these when evaluating:
 
 Primary references:
 
-* `VALIDATION.md`
-* `docs/runtime-cost.md`
-* `docs/collector-limits.md`
-* `scripts/run_operational_validation.py`
-* `scripts/measure_collector_limits.py`
+* [validation overview](../VALIDATION.md)
+* [runtime cost measurement](runtime-cost.md)
+* [collector limits and stress guidance](collector-limits.md)
+* [`scripts/run_operational_validation.py`](../scripts/run_operational_validation.py)
+* [`scripts/measure_collector_limits.py`](../scripts/measure_collector_limits.py)
 
 These measurements are:
 


### PR DESCRIPTION
### Motivation
- Improve navigation in `docs/operations.md` by converting a few user-facing path literals to clickable Markdown links so readers can jump directly to the referenced guidance and scripts without changing the guidance or claims.

### Description
- Converted user-facing path literals to Markdown links in `docs/operations.md`, replacing the `docs/runtime-cost.md`, `docs/collector-limits.md`, and `scripts/measure_collector_limits.py` mentions in the "Artifact sizing and retention expectations" section and replacing `VALIDATION.md`, `docs/runtime-cost.md`, `docs/collector-limits.md`, `scripts/run_operational_validation.py`, and `scripts/measure_collector_limits.py` mentions in the "Operational validation workflow" section while preserving bounded operational language and not changing any other docs text.

### Testing
- Ran `python3 scripts/validate_docs_contracts.py`, `python3 -m unittest scripts.tests.test_validate_docs_contracts`, `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, and `cargo test --workspace --locked`, and all completed successfully; no validator or unit-test updates were required and no commands were skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff01b28d048330bd092c7775b9e3ba)