### PR TITLE
Add focused tracing examples: live recorder and JSONL fixture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,6 +884,7 @@ version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
+ "tailtriage-analyzer",
  "tailtriage-core",
  "tempfile",
  "tracing",

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -14,6 +14,7 @@ include = [
   "README.md",
   "LICENSE",
   "src/**",
+  "examples/**",
 ]
 
 [dependencies]
@@ -30,4 +31,5 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dev-dependencies]
+tailtriage-analyzer.workspace = true
 tempfile = "3"

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -105,3 +105,8 @@ Use `#[tracing::instrument(fields(...))]` or `.instrument(...)` so span fields a
 Do not hold a manual entered-span guard across `.await`; async spans may enter/exit many times, and this recorder finalizes completed work on `on_close` (drop), not enter/exit transitions.
 
 Tracing span capture for request/stage/queue evidence works outside Tokio runtimes. Runtime-pressure evidence still requires tailtriage's Tokio sampler or future runtime-metrics import; tracing-only spans cannot infer executor or blocking-pool pressure by themselves.
+
+## Focused examples
+
+- `examples/live_recorder.rs`: scoped `tracing_subscriber` setup with `TracingRecorder`, one request span plus one stage span, in-memory shutdown/import, and text triage report rendering via `tailtriage-analyzer`.
+- `examples/tracing_spans.jsonl`: normalized JSONL fixture with one request span, one stage span, and one queue completed-span record.

--- a/tailtriage-tracing/examples/live_recorder.rs
+++ b/tailtriage-tracing/examples/live_recorder.rs
@@ -1,0 +1,37 @@
+use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+use tailtriage_tracing::TracingRecorder;
+use tracing_subscriber::prelude::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let recorder = TracingRecorder::builder("checkout-service")
+        .run_id("live-recorder-example")
+        .strict(false)
+        .build();
+
+    let subscriber = tracing_subscriber::registry().with(recorder.layer());
+    tracing::subscriber::with_default(subscriber, || {
+        let request = tracing::info_span!(
+            "http.request",
+            tt.kind = "request",
+            tt.request_id = "req-1",
+            tt.route = "/checkout",
+            tt.outcome = "ok"
+        );
+        let _request_entered = request.enter();
+
+        let stage = tracing::info_span!(
+            "db.query",
+            tt.kind = "stage",
+            tt.request_id = "req-1",
+            tt.stage = "db",
+            tt.success = true
+        );
+        drop(stage);
+    });
+
+    let imported = recorder.shutdown()?;
+    let report = analyze_run(imported.run(), AnalyzeOptions::default());
+    println!("{}", render_text(&report));
+
+    Ok(())
+}

--- a/tailtriage-tracing/examples/tracing_spans.jsonl
+++ b/tailtriage-tracing/examples/tracing_spans.jsonl
@@ -1,0 +1,3 @@
+{"span":{"name":"http.request","id":"span-req-1","started_at_unix_ms":1700000000000,"finished_at_unix_ms":1700000000120,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}
+{"span":{"name":"db.query","id":"span-stage-1","parent_id":"span-req-1","started_at_unix_ms":1700000000020,"finished_at_unix_ms":1700000000100,"fields":{"tt.kind":"stage","tt.request_id":"req-1","tt.stage":"db","tt.success":true}}}
+{"span":{"name":"permits.wait","id":"span-queue-1","parent_id":"span-req-1","started_at_unix_ms":1700000000005,"finished_at_unix_ms":1700000000020,"fields":{"tt.kind":"queue","tt.request_id":"req-1","tt.queue":"permits","tt.depth_at_start":2}}}

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -449,4 +449,15 @@ mod tests {
         assert_eq!(imported.run().stages.len(), 1);
         assert_eq!(imported.run().stages[0].stage, "db");
     }
+
+    #[test]
+    fn fixture_jsonl_has_request_stage_and_queue() {
+        let fixture_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("examples")
+            .join("tracing_spans.jsonl");
+        let imported = import_jsonl_path(fixture_path, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().stages.len(), 1);
+        assert_eq!(imported.run().queues.len(), 1);
+    }
 }


### PR DESCRIPTION
### Motivation

- Provide a minimal, focused example that teaches how to integrate `tailtriage-tracing` with `tracing_subscriber` and a `TracingRecorder` without expanding product scope. 
- Include a deterministic JSONL fixture to show the normalized completed-span shape supported by the importer for compact smoke tests and docs.

### Description

- Add `tailtriage-tracing/examples/live_recorder.rs` demonstrating building a `TracingRecorder`, installing its layer in a scoped subscriber, emitting a request span and a stage span with `tt.*` fields, calling `shutdown`, running `tailtriage-analyzer::analyze_run` in-memory, and printing the text report. 
- Add `tailtriage-tracing/examples/tracing_spans.jsonl` containing one request span, one stage span, and one queue span in the normalized JSONL shape. 
- Add a fixture-backed unit test in `tailtriage-tracing/src/jsonl.rs` that imports the added JSONL fixture and asserts at least one request, one stage, and one queue are present. 
- Update `tailtriage-tracing/Cargo.toml` to package `examples/**` and add `tailtriage-analyzer` as a `dev-dependency` for the example/test support, and update `tailtriage-tracing/README.md` with a narrow “Focused examples” section pointing to both new examples. 

### Testing

- Ran `cargo fmt --check` and it passed. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it passed. 
- Ran `cargo test --workspace` and all tests (including the new fixture-backed test) passed. 
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0775efee6c8330ae37f0fada8f0599)