### PR TITLE
tailtriage-cli: add tracing-json import subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,6 +828,7 @@ dependencies = [
  "serde_json",
  "tailtriage-analyzer",
  "tailtriage-core",
+ "tailtriage-tracing",
  "tempfile",
 ]
 

--- a/tailtriage-cli/Cargo.toml
+++ b/tailtriage-cli/Cargo.toml
@@ -27,6 +27,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 tailtriage-core.workspace = true
 tailtriage-analyzer.workspace = true
+tailtriage-tracing.workspace = true
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -42,7 +42,14 @@ Machine-readable JSON output:
 tailtriage analyze tailtriage-run.json --format json
 ```
 
+Import completed tracing span JSONL into a tailtriage Run artifact:
+
+```bash
+tailtriage import tracing-json spans.jsonl --service checkout --output run.json
+```
+
 `tailtriage analyze <run.json> --format json` emits the same pretty Report JSON as `tailtriage_analyzer::render_json_pretty`.
+`tailtriage import tracing-json` imports completed tracing span records in the documented JSONL shape and writes pretty Run JSON with import warnings on stderr.
 
 The CLI artifact loader requires at least one request event in `requests`. This is a CLI artifact-loading rule, not an in-process `tailtriage-analyzer` requirement for already-constructed `Run` values.
 CLI input is Run artifact JSON from disk. CLI does not consume Report JSON as input.

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -4,6 +4,7 @@ use clap::{Parser, ValueEnum};
 use tailtriage_analyzer::{render_json_pretty, render_text, try_analyze_run};
 use tailtriage_cli::artifact::load_run_artifact;
 use tailtriage_cli::{analyzer_options_help_text, build_analyze_options};
+use tailtriage_tracing::{import_jsonl_path, ImportOptions};
 
 #[derive(Debug, Parser)]
 #[command(name = "tailtriage")]
@@ -32,6 +33,36 @@ enum Command {
         /// Print analyzer option help and exit successfully.
         #[arg(long)]
         help_analyzer_options: bool,
+    },
+    /// Import tracing JSONL span records into a tailtriage run JSON artifact.
+    Import {
+        #[command(subcommand)]
+        command: ImportCommand,
+    },
+}
+
+#[derive(Debug, clap::Subcommand)]
+enum ImportCommand {
+    /// Import completed tracing span records in the documented JSONL shape.
+    TracingJson {
+        /// Path to tracing span JSONL input.
+        #[arg(value_name = "SPANS_JSONL")]
+        spans_jsonl: PathBuf,
+        /// Service name for output run metadata.
+        #[arg(long, value_name = "SERVICE")]
+        service: String,
+        /// Output path for pretty run JSON artifact.
+        #[arg(long, value_name = "RUN_JSON")]
+        output: PathBuf,
+        /// Optional service version for output run metadata.
+        #[arg(long, value_name = "VERSION")]
+        service_version: Option<String>,
+        /// Optional explicit run id for output run metadata.
+        #[arg(long, value_name = "RUN_ID")]
+        run_id: Option<String>,
+        /// Enable strict import mode (fail on malformed/incomplete tt.* spans).
+        #[arg(long)]
+        strict: bool,
     },
 }
 
@@ -79,6 +110,31 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
         }
+        Command::Import { command } => match command {
+            ImportCommand::TracingJson {
+                spans_jsonl,
+                service,
+                output,
+                service_version,
+                run_id,
+                strict,
+            } => {
+                let mut options = ImportOptions::new(service).strict(strict);
+                if let Some(version) = service_version {
+                    options = options.service_version(version);
+                }
+                if let Some(run_id) = run_id {
+                    options = options.run_id(run_id);
+                }
+
+                let imported = import_jsonl_path(&spans_jsonl, options)?;
+                for warning in imported.warnings() {
+                    eprintln!("warning: {}", warning.message());
+                }
+                let file = std::fs::File::create(&output)?;
+                serde_json::to_writer_pretty(file, imported.run())?;
+            }
+        },
     }
 
     Ok(())

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -222,6 +222,82 @@ fn missing_run_json_without_help_flag_fails_clearly() {
     assert!(stderr.contains("RUN_JSON") || stderr.contains("missing required"));
 }
 
+#[test]
+fn import_tracing_json_writes_valid_run_json_artifact() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, request_span_jsonl()).expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+
+    assert!(output.status.success(), "cli failed: {output:?}");
+    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
+        .expect("imported run should load via cli artifact loader");
+    let report = analyze_run(&loaded.run, AnalyzeOptions::default());
+    assert_eq!(report.request_count, 1);
+}
+
+#[test]
+fn import_tracing_json_strict_fails_on_incomplete_tailtriage_span() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("incomplete.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, incomplete_request_span_jsonl()).expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--strict")
+        .output()
+        .expect("cli should run");
+
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    assert!(!run_path.exists(), "output should not be created");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("strict import violation"));
+}
+
+#[test]
+fn import_tracing_json_non_strict_emits_warnings_and_writes_output() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("incomplete.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, incomplete_request_span_jsonl()).expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+
+    assert!(output.status.success(), "cli failed: {output:?}");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("warning:"));
+    assert!(run_path.exists(), "output should be created");
+}
+
 fn valid_cli_artifact_with_requests() -> &'static str {
     r#"{"schema_version":1,"metadata":{"run_id":"r1","service_name":"svc","service_version":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"mode":"light","host":null,"pid":null,"lifecycle_warnings":[],"unfinished_requests":{"count":0,"sample":[]}},"requests":[{"request_id":"req1","route":"/","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":10,"outcome":"ok"}],"stages":[],"queues":[],"inflight":[],"runtime_snapshots":[]}"#
 }
@@ -243,4 +319,14 @@ fn parse_report_json(output: std::process::Output) -> serde_json::Value {
 
 fn valid_cli_artifact_with_empty_requests() -> &'static str {
     r#"{"schema_version":1,"metadata":{"run_id":"r1","service_name":"svc","service_version":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"mode":"light","host":null,"pid":null,"lifecycle_warnings":[],"unfinished_requests":{"count":0,"sample":[]}},"requests":[],"stages":[],"queues":[],"inflight":[],"runtime_snapshots":[]}"#
+}
+
+fn request_span_jsonl() -> &'static str {
+    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.success":true}}}
+"#
+}
+
+fn incomplete_request_span_jsonl() -> &'static str {
+    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.success":true}}}
+"#
 }


### PR DESCRIPTION
### Motivation

- Provide a simple CLI path to convert completed tracing JSONL span records into a tailtriage Run artifact so users can import spans produced by existing tracing output into the existing analysis workflow.
- Reuse the existing `tailtriage-tracing` JSONL importer rather than reimplementing parsing or adding a tracing Layer or OTel integration.

### Description

- Add `tailtriage-tracing` as a dependency to `tailtriage-cli` and wire its JSONL importer into the CLI. (`tailtriage-cli/Cargo.toml`).
- Introduce a new top-level `import` command with a nested `tracing-json` subcommand with the requested shape: `tailtriage import tracing-json <SPANS_JSONL> --service <SERVICE> --output <RUN_JSON> [--service-version <VERSION>] [--run-id <RUN_ID>] [--strict]` (help text and flags implemented in `tailtriage-cli/src/main.rs`).
- Invoke `tailtriage_tracing::import_jsonl_path` with constructed `ImportOptions`, print non-fatal importer warnings to stderr as `warning: ...`, and write pretty Run JSON using `serde_json::to_writer_pretty` to the required `--output` file (no stdout output supported). The existing `tailtriage analyze` behavior is left unchanged.
- Add CLI integration tests and small deterministic fixtures to validate import success, strict-mode failure, and non-strict warning emission (`tailtriage-cli/tests/cli_boundary.rs`).
- Update `tailtriage-cli/README.md` with a minimal usage example for the new import command and bounded compatibility wording.

### Testing

- Ran formatting, lints, unit and integration tests, and docs validation: `cargo fmt --check` (passed), `cargo clippy --workspace --all-targets -- -D warnings` (passed), `cargo test --workspace` (passed), and `python3 scripts/validate_docs_contracts.py` (passed).
- Added and exercised these CLI tests: `import_tracing_json_writes_valid_run_json_artifact`, `import_tracing_json_strict_fails_on_incomplete_tailtriage_span`, and `import_tracing_json_non_strict_emits_warnings_and_writes_output`, all of which passed in the test run.
- Existing `tailtriage analyze` flows and analyzer tests remained unchanged and continued to pass during the full test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a075372d78c8330906f2943cb304367)