### PR TITLE
Finalize tracing JSONL intake: ignore unrelated malformed spans, support normalized duration_us, and surface open-span warnings

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -44,6 +44,8 @@ Supported stable contract (recommended for tests and integrations):
 Notes:
 
 - Importer accepts `started_at_unix_ms`/`finished_at_unix_ms` and aliases `start_unix_ms`/`end_unix_ms`.
+- Normalized spans require both start/end timestamps even when `duration_us` is present.
+- Optional `duration_us` is unsigned integer microseconds; when present, it overrides latency/wait derived from start/end timestamps for request, stage, and queue triage values.
 - In this phase, normalized shape uses **literal dotted keys** inside `fields` (for example `"tt.kind"` and `"tt.request_id"`), not nested objects that require flattening.
 - Importer reads `tt.*` fields from `fields`, `span.fields`, or top-level `tt.*` keys when present.
 - Scalars can be strings, bools, numbers, or null.
@@ -66,8 +68,6 @@ this phase, the importer supports:
 
 - normalized completed-span JSONL (shape above), and
 - close-event-like records only when they include explicit start/end unix-ms timestamps.
-
-Close-event-like records are supported only when explicit unix-ms start/end timestamps are present; timing is not guessed from line receive time, and broad compatibility with arbitrary tracing JSON is not claimed.
 
 ## Intended field shape
 

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -84,6 +84,7 @@ fn parse_record(
     strict: bool,
     warnings: &mut Vec<crate::ImportWarning>,
 ) -> Result<Option<SpanRecord>, ImportError> {
+    let has_tt = value_has_tailtriage_field(value);
     if let Some(span_obj) = value.get("span").and_then(Value::as_object) {
         if span_obj.contains_key("name")
             && (span_obj.contains_key("started_at_unix_ms")
@@ -91,9 +92,12 @@ fn parse_record(
             && (span_obj.contains_key("finished_at_unix_ms")
                 || span_obj.contains_key("end_unix_ms"))
         {
+            if !has_tt {
+                return Ok(None);
+            }
             return match parse_normalized_span(span_obj) {
                 Ok(span) => Ok(Some(span)),
-                Err(err) if value_has_tailtriage_field(value) => {
+                Err(err) if has_tt => {
                     let message = format!("line {line_no}: {err}");
                     if strict {
                         Err(ImportError::StrictViolation(message))
@@ -105,7 +109,7 @@ fn parse_record(
                 Err(err) => Err(err),
             };
         }
-        if value_has_tailtriage_field(value) && !indicates_close_event(value) {
+        if has_tt && !indicates_close_event(value) {
             let message = format!(
                 "line {line_no}: invalid field `span`: tailtriage span must include name, started_at_unix_ms/start_unix_ms, and finished_at_unix_ms/end_unix_ms"
             );
@@ -119,7 +123,7 @@ fn parse_record(
 
     match parse_close_event_shape(value) {
         Ok(result) => Ok(result),
-        Err(err) if value_has_tailtriage_field(value) => {
+        Err(err) if has_tt => {
             let message = format!("line {line_no}: {err}");
             if strict {
                 Err(ImportError::StrictViolation(message))
@@ -163,6 +167,15 @@ fn parse_normalized_span(
     }
     if let Some(parent_id) = parent_id {
         span = span.parent_id(parent_id);
+    }
+    if let Some(duration_us) = span_obj.get("duration_us") {
+        let duration_us = duration_us
+            .as_u64()
+            .ok_or_else(|| ImportError::InvalidField {
+                field: "duration_us",
+                reason: "expected unsigned integer microseconds as u64".to_owned(),
+            })?;
+        span = span.duration_us(duration_us);
     }
 
     let fields = extract_fields_for_span(&Value::Object(span_obj.clone()));
@@ -511,6 +524,67 @@ mod tests {
         let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
             .unwrap_err();
         assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn malformed_unrelated_normalized_spans_are_ignored() {
+        let input = r#"
+{"span":{"name":"req","id":123,"started_at_unix_ms":1,"finished_at_unix_ms":2}}
+{"span":{"name":"req","parent_id":{},"started_at_unix_ms":1,"finished_at_unix_ms":2}}
+{"span":{"name":123,"started_at_unix_ms":1,"finished_at_unix_ms":2}}
+"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.warnings().is_empty());
+    }
+
+    #[test]
+    fn malformed_tt_normalized_spans_warn_non_strict_error_strict() {
+        for input in [
+            r#"{"span":{"name":"req","id":123,"started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request"}}}"#,
+            r#"{"span":{"name":"req","parent_id":{},"started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request"}}}"#,
+            r#"{"span":{"name":123,"started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request"}}}"#,
+        ] {
+            let imported =
+                import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+            assert_eq!(imported.warnings().len(), 1);
+            let err =
+                import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+                    .unwrap_err();
+            assert!(matches!(err, ImportError::StrictViolation(_)));
+        }
+    }
+
+    #[test]
+    fn normalized_duration_us_overrides_request_stage_queue_latency() {
+        let input = r#"
+{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":1234,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
+{"span":{"name":"st","started_at_unix_ms":11,"finished_at_unix_ms":18,"duration_us":1234,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
+{"span":{"name":"q","started_at_unix_ms":10,"finished_at_unix_ms":11,"duration_us":1234,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":3}}}
+"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests[0].latency_us, 1234);
+        assert_eq!(imported.run().stages[0].latency_us, 1234);
+        assert_eq!(imported.run().queues[0].wait_us, 1234);
+    }
+
+    #[test]
+    fn invalid_duration_us_tt_span_warns_non_strict_errors_strict() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"duration_us":"bad","fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert_eq!(imported.warnings().len(), 1);
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+            .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn invalid_duration_us_unrelated_normalized_span_is_ignored() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"duration_us":"bad"}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.warnings().is_empty());
     }
 
     #[test]

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::fmt;
+use std::fmt::Write as _;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -69,6 +70,15 @@ struct OpenSpan {
     fields: BTreeMap<String, FieldValue>,
     started_at_unix_ms: u64,
     started_instant: Instant,
+    is_candidate: bool,
+}
+
+#[derive(Debug, Clone)]
+struct OpenSpanSample {
+    name: String,
+    id: Option<String>,
+    tt_kind: Option<String>,
+    tt_request_id: Option<String>,
 }
 
 fn lock_state(state: &Arc<Mutex<RecorderState>>) -> std::sync::MutexGuard<'_, RecorderState> {
@@ -102,12 +112,29 @@ impl TracingRecorder {
     ///
     /// Returns [`ImportError`] when strict conversion fails.
     pub fn snapshot_run(&self) -> Result<ImportedRun, ImportError> {
-        let (spans, dropped_open_spans, dropped_completed_spans) = {
+        let (
+            spans,
+            dropped_open_spans,
+            dropped_completed_spans,
+            open_candidate_count,
+            open_candidate_samples,
+        ) = {
             let state = lock_state(&self.state);
+            let open_candidates: Vec<&OpenSpan> = state
+                .open
+                .values()
+                .filter(|span| span.is_candidate)
+                .collect();
             (
                 state.completed.clone(),
                 state.dropped_open_spans,
                 state.dropped_completed_spans,
+                open_candidates.len(),
+                open_candidates
+                    .into_iter()
+                    .take(3)
+                    .map(open_span_sample)
+                    .collect::<Vec<_>>(),
             )
         };
         imported_with_drop_warnings(
@@ -115,6 +142,8 @@ impl TracingRecorder {
             self.options.clone(),
             dropped_open_spans,
             dropped_completed_spans,
+            open_candidate_count,
+            &open_candidate_samples,
         )
     }
 
@@ -213,6 +242,7 @@ where
             fields: visitor.fields,
             started_at_unix_ms: tailtriage_core::unix_time_ms(),
             started_instant: Instant::now(),
+            is_candidate: metadata_candidate || initial_candidate,
         };
         state.open.insert(id.into_u64().to_string(), open_span);
     }
@@ -274,12 +304,25 @@ fn imported_with_drop_warnings(
     options: ImportOptions,
     dropped_open_spans: u64,
     dropped_completed_spans: u64,
+    open_candidate_count: usize,
+    open_candidate_samples: &[OpenSpanSample],
 ) -> Result<ImportedRun, ImportError> {
+    if options.strict_mode() && open_candidate_count > 0 {
+        return Err(ImportError::StrictViolation(open_candidates_warning(
+            open_candidate_count,
+            open_candidate_samples,
+        )));
+    }
     let imported = run_from_span_records(spans, options)?;
-    if dropped_open_spans == 0 && dropped_completed_spans == 0 {
+    if dropped_open_spans == 0 && dropped_completed_spans == 0 && open_candidate_count == 0 {
         return Ok(imported);
     }
     let (mut run, mut warnings) = imported.into_parts();
+    if open_candidate_count > 0 {
+        let msg = open_candidates_warning(open_candidate_count, open_candidate_samples);
+        run.metadata.lifecycle_warnings.push(msg.clone());
+        warnings.push(crate::ImportWarning::new(msg));
+    }
     if dropped_open_spans > 0 {
         let msg = format!("live recorder dropped {dropped_open_spans} candidate spans because max_open_spans was reached");
         run.metadata.lifecycle_warnings.push(msg.clone());
@@ -292,6 +335,54 @@ fn imported_with_drop_warnings(
     }
     run.truncation.limits_hit = true;
     Ok(ImportedRun::new(run, warnings))
+}
+
+fn open_span_sample(span: &OpenSpan) -> OpenSpanSample {
+    OpenSpanSample {
+        name: span.name.clone(),
+        id: span.id.clone(),
+        tt_kind: scalar_string(span.fields.get("tt.kind")),
+        tt_request_id: scalar_string(span.fields.get("tt.request_id")),
+    }
+}
+
+fn scalar_string(value: Option<&FieldValue>) -> Option<String> {
+    match value {
+        Some(FieldValue::String(v)) => Some(v.clone()),
+        Some(FieldValue::Bool(v)) => Some(v.to_string()),
+        Some(FieldValue::I64(v)) => Some(v.to_string()),
+        Some(FieldValue::U64(v)) => Some(v.to_string()),
+        Some(FieldValue::F64(v)) => Some(v.to_string()),
+        Some(FieldValue::Null) | None => None,
+    }
+}
+
+fn open_candidates_warning(count: usize, samples: &[OpenSpanSample]) -> String {
+    let mut msg = format!(
+        "live recorder observed {count} open candidate span(s) at snapshot/shutdown; incomplete spans are not converted into fabricated completions"
+    );
+    if !samples.is_empty() {
+        let rendered = samples
+            .iter()
+            .map(|s| {
+                let mut sample = format!("name={}", s.name);
+                if let Some(id) = &s.id {
+                    let _ = write!(sample, ", id={id}");
+                }
+                if let Some(tt_kind) = &s.tt_kind {
+                    let _ = write!(sample, ", tt.kind={tt_kind}");
+                }
+                if let Some(tt_request_id) = &s.tt_request_id {
+                    let _ = write!(sample, ", tt.request_id={tt_request_id}");
+                }
+                sample
+            })
+            .collect::<Vec<_>>()
+            .join(" | ");
+        msg.push_str("; samples: ");
+        msg.push_str(&rendered);
+    }
+    msg
 }
 
 #[derive(Default)]
@@ -625,5 +716,84 @@ mod tests {
         let recorder = TracingRecorder::builder(" ").build();
         let err = recorder.snapshot_run().unwrap_err();
         assert!(matches!(err, ImportError::EmptyServiceName));
+    }
+
+    #[test]
+    fn open_candidate_non_strict_snapshot_warns_and_has_zero_requests() {
+        let recorder = TracingRecorder::builder("svc").build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let _span = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            );
+            let imported = recorder.snapshot_run().unwrap();
+            assert_eq!(imported.run().requests.len(), 0);
+            assert!(imported.warnings()[0]
+                .message()
+                .contains("open candidate span(s) at snapshot/shutdown"));
+            assert!(imported.warnings()[0].message().contains("name=request"));
+            assert!(imported.warnings()[0].message().contains("tt.kind=request"));
+            assert!(imported
+                .run()
+                .metadata
+                .lifecycle_warnings
+                .iter()
+                .any(|w| w.contains("open candidate span(s) at snapshot/shutdown")));
+        });
+    }
+
+    #[test]
+    fn open_candidate_non_strict_shutdown_warns() {
+        let recorder = TracingRecorder::builder("svc").build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let _span = tracing::info_span!("request", tt.kind = "request", tt.request_id = "r1");
+            let imported = recorder.shutdown().unwrap();
+            assert!(imported.warnings().iter().any(|w| w
+                .message()
+                .contains("open candidate span(s) at snapshot/shutdown")));
+        });
+    }
+
+    #[test]
+    fn open_candidate_strict_snapshot_errors() {
+        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let _span = tracing::info_span!("request", tt.kind = "request", tt.request_id = "r1");
+            let err = recorder.snapshot_run().unwrap_err();
+            assert!(matches!(err, ImportError::StrictViolation(_)));
+        });
+    }
+
+    #[test]
+    fn unrelated_open_span_does_not_warn() {
+        let recorder = TracingRecorder::builder("svc").build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let _span = tracing::info_span!("ordinary", foo = 1_u64);
+            let imported = recorder.snapshot_run().unwrap();
+            assert!(imported.warnings().is_empty());
+        });
+    }
+
+    #[test]
+    fn empty_tt_kind_open_span_still_counts_as_candidate() {
+        let recorder = TracingRecorder::builder("svc").build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let _span = tracing::info_span!(
+                "request",
+                tt.kind = tracing::field::Empty,
+                tt.request_id = "r1"
+            );
+            let imported = recorder.snapshot_run().unwrap();
+            assert!(imported.warnings().iter().any(|w| w
+                .message()
+                .contains("open candidate span(s) at snapshot/shutdown")));
+        });
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent malformed unrelated normalized `{"span": {...}}` records from causing fatal import errors by ensuring only records with `tt.*` fields are treated as tailtriage span failures. 
- Allow normalized JSONL producers to supply an explicit `duration_us` (microseconds) to override duration derived from start/end timestamps for request/stage/queue triage values. 
- Ensure live recorder snapshot/shutdown surfaces tracked but still-open `tt.*` candidate spans as lifecycle warnings in non-strict mode and as strict failures in strict mode without fabricating completions.

### Description
- Compute `has_tt` early in `parse_record` and return `Ok(None)` for normalized `span` shapes that are malformed but contain no `tt.*` fields, preserving fatal behavior for malformed JSON syntax and strict/non-strict handling for `tt.*` records (file: `tailtriage-tracing/src/jsonl.rs`).
- Parse optional normalized `duration_us` (only unsigned integer JSON numbers) in `parse_normalized_span` and call `SpanRecord::duration_us(...)` when valid; invalid `duration_us` on `tt.*` spans follows warn-or-error semantics, and invalid `duration_us` on unrelated normalized spans is ignored due to the `has_tt` check (file: `tailtriage-tracing/src/jsonl.rs`).
- Extend the live `TracingRecorder` snapshot/shutdown flow to detect open tracked candidate spans (those declared via metadata or fields with `tt.*`), return `ImportError::StrictViolation` in strict mode, and emit a stable-prefix lifecycle warning (also pushed into `run.metadata.lifecycle_warnings`) with up to three samples in non-strict mode; no open-span completions are fabricated (file: `tailtriage-tracing/src/recorder.rs`).
- Add tests covering: ignored unrelated malformed normalized spans, warn/error behavior for malformed `tt.*` normalized spans, normalized `duration_us` semantics (request/stage/queue), invalid `duration_us` handling, open-candidate snapshot/shutdown warnings and strict failures, unrelated open-span silence, and `tt.kind = tracing::field::Empty` counting as a candidate.
- Update `tailtriage-tracing/README.md` to document `duration_us` (optional unsigned microseconds, overrides derived duration) and to keep a concise caveat about supported shapes and required explicit unix-ms timestamps for close-event-like records.

### Testing
- Ran formatting and lints: `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, both succeeded. 
- Ran unit and integration tests: `cargo test --workspace --all-targets --all-features --locked`, all tests passed. 
- Ran docs contract validation: `python3 scripts/validate_docs_contracts.py`, succeeded. 
- Ran tracing parity and runtime-cost validations: `python3 scripts/demo_tool.py validate-tracing-parity all --profile release`, `python3 scripts/measure_runtime_cost.py --requests 1200 --concurrency 32 --work-ms 4 --rounds 2 --warmup-rounds 1 --artifact-dir demos/runtime_cost/artifacts/ci-smoke`, and `python3 scripts/validate_runtime_cost_summary.py --raw demos/runtime_cost/artifacts/ci-smoke/runtime-cost-raw.jsonl --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json`, all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0abc352a8c8330b93ded78004768ab)