### PR TITLE
Fix runtime-cost native finalization to use MemorySink and tidy parity help/text output

### DIFF
--- a/demos/runtime_cost/src/main.rs
+++ b/demos/runtime_cost/src/main.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use anyhow::{anyhow, bail, Context};
 use serde::Serialize;
 use tailtriage_analyzer::{render_json_pretty, try_analyze_run, AnalyzeOptions};
-use tailtriage_core::{CaptureLimitsOverride, CaptureMode, Run, Tailtriage};
+use tailtriage_core::{CaptureLimitsOverride, CaptureMode, MemorySink, Run, Tailtriage};
 use tailtriage_tokio::RuntimeSampler;
 use tailtriage_tracing::tokio::TracingTokioSession;
 use tailtriage_tracing::TracingRecorder;
@@ -162,6 +162,7 @@ enum Backend {
     Native {
         tailtriage: Arc<Tailtriage>,
         sampler: Option<RuntimeSampler>,
+        sink: MemorySink,
     },
     TracingRecorder {
         rec: TracingRecorder,
@@ -255,13 +256,8 @@ fn build_backend(cli: &Cli) -> anyhow::Result<Backend> {
                 .mode
                 .core_mode()
                 .ok_or_else(|| anyhow!("missing capture mode"))?;
-            let mut b = Tailtriage::builder("runtime_cost_demo").output(
-                cli.output_dir.join(
-                    cli.mode
-                        .artifact_file_name()
-                        .context("missing artifact filename")?,
-                ),
-            );
+            let sink = MemorySink::new();
+            let mut b = Tailtriage::builder("runtime_cost_demo").sink(sink.clone());
             b = match mode {
                 CaptureMode::Light => b.light(),
                 CaptureMode::Investigation => b.investigation(),
@@ -284,6 +280,7 @@ fn build_backend(cli: &Cli) -> anyhow::Result<Backend> {
             Ok(Backend::Native {
                 tailtriage: tt,
                 sampler,
+                sink,
             })
         }
         InstrumentationKind::Tracing => {
@@ -323,12 +320,15 @@ async fn finalize_backend_and_write_artifact(
         Backend::Native {
             tailtriage,
             sampler,
+            sink,
         } => {
             if let Some(s) = sampler {
                 s.shutdown().await;
             }
-            let run = tailtriage.snapshot();
             tailtriage.shutdown()?;
+            let run = sink.last_run().ok_or_else(|| {
+                anyhow!("native runtime-cost run sink did not receive finalized run")
+            })?;
             Some(run)
         }
         Backend::TracingRecorder { rec } => Some(rec.shutdown()?.into_parts().0),

--- a/scripts/demo_tool.py
+++ b/scripts/demo_tool.py
@@ -1091,7 +1091,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
     parity_parser = subparsers.add_parser(
         "validate-tracing-parity",
-        help="Run native/tracing parity checks for supported non-runtime-sensitive demos.",
+        help="Run native/tracing parity checks for demo scenarios, including runtime-sensitive demos.",
     )
     parity_parser.add_argument("scenario", choices=PARITY_SCENARIOS)
     parity_parser.add_argument("--profile", choices=PROFILE_CHOICES, default="dev")

--- a/scripts/measure_runtime_cost.py
+++ b/scripts/measure_runtime_cost.py
@@ -403,6 +403,35 @@ def _validate_sanity(summary: dict) -> None:
         )
 
 
+def _format_ratio(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:.2f}x"
+
+
+def print_ratio_table(summary: dict) -> None:
+    ratios = summary.get("tracing_vs_native_ratios", {})
+    rows = [
+        (
+            "tracing_light / core_light",
+            ratios.get("tracing_light_vs_core_light_latency_p95"),
+            ratios.get("tracing_light_vs_core_light_throughput"),
+        ),
+        (
+            "tracing_sampler / native_sampler",
+            ratios.get("tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95"),
+            ratios.get("tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput"),
+        ),
+        (
+            "tracing_drop_path / native_drop_path",
+            ratios.get("tracing_light_drop_path_vs_core_light_drop_path_latency_p95"),
+            ratios.get("tracing_light_drop_path_vs_core_light_drop_path_throughput"),
+        ),
+    ]
+    print("| comparison | p95 ratio | throughput ratio |")
+    print("|---|---:|---:|")
+    for comparison, p95_ratio, throughput_ratio in rows:
+        print(f"| {comparison} | {_format_ratio(p95_ratio)} | {_format_ratio(throughput_ratio)} |")
+
+
 def build_release_binary(root_dir: Path) -> Path:
     manifest_path = root_dir / "demos/runtime_cost/Cargo.toml"
     print("Building runtime_cost demo in release mode...", file=sys.stderr)
@@ -504,6 +533,7 @@ def main() -> None:
             print(f" - {reason}", file=sys.stderr)
 
     print(json.dumps(summary, indent=2))
+    print_ratio_table(summary)
     print(f"raw results: {raw_path}")
     print(f"summary: {summary_path}")
 


### PR DESCRIPTION
### Motivation
- Native runtime-cost builds were taking a pre-shutdown `snapshot()` and then `shutdown()` could write a finalized `Run`, allowing the pre-shutdown snapshot to overwrite the finalized artifact and bias native finalization timings.
- Make native finalization comparable to tracing by finalizing into memory first and then writing the artifact exactly once via the common writer.

### Description
- Change runtime-cost native backend to carry a `MemorySink` and build `Tailtriage` with `.sink(sink.clone())` instead of a direct `.output(...)` file sink (update in `demos/runtime_cost/src/main.rs`).
- On finalization, shutdown the `RuntimeSampler` (if present), call `tailtriage.shutdown()?`, then obtain the finalized `Run` from `sink.last_run()` and return it to the common `write_run_artifact` path so the artifact is written exactly once.
- Preserve all existing demo modes, artifact file names, and the single shared `write_run_artifact` writer; baseline still produces no artifact and other behavior is unchanged.
- Update `validate-tracing-parity` help text to say it covers demo scenarios "including runtime-sensitive demos" (`scripts/demo_tool.py`).
- Add an optional, compact human-readable overhead ratio table printed to stdout in `scripts/measure_runtime_cost.py` that uses existing `tracing_vs_native_ratios` and prints `n/a` for null ratios without changing the summary JSON schema.

### Testing
- Ran `cargo fmt --check` (passed).
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (passed).
- Ran `cargo test --workspace --all-targets --all-features --locked` (passed all tests).
- Ran `python3 scripts/validate_docs_contracts.py` (passed).
- Ran `python3 scripts/demo_tool.py validate-tracing-parity all --profile release` (parity checks wrote artifacts and passed).
- Ran `python3 scripts/measure_runtime_cost.py --requests 1200 --concurrency 32 --work-ms 4 --rounds 2 --warmup-rounds 1 --artifact-dir demos/runtime_cost/artifacts/ci-smoke` (completed and printed summary and compact ratio table).
- Ran `python3 scripts/validate_runtime_cost_summary.py --raw demos/runtime_cost/artifacts/ci-smoke/runtime-cost-raw.jsonl --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ab182379083308e3648f06ce6e720)