### PR TITLE
Fix JSONL normalized-span robustness, add `duration_us` support, and surface open live spans at snapshot

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -44,6 +44,8 @@ Supported stable contract (recommended for tests and integrations):
 Notes:
 
 - Importer accepts `started_at_unix_ms`/`finished_at_unix_ms` and aliases `start_unix_ms`/`end_unix_ms`.
+- Normalized spans may include optional `duration_us` (unsigned integer microseconds). When present, it overrides derived `(finished-start)` duration for request latency, stage latency, and queue wait.
+- Start/end unix-ms timestamps are still required even when `duration_us` is present.
 - In this phase, normalized shape uses **literal dotted keys** inside `fields` (for example `"tt.kind"` and `"tt.request_id"`), not nested objects that require flattening.
 - Importer reads `tt.*` fields from `fields`, `span.fields`, or top-level `tt.*` keys when present.
 - Scalars can be strings, bools, numbers, or null.
@@ -67,7 +69,7 @@ this phase, the importer supports:
 - normalized completed-span JSONL (shape above), and
 - close-event-like records only when they include explicit start/end unix-ms timestamps.
 
-Close-event-like records are supported only when explicit unix-ms start/end timestamps are present; timing is not guessed from line receive time, and broad compatibility with arbitrary tracing JSON is not claimed.
+Close-event-like records require explicit unix-ms start/end timestamps; timing is not guessed from line receive time, and broad compatibility with arbitrary tracing JSON is not claimed.
 
 ## Intended field shape
 

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -84,16 +84,20 @@ fn parse_record(
     strict: bool,
     warnings: &mut Vec<crate::ImportWarning>,
 ) -> Result<Option<SpanRecord>, ImportError> {
+    let has_tt = value_has_tailtriage_field(value);
     if let Some(span_obj) = value.get("span").and_then(Value::as_object) {
-        if span_obj.contains_key("name")
+        let is_normalized_shape = span_obj.contains_key("name")
             && (span_obj.contains_key("started_at_unix_ms")
                 || span_obj.contains_key("start_unix_ms"))
             && (span_obj.contains_key("finished_at_unix_ms")
-                || span_obj.contains_key("end_unix_ms"))
-        {
+                || span_obj.contains_key("end_unix_ms"));
+        if is_normalized_shape {
+            if !has_tt {
+                return Ok(None);
+            }
             return match parse_normalized_span(span_obj) {
                 Ok(span) => Ok(Some(span)),
-                Err(err) if value_has_tailtriage_field(value) => {
+                Err(err) => {
                     let message = format!("line {line_no}: {err}");
                     if strict {
                         Err(ImportError::StrictViolation(message))
@@ -102,10 +106,9 @@ fn parse_record(
                         Ok(None)
                     }
                 }
-                Err(err) => Err(err),
             };
         }
-        if value_has_tailtriage_field(value) && !indicates_close_event(value) {
+        if has_tt && !indicates_close_event(value) {
             let message = format!(
                 "line {line_no}: invalid field `span`: tailtriage span must include name, started_at_unix_ms/start_unix_ms, and finished_at_unix_ms/end_unix_ms"
             );
@@ -119,7 +122,7 @@ fn parse_record(
 
     match parse_close_event_shape(value) {
         Ok(result) => Ok(result),
-        Err(err) if value_has_tailtriage_field(value) => {
+        Err(err) if has_tt => {
             let message = format!("line {line_no}: {err}");
             if strict {
                 Err(ImportError::StrictViolation(message))
@@ -156,6 +159,7 @@ fn parse_normalized_span(
     let parent_id = optional_string(span_obj, "parent_id")?;
     let started_at_unix_ms = required_timestamp(span_obj, "started_at_unix_ms", "start_unix_ms")?;
     let finished_at_unix_ms = required_timestamp(span_obj, "finished_at_unix_ms", "end_unix_ms")?;
+    let duration_us = optional_duration_us(span_obj)?;
 
     let mut span = SpanRecord::new(name, started_at_unix_ms, finished_at_unix_ms);
     if let Some(id) = id {
@@ -163,6 +167,9 @@ fn parse_normalized_span(
     }
     if let Some(parent_id) = parent_id {
         span = span.parent_id(parent_id);
+    }
+    if let Some(duration_us) = duration_us {
+        span = span.duration_us(duration_us);
     }
 
     let fields = extract_fields_for_span(&Value::Object(span_obj.clone()));
@@ -338,6 +345,23 @@ fn required_timestamp_obj_or_nested(
     }
     Err(ImportError::MissingField(primary))
 }
+fn optional_duration_us(obj: &serde_json::Map<String, Value>) -> Result<Option<u64>, ImportError> {
+    match obj.get("duration_us") {
+        Some(Value::Number(n)) => n
+            .as_u64()
+            .ok_or_else(|| ImportError::InvalidField {
+                field: "duration_us",
+                reason: "expected unsigned integer microseconds as u64".to_owned(),
+            })
+            .map(Some),
+        Some(_) => Err(ImportError::InvalidField {
+            field: "duration_us",
+            reason: "expected unsigned integer microseconds as u64".to_owned(),
+        }),
+        None => Ok(None),
+    }
+}
+
 fn parse_u64(v: &Value, field: &'static str) -> Result<u64, ImportError> {
     v.as_u64().ok_or_else(|| ImportError::InvalidField {
         field,
@@ -511,6 +535,69 @@ mod tests {
         let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
             .unwrap_err();
         assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn malformed_unrelated_normalized_spans_are_ignored() {
+        let input = r#"
+{"span":{"name":"other","id":123,"started_at_unix_ms":1,"finished_at_unix_ms":2}}
+{"span":{"name":"other","parent_id":{},"started_at_unix_ms":1,"finished_at_unix_ms":2}}
+{"span":{"name":123,"started_at_unix_ms":1,"finished_at_unix_ms":2}}
+"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.warnings().is_empty());
+    }
+
+    #[test]
+    fn malformed_tt_normalized_spans_warn_non_strict_and_error_strict() {
+        let malformed = [
+            r#"{"span":{"name":"req","id":123,"started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request"}}}"#,
+            r#"{"span":{"name":"req","parent_id":{},"started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request"}}}"#,
+            r#"{"span":{"name":123,"started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request"}}}"#,
+        ];
+        for line in malformed {
+            let imported =
+                import_jsonl_reader(Cursor::new(line), ImportOptions::new("svc")).unwrap();
+            assert!(imported.run().requests.is_empty());
+            assert_eq!(imported.warnings().len(), 1);
+            let err =
+                import_jsonl_reader(Cursor::new(line), ImportOptions::new("svc").strict(true))
+                    .unwrap_err();
+            assert!(matches!(err, ImportError::StrictViolation(_)));
+        }
+    }
+
+    #[test]
+    fn normalized_duration_us_overrides_derived_latency() {
+        let input = r#"
+{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":1234,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
+{"span":{"name":"st","started_at_unix_ms":11,"finished_at_unix_ms":18,"duration_us":1234,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
+{"span":{"name":"q","started_at_unix_ms":10,"finished_at_unix_ms":11,"duration_us":1234,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":3}}}
+"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests[0].latency_us, 1234);
+        assert_eq!(imported.run().stages[0].latency_us, 1234);
+        assert_eq!(imported.run().queues[0].wait_us, 1234);
+    }
+
+    #[test]
+    fn invalid_duration_us_on_tt_span_warns_or_errors() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"duration_us":"bad","fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert_eq!(imported.warnings().len(), 1);
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+            .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn invalid_duration_us_on_unrelated_normalized_span_is_ignored() {
+        let input = r#"{"span":{"name":"other","started_at_unix_ms":1,"finished_at_unix_ms":2,"duration_us":"bad"}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.warnings().is_empty());
     }
 
     #[test]

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::fmt;
+use std::fmt::Write as _;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -69,6 +70,15 @@ struct OpenSpan {
     fields: BTreeMap<String, FieldValue>,
     started_at_unix_ms: u64,
     started_instant: Instant,
+    is_tt_candidate: bool,
+}
+
+#[derive(Debug, Clone)]
+struct OpenSpanSample {
+    name: String,
+    span_id: Option<String>,
+    tt_kind: Option<String>,
+    tt_request_id: Option<String>,
 }
 
 fn lock_state(state: &Arc<Mutex<RecorderState>>) -> std::sync::MutexGuard<'_, RecorderState> {
@@ -102,12 +112,35 @@ impl TracingRecorder {
     ///
     /// Returns [`ImportError`] when strict conversion fails.
     pub fn snapshot_run(&self) -> Result<ImportedRun, ImportError> {
-        let (spans, dropped_open_spans, dropped_completed_spans) = {
+        let (
+            spans,
+            dropped_open_spans,
+            dropped_completed_spans,
+            open_candidate_count,
+            open_samples,
+        ) = {
             let state = lock_state(&self.state);
+            let mut samples = Vec::new();
+            let mut count = 0_u64;
+            for open in state.open.values() {
+                if open.is_tt_candidate {
+                    count = count.saturating_add(1);
+                    if samples.len() < 3 {
+                        samples.push(OpenSpanSample {
+                            name: open.name.clone(),
+                            span_id: open.id.clone(),
+                            tt_kind: scalar_field_string(open.fields.get(TT_KIND)),
+                            tt_request_id: scalar_field_string(open.fields.get("tt.request_id")),
+                        });
+                    }
+                }
+            }
             (
                 state.completed.clone(),
                 state.dropped_open_spans,
                 state.dropped_completed_spans,
+                count,
+                samples,
             )
         };
         imported_with_drop_warnings(
@@ -115,6 +148,8 @@ impl TracingRecorder {
             self.options.clone(),
             dropped_open_spans,
             dropped_completed_spans,
+            open_candidate_count,
+            &open_samples,
         )
     }
 
@@ -213,6 +248,7 @@ where
             fields: visitor.fields,
             started_at_unix_ms: tailtriage_core::unix_time_ms(),
             started_instant: Instant::now(),
+            is_tt_candidate: metadata_candidate || initial_candidate,
         };
         state.open.insert(id.into_u64().to_string(), open_span);
     }
@@ -274,12 +310,42 @@ fn imported_with_drop_warnings(
     options: ImportOptions,
     dropped_open_spans: u64,
     dropped_completed_spans: u64,
+    open_candidate_count: u64,
+    open_samples: &[OpenSpanSample],
 ) -> Result<ImportedRun, ImportError> {
+    if options.strict_mode() && open_candidate_count > 0 {
+        return Err(ImportError::StrictViolation(format!(
+            "live recorder observed {open_candidate_count} open candidate span(s) at snapshot/shutdown; incomplete spans are not converted into fabricated completions"
+        )));
+    }
     let imported = run_from_span_records(spans, options)?;
-    if dropped_open_spans == 0 && dropped_completed_spans == 0 {
+    if dropped_open_spans == 0 && dropped_completed_spans == 0 && open_candidate_count == 0 {
         return Ok(imported);
     }
     let (mut run, mut warnings) = imported.into_parts();
+    if open_candidate_count > 0 {
+        let mut msg = format!(
+            "live recorder observed {open_candidate_count} open candidate span(s) at snapshot/shutdown; incomplete spans are not converted into fabricated completions"
+        );
+        if !open_samples.is_empty() {
+            let sample_text = open_samples
+                .iter()
+                .map(|sample| {
+                    format!(
+                        "name={}, id={}, tt.kind={}, tt.request_id={}",
+                        sample.name,
+                        sample.span_id.as_deref().unwrap_or("-"),
+                        sample.tt_kind.as_deref().unwrap_or("-"),
+                        sample.tt_request_id.as_deref().unwrap_or("-")
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("; ");
+            let _ = write!(&mut msg, "; samples: {sample_text}");
+        }
+        run.metadata.lifecycle_warnings.push(msg.clone());
+        warnings.push(crate::ImportWarning::new(msg));
+    }
     if dropped_open_spans > 0 {
         let msg = format!("live recorder dropped {dropped_open_spans} candidate spans because max_open_spans was reached");
         run.metadata.lifecycle_warnings.push(msg.clone());
@@ -290,8 +356,21 @@ fn imported_with_drop_warnings(
         run.metadata.lifecycle_warnings.push(msg.clone());
         warnings.push(crate::ImportWarning::new(msg));
     }
-    run.truncation.limits_hit = true;
+    if dropped_open_spans > 0 || dropped_completed_spans > 0 {
+        run.truncation.limits_hit = true;
+    }
     Ok(ImportedRun::new(run, warnings))
+}
+
+fn scalar_field_string(value: Option<&FieldValue>) -> Option<String> {
+    match value {
+        Some(FieldValue::String(v)) => Some(v.clone()),
+        Some(FieldValue::Bool(v)) => Some(v.to_string()),
+        Some(FieldValue::U64(v)) => Some(v.to_string()),
+        Some(FieldValue::I64(v)) => Some(v.to_string()),
+        Some(FieldValue::F64(v)) => Some(v.to_string()),
+        Some(FieldValue::Null) | None => None,
+    }
 }
 
 #[derive(Default)]
@@ -625,5 +704,70 @@ mod tests {
         let recorder = TracingRecorder::builder(" ").build();
         let err = recorder.snapshot_run().unwrap_err();
         assert!(matches!(err, ImportError::EmptyServiceName));
+    }
+
+    #[test]
+    fn open_candidate_span_warns_on_snapshot_and_shutdown_non_strict() {
+        with_recorder(|recorder| {
+            let _open = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r-open",
+                tt.route = "/open"
+            )
+            .entered();
+            let snapshot = recorder.snapshot_run().unwrap();
+            assert!(snapshot.run().requests.is_empty());
+            assert!(snapshot.warnings().iter().any(|w| w
+                .message()
+                .contains("open candidate span(s) at snapshot/shutdown")));
+            assert!(snapshot
+                .run()
+                .metadata
+                .lifecycle_warnings
+                .iter()
+                .any(|w| w.contains("open candidate span(s) at snapshot/shutdown")));
+            let shutdown = recorder.shutdown().unwrap();
+            assert!(shutdown.warnings().iter().any(|w| w
+                .message()
+                .contains("open candidate span(s) at snapshot/shutdown")));
+        });
+    }
+
+    #[test]
+    fn open_candidate_span_errors_in_strict_mode() {
+        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let _open =
+                tracing::info_span!("request", tt.kind = "request", tt.request_id = "r1").entered();
+            let err = recorder.snapshot_run().unwrap_err();
+            assert!(matches!(err, ImportError::StrictViolation(_)));
+        });
+    }
+
+    #[test]
+    fn unrelated_open_span_does_not_warn() {
+        with_recorder(|recorder| {
+            let _open = tracing::info_span!("other", user = 1_u64).entered();
+            let snapshot = recorder.snapshot_run().unwrap();
+            assert!(snapshot.warnings().is_empty());
+        });
+    }
+
+    #[test]
+    fn open_candidate_with_empty_tt_kind_still_warns() {
+        with_recorder(|recorder| {
+            let _open = tracing::info_span!(
+                "request",
+                tt.kind = tracing::field::Empty,
+                tt.request_id = "r-empty"
+            )
+            .entered();
+            let snapshot = recorder.snapshot_run().unwrap();
+            assert!(snapshot.warnings().iter().any(|w| w
+                .message()
+                .contains("open candidate span(s) at snapshot/shutdown")));
+        });
     }
 }


### PR DESCRIPTION
### Motivation
- Finish the final correctness/polish pass for tracing intake so JSONL import tolerates unrelated malformed normalized spans while still enforcing `tt.*` strictness and keep live recorder snapshot behavior honest about open candidate spans. 
- Support an explicit normalized `duration_us` override so externally produced normalized spans can carry monotonic duration in microseconds and feed existing latency/wait logic. 
- Ensure snapshot/shutdown surfaces open tracked candidate spans as warnings (non-strict) or errors (strict) instead of silently dropping them or fabricating completions.

### Description
- JSONL import: updated `parse_record` to compute `has_tt = value_has_tailtriage_field(value)` early and to treat normalized `{"span": {...}}` shapes without any `tt.*` keys as `Ok(None)` (ignored) before attempting to parse them, while preserving strict-or-warn behavior for malformed `tt.*` records in `tailtriage-tracing/src/jsonl.rs`.
- `duration_us` parsing: added `optional_duration_us` to parse an optional unsigned integer `duration_us` from normalized span objects and apply it via `SpanRecord::duration_us(...)`, causing request/stage/queue conversions to use the explicit microsecond duration when present in `tailtriage-tracing/src/jsonl.rs`.
- Live recorder snapshot: extended `TracingRecorder::snapshot_run()`/`shutdown()` to inspect `state.open` for tracked candidate spans, collect up to three `OpenSpanSample`s, and pass `open_candidate_count`/samples into the conversion helper so non-strict mode emits a bounded lifecycle warning (also appended to `ImportedRun::warnings()`), and strict mode returns `ImportError::StrictViolation` when open candidates exist in `tailtriage-tracing/src/recorder.rs`.
- Tests: added unit tests covering ignored unrelated malformed normalized spans, `tt.*` malformed normalized spans warning/error behavior, `duration_us` valid/invalid cases, and open-candidate snapshot/shutdown semantics (including `tt.kind = tracing::field::Empty` handling) in `tailtriage-tracing/src/jsonl.rs` and `tailtriage-tracing/src/recorder.rs`.
- Docs: updated `tailtriage-tracing/README.md` to document optional normalized `duration_us` semantics and removed a duplicated close-event caveat while retaining a concise compatibility boundary.

### Testing
- Ran `cargo fmt --check` and it passed. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed. 
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests (including newly added JSONL and recorder tests) passed. 
- Ran `python3 scripts/validate_docs_contracts.py`, `python3 scripts/demo_tool.py validate-tracing-parity all --profile release`, `python3 scripts/measure_runtime_cost.py --requests 1200 --concurrency 32 --work-ms 4 --rounds 2 --warmup-rounds 1 --artifact-dir demos/runtime_cost/artifacts/ci-smoke`, and `python3 scripts/validate_runtime_cost_summary.py --raw demos/runtime_cost/artifacts/ci-smoke/runtime-cost-raw.jsonl --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json`, and each command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0abc352a8c8330b93ded78004768ab)