### PR TITLE
Make analyzer confidence gate configurable and make overrides transactional

### DIFF
--- a/tailtriage-analyzer/src/lib.rs
+++ b/tailtriage-analyzer/src/lib.rs
@@ -603,7 +603,7 @@ fn analysis_warnings(run: &Run, suspects: &[Suspect], options: &AnalyzeOptions) 
     let strong_non_runtime_primary = suspects.first().is_some_and(|s| {
         (s.kind == DiagnosisKind::ApplicationQueueSaturation
             || s.kind == DiagnosisKind::DownstreamStageDominates)
-            && s.score >= 85
+            && s.score >= options.confidence.high_score_threshold
     });
 
     if run.runtime_snapshots.is_empty() {

--- a/tailtriage-analyzer/src/options/overrides.rs
+++ b/tailtriage-analyzer/src/options/overrides.rs
@@ -41,7 +41,7 @@ impl AnalyzeOptions {
         &VALID_OVERRIDE_PATHS
     }
 
-    /// Applies CLI overrides in order, validating after each applied override.
+    /// Applies CLI overrides in order as one transactional batch.
     ///
     /// # Errors
     /// Returns the first syntax, path, parse, or semantic validation error.
@@ -50,9 +50,11 @@ impl AnalyzeOptions {
         I: IntoIterator<Item = S>,
         S: AsRef<str>,
     {
+        let mut candidate = self.clone();
         for raw in overrides {
-            self.apply_override(raw.as_ref())?;
+            candidate.apply_override(raw.as_ref())?;
         }
+        *self = candidate;
         Ok(())
     }
 
@@ -71,8 +73,11 @@ impl AnalyzeOptions {
                 raw: raw.to_string(),
             });
         };
-        apply_override_path(self, path, value)?;
-        self.validate()
+        let mut candidate = self.clone();
+        apply_override_path(&mut candidate, path, value)?;
+        candidate.validate()?;
+        *self = candidate;
+        Ok(())
     }
 }
 
@@ -415,6 +420,61 @@ mod tests {
             })
         ));
     }
+
+    #[test]
+    fn apply_override_invalid_semantic_value_is_transactional() {
+        let mut opts = AnalyzeOptions::default();
+        let before = opts.route.breakdown_limit;
+        let err = opts
+            .apply_override("route.breakdown_limit=0")
+            .expect_err("must fail");
+        assert!(matches!(
+            err,
+            AnalyzeConfigError::InvalidConfigValue {
+                path: "route.breakdown_limit",
+                ..
+            }
+        ));
+        assert_eq!(opts.route.breakdown_limit, before);
+    }
+
+    #[test]
+    fn apply_override_invalid_path_is_transactional() {
+        let mut opts = AnalyzeOptions::default();
+        let before = opts.clone();
+        let err = opts.apply_override("bad.path=1").expect_err("must fail");
+        assert!(matches!(
+            err,
+            AnalyzeConfigError::UnknownOverridePath { .. }
+        ));
+        assert_eq!(opts, before);
+    }
+
+    #[test]
+    fn apply_overrides_is_transactional_when_later_override_fails() {
+        let mut opts = AnalyzeOptions::default();
+        let before = opts.clone();
+        let err = opts
+            .apply_overrides(["queueing.trigger_permille=450", "bad.path=1"])
+            .expect_err("must fail");
+        assert!(matches!(
+            err,
+            AnalyzeConfigError::UnknownOverridePath { .. }
+        ));
+        assert_eq!(opts, before);
+    }
+
+    #[test]
+    fn apply_overrides_repeated_valid_override_last_wins() {
+        let mut opts = AnalyzeOptions::default();
+        opts.apply_overrides([
+            "queueing.trigger_permille=350",
+            "queueing.trigger_permille=450",
+        ])
+        .expect("valid overrides");
+        assert_eq!(opts.queueing.trigger_permille, 450);
+    }
+
     #[test]
     fn apply_overrides_stops_on_first_error() {
         let mut opts = AnalyzeOptions::default();
@@ -429,7 +489,7 @@ mod tests {
             err,
             AnalyzeConfigError::UnknownOverridePath { .. }
         ));
-        assert_eq!(opts.queueing.trigger_permille, 450);
+        assert_eq!(opts.queueing.trigger_permille, 300);
         assert_eq!(opts.confidence.high_score_threshold, 85);
     }
 }

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -405,6 +405,50 @@ fn no_runtime_warning_not_emitted_for_clean_queue_primary() {
 }
 
 #[test]
+fn runtime_missing_warning_uses_configured_high_confidence_threshold() {
+    let mut run = test_run();
+    run.queues = vec![
+        QueueEvent {
+            request_id: "req-1".into(),
+            queue: "q".into(),
+            wait_us: 900,
+            waited_from_unix_ms: 0,
+            waited_until_unix_ms: 1,
+            depth_at_start: Some(9),
+        },
+        QueueEvent {
+            request_id: "req-2".into(),
+            queue: "q".into(),
+            wait_us: 900,
+            waited_from_unix_ms: 1,
+            waited_until_unix_ms: 2,
+            depth_at_start: Some(9),
+        },
+    ];
+
+    let default_report = analyze_run(&run, AnalyzeOptions::default());
+    assert_eq!(
+        default_report.primary_suspect.kind,
+        DiagnosisKind::ApplicationQueueSaturation
+    );
+    assert!(default_report.primary_suspect.score >= 85);
+    assert!(default_report.primary_suspect.score < 95);
+    assert!(!default_report
+        .warnings
+        .iter()
+        .any(|w| w.contains("No runtime snapshots captured")));
+    assert!(default_report.analyzer_config.is_none());
+
+    let strict_options = AnalyzeOptions::default().with_confidence(|o| o.high_score_threshold = 95);
+    let strict_report = analyze_run(&run, strict_options);
+    assert!(strict_report
+        .warnings
+        .iter()
+        .any(|w| w.contains("No runtime snapshots captured")));
+    assert!(strict_report.analyzer_config.is_some());
+}
+
+#[test]
 fn runtime_warning_emitted_when_insufficient_evidence() {
     let report = analyze_run(&test_run(), AnalyzeOptions::default());
     assert!(report


### PR DESCRIPTION
### Motivation

- Remove the remaining hard-coded confidence threshold used to suppress the "No runtime snapshots captured" warning so analyzer behavior follows configured confidence boundaries.
- Prevent partial/invalid `AnalyzeOptions` states when CLI/TOML overrides fail by making override application transactional at both single-override and batch levels.
- Close product-quality gaps from PR 518 and allow issue 511 to be closed after merge while preserving default behavior and analyzer-report transparency.

### Description

- Replaced the hard-coded `85` check in `analysis_warnings` with `options.confidence.high_score_threshold` so runtime-missing warning suppression honors `AnalyzeOptions`. (file: `tailtriage-analyzer/src/lib.rs`)
- Made `AnalyzeOptions::apply_override` transactional by applying the change to a clone, validating the clone, and committing only on success. (file: `tailtriage-analyzer/src/options/overrides.rs`)
- Made `AnalyzeOptions::apply_overrides` transactional as a batch by applying all overrides to a temporary clone and committing only if the full sequence succeeds; preserves ordered application and last-wins semantics for repeated paths. (file: `tailtriage-analyzer/src/options/overrides.rs`)
- Added focused tests for the new behaviors and updated one existing expectation to reflect all-or-nothing batch semantics: `runtime_missing_warning_uses_configured_high_confidence_threshold`, `apply_override_invalid_semantic_value_is_transactional`, `apply_override_invalid_path_is_transactional`, `apply_overrides_is_transactional_when_later_override_fails`, and `apply_overrides_repeated_valid_override_last_wins`. (file: `tailtriage-analyzer/src/tests.rs` and `.../options/overrides.rs` tests)
- Preserved report transparency: default `AnalyzeOptions::default()` continues to omit `analyzer_config` and non-default options still produce `analyzer_config` in reports.

### Testing

- Ran `cargo fmt --check` (passed).
- Ran `cargo clippy --workspace --all-targets -- -D warnings` (passed).
- Ran `cargo test --workspace` and all analyzer, workspace, and demo tests passed (including the new transactional and threshold tests).
- Ran `python3 scripts/validate_docs_contracts.py` (passed).
- Targeted tests added/verified: `runtime_missing_warning_uses_configured_high_confidence_threshold`, `apply_override_invalid_semantic_value_is_transactional`, `apply_override_invalid_path_is_transactional`, `apply_overrides_is_transactional_when_later_override_fails`, and `apply_overrides_repeated_valid_override_last_wins` (all succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06cc849fd08330be0c8edbc6f15cdd)