### PR TITLE
Harden tracing import/recorder validation and clarify tracing JSONL guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,9 @@ Import completed tracing span records (JSONL) into a Run artifact first when nee
 tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json
 ```
 
+`tailtriage import tracing-json` writes **Run JSON** (capture artifact and CLI input), not Report JSON. Use `--strict` to fail on malformed/incomplete `tt.*` spans; without `--strict`, malformed `tt.*` spans are skipped and surfaced as `warning: ...` lines on stderr.
+Tracing-only imports can provide request/stage/queue evidence outside Tokio runtimes, but they do not fabricate runtime-pressure snapshots.
+
 Analyzer thresholds can be tuned through Rust (`AnalyzeOptions`), TOML (`[analyzer]` with `schema_version = 1`), and CLI (`--analyzer-config` / `--analyzer-set`). Start with defaults first, then tune after representative runs. See [docs/diagnostics.md](docs/diagnostics.md), [docs/operations.md](docs/operations.md), and [`examples/analyzer-config.toml`](examples/analyzer-config.toml).
 
 #### Example output (representative JSON)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -68,6 +68,16 @@ Read output in this order:
 
 Then run one targeted check, change one thing, and re-run under comparable load.
 
+### Optional tracing JSONL bridge
+
+If you already have completed tracing span JSONL in the documented `tt.*` shape, import it into a Run artifact first:
+
+```bash
+tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json
+```
+
+`tailtriage import tracing-json` writes Run artifact JSON (not Report JSON). `--strict` fails import on malformed/incomplete `tt.*` spans; non-strict mode keeps import running and prints understandable `warning: ...` messages for skipped malformed `tt.*` spans. Tracing-only imports can carry request/stage/queue evidence outside Tokio runtimes, but runtime-pressure evidence remains Tokio-specific and runtime snapshots stay empty unless captured by the Tokio sampler path.
+
 
 ## 3) In-process analysis (embedded Rust)
 

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -387,17 +387,35 @@ mod tests {
     #[test]
     fn shutdown_output_is_analyzable_and_has_no_runtime_snapshots() {
         with_recorder(|recorder| {
-            let span = tracing::info_span!(
+            let request = tracing::info_span!(
                 "request",
                 tt.kind = "request",
                 tt.request_id = "r1",
                 tt.route = "/checkout"
             );
-            drop(span);
+            let queue = tracing::info_span!(
+                "queue",
+                tt.kind = "queue",
+                tt.request_id = "r1",
+                tt.queue = "db-pool"
+            );
+            let stage = tracing::info_span!(
+                "stage",
+                tt.kind = "stage",
+                tt.request_id = "r1",
+                tt.stage = "db.query"
+            );
+            drop(request);
+            drop(queue);
+            drop(stage);
 
             let imported = recorder.shutdown().unwrap();
-            assert!(imported.run().runtime_snapshots.is_empty());
-            let report = analyze_run(imported.run(), AnalyzeOptions::default());
+            let run = imported.run();
+            assert_eq!(run.requests.len(), 1);
+            assert_eq!(run.queues.len(), 1);
+            assert_eq!(run.stages.len(), 1);
+            assert!(run.runtime_snapshots.is_empty());
+            let report = analyze_run(run, AnalyzeOptions::default());
             assert_eq!(report.request_count, 1);
         });
     }

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -230,6 +230,7 @@ impl Visit for FieldVisitor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
     use tracing_subscriber::prelude::*;
 
     fn with_recorder<T>(f: impl FnOnce(&TracingRecorder) -> T) -> T {
@@ -380,6 +381,24 @@ mod tests {
             let run = recorder.snapshot_run().unwrap();
             assert_eq!(run.run().requests.len(), 1);
             assert_eq!(run.run().requests[0].route, "/late-kind");
+        });
+    }
+
+    #[test]
+    fn shutdown_output_is_analyzable_and_has_no_runtime_snapshots() {
+        with_recorder(|recorder| {
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/checkout"
+            );
+            drop(span);
+
+            let imported = recorder.shutdown().unwrap();
+            assert!(imported.run().runtime_snapshots.is_empty());
+            let report = analyze_run(imported.run(), AnalyzeOptions::default());
+            assert_eq!(report.request_count, 1);
         });
     }
 }

--- a/tailtriage-tracing/tests/tracing_examples.rs
+++ b/tailtriage-tracing/tests/tracing_examples.rs
@@ -64,10 +64,14 @@ fn imported_fixture_run_is_analyzable_and_has_no_runtime_snapshots() {
     let imported = import_jsonl_path(&fixture, ImportOptions::new("checkout-service"))
         .expect("fixture import should succeed");
 
+    let run = imported.run();
+    assert_eq!(run.requests.len(), 1);
+    assert_eq!(run.queues.len(), 1);
+    assert_eq!(run.stages.len(), 1);
     assert!(
-        imported.run().runtime_snapshots.is_empty(),
+        run.runtime_snapshots.is_empty(),
         "tracing-only import must not fabricate runtime snapshots"
     );
-    let report = analyze_run(imported.run(), AnalyzeOptions::default());
+    let report = analyze_run(run, AnalyzeOptions::default());
     assert_eq!(report.request_count, 1);
 }

--- a/tailtriage-tracing/tests/tracing_examples.rs
+++ b/tailtriage-tracing/tests/tracing_examples.rs
@@ -1,5 +1,6 @@
 use std::{fs::File, path::PathBuf};
 
+use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
 use tailtriage_tracing::{import_jsonl_path, import_jsonl_reader, ImportOptions};
 
 #[test]
@@ -53,4 +54,20 @@ fn jsonl_fixture_reader_and_path_import_parity_on_counts() {
     assert_eq!(run_path.requests.len(), run_reader.requests.len());
     assert_eq!(run_path.queues.len(), run_reader.queues.len());
     assert_eq!(run_path.stages.len(), run_reader.stages.len());
+}
+
+#[test]
+fn imported_fixture_run_is_analyzable_and_has_no_runtime_snapshots() {
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("examples")
+        .join("tracing_spans.jsonl");
+    let imported = import_jsonl_path(&fixture, ImportOptions::new("checkout-service"))
+        .expect("fixture import should succeed");
+
+    assert!(
+        imported.run().runtime_snapshots.is_empty(),
+        "tracing-only import must not fabricate runtime snapshots"
+    );
+    let report = analyze_run(imported.run(), AnalyzeOptions::default());
+    assert_eq!(report.request_count, 1);
 }


### PR DESCRIPTION
### Motivation

- Improve correctness and usability of the tracing intake added for #510 by tightening validation, surfacing clearer warnings, and making docs consistent about what the CLI emits and what tracing-only imports can (and cannot) provide.  
- Ensure both JSONL importer and live Layer recorder share a single conversion story and do not fabricate runtime snapshots for tracing-only captures.

### Description

- Added an integration test `imported_fixture_run_is_analyzable_and_has_no_runtime_snapshots` to `tailtriage-tracing/tests/tracing_examples.rs` that verifies JSONL-imported runs are analyzable via the existing analyzer API and contain no fabricated `runtime_snapshots`.  
- Added a live-recorder hardening test `shutdown_output_is_analyzable_and_has_no_runtime_snapshots` to `tailtriage-tracing/src/recorder.rs` that verifies `TracingRecorder::shutdown()` output is analyzable in-memory and preserves empty runtime snapshots for tracing-only captures.  
- Updated top-level `README.md` and `docs/user-guide.md` to explicitly state that `tailtriage import tracing-json` writes Run JSON (capture artifact / CLI input), not Report JSON; documented `--strict` vs non-strict behavior and that tracing-only imports can provide request/stage/queue evidence outside Tokio but cannot infer runtime-pressure snapshots.  
- Minor test-side imports adjusted to call the analyzer API with `AnalyzeOptions::default()` to keep tests robust and explicit; no analyzer behavior changed.  

### Testing

- Ran the full workspace validation and all automated checks: `cargo fmt --check` (passed), `cargo clippy --workspace --all-targets -- -D warnings` (passed), `cargo test --workspace` (all tests passed), and `python3 scripts/validate_docs_contracts.py` (passed).  
- New tests added in `tailtriage-tracing` passed as part of `cargo test --workspace` and specifically validate: JSONL import → analyzable Run JSON, live recorder shutdown → analyzable in-memory Run, and that no runtime snapshots are fabricated for tracing-only flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a080cef19c08330a8db540cfcdd1af2)