### PR TITLE
Add live tracing_subscriber Layer recorder to tailtriage-tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,6 +738,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared-state-lock-service-demo"
 version = "0.2.0"
 dependencies = [
@@ -871,6 +886,8 @@ dependencies = [
  "serde_json",
  "tailtriage-core",
  "tempfile",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -884,6 +901,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -978,6 +1004,48 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -20,6 +20,8 @@ include = [
 tailtriage-core.workspace = true
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -1,19 +1,65 @@
 # tailtriage-tracing
 
-`tailtriage-tracing` is a focused intake bridge surface for tracing-shaped span
-records that can be converted into `tailtriage_core::Run` inputs.
+`tailtriage-tracing` is a focused intake bridge for tracing-shaped span data that
+can be converted into `tailtriage_core::Run` triage inputs.
 
-This crate is intentionally narrow:
+This crate provides:
 
-- It defines semantic convention keys (`tt.*`) for triage-oriented span fields.
-- It defines typed intake records and import option/result types.
-- It converts typed `SpanRecord` values with `run_from_span_records`.
-- It imports JSONL from readers/paths when records contain completed span timing.
-- It does **not** install or provide a `tracing_subscriber::Layer`.
-- It does **not** implement OpenTelemetry or OTLP.
-- It does **not** change `tailtriage-analyzer`.
+- semantic convention keys (`tt.*`) for triage-oriented span fields
+- typed intake records and import option/result types
+- `run_from_span_records` for converting `SpanRecord` values into `Run`
+- JSONL import helpers for completed spans
+- a live `tracing_subscriber::Layer` recorder for completed spans
 
-## JSONL import support in this phase
+This crate does **not** provide OTel/OTLP integration and does **not** change
+`tailtriage-analyzer` behavior.
+
+## Live tracing recorder
+
+Public APIs:
+
+- `TracingRecorder`
+- `TracingRecorderBuilder`
+- `TailtriageLayer`
+
+Minimal example:
+
+```rust
+use tracing_subscriber::{layer::SubscriberExt, Registry};
+use tailtriage_tracing::TracingRecorder;
+
+let recorder = TracingRecorder::builder("checkout-service")
+    .service_version("1.2.3")
+    .build();
+
+let subscriber = Registry::default().with(recorder.layer());
+tracing::subscriber::with_default(subscriber, || {
+    let request = tracing::info_span!(
+        "http.request",
+        tt.kind = "request",
+        tt.request_id = "req-42",
+        tt.route = "/checkout"
+    );
+    let _entered = request.enter();
+});
+
+let imported = recorder.snapshot_run()?;
+assert_eq!(imported.run().requests.len(), 1);
+# Ok::<(), tailtriage_tracing::ImportError>(())
+```
+
+Async instrumentation note:
+
+- Prefer `#[tracing::instrument(fields(...))]` or `.instrument(...)`.
+- Do not hold a manual entered-span guard across `.await`.
+
+Runtime-pressure evidence note:
+
+- tracing spans work outside Tokio for request/stage/queue evidence.
+- Runtime-pressure evidence still requires tailtriage Tokio runtime sampling or
+  future runtime metrics import.
+
+## JSONL import support
 
 Public APIs:
 
@@ -38,31 +84,3 @@ Supported stable contract (recommended for tests and integrations):
   }
 }
 ```
-
-Notes:
-
-- Importer accepts `started_at_unix_ms`/`finished_at_unix_ms` and aliases `start_unix_ms`/`end_unix_ms`.
-- In this phase, normalized shape uses **literal dotted keys** inside `fields` (for example `"tt.kind"` and `"tt.request_id"`), not nested objects that require flattening.
-- Importer reads `tt.*` fields from `fields`, `span.fields`, or top-level `tt.*` keys when present.
-- Scalars can be strings, bools, numbers, or null.
-- Empty lines are ignored.
-- Malformed JSON line input is an import error in both strict and non-strict mode.
-
-## tracing-subscriber JSON caveat
-
-Direct `tracing-subscriber` JSON output can vary by formatter configuration. In
-this phase, the importer supports:
-
-- normalized completed-span JSONL (shape above), and
-- close-event-like records only when they include explicit start/end unix-ms timestamps.
-
-It does not guess missing timing from line receive time and does not claim broad
-automatic parsing for every tracing JSON variant.
-
-## Intended field shape
-
-Typical span fields are expected to follow this shape:
-
-- request: `tt.kind`, `tt.request_id`, `tt.route`
-- stage: `tt.kind`, `tt.request_id`, `tt.stage`
-- queue: `tt.kind`, `tt.request_id`, `tt.queue`, `tt.depth_at_start`

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -30,6 +30,7 @@
 mod convention;
 mod error;
 mod jsonl;
+mod live;
 mod types;
 
 use tailtriage_core::{
@@ -42,6 +43,7 @@ pub use convention::{
 };
 pub use error::ImportError;
 pub use jsonl::{import_jsonl_path, import_jsonl_reader};
+pub use live::{TailtriageLayer, TracingRecorder, TracingRecorderBuilder};
 pub use types::{FieldValue, ImportOptions, ImportWarning, ImportedRun, SpanKind, SpanRecord};
 
 /// Converts in-memory tracing span records into a `tailtriage_core::Run`.

--- a/tailtriage-tracing/src/live.rs
+++ b/tailtriage-tracing/src/live.rs
@@ -1,0 +1,334 @@
+use std::{
+    collections::BTreeMap,
+    fmt,
+    sync::{Arc, Mutex},
+};
+
+use tracing::{field::Visit, span, Subscriber};
+use tracing_subscriber::{layer::Context, registry::LookupSpan, Layer};
+
+use crate::{
+    run_from_span_records, FieldValue, ImportError, ImportOptions, ImportedRun, SpanRecord,
+};
+
+#[derive(Debug, Clone)]
+struct OpenSpan {
+    id: String,
+    parent_id: Option<String>,
+    name: String,
+    started_at_unix_ms: u64,
+    fields: BTreeMap<String, FieldValue>,
+}
+
+#[derive(Debug, Default)]
+struct RecorderState {
+    open_spans: BTreeMap<String, OpenSpan>,
+    completed_spans: Vec<SpanRecord>,
+}
+
+/// Builds a [`TracingRecorder`].
+#[derive(Debug, Clone)]
+pub struct TracingRecorderBuilder {
+    options: ImportOptions,
+}
+
+impl TracingRecorderBuilder {
+    /// Sets service version metadata.
+    #[must_use]
+    pub fn service_version(mut self, service_version: impl Into<String>) -> Self {
+        self.options = self.options.service_version(service_version);
+        self
+    }
+
+    /// Sets explicit run id metadata.
+    #[must_use]
+    pub fn run_id(mut self, run_id: impl Into<String>) -> Self {
+        self.options = self.options.run_id(run_id);
+        self
+    }
+
+    /// Enables or disables strict import behavior.
+    #[must_use]
+    pub fn strict(mut self, strict: bool) -> Self {
+        self.options = self.options.strict(strict);
+        self
+    }
+
+    /// Creates a recorder.
+    #[must_use]
+    pub fn build(self) -> TracingRecorder {
+        TracingRecorder {
+            options: self.options,
+            state: Arc::new(Mutex::new(RecorderState::default())),
+        }
+    }
+}
+
+/// Live in-memory recorder for completed tracing spans with `tt.*` fields.
+#[derive(Debug, Clone)]
+pub struct TracingRecorder {
+    options: ImportOptions,
+    state: Arc<Mutex<RecorderState>>,
+}
+
+impl TracingRecorder {
+    /// Creates a recorder builder.
+    pub fn builder(service_name: impl Into<String>) -> TracingRecorderBuilder {
+        TracingRecorderBuilder {
+            options: ImportOptions::new(service_name),
+        }
+    }
+
+    /// Returns a cloneable tracing layer that records span lifecycle updates.
+    #[must_use]
+    pub fn layer(&self) -> TailtriageLayer {
+        TailtriageLayer {
+            state: Arc::clone(&self.state),
+        }
+    }
+
+    /// Converts completed captured spans into an imported run snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ImportError`] when strict conversion rejects malformed `tt.*` spans.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal recorder mutex is poisoned.
+    pub fn snapshot_run(&self) -> Result<ImportedRun, ImportError> {
+        let completed = {
+            let state = self.state.lock().expect("recorder mutex poisoned");
+            state.completed_spans.clone()
+        };
+        run_from_span_records(completed, self.options.clone())
+    }
+
+    /// Converts completed captured spans into an imported run on shutdown.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ImportError`] when strict conversion rejects malformed `tt.*` spans.
+    pub fn shutdown(&self) -> Result<ImportedRun, ImportError> {
+        self.snapshot_run()
+    }
+}
+
+/// Tracing layer that captures completed spans into a [`TracingRecorder`].
+#[derive(Clone)]
+pub struct TailtriageLayer {
+    state: Arc<Mutex<RecorderState>>,
+}
+
+impl fmt::Debug for TailtriageLayer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TailtriageLayer").finish_non_exhaustive()
+    }
+}
+
+impl<S> Layer<S> for TailtriageLayer
+where
+    S: Subscriber + for<'span> LookupSpan<'span>,
+{
+    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
+        let Some(span_ref) = ctx.span(id) else {
+            return;
+        };
+
+        let mut visitor = FieldVisitor::default();
+        attrs.record(&mut visitor);
+        let metadata = span_ref.metadata();
+
+        let open_span = OpenSpan {
+            id: id.into_u64().to_string(),
+            parent_id: attrs
+                .parent()
+                .map(|p| p.into_u64().to_string())
+                .or_else(|| {
+                    span_ref
+                        .parent()
+                        .map(|parent| parent.id().into_u64().to_string())
+                }),
+            name: metadata.name().to_owned(),
+            started_at_unix_ms: tailtriage_core::unix_time_ms(),
+            fields: visitor.fields,
+        };
+
+        let mut state = self.state.lock().expect("recorder mutex poisoned");
+        state.open_spans.insert(open_span.id.clone(), open_span);
+    }
+
+    fn on_record(&self, id: &span::Id, values: &span::Record<'_>, _ctx: Context<'_, S>) {
+        let mut visitor = FieldVisitor::default();
+        values.record(&mut visitor);
+
+        let mut state = self.state.lock().expect("recorder mutex poisoned");
+        if let Some(open_span) = state.open_spans.get_mut(&id.into_u64().to_string()) {
+            open_span.fields.extend(visitor.fields);
+        }
+    }
+
+    fn on_close(&self, id: span::Id, _ctx: Context<'_, S>) {
+        let mut state = self.state.lock().expect("recorder mutex poisoned");
+        let Some(open_span) = state.open_spans.remove(&id.into_u64().to_string()) else {
+            return;
+        };
+
+        if !open_span.fields.contains_key("tt.kind") {
+            return;
+        }
+
+        let mut record = SpanRecord::new(
+            open_span.name,
+            open_span.started_at_unix_ms,
+            tailtriage_core::unix_time_ms(),
+        )
+        .id(open_span.id);
+
+        if let Some(parent_id) = open_span.parent_id {
+            record = record.parent_id(parent_id);
+        }
+        for (k, v) in open_span.fields {
+            record = record.field(k, v);
+        }
+        state.completed_spans.push(record);
+    }
+}
+
+#[derive(Default)]
+struct FieldVisitor {
+    fields: BTreeMap<String, FieldValue>,
+}
+
+impl Visit for FieldVisitor {
+    fn record_f64(&mut self, field: &tracing::field::Field, value: f64) {
+        self.fields
+            .insert(field.name().to_owned(), FieldValue::F64(value));
+    }
+
+    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+        self.fields
+            .insert(field.name().to_owned(), FieldValue::I64(value));
+    }
+
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        self.fields
+            .insert(field.name().to_owned(), FieldValue::U64(value));
+    }
+
+    fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+        self.fields
+            .insert(field.name().to_owned(), FieldValue::Bool(value));
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        self.fields.insert(
+            field.name().to_owned(),
+            FieldValue::String(value.to_owned()),
+        );
+    }
+
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn fmt::Debug) {
+        self.fields.insert(
+            field.name().to_owned(),
+            FieldValue::String(format!("{value:?}")),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tracing::{field::Empty, Level};
+    use tracing_subscriber::{layer::SubscriberExt, Registry};
+
+    use crate::{TracingRecorder, TT_OUTCOME};
+
+    #[test]
+    fn collects_request_span() {
+        let recorder = TracingRecorder::builder("svc").build();
+        let subscriber = Registry::default().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let request_span = tracing::info_span!(
+                "http.request",
+                tt.kind = "request",
+                tt.request_id = "req-1",
+                tt.route = "/checkout"
+            );
+            let _guard = request_span.enter();
+        });
+
+        let run = recorder.snapshot_run().expect("run");
+        assert_eq!(run.run().requests.len(), 1);
+    }
+
+    #[test]
+    fn collects_stage_span() {
+        let recorder = TracingRecorder::builder("svc").build();
+        let subscriber = Registry::default().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let stage_span = tracing::info_span!(
+                "db.stage",
+                tt.kind = "stage",
+                tt.request_id = "req-1",
+                tt.stage = "db"
+            );
+            let _guard = stage_span.enter();
+        });
+
+        let run = recorder.snapshot_run().expect("run");
+        assert_eq!(run.run().stages.len(), 1);
+    }
+
+    #[test]
+    fn collects_queue_span() {
+        let recorder = TracingRecorder::builder("svc").build();
+        let subscriber = Registry::default().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let queue_span = tracing::info_span!(
+                "permit.queue",
+                tt.kind = "queue",
+                tt.request_id = "req-1",
+                tt.queue = "permits"
+            );
+            let _guard = queue_span.enter();
+        });
+
+        let run = recorder.snapshot_run().expect("run");
+        assert_eq!(run.run().queues.len(), 1);
+    }
+
+    #[test]
+    fn on_record_updates_fields() {
+        let recorder = TracingRecorder::builder("svc").build();
+        let subscriber = Registry::default().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let request_span = tracing::info_span!(
+                "http.request",
+                tt.kind = "request",
+                tt.request_id = "req-1",
+                tt.route = "/checkout",
+                tt.outcome = Empty
+            );
+            request_span.record(TT_OUTCOME, "timeout");
+            let _guard = request_span.enter();
+        });
+
+        let run = recorder.snapshot_run().expect("run");
+        assert_eq!(run.run().requests[0].outcome, "timeout");
+    }
+
+    #[test]
+    fn unrelated_span_is_ignored() {
+        let recorder = TracingRecorder::builder("svc").build();
+        let subscriber = Registry::default().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let other_span = tracing::span!(Level::INFO, "not-tailtriage", request_id = "req-1");
+            let _guard = other_span.enter();
+        });
+
+        let run = recorder.snapshot_run().expect("run");
+        assert!(run.run().requests.is_empty());
+        assert!(run.run().stages.is_empty());
+        assert!(run.run().queues.is_empty());
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a small live recorder that captures completed `tracing` spans with `tt.*` fields so they can be analyzed without changing analyzer behavior or the CLI.
- Support common triage spans (request / stage / queue) from instrumented code and defer conversion to `tailtriage_core::Run` until an explicit snapshot/shutdown.
- Keep runtime/operational tradeoffs explicit by using in-memory storage and documenting async-span guidance and runtime-pressure limitations.

### Description

- Added a live recorder surface with the public types `TracingRecorder`, `TracingRecorderBuilder`, and `TailtriageLayer` and exported them from the crate root.
- Implemented a `tracing_subscriber::Layer` that captures span creation in `on_new_span`, applies later updates in `on_record`, finalizes completed spans at `on_close`, and ignores spans missing `tt.kind`; generated IDs use tracing span IDs as strings and timestamps use `tailtriage_core::unix_time_ms()`.
- Stored open/completed spans in-memory behind `Arc<Mutex<...>>` and deferred conversion to `tailtriage_core::Run` by calling the existing `run_from_span_records` from `TracingRecorder::snapshot_run` and `TracingRecorder::shutdown`.
- Implemented a `tracing::field::Visit` (`FieldVisitor`) that maps bools, integers, floats, strings, and debug values to `FieldValue` (debug values become strings), added unit tests for request/stage/queue capture, field updates, and unrelated-span filtering, updated `Cargo.toml` to add `tracing` and `tracing-subscriber`, and updated `tailtriage-tracing/README.md` with a minimal example and guidance.

### Testing

- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it passed.
- Ran `cargo test --workspace` and all tests passed (including new live-layer unit tests for request/stage/queue capture, `on_record` updates, and unrelated-span filtering).
- Ran `python3 scripts/validate_docs_contracts.py` and documentation contract validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a075ebbd990833087ae6e95016fcfd9)