### PR TITLE
Add focused tailtriage-tracing examples: live recorder and JSONL fixture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,6 +884,7 @@ version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
+ "tailtriage-analyzer",
  "tailtriage-core",
  "tempfile",
  "tracing",

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -14,6 +14,7 @@ include = [
   "README.md",
   "LICENSE",
   "src/**",
+  "examples/**",
 ]
 
 [dependencies]
@@ -30,4 +31,5 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dev-dependencies]
+tailtriage-analyzer.workspace = true
 tempfile = "3"

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -105,3 +105,11 @@ Use `#[tracing::instrument(fields(...))]` or `.instrument(...)` so span fields a
 Do not hold a manual entered-span guard across `.await`; async spans may enter/exit many times, and this recorder finalizes completed work on `on_close` (drop), not enter/exit transitions.
 
 Tracing span capture for request/stage/queue evidence works outside Tokio runtimes. Runtime-pressure evidence still requires tailtriage's Tokio sampler or future runtime-metrics import; tracing-only spans cannot infer executor or blocking-pool pressure by themselves.
+
+
+## Focused examples
+
+- `examples/live_recorder.rs`: records one request span and one stage span with `tt.*` fields, converts the captured spans into a run, then renders an in-memory analyzer text report.
+- `examples/tracing_spans.jsonl`: normalized JSONL fixture with one completed request, stage, and queue span for deterministic import/testing.
+
+These examples demonstrate tracing intake for tailtriage triage workflows only; they do not add telemetry backend behavior.

--- a/tailtriage-tracing/examples/live_recorder.rs
+++ b/tailtriage-tracing/examples/live_recorder.rs
@@ -1,0 +1,40 @@
+use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+use tailtriage_tracing::TracingRecorder;
+use tracing_subscriber::prelude::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let recorder = TracingRecorder::builder("checkout-service")
+        .service_version("0.1.0")
+        .run_id("live-recorder-example")
+        .strict(true)
+        .build();
+
+    let subscriber = tracing_subscriber::registry().with(recorder.layer());
+    tracing::subscriber::with_default(subscriber, || {
+        let request_span = tracing::info_span!(
+            "http.request",
+            tt.kind = "request",
+            tt.request_id = "req-100",
+            tt.route = "/checkout"
+        );
+
+        let request_guard = request_span.enter();
+        {
+            let stage_span = tracing::info_span!(
+                "checkout.db",
+                tt.kind = "stage",
+                tt.request_id = "req-100",
+                tt.stage = "db_call",
+                tt.success = true
+            );
+            let _stage_guard = stage_span.enter();
+        }
+        drop(request_guard);
+    });
+
+    let imported = recorder.shutdown()?;
+    let report = analyze_run(imported.run(), AnalyzeOptions::default());
+    println!("{}", render_text(&report));
+
+    Ok(())
+}

--- a/tailtriage-tracing/examples/tracing_spans.jsonl
+++ b/tailtriage-tracing/examples/tracing_spans.jsonl
@@ -1,0 +1,3 @@
+{"span":{"name":"http.request","id":"span-request-1","started_at_unix_ms":1700000000000,"finished_at_unix_ms":1700000000120,"fields":{"tt.kind":"request","tt.request_id":"req-42","tt.route":"/checkout"}}}
+{"span":{"name":"checkout.db","id":"span-stage-1","parent_id":"span-request-1","started_at_unix_ms":1700000000020,"finished_at_unix_ms":1700000000090,"fields":{"tt.kind":"stage","tt.request_id":"req-42","tt.stage":"db_call","tt.success":true}}}
+{"span":{"name":"admission.queue","id":"span-queue-1","parent_id":"span-request-1","started_at_unix_ms":1700000000002,"finished_at_unix_ms":1700000000018,"fields":{"tt.kind":"queue","tt.request_id":"req-42","tt.queue":"admission","tt.depth_at_start":3}}}

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -449,4 +449,14 @@ mod tests {
         assert_eq!(imported.run().stages.len(), 1);
         assert_eq!(imported.run().stages[0].stage, "db");
     }
+
+    #[test]
+    fn imports_examples_fixture_with_request_stage_and_queue() {
+        let input = include_str!("../examples/tracing_spans.jsonl");
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        let run = imported.run();
+        assert_eq!(run.requests.len(), 1);
+        assert_eq!(run.stages.len(), 1);
+        assert_eq!(run.queues.len(), 1);
+    }
 }


### PR DESCRIPTION
### Motivation

- Provide small, focused examples that teach the `tt.*` tracing intake path without expanding product scope or adding telemetry backends. 
- Offer a deterministic JSONL fixture to make import behavior and tests reproducible for smoke-style validation. 

### Description

- Add `tailtriage-tracing/examples/live_recorder.rs`, a minimal example that builds a `TracingRecorder`, installs its layer with a scoped subscriber, emits one request span and one stage span with `tt.*` fields, calls `shutdown`, analyzes the imported run in-memory with `tailtriage-analyzer`, and prints a text report. 
- Add `tailtriage-tracing/examples/tracing_spans.jsonl`, a normalized JSONL fixture containing one completed request span, one stage span, and one queue span in the supported shape. 
- Add a unit test to `tailtriage-tracing/src/jsonl.rs` that imports the JSONL fixture via `import_jsonl_reader` and asserts the imported run contains one request, one stage, and one queue. 
- Update `tailtriage-tracing/README.md` with a focused "Focused examples" section linking both the live recorder and JSONL fixture and explicitly note these are tracing intake examples (not a telemetry backend). 
- Adjust `tailtriage-tracing/Cargo.toml` to package `examples/**` and add `tailtriage-analyzer.workspace = true` as a `dev-dependency` so the example can render analyzer output. 

### Testing

- Ran `cargo fmt --check` and formatting check passed. 
- Ran `python3 scripts/validate_docs_contracts.py` and the docs contract validation passed. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and the linter passed with no warnings. 
- Ran `cargo test --workspace` and the full test-suite passed, including the new `tailtriage-tracing` import test which verifies request/stage/queue counts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0775efee6c8330ae37f0fada8f0599)