### PR TITLE
docs: document analyzer tuning (Rust/TOML/CLI) and operational guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,9 @@ tailtriage analyze tailtriage-run.json --format json
 
 For full report-field interpretation, see [`docs/diagnostics.md`](docs/diagnostics.md) and [`tailtriage-cli/README.md`](tailtriage-cli/README.md).
 
+Analyzer thresholds can be tuned through Rust (`AnalyzeOptions`), TOML (`[analyzer] schema_version = 1`), or CLI (`--analyzer-config`/`--analyzer-set`). Start with defaults first, then tune after representative runs. See [`docs/diagnostics.md`](docs/diagnostics.md), [`docs/user-guide.md`](docs/user-guide.md), and [`examples/analyzer-config.toml`](examples/analyzer-config.toml).
+
+
 `temporal_segments` is always present in JSON output and is usually an empty array. It is populated only when conservative within-run early/late checks find material signal movement (for example, different early/late primary suspects or a large early/late p95 shift). The global `primary_suspect` remains the primary full-run triage lead. Temporal segments are supporting within-run hints only and do not prove a phase-specific root cause. A temporal p95 warning means early/late latency changed materially in that run. Runtime and in-flight phase attribution is timestamp-filtered to each segment window and can be limited when those segment-filtered samples are sparse; with overlapping early/late request windows under concurrency, timestamp-filtered runtime/in-flight attribution is approximate.
 
 ## Operations guidance and overhead

--- a/SPEC.md
+++ b/SPEC.md
@@ -145,6 +145,16 @@ Semantics:
 
 Semantics are batch/snapshot for completed runs, not streaming analysis.
 
+Analyzer tuning contract:
+
+- `AnalyzeOptions` is a meaningful public surface for checked analyzer tuning in Rust.
+- Analyzer configuration is supported through Rust (`AnalyzeOptions` builders), TOML (`[analyzer] schema_version = 1`), and CLI (`--analyzer-config`, `--analyzer-set`).
+- `AnalyzeOptions::default()` preserves current analyzer behavior and is the recommended starting point.
+- Report JSON includes `analyzer_config` only when non-default analyzer options are used for that report.
+- Tuning changes interpretation/ranking of captured evidence; it does not change the capture artifact itself.
+- Analyzer semantics remain batch/snapshot analysis of completed runs, not streaming analysis.
+
+
 ### 5.9 Analyzer CLI (`tailtriage-cli`)
 
 `tailtriage-cli` owns artifact loading + command-line report emission and uses `tailtriage-analyzer` for analysis logic. CLI JSON output delegates to `tailtriage-analyzer`’s canonical pretty Report JSON renderer.

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,8 @@ Use these docs when wiring `tailtriage` into a service or interpreting output.
 
 - [User guide](user-guide.md) — end-to-end adoption path and operational workflow.
 - [Operations guide](operations.md) — primary production operations guidance for rollout path, capture-mode selection, runtime sampling decisions, artifact sizing, truncation/capture-limit handling, weak-signal troubleshooting, and current operational limits.
-- [Diagnostics guide](diagnostics.md) — how to read analyzer output, evidence quality, suspects, confidence, warnings, and field meanings.
+- [Diagnostics guide](diagnostics.md) — how to read analyzer output, evidence quality, suspects, confidence, warnings, and analyzer tuning guidance.
+- [Analyzer config example](../examples/analyzer-config.toml) — canonical `[analyzer] schema_version = 1` TOML starter for repeatable tuning.
 - [Analyzer README (`tailtriage-analyzer`)](../tailtriage-analyzer/README.md) — typed in-process report contract and rendering API.
 - [CLI README (`tailtriage-cli`)](../tailtriage-cli/README.md) — saved-artifact loading, schema validation, and text/JSON output.
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -102,6 +102,33 @@ Warnings show interpretation limits (missing signal families, sparse coverage, a
 
 As always: suspects are leads for next checks, not proof.
 
+
+## Analyzer tuning
+
+Start with `AnalyzeOptions::default()` (or no analyzer overrides in CLI/TOML). Defaults are the recommended baseline for first interpretation passes.
+
+Tune only after representative runs under comparable load show a recurring interpretation gap for your workload. Analyzer tuning changes how captured evidence is interpreted; it does not add missing queue/stage/runtime evidence and it does not recover truncated data.
+
+Tuning groups are organized by purpose:
+
+- `queueing`: queue-share/depth thresholds for queue-saturation signals
+- `blocking`: blocking-pool signal thresholds and minimum-sample constraints
+- `executor`: executor-pressure thresholds
+- `downstream`: downstream-stage filtering/correlation heuristics
+- `confidence`: score bands and ambiguity handling for confidence labeling
+- `evidence`: evidence-quality thresholds (for example low request-count boundaries)
+- `route`: route-breakdown emission gates and limits
+- `temporal`: early/late temporal-segment emission gates and movement thresholds
+
+When non-default analyzer options are used, report output includes `analyzer_config` with the non-default paths/values used for that diagnosis. Default runs omit `analyzer_config`.
+
+Suspects remain evidence-ranked leads and `confidence` remains ranking confidence for triage interpretation. Neither is causal proof.
+
+For full option paths and accepted value types, use:
+
+- `tailtriage analyze --help-analyzer-options`
+- `examples/analyzer-config.toml`
+
 ## Warning semantics
 
 `warnings[]` is additive and can include multiple classes together:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -203,6 +203,21 @@ For controller-managed runs, consider:
 
 based on whether bounded retention or uninterrupted capture matters more operationally.
 
+
+## Analyzer tuning in operations
+
+Prefer default analyzer behavior first. Treat tuning as a later calibration step after you have representative runs and stable instrumentation coverage.
+
+Operational guardrails:
+
+- do not tune around missing instrumentation; add queue/stage/runtime evidence first
+- do not use tuning to hide truncation; reduce density/increase limits and re-run
+- commit analyzer TOML (`[analyzer] schema_version = 1`) for production repeatability
+- compare runs only when analyzer config is the same, or explicitly account for config changes
+- tune after comparing representative runs and confirming workload fit
+
+Analyzer tuning changes report interpretation only. It does not change captured run artifacts.
+
 ## Operational guidance for bounded runs
 
 Prefer bounded investigative windows over continuous long-lived capture.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -91,6 +91,45 @@ Run artifact JSON is capture output and CLI input. Report JSON is analyzer/CLI o
 
 Current analyzer semantics are completed-run or stable-snapshot batch analysis, not live streaming analysis.
 
+
+## 3.1) Analyzer tuning (Rust, TOML, CLI)
+
+Start with defaults, then tune only after representative re-runs.
+
+Rust checked API example:
+
+```rust
+use tailtriage_analyzer::{AnalyzeOptions, try_analyze_run};
+# use tailtriage::Run;
+# fn demo(run: &Run) -> Result<(), Box<dyn std::error::Error>> {
+let options = AnalyzeOptions::default()
+    .with_queueing(|o| o.trigger_permille = 450);
+let report = try_analyze_run(run, options)?;
+# let _ = report;
+# Ok(())
+# }
+```
+
+TOML example:
+
+```toml
+[analyzer]
+schema_version = 1
+
+[analyzer.queueing]
+trigger_permille = 450
+```
+
+CLI example:
+
+```bash
+tailtriage analyze run.json \
+  --analyzer-config examples/analyzer-config.toml \
+  --analyzer-set queueing.trigger_permille=450
+```
+
+Use `tailtriage analyze --help-analyzer-options` for supported option paths and value types.
+
 ## 4) Request lifecycle contract (required)
 
 `begin_request(...)` / `begin_request_with(...)` returns `StartedRequest`:

--- a/tailtriage-analyzer/README.md
+++ b/tailtriage-analyzer/README.md
@@ -50,6 +50,56 @@ fn render_report(run: &Run) -> Result<String, Box<dyn std::error::Error>> {
 
 ## Report contract
 
+## Analyzer options and tuning
+
+Start with defaults:
+
+```rust
+use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
+# use tailtriage_core::Run;
+# fn demo(run: &Run) {
+let report = analyze_run(run, AnalyzeOptions::default());
+# let _ = report;
+# }
+```
+
+Checked custom options in process:
+
+```rust
+use tailtriage_analyzer::{try_analyze_run, AnalyzeOptions};
+# use tailtriage_core::Run;
+# fn demo(run: &Run) -> Result<(), Box<dyn std::error::Error>> {
+let options = AnalyzeOptions::default()
+    .with_queueing(|o| o.trigger_permille = 450);
+let report = try_analyze_run(run, options)?;
+# let _ = report;
+# Ok(())
+# }
+```
+
+TOML parsing example:
+
+```rust
+use tailtriage_analyzer::AnalyzeOptions;
+
+let options = AnalyzeOptions::from_toml_str(r#"
+[analyzer]
+schema_version = 1
+
+[analyzer.queueing]
+trigger_permille = 450
+"#)?;
+# Ok::<(), tailtriage_analyzer::AnalyzeConfigError>(())
+```
+
+`analyzer_config` report behavior:
+
+- default options: `analyzer_config` is omitted from report JSON
+- non-default options: `analyzer_config` includes non-default path/value overrides used for that report
+
+Analyzer tuning changes interpretation/ranking of captured evidence. It does not change the capture artifact.
+
+
 - `analyze_run` currently returns `Report` directly and is currently infallible
 - `AnalyzeOptions::default()` is the normal path today and leaves room for future analyzer options
 - `Report` is the typed analyzer output model and should be your primary integration surface

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -47,6 +47,31 @@ tailtriage analyze tailtriage-run.json --format json
 The CLI artifact loader requires at least one request event in `requests`. This is a CLI artifact-loading rule, not an in-process `tailtriage-analyzer` requirement for already-constructed `Run` values.
 CLI input is Run artifact JSON from disk. CLI does not consume Report JSON as input.
 
+
+## Analyzer tuning flags
+
+Use analyzer defaults first, then tune only after representative runs.
+
+```bash
+tailtriage analyze run.json --analyzer-config examples/analyzer-config.toml
+tailtriage analyze run.json --analyzer-set queueing.trigger_permille=450
+tailtriage analyze run.json --analyzer-config examples/analyzer-config.toml --analyzer-set queueing.trigger_permille=450
+tailtriage analyze --help-analyzer-options
+```
+
+Precedence:
+
+1. start from built-in defaults
+2. apply `--analyzer-config` TOML if present
+3. apply each `--analyzer-set PATH=VALUE` override
+
+Unknown paths or misspelled option names fail fast with an error (including suggestions for close matches where available).
+
+Report JSON vs artifact JSON remains unchanged:
+
+- CLI input: Run artifact JSON
+- CLI output: analyzer Report JSON
+
 ## How to read the result
 
 Read output in this order:


### PR DESCRIPTION
### Motivation

- Make analyzer tuning discoverable and bounded so users can safely adjust `AnalyzeOptions` without overclaiming diagnosis or implying it changes captured artifacts. 
- Provide consistent guidance across spec, user docs, operations, CLI, and crate READMEs so the public teaching surface matches the new Rust/TOML/CLI configuration surfaces. 
- Preserve the default-first workflow and prevent tuning being used to mask missing instrumentation or truncation.

### Description

- Add an "Analyzer tuning contract" to `SPEC.md` documenting that `AnalyzeOptions` is a meaningful public surface, that Rust/TOML/CLI config surfaces are supported, that `AnalyzeOptions::default()` preserves current behavior, and that `analyzer_config` appears in report JSON only for non-default options. 
- Add an "Analyzer tuning" section to `docs/diagnostics.md` describing start-with-defaults guidance, tuning groups (`queueing`, `blocking`, `executor`, `downstream`, `confidence`, `evidence`, `route`, `temporal`), `analyzer_config` visibility behavior, and reminders that suspects/confidence are leads, not proof. 
- Add operational guardrails to `docs/operations.md` that recommend default-first rollout, forbid tuning to hide missing instrumentation or truncation, ask teams to commit TOML for repeatability, and require accounting for analyzer-config changes when comparing runs. 
- Add concise examples to `docs/user-guide.md` showing the Rust checked API (`AnalyzeOptions::default().with_queueing(...)` + `try_analyze_run`), a TOML starter (`[analyzer] schema_version = 1`), and CLI usage (`--analyzer-config` / `--analyzer-set`) with a pointer to `--help-analyzer-options`. 
- Update `docs/README.md` and top-level `README.md` to surface analyzer tuning in the user journey and link `examples/analyzer-config.toml`. 
- Expand `tailtriage-analyzer/README.md` with default and checked in-process examples, TOML parsing example, and note about `analyzer_config` being emitted only for non-default options. 
- Expand `tailtriage-cli/README.md` with `--analyzer-config`, `--analyzer-set`, `--help-analyzer-options`, precedence rules, error behavior for unknown paths, and clarify Report JSON vs Run artifact JSON distinction.

### Testing

- Ran `cargo fmt --check` and it succeeded. 
- Ran `cargo test --workspace` and all unit, doc, and integration tests passed. 
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06b0f6d77c8330aa15d6bacc2930ce)