### PR TITLE
docs: document tailtriage-tracing adoption paths

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -104,6 +104,17 @@ Near-term tasks:
 - keep validation docs present-tense and stable, not PR-history oriented
 - update docs contract tests when public docs structure intentionally changes
 
+### 6) Tracing intake adoption path
+
+Keep tracing intake as a scoped adoption-friction improvement for teams that already instrument with Rust `tracing`.
+
+Near-term guidance:
+
+- keep `tailtriage-tracing` focused on converting tracing-shaped evidence into standard `Run` values
+- keep support centered on offline JSONL import and live in-memory `TracingRecorder`
+- keep analyzer semantics unchanged by tracing intake
+- keep positioning narrow: this is not observability-platform expansion, and OTel/OTLP remains out of scope for this slice
+
 ## Near-term sequencing
 
 Before the next public promotion or release:

--- a/README.md
+++ b/README.md
@@ -223,11 +223,18 @@ if let Some(finalized_run) = sink.take_run() {
 tailtriage analyze tailtriage-run.json --format json
 ```
 
-Import completed tracing span records (JSONL) into a Run artifact first when needed:
+### Already using `tracing`?
+
+Use `tailtriage-tracing` as an adoption path when you already emit Rust `tracing` spans.
 
 ```bash
 tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json
+tailtriage analyze tailtriage-run.json
 ```
+
+Or record completed `tt.*` spans in-process with `tailtriage_tracing::TracingRecorder`, then analyze the imported `Run` with the same analyzer workflow. Both paths produce standard `Run` data.
+
+Tracing-only runs usually do not include Tokio runtime snapshots. Request/stage/queue evidence can still be useful, but executor-pressure and blocking-pool suspects are usually weaker or absent until runtime snapshots are captured.
 
 Analyzer thresholds can be tuned through Rust (`AnalyzeOptions`), TOML (`[analyzer]` with `schema_version = 1`), and CLI (`--analyzer-config` / `--analyzer-set`). Start with defaults first, then tune after representative runs. See [docs/diagnostics.md](docs/diagnostics.md), [docs/operations.md](docs/operations.md), and [`examples/analyzer-config.toml`](examples/analyzer-config.toml).
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -44,6 +44,7 @@ Current workspace members include:
 - `tailtriage-axum`
 - `tailtriage-analyzer`
 - `tailtriage-cli`
+- `tailtriage-tracing`
 - demos crates under `demos/`
 
 Supporting repository areas:
@@ -164,6 +165,15 @@ Primary command:
 ```text
 tailtriage analyze <run.json>
 ```
+
+### 5.10 Optional tracing intake (`tailtriage-tracing`)
+
+`tailtriage-tracing` is an optional adoption surface for users who already have Rust `tracing` spans.
+
+- converts tracing-shaped request/stage/queue evidence into standard `Run` values
+- supports offline JSONL import and a live in-memory `TracingRecorder`
+- reuses the same analyzer semantics and report workflow
+- does not provide OpenTelemetry/OTLP or a tracing backend
 
 ## 6. Run artifact, analyzer, and CLI contracts
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ Most users should start with `tailtriage`.
 - [`tailtriage-axum`](../tailtriage-axum/README.md) — Axum middleware/extractor integration.
 - [`tailtriage-analyzer`](../tailtriage-analyzer/README.md) — in-process analysis of completed runs.
 - [`tailtriage-cli`](../tailtriage-cli/README.md) — command-line analysis of saved run artifacts.
-- [`tailtriage-tracing`](../tailtriage-tracing/README.md) — tracing-shaped span intake types for bridge conversions into `tailtriage_core::Run` (no OTel/OTLP).
+- [`tailtriage-tracing`](../tailtriage-tracing/README.md) — tracing intake for JSONL import and a live in-memory recorder; converts tracing-shaped spans into `tailtriage_core::Run` values (no OTel/OTLP).
 
 ## Capture and analysis workflow
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -156,6 +156,18 @@ Start conservatively.
 
 Prefer moderate intervals and bounded runs before increasing density.
 
+## Tracing-based run operations
+
+Tracing-based imports can still provide useful request/stage/queue evidence and triage direction.
+
+Operational limits to keep explicit:
+
+* tracing-only imports usually lack Tokio runtime snapshots
+* without runtime snapshots, executor-pressure and blocking-pool suspects can be lower-confidence or absent
+* use tailtriage Tokio runtime sampling when runtime-pressure evidence is needed
+
+Treat tracing-import reports the same way as any other report: evidence-ranked suspects and next checks are triage leads, not proof.
+
 ## Artifact sizing and retention expectations
 
 Artifact size depends on:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -250,7 +250,52 @@ It is not automatic diagnosis. Queue/stage/inflight instrumentation is still exp
 
 Adapter details: [tailtriage-axum/README.md](../tailtriage-axum/README.md)
 
-## 9) What to do when result is `insufficient_evidence`
+## 9) Using existing tracing spans
+
+If your service already emits Rust `tracing` spans, use `tailtriage-tracing` to convert tracing-shaped evidence into standard `Run` values, then use the same analyzer flow.
+
+### Offline JSONL import
+
+Use the documented completed-span JSONL shape from `tailtriage-tracing`.
+
+```bash
+tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json
+tailtriage analyze tailtriage-run.json
+```
+
+Import writes Run artifact JSON. Analysis is a separate step.
+
+### Live in-memory recorder
+
+`TracingRecorder` captures completed `tt.*` spans in-process, then you analyze the imported `Run` directly:
+
+```rust
+use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
+use tailtriage_tracing::TracingRecorder;
+use tracing_subscriber::prelude::*;
+
+let recorder = TracingRecorder::builder("checkout-service").build();
+let subscriber = tracing_subscriber::registry().with(recorder.layer());
+
+tracing::subscriber::with_default(subscriber, || {
+    let request = tracing::info_span!(
+        "http.request",
+        tt.kind = "request",
+        tt.request_id = "req-1",
+        tt.route = "/checkout"
+    );
+    let _entered = request.enter();
+});
+
+let imported = recorder.shutdown()?;
+let report = analyze_run(imported.run(), AnalyzeOptions::default());
+# let _ = report;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+Live recorder analysis can stay fully in-process.
+
+## 10) What to do when result is `insufficient_evidence`
 
 When `primary_suspect.kind` is `insufficient_evidence`:
 
@@ -261,7 +306,7 @@ When `primary_suspect.kind` is `insufficient_evidence`:
 
 Use [diagnostics.md](diagnostics.md) for interpretation details.
 
-## 10) Tokio primitive helpers
+## 11) Tokio primitive helpers
 
 Import via default crate path:
 
@@ -293,7 +338,7 @@ Semantics notes:
 - `timeout_stage(...)` is lazy: timeout budget starts when the returned future is polled/awaited, not when the helper is constructed.
 - If you need blocking work to start immediately or overlap with other work, call `tokio::task::spawn_blocking(...)` directly and instrument its `JoinHandle` with `join_task(...)`.
 
-## 11) Next docs
+## 12) Next docs
 
 - [Documentation index](README.md)
 - [Diagnostics guide](diagnostics.md)

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -1,26 +1,39 @@
 # tailtriage-tracing
 
-`tailtriage-tracing` is a focused intake bridge surface for tracing-shaped span
-records that can be converted into `tailtriage_core::Run` inputs.
+`tailtriage-tracing` is a narrow tracing intake surface for teams that already use Rust `tracing` spans.
 
-This crate is intentionally narrow:
+It converts tracing-shaped request/stage/queue evidence into standard `tailtriage_core::Run` values that feed the same analyzer/report workflow as native capture.
 
-- It defines semantic convention keys (`tt.*`) for triage-oriented span fields.
-- It defines typed intake records and import option/result types.
-- It converts typed `SpanRecord` values with `run_from_span_records`.
-- It imports JSONL from readers/paths when records contain completed span timing.
-- It provides an in-process `tracing_subscriber::Layer` recorder for completed `tt.*` spans.
-- It does **not** implement OpenTelemetry or OTLP.
-- It does **not** change `tailtriage-analyzer`.
+It is not a tracing backend, not an observability platform, and does not implement OpenTelemetry or OTLP.
 
-## JSONL import support in this phase
+## JSONL import support
 
-Public APIs:
+Public import APIs:
 
 - `import_jsonl_reader(reader, options)`
 - `import_jsonl_path(path, options)`
 
-Supported stable contract (recommended for tests and integrations):
+Offline CLI path:
+
+```bash
+tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json
+tailtriage analyze tailtriage-run.json
+```
+
+The import command writes pretty Run JSON (not Report JSON). Warnings are emitted to stderr as `warning: ...`.
+
+## tracing-subscriber JSON caveat
+
+`tracing-subscriber` JSON output formats vary by formatter options. This crate supports:
+
+- normalized completed-span JSONL (documented below)
+- close-event-like rows only when explicit unix-ms start/end timestamps are present
+
+It does not guess timing from line receive time, and it does not claim arbitrary tracing JSON compatibility.
+
+## Intended field shape
+
+Use literal dotted `tt.*` keys in the span `fields` object:
 
 ```json
 {
@@ -41,73 +54,51 @@ Supported stable contract (recommended for tests and integrations):
 
 Notes:
 
-- Importer accepts `started_at_unix_ms`/`finished_at_unix_ms` and aliases `start_unix_ms`/`end_unix_ms`.
-- In this phase, normalized shape uses **literal dotted keys** inside `fields` (for example `"tt.kind"` and `"tt.request_id"`), not nested objects that require flattening.
-- Importer reads `tt.*` fields from `fields`, `span.fields`, or top-level `tt.*` keys when present.
-- Scalars can be strings, bools, numbers, or null.
-- Empty lines are ignored.
-- Malformed JSON line input is an import error in both strict and non-strict mode.
-
-## tracing-subscriber JSON caveat
-
-Direct `tracing-subscriber` JSON output can vary by formatter configuration. In
-this phase, the importer supports:
-
-- normalized completed-span JSONL (shape above), and
-- close-event-like records only when they include explicit start/end unix-ms timestamps.
-
-It does not guess missing timing from line receive time and does not claim broad
-automatic parsing for every tracing JSON variant.
-
-## Intended field shape
-
-Typical span fields are expected to follow this shape:
-
-- request: `tt.kind`, `tt.request_id`, `tt.route`
-- stage: `tt.kind`, `tt.request_id`, `tt.stage`
-- queue: `tt.kind`, `tt.request_id`, `tt.queue`, `tt.depth_at_start`
-
+- normalized shape uses literal dotted keys (`"tt.kind"`), not nested key flattening
+- aliases `start_unix_ms`/`end_unix_ms` are accepted for start/end timing
+- empty lines are ignored
+- malformed JSON lines are import errors
 
 ## Live tracing recorder
 
+Use `TracingRecorder` for in-memory recording of completed `tt.*` spans:
+
 ```rust
-use tracing_subscriber::prelude::*;
 use tailtriage_tracing::TracingRecorder;
+use tracing_subscriber::prelude::*;
 
-let recorder = TracingRecorder::builder("checkout-service")
-    .service_version("1.2.3")
-    .run_id("run-42")
-    .strict(false)
-    .build();
-
+let recorder = TracingRecorder::builder("checkout-service").build();
 let subscriber = tracing_subscriber::registry().with(recorder.layer());
+
 tracing::subscriber::with_default(subscriber, || {
-    {
-        let request = tracing::info_span!(
-            "http.request",
-            tt.kind = "request",
-            tt.request_id = "req-42",
-            tt.route = "/checkout",
-            tt.outcome = tracing::field::Empty
-        );
-        let _entered = request.enter();
-        request.record("tt.outcome", "ok");
-    }
+    let request = tracing::info_span!(
+        "http.request",
+        tt.kind = "request",
+        tt.request_id = "req-1",
+        tt.route = "/checkout"
+    );
+    let _entered = request.enter();
 });
 
 let imported = recorder.shutdown()?;
 let run = imported.run();
-assert_eq!(run.requests.len(), 1);
+# let _ = run;
 # Ok::<(), tailtriage_tracing::ImportError>(())
 ```
 
-Use `#[tracing::instrument(fields(...))]` or `.instrument(...)` so span fields attach to async work correctly.
-Do not hold a manual entered-span guard across `.await`; async spans may enter/exit many times, and this recorder finalizes completed work on `on_close` (drop), not enter/exit transitions.
+## Async-span guidance
 
-Tracing span capture for request/stage/queue evidence works outside Tokio runtimes. Runtime-pressure evidence still requires tailtriage's Tokio sampler or future runtime-metrics import; tracing-only spans cannot infer executor or blocking-pool pressure by themselves.
+Prefer `#[tracing::instrument(fields(...))]` or `.instrument(...)` for async work so fields remain attached correctly.
 
+Do not hold a manual entered-span guard across `.await`; async spans can enter/exit repeatedly, and this recorder finalizes completed spans on close (`on_close`), not enter/exit transitions.
+
+## Runtime-pressure limitation
+
+Tracing-only runs can still provide request/stage/queue evidence.
+
+Runtime-pressure evidence remains Tokio-specific. Without runtime snapshots from tailtriage Tokio sampling, executor-pressure and blocking-pool suspects are usually weaker or absent.
 
 ## Examples
 
-- `examples/live_recorder.rs`: records one request span, one queue span, and one stage span with `TracingRecorder`, imports a run, and renders analyzer suspects and next checks.
-- `examples/tracing_spans.jsonl`: normalized completed-span JSONL fixture importable via `import_jsonl_path` or CLI `tailtriage import tracing-json`.
+- `examples/live_recorder.rs`
+- `examples/tracing_spans.jsonl`


### PR DESCRIPTION
### Motivation

- Teach and surface the supported `tailtriage-tracing` adoption paths for users who already emit Rust `tracing` spans so they can produce standard `Run` artifacts for existing analysis workflows.  
- Keep positioning narrow: `tailtriage-tracing` is an adoption bridge (JSONL import + live in-memory recorder), not a tracing backend, not OTel/OTLP, and not an observability platform.  
- Make operational limits explicit: tracing-only imports usually lack Tokio runtime snapshots, which lowers confidence for executor-pressure and blocking-pool suspects.  

### Description

- Added a short “Already using `tracing`?” section to the root `README.md` that documents the offline CLI import snippet and notes the live `TracingRecorder` option and runtime-snapshot limitation.  
- Updated `docs/README.md` to list `tailtriage-tracing` as a narrow tracing intake integration (JSONL import + live in-memory recorder → `tailtriage_core::Run`).  
- Added a concise “Using existing tracing spans” section in `docs/user-guide.md` that teaches exactly the two supported adoption paths with the preferred offline JSONL CLI snippet and a short `TracingRecorder` in-process example.  
- Added operational guidance for tracing-based runs in `docs/operations.md` that documents the lack of runtime snapshots for tracing-only imports and recommends using Tokio runtime sampling when runtime-pressure evidence is needed.  
- Polished `tailtriage-tracing/README.md` to document public import APIs (`import_jsonl_reader`, `import_jsonl_path`), the normalized dotted `tt.*` JSONL shape, close-event timestamp constraints, `TracingRecorder` live path, async-span guidance, runtime-pressure limitations, and links to existing examples.  
- Added `tailtriage-tracing` to `SPEC.md` as an optional tracing intake surface that converts tracing-shaped evidence into `Run` values and explicitly reuses existing analyzer semantics.  
- Added scoped tracing-intake guidance to `IMPLEMENTATION_PLAN.md` framing the change as an adoption-friction reduction (OTel/OTLP out of scope).  
- Files changed: `README.md`, `docs/README.md`, `docs/user-guide.md`, `docs/operations.md`, `tailtriage-tracing/README.md`, `SPEC.md`, `IMPLEMENTATION_PLAN.md`.

### Testing

- Ran formatting and lint/build/test/validation: `cargo fmt --check` (ok), `cargo clippy --workspace --all-targets -- -D warnings` (ok), and `cargo test --workspace` (all tests passed).  
- Ran the docs contract validator: `python3 scripts/validate_docs_contracts.py` (passed).  
- No code behavior was changed and the docs-validator was not weakened; all automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07860ee51083309a11a9238dbcd2f7)