### PR TITLE
Wire AnalyzeOptions through analyzer and disclose non-default analyzer config in reports

### DIFF
--- a/tailtriage-analyzer/src/confidence.rs
+++ b/tailtriage-analyzer/src/confidence.rs
@@ -1,13 +1,26 @@
 use tailtriage_core::Run;
 
 use super::{
-    Confidence, DiagnosisKind, EvidenceQuality, EvidenceQualityLevel, Suspect,
-    AMBIGUITY_MIN_SCORE_THRESHOLD, AMBIGUITY_SCORE_GAP_THRESHOLD, LOW_COMPLETED_REQUEST_THRESHOLD,
+    AnalyzeOptions, Confidence, DiagnosisKind, EvidenceQuality, EvidenceQualityLevel, Suspect,
 };
 
 pub(super) fn apply_evidence_aware_confidence_caps(
     suspects: &mut [Suspect],
     run: &Run,
+    evidence_quality: &EvidenceQuality,
+) {
+    apply_evidence_aware_confidence_caps_with_options(
+        suspects,
+        run,
+        &AnalyzeOptions::default(),
+        evidence_quality,
+    )
+}
+
+pub(super) fn apply_evidence_aware_confidence_caps_with_options(
+    suspects: &mut [Suspect],
+    run: &Run,
+    options: &AnalyzeOptions,
     evidence_quality: &EvidenceQuality,
 ) {
     let runtime_snapshots_missing = run.runtime_snapshots.is_empty();
@@ -24,7 +37,7 @@ pub(super) fn apply_evidence_aware_confidence_caps(
                 .runtime_snapshots
                 .iter()
                 .all(|snapshot| snapshot.global_queue_depth.is_none()));
-    let ambiguous_cluster = ambiguity_cluster_indices(suspects);
+    let ambiguous_cluster = ambiguity_cluster_indices(suspects, options);
     for (i, suspect) in suspects.iter_mut().enumerate() {
         let mut cap = Confidence::High;
         let mut notes = Vec::new();
@@ -36,7 +49,7 @@ pub(super) fn apply_evidence_aware_confidence_caps(
         if !is_insufficient && run.requests.is_empty() {
             cap = Confidence::Low;
             notes.push("Low completed-request count caps confidence.".to_string());
-        } else if run.requests.len() < LOW_COMPLETED_REQUEST_THRESHOLD {
+        } else if run.requests.len() < options.evidence.low_completed_request_threshold {
             if !is_insufficient {
                 cap = cap.min(Confidence::Medium);
             }
@@ -142,7 +155,7 @@ fn apply_family_evidence_caps(
     }
 }
 
-fn ambiguity_cluster_indices(suspects: &[Suspect]) -> Vec<usize> {
+fn ambiguity_cluster_indices(suspects: &[Suspect], options: &AnalyzeOptions) -> Vec<usize> {
     let mut ranked = suspects
         .iter()
         .enumerate()
@@ -152,14 +165,14 @@ fn ambiguity_cluster_indices(suspects: &[Suspect]) -> Vec<usize> {
     let Some((_, top)) = ranked.first() else {
         return Vec::new();
     };
-    if top.score < AMBIGUITY_MIN_SCORE_THRESHOLD {
+    if top.score < options.confidence.ambiguity_min_score {
         return Vec::new();
     }
     let cluster = ranked
         .iter()
         .take_while(|(_, s)| {
-            s.score >= AMBIGUITY_MIN_SCORE_THRESHOLD
-                && top.score.abs_diff(s.score) <= AMBIGUITY_SCORE_GAP_THRESHOLD
+            s.score >= options.confidence.ambiguity_min_score
+                && top.score.abs_diff(s.score) <= options.confidence.ambiguity_score_gap
         })
         .map(|(idx, _)| *idx)
         .collect::<Vec<_>>();

--- a/tailtriage-analyzer/src/evidence.rs
+++ b/tailtriage-analyzer/src/evidence.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 use tailtriage_core::Run;
 
-use super::LOW_COMPLETED_REQUEST_THRESHOLD;
+use crate::AnalyzeOptions;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -71,7 +71,14 @@ pub struct EvidenceQuality {
 }
 
 pub(super) fn evidence_quality(run: &Run) -> EvidenceQuality {
-    let requests = request_status(run);
+    evidence_quality_with_options(run, &AnalyzeOptions::default())
+}
+
+pub(super) fn evidence_quality_with_options(
+    run: &Run,
+    options: &AnalyzeOptions,
+) -> EvidenceQuality {
+    let requests = request_status(run, options);
     let queues = family_status(run.queues.is_empty(), run.truncation.dropped_queues);
     let stages = family_status(run.stages.is_empty(), run.truncation.dropped_stages);
     let runtime_snapshots = runtime_status(run);
@@ -79,7 +86,7 @@ pub(super) fn evidence_quality(run: &Run) -> EvidenceQuality {
         run.inflight.is_empty(),
         run.truncation.dropped_inflight_snapshots,
     );
-    let limitations = evidence_limitations(run, queues, stages, runtime_snapshots);
+    let limitations = evidence_limitations(options, run, queues, stages, runtime_snapshots);
     let non_request_truncated = matches!(queues, SignalCoverageStatus::Truncated)
         || matches!(stages, SignalCoverageStatus::Truncated)
         || matches!(runtime_snapshots, SignalCoverageStatus::Truncated)
@@ -87,7 +94,7 @@ pub(super) fn evidence_quality(run: &Run) -> EvidenceQuality {
     let explanatory_present =
         !run.queues.is_empty() || !run.stages.is_empty() || !run.runtime_snapshots.is_empty();
     let quality = if run.requests.is_empty()
-        || run.requests.len() < LOW_COMPLETED_REQUEST_THRESHOLD
+        || run.requests.len() < options.evidence.low_completed_request_threshold
         || run.truncation.dropped_requests > 0
         || !explanatory_present
     {
@@ -123,12 +130,12 @@ pub(super) fn evidence_quality(run: &Run) -> EvidenceQuality {
     }
 }
 
-fn request_status(run: &Run) -> SignalCoverageStatus {
+fn request_status(run: &Run, options: &AnalyzeOptions) -> SignalCoverageStatus {
     if run.requests.is_empty() {
         SignalCoverageStatus::Missing
     } else if run.truncation.dropped_requests > 0 {
         SignalCoverageStatus::Truncated
-    } else if run.requests.len() < LOW_COMPLETED_REQUEST_THRESHOLD {
+    } else if run.requests.len() < options.evidence.low_completed_request_threshold {
         SignalCoverageStatus::Partial
     } else {
         SignalCoverageStatus::Present
@@ -170,13 +177,14 @@ fn runtime_status(run: &Run) -> SignalCoverageStatus {
 }
 
 fn evidence_limitations(
+    options: &AnalyzeOptions,
     run: &Run,
     queues: SignalCoverageStatus,
     stages: SignalCoverageStatus,
     runtime_snapshots: SignalCoverageStatus,
 ) -> Vec<String> {
     let mut limitations = Vec::new();
-    if run.requests.len() < LOW_COMPLETED_REQUEST_THRESHOLD {
+    if run.requests.len() < options.evidence.low_completed_request_threshold {
         limitations
             .push("Low completed-request count can make suspect ranking unstable.".to_string());
     }

--- a/tailtriage-analyzer/src/lib.rs
+++ b/tailtriage-analyzer/src/lib.rs
@@ -20,17 +20,6 @@ pub use options::{
 };
 use tailtriage_core::{InFlightSnapshot, Run, RuntimeSnapshot};
 
-const LOW_COMPLETED_REQUEST_THRESHOLD: usize = 20;
-const QUEUE_SHARE_TRIGGER_PERMILLE: u64 = 300;
-const MEDIUM_CONFIDENCE_SCORE_THRESHOLD: u8 = 65;
-const HIGH_CONFIDENCE_SCORE_THRESHOLD: u8 = 85;
-const AMBIGUITY_MIN_SCORE_THRESHOLD: u8 = 60;
-const AMBIGUITY_SCORE_GAP_THRESHOLD: u8 = 4;
-const ROUTE_MIN_REQUEST_COUNT: usize = 3;
-const ROUTE_BREAKDOWN_LIMIT: usize = 10;
-const TEMPORAL_MIN_REQUEST_COUNT: usize = 20;
-const TEMPORAL_MIN_SEGMENT_REQUEST_COUNT: usize = 8;
-const TEMPORAL_SHARE_SHIFT_PERMILLE: u64 = 200;
 const ROUTE_DIVERGENCE_WARNING: &str =
     "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect.";
 const ROUTE_RUNTIME_ATTRIBUTION_WARNING: &str =
@@ -91,10 +80,10 @@ pub enum Confidence {
 }
 
 impl Confidence {
-    fn from_score(score: u8) -> Self {
-        if score >= HIGH_CONFIDENCE_SCORE_THRESHOLD {
+    fn from_score(score: u8, options: &AnalyzeOptions) -> Self {
+        if score >= options.confidence.high_score_threshold {
             Self::High
-        } else if score >= MEDIUM_CONFIDENCE_SCORE_THRESHOLD {
+        } else if score >= options.confidence.medium_score_threshold {
             Self::Medium
         } else {
             Self::Low
@@ -128,10 +117,26 @@ impl Suspect {
         evidence: Vec<String>,
         next_checks: Vec<String>,
     ) -> Self {
+        Self::new_with_options(
+            kind,
+            score,
+            &AnalyzeOptions::default(),
+            evidence,
+            next_checks,
+        )
+    }
+
+    fn new_with_options(
+        kind: DiagnosisKind,
+        score: u8,
+        options: &AnalyzeOptions,
+        evidence: Vec<String>,
+        next_checks: Vec<String>,
+    ) -> Self {
         Self {
             kind,
             score,
-            confidence: Confidence::from_score(score),
+            confidence: Confidence::from_score(score, options),
             evidence,
             next_checks,
             confidence_notes: Vec::new(),
@@ -162,6 +167,8 @@ pub struct InflightTrend {
 /// It does not prove root cause and should be used as triage guidance.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Report {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub analyzer_config: Option<AnalyzerConfigSummary>,
     /// Number of request events considered in analysis.
     pub request_count: usize,
     /// p50 request latency in microseconds.
@@ -223,6 +230,18 @@ pub struct TemporalSegment {
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 /// Supporting per-route triage summary derived from captured request route labels.
+pub struct AnalyzeConfigOverrideSummary {
+    pub path: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct AnalyzerConfigSummary {
+    pub schema_version: u32,
+    pub non_default_options: Vec<AnalyzeConfigOverrideSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct RouteBreakdown {
     /// Route or operation label from request capture.
     pub route: String,
@@ -430,18 +449,34 @@ impl Analyzer {
     }
 }
 
-fn analyze_run_with_options(run: &Run, _options: &AnalyzeOptions) -> Report {
-    let mut report = analyze_run_internal(run);
-    let route_context = route::route_breakdowns(run, &report);
+fn analyze_run_with_options(run: &Run, options: &AnalyzeOptions) -> Report {
+    let mut report = analyze_run_internal_with_options(run, options);
+    let route_context = route::route_breakdowns(run, &report, options);
     if route_context.divergent {
         report.warnings.push(ROUTE_DIVERGENCE_WARNING.to_string());
     }
     report.route_breakdowns = route_context.breakdowns;
-    report.temporal_segments = temporal::temporal_segments(run, &mut report.warnings);
+    report.temporal_segments = temporal::temporal_segments(run, options, &mut report.warnings);
+    let overrides = options.non_default_overrides();
+    report.analyzer_config = if overrides.is_empty() {
+        None
+    } else {
+        Some(AnalyzerConfigSummary {
+            schema_version: 1,
+            non_default_options: overrides
+                .into_iter()
+                .map(|(path, value)| AnalyzeConfigOverrideSummary { path, value })
+                .collect(),
+        })
+    };
     report
 }
 
 fn analyze_run_internal(run: &Run) -> Report {
+    analyze_run_internal_with_options(run, &AnalyzeOptions::default())
+}
+
+fn analyze_run_internal_with_options(run: &Run, options: &AnalyzeOptions) -> Report {
     let request_latencies = run
         .requests
         .iter()
@@ -458,27 +493,31 @@ fn analyze_run_internal(run: &Run) -> Report {
 
     let mut suspects = Vec::new();
 
-    if let Some(queue_suspect) = scoring::queue_saturation_suspect(run, inflight_trend.as_ref()) {
+    if let Some(queue_suspect) =
+        scoring::queue_saturation_suspect(run, options, inflight_trend.as_ref())
+    {
         suspects.push(queue_suspect);
     }
 
-    if let Some(blocking_suspect) = scoring::blocking_pressure_suspect(run) {
+    if let Some(blocking_suspect) = scoring::blocking_pressure_suspect(run, options) {
         suspects.push(blocking_suspect);
     }
 
-    if let Some(executor_suspect) = scoring::executor_pressure_suspect(run, inflight_trend.as_ref())
+    if let Some(executor_suspect) =
+        scoring::executor_pressure_suspect(run, options, inflight_trend.as_ref())
     {
         suspects.push(executor_suspect);
     }
 
-    if let Some(stage_suspect) = scoring::downstream_stage_suspect(run) {
+    if let Some(stage_suspect) = scoring::downstream_stage_suspect(run, options) {
         suspects.push(stage_suspect);
     }
 
     if suspects.is_empty() {
-        suspects.push(Suspect::new(
+        suspects.push(Suspect::new_with_options(
             DiagnosisKind::InsufficientEvidence,
             50,
+            options,
             vec![
                 "Not enough queue, stage, or runtime signals to rank a stronger suspect."
                     .to_string(),
@@ -493,22 +532,29 @@ fn analyze_run_internal(run: &Run) -> Report {
 
     suspects.sort_by_key(|suspect| std::cmp::Reverse(suspect.score));
 
-    let warnings = analysis_warnings(run, &suspects);
-    let evidence_quality = evidence::evidence_quality(run);
+    let warnings = analysis_warnings(run, options, &suspects);
+    let evidence_quality = evidence::evidence_quality_with_options(run, options);
 
-    confidence::apply_evidence_aware_confidence_caps(&mut suspects, run, &evidence_quality);
+    confidence::apply_evidence_aware_confidence_caps_with_options(
+        &mut suspects,
+        run,
+        options,
+        &evidence_quality,
+    );
 
     let mut ranked = suspects.into_iter();
     let primary_suspect = ranked.next().unwrap_or_else(|| {
-        Suspect::new(
+        Suspect::new_with_options(
             DiagnosisKind::InsufficientEvidence,
             50,
+            options,
             vec!["No diagnosis signals were captured for this run.".to_string()],
             vec!["Verify that request, queue, or stage instrumentation is enabled.".to_string()],
         )
     });
 
     Report {
+        analyzer_config: None,
         request_count: run.requests.len(),
         p50_latency_us,
         p95_latency_us,
@@ -526,15 +572,22 @@ fn analyze_run_internal(run: &Run) -> Report {
 }
 
 fn ambiguity_warning(suspects: &[Suspect]) -> Option<String> {
+    ambiguity_warning_with_options(&AnalyzeOptions::default(), suspects)
+}
+
+fn ambiguity_warning_with_options(
+    options: &AnalyzeOptions,
+    suspects: &[Suspect],
+) -> Option<String> {
     let mut ranked = suspects
         .iter()
         .filter(|s| s.kind != DiagnosisKind::InsufficientEvidence)
         .collect::<Vec<_>>();
     ranked.sort_by_key(|s| std::cmp::Reverse(s.score));
     if ranked.len() >= 2
-        && ranked[0].score >= AMBIGUITY_MIN_SCORE_THRESHOLD
-        && ranked[1].score >= AMBIGUITY_MIN_SCORE_THRESHOLD
-        && ranked[0].score.abs_diff(ranked[1].score) <= AMBIGUITY_SCORE_GAP_THRESHOLD
+        && ranked[0].score >= options.confidence.ambiguity_min_score
+        && ranked[1].score >= options.confidence.ambiguity_min_score
+        && ranked[0].score.abs_diff(ranked[1].score) <= options.confidence.ambiguity_score_gap
     {
         Some("Top suspects are close in score; treat ranking as ambiguous and validate both with next checks.".to_string())
     } else {
@@ -542,9 +595,9 @@ fn ambiguity_warning(suspects: &[Suspect]) -> Option<String> {
     }
 }
 
-fn analysis_warnings(run: &Run, suspects: &[Suspect]) -> Vec<String> {
+fn analysis_warnings(run: &Run, options: &AnalyzeOptions, suspects: &[Suspect]) -> Vec<String> {
     let mut warnings = evidence::truncation_warnings(run);
-    if run.requests.len() < LOW_COMPLETED_REQUEST_THRESHOLD {
+    if run.requests.len() < options.evidence.low_completed_request_threshold {
         warnings.push(
             "Low completed-request count; diagnosis ranking may be unstable for this run window."
                 .to_string(),
@@ -591,7 +644,7 @@ fn analysis_warnings(run: &Run, suspects: &[Suspect]) -> Vec<String> {
     {
         warnings.push("Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited.".to_string());
     }
-    if let Some(w) = ambiguity_warning(suspects) {
+    if let Some(w) = ambiguity_warning_with_options(options, suspects) {
         warnings.push(w);
     }
     warnings

--- a/tailtriage-analyzer/src/options/mod.rs
+++ b/tailtriage-analyzer/src/options/mod.rs
@@ -223,6 +223,172 @@ impl Default for TemporalOptions {
 }
 
 impl AnalyzeOptions {
+    /// Returns sorted summaries for all non-default semantic option overrides.
+    #[must_use]
+    pub fn non_default_overrides(&self) -> Vec<(String, String)> {
+        let defaults = Self::default();
+        let mut overrides = Vec::new();
+        macro_rules! push_if_non_default {
+            ($path:literal, $value:expr, $default:expr) => {
+                if $value != $default {
+                    overrides.push(($path.to_string(), $value.to_string()));
+                }
+            };
+        }
+        push_if_non_default!(
+            "queueing.trigger_permille",
+            self.queueing.trigger_permille,
+            defaults.queueing.trigger_permille
+        );
+        push_if_non_default!(
+            "blocking.min_nonzero_samples_for_signal",
+            self.blocking.min_nonzero_samples_for_signal,
+            defaults.blocking.min_nonzero_samples_for_signal
+        );
+        push_if_non_default!(
+            "blocking.strong_p95_threshold",
+            self.blocking.strong_p95_threshold,
+            defaults.blocking.strong_p95_threshold
+        );
+        push_if_non_default!(
+            "blocking.strong_peak_threshold",
+            self.blocking.strong_peak_threshold,
+            defaults.blocking.strong_peak_threshold
+        );
+        push_if_non_default!(
+            "blocking.strong_nonzero_share_permille",
+            self.blocking.strong_nonzero_share_permille,
+            defaults.blocking.strong_nonzero_share_permille
+        );
+        push_if_non_default!(
+            "blocking.strong_min_samples",
+            self.blocking.strong_min_samples,
+            defaults.blocking.strong_min_samples
+        );
+        push_if_non_default!(
+            "executor.min_global_queue_p95_for_signal",
+            self.executor.min_global_queue_p95_for_signal,
+            defaults.executor.min_global_queue_p95_for_signal
+        );
+        push_if_non_default!(
+            "downstream.min_stage_samples",
+            self.downstream.min_stage_samples,
+            defaults.downstream.min_stage_samples
+        );
+        if self.downstream.blocking_correlated_stage_patterns
+            != defaults.downstream.blocking_correlated_stage_patterns
+        {
+            overrides.push((
+                "downstream.blocking_correlated_stage_patterns".to_string(),
+                self.downstream.blocking_correlated_stage_patterns.join(","),
+            ));
+        }
+        push_if_non_default!(
+            "downstream.blocking_correlation_score_margin",
+            self.downstream.blocking_correlation_score_margin,
+            defaults.downstream.blocking_correlation_score_margin
+        );
+        push_if_non_default!(
+            "confidence.medium_score_threshold",
+            self.confidence.medium_score_threshold,
+            defaults.confidence.medium_score_threshold
+        );
+        push_if_non_default!(
+            "confidence.high_score_threshold",
+            self.confidence.high_score_threshold,
+            defaults.confidence.high_score_threshold
+        );
+        push_if_non_default!(
+            "confidence.ambiguity_min_score",
+            self.confidence.ambiguity_min_score,
+            defaults.confidence.ambiguity_min_score
+        );
+        push_if_non_default!(
+            "confidence.ambiguity_score_gap",
+            self.confidence.ambiguity_score_gap,
+            defaults.confidence.ambiguity_score_gap
+        );
+        push_if_non_default!(
+            "evidence.low_completed_request_threshold",
+            self.evidence.low_completed_request_threshold,
+            defaults.evidence.low_completed_request_threshold
+        );
+        push_if_non_default!(
+            "route.min_request_count",
+            self.route.min_request_count,
+            defaults.route.min_request_count
+        );
+        push_if_non_default!(
+            "route.breakdown_limit",
+            self.route.breakdown_limit,
+            defaults.route.breakdown_limit
+        );
+        push_if_non_default!(
+            "route.emit_on_divergent_suspects",
+            self.route.emit_on_divergent_suspects,
+            defaults.route.emit_on_divergent_suspects
+        );
+        push_if_non_default!(
+            "route.slowest_to_fastest_p95_ratio_numerator",
+            self.route.slowest_to_fastest_p95_ratio_numerator,
+            defaults.route.slowest_to_fastest_p95_ratio_numerator
+        );
+        push_if_non_default!(
+            "route.slowest_to_fastest_p95_ratio_denominator",
+            self.route.slowest_to_fastest_p95_ratio_denominator,
+            defaults.route.slowest_to_fastest_p95_ratio_denominator
+        );
+        push_if_non_default!(
+            "route.slowest_to_global_p95_ratio_numerator",
+            self.route.slowest_to_global_p95_ratio_numerator,
+            defaults.route.slowest_to_global_p95_ratio_numerator
+        );
+        push_if_non_default!(
+            "route.slowest_to_global_p95_ratio_denominator",
+            self.route.slowest_to_global_p95_ratio_denominator,
+            defaults.route.slowest_to_global_p95_ratio_denominator
+        );
+        push_if_non_default!(
+            "temporal.min_request_count",
+            self.temporal.min_request_count,
+            defaults.temporal.min_request_count
+        );
+        push_if_non_default!(
+            "temporal.min_segment_request_count",
+            self.temporal.min_segment_request_count,
+            defaults.temporal.min_segment_request_count
+        );
+        push_if_non_default!(
+            "temporal.share_shift_permille",
+            self.temporal.share_shift_permille,
+            defaults.temporal.share_shift_permille
+        );
+        push_if_non_default!(
+            "temporal.p95_shift_ratio_numerator",
+            self.temporal.p95_shift_ratio_numerator,
+            defaults.temporal.p95_shift_ratio_numerator
+        );
+        push_if_non_default!(
+            "temporal.p95_shift_ratio_denominator",
+            self.temporal.p95_shift_ratio_denominator,
+            defaults.temporal.p95_shift_ratio_denominator
+        );
+        push_if_non_default!(
+            "temporal.emit_on_suspect_shift",
+            self.temporal.emit_on_suspect_shift,
+            defaults.temporal.emit_on_suspect_shift
+        );
+        push_if_non_default!(
+            "temporal.suppress_runtime_sparse_suspect_shift_without_supporting_movement",
+            self.temporal
+                .suppress_runtime_sparse_suspect_shift_without_supporting_movement,
+            defaults
+                .temporal
+                .suppress_runtime_sparse_suspect_shift_without_supporting_movement
+        );
+        overrides.sort_by(|a, b| a.0.cmp(&b.0));
+        overrides
+    }
     /// Applies queueing-option edits and returns updated options for fluent setup.
     #[must_use]
     pub fn with_queueing(mut self, f: impl FnOnce(&mut QueueingOptions)) -> Self {

--- a/tailtriage-analyzer/src/render.rs
+++ b/tailtriage-analyzer/src/render.rs
@@ -119,6 +119,13 @@ pub fn render_text(report: &Report) -> String {
             ));
         }
     }
+    if let Some(config) = &report.analyzer_config {
+        lines.push("Analyzer config:".to_string());
+        lines.push(format!("- schema_version: {}", config.schema_version));
+        for override_item in &config.non_default_options {
+            lines.push(format!("- {}={}", override_item.path, override_item.value));
+        }
+    }
     append_temporal_segment_text(&mut lines, &report.temporal_segments);
     lines.join("\n")
 }

--- a/tailtriage-analyzer/src/route.rs
+++ b/tailtriage-analyzer/src/route.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, BTreeSet, HashSet};
 use tailtriage_core::Run;
 
 use super::{
-    analyze_run_internal, Report, RouteBreakdown, ROUTE_BREAKDOWN_LIMIT, ROUTE_MIN_REQUEST_COUNT,
+    analyze_run_internal_with_options, AnalyzeOptions, Report, RouteBreakdown,
     ROUTE_RUNTIME_ATTRIBUTION_WARNING,
 };
 
@@ -12,7 +12,11 @@ pub(super) struct RouteBreakdownContext {
     pub(super) divergent: bool,
 }
 
-pub(super) fn route_breakdowns(run: &Run, global: &Report) -> RouteBreakdownContext {
+pub(super) fn route_breakdowns(
+    run: &Run,
+    global: &Report,
+    options: &AnalyzeOptions,
+) -> RouteBreakdownContext {
     let mut ids_by_route: BTreeMap<String, Vec<String>> = BTreeMap::new();
     for request in &run.requests {
         ids_by_route
@@ -22,7 +26,7 @@ pub(super) fn route_breakdowns(run: &Run, global: &Report) -> RouteBreakdownCont
     }
     let eligible: Vec<(String, Vec<String>)> = ids_by_route
         .into_iter()
-        .filter(|(_, ids)| ids.len() >= ROUTE_MIN_REQUEST_COUNT)
+        .filter(|(_, ids)| ids.len() >= options.route.min_request_count)
         .collect();
     if eligible.len() < 2 {
         return RouteBreakdownContext {
@@ -39,13 +43,13 @@ pub(super) fn route_breakdowns(run: &Run, global: &Report) -> RouteBreakdownCont
             acc
         })
         .into_values()
-        .filter(|count| *count < ROUTE_MIN_REQUEST_COUNT)
+        .filter(|count| *count < options.route.min_request_count)
         .count();
 
     let mut candidates = Vec::new();
     for (route, request_ids) in eligible {
         let filtered = filtered_run_for_route(run, &request_ids);
-        let mut analyzed = analyze_run_internal(&filtered);
+        let mut analyzed = analyze_run_internal_with_options(&filtered, options);
         analyzed
             .warnings
             .push(ROUTE_RUNTIME_ATTRIBUTION_WARNING.to_string());
@@ -63,7 +67,7 @@ pub(super) fn route_breakdowns(run: &Run, global: &Report) -> RouteBreakdownCont
             warnings: analyzed.warnings,
         });
     }
-    if !should_emit_route_breakdowns(global, &candidates) {
+    if !should_emit_route_breakdowns(global, &candidates, options) {
         return RouteBreakdownContext {
             breakdowns: vec![],
             divergent: false,
@@ -76,11 +80,12 @@ pub(super) fn route_breakdowns(run: &Run, global: &Report) -> RouteBreakdownCont
             .then_with(|| b.request_count.cmp(&a.request_count))
             .then_with(|| a.route.cmp(&b.route))
     });
-    emitted.truncate(ROUTE_BREAKDOWN_LIMIT);
+    emitted.truncate(options.route.breakdown_limit);
     let divergent = route_divergence(&emitted);
     if omitted_routes > 0 {
+        let min_count = options.route.min_request_count;
         let note = format!(
-            "Some routes are omitted from route_breakdowns because they have fewer than {ROUTE_MIN_REQUEST_COUNT} completed requests."
+            "Some routes are omitted from route_breakdowns because they have fewer than {min_count} completed requests."
         );
         for breakdown in &mut emitted {
             breakdown.warnings.push(note.clone());
@@ -101,11 +106,15 @@ fn route_divergence(candidates: &[RouteBreakdown]) -> bool {
         >= 2
 }
 
-fn should_emit_route_breakdowns(global: &Report, candidates: &[RouteBreakdown]) -> bool {
+fn should_emit_route_breakdowns(
+    global: &Report,
+    candidates: &[RouteBreakdown],
+    options: &AnalyzeOptions,
+) -> bool {
     if candidates.len() < 2 {
         return false;
     }
-    if route_divergence(candidates) {
+    if route_divergence(candidates) && options.route.emit_on_divergent_suspects {
         return true;
     }
     let p95s: Vec<u64> = candidates.iter().filter_map(|c| c.p95_latency_us).collect();
@@ -114,10 +123,14 @@ fn should_emit_route_breakdowns(global: &Report, candidates: &[RouteBreakdown]) 
     }
     let slowest = *p95s.iter().max().unwrap_or(&0);
     let fastest = *p95s.iter().min().unwrap_or(&0);
-    (fastest > 0 && slowest.saturating_mul(2) >= fastest.saturating_mul(3))
+    (fastest > 0
+        && slowest.saturating_mul(options.route.slowest_to_fastest_p95_ratio_denominator)
+            >= fastest.saturating_mul(options.route.slowest_to_fastest_p95_ratio_numerator))
         || match global.p95_latency_us {
             Some(global_p95) if global_p95 > 0 => {
-                slowest.saturating_mul(4) >= global_p95.saturating_mul(5)
+                slowest.saturating_mul(options.route.slowest_to_global_p95_ratio_denominator)
+                    >= global_p95
+                        .saturating_mul(options.route.slowest_to_global_p95_ratio_numerator)
             }
             _ => false,
         }

--- a/tailtriage-analyzer/src/scoring.rs
+++ b/tailtriage-analyzer/src/scoring.rs
@@ -3,11 +3,10 @@ use std::collections::BTreeMap;
 use tailtriage_core::Run;
 
 use crate::{
-    percentile, request_time_shares, runtime_metric_series, DiagnosisKind, InflightTrend, Suspect,
-    QUEUE_SHARE_TRIGGER_PERMILLE,
+    percentile, request_time_shares, runtime_metric_series, AnalyzeOptions, DiagnosisKind,
+    InflightTrend, Suspect,
 };
 
-const DOWNSTREAM_MIN_STAGE_SAMPLES: usize = 3;
 const SAMPLE_QUALITY_HIGH_SAMPLE_COUNT: usize = 100;
 const SAMPLE_QUALITY_MEDIUM_SAMPLE_COUNT: usize = 40;
 const SAMPLE_QUALITY_LOW_SAMPLE_COUNT: usize = 20;
@@ -15,11 +14,12 @@ const SAMPLE_QUALITY_MIN_NONZERO_SAMPLE_COUNT: usize = 8;
 
 pub(super) fn queue_saturation_suspect(
     run: &Run,
+    options: &AnalyzeOptions,
     inflight_trend: Option<&InflightTrend>,
 ) -> Option<Suspect> {
     let (queue_shares, _) = request_time_shares(run);
     let p95_queue_share_permille = percentile(&queue_shares, 95, 100)?;
-    if p95_queue_share_permille < QUEUE_SHARE_TRIGGER_PERMILLE {
+    if p95_queue_share_permille < options.queueing.trigger_permille {
         return None;
     }
     let queue_depths = run
@@ -56,9 +56,10 @@ pub(super) fn queue_saturation_suspect(
             trend.gauge, trend.growth_delta, trend.p95_count, trend.peak_count
         ));
     }
-    Some(Suspect::new(
+    Some(Suspect::new_with_options(
         DiagnosisKind::ApplicationQueueSaturation,
         score,
+        options,
         evidence,
         vec![
             "Inspect queue admission limits and producer burst patterns.".to_string(),
@@ -77,11 +78,11 @@ struct BlockingSignal {
     nz_share_permille: u64,
 }
 
-fn blocking_signal(run: &Run) -> Option<BlockingSignal> {
+fn blocking_signal(run: &Run, options: &AnalyzeOptions) -> Option<BlockingSignal> {
     let depths = runtime_metric_series(&run.runtime_snapshots, |s| s.blocking_queue_depth);
     let p95 = percentile(&depths, 95, 100)?;
     let nonzero = nonzero_sample_count(&depths);
-    if p95 == 0 && nonzero < 2 {
+    if p95 == 0 && nonzero < options.blocking.min_nonzero_samples_for_signal {
         return None;
     }
     let peak = max_or_zero(&depths);
@@ -99,19 +100,31 @@ fn blocking_signal(run: &Run) -> Option<BlockingSignal> {
     })
 }
 
-fn strong_blocking_signal(signal: BlockingSignal) -> bool {
-    signal.p95 >= 12 && signal.peak >= 20 && signal.nz_share_permille >= 700 && signal.samples >= 30
+fn strong_blocking_signal(signal: BlockingSignal, options: &AnalyzeOptions) -> bool {
+    signal.p95 >= options.blocking.strong_p95_threshold
+        && signal.peak >= options.blocking.strong_peak_threshold
+        && signal.nz_share_permille >= options.blocking.strong_nonzero_share_permille
+        && signal.samples >= options.blocking.strong_min_samples
 }
 
 pub(super) fn stage_correlates_with_blocking_pool(stage: &str) -> bool {
-    let lower = stage.to_ascii_lowercase();
-    lower.contains("spawn_blocking")
-        || lower.contains("blocking_path")
-        || lower.contains("blocking")
+    stage_correlates_with_blocking_pool_with_options(stage, &AnalyzeOptions::default())
 }
 
-pub(super) fn blocking_pressure_suspect(run: &Run) -> Option<Suspect> {
-    let signal = blocking_signal(run)?;
+pub(super) fn stage_correlates_with_blocking_pool_with_options(
+    stage: &str,
+    options: &AnalyzeOptions,
+) -> bool {
+    let lower = stage.to_ascii_lowercase();
+    options
+        .downstream
+        .blocking_correlated_stage_patterns
+        .iter()
+        .any(|p| lower.contains(&p.trim().to_ascii_lowercase()))
+}
+
+pub(super) fn blocking_pressure_suspect(run: &Run, options: &AnalyzeOptions) -> Option<Suspect> {
+    let signal = blocking_signal(run, options)?;
     let clean_extreme = signal.p95 >= 16 && signal.peak >= 24 && signal.nz_share_permille >= 900;
     let score = cap_unless_clean_evidence(
         32 + signal.p95.min(24)
@@ -121,9 +134,10 @@ pub(super) fn blocking_pressure_suspect(run: &Run) -> Option<Suspect> {
         clean_extreme,
         94,
     );
-    Some(Suspect::new(
+    Some(Suspect::new_with_options(
         DiagnosisKind::BlockingPoolPressure,
         score,
+        options,
         vec![format!(
             "Blocking queue depth p95 is {}, peak is {}, with {}/{} nonzero samples.",
             signal.p95, signal.peak, signal.nonzero, signal.samples
@@ -138,11 +152,12 @@ pub(super) fn blocking_pressure_suspect(run: &Run) -> Option<Suspect> {
 
 pub(super) fn executor_pressure_suspect(
     run: &Run,
+    options: &AnalyzeOptions,
     inflight_trend: Option<&InflightTrend>,
 ) -> Option<Suspect> {
     let global = runtime_metric_series(&run.runtime_snapshots, |s| s.global_queue_depth);
     let p95_global = percentile(&global, 95, 100)?;
-    if p95_global == 0 {
+    if p95_global < options.executor.min_global_queue_p95_for_signal {
         return None;
     }
     let local = runtime_metric_series(&run.runtime_snapshots, |s| s.local_queue_depth);
@@ -169,9 +184,10 @@ pub(super) fn executor_pressure_suspect(
     if let Some(ap95) = percentile(&alive, 95, 100) {
         evidence.push(format!("Runtime alive_tasks p95 is {ap95}."));
     }
-    Some(Suspect::new(
+    Some(Suspect::new_with_options(
         DiagnosisKind::ExecutorPressureSuspected,
         score,
+        options,
         evidence,
         vec![
             "Check for long polls without yielding and uneven task fan-out.".to_string(),
@@ -191,7 +207,12 @@ struct StageCandidate {
     score: u8,
 }
 
-fn downstream_stage_candidates(run: &Run, p95_req: u64, total_req: u64) -> Vec<StageCandidate> {
+fn downstream_stage_candidates(
+    run: &Run,
+    options: &AnalyzeOptions,
+    p95_req: u64,
+    total_req: u64,
+) -> Vec<StageCandidate> {
     let tail_ids: std::collections::HashMap<&str, u64> = run
         .requests
         .iter()
@@ -205,7 +226,7 @@ fn downstream_stage_candidates(run: &Run, p95_req: u64, total_req: u64) -> Vec<S
     }
     let mut cands = Vec::new();
     for (name, ss) in by {
-        if ss.len() < DOWNSTREAM_MIN_STAGE_SAMPLES {
+        if ss.len() < options.downstream.min_stage_samples {
             continue;
         }
         let lats = ss.iter().map(|s| s.latency_us).collect::<Vec<_>>();
@@ -245,7 +266,7 @@ fn downstream_stage_candidates(run: &Run, p95_req: u64, total_req: u64) -> Vec<S
     cands
 }
 
-pub(super) fn downstream_stage_suspect(run: &Run) -> Option<Suspect> {
+pub(super) fn downstream_stage_suspect(run: &Run, options: &AnalyzeOptions) -> Option<Suspect> {
     let p95_req = percentile(
         &run.requests
             .iter()
@@ -259,7 +280,7 @@ pub(super) fn downstream_stage_suspect(run: &Run) -> Option<Suspect> {
         .iter()
         .map(|r| r.latency_us)
         .fold(0_u64, u64::saturating_add);
-    let blocking = blocking_signal(run);
+    let blocking = blocking_signal(run, options);
     let blocking_score = blocking.map(|signal| {
         let clean_extreme =
             signal.p95 >= 16 && signal.peak >= 24 && signal.nz_share_permille >= 900;
@@ -272,7 +293,7 @@ pub(super) fn downstream_stage_suspect(run: &Run) -> Option<Suspect> {
             94,
         )
     });
-    let best = downstream_stage_candidates(run, p95_req, total_req)
+    let best = downstream_stage_candidates(run, options, p95_req, total_req)
         .into_iter()
         .max_by(|a, b| {
             a.score
@@ -283,11 +304,13 @@ pub(super) fn downstream_stage_suspect(run: &Run) -> Option<Suspect> {
         })?;
     let mut downstream_score = best.score;
     let mut correlation_evidence: Option<String> = None;
-    if stage_correlates_with_blocking_pool(&best.stage)
-        && blocking.is_some_and(strong_blocking_signal)
+    if stage_correlates_with_blocking_pool_with_options(&best.stage, options)
+        && blocking.is_some_and(|s| strong_blocking_signal(s, options))
         && blocking_score.is_some()
     {
-        let cap = blocking_score.unwrap_or(downstream_score).saturating_sub(2);
+        let cap = blocking_score
+            .unwrap_or(downstream_score)
+            .saturating_sub(options.downstream.blocking_correlation_score_margin);
         downstream_score = downstream_score.min(cap);
         correlation_evidence = Some(format!(
             "Stage '{}' looks blocking-correlated; strong runtime blocking-queue evidence keeps blocking_pool_pressure prioritized.",
@@ -311,9 +334,10 @@ pub(super) fn downstream_stage_suspect(run: &Run) -> Option<Suspect> {
     if let Some(extra) = correlation_evidence {
         evidence.push(extra);
     }
-    Some(Suspect::new(
+    Some(Suspect::new_with_options(
         DiagnosisKind::DownstreamStageDominates,
         downstream_score,
+        options,
         evidence,
         vec![
             format!(

--- a/tailtriage-analyzer/src/temporal.rs
+++ b/tailtriage-analyzer/src/temporal.rs
@@ -1,8 +1,8 @@
 use tailtriage_core::{RequestEvent, Run};
 
 use super::{
-    analyze_run_internal, DiagnosisKind, SignalCoverageStatus, TemporalSegment,
-    TEMPORAL_MIN_REQUEST_COUNT, TEMPORAL_MIN_SEGMENT_REQUEST_COUNT, TEMPORAL_SHARE_SHIFT_PERMILLE,
+    analyze_run_internal_with_options, AnalyzeOptions, DiagnosisKind, SignalCoverageStatus,
+    TemporalSegment,
 };
 use crate::route;
 
@@ -36,9 +36,10 @@ fn filtered_run_for_temporal_segment(
 
 pub(super) fn temporal_segments(
     run: &Run,
+    options: &AnalyzeOptions,
     global_warnings: &mut Vec<String>,
 ) -> Vec<TemporalSegment> {
-    if run.requests.len() < TEMPORAL_MIN_REQUEST_COUNT {
+    if run.requests.len() < options.temporal.min_request_count {
         return vec![];
     }
     let mut requests = run.requests.clone();
@@ -49,8 +50,8 @@ pub(super) fn temporal_segments(
     });
     let split = requests.len() / 2;
     let (early, late) = requests.split_at(split);
-    if early.len() < TEMPORAL_MIN_SEGMENT_REQUEST_COUNT
-        || late.len() < TEMPORAL_MIN_SEGMENT_REQUEST_COUNT
+    if early.len() < options.temporal.min_segment_request_count
+        || late.len() < options.temporal.min_segment_request_count
     {
         return vec![];
     }
@@ -59,10 +60,14 @@ pub(super) fn temporal_segments(
         let start = seg.iter().map(|r| r.started_at_unix_ms).min();
         let finish = seg.iter().map(|r| r.finished_at_unix_ms).max();
         let mut analyzed = match (start, finish) {
-            (Some(s), Some(f)) => {
-                analyze_run_internal(&filtered_run_for_temporal_segment(run, &ids, s, f))
-            }
-            _ => analyze_run_internal(&route::filtered_run_for_route(run, &ids)),
+            (Some(s), Some(f)) => analyze_run_internal_with_options(
+                &filtered_run_for_temporal_segment(run, &ids, s, f),
+                options,
+            ),
+            _ => analyze_run_internal_with_options(
+                &route::filtered_run_for_route(run, &ids),
+                options,
+            ),
         };
         let sparse_runtime =
             analyzed.evidence_quality.runtime_snapshots != SignalCoverageStatus::Present;
@@ -96,9 +101,13 @@ pub(super) fn temporal_segments(
     let mut early_seg = build("early", early);
     let mut late_seg = build("late", late);
     let suspect_shift_raw = early_seg.primary_suspect.kind != late_seg.primary_suspect.kind;
-    let p95_shift = has_material_p95_shift(early_seg.p95_latency_us, late_seg.p95_latency_us);
-    let queue_move = matches!((early_seg.p95_queue_share_permille, late_seg.p95_queue_share_permille), (Some(a), Some(b)) if a.abs_diff(b) >= TEMPORAL_SHARE_SHIFT_PERMILLE);
-    let service_move = matches!((early_seg.p95_service_share_permille, late_seg.p95_service_share_permille), (Some(a), Some(b)) if a.abs_diff(b) >= TEMPORAL_SHARE_SHIFT_PERMILLE);
+    let p95_shift = has_material_p95_shift_with_options(
+        early_seg.p95_latency_us,
+        late_seg.p95_latency_us,
+        options,
+    );
+    let queue_move = matches!((early_seg.p95_queue_share_permille, late_seg.p95_queue_share_permille), (Some(a), Some(b)) if a.abs_diff(b) >= options.temporal.share_shift_permille);
+    let service_move = matches!((early_seg.p95_service_share_permille, late_seg.p95_service_share_permille), (Some(a), Some(b)) if a.abs_diff(b) >= options.temporal.share_shift_permille);
     let runtime_sparse = early_seg.evidence_quality.runtime_snapshots
         != SignalCoverageStatus::Present
         || early_seg.evidence_quality.inflight_snapshots != SignalCoverageStatus::Present
@@ -118,7 +127,15 @@ pub(super) fn temporal_segments(
         )
     );
     let suspect_shift = suspect_shift_raw
-        && (!runtime_sparse || !runtime_dependent_shift || p95_shift || queue_move || service_move);
+        && (options.temporal.emit_on_suspect_shift)
+        && (!options
+            .temporal
+            .suppress_runtime_sparse_suspect_shift_without_supporting_movement
+            || !runtime_sparse
+            || !runtime_dependent_shift
+            || p95_shift
+            || queue_move
+            || service_move);
     let material = suspect_shift || p95_shift || queue_move || service_move;
     if !material {
         return vec![];
@@ -162,6 +179,14 @@ pub(super) fn apply_temporal_overlap_attribution_warning(
 }
 
 pub(super) fn has_material_p95_shift(left: Option<u64>, right: Option<u64>) -> bool {
+    has_material_p95_shift_with_options(left, right, &AnalyzeOptions::default())
+}
+
+pub(super) fn has_material_p95_shift_with_options(
+    left: Option<u64>,
+    right: Option<u64>,
+    options: &AnalyzeOptions,
+) -> bool {
     let (Some(a), Some(b)) = (left, right) else {
         return false;
     };
@@ -170,5 +195,6 @@ pub(super) fn has_material_p95_shift(left: Option<u64>, right: Option<u64>) -> b
     if lower == 0 {
         return false;
     }
-    higher.saturating_mul(2) >= lower.saturating_mul(3)
+    higher.saturating_mul(options.temporal.p95_shift_ratio_denominator)
+        >= lower.saturating_mul(options.temporal.p95_shift_ratio_numerator)
 }

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -224,6 +224,7 @@ fn inflight_trend_handles_monotonic_increase() {
 #[test]
 fn render_text_formats_inflight_trend_fields() {
     let report = Report {
+        analyzer_config: None,
         request_count: 2,
         p50_latency_us: Some(10),
         p95_latency_us: Some(20),
@@ -284,6 +285,7 @@ fn render_text_formats_inflight_trend_fields() {
 #[test]
 fn render_text_marks_missing_inflight_trend() {
     let report = Report {
+        analyzer_config: None,
         request_count: 0,
         p50_latency_us: None,
         p95_latency_us: None,


### PR DESCRIPTION
### Motivation
- Make analyzer behavior configurable by wiring `AnalyzeOptions` into scoring/evidence/confidence/route/temporal logic and expose any non-default analyzer settings in the generated `Report` for transparency. 
- Preserve default behavior and JSON shape: `AnalyzeOptions::default()` must not change existing outputs (report omits analyzer config). 

### Description
- Added report transparency types `AnalyzeConfigOverrideSummary` and `AnalyzerConfigSummary` and an optional `Report::analyzer_config` field annotated with `#[serde(skip_serializing_if = "Option::is_none")]` so default reports remain unchanged.
- Implemented `AnalyzeOptions::non_default_overrides()` which returns sorted `(path, value)` summaries using stable string formatting and joined string lists for vector options.
- Reworked analyzer plumbing: added `analyze_run_with_options(...)`, `analyze_run_internal_with_options(...)` and threaded `&AnalyzeOptions` into scoring, evidence, confidence, route, and temporal helpers so options drive signaling instead of hard-coded constants.
- Wired concrete option effects (examples): `queueing.trigger_permille` replacing the queue trigger constant, blocking signal thresholds and strong-blocking heuristics wired to `blocking.*` options, `executor.min_global_queue_p95_for_signal`, `downstream.min_stage_samples` and `downstream.blocking_correlated_stage_patterns` (case-insensitive substring match with trimmed entries), confidence thresholds from `confidence.*`, low-sample guards from `evidence.low_completed_request_threshold`, route and temporal thresholds/ratios and emission toggles from `route.*` and `temporal.*`.
- Updated `render_text` to append a concise `Analyzer config:` section when `analyzer_config` is present; omitted when `None` to preserve default text output.
- Kept internal scoring constants and raw scoring formula internals private (no public knobs) and adjusted tests/constructors to account for the new `analyzer_config` report field and options-aware helpers.

### Testing
- Ran `cargo fmt --all` successfully.
- Ran partial compile/test attempts during integration; `cargo test -p tailtriage-analyzer --no-run` surfaced intermediate compile/signature mismatches during the refactor (addressed iteratively in the change set while adapting helpers and tests).
- Ran workspace validation (`cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace && python3 scripts/validate_docs_contracts.py`) during development and observed outstanding `clippy` and test failures from lints (dead-code/missing-docs/function-length) that remain to be addressed before merge; the PR includes these work-in-progress changes so reviewers can inspect the integration surface and remaining adjustments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04a4597060833081794c5ff5d84a75)