### PR TITLE
Add focused tailtriage-tracing live recorder example and JSONL fixture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,6 +884,7 @@ version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
+ "tailtriage-analyzer",
  "tailtriage-core",
  "tempfile",
  "tracing",

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -30,4 +30,5 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dev-dependencies]
+tailtriage-analyzer.workspace = true
 tempfile = "3"

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -48,6 +48,15 @@ Notes:
 - Empty lines are ignored.
 - Malformed JSON line input is an import error in both strict and non-strict mode.
 
+
+## Focused examples
+
+- `examples/live_recorder.rs`: records completed `tt.*` request/stage spans with
+  `TracingRecorder`, converts to an in-memory run, and renders an analyzer text
+  triage report.
+- `examples/tracing_spans.jsonl`: normalized JSONL fixture with one request, one
+  stage, and one queue completed span for deterministic intake/import smoke use.
+
 ## tracing-subscriber JSON caveat
 
 Direct `tracing-subscriber` JSON output can vary by formatter configuration. In

--- a/tailtriage-tracing/examples/live_recorder.rs
+++ b/tailtriage-tracing/examples/live_recorder.rs
@@ -1,0 +1,41 @@
+use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+use tailtriage_tracing::TracingRecorder;
+use tracing_subscriber::prelude::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let recorder = TracingRecorder::builder("checkout-service")
+        .service_version("1.0.0")
+        .run_id("live-recorder-example")
+        .strict(false)
+        .build();
+
+    let subscriber = tracing_subscriber::registry().with(recorder.layer());
+    tracing::subscriber::with_default(subscriber, || {
+        let request = tracing::info_span!(
+            "http.request",
+            tt.kind = "request",
+            tt.request_id = "req-1",
+            tt.route = "/checkout",
+            tt.outcome = tracing::field::Empty,
+        );
+        let _request_guard = request.enter();
+
+        let stage = tracing::info_span!(
+            "stage.db",
+            tt.kind = "stage",
+            tt.request_id = "req-1",
+            tt.stage = "db",
+            tt.success = true,
+        );
+        {
+            let _stage_guard = stage.enter();
+        }
+
+        request.record("tt.outcome", "ok");
+    });
+
+    let imported = recorder.shutdown()?;
+    let report = analyze_run(imported.run(), AnalyzeOptions::default());
+    println!("{}", render_text(&report));
+    Ok(())
+}

--- a/tailtriage-tracing/examples/tracing_spans.jsonl
+++ b/tailtriage-tracing/examples/tracing_spans.jsonl
@@ -1,0 +1,3 @@
+{"span":{"name":"http.request","id":"req-span-1","started_at_unix_ms":1700000000000,"finished_at_unix_ms":1700000000120,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}
+{"span":{"name":"stage.db","id":"stage-span-1","parent_id":"req-span-1","started_at_unix_ms":1700000000020,"finished_at_unix_ms":1700000000080,"fields":{"tt.kind":"stage","tt.request_id":"req-1","tt.stage":"db","tt.success":true}}}
+{"span":{"name":"queue.permits","id":"queue-span-1","parent_id":"req-span-1","started_at_unix_ms":1700000000005,"finished_at_unix_ms":1700000000015,"fields":{"tt.kind":"queue","tt.request_id":"req-1","tt.queue":"permits","tt.depth_at_start":2}}}

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -449,4 +449,13 @@ mod tests {
         assert_eq!(imported.run().stages.len(), 1);
         assert_eq!(imported.run().stages[0].stage, "db");
     }
+
+    #[test]
+    fn example_fixture_imports_request_stage_and_queue() {
+        let input = include_str!("../examples/tracing_spans.jsonl");
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().stages.len(), 1);
+        assert_eq!(imported.run().queues.len(), 1);
+    }
 }


### PR DESCRIPTION
### Motivation

- Provide small, focused examples that teach the `tracing` integration surface without expanding product scope.  
- Make it easy to smoke-test the tracing intake and importer using an in-repo JSONL fixture.  

### Description

- Added an example binary `tailtriage-tracing/examples/live_recorder.rs` that builds a `TracingRecorder`, installs its `Layer` on a scoped subscriber, emits a `request` span and a `stage` span with `tt.*` fields, calls `shutdown`, analyzes the in-memory run with `tailtriage-analyzer`, and prints the analyzer text report.  
- Added a deterministic normalized JSONL fixture `tailtriage-tracing/examples/tracing_spans.jsonl` containing one request, one stage, and one queue completed-span record in the supported shape.  
- Added a fixture-based unit test in `tailtriage-tracing/src/jsonl.rs` that imports the example JSONL via `import_jsonl_reader` and asserts there is at least one request, one stage, and one queue.  
- Updated `tailtriage-tracing/README.md` with a short “Focused examples” section pointing to the new example and fixture.  
- Added `tailtriage-analyzer.workspace = true` to `tailtriage-tracing` dev-dependencies so the example can compile and run against the workspace analyzer without widening public deps.  

### Testing

- Ran `cargo fmt --check` and it passed.  
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it passed without warnings.  
- Ran `cargo test --workspace` and all unit tests (including the new fixture test) passed.  
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0775efee6c8330ae37f0fada8f0599)