### PR TITLE
Persist JSONL parser warnings into imported run lifecycle metadata

### DIFF
--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -52,9 +52,27 @@ pub fn import_jsonl_reader<R: Read>(
     }
 
     let imported = run_from_span_records(spans, options)?;
-    let (run, mut conversion_warnings) = imported.into_parts();
+    let (mut run, mut conversion_warnings) = imported.into_parts();
+    attach_parse_warnings_to_lifecycle(&mut run, &parse_warnings);
     parse_warnings.append(&mut conversion_warnings);
     Ok(ImportedRun::new(run, parse_warnings))
+}
+
+fn attach_parse_warnings_to_lifecycle(
+    run: &mut tailtriage_core::Run,
+    parse_warnings: &[crate::ImportWarning],
+) {
+    for warning in parse_warnings {
+        let message = warning.message();
+        if !run
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|existing| existing == message)
+        {
+            run.metadata.lifecycle_warnings.push(message.to_owned());
+        }
+    }
 }
 
 /// Imports newline-delimited JSON records from a filesystem path.
@@ -509,6 +527,59 @@ mod tests {
         assert_eq!(imported.warnings().len(), 1);
         assert!(imported.warnings()[0].message().contains("line 1"));
 
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+            .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn parse_warnings_are_persisted_to_run_lifecycle_warnings() {
+        let input = r#"
+{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
+{"span":{"name":"broken","fields":{"tt.kind":"request","tt.request_id":"r2","tt.route":"/b"}}}
+"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.warnings().len(), 1);
+        let warning = imported.warnings()[0].message();
+        assert!(warning.contains("line 3"));
+        assert!(imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|entry| entry == warning));
+    }
+
+    #[test]
+    fn conversion_warnings_still_follow_existing_lifecycle_policy() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1"}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.warnings().len(), 1);
+        let conversion_warning = imported.warnings()[0].message();
+        assert!(imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|entry| entry == conversion_warning));
+    }
+
+    #[test]
+    fn unrelated_malformed_normalized_span_does_not_create_lifecycle_warning() {
+        let input = r#"
+{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
+{"span":{"name":"other","id":123,"started_at_unix_ms":3,"finished_at_unix_ms":4}}
+"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert!(imported.warnings().is_empty());
+        assert!(imported.run().metadata.lifecycle_warnings.is_empty());
+    }
+
+    #[test]
+    fn strict_parse_warning_case_still_errors_without_run() {
+        let input = r#"{"span":{"name":"broken","fields":{"tt.kind":"request","tt.request_id":"r2","tt.route":"/b"}}}"#;
         let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
             .unwrap_err();
         assert!(matches!(err, ImportError::StrictViolation(_)));


### PR DESCRIPTION
### Motivation

- Imported JSONL runs were not self-contained: parser-level warnings produced while skipping syntactically valid but malformed `tt.*` records were visible at import time but not persisted into the emitted `tailtriage_core::Run` metadata for later analysis.
- Ensure artifacts produced by `tailtriage import tracing-json` carry parser warnings in `metadata.lifecycle_warnings` so downstream `tailtriage analyze` or artifact review can surface the same leads without re-running the importer.

### Description

- Updated `tailtriage-tracing/src/jsonl.rs` only to persist parser-level warnings into the converted `Run` before returning `ImportedRun` and to preserve the existing warning ordering semantics (parser warnings first, then conversion warnings).
- Added a private helper `attach_parse_warnings_to_lifecycle(run: &mut tailtriage_core::Run, parse_warnings: &[crate::ImportWarning])` that appends parser warning messages to `run.metadata.lifecycle_warnings` while deduplicating against existing entries.
- Split the result from `run_from_span_records(spans, options)?` into `(mut run, mut conversion_warnings)`, attached parser warnings into `run.metadata.lifecycle_warnings`, then returned `ImportedRun::new(run, warnings)` with warnings ordered as: parser then conversion.
- Added focused unit tests in `tailtriage-tracing/src/jsonl.rs` to cover the regression cases: `parse_warnings_are_persisted_to_run_lifecycle_warnings`, `conversion_warnings_still_follow_existing_lifecycle_policy`, `unrelated_malformed_normalized_span_does_not_create_lifecycle_warning`, and `strict_parse_warning_case_still_errors_without_run`.

### Testing

- Ran formatting and linters: `cargo fmt --check` passed and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` passed.
- Ran full test suite: `cargo test --workspace --all-targets --all-features --locked` and the repository tests passed (all tests in workspace passed, with the new unit tests exercising the JSONL import behavior).
- Ran documentation validation: `python3 scripts/validate_docs_contracts.py` passed.
- Behavior validated by tests: parser warnings are preserved in both `ImportedRun::warnings()` and `ImportedRun::run().metadata.lifecycle_warnings`, malformed JSON still errors, unrelated non-`tt.*` malformed normalized spans remain ignored without warnings, and strict mode still fails for parser-warning cases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ad1373fec8330915ef30c098f5ed8)