### PR TITLE
Strengthen analyzer tuning public docs contract checks

### DIFF
--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -118,63 +118,93 @@ See VALIDATION.md, diagnostics.md, runtime-cost.md, and collector-limits.md.
     def test_analyzer_config_example_contract(self) -> None:
         validate_docs_contracts.validate_analyzer_config_example_contract()
 
+    def test_analyzer_config_example_contract_rejects_missing_schema_version(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "analyzer-config.toml"
+            path.write_text("[analyzer]\n[analyzer.queueing]\n", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, r"schema_version = 1"):
+                validate_docs_contracts.validate_analyzer_config_example_contract(config_path=path)
+
+    def test_analyzer_config_example_contract_rejects_missing_analyzer_table(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "analyzer-config.toml"
+            path.write_text("schema_version = 1\n", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, r"\[analyzer\]"):
+                validate_docs_contracts.validate_analyzer_config_example_contract(config_path=path)
+
+    def test_analyzer_config_example_contract_rejects_missing_group(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "analyzer-config.toml"
+            body = "[analyzer]\nschema_version = 1\n" + "\n".join(
+                f"[analyzer.{g}]" for g in validate_docs_contracts.ANALYZER_GROUPS if g != "temporal"
+            )
+            path.write_text(body, encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, r"temporal"):
+                validate_docs_contracts.validate_analyzer_config_example_contract(config_path=path)
+
+    def test_analyzer_config_example_contract_rejects_root_level_group(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "analyzer-config.toml"
+            body = "[analyzer]\nschema_version = 1\n" + "\n".join(
+                f"[analyzer.{g}]" for g in validate_docs_contracts.ANALYZER_GROUPS
+            ) + "\n[queueing]\ntrigger_permille = 100\n"
+            path.write_text(body, encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, r"root-level analyzer groups"):
+                validate_docs_contracts.validate_analyzer_config_example_contract(config_path=path)
+
     def test_extract_analyzer_paths_for_validation(self) -> None:
         text = """
-Use `queueing.trigger_permille` and `confidence.high_score_threshold`.
-Ignore file names like `foo.queueing.toml`.
+Use `queueing.trigger_permille`, queueing.trigger_permille=400,
+--analyzer-set queueing.trigger_permille=400, and `confidence.high_score_threshold`.
+Ignore file names like docs/operations.md, foo.bar, and include queuing.trigger_permille too.
 """
         paths = validate_docs_contracts._extract_analyzer_paths_for_validation(text)
         self.assertIn("queueing.trigger_permille", paths)
         self.assertIn("confidence.high_score_threshold", paths)
-        self.assertNotIn("foo.queueing.toml", paths)
+        self.assertIn("queuing.trigger_permille", paths)
+        self.assertNotIn("foo.bar", paths)
+        self.assertNotIn("docs/operations.md", paths)
 
-    def test_analyzer_tuning_docs_contract_rejects_root_level_table_header(self) -> None:
+    def test_analyzer_tuning_docs_contracts_on_committed_docs(self) -> None:
+        validate_docs_contracts.validate_analyzer_tuning_tokens_contract()
+        validate_docs_contracts.validate_no_root_level_analyzer_toml_in_docs()
+        validate_docs_contracts.validate_analyzer_override_paths_contract()
+
+    def test_analyzer_no_root_level_docs_rejects_root_level_table_header(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             repo_root = Path(tmp_dir)
             docs_dir = repo_root / "docs"
             docs_dir.mkdir(parents=True, exist_ok=True)
-            (docs_dir / "diagnostics.md").write_text(
-                "# Analyzer tuning\nAnalyzeOptions\n--help-analyzer-options\nsuspects are not proof\n",
-                encoding="utf-8",
-            )
-            (docs_dir / "operations.md").write_text(
-                "analyzer config representative runs truncation same analyzer config\n",
-                encoding="utf-8",
-            )
-            (docs_dir / "user-guide.md").write_text(
-                "[analyzer]\nschema_version = 1\n--analyzer-config\n--analyzer-set\ntry_analyze_run\n",
-                encoding="utf-8",
-            )
-            (repo_root / "tailtriage-analyzer").mkdir(parents=True, exist_ok=True)
-            (repo_root / "tailtriage-cli").mkdir(parents=True, exist_ok=True)
-            (repo_root / "tailtriage-analyzer" / "README.md").write_text(
-                "AnalyzeOptions try_analyze_run with_queueing analyzer_config\n",
-                encoding="utf-8",
-            )
-            (repo_root / "tailtriage-cli" / "README.md").write_text(
-                "--analyzer-config --analyzer-set --help-analyzer-options Report JSON\n[queueing]\n",
-                encoding="utf-8",
-            )
-
-            with (
-                mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root),
-                mock.patch.object(validate_docs_contracts, "DIAGNOSTICS_PATH", docs_dir / "diagnostics.md"),
-                mock.patch.object(validate_docs_contracts, "OPERATIONS_PATH", docs_dir / "operations.md"),
-                mock.patch.object(validate_docs_contracts, "USER_GUIDE_PATH", docs_dir / "user-guide.md"),
-                mock.patch.object(
-                    validate_docs_contracts,
-                    "ANALYZER_DOC_PATHS",
-                    (
-                        docs_dir / "diagnostics.md",
-                        docs_dir / "operations.md",
-                        docs_dir / "user-guide.md",
-                        repo_root / "tailtriage-analyzer" / "README.md",
-                        repo_root / "tailtriage-cli" / "README.md",
-                    ),
-                ),
-            ):
+            path = docs_dir / "diagnostics.md"
+            path.write_text("[queueing]\ntrigger_permille = 400\n", encoding="utf-8")
+            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root):
                 with self.assertRaisesRegex(ValueError, r"invalid root-level TOML header"):
-                    validate_docs_contracts.validate_analyzer_tuning_docs_contract()
+                    validate_docs_contracts.validate_no_root_level_analyzer_toml_in_docs(doc_paths=(path,))
+
+    def test_analyzer_no_root_level_docs_allows_namespaced_table_header(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "docs.md"
+            path.write_text("[analyzer.queueing]\ntrigger_permille = 400\n", encoding="utf-8")
+            validate_docs_contracts.validate_no_root_level_analyzer_toml_in_docs(doc_paths=(path,))
+
+    def test_analyzer_override_paths_contract_rejects_invalid_paths(self) -> None:
+        invalid_candidates = (
+            "confidence.high_threshold",
+            "route.max_routes",
+            "temporal.windows",
+            "queuing.trigger_permille",
+        )
+        for candidate in invalid_candidates:
+            with self.subTest(candidate=candidate):
+                with tempfile.TemporaryDirectory() as tmp_dir:
+                    repo_root = Path(tmp_dir)
+                    doc = repo_root / "docs.md"
+                    doc.write_text(f"`{candidate}`\n", encoding="utf-8")
+                    with mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root):
+                        with self.assertRaisesRegex(ValueError, candidate):
+                            validate_docs_contracts.validate_analyzer_override_paths_contract(
+                                doc_paths=(doc,)
+                            )
 
     def test_validation_ci_contract_checks_committed_workflow_and_docs(self) -> None:
         validate_docs_contracts.validate_diagnostic_benchmark_ci_contract()

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -115,6 +115,67 @@ See VALIDATION.md, diagnostics.md, runtime-cost.md, and collector-limits.md.
     def test_diagnostics_contract_truthfulness(self) -> None:
         validate_docs_contracts.validate_diagnostics_contract_truthfulness()
 
+    def test_analyzer_config_example_contract(self) -> None:
+        validate_docs_contracts.validate_analyzer_config_example_contract()
+
+    def test_extract_analyzer_paths_for_validation(self) -> None:
+        text = """
+Use `queueing.trigger_permille` and `confidence.high_score_threshold`.
+Ignore file names like `foo.queueing.toml`.
+"""
+        paths = validate_docs_contracts._extract_analyzer_paths_for_validation(text)
+        self.assertIn("queueing.trigger_permille", paths)
+        self.assertIn("confidence.high_score_threshold", paths)
+        self.assertNotIn("foo.queueing.toml", paths)
+
+    def test_analyzer_tuning_docs_contract_rejects_root_level_table_header(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            docs_dir = repo_root / "docs"
+            docs_dir.mkdir(parents=True, exist_ok=True)
+            (docs_dir / "diagnostics.md").write_text(
+                "# Analyzer tuning\nAnalyzeOptions\n--help-analyzer-options\nsuspects are not proof\n",
+                encoding="utf-8",
+            )
+            (docs_dir / "operations.md").write_text(
+                "analyzer config representative runs truncation same analyzer config\n",
+                encoding="utf-8",
+            )
+            (docs_dir / "user-guide.md").write_text(
+                "[analyzer]\nschema_version = 1\n--analyzer-config\n--analyzer-set\ntry_analyze_run\n",
+                encoding="utf-8",
+            )
+            (repo_root / "tailtriage-analyzer").mkdir(parents=True, exist_ok=True)
+            (repo_root / "tailtriage-cli").mkdir(parents=True, exist_ok=True)
+            (repo_root / "tailtriage-analyzer" / "README.md").write_text(
+                "AnalyzeOptions try_analyze_run with_queueing analyzer_config\n",
+                encoding="utf-8",
+            )
+            (repo_root / "tailtriage-cli" / "README.md").write_text(
+                "--analyzer-config --analyzer-set --help-analyzer-options Report JSON\n[queueing]\n",
+                encoding="utf-8",
+            )
+
+            with (
+                mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root),
+                mock.patch.object(validate_docs_contracts, "DIAGNOSTICS_PATH", docs_dir / "diagnostics.md"),
+                mock.patch.object(validate_docs_contracts, "OPERATIONS_PATH", docs_dir / "operations.md"),
+                mock.patch.object(validate_docs_contracts, "USER_GUIDE_PATH", docs_dir / "user-guide.md"),
+                mock.patch.object(
+                    validate_docs_contracts,
+                    "ANALYZER_DOC_PATHS",
+                    (
+                        docs_dir / "diagnostics.md",
+                        docs_dir / "operations.md",
+                        docs_dir / "user-guide.md",
+                        repo_root / "tailtriage-analyzer" / "README.md",
+                        repo_root / "tailtriage-cli" / "README.md",
+                    ),
+                ),
+            ):
+                with self.assertRaisesRegex(ValueError, r"invalid root-level TOML header"):
+                    validate_docs_contracts.validate_analyzer_tuning_docs_contract()
+
     def test_validation_ci_contract_checks_committed_workflow_and_docs(self) -> None:
         validate_docs_contracts.validate_diagnostic_benchmark_ci_contract()
         validate_docs_contracts.validate_validation_docs_ci_contract()

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -642,54 +642,60 @@ def validate_diagnostics_contract_truthfulness() -> None:
             "but docs/diagnostics.md lacks a matching field reference section"
         )
 
-def validate_analyzer_config_example_contract() -> None:
-    if not ANALYZER_CONFIG_EXAMPLE_PATH.exists():
-        raise ValueError("missing analyzer config example: examples/analyzer-config.toml")
-    text = ANALYZER_CONFIG_EXAMPLE_PATH.read_text(encoding="utf-8")
+def validate_analyzer_config_example_contract(*, config_path: Path = ANALYZER_CONFIG_EXAMPLE_PATH) -> None:
+    if not config_path.exists():
+        raise ValueError(f"missing analyzer config example: {config_path}")
+    text = config_path.read_text(encoding="utf-8")
     try:
         parsed = tomllib.loads(text)
     except tomllib.TOMLDecodeError as exc:
-        raise ValueError(f"invalid TOML in {ANALYZER_CONFIG_EXAMPLE_PATH}: {exc}") from exc
+        raise ValueError(f"invalid TOML in {config_path}: {exc}") from exc
 
     analyzer = parsed.get("analyzer")
     if not isinstance(analyzer, dict):
-        raise ValueError("examples/analyzer-config.toml must define an [analyzer] table")
+        raise ValueError(f"{config_path} must define an [analyzer] table")
     if analyzer.get("schema_version") != 1:
-        raise ValueError("examples/analyzer-config.toml must set analyzer.schema_version = 1")
+        raise ValueError(f"{config_path} must set analyzer.schema_version = 1")
 
     missing_groups = [group for group in ANALYZER_GROUPS if not isinstance(analyzer.get(group), dict)]
     if missing_groups:
         raise ValueError(
-            "examples/analyzer-config.toml missing required [analyzer.*] groups: "
+            f"{config_path} missing required [analyzer.*] groups: "
             f"{', '.join(missing_groups)}"
         )
 
     invalid_root = sorted(group for group in ANALYZER_GROUPS if isinstance(parsed.get(group), dict))
     if invalid_root:
         raise ValueError(
-            "examples/analyzer-config.toml must not define root-level analyzer groups: "
+            f"{config_path} must not define root-level analyzer groups: "
             f"{', '.join(invalid_root)}"
         )
 
 
 def _extract_analyzer_paths_for_validation(text: str) -> set[str]:
-    prefixes = "|".join(ANALYZER_GROUPS)
-    pattern = re.compile(rf"(?:`([^`]+)`|\b(({prefixes})\.[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*)\b)")
+    prefixes = "|".join((*ANALYZER_GROUPS, "queuing"))
+    pattern = re.compile(
+        rf"(?:`([^`]+)`|\b(--analyzer-set\s+)?(({prefixes})\.[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*)(?:=[^\s`]+)?)"
+    )
     paths: set[str] = set()
-    for quoted, bare, _ in pattern.findall(text):
-        candidate = quoted or bare
+    for quoted, _, bare_with_optional_value, _ in pattern.findall(text):
+        candidate = quoted or bare_with_optional_value
+        candidate = candidate.split("=", 1)[0].strip()
+        candidate = re.sub(r"^--analyzer-set\s+", "", candidate)
         if re.fullmatch(rf"(?:{prefixes})\.[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*", candidate):
             paths.add(candidate)
     return paths
 
 
-def validate_analyzer_tuning_docs_contract() -> None:
-    for path in ANALYZER_DOC_PATHS:
+def validate_no_root_level_analyzer_toml_in_docs(*, doc_paths: tuple[Path, ...] = ANALYZER_DOC_PATHS) -> None:
+    for path in doc_paths:
         text = path.read_text(encoding="utf-8")
         for group in ANALYZER_GROUPS:
             if re.search(rf"(?m)^\s*\[{group}\]\s*$", text):
                 raise ValueError(f"{path.relative_to(REPO_ROOT)} contains invalid root-level TOML header: [{group}]")
 
+
+def validate_analyzer_tuning_tokens_contract() -> None:
     diagnostics_text = DIAGNOSTICS_PATH.read_text(encoding="utf-8")
     diagnostics_lower = diagnostics_text.lower()
     diagnostics_required = ("analyzer tuning", "analyzeoptions", "--help-analyzer-options")
@@ -726,7 +732,8 @@ def validate_analyzer_tuning_docs_contract() -> None:
         if token not in analyzer_lower:
             raise ValueError(f"tailtriage-analyzer/README.md missing required analyzer token: {token}")
 
-    for path in ANALYZER_DOC_PATHS:
+def validate_analyzer_override_paths_contract(*, doc_paths: tuple[Path, ...] = ANALYZER_DOC_PATHS) -> None:
+    for path in doc_paths:
         text = path.read_text(encoding="utf-8")
         candidates = _extract_analyzer_paths_for_validation(text)
         invalid = sorted(candidate for candidate in candidates if candidate not in ANALYZER_V1_VALID_PATHS)
@@ -1096,7 +1103,9 @@ def main() -> int:
     validate_operations_guide_contract()
     validate_diagnostics_contract_truthfulness()
     validate_analyzer_config_example_contract()
-    validate_analyzer_tuning_docs_contract()
+    validate_no_root_level_analyzer_toml_in_docs()
+    validate_analyzer_tuning_tokens_contract()
+    validate_analyzer_override_paths_contract()
     validate_cli_not_presented_as_library_analyzer_api()
     validate_analyzer_cli_docs_split_contract()
     validate_capture_readmes_analyzer_cli_wording_contract()

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -16,6 +16,14 @@ DOCS_INDEX_PATH = REPO_ROOT / "docs" / "README.md"
 USER_GUIDE_PATH = REPO_ROOT / "docs" / "user-guide.md"
 DIAGNOSTICS_PATH = REPO_ROOT / "docs" / "diagnostics.md"
 OPERATIONS_PATH = REPO_ROOT / "docs" / "operations.md"
+ANALYZER_CONFIG_EXAMPLE_PATH = REPO_ROOT / "examples" / "analyzer-config.toml"
+ANALYZER_DOC_PATHS = (
+    DIAGNOSTICS_PATH,
+    OPERATIONS_PATH,
+    USER_GUIDE_PATH,
+    REPO_ROOT / "tailtriage-analyzer" / "README.md",
+    REPO_ROOT / "tailtriage-cli" / "README.md",
+)
 DIAGNOSTIC_VALIDATION_PATH = REPO_ROOT / "docs" / "diagnostic-validation.md"
 CI_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 ARCHITECTURE_PATH = REPO_ROOT / "docs" / "architecture.md"
@@ -122,6 +130,48 @@ RUSTDOC_INCLUDE_CRATE_LIBS = (
     REPO_ROOT / "tailtriage-analyzer" / "src" / "lib.rs",
     REPO_ROOT / "tailtriage-cli" / "src" / "lib.rs",
 )
+
+ANALYZER_GROUPS = (
+    "queueing",
+    "blocking",
+    "executor",
+    "downstream",
+    "confidence",
+    "evidence",
+    "route",
+    "temporal",
+)
+ANALYZER_V1_VALID_PATHS = {
+    "queueing.trigger_permille",
+    "blocking.min_nonzero_samples_for_signal",
+    "blocking.strong_p95_threshold",
+    "blocking.strong_peak_threshold",
+    "blocking.strong_nonzero_share_permille",
+    "blocking.strong_min_samples",
+    "executor.min_global_queue_p95_for_signal",
+    "downstream.blocking_correlated_stage_patterns",
+    "downstream.min_stage_samples",
+    "downstream.blocking_correlation_score_margin",
+    "confidence.medium_score_threshold",
+    "confidence.high_score_threshold",
+    "confidence.ambiguity_min_score",
+    "confidence.ambiguity_score_gap",
+    "evidence.low_completed_request_threshold",
+    "route.min_request_count",
+    "route.breakdown_limit",
+    "route.emit_on_divergent_suspects",
+    "route.slowest_to_fastest_p95_ratio_numerator",
+    "route.slowest_to_fastest_p95_ratio_denominator",
+    "route.slowest_to_global_p95_ratio_numerator",
+    "route.slowest_to_global_p95_ratio_denominator",
+    "temporal.min_request_count",
+    "temporal.min_segment_request_count",
+    "temporal.share_shift_permille",
+    "temporal.p95_shift_ratio_numerator",
+    "temporal.p95_shift_ratio_denominator",
+    "temporal.emit_on_suspect_shift",
+    "temporal.suppress_runtime_sparse_suspect_shift_without_supporting_movement",
+}
 
 
 def parse_args() -> argparse.Namespace:
@@ -592,6 +642,100 @@ def validate_diagnostics_contract_truthfulness() -> None:
             "but docs/diagnostics.md lacks a matching field reference section"
         )
 
+def validate_analyzer_config_example_contract() -> None:
+    if not ANALYZER_CONFIG_EXAMPLE_PATH.exists():
+        raise ValueError("missing analyzer config example: examples/analyzer-config.toml")
+    text = ANALYZER_CONFIG_EXAMPLE_PATH.read_text(encoding="utf-8")
+    try:
+        parsed = tomllib.loads(text)
+    except tomllib.TOMLDecodeError as exc:
+        raise ValueError(f"invalid TOML in {ANALYZER_CONFIG_EXAMPLE_PATH}: {exc}") from exc
+
+    analyzer = parsed.get("analyzer")
+    if not isinstance(analyzer, dict):
+        raise ValueError("examples/analyzer-config.toml must define an [analyzer] table")
+    if analyzer.get("schema_version") != 1:
+        raise ValueError("examples/analyzer-config.toml must set analyzer.schema_version = 1")
+
+    missing_groups = [group for group in ANALYZER_GROUPS if not isinstance(analyzer.get(group), dict)]
+    if missing_groups:
+        raise ValueError(
+            "examples/analyzer-config.toml missing required [analyzer.*] groups: "
+            f"{', '.join(missing_groups)}"
+        )
+
+    invalid_root = sorted(group for group in ANALYZER_GROUPS if isinstance(parsed.get(group), dict))
+    if invalid_root:
+        raise ValueError(
+            "examples/analyzer-config.toml must not define root-level analyzer groups: "
+            f"{', '.join(invalid_root)}"
+        )
+
+
+def _extract_analyzer_paths_for_validation(text: str) -> set[str]:
+    prefixes = "|".join(ANALYZER_GROUPS)
+    pattern = re.compile(rf"(?:`([^`]+)`|\b(({prefixes})\.[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*)\b)")
+    paths: set[str] = set()
+    for quoted, bare, _ in pattern.findall(text):
+        candidate = quoted or bare
+        if re.fullmatch(rf"(?:{prefixes})\.[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*", candidate):
+            paths.add(candidate)
+    return paths
+
+
+def validate_analyzer_tuning_docs_contract() -> None:
+    for path in ANALYZER_DOC_PATHS:
+        text = path.read_text(encoding="utf-8")
+        for group in ANALYZER_GROUPS:
+            if re.search(rf"(?m)^\s*\[{group}\]\s*$", text):
+                raise ValueError(f"{path.relative_to(REPO_ROOT)} contains invalid root-level TOML header: [{group}]")
+
+    diagnostics_text = DIAGNOSTICS_PATH.read_text(encoding="utf-8")
+    diagnostics_lower = diagnostics_text.lower()
+    diagnostics_required = ("analyzer tuning", "analyzeoptions", "--help-analyzer-options")
+    for token in diagnostics_required:
+        if token not in diagnostics_lower:
+            raise ValueError(f"docs/diagnostics.md missing required analyzer token: {token}")
+    if "not proof" not in diagnostics_lower:
+        raise ValueError("docs/diagnostics.md must include bounded wording that suspects are not proof")
+
+    operations_lower = OPERATIONS_PATH.read_text(encoding="utf-8").lower()
+    if "analyzer config" not in operations_lower and "analyzer tuning" not in operations_lower:
+        raise ValueError("docs/operations.md missing analyzer config/tuning guidance")
+    for token in ("representative runs", "truncation"):
+        if token not in operations_lower:
+            raise ValueError(f"docs/operations.md missing required analyzer-operations token: {token}")
+    if (
+        "same analyzer config" not in operations_lower
+        and re.search(r"analyzer config\s+is\s+the\s+same", operations_lower) is None
+    ):
+        raise ValueError("docs/operations.md must mention using the same analyzer config across comparisons")
+
+    user_guide_lower = USER_GUIDE_PATH.read_text(encoding="utf-8").lower()
+    for token in ("[analyzer]", "schema_version = 1", "--analyzer-config", "--analyzer-set", "try_analyze_run"):
+        if token not in user_guide_lower:
+            raise ValueError(f"docs/user-guide.md missing required analyzer token: {token}")
+
+    cli_lower = (REPO_ROOT / "tailtriage-cli" / "README.md").read_text(encoding="utf-8").lower()
+    for token in ("--analyzer-config", "--analyzer-set", "--help-analyzer-options", "report json"):
+        if token not in cli_lower:
+            raise ValueError(f"tailtriage-cli/README.md missing required analyzer token: {token}")
+
+    analyzer_lower = (REPO_ROOT / "tailtriage-analyzer" / "README.md").read_text(encoding="utf-8").lower()
+    for token in ("analyzeoptions", "try_analyze_run", "with_queueing", "analyzer_config"):
+        if token not in analyzer_lower:
+            raise ValueError(f"tailtriage-analyzer/README.md missing required analyzer token: {token}")
+
+    for path in ANALYZER_DOC_PATHS:
+        text = path.read_text(encoding="utf-8")
+        candidates = _extract_analyzer_paths_for_validation(text)
+        invalid = sorted(candidate for candidate in candidates if candidate not in ANALYZER_V1_VALID_PATHS)
+        if invalid:
+            raise ValueError(
+                f"{path.relative_to(REPO_ROOT)} contains invalid analyzer override path(s): "
+                + ", ".join(invalid)
+            )
+
 
 
 def _strip_allowed_analyzer_migration_note(text: str) -> str:
@@ -951,6 +1095,8 @@ def main() -> int:
     validate_user_guide_contract()
     validate_operations_guide_contract()
     validate_diagnostics_contract_truthfulness()
+    validate_analyzer_config_example_contract()
+    validate_analyzer_tuning_docs_contract()
     validate_cli_not_presented_as_library_analyzer_api()
     validate_analyzer_cli_docs_split_contract()
     validate_capture_readmes_analyzer_cli_wording_contract()


### PR DESCRIPTION
### Motivation
- Prevent stale or incorrect analyzer tuning docs and examples from drifting the public documentation contract. 
- Ensure the committed `examples/analyzer-config.toml` and analyzer-facing docs remain truthful to the v1 analyzer schema and bounded triage claims.

### Description
- Added constants for `examples/analyzer-config.toml` and the set of analyzer-facing docs in `ANALYZER_DOC_PATHS` and introduced `ANALYZER_GROUPS` and an explicit v1 allowlist `ANALYZER_V1_VALID_PATHS` for override-path validation in `scripts/validate_docs_contracts.py`.
- Implemented `validate_analyzer_config_example_contract()` to require the example file exists, parse as TOML via `tomllib`, include an `[analyzer]` table with `schema_version = 1`, include each required `[analyzer.<group>]` table, and reject root-level `[queueing]`/`[blocking]`-style group tables.
- Implemented `_extract_analyzer_paths_for_validation()` and `validate_analyzer_tuning_docs_contract()` to reject root-level analyzer TOML headers in public docs, require key analyzer tokens and bounded wording in `docs/diagnostics.md`, `docs/operations.md`, `docs/user-guide.md`, `tailtriage-analyzer/README.md`, and `tailtriage-cli/README.md`, and validate any dotted analyzer override-like paths against the exact v1 allowlist to catch stale paths.
- Wired the new validators into the main validation pipeline so they run with the rest of the docs contract checks and added small unit tests exercising the example validator, the path-extraction helper, and rejection of root-level TOML headers in docs (`scripts/tests/test_validate_docs_contracts.py`).

### Testing
- Ran `python3 -m unittest scripts.tests.test_validate_docs_contracts` and all tests passed (`Ran 48 tests` -> `OK`).
- Ran the validator `python3 scripts/validate_docs_contracts.py` and the full docs contract validation completed successfully (`docs contracts validated successfully`).
- No Rust source files were modified as part of this change set, so no `cargo` steps were required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06b5f06fb08330baa6e722ff3a82e5)