### PR TITLE
CI: gate tracing parity and bounded runtime-cost smoke for PR #547

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ env:
 # - pull_request and main push use path filters to skip irrelevant runs.
 # - docs-contracts enforces public documentation contracts.
 # - Ubuntu dev/release are the extended legs (demos/smokes/policy checks).
+# - Tracing parity is gated on Ubuntu extended dev via validate-tracing-parity all.
+# - Runtime-cost CI is a bounded smoke sanity check, not a rigorous benchmark result.
 # - Windows/macOS run Cargo compile/lint/test coverage to catch OS-specific behavior.
 # - The external crates.io consumer smoke step remains intentionally disabled.
 jobs:
@@ -269,7 +271,35 @@ jobs:
         if: matrix.extended && matrix.profile == 'dev'
         run: python3 scripts/check_demo_fixture_drift.py --profile ${{ matrix.profile }}
 
-      - name: Measure runtime cost (non-blocking)
-        if: matrix.extended
-        continue-on-error: true
-        run: python3 scripts/measure_runtime_cost.py
+      - name: Validate tracing parity across demos
+        if: matrix.os == 'ubuntu-latest' && matrix.profile == 'dev' && matrix.extended
+        run: python3 scripts/demo_tool.py validate-tracing-parity all --profile dev
+
+      - name: Validate runtime-cost summary helper unit tests
+        if: matrix.os == 'ubuntu-latest' && matrix.profile == 'dev' && matrix.extended
+        run: python3 -m unittest scripts.tests.test_measure_runtime_cost scripts.tests.test_validate_runtime_cost_summary
+
+      - name: Measure runtime cost (CI smoke)
+        if: matrix.os == 'ubuntu-latest' && matrix.profile == 'release' && matrix.extended
+        run: |
+          python3 scripts/measure_runtime_cost.py \
+            --requests 800 \
+            --concurrency 32 \
+            --work-ms 3 \
+            --rounds 1 \
+            --warmup-rounds 0 \
+            --artifact-dir demos/runtime_cost/artifacts/ci-smoke
+
+      - name: Validate runtime cost smoke summary
+        if: matrix.os == 'ubuntu-latest' && matrix.profile == 'release' && matrix.extended
+        run: |
+          python3 scripts/validate_runtime_cost_summary.py \
+            --raw demos/runtime_cost/artifacts/ci-smoke/runtime-cost-raw.jsonl \
+            --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json
+
+      - name: Upload runtime cost smoke artifacts
+        if: always() && matrix.os == 'ubuntu-latest' && matrix.profile == 'release' && matrix.extended
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtime-cost-ci-smoke
+          path: demos/runtime_cost/artifacts/ci-smoke/

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -104,6 +104,17 @@ Near-term tasks:
 - keep validation docs present-tense and stable, not PR-history oriented
 - update docs contract tests when public docs structure intentionally changes
 
+### 7) Tracing validation and CI readiness
+
+Keep tracing validation bounded, deterministic, and aligned with current scope.
+
+Near-term tasks:
+
+- keep semantic parity harness (`validate-tracing-parity all`) as the CI-facing tracing parity gate
+- keep runtime-sensitive tracing demos coupled to Tokio-session runtime snapshots (`TracingTokioSession`)
+- keep runtime-cost tracing-vs-native smoke validation in CI bounded to catastrophic sanity checks, with full measurement local
+- keep OTel/OTLP out of scope for tracing intake and runtime-cost validation
+
 ### 6) Tracing-intake adoption friction reduction
 
 Keep the optional tracing intake path clear for teams already using Rust `tracing`.

--- a/demos/README.md
+++ b/demos/README.md
@@ -15,6 +15,7 @@ Check out [`../docs/getting-started-demo.md`](../docs/getting-started-demo.md) f
 - Tracing inflight parity is out of scope for this phase.
 - `blocking_service` and `executor_pressure_service` also support `--instrumentation native|tracing`.
 - Runtime-sensitive tracing parity uses `TracingTokioSession` plus deterministic runtime snapshots recorded during workload execution.
+- CI-facing tracing parity gate is `python3 scripts/demo_tool.py validate-tracing-parity all --profile dev` on Ubuntu extended dev.
 - Tracing spans alone do not infer runtime pressure; runtime-sensitive parity relies on those recorded snapshots.
 - Tracing inflight remains out of scope unless explicitly implemented.
 - This tracing demo mode is not OTel/OTLP and not an observability backend.

--- a/docs/runtime-cost.md
+++ b/docs/runtime-cost.md
@@ -51,6 +51,16 @@ python3 scripts/measure_runtime_cost.py
 The script builds `demos/runtime_cost` in release mode and runs warmup + measured rounds.
 Each mode is executed as a separate process; this keeps process-global tracing subscriber installation valid for tracing modes.
 
+
+## CI smoke and local full measurement
+
+CI runs a bounded runtime-cost smoke on one Ubuntu extended leg to verify artifact shape and catastrophic-regression sanity checks only.
+
+- CI smoke command uses explicit small parameters and writes to `demos/runtime_cost/artifacts/ci-smoke/`.
+- CI then validates raw+summary artifacts with `scripts/validate_runtime_cost_summary.py`.
+- CI smoke keeps tracing modes enabled, including `tracing_light_tokio_sampler` runtime-snapshot and sampler-metadata checks.
+- Full runtime-cost measurement (`python3 scripts/measure_runtime_cost.py`) remains the developer/local path for richer directional comparisons.
+
 ## Inputs and knobs
 
 CLI options (with equivalent env vars):

--- a/scripts/tests/test_validate_runtime_cost_summary.py
+++ b/scripts/tests/test_validate_runtime_cost_summary.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import math
+import tempfile
+import unittest
+from pathlib import Path
+
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import validate_runtime_cost_summary  # noqa: E402
+
+
+class ValidateRuntimeCostSummaryTests(unittest.TestCase):
+    def _summary(self) -> dict:
+        modes = {m: {
+            "run_requests": {"median": 10},
+            "run_stages": {"median": 10},
+            "run_queues": {"median": 10},
+            "runtime_snapshots": {"median": 0},
+            "effective_tokio_sampler_config_present_rounds": 0,
+            "drop_path_signal_present_rounds": 0,
+        } for m in validate_runtime_cost_summary.EXPECTED_MODES}
+        modes["tracing_light_tokio_sampler"]["runtime_snapshots"]["median"] = 2
+        modes["tracing_light_tokio_sampler"]["effective_tokio_sampler_config_present_rounds"] = 1
+        modes["tracing_light_drop_path"]["drop_path_signal_present_rounds"] = 1
+        ratios = {k: 1.1 for k in validate_runtime_cost_summary.REQUIRED_RATIO_KEYS}
+        return {"absolute_metrics": modes, "tracing_vs_native_ratios": ratios}
+
+    def _write_and_validate(self, summary: dict) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            raw = root / "runtime-cost-raw.jsonl"
+            out = root / "runtime-cost-summary.json"
+            raw.write_text('{"ok":true}\n', encoding="utf-8")
+            out.write_text(json.dumps(summary), encoding="utf-8")
+            validate_runtime_cost_summary.validate(raw, out)
+
+    def test_valid_fixture_passes(self) -> None:
+        self._write_and_validate(self._summary())
+
+    def test_missing_mode_fails(self) -> None:
+        summary = self._summary()
+        del summary["absolute_metrics"]["tracing_light"]
+        with self.assertRaises(SystemExit):
+            self._write_and_validate(summary)
+
+    def test_missing_tracing_runtime_snapshots_fails(self) -> None:
+        summary = self._summary()
+        summary["absolute_metrics"]["tracing_light_tokio_sampler"]["runtime_snapshots"]["median"] = 0
+        with self.assertRaises(SystemExit):
+            self._write_and_validate(summary)
+
+    def test_missing_sampler_metadata_fails(self) -> None:
+        summary = self._summary()
+        summary["absolute_metrics"]["tracing_light_tokio_sampler"]["effective_tokio_sampler_config_present_rounds"] = 0
+        with self.assertRaises(SystemExit):
+            self._write_and_validate(summary)
+
+    def test_missing_drop_path_signal_fails(self) -> None:
+        summary = self._summary()
+        summary["absolute_metrics"]["tracing_light_drop_path"]["drop_path_signal_present_rounds"] = 0
+        with self.assertRaises(SystemExit):
+            self._write_and_validate(summary)
+
+    def test_nan_or_infinite_ratio_fails(self) -> None:
+        summary = self._summary()
+        summary["tracing_vs_native_ratios"]["tracing_light_vs_core_light_latency_p95"] = math.inf
+        with self.assertRaises(SystemExit):
+            self._write_and_validate(summary)
+
+    def test_missing_required_ratio_key_fails(self) -> None:
+        summary = self._summary()
+        del summary["tracing_vs_native_ratios"]["tracing_light_vs_core_light_throughput"]
+        with self.assertRaises(SystemExit):
+            self._write_and_validate(summary)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_runtime_cost_summary.py
+++ b/scripts/validate_runtime_cost_summary.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Validate bounded runtime-cost smoke outputs used by CI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+EXPECTED_MODES = (
+    "baseline",
+    "baked_in_no_request_context",
+    "core_light",
+    "core_investigation",
+    "core_light_tokio_sampler",
+    "core_investigation_tokio_sampler",
+    "core_light_drop_path",
+    "core_investigation_drop_path",
+    "tracing_light",
+    "tracing_light_tokio_sampler",
+    "tracing_light_drop_path",
+)
+
+REQUIRED_RATIO_KEYS = (
+    "tracing_light_vs_core_light_latency_p95",
+    "tracing_light_vs_core_light_throughput",
+    "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95",
+    "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput",
+    "tracing_light_drop_path_vs_core_light_drop_path_latency_p95",
+    "tracing_light_drop_path_vs_core_light_drop_path_throughput",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Validate runtime-cost smoke raw+summary artifacts.")
+    p.add_argument("--raw", required=True)
+    p.add_argument("--summary", required=True)
+    return p.parse_args()
+
+
+def _require(cond: bool, msg: str) -> None:
+    if not cond:
+        raise SystemExit(msg)
+
+
+def _median(summary: dict, mode: str, metric: str) -> float:
+    return float(summary["absolute_metrics"][mode][metric]["median"])
+
+
+def validate(raw_path: Path, summary_path: Path) -> None:
+    _require(raw_path.exists(), f"missing raw JSONL: {raw_path}")
+    _require(raw_path.stat().st_size > 0, f"raw JSONL is empty: {raw_path}")
+
+    _require(summary_path.exists(), f"missing summary JSON: {summary_path}")
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+
+    absolute_metrics = summary.get("absolute_metrics")
+    _require(isinstance(absolute_metrics, dict), "summary missing absolute_metrics")
+
+    missing_modes = [m for m in EXPECTED_MODES if m not in absolute_metrics]
+    _require(not missing_modes, f"summary missing modes: {', '.join(missing_modes)}")
+
+    for metric in ("run_requests", "run_stages", "run_queues"):
+        _require(_median(summary, "tracing_light", metric) > 0, f"tracing_light missing {metric} evidence")
+        _require(
+            _median(summary, "tracing_light_tokio_sampler", metric) > 0,
+            f"tracing_light_tokio_sampler missing {metric} evidence",
+        )
+
+    _require(_median(summary, "tracing_light_tokio_sampler", "runtime_snapshots") > 0, "tracing tokio sampler missing runtime snapshots")
+    _require(
+        int(absolute_metrics["tracing_light_tokio_sampler"].get("effective_tokio_sampler_config_present_rounds", 0)) > 0,
+        "tracing tokio sampler missing sampler metadata",
+    )
+    _require(
+        int(absolute_metrics["tracing_light_drop_path"].get("drop_path_signal_present_rounds", 0)) > 0,
+        "tracing drop-path mode missing drop-path signal",
+    )
+
+    ratios = summary.get("tracing_vs_native_ratios")
+    _require(isinstance(ratios, dict), "summary missing tracing_vs_native_ratios")
+    for key in REQUIRED_RATIO_KEYS:
+        _require(key in ratios, f"missing tracing-vs-native ratio key: {key}")
+        val = ratios[key]
+        _require(val is not None, f"ratio {key} is null")
+        _require(isinstance(val, (int, float)), f"ratio {key} is non-numeric")
+        _require(math.isfinite(float(val)), f"ratio {key} is NaN or infinite")
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    validate(Path(args.raw), Path(args.summary))
+    print("runtime-cost smoke summary validation passed")

--- a/validation/runtime-cost/README.md
+++ b/validation/runtime-cost/README.md
@@ -12,3 +12,5 @@ Tracing comparisons in this domain measure tailtriage semantic tracing spans (`t
 
 
 Unified orchestration: `scripts/validate_all.py` invokes runtime-cost operational validation in `full` and `publish` profiles while preserving direct domain-runner usage.
+
+CI additionally runs a bounded runtime-cost smoke and validates emitted summary/raw artifacts; this is a diagnostic sanity gate, not rigorous benchmark gating.


### PR DESCRIPTION
### Motivation

- Ensure tracing intake parity and runtime-sensitive tracing modes are protected by CI without adding flaky or heavy runtime benchmarks. 
- Provide a bounded, deterministic smoke that verifies tracing runtime-snapshot and sampler metadata presence and that tracing vs native artifacts are analyzable. 
- Keep the validation scope narrow: no Run schema, analyzer, collector semantics, or OTel/OTLP changes.

### Description

- Add a blocking tracing parity CI gate on the Ubuntu extended dev leg that runs `python3 scripts/demo_tool.py validate-tracing-parity all --profile dev` and keep existing native demo validators unchanged. 
- Replace the prior non-blocking runtime-cost step with a blocking bounded CI smoke on the Ubuntu extended release leg that runs `python3 scripts/measure_runtime_cost.py` with explicit small parameters and writes artifacts to `demos/runtime_cost/artifacts/ci-smoke`. 
- Add `scripts/validate_runtime_cost_summary.py` to deterministically validate the smoke artifacts (raw JSONL present/non-empty, expected modes present, tracing evidence/runtime-snapshots/sampler metadata/drop-path signal, required tracing-vs-native ratio keys numeric and finite). 
- Add unit tests `scripts/tests/test_validate_runtime_cost_summary.py` for the new validator and wire runtime-cost helper unit tests into the Ubuntu extended dev leg; upload CI smoke artifacts as `runtime-cost-ci-smoke` on the dedicated leg; update CI comments and narrow runtime-cost/tracing docs and implementation-plan notes to reflect CI smoke intent and bounded claims.

### Testing

- Ran `python3 -m unittest scripts.tests.test_measure_runtime_cost scripts.tests.test_validate_runtime_cost_summary` and the unit test suite completed successfully. 
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation succeeded. 
- Ran `python3 scripts/demo_tool.py validate-tracing-parity all --profile dev` and tracing parity validation completed successfully for the demo set. 
- Ran the bounded CI smoke `python3 scripts/measure_runtime_cost.py --requests 800 --concurrency 32 --work-ms 3 --rounds 1 --warmup-rounds 0 --artifact-dir demos/runtime_cost/artifacts/ci-smoke` and produced `runtime-cost-raw.jsonl` and `runtime-cost-summary.json`. 
- Ran `python3 scripts/validate_runtime_cost_summary.py --raw demos/runtime_cost/artifacts/ci-smoke/runtime-cost-raw.jsonl --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json` and the validator passed. 
- Ran repository checks `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, and `cargo test --workspace --all-targets --all-features --locked` and they completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a34bf98b883309598c22c2024d0a9)