### PR TITLE
Persist JSONL parser warnings into imported Run lifecycle metadata

### DIFF
--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -52,9 +52,27 @@ pub fn import_jsonl_reader<R: Read>(
     }
 
     let imported = run_from_span_records(spans, options)?;
-    let (run, mut conversion_warnings) = imported.into_parts();
+    let (mut run, mut conversion_warnings) = imported.into_parts();
+    attach_parse_warnings_to_lifecycle(&mut run, &parse_warnings);
     parse_warnings.append(&mut conversion_warnings);
     Ok(ImportedRun::new(run, parse_warnings))
+}
+
+fn attach_parse_warnings_to_lifecycle(
+    run: &mut tailtriage_core::Run,
+    parse_warnings: &[crate::ImportWarning],
+) {
+    for warning in parse_warnings {
+        let message = warning.message();
+        if !run
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|existing| existing == message)
+        {
+            run.metadata.lifecycle_warnings.push(message.to_owned());
+        }
+    }
 }
 
 /// Imports newline-delimited JSON records from a filesystem path.
@@ -691,6 +709,64 @@ mod tests {
     #[test]
     fn strict_close_event_like_tt_span_missing_timestamps_errors() {
         let input = r#"{"event":"close","span":{"name":"st","fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}"#;
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+            .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn parse_warnings_are_persisted_to_run_lifecycle_warnings() {
+        let input = r#"
+{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
+{"span":{"name":"req","fields":{"tt.kind":"request","tt.request_id":"r2","tt.route":"/b"}}}
+"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.warnings().len(), 1);
+        let parse_warning = imported.warnings()[0].message();
+        assert!(parse_warning.contains("line 3"));
+        assert!(imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|warning| warning == parse_warning));
+    }
+
+    #[test]
+    fn conversion_warnings_still_follow_existing_lifecycle_policy() {
+        let input = r#"
+{"span":{"name":"req-ok","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
+{"span":{"name":"req-missing-route","started_at_unix_ms":3,"finished_at_unix_ms":4,"fields":{"tt.kind":"request","tt.request_id":"r2"}}}
+"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.warnings().len(), 1);
+        let warning = imported.warnings()[0].message();
+        assert!(warning.contains("tt.route") || warning.contains("route"));
+        assert!(imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|entry| entry == warning));
+    }
+
+    #[test]
+    fn unrelated_malformed_normalized_span_does_not_create_lifecycle_warning() {
+        let input = r#"
+{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
+{"span":{"name":"other","id":123,"started_at_unix_ms":3,"finished_at_unix_ms":4}}
+"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert!(imported.warnings().is_empty());
+        assert!(imported.run().metadata.lifecycle_warnings.is_empty());
+    }
+
+    #[test]
+    fn strict_parse_warning_case_still_errors_without_run() {
+        let input = r#"{"span":{"name":"req","fields":{"tt.kind":"request","tt.request_id":"r2","tt.route":"/b"}}}"#;
         let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
             .unwrap_err();
         assert!(matches!(err, ImportError::StrictViolation(_)));


### PR DESCRIPTION
### Motivation
- Parser-level warnings produced while reading JSONL `tt.*` records were exposed to the importer UI but not persisted into the resulting `tailtriage_core::Run` metadata, leaving imported artifacts non-self-contained for later analysis.
- The change ensures syntactically valid-but-malformed `tt.*` records produce lifecycle warnings embedded in the Run so `tailtriage analyze` and artifact review see the same warnings as the import step.

### Description
- Update `import_jsonl_reader` in `tailtriage-tracing/src/jsonl.rs` to call a new private helper `attach_parse_warnings_to_lifecycle` after converting spans and before building `ImportedRun` so parse warnings are appended into `run.metadata.lifecycle_warnings`.
- Implement `attach_parse_warnings_to_lifecycle` to iterate parser warnings in order, push `warning.message()` into `run.metadata.lifecycle_warnings`, and avoid duplicating messages already present.
- Preserve user-facing warning ordering by appending conversion warnings after parser warnings and avoid changing conversion or analyzer behavior, Run schema, or CLI interfaces.
- Add targeted unit tests in `tailtriage-tracing` that assert parser warnings are preserved on `ImportedRun::warnings()` and on `run().metadata.lifecycle_warnings`, that conversion warnings continue to follow existing lifecycle policy, that unrelated malformed non-`tt.*` normalized spans remain ignored, and that strict mode still errors for parse-warning cases.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed.
- Ran `cargo test --workspace --all-targets --all-features --locked` with the full workspace and all new and existing tests passing.
- Ran `python3 scripts/validate_docs_contracts.py` and validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ad1373fec8330915ef30c098f5ed8)