### PR TITLE
Add focused examples and tests for tailtriage-tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,6 +884,7 @@ version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
+ "tailtriage-analyzer",
  "tailtriage-core",
  "tempfile",
  "tracing",

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -30,4 +30,5 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dev-dependencies]
+tailtriage-analyzer.workspace = true
 tempfile = "3"

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -68,6 +68,12 @@ Typical span fields are expected to follow this shape:
 - queue: `tt.kind`, `tt.request_id`, `tt.queue`, `tt.depth_at_start`
 
 
+
+## Examples
+
+- [`examples/live_recorder.rs`](examples/live_recorder.rs): capture completed `tt.*` spans with `TracingRecorder`, convert to a run, and render an analyzer report.
+- [`examples/import_jsonl.rs`](examples/import_jsonl.rs): import normalized JSONL spans from [`examples/tracing_spans.jsonl`](examples/tracing_spans.jsonl), then analyze and render a text report.
+
 ## Live tracing recorder
 
 ```rust

--- a/tailtriage-tracing/examples/import_jsonl.rs
+++ b/tailtriage-tracing/examples/import_jsonl.rs
@@ -1,0 +1,19 @@
+use std::error::Error;
+
+use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+use tailtriage_tracing::{import_jsonl_path, ImportOptions};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let imported = import_jsonl_path(
+        "examples/tracing_spans.jsonl",
+        ImportOptions::new("checkout-service")
+            .service_version("example")
+            .run_id("jsonl-example")
+            .strict(false),
+    )?;
+
+    let report = analyze_run(imported.run(), AnalyzeOptions::default());
+    println!("{}", render_text(&report));
+
+    Ok(())
+}

--- a/tailtriage-tracing/examples/live_recorder.rs
+++ b/tailtriage-tracing/examples/live_recorder.rs
@@ -1,0 +1,52 @@
+use std::error::Error;
+
+use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+use tailtriage_tracing::TracingRecorder;
+use tracing_subscriber::prelude::*;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let recorder = TracingRecorder::builder("checkout-service")
+        .service_version("example")
+        .run_id("live-recorder-example")
+        .strict(false)
+        .build();
+
+    let subscriber = tracing_subscriber::registry().with(recorder.layer());
+    tracing::subscriber::with_default(subscriber, || {
+        let request = tracing::info_span!(
+            "http.request",
+            tt.kind = "request",
+            tt.request_id = "req-live-1",
+            tt.route = "/checkout"
+        );
+        let _request_entered = request.enter();
+
+        {
+            let queue = tracing::info_span!(
+                "checkout.queue",
+                tt.kind = "queue",
+                tt.request_id = "req-live-1",
+                tt.queue = "db-pool",
+                tt.depth_at_start = 3_u64
+            );
+            let _queue_entered = queue.enter();
+        }
+
+        {
+            let stage = tracing::info_span!(
+                "checkout.db",
+                tt.kind = "stage",
+                tt.request_id = "req-live-1",
+                tt.stage = "db",
+                tt.success = true
+            );
+            let _stage_entered = stage.enter();
+        }
+    });
+
+    let imported = recorder.shutdown()?;
+    let report = analyze_run(imported.run(), AnalyzeOptions::default());
+    println!("{}", render_text(&report));
+
+    Ok(())
+}

--- a/tailtriage-tracing/examples/tracing_spans.jsonl
+++ b/tailtriage-tracing/examples/tracing_spans.jsonl
@@ -1,0 +1,3 @@
+{"span":{"name":"http.request","id":"req-span-1","parent_id":"root-1","started_at_unix_ms":1700000000000,"finished_at_unix_ms":1700000000150,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}
+{"span":{"name":"checkout.queue","id":"queue-span-1","parent_id":"req-span-1","started_at_unix_ms":1700000000010,"finished_at_unix_ms":1700000000045,"fields":{"tt.kind":"queue","tt.request_id":"req-1","tt.queue":"db-pool","tt.depth_at_start":4}}}
+{"span":{"name":"checkout.db","id":"stage-span-1","parent_id":"req-span-1","started_at_unix_ms":1700000000046,"finished_at_unix_ms":1700000000120,"fields":{"tt.kind":"stage","tt.request_id":"req-1","tt.stage":"db","tt.success":true}}}

--- a/tailtriage-tracing/tests/tracing_examples.rs
+++ b/tailtriage-tracing/tests/tracing_examples.rs
@@ -1,0 +1,57 @@
+use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
+use tailtriage_tracing::{import_jsonl_path, ImportOptions, TracingRecorder};
+use tracing_subscriber::prelude::*;
+
+#[test]
+fn jsonl_fixture_imports_and_analyzes() {
+    let imported = import_jsonl_path(
+        "examples/tracing_spans.jsonl",
+        ImportOptions::new("checkout-service").strict(false),
+    )
+    .expect("fixture should import");
+
+    let run = imported.run();
+    assert_eq!(run.requests.len(), 1);
+    assert_eq!(run.queues.len(), 1);
+    assert_eq!(run.stages.len(), 1);
+
+    let report = analyze_run(run, AnalyzeOptions::default());
+    assert!(report.request_count >= 1);
+}
+
+#[test]
+fn live_recorder_captures_and_analyzes() {
+    let recorder = TracingRecorder::builder("checkout-service")
+        .service_version("example")
+        .run_id("live-recorder-example-test")
+        .strict(false)
+        .build();
+
+    let subscriber = tracing_subscriber::registry().with(recorder.layer());
+    tracing::subscriber::with_default(subscriber, || {
+        let request = tracing::info_span!(
+            "http.request",
+            tt.kind = "request",
+            tt.request_id = "req-live-test",
+            tt.route = "/checkout"
+        );
+        let _request_entered = request.enter();
+
+        let stage = tracing::info_span!(
+            "checkout.db",
+            tt.kind = "stage",
+            tt.request_id = "req-live-test",
+            tt.stage = "db",
+            tt.success = true
+        );
+        let _stage_entered = stage.enter();
+    });
+
+    let imported = recorder.shutdown().expect("recorder should convert spans");
+    let run = imported.run();
+    assert_eq!(run.requests.len(), 1);
+    assert_eq!(run.stages.len(), 1);
+
+    let report = analyze_run(run, AnalyzeOptions::default());
+    assert!(report.request_count >= 1);
+}


### PR DESCRIPTION
### Motivation

- Provide focused, runnable onboarding examples and small fixture-backed tests for the existing `tailtriage-tracing` crate so users can see both live recorder and JSONL import workflows without changing core behavior or public APIs.
- Keep examples narrow and aligned with the documented JSONL shape and the real `TracingRecorder` usage so they are useful as smokeable integration examples and test fixtures.

### Description

- Added a live recorder example at `tailtriage-tracing/examples/live_recorder.rs` that uses `TracingRecorder`, `tracing_subscriber::prelude::*`, `tracing::subscriber::with_default`, and analyzer rendering (`analyze_run` + `render_text`).
- Added a JSONL import example at `tailtriage-tracing/examples/import_jsonl.rs` which imports `examples/tracing_spans.jsonl` via `import_jsonl_path` and renders an analyzer report.
- Added a normalized completed-span fixture at `tailtriage-tracing/examples/tracing_spans.jsonl` using the documented `{"span": {...}}` shape with literal dotted `tt.*` keys.
- Added focused integration tests at `tailtriage-tracing/tests/tracing_examples.rs` covering both the JSONL import and live recorder capture/analyze paths.
- Updated `tailtriage-tracing/README.md` to link the two examples and the fixture.
- Added `tailtriage-analyzer.workspace = true` as a `dev-dependency` in `tailtriage-tracing/Cargo.toml` to support analyzer rendering in examples/tests without changing runtime or public crate dependencies.
- No changes were made to core behavior, CLI, analyzer logic, JSONL parser shape, live recorder implementation, or public APIs.

### Testing

- Ran `cargo fmt --check`; result: success.
- Ran `cargo clippy --workspace --all-targets -- -D warnings`; result: success.
- Ran `cargo test --workspace`; result: failed due to a pre-existing, unrelated analyzer test (`tailtriage-analyzer/tests/end_to_end_capture_analysis.rs::queue_and_stage_data_drives_ranked_suspects`).
- Ran `cargo test -p tailtriage-tracing --all-targets`; result: success (all new examples/tests for `tailtriage-tracing` passed).
- Ran `python3 scripts/validate_docs_contracts.py`; result: success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07760737388330b5257a6936a4c6e8)