### PR TITLE
Honor outer `fields` and top-level `tt.*` keys when parsing normalized JSONL spans

### DIFF
--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -95,7 +95,7 @@ fn parse_record(
             if !has_tt {
                 return Ok(None);
             }
-            return match parse_normalized_span(span_obj) {
+            return match parse_normalized_span(value, span_obj) {
                 Ok(span) => Ok(Some(span)),
                 Err(err) => {
                     let message = format!("line {line_no}: {err}");
@@ -152,6 +152,7 @@ fn value_has_tailtriage_field(value: &Value) -> bool {
 }
 
 fn parse_normalized_span(
+    value: &Value,
     span_obj: &serde_json::Map<String, Value>,
 ) -> Result<SpanRecord, ImportError> {
     let name = required_string(span_obj, "name")?;
@@ -172,7 +173,7 @@ fn parse_normalized_span(
         span = span.duration_us(duration_us);
     }
 
-    let fields = extract_fields_for_span(&Value::Object(span_obj.clone()));
+    let fields = extract_fields_for_span(value);
     for (k, v) in fields {
         span = span.field(k, v);
     }
@@ -246,6 +247,7 @@ fn indicates_close_event(value: &Value) -> bool {
 }
 
 fn extract_fields_for_span(value: &Value) -> BTreeMap<String, FieldValue> {
+    // Precedence for duplicate keys is outer `fields` < `span.fields` < top-level `tt.*`.
     let mut out = BTreeMap::new();
     collect_fields_object(value.get("fields"), &mut out);
     collect_fields_object(value.get("span").and_then(|s| s.get("fields")), &mut out);
@@ -374,6 +376,66 @@ mod tests {
     use super::*;
     use crate::ImportOptions;
     use std::io::Cursor;
+
+    #[test]
+    fn normalized_request_with_outer_fields_imports() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2},"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/outer"}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].route, "/outer");
+    }
+
+    #[test]
+    fn normalized_request_with_top_level_tt_fields_imports() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2},"tt.kind":"request","tt.request_id":"r1","tt.route":"/top"}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].route, "/top");
+    }
+
+    #[test]
+    fn normalized_stage_and_queue_with_outer_or_top_level_fields_import() {
+        let input = r#"
+{"span":{"name":"st","started_at_unix_ms":11,"finished_at_unix_ms":18},"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}
+{"span":{"name":"st2","started_at_unix_ms":12,"finished_at_unix_ms":19},"tt.kind":"stage","tt.request_id":"r1","tt.stage":"cache"}
+{"span":{"name":"q","started_at_unix_ms":10,"finished_at_unix_ms":11},"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":3}}
+{"span":{"name":"q2","started_at_unix_ms":10,"finished_at_unix_ms":12},"tt.kind":"queue","tt.request_id":"r1","tt.queue":"worker","tt.depth_at_start":4}
+"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().stages.len(), 2);
+        assert_eq!(imported.run().stages[0].stage, "db");
+        assert_eq!(imported.run().stages[1].stage, "cache");
+        assert_eq!(imported.run().queues.len(), 2);
+        assert_eq!(imported.run().queues[0].depth_at_start, Some(3));
+        assert_eq!(imported.run().queues[1].depth_at_start, Some(4));
+    }
+
+    #[test]
+    fn normalized_span_fields_still_imports() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/span"}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].route, "/span");
+    }
+
+    #[test]
+    fn normalized_field_precedence_is_outer_then_span_then_top_level() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/span"}},"fields":{"tt.route":"/outer"},"tt.route":"/top"}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests[0].route, "/top");
+    }
+
+    #[test]
+    fn normalized_duration_us_works_with_outer_and_top_level_tt_fields() {
+        let outer = r#"{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":1234},"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/outer"}}"#;
+        let top = r#"{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":5678},"tt.kind":"request","tt.request_id":"r1","tt.route":"/top"}"#;
+        let imported_outer =
+            import_jsonl_reader(Cursor::new(outer), ImportOptions::new("svc")).unwrap();
+        let imported_top =
+            import_jsonl_reader(Cursor::new(top), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported_outer.run().requests[0].latency_us, 1234);
+        assert_eq!(imported_top.run().requests[0].latency_us, 5678);
+    }
 
     #[test]
     fn normalized_jsonl_request_only() {

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -122,7 +122,8 @@ where
                         started_at_unix_ms: span.started_at_unix_ms(),
                         finished_at_unix_ms: span.finished_at_unix_ms(),
                         latency_us: span.duration_us_ref().unwrap_or(
-                            (span.finished_at_unix_ms() - span.started_at_unix_ms()) * 1000,
+                            (span.finished_at_unix_ms() - span.started_at_unix_ms())
+                                .saturating_mul(1000),
                         ),
                         outcome,
                     });
@@ -146,7 +147,8 @@ where
                         started_at_unix_ms: span.started_at_unix_ms(),
                         finished_at_unix_ms: span.finished_at_unix_ms(),
                         latency_us: span.duration_us_ref().unwrap_or(
-                            (span.finished_at_unix_ms() - span.started_at_unix_ms()) * 1000,
+                            (span.finished_at_unix_ms() - span.started_at_unix_ms())
+                                .saturating_mul(1000),
                         ),
                         success,
                     });
@@ -170,7 +172,8 @@ where
                         waited_from_unix_ms: span.started_at_unix_ms(),
                         waited_until_unix_ms: span.finished_at_unix_ms(),
                         wait_us: span.duration_us_ref().unwrap_or(
-                            (span.finished_at_unix_ms() - span.started_at_unix_ms()) * 1000,
+                            (span.finished_at_unix_ms() - span.started_at_unix_ms())
+                                .saturating_mul(1000),
                         ),
                         depth_at_start,
                     });


### PR DESCRIPTION
### Motivation
- Normalized JSONL parsing only read `span`-nested `fields`, which dropped documented outer `fields` and top-level `tt.*` keys and caused valid normalized records to be ignored.
- The import must consume semantic `tt.*` data from all documented locations so request/stage/queue normalized shapes behave as documented.

### Description
- Change `parse_normalized_span` to accept the full JSON `value` along with the `span_obj` (`fn parse_normalized_span(value: &Value, span_obj: &serde_json::Map<String, Value>) -> Result<SpanRecord, ImportError>`), keep identity/timestamps/duration parsing on `span_obj`, and extract semantic fields with `let fields = extract_fields_for_span(value);`.
- Keep `span.fields` support and reuse existing `extract_fields_for_span` as the source of truth, adding an inline comment documenting precedence: outer `fields` < `span.fields` < top-level `tt.*` (later sources override earlier duplicates).
- Add focused tests exercising normalized JSONL import from outer `fields`, top-level `tt.*`, `span.fields`, stage/queue variants (including `tt.depth_at_start`), precedence (outer vs span vs top-level), and `duration_us` behavior when `tt.*` comes from outer/top-level locations.
- Apply defensive arithmetic for timestamp-derived microsecond durations in `run_from_span_records` by using `.saturating_mul(1000)` when deriving from non-inverted millisecond timestamps; explicit `duration_us` behavior is unchanged.
- Preserve all existing malformed/unrelated/strict-non-strict behaviors and do not change parser warning persistence or product scope.

### Testing
- Ran formatting: `cargo fmt --check` (passed).
- Ran linting: `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (passed).
- Ran the full test suite: `cargo test --workspace --all-targets --all-features --locked` (all tests passed, including new JSONL tests).
- Ran docs contract validation: `python3 scripts/validate_docs_contracts.py` (passed).
- Ran tracing parity validation: `python3 scripts/demo_tool.py validate-tracing-parity all --profile release` (passed).
- Measured runtime-cost artifacts and validated summary: `python3 scripts/measure_runtime_cost.py ...` and `python3 scripts/validate_runtime_cost_summary.py ...` (completed and validated as part of CI smoke profile).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ac93427a083308c412db695e696ae)