### PR TITLE
Add JSONL import support to tailtriage-tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,7 +867,9 @@ name = "tailtriage-tracing"
 version = "0.2.0"
 dependencies = [
  "serde",
+ "serde_json",
  "tailtriage-core",
+ "tempfile",
 ]
 
 [[package]]

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -19,6 +19,10 @@ include = [
 [dependencies]
 tailtriage-core.workspace = true
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dev-dependencies]
+tempfile = "3"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -1,17 +1,61 @@
 # tailtriage-tracing
 
 `tailtriage-tracing` is a focused intake bridge surface for tracing-shaped span
-records that are intended for future conversion into `tailtriage_core::Run` inputs.
+records that import into `tailtriage_core::Run` for tailtriage triage workflows.
 
 This crate is intentionally narrow:
 
 - It defines semantic convention keys (`tt.*`) for triage-oriented span fields.
 - It defines typed intake records and import option/result types.
-- It does **not** yet convert records into `tailtriage_core::Run`.
-- It does **not** parse JSONL.
+- It converts in-memory `SpanRecord` values into `tailtriage_core::Run`.
+- It imports newline-delimited JSON (JSONL) into `SpanRecord` values.
 - It does **not** install or provide a `tracing_subscriber::Layer`.
 - It does **not** implement OpenTelemetry or OTLP.
 - It does **not** change `tailtriage-analyzer`.
+- It does **not** add CLI import flags in this phase.
+
+## Supported JSONL shape in this phase
+
+Phase 1 intentionally supports records that can reconstruct a **completed span**
+with explicit unix-millisecond timestamps.
+
+Stable contract used by tests (recommended):
+
+```json
+{
+  "span": {
+    "name": "http.request",
+    "id": "span-1",
+    "parent_id": "root-1",
+    "started_at_unix_ms": 1700000000000,
+    "finished_at_unix_ms": 1700000000120,
+    "fields": {
+      "tt.kind": "request",
+      "tt.request_id": "req-42",
+      "tt.route": "/checkout"
+    }
+  }
+}
+```
+
+Accepted timestamp keys:
+
+- `started_at_unix_ms` / `finished_at_unix_ms`
+- alias: `start_unix_ms` / `end_unix_ms`
+
+Accepted `tt.kind` locations:
+
+- `fields.tt.kind`
+- `span.fields.tt.kind`
+- top-level `tt.kind`
+
+The importer also accepts close-event-like records when they include enough data
+for one completed span in one record (name + `tt.kind` + start/end unix-ms).
+
+Because direct `tracing-subscriber` JSON output varies by configuration, this
+phase does **not** claim automatic parsing for all tracing JSON formats. If the
+close record does not carry both start and finish unix-ms timestamps, it is not
+converted in this phase.
 
 ## Intended field shape
 
@@ -22,4 +66,4 @@ Typical span fields are expected to follow this shape:
 - queue: `tt.kind`, `tt.request_id`, `tt.queue`, `tt.depth_at_start`
 
 Use this crate when you want a coherent, explicit bridge surface for importing
-span-like data into future tailtriage import paths.
+span-like data into tailtriage triage workflows.

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -1,0 +1,234 @@
+use std::collections::BTreeMap;
+use std::io::{BufRead, BufReader, Read};
+use std::path::Path;
+
+use serde_json::Value;
+
+use crate::{FieldValue, ImportError, ImportOptions, ImportedRun, SpanRecord, TT_KIND};
+
+pub(crate) fn import_jsonl_reader<R: Read>(
+    reader: R,
+    options: ImportOptions,
+) -> Result<ImportedRun, ImportError> {
+    let mut spans = Vec::new();
+    let reader = BufReader::new(reader);
+
+    for (line_no, line_result) in reader.lines().enumerate() {
+        let line = line_result.map_err(|reason| ImportError::InvalidField {
+            field: "jsonl",
+            reason: format!("failed to read line {}: {reason}", line_no + 1),
+        })?;
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let value: Value =
+            serde_json::from_str(&line).map_err(|reason| ImportError::InvalidField {
+                field: "jsonl",
+                reason: format!("malformed JSON at line {}: {reason}", line_no + 1),
+            })?;
+
+        if let Some(span) = parse_span_record(&value) {
+            spans.push(span);
+        }
+    }
+
+    crate::run_from_span_records(spans, options)
+}
+
+pub(crate) fn import_jsonl_path(
+    path: impl AsRef<Path>,
+    options: ImportOptions,
+) -> Result<ImportedRun, ImportError> {
+    let path_ref = path.as_ref();
+    let file = std::fs::File::open(path_ref).map_err(|reason| ImportError::InvalidField {
+        field: "jsonl_path",
+        reason: format!("failed to open '{}': {reason}", path_ref.display()),
+    })?;
+    import_jsonl_reader(file, options)
+}
+
+fn parse_span_record(value: &Value) -> Option<SpanRecord> {
+    let span_obj = value.get("span").and_then(Value::as_object);
+
+    let name = find_name(value, span_obj)?;
+    let started_at_unix_ms =
+        find_timestamp(value, span_obj, "started_at_unix_ms", "start_unix_ms")?;
+    let finished_at_unix_ms =
+        find_timestamp(value, span_obj, "finished_at_unix_ms", "end_unix_ms")?;
+
+    let mut fields = BTreeMap::new();
+    collect_fields(&mut fields, value.get("fields"));
+    collect_fields(&mut fields, span_obj.and_then(|obj| obj.get("fields")));
+    if let Some(tt_kind) = nested_string(value.get("fields"), "tt.kind") {
+        fields.insert(TT_KIND.to_owned(), FieldValue::String(tt_kind.to_owned()));
+    }
+    if let Some(tt_kind) = nested_string(span_obj.and_then(|obj| obj.get("fields")), "tt.kind") {
+        fields.insert(TT_KIND.to_owned(), FieldValue::String(tt_kind.to_owned()));
+    }
+    if let Some(tt_kind) = value.get("tt.kind").and_then(Value::as_str) {
+        fields.insert(TT_KIND.to_owned(), FieldValue::String(tt_kind.to_owned()));
+    }
+
+    if !fields.contains_key(TT_KIND) {
+        return None;
+    }
+
+    let id = span_obj
+        .and_then(|obj| obj.get("id"))
+        .and_then(Value::as_str);
+    let parent_id = span_obj
+        .and_then(|obj| obj.get("parent_id"))
+        .and_then(Value::as_str);
+
+    let mut span = SpanRecord::new(name, started_at_unix_ms, finished_at_unix_ms);
+    if let Some(id) = id {
+        span = span.id(id);
+    }
+    if let Some(parent_id) = parent_id {
+        span = span.parent_id(parent_id);
+    }
+    for (key, value) in fields {
+        span = span.field(key, value);
+    }
+
+    Some(span)
+}
+
+fn find_name<'a>(
+    value: &'a Value,
+    span_obj: Option<&'a serde_json::Map<String, Value>>,
+) -> Option<&'a str> {
+    span_obj
+        .and_then(|obj| obj.get("name"))
+        .and_then(Value::as_str)
+        .or_else(|| value.get("span_name").and_then(Value::as_str))
+        .or_else(|| value.get("name").and_then(Value::as_str))
+}
+
+fn find_timestamp(
+    value: &Value,
+    span_obj: Option<&serde_json::Map<String, Value>>,
+    key: &str,
+    alias: &str,
+) -> Option<u64> {
+    span_obj
+        .and_then(|obj| obj.get(key).or_else(|| obj.get(alias)))
+        .and_then(Value::as_u64)
+        .or_else(|| {
+            value
+                .get(key)
+                .or_else(|| value.get(alias))
+                .and_then(Value::as_u64)
+        })
+}
+
+fn nested_string<'a>(value: Option<&'a Value>, dotted_key: &str) -> Option<&'a str> {
+    value
+        .and_then(Value::as_object)
+        .and_then(|obj| obj.get(dotted_key))
+        .and_then(Value::as_str)
+}
+
+fn collect_fields(target: &mut BTreeMap<String, FieldValue>, value: Option<&Value>) {
+    let Some(object) = value.and_then(Value::as_object) else {
+        return;
+    };
+    for (key, raw) in object {
+        if let Some(field_value) = to_field_value(raw) {
+            target.insert(key.clone(), field_value);
+        }
+    }
+}
+
+fn to_field_value(value: &Value) -> Option<FieldValue> {
+    match value {
+        Value::String(v) => Some(FieldValue::String(v.clone())),
+        Value::Bool(v) => Some(FieldValue::Bool(*v)),
+        Value::Number(v) => {
+            if let Some(u) = v.as_u64() {
+                Some(FieldValue::U64(u))
+            } else if let Some(i) = v.as_i64() {
+                Some(FieldValue::I64(i))
+            } else {
+                v.as_f64().map(FieldValue::F64)
+            }
+        }
+        Value::Null => Some(FieldValue::Null),
+        Value::Array(_) | Value::Object(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{import_jsonl_path, import_jsonl_reader, ImportOptions};
+
+    #[test]
+    fn normalized_jsonl_request_only() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
+        let imported = import_jsonl_reader(input.as_bytes(), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+    }
+
+    #[test]
+    fn normalized_jsonl_request_stage_queue() {
+        let input = [
+            r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":5,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#,
+            r#"{"span":{"name":"st","start_unix_ms":2,"end_unix_ms":3,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}"#,
+            r#"{"span":{"name":"q","started_at_unix_ms":3,"finished_at_unix_ms":4,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits"}}}"#,
+        ]
+        .join("\n");
+        let imported = import_jsonl_reader(input.as_bytes(), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().stages.len(), 1);
+        assert_eq!(imported.run().queues.len(), 1);
+    }
+
+    #[test]
+    fn unrelated_json_line_ignored_and_empty_lines_ignored() {
+        let input = "\n{\"level\":\"info\",\"message\":\"hello\"}\n\n";
+        let imported = import_jsonl_reader(input.as_bytes(), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.warnings().is_empty());
+    }
+
+    #[test]
+    fn malformed_json_returns_error() {
+        let err =
+            import_jsonl_reader("{not json}\n".as_bytes(), ImportOptions::new("svc")).unwrap_err();
+        assert!(matches!(
+            err,
+            ImportError::InvalidField { field: "jsonl", .. }
+        ));
+    }
+
+    #[test]
+    fn missing_required_fields_warns_via_conversion_core() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1"}}}"#;
+        let imported = import_jsonl_reader(input.as_bytes(), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert_eq!(imported.warnings().len(), 1);
+    }
+
+    #[test]
+    fn strict_mode_propagates_conversion_errors() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1"}}}"#;
+        assert!(
+            import_jsonl_reader(input.as_bytes(), ImportOptions::new("svc").strict(true)).is_err()
+        );
+    }
+
+    #[test]
+    fn path_based_import_works() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("spans.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/"}}}"#,
+        )
+        .unwrap();
+        let imported = import_jsonl_path(&path, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+    }
+}

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -29,6 +29,7 @@
 
 mod convention;
 mod error;
+mod jsonl;
 mod types;
 
 use tailtriage_core::{
@@ -41,6 +42,36 @@ pub use convention::{
 };
 pub use error::ImportError;
 pub use types::{FieldValue, ImportOptions, ImportWarning, ImportedRun, SpanKind, SpanRecord};
+
+/// Imports newline-delimited JSON span records and converts them into a
+/// `tailtriage_core::Run` using [`run_from_span_records`].
+///
+/// This phase supports normalized records and close-event-like records that
+/// carry explicit start/end unix-ms timestamps.
+///
+/// # Errors
+///
+/// Returns [`ImportError`] for malformed JSON and path/reader failures.
+pub fn import_jsonl_reader<R: std::io::Read>(
+    reader: R,
+    options: ImportOptions,
+) -> Result<ImportedRun, ImportError> {
+    jsonl::import_jsonl_reader(reader, options)
+}
+
+/// Imports newline-delimited JSON from a path and converts it into a
+/// `tailtriage_core::Run` using [`run_from_span_records`].
+///
+/// # Errors
+///
+/// Returns [`ImportError`] for I/O failures, malformed JSON, and strict-mode
+/// conversion violations.
+pub fn import_jsonl_path(
+    path: impl AsRef<std::path::Path>,
+    options: ImportOptions,
+) -> Result<ImportedRun, ImportError> {
+    jsonl::import_jsonl_path(path, options)
+}
 
 /// Converts in-memory tracing span records into a `tailtriage_core::Run`.
 ///


### PR DESCRIPTION
### Motivation
- Provide a Phase 1 importer so newline-delimited tracing JSON can be converted into `SpanRecord` values and fed into the existing conversion core for triage runs. 
- Keep the import surface narrow and predictable by requiring completed-span records with explicit unix-ms timestamps and by reusing `run_from_span_records` for strict/non-strict behavior and warnings.

### Description
- Added a new parser module `jsonl.rs` that implements a tolerant line-by-line JSONL reader and extractor which only produces `SpanRecord` values when a record carries a `tt.kind` and explicit timing/name data. 
- Exposed public APIs `import_jsonl_reader<R: std::io::Read>(reader: R, options: ImportOptions) -> Result<ImportedRun, ImportError>` and `import_jsonl_path(path: impl AsRef<std::path::Path>, options: ImportOptions) -> Result<ImportedRun, ImportError>` which delegate to the new parser and then call `run_from_span_records`. 
- Parser behavior: reads with `BufRead::lines()`, ignores empty lines, returns `ImportError` on malformed JSON, flattens scalar fields from `fields`, `span.fields`, or top-level keys, recognizes `tt.kind` in `fields.tt.kind`, `span.fields.tt.kind`, or top-level `tt.kind`, accepts timestamp keys `started_at_unix_ms`/`finished_at_unix_ms` and aliases `start_unix_ms`/`end_unix_ms`, and only converts records with both name and explicit start/end unix-ms. 
- Minimal dependency additions: `serde_json` (runtime) and `tempfile` for tests, and `tailtriage-tracing/README.md` updated to document the exact normalized JSONL shape supported in this Phase 1 importer.

### Testing
- Ran `cargo fmt --check` and it passed. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it passed. 
- Ran `cargo test --workspace`; all workspace tests (including the new `jsonl` unit tests: `normalized_jsonl_request_only`, `normalized_jsonl_request_stage_queue`, `unrelated_json_line_ignored_and_empty_lines_ignored`, `malformed_json_returns_error`, `missing_required_fields_warns_via_conversion_core`, `strict_mode_propagates_conversion_errors`, and `path_based_import_works`) passed. 
- Ran `python3 scripts/validate_docs_contracts.py` and documentation checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0732e027c08330ab5dbb4e47f06eb5)