### PR TITLE
Harden tracing import/report contract coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ Import completed tracing span records (JSONL) into a Run artifact first when nee
 tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json
 ```
 
+`tailtriage import tracing-json ...` writes Run JSON (capture artifact), not Report JSON (analysis output). Tracing-only import keeps `runtime_snapshots` empty; request/stage/queue evidence can come from any runtime, while executor/blocking-pressure evidence remains Tokio-sampler specific.
+
 Analyzer thresholds can be tuned through Rust (`AnalyzeOptions`), TOML (`[analyzer]` with `schema_version = 1`), and CLI (`--analyzer-config` / `--analyzer-set`). Start with defaults first, then tune after representative runs. See [docs/diagnostics.md](docs/diagnostics.md), [docs/operations.md](docs/operations.md), and [`examples/analyzer-config.toml`](examples/analyzer-config.toml).
 
 #### Example output (representative JSON)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -88,6 +88,7 @@ let json = render_json_pretty(&report)?;
 ```
 
 Run artifact JSON is capture output and CLI input. Report JSON is analyzer/CLI output. Typed `Report` is the in-process analyzer result.
+Tracing JSONL import and live tracing-layer recording also produce Run artifacts (not Report JSON). Those tracing-only runs preserve empty `runtime_snapshots`; they still support request/stage/queue triage outside Tokio, while runtime-pressure evidence remains Tokio-specific.
 
 Current analyzer semantics are completed-run or stable-snapshot batch analysis, not live streaming analysis.
 

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -382,4 +382,38 @@ mod tests {
             assert_eq!(run.run().requests[0].route, "/late-kind");
         });
     }
+
+    #[test]
+    fn imported_run_from_live_recorder_is_analyzable_and_has_no_runtime_snapshots() {
+        with_recorder(|recorder| {
+            let request = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r-live",
+                tt.route = "/live"
+            );
+            drop(request);
+
+            let queue = tracing::info_span!(
+                "queue",
+                tt.kind = "queue",
+                tt.request_id = "r-live",
+                tt.queue = "permits"
+            );
+            drop(queue);
+
+            let imported = recorder.shutdown().expect("shutdown should import");
+            let run = imported.run();
+            assert!(
+                run.runtime_snapshots.is_empty(),
+                "tracing-only import must not fabricate runtime snapshots"
+            );
+
+            let report = tailtriage_analyzer::analyze_run(
+                run,
+                tailtriage_analyzer::AnalyzeOptions::default(),
+            );
+            assert_eq!(report.request_count, 1);
+        });
+    }
 }


### PR DESCRIPTION
### Motivation
- Tighten correctness and user-facing contract around the tracing intake paths added for tracing import (issue #510) without changing analyzer behavior or adding features like OTel. 
- Ensure the live `tracing_subscriber` layer and JSONL importer share the same conversion core `run_from_span_records` contract and that tracing-only imports do not fabricate runtime snapshots. 
- Make warnings and docs clearer so users understand the distinction between capture (Run JSON) and analysis (Report JSON) and the Tokio-specific limits of runtime-pressure evidence.

### Description
- Added a focused live-recorder hardening test `imported_run_from_live_recorder_is_analyzable_and_has_no_runtime_snapshots` in `tailtriage-tracing` that verifies a tracing-only recorded `Run` is analyzable in memory and that `runtime_snapshots` remain empty. The test invokes `tailtriage_analyzer::analyze_run` with `AnalyzeOptions::default()` on the imported run. 
- Updated user docs to explicitly state that `tailtriage import tracing-json ...` writes Run JSON (capture artifact), not Report JSON (analyzer output), and that tracing-only imports keep `runtime_snapshots` empty while request/stage/queue evidence can come from any runtime but executor/blocking-pressure evidence remains Tokio-sampler specific; changes in `README.md` and `docs/user-guide.md`. 
- Small code clarity change in the new test to satisfy clippy (`Default::default()` → `AnalyzeOptions::default()`); no public API or analyzer logic was changed.

### Testing
- Ran formatting, lints, unit tests, and docs validation: `cargo fmt --check` (passed), `cargo clippy --workspace --all-targets -- -D warnings` (passed), `cargo test --workspace` (all tests passed), and `python3 scripts/validate_docs_contracts.py` (passed). 
- Added test coverage: new test in `tailtriage-tracing/src/recorder.rs` (passes); existing `tailtriage-tracing` JSONL and recorder tests continue to pass. 
- Verified CLI import/analyze integration tests under `tailtriage-cli` and analyzer tests remained green after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a080cef19c08330a8db540cfcdd1af2)