### PR TITLE
Add focused tracing intake examples and JSONL fixture to tailtriage-tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,6 +884,7 @@ version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
+ "tailtriage-analyzer",
  "tailtriage-core",
  "tempfile",
  "tracing",

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -14,6 +14,7 @@ include = [
   "README.md",
   "LICENSE",
   "src/**",
+  "examples/**",
 ]
 
 [dependencies]
@@ -30,4 +31,5 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dev-dependencies]
+tailtriage-analyzer.workspace = true
 tempfile = "3"

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -48,6 +48,14 @@ Notes:
 - Empty lines are ignored.
 - Malformed JSON line input is an import error in both strict and non-strict mode.
 
+
+## Examples
+
+- `examples/live_recorder.rs` shows scoped `tracing_subscriber` layer capture with
+  `TracingRecorder`, then in-memory triage analysis with `tailtriage-analyzer`.
+- `examples/tracing_spans.jsonl` is a tiny normalized JSONL fixture with one
+  request span, one stage span, and one queue span for importer smoke usage.
+
 ## tracing-subscriber JSON caveat
 
 Direct `tracing-subscriber` JSON output can vary by formatter configuration. In

--- a/tailtriage-tracing/examples/live_recorder.rs
+++ b/tailtriage-tracing/examples/live_recorder.rs
@@ -1,0 +1,37 @@
+use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+use tailtriage_tracing::TracingRecorder;
+use tracing_subscriber::prelude::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let recorder = TracingRecorder::builder("example-service")
+        .run_id("example-run")
+        .strict(false)
+        .build();
+
+    let subscriber = tracing_subscriber::registry().with(recorder.layer());
+    tracing::subscriber::with_default(subscriber, || {
+        let request = tracing::info_span!(
+            "http.request",
+            tt.kind = "request",
+            tt.request_id = "req-1",
+            tt.route = "/checkout"
+        );
+
+        let _request_guard = request.enter();
+        {
+            let stage = tracing::info_span!(
+                "db.query",
+                tt.kind = "stage",
+                tt.request_id = "req-1",
+                tt.stage = "db"
+            );
+            let _stage_guard = stage.enter();
+        }
+    });
+
+    let imported = recorder.shutdown()?;
+    let report = analyze_run(imported.run(), AnalyzeOptions::default());
+    println!("{}", render_text(&report));
+
+    Ok(())
+}

--- a/tailtriage-tracing/examples/tracing_spans.jsonl
+++ b/tailtriage-tracing/examples/tracing_spans.jsonl
@@ -1,0 +1,3 @@
+{"span":{"name":"http.request","id":"span-req-1","started_at_unix_ms":1700000000000,"finished_at_unix_ms":1700000000200,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout"}}}
+{"span":{"name":"db.query","id":"span-stage-1","parent_id":"span-req-1","started_at_unix_ms":1700000000040,"finished_at_unix_ms":1700000000160,"fields":{"tt.kind":"stage","tt.request_id":"req-1","tt.stage":"db"}}}
+{"span":{"name":"checkout.queue","id":"span-queue-1","parent_id":"span-req-1","started_at_unix_ms":1700000000010,"finished_at_unix_ms":1700000000040,"fields":{"tt.kind":"queue","tt.request_id":"req-1","tt.queue":"checkout-worker","tt.depth_at_start":3}}}

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -302,6 +302,15 @@ mod tests {
     use std::io::Cursor;
 
     #[test]
+    fn fixture_jsonl_imports_request_stage_and_queue() {
+        let input = include_str!("../examples/tracing_spans.jsonl");
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().stages.len(), 1);
+        assert_eq!(imported.run().queues.len(), 1);
+    }
+
+    #[test]
     fn normalized_jsonl_request_only() {
         let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();


### PR DESCRIPTION
### Motivation

- Provide a minimal, opinionated example that teaches the `tracing` integration path for tailtriage without expanding product scope. 
- Supply a tiny deterministic JSONL fixture to support importer smoke tests and examples usage.

### Description

- Add `examples/live_recorder.rs` demonstrating how to build a `TracingRecorder`, install its layer on a scoped `tracing_subscriber` subscriber, emit one `request` and one `stage` span with `tt.*` fields, call `shutdown`, then run in-memory analysis via `tailtriage_analyzer::analyze_run` and print the text report. 
- Add `examples/tracing_spans.jsonl` containing one `request`, one `stage`, and one `queue` completed-span record in the crate's normalized JSONL shape. 
- Update `tailtriage-tracing/Cargo.toml` to include `examples/**` in the package `include` list and add `tailtriage-analyzer` as a `dev-dependency` so the example compiles without widening the public API. 
- Add a unit test in `src/jsonl.rs` that imports `../examples/tracing_spans.jsonl` via `import_jsonl_reader` and asserts presence of one request, one stage, and one queue, and update `README.md` to reference both examples; no analyzer logic, CLI behavior, or OTLP/OTel support was added or changed.

### Testing

- Ran `cargo fmt --check` and it passed. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it passed. 
- Ran `cargo test --workspace` and the test suite passed (including the new JSONL importer test). 
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0775efee6c8330ae37f0fada8f0599)