### PR TITLE
docs: document analyzer tuning surfaces and operational guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ if let Some(finalized_run) = sink.take_run() {
 tailtriage analyze tailtriage-run.json --format json
 ```
 
+Analyzer thresholds can be tuned through Rust (`AnalyzeOptions`), TOML (`[analyzer]` with `schema_version = 1`), and CLI (`--analyzer-config` / `--analyzer-set`). Start with defaults first, then tune after representative runs. See [docs/diagnostics.md](docs/diagnostics.md), [docs/operations.md](docs/operations.md), and [`examples/analyzer-config.toml`](examples/analyzer-config.toml).
+
 #### Example output (representative JSON)
 
 ```json

--- a/SPEC.md
+++ b/SPEC.md
@@ -145,6 +145,16 @@ Semantics:
 
 Semantics are batch/snapshot for completed runs, not streaming analysis.
 
+
+Analyzer configuration contract:
+
+- `AnalyzeOptions` is a meaningful configuration surface for tuning analyzer interpretation thresholds while keeping the same capture artifact contract.
+- Analyzer configuration is supported across Rust (`AnalyzeOptions` builders), TOML (`[analyzer]` schema with `schema_version = 1`), and CLI (`--analyzer-config` plus `--analyzer-set`).
+- `AnalyzeOptions::default()` preserves the current analyzer behavior and is the recommended starting point.
+- Report JSON includes `analyzer_config` only when non-default analyzer options are used; default reports omit this field.
+- Analyzer tuning changes interpretation/ranking of already captured evidence; it does not change capture artifacts, capture limits, truncation, or what was collected.
+
+
 ### 5.9 Analyzer CLI (`tailtriage-cli`)
 
 `tailtriage-cli` owns artifact loading + command-line report emission and uses `tailtriage-analyzer` for analysis logic. CLI JSON output delegates to `tailtriage-analyzer`’s canonical pretty Report JSON renderer.

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,11 +24,11 @@ Most users should start with `tailtriage`.
 
 ## Capture and analysis workflow
 
-Use these docs when wiring `tailtriage` into a service or interpreting output.
+Use these docs when wiring `tailtriage` into a service or interpreting output. Analyzer tuning references are part of this same workflow (defaults first, tune after representative runs).
 
 - [User guide](user-guide.md) — end-to-end adoption path and operational workflow.
 - [Operations guide](operations.md) — primary production operations guidance for rollout path, capture-mode selection, runtime sampling decisions, artifact sizing, truncation/capture-limit handling, weak-signal troubleshooting, and current operational limits.
-- [Diagnostics guide](diagnostics.md) — how to read analyzer output, evidence quality, suspects, confidence, warnings, and field meanings.
+- [Diagnostics guide](diagnostics.md) — how to read analyzer output, evidence quality, suspects, confidence, warnings, and analyzer tuning guardrails.
 - [Analyzer README (`tailtriage-analyzer`)](../tailtriage-analyzer/README.md) — typed in-process report contract and rendering API.
 - [CLI README (`tailtriage-cli`)](../tailtriage-cli/README.md) — saved-artifact loading, schema validation, and text/JSON output.
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -102,6 +102,34 @@ Warnings show interpretation limits (missing signal families, sparse coverage, a
 
 As always: suspects are leads for next checks, not proof.
 
+## Analyzer tuning
+
+Start with defaults (`AnalyzeOptions::default()` or no analyzer overrides in CLI/TOML).
+
+Tune only after representative runs under comparable workload. First validate that capture evidence is usable (enough requests, relevant queue/stage instrumentation, and acceptable truncation state), then adjust analyzer thresholds if ranking behavior needs tighter workload fit.
+
+Analyzer option groups:
+
+- **queueing**: queue-share and queue-pressure thresholds for queue saturation leads
+- **blocking**: blocking-pool queue-depth/coverage thresholds
+- **executor**: runtime queue-depth thresholds for executor-pressure leads
+- **downstream**: stage eligibility and blocking-correlation heuristics
+- **confidence**: score bands and ambiguity boundaries for confidence labeling
+- **evidence**: low-evidence thresholds that shape evidence-quality interpretation
+- **route**: conservative route-breakdown emission thresholds
+- **temporal**: conservative within-run segment emission thresholds
+
+When non-default options are used, report JSON includes `analyzer_config` with the active non-default overrides. Default analyzer behavior omits `analyzer_config` from report JSON.
+
+Use tuning as interpretation control, not data repair: tuning cannot recover missing instrumentation and cannot compensate for truncation or dropped evidence.
+
+Suspects remain evidence-ranked leads, not proof. `confidence` is ranking confidence under observed evidence and limits; it is not causal certainty.
+
+For the complete option list and valid override paths, use:
+
+- `tailtriage analyze --help-analyzer-options`
+- `examples/analyzer-config.toml`
+
 ## Warning semantics
 
 `warnings[]` is additive and can include multiple classes together:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -40,6 +40,18 @@ Recommended progression:
 
 A conservative rollout usually gives better operational signal than enabling every feature immediately.
 
+## Analyzer tuning in operations
+
+Keep rollout conservative: prefer default analyzer behavior first and tune only after comparing representative runs for your workload profile.
+
+Operational guardrails:
+
+- Do not tune around missing instrumentation; add needed queue/stage/runtime evidence first.
+- Do not use tuning to hide truncation or dropped-event warnings; address capture density/limits and re-run.
+- Commit analyzer TOML used in production workflows so repeated runs are reproducible.
+- Compare runs only when analyzer config is the same, or explicitly account for changed analyzer config when interpreting movement.
+- Use tuning to improve workload fit of evidence interpretation after baseline runs, not as a substitute for capture quality.
+
 ## Choosing direct capture vs controller capture
 
 ### Direct capture

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -91,6 +91,45 @@ Run artifact JSON is capture output and CLI input. Report JSON is analyzer/CLI o
 
 Current analyzer semantics are completed-run or stable-snapshot batch analysis, not live streaming analysis.
 
+### Analyzer tuning examples
+
+Start from defaults, then tune only what you need.
+
+Rust (checked API):
+
+```rust
+use tailtriage::Run;
+use tailtriage_analyzer::{try_analyze_run, AnalyzeOptions};
+
+fn analyze_with_tuning(run: &Run) -> Result<(), Box<dyn std::error::Error>> {
+    let options = AnalyzeOptions::default()
+        .with_queueing(|o| o.trigger_permille = 450);
+    let report = try_analyze_run(run, options)?;
+    let _ = report;
+    Ok(())
+}
+```
+
+TOML (`[analyzer]` schema):
+
+```toml
+[analyzer]
+schema_version = 1
+
+[analyzer.queueing]
+trigger_permille = 450
+```
+
+CLI:
+
+```bash
+tailtriage analyze tailtriage-run.json \
+  --analyzer-config examples/analyzer-config.toml \
+  --analyzer-set queueing.trigger_permille=450
+```
+
+Use `tailtriage analyze --help-analyzer-options` to list supported override paths and value formats.
+
 ## 4) Request lifecycle contract (required)
 
 `begin_request(...)` / `begin_request_with(...)` returns `StartedRequest`:

--- a/tailtriage-analyzer/README.md
+++ b/tailtriage-analyzer/README.md
@@ -58,6 +58,55 @@ fn render_report(run: &Run) -> Result<String, Box<dyn std::error::Error>> {
 - `analyze_run_json` and `analyze_run_json_pretty` combine analysis + canonical JSON rendering
 - Report JSON is analyzer output and is distinct from raw Run artifact JSON input
 
+## Analyzer tuning options
+
+Start with defaults:
+
+```rust
+use tailtriage_analyzer::AnalyzeOptions;
+
+let options = AnalyzeOptions::default();
+let _ = options;
+```
+
+In-process checked custom options:
+
+```rust
+use tailtriage_analyzer::{try_analyze_run, AnalyzeOptions};
+use tailtriage_core::Run;
+
+fn analyze_checked(run: &Run) -> Result<(), Box<dyn std::error::Error>> {
+    let options = AnalyzeOptions::default()
+        .with_queueing(|o| o.trigger_permille = 450);
+    let report = try_analyze_run(run, options)?;
+    let _ = report;
+    Ok(())
+}
+```
+
+TOML parsing example:
+
+```rust
+use tailtriage_analyzer::AnalyzeOptions;
+
+let input = r#"
+[analyzer]
+schema_version = 1
+
+[analyzer.queueing]
+trigger_permille = 450
+"#;
+
+let options = AnalyzeOptions::from_toml_str(input)?;
+# Ok::<(), tailtriage_analyzer::AnalyzeConfigError>(())
+```
+
+Report transparency behavior:
+
+- default options omit `analyzer_config` from Report JSON
+- non-default options include `analyzer_config` with active non-default overrides
+- tuning changes interpretation of captured evidence; it does not change capture artifacts
+
 ## Semantics and boundaries
 
 - batch/snapshot analysis of one completed run

--- a/tailtriage-analyzer/src/options/mod.rs
+++ b/tailtriage-analyzer/src/options/mod.rs
@@ -9,6 +9,19 @@ mod toml;
 pub use descriptors::analyze_option_descriptors;
 
 /// Semantic analyzer options grouped by triage domain.
+///
+/// # Examples
+///
+/// ```
+/// use tailtriage_analyzer::AnalyzeOptions;
+///
+/// let options = AnalyzeOptions::default()
+///     .with_queueing(|o| o.trigger_permille = 450)
+///     .with_confidence(|o| o.high_score_threshold = 90);
+///
+/// assert_eq!(options.queueing.trigger_permille, 450);
+/// assert_eq!(options.confidence.high_score_threshold, 90);
+/// ```
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Default)]
 pub struct AnalyzeOptions {

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -47,6 +47,24 @@ tailtriage analyze tailtriage-run.json --format json
 The CLI artifact loader requires at least one request event in `requests`. This is a CLI artifact-loading rule, not an in-process `tailtriage-analyzer` requirement for already-constructed `Run` values.
 CLI input is Run artifact JSON from disk. CLI does not consume Report JSON as input.
 
+## Analyzer tuning flags
+
+Start with default analyzer behavior first.
+
+- `--analyzer-config <path>` loads analyzer options from TOML (`[analyzer]`, `schema_version = 1`).
+- `--analyzer-set PATH=VALUE` applies one override (repeatable).
+- `--help-analyzer-options` prints supported override paths and value formats.
+
+Precedence:
+
+1. analyzer defaults
+2. options loaded from `--analyzer-config`
+3. one or more `--analyzer-set PATH=VALUE` overrides (last assignment to the same path wins)
+
+Override parsing/validation errors fail fast so misspelled paths or invalid values are rejected rather than silently ignored.
+
+Run artifact JSON remains CLI input. Report JSON remains analyzer/CLI output. Analyzer tuning changes report interpretation, not captured artifact contents.
+
 ## How to read the result
 
 Read output in this order:


### PR DESCRIPTION
### Motivation

- Document the landed analyzer tuning surface so users know `AnalyzeOptions` is meaningful and configurable via Rust, TOML, and CLI without changing capture artifacts. 
- Reinforce conservative, defaults-first guidance and keep triage claims bounded (suspects are leads, not proof). 
- Provide concise examples and pointers so users can safely adopt and repeat tuning in production.

### Description

- Add analyzer configuration contract to `SPEC.md` documenting `AnalyzeOptions`, TOML ` [analyzer] schema_version = 1`, CLI support, default-omission of `analyzer_config` in Report JSON, and that tuning changes interpretation only. 
- Add an "Analyzer tuning" section to `docs/diagnostics.md` describing defaults-first workflow, option groups (queueing, blocking, executor, downstream, confidence, evidence, route, temporal), `analyzer_config` transparency, and the limits of tuning vs missing/truncated data. 
- Add operational guardrails to `docs/operations.md` (prefer defaults, do not tune around missing instrumentation or to hide truncation, commit TOML for repeatability, and compare runs with consistent config). 
- Add concise examples to `docs/user-guide.md` showing Rust checked API (`AnalyzeOptions::default().with_queueing(...)` + `try_analyze_run`), TOML (`[analyzer] schema_version = 1`), and CLI usage (`--analyzer-config`, `--analyzer-set` and `--help-analyzer-options`). 
- Update docs index and top-level READMEs to include analyzer tuning links and a short pointer mentioning tunable thresholds via Rust/TOML/CLI. 
- Extend `tailtriage-analyzer/README.md` and `tailtriage-cli/README.md` with usage, precedence, and report-vs-artifact distinctions. 
- Add a rustdoc example to `tailtriage-analyzer/src/options/mod.rs` demonstrating builder-style `AnalyzeOptions` tuning (no struct literals for non-exhaustive types). 

### Testing

- Ran `cargo fmt --check` which passed. 
- Ran `cargo test --workspace` and all unit tests and doc-tests succeeded. 
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06b0f6d77c8330aa15d6bacc2930ce)