### PR TITLE
Fix normalized JSONL tt field extraction precedence

### DIFF
--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -95,7 +95,7 @@ fn parse_record(
             if !has_tt {
                 return Ok(None);
             }
-            return match parse_normalized_span(span_obj) {
+            return match parse_normalized_span(value, span_obj) {
                 Ok(span) => Ok(Some(span)),
                 Err(err) => {
                     let message = format!("line {line_no}: {err}");
@@ -152,6 +152,7 @@ fn value_has_tailtriage_field(value: &Value) -> bool {
 }
 
 fn parse_normalized_span(
+    value: &Value,
     span_obj: &serde_json::Map<String, Value>,
 ) -> Result<SpanRecord, ImportError> {
     let name = required_string(span_obj, "name")?;
@@ -172,7 +173,7 @@ fn parse_normalized_span(
         span = span.duration_us(duration_us);
     }
 
-    let fields = extract_fields_for_span(&Value::Object(span_obj.clone()));
+    let fields = extract_fields_for_span(value);
     for (k, v) in fields {
         span = span.field(k, v);
     }
@@ -247,6 +248,7 @@ fn indicates_close_event(value: &Value) -> bool {
 
 fn extract_fields_for_span(value: &Value) -> BTreeMap<String, FieldValue> {
     let mut out = BTreeMap::new();
+    // Precedence is intentionally outer fields < span.fields < top-level tt.*.
     collect_fields_object(value.get("fields"), &mut out);
     collect_fields_object(value.get("span").and_then(|s| s.get("fields")), &mut out);
     collect_tt_top_level(value, &mut out);
@@ -579,6 +581,86 @@ mod tests {
         assert_eq!(imported.run().requests[0].latency_us, 1234);
         assert_eq!(imported.run().stages[0].latency_us, 1234);
         assert_eq!(imported.run().queues[0].wait_us, 1234);
+    }
+
+    #[test]
+    fn normalized_request_imports_from_outer_fields() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2},"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/outer"}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].route, "/outer");
+    }
+
+    #[test]
+    fn normalized_request_imports_from_top_level_tt_fields() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2},"tt.kind":"request","tt.request_id":"r1","tt.route":"/top"}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].route, "/top");
+    }
+
+    #[test]
+    fn normalized_stage_imports_from_outer_fields() {
+        let input = r#"{"span":{"name":"st","started_at_unix_ms":1,"finished_at_unix_ms":2},"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().stages.len(), 1);
+        assert_eq!(imported.run().stages[0].stage, "db");
+    }
+
+    #[test]
+    fn normalized_stage_imports_from_top_level_tt_fields() {
+        let input = r#"{"span":{"name":"st","started_at_unix_ms":1,"finished_at_unix_ms":2},"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().stages.len(), 1);
+        assert_eq!(imported.run().stages[0].stage, "db");
+    }
+
+    #[test]
+    fn normalized_queue_imports_from_outer_fields() {
+        let input = r#"{"span":{"name":"q","started_at_unix_ms":1,"finished_at_unix_ms":2},"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":3}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().queues.len(), 1);
+        assert_eq!(imported.run().queues[0].queue, "permits");
+        assert_eq!(imported.run().queues[0].depth_at_start, Some(3));
+    }
+
+    #[test]
+    fn normalized_queue_imports_from_top_level_tt_fields() {
+        let input = r#"{"span":{"name":"q","started_at_unix_ms":1,"finished_at_unix_ms":2},"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":3}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().queues.len(), 1);
+        assert_eq!(imported.run().queues[0].queue, "permits");
+        assert_eq!(imported.run().queues[0].depth_at_start, Some(3));
+    }
+
+    #[test]
+    fn normalized_span_fields_still_import() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/span"}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].route, "/span");
+    }
+
+    #[test]
+    fn normalized_fields_precedence_is_outer_then_span_then_top_level() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/span"}},"fields":{"tt.route":"/outer"},"tt.route":"/top"}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].route, "/top");
+    }
+
+    #[test]
+    fn normalized_duration_us_with_outer_fields_still_overrides_derived_latency() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":1234},"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/outer"}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests[0].latency_us, 1234);
+    }
+
+    #[test]
+    fn normalized_duration_us_with_top_level_fields_still_overrides_derived_latency() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":1234},"tt.kind":"request","tt.request_id":"r1","tt.route":"/top"}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests[0].latency_us, 1234);
     }
 
     #[test]

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -122,7 +122,8 @@ where
                         started_at_unix_ms: span.started_at_unix_ms(),
                         finished_at_unix_ms: span.finished_at_unix_ms(),
                         latency_us: span.duration_us_ref().unwrap_or(
-                            (span.finished_at_unix_ms() - span.started_at_unix_ms()) * 1000,
+                            (span.finished_at_unix_ms() - span.started_at_unix_ms())
+                                .saturating_mul(1000),
                         ),
                         outcome,
                     });
@@ -146,7 +147,8 @@ where
                         started_at_unix_ms: span.started_at_unix_ms(),
                         finished_at_unix_ms: span.finished_at_unix_ms(),
                         latency_us: span.duration_us_ref().unwrap_or(
-                            (span.finished_at_unix_ms() - span.started_at_unix_ms()) * 1000,
+                            (span.finished_at_unix_ms() - span.started_at_unix_ms())
+                                .saturating_mul(1000),
                         ),
                         success,
                     });
@@ -170,7 +172,8 @@ where
                         waited_from_unix_ms: span.started_at_unix_ms(),
                         waited_until_unix_ms: span.finished_at_unix_ms(),
                         wait_us: span.duration_us_ref().unwrap_or(
-                            (span.finished_at_unix_ms() - span.started_at_unix_ms()) * 1000,
+                            (span.finished_at_unix_ms() - span.started_at_unix_ms())
+                                .saturating_mul(1000),
                         ),
                         depth_at_start,
                     });


### PR DESCRIPTION
### Motivation

- Normalized JSONL parsing only inspected `span` when building `SpanRecord`, which dropped documented `outer fields` and top-level `tt.*` keys and caused normalized shapes to be detected but missing `tt.*` metadata. 
- The change must preserve existing strict/non-strict and `duration_us` semantics while consuming all documented field locations for request/stage/queue records.

### Description

- Change `parse_normalized_span` to accept the full JSON `Value` in addition to `span_obj` and continue reading identity/timestamps/`duration_us` from `span_obj` while extracting semantic fields from the full record via `extract_fields_for_span`.
- Keep and document extraction precedence as `outer fields` < `span.fields` < top-level `tt.*`, with later sources overriding earlier duplicates; added an inline comment at the extraction site explaining this behavior.
- Add unit tests that cover normalized imports from `fields` (outer), `span.fields`, and top-level `tt.*` for request/stage/queue records, a precedence test showing top-level overrides span and outer, and `duration_us` override behavior when `tt.*` comes from outer or top-level locations.
- Apply defensive arithmetic for derived durations by using `.saturating_mul(1000)` where durations are derived from timestamps, without changing explicit `duration_us` semantics.
- Preserve existing malformed/unrelated normalized-span behavior, strict/non-strict error paths, and warning persistence (no parser warnings persisted into run metadata as part of this change).

### Testing

- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed.
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests passed (including the new JSONL tests).
- Ran `python3 scripts/validate_docs_contracts.py` and it passed.
- Ran `python3 scripts/demo_tool.py validate-tracing-parity all --profile release` and it passed.
- Ran `python3 scripts/measure_runtime_cost.py --requests 1200 --concurrency 32 --work-ms 4 --rounds 2 --warmup-rounds 1 --artifact-dir demos/runtime_cost/artifacts/ci-smoke` and it completed successfully, and `python3 scripts/validate_runtime_cost_summary.py --raw demos/runtime_cost/artifacts/ci-smoke/runtime-cost-raw.jsonl --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json` also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ac93427a083308c412db695e696ae)