### PR TITLE
Tighten tailtriage-tracing API evolution points and kind parsing

### DIFF
--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -80,7 +80,17 @@ where
     for span in spans {
         let kind = match get_string_field_state(&span, TT_KIND) {
             StringFieldState::Missing => continue,
-            StringFieldState::Value(kind) => kind,
+            StringFieldState::Value(kind) => {
+                let Some(kind) = SpanKind::from_tt_kind(kind) else {
+                    strict_or_warn(
+                        options.strict_mode(),
+                        &mut warnings,
+                        format!("unknown tt.kind '{kind}' in span '{}'", span.name()),
+                    )?;
+                    continue;
+                };
+                kind
+            }
             StringFieldState::InvalidType => {
                 strict_or_warn(
                     options.strict_mode(),
@@ -106,7 +116,7 @@ where
         }
 
         match kind {
-            "request" => {
+            SpanKind::Request => {
                 let request_id =
                     required_string(&span, TT_REQUEST_ID, options.strict_mode(), &mut warnings)?;
                 let route = required_string(&span, TT_ROUTE, options.strict_mode(), &mut warnings)?;
@@ -130,7 +140,7 @@ where
                     update_min_max(&mut min_start, &mut max_finish, &span);
                 }
             }
-            "stage" => {
+            SpanKind::Stage => {
                 let request_id =
                     required_string(&span, TT_REQUEST_ID, options.strict_mode(), &mut warnings)?;
                 let stage = required_string(&span, TT_STAGE, options.strict_mode(), &mut warnings)?;
@@ -155,7 +165,7 @@ where
                     update_min_max(&mut min_start, &mut max_finish, &span);
                 }
             }
-            "queue" => {
+            SpanKind::Queue => {
                 let request_id =
                     required_string(&span, TT_REQUEST_ID, options.strict_mode(), &mut warnings)?;
                 let queue = required_string(&span, TT_QUEUE, options.strict_mode(), &mut warnings)?;
@@ -179,13 +189,6 @@ where
                     });
                     update_min_max(&mut min_start, &mut max_finish, &span);
                 }
-            }
-            other => {
-                strict_or_warn(
-                    options.strict_mode(),
-                    &mut warnings,
-                    format!("unknown tt.kind '{other}' in span '{}'", span.name()),
-                )?;
             }
         }
     }

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -39,6 +39,7 @@ pub const DEFAULT_MAX_OPEN_SPANS: usize = 8_192;
 pub const DEFAULT_MAX_COMPLETED_SPANS: usize = 10_000;
 /// Configurable in-memory limits for live tracing recorder retention.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct RecorderLimits {
     /// Maximum number of concurrently tracked open candidate spans.
     pub max_open_spans: usize,

--- a/tailtriage-tracing/src/tokio.rs
+++ b/tailtriage-tracing/src/tokio.rs
@@ -10,6 +10,7 @@ use crate::{ImportError, ImportedRun, RecorderLimits, TailtriageLayer, TracingRe
 
 /// Error returned when starting [`TracingTokioSession`].
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum TracingTokioSessionStartError {
     /// Underlying tracing recorder setup failed.
     Build(BuildError),
@@ -30,6 +31,7 @@ impl std::error::Error for TracingTokioSessionStartError {}
 
 /// Error returned when shutting down [`TracingTokioSession`].
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum TracingTokioSessionShutdownError {
     /// Snapshot import failed.
     Import(ImportError),

--- a/tailtriage-tracing/src/types.rs
+++ b/tailtriage-tracing/src/types.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 /// Semantic span kind used by tailtriage tracing intake.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum SpanKind {
     /// Request-level span.
     Request,
@@ -14,9 +15,23 @@ pub enum SpanKind {
     Queue,
 }
 
+impl SpanKind {
+    /// Parses a `tt.kind` string into a semantic span kind.
+    #[must_use]
+    pub fn from_tt_kind(value: &str) -> Option<Self> {
+        match value {
+            "request" => Some(Self::Request),
+            "stage" => Some(Self::Stage),
+            "queue" => Some(Self::Queue),
+            _ => None,
+        }
+    }
+}
+
 /// Supported scalar field values on imported spans.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum FieldValue {
     /// String field value.
     String(String),
@@ -161,6 +176,7 @@ impl SpanRecord {
 
 /// Import options for converting tracing-shaped spans into a run.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct ImportOptions {
     service_name: String,
     service_version: Option<String>,
@@ -224,6 +240,7 @@ impl ImportOptions {
 
 /// Non-fatal warning produced while importing tracing-shaped spans.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct ImportWarning {
     message: String,
 }
@@ -251,6 +268,7 @@ impl core::fmt::Display for ImportWarning {
 
 /// Result of a completed import operation.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct ImportedRun {
     run: tailtriage_core::Run,
     warnings: Vec<ImportWarning>,
@@ -368,5 +386,14 @@ mod tests {
         let (parts_run, parts_warnings) = imported.into_parts();
         assert_eq!(parts_run, run);
         assert_eq!(parts_warnings, warnings);
+    }
+
+    #[test]
+    fn span_kind_from_tt_kind_parses_supported_values() {
+        assert_eq!(SpanKind::from_tt_kind("request"), Some(SpanKind::Request));
+        assert_eq!(SpanKind::from_tt_kind("stage"), Some(SpanKind::Stage));
+        assert_eq!(SpanKind::from_tt_kind("queue"), Some(SpanKind::Queue));
+        assert_eq!(SpanKind::from_tt_kind("REQUEST"), None);
+        assert_eq!(SpanKind::from_tt_kind("other"), None);
     }
 }


### PR DESCRIPTION
### Motivation
- Make the new `tailtriage-tracing` public surface safer to evolve by explicitly marking likely-to-change types as extension points. 
- Make the `SpanKind` API coherent and authoritative for `tt.kind` interpretation so conversions stop matching raw strings at arbitrary call sites. 
- Preserve the existing import semantics (non-strict warnings vs strict errors) and avoid scope creep into tracing backends or OTLP/OTel semantics. 

### Description
- Marked evolving public types as `#[non_exhaustive]` to allow forward-compatible extension without breaking downstream consumers: `FieldValue`, `SpanKind`, `ImportOptions`, `ImportWarning`, `ImportedRun`, `RecorderLimits`, `TracingTokioSessionStartError`, and `TracingTokioSessionShutdownError`.
- Kept `SpanKind` public and added `SpanKind::from_tt_kind(&str) -> Option<SpanKind>` which accepts only the three literal values `request`, `stage`, and `queue` and returns `None` for any other value (no aliases accepted).
- Updated `run_from_span_records` to parse `tt.kind` using `SpanKind::from_tt_kind` and to match on typed `SpanKind` variants instead of raw strings, preserving the previous strict/non-strict behavior for unknown or invalid `tt.kind` values (non-strict: emit warning and skip span; strict: return `ImportError::StrictViolation`).
- Added unit tests for `SpanKind::from_tt_kind` and updated/kept existing tests that cover parsing each valid `tt.kind`, unknown-kind warnings/errors, and the unchanged behavior for missing or non-string `tt.kind` values.

### Testing
- Ran `cargo fmt --check` successfully.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` successfully.
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests passed; a single targeted equivalence test was rerun after an earlier transient parity observation and passed on rerun.
- Ran `python3 scripts/validate_docs_contracts.py` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ad71dd6a483309b25b5ae31e12c9b)