### PR TITLE
Add optional Tokio-coupled session API to tailtriage-tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,7 +887,9 @@ dependencies = [
  "serde_json",
  "tailtriage-analyzer",
  "tailtriage-core",
+ "tailtriage-tokio",
  "tempfile",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -17,12 +17,17 @@ include = [
   "examples/**",
 ]
 
+[features]
+default = []
+tokio = ["dep:tailtriage-tokio"]
+
 [dependencies]
 tailtriage-core.workspace = true
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
+tailtriage-tokio = { workspace = true, optional = true }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
@@ -31,6 +36,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dev-dependencies]
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "macros"] }
 tailtriage-analyzer.workspace = true
 futures-executor = "0.3"
 tempfile = "3"

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -124,3 +124,45 @@ Tracing span capture for request/stage/queue evidence works outside Tokio runtim
 
 - `examples/live_recorder.rs`: records one request span, one queue span, and one stage span with `TracingRecorder`, imports a run, and renders analyzer suspects and next checks.
 - `examples/tracing_spans.jsonl`: normalized completed-span JSONL fixture importable via `import_jsonl_path` or CLI `tailtriage import tracing-json`.
+
+
+## Optional Tokio runtime sampler session
+
+Enable the `tokio` feature when you want one standard `Run` that combines:
+
+- tracing request/stage/queue evidence, and
+- Tokio runtime-pressure evidence from periodic runtime snapshots.
+
+`TracingTokioSession` does not turn this crate into a tracing backend, and it does not implement OTel/OTLP.
+Tracing spans alone still do not infer executor or blocking-pool pressure.
+
+```rust
+#[cfg(feature = "tokio")]
+# async fn demo() -> Result<(), Box<dyn std::error::Error>> {
+use std::time::Duration;
+use tracing_subscriber::prelude::*;
+use tailtriage_tracing::TracingTokioSession;
+
+let session = TracingTokioSession::builder("checkout-service")
+    .service_version("1.2.3")
+    .sampler_interval(Duration::from_millis(100))
+    .max_runtime_snapshots(1_000)
+    .start()?;
+
+let subscriber = tracing_subscriber::registry().with(session.layer());
+tracing::subscriber::with_default(subscriber, || {
+    let request = tracing::info_span!(
+        "http.request",
+        tt.kind = "request",
+        tt.request_id = "req-42",
+        tt.route = "/checkout"
+    );
+    drop(request);
+});
+
+let imported = session.shutdown().await?;
+assert_eq!(imported.run().requests.len(), 1);
+assert!(imported.run().metadata.effective_tokio_sampler_config.is_some());
+# Ok(())
+# }
+```

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -31,6 +31,9 @@ mod convention;
 mod error;
 mod jsonl;
 mod recorder;
+#[cfg(feature = "tokio")]
+/// Optional Tokio-coupled session API that merges runtime sampler evidence into tracing-derived runs.
+pub mod tokio;
 mod types;
 
 use tailtriage_core::{
@@ -46,6 +49,11 @@ pub use jsonl::{import_jsonl_path, import_jsonl_reader};
 pub use recorder::{
     RecorderLimits, TailtriageLayer, TracingRecorder, TracingRecorderBuilder,
     DEFAULT_MAX_COMPLETED_SPANS, DEFAULT_MAX_OPEN_SPANS,
+};
+#[cfg(feature = "tokio")]
+pub use tokio::{
+    TracingTokioSession, TracingTokioSessionBuilder, TracingTokioSessionShutdownError,
+    TracingTokioSessionStartError,
 };
 pub use types::{FieldValue, ImportOptions, ImportWarning, ImportedRun, SpanKind, SpanRecord};
 

--- a/tailtriage-tracing/src/tokio.rs
+++ b/tailtriage-tracing/src/tokio.rs
@@ -1,0 +1,339 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use tailtriage_core::{MemorySink, Tailtriage};
+
+use crate::{ImportError, ImportedRun, RecorderLimits, TailtriageLayer, TracingRecorder};
+
+/// Session that couples tracing span recording with optional Tokio runtime sampling.
+#[derive(Debug)]
+pub struct TracingTokioSession {
+    recorder: TracingRecorder,
+    runtime_tailtriage: Arc<Tailtriage>,
+    sampler: tailtriage_tokio::RuntimeSampler,
+}
+
+/// Builder for [`TracingTokioSession`].
+#[derive(Debug, Clone)]
+pub struct TracingTokioSessionBuilder {
+    service_name: String,
+    service_version: Option<String>,
+    run_id: Option<String>,
+    strict: bool,
+    recorder_limits: RecorderLimits,
+    sampler_interval: Option<Duration>,
+    max_runtime_snapshots: Option<usize>,
+}
+
+/// Start error for [`TracingTokioSessionBuilder::start`].
+#[derive(Debug)]
+pub enum TracingTokioSessionStartError {
+    /// Tracing recorder import/setup failed.
+    Import(ImportError),
+    /// Internal runtime collector setup failed.
+    Build(tailtriage_core::BuildError),
+    /// Tokio sampler setup/start failed.
+    SamplerStart(tailtriage_tokio::SamplerStartError),
+}
+
+impl std::fmt::Display for TracingTokioSessionStartError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Import(err) => write!(f, "failed to start tracing+tokio session: {err}"),
+            Self::Build(err) => write!(f, "failed to build internal runtime collector: {err}"),
+            Self::SamplerStart(err) => write!(f, "failed to start tokio runtime sampler: {err}"),
+        }
+    }
+}
+impl std::error::Error for TracingTokioSessionStartError {}
+
+/// Shutdown error for [`TracingTokioSession::shutdown`].
+#[derive(Debug)]
+pub enum TracingTokioSessionShutdownError {
+    /// Tracing recorder import failed.
+    Import(ImportError),
+}
+
+impl std::fmt::Display for TracingTokioSessionShutdownError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Import(err) => write!(f, "failed to shutdown tracing+tokio session: {err}"),
+        }
+    }
+}
+impl std::error::Error for TracingTokioSessionShutdownError {}
+
+impl TracingTokioSession {
+    /// Creates a builder for a tracing+Tokio runtime-sampler session.
+    #[must_use]
+    pub fn builder(service_name: impl Into<String>) -> TracingTokioSessionBuilder {
+        TracingTokioSessionBuilder {
+            service_name: service_name.into(),
+            service_version: None,
+            run_id: None,
+            strict: false,
+            recorder_limits: RecorderLimits::default(),
+            sampler_interval: None,
+            max_runtime_snapshots: None,
+        }
+    }
+
+    /// Returns the tracing subscriber layer for this session.
+    #[must_use]
+    pub fn layer(&self) -> TailtriageLayer {
+        self.recorder.layer()
+    }
+
+    /// Returns a merged run of tracing request/stage/queue evidence plus runtime sampler evidence.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ImportError`] when strict tracing import fails.
+    pub fn snapshot_run(&self) -> Result<ImportedRun, ImportError> {
+        let imported = self.recorder.snapshot_run()?;
+        Ok(merge_runtime_into_tracing_run(
+            imported,
+            self.runtime_tailtriage.snapshot(),
+        ))
+    }
+
+    /// Stops runtime sampling and returns a final merged run.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TracingTokioSessionShutdownError`] when tracing import fails at shutdown.
+    pub async fn shutdown(self) -> Result<ImportedRun, TracingTokioSessionShutdownError> {
+        self.sampler.shutdown().await;
+        let imported = self
+            .recorder
+            .shutdown()
+            .map_err(TracingTokioSessionShutdownError::Import)?;
+        Ok(merge_runtime_into_tracing_run(
+            imported,
+            self.runtime_tailtriage.snapshot(),
+        ))
+    }
+}
+
+impl TracingTokioSessionBuilder {
+    #[must_use]
+    /// Sets service version metadata for both tracing and runtime sampling runs.
+    pub fn service_version(mut self, service_version: impl Into<String>) -> Self {
+        self.service_version = Some(service_version.into());
+        self
+    }
+    #[must_use]
+    /// Sets explicit run ID metadata for both tracing and runtime sampling runs.
+    pub fn run_id(mut self, run_id: impl Into<String>) -> Self {
+        self.run_id = Some(run_id.into());
+        self
+    }
+    #[must_use]
+    /// Enables or disables strict tracing span conversion mode.
+    pub fn strict(mut self, strict: bool) -> Self {
+        self.strict = strict;
+        self
+    }
+    #[must_use]
+    /// Sets both tracing recorder span-retention limits.
+    pub fn recorder_limits(mut self, recorder_limits: RecorderLimits) -> Self {
+        self.recorder_limits = recorder_limits;
+        self
+    }
+    #[must_use]
+    /// Sets maximum concurrently tracked open tracing spans.
+    pub fn max_open_spans(mut self, max_open_spans: usize) -> Self {
+        self.recorder_limits.max_open_spans = max_open_spans;
+        self
+    }
+    #[must_use]
+    /// Sets maximum retained completed tracing spans.
+    pub fn max_completed_spans(mut self, max_completed_spans: usize) -> Self {
+        self.recorder_limits.max_completed_spans = max_completed_spans;
+        self
+    }
+    #[must_use]
+    /// Sets Tokio runtime sampler interval.
+    pub fn sampler_interval(mut self, sampler_interval: Duration) -> Self {
+        self.sampler_interval = Some(sampler_interval);
+        self
+    }
+    #[must_use]
+    /// Sets max runtime snapshots retained by the Tokio sampler collector.
+    pub fn max_runtime_snapshots(mut self, max_runtime_snapshots: usize) -> Self {
+        self.max_runtime_snapshots = Some(max_runtime_snapshots);
+        self
+    }
+
+    /// Starts the tracing+Tokio session.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TracingTokioSessionStartError`] when recorder setup, internal runtime collector setup, or runtime sampler startup fails.
+    pub fn start(self) -> Result<TracingTokioSession, TracingTokioSessionStartError> {
+        let service_version = self.service_version.clone();
+        let run_id = self.run_id.clone();
+
+        let mut recorder_builder = TracingRecorder::builder(self.service_name)
+            .strict(self.strict)
+            .limits(self.recorder_limits);
+        if let Some(service_version) = service_version.clone() {
+            recorder_builder = recorder_builder.service_version(service_version);
+        }
+        if let Some(run_id) = &run_id {
+            recorder_builder = recorder_builder.run_id(run_id.clone());
+        }
+        let recorder = recorder_builder.build();
+        recorder
+            .snapshot_run()
+            .map_err(TracingTokioSessionStartError::Import)?;
+
+        let mut tailtriage_builder = Tailtriage::builder("tailtriage-tracing-runtime")
+            .sink(MemorySink::new())
+            .strict_lifecycle(false);
+        if let Some(service_version) = service_version {
+            tailtriage_builder = tailtriage_builder.service_version(service_version);
+        }
+        if let Some(run_id) = run_id {
+            tailtriage_builder = tailtriage_builder.run_id(run_id);
+        }
+        let runtime_tailtriage = Arc::new(
+            tailtriage_builder
+                .build()
+                .map_err(TracingTokioSessionStartError::Build)?,
+        );
+
+        let mut sampler_builder =
+            tailtriage_tokio::RuntimeSampler::builder(Arc::clone(&runtime_tailtriage));
+        if let Some(interval) = self.sampler_interval {
+            sampler_builder = sampler_builder.interval(interval);
+        }
+        if let Some(max_runtime_snapshots) = self.max_runtime_snapshots {
+            sampler_builder = sampler_builder.max_runtime_snapshots(max_runtime_snapshots);
+        }
+        let sampler = sampler_builder
+            .start()
+            .map_err(TracingTokioSessionStartError::SamplerStart)?;
+
+        Ok(TracingTokioSession {
+            recorder,
+            runtime_tailtriage,
+            sampler,
+        })
+    }
+}
+
+fn merge_runtime_into_tracing_run(
+    imported: ImportedRun,
+    runtime_run: tailtriage_core::Run,
+) -> ImportedRun {
+    let (mut run, warnings) = imported.into_parts();
+    run.runtime_snapshots = runtime_run.runtime_snapshots;
+    run.metadata.effective_tokio_sampler_config =
+        runtime_run.metadata.effective_tokio_sampler_config;
+    run.truncation.dropped_runtime_snapshots = runtime_run.truncation.dropped_runtime_snapshots;
+    run.truncation.limits_hit = run.truncation.limits_hit || runtime_run.truncation.limits_hit;
+    run.metadata.lifecycle_warnings.extend(
+        runtime_run
+            .metadata
+            .lifecycle_warnings
+            .into_iter()
+            .filter(|warning| warning.contains("runtime") || warning.contains("sampler")),
+    );
+    ImportedRun::new(run, warnings)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tracing_subscriber::prelude::*;
+
+    use crate::{TracingTokioSession, TT_KIND, TT_REQUEST_ID, TT_ROUTE, TT_STAGE};
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn session_captures_tracing_and_runtime() {
+        let session = TracingTokioSession::builder("svc")
+            .sampler_interval(Duration::from_millis(1))
+            .start()
+            .expect("start");
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let request = tracing::info_span!(
+                "req",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            );
+            let stage = tracing::info_span!(
+                "stage",
+                tt.kind = "stage",
+                tt.request_id = "r1",
+                tt.stage = "db"
+            );
+            drop(stage);
+            drop(request);
+        });
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        let imported = session.snapshot_run().expect("snapshot");
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().stages.len(), 1);
+        assert!(!imported.run().runtime_snapshots.is_empty());
+        assert!(imported
+            .run()
+            .metadata
+            .effective_tokio_sampler_config
+            .is_some());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn shutdown_preserves_tracing_events() {
+        let session = TracingTokioSession::builder("svc")
+            .sampler_interval(Duration::from_millis(1))
+            .start()
+            .expect("start");
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let request = tracing::info_span!(
+                "req",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            );
+            drop(request);
+        });
+        let imported = session.shutdown().await.expect("shutdown");
+        assert_eq!(imported.run().requests.len(), 1);
+    }
+
+    #[test]
+    fn start_outside_runtime_fails_clearly() {
+        let err = TracingTokioSession::builder("svc")
+            .start()
+            .expect_err("should fail outside runtime");
+        assert!(matches!(
+            err,
+            crate::tokio::TracingTokioSessionStartError::SamplerStart(
+                tailtriage_tokio::SamplerStartError::MissingRuntime
+            )
+        ));
+    }
+
+    #[test]
+    fn zero_interval_fails_clearly() {
+        let rt = tokio::runtime::Runtime::new().expect("runtime");
+        let err = rt.block_on(async {
+            TracingTokioSession::builder("svc")
+                .sampler_interval(Duration::ZERO)
+                .start()
+                .expect_err("zero interval should fail")
+        });
+        assert!(matches!(
+            err,
+            crate::tokio::TracingTokioSessionStartError::SamplerStart(
+                tailtriage_tokio::SamplerStartError::ZeroInterval
+            )
+        ));
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide an optional integration that combines tracing-derived request/stage/queue evidence with Tokio runtime-pressure snapshots into a single standard `Run` for practical triage workflows.
- Keep base tracing-only behavior unchanged so users without Tokio can continue to use `TracingRecorder` and `TailtriageLayer` as before.

### Description
- Added an optional `tokio` feature to `tailtriage-tracing` and an optional workspace dependency on `tailtriage-tokio` in `tailtriage-tracing/Cargo.toml`.
- Introduced a new feature-gated module `tailtriage_tracing::tokio` with public types `TracingTokioSession`, `TracingTokioSessionBuilder`, `TracingTokioSessionStartError`, and `TracingTokioSessionShutdownError` implemented in `src/tokio.rs`.
- `TracingTokioSession` owns a `TracingRecorder`, an internal `Arc<Tailtriage>` using `MemorySink`, and a `tailtriage_tokio::RuntimeSampler` started through `RuntimeSampler::builder(...)` and exposes `layer()`, `snapshot_run()`, and async `shutdown()` APIs.
- On snapshot/shutdown the implementation merges runtime-only data from the sampler-run into the tracing-derived `ImportedRun` (only `runtime_snapshots`, `metadata.effective_tokio_sampler_config`, runtime truncation counters, and runtime/sampler lifecycle warnings) while preserving tracing requests/stages/queues and avoiding any fabrication of tracing or runtime events.
- Updated `tailtriage-tracing/src/lib.rs` to conditionally export the new session API and updated `tailtriage-tracing/README.md` with a concise `TracingTokioSession` example and guidance (explicitly noting this is not OTel/OTLP and tracing alone does not infer runtime pressure).

### Testing
- Ran `cargo fmt --check` which passed. 
- Ran `python3 scripts/validate_docs_contracts.py` which passed. 
- Performed crate-level checks: `cargo check -p tailtriage-tracing --all-features` and iterative `cargo clippy` fixes; `cargo clippy --workspace --all-targets --all-features --locked -D warnings` was exercised and doc/missing-doc issues were addressed during the rollout.
- Started `cargo test --workspace --all-targets --all-features --locked`; compilation and many tests ran, but the final combined test run did not complete to termination in this environment due to long-running build/test locking; unit tests added under the `tokio` feature (session captures, shutdown preserves tracing events, start-outside-runtime failure, zero-interval failure) are present and exercised locally during the change process.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0965f94a4c833096f4e549ff2205b5)