### PR TITLE
Add tailtriage-tracing crate skeleton and intake public types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,6 +863,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "tailtriage-tracing"
+version = "0.2.0"
+dependencies = [
+ "serde",
+ "tailtriage-core",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "tailtriage-axum",
   "tailtriage-analyzer",
   "tailtriage-cli",
+  "tailtriage-tracing",
   "demos/demo_support",
   "demos/queue_service",
   "demos/blocking_service",
@@ -43,4 +44,5 @@ tailtriage-analyzer = { version = "0.2.0", path = "tailtriage-analyzer" }
 tailtriage-controller = { version = "0.2.0", path = "tailtriage-controller" }
 tailtriage-tokio = { version = "0.2.0", path = "tailtriage-tokio" }
 tailtriage-axum = { version = "0.2.0", path = "tailtriage-axum" }
+tailtriage-tracing = { version = "0.2.0", path = "tailtriage-tracing" }
 demo-support = { version = "0.2.0", path = "demos/demo_support" }

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "tailtriage-tracing"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Tracing intake bridge types and semantic conventions for tailtriage"
+documentation = "https://docs.rs/tailtriage-tracing"
+readme = "README.md"
+keywords = ["tokio", "latency", "tracing", "diagnostics", "triage"]
+categories = ["asynchronous", "development-tools::profiling", "development-tools::debugging"]
+include = [
+  "Cargo.toml",
+  "README.md",
+  "LICENSE",
+  "src/**",
+]
+
+[dependencies]
+tailtriage-core.workspace = true
+serde = { version = "1", features = ["derive"] }
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -1,0 +1,22 @@
+# tailtriage-tracing
+
+`tailtriage-tracing` is the tracing intake bridge for `tailtriage`.
+
+It defines the data model and semantic convention keys for span-shaped inputs that can be converted into `tailtriage_core::Run` artifacts.
+
+## Current scope
+
+This crate currently provides:
+
+- semantic convention constants for `tt.*` fields
+- span record and import option data types
+- warnings and import error types for future import flows
+
+This crate does **not** yet provide:
+
+- JSONL parsing
+- live `tracing` Layer capture
+- OpenTelemetry or OTLP import/export
+- analyzer changes
+
+The goal is to keep a narrow triage-focused intake surface that complements `tailtriage` diagnostics, without becoming a tracing backend or observability platform.

--- a/tailtriage-tracing/src/convention.rs
+++ b/tailtriage-tracing/src/convention.rs
@@ -1,0 +1,35 @@
+//! Semantic convention keys for `tailtriage` tracing intake.
+
+/// Span kind marker field key.
+pub const TT_KIND: &str = "tt.kind";
+/// Logical request identifier field key.
+pub const TT_REQUEST_ID: &str = "tt.request_id";
+/// Route or endpoint field key.
+pub const TT_ROUTE: &str = "tt.route";
+/// Stage name field key.
+pub const TT_STAGE: &str = "tt.stage";
+/// Queue name field key.
+pub const TT_QUEUE: &str = "tt.queue";
+/// Queue depth snapshot field key captured at queue wait start.
+pub const TT_DEPTH_AT_START: &str = "tt.depth_at_start";
+/// Outcome field key for request completion.
+pub const TT_OUTCOME: &str = "tt.outcome";
+/// Success indicator field key.
+pub const TT_SUCCESS: &str = "tt.success";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tt_semantic_keys_match_expected_values() {
+        assert_eq!(TT_KIND, "tt.kind");
+        assert_eq!(TT_REQUEST_ID, "tt.request_id");
+        assert_eq!(TT_ROUTE, "tt.route");
+        assert_eq!(TT_STAGE, "tt.stage");
+        assert_eq!(TT_QUEUE, "tt.queue");
+        assert_eq!(TT_DEPTH_AT_START, "tt.depth_at_start");
+        assert_eq!(TT_OUTCOME, "tt.outcome");
+        assert_eq!(TT_SUCCESS, "tt.success");
+    }
+}

--- a/tailtriage-tracing/src/error.rs
+++ b/tailtriage-tracing/src/error.rs
@@ -1,0 +1,24 @@
+use std::fmt;
+
+/// Error returned by tracing import operations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImportError {
+    /// Input data was malformed for import.
+    InvalidInput(String),
+    /// Strict mode rejected non-conforming input.
+    StrictViolation(String),
+    /// Failed to construct an output run.
+    RunBuild(String),
+}
+
+impl fmt::Display for ImportError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidInput(message) => write!(f, "invalid tracing input: {message}"),
+            Self::StrictViolation(message) => write!(f, "strict import violation: {message}"),
+            Self::RunBuild(message) => write!(f, "failed to build run artifact: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for ImportError {}

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -1,0 +1,33 @@
+#![doc = include_str!("../README.md")]
+#![warn(missing_docs)]
+
+//! Tracing intake bridge types for `tailtriage` triage workflows.
+//!
+//! This crate defines semantic keys and span-shaped intake data that future
+//! conversion utilities can map into [`tailtriage_core::Run`].
+//!
+//! It intentionally does not implement JSONL parsing, live recording, OpenTelemetry,
+//! or OTLP in this first slice.
+//!
+//! # Example
+//!
+//! ```
+//! use tailtriage_tracing::{FieldValue, SpanRecord, TT_KIND, TT_REQUEST_ID, TT_SUCCESS};
+//!
+//! let record = SpanRecord::new("http.request", 1_700_000_000_000, 1_700_000_000_120)
+//!     .field(TT_KIND, FieldValue::String("request".to_string()))
+//!     .field(TT_REQUEST_ID, FieldValue::String("req-42".to_string()))
+//!     .field(TT_SUCCESS, FieldValue::Bool(true));
+//!
+//! assert_eq!(record.fields().len(), 3);
+//! ```
+
+mod convention;
+mod error;
+mod types;
+
+pub use convention::{
+    TT_DEPTH_AT_START, TT_KIND, TT_OUTCOME, TT_QUEUE, TT_REQUEST_ID, TT_ROUTE, TT_STAGE, TT_SUCCESS,
+};
+pub use error::ImportError;
+pub use types::{FieldValue, ImportOptions, ImportWarning, ImportedRun, SpanKind, SpanRecord};

--- a/tailtriage-tracing/src/types.rs
+++ b/tailtriage-tracing/src/types.rs
@@ -1,0 +1,264 @@
+use std::collections::BTreeMap;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Supported `tt.kind` values for span records.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SpanKind {
+    /// A request-level span.
+    Request,
+    /// A stage-level span.
+    Stage,
+    /// A queue-level span.
+    Queue,
+}
+
+/// Scalar field value captured on an imported span.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum FieldValue {
+    /// UTF-8 string field value.
+    String(String),
+    /// Boolean field value.
+    Bool(bool),
+    /// Unsigned integer field value.
+    U64(u64),
+    /// Signed integer field value.
+    I64(i64),
+    /// Floating-point field value.
+    F64(f64),
+    /// Explicit null value.
+    Null,
+}
+
+/// Minimal span-shaped record for future tracing intake conversion.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SpanRecord {
+    id: Option<String>,
+    parent_id: Option<String>,
+    name: String,
+    fields: BTreeMap<String, FieldValue>,
+    started_at_unix_ms: u64,
+    finished_at_unix_ms: u64,
+}
+
+impl SpanRecord {
+    /// Creates a new span record with required timing fields.
+    pub fn new(name: impl Into<String>, started_at_unix_ms: u64, finished_at_unix_ms: u64) -> Self {
+        Self {
+            id: None,
+            parent_id: None,
+            name: name.into(),
+            fields: BTreeMap::new(),
+            started_at_unix_ms,
+            finished_at_unix_ms,
+        }
+    }
+
+    /// Adds or replaces a field and returns the updated record.
+    #[must_use]
+    pub fn field(mut self, key: impl Into<String>, value: FieldValue) -> Self {
+        self.fields.insert(key.into(), value);
+        self
+    }
+
+    /// Sets the optional span id.
+    #[must_use]
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = Some(id.into());
+        self
+    }
+
+    /// Sets the optional parent span id.
+    #[must_use]
+    pub fn parent_id(mut self, parent_id: impl Into<String>) -> Self {
+        self.parent_id = Some(parent_id.into());
+        self
+    }
+
+    /// Returns the optional span id.
+    #[must_use]
+    pub fn id_ref(&self) -> Option<&str> {
+        self.id.as_deref()
+    }
+    /// Returns the optional parent span id.
+    #[must_use]
+    pub fn parent_id_ref(&self) -> Option<&str> {
+        self.parent_id.as_deref()
+    }
+    /// Returns the span name.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+    /// Returns all span fields.
+    #[must_use]
+    pub fn fields(&self) -> &BTreeMap<String, FieldValue> {
+        &self.fields
+    }
+    /// Returns span start time in Unix milliseconds.
+    #[must_use]
+    pub fn started_at_unix_ms(&self) -> u64 {
+        self.started_at_unix_ms
+    }
+    /// Returns span end time in Unix milliseconds.
+    #[must_use]
+    pub fn finished_at_unix_ms(&self) -> u64 {
+        self.finished_at_unix_ms
+    }
+}
+
+/// Import configuration for converting span-shaped input into a run artifact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportOptions {
+    service_name: String,
+    service_version: Option<String>,
+    run_id: Option<String>,
+    strict: bool,
+}
+
+impl ImportOptions {
+    /// Creates options with a required service name.
+    pub fn new(service_name: impl Into<String>) -> Self {
+        Self {
+            service_name: service_name.into(),
+            service_version: None,
+            run_id: None,
+            strict: false,
+        }
+    }
+
+    /// Enables or disables strict import mode.
+    #[must_use]
+    pub fn strict(mut self, strict: bool) -> Self {
+        self.strict = strict;
+        self
+    }
+
+    /// Sets an explicit run id.
+    #[must_use]
+    pub fn run_id(mut self, run_id: impl Into<String>) -> Self {
+        self.run_id = Some(run_id.into());
+        self
+    }
+
+    /// Sets an optional service version label.
+    #[must_use]
+    pub fn service_version(mut self, service_version: impl Into<String>) -> Self {
+        self.service_version = Some(service_version.into());
+        self
+    }
+
+    /// Returns the configured service name.
+    #[must_use]
+    pub fn service_name(&self) -> &str {
+        &self.service_name
+    }
+    /// Returns the configured optional service version.
+    #[must_use]
+    pub fn service_version_ref(&self) -> Option<&str> {
+        self.service_version.as_deref()
+    }
+    /// Returns the configured optional run id.
+    #[must_use]
+    pub fn run_id_ref(&self) -> Option<&str> {
+        self.run_id.as_deref()
+    }
+    /// Returns whether strict mode is enabled.
+    #[must_use]
+    pub fn strict_enabled(&self) -> bool {
+        self.strict
+    }
+}
+
+/// Warning surfaced by import workflows while still producing output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportWarning {
+    message: String,
+}
+
+impl ImportWarning {
+    /// Creates a warning message.
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+    /// Returns the warning text.
+    #[must_use]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl fmt::Display for ImportWarning {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+/// Result of a future tracing import conversion.
+#[derive(Debug, Clone)]
+pub struct ImportedRun {
+    run: tailtriage_core::Run,
+    warnings: Vec<ImportWarning>,
+}
+
+impl ImportedRun {
+    /// Creates an imported run value from a run and warnings.
+    #[must_use]
+    pub fn new(run: tailtriage_core::Run, warnings: Vec<ImportWarning>) -> Self {
+        Self { run, warnings }
+    }
+
+    /// Returns the converted run artifact.
+    #[must_use]
+    pub fn run(&self) -> &tailtriage_core::Run {
+        &self.run
+    }
+
+    /// Returns non-fatal import warnings.
+    #[must_use]
+    pub fn warnings(&self) -> &[ImportWarning] {
+        &self.warnings
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn span_record_builder_stores_fields() {
+        let record = SpanRecord::new("request", 10, 20)
+            .id("span-1")
+            .parent_id("root")
+            .field("tt.request_id", FieldValue::String("req-1".to_string()))
+            .field("tt.success", FieldValue::Bool(true));
+
+        assert_eq!(record.id_ref(), Some("span-1"));
+        assert_eq!(record.parent_id_ref(), Some("root"));
+        assert_eq!(record.fields().len(), 2);
+    }
+
+    #[test]
+    fn import_options_builder_sets_flags() {
+        let options = ImportOptions::new("checkout")
+            .service_version("1.2.3")
+            .run_id("run-123")
+            .strict(true);
+
+        assert_eq!(options.service_name(), "checkout");
+        assert_eq!(options.service_version_ref(), Some("1.2.3"));
+        assert_eq!(options.run_id_ref(), Some("run-123"));
+        assert!(options.strict_enabled());
+    }
+
+    #[test]
+    fn import_warning_display_matches_message() {
+        let warning = ImportWarning::new("missing parent_id");
+        assert_eq!(warning.to_string(), "missing parent_id");
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide the first slice of issue #510 by adding a new workspace crate `tailtriage-tracing` to host tracing intake types and semantic conventions as a narrow bridge into `tailtriage_core::Run`.
- Keep scope minimal and triage-focused: no JSONL parsing, no live `tracing` Layer capture, no OTel/OTLP, and no analyzer or CLI changes in this PR.

### Description
- Add new workspace member and dependency entry `tailtriage-tracing` and a crate manifest with only `tailtriage-core` and `serde` as dependencies.
- Introduce semantic convention constants: `TT_KIND`, `TT_REQUEST_ID`, `TT_ROUTE`, `TT_STAGE`, `TT_QUEUE`, `TT_DEPTH_AT_START`, `TT_OUTCOME`, and `TT_SUCCESS`.
- Add public data types and APIs: `SpanKind`, `FieldValue`, `SpanRecord` (with `new`, `field`, `id`, `parent_id`, and accessors), `ImportOptions` (with `new`, `strict`, `run_id`, `service_version`, and accessors), `ImportWarning`, and `ImportedRun` (with `new`, `run`, `warnings`).
- Add `ImportError` enum with a manual `Display` and `Error` impl (no `thiserror`), and documentation clarifying the crate is an intake bridge that will map span-shaped inputs into `tailtriage_core::Run` in future work.
- Include crate `README.md`, rustdoc examples showing intended `tt.*` usage, and focused unit tests for constants and builder/accessor behavior.

### Testing
- Ran `cargo fmt --check` and it succeeded.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it succeeded with no warnings or errors.
- Ran `cargo test --workspace` and all unit tests and doc-tests passed, including the new tests in `tailtriage-tracing` validating constants, `SpanRecord` builder, `ImportOptions` builder, and `ImportWarning` display.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06e8b2b94083309783e9dd401a4df7)