### PR TITLE
Issue 511 integration hardening: normalize unknown analyzer option wording

### DIFF
--- a/tailtriage-analyzer/src/options/mod.rs
+++ b/tailtriage-analyzer/src/options/mod.rs
@@ -791,9 +791,9 @@ impl Display for AnalyzeConfigError {
             Self::InvalidOverrideSyntax { raw } => write!(f, "invalid override syntax: {raw}"),
             Self::UnknownOverridePath { path, suggestion } => {
                 if let Some(s) = suggestion {
-                    write!(f, "unknown override path '{path}', did you mean '{s}'?")
+                    write!(f, "unknown analyzer option '{path}'; did you mean '{s}'?")
                 } else {
-                    write!(f, "unknown override path '{path}'")
+                    write!(f, "unknown analyzer option '{path}'")
                 }
             }
             Self::InvalidOverrideValue {


### PR DESCRIPTION
### Motivation
- Finalize integration hardening for analyzer tuning (issue 511) by removing confusing CLI/operator wording and ensuring analyzer tuning surfaces remain honest, private scoring knobs are not exposed, and docs/tests remain consistent.
- Ensure analyzer-config and CLI behaviors, report transparency, and misspelling guidance follow the established product contract without adding new public options or dependencies.

### Description
- Normalized the unknown-override error wording in `tailtriage-analyzer` so misspellings read `unknown analyzer option '<path>'` (with suggestion when available) by editing `tailtriage-analyzer/src/options/mod.rs` and preserving existing behavior and suggestion logic. 
- Performed an audit for stale analyzer TOML examples, invalid legacy paths, and old hard-coded threshold names and found no changes required to public options or defaults. 
- Verified report-transparency and CLI semantics remain unchanged: default reports omit `analyzer_config`, non-default analyzer options appear in JSON, `--analyzer-set` uses `group.field` paths, and CLI overrides beat TOML settings. 
- No new analyzer option fields, scoring formula knobs, or dependencies were added, and no public docs were broadened beyond truthfulness fixes.

### Testing
- Ran formatting and lint checks: `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings` (both succeeded). 
- Ran the full test suite: `cargo test --workspace` (all tests passed). 
- Validated docs contract: `python3 scripts/validate_docs_contracts.py` (succeeded). 
- Performed CLI/manual checks that passed: `tailtriage analyze --help`, `tailtriage analyze --help-analyzer-options`, `tailtriage analyze <fixture> --analyzer-set queueing.trigger_permille=400 --format json`, `tailtriage analyze <fixture> --analyzer-config examples/analyzer-config.toml --format json`, and the misspelling case `tailtriage analyze <fixture> --analyzer-set queuing.trigger_permille=400` which now prints `unknown analyzer option 'queuing.trigger_permille'; did you mean 'queueing.trigger_permille'?`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06c02b51f8833086ab5334d4556f5c)