### PR TITLE
Finalize tracing JSONL normalized parsing, duration_us support, and open-span snapshot handling

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -32,6 +32,7 @@ Supported stable contract (recommended for tests and integrations):
     "parent_id": "root-1",
     "started_at_unix_ms": 1700000000000,
     "finished_at_unix_ms": 1700000000120,
+    "duration_us": 120000,
     "fields": {
       "tt.kind": "request",
       "tt.request_id": "req-42",
@@ -44,6 +45,9 @@ Supported stable contract (recommended for tests and integrations):
 Notes:
 
 - Importer accepts `started_at_unix_ms`/`finished_at_unix_ms` and aliases `start_unix_ms`/`end_unix_ms`.
+- `duration_us` is optional and must be an unsigned integer in microseconds.
+- When `duration_us` is present, it overrides duration derived from start/end timestamps for request latency, stage latency, and queue wait.
+- Start/end timestamps remain required even when `duration_us` is provided.
 - In this phase, normalized shape uses **literal dotted keys** inside `fields` (for example `"tt.kind"` and `"tt.request_id"`), not nested objects that require flattening.
 - Importer reads `tt.*` fields from `fields`, `span.fields`, or top-level `tt.*` keys when present.
 - Scalars can be strings, bools, numbers, or null.
@@ -66,8 +70,6 @@ this phase, the importer supports:
 
 - normalized completed-span JSONL (shape above), and
 - close-event-like records only when they include explicit start/end unix-ms timestamps.
-
-Close-event-like records are supported only when explicit unix-ms start/end timestamps are present; timing is not guessed from line receive time, and broad compatibility with arbitrary tracing JSON is not claimed.
 
 ## Intended field shape
 

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -84,16 +84,20 @@ fn parse_record(
     strict: bool,
     warnings: &mut Vec<crate::ImportWarning>,
 ) -> Result<Option<SpanRecord>, ImportError> {
+    let has_tt = value_has_tailtriage_field(value);
     if let Some(span_obj) = value.get("span").and_then(Value::as_object) {
-        if span_obj.contains_key("name")
+        let is_normalized_shape = span_obj.contains_key("name")
             && (span_obj.contains_key("started_at_unix_ms")
                 || span_obj.contains_key("start_unix_ms"))
             && (span_obj.contains_key("finished_at_unix_ms")
-                || span_obj.contains_key("end_unix_ms"))
-        {
+                || span_obj.contains_key("end_unix_ms"));
+        if is_normalized_shape {
+            if !has_tt {
+                return Ok(None);
+            }
             return match parse_normalized_span(span_obj) {
                 Ok(span) => Ok(Some(span)),
-                Err(err) if value_has_tailtriage_field(value) => {
+                Err(err) if has_tt => {
                     let message = format!("line {line_no}: {err}");
                     if strict {
                         Err(ImportError::StrictViolation(message))
@@ -102,10 +106,10 @@ fn parse_record(
                         Ok(None)
                     }
                 }
-                Err(err) => Err(err),
+                Err(_) => Ok(None),
             };
         }
-        if value_has_tailtriage_field(value) && !indicates_close_event(value) {
+        if has_tt && !indicates_close_event(value) {
             let message = format!(
                 "line {line_no}: invalid field `span`: tailtriage span must include name, started_at_unix_ms/start_unix_ms, and finished_at_unix_ms/end_unix_ms"
             );
@@ -119,7 +123,7 @@ fn parse_record(
 
     match parse_close_event_shape(value) {
         Ok(result) => Ok(result),
-        Err(err) if value_has_tailtriage_field(value) => {
+        Err(err) if has_tt => {
             let message = format!("line {line_no}: {err}");
             if strict {
                 Err(ImportError::StrictViolation(message))
@@ -156,6 +160,7 @@ fn parse_normalized_span(
     let parent_id = optional_string(span_obj, "parent_id")?;
     let started_at_unix_ms = required_timestamp(span_obj, "started_at_unix_ms", "start_unix_ms")?;
     let finished_at_unix_ms = required_timestamp(span_obj, "finished_at_unix_ms", "end_unix_ms")?;
+    let duration_us = optional_u64(span_obj, "duration_us")?;
 
     let mut span = SpanRecord::new(name, started_at_unix_ms, finished_at_unix_ms);
     if let Some(id) = id {
@@ -163,6 +168,9 @@ fn parse_normalized_span(
     }
     if let Some(parent_id) = parent_id {
         span = span.parent_id(parent_id);
+    }
+    if let Some(duration_us) = duration_us {
+        span = span.duration_us(duration_us);
     }
 
     let fields = extract_fields_for_span(&Value::Object(span_obj.clone()));
@@ -344,6 +352,15 @@ fn parse_u64(v: &Value, field: &'static str) -> Result<u64, ImportError> {
         reason: "expected unix timestamp in milliseconds as u64".to_owned(),
     })
 }
+fn optional_u64(
+    obj: &serde_json::Map<String, Value>,
+    field: &'static str,
+) -> Result<Option<u64>, ImportError> {
+    match obj.get(field) {
+        Some(v) => parse_u64(v, field).map(Some),
+        None => Ok(None),
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -511,6 +528,71 @@ mod tests {
         let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
             .unwrap_err();
         assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn malformed_unrelated_normalized_spans_are_ignored() {
+        let input = r#"
+{"span":{"name":"ok","id":123,"started_at_unix_ms":1,"finished_at_unix_ms":2}}
+{"span":{"name":"ok","parent_id":{},"started_at_unix_ms":1,"finished_at_unix_ms":2}}
+{"span":{"name":123,"started_at_unix_ms":1,"finished_at_unix_ms":2}}
+"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.warnings().is_empty());
+    }
+
+    #[test]
+    fn malformed_normalized_tt_spans_warn_non_strict_and_error_strict() {
+        let cases = [
+            r#"{"span":{"name":"ok","id":123,"started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request"}}}"#,
+            r#"{"span":{"name":"ok","parent_id":{},"started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request"}}}"#,
+            r#"{"span":{"name":123,"started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request"}}}"#,
+        ];
+        for input in cases {
+            let imported =
+                import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+            assert!(imported.run().requests.is_empty());
+            assert_eq!(imported.warnings().len(), 1);
+
+            let err =
+                import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+                    .unwrap_err();
+            assert!(matches!(err, ImportError::StrictViolation(_)));
+        }
+    }
+
+    #[test]
+    fn normalized_duration_us_overrides_derived_latency() {
+        let input = r#"
+{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":1234,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
+{"span":{"name":"st","started_at_unix_ms":11,"finished_at_unix_ms":18,"duration_us":1234,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
+{"span":{"name":"q","started_at_unix_ms":10,"finished_at_unix_ms":11,"duration_us":1234,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits"}}}
+"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests[0].latency_us, 1234);
+        assert_eq!(imported.run().stages[0].latency_us, 1234);
+        assert_eq!(imported.run().queues[0].wait_us, 1234);
+    }
+
+    #[test]
+    fn invalid_duration_us_on_tt_normalized_span_warns_or_errors() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":"bad","fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert_eq!(imported.warnings().len(), 1);
+
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+            .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn invalid_duration_us_on_unrelated_normalized_span_is_ignored() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":"bad","fields":{"user":"u1"}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.warnings().is_empty());
     }
 
     #[test]

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -70,6 +70,13 @@ struct OpenSpan {
     started_at_unix_ms: u64,
     started_instant: Instant,
 }
+#[derive(Debug, Clone)]
+struct OpenSpanSample {
+    name: String,
+    id: Option<String>,
+    tt_kind: Option<String>,
+    tt_request_id: Option<String>,
+}
 
 fn lock_state(state: &Arc<Mutex<RecorderState>>) -> std::sync::MutexGuard<'_, RecorderState> {
     match state.lock() {
@@ -102,12 +109,37 @@ impl TracingRecorder {
     ///
     /// Returns [`ImportError`] when strict conversion fails.
     pub fn snapshot_run(&self) -> Result<ImportedRun, ImportError> {
-        let (spans, dropped_open_spans, dropped_completed_spans) = {
+        let (
+            spans,
+            dropped_open_spans,
+            dropped_completed_spans,
+            open_candidate_count,
+            open_samples,
+        ) = {
             let state = lock_state(&self.state);
+            let open_candidates: Vec<&OpenSpan> = state
+                .open
+                .values()
+                .filter(|span| span.fields.keys().any(|k| k.starts_with("tt.")))
+                .collect();
             (
                 state.completed.clone(),
                 state.dropped_open_spans,
                 state.dropped_completed_spans,
+                open_candidates.len(),
+                open_candidates
+                    .iter()
+                    .take(3)
+                    .map(|span| OpenSpanSample {
+                        name: span.name.clone(),
+                        id: span.id.clone(),
+                        tt_kind: span.fields.get(TT_KIND).and_then(field_value_to_string),
+                        tt_request_id: span
+                            .fields
+                            .get("tt.request_id")
+                            .and_then(field_value_to_string),
+                    })
+                    .collect::<Vec<_>>(),
             )
         };
         imported_with_drop_warnings(
@@ -115,6 +147,8 @@ impl TracingRecorder {
             self.options.clone(),
             dropped_open_spans,
             dropped_completed_spans,
+            open_candidate_count,
+            &open_samples,
         )
     }
 
@@ -274,12 +308,24 @@ fn imported_with_drop_warnings(
     options: ImportOptions,
     dropped_open_spans: u64,
     dropped_completed_spans: u64,
+    open_candidate_count: usize,
+    open_samples: &[OpenSpanSample],
 ) -> Result<ImportedRun, ImportError> {
+    if options.strict_mode() && open_candidate_count > 0 {
+        return Err(ImportError::StrictViolation(
+            open_candidate_warning_message(open_candidate_count, open_samples),
+        ));
+    }
     let imported = run_from_span_records(spans, options)?;
-    if dropped_open_spans == 0 && dropped_completed_spans == 0 {
+    if dropped_open_spans == 0 && dropped_completed_spans == 0 && open_candidate_count == 0 {
         return Ok(imported);
     }
     let (mut run, mut warnings) = imported.into_parts();
+    if open_candidate_count > 0 {
+        let msg = open_candidate_warning_message(open_candidate_count, open_samples);
+        run.metadata.lifecycle_warnings.push(msg.clone());
+        warnings.push(crate::ImportWarning::new(msg));
+    }
     if dropped_open_spans > 0 {
         let msg = format!("live recorder dropped {dropped_open_spans} candidate spans because max_open_spans was reached");
         run.metadata.lifecycle_warnings.push(msg.clone());
@@ -290,8 +336,49 @@ fn imported_with_drop_warnings(
         run.metadata.lifecycle_warnings.push(msg.clone());
         warnings.push(crate::ImportWarning::new(msg));
     }
-    run.truncation.limits_hit = true;
+    if dropped_open_spans > 0 || dropped_completed_spans > 0 {
+        run.truncation.limits_hit = true;
+    }
     Ok(ImportedRun::new(run, warnings))
+}
+
+fn field_value_to_string(value: &FieldValue) -> Option<String> {
+    match value {
+        FieldValue::String(s) => Some(s.clone()),
+        FieldValue::Bool(b) => Some(b.to_string()),
+        FieldValue::I64(i) => Some(i.to_string()),
+        FieldValue::U64(u) => Some(u.to_string()),
+        FieldValue::F64(f) => Some(f.to_string()),
+        FieldValue::Null => None,
+    }
+}
+
+fn open_candidate_warning_message(count: usize, samples: &[OpenSpanSample]) -> String {
+    let mut msg = format!(
+        "live recorder observed {count} open candidate span(s) at snapshot/shutdown; incomplete spans are not converted into fabricated completions"
+    );
+    if !samples.is_empty() {
+        let rendered = samples
+            .iter()
+            .map(|sample| {
+                let mut parts = vec![format!("name={}", sample.name)];
+                if let Some(id) = &sample.id {
+                    parts.push(format!("id={id}"));
+                }
+                if let Some(tt_kind) = &sample.tt_kind {
+                    parts.push(format!("tt.kind={tt_kind}"));
+                }
+                if let Some(tt_request_id) = &sample.tt_request_id {
+                    parts.push(format!("tt.request_id={tt_request_id}"));
+                }
+                format!("{{{}}}", parts.join(", "))
+            })
+            .collect::<Vec<_>>()
+            .join("; ");
+        msg.push_str("; samples: ");
+        msg.push_str(&rendered);
+    }
+    msg
 }
 
 #[derive(Default)]
@@ -435,6 +522,82 @@ mod tests {
             assert_eq!(run.run().requests.len(), 1);
             assert_eq!(run.run().requests[0].request_id, "r1");
             assert_eq!(run.run().requests[0].route, "/checkout");
+        });
+    }
+
+    #[test]
+    fn snapshot_warns_for_open_candidate_in_non_strict_mode() {
+        with_recorder(|recorder| {
+            let _span = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r-open",
+                tt.route = "/open"
+            );
+            let imported = recorder.snapshot_run().unwrap();
+            assert!(imported.run().requests.is_empty());
+            let warning = imported
+                .warnings()
+                .iter()
+                .find(|w| {
+                    w.message()
+                        .contains("open candidate span(s) at snapshot/shutdown")
+                })
+                .expect("expected open candidate warning");
+            assert!(warning.message().contains("name=request"));
+            assert!(imported
+                .run()
+                .metadata
+                .lifecycle_warnings
+                .iter()
+                .any(|w| w.contains("open candidate span(s) at snapshot/shutdown")));
+        });
+    }
+
+    #[test]
+    fn shutdown_warns_for_open_candidate_in_non_strict_mode() {
+        with_recorder(|recorder| {
+            let _span = tracing::info_span!("request", tt.kind = "request", tt.request_id = "r1");
+            let imported = recorder.shutdown().unwrap();
+            assert!(imported.warnings().iter().any(|w| w
+                .message()
+                .contains("open candidate span(s) at snapshot/shutdown")));
+        });
+    }
+
+    #[test]
+    fn strict_snapshot_errors_for_open_candidate() {
+        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let _span = tracing::info_span!("request", tt.kind = "request", tt.request_id = "r1");
+            let err = recorder.snapshot_run().unwrap_err();
+            assert!(matches!(err, ImportError::StrictViolation(_)));
+        });
+    }
+
+    #[test]
+    fn unrelated_open_span_does_not_warn() {
+        with_recorder(|recorder| {
+            let _span = tracing::info_span!("other", user_id = 42_u64);
+            let imported = recorder.snapshot_run().unwrap();
+            assert!(imported.warnings().is_empty());
+        });
+    }
+
+    #[test]
+    fn empty_tt_kind_open_span_counts_as_open_candidate_warning() {
+        with_recorder(|recorder| {
+            let _span = tracing::info_span!(
+                "request",
+                tt.kind = tracing::field::Empty,
+                tt.request_id = "r1"
+            );
+            let imported = recorder.snapshot_run().unwrap();
+            assert!(imported.warnings().iter().any(|w| w
+                .message()
+                .contains("open candidate span(s) at snapshot/shutdown")));
+            assert_eq!(imported.run().requests.len(), 0);
         });
     }
 


### PR DESCRIPTION
### Motivation
- Fix incorrect failure semantics where malformed but unrelated normalized `{"span": {...}}` lines could abort JSONL import instead of being ignored.
- Allow normalized JSONL producers to supply an explicit unsigned `duration_us` to control request/stage/queue latency without removing the requirement for start/end timestamps.
- Ensure the live `TracingRecorder` surfaces open tracked `tt.*` candidate spans at snapshot/shutdown so incomplete work is visible (warn in non-strict, error in strict) without fabricating completions.

### Description
- JSONL importer: compute `has_tt = value_has_tailtriage_field(value)` once and use it to short-circuit unrelated normalized shapes by returning `Ok(None)` before attempting `parse_normalized_span`, preserving malformed-JSON as fatal and preserving strict-vs-non-strict semantics for malformed `tt.*` records.
- JSONL importer: parse optional `duration_us` (only unsigned integer JSON numbers) in `parse_normalized_span` and call `SpanRecord::duration_us(...)` when present so downstream conversion uses the explicit microsecond duration.
- Live recorder: `TracingRecorder::snapshot_run()` (and `shutdown()`) now inspects `state.open` for open candidate spans with any `tt.*` keys, samples up to 3 spans for a concise message, and: errors with `ImportError::StrictViolation` when strict and open candidates exist, or emits a single lifecycle warning (added to both `ImportedRun::warnings()` and `run.metadata.lifecycle_warnings`) in non-strict mode; truncation flags are only set for actual retention drops.
- Tests and docs: added focused unit tests for the JSONL behaviors (ignoring malformed unrelated normalized spans, strict/non-strict malformed-tt behavior, `duration_us` parsing and override semantics, invalid `duration_us` handling) and recorder tests for open-candidate snapshot/shutdown behavior (non-strict warning presence, lifecycle_warnings propagation, strict erroring, unrelated open spans ignored, `tt.kind = Empty` counted as a candidate); updated `tailtriage-tracing/README.md` to document `duration_us` semantics and keep a single concise caveat about supported normalized/close-event-like JSONL compatibility.

### Testing
- Ran formatting and lints: `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, both passed.
- Ran unit and integration tests: `cargo test --workspace --all-targets --all-features --locked`, which passed across the workspace (including new JSONL and recorder tests).
- Ran docs and demo validations: `python3 scripts/validate_docs_contracts.py` and `python3 scripts/demo_tool.py validate-tracing-parity all --profile release`, both passed.
- Ran runtime-cost validation and summary checks: `python3 scripts/measure_runtime_cost.py --requests 1200 --concurrency 32 --work-ms 4 --rounds 2 --warmup-rounds 1 --artifact-dir demos/runtime_cost/artifacts/ci-smoke` and `python3 scripts/validate_runtime_cost_summary.py --raw demos/runtime_cost/artifacts/ci-smoke/runtime-cost-raw.jsonl --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json`, both completed and produced expected artifacts and summary output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0abc352a8c8330b93ded78004768ab)