### PR TITLE
Add focused examples and JSONL fixture for tailtriage-tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,6 +884,7 @@ version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
+ "tailtriage-analyzer",
  "tailtriage-core",
  "tempfile",
  "tracing",

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -30,4 +30,5 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dev-dependencies]
+tailtriage-analyzer.workspace = true
 tempfile = "3"

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -68,6 +68,19 @@ Typical span fields are expected to follow this shape:
 - queue: `tt.kind`, `tt.request_id`, `tt.queue`, `tt.depth_at_start`
 
 
+
+## Examples
+
+- `examples/live_recorder.rs`: capture completed `tt.*` spans in-process with `TracingRecorder`, then analyze with `tailtriage-analyzer`.
+- `examples/import_jsonl.rs`: import normalized completed-span JSONL from `examples/tracing_spans.jsonl`, then analyze with `tailtriage-analyzer`.
+
+Run from this crate directory:
+
+```bash
+cargo run --example live_recorder
+cargo run --example import_jsonl
+```
+
 ## Live tracing recorder
 
 ```rust

--- a/tailtriage-tracing/examples/import_jsonl.rs
+++ b/tailtriage-tracing/examples/import_jsonl.rs
@@ -1,0 +1,26 @@
+use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+use tailtriage_tracing::{import_jsonl_path, ImportOptions};
+
+fn main() -> Result<(), tailtriage_tracing::ImportError> {
+    let imported = import_jsonl_path(
+        "examples/tracing_spans.jsonl",
+        ImportOptions::new("checkout-service")
+            .service_version("example")
+            .run_id("jsonl-import-example")
+            .strict(false),
+    )?;
+
+    let report = analyze_run(imported.run(), AnalyzeOptions::default());
+
+    println!("=== JSONL import run summary ===");
+    println!(
+        "requests={} stages={} queues={} warnings={}",
+        imported.run().requests.len(),
+        imported.run().stages.len(),
+        imported.run().queues.len(),
+        imported.warnings().len()
+    );
+    println!("\n=== Analyzer text report ===\n{}", render_text(&report));
+
+    Ok(())
+}

--- a/tailtriage-tracing/examples/live_recorder.rs
+++ b/tailtriage-tracing/examples/live_recorder.rs
@@ -1,0 +1,58 @@
+use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+use tailtriage_tracing::TracingRecorder;
+use tracing_subscriber::prelude::*;
+
+fn main() -> Result<(), tailtriage_tracing::ImportError> {
+    let recorder = TracingRecorder::builder("checkout-service")
+        .service_version("example")
+        .run_id("live-recorder-example")
+        .strict(false)
+        .build();
+
+    let subscriber = tracing_subscriber::registry().with(recorder.layer());
+    tracing::subscriber::with_default(subscriber, || {
+        let request = tracing::info_span!(
+            "http.request",
+            tt.kind = "request",
+            tt.request_id = "req-42",
+            tt.route = "/checkout",
+            tt.outcome = tracing::field::Empty
+        );
+        let _request_entered = request.enter();
+
+        let queue = tracing::info_span!(
+            "queue.db_pool",
+            tt.kind = "queue",
+            tt.request_id = "req-42",
+            tt.queue = "db_pool",
+            tt.depth_at_start = 4_u64
+        );
+        drop(queue);
+
+        let stage = tracing::info_span!(
+            "stage.db",
+            tt.kind = "stage",
+            tt.request_id = "req-42",
+            tt.stage = "db",
+            tt.success = true
+        );
+        drop(stage);
+
+        request.record("tt.outcome", "ok");
+    });
+
+    let imported = recorder.shutdown()?;
+    let report = analyze_run(imported.run(), AnalyzeOptions::default());
+
+    println!("=== TracingRecorder run summary ===");
+    println!(
+        "requests={} stages={} queues={} warnings={}",
+        imported.run().requests.len(),
+        imported.run().stages.len(),
+        imported.run().queues.len(),
+        imported.warnings().len()
+    );
+    println!("\n=== Analyzer text report ===\n{}", render_text(&report));
+
+    Ok(())
+}

--- a/tailtriage-tracing/examples/tracing_spans.jsonl
+++ b/tailtriage-tracing/examples/tracing_spans.jsonl
@@ -1,0 +1,3 @@
+{"span":{"name":"http.request","id":"span-1","started_at_unix_ms":1700000000000,"finished_at_unix_ms":1700000000140,"fields":{"tt.kind":"request","tt.request_id":"req-42","tt.route":"/checkout","tt.outcome":"ok"}}}
+{"span":{"name":"queue.db_pool","id":"span-2","parent_id":"span-1","started_at_unix_ms":1700000000010,"finished_at_unix_ms":1700000000040,"fields":{"tt.kind":"queue","tt.request_id":"req-42","tt.queue":"db_pool","tt.depth_at_start":4}}}
+{"span":{"name":"stage.db","id":"span-3","parent_id":"span-1","started_at_unix_ms":1700000000050,"finished_at_unix_ms":1700000000110,"fields":{"tt.kind":"stage","tt.request_id":"req-42","tt.stage":"db","tt.success":true}}}

--- a/tailtriage-tracing/tests/tracing_examples.rs
+++ b/tailtriage-tracing/tests/tracing_examples.rs
@@ -1,0 +1,32 @@
+use std::path::PathBuf;
+
+use tailtriage_tracing::{import_jsonl_path, ImportOptions};
+
+#[test]
+fn tracing_fixture_jsonl_imports_expected_shapes() {
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("examples")
+        .join("tracing_spans.jsonl");
+    let imported = import_jsonl_path(
+        fixture,
+        ImportOptions::new("checkout-service")
+            .service_version("example")
+            .run_id("fixture-example")
+            .strict(true),
+    )
+    .expect("fixture should parse as normalized completed-span jsonl");
+
+    let run = imported.run();
+    assert_eq!(run.requests.len(), 1);
+    assert_eq!(run.stages.len(), 1);
+    assert_eq!(run.queues.len(), 1);
+    assert!(imported.warnings().is_empty());
+
+    assert_eq!(run.requests[0].request_id, "req-42");
+    assert_eq!(run.requests[0].route, "/checkout");
+    assert_eq!(run.requests[0].outcome, "ok");
+    assert_eq!(run.queues[0].queue, "db_pool");
+    assert_eq!(run.queues[0].depth_at_start, Some(4));
+    assert_eq!(run.stages[0].stage, "db");
+    assert!(run.stages[0].success);
+}


### PR DESCRIPTION
### Motivation

- Provide small, focused examples and a fixture that demonstrate how to capture `tt.*` spans from `tracing` and how to import normalized completed-span JSONL without changing crate behavior or public APIs.
- Make it easier for new users to try the in-process `TracingRecorder` and the `import_jsonl_*` path with an analyzer-driven example and a deterministic test fixture.

### Description

- Add `examples/live_recorder.rs` that uses the real `tailtriage_tracing::TracingRecorder` with `tracing::subscriber::with_default`, captures request/queue/stage spans, then analyzes the imported run with `tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions}`.
- Add `examples/import_jsonl.rs` that calls `import_jsonl_path("examples/tracing_spans.jsonl", ImportOptions::...)` and renders an analyzer text report.
- Add normalized completed-span fixture `examples/tracing_spans.jsonl` containing request, queue, and stage spans using dotted `tt.*` field keys supported by `import_jsonl_path`.
- Add a focused test `tests/tracing_examples.rs` that imports the JSONL fixture with `ImportOptions::strict(true)` and asserts expected request/stage/queue counts and field values.
- Update `README.md` in the crate to link both examples and show `cargo run --example` commands, and add `tailtriage-analyzer.workspace = true` as a dev-dependency in `Cargo.toml` to support analyzer usage in examples/tests only.

### Testing

- Ran `cargo fmt --check` and it succeeded.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it succeeded with no warnings.
- Ran `cargo test --workspace` and all workspace tests (including the new `tailtriage-tracing` example fixture test) passed.
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07760737388330b5257a6936a4c6e8)