### PR TITLE
Tracing bridge: JSONL non-strict tolerance, recorder limits export, tests, and parity harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,6 +882,7 @@ dependencies = [
 name = "tailtriage-tracing"
 version = "0.2.0"
 dependencies = [
+ "futures-executor",
  "serde",
  "serde_json",
  "tailtriage-analyzer",

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -61,6 +61,9 @@ tailtriage import tracing-json "fixtures/tracing spans.jsonl" --service checkout
 ```
 
 The command imports completed tracing span records in the documented JSONL shape and writes pretty Run JSON (`serde_json::to_writer_pretty`), not Report JSON. Import warnings are printed to stderr as `warning: ...`. Analysis is a separate step: `tailtriage analyze tailtriage-run.json`.
+Malformed JSON input remains fatal. In non-strict mode, syntactically valid malformed/incomplete `tt.*` records are skipped with `warning: ...` lines.
+`--service` must not be empty or whitespace.
+Import fails when zero request events would be written (for example unrelated-only input or all-skipped malformed `tt.*` input), because `tailtriage analyze` requires at least one request in CLI-loaded run artifacts.
 
 `tailtriage analyze <run.json> --format json` emits the same pretty Report JSON as `tailtriage_analyzer::render_json_pretty`.
 

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -371,6 +371,73 @@ fn import_tracing_json_accepts_paths_with_spaces() {
         .expect("imported run should load in cli loader");
 }
 
+#[test]
+fn import_tracing_json_rejects_whitespace_service_name() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, one_valid_request_span_fixture()).expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg(" ")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("service name must not be empty"));
+    assert!(!run_path.exists(), "run output should not be written");
+}
+
+#[test]
+fn import_tracing_json_fails_when_only_unrelated_lines_are_present() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, r#"{"message":"ordinary"}"#).expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("zero request events"));
+    assert!(!run_path.exists(), "run output should not be written");
+}
+
+#[test]
+fn import_tracing_json_fails_when_non_strict_skips_all_malformed_tt_spans() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, malformed_tailtriage_span_fixture()).expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("warning:"));
+    assert!(stderr.contains("zero request events"));
+    assert!(!run_path.exists(), "run output should not be written");
+}
+
 fn valid_cli_artifact_with_requests() -> &'static str {
     r#"{"schema_version":1,"metadata":{"run_id":"r1","service_name":"svc","service_version":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"mode":"light","host":null,"pid":null,"lifecycle_warnings":[],"unfinished_requests":{"count":0,"sample":[]}},"requests":[{"request_id":"req1","route":"/","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":10,"outcome":"ok"}],"stages":[],"queues":[],"inflight":[],"runtime_snapshots":[]}"#
 }
@@ -409,6 +476,10 @@ fn incomplete_tailtriage_span_fixture() -> &'static str {
 fn one_valid_request_span_fixture() -> &'static str {
     r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.success":true}}}
 "#
+}
+
+fn malformed_tailtriage_span_fixture() -> &'static str {
+    r#"{"span":{"name":"req","started_at_unix_ms":"bad","finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#
 }
 
 fn mixed_valid_and_incomplete_request_span_fixture() -> &'static str {

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -32,4 +32,5 @@ workspace = true
 
 [dev-dependencies]
 tailtriage-analyzer.workspace = true
+futures-executor = "0.3"
 tempfile = "3"

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -49,6 +49,8 @@ Notes:
 - Scalars can be strings, bools, numbers, or null.
 - Empty lines are ignored.
 - Malformed JSON line input is an import error in both strict and non-strict mode.
+- In non-strict mode, syntactically valid but malformed/incomplete `tt.*` records are skipped with warnings.
+- In strict mode, malformed/incomplete `tt.*` records are import errors.
 
 CLI import for the same shape:
 
@@ -109,8 +111,11 @@ assert_eq!(run.requests.len(), 1);
 # Ok::<(), tailtriage_tracing::ImportError>(())
 ```
 
+The live recorder is bounded by default (`DEFAULT_MAX_OPEN_SPANS`, `DEFAULT_MAX_COMPLETED_SPANS`), and limits are configurable via `TracingRecorder::builder(...).max_open_spans(...)`, `.max_completed_spans(...)`, or `.limits(RecorderLimits { ... })`.
+
 Use `#[tracing::instrument(fields(...))]` or `.instrument(...)` so span fields attach to async work correctly.
 Do not hold a manual entered-span guard across `.await`; async spans may enter/exit many times, and this recorder finalizes completed work on `on_close` (drop), not enter/exit transitions.
+Live recorder latency/wait precision uses monotonic elapsed duration (`duration_us`) captured at close time.
 
 Tracing span capture for request/stage/queue evidence works outside Tokio runtimes. Runtime-pressure evidence still requires tailtriage's Tokio sampler or future runtime-metrics import; tracing-only spans cannot infer executor or blocking-pool pressure by themselves.
 

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -91,7 +91,19 @@ fn parse_record(
             && (span_obj.contains_key("finished_at_unix_ms")
                 || span_obj.contains_key("end_unix_ms"))
         {
-            return parse_normalized_span(span_obj).map(Some);
+            return match parse_normalized_span(span_obj) {
+                Ok(span) => Ok(Some(span)),
+                Err(err) if value_has_tailtriage_field(value) => {
+                    let message = format!("line {line_no}: {err}");
+                    if strict {
+                        Err(ImportError::StrictViolation(message))
+                    } else {
+                        warnings.push(crate::ImportWarning::new(message));
+                        Ok(None)
+                    }
+                }
+                Err(err) => Err(err),
+            };
         }
         if value_has_tailtriage_field(value) && !indicates_close_event(value) {
             let message = format!(
@@ -482,5 +494,45 @@ mod tests {
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().stages.len(), 1);
         assert_eq!(imported.run().stages[0].stage, "db");
+    }
+
+    #[test]
+    fn non_strict_normalized_tt_span_invalid_timestamp_warns_and_skips() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":"bad","finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert_eq!(imported.warnings().len(), 1);
+        assert!(imported.warnings()[0].message().contains("line 1"));
+    }
+
+    #[test]
+    fn strict_normalized_tt_span_invalid_timestamp_errors() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":"bad","finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+            .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn non_strict_close_event_like_tt_span_missing_timestamps_warns_and_skips() {
+        let input = r#"{"event":"close","span":{"name":"st","fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().stages.is_empty());
+        assert_eq!(imported.warnings().len(), 1);
+        assert!(imported.warnings()[0].message().contains("line 1"));
+    }
+
+    #[test]
+    fn strict_close_event_like_tt_span_missing_timestamps_errors() {
+        let input = r#"{"event":"close","span":{"name":"st","fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}"#;
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+            .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn empty_service_name_is_rejected_for_jsonl_import() {
+        let err = import_jsonl_reader(Cursor::new(""), ImportOptions::new("")).unwrap_err();
+        assert!(matches!(err, ImportError::EmptyServiceName));
     }
 }

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -43,7 +43,10 @@ pub use convention::{
 };
 pub use error::ImportError;
 pub use jsonl::{import_jsonl_path, import_jsonl_reader};
-pub use recorder::{TailtriageLayer, TracingRecorder, TracingRecorderBuilder};
+pub use recorder::{
+    RecorderLimits, TailtriageLayer, TracingRecorder, TracingRecorderBuilder,
+    DEFAULT_MAX_COMPLETED_SPANS, DEFAULT_MAX_OPEN_SPANS,
+};
 pub use types::{FieldValue, ImportOptions, ImportWarning, ImportedRun, SpanKind, SpanRecord};
 
 /// Converts in-memory tracing span records into a `tailtriage_core::Run`.
@@ -694,5 +697,39 @@ mod tests {
             .clone();
         assert!(!run.stages[0].success);
         assert_eq!(run.queues[0].depth_at_start, Some(9));
+    }
+
+    #[test]
+    fn span_duration_us_is_used_for_stage_latency() {
+        let spans = vec![SpanRecord::new("stage", 100, 100)
+            .duration_us(123)
+            .field(TT_KIND, "stage")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_STAGE, "db")];
+        let run = run_from_span_records(spans, ImportOptions::new("svc"))
+            .unwrap()
+            .run()
+            .clone();
+        assert_eq!(run.stages[0].latency_us, 123);
+    }
+
+    #[test]
+    fn span_duration_us_is_used_for_request_latency() {
+        let spans = vec![SpanRecord::new("req", 100, 100)
+            .duration_us(456)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+        let run = run_from_span_records(spans, ImportOptions::new("svc"))
+            .unwrap()
+            .run()
+            .clone();
+        assert_eq!(run.requests[0].latency_us, 456);
+    }
+
+    #[test]
+    fn empty_service_name_is_rejected() {
+        let err = run_from_span_records(Vec::new(), ImportOptions::new(" ")).unwrap_err();
+        assert!(matches!(err, ImportError::EmptyServiceName));
     }
 }

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -32,11 +32,16 @@ pub struct TailtriageLayer {
     state: Arc<Mutex<RecorderState>>,
     limits: RecorderLimits,
 }
+/// Default maximum number of concurrently tracked open candidate spans.
 pub const DEFAULT_MAX_OPEN_SPANS: usize = 8_192;
+/// Default maximum number of retained completed candidate spans.
 pub const DEFAULT_MAX_COMPLETED_SPANS: usize = 10_000;
+/// Configurable in-memory limits for live tracing recorder retention.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RecorderLimits {
+    /// Maximum number of concurrently tracked open candidate spans.
     pub max_open_spans: usize,
+    /// Maximum number of retained completed candidate spans.
     pub max_completed_spans: usize,
 }
 impl Default for RecorderLimits {
@@ -521,5 +526,104 @@ mod tests {
             let report = analyze_run(run, AnalyzeOptions::default());
             assert_eq!(report.request_count, 1);
         });
+    }
+
+    #[test]
+    fn completed_span_saturation_emits_warning_and_sets_limits_hit() {
+        let recorder = TracingRecorder::builder("svc")
+            .max_completed_spans(1)
+            .build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let span1 = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            );
+            drop(span1);
+            let span2 = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r2",
+                tt.route = "/b"
+            );
+            drop(span2);
+        });
+        let imported = recorder.snapshot_run().unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("dropped 1 completed spans")));
+        assert!(imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|w| w.contains("dropped 1 completed spans")));
+        assert!(imported.run().truncation.limits_hit);
+    }
+
+    #[test]
+    fn open_span_saturation_emits_warning_and_sets_limits_hit() {
+        let recorder = TracingRecorder::builder("svc").max_open_spans(1).build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let span1 = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            );
+            let span2 = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r2",
+                tt.route = "/b"
+            );
+            drop(span1);
+            drop(span2);
+        });
+        let imported = recorder.snapshot_run().unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("dropped 1 candidate spans")));
+        assert!(imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|w| w.contains("dropped 1 candidate spans")));
+        assert!(imported.run().truncation.limits_hit);
+    }
+
+    #[test]
+    fn unrelated_spans_do_not_consume_open_limit() {
+        let recorder = TracingRecorder::builder("svc").max_open_spans(1).build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let unrelated = tracing::info_span!("ordinary", foo = 1_u64);
+            let request = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            );
+            drop(request);
+            drop(unrelated);
+        });
+        let imported = recorder.snapshot_run().unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert!(imported.warnings().is_empty());
+    }
+
+    #[test]
+    fn empty_service_name_builder_errors_on_snapshot() {
+        let recorder = TracingRecorder::builder(" ").build();
+        let err = recorder.snapshot_run().unwrap_err();
+        assert!(matches!(err, ImportError::EmptyServiceName));
     }
 }

--- a/tailtriage-tracing/tests/equivalence.rs
+++ b/tailtriage-tracing/tests/equivalence.rs
@@ -1,0 +1,8 @@
+mod support;
+
+use support::equivalence_harness::assert_native_and_tracing_semantic_parity;
+
+#[test]
+fn native_and_tracing_runs_have_semantic_parity() {
+    assert_native_and_tracing_semantic_parity();
+}

--- a/tailtriage-tracing/tests/support/equivalence_harness.rs
+++ b/tailtriage-tracing/tests/support/equivalence_harness.rs
@@ -77,37 +77,50 @@ fn tracing_run() -> (Run, Vec<String>) {
                     tt.route = "/checkout"
                 );
                 {
-                    let queue = tracing::info_span!(
-                        "queue",
-                        tt.kind = "queue",
-                        tt.request_id = id,
-                        tt.queue = "permits",
-                        tt.depth_at_start = 3_u64
-                    );
-                    thread::sleep(Duration::from_millis(if slow { 4 } else { 1 }));
-                    drop(queue);
-                }
-                {
-                    let stage = tracing::info_span!(
-                        "stage",
-                        tt.kind = "stage",
-                        tt.request_id = id,
-                        tt.stage = "db",
-                        tt.success = true
-                    );
-                    thread::sleep(Duration::from_millis(if slow { 6 } else { 2 }));
-                    drop(stage);
-                }
-                {
-                    let stage = tracing::info_span!(
-                        "stage",
-                        tt.kind = "stage",
-                        tt.request_id = id,
-                        tt.stage = "cache",
-                        tt.success = true
-                    );
-                    thread::sleep(Duration::from_millis(1));
-                    drop(stage);
+                    let _request_guard = request.enter();
+
+                    {
+                        let queue = tracing::info_span!(
+                            "queue",
+                            tt.kind = "queue",
+                            tt.request_id = id,
+                            tt.queue = "permits",
+                            tt.depth_at_start = 3_u64
+                        );
+                        {
+                            let _queue_guard = queue.enter();
+                            thread::sleep(Duration::from_millis(if slow { 4 } else { 1 }));
+                        }
+                        drop(queue);
+                    }
+                    {
+                        let stage = tracing::info_span!(
+                            "stage",
+                            tt.kind = "stage",
+                            tt.request_id = id,
+                            tt.stage = "db",
+                            tt.success = true
+                        );
+                        {
+                            let _stage_guard = stage.enter();
+                            thread::sleep(Duration::from_millis(if slow { 6 } else { 2 }));
+                        }
+                        drop(stage);
+                    }
+                    {
+                        let stage = tracing::info_span!(
+                            "stage",
+                            tt.kind = "stage",
+                            tt.request_id = id,
+                            tt.stage = "cache",
+                            tt.success = true
+                        );
+                        {
+                            let _stage_guard = stage.enter();
+                            thread::sleep(Duration::from_millis(1));
+                        }
+                        drop(stage);
+                    }
                 }
                 drop(request);
             }
@@ -126,7 +139,7 @@ fn tracing_run() -> (Run, Vec<String>) {
 fn compare_runs(native_run: &Run, tracing_run: &Run) -> ArtifactEquivalenceReport {
     let mut mismatches = Vec::new();
     if native_run.runtime_snapshots != tracing_run.runtime_snapshots {
-        mismatches.push("runtime_snapshots differ".to_owned());
+        mismatches.push("runtime snapshots mismatch".to_owned());
     }
     if native_run.truncation.limits_hit || tracing_run.truncation.limits_hit {
         mismatches.push("truncation.limits_hit must be false for both runs".to_owned());
@@ -153,7 +166,7 @@ fn compare_runs(native_run: &Run, tracing_run: &Run) -> ArtifactEquivalenceRepor
         })
         .collect();
     if nreq.keys().collect::<BTreeSet<_>>() != treq.keys().collect::<BTreeSet<_>>() {
-        mismatches.push("request id sets differ".to_owned());
+        mismatches.push("request id set mismatch".to_owned());
     }
     for (id, (route, outcome, lat)) in &nreq {
         if *lat == 0 {
@@ -184,7 +197,7 @@ fn compare_runs(native_run: &Run, tracing_run: &Run) -> ArtifactEquivalenceRepor
         .max_by_key(|(_, (_, _, lat))| *lat)
         .map(|(id, _)| id.clone());
     if slow_native != slow_tracing {
-        mismatches.push("slowest request id differs".to_owned());
+        mismatches.push("slowest request mismatch".to_owned());
     }
 
     let nstage: BTreeSet<_> = native_run

--- a/tailtriage-tracing/tests/support/equivalence_harness.rs
+++ b/tailtriage-tracing/tests/support/equivalence_harness.rs
@@ -1,0 +1,234 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::thread;
+use std::time::Duration;
+
+use futures_executor::block_on;
+use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
+use tailtriage_core::{MemorySink, Run, Tailtriage};
+use tailtriage_tracing::TracingRecorder;
+use tracing_subscriber::prelude::*;
+
+pub fn assert_native_and_tracing_semantic_parity() {
+    let native_run = native_run();
+    let (tracing_run, warnings) = tracing_run();
+
+    let report = compare_runs(&native_run, &tracing_run);
+    assert!(
+        report.mismatches.is_empty(),
+        "semantic parity mismatches: {}",
+        report.mismatches.join("; ")
+    );
+    assert!(
+        warnings.is_empty(),
+        "unexpected tracing warnings: {warnings:?}"
+    );
+}
+
+struct ArtifactEquivalenceReport {
+    mismatches: Vec<String>,
+}
+
+fn native_run() -> Run {
+    let sink = MemorySink::default();
+    let tt = Tailtriage::builder("svc")
+        .sink(sink.clone())
+        .build()
+        .unwrap();
+    for (id, slow) in [("r1", false), ("r2", true), ("r3", false)] {
+        let started = tt.begin_request_with(
+            "/checkout",
+            tailtriage_core::RequestOptions::new().request_id(id),
+        );
+        block_on(
+            started
+                .handle
+                .queue("permits")
+                .with_depth_at_start(3)
+                .await_on(async {
+                    thread::sleep(Duration::from_millis(if slow { 4 } else { 1 }));
+                }),
+        );
+        block_on(started.handle.stage("db").await_on(async {
+            thread::sleep(Duration::from_millis(if slow { 6 } else { 2 }));
+            Ok::<(), std::io::Error>(())
+        }))
+        .unwrap();
+        block_on(started.handle.stage("cache").await_on(async {
+            thread::sleep(Duration::from_millis(1));
+            Ok::<(), std::io::Error>(())
+        }))
+        .unwrap();
+        started.completion.finish_ok();
+    }
+    tt.shutdown().unwrap();
+    sink.last_run().unwrap()
+}
+
+fn tracing_run() -> (Run, Vec<String>) {
+    let recorder = TracingRecorder::builder("svc").build();
+    let subscriber = tracing_subscriber::registry().with(recorder.layer());
+    tracing::subscriber::with_default(subscriber, || {
+        block_on(async {
+            for (id, slow) in [("r1", false), ("r2", true), ("r3", false)] {
+                let request = tracing::info_span!(
+                    "request",
+                    tt.kind = "request",
+                    tt.request_id = id,
+                    tt.route = "/checkout"
+                );
+                {
+                    let queue = tracing::info_span!(
+                        "queue",
+                        tt.kind = "queue",
+                        tt.request_id = id,
+                        tt.queue = "permits",
+                        tt.depth_at_start = 3_u64
+                    );
+                    thread::sleep(Duration::from_millis(if slow { 4 } else { 1 }));
+                    drop(queue);
+                }
+                {
+                    let stage = tracing::info_span!(
+                        "stage",
+                        tt.kind = "stage",
+                        tt.request_id = id,
+                        tt.stage = "db",
+                        tt.success = true
+                    );
+                    thread::sleep(Duration::from_millis(if slow { 6 } else { 2 }));
+                    drop(stage);
+                }
+                {
+                    let stage = tracing::info_span!(
+                        "stage",
+                        tt.kind = "stage",
+                        tt.request_id = id,
+                        tt.stage = "cache",
+                        tt.success = true
+                    );
+                    thread::sleep(Duration::from_millis(1));
+                    drop(stage);
+                }
+                drop(request);
+            }
+        });
+    });
+    let imported = recorder.snapshot_run().unwrap();
+    let warnings = imported
+        .warnings()
+        .iter()
+        .map(|w| w.message().to_owned())
+        .collect();
+    (imported.run().clone(), warnings)
+}
+
+#[allow(clippy::too_many_lines)]
+fn compare_runs(native_run: &Run, tracing_run: &Run) -> ArtifactEquivalenceReport {
+    let mut mismatches = Vec::new();
+    if native_run.runtime_snapshots != tracing_run.runtime_snapshots {
+        mismatches.push("runtime_snapshots differ".to_owned());
+    }
+    if native_run.truncation.limits_hit || tracing_run.truncation.limits_hit {
+        mismatches.push("truncation.limits_hit must be false for both runs".to_owned());
+    }
+
+    let nreq: BTreeMap<_, _> = native_run
+        .requests
+        .iter()
+        .map(|r| {
+            (
+                r.request_id.clone(),
+                (r.route.clone(), r.outcome.clone(), r.latency_us),
+            )
+        })
+        .collect();
+    let treq: BTreeMap<_, _> = tracing_run
+        .requests
+        .iter()
+        .map(|r| {
+            (
+                r.request_id.clone(),
+                (r.route.clone(), r.outcome.clone(), r.latency_us),
+            )
+        })
+        .collect();
+    if nreq.keys().collect::<BTreeSet<_>>() != treq.keys().collect::<BTreeSet<_>>() {
+        mismatches.push("request id sets differ".to_owned());
+    }
+    for (id, (route, outcome, lat)) in &nreq {
+        if *lat == 0 {
+            mismatches.push(format!("native request {id} latency not positive"));
+        }
+        match treq.get(id) {
+            Some((tr, to, tl)) => {
+                if route != tr {
+                    mismatches.push(format!("route mismatch for {id}"));
+                }
+                if outcome != to {
+                    mismatches.push(format!("outcome mismatch for {id}"));
+                }
+                if *tl == 0 {
+                    mismatches.push(format!("tracing request {id} latency not positive"));
+                }
+            }
+            None => mismatches.push(format!("missing tracing request {id}")),
+        }
+    }
+
+    let slow_native = nreq
+        .iter()
+        .max_by_key(|(_, (_, _, lat))| *lat)
+        .map(|(id, _)| id.clone());
+    let slow_tracing = treq
+        .iter()
+        .max_by_key(|(_, (_, _, lat))| *lat)
+        .map(|(id, _)| id.clone());
+    if slow_native != slow_tracing {
+        mismatches.push("slowest request id differs".to_owned());
+    }
+
+    let nstage: BTreeSet<_> = native_run
+        .stages
+        .iter()
+        .map(|s| (s.request_id.clone(), s.stage.clone(), s.success))
+        .collect();
+    let tstage: BTreeSet<_> = tracing_run
+        .stages
+        .iter()
+        .map(|s| (s.request_id.clone(), s.stage.clone(), s.success))
+        .collect();
+    if nstage != tstage {
+        mismatches.push("stage correlation shape differs".to_owned());
+    }
+    if native_run.stages.iter().any(|s| s.latency_us == 0)
+        || tracing_run.stages.iter().any(|s| s.latency_us == 0)
+    {
+        mismatches.push("stage latencies must be positive".to_owned());
+    }
+
+    let nqueue: BTreeSet<_> = native_run
+        .queues
+        .iter()
+        .map(|q| (q.request_id.clone(), q.queue.clone(), q.depth_at_start))
+        .collect();
+    let tqueue: BTreeSet<_> = tracing_run
+        .queues
+        .iter()
+        .map(|q| (q.request_id.clone(), q.queue.clone(), q.depth_at_start))
+        .collect();
+    if nqueue != tqueue {
+        mismatches.push("queue correlation shape differs".to_owned());
+    }
+    if native_run.queues.iter().any(|q| q.wait_us == 0)
+        || tracing_run.queues.iter().any(|q| q.wait_us == 0)
+    {
+        mismatches.push("queue latencies must be positive".to_owned());
+    }
+
+    if analyze_run(native_run, AnalyzeOptions::default()).request_count != 3
+        || analyze_run(tracing_run, AnalyzeOptions::default()).request_count != 3
+    {
+        mismatches.push("analyzer request_count must equal 3 for both runs".to_owned());
+    }
+    ArtifactEquivalenceReport { mismatches }
+}

--- a/tailtriage-tracing/tests/support/mod.rs
+++ b/tailtriage-tracing/tests/support/mod.rs
@@ -1,0 +1,1 @@
+pub mod equivalence_harness;


### PR DESCRIPTION
### Motivation

- Finish the remaining blocker for the tracing bridge by making JSONL import tolerant in non-strict mode for malformed `tt.*` normalized records while preserving strict-mode failures and fatal malformed-JSON behavior.
- Expose live-recorder limits from the crate root so callers can inspect/configure recorder bounds and keep rustdoc diagnostics satisfied.
- Add coverage for recorder truncation behaviors, explicit duration precision handling, service-name validation, CLI zero-request boundaries, and a native-vs-tracing semantic parity harness to validate behavioral parity.

### Description

- JSONL parser: `parse_record` now intercepts `parse_normalized_span` errors for records that contain `tt.*` fields and, depending on `strict`, either returns `ImportError::StrictViolation` or pushes a `ImportWarning` and skips the record; malformed JSON and I/O errors remain fatal (`tailtriage-tracing/src/jsonl.rs`).
- Crate exports & docs: re-exported `RecorderLimits`, `DEFAULT_MAX_OPEN_SPANS`, and `DEFAULT_MAX_COMPLETED_SPANS` from the crate root and added rustdoc comments on the constants/struct to satisfy `#![warn(missing_docs)]` (`tailtriage-tracing/src/lib.rs`, `tailtriage-tracing/src/recorder.rs`).
- Recorder tests & behavior: added tests for completed-span and open-span saturation, verified unrelated spans do not consume the open-span limit, and added builder snapshot validation for empty service name; recorder uses monotonic `duration_us` for live span latency (`tailtriage-tracing/src/recorder.rs`).
- Duration & service-name tests: added tests that explicit `duration_us` in `SpanRecord` is preserved for stage/request latency and that empty/whitespace service names return `ImportError::EmptyServiceName` for conversion, JSONL import, recorder snapshot, and CLI import paths (`tailtriage-tracing/src/lib.rs`, `tailtriage-tracing/src/jsonl.rs`, `tailtriage-tracing/src/recorder.rs`).
- CLI boundary tests: added CLI tests that `--service` must not be empty/whitespace, importing unrelated-only input fails with `zero request events`, and non-strict imports that skip all malformed `tt.*` spans fail with warnings and no output file (`tailtriage-cli/tests/cli_boundary.rs`).
- Parity harness: integrated a semantic equivalence harness (no Tokio) using `futures-executor` dev-dependency; added `tests/equivalence.rs` and `tests/support/equivalence_harness.rs` which drive both native `tailtriage_core::Tailtriage` and `TracingRecorder` paths and assert semantic parity on IDs, routes, outcomes, stage/queue correlation, positive latencies, slowest-request ordering, no runtime snapshots, no truncation, and analyzability with `tailtriage_analyzer`.
- Docs: updated `tailtriage-tracing/README.md` and `tailtriage-cli/README.md` to document non-strict skip+warning semantics, fatal malformed JSON, bounded/configurable recorder defaults, monotonic live duration precision, CLI zero-request failure rule, and the `--service` validation.
- Scope preserved: no analyzer behavior changes, no Run-schema changes, no OTel/OTLP added, parity harness uses `futures-executor` (no Tokio), and CLI `warning:` prefix unchanged.

### Testing

- Ran formatting and lints: `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings` and both passed.
- Ran unit/integration tests: `cargo test --workspace` and all workspace tests (including the new recorder, jsonl, CLI boundary, and equivalence harness tests) passed.
- Docs contract: `python3 scripts/validate_docs_contracts.py` ran and passed.
- Summary of automated checks executed successfully: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, and `python3 scripts/validate_docs_contracts.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08c9b715f48330805fe99c49f2ccb3)