### PR TITLE
Fix JSONL import tolerance; export recorder limits; add recorder & CLI boundary tests

### DIFF
--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -371,6 +371,73 @@ fn import_tracing_json_accepts_paths_with_spaces() {
         .expect("imported run should load in cli loader");
 }
 
+#[test]
+fn import_tracing_json_rejects_empty_service_name() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, one_valid_request_span_fixture()).expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg(" ")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+    assert!(!output.status.success());
+    assert!(!run_path.exists());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("service name must not be empty"));
+}
+
+#[test]
+fn import_tracing_json_only_unrelated_lines_fails_with_zero_request_events() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, "{\"message\":\"ordinary\"}\n").expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+    assert!(!output.status.success());
+    assert!(!run_path.exists());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("zero request events"));
+}
+
+#[test]
+fn import_tracing_json_only_malformed_tt_lines_non_strict_fails_with_warning_and_zero_requests() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, malformed_tt_line_fixture()).expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+    assert!(!output.status.success());
+    assert!(!run_path.exists());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("warning:"));
+    assert!(stderr.contains("zero request events"));
+}
+
 fn valid_cli_artifact_with_requests() -> &'static str {
     r#"{"schema_version":1,"metadata":{"run_id":"r1","service_name":"svc","service_version":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"mode":"light","host":null,"pid":null,"lifecycle_warnings":[],"unfinished_requests":{"count":0,"sample":[]}},"requests":[{"request_id":"req1","route":"/","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":10,"outcome":"ok"}],"stages":[],"queues":[],"inflight":[],"runtime_snapshots":[]}"#
 }
@@ -414,5 +481,10 @@ fn one_valid_request_span_fixture() -> &'static str {
 fn mixed_valid_and_incomplete_request_span_fixture() -> &'static str {
     r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1"}}}
 {"span":{"name":"http.request","started_at_unix_ms":1020,"finished_at_unix_ms":1032,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout","tt.success":true}}}
+"#
+}
+
+fn malformed_tt_line_fixture() -> &'static str {
+    r#"{"span":{"name":"http.request","started_at_unix_ms":"bad","finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout"}}}
 "#
 }

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -91,7 +91,19 @@ fn parse_record(
             && (span_obj.contains_key("finished_at_unix_ms")
                 || span_obj.contains_key("end_unix_ms"))
         {
-            return parse_normalized_span(span_obj).map(Some);
+            return match parse_normalized_span(span_obj) {
+                Ok(span) => Ok(Some(span)),
+                Err(err) if value_has_tailtriage_field(value) => {
+                    let message = format!("line {line_no}: {err}");
+                    if strict {
+                        Err(ImportError::StrictViolation(message))
+                    } else {
+                        warnings.push(crate::ImportWarning::new(message));
+                        Ok(None)
+                    }
+                }
+                Err(err) => Err(err),
+            };
         }
         if value_has_tailtriage_field(value) && !indicates_close_event(value) {
             let message = format!(
@@ -244,6 +256,7 @@ fn collect_fields_object(value: Option<&Value>, out: &mut BTreeMap<String, Field
         }
     }
 }
+
 fn collect_tt_top_level(value: &Value, out: &mut BTreeMap<String, FieldValue>) {
     let Some(map) = value.as_object() else {
         return;
@@ -482,5 +495,45 @@ mod tests {
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().stages.len(), 1);
         assert_eq!(imported.run().stages[0].stage, "db");
+    }
+
+    #[test]
+    fn normalized_tt_record_invalid_timestamp_warns_non_strict_with_line() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":"bad","finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert_eq!(imported.warnings().len(), 1);
+        assert!(imported.warnings()[0].message().contains("line 1"));
+    }
+
+    #[test]
+    fn normalized_tt_record_invalid_timestamp_errors_strict() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":"bad","finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+            .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn close_event_like_tt_record_missing_timestamps_warns_non_strict_with_line() {
+        let input = r#"{"event":"close","fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert_eq!(imported.warnings().len(), 1);
+        assert!(imported.warnings()[0].message().contains("line 1"));
+    }
+
+    #[test]
+    fn close_event_like_tt_record_missing_timestamps_errors_strict() {
+        let input = r#"{"event":"close","fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}"#;
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+            .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn empty_service_name_errors_for_jsonl_import() {
+        let err = import_jsonl_reader(Cursor::new(""), ImportOptions::new("")).unwrap_err();
+        assert!(matches!(err, ImportError::EmptyServiceName));
     }
 }

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -43,7 +43,10 @@ pub use convention::{
 };
 pub use error::ImportError;
 pub use jsonl::{import_jsonl_path, import_jsonl_reader};
-pub use recorder::{TailtriageLayer, TracingRecorder, TracingRecorderBuilder};
+pub use recorder::{
+    RecorderLimits, TailtriageLayer, TracingRecorder, TracingRecorderBuilder,
+    DEFAULT_MAX_COMPLETED_SPANS, DEFAULT_MAX_OPEN_SPANS,
+};
 pub use types::{FieldValue, ImportOptions, ImportWarning, ImportedRun, SpanKind, SpanRecord};
 
 /// Converts in-memory tracing span records into a `tailtriage_core::Run`.
@@ -519,6 +522,34 @@ mod tests {
             imported.run().metadata.finished_at_unix_ms,
             imported.run().metadata.started_at_unix_ms
         );
+    }
+
+    #[test]
+    fn explicit_duration_us_is_used_for_stage_and_request() {
+        let spans = vec![
+            SpanRecord::new("stage", 100, 100)
+                .duration_us(123)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+            SpanRecord::new("request", 200, 200)
+                .duration_us(456)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+        ];
+        let run = run_from_span_records(spans, ImportOptions::new("svc"))
+            .unwrap()
+            .run()
+            .clone();
+        assert_eq!(run.stages[0].latency_us, 123);
+        assert_eq!(run.requests[0].latency_us, 456);
+    }
+
+    #[test]
+    fn empty_service_name_errors() {
+        let err = run_from_span_records(Vec::new(), ImportOptions::new(" ")).unwrap_err();
+        assert!(matches!(err, ImportError::EmptyServiceName));
     }
 
     #[test]

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -32,11 +32,16 @@ pub struct TailtriageLayer {
     state: Arc<Mutex<RecorderState>>,
     limits: RecorderLimits,
 }
+/// Default maximum number of concurrently tracked candidate open spans.
 pub const DEFAULT_MAX_OPEN_SPANS: usize = 8_192;
+/// Default maximum number of retained completed candidate spans.
 pub const DEFAULT_MAX_COMPLETED_SPANS: usize = 10_000;
+/// Limits for in-memory live tracing recorder retention.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RecorderLimits {
+    /// Maximum number of concurrently tracked candidate open spans.
     pub max_open_spans: usize,
+    /// Maximum number of retained completed candidate spans.
     pub max_completed_spans: usize,
 }
 impl Default for RecorderLimits {
@@ -521,5 +526,104 @@ mod tests {
             let report = analyze_run(run, AnalyzeOptions::default());
             assert_eq!(report.request_count, 1);
         });
+    }
+
+    #[test]
+    fn completed_span_limit_saturation_sets_warnings_and_truncation() {
+        let recorder = TracingRecorder::builder("svc")
+            .max_completed_spans(1)
+            .build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            ));
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r2",
+                tt.route = "/a"
+            ));
+        });
+        let imported = recorder.snapshot_run().unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("dropped 1 completed spans")));
+        assert!(imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|w| w.contains("dropped 1 completed spans")));
+        assert!(imported.run().truncation.limits_hit);
+    }
+
+    #[test]
+    fn open_span_limit_saturation_sets_warnings_and_truncation() {
+        let recorder = TracingRecorder::builder("svc").max_open_spans(1).build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let a = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            );
+            let b = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r2",
+                tt.route = "/a"
+            );
+            drop(a);
+            drop(b);
+        });
+        let imported = recorder.snapshot_run().unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("dropped 1 candidate spans")));
+        assert!(imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|w| w.contains("dropped 1 candidate spans")));
+        assert!(imported.run().truncation.limits_hit);
+    }
+
+    #[test]
+    fn unrelated_spans_do_not_consume_open_limit() {
+        let recorder = TracingRecorder::builder("svc").max_open_spans(1).build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let unrelated = tracing::info_span!("other", user_id = 1_u64);
+            let request = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            );
+            drop(request);
+            drop(unrelated);
+        });
+        let imported = recorder.snapshot_run().unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert!(imported.warnings().is_empty());
+    }
+
+    #[test]
+    fn builder_with_empty_service_name_errors_on_snapshot() {
+        let err = TracingRecorder::builder(" ")
+            .build()
+            .snapshot_run()
+            .unwrap_err();
+        assert!(matches!(err, ImportError::EmptyServiceName));
     }
 }


### PR DESCRIPTION
### Motivation
- Make JSONL import tolerant in non-strict mode for malformed normalized `span` records that contain `tt.*` fields so they warn-and-skip instead of hard-failing, while preserving strict-mode behavior and existing malformed-JSON/I/O semantics. 
- Expose recorder retention configuration from the crate root so callers can observe and configure recorder limits. 
- Add coverage for recorder saturation, explicit `duration_us` precision, empty-service-name validation, and CLI zero-request boundary cases to lock down regression surface for the tracing bridge and import CLI. 

### Description
- JSONL parser: when a normalized `span` object fails conversion, treat it as a strict error in `strict` mode and emit a `warning` and skip in non-strict mode only when `value_has_tailtriage_field(value)` is true, and include the JSONL `line` number in the message; implemented in `tailtriage-tracing/src/jsonl.rs` (changes around `parse_record` / `parse_normalized_span`).
- Re-exports: added `RecorderLimits`, `DEFAULT_MAX_OPEN_SPANS`, and `DEFAULT_MAX_COMPLETED_SPANS` to the crate root exports in `tailtriage-tracing/src/lib.rs` and retained `#![warn(missing_docs)]` by adding doc comments for the new public constants/struct fields in `tailtriage-tracing/src/recorder.rs`.
- Recorder tests: added tests for completed-span saturation, open-span saturation, unrelated spans not consuming open limit, and builder empty-service-name behavior under `tailtriage-tracing/src/recorder.rs`.
- JSONL/run tests: added non-strict/strict JSONL tests for malformed normalized `tt.*` records and close-event-like records (including line-number assertions), an `empty_service_name` JSONL test, and explicit `duration_us` precision tests in `tailtriage-tracing/src/jsonl.rs` and `tailtriage-tracing/src/lib.rs` tests.
- CLI boundary tests: added CLI tests that assert `--service` rejects whitespace-only names, that imports with only unrelated lines fail with `zero request events`, and that non-strict imports that skip all malformed `tt.*` records fail and print `warning:`; changes in `tailtriage-cli/tests/cli_boundary.rs` including a `malformed_tt_line_fixture`.

### Testing
- Ran `cargo fmt --all` and formatting completed successfully. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and no lints remained. 
- Ran `cargo test --workspace` (and earlier targeted `cargo test -p tailtriage-tracing -p tailtriage-cli`) and all unit/integration tests passed across the workspace. 
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08c9b715f48330805fe99c49f2ccb3)