### PR TITLE
CI: gate tracing parity and bounded runtime-cost smoke for PR #547

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ env:
 # - pull_request and main push use path filters to skip irrelevant runs.
 # - docs-contracts enforces public documentation contracts.
 # - Ubuntu dev/release are the extended legs (demos/smokes/policy checks).
+# - tracing parity is gated on Ubuntu extended dev via validate-tracing-parity.
+# - runtime-cost smoke is a bounded diagnostic sanity check (not rigorous benchmark gating).
 # - Windows/macOS run Cargo compile/lint/test coverage to catch OS-specific behavior.
 # - The external crates.io consumer smoke step remains intentionally disabled.
 jobs:
@@ -210,6 +212,10 @@ jobs:
         if: matrix.extended
         run: python3 scripts/demo_tool.py validate retry-storm --profile ${{ matrix.profile }}
 
+      - name: Validate tracing parity (all demos)
+        if: matrix.os == 'ubuntu-latest' && matrix.profile == 'dev' && matrix.extended
+        run: python3 scripts/demo_tool.py validate-tracing-parity all --profile dev
+
       - name: Smoke-check public examples
         if: matrix.extended && matrix.profile == 'dev'
         run: python3 scripts/smoke_public_examples.py
@@ -241,6 +247,14 @@ jobs:
         if: matrix.extended && matrix.profile == 'dev'
         run: python3 -m unittest scripts.tests.test_diagnostic_benchmark
 
+      - name: Validate runtime-cost helper unit tests
+        if: matrix.os == 'ubuntu-latest' && matrix.profile == 'dev' && matrix.extended
+        run: python3 -m unittest scripts.tests.test_measure_runtime_cost
+
+      - name: Validate runtime-cost summary validator unit tests
+        if: matrix.os == 'ubuntu-latest' && matrix.profile == 'dev' && matrix.extended
+        run: python3 -m unittest scripts.tests.test_validate_runtime_cost_summary
+
       - name: Validate deterministic diagnostics benchmark corpus
         if: matrix.extended && matrix.profile == 'dev'
         run: |
@@ -269,7 +283,27 @@ jobs:
         if: matrix.extended && matrix.profile == 'dev'
         run: python3 scripts/check_demo_fixture_drift.py --profile ${{ matrix.profile }}
 
-      - name: Measure runtime cost (non-blocking)
-        if: matrix.extended
-        continue-on-error: true
-        run: python3 scripts/measure_runtime_cost.py
+      - name: Measure runtime cost (CI smoke)
+        if: matrix.os == 'ubuntu-latest' && matrix.profile == 'release' && matrix.extended
+        run: |
+          python3 scripts/measure_runtime_cost.py \
+            --requests 1200 \
+            --concurrency 32 \
+            --work-ms 4 \
+            --rounds 1 \
+            --warmup-rounds 0 \
+            --artifact-dir demos/runtime_cost/artifacts/ci-smoke
+
+      - name: Validate runtime-cost CI smoke summary
+        if: matrix.os == 'ubuntu-latest' && matrix.profile == 'release' && matrix.extended
+        run: |
+          python3 scripts/validate_runtime_cost_summary.py \
+            --raw demos/runtime_cost/artifacts/ci-smoke/runtime-cost-raw.jsonl \
+            --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json
+
+      - name: Upload runtime-cost CI smoke artifacts
+        if: always() && matrix.os == 'ubuntu-latest' && matrix.profile == 'release' && matrix.extended
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtime-cost-ci-smoke
+          path: demos/runtime_cost/artifacts/ci-smoke/

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -31,7 +31,7 @@ Normal CI keeps deterministic diagnostics and docs contracts as gates but does n
 | Deterministic corpus | Yes in normal CI and in `validation-snapshot.yml` | bounded analyzer/report behavior on committed fixtures | production root cause certainty or universal accuracy |
 | Repeated-run matrix | No (manual/local) | stability metrics across repeated controlled runs on one machine/workload profile | universal stability across production environments |
 | Mitigation matrix | No (manual/local) | baseline vs mitigated movement checks for next-check usefulness | formal causal proof |
-| Runtime-cost measurement | Partially (non-blocking measure in CI) | overhead measurement under documented synthetic workloads | universal production overhead guarantees |
+| Runtime-cost measurement | Yes (bounded smoke + summary validation in CI; full runs manual/local) | overhead measurement under documented synthetic workloads | universal production overhead guarantees |
 | Collector-limit stress | Yes (smoke profile + summary validation) | bounded drop/truncation/warning/downgrade behavior under stress | zero drops under all load |
 | Real-service validation | No (planned) | future curated real-service truth checks when artifacts exist | current real-service validation coverage |
 
@@ -71,6 +71,7 @@ Operational validation has dedicated domain folders under `validation/runtime-co
 `scripts/run_operational_validation.py` adds manual/local operational validation for runtime-cost and collector-limit behavior. It emits raw JSONL records, stable summary JSON, and optional scorecard markdown under `target/operational-validation/`.
 
 Runtime-cost results are machine/workload/profile scoped and are not universal production guarantees.
+Normal CI uses bounded runtime-cost smoke as a diagnostic sanity gate (including tracing modes and catastrophic-ratio checks), not as rigorous benchmark certification.
 
 ## Collector-limit validation
 Collector-limit validation checks visible bounded drops, truncation warnings, and confidence downgrade behavior.

--- a/demos/README.md
+++ b/demos/README.md
@@ -19,6 +19,7 @@ Check out [`../docs/getting-started-demo.md`](../docs/getting-started-demo.md) f
 - Tracing inflight remains out of scope unless explicitly implemented.
 - This tracing demo mode is not OTel/OTLP and not an observability backend.
 - Suspects in parity runs remain triage leads, not proof of root cause.
+- CI-facing tracing parity coverage uses `python3 scripts/demo_tool.py validate-tracing-parity all --profile dev` on Ubuntu extended dev.
 
 ## Strongest public demonstration scenarios
 

--- a/docs/runtime-cost.md
+++ b/docs/runtime-cost.md
@@ -51,6 +51,8 @@ python3 scripts/measure_runtime_cost.py
 The script builds `demos/runtime_cost` in release mode and runs warmup + measured rounds.
 Each mode is executed as a separate process; this keeps process-global tracing subscriber installation valid for tracing modes.
 
+CI runs a bounded smoke variant (single short round) to confirm artifacts, tracing-vs-native sanity metrics, runtime snapshots for `tracing_light_tokio_sampler`, sampler metadata, and drop-path signals. Full multi-round measurement remains a local/developer validation path.
+
 ## Inputs and knobs
 
 CLI options (with equivalent env vars):
@@ -78,13 +80,14 @@ Per-mode records now include instrumentation family (`baseline` / `native` / `tr
 - Use **Post-limit / drop-path overhead** only for intentionally saturated-limit behavior.
 
 If `measurement_quality` reports noisy/unstable, rerun on a quieter machine state before drawing stronger conclusions.
-Numbers are directional and machine/workload/profile scoped; broad thresholds are intended only to catch catastrophic regressions.
+Numbers are directional and machine/workload/profile scoped; CI thresholds are catastrophic-regression checks only, not rigorous benchmark claims.
 
 ## Semantics reminder
 
 - `CaptureMode` changes retention defaults; it does not auto-start the runtime sampler.
 - Tracing modes measure tailtriage semantic `tt.*` tracing spans (not OTel/OTLP export).
 - Tracing spans alone do not imply runtime-pressure evidence; runtime-pressure evidence requires Tokio-session runtime snapshots.
+- `TracingTokioSession` mode is a separate runtime-sampling coupling path from tracing spans themselves.
 - Post-limit overhead improvements come from cheaper drop-path handling after limits are hit, while preserving drop counters and truncation visibility.
 
 ## Operational validation runner

--- a/scripts/tests/test_validate_runtime_cost_summary.py
+++ b/scripts/tests/test_validate_runtime_cost_summary.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import scripts.validate_runtime_cost_summary as validator
+
+
+def _valid_summary() -> dict:
+    modes = {}
+    for mode in validator.EXPECTED_MODES:
+        modes[mode] = {
+            "run_requests": {"median": 1},
+            "run_stages": {"median": 1},
+            "run_queues": {"median": 1},
+            "runtime_snapshots": {"median": 0},
+            "effective_tokio_sampler_config_present_rounds": 0,
+            "drop_path_signal_present_rounds": 0,
+        }
+    modes["tracing_light_tokio_sampler"]["runtime_snapshots"]["median"] = 1
+    modes["tracing_light_tokio_sampler"]["effective_tokio_sampler_config_present_rounds"] = 1
+    modes["tracing_light_drop_path"]["drop_path_signal_present_rounds"] = 1
+
+    ratios = {key: 1.0 for key in validator.REQUIRED_RATIO_KEYS}
+    return {"absolute_metrics": modes, "tracing_vs_native_ratios": ratios}
+
+
+class ValidateRuntimeCostSummaryTests(unittest.TestCase):
+    def _write(self, summary: dict, raw_content: str = '{"ok":true}\n') -> tuple[Path, Path, tempfile.TemporaryDirectory]:
+        tmp = tempfile.TemporaryDirectory()
+        raw = Path(tmp.name) / "runtime-cost-raw.jsonl"
+        out = Path(tmp.name) / "runtime-cost-summary.json"
+        raw.write_text(raw_content, encoding="utf-8")
+        out.write_text(json.dumps(summary), encoding="utf-8")
+        return raw, out, tmp
+
+    def test_valid_fixture_passes(self) -> None:
+        raw, out, tmp = self._write(_valid_summary())
+        with tmp:
+            validator.validate(raw, out)
+
+    def test_missing_mode_fails(self) -> None:
+        summary = _valid_summary()
+        del summary["absolute_metrics"]["baseline"]
+        raw, out, tmp = self._write(summary)
+        with tmp, self.assertRaises(SystemExit):
+            validator.validate(raw, out)
+
+    def test_missing_tracing_runtime_snapshots_fails(self) -> None:
+        summary = _valid_summary()
+        summary["absolute_metrics"]["tracing_light_tokio_sampler"]["runtime_snapshots"]["median"] = 0
+        raw, out, tmp = self._write(summary)
+        with tmp, self.assertRaises(SystemExit):
+            validator.validate(raw, out)
+
+    def test_missing_sampler_metadata_fails(self) -> None:
+        summary = _valid_summary()
+        summary["absolute_metrics"]["tracing_light_tokio_sampler"]["effective_tokio_sampler_config_present_rounds"] = 0
+        raw, out, tmp = self._write(summary)
+        with tmp, self.assertRaises(SystemExit):
+            validator.validate(raw, out)
+
+    def test_missing_drop_path_signal_fails(self) -> None:
+        summary = _valid_summary()
+        summary["absolute_metrics"]["tracing_light_drop_path"]["drop_path_signal_present_rounds"] = 0
+        raw, out, tmp = self._write(summary)
+        with tmp, self.assertRaises(SystemExit):
+            validator.validate(raw, out)
+
+    def test_nan_ratio_fails(self) -> None:
+        summary = _valid_summary()
+        summary["tracing_vs_native_ratios"]["tracing_light_vs_core_light_latency_p95"] = float("nan")
+        raw, out, tmp = self._write(summary)
+        with tmp, self.assertRaises(SystemExit):
+            validator.validate(raw, out)
+
+    def test_missing_required_ratio_key_fails(self) -> None:
+        summary = _valid_summary()
+        del summary["tracing_vs_native_ratios"]["tracing_light_vs_core_light_latency_p95"]
+        raw, out, tmp = self._write(summary)
+        with tmp, self.assertRaises(SystemExit):
+            validator.validate(raw, out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_runtime_cost_summary.py
+++ b/scripts/validate_runtime_cost_summary.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Validate runtime-cost smoke outputs for CI sanity checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+EXPECTED_MODES = (
+    "baseline",
+    "baked_in_no_request_context",
+    "core_light",
+    "core_investigation",
+    "core_light_tokio_sampler",
+    "core_investigation_tokio_sampler",
+    "core_light_drop_path",
+    "core_investigation_drop_path",
+    "tracing_light",
+    "tracing_light_tokio_sampler",
+    "tracing_light_drop_path",
+)
+
+REQUIRED_RATIO_KEYS = (
+    "tracing_light_vs_core_light_latency_p95",
+    "tracing_light_vs_core_light_throughput",
+    "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95",
+    "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput",
+    "tracing_light_drop_path_vs_core_light_drop_path_latency_p95",
+    "tracing_light_drop_path_vs_core_light_drop_path_throughput",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate runtime-cost smoke summary outputs.")
+    parser.add_argument("--raw", required=True, help="Path to runtime-cost-raw.jsonl")
+    parser.add_argument("--summary", required=True, help="Path to runtime-cost-summary.json")
+    return parser.parse_args()
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+def _median(summary: dict, mode: str, key: str) -> float:
+    return summary["absolute_metrics"][mode][key]["median"]
+
+
+def validate(raw_path: Path, summary_path: Path) -> None:
+    if not raw_path.exists():
+        fail(f"raw JSONL not found: {raw_path}")
+    raw_lines = [line for line in raw_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    if not raw_lines:
+        fail(f"raw JSONL is empty: {raw_path}")
+
+    if not summary_path.exists():
+        fail(f"summary JSON not found: {summary_path}")
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+
+    modes = summary.get("absolute_metrics", {})
+    missing_modes = [mode for mode in EXPECTED_MODES if mode not in modes]
+    if missing_modes:
+        fail(f"summary is missing expected modes: {', '.join(missing_modes)}")
+
+    for mode in ("tracing_light", "tracing_light_tokio_sampler"):
+        if _median(summary, mode, "run_requests") <= 0:
+            fail(f"{mode} must include non-zero request evidence")
+        if _median(summary, mode, "run_stages") <= 0:
+            fail(f"{mode} must include non-zero stage evidence")
+        if _median(summary, mode, "run_queues") <= 0:
+            fail(f"{mode} must include non-zero queue evidence")
+
+    if _median(summary, "tracing_light_tokio_sampler", "runtime_snapshots") <= 0:
+        fail("tracing_light_tokio_sampler must include non-zero runtime snapshots")
+    if summary["absolute_metrics"]["tracing_light_tokio_sampler"]["effective_tokio_sampler_config_present_rounds"] <= 0:
+        fail("tracing_light_tokio_sampler must include sampler metadata")
+    if summary["absolute_metrics"]["tracing_light_drop_path"]["drop_path_signal_present_rounds"] <= 0:
+        fail("tracing_light_drop_path must include drop-path signal")
+
+    ratios = summary.get("tracing_vs_native_ratios")
+    if not isinstance(ratios, dict):
+        fail("summary is missing tracing_vs_native_ratios")
+
+    for key in REQUIRED_RATIO_KEYS:
+        if key not in ratios:
+            fail(f"missing required tracing-vs-native ratio key: {key}")
+        value = ratios[key]
+        if value is None or not isinstance(value, (int, float)) or not math.isfinite(value):
+            fail(f"{key} must be a finite numeric value")
+
+    if ratios["tracing_light_vs_core_light_latency_p95"] > 20:
+        fail("catastrophic threshold failed: tracing_light_vs_core_light_latency_p95 > 20x")
+    if ratios["tracing_light_vs_core_light_throughput"] < 0.05:
+        fail("catastrophic threshold failed: tracing_light_vs_core_light_throughput < 0.05x")
+    if ratios["tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95"] > 20:
+        fail("catastrophic threshold failed: tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95 > 20x")
+    if ratios["tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput"] < 0.05:
+        fail("catastrophic threshold failed: tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput < 0.05x")
+    if ratios["tracing_light_drop_path_vs_core_light_drop_path_latency_p95"] > 20:
+        fail("catastrophic threshold failed: tracing_light_drop_path_vs_core_light_drop_path_latency_p95 > 20x")
+    if ratios["tracing_light_drop_path_vs_core_light_drop_path_throughput"] < 0.05:
+        fail("catastrophic threshold failed: tracing_light_drop_path_vs_core_light_drop_path_throughput < 0.05x")
+
+
+def main() -> None:
+    args = parse_args()
+    validate(Path(args.raw), Path(args.summary))
+    print("runtime-cost summary validation passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/runtime-cost/README.md
+++ b/validation/runtime-cost/README.md
@@ -9,6 +9,7 @@ Generated outputs are written under `target/operational-validation/` and are not
 
 Runtime-cost numbers are machine/workload/profile scoped for local triage validation and are not universal production guarantees.
 Tracing comparisons in this domain measure tailtriage semantic tracing spans (`tt.*`) and optional Tokio-session runtime sampling; they do not add OTel/OTLP behavior.
+Normal CI runs a bounded runtime-cost smoke plus summary validation for diagnostic sanity; full measurement remains local/developer-run and CI thresholds are catastrophic-regression checks only.
 
 
 Unified orchestration: `scripts/validate_all.py` invokes runtime-cost operational validation in `full` and `publish` profiles while preserving direct domain-runner usage.


### PR DESCRIPTION
### Motivation

- Add deterministic CI coverage for the tracing work so native-vs-tracing parity and runtime-sensitive tracing modes are validated in a bounded, non‑flaky way.
- Prevent regressions in runtime-cost artifacts, runtime-sampler outputs, and tracing-vs-native sanity metrics while keeping full multi-round runtime-cost measurement as a local developer task.
- Keep scope narrow: no analyzer behavior, Run schema, collector semantics, or OTel/OTLP additions were to be changed.

### Description

- Update `.github/workflows/ci.yml` to add a blocking tracing parity validation step that runs only on the Ubuntu extended `dev` leg (`python3 scripts/demo_tool.py validate-tracing-parity all --profile dev`).
- Replace the existing unbounded non-blocking runtime-cost step with a blocking bounded CI smoke on Ubuntu extended `release` that runs `python3 scripts/measure_runtime_cost.py` with small-but-safe parameters and uploads artifacts via `actions/upload-artifact@v4`.
- Add `scripts/validate_runtime_cost_summary.py`, a small deterministic validator that asserts presence of expected modes, tracing request/stage/queue evidence, Tokio sampler runtime snapshots and sampler metadata, drop-path signal, required tracing-vs-native ratio keys, finite numeric ratios, and a set of catastrophic sanity thresholds.
- Add unit tests `scripts/tests/test_validate_runtime_cost_summary.py` for the validator and wire existing runtime-cost helper tests to run once on Ubuntu extended dev; update docs (`docs/runtime-cost.md`, `validation/runtime-cost/README.md`, `demos/README.md`, and `VALIDATION.md`) to document the CI smoke intent and tracing scope.

### Testing

- Ran Python unit tests: `python3 -m unittest scripts.tests.test_measure_runtime_cost scripts.tests.test_validate_runtime_cost_summary` and they passed.
- Executed a bounded runtime-cost CI smoke locally with `python3 scripts/measure_runtime_cost.py --requests 1200 --concurrency 32 --work-ms 4 --rounds 1 --warmup-rounds 0 --artifact-dir demos/runtime_cost/artifacts/ci-smoke` and the run produced `runtime-cost-raw.jsonl` and `runtime-cost-summary.json` and emitted a stability warning (expected for single-round smoke).
- Validated the smoke outputs with `python3 scripts/validate_runtime_cost_summary.py --raw demos/runtime_cost/artifacts/ci-smoke/runtime-cost-raw.jsonl --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json` and the validator passed.
- Ran tracing parity validation `python3 scripts/demo_tool.py validate-tracing-parity all --profile dev`, `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, and `python3 scripts/validate_docs_contracts.py`, all of which succeeded in the local validation performed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a34bf98b883309598c22c2024d0a9)