### PR TITLE
Add focused tailtriage-tracing examples and fixture tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,6 +884,7 @@ version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
+ "tailtriage-analyzer",
  "tailtriage-core",
  "tempfile",
  "tracing",

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -30,4 +30,5 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dev-dependencies]
+tailtriage-analyzer.workspace = true
 tempfile = "3"

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -68,6 +68,12 @@ Typical span fields are expected to follow this shape:
 - queue: `tt.kind`, `tt.request_id`, `tt.queue`, `tt.depth_at_start`
 
 
+
+## Examples
+
+- `examples/live_recorder.rs`: captures completed `tt.*` spans from a real `TracingRecorder`, then runs analyzer text output for a quick local triage loop.
+- `examples/tracing_spans.jsonl`: normalized completed-span JSONL fixture compatible with `import_jsonl_reader` and `import_jsonl_path`.
+
 ## Live tracing recorder
 
 ```rust

--- a/tailtriage-tracing/examples/live_recorder.rs
+++ b/tailtriage-tracing/examples/live_recorder.rs
@@ -1,0 +1,56 @@
+use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions};
+use tailtriage_tracing::TracingRecorder;
+use tracing_subscriber::prelude::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let recorder = TracingRecorder::builder("checkout-service")
+        .service_version("example")
+        .run_id("live-recorder-example")
+        .strict(false)
+        .build();
+
+    let subscriber = tracing_subscriber::registry().with(recorder.layer());
+
+    tracing::subscriber::with_default(subscriber, || {
+        let request = tracing::info_span!(
+            "http.request",
+            tt.kind = "request",
+            tt.request_id = "req-42",
+            tt.route = "/checkout",
+            tt.outcome = tracing::field::Empty
+        );
+        let _request_entered = request.enter();
+
+        {
+            let queue = tracing::info_span!(
+                "queue.db",
+                tt.kind = "queue",
+                tt.request_id = "req-42",
+                tt.queue = "db_pool",
+                tt.depth_at_start = 3_u64
+            );
+            let _queue_entered = queue.enter();
+        }
+
+        {
+            let stage = tracing::info_span!(
+                "stage.db",
+                tt.kind = "stage",
+                tt.request_id = "req-42",
+                tt.stage = "db.query",
+                tt.success = true
+            );
+            let _stage_entered = stage.enter();
+        }
+
+        request.record("tt.outcome", "ok");
+    });
+
+    let imported = recorder.shutdown()?;
+    let run = imported.run();
+    let report = analyze_run(run, AnalyzeOptions::default());
+
+    println!("{}", render_text(&report));
+
+    Ok(())
+}

--- a/tailtriage-tracing/examples/tracing_spans.jsonl
+++ b/tailtriage-tracing/examples/tracing_spans.jsonl
@@ -1,0 +1,3 @@
+{"span":{"name":"http.request","id":"req-span-1","started_at_unix_ms":1700000000000,"finished_at_unix_ms":1700000000120,"fields":{"tt.kind":"request","tt.request_id":"req-42","tt.route":"/checkout","tt.outcome":"ok"}}}
+{"span":{"name":"queue.db","id":"queue-span-1","parent_id":"req-span-1","started_at_unix_ms":1700000000005,"finished_at_unix_ms":1700000000035,"fields":{"tt.kind":"queue","tt.request_id":"req-42","tt.queue":"db_pool","tt.depth_at_start":3}}}
+{"span":{"name":"stage.db","id":"stage-span-1","parent_id":"req-span-1","started_at_unix_ms":1700000000036,"finished_at_unix_ms":1700000000110,"fields":{"tt.kind":"stage","tt.request_id":"req-42","tt.stage":"db.query","tt.success":true}}}

--- a/tailtriage-tracing/tests/tracing_examples.rs
+++ b/tailtriage-tracing/tests/tracing_examples.rs
@@ -1,0 +1,51 @@
+use std::{fs::File, path::PathBuf};
+
+use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
+use tailtriage_tracing::{import_jsonl_path, import_jsonl_reader, ImportOptions};
+
+#[test]
+fn jsonl_fixture_imports_and_analyzes() {
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("examples")
+        .join("tracing_spans.jsonl");
+
+    let imported = import_jsonl_path(
+        &fixture,
+        ImportOptions::new("checkout-service").strict(true),
+    )
+    .expect("fixture should parse and import");
+
+    let run = imported.run();
+    assert_eq!(run.requests.len(), 1);
+    assert_eq!(run.queues.len(), 1);
+    assert_eq!(run.stages.len(), 1);
+
+    let report = analyze_run(run, AnalyzeOptions::default());
+    assert_eq!(report.request_count, 1);
+    assert!(
+        !report.primary_suspect.evidence.is_empty(),
+        "expected at least one suspect lead from imported data"
+    );
+}
+
+#[test]
+fn jsonl_fixture_reader_and_path_match() {
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("examples")
+        .join("tracing_spans.jsonl");
+
+    let from_path = import_jsonl_path(
+        &fixture,
+        ImportOptions::new("checkout-service").strict(true),
+    )
+    .expect("path import should succeed");
+
+    let file = File::open(&fixture).expect("fixture should open");
+    let from_reader =
+        import_jsonl_reader(file, ImportOptions::new("checkout-service").strict(true))
+            .expect("reader import should succeed");
+
+    assert_eq!(from_path.run().requests, from_reader.run().requests);
+    assert_eq!(from_path.run().queues, from_reader.run().queues);
+    assert_eq!(from_path.run().stages, from_reader.run().stages);
+}


### PR DESCRIPTION
### Motivation

- Provide small, focused onboarding examples for the existing `tailtriage-tracing` crate so developers can quickly try the live recorder and JSONL import flows. 
- Ship a normalized completed-span JSONL fixture that matches the documented import contract so tests and integrations have a stable sample input. 
- Add narrow example tests to protect the documented import path and reader/parity behavior without changing core crate behavior or public APIs.

### Description

- Add `examples/live_recorder.rs` that demonstrates using the real `TracingRecorder` wired with `tracing_subscriber::prelude::*` and `tracing::subscriber::with_default`, then runs `tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions}` on the captured run. 
- Add `examples/tracing_spans.jsonl` containing normalized completed-span JSONL in the documented shape supported by `import_jsonl_reader` / `import_jsonl_path`. 
- Add `tests/tracing_examples.rs` with two focused tests that (1) import the JSONL fixture with `import_jsonl_path` and run the analyzer for basic sanity, and (2) verify parity between `import_jsonl_reader` and `import_jsonl_path`. 
- Update `README.md` to link both new example artifacts and add a short `## Examples` section. 
- Add a dev-only workspace dependency `tailtriage-analyzer.workspace = true` in `tailtriage-tracing/Cargo.toml` to allow the example and tests to invoke analyzer helpers without changing runtime or public APIs.

### Testing

- Ran `cargo fmt --check` and it passed. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it passed. 
- Ran `cargo test --workspace` (including `cargo test -p tailtriage-tracing --test tracing_examples`) and all tests passed. 
- Ran `python3 scripts/validate_docs_contracts.py` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07760737388330b5257a6936a4c6e8)