### PR TITLE
docs: document tailtriage-tracing integration (JSONL import & TracingRecorder)

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -104,6 +104,18 @@ Near-term tasks:
 - keep validation docs present-tense and stable, not PR-history oriented
 - update docs contract tests when public docs structure intentionally changes
 
+### 6) Tracing intake adoption friction
+
+Keep the optional `tailtriage-tracing` path clear for users who already instrument with `tracing`.
+
+Near-term tasks:
+
+- keep JSONL import and live recorder guidance aligned with implemented APIs
+- reinforce that tracing intake produces standard `Run` artifacts for the existing analyzer
+- keep runtime-pressure limitations explicit when runtime snapshots are missing
+- keep this scoped as adoption-friction reduction, not observability-platform expansion
+- keep OpenTelemetry/OTLP out of scope for this completed slice
+
 ## Near-term sequencing
 
 Before the next public promotion or release:

--- a/README.md
+++ b/README.md
@@ -223,11 +223,20 @@ if let Some(finalized_run) = sink.take_run() {
 tailtriage analyze tailtriage-run.json --format json
 ```
 
-Import completed tracing span records (JSONL) into a Run artifact first when needed:
+### Already using tracing?
+
+Use `tailtriage-tracing` as a narrow adoption path when you already emit Rust `tracing` spans.
+
+Offline JSONL import:
 
 ```bash
 tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json
+tailtriage analyze tailtriage-run.json
 ```
+
+Live in-memory path: `tailtriage_tracing::TracingRecorder` records completed `tt.*` spans and converts them into the same standard `Run` data consumed by `tailtriage_analyzer` and `tailtriage-cli`.
+
+Tracing-only runs usually do not include Tokio runtime snapshots. Request/stage/queue evidence can still drive triage, but executor-pressure and blocking-pool suspects may be weaker or absent without runtime sampling.
 
 Analyzer thresholds can be tuned through Rust (`AnalyzeOptions`), TOML (`[analyzer]` with `schema_version = 1`), and CLI (`--analyzer-config` / `--analyzer-set`). Start with defaults first, then tune after representative runs. See [docs/diagnostics.md](docs/diagnostics.md), [docs/operations.md](docs/operations.md), and [`examples/analyzer-config.toml`](examples/analyzer-config.toml).
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -155,7 +155,16 @@ Analyzer configuration contract:
 - Analyzer tuning changes interpretation/ranking of already captured evidence; it does not change capture artifacts, capture limits, truncation, or what was collected.
 
 
-### 5.9 Analyzer CLI (`tailtriage-cli`)
+### 5.9 Optional tracing intake (`tailtriage-tracing`)
+
+`tailtriage-tracing` is an optional adoption surface for users who already have `tracing` spans.
+
+- converts tracing-shaped request/stage/queue evidence into standard `Run` values
+- supports offline JSONL import and a live in-memory recorder
+- feeds the existing analyzer/report workflow without changing analyzer semantics
+- does not provide OpenTelemetry/OTLP or a tracing backend
+
+### 5.10 Analyzer CLI (`tailtriage-cli`)
 
 `tailtriage-cli` owns artifact loading + command-line report emission and uses `tailtriage-analyzer` for analysis logic. CLI JSON output delegates to `tailtriage-analyzer`’s canonical pretty Report JSON renderer.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ Most users should start with `tailtriage`.
 - [`tailtriage-axum`](../tailtriage-axum/README.md) — Axum middleware/extractor integration.
 - [`tailtriage-analyzer`](../tailtriage-analyzer/README.md) — in-process analysis of completed runs.
 - [`tailtriage-cli`](../tailtriage-cli/README.md) — command-line analysis of saved run artifacts.
-- [`tailtriage-tracing`](../tailtriage-tracing/README.md) — tracing-shaped span intake types for bridge conversions into `tailtriage_core::Run` (no OTel/OTLP).
+- [`tailtriage-tracing`](../tailtriage-tracing/README.md) — tracing intake for JSONL import and live in-memory recorder; converts tracing-shaped spans into `tailtriage_core::Run` values (no OTel/OTLP).
 
 ## Capture and analysis workflow
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -439,6 +439,19 @@ These measurements are:
 
 They are not universal production guarantees.
 
+## Tracing-based run operations
+
+When runs are imported from tracing-shaped spans (`tailtriage import tracing-json`) or captured through `tailtriage_tracing::TracingRecorder`, request/stage/queue evidence can still support useful triage.
+
+Operational guidance:
+
+* tracing-only imports usually lack Tokio runtime snapshots
+* without runtime snapshots, executor-pressure and blocking-pool suspects can be lower-confidence or absent
+* enable tailtriage Tokio runtime sampling when runtime-pressure evidence is required
+* treat evidence-ranked suspects and next checks as triage leads, not proof
+
+Tracing intake is an adoption path for existing `tracing` instrumentation, not a replacement for runtime sampling when runtime-pressure diagnosis is required.
+
 ## Current known limits and non-fits
 
 `tailtriage` is intentionally not:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -250,7 +250,48 @@ It is not automatic diagnosis. Queue/stage/inflight instrumentation is still exp
 
 Adapter details: [tailtriage-axum/README.md](../tailtriage-axum/README.md)
 
-## 9) What to do when result is `insufficient_evidence`
+## 9) Using existing tracing spans
+
+If your service already has Rust `tracing` spans, use `tailtriage-tracing` to convert tracing-shaped evidence into standard `Run` data for the same analyzer workflow.
+
+Offline JSONL import path:
+
+```bash
+tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json
+tailtriage analyze tailtriage-run.json
+```
+
+Use the documented completed-span JSONL shape from `tailtriage-tracing` (including literal dotted `tt.*` keys). Arbitrary `tracing-subscriber` JSON layouts are not the supported contract.
+
+Live in-memory recorder path:
+
+```rust
+use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
+use tailtriage_tracing::TracingRecorder;
+use tracing_subscriber::prelude::*;
+
+let recorder = TracingRecorder::builder("checkout-service").build();
+let subscriber = tracing_subscriber::registry().with(recorder.layer());
+
+tracing::subscriber::with_default(subscriber, || {
+    let request = tracing::info_span!(
+        "http.request",
+        tt.kind = "request",
+        tt.request_id = "req-1",
+        tt.route = "/checkout"
+    );
+    let _entered = request.enter();
+});
+
+let imported = recorder.shutdown()?;
+let report = analyze_run(imported.run(), AnalyzeOptions::default());
+# let _ = report;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+Use CLI analysis after offline import. With the live recorder path, analysis can run in-process immediately after `shutdown()`.
+
+## 10) What to do when result is `insufficient_evidence`
 
 When `primary_suspect.kind` is `insufficient_evidence`:
 
@@ -261,7 +302,7 @@ When `primary_suspect.kind` is `insufficient_evidence`:
 
 Use [diagnostics.md](diagnostics.md) for interpretation details.
 
-## 10) Tokio primitive helpers
+## 11) Tokio primitive helpers
 
 Import via default crate path:
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -1,26 +1,27 @@
 # tailtriage-tracing
 
-`tailtriage-tracing` is a focused intake bridge surface for tracing-shaped span
-records that can be converted into `tailtriage_core::Run` inputs.
+`tailtriage-tracing` is a focused intake bridge for teams that already instrument with Rust `tracing` spans.
+
+It converts tracing-shaped request/stage/queue evidence into standard `tailtriage_core::Run` values for the same analyzer/report workflow used by native `tailtriage` capture.
 
 This crate is intentionally narrow:
 
-- It defines semantic convention keys (`tt.*`) for triage-oriented span fields.
-- It defines typed intake records and import option/result types.
-- It converts typed `SpanRecord` values with `run_from_span_records`.
-- It imports JSONL from readers/paths when records contain completed span timing.
-- It provides an in-process `tracing_subscriber::Layer` recorder for completed `tt.*` spans.
-- It does **not** implement OpenTelemetry or OTLP.
-- It does **not** change `tailtriage-analyzer`.
+- semantic `tt.*` conventions for triage-oriented span fields
+- `SpanRecord -> Run` conversion via `run_from_span_records`
+- JSONL import via `import_jsonl_reader` and `import_jsonl_path`
+- live in-memory recording with `TracingRecorder`
+- no OpenTelemetry/OTLP implementation
+- no tracing backend behavior
+- no analyzer semantic changes
 
-## JSONL import support in this phase
+## JSONL import support
 
 Public APIs:
 
 - `import_jsonl_reader(reader, options)`
 - `import_jsonl_path(path, options)`
 
-Supported stable contract (recommended for tests and integrations):
+Normalized completed-span JSONL contract:
 
 ```json
 {
@@ -39,75 +40,67 @@ Supported stable contract (recommended for tests and integrations):
 }
 ```
 
-Notes:
-
-- Importer accepts `started_at_unix_ms`/`finished_at_unix_ms` and aliases `start_unix_ms`/`end_unix_ms`.
-- In this phase, normalized shape uses **literal dotted keys** inside `fields` (for example `"tt.kind"` and `"tt.request_id"`), not nested objects that require flattening.
-- Importer reads `tt.*` fields from `fields`, `span.fields`, or top-level `tt.*` keys when present.
-- Scalars can be strings, bools, numbers, or null.
+- Use literal dotted `tt.*` keys in `fields`.
+- Import reads `tt.*` fields from `fields`, `span.fields`, or top-level `tt.*` keys when present.
 - Empty lines are ignored.
-- Malformed JSON line input is an import error in both strict and non-strict mode.
+- Malformed JSON lines are import errors.
 
 ## tracing-subscriber JSON caveat
 
-Direct `tracing-subscriber` JSON output can vary by formatter configuration. In
-this phase, the importer supports:
+`tracing-subscriber` JSON output varies by formatter settings. This importer supports:
 
-- normalized completed-span JSONL (shape above), and
-- close-event-like records only when they include explicit start/end unix-ms timestamps.
+- normalized completed-span JSONL in the documented shape
+- close-event-like records only when explicit unix-ms start/end timestamps are present
 
-It does not guess missing timing from line receive time and does not claim broad
-automatic parsing for every tracing JSON variant.
+It does not guess timing from line receive time.
 
 ## Intended field shape
 
-Typical span fields are expected to follow this shape:
+Typical span fields:
 
 - request: `tt.kind`, `tt.request_id`, `tt.route`
 - stage: `tt.kind`, `tt.request_id`, `tt.stage`
 - queue: `tt.kind`, `tt.request_id`, `tt.queue`, `tt.depth_at_start`
 
-
 ## Live tracing recorder
 
 ```rust
-use tracing_subscriber::prelude::*;
+use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
 use tailtriage_tracing::TracingRecorder;
+use tracing_subscriber::prelude::*;
 
-let recorder = TracingRecorder::builder("checkout-service")
-    .service_version("1.2.3")
-    .run_id("run-42")
-    .strict(false)
-    .build();
-
+let recorder = TracingRecorder::builder("checkout-service").build();
 let subscriber = tracing_subscriber::registry().with(recorder.layer());
+
 tracing::subscriber::with_default(subscriber, || {
-    {
-        let request = tracing::info_span!(
-            "http.request",
-            tt.kind = "request",
-            tt.request_id = "req-42",
-            tt.route = "/checkout",
-            tt.outcome = tracing::field::Empty
-        );
-        let _entered = request.enter();
-        request.record("tt.outcome", "ok");
-    }
+    let request = tracing::info_span!(
+        "http.request",
+        tt.kind = "request",
+        tt.request_id = "req-1",
+        tt.route = "/checkout"
+    );
+    let _entered = request.enter();
 });
 
 let imported = recorder.shutdown()?;
-let run = imported.run();
-assert_eq!(run.requests.len(), 1);
-# Ok::<(), tailtriage_tracing::ImportError>(())
+let report = analyze_run(imported.run(), AnalyzeOptions::default());
+# let _ = report;
+# Ok::<(), Box<dyn std::error::Error>>(())
 ```
-
-Use `#[tracing::instrument(fields(...))]` or `.instrument(...)` so span fields attach to async work correctly.
-Do not hold a manual entered-span guard across `.await`; async spans may enter/exit many times, and this recorder finalizes completed work on `on_close` (drop), not enter/exit transitions.
-
-Tracing span capture for request/stage/queue evidence works outside Tokio runtimes. Runtime-pressure evidence still requires tailtriage's Tokio sampler or future runtime-metrics import; tracing-only spans cannot infer executor or blocking-pool pressure by themselves.
-
 
 ## Examples
 
-- `examples/live_recorder.rs`: records one request span, one queue span, and one stage span with `TracingRecorder`, imports a run, and renders analyzer suspects and next checks.
-- `examples/tracing_spans.jsonl`: normalized completed-span JSONL fixture importable via `import_jsonl_path` or CLI `tailtriage import tracing-json`.
+- `examples/live_recorder.rs`
+- `examples/tracing_spans.jsonl`
+
+## Async span guidance
+
+Use `#[tracing::instrument(fields(...))]` or `.instrument(...)` so fields attach to async work correctly.
+
+Do not hold a manual entered-span guard across `.await`; async spans can enter/exit repeatedly, while this recorder finalizes completed spans on close.
+
+## Runtime-pressure limitation
+
+Tracing-only imports are useful for request/stage/queue triage evidence, but they usually do not include Tokio runtime snapshots.
+
+Without runtime snapshots, executor-pressure and blocking-pool suspects may be weaker or absent. For runtime-pressure evidence, use tailtriage Tokio runtime sampling.


### PR DESCRIPTION
### Motivation

- Provide clear, public guidance for the completed `tailtriage-tracing` integration so users can adopt it without confusion.
- Teach exactly two supported adoption paths (offline JSONL import and live in-memory `TracingRecorder`) and show how both produce standard `Run` artifacts for analysis.
- Explicitly surface runtime-pressure limitations and scope guardrails so tracing intake is not misread as a tracing backend, OTel/OTLP support, or a replacement for runtime sampling.

### Description

- Add a concise “Already using tracing?” section to the root `README.md` that documents the offline CLI import (`tailtriage import tracing-json ...`) and the live in-memory `TracingRecorder` path, and that notes runtime-snapshot limitations.
- Update `docs/README.md` to list `tailtriage-tracing` as a narrow tracing intake for JSONL import and a live recorder that converts tracing-shaped spans into `tailtriage_core::Run` values.
- Add a `Using existing tracing spans` section to `docs/user-guide.md` that shows the offline JSONL CLI flow and a short live recorder Rust snippet, and instructs users to use the documented completed-span JSONL shape.
- Add `Tracing-based run operations` guidance to `docs/operations.md` that explains evidence coverage from tracing-only imports, the usual absence of Tokio runtime snapshots, the resulting confidence limits for executor/blocking suspects, and the advice to enable Tokio runtime sampling when runtime-pressure signals are required.
- Replace and polish `tailtriage-tracing/README.md` to clearly document `import_jsonl_reader`, `import_jsonl_path`, the normalized completed-span JSONL contract (literal dotted `tt.*` keys), the `TracingRecorder` live flow, async-span guidance, examples, and runtime-pressure limitations.
- Add `tailtriage-tracing` as an optional integration surface in `SPEC.md` and frame it as converting tracing-shaped request/stage/queue evidence into standard Runs while explicitly excluding OTel/OTLP and tracing-backend claims. 
- Add a tracing intake workstream to `IMPLEMENTATION_PLAN.md` that frames `tailtriage-tracing` as an adoption-friction improvement and keeps OTel/OTLP out of scope. 
- Leave `scripts/validate_docs_contracts.py` unchanged and make no behavior, dependency, CLI flag, parser, or analyzer changes; this is documentation-only.

### Testing

- Ran formatter check with `cargo fmt --check` which succeeded. 
- Ran lints with `cargo clippy --workspace --all-targets -- -D warnings` which succeeded. 
- Ran the full test suite with `cargo test --workspace` which completed with all tests passing. 
- Ran documentation contract validation with `python3 scripts/validate_docs_contracts.py` which reported successful validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07860ee51083309a11a9238dbcd2f7)