### PR TITLE
Add strict [analyzer] TOML parsing and merge support for AnalyzeOptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,6 +804,7 @@ dependencies = [
  "serde_json",
  "tailtriage-core",
  "tokio",
+ "toml",
 ]
 
 [[package]]

--- a/tailtriage-analyzer/Cargo.toml
+++ b/tailtriage-analyzer/Cargo.toml
@@ -15,6 +15,7 @@ include = ["Cargo.toml", "README.md", "LICENSE", "src/**"]
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 tailtriage-core.workspace = true
+toml = "0.8"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/tailtriage-analyzer/examples/analyzer-config.toml
+++ b/tailtriage-analyzer/examples/analyzer-config.toml
@@ -1,0 +1,47 @@
+[analyzer]
+schema_version = 1
+
+[analyzer.queueing]
+trigger_permille = 400
+
+[analyzer.blocking]
+min_nonzero_samples_for_signal = 2
+strong_p95_threshold = 12
+strong_peak_threshold = 20
+strong_nonzero_share_permille = 700
+strong_min_samples = 30
+
+[analyzer.executor]
+min_global_queue_p95_for_signal = 1
+
+[analyzer.downstream]
+min_stage_samples = 3
+blocking_correlated_stage_patterns = ["spawn_blocking", "blocking_path", "blocking"]
+blocking_correlation_score_margin = 2
+
+[analyzer.confidence]
+medium_score_threshold = 65
+high_score_threshold = 85
+ambiguity_min_score = 60
+ambiguity_score_gap = 4
+
+[analyzer.evidence]
+low_completed_request_threshold = 20
+
+[analyzer.route]
+min_request_count = 3
+breakdown_limit = 10
+emit_on_divergent_suspects = true
+slowest_to_fastest_p95_ratio_numerator = 3
+slowest_to_fastest_p95_ratio_denominator = 2
+slowest_to_global_p95_ratio_numerator = 5
+slowest_to_global_p95_ratio_denominator = 4
+
+[analyzer.temporal]
+min_request_count = 20
+min_segment_request_count = 8
+share_shift_permille = 200
+p95_shift_ratio_numerator = 3
+p95_shift_ratio_denominator = 2
+emit_on_suspect_shift = true
+suppress_runtime_sparse_suspect_shift_without_supporting_movement = true

--- a/tailtriage-analyzer/src/options/mod.rs
+++ b/tailtriage-analyzer/src/options/mod.rs
@@ -4,6 +4,7 @@ use std::error::Error;
 use std::fmt::{Display, Formatter};
 
 mod descriptors;
+mod toml;
 pub use descriptors::analyze_option_descriptors;
 
 /// Semantic analyzer options grouped by triage domain.
@@ -541,6 +542,24 @@ fn temporal_non_default_overrides(
     }
 }
 impl AnalyzeOptions {
+    /// Parses analyzer TOML from `input` using `[analyzer]` v1 schema and defaults for missing groups/fields.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AnalyzeConfigError`] when TOML is invalid, required analyzer schema fields are missing,
+    /// unknown analyzer fields are present, or resulting values fail validation.
+    pub fn from_toml_str(input: &str) -> Result<Self, AnalyzeConfigError> {
+        toml::parse_from_toml_str(input)
+    }
+    /// Merges analyzer TOML from `input` over `self` using `[analyzer]` v1 schema.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AnalyzeConfigError`] when TOML is invalid, required analyzer schema fields are missing,
+    /// unknown analyzer fields are present, or resulting values fail validation.
+    pub fn merge_toml_str(self, input: &str) -> Result<Self, AnalyzeConfigError> {
+        toml::merge_toml_str(self, input)
+    }
     /// Returns sorted non-default semantic option overrides as stable path/value summaries.
     #[must_use]
     pub fn non_default_overrides(&self) -> Vec<AnalyzeConfigOverrideSummary> {

--- a/tailtriage-analyzer/src/options/toml.rs
+++ b/tailtriage-analyzer/src/options/toml.rs
@@ -1,0 +1,257 @@
+use super::{
+    AnalyzeConfigError, AnalyzeOptions, BlockingOptions, ConfidenceOptions, DownstreamOptions,
+    EvidenceOptions, ExecutorOptions, QueueingOptions, RouteOptions, TemporalOptions,
+};
+use serde::Deserialize;
+
+const SUPPORTED_SCHEMA_VERSION: u64 = 1;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AnalyzerToml {
+    schema_version: Option<u64>,
+    queueing: Option<QueueingPartial>,
+    blocking: Option<BlockingPartial>,
+    executor: Option<ExecutorPartial>,
+    downstream: Option<DownstreamPartial>,
+    confidence: Option<ConfidencePartial>,
+    evidence: Option<EvidencePartial>,
+    route: Option<RoutePartial>,
+    temporal: Option<TemporalPartial>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct QueueingPartial {
+    trigger_permille: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct BlockingPartial {
+    min_nonzero_samples_for_signal: Option<usize>,
+    strong_p95_threshold: Option<u64>,
+    strong_peak_threshold: Option<u64>,
+    strong_nonzero_share_permille: Option<u64>,
+    strong_min_samples: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ExecutorPartial {
+    min_global_queue_p95_for_signal: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DownstreamPartial {
+    min_stage_samples: Option<usize>,
+    blocking_correlated_stage_patterns: Option<Vec<String>>,
+    blocking_correlation_score_margin: Option<u8>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ConfidencePartial {
+    medium_score_threshold: Option<u8>,
+    high_score_threshold: Option<u8>,
+    ambiguity_min_score: Option<u8>,
+    ambiguity_score_gap: Option<u8>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvidencePartial {
+    low_completed_request_threshold: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RoutePartial {
+    min_request_count: Option<usize>,
+    breakdown_limit: Option<usize>,
+    emit_on_divergent_suspects: Option<bool>,
+    slowest_to_fastest_p95_ratio_numerator: Option<u64>,
+    slowest_to_fastest_p95_ratio_denominator: Option<u64>,
+    slowest_to_global_p95_ratio_numerator: Option<u64>,
+    slowest_to_global_p95_ratio_denominator: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TemporalPartial {
+    min_request_count: Option<usize>,
+    min_segment_request_count: Option<usize>,
+    share_shift_permille: Option<u64>,
+    p95_shift_ratio_numerator: Option<u64>,
+    p95_shift_ratio_denominator: Option<u64>,
+    emit_on_suspect_shift: Option<bool>,
+    suppress_runtime_sparse_suspect_shift_without_supporting_movement: Option<bool>,
+}
+
+pub(super) fn parse_from_toml_str(input: &str) -> Result<AnalyzeOptions, AnalyzeConfigError> {
+    AnalyzeOptions::default().merge_toml_str(input)
+}
+
+pub(super) fn merge_toml_str(
+    mut options: AnalyzeOptions,
+    input: &str,
+) -> Result<AnalyzeOptions, AnalyzeConfigError> {
+    let parsed: toml::Value =
+        toml::from_str(input).map_err(|error| AnalyzeConfigError::InvalidToml {
+            message: error.to_string(),
+        })?;
+    let analyzer_value = parsed
+        .as_table()
+        .and_then(|root| root.get("analyzer"))
+        .ok_or(AnalyzeConfigError::MissingAnalyzerTable)?;
+    let analyzer: AnalyzerToml =
+        analyzer_value
+            .clone()
+            .try_into()
+            .map_err(|error: toml::de::Error| AnalyzeConfigError::InvalidToml {
+                message: error.to_string(),
+            })?;
+
+    let schema_version = analyzer
+        .schema_version
+        .ok_or(AnalyzeConfigError::MissingSchemaVersion)?;
+    if schema_version != SUPPORTED_SCHEMA_VERSION {
+        return Err(AnalyzeConfigError::UnsupportedSchemaVersion {
+            found: schema_version,
+            supported: SUPPORTED_SCHEMA_VERSION,
+        });
+    }
+
+    if let Some(queueing) = analyzer.queueing.as_ref() {
+        apply_queueing(&mut options.queueing, queueing);
+    }
+    if let Some(blocking) = analyzer.blocking.as_ref() {
+        apply_blocking(&mut options.blocking, blocking);
+    }
+    if let Some(executor) = analyzer.executor.as_ref() {
+        apply_executor(&mut options.executor, executor);
+    }
+    if let Some(downstream) = analyzer.downstream.as_ref() {
+        apply_downstream(&mut options.downstream, downstream);
+    }
+    if let Some(confidence) = analyzer.confidence.as_ref() {
+        apply_confidence(&mut options.confidence, confidence);
+    }
+    if let Some(evidence) = analyzer.evidence.as_ref() {
+        apply_evidence(&mut options.evidence, evidence);
+    }
+    if let Some(route) = analyzer.route.as_ref() {
+        apply_route(&mut options.route, route);
+    }
+    if let Some(temporal) = analyzer.temporal.as_ref() {
+        apply_temporal(&mut options.temporal, temporal);
+    }
+
+    options.validate()?;
+    Ok(options)
+}
+
+fn apply_queueing(target: &mut QueueingOptions, source: &QueueingPartial) {
+    if let Some(v) = source.trigger_permille {
+        target.trigger_permille = v;
+    }
+}
+fn apply_blocking(target: &mut BlockingOptions, source: &BlockingPartial) {
+    if let Some(v) = source.min_nonzero_samples_for_signal {
+        target.min_nonzero_samples_for_signal = v;
+    }
+    if let Some(v) = source.strong_p95_threshold {
+        target.strong_p95_threshold = v;
+    }
+    if let Some(v) = source.strong_peak_threshold {
+        target.strong_peak_threshold = v;
+    }
+    if let Some(v) = source.strong_nonzero_share_permille {
+        target.strong_nonzero_share_permille = v;
+    }
+    if let Some(v) = source.strong_min_samples {
+        target.strong_min_samples = v;
+    }
+}
+fn apply_executor(target: &mut ExecutorOptions, source: &ExecutorPartial) {
+    if let Some(v) = source.min_global_queue_p95_for_signal {
+        target.min_global_queue_p95_for_signal = v;
+    }
+}
+fn apply_downstream(target: &mut DownstreamOptions, source: &DownstreamPartial) {
+    if let Some(v) = source.min_stage_samples {
+        target.min_stage_samples = v;
+    }
+    if let Some(v) = &source.blocking_correlated_stage_patterns {
+        target.blocking_correlated_stage_patterns.clone_from(v);
+    }
+    if let Some(v) = source.blocking_correlation_score_margin {
+        target.blocking_correlation_score_margin = v;
+    }
+}
+fn apply_confidence(target: &mut ConfidenceOptions, source: &ConfidencePartial) {
+    if let Some(v) = source.medium_score_threshold {
+        target.medium_score_threshold = v;
+    }
+    if let Some(v) = source.high_score_threshold {
+        target.high_score_threshold = v;
+    }
+    if let Some(v) = source.ambiguity_min_score {
+        target.ambiguity_min_score = v;
+    }
+    if let Some(v) = source.ambiguity_score_gap {
+        target.ambiguity_score_gap = v;
+    }
+}
+fn apply_evidence(target: &mut EvidenceOptions, source: &EvidencePartial) {
+    if let Some(v) = source.low_completed_request_threshold {
+        target.low_completed_request_threshold = v;
+    }
+}
+fn apply_route(target: &mut RouteOptions, source: &RoutePartial) {
+    if let Some(v) = source.min_request_count {
+        target.min_request_count = v;
+    }
+    if let Some(v) = source.breakdown_limit {
+        target.breakdown_limit = v;
+    }
+    if let Some(v) = source.emit_on_divergent_suspects {
+        target.emit_on_divergent_suspects = v;
+    }
+    if let Some(v) = source.slowest_to_fastest_p95_ratio_numerator {
+        target.slowest_to_fastest_p95_ratio_numerator = v;
+    }
+    if let Some(v) = source.slowest_to_fastest_p95_ratio_denominator {
+        target.slowest_to_fastest_p95_ratio_denominator = v;
+    }
+    if let Some(v) = source.slowest_to_global_p95_ratio_numerator {
+        target.slowest_to_global_p95_ratio_numerator = v;
+    }
+    if let Some(v) = source.slowest_to_global_p95_ratio_denominator {
+        target.slowest_to_global_p95_ratio_denominator = v;
+    }
+}
+fn apply_temporal(target: &mut TemporalOptions, source: &TemporalPartial) {
+    if let Some(v) = source.min_request_count {
+        target.min_request_count = v;
+    }
+    if let Some(v) = source.min_segment_request_count {
+        target.min_segment_request_count = v;
+    }
+    if let Some(v) = source.share_shift_permille {
+        target.share_shift_permille = v;
+    }
+    if let Some(v) = source.p95_shift_ratio_numerator {
+        target.p95_shift_ratio_numerator = v;
+    }
+    if let Some(v) = source.p95_shift_ratio_denominator {
+        target.p95_shift_ratio_denominator = v;
+    }
+    if let Some(v) = source.emit_on_suspect_shift {
+        target.emit_on_suspect_shift = v;
+    }
+    if let Some(v) = source.suppress_runtime_sparse_suspect_shift_without_supporting_movement {
+        target.suppress_runtime_sparse_suspect_shift_without_supporting_movement = v;
+    }
+}

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -2596,3 +2596,140 @@ fn option_confidence_high_score_threshold_changes_scoring_suspect_bucket() {
     assert_eq!(strict_report.primary_suspect.score, 90);
     assert_eq!(strict_report.primary_suspect.confidence, Confidence::Medium);
 }
+
+#[test]
+fn analyzer_toml_full_parses() {
+    let input = std::fs::read_to_string("tailtriage-analyzer/examples/analyzer-config.toml")
+        .or_else(|_| std::fs::read_to_string("examples/analyzer-config.toml"))
+        .expect("example config exists");
+    let opts = AnalyzeOptions::from_toml_str(&input).expect("full analyzer toml parses");
+    assert_eq!(opts.queueing.trigger_permille, 400);
+}
+
+#[test]
+fn analyzer_toml_sparse_parses_with_defaults() {
+    let opts = AnalyzeOptions::from_toml_str(
+        "[analyzer]\nschema_version=1\n[analyzer.queueing]\ntrigger_permille=450",
+    )
+    .expect("sparse analyzer toml parses");
+    assert_eq!(opts.queueing.trigger_permille, 450);
+    assert_eq!(
+        opts.blocking.strong_p95_threshold,
+        AnalyzeOptions::default().blocking.strong_p95_threshold
+    );
+}
+
+#[test]
+fn merge_toml_str_applies_over_non_default_base() {
+    let base = AnalyzeOptions::default().with_blocking(|o| o.strong_p95_threshold = 99);
+    let merged = base
+        .merge_toml_str("[analyzer]\nschema_version=1\n[analyzer.queueing]\ntrigger_permille=410")
+        .expect("merge parses");
+    assert_eq!(merged.queueing.trigger_permille, 410);
+    assert_eq!(merged.blocking.strong_p95_threshold, 99);
+}
+
+#[test]
+fn analyzer_toml_missing_analyzer_fails() {
+    let err =
+        AnalyzeOptions::from_toml_str("[queueing]\ntrigger_permille=400").expect_err("must fail");
+    assert!(matches!(err, AnalyzeConfigError::MissingAnalyzerTable));
+}
+
+#[test]
+fn analyzer_toml_missing_schema_version_fails() {
+    let err =
+        AnalyzeOptions::from_toml_str("[analyzer]\n[analyzer.queueing]\ntrigger_permille=400")
+            .expect_err("must fail");
+    assert!(matches!(err, AnalyzeConfigError::MissingSchemaVersion));
+}
+
+#[test]
+fn analyzer_toml_unsupported_schema_version_fails() {
+    let err = AnalyzeOptions::from_toml_str("[analyzer]\nschema_version=2").expect_err("must fail");
+    assert!(matches!(
+        err,
+        AnalyzeConfigError::UnsupportedSchemaVersion {
+            found: 2,
+            supported: 1
+        }
+    ));
+}
+
+#[test]
+fn analyzer_toml_unknown_top_level_sibling_is_ignored() {
+    let opts = AnalyzeOptions::from_toml_str("[shared]\nfoo='bar'\n[analyzer]\nschema_version=1")
+        .expect("sibling table ignored");
+    assert_eq!(opts, AnalyzeOptions::default());
+}
+
+#[test]
+fn analyzer_toml_unknown_field_under_analyzer_fails() {
+    let err = AnalyzeOptions::from_toml_str("[analyzer]\nschema_version=1\nextra=1")
+        .expect_err("must fail");
+    assert!(matches!(err, AnalyzeConfigError::InvalidToml { .. }));
+}
+
+#[test]
+fn analyzer_toml_unknown_subgroup_fails() {
+    let err =
+        AnalyzeOptions::from_toml_str("[analyzer]\nschema_version=1\n[analyzer.unknown]\nfoo=1")
+            .expect_err("must fail");
+    assert!(matches!(err, AnalyzeConfigError::InvalidToml { .. }));
+}
+
+#[test]
+fn analyzer_toml_unknown_field_inside_known_subgroup_fails() {
+    let err =
+        AnalyzeOptions::from_toml_str("[analyzer]\nschema_version=1\n[analyzer.queueing]\nnope=1")
+            .expect_err("must fail");
+    assert!(matches!(err, AnalyzeConfigError::InvalidToml { .. }));
+}
+
+#[test]
+fn analyzer_toml_invalid_type_fails() {
+    let err = AnalyzeOptions::from_toml_str(
+        "[analyzer]\nschema_version=1\n[analyzer.queueing]\ntrigger_permille='high'",
+    )
+    .expect_err("must fail");
+    assert!(matches!(err, AnalyzeConfigError::InvalidToml { .. }));
+}
+
+#[test]
+fn analyzer_toml_invalid_range_fails_validation() {
+    let err = AnalyzeOptions::from_toml_str(
+        "[analyzer]\nschema_version=1\n[analyzer.queueing]\ntrigger_permille=1001",
+    )
+    .expect_err("must fail");
+    assert!(matches!(
+        err,
+        AnalyzeConfigError::InvalidConfigValue {
+            path: "queueing.trigger_permille",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn analyzer_toml_pattern_list_parses() {
+    let opts = AnalyzeOptions::from_toml_str(
+        "[analyzer]\nschema_version=1\n[analyzer.downstream]\nblocking_correlated_stage_patterns=['spawn_blocking','blocking']",
+    )
+    .expect("list parses");
+    assert_eq!(opts.downstream.blocking_correlated_stage_patterns.len(), 2);
+}
+
+#[test]
+fn analyzer_toml_empty_pattern_fails_validation() {
+    let err = AnalyzeOptions::from_toml_str(
+        "[analyzer]\nschema_version=1\n[analyzer.downstream]\nblocking_correlated_stage_patterns=['']",
+    )
+    .expect_err("empty pattern should fail");
+    assert!(matches!(
+        err,
+        AnalyzeConfigError::InvalidConfigValue {
+            path: "downstream.blocking_correlated_stage_patterns",
+            ..
+        }
+    ));
+}


### PR DESCRIPTION
### Motivation
- Enable analyzer-local TOML configuration for `tailtriage-analyzer` using an explicit `[analyzer]` namespace and a strict v1 schema to avoid collisions with controller TOML and keep schema evolution explicit. 
- Provide a safe merge path that applies analyzer config over defaults or an existing `AnalyzeOptions` instance and validates semantics before use.

### Description
- Added a new strict TOML parser module at `tailtriage-analyzer/src/options/toml.rs` that decodes a required `[analyzer]` table (requires `schema_version = 1`) and private partial structs for each optional subgroup (`queueing`, `blocking`, `executor`, `downstream`, `confidence`, `evidence`, `route`, `temporal`) with `deny_unknown_fields` to reject unknown fields/subgroups. 
- Exposed two public convenience APIs on `AnalyzeOptions`: `from_toml_str(input: &str) -> Result<Self, AnalyzeConfigError>` and `merge_toml_str(self, input: &str) -> Result<Self, AnalyzeConfigError>`, where `from_toml_str` starts from `AnalyzeOptions::default()` and `merge_toml_str` overlays values onto `self`; both validate the resulting options. 
- Enforced parsing/validation rules that produce the specified `AnalyzeConfigError` variants for missing `[analyzer]`, missing `schema_version`, unsupported `schema_version`, unknown analyzer fields/subgroups, invalid TOML types, and semantic validation failures (e.g., out-of-range values or empty downstream patterns). Top-level sibling tables outside `[analyzer]` are deliberately ignored. 
- Added `tailtriage-analyzer/examples/analyzer-config.toml` as a real, parseable v1 example covering every v1 field. 
- Added `toml = "0.8"` to `tailtriage-analyzer/Cargo.toml` and implemented all changes without adding any other dependencies. 
- Added unit tests in `tailtriage-analyzer/src/tests.rs` that exercise full/sparse parsing, merge semantics, strictness/error modes, list parsing, validation failure cases, and example-file parsing.

### Testing
- Ran `cargo fmt --check` and it passed. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it passed. 
- Ran `cargo test --workspace` and all tests (including the new analyzer TOML tests) passed. 
- Ran `python3 scripts/validate_docs_contracts.py` and the docs contract checks passed. 
- New analyzer TOML tests added and executed successfully: `analyzer_toml_full_parses`, `analyzer_toml_sparse_parses_with_defaults`, `merge_toml_str_applies_over_non_default_base`, `analyzer_toml_missing_analyzer_fails`, `analyzer_toml_missing_schema_version_fails`, `analyzer_toml_unsupported_schema_version_fails`, `analyzer_toml_unknown_top_level_sibling_is_ignored`, `analyzer_toml_unknown_field_under_analyzer_fails`, `analyzer_toml_unknown_subgroup_fails`, `analyzer_toml_unknown_field_inside_known_subgroup_fails`, `analyzer_toml_invalid_type_fails`, `analyzer_toml_invalid_range_fails_validation`, `analyzer_toml_pattern_list_parses`, and `analyzer_toml_empty_pattern_fails_validation`, and all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05f6018df48330a9d1e1c2d065fa99)