### PR TITLE
Add focused examples and fixture test for tailtriage-tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,6 +884,7 @@ version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
+ "tailtriage-analyzer",
  "tailtriage-core",
  "tempfile",
  "tracing",

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -14,6 +14,7 @@ include = [
   "README.md",
   "LICENSE",
   "src/**",
+  "examples/**",
 ]
 
 [dependencies]
@@ -30,4 +31,5 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dev-dependencies]
+tailtriage-analyzer.workspace = true
 tempfile = "3"

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -109,5 +109,5 @@ Tracing span capture for request/stage/queue evidence works outside Tokio runtim
 
 ## Examples
 
-- `examples/live_recorder.rs`: captures completed `tt.*` spans with `TracingRecorder`, imports a run, and renders analyzer suspects and next checks.
-- `examples/tracing_spans.jsonl`: normalized completed-span JSONL fixture for `import_jsonl_reader`/`import_jsonl_path` workflows.
+- `examples/live_recorder.rs`: records one request span, one queue span, and one stage span with `TracingRecorder`, imports a run, and renders analyzer suspects and next checks.
+- `examples/tracing_spans.jsonl`: normalized completed-span JSONL fixture importable via `import_jsonl_path` or CLI `tailtriage import tracing-json`.

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -105,3 +105,9 @@ Use `#[tracing::instrument(fields(...))]` or `.instrument(...)` so span fields a
 Do not hold a manual entered-span guard across `.await`; async spans may enter/exit many times, and this recorder finalizes completed work on `on_close` (drop), not enter/exit transitions.
 
 Tracing span capture for request/stage/queue evidence works outside Tokio runtimes. Runtime-pressure evidence still requires tailtriage's Tokio sampler or future runtime-metrics import; tracing-only spans cannot infer executor or blocking-pool pressure by themselves.
+
+
+## Examples
+
+- `examples/live_recorder.rs`: captures completed `tt.*` spans with `TracingRecorder`, imports a run, and renders analyzer suspects and next checks.
+- `examples/tracing_spans.jsonl`: normalized completed-span JSONL fixture for `import_jsonl_reader`/`import_jsonl_path` workflows.

--- a/tailtriage-tracing/examples/live_recorder.rs
+++ b/tailtriage-tracing/examples/live_recorder.rs
@@ -1,0 +1,54 @@
+use std::error::Error;
+
+use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+use tailtriage_tracing::TracingRecorder;
+use tracing_subscriber::prelude::*;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let recorder = TracingRecorder::builder("checkout-service")
+        .service_version("example")
+        .run_id("live-recorder-example")
+        .strict(false)
+        .build();
+
+    let subscriber = tracing_subscriber::registry().with(recorder.layer());
+
+    tracing::subscriber::with_default(subscriber, || {
+        let request = tracing::info_span!(
+            "http.request",
+            tt.kind = "request",
+            tt.request_id = "req-1",
+            tt.route = "/checkout",
+            tt.outcome = "ok"
+        );
+        let _request_entered = request.enter();
+
+        {
+            let queue = tracing::info_span!(
+                "checkout.queue",
+                tt.kind = "queue",
+                tt.request_id = "req-1",
+                tt.queue = "db-pool",
+                tt.depth_at_start = 4_u64
+            );
+            let _queue_entered = queue.enter();
+        }
+
+        {
+            let stage = tracing::info_span!(
+                "checkout.stage",
+                tt.kind = "stage",
+                tt.request_id = "req-1",
+                tt.stage = "db.query",
+                tt.success = true
+            );
+            let _stage_entered = stage.enter();
+        }
+    });
+
+    let imported = recorder.shutdown()?;
+    let run = imported.run();
+    let diagnosis = analyze_run(run, AnalyzeOptions::default());
+    println!("{}", render_text(&diagnosis));
+    Ok(())
+}

--- a/tailtriage-tracing/examples/tracing_spans.jsonl
+++ b/tailtriage-tracing/examples/tracing_spans.jsonl
@@ -1,0 +1,3 @@
+{"span":{"name":"http.request","id":"span-1","started_at_unix_ms":1700000000000,"finished_at_unix_ms":1700000000120,"fields":{"tt.kind":"request","tt.request_id":"req-42","tt.route":"/checkout","tt.outcome":"ok"}}}
+{"span":{"name":"checkout.queue","id":"span-2","parent_id":"span-1","started_at_unix_ms":1700000000010,"finished_at_unix_ms":1700000000060,"fields":{"tt.kind":"queue","tt.request_id":"req-42","tt.queue":"db-pool","tt.depth_at_start":7}}}
+{"span":{"name":"checkout.stage","id":"span-3","parent_id":"span-1","started_at_unix_ms":1700000000065,"finished_at_unix_ms":1700000000110,"fields":{"tt.kind":"stage","tt.request_id":"req-42","tt.stage":"db.query","tt.success":true}}}

--- a/tailtriage-tracing/tests/tracing_examples.rs
+++ b/tailtriage-tracing/tests/tracing_examples.rs
@@ -1,6 +1,6 @@
-use std::path::PathBuf;
+use std::{fs::File, path::PathBuf};
 
-use tailtriage_tracing::{import_jsonl_path, ImportOptions};
+use tailtriage_tracing::{import_jsonl_path, import_jsonl_reader, ImportOptions};
 
 #[test]
 fn jsonl_fixture_imports_completed_span_shape() {
@@ -21,5 +21,36 @@ fn jsonl_fixture_imports_completed_span_shape() {
     assert_eq!(run.requests.len(), 1);
     assert_eq!(run.queues.len(), 1);
     assert_eq!(run.stages.len(), 1);
+    assert_eq!(run.requests[0].request_id, "req-42");
+    assert_eq!(run.requests[0].route, "/checkout");
+    assert_eq!(run.requests[0].outcome, "ok");
+    assert_eq!(run.queues[0].queue, "db-pool");
+    assert_eq!(run.queues[0].depth_at_start, Some(7));
+    assert_eq!(run.stages[0].stage, "db.query");
+    assert!(run.stages[0].success);
     assert!(imported.warnings().is_empty());
+}
+
+#[test]
+fn jsonl_fixture_reader_and_path_import_parity_on_counts() {
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("examples")
+        .join("tracing_spans.jsonl");
+
+    let options = ImportOptions::new("checkout-service")
+        .service_version("example")
+        .run_id("fixture-example")
+        .strict(true);
+
+    let from_path =
+        import_jsonl_path(&fixture, options.clone()).expect("path import should succeed");
+
+    let file = File::open(&fixture).expect("fixture should open");
+    let from_reader = import_jsonl_reader(file, options).expect("reader import should succeed");
+
+    let run_path = from_path.run();
+    let run_reader = from_reader.run();
+    assert_eq!(run_path.requests.len(), run_reader.requests.len());
+    assert_eq!(run_path.queues.len(), run_reader.queues.len());
+    assert_eq!(run_path.stages.len(), run_reader.stages.len());
 }

--- a/tailtriage-tracing/tests/tracing_examples.rs
+++ b/tailtriage-tracing/tests/tracing_examples.rs
@@ -1,0 +1,25 @@
+use std::path::PathBuf;
+
+use tailtriage_tracing::{import_jsonl_path, ImportOptions};
+
+#[test]
+fn jsonl_fixture_imports_completed_span_shape() {
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("examples")
+        .join("tracing_spans.jsonl");
+
+    let imported = import_jsonl_path(
+        &fixture,
+        ImportOptions::new("checkout-service")
+            .service_version("example")
+            .run_id("fixture-example")
+            .strict(true),
+    )
+    .expect("fixture should import");
+
+    let run = imported.run();
+    assert_eq!(run.requests.len(), 1);
+    assert_eq!(run.queues.len(), 1);
+    assert_eq!(run.stages.len(), 1);
+    assert!(imported.warnings().is_empty());
+}


### PR DESCRIPTION
### Motivation

- Provide compact, real-world examples to make `tailtriage-tracing` easier to adopt and test in isolation. 
- Offer a deterministic JSONL fixture that matches the documented normalized completed-span shape for importer-based validation. 
- Supply a minimal focused test and a runnable live-example that demonstrate the intended intake -> analyze -> render workflow without changing core behavior or public APIs.

### Description

- Add `examples/live_recorder.rs` that uses the real `tailtriage_tracing::TracingRecorder`, installs it via `tracing_subscriber::prelude::*`, sets the subscriber with `tracing::subscriber::with_default`, and runs analysis via `tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions}`. 
- Add `examples/tracing_spans.jsonl`, a normalized completed-span JSONL fixture that uses `started_at_unix_ms`, `finished_at_unix_ms`, and `fields` with `tt.*` keys. 
- Add a focused test `tests/tracing_examples.rs` which imports the fixture with `import_jsonl_path` and asserts one request, one queue, one stage, and no warnings in strict mode. 
- Update `README.md` to link both examples and add `examples/**` to `include` and `tailtriage-analyzer.workspace = true` as a dev-dependency for the live recorder example only.

### Testing

- Ran `cargo fmt --check` and it passed. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it passed. 
- Ran `cargo test --workspace` and all workspace tests (including the new example test) passed. 
- Ran `python3 scripts/validate_docs_contracts.py` and the docs contract validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07760737388330b5257a6936a4c6e8)