### PR TITLE
Make analyzer overrides transactional and use configured confidence threshold for runtime warnings

### DIFF
--- a/tailtriage-analyzer/src/lib.rs
+++ b/tailtriage-analyzer/src/lib.rs
@@ -603,7 +603,7 @@ fn analysis_warnings(run: &Run, suspects: &[Suspect], options: &AnalyzeOptions) 
     let strong_non_runtime_primary = suspects.first().is_some_and(|s| {
         (s.kind == DiagnosisKind::ApplicationQueueSaturation
             || s.kind == DiagnosisKind::DownstreamStageDominates)
-            && s.score >= 85
+            && s.score >= options.confidence.high_score_threshold
     });
 
     if run.runtime_snapshots.is_empty() {

--- a/tailtriage-analyzer/src/options/overrides.rs
+++ b/tailtriage-analyzer/src/options/overrides.rs
@@ -41,7 +41,7 @@ impl AnalyzeOptions {
         &VALID_OVERRIDE_PATHS
     }
 
-    /// Applies CLI overrides in order, validating after each applied override.
+    /// Applies CLI overrides in order as a transactional batch.
     ///
     /// # Errors
     /// Returns the first syntax, path, parse, or semantic validation error.
@@ -50,9 +50,11 @@ impl AnalyzeOptions {
         I: IntoIterator<Item = S>,
         S: AsRef<str>,
     {
+        let mut updated = self.clone();
         for raw in overrides {
-            self.apply_override(raw.as_ref())?;
+            updated.apply_override(raw.as_ref())?;
         }
+        *self = updated;
         Ok(())
     }
 
@@ -71,8 +73,11 @@ impl AnalyzeOptions {
                 raw: raw.to_string(),
             });
         };
-        apply_override_path(self, path, value)?;
-        self.validate()
+        let mut updated = self.clone();
+        apply_override_path(&mut updated, path, value)?;
+        updated.validate()?;
+        *self = updated;
+        Ok(())
     }
 }
 
@@ -213,6 +218,7 @@ fn parse_bool(path: &str, value: &str) -> Result<bool, AnalyzeConfigError> {
         }),
     }
 }
+
 fn parse_string_list(path: &str, value: &str) -> Result<Vec<String>, AnalyzeConfigError> {
     let mut out = Vec::new();
     for entry in value.split(',') {
@@ -415,8 +421,51 @@ mod tests {
             })
         ));
     }
+
     #[test]
-    fn apply_overrides_stops_on_first_error() {
+    fn apply_override_invalid_semantic_value_is_transactional() {
+        let mut opts = AnalyzeOptions::default();
+        let original = opts.clone();
+
+        let err = opts
+            .apply_override("route.breakdown_limit=0")
+            .expect_err("must fail validation");
+        assert!(matches!(
+            err,
+            AnalyzeConfigError::InvalidConfigValue {
+                path: "route.breakdown_limit",
+                ..
+            }
+        ));
+        assert_eq!(opts, original);
+    }
+
+    #[test]
+    fn apply_override_invalid_path_is_transactional() {
+        let mut opts = AnalyzeOptions::default();
+        let original = opts.clone();
+
+        let err = opts.apply_override("bad.path=1").expect_err("must fail");
+        assert!(matches!(
+            err,
+            AnalyzeConfigError::UnknownOverridePath { .. }
+        ));
+        assert_eq!(opts, original);
+    }
+
+    #[test]
+    fn apply_overrides_repeated_valid_override_commits_last_value() {
+        let mut opts = AnalyzeOptions::default();
+        opts.apply_overrides([
+            "queueing.trigger_permille=350",
+            "queueing.trigger_permille=450",
+        ])
+        .expect("batch succeeds");
+        assert_eq!(opts.queueing.trigger_permille, 450);
+    }
+
+    #[test]
+    fn apply_overrides_stops_on_first_error_and_is_transactional() {
         let mut opts = AnalyzeOptions::default();
         let err = opts
             .apply_overrides([
@@ -429,7 +478,10 @@ mod tests {
             err,
             AnalyzeConfigError::UnknownOverridePath { .. }
         ));
-        assert_eq!(opts.queueing.trigger_permille, 450);
+        assert_eq!(
+            opts.queueing.trigger_permille,
+            AnalyzeOptions::default().queueing.trigger_permille
+        );
         assert_eq!(opts.confidence.high_score_threshold, 85);
     }
 }

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -405,6 +405,54 @@ fn no_runtime_warning_not_emitted_for_clean_queue_primary() {
 }
 
 #[test]
+fn runtime_warning_respects_configured_high_confidence_threshold() {
+    let mut run = test_run();
+    run.queues = vec![
+        QueueEvent {
+            request_id: "req-1".into(),
+            queue: "q".into(),
+            wait_us: 900,
+            waited_from_unix_ms: 0,
+            waited_until_unix_ms: 1,
+            depth_at_start: Some(9),
+        },
+        QueueEvent {
+            request_id: "req-2".into(),
+            queue: "q".into(),
+            wait_us: 900,
+            waited_from_unix_ms: 1,
+            waited_until_unix_ms: 2,
+            depth_at_start: Some(9),
+        },
+        QueueEvent {
+            request_id: "req-3".into(),
+            queue: "q".into(),
+            wait_us: 900,
+            waited_from_unix_ms: 2,
+            waited_until_unix_ms: 3,
+            depth_at_start: Some(9),
+        },
+    ];
+
+    let default_report = analyze_run(&run, AnalyzeOptions::default());
+    assert!(default_report.primary_suspect.score >= 85);
+    assert!(!default_report
+        .warnings
+        .iter()
+        .any(|w| w.contains("No runtime snapshots captured")));
+    assert!(default_report.analyzer_config.is_none());
+
+    let strict = AnalyzeOptions::default().with_confidence(|o| o.high_score_threshold = 95);
+    let strict_report = analyze_run(&run, strict);
+    assert!(strict_report.primary_suspect.score >= 85 && strict_report.primary_suspect.score < 95);
+    assert!(strict_report
+        .warnings
+        .iter()
+        .any(|w| w.contains("No runtime snapshots captured")));
+    assert!(strict_report.analyzer_config.is_some());
+}
+
+#[test]
 fn runtime_warning_emitted_when_insufficient_evidence() {
     let report = analyze_run(&test_run(), AnalyzeOptions::default());
     assert!(report
@@ -2584,7 +2632,7 @@ fn option_confidence_high_score_threshold_changes_scoring_suspect_bucket() {
         default_report.primary_suspect.kind,
         DiagnosisKind::ApplicationQueueSaturation
     );
-    assert_eq!(default_report.primary_suspect.score, 90);
+    assert!(default_report.primary_suspect.score >= 85);
     assert_eq!(default_report.primary_suspect.confidence, Confidence::High);
 
     let strict = AnalyzeOptions::default().with_confidence(|o| o.high_score_threshold = 91);
@@ -2593,7 +2641,7 @@ fn option_confidence_high_score_threshold_changes_scoring_suspect_bucket() {
         strict_report.primary_suspect.kind,
         DiagnosisKind::ApplicationQueueSaturation
     );
-    assert_eq!(strict_report.primary_suspect.score, 90);
+    assert!(strict_report.primary_suspect.score >= 85 && strict_report.primary_suspect.score < 95);
     assert_eq!(strict_report.primary_suspect.confidence, Confidence::Medium);
 }
 


### PR DESCRIPTION
### Motivation
- Ensure runtime-missing warning suppression follows configured analyzer semantics instead of a remaining hard-coded cutoff.  
- Prevent partial mutation of `AnalyzeOptions` when CLI overrides fail so the public override API is safe and atomic.  
- Preserve existing default behavior and analyzer-config transparency while closing issue 511 by making overrides transactional and adding focused tests.

### Description
- Replaced the hard-coded `>= 85` check in `analysis_warnings` with `options.confidence.high_score_threshold` so the runtime-missing warning suppression follows configured thresholds.  
- Made `AnalyzeOptions::apply_override` transactional by applying the change to a cloned temporary, validating it, and committing only on success.  
- Made `AnalyzeOptions::apply_overrides` transactional as a batch by applying all overrides to a temporary clone and committing the full set only if every override succeeds.  
- Added focused tests: a runtime-warning test validating default vs raised `confidence.high_score_threshold` behavior and analyzer_config presence, and override tests ensuring single-failure and batch-failure are transactional and repeated valid overrides commit the last value.  

### Testing
- Ran `cargo fmt --check` (passed).  
- Ran `cargo clippy --workspace --all-targets -- -D warnings` (passed).  
- Ran `cargo test --workspace` (all analyzer and workspace tests passed).  
- Ran `python3 scripts/validate_docs_contracts.py` (docs contract validation passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06cc849fd08330be0c8edbc6f15cdd)