### PR TITLE
Clarify analyzer override typo messaging

### DIFF
--- a/tailtriage-analyzer/src/options/mod.rs
+++ b/tailtriage-analyzer/src/options/mod.rs
@@ -791,9 +791,9 @@ impl Display for AnalyzeConfigError {
             Self::InvalidOverrideSyntax { raw } => write!(f, "invalid override syntax: {raw}"),
             Self::UnknownOverridePath { path, suggestion } => {
                 if let Some(s) = suggestion {
-                    write!(f, "unknown override path '{path}', did you mean '{s}'?")
+                    write!(f, "unknown analyzer option '{path}'; did you mean '{s}'?")
                 } else {
-                    write!(f, "unknown override path '{path}'")
+                    write!(f, "unknown analyzer option '{path}'")
                 }
             }
             Self::InvalidOverrideValue {


### PR DESCRIPTION
### Motivation
- Final integration hardening for issue 511 found the operator-facing misspelling message used the internal phrasing `unknown override path ...` instead of the expected `unknown analyzer option ...`, so clarify the wording without changing behavior or config surface.

### Description
- Change `AnalyzeConfigError::UnknownOverridePath` display text to emit `unknown analyzer option '{path}'` (with suggestion when available) in `tailtriage-analyzer/src/options/mod.rs`, preserving existing suggestion logic and behavior.

### Testing
- Ran the required automated gates: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, and `python3 scripts/validate_docs_contracts.py`, and all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06c02b51f8833086ab5334d4556f5c)