### PR TITLE
docs: add analyzer tuning guidance and examples across public docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ cargo add tailtriage-analyzer
 ```
 
 Add `tailtriage-analyzer` when you want to analyze a completed Run inside Rust code.
+Analyzer thresholds can be tuned through Rust (`AnalyzeOptions`), TOML analyzer config, and CLI flags. Start with defaults first; see [docs/diagnostics.md](docs/diagnostics.md) and [docs/user-guide.md](docs/user-guide.md).
 - `tailtriage-cli` consumes Run artifact JSON from disk.
 - `tailtriage-analyzer` produces typed `Report` values in process and renders **Report JSON** when you call analyzer renderers.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -145,6 +145,16 @@ Semantics:
 
 Semantics are batch/snapshot for completed runs, not streaming analysis.
 
+
+Analyzer options contract:
+
+- `AnalyzeOptions` is a meaningful analyzer-tuning surface for in-process Rust analysis.
+- Analyzer configuration is supported through Rust (`AnalyzeOptions` builders), TOML (`[analyzer]` schema), and CLI flags (`--analyzer-config`, `--analyzer-set`).
+- Default options preserve the current analyzer behavior.
+- Report JSON includes `analyzer_config` only when non-default analyzer options are used.
+- Analyzer tuning changes how captured evidence is interpreted and ranked; it does not change run capture artifacts.
+- Batch/snapshot analyzer semantics remain unchanged for tuned and default analysis paths.
+
 ### 5.9 Analyzer CLI (`tailtriage-cli`)
 
 `tailtriage-cli` owns artifact loading + command-line report emission and uses `tailtriage-analyzer` for analysis logic. CLI JSON output delegates to `tailtriage-analyzer`’s canonical pretty Report JSON renderer.

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,9 +28,9 @@ Use these docs when wiring `tailtriage` into a service or interpreting output.
 
 - [User guide](user-guide.md) — end-to-end adoption path and operational workflow.
 - [Operations guide](operations.md) — primary production operations guidance for rollout path, capture-mode selection, runtime sampling decisions, artifact sizing, truncation/capture-limit handling, weak-signal troubleshooting, and current operational limits.
-- [Diagnostics guide](diagnostics.md) — how to read analyzer output, evidence quality, suspects, confidence, warnings, and field meanings.
+- [Diagnostics guide](diagnostics.md) — how to read analyzer output, evidence quality, suspects, confidence, warnings, field meanings, and analyzer tuning guidance.
 - [Analyzer README (`tailtriage-analyzer`)](../tailtriage-analyzer/README.md) — typed in-process report contract and rendering API.
-- [CLI README (`tailtriage-cli`)](../tailtriage-cli/README.md) — saved-artifact loading, schema validation, and text/JSON output.
+- [CLI README (`tailtriage-cli`)](../tailtriage-cli/README.md) — saved-artifact loading, analyzer config flags, schema validation, and text/JSON output.
 
 ## Controller and runtime integrations
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -102,6 +102,35 @@ Warnings show interpretation limits (missing signal families, sparse coverage, a
 
 As always: suspects are leads for next checks, not proof.
 
+
+## Analyzer tuning
+
+Start with `AnalyzeOptions::default()` (or no analyzer flags in CLI).
+
+Tune only after representative runs under comparable workload show a repeatable fit problem for default ranking behavior.
+
+Use tuning groups intentionally:
+
+- queueing
+- blocking
+- executor
+- downstream
+- confidence
+- evidence
+- route
+- temporal
+
+Non-default analyzer settings are surfaced in Report JSON as `analyzer_config`. With defaults, `analyzer_config` is omitted.
+
+Tuning changes interpretation of captured evidence. It does not add missing capture evidence, recover truncated events, or replace missing instrumentation.
+
+Suspects remain evidence-ranked leads, not proof. `confidence` remains ranking confidence, not causal certainty.
+
+For full option discovery and parseable examples, use:
+
+- `tailtriage analyze --help-analyzer-options`
+- `examples/analyzer-config.toml`
+
 ## Warning semantics
 
 `warnings[]` is additive and can include multiple classes together:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -203,6 +203,21 @@ For controller-managed runs, consider:
 
 based on whether bounded retention or uninterrupted capture matters more operationally.
 
+
+## Analyzer tuning in operations
+
+Prefer default analyzer behavior first.
+
+Do not tune around missing instrumentation. Add queue/stage/runtime signal where needed, then re-run.
+
+Do not use tuning to hide truncation. If limits were hit, address capture density/limits and compare again.
+
+For production repeatability, commit analyzer TOML (for example `examples/analyzer-config.toml` shape with `[analyzer]` and `schema_version = 1`) and treat it as part of run context.
+
+Compare runs only when analyzer config is the same, or explicitly account for analyzer-config changes in interpretation.
+
+Apply analyzer tuning only after comparing representative runs and confirming workload fit.
+
 ## Operational guidance for bounded runs
 
 Prefer bounded investigative windows over continuous long-lived capture.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -77,7 +77,7 @@ If you want analysis/report generation inside service code or tests, use `tailtr
 use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
 use tailtriage_analyzer::render_json_pretty;
 
-# use tailtriage::Run;
+# use tailtriage_core::Run;
 # fn example(run: Run) -> Result<(), Box<dyn std::error::Error>> {
 let report = analyze_run(&run, AnalyzeOptions::default());
 let text = render_text(&report);
@@ -90,6 +90,41 @@ let json = render_json_pretty(&report)?;
 Run artifact JSON is capture output and CLI input. Report JSON is analyzer/CLI output. Typed `Report` is the in-process analyzer result.
 
 Current analyzer semantics are completed-run or stable-snapshot batch analysis, not live streaming analysis.
+
+
+## 3.1) Analyzer tuning (Rust, TOML, CLI)
+
+Start with defaults. Tune only after representative runs under comparable load.
+
+Rust checked API example:
+
+```rust
+use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
+
+# use tailtriage_core::Run;
+# fn example(run: Run) {
+let opts = AnalyzeOptions::default().with_queueing(|q| q.trigger_permille = 450);
+let _report = tailtriage_analyzer::try_analyze_run(&run, opts).expect("valid analyzer options");
+# }
+```
+
+TOML example:
+
+```toml
+[analyzer]
+schema_version = 1
+
+[analyzer.queueing]
+trigger_permille = 450
+```
+
+CLI example:
+
+```bash
+tailtriage analyze tailtriage-run.json   --analyzer-config examples/analyzer-config.toml   --analyzer-set queueing.trigger_permille=450
+```
+
+Use `tailtriage analyze --help-analyzer-options` for the full option list.
 
 ## 4) Request lifecycle contract (required)
 

--- a/tailtriage-analyzer/README.md
+++ b/tailtriage-analyzer/README.md
@@ -89,3 +89,42 @@ fn render_report(run: &Run) -> Result<String, Box<dyn std::error::Error>> {
 
 use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
 ```
+
+
+## Custom analyzer options (checked)
+
+Start with defaults and tune only when representative runs show a repeatable fit issue.
+
+```rust
+use tailtriage_analyzer::AnalyzeOptions;
+
+let opts = AnalyzeOptions::default().with_queueing(|q| q.trigger_permille = 450);
+```
+
+To validate options and analyze in one checked call:
+
+```rust
+use tailtriage_analyzer::AnalyzeOptions;
+# use tailtriage_core::Run;
+# fn demo(run: Run) {
+let opts = AnalyzeOptions::default().with_queueing(|q| q.trigger_permille = 450);
+let _report = tailtriage_analyzer::try_analyze_run(&run, opts).expect("valid analyzer options");
+# }
+```
+
+TOML string parsing example:
+
+```rust
+use tailtriage_analyzer::AnalyzeOptions;
+
+let toml = r#"
+[analyzer]
+schema_version = 1
+
+[analyzer.queueing]
+trigger_permille = 450
+"#;
+let _opts = AnalyzeOptions::from_toml_str(toml).expect("valid analyzer config");
+```
+
+Report JSON includes `analyzer_config` only when non-default options were used.

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -47,6 +47,21 @@ tailtriage analyze tailtriage-run.json --format json
 The CLI artifact loader requires at least one request event in `requests`. This is a CLI artifact-loading rule, not an in-process `tailtriage-analyzer` requirement for already-constructed `Run` values.
 CLI input is Run artifact JSON from disk. CLI does not consume Report JSON as input.
 
+
+## Analyzer tuning flags
+
+Use analyzer defaults first. For tuned analysis:
+
+- `--analyzer-config <path>` loads analyzer TOML (`[analyzer]` with `schema_version = 1`).
+- `--analyzer-set PATH=VALUE` overrides one analyzer field and can be repeated.
+- `--help-analyzer-options` prints available analyzer config paths and value types.
+
+Precedence: defaults < `--analyzer-config` < repeated `--analyzer-set` overrides.
+
+Unknown/misspelled analyzer paths are rejected as errors.
+
+Run artifact JSON remains CLI input. Report JSON remains analyzer/CLI output.
+
 ## How to read the result
 
 Read output in this order:


### PR DESCRIPTION
### Motivation

- Document that analyzer tuning is a meaningful surface (`AnalyzeOptions`) available via Rust builders, TOML (`[analyzer]`), and CLI flags so users can tune report interpretation while preserving defaults.
- Make the public docs truthful about what tuning affects: interpretation/ranking of captured evidence, not capture artifacts, and that tuned analysis remains batch/snapshot semantics.
- Provide safe operational guidance to avoid misuse (tuning around missing instrumentation or truncation) and supply short, parseable examples for Rust/TOML/CLI entry points.

### Description

- Added an "Analyzer options contract" entry to `SPEC.md` documenting `AnalyzeOptions`, Rust/TOML/CLI config paths, default-preserving behavior, conditional `analyzer_config` emission in reports, and unchanged batch/snapshot semantics. 
- Added an "Analyzer tuning" section to `docs/diagnostics.md` covering start-with-defaults guidance, tuning groups (queueing, blocking, executor, downstream, confidence, evidence, route, temporal), report transparency, and bounded interpretation language that suspects remain leads, not proof. 
- Added operational guidance to `docs/operations.md` advising to prefer defaults first, not to tune around missing instrumentation or truncation, to commit analyzer TOML for repeatability, and to compare runs only when analyzer config is consistent or accounted for. 
- Added concise, checked examples to `docs/user-guide.md` showing Rust builder-style tuning via `AnalyzeOptions::default().with_queueing(...)`, a TOML v1 example (`[analyzer] schema_version = 1`), and CLI examples using `--analyzer-config` and `--analyzer-set`, plus mention of `--help-analyzer-options`. 
- Updated docs index (`docs/README.md`) and top-level `README.md` to point users toward analyzer tuning guidance and examples without expanding claims. 
- Extended `tailtriage-analyzer/README.md` with in-process checked examples (`AnalyzeOptions` builder, `try_analyze_run`, TOML parse example) and clarified that `analyzer_config` appears in reports only for non-default options. 
- Extended `tailtriage-cli/README.md` with `--analyzer-config`, `--analyzer-set`, `--help-analyzer-options`, precedence rules, misspelling/error behavior, and clarified Run-artifact JSON vs Report-JSON distinction. 

### Testing

- Ran `cargo fmt --check`; check passed. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings`; linting passed with zero warnings. 
- Ran `cargo test --workspace`; the full test suite (unit tests and doctests) passed. 
- Ran `python3 scripts/validate_docs_contracts.py`; docs contract validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06b0f6d77c8330aa15d6bacc2930ce)