### PR TITLE
Polish analyzer option typo error wording

### DIFF
--- a/tailtriage-analyzer/src/options/mod.rs
+++ b/tailtriage-analyzer/src/options/mod.rs
@@ -791,9 +791,9 @@ impl Display for AnalyzeConfigError {
             Self::InvalidOverrideSyntax { raw } => write!(f, "invalid override syntax: {raw}"),
             Self::UnknownOverridePath { path, suggestion } => {
                 if let Some(s) = suggestion {
-                    write!(f, "unknown override path '{path}', did you mean '{s}'?")
+                    write!(f, "unknown analyzer option '{path}'; did you mean '{s}'?")
                 } else {
-                    write!(f, "unknown override path '{path}'")
+                    write!(f, "unknown analyzer option '{path}'")
                 }
             }
             Self::InvalidOverrideValue {


### PR DESCRIPTION
### Motivation
- Small UX polish to make analyzer override error wording consistent with the CLI and test expectations so misspelling guidance reads `unknown analyzer option ...` instead of `unknown override path ...` as part of the issue-511 final hardening pass.

### Description
- Replace the `unknown override path` phrasing with `unknown analyzer option` in `tailtriage-analyzer/src/options/mod.rs` so the CLI suggestion message and tests reflect the intended analyzer-option wording.

### Testing
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `python3 scripts/validate_docs_contracts.py`, exercised `tailtriage analyze --help` and `--help-analyzer-options`, and verified `--analyzer-set queuing.trigger_permille=400` fails with the expected suggestion `unknown analyzer option 'queuing.trigger_permille'; did you mean 'queueing.trigger_permille'?`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06c02b51f8833086ab5334d4556f5c)