### PR TITLE
Harden tracing import warnings and add analyzer-path tests for tracing import

### DIFF
--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -95,7 +95,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
                 let imported = import_jsonl_path(spans_jsonl, options)?;
                 for warning in imported.warnings() {
-                    eprintln!("warning: {}", warning.message());
+                    eprintln!("warning: tracing import: {}", warning.message());
                 }
 
                 let file = std::fs::File::create(&output)?;

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -304,7 +304,7 @@ fn import_tracing_json_non_strict_writes_output_and_emits_warning_to_stderr() {
     assert!(output.status.success(), "cli failed: {output:?}");
     assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
-    assert!(stderr.contains("warning:"));
+    assert!(stderr.contains("warning: tracing import:"));
     assert!(run_path.exists(), "run output should be written");
 
     let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)

--- a/tailtriage-tracing/tests/tracing_examples.rs
+++ b/tailtriage-tracing/tests/tracing_examples.rs
@@ -54,3 +54,66 @@ fn jsonl_fixture_reader_and_path_import_parity_on_counts() {
     assert_eq!(run_path.queues.len(), run_reader.queues.len());
     assert_eq!(run_path.stages.len(), run_reader.stages.len());
 }
+
+#[test]
+fn imported_jsonl_run_is_analyzable_and_has_no_runtime_snapshots() {
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("examples")
+        .join("tracing_spans.jsonl");
+
+    let imported = import_jsonl_path(
+        &fixture,
+        ImportOptions::new("checkout-service").strict(true),
+    )
+    .expect("fixture should import");
+
+    let run = imported.run();
+    assert!(run.runtime_snapshots.is_empty());
+
+    let report =
+        tailtriage_analyzer::analyze_run(run, tailtriage_analyzer::AnalyzeOptions::default());
+    assert_eq!(report.request_count, 1);
+}
+
+#[test]
+fn live_recorder_output_is_analyzable_and_has_no_runtime_snapshots() {
+    use tailtriage_tracing::TracingRecorder;
+    use tracing_subscriber::prelude::*;
+
+    let recorder = TracingRecorder::builder("checkout-service")
+        .strict(true)
+        .build();
+    let subscriber = tracing_subscriber::registry().with(recorder.layer());
+
+    tracing::subscriber::with_default(subscriber, || {
+        {
+            let request = tracing::info_span!(
+                "http.request",
+                tt.kind = "request",
+                tt.request_id = "req-live",
+                tt.route = "/live",
+                tt.success = tracing::field::Empty
+            );
+            let _entered = request.enter();
+            request.record("tt.success", true);
+        }
+
+        let queue = tracing::info_span!(
+            "queue.wait",
+            tt.kind = "queue",
+            tt.request_id = "req-live",
+            tt.queue = "db",
+            tt.depth_at_start = 2_u64
+        );
+        drop(queue);
+    });
+
+    let imported = recorder.shutdown().expect("shutdown should convert spans");
+    let run = imported.run();
+    assert!(run.runtime_snapshots.is_empty());
+    assert_eq!(run.requests.len(), 1);
+
+    let report =
+        tailtriage_analyzer::analyze_run(run, tailtriage_analyzer::AnalyzeOptions::default());
+    assert_eq!(report.request_count, 1);
+}


### PR DESCRIPTION
### Motivation
- Improve usability and clarity of tracing JSONL imports by making non-strict conversion warnings easier to interpret. 
- Close test gaps to ensure tracing import artifacts (JSONL and live recorder) are directly analyzable by existing analyzer APIs and do not fabricate runtime snapshots.
- Keep the tracing intake surface narrow and correct without adding new features or changing analyzer behavior.

### Description
- Clarify CLI import warnings by prefixing printed warnings with `warning: tracing import:` for all `import tracing-json` runs to make non-strict skips obvious (change in `tailtriage-cli/src/main.rs`).
- Update CLI boundary test to assert the new warning prefix (change in `tailtriage-cli/tests/cli_boundary.rs`).
- Add focused integration/unit tests to `tailtriage-tracing` that verify JSONL-imported runs and live `TracingRecorder` output are analyzable in-process and that tracing-only imports leave `runtime_snapshots` empty (changes in `tailtriage-tracing/tests/tracing_examples.rs`).
- No public API redesigns or analyzer changes; `run_from_span_records` remains the single conversion core used by both `import_jsonl_*` and the live recorder (`TracingRecorder.snapshot_run`/`shutdown`).

### Testing
- Ran formatting, linting, unit tests, and docs contract validation: `cargo fmt --check` (passed), `cargo clippy --workspace --all-targets -- -D warnings` (passed), `cargo test --workspace` (all tests passed), and `python3 scripts/validate_docs_contracts.py` (passed).
- Updated/added tests include CLI boundary updates and new tracing tests that assert analyzability and absence of fabricated runtime snapshots; all new and existing tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a080cef19c08330a8db540cfcdd1af2)