### PR TITLE
Tighten tailtriage-tracing public API evolution surface

### DIFF
--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -80,7 +80,18 @@ where
     for span in spans {
         let kind = match get_string_field_state(&span, TT_KIND) {
             StringFieldState::Missing => continue,
-            StringFieldState::Value(kind) => kind,
+            StringFieldState::Value(kind) => {
+                if let Some(kind) = parse_span_kind(kind) {
+                    kind
+                } else {
+                    strict_or_warn(
+                        options.strict_mode(),
+                        &mut warnings,
+                        format!("unknown tt.kind '{kind}' in span '{}'", span.name()),
+                    )?;
+                    continue;
+                }
+            }
             StringFieldState::InvalidType => {
                 strict_or_warn(
                     options.strict_mode(),
@@ -106,7 +117,7 @@ where
         }
 
         match kind {
-            "request" => {
+            SpanKind::Request => {
                 let request_id =
                     required_string(&span, TT_REQUEST_ID, options.strict_mode(), &mut warnings)?;
                 let route = required_string(&span, TT_ROUTE, options.strict_mode(), &mut warnings)?;
@@ -130,7 +141,7 @@ where
                     update_min_max(&mut min_start, &mut max_finish, &span);
                 }
             }
-            "stage" => {
+            SpanKind::Stage => {
                 let request_id =
                     required_string(&span, TT_REQUEST_ID, options.strict_mode(), &mut warnings)?;
                 let stage = required_string(&span, TT_STAGE, options.strict_mode(), &mut warnings)?;
@@ -155,7 +166,7 @@ where
                     update_min_max(&mut min_start, &mut max_finish, &span);
                 }
             }
-            "queue" => {
+            SpanKind::Queue => {
                 let request_id =
                     required_string(&span, TT_REQUEST_ID, options.strict_mode(), &mut warnings)?;
                 let queue = required_string(&span, TT_QUEUE, options.strict_mode(), &mut warnings)?;
@@ -179,13 +190,6 @@ where
                     });
                     update_min_max(&mut min_start, &mut max_finish, &span);
                 }
-            }
-            other => {
-                strict_or_warn(
-                    options.strict_mode(),
-                    &mut warnings,
-                    format!("unknown tt.kind '{other}' in span '{}'", span.name()),
-                )?;
             }
         }
     }
@@ -271,6 +275,15 @@ fn get_string_field_state<'a>(span: &'a SpanRecord, key: &str) -> StringFieldSta
         Some(FieldValue::String(value)) => StringFieldState::Value(value.as_str()),
         Some(_) => StringFieldState::InvalidType,
         None => StringFieldState::Missing,
+    }
+}
+
+fn parse_span_kind(kind: &str) -> Option<SpanKind> {
+    match kind {
+        "request" => Some(SpanKind::Request),
+        "stage" => Some(SpanKind::Stage),
+        "queue" => Some(SpanKind::Queue),
+        _ => None,
     }
 }
 
@@ -497,6 +510,22 @@ mod tests {
         let spans = vec![SpanRecord::new("x", 1, 2).field(TT_KIND, "wat")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.warnings().len(), 1);
+    }
+
+    #[test]
+    fn unknown_kind_errors_in_strict() {
+        let spans = vec![SpanRecord::new("x", 1, 2).field(TT_KIND, "wat")];
+        let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn span_kind_parser_accepts_exact_supported_values_only() {
+        assert_eq!(parse_span_kind("request"), Some(SpanKind::Request));
+        assert_eq!(parse_span_kind("stage"), Some(SpanKind::Stage));
+        assert_eq!(parse_span_kind("queue"), Some(SpanKind::Queue));
+        assert_eq!(parse_span_kind("REQUEST"), None);
+        assert_eq!(parse_span_kind("unknown"), None);
     }
 
     #[test]

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -39,6 +39,7 @@ pub const DEFAULT_MAX_OPEN_SPANS: usize = 8_192;
 pub const DEFAULT_MAX_COMPLETED_SPANS: usize = 10_000;
 /// Configurable in-memory limits for live tracing recorder retention.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct RecorderLimits {
     /// Maximum number of concurrently tracked open candidate spans.
     pub max_open_spans: usize,

--- a/tailtriage-tracing/src/tokio.rs
+++ b/tailtriage-tracing/src/tokio.rs
@@ -10,6 +10,7 @@ use crate::{ImportError, ImportedRun, RecorderLimits, TailtriageLayer, TracingRe
 
 /// Error returned when starting [`TracingTokioSession`].
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum TracingTokioSessionStartError {
     /// Underlying tracing recorder setup failed.
     Build(BuildError),
@@ -30,6 +31,7 @@ impl std::error::Error for TracingTokioSessionStartError {}
 
 /// Error returned when shutting down [`TracingTokioSession`].
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum TracingTokioSessionShutdownError {
     /// Snapshot import failed.
     Import(ImportError),

--- a/tailtriage-tracing/src/types.rs
+++ b/tailtriage-tracing/src/types.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 /// Semantic span kind used by tailtriage tracing intake.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum SpanKind {
     /// Request-level span.
     Request,
@@ -17,6 +18,7 @@ pub enum SpanKind {
 /// Supported scalar field values on imported spans.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum FieldValue {
     /// String field value.
     String(String),
@@ -161,6 +163,7 @@ impl SpanRecord {
 
 /// Import options for converting tracing-shaped spans into a run.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct ImportOptions {
     service_name: String,
     service_version: Option<String>,
@@ -224,6 +227,7 @@ impl ImportOptions {
 
 /// Non-fatal warning produced while importing tracing-shaped spans.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct ImportWarning {
     message: String,
 }
@@ -251,6 +255,7 @@ impl core::fmt::Display for ImportWarning {
 
 /// Result of a completed import operation.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct ImportedRun {
     run: tailtriage_core::Run,
     warnings: Vec<ImportWarning>,


### PR DESCRIPTION
### Motivation

- Make the first public `tailtriage-tracing` surface safer to evolve by explicitly marking likely-to-change types as non-exhaustive. 
- Fix the incoherent `SpanKind` exposure by making it useful in conversion rather than leaving callers to match raw `tt.kind` strings. 
- Provide a compact, stable API shape for `tt.*` tracing intake without expanding scope into tracing backends or OpenTelemetry.

### Description

- Marked these public API types as `#[non_exhaustive]` to preserve future evolution without breaking consumers: `FieldValue`, `SpanKind`, `ImportOptions`, `ImportWarning`, `ImportedRun`, `RecorderLimits`, `TracingTokioSessionStartError`, and `TracingTokioSessionShutdownError`.
- Implemented a small, explicit parser `parse_span_kind(&str) -> Option<SpanKind>` that accepts only the exact `tt.kind` values `"request"`, `"stage"`, and `"queue"`, and updated `run_from_span_records` to use the parsed `SpanKind` instead of matching raw strings.
- Preserved the previous strict/non-strict semantics for unknown `tt.kind` values: in non-strict mode an unknown kind emits a warning and the span is skipped, and in strict mode the first unknown-kind triggers `ImportError::StrictViolation` (no new aliases or accepted values added).
- Added unit tests to cover the revised parsing and behavior: a parser unit test for each supported kind and rejection of non-exact values, a strict-mode test for unknown kind errors, and ensured existing tests covering missing and non-string `tt.kind` remain unchanged.
- No new dependencies were added and no scope change toward OTel/OTLP or backend behavior was introduced.

### Testing

- Ran `cargo fmt --check` and it completed successfully. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and fixed an initial lint by refactoring into an `if let`; the final run completed successfully. 
- Ran `cargo test --workspace --all-targets --all-features --locked` and the full test suite passed (including the new/updated tests in `tailtriage-tracing`).
- Ran `python3 scripts/validate_docs_contracts.py` and it completed successfully.

All required validation commands listed in the task completed successfully; no commands failed or were skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ad71dd6a483309b25b5ae31e12c9b)