### PR TITLE
docs: add analyzer tuning guidance and examples (Rust/TOML/CLI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,8 @@ tailtriage analyze tailtriage-run.json --format json
 
 For full report-field interpretation, see [`docs/diagnostics.md`](docs/diagnostics.md) and [`tailtriage-cli/README.md`](tailtriage-cli/README.md).
 
+Analyzer thresholds are tunable through Rust (`AnalyzeOptions`), analyzer TOML (`[analyzer]`), and CLI flags (`--analyzer-config`, `--analyzer-set`). Start with defaults first, then tune only after representative runs. See [`docs/user-guide.md`](docs/user-guide.md), [`docs/diagnostics.md`](docs/diagnostics.md), and [`examples/analyzer-config.toml`](examples/analyzer-config.toml).
+
 `temporal_segments` is always present in JSON output and is usually an empty array. It is populated only when conservative within-run early/late checks find material signal movement (for example, different early/late primary suspects or a large early/late p95 shift). The global `primary_suspect` remains the primary full-run triage lead. Temporal segments are supporting within-run hints only and do not prove a phase-specific root cause. A temporal p95 warning means early/late latency changed materially in that run. Runtime and in-flight phase attribution is timestamp-filtered to each segment window and can be limited when those segment-filtered samples are sparse; with overlapping early/late request windows under concurrency, timestamp-filtered runtime/in-flight attribution is approximate.
 
 ## Operations guidance and overhead

--- a/SPEC.md
+++ b/SPEC.md
@@ -143,6 +143,12 @@ Semantics:
 - `analyze_run_json(&Run, AnalyzeOptions)` for analyze+compact Report JSON
 - `analyze_run_json_pretty(&Run, AnalyzeOptions)` for analyze+pretty Report JSON
 
+`AnalyzeOptions` is a meaningful analyzer tuning surface. Equivalent analyzer configuration is available in-process (Rust), via analyzer TOML (`[analyzer]` with `schema_version = 1`), and via CLI flags. Defaults preserve current analyzer behavior.
+
+Report JSON includes `analyzer_config` only when non-default analyzer options are used.
+
+Analyzer tuning only changes how captured evidence is interpreted; it does not change run capture artifacts.
+
 Semantics are batch/snapshot for completed runs, not streaming analysis.
 
 ### 5.9 Analyzer CLI (`tailtriage-cli`)

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,9 +26,9 @@ Most users should start with `tailtriage`.
 
 Use these docs when wiring `tailtriage` into a service or interpreting output.
 
-- [User guide](user-guide.md) — end-to-end adoption path and operational workflow.
+- [User guide](user-guide.md) — end-to-end adoption path, plus concise analyzer tuning examples for Rust/TOML/CLI.
 - [Operations guide](operations.md) — primary production operations guidance for rollout path, capture-mode selection, runtime sampling decisions, artifact sizing, truncation/capture-limit handling, weak-signal troubleshooting, and current operational limits.
-- [Diagnostics guide](diagnostics.md) — how to read analyzer output, evidence quality, suspects, confidence, warnings, and field meanings.
+- [Diagnostics guide](diagnostics.md) — how to read analyzer output, evidence quality, suspects, confidence, warnings, and analyzer tuning boundaries.
 - [Analyzer README (`tailtriage-analyzer`)](../tailtriage-analyzer/README.md) — typed in-process report contract and rendering API.
 - [CLI README (`tailtriage-cli`)](../tailtriage-cli/README.md) — saved-artifact loading, schema validation, and text/JSON output.
 
@@ -72,3 +72,5 @@ Use these docs for project-level information rather than product workflow guidan
 - [Contributing guide](../CONTRIBUTING.md) — contributor workflow, scope guardrails, local checks, and docs-update expectations.
 - [Code of Conduct](../CODE_OF_CONDUCT.md) — community participation policy.
 - [Security policy](../SECURITY.md) — private vulnerability reporting guidance.
+
+- [Analyzer config example](../examples/analyzer-config.toml) — maintained `[analyzer]` TOML starter with `schema_version = 1`.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -102,6 +102,39 @@ Warnings show interpretation limits (missing signal families, sparse coverage, a
 
 As always: suspects are leads for next checks, not proof.
 
+## Analyzer tuning
+
+Start with analyzer defaults.
+
+Tune only after you have representative bounded runs and a clear reason to adjust interpretation thresholds.
+
+Analyzer tuning groups map to report interpretation families:
+
+- `queueing`
+- `blocking`
+- `executor`
+- `downstream`
+- `confidence`
+- `evidence`
+- `route`
+- `temporal`
+
+Non-default analyzer settings appear in Report JSON as `analyzer_config` so downstream comparisons can see interpretation changes.
+
+Analyzer tuning does not change capture artifacts. It changes how the analyzer interprets already captured evidence.
+
+Do not use analyzer tuning to compensate for missing instrumentation or truncation. Improve capture quality first, then tune if needed.
+
+Suspects remain evidence-ranked leads, not proof. Confidence is ranking confidence under observed evidence limits, not causal certainty.
+
+For the complete option surface and field-level help, use:
+
+```bash
+tailtriage analyze --help-analyzer-options
+```
+
+For a maintained starter config, use [`examples/analyzer-config.toml`](../examples/analyzer-config.toml).
+
 ## Warning semantics
 
 `warnings[]` is additive and can include multiple classes together:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -75,6 +75,21 @@ enable -> capture -> disable -> re-enable later
 
 Controller capture is usually the better production operational model.
 
+## Analyzer tuning in production
+
+Prefer default analyzer behavior first.
+
+Use analyzer tuning only after comparing representative runs and confirming workload fit for a threshold adjustment.
+
+Operational guardrails:
+
+* do not tune around missing queue/stage/runtime instrumentation
+* do not use tuning to hide truncation or dropped-signal warnings
+* commit analyzer TOML (`[analyzer]` with `schema_version = 1`) for repeatable production analysis
+* compare runs only when analyzer configuration is the same, or explicitly account for changed analyzer config in interpretation
+
+Analyzer tuning changes interpretation of captured evidence. It does not change capture artifacts.
+
 ## Capture mode guidance
 
 ### `light`

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -91,6 +91,49 @@ Run artifact JSON is capture output and CLI input. Report JSON is analyzer/CLI o
 
 Current analyzer semantics are completed-run or stable-snapshot batch analysis, not live streaming analysis.
 
+## 3a) Analyzer tuning (Rust, TOML, CLI)
+
+Start with defaults. Tune only after representative runs.
+
+Rust checked API example:
+
+```rust
+use tailtriage_analyzer::{AnalyzeOptions, try_analyze_run};
+# use tailtriage::Run;
+# fn example(run: &Run) -> Result<(), Box<dyn std::error::Error>> {
+let options = AnalyzeOptions::default().with_queueing(|q| {
+    q.trigger_permille = 450;
+}) ;
+
+let report = try_analyze_run(run, options)?;
+# let _ = report;
+# Ok(())
+# }
+```
+
+TOML example:
+
+```toml
+[analyzer]
+schema_version = 1
+
+[analyzer.queueing]
+trigger_permille = 450
+```
+
+CLI example:
+
+```bash
+tailtriage analyze tailtriage-run.json \
+  --analyzer-config examples/analyzer-config.toml \
+  --analyzer-set analyzer.queueing.trigger_permille=450 \
+  --format json
+```
+
+Use `tailtriage analyze --help-analyzer-options` for the full option list.
+
+Non-default analyzer options are emitted as `analyzer_config` in Report JSON.
+
 ## 4) Request lifecycle contract (required)
 
 `begin_request(...)` / `begin_request_with(...)` returns `StartedRequest`:

--- a/tailtriage-analyzer/README.md
+++ b/tailtriage-analyzer/README.md
@@ -58,6 +58,57 @@ fn render_report(run: &Run) -> Result<String, Box<dyn std::error::Error>> {
 - `analyze_run_json` and `analyze_run_json_pretty` combine analysis + canonical JSON rendering
 - Report JSON is analyzer output and is distinct from raw Run artifact JSON input
 
+## Analyzer options and tuning
+
+Start with defaults:
+
+```rust
+use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
+# use tailtriage_core::Run;
+# fn example(run: &Run) {
+let report = analyze_run(run, AnalyzeOptions::default());
+# let _ = report;
+# }
+```
+
+Checked custom options in process:
+
+```rust
+use tailtriage_analyzer::{
+    try_analyze_run, AnalyzeOptions,
+};
+# use tailtriage_core::Run;
+# fn example(run: &Run) -> Result<(), Box<dyn std::error::Error>> {
+let options = AnalyzeOptions::default().with_queueing(|q| {
+    q.trigger_permille = 450;
+}) ;
+let report = try_analyze_run(run, options)?;
+# let _ = report;
+# Ok(())
+# }
+```
+
+Parse analyzer options from TOML text:
+
+```rust
+use tailtriage_analyzer::AnalyzeOptions;
+
+let toml = r#"
+[analyzer]
+schema_version = 1
+
+[analyzer.queueing]
+trigger_permille = 450
+"#;
+
+let options = AnalyzeOptions::from_toml_str(toml)?;
+# Ok::<(), tailtriage_analyzer::AnalyzeConfigError>(())
+```
+
+When non-default analyzer options are used, Report JSON includes `analyzer_config`. With default options, `analyzer_config` is omitted.
+
+Analyzer tuning changes interpretation of captured evidence; it does not change capture artifacts.
+
 ## Semantics and boundaries
 
 - batch/snapshot analysis of one completed run

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -47,6 +47,22 @@ tailtriage analyze tailtriage-run.json --format json
 The CLI artifact loader requires at least one request event in `requests`. This is a CLI artifact-loading rule, not an in-process `tailtriage-analyzer` requirement for already-constructed `Run` values.
 CLI input is Run artifact JSON from disk. CLI does not consume Report JSON as input.
 
+## Analyzer configuration options
+
+`tailtriage analyze` supports analyzer tuning via:
+
+- `--analyzer-config <PATH>`: load analyzer TOML (`[analyzer]`, `schema_version = 1`)
+- `--analyzer-set PATH=VALUE`: override one option path (repeatable)
+- `--help-analyzer-options`: print analyzer option help and paths
+
+Precedence is: defaults < `--analyzer-config` < `--analyzer-set`.
+
+Unknown paths and misspelled option keys fail fast so incorrect settings are caught.
+
+Non-default analyzer options appear in Report JSON as `analyzer_config`.
+
+Run artifact JSON remains CLI input. Report JSON remains analyzer/CLI output.
+
 ## How to read the result
 
 Read output in this order:


### PR DESCRIPTION
### Motivation

- The analyzer and CLI gained configurable tuning semantics and the public docs must explain that `AnalyzeOptions` is a meaningful interpretation surface while preserving default behavior.
- Users need concise, accurate guidance for safe operational tuning (defaults-first, representative runs) without implying tuning changes capture artifacts or proves root cause.
- Ensure discoverability and repeatability for Rust/TOML/CLI config paths and avoid multiple competing onboarding stories.

### Description

- Documented analyzer tuning in `SPEC.md`, noting that `AnalyzeOptions` is a meaningful tuning surface, that `Report` JSON includes `analyzer_config` only for non-default options, and that tuning changes interpretation only (not capture artifacts). 
- Added an "Analyzer tuning" section to `docs/diagnostics.md` covering defaults-first advice, tuning groups (`queueing`, `blocking`, `executor`, `downstream`, `confidence`, `evidence`, `route`, `temporal`), the `analyzer_config` visibility in reports, and the bounded claim that suspects are leads not proof. 
- Added production guidance to `docs/operations.md` with guardrails: prefer defaults, do not tune around missing instrumentation or truncation, commit TOML for repeatability, and compare runs only with consistent analyzer config. 
- Added concise, parseable examples to `docs/user-guide.md` showing Rust builder-style `AnalyzeOptions` usage (`with_*`), a TOML starter (`[analyzer] schema_version = 1`), and CLI usage (`--analyzer-config` / `--analyzer-set`) with a pointer to `--help-analyzer-options`. 
- Updated `docs/README.md` and top-level `README.md` to include analyzer-tuning links in the user journey and added `examples/analyzer-config.toml` as the maintained starter. 
- Enhanced crate READMEs: `tailtriage-analyzer/README.md` shows checked in-process option usage and TOML parsing (`AnalyzeOptions::from_toml_str`), and `tailtriage-cli/README.md` documents `--analyzer-config`, `--analyzer-set`, `--help-analyzer-options`, precedence, and misspelling/unknown-path failure behavior.

### Testing

- Ran `cargo fmt --check` and it passed. 
- Ran `cargo test --workspace` (unit tests + doctests) and all tests passed. 
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06b0f6d77c8330aa15d6bacc2930ce)