### PR TITLE
Add `tailtriage-tracing` workspace crate skeleton for tracing intake bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,6 +863,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "tailtriage-tracing"
+version = "0.2.0"
+dependencies = [
+ "serde",
+ "tailtriage-core",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "tailtriage-axum",
   "tailtriage-analyzer",
   "tailtriage-cli",
+  "tailtriage-tracing",
   "demos/demo_support",
   "demos/queue_service",
   "demos/blocking_service",
@@ -43,4 +44,5 @@ tailtriage-analyzer = { version = "0.2.0", path = "tailtriage-analyzer" }
 tailtriage-controller = { version = "0.2.0", path = "tailtriage-controller" }
 tailtriage-tokio = { version = "0.2.0", path = "tailtriage-tokio" }
 tailtriage-axum = { version = "0.2.0", path = "tailtriage-axum" }
+tailtriage-tracing = { version = "0.2.0", path = "tailtriage-tracing" }
 demo-support = { version = "0.2.0", path = "demos/demo_support" }

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ Most users should start with `tailtriage`.
 - [`tailtriage-axum`](../tailtriage-axum/README.md) — Axum middleware/extractor integration.
 - [`tailtriage-analyzer`](../tailtriage-analyzer/README.md) — in-process analysis of completed runs.
 - [`tailtriage-cli`](../tailtriage-cli/README.md) — command-line analysis of saved run artifacts.
+- [`tailtriage-tracing`](../tailtriage-tracing/README.md) — tracing-shaped intake bridge types and semantic conventions for future run import paths.
 
 ## Capture and analysis workflow
 

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "tailtriage-tracing"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+tailtriage-core.workspace = true
+serde = { version = "1", features = ["derive"] }

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -1,0 +1,23 @@
+# tailtriage-tracing
+
+`tailtriage-tracing` is the tracing intake bridge for `tailtriage`.
+
+This crate defines semantic-convention constants and import-facing data types that will be used to convert tracing-shaped span records into `tailtriage_core::Run`.
+
+## Scope (first slice)
+
+This crate currently provides:
+
+- `tt.*` semantic field-name constants
+- data types for span-like records and import options
+- warning and error types for future import workflows
+
+This crate does **not** yet provide:
+
+- JSONL parsing
+- a `tracing::Layer`
+- CLI commands
+- OpenTelemetry or OTLP intake/export
+- analyzer behavior changes
+
+`tailtriage-tracing` is not a tracing backend, not an observability platform, and not a replacement analyzer.

--- a/tailtriage-tracing/src/convention.rs
+++ b/tailtriage-tracing/src/convention.rs
@@ -1,0 +1,18 @@
+//! Semantic-convention keys for trace-shaped intake into tailtriage.
+
+/// Span kind key.
+pub const TT_KIND: &str = "tt.kind";
+/// Request identifier key.
+pub const TT_REQUEST_ID: &str = "tt.request_id";
+/// Route identifier key.
+pub const TT_ROUTE: &str = "tt.route";
+/// Stage identifier key.
+pub const TT_STAGE: &str = "tt.stage";
+/// Queue identifier key.
+pub const TT_QUEUE: &str = "tt.queue";
+/// Queue depth snapshot key.
+pub const TT_DEPTH_AT_START: &str = "tt.depth_at_start";
+/// Outcome key.
+pub const TT_OUTCOME: &str = "tt.outcome";
+/// Success flag key.
+pub const TT_SUCCESS: &str = "tt.success";

--- a/tailtriage-tracing/src/error.rs
+++ b/tailtriage-tracing/src/error.rs
@@ -1,0 +1,29 @@
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
+/// Import failure for trace-shaped intake conversion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImportError {
+    /// Required field was missing.
+    MissingField(&'static str),
+    /// Field value was invalid for conversion.
+    InvalidField { field: &'static str, reason: String },
+    /// Strict mode rejected input with warnings.
+    StrictModeRejected,
+}
+
+impl Display for ImportError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingField(field) => write!(f, "missing required field: {field}"),
+            Self::InvalidField { field, reason } => {
+                write!(f, "invalid field '{field}': {reason}")
+            }
+            Self::StrictModeRejected => {
+                write!(f, "strict import rejected input due to conversion warnings")
+            }
+        }
+    }
+}
+
+impl Error for ImportError {}

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -1,0 +1,82 @@
+//! Tracing intake bridge types for `tailtriage`.
+//!
+//! This crate defines semantic conventions and strongly typed import-facing structures
+//! that future functionality will use to convert trace-shaped spans into
+//! [`tailtriage_core::Run`].
+//!
+//! It currently does **not** implement JSONL parsing, a `tracing::Layer`, CLI commands,
+//! or OpenTelemetry/OTLP support.
+//!
+//! # Example
+//! ```
+//! use tailtriage_tracing::{SpanRecord, TT_KIND, TT_REQUEST_ID, TT_ROUTE};
+//!
+//! let span = SpanRecord::new("request", 1_700_000_000_000, 1_700_000_000_010)
+//!     .field(TT_KIND, "request")
+//!     .field(TT_REQUEST_ID, "req-42")
+//!     .field(TT_ROUTE, "/checkout");
+//!
+//! assert_eq!(span.name(), "request");
+//! ```
+
+mod convention;
+mod error;
+mod types;
+
+pub use convention::{
+    TT_DEPTH_AT_START, TT_KIND, TT_OUTCOME, TT_QUEUE, TT_REQUEST_ID, TT_ROUTE, TT_STAGE, TT_SUCCESS,
+};
+pub use error::ImportError;
+pub use types::{FieldValue, ImportOptions, ImportWarning, ImportedRun, SpanKind, SpanRecord};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constants_match_contract() {
+        assert_eq!(TT_KIND, "tt.kind");
+        assert_eq!(TT_REQUEST_ID, "tt.request_id");
+        assert_eq!(TT_ROUTE, "tt.route");
+        assert_eq!(TT_STAGE, "tt.stage");
+        assert_eq!(TT_QUEUE, "tt.queue");
+        assert_eq!(TT_DEPTH_AT_START, "tt.depth_at_start");
+        assert_eq!(TT_OUTCOME, "tt.outcome");
+        assert_eq!(TT_SUCCESS, "tt.success");
+    }
+
+    #[test]
+    fn span_record_builder_stores_fields() {
+        let span = SpanRecord::new("queue_wait", 10, 20)
+            .field(TT_KIND, "queue")
+            .field(TT_QUEUE, "checkout")
+            .field(TT_DEPTH_AT_START, 5_u64);
+        assert_eq!(
+            span.fields().get(TT_KIND),
+            Some(&FieldValue::String("queue".to_owned()))
+        );
+        assert_eq!(
+            span.fields().get(TT_DEPTH_AT_START),
+            Some(&FieldValue::U64(5))
+        );
+    }
+
+    #[test]
+    fn import_options_builder_sets_values() {
+        let opts = ImportOptions::new("checkout-service")
+            .service_version("1.2.3")
+            .run_id("run-99")
+            .strict(true);
+
+        assert_eq!(opts.service_name(), "checkout-service");
+        assert_eq!(opts.service_version_value(), Some("1.2.3"));
+        assert_eq!(opts.run_id_value(), Some("run-99"));
+        assert!(opts.strict_mode());
+    }
+
+    #[test]
+    fn import_warning_display_uses_message() {
+        let warning = ImportWarning::new("missing optional tt.route");
+        assert_eq!(warning.to_string(), "missing optional tt.route");
+    }
+}

--- a/tailtriage-tracing/src/types.rs
+++ b/tailtriage-tracing/src/types.rs
@@ -1,0 +1,220 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Canonical kind for a span-like record used during import.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SpanKind {
+    /// Request lifecycle span.
+    Request,
+    /// Application stage span.
+    Stage,
+    /// Queue wait span.
+    Queue,
+}
+
+/// Scalar field value captured from a span-like record.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum FieldValue {
+    /// String value.
+    String(String),
+    /// Boolean value.
+    Bool(bool),
+    /// Unsigned integer value.
+    U64(u64),
+    /// Signed integer value.
+    I64(i64),
+    /// Floating-point value.
+    F64(f64),
+    /// Explicit null.
+    Null,
+}
+
+impl From<&str> for FieldValue {
+    fn from(value: &str) -> Self {
+        Self::String(value.to_owned())
+    }
+}
+impl From<String> for FieldValue {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+impl From<bool> for FieldValue {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+impl From<u64> for FieldValue {
+    fn from(value: u64) -> Self {
+        Self::U64(value)
+    }
+}
+impl From<i64> for FieldValue {
+    fn from(value: i64) -> Self {
+        Self::I64(value)
+    }
+}
+impl From<f64> for FieldValue {
+    fn from(value: f64) -> Self {
+        Self::F64(value)
+    }
+}
+
+/// Span-like record that future import paths will convert into tailtriage events.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SpanRecord {
+    id: Option<String>,
+    parent_id: Option<String>,
+    name: String,
+    fields: BTreeMap<String, FieldValue>,
+    started_at_unix_ms: u64,
+    finished_at_unix_ms: u64,
+}
+
+impl SpanRecord {
+    /// Create a span-like record with no id, parent id, or fields.
+    #[must_use]
+    pub fn new(name: impl Into<String>, started_at_unix_ms: u64, finished_at_unix_ms: u64) -> Self {
+        Self {
+            id: None,
+            parent_id: None,
+            name: name.into(),
+            fields: BTreeMap::new(),
+            started_at_unix_ms,
+            finished_at_unix_ms,
+        }
+    }
+
+    /// Add or replace a field on this record.
+    #[must_use]
+    pub fn field(mut self, key: impl Into<String>, value: impl Into<FieldValue>) -> Self {
+        self.fields.insert(key.into(), value.into());
+        self
+    }
+
+    #[must_use]
+    pub fn id(&self) -> Option<&str> {
+        self.id.as_deref()
+    }
+    #[must_use]
+    pub fn parent_id(&self) -> Option<&str> {
+        self.parent_id.as_deref()
+    }
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+    #[must_use]
+    pub fn fields(&self) -> &BTreeMap<String, FieldValue> {
+        &self.fields
+    }
+    #[must_use]
+    pub fn started_at_unix_ms(&self) -> u64 {
+        self.started_at_unix_ms
+    }
+    #[must_use]
+    pub fn finished_at_unix_ms(&self) -> u64 {
+        self.finished_at_unix_ms
+    }
+}
+
+/// Import configuration for converting trace-shaped input into a run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportOptions {
+    service_name: String,
+    service_version: Option<String>,
+    run_id: Option<String>,
+    strict: bool,
+}
+
+impl ImportOptions {
+    /// Create options with a required service name.
+    #[must_use]
+    pub fn new(service_name: impl Into<String>) -> Self {
+        Self {
+            service_name: service_name.into(),
+            service_version: None,
+            run_id: None,
+            strict: false,
+        }
+    }
+
+    #[must_use]
+    pub fn strict(mut self, strict: bool) -> Self {
+        self.strict = strict;
+        self
+    }
+    #[must_use]
+    pub fn run_id(mut self, run_id: impl Into<String>) -> Self {
+        self.run_id = Some(run_id.into());
+        self
+    }
+    #[must_use]
+    pub fn service_version(mut self, service_version: impl Into<String>) -> Self {
+        self.service_version = Some(service_version.into());
+        self
+    }
+
+    #[must_use]
+    pub fn service_name(&self) -> &str {
+        &self.service_name
+    }
+    #[must_use]
+    pub fn service_version_value(&self) -> Option<&str> {
+        self.service_version.as_deref()
+    }
+    #[must_use]
+    pub fn run_id_value(&self) -> Option<&str> {
+        self.run_id.as_deref()
+    }
+    #[must_use]
+    pub fn strict_mode(&self) -> bool {
+        self.strict
+    }
+}
+
+/// Non-fatal import note.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportWarning {
+    message: String,
+}
+impl ImportWarning {
+    #[must_use]
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+    #[must_use]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+impl std::fmt::Display for ImportWarning {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+/// Result container for conversion output.
+#[derive(Debug, Clone)]
+pub struct ImportedRun {
+    run: tailtriage_core::Run,
+    warnings: Vec<ImportWarning>,
+}
+
+impl ImportedRun {
+    #[must_use]
+    pub fn new(run: tailtriage_core::Run, warnings: Vec<ImportWarning>) -> Self {
+        Self { run, warnings }
+    }
+    #[must_use]
+    pub fn run(&self) -> &tailtriage_core::Run {
+        &self.run
+    }
+    #[must_use]
+    pub fn warnings(&self) -> &[ImportWarning] {
+        &self.warnings
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a focused first slice for a tracing-shaped intake bridge that will convert trace-like spans into `tailtriage_core::Run` without implementing import runtime or protocol concerns yet.
- Establish a minimal, well-documented crate surface with semantic-convention keys and typed import-facing primitives to guide future import/Layer/OTel work.

### Description
- Add a new workspace member crate `tailtriage-tracing` and register it in the root `Cargo.toml` with a minimal dependency set (`tailtriage-core` + `serde` derive). 
- Implement semantic-convention constants (`TT_KIND`, `TT_REQUEST_ID`, `TT_ROUTE`, `TT_STAGE`, `TT_QUEUE`, `TT_DEPTH_AT_START`, `TT_OUTCOME`, `TT_SUCCESS`) in `convention.rs` and re-export them from `lib.rs`.
- Add typed public data types and helpers in `types.rs`: `SpanKind`, `FieldValue`, `SpanRecord` with `new` and `field` builders, `ImportOptions` with `new`, `strict`, `run_id`, and `service_version` builders and accessors, `ImportedRun`, and `ImportWarning` with `Display`.
- Add manual `ImportError` enum with `Display` + `std::error::Error` impl in `error.rs` (no `thiserror`).
- Add crate `README.md` and crate-level docs in `lib.rs` explaining scope and non-goals (no JSONL parsing, no `tracing::Layer`, no CLI, no OTel/OTLP, no analyzer changes), and update `docs/README.md` to include the new crate link.

### Testing
- Ran `cargo fmt --check` and formatting checks passed. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and there were no lints/warnings left as errors. 
- Ran `cargo test --workspace` which executed workspace tests including new unit tests `constants_match_contract`, `span_record_builder_stores_fields`, `import_options_builder_sets_values`, and `import_warning_display_uses_message`, all of which passed. 
- Ran `python3 scripts/validate_docs_contracts.py` and documentation contract validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06e8b2b94083309783e9dd401a4df7)