### PR TITLE
Add tracing modes to runtime_cost and compare native vs tracing overhead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,9 +648,13 @@ dependencies = [
  "anyhow",
  "serde",
  "serde_json",
+ "tailtriage-analyzer",
  "tailtriage-core",
  "tailtriage-tokio",
+ "tailtriage-tracing",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/demos/runtime_cost/Cargo.toml
+++ b/demos/runtime_cost/Cargo.toml
@@ -10,9 +10,13 @@ publish = false
 anyhow = "1"
 tailtriage-core.workspace = true
 tailtriage-tokio.workspace = true
+tailtriage-analyzer.workspace = true
+tailtriage-tracing = { workspace = true, features = ["tokio"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
 
 [lints]
 workspace = true

--- a/demos/runtime_cost/src/main.rs
+++ b/demos/runtime_cost/src/main.rs
@@ -12,7 +12,7 @@ use tailtriage_tracing::tokio::TracingTokioSession;
 use tailtriage_tracing::TracingRecorder;
 use tokio::sync::{Mutex, Semaphore};
 use tracing::Instrument;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+use tracing_subscriber::layer::SubscriberExt;
 
 const DEFAULT_REQUESTS: usize = 800;
 const DEFAULT_CONCURRENCY: usize = 32;
@@ -178,9 +178,8 @@ async fn main() -> anyhow::Result<()> {
     let mut backend = build_backend(&cli)?;
     let (mut latencies, elapsed) = run_requests(&cli, &backend).await?;
     let finalize_start = Instant::now();
-    let run = finalize_backend(&mut backend).await?;
+    let (run, artifact_path) = finalize_backend_and_write_artifact(&cli, &mut backend).await?;
     let artifact_finalize_ms = finalize_start.elapsed().as_secs_f64() * 1000.0;
-    let artifact_path = write_run_artifact(&cli, run.as_ref())?;
     let analyze_start = Instant::now();
     let (analyze_ms, report_render_ms) = if let Some(ref run_value) = run {
         let report = try_analyze_run(run_value, AnalyzeOptions::default())?;
@@ -291,11 +290,12 @@ fn build_backend(cli: &Cli) -> anyhow::Result<Backend> {
             if cli.mode.uses_runtime_sampler() {
                 let session = TracingTokioSession::builder("runtime_cost_demo")
                     .strict(false)
-                    .max_open_spans(64)
-                    .max_completed_spans(64)
                     .start()?;
                 // One mode runs per process in this demo, so process-global subscriber init is acceptable.
-                tracing_subscriber::registry().with(session.layer()).init();
+                tracing::subscriber::set_global_default(
+                    tracing_subscriber::registry().with(session.layer()),
+                )
+                .map_err(|e| anyhow!("failed installing tracing Tokio session subscriber: {e}"))?;
                 Ok(Backend::TracingTokio { session })
             } else {
                 let mut b = TracingRecorder::builder("runtime_cost_demo").strict(false);
@@ -304,16 +304,22 @@ fn build_backend(cli: &Cli) -> anyhow::Result<Backend> {
                 }
                 let rec = b.build();
                 // One mode runs per process in this demo, so process-global subscriber init is acceptable.
-                tracing_subscriber::registry().with(rec.layer()).init();
+                tracing::subscriber::set_global_default(
+                    tracing_subscriber::registry().with(rec.layer()),
+                )
+                .map_err(|e| anyhow!("failed installing tracing recorder subscriber: {e}"))?;
                 Ok(Backend::TracingRecorder { rec })
             }
         }
     }
 }
 
-async fn finalize_backend(b: &mut Backend) -> anyhow::Result<Option<Run>> {
-    match std::mem::replace(b, Backend::None) {
-        Backend::None => Ok(None),
+async fn finalize_backend_and_write_artifact(
+    cli: &Cli,
+    b: &mut Backend,
+) -> anyhow::Result<(Option<Run>, Option<String>)> {
+    let run = match std::mem::replace(b, Backend::None) {
+        Backend::None => None,
         Backend::Native {
             tailtriage,
             sampler,
@@ -323,11 +329,13 @@ async fn finalize_backend(b: &mut Backend) -> anyhow::Result<Option<Run>> {
             }
             let run = tailtriage.snapshot();
             tailtriage.shutdown()?;
-            Ok(Some(run))
+            Some(run)
         }
-        Backend::TracingRecorder { rec } => Ok(Some(rec.shutdown()?.into_parts().0)),
-        Backend::TracingTokio { session } => Ok(Some(session.shutdown().await?.into_parts().0)),
-    }
+        Backend::TracingRecorder { rec } => Some(rec.shutdown()?.into_parts().0),
+        Backend::TracingTokio { session } => Some(session.shutdown().await?.into_parts().0),
+    };
+    let artifact_path = write_run_artifact(cli, run.as_ref())?;
+    Ok((run, artifact_path))
 }
 fn write_run_artifact(cli: &Cli, run: Option<&Run>) -> anyhow::Result<Option<String>> {
     let Some(run) = run else { return Ok(None) };

--- a/demos/runtime_cost/src/main.rs
+++ b/demos/runtime_cost/src/main.rs
@@ -1,12 +1,18 @@
+use std::hint::black_box;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use anyhow::{bail, Context};
+use anyhow::{anyhow, bail, Context};
 use serde::Serialize;
-use tailtriage_core::{CaptureLimitsOverride, CaptureMode, Tailtriage};
+use tailtriage_analyzer::{render_json_pretty, try_analyze_run, AnalyzeOptions};
+use tailtriage_core::{CaptureLimitsOverride, CaptureMode, Run, Tailtriage};
 use tailtriage_tokio::RuntimeSampler;
+use tailtriage_tracing::tokio::TracingTokioSession;
+use tailtriage_tracing::TracingRecorder;
 use tokio::sync::{Mutex, Semaphore};
+use tracing::Instrument;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 const DEFAULT_REQUESTS: usize = 800;
 const DEFAULT_CONCURRENCY: usize = 32;
@@ -23,52 +29,85 @@ enum Mode {
     CoreInvestigationTokioSampler,
     CoreLightDropPath,
     CoreInvestigationDropPath,
+    TracingLight,
+    TracingLightTokioSampler,
+    TracingLightDropPath,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum InstrumentationKind {
+    Baseline,
+    Native,
+    Tracing,
 }
 
 impl Mode {
-    fn parse(value: &str) -> Option<Self> {
-        match value {
-            "baseline" => Some(Self::Baseline),
-            "baked_in_no_request_context" => Some(Self::BakedInNoRequestContext),
-            "core_light" => Some(Self::CoreLight),
-            "core_investigation" => Some(Self::CoreInvestigation),
-            "core_light_tokio_sampler" => Some(Self::CoreLightTokioSampler),
-            "core_investigation_tokio_sampler" => Some(Self::CoreInvestigationTokioSampler),
-            "core_light_drop_path" => Some(Self::CoreLightDropPath),
-            "core_investigation_drop_path" => Some(Self::CoreInvestigationDropPath),
-            _ => None,
-        }
+    fn parse(v: &str) -> Option<Self> {
+        Some(match v {
+            "baseline" => Self::Baseline,
+            "baked_in_no_request_context" => Self::BakedInNoRequestContext,
+            "core_light" => Self::CoreLight,
+            "core_investigation" => Self::CoreInvestigation,
+            "core_light_tokio_sampler" => Self::CoreLightTokioSampler,
+            "core_investigation_tokio_sampler" => Self::CoreInvestigationTokioSampler,
+            "core_light_drop_path" => Self::CoreLightDropPath,
+            "core_investigation_drop_path" => Self::CoreInvestigationDropPath,
+            "tracing_light" => Self::TracingLight,
+            "tracing_light_tokio_sampler" => Self::TracingLightTokioSampler,
+            "tracing_light_drop_path" => Self::TracingLightDropPath,
+            _ => return None,
+        })
     }
-
     fn core_mode(self) -> Option<CaptureMode> {
         match self {
-            Self::Baseline => None,
-            Self::BakedInNoRequestContext
-            | Self::CoreLight
+            Self::CoreLight
             | Self::CoreLightTokioSampler
-            | Self::CoreLightDropPath => Some(CaptureMode::Light),
+            | Self::CoreLightDropPath
+            | Self::BakedInNoRequestContext => Some(CaptureMode::Light),
             Self::CoreInvestigation
             | Self::CoreInvestigationTokioSampler
             | Self::CoreInvestigationDropPath => Some(CaptureMode::Investigation),
+            _ => None,
         }
     }
-
-    fn uses_tokio_sampler(self) -> bool {
+    fn instrumentation(self) -> InstrumentationKind {
+        match self {
+            Self::Baseline => InstrumentationKind::Baseline,
+            Self::TracingLight | Self::TracingLightTokioSampler | Self::TracingLightDropPath => {
+                InstrumentationKind::Tracing
+            }
+            _ => InstrumentationKind::Native,
+        }
+    }
+    fn uses_runtime_sampler(self) -> bool {
         matches!(
             self,
-            Self::CoreLightTokioSampler | Self::CoreInvestigationTokioSampler
+            Self::CoreLightTokioSampler
+                | Self::CoreInvestigationTokioSampler
+                | Self::TracingLightTokioSampler
         )
     }
-
     fn uses_drop_path_limits(self) -> bool {
         matches!(
             self,
-            Self::CoreLightDropPath | Self::CoreInvestigationDropPath
+            Self::CoreLightDropPath | Self::CoreInvestigationDropPath | Self::TracingLightDropPath
         )
     }
-
-    fn omits_request_context(self) -> bool {
-        matches!(self, Self::BakedInNoRequestContext)
+    fn artifact_file_name(self) -> Option<&'static str> {
+        Some(match self {
+            Self::Baseline => return None,
+            Self::BakedInNoRequestContext => "run-baked_in_no_request_context.json",
+            Self::CoreLight => "run-core_light.json",
+            Self::CoreInvestigation => "run-core_investigation.json",
+            Self::CoreLightTokioSampler => "run-core_light_tokio_sampler.json",
+            Self::CoreInvestigationTokioSampler => "run-core_investigation_tokio_sampler.json",
+            Self::CoreLightDropPath => "run-core_light_drop_path.json",
+            Self::CoreInvestigationDropPath => "run-core_investigation_drop_path.json",
+            Self::TracingLight => "run-tracing_light.json",
+            Self::TracingLightTokioSampler => "run-tracing_light_tokio_sampler.json",
+            Self::TracingLightDropPath => "run-tracing_light_drop_path.json",
+        })
     }
 }
 
@@ -80,10 +119,14 @@ struct Cli {
     work_ms: u64,
     output_dir: PathBuf,
 }
-
 #[derive(Debug, Serialize)]
+#[allow(clippy::struct_excessive_bools)]
 struct Measurement {
     mode: Mode,
+    instrumentation: InstrumentationKind,
+    uses_runtime_sampler: bool,
+    uses_drop_path_limits: bool,
+    inflight_supported: bool,
     requests: usize,
     concurrency: usize,
     work_ms: u64,
@@ -91,9 +134,19 @@ struct Measurement {
     latency_p50_ms: f64,
     latency_p95_ms: f64,
     latency_p99_ms: f64,
+    run_requests: u64,
+    run_stages: u64,
+    run_queues: u64,
+    runtime_snapshots: u64,
+    artifact_finalize_ms: f64,
+    analyze_ms: f64,
+    report_render_ms: f64,
+    effective_tokio_sampler_config_present: bool,
+    drop_path_signal_present: bool,
+    lifecycle_warning_count: u64,
+    artifact_path: Option<String>,
     truncation: Option<TruncationMeasurement>,
 }
-
 #[derive(Debug, Serialize)]
 struct TruncationMeasurement {
     dropped_requests: u64,
@@ -104,47 +157,73 @@ struct TruncationMeasurement {
     limits_reached: bool,
 }
 
-struct Instrumentation {
-    tailtriage: Option<Arc<Tailtriage>>,
-    sampler: Option<RuntimeSampler>,
+enum Backend {
+    None,
+    Native {
+        tailtriage: Arc<Tailtriage>,
+        sampler: Option<RuntimeSampler>,
+    },
+    TracingRecorder {
+        rec: TracingRecorder,
+    },
+    TracingTokio {
+        session: TracingTokioSession,
+    },
 }
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 4)]
 async fn main() -> anyhow::Result<()> {
     let cli = parse_cli()?;
-    std::fs::create_dir_all(&cli.output_dir)
-        .with_context(|| format!("failed to create {}", cli.output_dir.display()))?;
-
-    let instrumentation = build_instrumentation(&cli)?;
-    let (mut latencies, elapsed) = run_requests(&cli, instrumentation.tailtriage.as_ref()).await?;
-
-    if let Some(sampler) = instrumentation.sampler {
-        sampler.shutdown().await;
-    }
-
-    let truncation = if let Some(tailtriage) = instrumentation.tailtriage.as_ref() {
-        let snapshot = tailtriage.snapshot();
-        let truncation = snapshot.truncation;
-        Some(TruncationMeasurement {
-            dropped_requests: truncation.dropped_requests,
-            dropped_stages: truncation.dropped_stages,
-            dropped_queues: truncation.dropped_queues,
-            dropped_inflight_snapshots: truncation.dropped_inflight_snapshots,
-            dropped_runtime_snapshots: truncation.dropped_runtime_snapshots,
-            limits_reached: truncation.limits_hit,
-        })
+    std::fs::create_dir_all(&cli.output_dir)?;
+    let mut backend = build_backend(&cli)?;
+    let (mut latencies, elapsed) = run_requests(&cli, &backend).await?;
+    let finalize_start = Instant::now();
+    let run = finalize_backend(&mut backend).await?;
+    let artifact_finalize_ms = finalize_start.elapsed().as_secs_f64() * 1000.0;
+    let artifact_path = write_run_artifact(&cli, run.as_ref())?;
+    let analyze_start = Instant::now();
+    let (analyze_ms, report_render_ms) = if let Some(ref run_value) = run {
+        let report = try_analyze_run(run_value, AnalyzeOptions::default())?;
+        let analyze_ms = analyze_start.elapsed().as_secs_f64() * 1000.0;
+        let render_start = Instant::now();
+        black_box(render_json_pretty(&report)?);
+        (analyze_ms, render_start.elapsed().as_secs_f64() * 1000.0)
     } else {
-        None
+        (0.0, 0.0)
     };
-
-    if let Some(tailtriage) = instrumentation.tailtriage {
-        tailtriage.shutdown()?;
-    }
-
     latencies.sort_unstable();
-
-    let measurement = Measurement {
+    let truncation = run.as_ref().map(|r| TruncationMeasurement {
+        dropped_requests: r.truncation.dropped_requests,
+        dropped_stages: r.truncation.dropped_stages,
+        dropped_queues: r.truncation.dropped_queues,
+        dropped_inflight_snapshots: r.truncation.dropped_inflight_snapshots,
+        dropped_runtime_snapshots: r.truncation.dropped_runtime_snapshots,
+        limits_reached: r.truncation.limits_hit,
+    });
+    let run_requests = run.as_ref().map_or(0, |r| r.requests.len() as u64);
+    let run_stages = run.as_ref().map_or(0, |r| r.stages.len() as u64);
+    let run_queues = run.as_ref().map_or(0, |r| r.queues.len() as u64);
+    let runtime_snapshots = run.as_ref().map_or(0, |r| r.runtime_snapshots.len() as u64);
+    let effective_tokio_sampler_config_present = run
+        .as_ref()
+        .is_some_and(|r| r.metadata.effective_tokio_sampler_config.is_some());
+    let lifecycle_warning_count = run
+        .as_ref()
+        .map_or(0, |r| r.metadata.lifecycle_warnings.len() as u64);
+    let drop_path_signal_present = truncation.as_ref().is_some_and(|t| {
+        t.limits_reached
+            || t.dropped_requests > 0
+            || t.dropped_stages > 0
+            || t.dropped_queues > 0
+            || t.dropped_inflight_snapshots > 0
+            || t.dropped_runtime_snapshots > 0
+    }) || lifecycle_warning_count > 0;
+    let m = Measurement {
         mode: cli.mode,
+        instrumentation: cli.mode.instrumentation(),
+        uses_runtime_sampler: cli.mode.uses_runtime_sampler(),
+        uses_drop_path_limits: cli.mode.uses_drop_path_limits(),
+        inflight_supported: matches!(cli.mode.instrumentation(), InstrumentationKind::Native),
         requests: cli.requests,
         concurrency: cli.concurrency,
         work_ms: cli.work_ms,
@@ -152,129 +231,220 @@ async fn main() -> anyhow::Result<()> {
         latency_p50_ms: percentile_ms(&latencies, 50, 100)?,
         latency_p95_ms: percentile_ms(&latencies, 95, 100)?,
         latency_p99_ms: percentile_ms(&latencies, 99, 100)?,
+        run_requests,
+        run_stages,
+        run_queues,
+        runtime_snapshots,
+        artifact_finalize_ms,
+        analyze_ms,
+        report_render_ms,
+        effective_tokio_sampler_config_present,
+        drop_path_signal_present,
+        lifecycle_warning_count,
+        artifact_path,
         truncation,
     };
-
-    println!("{}", serde_json::to_string(&measurement)?);
-
+    println!("{}", serde_json::to_string(&m)?);
     Ok(())
 }
 
-fn build_instrumentation(cli: &Cli) -> anyhow::Result<Instrumentation> {
-    let Some(capture_mode) = cli.mode.core_mode() else {
-        return Ok(Instrumentation {
-            tailtriage: None,
-            sampler: None,
-        });
-    };
-
-    let mut builder = Tailtriage::builder("runtime_cost_demo").output(
-        cli.output_dir
-            .join(format!("run-{:?}.json", cli.mode).to_lowercase()),
-    );
-    builder = match capture_mode {
-        CaptureMode::Light => builder.light(),
-        CaptureMode::Investigation => builder.investigation(),
-    };
-
-    if cli.mode.uses_drop_path_limits() {
-        builder = builder.capture_limits_override(CaptureLimitsOverride {
-            max_requests: Some(64),
-            max_stages: Some(64),
-            max_queues: Some(64),
-            max_inflight_snapshots: Some(64),
-            max_runtime_snapshots: Some(64),
-        });
+fn build_backend(cli: &Cli) -> anyhow::Result<Backend> {
+    match cli.mode.instrumentation() {
+        InstrumentationKind::Baseline => Ok(Backend::None),
+        InstrumentationKind::Native => {
+            let mode = cli
+                .mode
+                .core_mode()
+                .ok_or_else(|| anyhow!("missing capture mode"))?;
+            let mut b = Tailtriage::builder("runtime_cost_demo").output(
+                cli.output_dir.join(
+                    cli.mode
+                        .artifact_file_name()
+                        .context("missing artifact filename")?,
+                ),
+            );
+            b = match mode {
+                CaptureMode::Light => b.light(),
+                CaptureMode::Investigation => b.investigation(),
+            };
+            if cli.mode.uses_drop_path_limits() {
+                b = b.capture_limits_override(CaptureLimitsOverride {
+                    max_requests: Some(64),
+                    max_stages: Some(64),
+                    max_queues: Some(64),
+                    max_inflight_snapshots: Some(64),
+                    max_runtime_snapshots: Some(64),
+                });
+            }
+            let tt = Arc::new(b.build()?);
+            let sampler = if cli.mode.uses_runtime_sampler() {
+                Some(RuntimeSampler::builder(Arc::clone(&tt)).start()?)
+            } else {
+                None
+            };
+            Ok(Backend::Native {
+                tailtriage: tt,
+                sampler,
+            })
+        }
+        InstrumentationKind::Tracing => {
+            if cli.mode.uses_runtime_sampler() {
+                let session = TracingTokioSession::builder("runtime_cost_demo")
+                    .strict(false)
+                    .max_open_spans(64)
+                    .max_completed_spans(64)
+                    .start()?;
+                // One mode runs per process in this demo, so process-global subscriber init is acceptable.
+                tracing_subscriber::registry().with(session.layer()).init();
+                Ok(Backend::TracingTokio { session })
+            } else {
+                let mut b = TracingRecorder::builder("runtime_cost_demo").strict(false);
+                if cli.mode.uses_drop_path_limits() {
+                    b = b.max_open_spans(64).max_completed_spans(64);
+                }
+                let rec = b.build();
+                // One mode runs per process in this demo, so process-global subscriber init is acceptable.
+                tracing_subscriber::registry().with(rec.layer()).init();
+                Ok(Backend::TracingRecorder { rec })
+            }
+        }
     }
-
-    let tailtriage = Arc::new(builder.build()?);
-    let sampler = if cli.mode.uses_tokio_sampler() {
-        Some(RuntimeSampler::builder(Arc::clone(&tailtriage)).start()?)
-    } else {
-        None
-    };
-
-    Ok(Instrumentation {
-        tailtriage: Some(tailtriage),
-        sampler,
-    })
 }
 
-async fn run_requests(
-    cli: &Cli,
-    tailtriage: Option<&Arc<Tailtriage>>,
-) -> anyhow::Result<(Vec<u64>, Duration)> {
-    let latencies_us = Arc::new(Mutex::new(Vec::<u64>::with_capacity(cli.requests)));
-    let semaphore = Arc::new(Semaphore::new(cli.concurrency));
+async fn finalize_backend(b: &mut Backend) -> anyhow::Result<Option<Run>> {
+    match std::mem::replace(b, Backend::None) {
+        Backend::None => Ok(None),
+        Backend::Native {
+            tailtriage,
+            sampler,
+        } => {
+            if let Some(s) = sampler {
+                s.shutdown().await;
+            }
+            let run = tailtriage.snapshot();
+            tailtriage.shutdown()?;
+            Ok(Some(run))
+        }
+        Backend::TracingRecorder { rec } => Ok(Some(rec.shutdown()?.into_parts().0)),
+        Backend::TracingTokio { session } => Ok(Some(session.shutdown().await?.into_parts().0)),
+    }
+}
+fn write_run_artifact(cli: &Cli, run: Option<&Run>) -> anyhow::Result<Option<String>> {
+    let Some(run) = run else { return Ok(None) };
+    let path = cli.output_dir.join(
+        cli.mode
+            .artifact_file_name()
+            .context("missing artifact file name")?,
+    );
+    let file = std::fs::File::create(&path)?;
+    serde_json::to_writer_pretty(file, run)?;
+    Ok(Some(path.display().to_string()))
+}
 
-    let wall_start = Instant::now();
+async fn run_requests(cli: &Cli, b: &Backend) -> anyhow::Result<(Vec<u64>, Duration)> {
+    let native_tailtriage = match b {
+        Backend::Native { tailtriage, .. } => Some(Arc::clone(tailtriage)),
+        _ => None,
+    };
+    let latencies = Arc::new(Mutex::new(Vec::<u64>::with_capacity(cli.requests)));
+    let sem = Arc::new(Semaphore::new(cli.concurrency));
+    let wall = Instant::now();
     let mut tasks = Vec::with_capacity(cli.requests);
-
     for idx in 0..cli.requests {
-        let sem = Arc::clone(&semaphore);
-        let latencies = Arc::clone(&latencies_us);
+        let sem = Arc::clone(&sem);
+        let lat = Arc::clone(&latencies);
+        let work = Duration::from_millis(cli.work_ms);
         let mode = cli.mode;
-        let work_duration = Duration::from_millis(cli.work_ms);
-        let tailtriage = tailtriage.map(Arc::clone);
-
+        let native_tailtriage_for_task = native_tailtriage.clone();
         tasks.push(tokio::spawn(async move {
             let start = Instant::now();
-
-            match (mode, tailtriage) {
-                (Mode::Baseline, _) => {
-                    let permit = sem.acquire().await.expect("semaphore closed");
-                    tokio::time::sleep(work_duration).await;
-                    drop(permit);
-                }
-                (mode, Some(_)) if mode.omits_request_context() => {
-                    let permit = sem.acquire().await.expect("semaphore closed");
-                    tokio::time::sleep(work_duration).await;
-                    drop(permit);
-                }
-                (_, Some(ts)) => {
-                    let request_id = format!("request-{idx}");
-                    let started = ts.begin_request_with(
-                        "/runtime-cost",
-                        tailtriage_core::RequestOptions::new().request_id(request_id),
-                    );
-                    let request = started.handle.clone();
-
-                    {
-                        let _inflight = request.inflight("runtime_cost_requests");
-                        let permit = request
-                            .queue("worker_semaphore")
-                            .await_on(sem.acquire())
-                            .await
-                            .expect("semaphore closed");
-
-                        request
-                            .stage("simulated_work")
-                            .await_value(tokio::time::sleep(work_duration))
-                            .await;
-
-                        drop(permit);
-                    }
-
-                    started.completion.finish(tailtriage_core::Outcome::Ok);
-                }
-                (_, None) => unreachable!("instrumented modes require a collector"),
+            if matches!(mode, Mode::Baseline | Mode::BakedInNoRequestContext) {
+                let permit = sem.acquire().await.expect("semaphore closed");
+                tokio::time::sleep(work).await;
+                drop(permit);
+            } else if matches!(mode.instrumentation(), InstrumentationKind::Native) {
+                native_request(sem, work, idx, native_tailtriage_for_task).await;
+            } else {
+                tracing_request(sem, work, idx).await;
             }
-
-            let elapsed_us = u64::try_from(start.elapsed().as_micros()).unwrap_or(u64::MAX);
-            latencies.lock().await.push(elapsed_us);
+            lat.lock()
+                .await
+                .push(u64::try_from(start.elapsed().as_micros()).unwrap_or(u64::MAX));
         }));
     }
-
-    for task in tasks {
-        task.await.context("request task panicked")?;
+    for t in tasks {
+        t.await.context("request task panicked")?;
     }
+    Ok((
+        Arc::into_inner(latencies)
+            .expect("all refs dropped")
+            .into_inner(),
+        wall.elapsed(),
+    ))
+}
 
-    let elapsed = wall_start.elapsed();
-    let latencies = Arc::into_inner(latencies_us)
-        .expect("all task refs dropped")
-        .into_inner();
-
-    Ok((latencies, elapsed))
+async fn native_request(
+    sem: Arc<Semaphore>,
+    work: Duration,
+    idx: usize,
+    tailtriage: Option<Arc<Tailtriage>>,
+) {
+    let Some(tailtriage) = tailtriage else {
+        return;
+    };
+    let request_id = format!("request-{idx}");
+    let started = tailtriage.begin_request_with(
+        "/runtime-cost",
+        tailtriage_core::RequestOptions::new().request_id(request_id),
+    );
+    let request = started.handle.clone();
+    let _inflight = request.inflight("runtime_cost_requests");
+    let permit = request
+        .queue("worker_semaphore")
+        .await_on(sem.acquire())
+        .await
+        .expect("semaphore closed");
+    request
+        .stage("simulated_work")
+        .await_value(tokio::time::sleep(work))
+        .await;
+    drop(permit);
+    started.completion.finish(tailtriage_core::Outcome::Ok);
+}
+async fn tracing_request(sem: Arc<Semaphore>, work: Duration, idx: usize) {
+    let request_id = format!("request-{idx}");
+    let request_id_for_request = request_id.clone();
+    async move {
+        let queue_span = tracing::info_span!(
+            "runtime.queue",
+            tt.kind = "queue",
+            tt.request_id = %request_id,
+            tt.queue = "worker_semaphore",
+            tt.depth_at_start = 0_u64
+        );
+        let permit = sem
+            .acquire()
+            .instrument(queue_span)
+            .await
+            .expect("semaphore closed");
+        let stage_span = tracing::info_span!(
+            "runtime.stage",
+            tt.kind = "stage",
+            tt.request_id = %request_id,
+            tt.stage = "simulated_work",
+            tt.success = true
+        );
+        tokio::time::sleep(work).instrument(stage_span).await;
+        drop(permit);
+    }
+    .instrument(tracing::info_span!(
+        "runtime.request",
+        tt.kind = "request",
+        tt.request_id = %request_id_for_request,
+        tt.route = "/runtime-cost",
+        tt.outcome = "ok"
+    ))
+    .await;
 }
 
 fn parse_cli() -> anyhow::Result<Cli> {
@@ -283,17 +453,14 @@ fn parse_cli() -> anyhow::Result<Cli> {
     let mut concurrency = DEFAULT_CONCURRENCY;
     let mut work_ms = DEFAULT_WORK_MS;
     let mut output_dir = PathBuf::from("demos/runtime_cost/artifacts");
-
     let mut args = std::env::args().skip(1);
     while let Some(arg) = args.next() {
         match arg.as_str() {
             "--mode" => {
-                let value = args.next().context("missing value for --mode")?;
-                mode = Mode::parse(&value);
+                let v = args.next().context("missing value for --mode")?;
+                mode = Mode::parse(&v);
                 if mode.is_none() {
-                    bail!(
-                        "invalid --mode {value}; expected baseline|baked_in_no_request_context|core_light|core_investigation|core_light_tokio_sampler|core_investigation_tokio_sampler|core_light_drop_path|core_investigation_drop_path"
-                    );
+                    bail!("invalid --mode {v}; expected baseline|baked_in_no_request_context|core_light|core_investigation|core_light_tokio_sampler|core_investigation_tokio_sampler|core_light_drop_path|core_investigation_drop_path|tracing_light|tracing_light_tokio_sampler|tracing_light_drop_path");
                 }
             }
             "--requests" => {
@@ -327,13 +494,10 @@ fn parse_cli() -> anyhow::Result<Cli> {
             _ => bail!("unknown arg: {arg}"),
         }
     }
-
     let mode = mode.context("--mode is required")?;
-
     if requests == 0 || concurrency == 0 || work_ms == 0 {
-        bail!("--requests, --concurrency, and --work-ms must be > 0");
+        bail!("--requests, --concurrency, and --work-ms must be > 0")
     }
-
     Ok(Cli {
         mode,
         requests,
@@ -342,44 +506,51 @@ fn parse_cli() -> anyhow::Result<Cli> {
         output_dir,
     })
 }
-
 fn print_help() {
-    eprintln!(
-        "runtime_cost --mode <baseline|baked_in_no_request_context|core_light|core_investigation|core_light_tokio_sampler|core_investigation_tokio_sampler|core_light_drop_path|core_investigation_drop_path> [--requests N] [--concurrency N] [--work-ms N] [--output-dir DIR]"
-    );
-    eprintln!(
-        "mode semantics: baked_in_no_request_context starts tailtriage but skips request-context instrumentation; core_* adds request-context instrumentation; *_tokio_sampler additionally starts RuntimeSampler; *_drop_path intentionally hits capture limits."
-    );
+    eprintln!("runtime_cost --mode <baseline|baked_in_no_request_context|core_light|core_investigation|core_light_tokio_sampler|core_investigation_tokio_sampler|core_light_drop_path|core_investigation_drop_path|tracing_light|tracing_light_tokio_sampler|tracing_light_drop_path> [--requests N] [--concurrency N] [--work-ms N] [--output-dir DIR]");
 }
-
-fn requests_per_second(request_count: usize, elapsed: Duration) -> anyhow::Result<f64> {
-    let total_requests = u64::try_from(request_count)?;
-    let request_rate_input = total_requests.to_string().parse::<f64>()?;
-    Ok(request_rate_input / elapsed.as_secs_f64())
+fn requests_per_second(n: usize, e: Duration) -> anyhow::Result<f64> {
+    Ok(u64::try_from(n)?.to_string().parse::<f64>()? / e.as_secs_f64())
 }
-
-fn percentile_ms(sorted_us: &[u64], numerator: u64, denominator: u64) -> anyhow::Result<f64> {
+fn percentile_ms(sorted_us: &[u64], num: u64, den: u64) -> anyhow::Result<f64> {
     if sorted_us.is_empty() {
         return Ok(0.0);
     }
-
-    anyhow::ensure!(denominator != 0, "percentile denominator must be non-zero");
-    anyhow::ensure!(
-        numerator <= denominator,
-        "percentile numerator must be <= denominator"
-    );
-
-    let max_index = sorted_us.len() - 1;
-    let max_index_u64 = u64::try_from(max_index)?;
-    let scaled = u128::from(max_index_u64) * u128::from(numerator);
-    let rounded = scaled + (u128::from(denominator) / 2);
-    let index_u128 = rounded / u128::from(denominator);
-    let index = usize::try_from(index_u128)?;
-
-    micros_to_millis_f64(sorted_us[index])
+    anyhow::ensure!(den != 0, "percentile denominator must be non-zero");
+    anyhow::ensure!(num <= den, "percentile numerator must be <= denominator");
+    let max = sorted_us.len() - 1;
+    let scaled = u128::from(u64::try_from(max)?) * u128::from(num);
+    let idx = usize::try_from((scaled + (u128::from(den) / 2)) / u128::from(den))?;
+    micros_to_millis_f64(sorted_us[idx])
+}
+fn micros_to_millis_f64(m: u64) -> anyhow::Result<f64> {
+    Ok(m.to_string().parse::<f64>()? / 1_000.0)
 }
 
-fn micros_to_millis_f64(micros: u64) -> anyhow::Result<f64> {
-    let micros_value = micros.to_string().parse::<f64>()?;
-    Ok(micros_value / 1_000.0)
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn mode_parse_accepts_tracing_modes() {
+        assert_eq!(Mode::parse("tracing_light"), Some(Mode::TracingLight));
+        assert_eq!(
+            Mode::parse("tracing_light_tokio_sampler"),
+            Some(Mode::TracingLightTokioSampler)
+        );
+        assert_eq!(
+            Mode::parse("tracing_light_drop_path"),
+            Some(Mode::TracingLightDropPath)
+        );
+    }
+    #[test]
+    fn mode_parse_rejects_unknown() {
+        assert_eq!(Mode::parse("wat"), None);
+    }
+    #[test]
+    fn mode_classification_works() {
+        let m = Mode::TracingLightTokioSampler;
+        assert_eq!(m.instrumentation(), InstrumentationKind::Tracing);
+        assert!(m.uses_runtime_sampler());
+        assert!(!m.uses_drop_path_limits());
+    }
 }

--- a/docs/runtime-cost.md
+++ b/docs/runtime-cost.md
@@ -19,6 +19,9 @@ Measured categories:
 - `core_investigation_tokio_sampler`
 - `core_light_drop_path` (intentionally saturated limits)
 - `core_investigation_drop_path` (intentionally saturated limits)
+- `tracing_light`
+- `tracing_light_tokio_sampler`
+- `tracing_light_drop_path`
 
 Derived attribution sections in summary output:
 
@@ -27,6 +30,7 @@ Derived attribution sections in summary output:
 - Tokio mode overhead
 - Incremental runtime sampler overhead
 - Post-limit / drop-path overhead
+- tracing-vs-native ratio summaries
 
 ## What this path does not measure
 
@@ -45,6 +49,7 @@ python3 scripts/measure_runtime_cost.py
 ```
 
 The script builds `demos/runtime_cost` in release mode and runs warmup + measured rounds.
+Each mode is executed as a separate process; this keeps process-global tracing subscriber installation valid for tracing modes.
 
 ## Inputs and knobs
 
@@ -63,6 +68,8 @@ Path: `demos/runtime_cost/artifacts/`
 - `runtime-cost-raw.jsonl` (per-sample raw records)
 - `runtime-cost-summary.json` (aggregates + overhead attribution + quality labels)
 
+Per-mode records now include instrumentation family (`baseline` / `native` / `tracing`), runtime sampler/drop-path flags, run evidence counts, runtime snapshot counts, artifact finalization/analyze/render timings, sampler-metadata presence, inflight support, lifecycle warning count, and artifact path.
+
 ## Interpreting results
 
 - Use **Baked-in overhead** to isolate collector-present cost when request instrumentation is skipped.
@@ -71,10 +78,13 @@ Path: `demos/runtime_cost/artifacts/`
 - Use **Post-limit / drop-path overhead** only for intentionally saturated-limit behavior.
 
 If `measurement_quality` reports noisy/unstable, rerun on a quieter machine state before drawing stronger conclusions.
+Numbers are directional and machine/workload/profile scoped; broad thresholds are intended only to catch catastrophic regressions.
 
 ## Semantics reminder
 
 - `CaptureMode` changes retention defaults; it does not auto-start the runtime sampler.
+- Tracing modes measure tailtriage semantic `tt.*` tracing spans (not OTel/OTLP export).
+- Tracing spans alone do not imply runtime-pressure evidence; runtime-pressure evidence requires Tokio-session runtime snapshots.
 - Post-limit overhead improvements come from cheaper drop-path handling after limits are hit, while preserving drop counters and truncation visibility.
 
 ## Operational validation runner

--- a/scripts/measure_runtime_cost.py
+++ b/scripts/measure_runtime_cost.py
@@ -366,6 +366,41 @@ def _validate_sanity(summary: dict) -> None:
         raise SystemExit("tracing_light_tokio_sampler must include sampler metadata")
     if abs_m["tracing_light_drop_path"]["drop_path_signal_present_rounds"] <= 0:
         raise SystemExit("tracing_light_drop_path must include drop-path signal")
+    ratios = summary["tracing_vs_native_ratios"]
+    required_ratio_keys = (
+        "tracing_light_vs_core_light_latency_p95",
+        "tracing_light_vs_core_light_throughput",
+        "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95",
+        "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput",
+        "tracing_light_drop_path_vs_core_light_drop_path_latency_p95",
+        "tracing_light_drop_path_vs_core_light_drop_path_throughput",
+    )
+    for key in required_ratio_keys:
+        value = ratios.get(key)
+        if value is None:
+            raise SystemExit(f"{key} is required and cannot be null (likely zero/missing denominator)")
+        if value != value or value in (float("inf"), float("-inf")):
+            raise SystemExit(f"{key} must be finite (not NaN or infinity)")
+    if ratios["tracing_light_vs_core_light_latency_p95"] > 20:
+        raise SystemExit("tracing_light_vs_core_light_latency_p95 exceeds catastrophic threshold (>20x)")
+    if ratios["tracing_light_vs_core_light_throughput"] < 0.05:
+        raise SystemExit("tracing_light_vs_core_light_throughput is below catastrophic threshold (<0.05x)")
+    if ratios["tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95"] > 20:
+        raise SystemExit(
+            "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95 exceeds catastrophic threshold (>20x)"
+        )
+    if ratios["tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput"] < 0.05:
+        raise SystemExit(
+            "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput is below catastrophic threshold (<0.05x)"
+        )
+    if ratios["tracing_light_drop_path_vs_core_light_drop_path_latency_p95"] > 20:
+        raise SystemExit(
+            "tracing_light_drop_path_vs_core_light_drop_path_latency_p95 exceeds catastrophic threshold (>20x)"
+        )
+    if ratios["tracing_light_drop_path_vs_core_light_drop_path_throughput"] < 0.05:
+        raise SystemExit(
+            "tracing_light_drop_path_vs_core_light_drop_path_throughput is below catastrophic threshold (<0.05x)"
+        )
 
 
 def build_release_binary(root_dir: Path) -> Path:

--- a/scripts/measure_runtime_cost.py
+++ b/scripts/measure_runtime_cost.py
@@ -20,11 +20,27 @@ MODES = (
     "core_investigation_tokio_sampler",
     "core_light_drop_path",
     "core_investigation_drop_path",
+    "tracing_light",
+    "tracing_light_tokio_sampler",
+    "tracing_light_drop_path",
 )
 UNSATURATED_CORE_MODES = ("core_light", "core_investigation")
 SATURATED_DROP_PATH_MODES = ("core_light_drop_path", "core_investigation_drop_path")
 TOKIO_SAMPLER_MODES = ("core_light_tokio_sampler", "core_investigation_tokio_sampler")
-METRIC_KEYS = ("throughput_rps", "latency_p50_ms", "latency_p95_ms", "latency_p99_ms")
+METRIC_KEYS = (
+    "throughput_rps",
+    "latency_p50_ms",
+    "latency_p95_ms",
+    "latency_p99_ms",
+    "artifact_finalize_ms",
+    "analyze_ms",
+    "report_render_ms",
+    "run_requests",
+    "run_stages",
+    "run_queues",
+    "runtime_snapshots",
+    "lifecycle_warning_count",
+)
 DEFAULT_REQUESTS = 6000
 DEFAULT_CONCURRENCY = 64
 DEFAULT_WORK_MS = 3
@@ -81,6 +97,15 @@ def summarize_values(values: list[float]) -> dict[str, float]:
         "stdev": stdev,
         "cv": stdev / abs(mean) if mean else 0.0,
     }
+
+
+def safe_ratio(comparison: float, reference: float) -> float | None:
+    if reference <= 0:
+        return None
+    ratio = comparison / reference
+    if ratio != ratio or ratio in (float("inf"), float("-inf")):
+        return None
+    return ratio
 
 
 def paired_delta_rows(measured_rounds: list[dict], mode: str, metric: str) -> list[float]:
@@ -141,6 +166,14 @@ def summarize_mode_metrics(by_mode: dict[str, list[dict]], mode: str) -> dict:
             ),
             "limit_reached_rounds": sum(1 for entry in truncations if entry["limits_reached"]),
         }
+    summary["effective_tokio_sampler_config_present_rounds"] = sum(
+        1 for row in by_mode[mode] if row.get("effective_tokio_sampler_config_present")
+    )
+    summary["inflight_supported"] = bool(by_mode[mode][0].get("inflight_supported"))
+    summary["drop_path_signal_present_rounds"] = sum(
+        1 for row in by_mode[mode] if row.get("drop_path_signal_present")
+    )
+    summary["artifact_path_last"] = by_mode[mode][-1].get("artifact_path")
     return summary
 
 
@@ -229,6 +262,7 @@ def summarize(raw_path: Path, summary_path: Path) -> dict:
         "incremental_runtime_sampler_overhead_pct": {
             "Incremental runtime sampler overhead": {},
         },
+        "tracing_vs_native_ratios": {},
     }
 
     for mode in MODES:
@@ -263,13 +297,75 @@ def summarize(raw_path: Path, summary_path: Path) -> dict:
             for metric in METRIC_KEYS
         },
     }
+    abs_m = summary["absolute_metrics"]
+    summary["tracing_vs_native_ratios"] = {
+        "core_light_vs_baseline_latency_p95": safe_ratio(
+            abs_m["core_light"]["latency_p95_ms"]["median"], abs_m["baseline"]["latency_p95_ms"]["median"]
+        ),
+        "tracing_light_vs_baseline_latency_p95": safe_ratio(
+            abs_m["tracing_light"]["latency_p95_ms"]["median"], abs_m["baseline"]["latency_p95_ms"]["median"]
+        ),
+        "tracing_light_vs_core_light_latency_p95": safe_ratio(
+            abs_m["tracing_light"]["latency_p95_ms"]["median"], abs_m["core_light"]["latency_p95_ms"]["median"]
+        ),
+        "core_light_tokio_sampler_vs_core_light_latency_p95": safe_ratio(
+            abs_m["core_light_tokio_sampler"]["latency_p95_ms"]["median"], abs_m["core_light"]["latency_p95_ms"]["median"]
+        ),
+        "tracing_light_tokio_sampler_vs_tracing_light_latency_p95": safe_ratio(
+            abs_m["tracing_light_tokio_sampler"]["latency_p95_ms"]["median"], abs_m["tracing_light"]["latency_p95_ms"]["median"]
+        ),
+        "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": safe_ratio(
+            abs_m["tracing_light_tokio_sampler"]["latency_p95_ms"]["median"], abs_m["core_light_tokio_sampler"]["latency_p95_ms"]["median"]
+        ),
+        "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": safe_ratio(
+            abs_m["tracing_light_drop_path"]["latency_p95_ms"]["median"], abs_m["core_light_drop_path"]["latency_p95_ms"]["median"]
+        ),
+        "tracing_light_vs_core_light_throughput": safe_ratio(
+            abs_m["tracing_light"]["throughput_rps"]["median"], abs_m["core_light"]["throughput_rps"]["median"]
+        ),
+        "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": safe_ratio(
+            abs_m["tracing_light_tokio_sampler"]["throughput_rps"]["median"], abs_m["core_light_tokio_sampler"]["throughput_rps"]["median"]
+        ),
+        "tracing_light_drop_path_vs_core_light_drop_path_throughput": safe_ratio(
+            abs_m["tracing_light_drop_path"]["throughput_rps"]["median"], abs_m["core_light_drop_path"]["throughput_rps"]["median"]
+        ),
+        "tracing_finalize_vs_native_finalize": safe_ratio(
+            abs_m["tracing_light"]["artifact_finalize_ms"]["median"], abs_m["core_light"]["artifact_finalize_ms"]["median"]
+        ),
+        "tracing_analyze_vs_native_analyze": safe_ratio(
+            abs_m["tracing_light"]["analyze_ms"]["median"], abs_m["core_light"]["analyze_ms"]["median"]
+        ),
+        "tracing_render_vs_native_render": safe_ratio(
+            abs_m["tracing_light"]["report_render_ms"]["median"], abs_m["core_light"]["report_render_ms"]["median"]
+        ),
+    }
 
     quality, reasons = assess_quality(summary, measured_rounds)
     summary["measurement_quality"] = quality
     summary["stability_warning"] = None if quality == QUALITY_STABLE else reasons
+    _validate_sanity(summary)
 
     summary_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
     return summary
+
+
+def _validate_sanity(summary: dict) -> None:
+    abs_m = summary["absolute_metrics"]
+    required = ("core_light", "tracing_light", "tracing_light_tokio_sampler")
+    for mode in MODES:
+        if abs_m[mode]["throughput_rps"]["median"] <= 0:
+            raise SystemExit(f"{mode} throughput must be > 0")
+        if abs_m[mode]["latency_p95_ms"]["median"] <= 0:
+            raise SystemExit(f"{mode} p95 must be > 0")
+    for mode in required:
+        if abs_m[mode]["run_requests"]["median"] <= 0 or abs_m[mode]["run_stages"]["median"] <= 0 or abs_m[mode]["run_queues"]["median"] <= 0:
+            raise SystemExit(f"{mode} must record request/stage/queue evidence")
+    if abs_m["tracing_light_tokio_sampler"]["runtime_snapshots"]["median"] <= 0:
+        raise SystemExit("tracing_light_tokio_sampler must have runtime snapshots")
+    if abs_m["tracing_light_tokio_sampler"]["effective_tokio_sampler_config_present_rounds"] <= 0:
+        raise SystemExit("tracing_light_tokio_sampler must include sampler metadata")
+    if abs_m["tracing_light_drop_path"]["drop_path_signal_present_rounds"] <= 0:
+        raise SystemExit("tracing_light_drop_path must include drop-path signal")
 
 
 def build_release_binary(root_dir: Path) -> Path:

--- a/scripts/tests/test_measure_runtime_cost.py
+++ b/scripts/tests/test_measure_runtime_cost.py
@@ -18,6 +18,52 @@ import measure_runtime_cost  # noqa: E402
 
 
 class RuntimeCostSummaryTests(unittest.TestCase):
+    def _base_row(self, mode: str, round_idx: int, latency_p95_ms: float = 2.0, throughput_rps: float = 1000.0) -> dict:
+        row = {
+            "mode": mode,
+            "requests": 100,
+            "concurrency": 10,
+            "work_ms": 1,
+            "throughput_rps": throughput_rps,
+            "latency_p50_ms": 1.0,
+            "latency_p95_ms": latency_p95_ms,
+            "latency_p99_ms": 3.0,
+            "artifact_finalize_ms": 0.5,
+            "analyze_ms": 0.5,
+            "report_render_ms": 0.5,
+            "run_requests": 100,
+            "run_stages": 100,
+            "run_queues": 100,
+            "runtime_snapshots": 10 if mode == "tracing_light_tokio_sampler" else 0,
+            "effective_tokio_sampler_config_present": mode == "tracing_light_tokio_sampler",
+            "inflight_supported": mode.startswith("core_") or mode == "baked_in_no_request_context",
+            "drop_path_signal_present": mode.endswith("drop_path"),
+            "lifecycle_warning_count": 0,
+            "artifact_path": None,
+            "round": round_idx,
+            "phase": "measured",
+            "is_warmup": False,
+        }
+        if mode != "baseline":
+            row["truncation"] = {
+                "dropped_requests": 0,
+                "dropped_stages": 0,
+                "dropped_queues": 0,
+                "dropped_inflight_snapshots": 0,
+                "dropped_runtime_snapshots": 0,
+                "limits_reached": False,
+            }
+        if mode == "tracing_light_drop_path":
+            row["truncation"] = {
+                "dropped_requests": 4,
+                "dropped_stages": 4,
+                "dropped_queues": 4,
+                "dropped_inflight_snapshots": 4,
+                "dropped_runtime_snapshots": 1,
+                "limits_reached": True,
+            }
+        return row
+
     def test_mode_matrix_preserves_unsaturated_saturated_and_sampler_scenarios(self) -> None:
         self.assertEqual(
             measure_runtime_cost.UNSATURATED_CORE_MODES,
@@ -57,53 +103,7 @@ class RuntimeCostSummaryTests(unittest.TestCase):
             raw_path = Path(tmp) / "runtime-cost-raw.jsonl"
             summary_path = Path(tmp) / "runtime-cost-summary.json"
 
-            rows = []
-            for round_idx in range(4):
-                for mode in measure_runtime_cost.MODES:
-                    row = {
-                        "mode": mode,
-                        "requests": 100,
-                        "concurrency": 10,
-                        "work_ms": 1,
-                        "throughput_rps": 1000.0,
-                        "latency_p50_ms": 1.0,
-                        "latency_p95_ms": 2.0,
-                        "latency_p99_ms": 3.0,
-                        "artifact_finalize_ms": 0.5,
-                        "analyze_ms": 0.5,
-                        "report_render_ms": 0.5,
-                        "run_requests": 100,
-                        "run_stages": 100,
-                        "run_queues": 100,
-                        "runtime_snapshots": 10 if mode == "tracing_light_tokio_sampler" else 0,
-                        "effective_tokio_sampler_config_present": mode == "tracing_light_tokio_sampler",
-                        "inflight_supported": mode.startswith("core_") or mode == "baked_in_no_request_context",
-                        "drop_path_signal_present": mode.endswith("drop_path"),
-                        "lifecycle_warning_count": 0,
-                        "artifact_path": None,
-                        "round": round_idx,
-                        "phase": "measured",
-                        "is_warmup": False,
-                    }
-                    if mode != "baseline":
-                        row["truncation"] = {
-                            "dropped_requests": 0,
-                            "dropped_stages": 0,
-                            "dropped_queues": 0,
-                            "dropped_inflight_snapshots": 0,
-                            "dropped_runtime_snapshots": 0,
-                            "limits_reached": False,
-                        }
-                    if mode == "core_light_drop_path":
-                        row["truncation"] = {
-                            "dropped_requests": 4,
-                            "dropped_stages": 4,
-                            "dropped_queues": 4,
-                            "dropped_inflight_snapshots": 4,
-                            "dropped_runtime_snapshots": 0,
-                            "limits_reached": True,
-                        }
-                    rows.append(row)
+            rows = [self._base_row(mode, round_idx) for round_idx in range(4) for mode in measure_runtime_cost.MODES]
 
             raw_path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
             summary = measure_runtime_cost.summarize(raw_path, summary_path)
@@ -129,9 +129,94 @@ class RuntimeCostSummaryTests(unittest.TestCase):
                 summary["incremental_runtime_sampler_overhead_pct"],
             )
 
-            drop_summary = summary["absolute_metrics"]["core_light_drop_path"]["truncation"]
+            expected_ratio_keys = {
+                "core_light_vs_baseline_latency_p95",
+                "tracing_light_vs_baseline_latency_p95",
+                "tracing_light_vs_core_light_latency_p95",
+                "core_light_tokio_sampler_vs_core_light_latency_p95",
+                "tracing_light_tokio_sampler_vs_tracing_light_latency_p95",
+                "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95",
+                "tracing_light_drop_path_vs_core_light_drop_path_latency_p95",
+                "tracing_light_vs_core_light_throughput",
+                "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput",
+                "tracing_light_drop_path_vs_core_light_drop_path_throughput",
+                "tracing_finalize_vs_native_finalize",
+                "tracing_analyze_vs_native_analyze",
+                "tracing_render_vs_native_render",
+            }
+            self.assertEqual(set(summary["tracing_vs_native_ratios"].keys()), expected_ratio_keys)
+            self.assertGreater(summary["absolute_metrics"]["core_light"]["run_requests"]["median"], 0)
+            self.assertGreater(summary["absolute_metrics"]["tracing_light"]["run_stages"]["median"], 0)
+            self.assertGreater(summary["absolute_metrics"]["tracing_light_tokio_sampler"]["run_queues"]["median"], 0)
+            self.assertGreater(summary["absolute_metrics"]["tracing_light_tokio_sampler"]["runtime_snapshots"]["median"], 0)
+            self.assertGreater(
+                summary["absolute_metrics"]["tracing_light_tokio_sampler"]["effective_tokio_sampler_config_present_rounds"],
+                0,
+            )
+            self.assertGreater(summary["absolute_metrics"]["tracing_light_drop_path"]["drop_path_signal_present_rounds"], 0)
+
+            drop_summary = summary["absolute_metrics"]["tracing_light_drop_path"]["truncation"]
             self.assertEqual(drop_summary["limit_reached_rounds"], 4)
             self.assertGreater(drop_summary["dropped_requests"]["mean"], 0)
+
+    def test_sanity_fails_on_catastrophic_latency_ratio(self) -> None:
+        summary = {"absolute_metrics": {m: {"throughput_rps": {"median": 10.0}, "latency_p95_ms": {"median": 2.0},
+                                            "run_requests": {"median": 1}, "run_stages": {"median": 1}, "run_queues": {"median": 1},
+                                            "runtime_snapshots": {"median": 0},
+                                            "effective_tokio_sampler_config_present_rounds": 0,
+                                            "drop_path_signal_present_rounds": 0} for m in measure_runtime_cost.MODES},
+                   "tracing_vs_native_ratios": {
+                       "tracing_light_vs_core_light_latency_p95": 25.0,
+                       "tracing_light_vs_core_light_throughput": 0.5,
+                       "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.0,
+                       "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 1.0,
+                       "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.0,
+                       "tracing_light_drop_path_vs_core_light_drop_path_throughput": 1.0,
+                   }}
+        summary["absolute_metrics"]["tracing_light_tokio_sampler"]["runtime_snapshots"]["median"] = 1
+        summary["absolute_metrics"]["tracing_light_tokio_sampler"]["effective_tokio_sampler_config_present_rounds"] = 1
+        summary["absolute_metrics"]["tracing_light_drop_path"]["drop_path_signal_present_rounds"] = 1
+        with self.assertRaises(SystemExit):
+            measure_runtime_cost._validate_sanity(summary)
+
+    def test_sanity_fails_on_catastrophic_throughput_ratio(self) -> None:
+        summary = {"absolute_metrics": {m: {"throughput_rps": {"median": 10.0}, "latency_p95_ms": {"median": 2.0},
+                                            "run_requests": {"median": 1}, "run_stages": {"median": 1}, "run_queues": {"median": 1},
+                                            "runtime_snapshots": {"median": 0},
+                                            "effective_tokio_sampler_config_present_rounds": 0,
+                                            "drop_path_signal_present_rounds": 0} for m in measure_runtime_cost.MODES},
+                   "tracing_vs_native_ratios": {
+                       "tracing_light_vs_core_light_latency_p95": 1.0,
+                       "tracing_light_vs_core_light_throughput": 0.01,
+                       "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.0,
+                       "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 1.0,
+                       "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.0,
+                       "tracing_light_drop_path_vs_core_light_drop_path_throughput": 1.0,
+                   }}
+        summary["absolute_metrics"]["tracing_light_tokio_sampler"]["runtime_snapshots"]["median"] = 1
+        summary["absolute_metrics"]["tracing_light_tokio_sampler"]["effective_tokio_sampler_config_present_rounds"] = 1
+        summary["absolute_metrics"]["tracing_light_drop_path"]["drop_path_signal_present_rounds"] = 1
+        with self.assertRaises(SystemExit):
+            measure_runtime_cost._validate_sanity(summary)
+
+    def test_sanity_passes_for_reasonable_tracing_ratios(self) -> None:
+        summary = {"absolute_metrics": {m: {"throughput_rps": {"median": 10.0}, "latency_p95_ms": {"median": 2.0},
+                                            "run_requests": {"median": 1}, "run_stages": {"median": 1}, "run_queues": {"median": 1},
+                                            "runtime_snapshots": {"median": 0},
+                                            "effective_tokio_sampler_config_present_rounds": 0,
+                                            "drop_path_signal_present_rounds": 0} for m in measure_runtime_cost.MODES},
+                   "tracing_vs_native_ratios": {
+                       "tracing_light_vs_core_light_latency_p95": 2.0,
+                       "tracing_light_vs_core_light_throughput": 0.8,
+                       "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 2.0,
+                       "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 0.8,
+                       "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 2.0,
+                       "tracing_light_drop_path_vs_core_light_drop_path_throughput": 0.8,
+                   }}
+        summary["absolute_metrics"]["tracing_light_tokio_sampler"]["runtime_snapshots"]["median"] = 1
+        summary["absolute_metrics"]["tracing_light_tokio_sampler"]["effective_tokio_sampler_config_present_rounds"] = 1
+        summary["absolute_metrics"]["tracing_light_drop_path"]["drop_path_signal_present_rounds"] = 1
+        measure_runtime_cost._validate_sanity(summary)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_measure_runtime_cost.py
+++ b/scripts/tests/test_measure_runtime_cost.py
@@ -42,8 +42,15 @@ class RuntimeCostSummaryTests(unittest.TestCase):
                 "core_investigation_tokio_sampler",
                 "core_light_drop_path",
                 "core_investigation_drop_path",
+                "tracing_light",
+                "tracing_light_tokio_sampler",
+                "tracing_light_drop_path",
             ),
         )
+
+    def test_safe_ratio_handles_zero_denominator(self) -> None:
+        self.assertIsNone(measure_runtime_cost.safe_ratio(10.0, 0.0))
+        self.assertEqual(measure_runtime_cost.safe_ratio(10.0, 2.0), 5.0)
 
     def test_summary_includes_required_overhead_headings_and_drop_path(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -62,6 +69,18 @@ class RuntimeCostSummaryTests(unittest.TestCase):
                         "latency_p50_ms": 1.0,
                         "latency_p95_ms": 2.0,
                         "latency_p99_ms": 3.0,
+                        "artifact_finalize_ms": 0.5,
+                        "analyze_ms": 0.5,
+                        "report_render_ms": 0.5,
+                        "run_requests": 100,
+                        "run_stages": 100,
+                        "run_queues": 100,
+                        "runtime_snapshots": 10 if mode == "tracing_light_tokio_sampler" else 0,
+                        "effective_tokio_sampler_config_present": mode == "tracing_light_tokio_sampler",
+                        "inflight_supported": mode.startswith("core_") or mode == "baked_in_no_request_context",
+                        "drop_path_signal_present": mode.endswith("drop_path"),
+                        "lifecycle_warning_count": 0,
+                        "artifact_path": None,
                         "round": round_idx,
                         "phase": "measured",
                         "is_warmup": False,

--- a/validation/runtime-cost/README.md
+++ b/validation/runtime-cost/README.md
@@ -8,6 +8,7 @@ This directory is the operational validation domain for runtime-cost checks.
 Generated outputs are written under `target/operational-validation/` and are not committed by default.
 
 Runtime-cost numbers are machine/workload/profile scoped for local triage validation and are not universal production guarantees.
+Tracing comparisons in this domain measure tailtriage semantic tracing spans (`tt.*`) and optional Tokio-session runtime sampling; they do not add OTel/OTLP behavior.
 
 
 Unified orchestration: `scripts/validate_all.py` invokes runtime-cost operational validation in `full` and `publish` profiles while preserving direct domain-runner usage.


### PR DESCRIPTION
### Motivation
- Provide a measurement path that compares native `tailtriage` instrumentation against `tt.*` tracing intake and the tracing Tokio session so runtime-cost reports show absolute and relative overhead across instrumentation families.
- Keep the existing `runtime_cost` workload shape and release-binary run style while exposing per-run finalize/analyze/render timings, artifact counts, runtime-snapshot presence, and drop-path signals for broad diagnostic validation.

### Description
- Extend `demos/runtime_cost` binary to add modes `tracing_light`, `tracing_light_tokio_sampler`, and `tracing_light_drop_path`, add an internal `Backend` enum to pick baseline/native/tracing backends, and record identical request/queue/stage semantics for parity comparisons; tracing modes install a process-global subscriber with a short comment explaining the one-mode-per-process rule and emit Run JSON artifacts via `serde_json::to_writer_pretty`.
- Wire in in-process analysis/report timing using `tailtriage-analyzer` via `try_analyze_run` and `render_json_pretty`, and add per-run fields including `instrumentation`, `uses_runtime_sampler`, `uses_drop_path_limits`, `run_requests`, `run_stages`, `run_queues`, `runtime_snapshots`, `artifact_finalize_ms`, `analyze_ms`, `report_render_ms`, `effective_tokio_sampler_config_present`, `inflight_supported`, `drop_path_signal_present`, `lifecycle_warning_count`, and `artifact_path`.
- Update `demos/runtime_cost/Cargo.toml` to add `tailtriage-tracing` and `tailtriage-analyzer` (workspace members) and minimal `tracing` / `tracing-subscriber` entries to support standalone tracing recorder/session usage.
- Extend `scripts/measure_runtime_cost.py` to run the tracing modes, include the new absolute metrics in `METRIC_KEYS`, compute safe tracing-vs-native ratio summaries, enforce broad sanity checks for catastrophic failures (missing evidence, sampler metadata, runtime snapshots, drop-path signal), and preserve raw JSONL + summary JSON outputs and rotating/warmup semantics; update test fixtures and docs (`docs/runtime-cost.md`, `validation/runtime-cost/README.md`) accordingly.

### Testing
- `cargo fmt --check` was run and succeeded for the modified files.
- Focused Rust checks: `cargo test -p runtime_cost` ran and its unit tests (including new `Mode` parsing and classification tests) passed.
- Python tests: `python3 -m unittest scripts.tests.test_measure_runtime_cost` ran and passed for the expanded summary/schema expectations (including the new tracing-mode rows and `safe_ratio` behavior).
- Focused `cargo clippy -p runtime_cost -- -D warnings` was exercised and issues fixed for the demo crate; a full workspace `--locked` clippy/test run was blocked earlier by a lockfile update requirement, so full workspace `--locked` checks were not completed in this pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a2b1c5a6883309f6871f388e2d7da)