### PR TITLE
Fix runtime-cost native finalization via MemorySink and update tracing-parity help text

### DIFF
--- a/demos/runtime_cost/src/main.rs
+++ b/demos/runtime_cost/src/main.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use anyhow::{anyhow, bail, Context};
 use serde::Serialize;
 use tailtriage_analyzer::{render_json_pretty, try_analyze_run, AnalyzeOptions};
-use tailtriage_core::{CaptureLimitsOverride, CaptureMode, Run, Tailtriage};
+use tailtriage_core::{CaptureLimitsOverride, CaptureMode, MemorySink, Run, Tailtriage};
 use tailtriage_tokio::RuntimeSampler;
 use tailtriage_tracing::tokio::TracingTokioSession;
 use tailtriage_tracing::TracingRecorder;
@@ -162,6 +162,7 @@ enum Backend {
     Native {
         tailtriage: Arc<Tailtriage>,
         sampler: Option<RuntimeSampler>,
+        sink: MemorySink,
     },
     TracingRecorder {
         rec: TracingRecorder,
@@ -255,13 +256,8 @@ fn build_backend(cli: &Cli) -> anyhow::Result<Backend> {
                 .mode
                 .core_mode()
                 .ok_or_else(|| anyhow!("missing capture mode"))?;
-            let mut b = Tailtriage::builder("runtime_cost_demo").output(
-                cli.output_dir.join(
-                    cli.mode
-                        .artifact_file_name()
-                        .context("missing artifact filename")?,
-                ),
-            );
+            let sink = MemorySink::new();
+            let mut b = Tailtriage::builder("runtime_cost_demo").sink(sink.clone());
             b = match mode {
                 CaptureMode::Light => b.light(),
                 CaptureMode::Investigation => b.investigation(),
@@ -284,6 +280,7 @@ fn build_backend(cli: &Cli) -> anyhow::Result<Backend> {
             Ok(Backend::Native {
                 tailtriage: tt,
                 sampler,
+                sink,
             })
         }
         InstrumentationKind::Tracing => {
@@ -323,12 +320,15 @@ async fn finalize_backend_and_write_artifact(
         Backend::Native {
             tailtriage,
             sampler,
+            sink,
         } => {
             if let Some(s) = sampler {
                 s.shutdown().await;
             }
-            let run = tailtriage.snapshot();
             tailtriage.shutdown()?;
+            let run = sink.last_run().ok_or_else(|| {
+                anyhow!("native runtime-cost run sink did not receive finalized run")
+            })?;
             Some(run)
         }
         Backend::TracingRecorder { rec } => Some(rec.shutdown()?.into_parts().0),
@@ -538,6 +538,7 @@ fn micros_to_millis_f64(m: u64) -> anyhow::Result<f64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
     #[test]
     fn mode_parse_accepts_tracing_modes() {
         assert_eq!(Mode::parse("tracing_light"), Some(Mode::TracingLight));
@@ -560,5 +561,43 @@ mod tests {
         assert_eq!(m.instrumentation(), InstrumentationKind::Tracing);
         assert!(m.uses_runtime_sampler());
         assert!(!m.uses_drop_path_limits());
+    }
+
+    #[test]
+    fn native_backend_uses_memory_sink() {
+        let cli = Cli {
+            mode: Mode::CoreLight,
+            requests: DEFAULT_REQUESTS,
+            concurrency: DEFAULT_CONCURRENCY,
+            work_ms: DEFAULT_WORK_MS,
+            output_dir: PathBuf::from("unused"),
+        };
+        let backend = build_backend(&cli).expect("native backend should build");
+        match backend {
+            Backend::Native { sink, .. } => assert!(sink.last_run().is_none()),
+            _ => panic!("expected native backend"),
+        }
+    }
+
+    #[test]
+    fn artifact_file_name_still_derived_from_mode() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time should be after unix epoch")
+            .as_nanos();
+        let output_dir = PathBuf::from(format!("/tmp/tailtriage-runtime-cost-test-{unique}"));
+        let cli = Cli {
+            mode: Mode::CoreLight,
+            requests: DEFAULT_REQUESTS,
+            concurrency: DEFAULT_CONCURRENCY,
+            work_ms: DEFAULT_WORK_MS,
+            output_dir: output_dir.clone(),
+        };
+        let artifact_name = cli
+            .mode
+            .artifact_file_name()
+            .expect("core mode should still provide artifact filename");
+        let derived_path = cli.output_dir.join(artifact_name);
+        assert!(derived_path.ends_with("run-core_light.json"));
     }
 }

--- a/scripts/demo_tool.py
+++ b/scripts/demo_tool.py
@@ -1091,7 +1091,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
     parity_parser = subparsers.add_parser(
         "validate-tracing-parity",
-        help="Run native/tracing parity checks for supported non-runtime-sensitive demos.",
+        help="Run native/tracing parity checks for demo scenarios, including runtime-sensitive demos.",
     )
     parity_parser.add_argument("scenario", choices=PARITY_SCENARIOS)
     parity_parser.add_argument("--profile", choices=PROFILE_CHOICES, default="dev")

--- a/scripts/measure_runtime_cost.py
+++ b/scripts/measure_runtime_cost.py
@@ -504,6 +504,28 @@ def main() -> None:
             print(f" - {reason}", file=sys.stderr)
 
     print(json.dumps(summary, indent=2))
+    ratios = summary["tracing_vs_native_ratios"]
+    print("| comparison | p95 ratio | throughput ratio |")
+    print("|---|---:|---:|")
+
+    def format_ratio(value: float | None) -> str:
+        return "n/a" if value is None else f"{value:.2f}x"
+
+    print(
+        "| tracing_light / core_light | "
+        f"{format_ratio(ratios.get('tracing_light_vs_core_light_latency_p95'))} | "
+        f"{format_ratio(ratios.get('tracing_light_vs_core_light_throughput'))} |"
+    )
+    print(
+        "| tracing_sampler / native_sampler | "
+        f"{format_ratio(ratios.get('tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95'))} | "
+        f"{format_ratio(ratios.get('tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput'))} |"
+    )
+    print(
+        "| tracing_drop_path / native_drop_path | "
+        f"{format_ratio(ratios.get('tracing_light_drop_path_vs_core_light_drop_path_latency_p95'))} | "
+        f"{format_ratio(ratios.get('tracing_light_drop_path_vs_core_light_drop_path_throughput'))} |"
+    )
     print(f"raw results: {raw_path}")
     print(f"summary: {summary_path}")
 


### PR DESCRIPTION
### Motivation

- Prevent the native runtime-cost path from writing a pre-shutdown snapshot file that overwrote the finalized native artifact and biased finalize-time measurements.
- Make native runtime-cost finalization produce the same finalized `Run` artifact shape as tracing backends (finalize to memory then write once), so overhead comparisons are comparable.
- Keep all existing runtime-cost modes, artifact filenames, and CI/test layout unchanged.

### Description

- Changed the runtime-cost `Backend::Native` shape to include a `MemorySink` and build `Tailtriage` with `.sink(sink.clone())` instead of setting a direct `.output(...)` path so native finalization writes into memory first.
- Updated `finalize_backend_and_write_artifact` to: shutdown optional `RuntimeSampler`, call `tailtriage.shutdown()?`, then obtain the finalized `Run` from `sink.last_run()` and return it to the common `write_run_artifact` writer so the artifact is written exactly once.
- Kept `write_run_artifact` and artifact filename derivation unchanged so file names and writer semantics remain centralized and stable.
- Fixed stale help text for `validate-tracing-parity` to include runtime-sensitive demos.
- Added focused unit tests in `demos/runtime_cost` verifying the native backend uses `MemorySink` and that artifact filenames are still derived from the mode, and added a compact human-readable overhead ratio table printout to `scripts/measure_runtime_cost.py` that is null-safe and does not change the summary JSON schema.

### Testing

- Ran `cargo fmt --check` which passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which passed.
- Ran `cargo test --workspace --all-targets --all-features --locked` which failed due to an existing analyzer end-to-end test in the current branch state (`tailtriage-analyzer::end_to_end_capture_analysis::queue_and_stage_data_drives_ranked_suspects`), not related to the runtime-cost changes; other unit tests (including the added runtime_cost tests) passed.
- Ran `python3 scripts/validate_docs_contracts.py` which passed.
- Ran `python3 scripts/demo_tool.py validate-tracing-parity all --profile release` which completed successfully.
- Ran the runtime-cost measurement smoke `python3 scripts/measure_runtime_cost.py --requests 1200 --concurrency 32 --work-ms 4 --rounds 2 --warmup-rounds 1 --artifact-dir demos/runtime_cost/artifacts/ci-smoke` which completed and produced the summary JSON plus the compact ratio table.
- Ran `python3 scripts/validate_runtime_cost_summary.py --raw demos/runtime_cost/artifacts/ci-smoke/runtime-cost-raw.jsonl --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ab182379083308e3648f06ce6e720)