### PR TITLE
docs: document tailtriage-tracing integration (JSONL import & TracingRecorder)

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -104,6 +104,17 @@ Near-term tasks:
 - keep validation docs present-tense and stable, not PR-history oriented
 - update docs contract tests when public docs structure intentionally changes
 
+### 6) Tracing-intake adoption friction reduction
+
+Keep the optional tracing intake path clear for teams already using Rust `tracing`.
+
+Near-term tasks:
+
+- document offline JSONL import and live in-memory recorder usage in public docs
+- keep positioning explicit: tracing intake converts tracing-shaped evidence into standard Runs for the existing analyzer
+- preserve bounded claims: no tracing backend semantics, no OTel/OTLP, no observability-platform expansion
+- keep runtime-pressure guidance explicit: tracing-only imports usually lack runtime snapshots, so Tokio sampling remains the path for runtime-pressure evidence
+
 ## Near-term sequencing
 
 Before the next public promotion or release:

--- a/README.md
+++ b/README.md
@@ -66,6 +66,19 @@ Add `tailtriage-analyzer` when you want to analyze a completed Run inside Rust c
 - `tailtriage-cli` consumes Run artifact JSON from disk.
 - `tailtriage-analyzer` produces typed `Report` values in process and renders **Report JSON** when you call analyzer renderers.
 
+### Already using tracing?
+
+If your service already emits `tracing` spans, use `tailtriage-tracing` as a narrow intake path.
+
+- Offline JSONL import:
+  ```bash
+  tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json
+  tailtriage analyze tailtriage-run.json
+  ```
+- Live in-memory import: `tailtriage_tracing::TracingRecorder`
+
+Both paths convert tracing-shaped evidence into standard `tailtriage_core::Run` data and feed the same analyzer/report workflow. Runtime-pressure evidence still requires runtime snapshots (for example via the Tokio sampler).
+
 ## Why not just tokio-console or tokio-metrics?
 
 Those tools are complementary building blocks. `tailtriage` fills a different gap: it turns request lifecycle timing plus optional runtime signals into a focused triage loop:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ If your service already emits `tracing` spans, use `tailtriage-tracing` as a nar
   ```
 - Live in-memory import: `tailtriage_tracing::TracingRecorder`
 
-Both paths convert tracing-shaped evidence into standard `tailtriage_core::Run` data and feed the same analyzer/report workflow. Runtime-pressure evidence still requires runtime snapshots (for example via the Tokio sampler).
+Both paths convert tracing-shaped evidence into standard `tailtriage_core::Run` data and feed the same analyzer/report workflow (evidence-ranked suspects and next checks). Runtime-pressure evidence still requires runtime snapshots (for example via the Tokio sampler).
 
 ## Why not just tokio-console or tokio-metrics?
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -44,6 +44,7 @@ Current workspace members include:
 - `tailtriage-axum`
 - `tailtriage-analyzer`
 - `tailtriage-cli`
+- `tailtriage-tracing`
 - demos crates under `demos/`
 
 Supporting repository areas:
@@ -155,7 +156,17 @@ Analyzer configuration contract:
 - Analyzer tuning changes interpretation/ranking of already captured evidence; it does not change capture artifacts, capture limits, truncation, or what was collected.
 
 
-### 5.9 Analyzer CLI (`tailtriage-cli`)
+### 5.9 Optional tracing intake (`tailtriage-tracing`)
+
+`tailtriage-tracing` is an optional integration surface for services that already emit Rust `tracing` spans.
+
+- converts tracing-shaped request/stage/queue evidence into standard `Run` values
+- supports offline JSONL import and a live in-memory `TracingRecorder`
+- reuses the same analyzer/report workflow as native capture artifacts
+- does not alter analyzer semantics
+- does not provide OTel/OTLP or a tracing backend
+
+### 5.10 Analyzer CLI (`tailtriage-cli`)
 
 `tailtriage-cli` owns artifact loading + command-line report emission and uses `tailtriage-analyzer` for analysis logic. CLI JSON output delegates to `tailtriage-analyzer`’s canonical pretty Report JSON renderer.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ Most users should start with `tailtriage`.
 - [`tailtriage-axum`](../tailtriage-axum/README.md) — Axum middleware/extractor integration.
 - [`tailtriage-analyzer`](../tailtriage-analyzer/README.md) — in-process analysis of completed runs.
 - [`tailtriage-cli`](../tailtriage-cli/README.md) — command-line analysis of saved run artifacts.
-- [`tailtriage-tracing`](../tailtriage-tracing/README.md) — tracing-shaped span intake types for bridge conversions into `tailtriage_core::Run` (no OTel/OTLP).
+- [`tailtriage-tracing`](../tailtriage-tracing/README.md) — tracing intake for JSONL import and a live in-memory recorder; converts tracing-shaped spans into standard `tailtriage_core::Run` values (no OTel/OTLP).
 
 ## Capture and analysis workflow
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -156,6 +156,18 @@ Start conservatively.
 
 Prefer moderate intervals and bounded runs before increasing density.
 
+## Operating with tracing-based runs
+
+Tracing-based imports can still provide useful request, stage, and queue evidence for triage.
+
+Important limits for production interpretation:
+
+* tracing-only imports usually do not include runtime snapshots
+* without runtime snapshots, executor-pressure and blocking-pool suspects can be weaker or absent
+* use tailtriage Tokio runtime sampling when runtime-pressure evidence is required
+
+Treat tracing-based reports the same way as other reports: evidence-ranked suspects and next checks are triage leads, not proof.
+
 ## Artifact sizing and retention expectations
 
 Artifact size depends on:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -32,6 +32,45 @@ cargo add tailtriage --features axum
 
 The `controller` and `tokio` namespaces are available with default features; `axum` remains opt-in.
 
+### Using existing tracing spans
+
+If you already instrument request/stage/queue work with Rust `tracing`, use `tailtriage-tracing` as an intake path into the same triage workflow.
+
+Offline JSONL import:
+
+```bash
+tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json
+tailtriage analyze tailtriage-run.json
+```
+
+Use the documented completed-span JSONL shape from `tailtriage-tracing` (normalized literal dotted `tt.*` keys). Analysis stays a separate step after import.
+
+Live in-memory recorder:
+
+```rust
+use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
+use tailtriage_tracing::TracingRecorder;
+use tracing_subscriber::prelude::*;
+
+let recorder = TracingRecorder::builder("checkout-service").build();
+let subscriber = tracing_subscriber::registry().with(recorder.layer());
+
+tracing::subscriber::with_default(subscriber, || {
+    let request = tracing::info_span!(
+        "http.request",
+        tt.kind = "request",
+        tt.request_id = "req-1",
+        tt.route = "/checkout"
+    );
+    let _entered = request.enter();
+});
+
+let imported = recorder.shutdown()?;
+let report = analyze_run(imported.run(), AnalyzeOptions::default());
+```
+
+This live path supports in-process diagnosis without writing an intermediate Run file.
+
 ## 2) Core workflow: capture -> analyze -> next check -> re-run
 
 ### Capture

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -13,6 +13,8 @@ This crate is intentionally narrow:
 - It does **not** implement OpenTelemetry or OTLP.
 - It does **not** change `tailtriage-analyzer`.
 
+Both JSONL import and live recorder intake produce standard `tailtriage_core::Run` values for the same analyzer/report workflow.
+
 ## JSONL import support in this phase
 
 Public APIs:
@@ -48,6 +50,13 @@ Notes:
 - Empty lines are ignored.
 - Malformed JSON line input is an import error in both strict and non-strict mode.
 
+CLI import for the same shape:
+
+```bash
+tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json
+tailtriage analyze tailtriage-run.json
+```
+
 ## tracing-subscriber JSON caveat
 
 Direct `tracing-subscriber` JSON output can vary by formatter configuration. In
@@ -56,8 +65,7 @@ this phase, the importer supports:
 - normalized completed-span JSONL (shape above), and
 - close-event-like records only when they include explicit start/end unix-ms timestamps.
 
-It does not guess missing timing from line receive time and does not claim broad
-automatic parsing for every tracing JSON variant.
+It supports close-event-like records only when explicit unix-ms timestamps are present. It does not guess timing from line receive time and does not claim broad automatic parsing for every tracing JSON variant.
 
 ## Intended field shape
 


### PR DESCRIPTION
### Motivation
- Provide clear public guidance for the completed `tailtriage-tracing` intake so teams already using `tracing` can adopt with low friction. 
- Teach exactly two supported adoption paths (offline JSONL import and live in-memory `TracingRecorder`) and how they map into the existing triage workflow. 
- Clarify runtime-pressure limitations for tracing-only imports so evidence interpretation remains bounded and accurate. 

### Description
- Add a short “Already using tracing?” section to the root `README.md` that points to the CLI JSONL import and `tailtriage_tracing::TracingRecorder` live path and notes both produce standard `tailtriage_core::Run` inputs while runtime-pressure evidence still requires runtime snapshots. 
- Update `docs/README.md`, `docs/user-guide.md`, and `docs/operations.md` to list and document `tailtriage-tracing` as a narrow intake bridge and to teach the two adoption paths and operational limits (including that tracing-only imports usually lack runtime snapshots and may reduce executor/blocking confidence). 
- Polish `tailtriage-tracing/README.md` to document `import_jsonl_reader`/`import_jsonl_path`, the normalized literal dotted `tt.*` JSONL shape, explicit-timestamp close-event behavior (no timing guessing from receive time), the CLI import snippet, `TracingRecorder` live usage, and example links. 
- Add `tailtriage-tracing` to `SPEC.md` as an optional tracing intake surface and add scoped guidance to `IMPLEMENTATION_PLAN.md` describing the adoption-friction reduction workstream without expanding analyzer semantics or platform scope. 

### Testing
- Ran formatting and lint checks: `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings`, and both completed successfully. 
- Ran the full test suite: `cargo test --workspace`, which passed. 
- Validated docs contract: `python3 scripts/validate_docs_contracts.py`, which passed and reported "docs contracts validated successfully."

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07860ee51083309a11a9238dbcd2f7)