### PR TITLE
Use MemorySink for native runtime-cost finalization; update tracing-parity help text

### DIFF
--- a/demos/runtime_cost/src/main.rs
+++ b/demos/runtime_cost/src/main.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use anyhow::{anyhow, bail, Context};
 use serde::Serialize;
 use tailtriage_analyzer::{render_json_pretty, try_analyze_run, AnalyzeOptions};
-use tailtriage_core::{CaptureLimitsOverride, CaptureMode, Run, Tailtriage};
+use tailtriage_core::{CaptureLimitsOverride, CaptureMode, MemorySink, Run, Tailtriage};
 use tailtriage_tokio::RuntimeSampler;
 use tailtriage_tracing::tokio::TracingTokioSession;
 use tailtriage_tracing::TracingRecorder;
@@ -162,6 +162,7 @@ enum Backend {
     Native {
         tailtriage: Arc<Tailtriage>,
         sampler: Option<RuntimeSampler>,
+        sink: MemorySink,
     },
     TracingRecorder {
         rec: TracingRecorder,
@@ -255,13 +256,8 @@ fn build_backend(cli: &Cli) -> anyhow::Result<Backend> {
                 .mode
                 .core_mode()
                 .ok_or_else(|| anyhow!("missing capture mode"))?;
-            let mut b = Tailtriage::builder("runtime_cost_demo").output(
-                cli.output_dir.join(
-                    cli.mode
-                        .artifact_file_name()
-                        .context("missing artifact filename")?,
-                ),
-            );
+            let sink = MemorySink::new();
+            let mut b = Tailtriage::builder("runtime_cost_demo").sink(sink.clone());
             b = match mode {
                 CaptureMode::Light => b.light(),
                 CaptureMode::Investigation => b.investigation(),
@@ -284,6 +280,7 @@ fn build_backend(cli: &Cli) -> anyhow::Result<Backend> {
             Ok(Backend::Native {
                 tailtriage: tt,
                 sampler,
+                sink,
             })
         }
         InstrumentationKind::Tracing => {
@@ -323,13 +320,15 @@ async fn finalize_backend_and_write_artifact(
         Backend::Native {
             tailtriage,
             sampler,
+            sink,
         } => {
             if let Some(s) = sampler {
                 s.shutdown().await;
             }
-            let run = tailtriage.snapshot();
             tailtriage.shutdown()?;
-            Some(run)
+            Some(sink.last_run().ok_or_else(|| {
+                anyhow!("native runtime-cost run sink did not receive finalized run")
+            })?)
         }
         Backend::TracingRecorder { rec } => Some(rec.shutdown()?.into_parts().0),
         Backend::TracingTokio { session } => Some(session.shutdown().await?.into_parts().0),
@@ -538,6 +537,35 @@ fn micros_to_millis_f64(m: u64) -> anyhow::Result<f64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[tokio::test(flavor = "current_thread")]
+    async fn native_finalize_reads_finalized_run_from_memory_sink() {
+        let output_dir = std::env::temp_dir().join(format!(
+            "tailtriage-runtime-cost-test-{}",
+            std::process::id()
+        ));
+        let cli = Cli {
+            mode: Mode::CoreLight,
+            requests: 1,
+            concurrency: 1,
+            work_ms: 1,
+            output_dir: output_dir.clone(),
+        };
+        std::fs::create_dir_all(&output_dir).expect("create output dir");
+        let mut backend = build_backend(&cli).expect("build backend");
+        let (latencies, _) = run_requests(&cli, &backend).await.expect("run requests");
+        assert_eq!(latencies.len(), 1);
+        let (run, artifact_path) = finalize_backend_and_write_artifact(&cli, &mut backend)
+            .await
+            .expect("finalize and write");
+        let run = run.expect("native run should exist");
+        assert!(!run.requests.is_empty());
+        let artifact_path = artifact_path.expect("artifact path should exist");
+        assert_eq!(
+            PathBuf::from(artifact_path),
+            output_dir.join("run-core_light.json")
+        );
+    }
+
     #[test]
     fn mode_parse_accepts_tracing_modes() {
         assert_eq!(Mode::parse("tracing_light"), Some(Mode::TracingLight));

--- a/scripts/demo_tool.py
+++ b/scripts/demo_tool.py
@@ -1091,7 +1091,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
     parity_parser = subparsers.add_parser(
         "validate-tracing-parity",
-        help="Run native/tracing parity checks for supported non-runtime-sensitive demos.",
+        help="Run native/tracing parity checks for demo scenarios, including runtime-sensitive demos.",
     )
     parity_parser.add_argument("scenario", choices=PARITY_SCENARIOS)
     parity_parser.add_argument("--profile", choices=PROFILE_CHOICES, default="dev")

--- a/scripts/measure_runtime_cost.py
+++ b/scripts/measure_runtime_cost.py
@@ -504,6 +504,30 @@ def main() -> None:
             print(f" - {reason}", file=sys.stderr)
 
     print(json.dumps(summary, indent=2))
+    ratios = summary.get("tracing_vs_native_ratios", {})
+    rows = (
+        (
+            "tracing_light / core_light",
+            ratios.get("tracing_light_vs_core_light_latency_p95"),
+            ratios.get("tracing_light_vs_core_light_throughput"),
+        ),
+        (
+            "tracing_sampler / native_sampler",
+            ratios.get("tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95"),
+            ratios.get("tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput"),
+        ),
+        (
+            "tracing_drop_path / native_drop_path",
+            ratios.get("tracing_light_drop_path_vs_core_light_drop_path_latency_p95"),
+            ratios.get("tracing_light_drop_path_vs_core_light_drop_path_throughput"),
+        ),
+    )
+    print("| comparison | p95 ratio | throughput ratio |")
+    print("|---|---:|---:|")
+    for name, p95_ratio, throughput_ratio in rows:
+        p95_text = "n/a" if p95_ratio is None else f"{p95_ratio:.2f}x"
+        throughput_text = "n/a" if throughput_ratio is None else f"{throughput_ratio:.2f}x"
+        print(f"| {name} | {p95_text} | {throughput_text} |")
     print(f"raw results: {raw_path}")
     print(f"summary: {summary_path}")
 


### PR DESCRIPTION
### Motivation
- Prevent native runtime-cost finalization from writing a pre-shutdown snapshot to disk and biasing native artifact finalize timing by finalizing native runs in-memory like tracing does.
- Make `validate-tracing-parity` help text accurate about including runtime-sensitive demos.

### Description
- Switch the runtime-cost demo native backend to use `MemorySink` by adding `sink: MemorySink` to `Backend::Native` and building `Tailtriage` with `.sink(sink.clone())` instead of direct `.output(...)` (file: `demos/runtime_cost/src/main.rs`).
- Change finalization ordering for native backend to: shutdown sampler (if present) → call `tailtriage.shutdown()` → read the finalized `Run` from `sink.last_run()` and return it to the common writer, ensuring the artifact is written exactly once via `write_run_artifact` (file: `demos/runtime_cost/src/main.rs`).
- Add a focused async test `native_finalize_reads_finalized_run_from_memory_sink` that builds a native backend, runs a single request, finalizes, and verifies a finalized `Run` and the expected artifact path (file: `demos/runtime_cost/src/main.rs`).
- Update `validate-tracing-parity` subcommand help text to: `Run native/tracing parity checks for demo scenarios, including runtime-sensitive demos.` (file: `scripts/demo_tool.py`).
- Optionally print a compact human-readable overhead ratio table to stdout in `scripts/measure_runtime_cost.py` using existing `tracing_vs_native_ratios` without changing the JSON summary schema (file: `scripts/measure_runtime_cost.py`).

### Testing
- Ran `cargo fmt --check` (passed).
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (passed).
- Ran `cargo test --workspace --all-targets --all-features --locked` and the new demo unit test passed (all tests passed).
- Ran `python3 scripts/validate_docs_contracts.py` (passed).
- Ran `python3 scripts/demo_tool.py validate-tracing-parity all --profile release` (passed).
- Ran the smoke measurement `python3 scripts/measure_runtime_cost.py --requests 1200 --concurrency 32 --work-ms 4 --rounds 2 --warmup-rounds 1 --artifact-dir demos/runtime_cost/artifacts/ci-smoke` and it completed and produced the expected outputs (passed).
- Ran `python3 scripts/validate_runtime_cost_summary.py --raw demos/runtime_cost/artifacts/ci-smoke/runtime-cost-raw.jsonl --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ab182379083308e3648f06ce6e720)