### PR TITLE
Gate tracing parity and add bounded runtime-cost CI smoke with validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ env:
 # - pull_request and main push use path filters to skip irrelevant runs.
 # - docs-contracts enforces public documentation contracts.
 # - Ubuntu dev/release are the extended legs (demos/smokes/policy checks).
+# - Tracing parity is gated on the Ubuntu extended dev leg.
+# - Runtime-cost CI smoke is a bounded diagnostic sanity check on one Ubuntu extended leg.
+# - Full runtime-cost measurements remain local and are not rigorous CI benchmark claims.
 # - Windows/macOS run Cargo compile/lint/test coverage to catch OS-specific behavior.
 # - The external crates.io consumer smoke step remains intentionally disabled.
 jobs:
@@ -210,6 +213,10 @@ jobs:
         if: matrix.extended
         run: python3 scripts/demo_tool.py validate retry-storm --profile ${{ matrix.profile }}
 
+      - name: Validate tracing parity (all demos)
+        if: matrix.os == 'ubuntu-latest' && matrix.profile == 'dev' && matrix.extended
+        run: python3 scripts/demo_tool.py validate-tracing-parity all --profile dev
+
       - name: Smoke-check public examples
         if: matrix.extended && matrix.profile == 'dev'
         run: python3 scripts/smoke_public_examples.py
@@ -241,6 +248,14 @@ jobs:
         if: matrix.extended && matrix.profile == 'dev'
         run: python3 -m unittest scripts.tests.test_diagnostic_benchmark
 
+      - name: Validate runtime-cost measurement helper unit tests
+        if: matrix.extended && matrix.profile == 'dev'
+        run: python3 -m unittest scripts.tests.test_measure_runtime_cost
+
+      - name: Validate runtime-cost summary validator unit tests
+        if: matrix.extended && matrix.profile == 'dev'
+        run: python3 -m unittest scripts.tests.test_validate_runtime_cost_summary
+
       - name: Validate deterministic diagnostics benchmark corpus
         if: matrix.extended && matrix.profile == 'dev'
         run: |
@@ -269,7 +284,27 @@ jobs:
         if: matrix.extended && matrix.profile == 'dev'
         run: python3 scripts/check_demo_fixture_drift.py --profile ${{ matrix.profile }}
 
-      - name: Measure runtime cost (non-blocking)
-        if: matrix.extended
-        continue-on-error: true
-        run: python3 scripts/measure_runtime_cost.py
+      - name: Measure runtime cost (bounded CI smoke)
+        if: matrix.extended && matrix.profile == 'release'
+        run: |
+          python3 scripts/measure_runtime_cost.py \
+            --requests 800 \
+            --concurrency 32 \
+            --work-ms 3 \
+            --rounds 1 \
+            --warmup-rounds 0 \
+            --artifact-dir demos/runtime_cost/artifacts/ci-smoke
+
+      - name: Validate runtime-cost smoke outputs
+        if: matrix.extended && matrix.profile == 'release'
+        run: |
+          python3 scripts/validate_runtime_cost_summary.py \
+            --raw demos/runtime_cost/artifacts/ci-smoke/runtime-cost-raw.jsonl \
+            --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json
+
+      - name: Upload runtime-cost smoke artifacts
+        if: always() && matrix.extended && matrix.profile == 'release'
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtime-cost-ci-smoke
+          path: demos/runtime_cost/artifacts/ci-smoke/

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -114,6 +114,7 @@ Near-term tasks:
 - keep positioning explicit: tracing intake converts tracing-shaped evidence into standard Runs for the existing analyzer
 - preserve bounded claims: no tracing backend semantics, no OTel/OTLP, no observability-platform expansion
 - keep runtime-pressure guidance explicit: tracing-only imports usually lack runtime snapshots, so Tokio sampling remains the path for runtime-pressure evidence
+- keep parity/validation posture explicit: semantic parity harness exists, runtime-sensitive demos use `TracingTokioSession`, runtime-cost tracing-vs-native measurement exists, and CI gates one bounded tracing-parity leg plus one bounded runtime-cost smoke leg
 
 ## Near-term sequencing
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -16,6 +16,7 @@ Check out [`../docs/getting-started-demo.md`](../docs/getting-started-demo.md) f
 - `blocking_service` and `executor_pressure_service` also support `--instrumentation native|tracing`.
 - Runtime-sensitive tracing parity uses `TracingTokioSession` plus deterministic runtime snapshots recorded during workload execution.
 - Tracing spans alone do not infer runtime pressure; runtime-sensitive parity relies on those recorded snapshots.
+- CI-facing tracing parity coverage uses `python3 scripts/demo_tool.py validate-tracing-parity all --profile dev` on the Ubuntu extended dev leg.
 - Tracing inflight remains out of scope unless explicitly implemented.
 - This tracing demo mode is not OTel/OTLP and not an observability backend.
 - Suspects in parity runs remain triage leads, not proof of root cause.

--- a/docs/runtime-cost.md
+++ b/docs/runtime-cost.md
@@ -51,6 +51,22 @@ python3 scripts/measure_runtime_cost.py
 The script builds `demos/runtime_cost` in release mode and runs warmup + measured rounds.
 Each mode is executed as a separate process; this keeps process-global tracing subscriber installation valid for tracing modes.
 
+## CI smoke command (bounded)
+
+CI runs a bounded smoke check for runtime-cost artifacts:
+
+```bash
+python3 scripts/measure_runtime_cost.py \
+  --requests 800 \
+  --concurrency 32 \
+  --work-ms 3 \
+  --rounds 1 \
+  --warmup-rounds 0 \
+  --artifact-dir demos/runtime_cost/artifacts/ci-smoke
+```
+
+That CI smoke is a diagnostic sanity gate only. It validates artifact shape, tracing/native ratio availability, runtime-snapshot presence for `tracing_light_tokio_sampler`, and catastrophic-regression thresholds. It is not a rigorous benchmark claim.
+
 ## Inputs and knobs
 
 CLI options (with equivalent env vars):
@@ -85,6 +101,7 @@ Numbers are directional and machine/workload/profile scoped; broad thresholds ar
 - `CaptureMode` changes retention defaults; it does not auto-start the runtime sampler.
 - Tracing modes measure tailtriage semantic `tt.*` tracing spans (not OTel/OTLP export).
 - Tracing spans alone do not imply runtime-pressure evidence; runtime-pressure evidence requires Tokio-session runtime snapshots.
+- `tracing_light_tokio_sampler` runtime-pressure evidence relies on `TracingTokioSession` runtime sampling and its sampler metadata.
 - Post-limit overhead improvements come from cheaper drop-path handling after limits are hit, while preserving drop counters and truncation visibility.
 
 ## Operational validation runner

--- a/scripts/tests/test_validate_runtime_cost_summary.py
+++ b/scripts/tests/test_validate_runtime_cost_summary.py
@@ -1,0 +1,80 @@
+import copy
+import math
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import validate_runtime_cost_summary
+
+
+class ValidateRuntimeCostSummaryTests(unittest.TestCase):
+    def _valid_summary(self) -> dict:
+        metric = {"median": 1.0}
+        modes = {
+            mode: {
+                "throughput_rps": metric,
+                "latency_p95_ms": metric,
+                "run_requests": metric,
+                "run_stages": metric,
+                "run_queues": metric,
+                "runtime_snapshots": metric,
+                "effective_tokio_sampler_config_present_rounds": 1,
+                "drop_path_signal_present_rounds": 1,
+            }
+            for mode in validate_runtime_cost_summary.EXPECTED_MODES
+        }
+        modes["tracing_light_drop_path"]["drop_path_signal_present_rounds"] = 1
+        return {
+            "absolute_metrics": modes,
+            "tracing_vs_native_ratios": {key: 1.0 for key in validate_runtime_cost_summary.REQUIRED_RATIO_KEYS},
+        }
+
+    def test_valid_fixture_passes(self) -> None:
+        validate_runtime_cost_summary.validate_summary(self._valid_summary())
+
+    def test_missing_mode_fails(self) -> None:
+        summary = self._valid_summary()
+        del summary["absolute_metrics"]["tracing_light"]
+        with self.assertRaises(SystemExit):
+            validate_runtime_cost_summary.validate_summary(summary)
+
+    def test_missing_tracing_runtime_snapshots_fails(self) -> None:
+        summary = self._valid_summary()
+        summary["absolute_metrics"]["tracing_light_tokio_sampler"]["runtime_snapshots"]["median"] = 0.0
+        with self.assertRaises(SystemExit):
+            validate_runtime_cost_summary.validate_summary(summary)
+
+    def test_missing_sampler_metadata_fails(self) -> None:
+        summary = self._valid_summary()
+        summary["absolute_metrics"]["tracing_light_tokio_sampler"]["effective_tokio_sampler_config_present_rounds"] = 0
+        with self.assertRaises(SystemExit):
+            validate_runtime_cost_summary.validate_summary(summary)
+
+    def test_missing_drop_path_signal_fails(self) -> None:
+        summary = self._valid_summary()
+        summary["absolute_metrics"]["tracing_light_drop_path"]["drop_path_signal_present_rounds"] = 0
+        with self.assertRaises(SystemExit):
+            validate_runtime_cost_summary.validate_summary(summary)
+
+    def test_non_finite_ratio_fails(self) -> None:
+        summary = self._valid_summary()
+        summary["tracing_vs_native_ratios"]["tracing_light_vs_core_light_latency_p95"] = math.inf
+        with self.assertRaises(SystemExit):
+            validate_runtime_cost_summary.validate_summary(summary)
+
+    def test_missing_required_ratio_key_fails(self) -> None:
+        summary = self._valid_summary()
+        del summary["tracing_vs_native_ratios"]["tracing_light_vs_core_light_latency_p95"]
+        with self.assertRaises(SystemExit):
+            validate_runtime_cost_summary.validate_summary(summary)
+
+    def test_raw_jsonl_guard(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            raw = Path(tmp) / "raw.jsonl"
+            raw.write_text("\n", encoding="utf-8")
+            with self.assertRaises(SystemExit):
+                validate_runtime_cost_summary._read_non_empty_jsonl(raw)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_runtime_cost_summary.py
+++ b/scripts/validate_runtime_cost_summary.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Validate runtime-cost smoke artifacts for CI sanity coverage."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from scripts import measure_runtime_cost
+
+
+EXPECTED_MODES = measure_runtime_cost.MODES
+REQUIRED_RATIO_KEYS = (
+    "tracing_light_vs_core_light_latency_p95",
+    "tracing_light_vs_core_light_throughput",
+    "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95",
+    "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput",
+    "tracing_light_drop_path_vs_core_light_drop_path_latency_p95",
+    "tracing_light_drop_path_vs_core_light_drop_path_throughput",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate runtime-cost smoke raw/summary artifacts.")
+    parser.add_argument("--raw", required=True, help="Path to runtime-cost raw JSONL file.")
+    parser.add_argument("--summary", required=True, help="Path to runtime-cost summary JSON file.")
+    return parser.parse_args()
+
+
+def _read_non_empty_jsonl(path: Path) -> None:
+    if not path.exists():
+        raise SystemExit(f"raw JSONL does not exist: {path}")
+    lines = [line for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    if not lines:
+        raise SystemExit(f"raw JSONL is empty: {path}")
+
+
+def _read_summary(path: Path) -> dict:
+    if not path.exists():
+        raise SystemExit(f"summary JSON does not exist: {path}")
+    try:
+        summary = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"summary JSON is invalid: {path}: {exc}") from exc
+    if not isinstance(summary, dict):
+        raise SystemExit("summary JSON root must be an object")
+    return summary
+
+
+def validate_summary(summary: dict) -> None:
+    absolute_metrics = summary.get("absolute_metrics")
+    if not isinstance(absolute_metrics, dict):
+        raise SystemExit("summary must include absolute_metrics object")
+
+    missing_modes = [mode for mode in EXPECTED_MODES if mode not in absolute_metrics]
+    if missing_modes:
+        raise SystemExit(f"summary missing expected modes: {', '.join(missing_modes)}")
+
+    measure_runtime_cost._validate_sanity(summary)
+
+    ratios = summary.get("tracing_vs_native_ratios")
+    if not isinstance(ratios, dict):
+        raise SystemExit("summary must include tracing_vs_native_ratios object")
+
+    for key in REQUIRED_RATIO_KEYS:
+        if key not in ratios:
+            raise SystemExit(f"summary missing required tracing-vs-native ratio key: {key}")
+
+
+def main() -> None:
+    args = parse_args()
+    raw_path = Path(args.raw)
+    summary_path = Path(args.summary)
+    _read_non_empty_jsonl(raw_path)
+    summary = _read_summary(summary_path)
+    validate_summary(summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/runtime-cost/README.md
+++ b/validation/runtime-cost/README.md
@@ -9,6 +9,7 @@ Generated outputs are written under `target/operational-validation/` and are not
 
 Runtime-cost numbers are machine/workload/profile scoped for local triage validation and are not universal production guarantees.
 Tracing comparisons in this domain measure tailtriage semantic tracing spans (`tt.*`) and optional Tokio-session runtime sampling; they do not add OTel/OTLP behavior.
+CI additionally runs a bounded runtime-cost smoke plus `scripts/validate_runtime_cost_summary.py` to confirm analyzable artifacts and catastrophic-regression sanity checks; this is not rigorous benchmark gating.
 
 
 Unified orchestration: `scripts/validate_all.py` invokes runtime-cost operational validation in `full` and `publish` profiles while preserving direct domain-runner usage.


### PR DESCRIPTION
### Motivation
- Ensure the new tracing intake and tracing-vs-native runtime-cost paths are protected by deterministic, bounded CI checks without expanding scope or changing analyzer/Run/collector semantics. 
- Provide a compact CI smoke that exercises tracing runtime-sampling modes and produces analyzable artifacts while avoiding long or flaky full benchmark runs. 
- Make the CI policy and public docs explicit about tracing parity, Tokio sampler coupling, and the limited, sanity-check nature of runtime-cost CI checks.

### Description
- Add a blocking tracing parity validation step on the Ubuntu extended `dev` leg that runs `python3 scripts/demo_tool.py validate-tracing-parity all --profile dev`. 
- Replace the non-blocking unbounded runtime-cost step with a blocking bounded smoke on the Ubuntu extended `release` leg that runs `python3 scripts/measure_runtime_cost.py --requests 800 --concurrency 32 --work-ms 3 --rounds 1 --warmup-rounds 0 --artifact-dir demos/runtime_cost/artifacts/ci-smoke`. 
- Add `scripts/validate_runtime_cost_summary.py` to deterministically validate smoke artifacts (raw JSONL non-empty, summary parses, expected modes present, tracing snapshots/sampler metadata/drop-path signal present, required tracing-vs-native ratio keys finite), and add unit tests in `scripts/tests/test_validate_runtime_cost_summary.py`. 
- Wire unit test steps for `scripts.tests.test_measure_runtime_cost` and `scripts.tests.test_validate_runtime_cost_summary` into CI once on Ubuntu extended `dev`, upload smoke artifacts as `runtime-cost-ci-smoke` on the smoke leg, and update CI comments and runtime-cost/tracing docs to clearly describe the CI posture and non-OTel scope.

### Testing
- Ran `python3 -m unittest scripts.tests.test_validate_runtime_cost_summary scripts.tests.test_measure_runtime_cost` and both test suites passed. 
- Executed `python3 scripts/demo_tool.py validate-tracing-parity all --profile dev` and the tracing parity check completed successfully across demos. 
- Executed the bounded smoke `python3 scripts/measure_runtime_cost.py --requests 800 --concurrency 32 --work-ms 3 --rounds 1 --warmup-rounds 0 --artifact-dir demos/runtime_cost/artifacts/ci-smoke` and then `python3 scripts/validate_runtime_cost_summary.py --raw demos/runtime_cost/artifacts/ci-smoke/runtime-cost-raw.jsonl --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json`, and the validator passed. 
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, and `python3 scripts/validate_docs_contracts.py`, and all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a34bf98b883309598c22c2024d0a9)