### PR TITLE
Upgrade tracing parity validation to structured full harness

### DIFF
--- a/tailtriage-tracing/tests/equivalence.rs
+++ b/tailtriage-tracing/tests/equivalence.rs
@@ -1,8 +1,78 @@
 mod support;
 
-use support::equivalence_harness::assert_native_and_tracing_semantic_parity;
+use support::equivalence_harness::{
+    assert_native_and_tracing_full_parity, build_parity_report, normalize_rendered_report,
+    tracing_run_with_queue_name,
+};
+use tailtriage_core::{MemorySink, Tailtriage};
 
 #[test]
 fn native_and_tracing_runs_have_semantic_parity() {
-    assert_native_and_tracing_semantic_parity();
+    assert_native_and_tracing_full_parity();
+}
+
+#[test]
+fn parity_reports_queue_mismatch_when_tracing_queue_changes() {
+    let sink = MemorySink::default();
+    let tt = Tailtriage::builder("svc")
+        .sink(sink.clone())
+        .build()
+        .expect("tailtriage should build");
+    // same canonical scenario as harness native path
+    for (id, slow) in [("r1", false), ("r2", true), ("r3", false)] {
+        let started = tt.begin_request_with(
+            "/checkout",
+            tailtriage_core::RequestOptions::new().request_id(id),
+        );
+        futures_executor::block_on(
+            started
+                .handle
+                .queue("permits")
+                .with_depth_at_start(3)
+                .await_on(async {
+                    std::thread::sleep(std::time::Duration::from_millis(if slow { 4 } else { 1 }));
+                }),
+        );
+        futures_executor::block_on(started.handle.stage("db").await_on(async {
+            std::thread::sleep(std::time::Duration::from_millis(if slow { 6 } else { 2 }));
+            Ok::<(), std::io::Error>(())
+        }))
+        .expect("db stage should succeed");
+        futures_executor::block_on(started.handle.stage("cache").await_on(async {
+            std::thread::sleep(std::time::Duration::from_millis(1));
+            Ok::<(), std::io::Error>(())
+        }))
+        .expect("cache stage should succeed");
+        started.completion.finish_ok();
+    }
+    tt.shutdown().expect("shutdown should succeed");
+    let native_run = sink.last_run().expect("native run exists");
+
+    let (tracing_run, warnings) = tracing_run_with_queue_name("permits_changed");
+    assert!(warnings.is_empty(), "warnings should be empty");
+
+    let parity_report = build_parity_report(&native_run, &tracing_run);
+    assert!(
+        parity_report
+            .run_report
+            .mismatches
+            .iter()
+            .any(|m| m.contains("queue set mismatch")),
+        "expected explicit queue mismatch in run report: {:?}",
+        parity_report.run_report.mismatches
+    );
+}
+
+#[test]
+fn normalization_removes_unstable_values_but_keeps_semantic_diff() {
+    let native = "Run: abc123\nGenerated: 2026-05-17T12:00:00Z\nPrimary suspect: application_queue_saturation\np95 latency: 2450µs";
+    let tracing = "Run: def456\nGenerated: 2026-05-17T12:00:01Z\nPrimary suspect: downstream_stage_dominates\np95 latency: 1900µs";
+    let n = normalize_rendered_report(native);
+    let t = normalize_rendered_report(tracing);
+    assert_ne!(
+        n, t,
+        "semantic difference should remain after normalization"
+    );
+    assert!(n.contains("Run: <normalized>"));
+    assert!(t.contains("Generated: <normalized>"));
 }

--- a/tailtriage-tracing/tests/support/equivalence_harness.rs
+++ b/tailtriage-tracing/tests/support/equivalence_harness.rs
@@ -3,29 +3,127 @@ use std::thread;
 use std::time::Duration;
 
 use futures_executor::block_on;
-use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
+use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions, Report};
 use tailtriage_core::{MemorySink, Run, Tailtriage};
 use tailtriage_tracing::TracingRecorder;
 use tracing_subscriber::prelude::*;
 
-pub fn assert_native_and_tracing_semantic_parity() {
+pub fn assert_native_and_tracing_full_parity() {
     let native_run = native_run();
     let (tracing_run, warnings) = tracing_run();
 
-    let report = compare_runs(&native_run, &tracing_run);
-    assert!(
-        report.mismatches.is_empty(),
-        "semantic parity mismatches: {}",
-        report.mismatches.join("; ")
-    );
+    let report = build_parity_report(&native_run, &tracing_run);
     assert!(
         warnings.is_empty(),
         "unexpected tracing warnings: {warnings:?}"
     );
+    assert_parity_report(&report);
 }
 
-struct ArtifactEquivalenceReport {
-    mismatches: Vec<String>,
+pub fn build_parity_report(native_run: &Run, tracing_run: &Run) -> ParityReport {
+    let native_analysis = analyze_run(native_run, AnalyzeOptions::default());
+    let tracing_analysis = analyze_run(tracing_run, AnalyzeOptions::default());
+
+    let run_report = compare_runs(native_run, tracing_run);
+    let analyzer_report = compare_analyzer_reports(&native_analysis, &tracing_analysis);
+    let rendered_report = compare_rendered_reports(&native_analysis, &tracing_analysis);
+
+    ParityReport {
+        run_report,
+        analyzer_report,
+        rendered_report,
+        mismatches: Vec::new(),
+    }
+    .with_aggregate_mismatches()
+}
+
+pub fn assert_parity_report(report: &ParityReport) {
+    assert!(
+        report.mismatches.is_empty(),
+        "native-vs-tracing parity mismatch\n{}",
+        report.render_failure_summary()
+    );
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct RunParityReport {
+    pub mismatches: Vec<String>,
+    pub native_request_count: usize,
+    pub tracing_request_count: usize,
+    pub native_stage_count: usize,
+    pub tracing_stage_count: usize,
+    pub native_queue_count: usize,
+    pub tracing_queue_count: usize,
+    pub native_slowest_request_id: Option<String>,
+    pub tracing_slowest_request_id: Option<String>,
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct AnalyzerParityReport {
+    pub mismatches: Vec<String>,
+    pub native_request_count: usize,
+    pub tracing_request_count: usize,
+    pub native_primary_suspect_kind: Option<String>,
+    pub tracing_primary_suspect_kind: Option<String>,
+    pub native_primary_score: Option<u8>,
+    pub tracing_primary_score: Option<u8>,
+    pub native_p95_latency_us: Option<u64>,
+    pub tracing_p95_latency_us: Option<u64>,
+    pub native_p99_latency_us: Option<u64>,
+    pub tracing_p99_latency_us: Option<u64>,
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct RenderedReportParityReport {
+    pub mismatches: Vec<String>,
+    pub native_section_count: usize,
+    pub tracing_section_count: usize,
+    pub native_primary_suspect_kind_text: Option<String>,
+    pub tracing_primary_suspect_kind_text: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct ParityReport {
+    pub run_report: RunParityReport,
+    pub analyzer_report: AnalyzerParityReport,
+    pub rendered_report: RenderedReportParityReport,
+    pub mismatches: Vec<String>,
+}
+
+impl ParityReport {
+    fn with_aggregate_mismatches(mut self) -> Self {
+        self.mismatches.extend(
+            self.run_report
+                .mismatches
+                .iter()
+                .map(|m| format!("run: {m}")),
+        );
+        self.mismatches.extend(
+            self.analyzer_report
+                .mismatches
+                .iter()
+                .map(|m| format!("analyzer: {m}")),
+        );
+        self.mismatches.extend(
+            self.rendered_report
+                .mismatches
+                .iter()
+                .map(|m| format!("rendered-report: {m}")),
+        );
+        self
+    }
+
+    fn render_failure_summary(&self) -> String {
+        format!(
+            "Run mismatches:\n- {}\nAnalyzer mismatches:\n- {}\nRendered report mismatches:\n- {}",
+            self.run_report.mismatches.join("\n- "),
+            self.analyzer_report.mismatches.join("\n- "),
+            self.rendered_report.mismatches.join("\n- ")
+        )
+    }
 }
 
 fn native_run() -> Run {
@@ -34,6 +132,33 @@ fn native_run() -> Run {
         .sink(sink.clone())
         .build()
         .unwrap();
+    emit_scenario_with_tailtriage(&tt, "permits");
+    tt.shutdown().unwrap();
+    sink.last_run().unwrap()
+}
+
+fn tracing_run() -> (Run, Vec<String>) {
+    tracing_run_with_queue_name("permits")
+}
+
+pub fn tracing_run_with_queue_name(queue_name: &str) -> (Run, Vec<String>) {
+    let recorder = TracingRecorder::builder("svc").build();
+    let subscriber = tracing_subscriber::registry().with(recorder.layer());
+    tracing::subscriber::with_default(subscriber, || {
+        block_on(async {
+            emit_scenario_with_tracing(queue_name);
+        });
+    });
+    let imported = recorder.snapshot_run().unwrap();
+    let warnings = imported
+        .warnings()
+        .iter()
+        .map(|w| w.message().to_owned())
+        .collect();
+    (imported.run().clone(), warnings)
+}
+
+fn emit_scenario_with_tailtriage(tt: &Tailtriage, queue_name: &str) {
     for (id, slow) in [("r1", false), ("r2", true), ("r3", false)] {
         let started = tt.begin_request_with(
             "/checkout",
@@ -42,7 +167,7 @@ fn native_run() -> Run {
         block_on(
             started
                 .handle
-                .queue("permits")
+                .queue(queue_name)
                 .with_depth_at_start(3)
                 .await_on(async {
                     thread::sleep(Duration::from_millis(if slow { 4 } else { 1 }));
@@ -60,146 +185,104 @@ fn native_run() -> Run {
         .unwrap();
         started.completion.finish_ok();
     }
-    tt.shutdown().unwrap();
-    sink.last_run().unwrap()
 }
 
-fn tracing_run() -> (Run, Vec<String>) {
-    let recorder = TracingRecorder::builder("svc").build();
-    let subscriber = tracing_subscriber::registry().with(recorder.layer());
-    tracing::subscriber::with_default(subscriber, || {
-        block_on(async {
-            for (id, slow) in [("r1", false), ("r2", true), ("r3", false)] {
-                let request = tracing::info_span!(
-                    "request",
-                    tt.kind = "request",
+fn emit_scenario_with_tracing(queue_name: &str) {
+    for (id, slow) in [("r1", false), ("r2", true), ("r3", false)] {
+        let request = tracing::info_span!(
+            "request",
+            tt.kind = "request",
+            tt.request_id = id,
+            tt.route = "/checkout"
+        );
+        {
+            let _request_guard = request.enter();
+            {
+                let queue = tracing::info_span!(
+                    "queue",
+                    tt.kind = "queue",
                     tt.request_id = id,
-                    tt.route = "/checkout"
+                    tt.queue = queue_name,
+                    tt.depth_at_start = 3_u64
                 );
                 {
-                    let _request_guard = request.enter();
-
-                    {
-                        let queue = tracing::info_span!(
-                            "queue",
-                            tt.kind = "queue",
-                            tt.request_id = id,
-                            tt.queue = "permits",
-                            tt.depth_at_start = 3_u64
-                        );
-                        {
-                            let _queue_guard = queue.enter();
-                            thread::sleep(Duration::from_millis(if slow { 4 } else { 1 }));
-                        }
-                        drop(queue);
-                    }
-                    {
-                        let stage = tracing::info_span!(
-                            "stage",
-                            tt.kind = "stage",
-                            tt.request_id = id,
-                            tt.stage = "db",
-                            tt.success = true
-                        );
-                        {
-                            let _stage_guard = stage.enter();
-                            thread::sleep(Duration::from_millis(if slow { 6 } else { 2 }));
-                        }
-                        drop(stage);
-                    }
-                    {
-                        let stage = tracing::info_span!(
-                            "stage",
-                            tt.kind = "stage",
-                            tt.request_id = id,
-                            tt.stage = "cache",
-                            tt.success = true
-                        );
-                        {
-                            let _stage_guard = stage.enter();
-                            thread::sleep(Duration::from_millis(1));
-                        }
-                        drop(stage);
-                    }
+                    let _queue_guard = queue.enter();
+                    thread::sleep(Duration::from_millis(if slow { 4 } else { 1 }));
                 }
-                drop(request);
+                drop(queue);
             }
-        });
-    });
-    let imported = recorder.snapshot_run().unwrap();
-    let warnings = imported
-        .warnings()
-        .iter()
-        .map(|w| w.message().to_owned())
-        .collect();
-    (imported.run().clone(), warnings)
+            {
+                let stage = tracing::info_span!(
+                    "stage",
+                    tt.kind = "stage",
+                    tt.request_id = id,
+                    tt.stage = "db",
+                    tt.success = true
+                );
+                {
+                    let _stage_guard = stage.enter();
+                    thread::sleep(Duration::from_millis(if slow { 6 } else { 2 }));
+                }
+                drop(stage);
+            }
+            {
+                let stage = tracing::info_span!(
+                    "stage",
+                    tt.kind = "stage",
+                    tt.request_id = id,
+                    tt.stage = "cache",
+                    tt.success = true
+                );
+                {
+                    let _stage_guard = stage.enter();
+                    thread::sleep(Duration::from_millis(1));
+                }
+                drop(stage);
+            }
+        }
+        drop(request);
+    }
 }
 
-#[allow(clippy::too_many_lines)]
-fn compare_runs(native_run: &Run, tracing_run: &Run) -> ArtifactEquivalenceReport {
+fn compare_runs(native_run: &Run, tracing_run: &Run) -> RunParityReport {
     let mut mismatches = Vec::new();
-    if native_run.runtime_snapshots != tracing_run.runtime_snapshots {
-        mismatches.push("runtime snapshots mismatch".to_owned());
+    if !native_run.runtime_snapshots.is_empty() || !tracing_run.runtime_snapshots.is_empty() {
+        mismatches.push("runtime snapshots should be empty in parity scenario".to_owned());
     }
     if native_run.truncation.limits_hit || tracing_run.truncation.limits_hit {
         mismatches.push("truncation.limits_hit must be false for both runs".to_owned());
     }
-
     let nreq: BTreeMap<_, _> = native_run
         .requests
         .iter()
-        .map(|r| {
-            (
-                r.request_id.clone(),
-                (r.route.clone(), r.outcome.clone(), r.latency_us),
-            )
-        })
+        .map(|r| (r.request_id.clone(), (&r.route, &r.outcome, r.latency_us)))
         .collect();
     let treq: BTreeMap<_, _> = tracing_run
         .requests
         .iter()
-        .map(|r| {
-            (
-                r.request_id.clone(),
-                (r.route.clone(), r.outcome.clone(), r.latency_us),
-            )
-        })
+        .map(|r| (r.request_id.clone(), (&r.route, &r.outcome, r.latency_us)))
         .collect();
     if nreq.keys().collect::<BTreeSet<_>>() != treq.keys().collect::<BTreeSet<_>>() {
         mismatches.push("request id set mismatch".to_owned());
     }
-    for (id, (route, outcome, lat)) in &nreq {
-        if *lat == 0 {
-            mismatches.push(format!("native request {id} latency not positive"));
-        }
+    for (id, (nr, no, nl)) in &nreq {
         match treq.get(id) {
             Some((tr, to, tl)) => {
-                if route != tr {
-                    mismatches.push(format!("route mismatch for {id}"));
+                if nr != tr {
+                    mismatches.push(format!(
+                        "route mismatch for {id}: native={nr}, tracing={tr}"
+                    ));
                 }
-                if outcome != to {
+                if no != to {
                     mismatches.push(format!("outcome mismatch for {id}"));
                 }
-                if *tl == 0 {
-                    mismatches.push(format!("tracing request {id} latency not positive"));
+                if *nl == 0 || *tl == 0 {
+                    mismatches.push(format!("request latency must be positive for {id}"));
                 }
             }
             None => mismatches.push(format!("missing tracing request {id}")),
         }
     }
-
-    let slow_native = nreq
-        .iter()
-        .max_by_key(|(_, (_, _, lat))| *lat)
-        .map(|(id, _)| id.clone());
-    let slow_tracing = treq
-        .iter()
-        .max_by_key(|(_, (_, _, lat))| *lat)
-        .map(|(id, _)| id.clone());
-    if slow_native != slow_tracing {
-        mismatches.push("slowest request mismatch".to_owned());
-    }
-
     let nstage: BTreeSet<_> = native_run
         .stages
         .iter()
@@ -211,14 +294,8 @@ fn compare_runs(native_run: &Run, tracing_run: &Run) -> ArtifactEquivalenceRepor
         .map(|s| (s.request_id.clone(), s.stage.clone(), s.success))
         .collect();
     if nstage != tstage {
-        mismatches.push("stage correlation shape differs".to_owned());
+        mismatches.push("stage set mismatch".to_owned());
     }
-    if native_run.stages.iter().any(|s| s.latency_us == 0)
-        || tracing_run.stages.iter().any(|s| s.latency_us == 0)
-    {
-        mismatches.push("stage latencies must be positive".to_owned());
-    }
-
     let nqueue: BTreeSet<_> = native_run
         .queues
         .iter()
@@ -230,18 +307,158 @@ fn compare_runs(native_run: &Run, tracing_run: &Run) -> ArtifactEquivalenceRepor
         .map(|q| (q.request_id.clone(), q.queue.clone(), q.depth_at_start))
         .collect();
     if nqueue != tqueue {
-        mismatches.push("queue correlation shape differs".to_owned());
+        mismatches.push(format!(
+            "queue set mismatch: native={nqueue:?}, tracing={tqueue:?}"
+        ));
+    }
+    if native_run.stages.iter().any(|s| s.latency_us == 0)
+        || tracing_run.stages.iter().any(|s| s.latency_us == 0)
+    {
+        mismatches.push("stage durations must be positive".to_owned());
     }
     if native_run.queues.iter().any(|q| q.wait_us == 0)
         || tracing_run.queues.iter().any(|q| q.wait_us == 0)
     {
-        mismatches.push("queue latencies must be positive".to_owned());
+        mismatches.push("queue durations must be positive".to_owned());
+    }
+    let slow_native = nreq
+        .iter()
+        .max_by_key(|(_, (_, _, lat))| *lat)
+        .map(|(id, _)| id.clone());
+    let slow_tracing = treq
+        .iter()
+        .max_by_key(|(_, (_, _, lat))| *lat)
+        .map(|(id, _)| id.clone());
+    if slow_native != slow_tracing {
+        mismatches.push(format!(
+            "slowest request mismatch: native={slow_native:?}, tracing={slow_tracing:?}"
+        ));
     }
 
-    if analyze_run(native_run, AnalyzeOptions::default()).request_count != 3
-        || analyze_run(tracing_run, AnalyzeOptions::default()).request_count != 3
-    {
-        mismatches.push("analyzer request_count must equal 3 for both runs".to_owned());
+    RunParityReport {
+        mismatches,
+        native_request_count: native_run.requests.len(),
+        tracing_request_count: tracing_run.requests.len(),
+        native_stage_count: native_run.stages.len(),
+        tracing_stage_count: tracing_run.stages.len(),
+        native_queue_count: native_run.queues.len(),
+        tracing_queue_count: tracing_run.queues.len(),
+        native_slowest_request_id: slow_native,
+        tracing_slowest_request_id: slow_tracing,
     }
-    ArtifactEquivalenceReport { mismatches }
+}
+
+fn compare_analyzer_reports(native: &Report, tracing: &Report) -> AnalyzerParityReport {
+    let mut mismatches = Vec::new();
+    if native.request_count != tracing.request_count {
+        mismatches.push(format!(
+            "request_count mismatch: native={}, tracing={}",
+            native.request_count, tracing.request_count
+        ));
+    }
+    if native.primary_suspect.kind != tracing.primary_suspect.kind {
+        mismatches.push(format!(
+            "primary suspect kind mismatch: native={}, tracing={}",
+            native.primary_suspect.kind.as_str(),
+            tracing.primary_suspect.kind.as_str()
+        ));
+    }
+    if native.primary_suspect.score != tracing.primary_suspect.score {
+        mismatches.push(format!(
+            "primary suspect score differs: native={}, tracing={}",
+            native.primary_suspect.score, tracing.primary_suspect.score
+        ));
+    }
+    for label in ["/checkout", "db", "cache", "permits"] {
+        let nn = report_contains_label(native, label);
+        let tn = report_contains_label(tracing, label);
+        if nn != tn {
+            mismatches.push(format!(
+                "label presence mismatch for '{label}': native={nn}, tracing={tn}"
+            ));
+        }
+    }
+    if native.p95_latency_us.unwrap_or(0) == 0 || tracing.p95_latency_us.unwrap_or(0) == 0 {
+        mismatches.push("p95 latency must be present and non-zero".to_owned());
+    }
+    if native.p99_latency_us.unwrap_or(0) == 0 || tracing.p99_latency_us.unwrap_or(0) == 0 {
+        mismatches.push("p99 latency must be present and non-zero".to_owned());
+    }
+    AnalyzerParityReport {
+        mismatches,
+        native_request_count: native.request_count,
+        tracing_request_count: tracing.request_count,
+        native_primary_suspect_kind: Some(native.primary_suspect.kind.as_str().to_owned()),
+        tracing_primary_suspect_kind: Some(tracing.primary_suspect.kind.as_str().to_owned()),
+        native_primary_score: Some(native.primary_suspect.score),
+        tracing_primary_score: Some(tracing.primary_suspect.score),
+        native_p95_latency_us: native.p95_latency_us,
+        tracing_p95_latency_us: tracing.p95_latency_us,
+        native_p99_latency_us: native.p99_latency_us,
+        tracing_p99_latency_us: tracing.p99_latency_us,
+    }
+}
+fn report_contains_label(report: &Report, label: &str) -> bool {
+    let text = render_text(report);
+    let json = serde_json::to_string(report).unwrap_or_default();
+    text.contains(label) || json.contains(label)
+}
+
+fn compare_rendered_reports(native: &Report, tracing: &Report) -> RenderedReportParityReport {
+    let mut mismatches = Vec::new();
+    let native_text = normalize_rendered_report(&render_text(native));
+    let tracing_text = normalize_rendered_report(&render_text(tracing));
+    for section in ["Primary suspect:", "Evidence:", "Next checks:"] {
+        if !(native_text.contains(section) && tracing_text.contains(section)) {
+            mismatches.push(format!(
+                "missing key section '{section}' in one or both reports"
+            ));
+        }
+    }
+    if extract_primary_suspect_kind_text(&native_text)
+        != extract_primary_suspect_kind_text(&tracing_text)
+    {
+        mismatches.push(format!(
+            "primary suspect text mismatch: native={:?}, tracing={:?}",
+            extract_primary_suspect_kind_text(&native_text),
+            extract_primary_suspect_kind_text(&tracing_text)
+        ));
+    }
+    RenderedReportParityReport {
+        mismatches,
+        native_section_count: native_text.lines().filter(|l| l.ends_with(':')).count(),
+        tracing_section_count: tracing_text.lines().filter(|l| l.ends_with(':')).count(),
+        native_primary_suspect_kind_text: extract_primary_suspect_kind_text(&native_text),
+        tracing_primary_suspect_kind_text: extract_primary_suspect_kind_text(&tracing_text),
+    }
+}
+
+pub fn normalize_rendered_report(input: &str) -> String {
+    input
+        .lines()
+        .map(normalize_line)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+fn normalize_line(line: &str) -> String {
+    let mut s = line.to_owned();
+    for key in ["Run:", "Generated:"] {
+        if s.contains(key) {
+            return format!("{key} <normalized>");
+        }
+    }
+    if s.contains("µs") || s.contains("ms") {
+        s = strip_digits(&s);
+    }
+    s
+}
+fn strip_digits(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_ascii_digit() { '#' } else { c })
+        .collect()
+}
+fn extract_primary_suspect_kind_text(text: &str) -> Option<String> {
+    text.lines()
+        .find(|l| l.to_ascii_lowercase().contains("primary suspect"))
+        .map(strip_digits)
 }


### PR DESCRIPTION
### Motivation
- Replace the minimal native-vs-tracing parity check with a structured, actionable harness that compares captured `Run` artifacts, analyzer `Report`s, and rendered text output so parity failures produce evidence-ranked, debuggable mismatch reports.
- Make the parity validation deterministic and reusable for CI and future negative tests while keeping it test-support-only under `tailtriage-tracing/tests/support/`.

### Description
- Add a reusable parity harness in `tailtriage-tracing/tests/support/equivalence_harness.rs` with typed reports: `RunParityReport`, `AnalyzerParityReport`, `RenderedReportParityReport`, and top-level `ParityReport`, each containing `mismatches: Vec<String>` and actionable summary fields.  
- Provide top-level APIs `assert_native_and_tracing_full_parity()`, `build_parity_report()`, and `assert_parity_report()` to run comparisons end-to-end.  
- Implement `compare_runs()`, `compare_analyzer_reports()`, and `compare_rendered_reports()` to validate run-shape parity, analyzer output parity (via `AnalyzeOptions::default()`), and normalized rendered-report parity respectively, plus `normalize_rendered_report()` to remove unstable values like run IDs/timestamps and digit-heavy durations.  
- Keep the canonical deterministic scenario (3 requests, route `/checkout`, IDs `r1/r2/r3`, stages `db`/`cache`, queue `permits`, one slow request) and expose `tracing_run_with_queue_name()` to allow negative tests that mutate the tracing path (for example, a changed queue name).
- Upgrade `tailtriage-tracing/tests/equivalence.rs` to call the new full-parity assertion and add two negative tests: a queue-name mismatch case and a normalization-focused case that verifies normalization removes unstable values while preserving semantic differences.

### Testing
- Ran formatting check with `cargo fmt --check` and it passed.  
- Ran linting with `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and all issues were fixed so the command completed successfully.  
- Ran the full test suite with `cargo test --workspace --all-targets --all-features --locked` and the workspace tests passed; the targeted `tailtriage-tracing` equivalence test binary was run with `cargo test -p tailtriage-tracing --test equivalence --locked` and all three equivalence tests passed.  
- Ran the docs contract validator with `python3 scripts/validate_docs_contracts.py` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0950a8ea788330b27aee45b5faf9fb)