### PR TITLE
Add runtime snapshot injection API for TracingTokioSession and enable Tokio feature for demo support

### DIFF
--- a/demos/demo_support/Cargo.toml
+++ b/demos/demo_support/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1"
 serde_json = "1"
 tailtriage-core.workspace = true
-tailtriage-tracing.workspace = true
+tailtriage-tracing = { workspace = true, features = ["tokio"] }
 tokio = { version = "1", features = ["sync", "time"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }

--- a/tailtriage-tracing/src/tokio.rs
+++ b/tailtriage-tracing/src/tokio.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use tailtriage_core::{BuildError, CaptureLimitsOverride, MemorySink, Run, Tailtriage};
+use tailtriage_core::{
+    BuildError, CaptureLimitsOverride, MemorySink, Run, RuntimeSnapshot, Tailtriage,
+};
 use tailtriage_tokio::{RuntimeSampler, SamplerStartError};
 
 use crate::{ImportError, ImportedRun, RecorderLimits, TailtriageLayer, TracingRecorder};
@@ -84,6 +86,11 @@ impl TracingTokioSession {
         let imported = self.recorder.snapshot_run()?;
         let runtime = self.runtime_collector.snapshot();
         Ok(merge_runtime_data(imported, &runtime))
+    }
+
+    /// Records a runtime snapshot into the runtime collector used by this session.
+    pub fn record_runtime_snapshot(&self, snapshot: RuntimeSnapshot) {
+        self.runtime_collector.record_runtime_snapshot(snapshot);
     }
 
     /// Stops runtime sampling and returns one merged imported run.

--- a/tailtriage-tracing/tests/tokio_session.rs
+++ b/tailtriage-tracing/tests/tokio_session.rs
@@ -2,6 +2,7 @@
 
 use std::time::Duration;
 
+use tailtriage_core::{unix_time_ms, RuntimeSnapshot};
 use tailtriage_tokio::SamplerStartError;
 use tailtriage_tracing::tokio::{TracingTokioSession, TracingTokioSessionStartError};
 use tracing_subscriber::prelude::*;
@@ -134,4 +135,59 @@ async fn shutdown_preserves_tracing_spans() {
     let imported = session.shutdown().await.expect("shutdown");
     assert_eq!(imported.run().requests.len(), 1);
     assert_eq!(imported.run().requests[0].request_id, "r-shutdown");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn record_runtime_snapshot_appears_in_snapshot_run() {
+    let session = TracingTokioSession::builder("svc")
+        .start()
+        .expect("start session");
+    let at = unix_time_ms();
+    session.record_runtime_snapshot(RuntimeSnapshot {
+        at_unix_ms: at,
+        alive_tasks: Some(1),
+        global_queue_depth: Some(2),
+        local_queue_depth: Some(3),
+        blocking_queue_depth: Some(4),
+        remote_schedule_count: None,
+    });
+    let imported = session.snapshot_run().expect("snapshot run");
+    assert!(imported
+        .run()
+        .runtime_snapshots
+        .iter()
+        .any(|s| s.at_unix_ms == at && s.blocking_queue_depth == Some(4)));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn record_runtime_snapshot_appears_in_shutdown_and_preserves_events() {
+    let session = TracingTokioSession::builder("svc")
+        .start()
+        .expect("start session");
+    let subscriber = tracing_subscriber::registry().with(session.layer());
+    tracing::subscriber::with_default(subscriber, || {
+        tracing::info_span!(
+            "req",
+            tt.kind = "request",
+            tt.request_id = "r2",
+            tt.route = "/r2"
+        )
+        .in_scope(|| {});
+    });
+    let at = unix_time_ms();
+    session.record_runtime_snapshot(RuntimeSnapshot {
+        at_unix_ms: at,
+        alive_tasks: None,
+        global_queue_depth: None,
+        local_queue_depth: None,
+        blocking_queue_depth: Some(7),
+        remote_schedule_count: None,
+    });
+    let imported = session.shutdown().await.expect("shutdown");
+    assert_eq!(imported.run().requests.len(), 1);
+    assert!(imported
+        .run()
+        .runtime_snapshots
+        .iter()
+        .any(|s| s.at_unix_ms == at));
 }


### PR DESCRIPTION
### Motivation
- Enable runtime-sensitive tracing parity for the blocking and executor demos by allowing deterministic runtime snapshots to be recorded while still capturing tracing spans and sampler metadata. 
- Provide a narrow, controlled integration point so demos and tests can reproduce runtime-pressure evidence without fabricating snapshots after-the-fact or disabling the live sampler.

### Description
- Enabled the Tokio-backed tracing helper for demos by changing `demos/demo_support/Cargo.toml` to `tailtriage-tracing = { workspace = true, features = ["tokio"] }` so runtime sampler/session types are available. 
- Added `pub fn record_runtime_snapshot(&self, snapshot: RuntimeSnapshot)` to `TracingTokioSession` so callers can inject deterministic `RuntimeSnapshot` values into the session's runtime collector without altering tracing span import/merge semantics. 
- Kept existing merge behavior intact by recording into the internal runtime collector and reusing `merge_runtime_data(...)` on `snapshot_run()` and `shutdown()`. 
- Added focused tests in `tailtriage-tracing/tests/tokio_session.rs` that assert `record_runtime_snapshot(...)` shows up in `snapshot_run()` and in `shutdown()` output and that tracing request events remain preserved.

### Testing
- Ran formatting and lint checks which passed: `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`. 
- Ran the full test suite which passed: `cargo test --workspace --all-targets --all-features --locked`, including the new `tokio_session` tests validating injected snapshots. 
- Ran docs contract validation which passed: `python3 scripts/validate_docs_contracts.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09e431cd208330b729106718d87dad)