### PR TITLE
Upgrade tracing/native parity validation to structured full harness

### DIFF
--- a/tailtriage-tracing/tests/equivalence.rs
+++ b/tailtriage-tracing/tests/equivalence.rs
@@ -1,8 +1,8 @@
 mod support;
 
-use support::equivalence_harness::assert_native_and_tracing_semantic_parity;
+use support::equivalence_harness::assert_native_and_tracing_full_parity;
 
 #[test]
-fn native_and_tracing_runs_have_semantic_parity() {
-    assert_native_and_tracing_semantic_parity();
+fn native_and_tracing_runs_have_full_parity() {
+    assert_native_and_tracing_full_parity();
 }

--- a/tailtriage-tracing/tests/support/equivalence_harness.rs
+++ b/tailtriage-tracing/tests/support/equivalence_harness.rs
@@ -3,32 +3,141 @@ use std::thread;
 use std::time::Duration;
 
 use futures_executor::block_on;
-use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
+use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions, Report};
 use tailtriage_core::{MemorySink, Run, Tailtriage};
 use tailtriage_tracing::TracingRecorder;
 use tracing_subscriber::prelude::*;
 
-pub fn assert_native_and_tracing_semantic_parity() {
-    let native_run = native_run();
-    let (tracing_run, warnings) = tracing_run();
+#[allow(dead_code)]
+pub struct RunParityReport {
+    pub mismatches: Vec<String>,
+    pub request_count_native: usize,
+    pub request_count_tracing: usize,
+    pub stage_count_native: usize,
+    pub stage_count_tracing: usize,
+    pub queue_count_native: usize,
+    pub queue_count_tracing: usize,
+    pub slowest_request_id_native: Option<String>,
+    pub slowest_request_id_tracing: Option<String>,
+}
 
-    let report = compare_runs(&native_run, &tracing_run);
-    assert!(
-        report.mismatches.is_empty(),
-        "semantic parity mismatches: {}",
-        report.mismatches.join("; ")
-    );
+#[allow(dead_code)]
+pub struct AnalyzerParityReport {
+    pub mismatches: Vec<String>,
+    pub request_count_native: usize,
+    pub request_count_tracing: usize,
+    pub primary_suspect_native: String,
+    pub primary_suspect_tracing: String,
+    pub primary_score_native: u8,
+    pub primary_score_tracing: u8,
+}
+
+#[allow(dead_code)]
+pub struct RenderedReportParityReport {
+    pub mismatches: Vec<String>,
+    pub normalized_text_native: String,
+    pub normalized_text_tracing: String,
+}
+
+#[allow(dead_code)]
+pub struct ParityReport {
+    pub mismatches: Vec<String>,
+    pub run_report: RunParityReport,
+    pub analyzer_report: AnalyzerParityReport,
+    pub rendered_report: RenderedReportParityReport,
+}
+
+pub fn assert_native_and_tracing_full_parity() {
+    let native = native_run();
+    let (tracing_run, warnings) = tracing_run();
+    let report = build_full_parity_report(&native, &tracing_run);
+
     assert!(
         warnings.is_empty(),
         "unexpected tracing warnings: {warnings:?}"
     );
+    assert!(
+        report.mismatches.is_empty(),
+        "full parity mismatches:\n{}",
+        report.mismatches.join("\n")
+    );
 }
 
-struct ArtifactEquivalenceReport {
-    mismatches: Vec<String>,
+#[test]
+fn parity_report_detects_queue_mismatch() {
+    let native = native_run();
+    let mut tracing_run = native.clone();
+    let queue = tracing_run
+        .queues
+        .iter_mut()
+        .find(|q| q.request_id == "r2")
+        .expect("r2 queue should exist");
+    queue.queue = "permits_changed".to_owned();
+
+    let report = build_full_parity_report(&native, &tracing_run);
+    assert!(
+        report
+            .run_report
+            .mismatches
+            .iter()
+            .any(|m| m.contains("queue set mismatch")),
+        "expected queue mismatch, got: {:?}",
+        report.run_report.mismatches
+    );
+}
+
+#[test]
+fn report_normalization_keeps_semantic_differences_visible() {
+    let native = native_run();
+    let mut tracing_run = native.clone();
+    tracing_run.requests.clear();
+    tracing_run.stages.clear();
+    tracing_run.queues.clear();
+
+    let report = build_full_parity_report(&native, &tracing_run);
+    assert!(
+        report
+            .rendered_report
+            .mismatches
+            .iter()
+            .any(|m| m.contains("semantic token mismatch") || m.contains("primary suspect text")),
+        "normalization should not hide semantic differences: {:?}",
+        report.rendered_report.mismatches
+    );
+}
+
+fn build_full_parity_report(native_run: &Run, tracing_run: &Run) -> ParityReport {
+    let run_report = compare_runs(native_run, tracing_run);
+    let native_analysis = analyze_run(native_run, AnalyzeOptions::default());
+    let tracing_analysis = analyze_run(tracing_run, AnalyzeOptions::default());
+    let analyzer_report = compare_analyzer_reports(&native_analysis, &tracing_analysis);
+    let rendered_report = compare_rendered_reports(&native_analysis, &tracing_analysis);
+
+    let mut mismatches = Vec::new();
+    mismatches.extend(run_report.mismatches.iter().map(|m| format!("[run] {m}")));
+    mismatches.extend(
+        analyzer_report
+            .mismatches
+            .iter()
+            .map(|m| format!("[analyzer] {m}")),
+    );
+    mismatches.extend(
+        rendered_report
+            .mismatches
+            .iter()
+            .map(|m| format!("[rendered] {m}")),
+    );
+
+    ParityReport {
+        mismatches,
+        run_report,
+        analyzer_report,
+        rendered_report,
+    }
 }
 
 fn native_run() -> Run {
+    /* unchanged scenario */
     let sink = MemorySink::default();
     let tt = Tailtriage::builder("svc")
         .sink(sink.clone())
@@ -65,6 +174,7 @@ fn native_run() -> Run {
 }
 
 fn tracing_run() -> (Run, Vec<String>) {
+    /* unchanged scenario */
     let recorder = TracingRecorder::builder("svc").build();
     let subscriber = tracing_subscriber::registry().with(recorder.layer());
     tracing::subscriber::with_default(subscriber, || {
@@ -78,49 +188,42 @@ fn tracing_run() -> (Run, Vec<String>) {
                 );
                 {
                     let _request_guard = request.enter();
-
+                    let queue = tracing::info_span!(
+                        "queue",
+                        tt.kind = "queue",
+                        tt.request_id = id,
+                        tt.queue = "permits",
+                        tt.depth_at_start = 3_u64
+                    );
                     {
-                        let queue = tracing::info_span!(
-                            "queue",
-                            tt.kind = "queue",
-                            tt.request_id = id,
-                            tt.queue = "permits",
-                            tt.depth_at_start = 3_u64
-                        );
-                        {
-                            let _queue_guard = queue.enter();
-                            thread::sleep(Duration::from_millis(if slow { 4 } else { 1 }));
-                        }
-                        drop(queue);
+                        let _queue_guard = queue.enter();
+                        thread::sleep(Duration::from_millis(if slow { 4 } else { 1 }));
                     }
+                    drop(queue);
+                    let stage = tracing::info_span!(
+                        "stage",
+                        tt.kind = "stage",
+                        tt.request_id = id,
+                        tt.stage = "db",
+                        tt.success = true
+                    );
                     {
-                        let stage = tracing::info_span!(
-                            "stage",
-                            tt.kind = "stage",
-                            tt.request_id = id,
-                            tt.stage = "db",
-                            tt.success = true
-                        );
-                        {
-                            let _stage_guard = stage.enter();
-                            thread::sleep(Duration::from_millis(if slow { 6 } else { 2 }));
-                        }
-                        drop(stage);
+                        let _stage_guard = stage.enter();
+                        thread::sleep(Duration::from_millis(if slow { 6 } else { 2 }));
                     }
+                    drop(stage);
+                    let stage = tracing::info_span!(
+                        "stage",
+                        tt.kind = "stage",
+                        tt.request_id = id,
+                        tt.stage = "cache",
+                        tt.success = true
+                    );
                     {
-                        let stage = tracing::info_span!(
-                            "stage",
-                            tt.kind = "stage",
-                            tt.request_id = id,
-                            tt.stage = "cache",
-                            tt.success = true
-                        );
-                        {
-                            let _stage_guard = stage.enter();
-                            thread::sleep(Duration::from_millis(1));
-                        }
-                        drop(stage);
+                        let _stage_guard = stage.enter();
+                        thread::sleep(Duration::from_millis(1));
                     }
+                    drop(stage);
                 }
                 drop(request);
             }
@@ -136,15 +239,8 @@ fn tracing_run() -> (Run, Vec<String>) {
 }
 
 #[allow(clippy::too_many_lines)]
-fn compare_runs(native_run: &Run, tracing_run: &Run) -> ArtifactEquivalenceReport {
+fn compare_runs(native_run: &Run, tracing_run: &Run) -> RunParityReport {
     let mut mismatches = Vec::new();
-    if native_run.runtime_snapshots != tracing_run.runtime_snapshots {
-        mismatches.push("runtime snapshots mismatch".to_owned());
-    }
-    if native_run.truncation.limits_hit || tracing_run.truncation.limits_hit {
-        mismatches.push("truncation.limits_hit must be false for both runs".to_owned());
-    }
-
     let nreq: BTreeMap<_, _> = native_run
         .requests
         .iter()
@@ -165,6 +261,7 @@ fn compare_runs(native_run: &Run, tracing_run: &Run) -> ArtifactEquivalenceRepor
             )
         })
         .collect();
+
     if nreq.keys().collect::<BTreeSet<_>>() != treq.keys().collect::<BTreeSet<_>>() {
         mismatches.push("request id set mismatch".to_owned());
     }
@@ -172,32 +269,19 @@ fn compare_runs(native_run: &Run, tracing_run: &Run) -> ArtifactEquivalenceRepor
         if *lat == 0 {
             mismatches.push(format!("native request {id} latency not positive"));
         }
-        match treq.get(id) {
-            Some((tr, to, tl)) => {
-                if route != tr {
-                    mismatches.push(format!("route mismatch for {id}"));
-                }
-                if outcome != to {
-                    mismatches.push(format!("outcome mismatch for {id}"));
-                }
-                if *tl == 0 {
-                    mismatches.push(format!("tracing request {id} latency not positive"));
-                }
+        if let Some((tr, to, tl)) = treq.get(id) {
+            if route != tr {
+                mismatches.push(format!(
+                    "route mismatch for {id}: native={route} tracing={tr}"
+                ));
             }
-            None => mismatches.push(format!("missing tracing request {id}")),
+            if outcome != to {
+                mismatches.push(format!("outcome mismatch for {id}"));
+            }
+            if *tl == 0 {
+                mismatches.push(format!("tracing request {id} latency not positive"));
+            }
         }
-    }
-
-    let slow_native = nreq
-        .iter()
-        .max_by_key(|(_, (_, _, lat))| *lat)
-        .map(|(id, _)| id.clone());
-    let slow_tracing = treq
-        .iter()
-        .max_by_key(|(_, (_, _, lat))| *lat)
-        .map(|(id, _)| id.clone());
-    if slow_native != slow_tracing {
-        mismatches.push("slowest request mismatch".to_owned());
     }
 
     let nstage: BTreeSet<_> = native_run
@@ -211,12 +295,7 @@ fn compare_runs(native_run: &Run, tracing_run: &Run) -> ArtifactEquivalenceRepor
         .map(|s| (s.request_id.clone(), s.stage.clone(), s.success))
         .collect();
     if nstage != tstage {
-        mismatches.push("stage correlation shape differs".to_owned());
-    }
-    if native_run.stages.iter().any(|s| s.latency_us == 0)
-        || tracing_run.stages.iter().any(|s| s.latency_us == 0)
-    {
-        mismatches.push("stage latencies must be positive".to_owned());
+        mismatches.push("stage set mismatch".to_owned());
     }
 
     let nqueue: BTreeSet<_> = native_run
@@ -230,18 +309,178 @@ fn compare_runs(native_run: &Run, tracing_run: &Run) -> ArtifactEquivalenceRepor
         .map(|q| (q.request_id.clone(), q.queue.clone(), q.depth_at_start))
         .collect();
     if nqueue != tqueue {
-        mismatches.push("queue correlation shape differs".to_owned());
+        mismatches.push(format!(
+            "queue set mismatch: native={nqueue:?} tracing={tqueue:?}"
+        ));
+    }
+
+    if native_run.runtime_snapshots != tracing_run.runtime_snapshots
+        || !native_run.runtime_snapshots.is_empty()
+    {
+        mismatches.push("runtime snapshots must match and be empty".to_owned());
+    }
+    if native_run.truncation.limits_hit || tracing_run.truncation.limits_hit {
+        mismatches.push("truncation.limits_hit must be false".to_owned());
+    }
+    if native_run.requests.len() != tracing_run.requests.len() {
+        mismatches.push("request count mismatch".to_owned());
+    }
+    if native_run.stages.len() != tracing_run.stages.len() {
+        mismatches.push("stage count mismatch".to_owned());
+    }
+    if native_run.queues.len() != tracing_run.queues.len() {
+        mismatches.push("queue count mismatch".to_owned());
+    }
+    if native_run.stages.iter().any(|s| s.latency_us == 0)
+        || tracing_run.stages.iter().any(|s| s.latency_us == 0)
+    {
+        mismatches.push("all stage durations must be positive".to_owned());
     }
     if native_run.queues.iter().any(|q| q.wait_us == 0)
         || tracing_run.queues.iter().any(|q| q.wait_us == 0)
     {
-        mismatches.push("queue latencies must be positive".to_owned());
+        mismatches.push("all queue durations must be positive".to_owned());
     }
 
-    if analyze_run(native_run, AnalyzeOptions::default()).request_count != 3
-        || analyze_run(tracing_run, AnalyzeOptions::default()).request_count != 3
-    {
-        mismatches.push("analyzer request_count must equal 3 for both runs".to_owned());
+    let slow_n = nreq
+        .iter()
+        .max_by_key(|(_, (_, _, lat))| *lat)
+        .map(|(id, _)| id.clone());
+    let slow_t = treq
+        .iter()
+        .max_by_key(|(_, (_, _, lat))| *lat)
+        .map(|(id, _)| id.clone());
+    if slow_n != slow_t {
+        mismatches.push(format!(
+            "slowest request mismatch: native={slow_n:?} tracing={slow_t:?}"
+        ));
     }
-    ArtifactEquivalenceReport { mismatches }
+
+    RunParityReport {
+        mismatches,
+        request_count_native: native_run.requests.len(),
+        request_count_tracing: tracing_run.requests.len(),
+        stage_count_native: native_run.stages.len(),
+        stage_count_tracing: tracing_run.stages.len(),
+        queue_count_native: native_run.queues.len(),
+        queue_count_tracing: tracing_run.queues.len(),
+        slowest_request_id_native: slow_n,
+        slowest_request_id_tracing: slow_t,
+    }
+}
+
+fn compare_analyzer_reports(native: &Report, tracing: &Report) -> AnalyzerParityReport {
+    let mut mismatches = Vec::new();
+    if native.request_count != tracing.request_count {
+        mismatches.push("request_count mismatch".to_owned());
+    }
+    if native.primary_suspect.kind != tracing.primary_suspect.kind {
+        mismatches.push(format!(
+            "primary suspect mismatch: native={} tracing={}",
+            native.primary_suspect.kind.as_str(),
+            tracing.primary_suspect.kind.as_str()
+        ));
+    }
+    if native.p95_latency_us.unwrap_or(0) == 0 || tracing.p95_latency_us.unwrap_or(0) == 0 {
+        mismatches.push("p95 latency must be present and non-zero".to_owned());
+    }
+    if native.p99_latency_us.unwrap_or(0) == 0 || tracing.p99_latency_us.unwrap_or(0) == 0 {
+        mismatches.push("p99 latency must be present and non-zero".to_owned());
+    }
+
+    let labels = |report: &Report| {
+        let mut labels = BTreeSet::new();
+        for text in &report.primary_suspect.evidence {
+            if text.contains("/checkout") {
+                labels.insert("route:/checkout".to_owned());
+            }
+            if text.contains("db") {
+                labels.insert("stage:db".to_owned());
+            }
+            if text.contains("cache") {
+                labels.insert("stage:cache".to_owned());
+            }
+            if text.contains("permits") || text.contains("queue") {
+                labels.insert("queue:permits_or_queue_signal".to_owned());
+            }
+        }
+        labels
+    };
+    let nlabels = labels(native);
+    let tlabels = labels(tracing);
+    if nlabels != tlabels {
+        mismatches.push(format!(
+            "evidence labels differ: native={nlabels:?} tracing={tlabels:?}"
+        ));
+    }
+
+    AnalyzerParityReport {
+        mismatches,
+        request_count_native: native.request_count,
+        request_count_tracing: tracing.request_count,
+        primary_suspect_native: native.primary_suspect.kind.as_str().to_owned(),
+        primary_suspect_tracing: tracing.primary_suspect.kind.as_str().to_owned(),
+        primary_score_native: native.primary_suspect.score,
+        primary_score_tracing: tracing.primary_suspect.score,
+    }
+}
+
+fn normalize_rendered_text(text: &str) -> String {
+    text.lines()
+        .map(|line| {
+            if line.contains("run ")
+                || line.contains("captured")
+                || line.contains("latency")
+                || line.contains("p95")
+                || line.contains("p99")
+                || line.contains("us")
+            {
+                "<normalized-unstable>".to_owned()
+            } else {
+                line.trim().to_owned()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn compare_rendered_reports(native: &Report, tracing: &Report) -> RenderedReportParityReport {
+    let n = normalize_rendered_text(&render_text(native));
+    let t = normalize_rendered_text(&render_text(tracing));
+    let mut mismatches = Vec::new();
+    if n.trim().is_empty() || t.trim().is_empty() {
+        mismatches.push("rendered text must be non-empty".to_owned());
+    }
+    if !n.to_lowercase().contains("next checks") || !t.to_lowercase().contains("next checks") {
+        mismatches.push("missing key section: next checks".to_owned());
+    }
+    let semantic_tokens = |text: &str| {
+        let lower = text.to_lowercase();
+        let mut tokens = BTreeSet::new();
+        for token in ["/checkout", "db", "cache", "permits", "next checks"] {
+            if lower.contains(token) {
+                tokens.insert(token.to_owned());
+            }
+        }
+        tokens
+    };
+    let ntokens = semantic_tokens(&n);
+    let ttokens = semantic_tokens(&t);
+    if ntokens != ttokens {
+        mismatches.push(format!(
+            "semantic token mismatch after normalization: native={ntokens:?} tracing={ttokens:?}"
+        ));
+    }
+    let np = native.primary_suspect.kind.as_str();
+    let tp = tracing.primary_suspect.kind.as_str();
+    if np != tp {
+        mismatches.push(format!(
+            "primary suspect text differs: native={np} tracing={tp}"
+        ));
+    }
+    RenderedReportParityReport {
+        mismatches,
+        normalized_text_native: n,
+        normalized_text_tracing: t,
+    }
 }


### PR DESCRIPTION
### Motivation
- The existing semantic-parity smoke check was too weak for the validation branch and only compared basic artifact shape and analyzer request counts. This change provides a structured, actionable parity harness that compares run artifacts, analyzer output, and rendered reports. 
- The harness stays test-support-only and preserves the deterministic canonical scenario (3 requests, route `/checkout`, IDs `r1/r2/r3`, stages `db`/`cache`, queue `permits`) to keep failures reproducible.

### Description
- Introduced structured parity report types `RunParityReport`, `AnalyzerParityReport`, `RenderedReportParityReport`, and `ParityReport` in `tailtriage-tracing/tests/support/equivalence_harness.rs`, each containing `mismatches: Vec<String>` plus summary fields for actionable failure output.
- Added top-level assertion `assert_native_and_tracing_full_parity()` that builds a full `ParityReport` via `build_full_parity_report()` and fails with section-tagged mismatch messages when parity is violated.
- Implemented detailed comparisons: `compare_runs()` validates request/stage/queue shapes and counts, truncation/runtime-snapshot expectations, positive durations, and slowest-request identity without requiring exact timestamps/latencies; `compare_analyzer_reports()` runs `analyze_run(..., AnalyzeOptions::default())` and checks request counts, primary suspect kind, p95/p99 presence, and relevant evidence labels; `compare_rendered_reports()` renders text via the analyzer renderer, normalizes unstable values (run ids, timestamps, exact durations/latencies), and checks for key sections plus semantic tokens and primary suspect text parity instead of byte-for-byte equality.
- Kept both capture paths: native path via `tailtriage_core::Tailtriage` and tracing path via `tailtriage_tracing::TracingRecorder`, producing `tailtriage_core::Run` for comparison.
- Added two negative tests under the same harness: one that mutates a queue name to exercise queue mismatch detection, and one that verifies normalization does not hide semantic differences in rendered reports.
- Updated the test entry in `tailtriage-tracing/tests/equivalence.rs` to call the new `assert_native_and_tracing_full_parity()` entrypoint.

### Testing
- Ran docs contract validation with `python3 scripts/validate_docs_contracts.py` which succeeded.
- Ran formatting check with `cargo fmt --check` which passed after formatting adjustments.
- Ran linting with `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which passed with no warnings.
- Ran the full test suite with `cargo test --workspace --all-targets --all-features --locked` and all tests passed, including the updated `tailtriage-tracing` equivalence tests and the added negative cases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0950a8ea788330b27aee45b5faf9fb)