### PR TITLE
Add live tracing_subscriber Layer recorder to tailtriage-tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,6 +738,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared-state-lock-service-demo"
 version = "0.2.0"
 dependencies = [
@@ -869,8 +884,11 @@ version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
+ "tailtriage-analyzer",
  "tailtriage-core",
  "tempfile",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -884,6 +902,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -978,6 +1005,48 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -20,6 +20,8 @@ include = [
 tailtriage-core.workspace = true
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
@@ -29,3 +31,4 @@ workspace = true
 
 [dev-dependencies]
 tempfile = "3"
+tailtriage-analyzer.workspace = true

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -1,19 +1,68 @@
 # tailtriage-tracing
 
-`tailtriage-tracing` is a focused intake bridge surface for tracing-shaped span
+`tailtriage-tracing` is a focused intake bridge for tracing-shaped span
 records that can be converted into `tailtriage_core::Run` inputs.
 
-This crate is intentionally narrow:
+This crate provides:
 
-- It defines semantic convention keys (`tt.*`) for triage-oriented span fields.
-- It defines typed intake records and import option/result types.
-- It converts typed `SpanRecord` values with `run_from_span_records`.
-- It imports JSONL from readers/paths when records contain completed span timing.
-- It does **not** install or provide a `tracing_subscriber::Layer`.
-- It does **not** implement OpenTelemetry or OTLP.
-- It does **not** change `tailtriage-analyzer`.
+- semantic convention keys (`tt.*`) for triage-oriented span fields,
+- typed intake records and import option/result types,
+- JSONL import helpers,
+- a live `tracing_subscriber::Layer` recorder for completed spans.
 
-## JSONL import support in this phase
+This crate does **not** add OTel/OTLP export and does **not** change analyzer behavior.
+
+## Live recorder example
+
+```rust
+use tracing::info_span;
+use tracing_subscriber::prelude::*;
+use tailtriage_tracing::TracingRecorder;
+
+let recorder = TracingRecorder::builder("checkout-service")
+    .service_version("1.2.3")
+    .run_id("demo-run")
+    .strict(false)
+    .build();
+
+let subscriber = tracing_subscriber::registry().with(recorder.layer());
+tracing::subscriber::with_default(subscriber, || {
+    let request = info_span!(
+        "http.request",
+        tt.kind = "request",
+        tt.request_id = "req-42",
+        tt.route = "/checkout",
+    );
+    let _request_guard = request.enter();
+
+    let stage = info_span!(
+        "db.stage",
+        tt.kind = "stage",
+        tt.request_id = "req-42",
+        tt.stage = "db",
+        tt.success = true,
+    );
+    let _stage_guard = stage.enter();
+});
+
+let imported = recorder.snapshot_run()?;
+assert_eq!(imported.run().requests.len(), 1);
+# Ok::<(), tailtriage_tracing::ImportError>(())
+```
+
+## Async span guidance
+
+For async code, prefer `#[tracing::instrument(fields(...))]` or future instrumentation with
+`.instrument(...)` so spans close at the right lifecycle boundaries. Avoid holding a manual
+entered-span guard across `.await` points.
+
+## Runtime-pressure evidence note
+
+Tracing spans can be captured in non-Tokio runtimes for request/stage/queue triage evidence.
+Runtime-pressure evidence (executor pressure and blocking-pool pressure) still requires
+`tailtriage` runtime sampling (or future runtime metrics import) to be present in the run.
+
+## JSONL import support
 
 Public APIs:
 
@@ -38,31 +87,3 @@ Supported stable contract (recommended for tests and integrations):
   }
 }
 ```
-
-Notes:
-
-- Importer accepts `started_at_unix_ms`/`finished_at_unix_ms` and aliases `start_unix_ms`/`end_unix_ms`.
-- In this phase, normalized shape uses **literal dotted keys** inside `fields` (for example `"tt.kind"` and `"tt.request_id"`), not nested objects that require flattening.
-- Importer reads `tt.*` fields from `fields`, `span.fields`, or top-level `tt.*` keys when present.
-- Scalars can be strings, bools, numbers, or null.
-- Empty lines are ignored.
-- Malformed JSON line input is an import error in both strict and non-strict mode.
-
-## tracing-subscriber JSON caveat
-
-Direct `tracing-subscriber` JSON output can vary by formatter configuration. In
-this phase, the importer supports:
-
-- normalized completed-span JSONL (shape above), and
-- close-event-like records only when they include explicit start/end unix-ms timestamps.
-
-It does not guess missing timing from line receive time and does not claim broad
-automatic parsing for every tracing JSON variant.
-
-## Intended field shape
-
-Typical span fields are expected to follow this shape:
-
-- request: `tt.kind`, `tt.request_id`, `tt.route`
-- stage: `tt.kind`, `tt.request_id`, `tt.stage`
-- queue: `tt.kind`, `tt.request_id`, `tt.queue`, `tt.depth_at_start`

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -30,6 +30,7 @@
 mod convention;
 mod error;
 mod jsonl;
+mod recorder;
 mod types;
 
 use tailtriage_core::{
@@ -42,6 +43,7 @@ pub use convention::{
 };
 pub use error::ImportError;
 pub use jsonl::{import_jsonl_path, import_jsonl_reader};
+pub use recorder::{TailtriageLayer, TracingRecorder, TracingRecorderBuilder};
 pub use types::{FieldValue, ImportOptions, ImportWarning, ImportedRun, SpanKind, SpanRecord};
 
 /// Converts in-memory tracing span records into a `tailtriage_core::Run`.

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -1,0 +1,334 @@
+use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::{Arc, Mutex};
+
+use tracing::field::{Field, Visit};
+use tracing::span::{Attributes, Id, Record};
+use tracing::Subscriber;
+use tracing_subscriber::layer::{Context, Layer};
+use tracing_subscriber::registry::LookupSpan;
+
+use crate::{
+    run_from_span_records, FieldValue, ImportError, ImportOptions, ImportedRun, SpanRecord,
+};
+
+/// In-memory live recorder for completed tracing spans with `tt.*` fields.
+#[derive(Debug, Clone)]
+pub struct TracingRecorder {
+    state: Arc<Mutex<RecorderState>>,
+    options: ImportOptions,
+}
+
+/// Builder for configuring a [`TracingRecorder`].
+#[derive(Debug, Clone)]
+pub struct TracingRecorderBuilder {
+    options: ImportOptions,
+}
+
+/// `tracing_subscriber::Layer` that collects span lifecycle data for [`TracingRecorder`].
+#[derive(Debug, Clone)]
+pub struct TailtriageLayer {
+    state: Arc<Mutex<RecorderState>>,
+}
+
+#[derive(Debug, Default)]
+struct RecorderState {
+    open_spans: BTreeMap<String, OpenSpan>,
+    completed_spans: Vec<SpanRecord>,
+}
+
+#[derive(Debug)]
+struct OpenSpan {
+    name: String,
+    parent_id: Option<String>,
+    fields: BTreeMap<String, FieldValue>,
+    started_at_unix_ms: u64,
+}
+
+impl TracingRecorder {
+    /// Creates a recorder builder with required service name metadata.
+    pub fn builder(service_name: impl Into<String>) -> TracingRecorderBuilder {
+        TracingRecorderBuilder {
+            options: ImportOptions::new(service_name),
+        }
+    }
+
+    /// Returns a cloneable tracing layer connected to this recorder.
+    #[must_use]
+    pub fn layer(&self) -> TailtriageLayer {
+        TailtriageLayer {
+            state: Arc::clone(&self.state),
+        }
+    }
+
+    /// Finalizes currently completed spans into an imported run snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Returns any strict import validation error from `run_from_span_records`.
+    pub fn snapshot_run(&self) -> Result<ImportedRun, ImportError> {
+        let records = lock_state(&self.state).completed_spans.clone();
+        run_from_span_records(records, self.options.clone())
+    }
+
+    /// Finalizes currently completed spans into an imported run during shutdown.
+    ///
+    /// # Errors
+    ///
+    /// Returns any strict import validation error from `run_from_span_records`.
+    pub fn shutdown(&self) -> Result<ImportedRun, ImportError> {
+        self.snapshot_run()
+    }
+}
+
+impl TracingRecorderBuilder {
+    /// Sets optional service version metadata.
+    #[must_use]
+    pub fn service_version(mut self, service_version: impl Into<String>) -> Self {
+        self.options = self.options.service_version(service_version);
+        self
+    }
+
+    /// Sets optional run id metadata.
+    #[must_use]
+    pub fn run_id(mut self, run_id: impl Into<String>) -> Self {
+        self.options = self.options.run_id(run_id);
+        self
+    }
+
+    /// Enables or disables strict conversion semantics.
+    #[must_use]
+    pub fn strict(mut self, strict: bool) -> Self {
+        self.options = self.options.strict(strict);
+        self
+    }
+
+    /// Builds the recorder.
+    #[must_use]
+    pub fn build(self) -> TracingRecorder {
+        TracingRecorder {
+            state: Arc::new(Mutex::new(RecorderState::default())),
+            options: self.options,
+        }
+    }
+}
+
+impl<S> Layer<S> for TailtriageLayer
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let mut visitor = FieldVisitor::default();
+        attrs.record(&mut visitor);
+
+        let parent_id = ctx.span(id).and_then(|span_ref| {
+            span_ref
+                .parent()
+                .map(|parent| parent.id().into_u64().to_string())
+        });
+
+        let open = OpenSpan {
+            name: attrs.metadata().name().to_owned(),
+            parent_id,
+            fields: visitor.fields,
+            started_at_unix_ms: tailtriage_core::unix_time_ms(),
+        };
+
+        lock_state(&self.state)
+            .open_spans
+            .insert(id.into_u64().to_string(), open);
+    }
+
+    fn on_record(&self, id: &Id, values: &Record<'_>, _ctx: Context<'_, S>) {
+        let mut visitor = FieldVisitor::default();
+        values.record(&mut visitor);
+        let mut state = lock_state(&self.state);
+        if let Some(span) = state.open_spans.get_mut(&id.into_u64().to_string()) {
+            for (k, v) in visitor.fields {
+                span.fields.insert(k, v);
+            }
+        }
+    }
+
+    fn on_close(&self, id: Id, _ctx: Context<'_, S>) {
+        let finish = tailtriage_core::unix_time_ms();
+        let mut state = lock_state(&self.state);
+        let Some(span) = state.open_spans.remove(&id.into_u64().to_string()) else {
+            return;
+        };
+
+        if !matches!(span.fields.get("tt.kind"), Some(FieldValue::String(_))) {
+            return;
+        }
+
+        let mut record = SpanRecord::new(span.name, span.started_at_unix_ms, finish)
+            .id(id.into_u64().to_string());
+        if let Some(parent_id) = span.parent_id {
+            record = record.parent_id(parent_id);
+        }
+        for (k, v) in span.fields {
+            record = record.field(k, v);
+        }
+        state.completed_spans.push(record);
+    }
+}
+
+fn lock_state(state: &Arc<Mutex<RecorderState>>) -> std::sync::MutexGuard<'_, RecorderState> {
+    match state.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+#[derive(Default)]
+struct FieldVisitor {
+    fields: BTreeMap<String, FieldValue>,
+}
+
+impl Visit for FieldVisitor {
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.fields
+            .insert(field.name().to_owned(), FieldValue::Bool(value));
+    }
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.fields
+            .insert(field.name().to_owned(), FieldValue::I64(value));
+    }
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.fields
+            .insert(field.name().to_owned(), FieldValue::U64(value));
+    }
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.fields
+            .insert(field.name().to_owned(), FieldValue::F64(value));
+    }
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.fields.insert(
+            field.name().to_owned(),
+            FieldValue::String(value.to_owned()),
+        );
+    }
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.fields.insert(
+            field.name().to_owned(),
+            FieldValue::String(format!("{value:?}")),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tracing::field::Empty;
+    use tracing::info_span;
+    use tracing_subscriber::prelude::*;
+
+    use super::*;
+
+    #[test]
+    fn request_span_collected() {
+        let recorder = TracingRecorder::builder("svc").build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let span = info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/x"
+            );
+            let _guard = span.enter();
+        });
+
+        let imported = recorder.snapshot_run().unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+    }
+
+    #[test]
+    fn stage_span_collected() {
+        let recorder = TracingRecorder::builder("svc").build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let span = info_span!(
+                "stage",
+                tt.kind = "stage",
+                tt.request_id = "r1",
+                tt.stage = "db"
+            );
+            let _guard = span.enter();
+        });
+
+        assert_eq!(recorder.snapshot_run().unwrap().run().stages.len(), 1);
+    }
+
+    #[test]
+    fn queue_span_collected() {
+        let recorder = TracingRecorder::builder("svc").build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let span = info_span!(
+                "queue",
+                tt.kind = "queue",
+                tt.request_id = "r1",
+                tt.queue = "permits"
+            );
+            let _guard = span.enter();
+        });
+
+        assert_eq!(recorder.snapshot_run().unwrap().run().queues.len(), 1);
+    }
+
+    #[test]
+    fn on_record_updates_field() {
+        let recorder = TracingRecorder::builder("svc").build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let span = info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/x",
+                tt.outcome = Empty
+            );
+            span.record("tt.outcome", "error");
+            let _guard = span.enter();
+        });
+
+        let imported = recorder.snapshot_run().unwrap();
+        assert_eq!(imported.run().requests[0].outcome, "error");
+    }
+
+    #[test]
+    fn unrelated_spans_ignored() {
+        let recorder = TracingRecorder::builder("svc").build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let _span = info_span!("ordinary", foo = 1_u64);
+        });
+
+        let imported = recorder.snapshot_run().unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.run().stages.is_empty());
+        assert!(imported.run().queues.is_empty());
+    }
+
+    #[test]
+    fn converted_run_analyzes_in_memory() {
+        let recorder = TracingRecorder::builder("svc").build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let span = info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/x"
+            );
+            let _guard = span.enter();
+        });
+
+        let imported = recorder.snapshot_run().unwrap();
+        let report = tailtriage_analyzer::analyze_run(
+            imported.run(),
+            tailtriage_analyzer::AnalyzeOptions::default(),
+        );
+        assert!(report.request_count >= 1);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a small live recorder that captures completed `tracing` spans tagged with `tt.*` into in-memory `SpanRecord`s so runs can be created from live instrumented services.
- Keep import/conversion behavior unchanged by reusing the existing `run_from_span_records` function and deferring conversion until an explicit snapshot/shutdown call.
- Offer a minimal, safe integration path for users who want quick triage evidence from `tracing` without adding OTel/OTLP or changing analyzer/CLI behavior.

### Description
- Added a new `recorder.rs` module exposing `pub struct TracingRecorder`, `TracingRecorderBuilder`, and a cloneable `TailtriageLayer` that implements `tracing_subscriber::Layer`.
- The layer captures lifecycle events using `on_new_span` (initial fields + `tailtriage_core::unix_time_ms()` start), `on_record` (update fields, latest wins), and `on_close` (finalize and store a `SpanRecord` using tracing span-id strings and parent ids); spans missing `tt.kind` are ignored.
- The recorder stores data behind `Arc<Mutex<...>>` and exposes `TracingRecorder::layer()`, `TracingRecorder::snapshot_run()` and `TracingRecorder::shutdown()` (the latter reuses `snapshot_run`); conversion into `tailtriage_core::Run` is done by calling the existing `run_from_span_records`.
- Implemented a `tracing::field::Visit` `FieldVisitor` that converts bool/i64/u64/f64/string/debug into `FieldValue` (debug values become strings), and updated public exports and `tailtriage-tracing/README.md` with a minimal usage example and async-span guidance.
- Added crate dependencies: `tracing = "0.1"` and `tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }`.

### Testing
- Added unit tests exercising request/stage/queue span collection, `on_record` updates, ignoring unrelated spans, and in-memory analyzer compatibility, all implemented using `tracing_subscriber::registry().with(recorder.layer())` and scoped subscriber dispatch.
- Ran `cargo fmt --check` which passed.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` which passed.
- Ran `cargo test --workspace` which passed (all workspace tests, including the new recorder tests, succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a075ebbd990833087ae6e95016fcfd9)