### PR TITLE
Tighten tailtriage-tracing public API evolution points

### DIFF
--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -105,8 +105,17 @@ where
             continue;
         }
 
+        let Some(kind) = SpanKind::parse(kind) else {
+            strict_or_warn(
+                options.strict_mode(),
+                &mut warnings,
+                format!("unknown tt.kind '{kind}' in span '{}'", span.name()),
+            )?;
+            continue;
+        };
+
         match kind {
-            "request" => {
+            SpanKind::Request => {
                 let request_id =
                     required_string(&span, TT_REQUEST_ID, options.strict_mode(), &mut warnings)?;
                 let route = required_string(&span, TT_ROUTE, options.strict_mode(), &mut warnings)?;
@@ -130,7 +139,7 @@ where
                     update_min_max(&mut min_start, &mut max_finish, &span);
                 }
             }
-            "stage" => {
+            SpanKind::Stage => {
                 let request_id =
                     required_string(&span, TT_REQUEST_ID, options.strict_mode(), &mut warnings)?;
                 let stage = required_string(&span, TT_STAGE, options.strict_mode(), &mut warnings)?;
@@ -155,7 +164,7 @@ where
                     update_min_max(&mut min_start, &mut max_finish, &span);
                 }
             }
-            "queue" => {
+            SpanKind::Queue => {
                 let request_id =
                     required_string(&span, TT_REQUEST_ID, options.strict_mode(), &mut warnings)?;
                 let queue = required_string(&span, TT_QUEUE, options.strict_mode(), &mut warnings)?;
@@ -179,13 +188,6 @@ where
                     });
                     update_min_max(&mut min_start, &mut max_finish, &span);
                 }
-            }
-            other => {
-                strict_or_warn(
-                    options.strict_mode(),
-                    &mut warnings,
-                    format!("unknown tt.kind '{other}' in span '{}'", span.name()),
-                )?;
             }
         }
     }

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -39,6 +39,7 @@ pub const DEFAULT_MAX_OPEN_SPANS: usize = 8_192;
 pub const DEFAULT_MAX_COMPLETED_SPANS: usize = 10_000;
 /// Configurable in-memory limits for live tracing recorder retention.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct RecorderLimits {
     /// Maximum number of concurrently tracked open candidate spans.
     pub max_open_spans: usize,

--- a/tailtriage-tracing/src/tokio.rs
+++ b/tailtriage-tracing/src/tokio.rs
@@ -10,6 +10,7 @@ use crate::{ImportError, ImportedRun, RecorderLimits, TailtriageLayer, TracingRe
 
 /// Error returned when starting [`TracingTokioSession`].
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum TracingTokioSessionStartError {
     /// Underlying tracing recorder setup failed.
     Build(BuildError),
@@ -30,6 +31,7 @@ impl std::error::Error for TracingTokioSessionStartError {}
 
 /// Error returned when shutting down [`TracingTokioSession`].
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum TracingTokioSessionShutdownError {
     /// Snapshot import failed.
     Import(ImportError),

--- a/tailtriage-tracing/src/types.rs
+++ b/tailtriage-tracing/src/types.rs
@@ -3,7 +3,8 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 
 /// Semantic span kind used by tailtriage tracing intake.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum SpanKind {
     /// Request-level span.
@@ -16,6 +17,7 @@ pub enum SpanKind {
 
 /// Supported scalar field values on imported spans.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 #[serde(untagged)]
 pub enum FieldValue {
     /// String field value.
@@ -30,6 +32,19 @@ pub enum FieldValue {
     F64(f64),
     /// Null field value.
     Null,
+}
+
+impl SpanKind {
+    /// Parses `tt.kind` values used by tracing import.
+    #[must_use]
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "request" => Some(Self::Request),
+            "stage" => Some(Self::Stage),
+            "queue" => Some(Self::Queue),
+            _ => None,
+        }
+    }
 }
 
 impl From<&str> for FieldValue {
@@ -161,6 +176,7 @@ impl SpanRecord {
 
 /// Import options for converting tracing-shaped spans into a run.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct ImportOptions {
     service_name: String,
     service_version: Option<String>,
@@ -224,6 +240,7 @@ impl ImportOptions {
 
 /// Non-fatal warning produced while importing tracing-shaped spans.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct ImportWarning {
     message: String,
 }
@@ -251,6 +268,7 @@ impl core::fmt::Display for ImportWarning {
 
 /// Result of a completed import operation.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct ImportedRun {
     run: tailtriage_core::Run,
     warnings: Vec<ImportWarning>,
@@ -286,6 +304,15 @@ impl ImportedRun {
 mod tests {
     use super::*;
     use crate::{TT_DEPTH_AT_START, TT_KIND, TT_SUCCESS};
+
+    #[test]
+    fn span_kind_parse_supports_only_convention_values() {
+        assert_eq!(SpanKind::parse("request"), Some(SpanKind::Request));
+        assert_eq!(SpanKind::parse("stage"), Some(SpanKind::Stage));
+        assert_eq!(SpanKind::parse("queue"), Some(SpanKind::Queue));
+        assert_eq!(SpanKind::parse("REQUEST"), None);
+        assert_eq!(SpanKind::parse("wat"), None);
+    }
 
     #[test]
     fn span_record_builder_stores_fields() {


### PR DESCRIPTION
### Motivation
- Several newly public types in `tailtriage-tracing` are likely to evolve and must be safe for forward-compatible extension. 
- `SpanKind` was exposed but conversion used raw `tt.kind` strings directly, making the API surface incoherent and brittle. 
- The tracing-field convention needs a small, explicit parsing API so consumers rely on a stable shape without expanding scope into tracing backends or OTel/OTLP.

### Description
- Marked evolving public API types as `#[non_exhaustive]` to allow safe forwards-compatible additions; the types updated are `FieldValue`, `SpanKind`, `ImportOptions`, `ImportWarning`, `ImportedRun`, `RecorderLimits`, `TracingTokioSessionStartError`, and `TracingTokioSessionShutdownError`.
- Kept `SpanKind` public and added a dedicated parser `SpanKind::parse(&str) -> Option<SpanKind>` that accepts only the convention values `request`, `stage`, and `queue` and rejects all others (no new aliases).
- Reworked import conversion to call `SpanKind::parse` and branch on `SpanKind` variants instead of matching raw strings, preserving previous strict/non-strict semantics (unknown kinds warn+skip in non-strict and error in strict).
- Added a unit test `span_kind_parse_supports_only_convention_values` and kept existing import/conversion tests to validate valid kinds, unknown-kind warnings/errors, and unchanged behavior for missing or non-string `tt.kind`.

### Testing
- Ran the repository validation suite: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, and `python3 scripts/validate_docs_contracts.py`, and all commands completed successfully.
- Tests added/updated: added `types::tests::span_kind_parse_supports_only_convention_values` and exercised existing `run_from_span_records` tests that cover unknown, missing, and non-string `tt.kind` behavior; all tests passed.
- Public API changes are limited to `#[non_exhaustive]` annotations and the small `SpanKind::parse` helper, and no extra dependencies or scope creep into OpenTelemetry/tracing backend functionality were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ad71dd6a483309b25b5ae31e12c9b)