### PR TITLE
Add optional Tokio-coupled tracing session in tailtriage-tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,7 +887,9 @@ dependencies = [
  "serde_json",
  "tailtriage-analyzer",
  "tailtriage-core",
+ "tailtriage-tokio",
  "tempfile",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -17,8 +17,14 @@ include = [
   "examples/**",
 ]
 
+[features]
+default = []
+tokio = ["dep:tailtriage-tokio", "dep:tokio"]
+
 [dependencies]
 tailtriage-core.workspace = true
+tailtriage-tokio = { workspace = true, optional = true }
+tokio = { version = "1", features = ["rt", "sync", "time"], optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -120,6 +120,51 @@ Live recorder latency/wait precision uses monotonic elapsed duration (`duration_
 Tracing span capture for request/stage/queue evidence works outside Tokio runtimes. Runtime-pressure evidence still requires tailtriage's Tokio sampler or future runtime-metrics import; tracing-only spans cannot infer executor or blocking-pool pressure by themselves.
 
 
+
+## Optional Tokio runtime sampler coupling
+
+Enable the optional `tokio` feature when you want one standard run that combines:
+
+- tracing request/stage/queue evidence, and
+- Tokio runtime-pressure snapshots from `tailtriage-tokio::RuntimeSampler`.
+
+This is optional. Base `TracingRecorder` usage stays available without Tokio.
+
+```rust
+# #[cfg(feature = "tokio")]
+# {
+use std::time::Duration;
+use tailtriage_tracing::tokio::TracingTokioSession;
+use tracing_subscriber::prelude::*;
+
+# #[tokio::main(flavor = "current_thread")]
+# async fn main() -> Result<(), Box<dyn std::error::Error>> {
+let session = TracingTokioSession::builder("checkout-service")
+    .service_version("1.2.3")
+    .sampler_interval(Duration::from_millis(200))
+    .max_runtime_snapshots(2_000)
+    .start()?;
+
+let subscriber = tracing_subscriber::registry().with(session.layer());
+tracing::subscriber::with_default(subscriber, || {
+    tracing::info_span!(
+        "http.request",
+        tt.kind = "request",
+        tt.request_id = "req-42",
+        tt.route = "/checkout"
+    )
+    .in_scope(|| {});
+});
+
+let imported = session.shutdown().await?;
+assert!(!imported.run().runtime_snapshots.is_empty());
+# Ok(())
+# }
+# }
+```
+
+This crate is still not an OTel/OTLP exporter and not a tracing backend.
+
 ## Examples
 
 - `examples/live_recorder.rs`: records one request span, one queue span, and one stage span with `TracingRecorder`, imports a run, and renders analyzer suspects and next checks.

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -31,6 +31,9 @@ mod convention;
 mod error;
 mod jsonl;
 mod recorder;
+#[cfg(feature = "tokio")]
+/// Optional Tokio runtime sampler coupling for tracing sessions.
+pub mod tokio;
 mod types;
 
 use tailtriage_core::{

--- a/tailtriage-tracing/src/tokio.rs
+++ b/tailtriage-tracing/src/tokio.rs
@@ -1,0 +1,230 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use tailtriage_core::{BuildError, CaptureLimitsOverride, MemorySink, Run, Tailtriage};
+use tailtriage_tokio::{RuntimeSampler, SamplerStartError};
+
+use crate::{ImportError, ImportedRun, RecorderLimits, TailtriageLayer, TracingRecorder};
+
+/// Error returned when starting [`TracingTokioSession`].
+#[derive(Debug)]
+pub enum TracingTokioSessionStartError {
+    /// Underlying tracing recorder setup failed.
+    Build(BuildError),
+    /// Tokio runtime sampler failed to start.
+    SamplerStart(SamplerStartError),
+}
+
+impl core::fmt::Display for TracingTokioSessionStartError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Build(err) => write!(f, "failed to build tailtriage runtime collector: {err}"),
+            Self::SamplerStart(err) => write!(f, "failed to start Tokio runtime sampler: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for TracingTokioSessionStartError {}
+
+/// Error returned when shutting down [`TracingTokioSession`].
+#[derive(Debug)]
+pub enum TracingTokioSessionShutdownError {
+    /// Snapshot import failed.
+    Import(ImportError),
+}
+
+impl core::fmt::Display for TracingTokioSessionShutdownError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Import(err) => write!(f, "failed to import tracing spans during shutdown: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for TracingTokioSessionShutdownError {}
+
+/// Builder for [`TracingTokioSession`].
+#[derive(Debug, Clone)]
+pub struct TracingTokioSessionBuilder {
+    recorder_builder: crate::TracingRecorderBuilder,
+    sampler_interval: Option<Duration>,
+    max_runtime_snapshots: Option<usize>,
+}
+
+/// Combined tracing and Tokio runtime sampler session.
+#[derive(Debug)]
+pub struct TracingTokioSession {
+    recorder: TracingRecorder,
+    runtime_collector: Arc<Tailtriage>,
+    sampler: RuntimeSampler,
+}
+
+impl TracingTokioSession {
+    /// Creates a builder with required service name metadata.
+    pub fn builder(service_name: impl Into<String>) -> TracingTokioSessionBuilder {
+        TracingTokioSessionBuilder {
+            recorder_builder: TracingRecorder::builder(service_name),
+            sampler_interval: None,
+            max_runtime_snapshots: None,
+        }
+    }
+
+    /// Returns a cloneable layer that captures spans for tracing import.
+    #[must_use]
+    pub fn layer(&self) -> TailtriageLayer {
+        self.recorder.layer()
+    }
+
+    /// Converts currently completed spans and runtime snapshots into one imported run.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::ImportError`] when strict span import fails.
+    pub fn snapshot_run(&self) -> Result<ImportedRun, crate::ImportError> {
+        let mut imported = self.recorder.snapshot_run()?;
+        let runtime = self.runtime_collector.snapshot();
+        merge_runtime_data(imported.run_mut(), &runtime);
+        Ok(imported)
+    }
+
+    /// Stops runtime sampling and returns one merged imported run.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TracingTokioSessionShutdownError::Import`] when strict span import fails.
+    pub async fn shutdown(self) -> Result<ImportedRun, TracingTokioSessionShutdownError> {
+        self.sampler.shutdown().await;
+        let mut imported = self
+            .recorder
+            .snapshot_run()
+            .map_err(TracingTokioSessionShutdownError::Import)?;
+        let runtime = self.runtime_collector.snapshot();
+        merge_runtime_data(imported.run_mut(), &runtime);
+        Ok(imported)
+    }
+}
+
+impl TracingTokioSessionBuilder {
+    /// Sets service version metadata.
+    #[must_use]
+    pub fn service_version(mut self, service_version: impl Into<String>) -> Self {
+        self.recorder_builder = self.recorder_builder.service_version(service_version);
+        self
+    }
+    /// Sets explicit run-id metadata.
+    #[must_use]
+    pub fn run_id(mut self, run_id: impl Into<String>) -> Self {
+        self.recorder_builder = self.recorder_builder.run_id(run_id);
+        self
+    }
+    /// Enables or disables strict conversion mode.
+    #[must_use]
+    pub fn strict(mut self, strict: bool) -> Self {
+        self.recorder_builder = self.recorder_builder.strict(strict);
+        self
+    }
+    /// Sets both open/completed in-memory span retention limits.
+    #[must_use]
+    pub fn recorder_limits(mut self, limits: RecorderLimits) -> Self {
+        self.recorder_builder = self.recorder_builder.limits(limits);
+        self
+    }
+    /// Sets maximum number of concurrently tracked open candidate spans.
+    #[must_use]
+    pub fn max_open_spans(mut self, max_open_spans: usize) -> Self {
+        self.recorder_builder = self.recorder_builder.max_open_spans(max_open_spans);
+        self
+    }
+    /// Sets maximum number of retained completed candidate spans.
+    #[must_use]
+    pub fn max_completed_spans(mut self, max_completed_spans: usize) -> Self {
+        self.recorder_builder = self
+            .recorder_builder
+            .max_completed_spans(max_completed_spans);
+        self
+    }
+    /// Sets runtime sampler interval.
+    #[must_use]
+    pub fn sampler_interval(mut self, sampler_interval: Duration) -> Self {
+        self.sampler_interval = Some(sampler_interval);
+        self
+    }
+    /// Sets runtime sampler retention cap for runtime snapshots.
+    #[must_use]
+    pub fn max_runtime_snapshots(mut self, max_runtime_snapshots: usize) -> Self {
+        self.max_runtime_snapshots = Some(max_runtime_snapshots);
+        self
+    }
+
+    /// Builds the session and starts Tokio runtime sampling.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TracingTokioSessionStartError`] when runtime collector build fails,
+    /// when sampler interval is zero, or when there is no active Tokio runtime.
+    pub fn start(self) -> Result<TracingTokioSession, TracingTokioSessionStartError> {
+        let recorder = self.recorder_builder.build();
+        let sink = MemorySink::new();
+        let mut builder = Tailtriage::builder("tailtriage-tracing-runtime")
+            .sink(sink)
+            .strict_lifecycle(false);
+        if let Some(interval) = self.sampler_interval {
+            if interval.is_zero() {
+                return Err(TracingTokioSessionStartError::SamplerStart(
+                    SamplerStartError::ZeroInterval,
+                ));
+            }
+        }
+        if let Some(limit) = self.max_runtime_snapshots {
+            builder = builder.capture_limits_override(CaptureLimitsOverride {
+                max_runtime_snapshots: Some(limit),
+                ..CaptureLimitsOverride::default()
+            });
+        }
+        let runtime_collector = Arc::new(
+            builder
+                .build()
+                .map_err(TracingTokioSessionStartError::Build)?,
+        );
+        let sampler_builder = RuntimeSampler::builder(Arc::clone(&runtime_collector));
+        let sampler_builder = if let Some(interval) = self.sampler_interval {
+            sampler_builder.interval(interval)
+        } else {
+            sampler_builder
+        };
+        let sampler_builder = if let Some(limit) = self.max_runtime_snapshots {
+            sampler_builder.max_runtime_snapshots(limit)
+        } else {
+            sampler_builder
+        };
+        let sampler = sampler_builder
+            .start()
+            .map_err(TracingTokioSessionStartError::SamplerStart)?;
+        Ok(TracingTokioSession {
+            recorder,
+            runtime_collector,
+            sampler,
+        })
+    }
+}
+
+fn merge_runtime_data(tracing_run: &mut Run, runtime_run: &Run) {
+    tracing_run
+        .runtime_snapshots
+        .clone_from(&runtime_run.runtime_snapshots);
+    tracing_run.metadata.effective_tokio_sampler_config =
+        runtime_run.metadata.effective_tokio_sampler_config;
+    tracing_run.truncation.dropped_runtime_snapshots =
+        runtime_run.truncation.dropped_runtime_snapshots;
+    tracing_run.truncation.limits_hit =
+        tracing_run.truncation.limits_hit || runtime_run.truncation.limits_hit;
+    let existing = tracing_run.metadata.lifecycle_warnings.clone();
+    tracing_run.metadata.lifecycle_warnings.extend(
+        runtime_run
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .filter(|warning| warning.contains("runtime") && !existing.contains(*warning))
+            .cloned(),
+    );
+}

--- a/tailtriage-tracing/src/tokio.rs
+++ b/tailtriage-tracing/src/tokio.rs
@@ -81,10 +81,9 @@ impl TracingTokioSession {
     ///
     /// Returns [`crate::ImportError`] when strict span import fails.
     pub fn snapshot_run(&self) -> Result<ImportedRun, crate::ImportError> {
-        let mut imported = self.recorder.snapshot_run()?;
+        let imported = self.recorder.snapshot_run()?;
         let runtime = self.runtime_collector.snapshot();
-        merge_runtime_data(imported.run_mut(), &runtime);
-        Ok(imported)
+        Ok(merge_runtime_data(imported, &runtime))
     }
 
     /// Stops runtime sampling and returns one merged imported run.
@@ -94,13 +93,12 @@ impl TracingTokioSession {
     /// Returns [`TracingTokioSessionShutdownError::Import`] when strict span import fails.
     pub async fn shutdown(self) -> Result<ImportedRun, TracingTokioSessionShutdownError> {
         self.sampler.shutdown().await;
-        let mut imported = self
+        let imported = self
             .recorder
             .snapshot_run()
             .map_err(TracingTokioSessionShutdownError::Import)?;
         let runtime = self.runtime_collector.snapshot();
-        merge_runtime_data(imported.run_mut(), &runtime);
-        Ok(imported)
+        Ok(merge_runtime_data(imported, &runtime))
     }
 }
 
@@ -208,7 +206,8 @@ impl TracingTokioSessionBuilder {
     }
 }
 
-fn merge_runtime_data(tracing_run: &mut Run, runtime_run: &Run) {
+fn merge_runtime_data(imported: ImportedRun, runtime_run: &Run) -> ImportedRun {
+    let (mut tracing_run, warnings) = imported.into_parts();
     tracing_run
         .runtime_snapshots
         .clone_from(&runtime_run.runtime_snapshots);
@@ -218,13 +217,102 @@ fn merge_runtime_data(tracing_run: &mut Run, runtime_run: &Run) {
         runtime_run.truncation.dropped_runtime_snapshots;
     tracing_run.truncation.limits_hit =
         tracing_run.truncation.limits_hit || runtime_run.truncation.limits_hit;
-    let existing = tracing_run.metadata.lifecycle_warnings.clone();
-    tracing_run.metadata.lifecycle_warnings.extend(
+    for warning in &runtime_run.metadata.lifecycle_warnings {
+        if !tracing_run.metadata.lifecycle_warnings.contains(warning) {
+            tracing_run
+                .metadata
+                .lifecycle_warnings
+                .push(warning.clone());
+        }
+    }
+    ImportedRun::new(tracing_run, warnings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::merge_runtime_data;
+    use crate::ImportedRun;
+    use tailtriage_core::{MemorySink, Tailtriage};
+
+    fn empty_run(service_name: &str) -> tailtriage_core::Run {
+        Tailtriage::builder(service_name)
+            .sink(MemorySink::new())
+            .build()
+            .expect("build collector")
+            .snapshot()
+    }
+
+    #[test]
+    fn merge_runtime_data_preserves_tracing_events_and_merges_runtime_fields() {
+        let mut tracing_run = empty_run("tracing");
+        tracing_run.requests.push(tailtriage_core::RequestEvent {
+            request_id: "r1".into(),
+            route: "/r1".into(),
+            kind: Some("http".into()),
+            started_at_unix_ms: 1,
+            finished_at_unix_ms: 2,
+            latency_us: 1_000,
+            outcome: "ok".into(),
+        });
+        tracing_run.stages.push(tailtriage_core::StageEvent {
+            request_id: "r1".into(),
+            stage: "db".into(),
+            started_at_unix_ms: 1,
+            finished_at_unix_ms: 2,
+            latency_us: 1_000,
+            success: true,
+        });
+        tracing_run.queues.push(tailtriage_core::QueueEvent {
+            request_id: "r1".into(),
+            queue: "global".into(),
+            waited_from_unix_ms: 1,
+            waited_until_unix_ms: 2,
+            wait_us: 1_000,
+            depth_at_start: Some(2),
+        });
+        tracing_run.metadata.lifecycle_warnings = vec!["trace-warning".into(), "shared".into()];
+        tracing_run.truncation.limits_hit = false;
+
+        let mut runtime_run = empty_run("runtime");
         runtime_run
-            .metadata
-            .lifecycle_warnings
-            .iter()
-            .filter(|warning| warning.contains("runtime") && !existing.contains(*warning))
-            .cloned(),
-    );
+            .runtime_snapshots
+            .push(tailtriage_core::RuntimeSnapshot {
+                at_unix_ms: 10,
+                alive_tasks: Some(3),
+                global_queue_depth: Some(4),
+                local_queue_depth: Some(5),
+                blocking_queue_depth: Some(6),
+                remote_schedule_count: Some(7),
+            });
+        runtime_run.metadata.effective_tokio_sampler_config =
+            Some(tailtriage_core::EffectiveTokioSamplerConfig {
+                inherited_mode: tailtriage_core::CaptureMode::Light,
+                explicit_mode_override: None,
+                resolved_mode: tailtriage_core::CaptureMode::Light,
+                resolved_sampler_cadence_ms: 25,
+                resolved_runtime_snapshot_retention: 10,
+            });
+        runtime_run.truncation.dropped_runtime_snapshots = 7;
+        runtime_run.truncation.limits_hit = true;
+        runtime_run.metadata.lifecycle_warnings = vec!["shared".into(), "non-runtime".into()];
+
+        let merged =
+            merge_runtime_data(ImportedRun::new(tracing_run.clone(), vec![]), &runtime_run);
+        let run = merged.run();
+        assert_eq!(run.requests, tracing_run.requests);
+        assert_eq!(run.stages, tracing_run.stages);
+        assert_eq!(run.queues, tracing_run.queues);
+        assert_eq!(run.runtime_snapshots, runtime_run.runtime_snapshots);
+        assert_eq!(
+            run.metadata.effective_tokio_sampler_config,
+            runtime_run.metadata.effective_tokio_sampler_config
+        );
+        assert_eq!(run.truncation.dropped_runtime_snapshots, 7);
+        assert!(run.truncation.limits_hit);
+        assert_eq!(
+            run.metadata.lifecycle_warnings,
+            vec!["trace-warning", "shared", "non-runtime"]
+        );
+        assert_eq!(run.requests.len(), 1);
+    }
 }

--- a/tailtriage-tracing/src/types.rs
+++ b/tailtriage-tracing/src/types.rs
@@ -269,12 +269,6 @@ impl ImportedRun {
         &self.run
     }
 
-    /// Returns mutable converted run artifact.
-    #[must_use]
-    pub fn run_mut(&mut self) -> &mut tailtriage_core::Run {
-        &mut self.run
-    }
-
     /// Returns non-fatal warnings emitted during conversion.
     #[must_use]
     pub fn warnings(&self) -> &[ImportWarning] {

--- a/tailtriage-tracing/src/types.rs
+++ b/tailtriage-tracing/src/types.rs
@@ -269,6 +269,12 @@ impl ImportedRun {
         &self.run
     }
 
+    /// Returns mutable converted run artifact.
+    #[must_use]
+    pub fn run_mut(&mut self) -> &mut tailtriage_core::Run {
+        &mut self.run
+    }
+
     /// Returns non-fatal warnings emitted during conversion.
     #[must_use]
     pub fn warnings(&self) -> &[ImportWarning] {

--- a/tailtriage-tracing/tests/tokio_session.rs
+++ b/tailtriage-tracing/tests/tokio_session.rs
@@ -34,7 +34,7 @@ async fn session_merges_tracing_and_runtime() {
                     tt.kind = "queue",
                     tt.request_id = "r1",
                     tt.queue = "global",
-                    tt.queue_depth = 2_u64
+                    tt.depth_at_start = 2_u64
                 )
                 .in_scope(|| {});
             });
@@ -47,6 +47,7 @@ async fn session_merges_tracing_and_runtime() {
     assert!(!run.requests.is_empty());
     assert!(!run.stages.is_empty());
     assert!(!run.queues.is_empty());
+    assert_eq!(run.queues[0].depth_at_start, Some(2));
     assert!(!run.runtime_snapshots.is_empty());
     assert!(run.metadata.effective_tokio_sampler_config.is_some());
 }

--- a/tailtriage-tracing/tests/tokio_session.rs
+++ b/tailtriage-tracing/tests/tokio_session.rs
@@ -2,7 +2,8 @@
 
 use std::time::Duration;
 
-use tailtriage_tracing::tokio::TracingTokioSession;
+use tailtriage_tokio::SamplerStartError;
+use tailtriage_tracing::tokio::{TracingTokioSession, TracingTokioSessionStartError};
 use tracing_subscriber::prelude::*;
 
 #[tokio::test(flavor = "current_thread")]
@@ -27,7 +28,16 @@ async fn session_merges_tracing_and_runtime() {
                 tt.request_id = "r1",
                 tt.stage = "db"
             )
-            .in_scope(|| {});
+            .in_scope(|| {
+                tracing::info_span!(
+                    "queue",
+                    tt.kind = "queue",
+                    tt.request_id = "r1",
+                    tt.queue = "global",
+                    tt.queue_depth = 2_u64
+                )
+                .in_scope(|| {});
+            });
         });
     });
 
@@ -36,6 +46,7 @@ async fn session_merges_tracing_and_runtime() {
     let run = imported.run();
     assert!(!run.requests.is_empty());
     assert!(!run.stages.is_empty());
+    assert!(!run.queues.is_empty());
     assert!(!run.runtime_snapshots.is_empty());
     assert!(run.metadata.effective_tokio_sampler_config.is_some());
 }
@@ -45,7 +56,22 @@ fn start_outside_runtime_fails_clearly() {
     let err = TracingTokioSession::builder("svc")
         .start()
         .expect_err("must fail outside tokio runtime");
-    assert!(err.to_string().contains("active Tokio runtime"));
+    assert!(matches!(
+        err,
+        TracingTokioSessionStartError::SamplerStart(SamplerStartError::MissingRuntime)
+    ));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn zero_sampler_interval_fails_clearly() {
+    let err = TracingTokioSession::builder("svc")
+        .sampler_interval(Duration::ZERO)
+        .start()
+        .expect_err("zero interval must fail");
+    assert!(matches!(
+        err,
+        TracingTokioSessionStartError::SamplerStart(SamplerStartError::ZeroInterval)
+    ));
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -69,4 +95,26 @@ async fn runtime_merge_keeps_tracing_requests() {
     tokio::time::sleep(Duration::from_millis(5)).await;
     let imported = session.snapshot_run().expect("snapshot run");
     assert_eq!(imported.run().requests.len(), 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn shutdown_preserves_tracing_spans() {
+    let session = TracingTokioSession::builder("svc")
+        .sampler_interval(Duration::from_millis(1))
+        .start()
+        .expect("start session");
+    let subscriber = tracing_subscriber::registry().with(session.layer());
+    tracing::subscriber::with_default(subscriber, || {
+        tracing::info_span!(
+            "req",
+            tt.kind = "request",
+            tt.request_id = "r-shutdown",
+            tt.route = "/shutdown"
+        )
+        .in_scope(|| {});
+    });
+    tokio::time::sleep(Duration::from_millis(5)).await;
+    let imported = session.shutdown().await.expect("shutdown");
+    assert_eq!(imported.run().requests.len(), 1);
+    assert_eq!(imported.run().requests[0].request_id, "r-shutdown");
 }

--- a/tailtriage-tracing/tests/tokio_session.rs
+++ b/tailtriage-tracing/tests/tokio_session.rs
@@ -6,6 +6,22 @@ use tailtriage_tokio::SamplerStartError;
 use tailtriage_tracing::tokio::{TracingTokioSession, TracingTokioSessionStartError};
 use tracing_subscriber::prelude::*;
 
+async fn wait_for_runtime_snapshot(session: &TracingTokioSession) {
+    let deadline = tokio::time::Instant::now() + Duration::from_millis(500);
+    loop {
+        let imported = session.snapshot_run().expect("snapshot run");
+        if !imported.run().runtime_snapshots.is_empty() {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "runtime sampler did not produce a snapshot before timeout"
+        );
+        tokio::task::yield_now().await;
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn session_merges_tracing_and_runtime() {
     let session = TracingTokioSession::builder("svc")
@@ -41,7 +57,7 @@ async fn session_merges_tracing_and_runtime() {
         });
     });
 
-    tokio::time::sleep(Duration::from_millis(5)).await;
+    wait_for_runtime_snapshot(&session).await;
     let imported = session.shutdown().await.expect("shutdown session");
     let run = imported.run();
     assert!(!run.requests.is_empty());

--- a/tailtriage-tracing/tests/tokio_session.rs
+++ b/tailtriage-tracing/tests/tokio_session.rs
@@ -1,0 +1,72 @@
+#![cfg(feature = "tokio")]
+
+use std::time::Duration;
+
+use tailtriage_tracing::tokio::TracingTokioSession;
+use tracing_subscriber::prelude::*;
+
+#[tokio::test(flavor = "current_thread")]
+async fn session_merges_tracing_and_runtime() {
+    let session = TracingTokioSession::builder("svc")
+        .sampler_interval(Duration::from_millis(1))
+        .start()
+        .expect("start session");
+
+    let subscriber = tracing_subscriber::registry().with(session.layer());
+    tracing::subscriber::with_default(subscriber, || {
+        tracing::info_span!(
+            "req",
+            tt.kind = "request",
+            tt.request_id = "r1",
+            tt.route = "/checkout"
+        )
+        .in_scope(|| {
+            tracing::info_span!(
+                "stage",
+                tt.kind = "stage",
+                tt.request_id = "r1",
+                tt.stage = "db"
+            )
+            .in_scope(|| {});
+        });
+    });
+
+    tokio::time::sleep(Duration::from_millis(5)).await;
+    let imported = session.shutdown().await.expect("shutdown session");
+    let run = imported.run();
+    assert!(!run.requests.is_empty());
+    assert!(!run.stages.is_empty());
+    assert!(!run.runtime_snapshots.is_empty());
+    assert!(run.metadata.effective_tokio_sampler_config.is_some());
+}
+
+#[test]
+fn start_outside_runtime_fails_clearly() {
+    let err = TracingTokioSession::builder("svc")
+        .start()
+        .expect_err("must fail outside tokio runtime");
+    assert!(err.to_string().contains("active Tokio runtime"));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn runtime_merge_keeps_tracing_requests() {
+    let session = TracingTokioSession::builder("svc")
+        .sampler_interval(Duration::from_millis(1))
+        .start()
+        .expect("start session");
+
+    let subscriber = tracing_subscriber::registry().with(session.layer());
+    tracing::subscriber::with_default(subscriber, || {
+        tracing::info_span!(
+            "req",
+            tt.kind = "request",
+            tt.request_id = "same",
+            tt.route = "/same"
+        )
+        .in_scope(|| {});
+    });
+
+    tokio::time::sleep(Duration::from_millis(5)).await;
+    let imported = session.snapshot_run().expect("snapshot run");
+    assert_eq!(imported.run().requests.len(), 1);
+}


### PR DESCRIPTION
### Motivation

- Provide an opt-in path to produce one standard `Run` that combines tracing-derived request/stage/queue evidence with Tokio runtime-pressure snapshots so triage can rank runtime-sensitive suspects without changing tracing-only behavior.
- Keep the base `TracingRecorder` usable outside Tokio and avoid fabricating runtime pressure from tracing spans alone.

### Description

- Add an optional `tokio` feature to `tailtriage-tracing` and optional workspace dependencies on `tailtriage-tokio` and `tokio`, and expose a feature-gated module `tailtriage_tracing::tokio`.
- Implement `TracingTokioSession`, `TracingTokioSessionBuilder`, `TracingTokioSessionStartError`, and `TracingTokioSessionShutdownError` with the requested builder surface including `service_version`, `run_id`, `strict`, `recorder_limits`, `max_open_spans`, `max_completed_spans`, `sampler_interval`, and `max_runtime_snapshots` and methods `start()`, `layer()`, `snapshot_run()`, and async `shutdown()`.
- Internally the session owns a `TracingRecorder`, an `Arc<Tailtriage>` (built with a `MemorySink`) and a `tailtriage_tokio::RuntimeSampler`; runtime sampling is started via `RuntimeSampler::builder(...)` and merged on `snapshot_run`/`shutdown`.
- Merge only runtime-related data into the tracing-derived `Run`: `runtime_snapshots`, `metadata.effective_tokio_sampler_config`, runtime truncation counters, and runtime lifecycle warnings, while preserving tracing requests/stages/queues and avoiding fabrication of cross-domain events.
- Add `ImportedRun::run_mut()` to support in-place merging and update `tailtriage-tracing/README.md` with the optional Tokio coupling docs and a concise example.

### Testing

- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed.
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests (including feature-gated Tokio tests) passed.
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0965f94a4c833096f4e549ff2205b5)