### PR TITLE
Fix JSONL normalized-span parsing, add `duration_us`, and surface open-span warnings

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -44,6 +44,7 @@ Supported stable contract (recommended for tests and integrations):
 Notes:
 
 - Importer accepts `started_at_unix_ms`/`finished_at_unix_ms` and aliases `start_unix_ms`/`end_unix_ms`.
+- `duration_us` is optional normalized input in microseconds; when present, it overrides timestamp-derived duration for request latency, stage latency, and queue wait, while start/end timestamps remain required.
 - In this phase, normalized shape uses **literal dotted keys** inside `fields` (for example `"tt.kind"` and `"tt.request_id"`), not nested objects that require flattening.
 - Importer reads `tt.*` fields from `fields`, `span.fields`, or top-level `tt.*` keys when present.
 - Scalars can be strings, bools, numbers, or null.
@@ -66,8 +67,6 @@ this phase, the importer supports:
 
 - normalized completed-span JSONL (shape above), and
 - close-event-like records only when they include explicit start/end unix-ms timestamps.
-
-Close-event-like records are supported only when explicit unix-ms start/end timestamps are present; timing is not guessed from line receive time, and broad compatibility with arbitrary tracing JSON is not claimed.
 
 ## Intended field shape
 

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -84,6 +84,7 @@ fn parse_record(
     strict: bool,
     warnings: &mut Vec<crate::ImportWarning>,
 ) -> Result<Option<SpanRecord>, ImportError> {
+    let has_tt = value_has_tailtriage_field(value);
     if let Some(span_obj) = value.get("span").and_then(Value::as_object) {
         if span_obj.contains_key("name")
             && (span_obj.contains_key("started_at_unix_ms")
@@ -91,9 +92,12 @@ fn parse_record(
             && (span_obj.contains_key("finished_at_unix_ms")
                 || span_obj.contains_key("end_unix_ms"))
         {
+            if !has_tt {
+                return Ok(None);
+            }
             return match parse_normalized_span(span_obj) {
                 Ok(span) => Ok(Some(span)),
-                Err(err) if value_has_tailtriage_field(value) => {
+                Err(err) => {
                     let message = format!("line {line_no}: {err}");
                     if strict {
                         Err(ImportError::StrictViolation(message))
@@ -102,10 +106,9 @@ fn parse_record(
                         Ok(None)
                     }
                 }
-                Err(err) => Err(err),
             };
         }
-        if value_has_tailtriage_field(value) && !indicates_close_event(value) {
+        if has_tt && !indicates_close_event(value) {
             let message = format!(
                 "line {line_no}: invalid field `span`: tailtriage span must include name, started_at_unix_ms/start_unix_ms, and finished_at_unix_ms/end_unix_ms"
             );
@@ -119,7 +122,7 @@ fn parse_record(
 
     match parse_close_event_shape(value) {
         Ok(result) => Ok(result),
-        Err(err) if value_has_tailtriage_field(value) => {
+        Err(err) if has_tt => {
             let message = format!("line {line_no}: {err}");
             if strict {
                 Err(ImportError::StrictViolation(message))
@@ -156,6 +159,7 @@ fn parse_normalized_span(
     let parent_id = optional_string(span_obj, "parent_id")?;
     let started_at_unix_ms = required_timestamp(span_obj, "started_at_unix_ms", "start_unix_ms")?;
     let finished_at_unix_ms = required_timestamp(span_obj, "finished_at_unix_ms", "end_unix_ms")?;
+    let duration_us = optional_u64(span_obj, "duration_us")?;
 
     let mut span = SpanRecord::new(name, started_at_unix_ms, finished_at_unix_ms);
     if let Some(id) = id {
@@ -164,6 +168,9 @@ fn parse_normalized_span(
     if let Some(parent_id) = parent_id {
         span = span.parent_id(parent_id);
     }
+    if let Some(duration_us) = duration_us {
+        span = span.duration_us(duration_us);
+    }
 
     let fields = extract_fields_for_span(&Value::Object(span_obj.clone()));
     for (k, v) in fields {
@@ -171,6 +178,26 @@ fn parse_normalized_span(
     }
 
     Ok(span)
+}
+
+fn optional_u64(
+    obj: &serde_json::Map<String, Value>,
+    key: &str,
+) -> Result<Option<u64>, ImportError> {
+    match obj.get(key) {
+        Some(Value::Number(n)) => n
+            .as_u64()
+            .map(Some)
+            .ok_or_else(|| ImportError::InvalidField {
+                field: "duration_us",
+                reason: "must be an unsigned integer".to_owned(),
+            }),
+        Some(_) => Err(ImportError::InvalidField {
+            field: "duration_us",
+            reason: "must be an unsigned integer".to_owned(),
+        }),
+        None => Ok(None),
+    }
 }
 
 fn parse_close_event_shape(value: &Value) -> Result<Option<SpanRecord>, ImportError> {
@@ -511,6 +538,67 @@ mod tests {
         let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
             .unwrap_err();
         assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn malformed_unrelated_normalized_spans_are_ignored() {
+        for input in [
+            r#"{"span":{"name":"req","id":123,"started_at_unix_ms":1,"finished_at_unix_ms":2}}"#,
+            r#"{"span":{"name":"req","parent_id":{},"started_at_unix_ms":1,"finished_at_unix_ms":2}}"#,
+            r#"{"span":{"name":123,"started_at_unix_ms":1,"finished_at_unix_ms":2}}"#,
+        ] {
+            let imported =
+                import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+            assert!(imported.warnings().is_empty());
+            assert!(imported.run().requests.is_empty());
+        }
+    }
+
+    #[test]
+    fn malformed_tt_normalized_spans_warn_or_error() {
+        for input in [
+            r#"{"span":{"name":"req","id":123,"started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request"}}}"#,
+            r#"{"span":{"name":"req","parent_id":{},"started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request"}}}"#,
+            r#"{"span":{"name":123,"started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request"}}}"#,
+        ] {
+            let imported =
+                import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+            assert_eq!(imported.warnings().len(), 1);
+            let err =
+                import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+                    .unwrap_err();
+            assert!(matches!(err, ImportError::StrictViolation(_)));
+        }
+    }
+
+    #[test]
+    fn normalized_duration_us_is_used() {
+        let input = r#"
+{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":9999,"duration_us":1234,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
+{"span":{"name":"st","started_at_unix_ms":10,"finished_at_unix_ms":9999,"duration_us":1234,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
+{"span":{"name":"q","started_at_unix_ms":10,"finished_at_unix_ms":9999,"duration_us":1234,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits"}}}
+"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests[0].latency_us, 1234);
+        assert_eq!(imported.run().stages[0].latency_us, 1234);
+        assert_eq!(imported.run().queues[0].wait_us, 1234);
+    }
+
+    #[test]
+    fn invalid_duration_us_tt_warns_or_errors() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"duration_us":"bad","fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.warnings().len(), 1);
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+            .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn invalid_duration_us_unrelated_is_ignored() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"duration_us":"bad"}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.warnings().is_empty());
     }
 
     #[test]

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -70,6 +70,13 @@ struct OpenSpan {
     started_at_unix_ms: u64,
     started_instant: Instant,
 }
+#[derive(Debug, Clone)]
+struct OpenSpanSample {
+    name: String,
+    id: Option<String>,
+    tt_kind: Option<String>,
+    tt_request_id: Option<String>,
+}
 
 fn lock_state(state: &Arc<Mutex<RecorderState>>) -> std::sync::MutexGuard<'_, RecorderState> {
     match state.lock() {
@@ -102,19 +109,44 @@ impl TracingRecorder {
     ///
     /// Returns [`ImportError`] when strict conversion fails.
     pub fn snapshot_run(&self) -> Result<ImportedRun, ImportError> {
-        let (spans, dropped_open_spans, dropped_completed_spans) = {
+        let (
+            spans,
+            dropped_open_spans,
+            dropped_completed_spans,
+            open_candidate_count,
+            open_samples,
+        ) = {
             let state = lock_state(&self.state);
+            let candidates: Vec<_> = state
+                .open
+                .values()
+                .filter(|span| span.fields.keys().any(|k| k.starts_with("tt.")))
+                .collect();
             (
                 state.completed.clone(),
                 state.dropped_open_spans,
                 state.dropped_completed_spans,
+                candidates.len(),
+                candidates
+                    .into_iter()
+                    .take(3)
+                    .map(|span| OpenSpanSample {
+                        name: span.name.clone(),
+                        id: span.id.clone(),
+                        tt_kind: scalar_field_string(span.fields.get("tt.kind")),
+                        tt_request_id: scalar_field_string(span.fields.get("tt.request_id")),
+                    })
+                    .collect::<Vec<_>>(),
             )
         };
         imported_with_drop_warnings(
             spans,
             self.options.clone(),
+            self.options.strict_mode(),
             dropped_open_spans,
             dropped_completed_spans,
+            open_candidate_count,
+            &open_samples,
         )
     }
 
@@ -272,14 +304,41 @@ fn fields_have_tailtriage_key(fields: &BTreeMap<String, FieldValue>) -> bool {
 fn imported_with_drop_warnings(
     spans: Vec<SpanRecord>,
     options: ImportOptions,
+    strict: bool,
     dropped_open_spans: u64,
     dropped_completed_spans: u64,
+    open_candidate_count: usize,
+    open_samples: &[OpenSpanSample],
 ) -> Result<ImportedRun, ImportError> {
     let imported = run_from_span_records(spans, options)?;
-    if dropped_open_spans == 0 && dropped_completed_spans == 0 {
+    if open_candidate_count > 0 && strict {
+        return Err(ImportError::StrictViolation(format!(
+            "live recorder observed {open_candidate_count} open candidate span(s) at snapshot/shutdown; incomplete spans are not converted into fabricated completions"
+        )));
+    }
+    if dropped_open_spans == 0 && dropped_completed_spans == 0 && open_candidate_count == 0 {
         return Ok(imported);
     }
     let (mut run, mut warnings) = imported.into_parts();
+    if open_candidate_count > 0 {
+        let mut msg = format!("live recorder observed {open_candidate_count} open candidate span(s) at snapshot/shutdown; incomplete spans are not converted into fabricated completions");
+        if !open_samples.is_empty() {
+            let samples = open_samples
+                .iter()
+                .map(|sample| {
+                    format!(
+                        "name={}, id={:?}, tt.kind={:?}, tt.request_id={:?}",
+                        sample.name, sample.id, sample.tt_kind, sample.tt_request_id
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("; ");
+            msg.push_str("; samples: ");
+            msg.push_str(&samples);
+        }
+        run.metadata.lifecycle_warnings.push(msg.clone());
+        warnings.push(crate::ImportWarning::new(msg));
+    }
     if dropped_open_spans > 0 {
         let msg = format!("live recorder dropped {dropped_open_spans} candidate spans because max_open_spans was reached");
         run.metadata.lifecycle_warnings.push(msg.clone());
@@ -292,6 +351,17 @@ fn imported_with_drop_warnings(
     }
     run.truncation.limits_hit = true;
     Ok(ImportedRun::new(run, warnings))
+}
+
+fn scalar_field_string(value: Option<&FieldValue>) -> Option<String> {
+    match value {
+        Some(FieldValue::String(v)) => Some(v.clone()),
+        Some(FieldValue::Bool(v)) => Some(v.to_string()),
+        Some(FieldValue::I64(v)) => Some(v.to_string()),
+        Some(FieldValue::U64(v)) => Some(v.to_string()),
+        Some(FieldValue::F64(v)) => Some(v.to_string()),
+        Some(FieldValue::Null) | None => None,
+    }
 }
 
 #[derive(Default)]
@@ -625,5 +695,63 @@ mod tests {
         let recorder = TracingRecorder::builder(" ").build();
         let err = recorder.snapshot_run().unwrap_err();
         assert!(matches!(err, ImportError::EmptyServiceName));
+    }
+
+    #[test]
+    fn open_candidate_warns_in_snapshot_and_shutdown_non_strict() {
+        with_recorder(|recorder| {
+            let _open = tracing::info_span!("request", tt.kind = "request", tt.request_id = "r1");
+            let imported = recorder.snapshot_run().unwrap();
+            assert!(imported.run().requests.is_empty());
+            assert!(imported.warnings().iter().any(|w| w
+                .message()
+                .contains("open candidate span(s) at snapshot/shutdown")));
+            assert!(imported
+                .run()
+                .metadata
+                .lifecycle_warnings
+                .iter()
+                .any(|w| w.contains("open candidate span(s) at snapshot/shutdown")));
+            let shutdown = recorder.shutdown().unwrap();
+            assert!(shutdown.warnings().iter().any(|w| w
+                .message()
+                .contains("open candidate span(s) at snapshot/shutdown")));
+        });
+    }
+
+    #[test]
+    fn strict_snapshot_errors_for_open_candidate() {
+        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let _open = tracing::info_span!("request", tt.kind = "request", tt.request_id = "r1");
+            let err = recorder.snapshot_run().unwrap_err();
+            assert!(matches!(err, ImportError::StrictViolation(_)));
+        });
+    }
+
+    #[test]
+    fn unrelated_open_span_does_not_warn() {
+        with_recorder(|recorder| {
+            let _open = tracing::info_span!("ordinary", foo = 1_u64);
+            let imported = recorder.snapshot_run().unwrap();
+            assert!(imported.warnings().is_empty());
+        });
+    }
+
+    #[test]
+    fn empty_tt_kind_still_counts_as_open_candidate() {
+        with_recorder(|recorder| {
+            let _open = tracing::info_span!(
+                "request",
+                tt.kind = tracing::field::Empty,
+                tt.request_id = "r1"
+            );
+            let imported = recorder.snapshot_run().unwrap();
+            assert!(imported
+                .warnings()
+                .iter()
+                .any(|w| w.message().contains("tt.kind")));
+        });
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent malformed unrelated normalized `{"span": {...}}` records from aborting imports while preserving strict/non-strict behavior for `tt.*` records and keeping malformed JSON fatal. 
- Respect explicit normalized `duration_us` values so JSONL inputs can specify microsecond durations that override timestamp-derived durations. 
- Ensure open tracked candidate spans observed by the live recorder are surfaced at `snapshot_run`/`shutdown` instead of being silently omitted. 

### Description
- JSONL parsing: compute `has_tt = value_has_tailtriage_field(value)` once and gate normalized-shape parsing so unrelated malformed normalized spans return `Ok(None)` while `tt.*` tagged normalized spans still strict-or-warn on parse errors (`tailtriage-tracing/src/jsonl.rs`).
- `duration_us`: added parsing helper `optional_u64` and wire `duration_us` from normalized span objects into `SpanRecord::duration_us(...)` (unsigned integer only); invalid `duration_us` on `tt.*` records respects strict/non-strict rules and is ignored for unrelated normalized spans (`tailtriage-tracing/src/jsonl.rs`).
- Live recorder snapshot/shutdown: inspect `state.open` for tracked candidate spans with `tt.*` fields, return `ImportError::StrictViolation` in strict mode, and in non-strict mode add a single lifecycle warning (also pushed into `ImportedRun::warnings()`) with up to 3 samples containing `name`, `id`, `tt.kind`, and `tt.request_id` when scalar; do not fabricate completions or change truncation behavior (`tailtriage-tracing/src/recorder.rs`).
- Tests: added unit tests covering ignored malformed unrelated normalized spans, strict/non-strict behavior for malformed `tt.*` normalized spans, normalized `duration_us` happy and error cases, and recorder snapshot/shutdown open-span warning/error cases (`tailtriage-tracing/src/jsonl.rs` and `tailtriage-tracing/src/recorder.rs`).
- Docs/PR polish: document `duration_us` semantics in `tailtriage-tracing/README.md` and remove the duplicated adjacent caveat while preserving the narrow compatibility claim.

### Testing
- Ran formatting, lints, unit tests, docs validation, tracing parity demos, and runtime-cost measurement: all commands completed successfully.
  - `cargo fmt --check` (passed)
  - `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (passed)
  - `cargo test --workspace --all-targets --all-features --locked` (passed)
  - `python3 scripts/validate_docs_contracts.py` (passed)
  - `python3 scripts/demo_tool.py validate-tracing-parity all --profile release` (passed)
  - `python3 scripts/measure_runtime_cost.py --requests 1200 --concurrency 32 --work-ms 4 --rounds 2 --warmup-rounds 1 --artifact-dir demos/runtime_cost/artifacts/ci-smoke` (ran and produced artifacts)
  - `python3 scripts/validate_runtime_cost_summary.py --raw demos/runtime_cost/artifacts/ci-smoke/runtime-cost-raw.jsonl --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json` (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0abc352a8c8330b93ded78004768ab)