### PR TITLE
Add live tracing_subscriber layer recorder to tailtriage-tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,6 +738,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared-state-lock-service-demo"
 version = "0.2.0"
 dependencies = [
@@ -871,6 +886,8 @@ dependencies = [
  "serde_json",
  "tailtriage-core",
  "tempfile",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -884,6 +901,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -978,6 +1004,48 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -20,6 +20,8 @@ include = [
 tailtriage-core.workspace = true
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -9,7 +9,7 @@ This crate is intentionally narrow:
 - It defines typed intake records and import option/result types.
 - It converts typed `SpanRecord` values with `run_from_span_records`.
 - It imports JSONL from readers/paths when records contain completed span timing.
-- It does **not** install or provide a `tracing_subscriber::Layer`.
+- It provides an in-process `tracing_subscriber::Layer` recorder for completed `tt.*` spans.
 - It does **not** implement OpenTelemetry or OTLP.
 - It does **not** change `tailtriage-analyzer`.
 
@@ -66,3 +66,39 @@ Typical span fields are expected to follow this shape:
 - request: `tt.kind`, `tt.request_id`, `tt.route`
 - stage: `tt.kind`, `tt.request_id`, `tt.stage`
 - queue: `tt.kind`, `tt.request_id`, `tt.queue`, `tt.depth_at_start`
+
+
+## Live tracing recorder
+
+```rust
+use tracing_subscriber::prelude::*;
+use tailtriage_tracing::TracingRecorder;
+
+let recorder = TracingRecorder::builder("checkout-service")
+    .service_version("1.2.3")
+    .run_id("run-42")
+    .strict(false)
+    .build();
+
+let subscriber = tracing_subscriber::registry().with(recorder.layer());
+tracing::subscriber::with_default(subscriber, || {
+    let request = tracing::info_span!(
+        "http.request",
+        tt.kind = "request",
+        tt.request_id = "req-42",
+        tt.route = "/checkout",
+        tt.outcome = tracing::field::Empty
+    );
+    request.record("tt.outcome", "ok");
+});
+
+let imported = recorder.shutdown()?;
+let run = imported.run();
+assert_eq!(run.requests.len(), 1);
+# Ok::<(), tailtriage_tracing::ImportError>(())
+```
+
+Use `#[tracing::instrument(fields(...))]` or `.instrument(...)` so span fields attach to async work correctly.
+Do not hold a manual entered-span guard across `.await`; async spans may enter/exit many times, and this recorder finalizes completed work on `on_close` (drop), not enter/exit transitions.
+
+Tracing span capture for request/stage/queue evidence works outside Tokio runtimes. Runtime-pressure evidence still requires tailtriage's Tokio sampler or future runtime-metrics import; tracing-only spans cannot infer executor or blocking-pool pressure by themselves.

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -82,14 +82,17 @@ let recorder = TracingRecorder::builder("checkout-service")
 
 let subscriber = tracing_subscriber::registry().with(recorder.layer());
 tracing::subscriber::with_default(subscriber, || {
-    let request = tracing::info_span!(
-        "http.request",
-        tt.kind = "request",
-        tt.request_id = "req-42",
-        tt.route = "/checkout",
-        tt.outcome = tracing::field::Empty
-    );
-    request.record("tt.outcome", "ok");
+    {
+        let request = tracing::info_span!(
+            "http.request",
+            tt.kind = "request",
+            tt.request_id = "req-42",
+            tt.route = "/checkout",
+            tt.outcome = tracing::field::Empty
+        );
+        let _entered = request.enter();
+        request.record("tt.outcome", "ok");
+    }
 });
 
 let imported = recorder.shutdown()?;

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -30,6 +30,7 @@
 mod convention;
 mod error;
 mod jsonl;
+mod recorder;
 mod types;
 
 use tailtriage_core::{
@@ -42,6 +43,7 @@ pub use convention::{
 };
 pub use error::ImportError;
 pub use jsonl::{import_jsonl_path, import_jsonl_reader};
+pub use recorder::{TailtriageLayer, TracingRecorder, TracingRecorderBuilder};
 pub use types::{FieldValue, ImportOptions, ImportWarning, ImportedRun, SpanKind, SpanRecord};
 
 /// Converts in-memory tracing span records into a `tailtriage_core::Run`.

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -44,6 +44,13 @@ struct OpenSpan {
     started_at_unix_ms: u64,
 }
 
+fn lock_state(state: &Arc<Mutex<RecorderState>>) -> std::sync::MutexGuard<'_, RecorderState> {
+    match state.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
 impl TracingRecorder {
     /// Creates a builder with required service name metadata.
     pub fn builder(service_name: impl Into<String>) -> TracingRecorderBuilder {
@@ -64,13 +71,10 @@ impl TracingRecorder {
     ///
     /// # Errors
     ///
-    /// Returns [`ImportError`] when strict conversion fails or the recorder mutex is poisoned.
+    /// Returns [`ImportError`] when strict conversion fails.
     pub fn snapshot_run(&self) -> Result<ImportedRun, ImportError> {
         let spans = {
-            let state = self.state.lock().map_err(|e| ImportError::InvalidField {
-                field: "recorder",
-                reason: format!("recorder mutex poisoned: {e}"),
-            })?;
+            let state = lock_state(&self.state);
             state.completed.clone()
         };
         run_from_span_records(spans, self.options.clone())
@@ -82,7 +86,7 @@ impl TracingRecorder {
     ///
     /// # Errors
     ///
-    /// Returns [`ImportError`] when strict conversion fails or the recorder mutex is poisoned.
+    /// Returns [`ImportError`] when strict conversion fails.
     pub fn shutdown(&self) -> Result<ImportedRun, ImportError> {
         self.snapshot_run()
     }
@@ -142,45 +146,42 @@ where
             fields: visitor.fields,
             started_at_unix_ms: tailtriage_core::unix_time_ms(),
         };
-        if let Ok(mut state) = self.state.lock() {
-            state.open.insert(id.into_u64().to_string(), open_span);
-        }
+        let mut state = lock_state(&self.state);
+        state.open.insert(id.into_u64().to_string(), open_span);
     }
 
     fn on_record(&self, span_id: &Id, values: &tracing::span::Record<'_>, _ctx: Context<'_, S>) {
         let mut visitor = FieldVisitor::default();
         values.record(&mut visitor);
-        if let Ok(mut state) = self.state.lock() {
-            let key = span_id.into_u64().to_string();
-            if let Some(span) = state.open.get_mut(&key) {
-                span.fields.extend(visitor.fields);
-            }
+        let mut state = lock_state(&self.state);
+        let key = span_id.into_u64().to_string();
+        if let Some(span) = state.open.get_mut(&key) {
+            span.fields.extend(visitor.fields);
         }
     }
 
     fn on_close(&self, id: Id, _ctx: Context<'_, S>) {
-        if let Ok(mut state) = self.state.lock() {
-            let key = id.into_u64().to_string();
-            if let Some(open) = state.open.remove(&key) {
-                if !open.fields.contains_key(TT_KIND) {
-                    return;
-                }
-                let mut record = SpanRecord::new(
-                    open.name,
-                    open.started_at_unix_ms,
-                    tailtriage_core::unix_time_ms(),
-                );
-                if let Some(span_id) = open.id {
-                    record = record.id(span_id);
-                }
-                if let Some(parent_id) = open.parent_id {
-                    record = record.parent_id(parent_id);
-                }
-                for (k, v) in open.fields {
-                    record = record.field(k, v);
-                }
-                state.completed.push(record);
+        let mut state = lock_state(&self.state);
+        let key = id.into_u64().to_string();
+        if let Some(open) = state.open.remove(&key) {
+            if !open.fields.contains_key(TT_KIND) {
+                return;
             }
+            let mut record = SpanRecord::new(
+                open.name,
+                open.started_at_unix_ms,
+                tailtriage_core::unix_time_ms(),
+            );
+            if let Some(span_id) = open.id {
+                record = record.id(span_id);
+            }
+            if let Some(parent_id) = open.parent_id {
+                record = record.parent_id(parent_id);
+            }
+            for (k, v) in open.fields {
+                record = record.field(k, v);
+            }
+            state.completed.push(record);
         }
     }
 }
@@ -308,6 +309,77 @@ mod tests {
             assert!(run.run().requests.is_empty());
             assert!(run.run().stages.is_empty());
             assert!(run.run().queues.is_empty());
+        });
+    }
+
+    #[test]
+    fn shutdown_returns_imported_run() {
+        with_recorder(|recorder| {
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/checkout"
+            );
+            drop(span);
+            let run = recorder.shutdown().unwrap();
+            assert_eq!(run.run().requests.len(), 1);
+            assert_eq!(run.run().requests[0].request_id, "r1");
+            assert_eq!(run.run().requests[0].route, "/checkout");
+        });
+    }
+
+    #[test]
+    fn builder_metadata_applies_to_imported_run() {
+        let recorder = TracingRecorder::builder("checkout-service")
+            .service_version("1.2.3")
+            .run_id("run-42")
+            .strict(false)
+            .build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/checkout"
+            );
+            drop(span);
+        });
+
+        let run = recorder.snapshot_run().unwrap();
+        assert_eq!(run.run().metadata.service_name, "checkout-service");
+        assert_eq!(run.run().metadata.service_version.as_deref(), Some("1.2.3"));
+        assert_eq!(run.run().metadata.run_id, "run-42");
+    }
+
+    #[test]
+    fn strict_mode_errors_on_malformed_request() {
+        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("request", tt.kind = "request", tt.request_id = "r1");
+            drop(span);
+        });
+
+        assert!(recorder.snapshot_run().is_err());
+    }
+
+    #[test]
+    fn tt_kind_recorded_later_is_captured() {
+        with_recorder(|recorder| {
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = tracing::field::Empty,
+                tt.request_id = "r1",
+                tt.route = "/late-kind"
+            );
+            span.record("tt.kind", "request");
+            drop(span);
+
+            let run = recorder.snapshot_run().unwrap();
+            assert_eq!(run.run().requests.len(), 1);
+            assert_eq!(run.run().requests[0].route, "/late-kind");
         });
     }
 }

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -1,0 +1,313 @@
+use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::{Arc, Mutex};
+
+use tracing::field::{Field, Visit};
+use tracing::{Id, Subscriber};
+use tracing_subscriber::layer::{Context, Layer};
+
+use crate::{
+    run_from_span_records, FieldValue, ImportError, ImportOptions, ImportedRun, SpanRecord, TT_KIND,
+};
+
+/// In-memory recorder for completed tracing spans with `tt.*` fields.
+#[derive(Debug, Clone)]
+pub struct TracingRecorder {
+    state: Arc<Mutex<RecorderState>>,
+    options: ImportOptions,
+}
+
+/// Builder for [`TracingRecorder`].
+#[derive(Debug, Clone)]
+pub struct TracingRecorderBuilder {
+    options: ImportOptions,
+}
+
+/// `tracing_subscriber` layer that feeds completed spans into a [`TracingRecorder`].
+#[derive(Debug, Clone)]
+pub struct TailtriageLayer {
+    state: Arc<Mutex<RecorderState>>,
+}
+
+#[derive(Debug, Default)]
+struct RecorderState {
+    open: BTreeMap<String, OpenSpan>,
+    completed: Vec<SpanRecord>,
+}
+
+#[derive(Debug)]
+struct OpenSpan {
+    id: Option<String>,
+    parent_id: Option<String>,
+    name: String,
+    fields: BTreeMap<String, FieldValue>,
+    started_at_unix_ms: u64,
+}
+
+impl TracingRecorder {
+    /// Creates a builder with required service name metadata.
+    pub fn builder(service_name: impl Into<String>) -> TracingRecorderBuilder {
+        TracingRecorderBuilder {
+            options: ImportOptions::new(service_name),
+        }
+    }
+
+    /// Returns a cloneable layer that captures `on_new_span`, `on_record`, and `on_close`.
+    #[must_use]
+    pub fn layer(&self) -> TailtriageLayer {
+        TailtriageLayer {
+            state: Arc::clone(&self.state),
+        }
+    }
+
+    /// Converts currently completed spans into an imported run.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ImportError`] when strict conversion fails or the recorder mutex is poisoned.
+    pub fn snapshot_run(&self) -> Result<ImportedRun, ImportError> {
+        let spans = {
+            let state = self.state.lock().map_err(|e| ImportError::InvalidField {
+                field: "recorder",
+                reason: format!("recorder mutex poisoned: {e}"),
+            })?;
+            state.completed.clone()
+        };
+        run_from_span_records(spans, self.options.clone())
+    }
+
+    /// Converts currently completed spans into an imported run.
+    ///
+    /// This is currently equivalent to [`Self::snapshot_run`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ImportError`] when strict conversion fails or the recorder mutex is poisoned.
+    pub fn shutdown(&self) -> Result<ImportedRun, ImportError> {
+        self.snapshot_run()
+    }
+}
+
+impl TracingRecorderBuilder {
+    /// Sets service version metadata.
+    #[must_use]
+    pub fn service_version(mut self, service_version: impl Into<String>) -> Self {
+        self.options = self.options.service_version(service_version);
+        self
+    }
+
+    /// Sets explicit run-id metadata.
+    #[must_use]
+    pub fn run_id(mut self, run_id: impl Into<String>) -> Self {
+        self.options = self.options.run_id(run_id);
+        self
+    }
+
+    /// Enables or disables strict conversion mode.
+    #[must_use]
+    pub fn strict(mut self, strict: bool) -> Self {
+        self.options = self.options.strict(strict);
+        self
+    }
+
+    /// Builds a recorder instance.
+    #[must_use]
+    pub fn build(self) -> TracingRecorder {
+        TracingRecorder {
+            state: Arc::new(Mutex::new(RecorderState::default())),
+            options: self.options,
+        }
+    }
+}
+
+impl<S> Layer<S> for TailtriageLayer
+where
+    S: Subscriber,
+{
+    fn on_new_span(&self, attrs: &tracing::span::Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let mut visitor = FieldVisitor::default();
+        attrs.record(&mut visitor);
+        let parent_id = attrs
+            .parent()
+            .map(|pid| pid.into_u64().to_string())
+            .or_else(|| {
+                ctx.current_span()
+                    .id()
+                    .map(|pid| pid.into_u64().to_string())
+            });
+        let open_span = OpenSpan {
+            id: Some(id.into_u64().to_string()),
+            parent_id,
+            name: attrs.metadata().name().to_owned(),
+            fields: visitor.fields,
+            started_at_unix_ms: tailtriage_core::unix_time_ms(),
+        };
+        if let Ok(mut state) = self.state.lock() {
+            state.open.insert(id.into_u64().to_string(), open_span);
+        }
+    }
+
+    fn on_record(&self, span_id: &Id, values: &tracing::span::Record<'_>, _ctx: Context<'_, S>) {
+        let mut visitor = FieldVisitor::default();
+        values.record(&mut visitor);
+        if let Ok(mut state) = self.state.lock() {
+            let key = span_id.into_u64().to_string();
+            if let Some(span) = state.open.get_mut(&key) {
+                span.fields.extend(visitor.fields);
+            }
+        }
+    }
+
+    fn on_close(&self, id: Id, _ctx: Context<'_, S>) {
+        if let Ok(mut state) = self.state.lock() {
+            let key = id.into_u64().to_string();
+            if let Some(open) = state.open.remove(&key) {
+                if !open.fields.contains_key(TT_KIND) {
+                    return;
+                }
+                let mut record = SpanRecord::new(
+                    open.name,
+                    open.started_at_unix_ms,
+                    tailtriage_core::unix_time_ms(),
+                );
+                if let Some(span_id) = open.id {
+                    record = record.id(span_id);
+                }
+                if let Some(parent_id) = open.parent_id {
+                    record = record.parent_id(parent_id);
+                }
+                for (k, v) in open.fields {
+                    record = record.field(k, v);
+                }
+                state.completed.push(record);
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct FieldVisitor {
+    fields: BTreeMap<String, FieldValue>,
+}
+
+impl Visit for FieldVisitor {
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.fields
+            .insert(field.name().to_owned(), FieldValue::Bool(value));
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.fields
+            .insert(field.name().to_owned(), FieldValue::I64(value));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.fields
+            .insert(field.name().to_owned(), FieldValue::U64(value));
+    }
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.fields
+            .insert(field.name().to_owned(), FieldValue::F64(value));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.fields.insert(
+            field.name().to_owned(),
+            FieldValue::String(value.to_owned()),
+        );
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.fields.insert(
+            field.name().to_owned(),
+            FieldValue::String(format!("{value:?}")),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tracing_subscriber::prelude::*;
+
+    fn with_recorder<T>(f: impl FnOnce(&TracingRecorder) -> T) -> T {
+        let recorder = TracingRecorder::builder("svc").run_id("rid").build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || f(&recorder))
+    }
+
+    #[test]
+    fn request_span_collected() {
+        with_recorder(|recorder| {
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            );
+            drop(span);
+            let run = recorder.snapshot_run().unwrap();
+            assert_eq!(run.run().requests.len(), 1);
+        });
+    }
+
+    #[test]
+    fn stage_span_collected() {
+        with_recorder(|recorder| {
+            let span = tracing::info_span!(
+                "stage",
+                tt.kind = "stage",
+                tt.request_id = "r1",
+                tt.stage = "db"
+            );
+            drop(span);
+            let run = recorder.snapshot_run().unwrap();
+            assert_eq!(run.run().stages.len(), 1);
+        });
+    }
+
+    #[test]
+    fn queue_span_collected() {
+        with_recorder(|recorder| {
+            let span = tracing::info_span!(
+                "queue",
+                tt.kind = "queue",
+                tt.request_id = "r1",
+                tt.queue = "permits"
+            );
+            drop(span);
+            let run = recorder.snapshot_run().unwrap();
+            assert_eq!(run.run().queues.len(), 1);
+        });
+    }
+
+    #[test]
+    fn on_record_updates_field() {
+        with_recorder(|recorder| {
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a",
+                tt.outcome = tracing::field::Empty
+            );
+            span.record("tt.outcome", "timeout");
+            drop(span);
+            let run = recorder.snapshot_run().unwrap();
+            assert_eq!(run.run().requests[0].outcome, "timeout");
+        });
+    }
+
+    #[test]
+    fn unrelated_span_ignored() {
+        with_recorder(|recorder| {
+            let span = tracing::info_span!("other", user_id = 42_u64);
+            drop(span);
+            let run = recorder.snapshot_run().unwrap();
+            assert!(run.run().requests.is_empty());
+            assert!(run.run().stages.is_empty());
+            assert!(run.run().queues.is_empty());
+        });
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a small in-process recorder to capture completed `tt.*` tracing spans live and convert them to `tailtriage_core::Run` without changing analyzer or CLI behavior. 
- Reuse existing conversion logic (`run_from_span_records`) and the typed `SpanRecord` shape so live capture and JSONL import share the same contract.

### Description
- Added a new module that implements a builder-backed in-memory recorder and a cloneable `tracing_subscriber::Layer`: `TracingRecorder`, `TracingRecorderBuilder`, and `TailtriageLayer` (file: `tailtriage-tracing/src/recorder.rs`).
- The layer captures lifecycle events only: `on_new_span` records start time and initial fields, `on_record` merges later-recorded fields (last-write wins), and `on_close` finalizes spans into `SpanRecord` values using `tailtriage_core::unix_time_ms()` for timestamps; spans without `tt.kind` are ignored.  
- Span state is kept in-memory behind `Arc<Mutex<...>>` until `TracingRecorder::snapshot_run()` or `TracingRecorder::shutdown()` is called; both call `run_from_span_records` to produce an `ImportedRun`. 
- Field capture uses a `tracing::field::Visit` implementation that maps bools, integers, floats, strings, and debug-only values into `FieldValue` (debug values become strings). 
- Public API surface added: `TracingRecorder`, `TracingRecorderBuilder`, `TailtriageLayer`, `TracingRecorder::builder(...)`, builder setters (`service_version`, `run_id`, `strict`), `build()`, `TracingRecorder::layer()`, `snapshot_run()`, and `shutdown()`. 
- Added requested dependencies (`tracing = "0.1"` and `tracing-subscriber = { version = "0.3", default-features = false, features = ["registry","std"] }`) and exported the new API from the crate root. 
- Added unit tests that exercise the recorder with a scoped `tracing_subscriber::registry().with(recorder.layer())` subscriber to avoid global subscriber interference. 
- Updated `tailtriage-tracing/README.md` with a minimal live recorder example and explicit guidance about async spans (recommend `#[tracing::instrument(fields(...))]` or `.instrument(...)` and warn that runtime-pressure evidence requires the Tokio sampler). 

### Testing
- Ran formatting, lints, unit tests, and docs contract validation: `cargo fmt --check` (passed), `cargo clippy --workspace --all-targets -- -D warnings` (passed), `cargo test --workspace` (all tests passed), and `python3 scripts/validate_docs_contracts.py` (passed). 
- Added and ran recorder unit tests covering: request/span/stage/queue capture, `on_record` field updates (e.g. `tt.outcome`), and ignoring unrelated spans (all passed). 
- Confirmed the recorder finalization path uses `run_from_span_records` to produce analyzable `ImportedRun` output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a075ebbd990833087ae6e95016fcfd9)