### PR TITLE
Add JSONL import support to tailtriage-tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,7 +867,9 @@ name = "tailtriage-tracing"
 version = "0.2.0"
 dependencies = [
  "serde",
+ "serde_json",
  "tailtriage-core",
+ "tempfile",
 ]
 
 [[package]]

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -19,9 +19,13 @@ include = [
 [dependencies]
 tailtriage-core.workspace = true
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -1,25 +1,60 @@
 # tailtriage-tracing
 
-`tailtriage-tracing` is a focused intake bridge surface for tracing-shaped span
-records that are intended for future conversion into `tailtriage_core::Run` inputs.
+`tailtriage-tracing` is a focused triage intake bridge for tracing-shaped span
+records. It converts finished span records into `tailtriage_core::Run` by
+reusing the `run_from_span_records` conversion core.
 
 This crate is intentionally narrow:
 
 - It defines semantic convention keys (`tt.*`) for triage-oriented span fields.
 - It defines typed intake records and import option/result types.
-- It does **not** yet convert records into `tailtriage_core::Run`.
-- It does **not** parse JSONL.
-- It does **not** install or provide a `tracing_subscriber::Layer`.
+- It imports JSONL with explicit completed-span timestamps.
+- It does **not** provide a live `tracing_subscriber::Layer`.
 - It does **not** implement OpenTelemetry or OTLP.
-- It does **not** change `tailtriage-analyzer`.
+- It does **not** change `tailtriage-analyzer` behavior.
 
-## Intended field shape
+## Supported JSONL shape (Phase 1)
 
-Typical span fields are expected to follow this shape:
+Phase 1 supports records that can recover a completed span from one line and
+include explicit unix-millisecond start/end timestamps.
 
-- request: `tt.kind`, `tt.request_id`, `tt.route`
-- stage: `tt.kind`, `tt.request_id`, `tt.stage`
-- queue: `tt.kind`, `tt.request_id`, `tt.queue`, `tt.depth_at_start`
+Stable normalized contract used by tests:
 
-Use this crate when you want a coherent, explicit bridge surface for importing
-span-like data into future tailtriage import paths.
+```json
+{
+  "span": {
+    "name": "http.request",
+    "id": "s1",
+    "parent_id": "p1",
+    "started_at_unix_ms": 1700000000000,
+    "finished_at_unix_ms": 1700000000120,
+    "fields": {
+      "tt.kind": "request",
+      "tt.request_id": "req-42",
+      "tt.route": "/checkout",
+      "tt.success": true
+    }
+  }
+}
+```
+
+Also accepted aliases for timestamps:
+
+- `start_unix_ms` for `started_at_unix_ms`
+- `end_unix_ms` for `finished_at_unix_ms`
+
+Field flattening accepts `tt.kind` under:
+
+- `fields.tt.kind`
+- `span.fields.tt.kind`
+- top-level `tt.kind`
+
+`tracing-subscriber` JSON can vary by formatter/configuration. This importer
+only accepts close-event records when those records carry explicit start/end
+unix-ms timestamps. It does not guess missing timing from log receive time.
+
+## Notes
+
+The normalized JSONL shape above is the stable contract for tests and examples.
+CLI examples can document how to emit this shape directly or use future live
+recorder support.

--- a/tailtriage-tracing/src/error.rs
+++ b/tailtriage-tracing/src/error.rs
@@ -3,6 +3,13 @@ use core::fmt;
 /// Import failures for tracing-shaped span ingestion.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ImportError {
+    /// Could not read input bytes from reader or path.
+    Io(String),
+    /// A JSONL line could not be parsed as JSON.
+    MalformedJsonLine {
+        /// Parse failure details.
+        message: String,
+    },
     /// Required field or option is missing.
     MissingField(&'static str),
     /// Field value had an invalid type or invalid content.
@@ -19,6 +26,8 @@ pub enum ImportError {
 impl fmt::Display for ImportError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Io(message) => write!(f, "io error: {message}"),
+            Self::MalformedJsonLine { message } => write!(f, "malformed JSONL line: {message}"),
             Self::MissingField(field) => write!(f, "missing required field: {field}"),
             Self::InvalidField { field, reason } => {
                 write!(f, "invalid field `{field}`: {reason}")

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -1,0 +1,227 @@
+use std::collections::BTreeMap;
+use std::io::{BufRead, BufReader, Read};
+use std::path::Path;
+
+use serde_json::Value;
+
+use crate::{FieldValue, ImportError, ImportOptions, ImportedRun, SpanRecord, TT_KIND};
+
+/// Imports newline-delimited JSON span records from a reader.
+///
+/// The parser accepts normalized records and close-event records that include
+/// explicit unix-ms start and finish timestamps.
+///
+/// # Errors
+///
+/// Returns [`ImportError::Io`] for read failures, [`ImportError::MalformedJsonLine`]
+/// for malformed JSON lines, and conversion errors propagated from
+/// [`crate::run_from_span_records`].
+pub fn import_jsonl_reader<R: Read>(
+    reader: R,
+    options: ImportOptions,
+) -> Result<ImportedRun, ImportError> {
+    let mut spans = Vec::new();
+    for line in BufReader::new(reader).lines() {
+        let line = line.map_err(|e| ImportError::Io(e.to_string()))?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let value: Value =
+            serde_json::from_str(trimmed).map_err(|e| ImportError::MalformedJsonLine {
+                message: e.to_string(),
+            })?;
+        if let Some(span) = parse_line(&value)? {
+            spans.push(span);
+        }
+    }
+
+    crate::run_from_span_records(spans, options)
+}
+
+/// Imports newline-delimited JSON span records from a filesystem path.
+///
+/// # Errors
+///
+/// Returns [`ImportError::Io`] when opening the file fails, and propagates
+/// parsing/conversion errors from [`import_jsonl_reader`].
+pub fn import_jsonl_path(
+    path: impl AsRef<Path>,
+    options: ImportOptions,
+) -> Result<ImportedRun, ImportError> {
+    let file = std::fs::File::open(path.as_ref()).map_err(|e| ImportError::Io(e.to_string()))?;
+    import_jsonl_reader(file, options)
+}
+
+fn parse_line(value: &Value) -> Result<Option<SpanRecord>, ImportError> {
+    let Some(object) = value.as_object() else {
+        return Ok(None);
+    };
+
+    if let Some(span) = object.get("span").and_then(Value::as_object) {
+        if let Some(record) = parse_span_object(span)? {
+            return Ok(Some(record));
+        }
+    }
+
+    let is_close = object
+        .get("event")
+        .and_then(Value::as_str)
+        .is_some_and(|v| v.eq_ignore_ascii_case("close"))
+        || object
+            .get("message")
+            .and_then(Value::as_str)
+            .is_some_and(|v| v.eq_ignore_ascii_case("close"));
+
+    if !is_close {
+        return Ok(None);
+    }
+
+    if let Some(record) = parse_close_event(object)? {
+        return Ok(Some(record));
+    }
+
+    Ok(None)
+}
+
+fn parse_span_object(
+    span: &serde_json::Map<String, Value>,
+) -> Result<Option<SpanRecord>, ImportError> {
+    let mut fields = extract_fields(None, Some(span), None);
+    if !fields.contains_key(TT_KIND) {
+        return Ok(None);
+    }
+
+    let name = span
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_owned();
+    let started = read_ts(span, "started_at_unix_ms", "start_unix_ms")?;
+    let finished = read_ts(span, "finished_at_unix_ms", "end_unix_ms")?;
+
+    let (Some(started_at_unix_ms), Some(finished_at_unix_ms)) = (started, finished) else {
+        return Err(ImportError::InvalidField {
+            field: "span",
+            reason: "tailtriage span missing start/end unix-ms timestamps".to_owned(),
+        });
+    };
+
+    let mut record = SpanRecord::new(name, started_at_unix_ms, finished_at_unix_ms);
+    if let Some(id) = span.get("id").and_then(Value::as_str) {
+        record = record.id(id);
+    }
+    if let Some(parent_id) = span.get("parent_id").and_then(Value::as_str) {
+        record = record.parent_id(parent_id);
+    }
+    for (k, v) in &mut fields {
+        record = record.field(k.as_str(), v.clone());
+    }
+    Ok(Some(record))
+}
+
+fn parse_close_event(
+    object: &serde_json::Map<String, Value>,
+) -> Result<Option<SpanRecord>, ImportError> {
+    let span_obj = object.get("span").and_then(Value::as_object);
+    let fields_obj = object.get("fields").and_then(Value::as_object);
+    let mut fields = extract_fields(fields_obj, span_obj, Some(object));
+    if !fields.contains_key(TT_KIND) {
+        return Ok(None);
+    }
+
+    let name = span_obj
+        .and_then(|s| s.get("name"))
+        .and_then(Value::as_str)
+        .or_else(|| object.get("span_name").and_then(Value::as_str))
+        .unwrap_or("unknown")
+        .to_owned();
+
+    let started = if let Some(s) = span_obj {
+        read_ts(s, "started_at_unix_ms", "start_unix_ms")?
+    } else {
+        None
+    }
+    .or(read_ts(object, "started_at_unix_ms", "start_unix_ms")?);
+    let finished = if let Some(s) = span_obj {
+        read_ts(s, "finished_at_unix_ms", "end_unix_ms")?
+    } else {
+        None
+    }
+    .or(read_ts(object, "finished_at_unix_ms", "end_unix_ms")?);
+
+    let (Some(started_at_unix_ms), Some(finished_at_unix_ms)) = (started, finished) else {
+        return Err(ImportError::InvalidField {
+            field: "span",
+            reason: "tailtriage close event missing start/end unix-ms timestamps".to_owned(),
+        });
+    };
+
+    let mut record = SpanRecord::new(name, started_at_unix_ms, finished_at_unix_ms);
+    for (k, v) in &mut fields {
+        record = record.field(k.as_str(), v.clone());
+    }
+    Ok(Some(record))
+}
+
+fn extract_fields(
+    fields_obj: Option<&serde_json::Map<String, Value>>,
+    span_obj: Option<&serde_json::Map<String, Value>>,
+    top: Option<&serde_json::Map<String, Value>>,
+) -> BTreeMap<String, FieldValue> {
+    let mut out = BTreeMap::new();
+    if let Some(fields) = fields_obj {
+        append_values(&mut out, fields);
+    }
+    if let Some(span) = span_obj {
+        if let Some(fields) = span.get("fields").and_then(Value::as_object) {
+            append_values(&mut out, fields);
+        }
+    }
+    if let Some(top) = top {
+        append_values(&mut out, top);
+    }
+    out
+}
+
+fn append_values(out: &mut BTreeMap<String, FieldValue>, map: &serde_json::Map<String, Value>) {
+    for (key, value) in map {
+        if key == "fields" || key == "span" || key == "event" || key == "message" {
+            continue;
+        }
+        if let Some(converted) = value_to_field(value) {
+            out.insert(key.to_owned(), converted);
+        }
+    }
+}
+
+fn value_to_field(value: &Value) -> Option<FieldValue> {
+    match value {
+        Value::String(v) => Some(FieldValue::String(v.clone())),
+        Value::Bool(v) => Some(FieldValue::Bool(*v)),
+        Value::Number(v) => v
+            .as_u64()
+            .map(FieldValue::U64)
+            .or_else(|| v.as_i64().map(FieldValue::I64))
+            .or_else(|| v.as_f64().map(FieldValue::F64)),
+        Value::Null => Some(FieldValue::Null),
+        Value::Array(_) | Value::Object(_) => None,
+    }
+}
+
+fn read_ts(
+    map: &serde_json::Map<String, Value>,
+    key: &'static str,
+    alias: &'static str,
+) -> Result<Option<u64>, ImportError> {
+    map.get(key)
+        .or_else(|| map.get(alias))
+        .map(|v| match v.as_u64() {
+            Some(ts) => Ok(ts),
+            None => Err(ImportError::InvalidField {
+                field: key,
+                reason: "expected unix timestamp in milliseconds as u64".to_owned(),
+            }),
+        })
+        .transpose()
+}

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -29,6 +29,7 @@
 
 mod convention;
 mod error;
+mod jsonl;
 mod types;
 
 use tailtriage_core::{
@@ -40,6 +41,7 @@ pub use convention::{
     TT_DEPTH_AT_START, TT_KIND, TT_OUTCOME, TT_QUEUE, TT_REQUEST_ID, TT_ROUTE, TT_STAGE, TT_SUCCESS,
 };
 pub use error::ImportError;
+pub use jsonl::{import_jsonl_path, import_jsonl_reader};
 pub use types::{FieldValue, ImportOptions, ImportWarning, ImportedRun, SpanKind, SpanRecord};
 
 /// Converts in-memory tracing span records into a `tailtriage_core::Run`.
@@ -676,5 +678,64 @@ mod tests {
             .clone();
         assert!(!run.stages[0].success);
         assert_eq!(run.queues[0].depth_at_start, Some(9));
+    }
+}
+
+#[cfg(test)]
+mod jsonl_tests {
+    use std::io::Cursor;
+
+    use super::*;
+
+    #[test]
+    fn import_normalized_request_only() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/x","tt.success":true}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+    }
+
+    #[test]
+    fn import_normalized_request_stage_queue() {
+        let input = [
+            r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":10,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/x","tt.success":true}}}"#,
+            r#"{"span":{"name":"st","started_at_unix_ms":2,"finished_at_unix_ms":7,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db","tt.success":true}}}"#,
+            r#"{"span":{"name":"q","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"db","tt.depth_at_start":3}}}"#,
+        ].join("\n");
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().stages.len(), 1);
+        assert_eq!(imported.run().queues.len(), 1);
+    }
+
+    #[test]
+    fn unrelated_and_empty_lines_ignored() {
+        let input = "\n{\"event\":\"info\",\"fields\":{\"foo\":\"bar\"}}\n\n";
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+    }
+
+    #[test]
+    fn malformed_json_errors() {
+        let err = import_jsonl_reader(Cursor::new("{"), ImportOptions::new("svc")).unwrap_err();
+        assert!(matches!(err, ImportError::MalformedJsonLine { .. }));
+    }
+
+    #[test]
+    fn missing_required_fields_warning_and_strict_error() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.route":"/x"}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(!imported.warnings().is_empty());
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+            .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn import_path_works() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("spans.jsonl");
+        std::fs::write(&path, r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/x","tt.success":true}}}"#).unwrap();
+        let imported = import_jsonl_path(&path, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
     }
 }


### PR DESCRIPTION
### Motivation

- Provide a Phase‑1 importer so users can feed newline-delimited tracing JSON into the existing conversion core without adding CLI, a live `tracing` layer, or OTel support.
- Offer a narrowly scoped, explicit contract that accepts completed-span records (with explicit unix-ms start/end) and reuses `run_from_span_records` for conversion and validation.

### Description

- Added two public APIs: `pub fn import_jsonl_reader<R: std::io::Read>(reader: R, options: ImportOptions) -> Result<ImportedRun, ImportError>` and `pub fn import_jsonl_path(path: impl AsRef<std::path::Path>, options: ImportOptions) -> Result<ImportedRun, ImportError>` exposed from the crate root via a new `jsonl` module.
- Implemented `src/jsonl.rs` which parses input one line at a time with `BufRead`, ignores empty lines, errors on malformed JSON lines, flattens scalar fields from top-level / `fields` / `span.fields`, and converts only records that include a `tt.kind` and explicit `started_at_unix_ms`/`finished_at_unix_ms` (aliases `start_unix_ms`/`end_unix_ms` supported) into `SpanRecord` values.
- Supported input shapes: the normalized `{ "span": { ... } }` shape (stable test contract) and tracing-subscriber-like close-event shapes when the record contains explicit start/finish unix-ms timestamps; the importer will skip unrelated tracing lines silently.
- Reused `run_from_span_records` for all downstream conversion and warning/strict logic; did not add CLI flags, live `tracing` Layer, or OTel support.
- Extended `ImportError` with `Io` and `MalformedJsonLine` variants and added `serde_json` (runtime) and `tempfile` (dev) dependencies; updated `README.md` to document the exact normalized JSONL shape and limitations.

### Testing

- Added unit tests covering: normalized request-only import, normalized request+stage+queue import, unrelated/empty lines ignored, malformed JSON returns `MalformedJsonLine`, strict-mode behavior propagates conversion errors, and `import_jsonl_path` using a tempfile; all new tests passed.
- Ran repository validation: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, and `python3 scripts/validate_docs_contracts.py`, and they all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0732e027c08330ab5dbb4e47f06eb5)