### PR TITLE
Add `tailtriage import tracing-json` CLI command for JSONL ingestion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,6 +828,7 @@ dependencies = [
  "serde_json",
  "tailtriage-analyzer",
  "tailtriage-core",
+ "tailtriage-tracing",
  "tempfile",
 ]
 

--- a/tailtriage-cli/Cargo.toml
+++ b/tailtriage-cli/Cargo.toml
@@ -27,6 +27,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 tailtriage-core.workspace = true
 tailtriage-analyzer.workspace = true
+tailtriage-tracing.workspace = true
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -47,6 +47,24 @@ tailtriage analyze tailtriage-run.json --format json
 The CLI artifact loader requires at least one request event in `requests`. This is a CLI artifact-loading rule, not an in-process `tailtriage-analyzer` requirement for already-constructed `Run` values.
 CLI input is Run artifact JSON from disk. CLI does not consume Report JSON as input.
 
+
+## Import tracing JSONL into run artifacts
+
+Import completed tracing span records in the documented JSONL shape into a tailtriage Run JSON artifact:
+
+```bash
+tailtriage import tracing-json spans.jsonl --service checkout --output run.json
+```
+
+Optional metadata and strict mode:
+
+```bash
+tailtriage import tracing-json spans.jsonl --service checkout --output run.json --service-version v1 --run-id run-42 --strict
+```
+
+`tailtriage import tracing-json` writes pretty Run JSON and prints import warnings to stderr as `warning: ...`.
+This command only imports to Run JSON; run analysis separately with `tailtriage analyze run.json`.
+
 ## Analyzer tuning flags
 
 Start with default analyzer behavior first.

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -4,6 +4,7 @@ use clap::{Parser, ValueEnum};
 use tailtriage_analyzer::{render_json_pretty, render_text, try_analyze_run};
 use tailtriage_cli::artifact::load_run_artifact;
 use tailtriage_cli::{analyzer_options_help_text, build_analyze_options};
+use tailtriage_tracing::{import_jsonl_path, ImportOptions};
 
 #[derive(Debug, Parser)]
 #[command(name = "tailtriage")]
@@ -32,6 +33,36 @@ enum Command {
         /// Print analyzer option help and exit successfully.
         #[arg(long)]
         help_analyzer_options: bool,
+    },
+    /// Import artifacts into tailtriage run JSON.
+    Import {
+        #[command(subcommand)]
+        command: ImportCommand,
+    },
+}
+
+#[derive(Debug, clap::Subcommand)]
+enum ImportCommand {
+    /// Import completed tracing span records in JSONL into tailtriage run JSON.
+    TracingJson {
+        /// Path to newline-delimited JSON span records.
+        #[arg(value_name = "SPANS_JSONL")]
+        spans_jsonl: PathBuf,
+        /// Service name metadata for the imported run.
+        #[arg(long, value_name = "SERVICE")]
+        service: String,
+        /// Output path for pretty tailtriage run JSON.
+        #[arg(long, value_name = "RUN_JSON")]
+        output: PathBuf,
+        /// Optional service version metadata.
+        #[arg(long, value_name = "VERSION")]
+        service_version: Option<String>,
+        /// Optional run ID override.
+        #[arg(long, value_name = "RUN_ID")]
+        run_id: Option<String>,
+        /// Fail on malformed tailtriage spans instead of warning and skipping.
+        #[arg(long)]
+        strict: bool,
     },
 }
 
@@ -78,6 +109,33 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                     println!("{}", render_json_pretty(&report)?);
                 }
             }
+        }
+        Command::Import {
+            command:
+                ImportCommand::TracingJson {
+                    spans_jsonl,
+                    service,
+                    output,
+                    service_version,
+                    run_id,
+                    strict,
+                },
+        } => {
+            let mut options = ImportOptions::new(service).strict(strict);
+            if let Some(service_version) = service_version {
+                options = options.service_version(service_version);
+            }
+            if let Some(run_id) = run_id {
+                options = options.run_id(run_id);
+            }
+
+            let imported = import_jsonl_path(&spans_jsonl, options)?;
+            for warning in imported.warnings() {
+                eprintln!("warning: {warning}");
+            }
+
+            let file = std::fs::File::create(&output)?;
+            serde_json::to_writer_pretty(file, imported.run())?;
         }
     }
 

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -244,3 +244,101 @@ fn parse_report_json(output: std::process::Output) -> serde_json::Value {
 fn valid_cli_artifact_with_empty_requests() -> &'static str {
     r#"{"schema_version":1,"metadata":{"run_id":"r1","service_name":"svc","service_version":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"mode":"light","host":null,"pid":null,"lifecycle_warnings":[],"unfinished_requests":{"count":0,"sample":[]}},"requests":[],"stages":[],"queues":[],"inflight":[],"runtime_snapshots":[]}"#
 }
+
+#[test]
+fn import_tracing_json_writes_run_json_that_loader_and_analyzer_accept() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+
+    std::fs::write(
+        &spans_path,
+        concat!(
+            "{\"span\":{\"name\":\"http.request\",\"started_at_unix_ms\":1000,\"finished_at_unix_ms\":1012,\"fields\":{\"tt.kind\":\"request\",\"tt.request_id\":\"req-1\",\"tt.route\":\"/checkout\",\"tt.success\":true}}}\n",
+            "{\"span\":{\"name\":\"db.stage\",\"started_at_unix_ms\":1002,\"finished_at_unix_ms\":1008,\"fields\":{\"tt.kind\":\"stage\",\"tt.request_id\":\"req-1\",\"tt.stage\":\"db\",\"tt.success\":true}}}\n"
+        ),
+    )
+    .expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+
+    assert!(output.status.success(), "cli failed: {output:?}");
+    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
+        .expect("imported run should load with CLI loader");
+    let report = analyze_run(&loaded.run, AnalyzeOptions::default());
+    assert_eq!(report.request_count, 1);
+}
+
+#[test]
+fn import_tracing_json_strict_mode_fails_on_incomplete_tailtriage_span() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+
+    std::fs::write(
+        &spans_path,
+        "{\"span\":{\"name\":\"http.request\",\"started_at_unix_ms\":1000,\"finished_at_unix_ms\":1012,\"fields\":{\"tt.kind\":\"request\",\"tt.request_id\":\"req-1\",\"tt.success\":true}}}\n",
+    )
+    .expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--strict")
+        .output()
+        .expect("cli should run");
+
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("strict import violation"));
+    assert!(!run_path.exists());
+}
+
+#[test]
+fn import_tracing_json_non_strict_writes_output_and_warns_for_incomplete_span() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+
+    std::fs::write(
+        &spans_path,
+        concat!(
+            "{\"span\":{\"name\":\"http.request\",\"started_at_unix_ms\":1000,\"finished_at_unix_ms\":1012,\"fields\":{\"tt.kind\":\"request\",\"tt.request_id\":\"req-1\",\"tt.success\":true}}}\n",
+            "{\"span\":{\"name\":\"http.request\",\"started_at_unix_ms\":2000,\"finished_at_unix_ms\":2020,\"fields\":{\"tt.kind\":\"request\",\"tt.request_id\":\"req-2\",\"tt.route\":\"/checkout\",\"tt.success\":true}}}\n"
+        ),
+    )
+    .expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+
+    assert!(output.status.success(), "cli failed: {output:?}");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("warning:"));
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path).expect("run loads");
+    assert_eq!(loaded.run.requests.len(), 1);
+}


### PR DESCRIPTION
### Motivation

- Provide a CLI path to convert completed tracing JSONL span records into a `tailtriage` Run JSON artifact using the existing importer rather than forcing users to use in-process APIs. 
- Keep analysis behavior unchanged and avoid adding any runtime tracing Layer or OTel/OTLP support in this change. 
- Require an explicit output file and surface import warnings clearly so users can run `tailtriage analyze` on the generated artifact as a separate step.

### Description

- Add a new top-level `import` subcommand with nested `tracing-json` in the CLI, matching the shape: `tailtriage import tracing-json <SPANS_JSONL> --service <SERVICE> --output <RUN_JSON> [--service-version <VERSION>] [--run-id <RUN_ID>] [--strict]`.
- Wire the existing `tailtriage-tracing` JSONL importer into the CLI by calling `import_jsonl_path` with `ImportOptions`, honoring the `--strict`, `--service-version`, and `--run-id` flags.
- Print importer warnings to stderr prefixed as `warning: ...` and write the imported `Run` to the required `--output` path using `serde_json::to_writer_pretty`.
- Add `tailtriage-tracing` as a workspace dependency for the CLI, update `tailtriage-cli/README.md` with usage notes for `import tracing-json`, and add CLI integration tests exercising successful import, strict-mode failure, and non-strict warning behavior.

### Testing

- Ran formatting and lint checks: `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings`, both succeeded.
- Ran full test suite: `cargo test --workspace` completed successfully and the new CLI tests passed (import success, strict failure, non-strict warning cases).
- Ran documentation validator: `python3 scripts/validate_docs_contracts.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a075372d78c8330906f2943cb304367)