### PR TITLE
Fix normalized JSONL extraction from outer fields and top-level tt keys

### DIFF
--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -95,7 +95,7 @@ fn parse_record(
             if !has_tt {
                 return Ok(None);
             }
-            return match parse_normalized_span(span_obj) {
+            return match parse_normalized_span(value, span_obj) {
                 Ok(span) => Ok(Some(span)),
                 Err(err) => {
                     let message = format!("line {line_no}: {err}");
@@ -152,6 +152,7 @@ fn value_has_tailtriage_field(value: &Value) -> bool {
 }
 
 fn parse_normalized_span(
+    value: &Value,
     span_obj: &serde_json::Map<String, Value>,
 ) -> Result<SpanRecord, ImportError> {
     let name = required_string(span_obj, "name")?;
@@ -172,7 +173,7 @@ fn parse_normalized_span(
         span = span.duration_us(duration_us);
     }
 
-    let fields = extract_fields_for_span(&Value::Object(span_obj.clone()));
+    let fields = extract_fields_for_span(value);
     for (k, v) in fields {
         span = span.field(k, v);
     }
@@ -247,6 +248,7 @@ fn indicates_close_event(value: &Value) -> bool {
 
 fn extract_fields_for_span(value: &Value) -> BTreeMap<String, FieldValue> {
     let mut out = BTreeMap::new();
+    // Precedence for duplicate keys is: outer fields < span.fields < top-level tt.*.
     collect_fields_object(value.get("fields"), &mut out);
     collect_fields_object(value.get("span").and_then(|s| s.get("fields")), &mut out);
     collect_tt_top_level(value, &mut out);
@@ -579,6 +581,83 @@ mod tests {
         assert_eq!(imported.run().requests[0].latency_us, 1234);
         assert_eq!(imported.run().stages[0].latency_us, 1234);
         assert_eq!(imported.run().queues[0].wait_us, 1234);
+    }
+
+    #[test]
+    fn normalized_request_fields_import_from_outer_fields() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2},"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/outer"}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].route, "/outer");
+    }
+
+    #[test]
+    fn normalized_request_fields_import_from_top_level_tt_keys() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2},"tt.kind":"request","tt.request_id":"r1","tt.route":"/top"}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].route, "/top");
+    }
+
+    #[test]
+    fn normalized_stage_fields_import_from_outer_fields() {
+        let input = r#"{"span":{"name":"st","started_at_unix_ms":1,"finished_at_unix_ms":2},"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().stages.len(), 1);
+        assert_eq!(imported.run().stages[0].stage, "db");
+    }
+
+    #[test]
+    fn normalized_stage_fields_import_from_top_level_tt_keys() {
+        let input = r#"{"span":{"name":"st","started_at_unix_ms":1,"finished_at_unix_ms":2},"tt.kind":"stage","tt.request_id":"r1","tt.stage":"cache"}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().stages.len(), 1);
+        assert_eq!(imported.run().stages[0].stage, "cache");
+    }
+
+    #[test]
+    fn normalized_queue_fields_import_from_outer_fields() {
+        let input = r#"{"span":{"name":"q","started_at_unix_ms":1,"finished_at_unix_ms":2},"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":3}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().queues.len(), 1);
+        assert_eq!(imported.run().queues[0].depth_at_start, Some(3));
+    }
+
+    #[test]
+    fn normalized_queue_fields_import_from_top_level_tt_keys() {
+        let input = r#"{"span":{"name":"q","started_at_unix_ms":1,"finished_at_unix_ms":2},"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":7}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().queues.len(), 1);
+        assert_eq!(imported.run().queues[0].depth_at_start, Some(7));
+    }
+
+    #[test]
+    fn normalized_span_fields_still_imports() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/span"}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].route, "/span");
+    }
+
+    #[test]
+    fn normalized_field_precedence_is_outer_then_span_then_top_level() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.route":"/span","tt.kind":"request","tt.request_id":"r1"}},"fields":{"tt.route":"/outer"},"tt.route":"/top"}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests[0].route, "/top");
+    }
+
+    #[test]
+    fn normalized_duration_us_from_outer_fields_still_overrides_derived_latency() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":1234},"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/outer"}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests[0].latency_us, 1234);
+    }
+
+    #[test]
+    fn normalized_duration_us_from_top_level_tt_keys_still_overrides_derived_latency() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":1234},"tt.kind":"request","tt.request_id":"r1","tt.route":"/top"}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests[0].latency_us, 1234);
     }
 
     #[test]

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -122,7 +122,8 @@ where
                         started_at_unix_ms: span.started_at_unix_ms(),
                         finished_at_unix_ms: span.finished_at_unix_ms(),
                         latency_us: span.duration_us_ref().unwrap_or(
-                            (span.finished_at_unix_ms() - span.started_at_unix_ms()) * 1000,
+                            (span.finished_at_unix_ms() - span.started_at_unix_ms())
+                                .saturating_mul(1000),
                         ),
                         outcome,
                     });
@@ -146,7 +147,8 @@ where
                         started_at_unix_ms: span.started_at_unix_ms(),
                         finished_at_unix_ms: span.finished_at_unix_ms(),
                         latency_us: span.duration_us_ref().unwrap_or(
-                            (span.finished_at_unix_ms() - span.started_at_unix_ms()) * 1000,
+                            (span.finished_at_unix_ms() - span.started_at_unix_ms())
+                                .saturating_mul(1000),
                         ),
                         success,
                     });
@@ -170,7 +172,8 @@ where
                         waited_from_unix_ms: span.started_at_unix_ms(),
                         waited_until_unix_ms: span.finished_at_unix_ms(),
                         wait_us: span.duration_us_ref().unwrap_or(
-                            (span.finished_at_unix_ms() - span.started_at_unix_ms()) * 1000,
+                            (span.finished_at_unix_ms() - span.started_at_unix_ms())
+                                .saturating_mul(1000),
                         ),
                         depth_at_start,
                     });


### PR DESCRIPTION
### Motivation

- Normalized JSONL parsing previously only extracted `tt.*` semantic fields from the nested `span.fields`, which dropped documented outer `fields` and top-level `tt.*` keys and caused valid normalized records to be ignored. 
- The importer must treat normalized shapes as consuming `tt.*` from all documented locations (outer `fields`, `span.fields`, and top-level `tt.*`) while still reading identity/timestamps/`duration_us` from the `span` object.

### Description

- Change `parse_normalized_span` to accept the full outer `Value` in addition to `span` so semantic extraction can run across the entire record by calling `extract_fields_for_span(value)`. 
- Keep normalized identity, timestamps, and `duration_us` read from `span` only, and apply extracted fields into the created `SpanRecord`. 
- Preserve and document extraction precedence as `outer fields < span.fields < top-level tt.*`, meaning later sources override earlier duplicate keys, and add an inline comment next to `extract_fields_for_span` to record that behavior. 
- Add multiple unit tests exercising normalized JSONL variants (request/stage/queue) importing `tt.*` from outer `fields`, top-level `tt.*`, and `span.fields`, a precedence test confirming top-level wins, and duration_us coverage when `tt.*` is provided outside `span.fields`. 
- Apply defensive `saturating_mul(1000)` in `run_from_span_records` when deriving microsecond durations from millisecond timestamps for request, stage, and queue records without changing explicit `duration_us` behavior.

### Testing

- Ran `cargo fmt --check` and it passed. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed. 
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests passed. 
- Ran `python3 scripts/validate_docs_contracts.py`, `python3 scripts/demo_tool.py validate-tracing-parity all --profile release`, `python3 scripts/measure_runtime_cost.py --requests 1200 --concurrency 32 --work-ms 4 --rounds 2 --warmup-rounds 1 --artifact-dir demos/runtime_cost/artifacts/ci-smoke`, and `python3 scripts/validate_runtime_cost_summary.py --raw demos/runtime_cost/artifacts/ci-smoke/runtime-cost-raw.jsonl --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json`; all validations completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ac93427a083308c412db695e696ae)