### PR TITLE
analyzer: add strict [analyzer] TOML parsing and merge APIs for AnalyzeOptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,6 +804,7 @@ dependencies = [
  "serde_json",
  "tailtriage-core",
  "tokio",
+ "toml",
 ]
 
 [[package]]

--- a/examples/analyzer-config.toml
+++ b/examples/analyzer-config.toml
@@ -1,0 +1,48 @@
+[analyzer]
+schema_version = 1
+
+[analyzer.queueing]
+trigger_permille = 400
+
+[analyzer.blocking]
+min_nonzero_samples_for_signal = 2
+strong_p95_threshold = 12
+strong_peak_threshold = 20
+strong_nonzero_share_permille = 700
+strong_min_samples = 30
+
+[analyzer.executor]
+min_global_queue_p95_for_signal = 1
+
+[analyzer.downstream]
+# Patterns are substring matches used for blocking-correlation heuristics.
+blocking_correlated_stage_patterns = ["spawn_blocking", "blocking_path", "blocking"]
+min_stage_samples = 3
+blocking_correlation_score_margin = 2
+
+[analyzer.confidence]
+medium_score_threshold = 65
+high_score_threshold = 85
+ambiguity_min_score = 60
+ambiguity_score_gap = 4
+
+[analyzer.evidence]
+low_completed_request_threshold = 20
+
+[analyzer.route]
+min_request_count = 3
+breakdown_limit = 10
+emit_on_divergent_suspects = true
+slowest_to_fastest_p95_ratio_numerator = 3
+slowest_to_fastest_p95_ratio_denominator = 2
+slowest_to_global_p95_ratio_numerator = 5
+slowest_to_global_p95_ratio_denominator = 4
+
+[analyzer.temporal]
+min_request_count = 20
+min_segment_request_count = 8
+share_shift_permille = 200
+p95_shift_ratio_numerator = 3
+p95_shift_ratio_denominator = 2
+emit_on_suspect_shift = true
+suppress_runtime_sparse_suspect_shift_without_supporting_movement = true

--- a/tailtriage-analyzer/Cargo.toml
+++ b/tailtriage-analyzer/Cargo.toml
@@ -15,6 +15,7 @@ include = ["Cargo.toml", "README.md", "LICENSE", "src/**"]
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 tailtriage-core.workspace = true
+toml = "0.8"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/tailtriage-analyzer/src/options/mod.rs
+++ b/tailtriage-analyzer/src/options/mod.rs
@@ -4,6 +4,7 @@ use std::error::Error;
 use std::fmt::{Display, Formatter};
 
 mod descriptors;
+mod toml;
 pub use descriptors::analyze_option_descriptors;
 
 /// Semantic analyzer options grouped by triage domain.

--- a/tailtriage-analyzer/src/options/toml.rs
+++ b/tailtriage-analyzer/src/options/toml.rs
@@ -1,0 +1,254 @@
+use super::{
+    AnalyzeConfigError, AnalyzeOptions, BlockingOptions, ConfidenceOptions, DownstreamOptions,
+    EvidenceOptions, ExecutorOptions, QueueingOptions, RouteOptions, TemporalOptions,
+};
+use serde::Deserialize;
+
+const SUPPORTED_SCHEMA_VERSION: u64 = 1;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AnalyzerTomlConfig {
+    schema_version: Option<u64>,
+    queueing: Option<QueueingOptionsToml>,
+    blocking: Option<BlockingOptionsToml>,
+    executor: Option<ExecutorOptionsToml>,
+    downstream: Option<DownstreamOptionsToml>,
+    confidence: Option<ConfidenceOptionsToml>,
+    evidence: Option<EvidenceOptionsToml>,
+    route: Option<RouteOptionsToml>,
+    temporal: Option<TemporalOptionsToml>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct QueueingOptionsToml {
+    trigger_permille: Option<u64>,
+}
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct BlockingOptionsToml {
+    min_nonzero_samples_for_signal: Option<usize>,
+    strong_p95_threshold: Option<u64>,
+    strong_peak_threshold: Option<u64>,
+    strong_nonzero_share_permille: Option<u64>,
+    strong_min_samples: Option<usize>,
+}
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ExecutorOptionsToml {
+    min_global_queue_p95_for_signal: Option<u64>,
+}
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DownstreamOptionsToml {
+    min_stage_samples: Option<usize>,
+    blocking_correlated_stage_patterns: Option<Vec<String>>,
+    blocking_correlation_score_margin: Option<u8>,
+}
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ConfidenceOptionsToml {
+    medium_score_threshold: Option<u8>,
+    high_score_threshold: Option<u8>,
+    ambiguity_min_score: Option<u8>,
+    ambiguity_score_gap: Option<u8>,
+}
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvidenceOptionsToml {
+    low_completed_request_threshold: Option<usize>,
+}
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RouteOptionsToml {
+    min_request_count: Option<usize>,
+    breakdown_limit: Option<usize>,
+    emit_on_divergent_suspects: Option<bool>,
+    slowest_to_fastest_p95_ratio_numerator: Option<u64>,
+    slowest_to_fastest_p95_ratio_denominator: Option<u64>,
+    slowest_to_global_p95_ratio_numerator: Option<u64>,
+    slowest_to_global_p95_ratio_denominator: Option<u64>,
+}
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TemporalOptionsToml {
+    min_request_count: Option<usize>,
+    min_segment_request_count: Option<usize>,
+    share_shift_permille: Option<u64>,
+    p95_shift_ratio_numerator: Option<u64>,
+    p95_shift_ratio_denominator: Option<u64>,
+    emit_on_suspect_shift: Option<bool>,
+    suppress_runtime_sparse_suspect_shift_without_supporting_movement: Option<bool>,
+}
+
+impl AnalyzeOptions {
+    /// Parses strict analyzer TOML from a shared config string.
+    ///
+    /// # Errors
+    /// Returns [`AnalyzeConfigError`] when `[analyzer]` is missing, schema rules fail,
+    /// TOML decode fails, or parsed values fail semantic validation.
+    pub fn from_toml_str(input: &str) -> Result<Self, AnalyzeConfigError> {
+        Self::default().merge_toml_str(input)
+    }
+
+    /// Merges strict analyzer TOML into existing options.
+    ///
+    /// # Errors
+    /// Returns [`AnalyzeConfigError`] when `[analyzer]` is missing, schema rules fail,
+    /// TOML decode fails, or merged values fail semantic validation.
+    pub fn merge_toml_str(mut self, input: &str) -> Result<Self, AnalyzeConfigError> {
+        let root: toml::Value =
+            toml::from_str(input).map_err(|e| AnalyzeConfigError::InvalidToml {
+                message: e.to_string(),
+            })?;
+        let Some(analyzer_value) = root.get("analyzer") else {
+            return Err(AnalyzeConfigError::MissingAnalyzerTable);
+        };
+        let config: AnalyzerTomlConfig =
+            analyzer_value
+                .clone()
+                .try_into()
+                .map_err(|e: toml::de::Error| AnalyzeConfigError::InvalidToml {
+                    message: e.to_string(),
+                })?;
+        let Some(schema_version) = config.schema_version else {
+            return Err(AnalyzeConfigError::MissingSchemaVersion);
+        };
+        if schema_version != SUPPORTED_SCHEMA_VERSION {
+            return Err(AnalyzeConfigError::UnsupportedSchemaVersion {
+                found: schema_version,
+                supported: SUPPORTED_SCHEMA_VERSION,
+            });
+        }
+        if let Some(p) = &config.queueing {
+            apply_queueing(&mut self.queueing, p);
+        }
+        if let Some(p) = &config.blocking {
+            apply_blocking(&mut self.blocking, p);
+        }
+        if let Some(p) = &config.executor {
+            apply_executor(&mut self.executor, p);
+        }
+        if let Some(p) = &config.downstream {
+            apply_downstream(&mut self.downstream, p);
+        }
+        if let Some(p) = &config.confidence {
+            apply_confidence(&mut self.confidence, p);
+        }
+        if let Some(p) = &config.evidence {
+            apply_evidence(&mut self.evidence, p);
+        }
+        if let Some(p) = &config.route {
+            apply_route(&mut self.route, p);
+        }
+        if let Some(p) = &config.temporal {
+            apply_temporal(&mut self.temporal, p);
+        }
+        self.validate()?;
+        Ok(self)
+    }
+}
+fn apply_queueing(out: &mut QueueingOptions, p: &QueueingOptionsToml) {
+    if let Some(v) = p.trigger_permille {
+        out.trigger_permille = v;
+    }
+}
+fn apply_blocking(out: &mut BlockingOptions, p: &BlockingOptionsToml) {
+    if let Some(v) = p.min_nonzero_samples_for_signal {
+        out.min_nonzero_samples_for_signal = v;
+    }
+    if let Some(v) = p.strong_p95_threshold {
+        out.strong_p95_threshold = v;
+    }
+    if let Some(v) = p.strong_peak_threshold {
+        out.strong_peak_threshold = v;
+    }
+    if let Some(v) = p.strong_nonzero_share_permille {
+        out.strong_nonzero_share_permille = v;
+    }
+    if let Some(v) = p.strong_min_samples {
+        out.strong_min_samples = v;
+    }
+}
+fn apply_executor(out: &mut ExecutorOptions, p: &ExecutorOptionsToml) {
+    if let Some(v) = p.min_global_queue_p95_for_signal {
+        out.min_global_queue_p95_for_signal = v;
+    }
+}
+fn apply_downstream(out: &mut DownstreamOptions, p: &DownstreamOptionsToml) {
+    if let Some(v) = p.min_stage_samples {
+        out.min_stage_samples = v;
+    }
+    if let Some(v) = &p.blocking_correlated_stage_patterns {
+        out.blocking_correlated_stage_patterns.clone_from(v);
+    }
+    if let Some(v) = p.blocking_correlation_score_margin {
+        out.blocking_correlation_score_margin = v;
+    }
+}
+fn apply_confidence(out: &mut ConfidenceOptions, p: &ConfidenceOptionsToml) {
+    if let Some(v) = p.medium_score_threshold {
+        out.medium_score_threshold = v;
+    }
+    if let Some(v) = p.high_score_threshold {
+        out.high_score_threshold = v;
+    }
+    if let Some(v) = p.ambiguity_min_score {
+        out.ambiguity_min_score = v;
+    }
+    if let Some(v) = p.ambiguity_score_gap {
+        out.ambiguity_score_gap = v;
+    }
+}
+fn apply_evidence(out: &mut EvidenceOptions, p: &EvidenceOptionsToml) {
+    if let Some(v) = p.low_completed_request_threshold {
+        out.low_completed_request_threshold = v;
+    }
+}
+fn apply_route(out: &mut RouteOptions, p: &RouteOptionsToml) {
+    if let Some(v) = p.min_request_count {
+        out.min_request_count = v;
+    }
+    if let Some(v) = p.breakdown_limit {
+        out.breakdown_limit = v;
+    }
+    if let Some(v) = p.emit_on_divergent_suspects {
+        out.emit_on_divergent_suspects = v;
+    }
+    if let Some(v) = p.slowest_to_fastest_p95_ratio_numerator {
+        out.slowest_to_fastest_p95_ratio_numerator = v;
+    }
+    if let Some(v) = p.slowest_to_fastest_p95_ratio_denominator {
+        out.slowest_to_fastest_p95_ratio_denominator = v;
+    }
+    if let Some(v) = p.slowest_to_global_p95_ratio_numerator {
+        out.slowest_to_global_p95_ratio_numerator = v;
+    }
+    if let Some(v) = p.slowest_to_global_p95_ratio_denominator {
+        out.slowest_to_global_p95_ratio_denominator = v;
+    }
+}
+fn apply_temporal(out: &mut TemporalOptions, p: &TemporalOptionsToml) {
+    if let Some(v) = p.min_request_count {
+        out.min_request_count = v;
+    }
+    if let Some(v) = p.min_segment_request_count {
+        out.min_segment_request_count = v;
+    }
+    if let Some(v) = p.share_shift_permille {
+        out.share_shift_permille = v;
+    }
+    if let Some(v) = p.p95_shift_ratio_numerator {
+        out.p95_shift_ratio_numerator = v;
+    }
+    if let Some(v) = p.p95_shift_ratio_denominator {
+        out.p95_shift_ratio_denominator = v;
+    }
+    if let Some(v) = p.emit_on_suspect_shift {
+        out.emit_on_suspect_shift = v;
+    }
+    if let Some(v) = p.suppress_runtime_sparse_suspect_shift_without_supporting_movement {
+        out.suppress_runtime_sparse_suspect_shift_without_supporting_movement = v;
+    }
+}

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -2613,15 +2613,13 @@ fn analyzer_toml_sparse_preserves_defaults() {
 }
 
 #[test]
-fn analyzer_toml_merge_over_base() {
-    let base = AnalyzeOptions::default().with_queueing(|o| o.trigger_permille = 350);
+fn analyzer_toml_merge_sparse_preserves_unrelated_non_default_base_values() {
+    let base = AnalyzeOptions::default().with_blocking(|o| o.strong_p95_threshold = 99);
     let merged = base
-        .merge_toml_str(
-            "[analyzer]\nschema_version=1\n[analyzer.blocking]\nstrong_min_samples=99\n",
-        )
+        .merge_toml_str("[analyzer]\nschema_version=1\n[analyzer.queueing]\ntrigger_permille=410\n")
         .expect("merge");
-    assert_eq!(merged.queueing.trigger_permille, 350);
-    assert_eq!(merged.blocking.strong_min_samples, 99);
+    assert_eq!(merged.queueing.trigger_permille, 410);
+    assert_eq!(merged.blocking.strong_p95_threshold, 99);
 }
 
 #[test]
@@ -2631,6 +2629,14 @@ fn analyzer_toml_missing_analyzer_fails() {
         Err(AnalyzeConfigError::MissingAnalyzerTable)
     ));
 }
+#[test]
+fn analyzer_toml_root_level_queueing_group_is_rejected() {
+    assert!(matches!(
+        AnalyzeOptions::from_toml_str("[queueing]\ntrigger_permille=400\n"),
+        Err(AnalyzeConfigError::MissingAnalyzerTable)
+    ));
+}
+
 #[test]
 fn analyzer_toml_missing_schema_fails() {
     assert!(matches!(
@@ -2700,9 +2706,29 @@ fn analyzer_toml_invalid_range_fails_validation() {
     ));
 }
 #[test]
-fn analyzer_toml_example_file_parses() {
+fn analyzer_toml_canonical_example_path_parses() {
     let _ = AnalyzeOptions::from_toml_str(include_str!("../../examples/analyzer-config.toml"))
-        .expect("example parse");
+        .expect("canonical repo-root example parse");
+}
+
+#[test]
+fn analyzer_toml_example_file_has_v1_namespaced_groups_only() {
+    let input = include_str!("../../examples/analyzer-config.toml");
+    assert!(input.contains("[analyzer]"));
+    assert!(input.contains("schema_version = 1"));
+    for group in [
+        "queueing",
+        "blocking",
+        "executor",
+        "downstream",
+        "confidence",
+        "evidence",
+        "route",
+        "temporal",
+    ] {
+        assert!(input.contains(&format!("[analyzer.{group}]")));
+        assert!(!input.contains(&format!("[{group}]")));
+    }
 }
 #[test]
 fn analyzer_toml_downstream_patterns_list_parses() {

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -2596,3 +2596,131 @@ fn option_confidence_high_score_threshold_changes_scoring_suspect_bucket() {
     assert_eq!(strict_report.primary_suspect.score, 90);
     assert_eq!(strict_report.primary_suspect.confidence, Confidence::Medium);
 }
+
+#[test]
+fn analyzer_toml_full_parses() {
+    let input = include_str!("../../examples/analyzer-config.toml");
+    let options = AnalyzeOptions::from_toml_str(input).expect("parse full analyzer toml");
+    assert_eq!(options.queueing.trigger_permille, 400);
+}
+
+#[test]
+fn analyzer_toml_sparse_preserves_defaults() {
+    let input = "[analyzer]\nschema_version=1\n[analyzer.queueing]\ntrigger_permille=450\n";
+    let options = AnalyzeOptions::from_toml_str(input).expect("parse sparse toml");
+    assert_eq!(options.queueing.trigger_permille, 450);
+    assert_eq!(options.blocking, AnalyzeOptions::default().blocking);
+}
+
+#[test]
+fn analyzer_toml_merge_over_base() {
+    let base = AnalyzeOptions::default().with_queueing(|o| o.trigger_permille = 350);
+    let merged = base
+        .merge_toml_str(
+            "[analyzer]\nschema_version=1\n[analyzer.blocking]\nstrong_min_samples=99\n",
+        )
+        .expect("merge");
+    assert_eq!(merged.queueing.trigger_permille, 350);
+    assert_eq!(merged.blocking.strong_min_samples, 99);
+}
+
+#[test]
+fn analyzer_toml_missing_analyzer_fails() {
+    assert!(matches!(
+        AnalyzeOptions::from_toml_str("[other]\na=1\n"),
+        Err(AnalyzeConfigError::MissingAnalyzerTable)
+    ));
+}
+#[test]
+fn analyzer_toml_missing_schema_fails() {
+    assert!(matches!(
+        AnalyzeOptions::from_toml_str("[analyzer]\n"),
+        Err(AnalyzeConfigError::MissingSchemaVersion)
+    ));
+}
+#[test]
+fn analyzer_toml_unsupported_schema_fails() {
+    assert!(matches!(
+        AnalyzeOptions::from_toml_str("[analyzer]\nschema_version=2\n"),
+        Err(AnalyzeConfigError::UnsupportedSchemaVersion {
+            found: 2,
+            supported: 1
+        })
+    ));
+}
+#[test]
+fn analyzer_toml_unknown_top_level_sibling_ignored() {
+    let input = "[controller]\nmode='light'\n[analyzer]\nschema_version=1\n";
+    assert!(AnalyzeOptions::from_toml_str(input).is_ok());
+}
+#[test]
+fn analyzer_toml_unknown_field_under_analyzer_fails() {
+    assert!(matches!(
+        AnalyzeOptions::from_toml_str("[analyzer]\nschema_version=1\nfoo=1\n"),
+        Err(AnalyzeConfigError::InvalidToml { .. })
+    ));
+}
+#[test]
+fn analyzer_toml_unknown_subgroup_fails() {
+    assert!(matches!(
+        AnalyzeOptions::from_toml_str("[analyzer]\nschema_version=1\n[analyzer.unknown]\na=1\n"),
+        Err(AnalyzeConfigError::InvalidToml { .. })
+    ));
+}
+#[test]
+fn analyzer_toml_unknown_field_in_known_subgroup_fails() {
+    assert!(matches!(
+        AnalyzeOptions::from_toml_str(
+            "[analyzer]\nschema_version=1\n[analyzer.queueing]\nnope=1\n"
+        ),
+        Err(AnalyzeConfigError::InvalidToml { .. })
+    ));
+}
+#[test]
+fn analyzer_toml_invalid_type_fails() {
+    assert!(matches!(
+        AnalyzeOptions::from_toml_str(
+            "[analyzer]\nschema_version=1\n[analyzer.queueing]\ntrigger_permille='bad'\n"
+        ),
+        Err(AnalyzeConfigError::InvalidToml { .. })
+    ));
+}
+#[test]
+fn analyzer_toml_invalid_range_fails_validation() {
+    let err = AnalyzeOptions::from_toml_str(
+        "[analyzer]\nschema_version=1\n[analyzer.queueing]\ntrigger_permille=1001\n",
+    )
+    .expect_err("invalid range");
+    assert!(matches!(
+        err,
+        AnalyzeConfigError::InvalidConfigValue {
+            path: "queueing.trigger_permille",
+            ..
+        }
+    ));
+}
+#[test]
+fn analyzer_toml_example_file_parses() {
+    let _ = AnalyzeOptions::from_toml_str(include_str!("../../examples/analyzer-config.toml"))
+        .expect("example parse");
+}
+#[test]
+fn analyzer_toml_downstream_patterns_list_parses() {
+    let input = "[analyzer]\nschema_version=1\n[analyzer.downstream]\nblocking_correlated_stage_patterns=['db','cache']\n";
+    let opts = AnalyzeOptions::from_toml_str(input).expect("parse list");
+    assert_eq!(
+        opts.downstream.blocking_correlated_stage_patterns,
+        vec!["db", "cache"]
+    );
+}
+#[test]
+fn analyzer_toml_empty_pattern_fails_validation() {
+    let err = AnalyzeOptions::from_toml_str("[analyzer]\nschema_version=1\n[analyzer.downstream]\nblocking_correlated_stage_patterns=['']\n").expect_err("must fail");
+    assert!(matches!(
+        err,
+        AnalyzeConfigError::InvalidConfigValue {
+            path: "downstream.blocking_correlated_stage_patterns",
+            ..
+        }
+    ));
+}


### PR DESCRIPTION
### Motivation
- Provide analyzer-scoped configuration parsing so analyzer runtime options can be loaded from shared TOML files without colliding with controller config by requiring an `[analyzer]` table and `schema_version = 1`.
- Keep the parser strict and explicit to avoid silent misconfiguration by rejecting unknown fields/subgroups inside `[analyzer]` while allowing sibling top-level tables to coexist in the same TOML file.

### Description
- Add a new parser module at `tailtriage-analyzer/src/options/toml.rs` implementing private partial TOML structs with `#[serde(deny_unknown_fields)]` and apply helpers to merge parsed fields into the runtime `AnalyzeOptions` structs.
- Expose two public APIs on `AnalyzeOptions`: `from_toml_str(input: &str) -> Result<Self, AnalyzeConfigError>` and `merge_toml_str(self, input: &str) -> Result<Self, AnalyzeConfigError>`, where `from_toml_str` builds from defaults and `merge_toml_str` applies over an existing base and both run `validate()` afterwards.
- Enforce the required TOML schema: require `[analyzer]` and `schema_version = 1`, return specific `AnalyzeConfigError` variants for missing/unsupported schema and for TOML/validation errors, and ignore sibling top-level tables outside `[analyzer]`.
- Wire the new module into `tailtriage-analyzer/src/options/mod.rs`, add `toml = "0.8"` to `tailtriage-analyzer/Cargo.toml`, and add a full example `examples/analyzer-config.toml` containing every v1 analyzer field.
- Add unit tests that cover full and sparse parsing, merging over a non-default base, schema errors, unknown-key rejection, invalid types, validation-range failures, list parsing for `downstream.blocking_correlated_stage_patterns`, empty-pattern validation, and parsing of the example file.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it passed with no warnings.
- Ran `cargo test --workspace` and all tests (including the new analyzer TOML tests) passed.
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05f6018df48330a9d1e1c2d065fa99)