### PR TITLE
Add optional Tokio-coupled Tracing session to tailtriage-tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,7 +887,9 @@ dependencies = [
  "serde_json",
  "tailtriage-analyzer",
  "tailtriage-core",
+ "tailtriage-tokio",
  "tempfile",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -19,10 +19,15 @@ include = [
 
 [dependencies]
 tailtriage-core.workspace = true
+tailtriage-tokio = { workspace = true, optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
+
+[features]
+default = []
+tokio = ["dep:tailtriage-tokio"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
@@ -34,3 +39,4 @@ workspace = true
 tailtriage-analyzer.workspace = true
 futures-executor = "0.3"
 tempfile = "3"
+tokio = { version = "1", features = ["rt", "time", "macros"] }

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -124,3 +124,43 @@ Tracing span capture for request/stage/queue evidence works outside Tokio runtim
 
 - `examples/live_recorder.rs`: records one request span, one queue span, and one stage span with `TracingRecorder`, imports a run, and renders analyzer suspects and next checks.
 - `examples/tracing_spans.jsonl`: normalized completed-span JSONL fixture importable via `import_jsonl_path` or CLI `tailtriage import tracing-json`.
+
+
+## Optional Tokio runtime sampler coupling
+
+Enable feature `tokio` when you want one standard run with both:
+
+- tracing-derived request/stage/queue evidence, and
+- Tokio runtime-pressure snapshots from `tailtriage-tokio::RuntimeSampler`.
+
+`tailtriage-tracing` without this feature remains Tokio-agnostic. It is not a tracing backend and does not implement OTel/OTLP.
+
+```rust
+use std::time::Duration;
+use tailtriage_tracing::TracingTokioSession;
+use tracing_subscriber::prelude::*;
+
+# #[tokio::main(flavor = "current_thread")]
+# async fn main() -> Result<(), Box<dyn std::error::Error>> {
+let session = TracingTokioSession::builder("checkout-service")
+    .sampler_interval(Duration::from_millis(100))
+    .max_runtime_snapshots(128)
+    .start()?;
+
+let subscriber = tracing_subscriber::registry().with(session.layer());
+tracing::subscriber::with_default(subscriber, || {
+    let request = tracing::info_span!(
+        "http.request",
+        tt.kind = "request",
+        tt.request_id = "req-42",
+        tt.route = "/checkout",
+        tt.outcome = "ok"
+    );
+    let _entered = request.enter();
+});
+
+let imported = session.shutdown().await?;
+assert!(!imported.run().runtime_snapshots.is_empty());
+# Ok(())
+# }
+```

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -31,6 +31,9 @@ mod convention;
 mod error;
 mod jsonl;
 mod recorder;
+/// Optional Tokio runtime sampler coupling for tracing intake sessions.
+#[cfg(feature = "tokio")]
+pub mod tokio;
 mod types;
 
 use tailtriage_core::{
@@ -38,6 +41,11 @@ use tailtriage_core::{
     TruncationSummary, UnfinishedRequests, SCHEMA_VERSION,
 };
 
+#[cfg(feature = "tokio")]
+pub use crate::tokio::{
+    TracingTokioSession, TracingTokioSessionBuilder, TracingTokioSessionShutdownError,
+    TracingTokioSessionStartError,
+};
 pub use convention::{
     TT_DEPTH_AT_START, TT_KIND, TT_OUTCOME, TT_QUEUE, TT_REQUEST_ID, TT_ROUTE, TT_STAGE, TT_SUCCESS,
 };

--- a/tailtriage-tracing/src/tokio.rs
+++ b/tailtriage-tracing/src/tokio.rs
@@ -1,0 +1,277 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use tailtriage_core::{MemorySink, Tailtriage};
+use tailtriage_tokio::{RuntimeSampler, SamplerStartError};
+
+use crate::{ImportError, ImportedRun, RecorderLimits, TailtriageLayer, TracingRecorder};
+
+/// Couples tracing span intake with Tokio runtime sampling in one session.
+#[derive(Debug)]
+pub struct TracingTokioSession {
+    recorder: TracingRecorder,
+    runtime_tailtriage: Arc<Tailtriage>,
+    runtime_sampler: RuntimeSampler,
+}
+
+/// Builder for [`TracingTokioSession`].
+#[derive(Debug, Clone)]
+pub struct TracingTokioSessionBuilder {
+    service_name: String,
+    service_version: Option<String>,
+    run_id: Option<String>,
+    strict: bool,
+    limits: RecorderLimits,
+    sampler_interval: Option<Duration>,
+    max_runtime_snapshots: Option<usize>,
+}
+
+/// Error returned when starting a [`TracingTokioSession`] fails.
+#[derive(Debug)]
+pub enum TracingTokioSessionStartError {
+    /// Tracing recorder import configuration failed.
+    Import(ImportError),
+    /// Tokio runtime sampler failed to start.
+    SamplerStart(SamplerStartError),
+}
+
+impl core::fmt::Display for TracingTokioSessionStartError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Import(err) => write!(f, "failed to build tracing recorder: {err}"),
+            Self::SamplerStart(err) => write!(f, "failed to start Tokio runtime sampler: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for TracingTokioSessionStartError {}
+
+/// Error returned when shutting down a [`TracingTokioSession`] fails.
+#[derive(Debug)]
+pub enum TracingTokioSessionShutdownError {
+    /// Failed to import tracing spans into a run.
+    Import(ImportError),
+}
+
+impl core::fmt::Display for TracingTokioSessionShutdownError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Import(err) => write!(f, "failed to import tracing run during shutdown: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for TracingTokioSessionShutdownError {}
+
+impl TracingTokioSession {
+    /// Creates a session builder for one service.
+    #[must_use]
+    pub fn builder(service_name: impl Into<String>) -> TracingTokioSessionBuilder {
+        TracingTokioSessionBuilder {
+            service_name: service_name.into(),
+            service_version: None,
+            run_id: None,
+            strict: false,
+            limits: RecorderLimits::default(),
+            sampler_interval: None,
+            max_runtime_snapshots: None,
+        }
+    }
+
+    /// Returns the tracing layer that records `tt.*` spans.
+    #[must_use]
+    pub fn layer(&self) -> TailtriageLayer {
+        self.recorder.layer()
+    }
+
+    /// Builds a point-in-time merged run from tracing spans and runtime snapshots.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ImportError`] when tracing span import fails.
+    pub fn snapshot_run(&self) -> Result<ImportedRun, ImportError> {
+        let tracing_run = self.recorder.snapshot_run()?;
+        Ok(merge_runtime_data(
+            tracing_run,
+            self.runtime_tailtriage.snapshot(),
+        ))
+    }
+
+    /// Stops runtime sampling and returns a final merged run.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TracingTokioSessionShutdownError`] when tracing import fails.
+    pub async fn shutdown(self) -> Result<ImportedRun, TracingTokioSessionShutdownError> {
+        self.runtime_sampler.shutdown().await;
+        let tracing_run = self
+            .recorder
+            .snapshot_run()
+            .map_err(TracingTokioSessionShutdownError::Import)?;
+        Ok(merge_runtime_data(
+            tracing_run,
+            self.runtime_tailtriage.snapshot(),
+        ))
+    }
+}
+
+impl TracingTokioSessionBuilder {
+    /// Sets optional service version metadata.
+    #[must_use]
+    pub fn service_version(mut self, service_version: impl Into<String>) -> Self {
+        self.service_version = Some(service_version.into());
+        self
+    }
+    /// Sets optional run id metadata.
+    #[must_use]
+    pub fn run_id(mut self, run_id: impl Into<String>) -> Self {
+        self.run_id = Some(run_id.into());
+        self
+    }
+    /// Enables strict tracing span import validation.
+    #[must_use]
+    pub fn strict(mut self, strict: bool) -> Self {
+        self.strict = strict;
+        self
+    }
+    /// Sets both tracing recorder limits at once.
+    #[must_use]
+    pub fn recorder_limits(mut self, limits: RecorderLimits) -> Self {
+        self.limits = limits;
+        self
+    }
+    /// Sets maximum tracked open spans.
+    #[must_use]
+    pub fn max_open_spans(mut self, max_open_spans: usize) -> Self {
+        self.limits.max_open_spans = max_open_spans;
+        self
+    }
+    /// Sets maximum retained completed spans.
+    #[must_use]
+    pub fn max_completed_spans(mut self, max_completed_spans: usize) -> Self {
+        self.limits.max_completed_spans = max_completed_spans;
+        self
+    }
+    /// Sets runtime sampler interval. Zero duration is rejected at `start()`.
+    #[must_use]
+    pub fn sampler_interval(mut self, sampler_interval: Duration) -> Self {
+        self.sampler_interval = Some(sampler_interval);
+        self
+    }
+    /// Sets runtime sampler retention cap before core-cap clamping.
+    #[must_use]
+    pub fn max_runtime_snapshots(mut self, max_runtime_snapshots: usize) -> Self {
+        self.max_runtime_snapshots = Some(max_runtime_snapshots);
+        self
+    }
+
+    /// Starts tracing recording and Tokio runtime sampling.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TracingTokioSessionStartError`] when builder configuration is invalid
+    /// or when runtime sampler startup fails (for example missing Tokio runtime or zero interval).
+    pub fn start(self) -> Result<TracingTokioSession, TracingTokioSessionStartError> {
+        let mut recorder_builder = TracingRecorder::builder(self.service_name.clone())
+            .strict(self.strict)
+            .limits(self.limits);
+        if let Some(service_version) = self.service_version {
+            recorder_builder = recorder_builder.service_version(service_version);
+        }
+        if let Some(run_id) = self.run_id.clone() {
+            recorder_builder = recorder_builder.run_id(run_id);
+        }
+        let recorder = recorder_builder.build();
+
+        let mut runtime_builder = Tailtriage::builder(self.service_name.clone());
+        if let Some(run_id) = self.run_id.clone() {
+            runtime_builder = runtime_builder.run_id(run_id);
+        }
+        let runtime_tailtriage = Arc::new(
+            runtime_builder
+                .sink(MemorySink::new())
+                .build()
+                .map_err(|_| {
+                    TracingTokioSessionStartError::Import(ImportError::EmptyServiceName)
+                })?,
+        );
+
+        let mut sampler_builder = RuntimeSampler::builder(Arc::clone(&runtime_tailtriage));
+        if let Some(interval) = self.sampler_interval {
+            sampler_builder = sampler_builder.interval(interval);
+        }
+        if let Some(max_runtime_snapshots) = self.max_runtime_snapshots {
+            sampler_builder = sampler_builder.max_runtime_snapshots(max_runtime_snapshots);
+        }
+        let runtime_sampler = sampler_builder
+            .start()
+            .map_err(TracingTokioSessionStartError::SamplerStart)?;
+
+        Ok(TracingTokioSession {
+            recorder,
+            runtime_tailtriage,
+            runtime_sampler,
+        })
+    }
+}
+
+fn merge_runtime_data(tracing_run: ImportedRun, runtime_run: tailtriage_core::Run) -> ImportedRun {
+    let (mut run, warnings) = tracing_run.into_parts();
+    run.runtime_snapshots = runtime_run.runtime_snapshots;
+    run.metadata.effective_tokio_sampler_config =
+        runtime_run.metadata.effective_tokio_sampler_config;
+    run.truncation.dropped_runtime_snapshots = runtime_run.truncation.dropped_runtime_snapshots;
+    for warning in runtime_run.metadata.lifecycle_warnings {
+        if warning.contains("runtime") {
+            run.metadata.lifecycle_warnings.push(warning);
+        }
+    }
+    ImportedRun::new(run, warnings)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tracing::info_span;
+    use tracing_subscriber::prelude::*;
+
+    use super::*;
+
+    #[test]
+    fn start_outside_runtime_fails_clearly() {
+        let err = TracingTokioSession::builder("svc")
+            .sampler_interval(Duration::from_millis(1))
+            .start()
+            .expect_err("must fail outside Tokio runtime");
+        match err {
+            TracingTokioSessionStartError::SamplerStart(SamplerStartError::MissingRuntime) => {}
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn session_merges_tracing_and_runtime() {
+        let session = TracingTokioSession::builder("svc")
+            .sampler_interval(Duration::from_millis(1))
+            .start()
+            .expect("session starts");
+        let _guard = tracing_subscriber::registry()
+            .with(session.layer())
+            .set_default();
+        let span = info_span!(
+            "req",
+            tt.kind = "request",
+            tt.request_id = "r1",
+            tt.route = "/r"
+        );
+        let entered = span.enter();
+        drop(entered);
+        drop(span);
+        tokio::time::sleep(Duration::from_millis(3)).await;
+        let run = session.shutdown().await.expect("shutdown ok");
+        assert!(!run.run().runtime_snapshots.is_empty());
+        assert!(run.run().metadata.effective_tokio_sampler_config.is_some());
+        assert_eq!(run.run().requests.len(), 1);
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide an optional, minimal integration that lets tracing instrumentation produce request/stage/queue evidence while optionally attaching Tokio runtime-pressure snapshots into the same standardized `Run` for stronger triage evidence.  
- Preserve the existing tracing-only workflow so spans do not pretend to infer runtime pressure by themselves and non-Tokio users are unaffected.  
- Keep the dependency surface and scope narrow: reuse `tailtriage-tokio` runtime sampler for runtime evidence and avoid introducing OTLP/OTel or analyzer changes.

### Description

- Added an optional `tokio` feature to `tailtriage-tracing` and an optional workspace dependency on `tailtriage-tokio` in `tailtriage-tracing/Cargo.toml`.  
- Introduced a new feature-gated module `tailtriage_tracing::tokio` implementing `TracingTokioSession`, `TracingTokioSessionBuilder`, `TracingTokioSessionStartError`, and `TracingTokioSessionShutdownError` with the requested builder API and methods (`builder`, `service_version`, `run_id`, `strict`, `recorder_limits`, `max_open_spans`, `max_completed_spans`, `sampler_interval`, `max_runtime_snapshots`, `start`, `layer`, `snapshot_run`, `shutdown`).  
- Session internals own a `TracingRecorder`, an `Arc<Tailtriage>` using `MemorySink` for sampler collection, and a `tailtriage_tokio::RuntimeSampler` started via `RuntimeSampler::builder(...)`.  
- On `snapshot_run()` and `shutdown()` the code merges only runtime-derived fields into the tracing-derived `ImportedRun` (`runtime_snapshots`, `metadata.effective_tokio_sampler_config`, runtime truncation counters, and runtime lifecycle warnings) and explicitly avoids overwriting tracing request/stage/queue events or fabricating runtime/tracing events.  
- Documentation updated in `tailtriage-tracing/README.md` to explain feature gating, non-goals (no OTLP/OTel, not a tracing backend), and include a concise `TracingTokioSession` example.  
- Exposed the new types publicly behind the `tokio` feature and added feature-gated tests within the new module.

### Testing

- Ran formatting and static checks: `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and they passed.  
- Ran the full test suite with features: `cargo test --workspace --all-targets --all-features --locked` and all tests (including the new Tokio-gated tests) passed.  
- Validated documentation contracts with `python3 scripts/validate_docs_contracts.py` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0965f94a4c833096f4e549ff2205b5)