### PR TITLE
docs: polish tailtriage-tracing adoption guidance across public docs

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -104,6 +104,18 @@ Near-term tasks:
 - keep validation docs present-tense and stable, not PR-history oriented
 - update docs contract tests when public docs structure intentionally changes
 
+### 6) Tracing intake adoption path
+
+Keep tracing intake as a scoped adoption-friction reduction path for users who already instrument with `tracing`.
+
+Near-term tasks:
+
+- keep docs clear on the two supported tracing adoption paths: offline JSONL import and live in-memory recorder
+- keep tracing intake mapped to standard `Run` artifacts and the existing analyzer/report workflow
+- keep runtime-pressure limitations explicit when runtime snapshots are absent
+- avoid broadening into observability-platform positioning
+- keep OTel/OTLP out of scope for this completed slice
+
 ## Near-term sequencing
 
 Before the next public promotion or release:

--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ Add `tailtriage-analyzer` when you want to analyze a completed Run inside Rust c
 - `tailtriage-cli` consumes Run artifact JSON from disk.
 - `tailtriage-analyzer` produces typed `Report` values in process and renders **Report JSON** when you call analyzer renderers.
 
+## Already using `tracing`?
+
+If your service already emits completed `tracing` spans with `tt.*` fields, use `tailtriage-tracing` as an intake path into the same triage workflow.
+
+- Offline import path (JSONL -> Run JSON):
+
+```bash
+tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json
+tailtriage analyze tailtriage-run.json
+```
+
+- Live in-process path: record completed spans with `tailtriage_tracing::TracingRecorder`, then analyze the imported `Run`.
+
+Both paths produce standard `tailtriage_core::Run` data for the existing analyzer/report workflow. Runtime-pressure evidence still requires Tokio runtime snapshots; tracing-only imports are often strongest for request/stage/queue evidence.
+
 ## Why not just tokio-console or tokio-metrics?
 
 Those tools are complementary building blocks. `tailtriage` fills a different gap: it turns request lifecycle timing plus optional runtime signals into a focused triage loop:

--- a/SPEC.md
+++ b/SPEC.md
@@ -44,6 +44,7 @@ Current workspace members include:
 - `tailtriage-axum`
 - `tailtriage-analyzer`
 - `tailtriage-cli`
+- `tailtriage-tracing`
 - demos crates under `demos/`
 
 Supporting repository areas:
@@ -164,6 +165,18 @@ Primary command:
 ```text
 tailtriage analyze <run.json>
 ```
+
+### 5.10 Optional tracing intake (`tailtriage-tracing`)
+
+`tailtriage-tracing` is an optional integration surface for services that already emit tracing-shaped request/stage/queue spans.
+
+It supports:
+
+- JSONL import (`import_jsonl_reader`, `import_jsonl_path`)
+- live in-memory recording via `TracingRecorder`
+- conversion into standard `Run` values consumed by existing analyzer/report workflows
+
+It does not alter analyzer semantics and does not provide OTel/OTLP or a tracing backend.
 
 ## 6. Run artifact, analyzer, and CLI contracts
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ Most users should start with `tailtriage`.
 - [`tailtriage-axum`](../tailtriage-axum/README.md) — Axum middleware/extractor integration.
 - [`tailtriage-analyzer`](../tailtriage-analyzer/README.md) — in-process analysis of completed runs.
 - [`tailtriage-cli`](../tailtriage-cli/README.md) — command-line analysis of saved run artifacts.
-- [`tailtriage-tracing`](../tailtriage-tracing/README.md) — tracing-shaped span intake types for bridge conversions into `tailtriage_core::Run` (no OTel/OTLP).
+- [`tailtriage-tracing`](../tailtriage-tracing/README.md) — tracing intake for JSONL import and live in-memory recorder; converts tracing-shaped spans into standard `tailtriage_core::Run` values (not a telemetry backend, no OTel/OTLP).
 
 ## Capture and analysis workflow
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -156,6 +156,20 @@ Start conservatively.
 
 Prefer moderate intervals and bounded runs before increasing density.
 
+## Tracing-based run operations guidance
+
+When you import completed tracing spans (JSONL) or use the live `TracingRecorder`, the resulting run can still provide strong request/stage/queue evidence for triage.
+
+Operational constraints for tracing-only runs:
+
+- tracing-only imports usually do not include Tokio runtime snapshots
+- without runtime snapshots, executor-pressure and blocking-pool suspects can be weaker or absent
+- request/stage/queue evidence can still produce useful evidence-ranked suspects and next checks
+
+When runtime-pressure evidence is required, run `tailtriage` capture with Tokio runtime sampling enabled and compare results under a similar window.
+
+Treat all reports as triage leads. Suspects are leads, not proof of root cause.
+
 ## Artifact sizing and retention expectations
 
 Artifact size depends on:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -239,7 +239,48 @@ Key constraints:
 
 Sampler details: [tailtriage-tokio/README.md](../tailtriage-tokio/README.md)
 
-## 8) Axum adapter: what it is and is not
+## 8) Using existing `tracing` spans
+
+If your service already has `tracing` spans, use `tailtriage-tracing` to convert tracing-shaped request/stage/queue evidence into a standard `Run`, then use the same analyzer workflow.
+
+Offline JSONL import:
+
+```bash
+tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json
+tailtriage analyze tailtriage-run.json
+```
+
+Use the documented completed-span JSONL shape from `tailtriage-tracing` (including literal dotted `tt.*` keys). This import path writes Run JSON, and analysis is a separate step.
+
+Live in-memory recorder:
+
+```rust
+use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
+use tailtriage_tracing::TracingRecorder;
+use tracing_subscriber::prelude::*;
+
+let recorder = TracingRecorder::builder("checkout-service").build();
+let subscriber = tracing_subscriber::registry().with(recorder.layer());
+
+tracing::subscriber::with_default(subscriber, || {
+    let request = tracing::info_span!(
+        "http.request",
+        tt.kind = "request",
+        tt.request_id = "req-1",
+        tt.route = "/checkout"
+    );
+    let _entered = request.enter();
+});
+
+let imported = recorder.shutdown()?;
+let report = analyze_run(imported.run(), AnalyzeOptions::default());
+# let _ = report;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+This live path supports in-process diagnosis from imported span evidence. It is an adoption path for existing `tracing` instrumentation, not a tracing backend or OpenTelemetry implementation.
+
+## 9) Axum adapter: what it is and is not
 
 `tailtriage-axum` is a framework-boundary ergonomics layer:
 
@@ -250,7 +291,7 @@ It is not automatic diagnosis. Queue/stage/inflight instrumentation is still exp
 
 Adapter details: [tailtriage-axum/README.md](../tailtriage-axum/README.md)
 
-## 9) What to do when result is `insufficient_evidence`
+## 10) What to do when result is `insufficient_evidence`
 
 When `primary_suspect.kind` is `insufficient_evidence`:
 
@@ -261,7 +302,7 @@ When `primary_suspect.kind` is `insufficient_evidence`:
 
 Use [diagnostics.md](diagnostics.md) for interpretation details.
 
-## 10) Tokio primitive helpers
+## 11) Tokio primitive helpers
 
 Import via default crate path:
 
@@ -293,7 +334,7 @@ Semantics notes:
 - `timeout_stage(...)` is lazy: timeout budget starts when the returned future is polled/awaited, not when the helper is constructed.
 - If you need blocking work to start immediately or overlap with other work, call `tokio::task::spawn_blocking(...)` directly and instrument its `JoinHandle` with `join_task(...)`.
 
-## 11) Next docs
+## 12) Next docs
 
 - [Documentation index](README.md)
 - [Diagnostics guide](diagnostics.md)

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -1,33 +1,41 @@
 # tailtriage-tracing
 
-`tailtriage-tracing` is a focused intake bridge surface for tracing-shaped span
-records that can be converted into `tailtriage_core::Run` inputs.
+`tailtriage-tracing` is a narrow adoption path for teams that already use Rust `tracing` spans.
 
-This crate is intentionally narrow:
+It converts tracing-shaped request/stage/queue evidence into standard `tailtriage_core::Run` values for the same analyzer/report workflow used by native capture. It is not a tracing backend, not an observability platform, and does not implement OpenTelemetry or OTLP.
 
-- It defines semantic convention keys (`tt.*`) for triage-oriented span fields.
-- It defines typed intake records and import option/result types.
-- It converts typed `SpanRecord` values with `run_from_span_records`.
-- It imports JSONL from readers/paths when records contain completed span timing.
-- It provides an in-process `tracing_subscriber::Layer` recorder for completed `tt.*` spans.
-- It does **not** implement OpenTelemetry or OTLP.
-- It does **not** change `tailtriage-analyzer`.
+## JSONL import support
 
-## JSONL import support in this phase
-
-Public APIs:
+Public import APIs:
 
 - `import_jsonl_reader(reader, options)`
 - `import_jsonl_path(path, options)`
+- `run_from_span_records(records, options)` for typed `SpanRecord -> Run` conversion
 
-Supported stable contract (recommended for tests and integrations):
+Offline workflow:
+
+```bash
+tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json
+tailtriage analyze tailtriage-run.json
+```
+
+The import command writes pretty Run JSON. Analysis is a separate step.
+
+## tracing-subscriber JSON caveat
+
+`tracing-subscriber` JSON output varies by formatter configuration. This crate supports the documented completed-span JSONL shape and close-event-like records only when explicit unix-ms start/end timestamps are present.
+
+It does not guess timing from line receive time and does not claim compatibility with arbitrary tracing JSON variants.
+
+## Intended field shape
+
+Use normalized completed-span JSONL with literal dotted `tt.*` keys:
 
 ```json
 {
   "span": {
     "name": "http.request",
     "id": "span-1",
-    "parent_id": "root-1",
     "started_at_unix_ms": 1700000000000,
     "finished_at_unix_ms": 1700000000120,
     "fields": {
@@ -39,75 +47,43 @@ Supported stable contract (recommended for tests and integrations):
 }
 ```
 
-Notes:
-
-- Importer accepts `started_at_unix_ms`/`finished_at_unix_ms` and aliases `start_unix_ms`/`end_unix_ms`.
-- In this phase, normalized shape uses **literal dotted keys** inside `fields` (for example `"tt.kind"` and `"tt.request_id"`), not nested objects that require flattening.
-- Importer reads `tt.*` fields from `fields`, `span.fields`, or top-level `tt.*` keys when present.
-- Scalars can be strings, bools, numbers, or null.
-- Empty lines are ignored.
-- Malformed JSON line input is an import error in both strict and non-strict mode.
-
-## tracing-subscriber JSON caveat
-
-Direct `tracing-subscriber` JSON output can vary by formatter configuration. In
-this phase, the importer supports:
-
-- normalized completed-span JSONL (shape above), and
-- close-event-like records only when they include explicit start/end unix-ms timestamps.
-
-It does not guess missing timing from line receive time and does not claim broad
-automatic parsing for every tracing JSON variant.
-
-## Intended field shape
-
-Typical span fields are expected to follow this shape:
-
-- request: `tt.kind`, `tt.request_id`, `tt.route`
-- stage: `tt.kind`, `tt.request_id`, `tt.stage`
-- queue: `tt.kind`, `tt.request_id`, `tt.queue`, `tt.depth_at_start`
-
+Supported timing keys include `started_at_unix_ms` / `finished_at_unix_ms` and aliases `start_unix_ms` / `end_unix_ms`.
 
 ## Live tracing recorder
 
 ```rust
-use tracing_subscriber::prelude::*;
+use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
 use tailtriage_tracing::TracingRecorder;
+use tracing_subscriber::prelude::*;
 
-let recorder = TracingRecorder::builder("checkout-service")
-    .service_version("1.2.3")
-    .run_id("run-42")
-    .strict(false)
-    .build();
-
+let recorder = TracingRecorder::builder("checkout-service").build();
 let subscriber = tracing_subscriber::registry().with(recorder.layer());
+
 tracing::subscriber::with_default(subscriber, || {
-    {
-        let request = tracing::info_span!(
-            "http.request",
-            tt.kind = "request",
-            tt.request_id = "req-42",
-            tt.route = "/checkout",
-            tt.outcome = tracing::field::Empty
-        );
-        let _entered = request.enter();
-        request.record("tt.outcome", "ok");
-    }
+    let request = tracing::info_span!(
+        "http.request",
+        tt.kind = "request",
+        tt.request_id = "req-1",
+        tt.route = "/checkout"
+    );
+    let _entered = request.enter();
 });
 
 let imported = recorder.shutdown()?;
-let run = imported.run();
-assert_eq!(run.requests.len(), 1);
-# Ok::<(), tailtriage_tracing::ImportError>(())
+let report = analyze_run(imported.run(), AnalyzeOptions::default());
+# let _ = report;
+# Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
-Use `#[tracing::instrument(fields(...))]` or `.instrument(...)` so span fields attach to async work correctly.
-Do not hold a manual entered-span guard across `.await`; async spans may enter/exit many times, and this recorder finalizes completed work on `on_close` (drop), not enter/exit transitions.
+## Async-span guidance
 
-Tracing span capture for request/stage/queue evidence works outside Tokio runtimes. Runtime-pressure evidence still requires tailtriage's Tokio sampler or future runtime-metrics import; tracing-only spans cannot infer executor or blocking-pool pressure by themselves.
+Use `#[tracing::instrument(fields(...))]` or `.instrument(...)` so span fields attach correctly across async work. Avoid holding a manual entered-span guard across `.await`; completed spans finalize on close (`on_close`), not on enter/exit transitions.
 
+## Runtime-pressure limitation
+
+Tracing-shaped imports can provide request/stage/queue evidence, but runtime-pressure evidence remains Tokio-specific. Tracing-only runs usually have no runtime snapshots, so executor-pressure and blocking-pool suspects can be weaker or absent.
 
 ## Examples
 
-- `examples/live_recorder.rs`: records one request span, one queue span, and one stage span with `TracingRecorder`, imports a run, and renders analyzer suspects and next checks.
-- `examples/tracing_spans.jsonl`: normalized completed-span JSONL fixture importable via `import_jsonl_path` or CLI `tailtriage import tracing-json`.
+- `examples/live_recorder.rs`
+- `examples/tracing_spans.jsonl`


### PR DESCRIPTION
### Motivation

- Document the completed `tailtriage-tracing` integration so users who already emit `tracing` spans have a clear, narrow adoption path into the existing triage workflow. 
- Clarify that tracing intake converts tracing-shaped evidence into standard `Run` artifacts consumed by the analyzer and that runtime-pressure evidence still depends on Tokio runtime snapshots. 
- Keep public positioning tight: `tailtriage-tracing` is an adoption bridge for `tracing` spans, not a tracing backend, OpenTelemetry/OTLP implementation, or an observability platform.

### Description

- Add a brief “Already using `tracing`?” section to the root `README.md` that teaches the two supported paths: offline JSONL import via `tailtriage import tracing-json ...` and the live `tailtriage_tracing::TracingRecorder` path. 
- Update `docs/README.md` to list `tailtriage-tracing` as a narrow intake crate that converts tracing-shaped spans into `tailtriage_core::Run` values (JSONL import + live recorder) and explicitly avoid backend/OTel positioning. 
- Add a concise “Using existing `tracing` spans” section to `docs/user-guide.md` with the offline import snippet and the live in-memory recorder snippet and guidance about the required completed-span JSONL shape (literal dotted `tt.*` keys). 
- Add operational guidance in `docs/operations.md` and polish `tailtriage-tracing/README.md` to document `import_jsonl_reader`, `import_jsonl_path`, `run_from_span_records`, the normalized JSONL shape, close-event timestamp caveats, `TracingRecorder` usage, async-span guidance, runtime-pressure limitations, and example links. 
- Update `SPEC.md` and `IMPLEMENTATION_PLAN.md` to include tracing intake as an optional, scoped integration that converts tracing-shaped evidence into Runs without changing analyzer semantics or expanding scope to OTel/OTLP. 

### Testing

- Ran `cargo fmt --check`, which succeeded. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings`, which succeeded. 
- Ran `cargo test --workspace`, which completed with all tests passing. 
- Ran the docs contract validator `python3 scripts/validate_docs_contracts.py`, which validated the updated docs successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07860ee51083309a11a9238dbcd2f7)