### PR TITLE
Persist JSONL parser warnings in Run lifecycle metadata

### DIFF
--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -52,9 +52,27 @@ pub fn import_jsonl_reader<R: Read>(
     }
 
     let imported = run_from_span_records(spans, options)?;
-    let (run, mut conversion_warnings) = imported.into_parts();
+    let (mut run, mut conversion_warnings) = imported.into_parts();
+    attach_parse_warnings_to_lifecycle(&mut run, &parse_warnings);
     parse_warnings.append(&mut conversion_warnings);
     Ok(ImportedRun::new(run, parse_warnings))
+}
+
+fn attach_parse_warnings_to_lifecycle(
+    run: &mut tailtriage_core::Run,
+    parse_warnings: &[crate::ImportWarning],
+) {
+    for warning in parse_warnings {
+        let message = warning.message();
+        if !run
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|existing| existing == message)
+        {
+            run.metadata.lifecycle_warnings.push(message.to_owned());
+        }
+    }
 }
 
 /// Imports newline-delimited JSON records from a filesystem path.
@@ -549,6 +567,64 @@ mod tests {
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
         assert!(imported.run().requests.is_empty());
         assert!(imported.warnings().is_empty());
+    }
+
+    #[test]
+    fn parse_warnings_are_persisted_to_run_lifecycle_warnings() {
+        let input = r#"
+{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok"}}}
+{"span":{"name":"broken","fields":{"tt.kind":"request","tt.request_id":"r2","tt.route":"/broken"}}}
+"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.warnings().len(), 1);
+        let warning_message = imported.warnings()[0].message();
+        assert!(warning_message.contains("line 3"));
+        assert!(imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|warning| warning == warning_message));
+    }
+
+    #[test]
+    fn conversion_warnings_still_follow_existing_lifecycle_policy() {
+        let input = r#"
+{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok"}}}
+{"span":{"name":"req2","started_at_unix_ms":3,"finished_at_unix_ms":4,"fields":{"tt.kind":"request","tt.request_id":"r2"}}}
+"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.warnings().len(), 1);
+        let conversion_warning = imported.warnings()[0].message();
+        assert!(conversion_warning.contains("tt.route"));
+        assert!(imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|warning| warning == conversion_warning));
+    }
+
+    #[test]
+    fn unrelated_malformed_normalized_span_does_not_create_lifecycle_warning() {
+        let input = r#"
+{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok"}}}
+{"span":{"name":"other","id":123,"started_at_unix_ms":3,"finished_at_unix_ms":4}}
+"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert!(imported.warnings().is_empty());
+        assert!(imported.run().metadata.lifecycle_warnings.is_empty());
+    }
+
+    #[test]
+    fn strict_parse_warning_case_still_errors_without_run() {
+        let input = r#"{"span":{"name":"req","fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+            .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Parser-level warnings produced while reading JSONL (syntactically valid but malformed `tt.*` records) were returned via `ImportedRun::warnings()` but not persisted into the produced `tailtriage_core::Run` metadata, leaving imported artifacts non-self-contained.
- This is a narrow polish to ensure imported Run artifacts carry the same parser warnings so later `tailtriage analyze` or artifact review sees the same lifecycle warnings as the import step.

### Description
- Updated `import_jsonl_reader` in `tailtriage-tracing/src/jsonl.rs` to attach parser warnings into `run.metadata.lifecycle_warnings` before combining parse and conversion warnings for the returned `ImportedRun` via `ImportedRun::new(run, warnings)`.
- Added a private helper `attach_parse_warnings_to_lifecycle(run: &mut tailtriage_core::Run, parse_warnings: &[crate::ImportWarning])` that appends parse warning messages in line order while avoiding duplicates already present in lifecycle warnings.
- Added focused tests in `tailtriage-tracing/src/jsonl.rs` to validate that parse warnings are persisted to lifecycle metadata, conversion warnings retain existing lifecycle behavior, unrelated malformed non-`tt.*` normalized spans remain ignored, and strict mode still errors before producing a run.

### Testing
- Ran `cargo fmt --check` which passed. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which passed. 
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests (including the new JSONL tests) passed. 
- Ran `python3 scripts/validate_docs_contracts.py` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ad1373fec8330915ef30c098f5ed8)