### PR TITLE
Add tailtriage-tracing workspace crate skeleton for tracing intake bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,6 +863,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "tailtriage-tracing"
+version = "0.2.0"
+dependencies = [
+ "serde",
+ "tailtriage-core",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "tailtriage-axum",
   "tailtriage-analyzer",
   "tailtriage-cli",
+  "tailtriage-tracing",
   "demos/demo_support",
   "demos/queue_service",
   "demos/blocking_service",
@@ -43,4 +44,6 @@ tailtriage-analyzer = { version = "0.2.0", path = "tailtriage-analyzer" }
 tailtriage-controller = { version = "0.2.0", path = "tailtriage-controller" }
 tailtriage-tokio = { version = "0.2.0", path = "tailtriage-tokio" }
 tailtriage-axum = { version = "0.2.0", path = "tailtriage-axum" }
+tailtriage-tracing = { version = "0.2.0", path = "tailtriage-tracing" }
 demo-support = { version = "0.2.0", path = "demos/demo_support" }
+serde = { version = "1", features = ["derive"] }

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ Most users should start with `tailtriage`.
 - [`tailtriage-axum`](../tailtriage-axum/README.md) — Axum middleware/extractor integration.
 - [`tailtriage-analyzer`](../tailtriage-analyzer/README.md) — in-process analysis of completed runs.
 - [`tailtriage-cli`](../tailtriage-cli/README.md) — command-line analysis of saved run artifacts.
+- [`tailtriage-tracing`](../tailtriage-tracing/README.md) — tracing-shaped intake data types and semantic conventions for future run import; no JSONL/layer/OTel bridge implementation yet.
 
 ## Capture and analysis workflow
 

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "tailtriage-tracing"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+tailtriage-core.workspace = true
+serde = { version = "1", features = ["derive"] }

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -1,0 +1,23 @@
+# tailtriage-tracing
+
+`tailtriage-tracing` is a focused tracing intake bridge for `tailtriage`.
+
+This crate defines public semantic convention constants and typed intake records that will be converted into `tailtriage_core::Run`.
+
+## Scope in this first slice
+
+This crate currently provides:
+
+- `tt.*` semantic convention constants
+- span and import data types
+- import option and warning/error scaffolding
+
+This crate does **not** yet provide:
+
+- JSONL parsing
+- live `tracing` subscriber/layer recording
+- OpenTelemetry/OTLP ingestion or export
+- CLI commands
+- analyzer behavior changes
+
+`tailtriage-tracing` is not a tracing backend and not an observability platform. It exists to help triage workflows by bridging tracing-shaped span data into the `tailtriage` run schema.

--- a/tailtriage-tracing/src/convention.rs
+++ b/tailtriage-tracing/src/convention.rs
@@ -1,0 +1,18 @@
+//! Semantic convention keys for tracing intake fields.
+
+/// Span kind field key (`request`, `stage`, or `queue`).
+pub const TT_KIND: &str = "tt.kind";
+/// Request identifier field key.
+pub const TT_REQUEST_ID: &str = "tt.request_id";
+/// Route or operation name field key.
+pub const TT_ROUTE: &str = "tt.route";
+/// Stage name field key.
+pub const TT_STAGE: &str = "tt.stage";
+/// Queue name field key.
+pub const TT_QUEUE: &str = "tt.queue";
+/// Queue depth-at-start field key.
+pub const TT_DEPTH_AT_START: &str = "tt.depth_at_start";
+/// Outcome text field key.
+pub const TT_OUTCOME: &str = "tt.outcome";
+/// Success boolean field key.
+pub const TT_SUCCESS: &str = "tt.success";

--- a/tailtriage-tracing/src/error.rs
+++ b/tailtriage-tracing/src/error.rs
@@ -1,0 +1,24 @@
+//! Error types for tracing intake import scaffolding.
+
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
+/// Import errors for tracing intake conversion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImportError {
+    /// Input data is malformed for conversion.
+    InvalidInput(String),
+    /// Input data is missing a required field.
+    MissingField(&'static str),
+}
+
+impl Display for ImportError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidInput(message) => write!(f, "invalid import input: {message}"),
+            Self::MissingField(field) => write!(f, "missing required field: {field}"),
+        }
+    }
+}
+
+impl Error for ImportError {}

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -1,0 +1,79 @@
+//! `tailtriage-tracing` provides tracing intake bridge types for `tailtriage` triage workflows.
+//!
+//! This crate defines semantic convention constants and typed span records that will be
+//! converted into [`tailtriage_core::Run`] in later slices.
+//!
+//! It does **not** currently implement JSONL parsing, live tracing layers, CLI integration,
+//! or OpenTelemetry/OTLP ingestion.
+//!
+//! # Example
+//! ```
+//! use tailtriage_tracing::{FieldValue, SpanRecord, TT_KIND, TT_REQUEST_ID, TT_ROUTE};
+//!
+//! let span = SpanRecord::new("http.request", 1_700_000_000_000, 1_700_000_000_120)
+//!     .field(TT_KIND, FieldValue::String("request".into()))
+//!     .field(TT_REQUEST_ID, FieldValue::String("req-42".into()))
+//!     .field(TT_ROUTE, FieldValue::String("GET /items/:id".into()));
+//!
+//! assert_eq!(span.name(), "http.request");
+//! ```
+
+mod convention;
+mod error;
+mod types;
+
+pub use convention::*;
+pub use error::ImportError;
+pub use types::{FieldValue, ImportOptions, ImportWarning, ImportedRun, SpanKind, SpanRecord};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constants_match_expected_keys() {
+        assert_eq!(TT_KIND, "tt.kind");
+        assert_eq!(TT_REQUEST_ID, "tt.request_id");
+        assert_eq!(TT_ROUTE, "tt.route");
+        assert_eq!(TT_STAGE, "tt.stage");
+        assert_eq!(TT_QUEUE, "tt.queue");
+        assert_eq!(TT_DEPTH_AT_START, "tt.depth_at_start");
+        assert_eq!(TT_OUTCOME, "tt.outcome");
+        assert_eq!(TT_SUCCESS, "tt.success");
+    }
+
+    #[test]
+    fn span_record_builder_stores_fields() {
+        let span = SpanRecord::new("work", 10, 20)
+            .field(TT_KIND, FieldValue::String("stage".to_string()))
+            .field(TT_SUCCESS, FieldValue::Bool(true));
+
+        assert_eq!(span.name(), "work");
+        assert_eq!(span.started_at_unix_ms(), 10);
+        assert_eq!(span.finished_at_unix_ms(), 20);
+        assert_eq!(
+            span.fields().get(TT_KIND),
+            Some(&FieldValue::String("stage".to_string()))
+        );
+        assert_eq!(span.fields().get(TT_SUCCESS), Some(&FieldValue::Bool(true)));
+    }
+
+    #[test]
+    fn import_options_builder_sets_values() {
+        let options = ImportOptions::new("checkout")
+            .service_version("1.2.3")
+            .run_id("run-123")
+            .strict(true);
+
+        assert_eq!(options.service_name(), "checkout");
+        assert_eq!(options.service_version_ref(), Some("1.2.3"));
+        assert_eq!(options.run_id_ref(), Some("run-123"));
+        assert!(options.strict_mode());
+    }
+
+    #[test]
+    fn import_warning_display_is_message() {
+        let warning = ImportWarning::new("missing optional field: tt.route");
+        assert_eq!(warning.to_string(), "missing optional field: tt.route");
+    }
+}

--- a/tailtriage-tracing/src/types.rs
+++ b/tailtriage-tracing/src/types.rs
@@ -1,0 +1,188 @@
+//! Public intake types for tracing-shaped span records.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fmt::{Display, Formatter};
+
+/// The semantic category of a span record in tailtriage intake.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SpanKind {
+    /// Request-level span.
+    Request,
+    /// Stage-level span.
+    Stage,
+    /// Queue-level span.
+    Queue,
+}
+
+/// Typed field values captured on imported span records.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum FieldValue {
+    String(String),
+    Bool(bool),
+    U64(u64),
+    I64(i64),
+    F64(f64),
+    Null,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SpanRecord {
+    id: Option<String>,
+    parent_id: Option<String>,
+    name: String,
+    fields: BTreeMap<String, FieldValue>,
+    started_at_unix_ms: u64,
+    finished_at_unix_ms: u64,
+}
+
+impl SpanRecord {
+    #[must_use]
+    pub fn new(name: impl Into<String>, started_at_unix_ms: u64, finished_at_unix_ms: u64) -> Self {
+        Self {
+            id: None,
+            parent_id: None,
+            name: name.into(),
+            fields: BTreeMap::new(),
+            started_at_unix_ms,
+            finished_at_unix_ms,
+        }
+    }
+    #[must_use]
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = Some(id.into());
+        self
+    }
+    #[must_use]
+    pub fn parent_id(mut self, parent_id: impl Into<String>) -> Self {
+        self.parent_id = Some(parent_id.into());
+        self
+    }
+    #[must_use]
+    pub fn field(mut self, key: impl Into<String>, value: FieldValue) -> Self {
+        self.fields.insert(key.into(), value);
+        self
+    }
+
+    #[must_use]
+    pub fn id_ref(&self) -> Option<&str> {
+        self.id.as_deref()
+    }
+    #[must_use]
+    pub fn parent_id_ref(&self) -> Option<&str> {
+        self.parent_id.as_deref()
+    }
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+    #[must_use]
+    pub fn fields(&self) -> &BTreeMap<String, FieldValue> {
+        &self.fields
+    }
+    #[must_use]
+    pub fn started_at_unix_ms(&self) -> u64 {
+        self.started_at_unix_ms
+    }
+    #[must_use]
+    pub fn finished_at_unix_ms(&self) -> u64 {
+        self.finished_at_unix_ms
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ImportOptions {
+    service_name: String,
+    service_version: Option<String>,
+    run_id: Option<String>,
+    strict: bool,
+}
+
+impl ImportOptions {
+    #[must_use]
+    pub fn new(service_name: impl Into<String>) -> Self {
+        Self {
+            service_name: service_name.into(),
+            service_version: None,
+            run_id: None,
+            strict: false,
+        }
+    }
+    #[must_use]
+    pub fn strict(mut self, strict: bool) -> Self {
+        self.strict = strict;
+        self
+    }
+    #[must_use]
+    pub fn run_id(mut self, run_id: impl Into<String>) -> Self {
+        self.run_id = Some(run_id.into());
+        self
+    }
+    #[must_use]
+    pub fn service_version(mut self, service_version: impl Into<String>) -> Self {
+        self.service_version = Some(service_version.into());
+        self
+    }
+
+    #[must_use]
+    pub fn service_name(&self) -> &str {
+        &self.service_name
+    }
+    #[must_use]
+    pub fn service_version_ref(&self) -> Option<&str> {
+        self.service_version.as_deref()
+    }
+    #[must_use]
+    pub fn run_id_ref(&self) -> Option<&str> {
+        self.run_id.as_deref()
+    }
+    #[must_use]
+    pub fn strict_mode(&self) -> bool {
+        self.strict
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ImportedRun {
+    run: tailtriage_core::Run,
+    warnings: Vec<ImportWarning>,
+}
+
+impl ImportedRun {
+    #[must_use]
+    pub fn new(run: tailtriage_core::Run, warnings: Vec<ImportWarning>) -> Self {
+        Self { run, warnings }
+    }
+    #[must_use]
+    pub fn run(&self) -> &tailtriage_core::Run {
+        &self.run
+    }
+    #[must_use]
+    pub fn warnings(&self) -> &[ImportWarning] {
+        &self.warnings
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ImportWarning {
+    message: String,
+}
+
+impl ImportWarning {
+    #[must_use]
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+    #[must_use]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl Display for ImportWarning {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}


### PR DESCRIPTION
### Motivation

- Introduce a focused crate to represent tracing-shaped intake data and semantic conventions so future slices can convert spans into `tailtriage_core::Run` without mixing import types into existing crates.
- Keep the first slice intentionally narrow: only types, semantic keys, and small error/warning scaffolding are required to define the public intake contract and docs before implementing parsing or runtime adapters.

### Description

- Add new workspace crate `tailtriage-tracing` with minimal dependencies (`tailtriage-core` + `serde` derive) and register it in the workspace members and workspace dependencies.
- Add semantic convention constants: `TT_KIND`, `TT_REQUEST_ID`, `TT_ROUTE`, `TT_STAGE`, `TT_QUEUE`, `TT_DEPTH_AT_START`, `TT_OUTCOME`, and `TT_SUCCESS` in `src/convention.rs`.
- Add public intake API types in `src/types.rs`: `SpanKind`, `FieldValue`, `SpanRecord` (with `new`, `.id`, `.parent_id`, `.field`, and accessors), `ImportOptions` (with `new`, `.strict`, `.run_id`, `.service_version`, and accessors), `ImportedRun`, and `ImportWarning` (with `Display`).
- Add a small `ImportError` enum with manual `Display` and `Error` impl in `src/error.rs` (no `thiserror`).
- Provide crate-level docs/README clarifying scope and non-goals (no JSONL parsing, no tracing Layer, no OTel/OTLP, no CLI or analyzer changes yet) and include an in-doc example showing intended `tt.*` fields.
- Export the public symbols from `lib.rs` and add unit tests for constants, `SpanRecord` builder, `ImportOptions` builder, and `ImportWarning` display.
- Update `docs/README.md` to include the new crate README so docs contract validation remains truthful.

### Testing

- Ran formatting, lints, unit tests, and docs contract validation: `cargo fmt --check` (passed), `cargo clippy --workspace --all-targets -- -D warnings` (passed), `cargo test --workspace` (all tests passed), and `python3 scripts/validate_docs_contracts.py` (passed).
- All added unit tests in `tailtriage-tracing` passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06e8b2b94083309783e9dd401a4df7)