### PR TITLE
Enforce analyzer tuning docs and config contracts

### DIFF
--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -226,6 +226,39 @@ Normal CI does not publish durable diagnostic scorecards.
     def test_capture_readmes_analyzer_cli_wording_contract(self) -> None:
         validate_docs_contracts.validate_capture_readmes_analyzer_cli_wording_contract()
 
+    def test_analyzer_config_example_contract(self) -> None:
+        validate_docs_contracts.validate_analyzer_config_example_contract()
+
+    def test_analyzer_config_example_contract_fails_without_schema_version(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config_path = Path(tmp_dir) / "analyzer-config.toml"
+            config_path.write_text(
+                """[analyzer]
+[analyzer.queueing]
+[analyzer.blocking]
+[analyzer.executor]
+[analyzer.downstream]
+[analyzer.confidence]
+[analyzer.evidence]
+[analyzer.route]
+[analyzer.temporal]
+""",
+                encoding="utf-8",
+            )
+            with mock.patch.object(
+                validate_docs_contracts, "ANALYZER_CONFIG_EXAMPLE_PATH", config_path
+            ):
+                with self.assertRaisesRegex(ValueError, r"schema_version = 1"):
+                    validate_docs_contracts.validate_analyzer_config_example_contract()
+
+    def test_extract_analyzer_override_paths_filters_prefixes(self) -> None:
+        text = """
+Use `queueing.trigger_permille` and ignore `foo.bar`.
+`docs/operations.md` should not match as an analyzer override path.
+"""
+        extracted = validate_docs_contracts._extract_analyzer_override_paths(text)
+        self.assertEqual(extracted, {"queueing.trigger_permille"})
+
     def test_capture_readme_wording_rejects_cli_only_stale_phrase(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             repo_root = Path(tmp_dir)

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -16,6 +16,9 @@ DOCS_INDEX_PATH = REPO_ROOT / "docs" / "README.md"
 USER_GUIDE_PATH = REPO_ROOT / "docs" / "user-guide.md"
 DIAGNOSTICS_PATH = REPO_ROOT / "docs" / "diagnostics.md"
 OPERATIONS_PATH = REPO_ROOT / "docs" / "operations.md"
+ANALYZER_CONFIG_EXAMPLE_PATH = REPO_ROOT / "examples" / "analyzer-config.toml"
+ANALYZER_README_PATH = REPO_ROOT / "tailtriage-analyzer" / "README.md"
+CLI_README_PATH = REPO_ROOT / "tailtriage-cli" / "README.md"
 DIAGNOSTIC_VALIDATION_PATH = REPO_ROOT / "docs" / "diagnostic-validation.md"
 CI_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 ARCHITECTURE_PATH = REPO_ROOT / "docs" / "architecture.md"
@@ -112,6 +115,30 @@ STALE_VALIDATION_DOC_PHRASES = (
     "no in normal pr ci",
 )
 
+
+
+ANALYZER_GROUPS = (
+    "queueing",
+    "blocking",
+    "executor",
+    "downstream",
+    "confidence",
+    "evidence",
+    "route",
+    "temporal",
+)
+
+ANALYZER_DOC_PATHS = (
+    DIAGNOSTICS_PATH,
+    OPERATIONS_PATH,
+    USER_GUIDE_PATH,
+    ANALYZER_README_PATH,
+    CLI_README_PATH,
+)
+
+ANALYZER_V1_VALID_PATHS = {
+    "queueing.trigger_permille",
+}
 
 RUSTDOC_INCLUDE_CRATE_LIBS = (
     REPO_ROOT / "tailtriage" / "src" / "lib.rs",
@@ -839,6 +866,111 @@ def validate_validation_docs_ci_contract(
         )
 
 
+
+def validate_analyzer_config_example_contract() -> None:
+    if not ANALYZER_CONFIG_EXAMPLE_PATH.exists():
+        raise ValueError("missing required analyzer config example: examples/analyzer-config.toml")
+
+    parsed = tomllib.loads(ANALYZER_CONFIG_EXAMPLE_PATH.read_text(encoding="utf-8"))
+    analyzer = parsed.get("analyzer")
+    if not isinstance(analyzer, dict):
+        raise ValueError("examples/analyzer-config.toml must include an [analyzer] table")
+
+    if analyzer.get("schema_version") != 1:
+        raise ValueError("examples/analyzer-config.toml must set analyzer.schema_version = 1")
+
+    for group in ANALYZER_GROUPS:
+        if not isinstance(analyzer.get(group), dict):
+            raise ValueError(f"examples/analyzer-config.toml missing [analyzer.{group}] table")
+
+    for group in ("queueing", "blocking", "confidence"):
+        if isinstance(parsed.get(group), dict):
+            raise ValueError(f"examples/analyzer-config.toml must not include root-level [{group}] table")
+
+
+def validate_public_docs_analyzer_tuning_contract() -> None:
+    diagnostics_text = DIAGNOSTICS_PATH.read_text(encoding="utf-8")
+    diagnostics_lower = diagnostics_text.lower()
+    diagnostics_tokens = ("analyzer tuning", "analyzeoptions", "--help-analyzer-options")
+    for token in diagnostics_tokens:
+        if token not in diagnostics_lower:
+            raise ValueError(f"docs/diagnostics.md missing required analyzer tuning token: {token}")
+    if "not proof" not in diagnostics_lower and "not proof of root cause" not in diagnostics_lower:
+        raise ValueError("docs/diagnostics.md must include bounded wording that suspects are not proof")
+
+    operations_text = OPERATIONS_PATH.read_text(encoding="utf-8")
+    operations_lower = operations_text.lower()
+    if "analyzer config" not in operations_lower and "analyzer tuning" not in operations_lower:
+        raise ValueError("docs/operations.md must mention analyzer config or analyzer tuning")
+    for token in ("representative runs", "truncation"):
+        if token not in operations_lower:
+            raise ValueError(f"docs/operations.md missing required analyzer tuning token: {token}")
+    if "same analyzer config" not in operations_lower and "analyzer config is the same" not in operations_lower:
+        raise ValueError(
+            "docs/operations.md must mention using the same analyzer config across comparisons"
+        )
+
+    user_guide_text = USER_GUIDE_PATH.read_text(encoding="utf-8")
+    for token in ("[analyzer]", "schema_version = 1", "--analyzer-config", "--analyzer-set", "try_analyze_run"):
+        if token not in user_guide_text:
+            raise ValueError(f"docs/user-guide.md missing required analyzer token: {token}")
+
+    cli_readme_text = CLI_README_PATH.read_text(encoding="utf-8")
+    for token in ("--analyzer-config", "--analyzer-set", "--help-analyzer-options", "Report JSON"):
+        if token not in cli_readme_text:
+            raise ValueError(f"tailtriage-cli/README.md missing required analyzer token: {token}")
+
+    analyzer_readme_text = ANALYZER_README_PATH.read_text(encoding="utf-8")
+    for token in ("AnalyzeOptions", "try_analyze_run", "with_queueing", "analyzer_config"):
+        if token not in analyzer_readme_text:
+            raise ValueError(f"tailtriage-analyzer/README.md missing required analyzer token: {token}")
+
+
+def validate_no_root_level_analyzer_toml_in_docs() -> None:
+    bad_header_pattern = re.compile(
+        r"(?m)^\s*\[(queueing|blocking|executor|downstream|confidence|evidence|route|temporal)\]\s*$"
+    )
+    failures = []
+    for path in ANALYZER_DOC_PATHS:
+        text = path.read_text(encoding="utf-8")
+        for m in bad_header_pattern.finditer(text):
+            failures.append(
+                f"{path.relative_to(REPO_ROOT)} contains root-level analyzer TOML header: {m.group(0).strip()}"
+            )
+    if failures:
+        raise ValueError(
+            "root-level analyzer TOML headers are not allowed in public docs:\n"
+            + "\n".join(failures)
+        )
+
+
+def _extract_analyzer_override_paths(text: str) -> set[str]:
+    candidates = set()
+    backticked = re.findall(r"`([^`]+)`", text)
+    dotted = re.findall(r"\b(?:" + "|".join(ANALYZER_GROUPS) + r")\.[A-Za-z0-9_\.-]+\b", text)
+    for token in [*backticked, *dotted]:
+        token = token.strip()
+        if token.count(".") < 1:
+            continue
+        prefix = token.split(".", 1)[0]
+        if prefix in ANALYZER_GROUPS:
+            candidates.add(token)
+    return candidates
+
+
+def validate_analyzer_override_paths_contract() -> None:
+    failures = []
+    for path in ANALYZER_DOC_PATHS:
+        text = path.read_text(encoding="utf-8")
+        for token in sorted(_extract_analyzer_override_paths(text)):
+            if token not in ANALYZER_V1_VALID_PATHS:
+                failures.append(
+                    f"{path.relative_to(REPO_ROOT)} contains unknown analyzer override path: {token}"
+                )
+    if failures:
+        raise ValueError("stale/invalid analyzer override paths found:\n" + "\n".join(failures))
+
+
 def validate_architecture_contract() -> None:
     text = ARCHITECTURE_PATH.read_text(encoding="utf-8")
     required_tokens = (
@@ -951,6 +1083,10 @@ def main() -> int:
     validate_user_guide_contract()
     validate_operations_guide_contract()
     validate_diagnostics_contract_truthfulness()
+    validate_analyzer_config_example_contract()
+    validate_public_docs_analyzer_tuning_contract()
+    validate_no_root_level_analyzer_toml_in_docs()
+    validate_analyzer_override_paths_contract()
     validate_cli_not_presented_as_library_analyzer_api()
     validate_analyzer_cli_docs_split_contract()
     validate_capture_readmes_analyzer_cli_wording_contract()


### PR DESCRIPTION
### Motivation
- Make analyzer tuning guidance and the analyzer-config example part of the public docs contract so docs and examples stay truthful and avoid stale/ambiguous analyzer guidance.
- Prevent doc snippets that present root-level analyzer TOML (e.g., `[queueing]`) or stale analyzer override paths from creeping into public-facing docs.

### Description
- Added analyzer-related constants and allowed-surface declarations: `ANALYZER_CONFIG_EXAMPLE_PATH`, `ANALYZER_README_PATH`, `CLI_README_PATH`, `ANALYZER_GROUPS`, `ANALYZER_DOC_PATHS`, and `ANALYZER_V1_VALID_PATHS` in `scripts/validate_docs_contracts.py`.
- Implemented `validate_analyzer_config_example_contract()` to enforce `examples/analyzer-config.toml` exists, parses with `tomllib`, includes a top-level `[analyzer]` table, sets `analyzer.schema_version = 1`, has required `[analyzer.<group>]` sub-tables, and rejects certain root-level analyzer tables.
- Implemented `validate_public_docs_analyzer_tuning_contract()` to require analyzer-tuning tokens and bounded-claim wording across `docs/diagnostics.md`, `docs/operations.md`, `docs/user-guide.md`, `tailtriage-cli/README.md`, and `tailtriage-analyzer/README.md`.
- Implemented `validate_no_root_level_analyzer_toml_in_docs()` to detect and reject root-level TOML headers like `[queueing]`, `[blocking]`, etc., in public analyzer docs.
- Implemented override-path extraction and `validate_analyzer_override_paths_contract()` to detect backticked or dotted analyzer override paths and reject any not present in the explicit v1 allowlist.
- Hooked all new checks into `main()` so they run as part of the standard docs-contract validation.
- Updated unit tests in `scripts/tests/test_validate_docs_contracts.py` to add positive and negative tests for the analyzer-config example and to test the override-path extraction helper.

Files changed:
- `scripts/validate_docs_contracts.py` (new constants and validation functions; integrated into `main()`)
- `scripts/tests/test_validate_docs_contracts.py` (new unit tests)

### Testing
- Ran `python3 scripts/validate_docs_contracts.py` and it completed successfully.
- Ran `python3 -m unittest scripts.tests.test_validate_docs_contracts` and all tests passed.
- The validator now fails when `examples/analyzer-config.toml` is missing or does not contain `[analyzer]` with `schema_version = 1`, when public docs contain root-level analyzer TOML headers (e.g., `[queueing]`), or when docs mention analyzer override paths not in the v1 allowlist (e.g., stale/conflicting tokens).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06b5f06fb08330baa6e722ff3a82e5)