### PR TITLE
Fix runtime-cost native finalization parity and update tracing parity help text

### DIFF
--- a/demos/runtime_cost/src/main.rs
+++ b/demos/runtime_cost/src/main.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use anyhow::{anyhow, bail, Context};
 use serde::Serialize;
 use tailtriage_analyzer::{render_json_pretty, try_analyze_run, AnalyzeOptions};
-use tailtriage_core::{CaptureLimitsOverride, CaptureMode, Run, Tailtriage};
+use tailtriage_core::{CaptureLimitsOverride, CaptureMode, MemorySink, Run, Tailtriage};
 use tailtriage_tokio::RuntimeSampler;
 use tailtriage_tracing::tokio::TracingTokioSession;
 use tailtriage_tracing::TracingRecorder;
@@ -162,6 +162,7 @@ enum Backend {
     Native {
         tailtriage: Arc<Tailtriage>,
         sampler: Option<RuntimeSampler>,
+        sink: MemorySink,
     },
     TracingRecorder {
         rec: TracingRecorder,
@@ -255,13 +256,8 @@ fn build_backend(cli: &Cli) -> anyhow::Result<Backend> {
                 .mode
                 .core_mode()
                 .ok_or_else(|| anyhow!("missing capture mode"))?;
-            let mut b = Tailtriage::builder("runtime_cost_demo").output(
-                cli.output_dir.join(
-                    cli.mode
-                        .artifact_file_name()
-                        .context("missing artifact filename")?,
-                ),
-            );
+            let sink = MemorySink::new();
+            let mut b = Tailtriage::builder("runtime_cost_demo").sink(sink.clone());
             b = match mode {
                 CaptureMode::Light => b.light(),
                 CaptureMode::Investigation => b.investigation(),
@@ -284,6 +280,7 @@ fn build_backend(cli: &Cli) -> anyhow::Result<Backend> {
             Ok(Backend::Native {
                 tailtriage: tt,
                 sampler,
+                sink,
             })
         }
         InstrumentationKind::Tracing => {
@@ -323,12 +320,15 @@ async fn finalize_backend_and_write_artifact(
         Backend::Native {
             tailtriage,
             sampler,
+            sink,
         } => {
             if let Some(s) = sampler {
                 s.shutdown().await;
             }
-            let run = tailtriage.snapshot();
             tailtriage.shutdown()?;
+            let run = sink.last_run().ok_or_else(|| {
+                anyhow!("native runtime-cost run sink did not receive finalized run")
+            })?;
             Some(run)
         }
         Backend::TracingRecorder { rec } => Some(rec.shutdown()?.into_parts().0),

--- a/scripts/demo_tool.py
+++ b/scripts/demo_tool.py
@@ -1091,7 +1091,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
     parity_parser = subparsers.add_parser(
         "validate-tracing-parity",
-        help="Run native/tracing parity checks for supported non-runtime-sensitive demos.",
+        help="Run native/tracing parity checks for demo scenarios, including runtime-sensitive demos.",
     )
     parity_parser.add_argument("scenario", choices=PARITY_SCENARIOS)
     parity_parser.add_argument("--profile", choices=PROFILE_CHOICES, default="dev")

--- a/scripts/measure_runtime_cost.py
+++ b/scripts/measure_runtime_cost.py
@@ -504,6 +504,29 @@ def main() -> None:
             print(f" - {reason}", file=sys.stderr)
 
     print(json.dumps(summary, indent=2))
+    ratios = summary.get("tracing_vs_native_ratios", {})
+
+    def ratio_text(key: str) -> str:
+        value = ratios.get(key)
+        return f"{value:.2f}x" if isinstance(value, (int, float)) and value is not None else "n/a"
+
+    print("| comparison | p95 ratio | throughput ratio |")
+    print("|---|---:|---:|")
+    print(
+        "| tracing_light / core_light | "
+        f"{ratio_text('tracing_light_vs_core_light_latency_p95')} | "
+        f"{ratio_text('tracing_light_vs_core_light_throughput')} |"
+    )
+    print(
+        "| tracing_sampler / native_sampler | "
+        f"{ratio_text('tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95')} | "
+        f"{ratio_text('tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput')} |"
+    )
+    print(
+        "| tracing_drop_path / native_drop_path | "
+        f"{ratio_text('tracing_light_drop_path_vs_core_light_drop_path_latency_p95')} | "
+        f"{ratio_text('tracing_light_drop_path_vs_core_light_drop_path_throughput')} |"
+    )
     print(f"raw results: {raw_path}")
     print(f"summary: {summary_path}")
 


### PR DESCRIPTION
### Motivation
- Native runtime-cost runs were snapshotting before `shutdown()`, allowing the pre-shutdown snapshot to be written and overwriting the finalized artifact which biased native finalization timing. 
- The goal is to make native and tracing runtime-cost finalization paths comparable by finalizing native runs to memory first and writing the finalized `Run` exactly once via the common writer. 

### Description
- Change the native demo backend to carry a `MemorySink` in `Backend::Native` and build `Tailtriage` with `.sink(sink.clone())` instead of direct `.output(...)` to avoid writing artifacts before finalization. 
- In `finalize_backend_and_write_artifact` shut down the sampler (if any), call `tailtriage.shutdown()`, then obtain the finalized `Run` from `sink.last_run()` and return it to the common writer so artifact files are written exactly once by `write_run_artifact`. 
- Preserve artifact file names, modes, workload shape, truncation behavior, and all existing runtime-cost modes and semantics. 
- Update `validate-tracing-parity` CLI help text to include runtime-sensitive demos. 
- Add a compact human-readable overhead ratio table to `scripts/measure_runtime_cost.py` that prints selected `tracing_vs_native_ratios` rows without changing the summary JSON schema and that prints `n/a` for null ratios. 

### Testing
- Ran formatting and static checks: `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, both succeeded. 
- Ran the full test suite with `cargo test --workspace --all-targets --all-features --locked`, which passed. 
- Ran docs contract validation with `python3 scripts/validate_docs_contracts.py`, which passed. 
- Ran the parity validator `python3 scripts/demo_tool.py validate-tracing-parity all --profile release`, which completed successfully. 
- Exercised the runtime-cost measurement flow with `python3 scripts/measure_runtime_cost.py --requests 1200 --concurrency 32 --work-ms 4 --rounds 2 --warmup-rounds 1 --artifact-dir demos/runtime_cost/artifacts/ci-smoke`, which completed and printed the optional ratio table. 
- Validated runtime-cost summary with `python3 scripts/validate_runtime_cost_summary.py --raw demos/runtime_cost/artifacts/ci-smoke/runtime-cost-raw.jsonl --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ab182379083308e3648f06ce6e720)