### PR TITLE
Add focused tracing intake examples and JSONL fixture smoke coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,6 +858,8 @@ dependencies = [
 name = "tailtriage-tokio"
 version = "0.2.0"
 dependencies = [
+ "serde_json",
+ "tailtriage-analyzer",
  "tailtriage-core",
  "tokio",
 ]

--- a/scripts/smoke_public_examples.py
+++ b/scripts/smoke_public_examples.py
@@ -37,6 +37,11 @@ EXAMPLES = [
         "artifact": "tailtriage-run.json",
     },
     {
+        "package": "tailtriage-tokio",
+        "name": "live_recorder",
+        "artifact": "tailtriage-run.json",
+    },
+    {
         "package": "tailtriage-controller",
         "name": "controller_minimal",
         "artifact": "tailtriage-run-generation-1.json",

--- a/tailtriage-tokio/Cargo.toml
+++ b/tailtriage-tokio/Cargo.toml
@@ -20,6 +20,10 @@ include = [
 [dependencies]
 tailtriage-core.workspace = true
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
+serde_json = "1"
+
+[dev-dependencies]
+tailtriage-analyzer.workspace = true
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -43,6 +43,13 @@ Examples:
 
 This crate does not change core request lifecycle semantics.
 
+## Focused examples
+
+- `examples/live_recorder.rs`: minimal tracing-intake-style walkthrough that records one request with one queue and one stage signal, shuts down, then analyzes in-memory and prints a text triage report.
+- `examples/tracing_spans.jsonl`: tiny normalized JSONL fixture with one request, one stage, and one queue completed-span style record for smoke-style ingestion checks.
+
+These examples are a narrow tracing intake path for tailtriage triage workflows, not a telemetry backend surface.
+
 ## When to choose this crate
 
 Choose `tailtriage-tokio` when:

--- a/tailtriage-tokio/examples/live_recorder.rs
+++ b/tailtriage-tokio/examples/live_recorder.rs
@@ -1,0 +1,51 @@
+use std::{error::Error, fs};
+
+use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+use tailtriage_core::{Outcome, Run, Tailtriage};
+
+struct TracingRecorder {
+    run: Tailtriage,
+}
+
+impl TracingRecorder {
+    fn new() -> Result<Self, Box<dyn Error>> {
+        Ok(Self {
+            run: Tailtriage::builder("tracing-intake-example")
+                .output("tailtriage-run.json")
+                .build()?,
+        })
+    }
+
+    fn shutdown(self) -> Result<Run, Box<dyn Error>> {
+        self.run.shutdown()?;
+        let payload = fs::read_to_string("tailtriage-run.json")?;
+        Ok(serde_json::from_str(&payload)?)
+    }
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let recorder = TracingRecorder::new()?;
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+
+    runtime.block_on(async {
+        let started = recorder.run.begin_request("/live");
+        started
+            .handle
+            .queue("tt.queue.ingress")
+            .await_on(async {})
+            .await;
+        started
+            .handle
+            .stage("tt.stage.downstream")
+            .await_value(async {})
+            .await;
+        started.completion.finish(Outcome::Ok);
+    });
+
+    let run = recorder.shutdown()?;
+    let report = analyze_run(&run, AnalyzeOptions::default());
+    println!("{}", render_text(&report));
+    Ok(())
+}

--- a/tailtriage-tokio/examples/tracing_spans.jsonl
+++ b/tailtriage-tokio/examples/tracing_spans.jsonl
@@ -1,0 +1,3 @@
+{"schema_version":1,"record_type":"request","request_id":"req-1","route":"/demo","latency_us":1200,"start_unix_us":1000000,"end_unix_us":1001200,"outcome":"ok"}
+{"schema_version":1,"record_type":"stage","request_id":"req-1","stage":"downstream","duration_us":800,"success":true}
+{"schema_version":1,"record_type":"queue","request_id":"req-1","queue":"ingress","wait_us":300,"depth_at_start":2}

--- a/tailtriage-tokio/tests/tracing_fixture_smoke.rs
+++ b/tailtriage-tokio/tests/tracing_fixture_smoke.rs
@@ -1,0 +1,20 @@
+use std::collections::BTreeSet;
+
+#[test]
+fn tracing_fixture_has_request_stage_and_queue_records() {
+    let data = include_str!("../examples/tracing_spans.jsonl");
+    let mut record_types = BTreeSet::new();
+
+    for line in data.lines().filter(|line| !line.trim().is_empty()) {
+        let value: serde_json::Value = serde_json::from_str(line).expect("valid jsonl line");
+        let record_type = value
+            .get("record_type")
+            .and_then(serde_json::Value::as_str)
+            .expect("record_type string");
+        record_types.insert(record_type.to_string());
+    }
+
+    assert!(record_types.contains("request"));
+    assert!(record_types.contains("stage"));
+    assert!(record_types.contains("queue"));
+}


### PR DESCRIPTION
### Motivation

- Provide a minimal, focused tracing-intake example that teaches how to record `tt.*` queue and stage signals and run in-process analysis without broadening product scope. 
- Supply a tiny JSONL fixture for deterministic smoke validation of normalized tracing-completed-span records. 
- Keep examples narrow to the triage intake path and avoid adding telemetry backend or analyzer behavior changes.

### Description

- Add `tailtriage-tokio/examples/live_recorder.rs`, a small example that builds a `Tailtriage` recorder, records one request with one `tt.queue.*` queue event and one `tt.stage.*` stage event inside a scoped Tokio runtime, shuts down, loads the resulting `Run`, analyzes it with `tailtriage-analyzer`, and prints a text triage report. 
- Add `tailtriage-tokio/examples/tracing_spans.jsonl`, a tiny normalized JSONL fixture containing one `request`, one `stage`, and one `queue` record. 
- Add `tailtriage-tokio/tests/tracing_fixture_smoke.rs`, a unit test that asserts the JSONL fixture contains `request`, `stage`, and `queue` records. 
- Update `tailtriage-tokio/README.md` to point to the two focused examples and emphasize narrow triage intake positioning. 
- Update `tailtriage-tokio/Cargo.toml` to add `serde_json` and `tailtriage-analyzer` (dev) for example/test support. 
- Add the example to the public examples smoke script by updating `scripts/smoke_public_examples.py` to include the new `live_recorder` example.

### Testing

- Ran `cargo fmt --check` and fixed formatting; result: success. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings`; result: success. 
- Ran `cargo test --workspace` which executed crate tests and the new fixture smoke test; result: success (all tests passed). 
- Ran `python3 scripts/validate_docs_contracts.py` to validate docs contract; result: success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a076f9193bc8330b56b0273a7d9c86c)