### PR TITLE
Tighten tailtriage-tracing public API for safer v1 evolution

### DIFF
--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -80,7 +80,17 @@ where
     for span in spans {
         let kind = match get_string_field_state(&span, TT_KIND) {
             StringFieldState::Missing => continue,
-            StringFieldState::Value(kind) => kind,
+            StringFieldState::Value(kind) => {
+                let Some(kind) = SpanKind::parse(kind) else {
+                    strict_or_warn(
+                        options.strict_mode(),
+                        &mut warnings,
+                        format!("unknown tt.kind '{kind}' in span '{}'", span.name()),
+                    )?;
+                    continue;
+                };
+                kind
+            }
             StringFieldState::InvalidType => {
                 strict_or_warn(
                     options.strict_mode(),
@@ -106,7 +116,7 @@ where
         }
 
         match kind {
-            "request" => {
+            SpanKind::Request => {
                 let request_id =
                     required_string(&span, TT_REQUEST_ID, options.strict_mode(), &mut warnings)?;
                 let route = required_string(&span, TT_ROUTE, options.strict_mode(), &mut warnings)?;
@@ -130,7 +140,7 @@ where
                     update_min_max(&mut min_start, &mut max_finish, &span);
                 }
             }
-            "stage" => {
+            SpanKind::Stage => {
                 let request_id =
                     required_string(&span, TT_REQUEST_ID, options.strict_mode(), &mut warnings)?;
                 let stage = required_string(&span, TT_STAGE, options.strict_mode(), &mut warnings)?;
@@ -155,7 +165,7 @@ where
                     update_min_max(&mut min_start, &mut max_finish, &span);
                 }
             }
-            "queue" => {
+            SpanKind::Queue => {
                 let request_id =
                     required_string(&span, TT_REQUEST_ID, options.strict_mode(), &mut warnings)?;
                 let queue = required_string(&span, TT_QUEUE, options.strict_mode(), &mut warnings)?;
@@ -179,13 +189,6 @@ where
                     });
                     update_min_max(&mut min_start, &mut max_finish, &span);
                 }
-            }
-            other => {
-                strict_or_warn(
-                    options.strict_mode(),
-                    &mut warnings,
-                    format!("unknown tt.kind '{other}' in span '{}'", span.name()),
-                )?;
             }
         }
     }
@@ -400,6 +403,15 @@ mod tests {
     use super::*;
 
     #[test]
+    fn span_kind_parser_accepts_supported_values_only() {
+        assert_eq!(SpanKind::parse("request"), Some(SpanKind::Request));
+        assert_eq!(SpanKind::parse("stage"), Some(SpanKind::Stage));
+        assert_eq!(SpanKind::parse("queue"), Some(SpanKind::Queue));
+        assert_eq!(SpanKind::parse("Request"), None);
+        assert_eq!(SpanKind::parse("wat"), None);
+    }
+
+    #[test]
     fn request_only_conversion_creates_one_request_event() {
         let spans = vec![SpanRecord::new("req", 100, 110)
             .field(TT_KIND, "request")
@@ -497,6 +509,13 @@ mod tests {
         let spans = vec![SpanRecord::new("x", 1, 2).field(TT_KIND, "wat")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.warnings().len(), 1);
+    }
+
+    #[test]
+    fn unknown_kind_errors_in_strict() {
+        let spans = vec![SpanRecord::new("x", 1, 2).field(TT_KIND, "wat")];
+        let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
     }
 
     #[test]

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -39,6 +39,7 @@ pub const DEFAULT_MAX_OPEN_SPANS: usize = 8_192;
 pub const DEFAULT_MAX_COMPLETED_SPANS: usize = 10_000;
 /// Configurable in-memory limits for live tracing recorder retention.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct RecorderLimits {
     /// Maximum number of concurrently tracked open candidate spans.
     pub max_open_spans: usize,

--- a/tailtriage-tracing/src/tokio.rs
+++ b/tailtriage-tracing/src/tokio.rs
@@ -10,6 +10,7 @@ use crate::{ImportError, ImportedRun, RecorderLimits, TailtriageLayer, TracingRe
 
 /// Error returned when starting [`TracingTokioSession`].
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum TracingTokioSessionStartError {
     /// Underlying tracing recorder setup failed.
     Build(BuildError),
@@ -30,6 +31,7 @@ impl std::error::Error for TracingTokioSessionStartError {}
 
 /// Error returned when shutting down [`TracingTokioSession`].
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum TracingTokioSessionShutdownError {
     /// Snapshot import failed.
     Import(ImportError),

--- a/tailtriage-tracing/src/types.rs
+++ b/tailtriage-tracing/src/types.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 /// Semantic span kind used by tailtriage tracing intake.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum SpanKind {
     /// Request-level span.
     Request,
@@ -14,9 +15,23 @@ pub enum SpanKind {
     Queue,
 }
 
+impl SpanKind {
+    /// Parses a `tt.kind` field value into a semantic span kind.
+    #[must_use]
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "request" => Some(Self::Request),
+            "stage" => Some(Self::Stage),
+            "queue" => Some(Self::Queue),
+            _ => None,
+        }
+    }
+}
+
 /// Supported scalar field values on imported spans.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum FieldValue {
     /// String field value.
     String(String),
@@ -161,6 +176,7 @@ impl SpanRecord {
 
 /// Import options for converting tracing-shaped spans into a run.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct ImportOptions {
     service_name: String,
     service_version: Option<String>,
@@ -224,6 +240,7 @@ impl ImportOptions {
 
 /// Non-fatal warning produced while importing tracing-shaped spans.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct ImportWarning {
     message: String,
 }
@@ -251,6 +268,7 @@ impl core::fmt::Display for ImportWarning {
 
 /// Result of a completed import operation.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct ImportedRun {
     run: tailtriage_core::Run,
     warnings: Vec<ImportWarning>,


### PR DESCRIPTION
### Motivation
- Reduce risk of accidental semver breakage by marking evolving public types as future-extensible and preventing exhaustive matches. 
- Make the newly-public `SpanKind` coherent and usable without expanding scope into tracing backends or OTLP.
- Preserve the existing strict/non-strict conversion semantics for `tt.kind` while giving callers a stable API surface to parse kinds.

### Description
- Marked the following public types as `#[non_exhaustive]` to allow forward evolution: `FieldValue`, `SpanKind`, `ImportOptions`, `ImportWarning`, `ImportedRun`, `RecorderLimits`, `TracingTokioSessionStartError`, and `TracingTokioSessionShutdownError`.
- Implemented `SpanKind::parse(&str) -> Option<SpanKind>` that accepts only the exact `tt.kind` values `request`, `stage`, and `queue` and returns `None` for all other inputs (no aliases accepted). 
- Updated `run_from_span_records` to use `SpanKind::parse` and preserved prior behavior for unknown/missing/non-string `tt.kind` values: non-strict mode emits a warning and skips the span, strict mode returns `ImportError::StrictViolation` on the first offending span.
- Added tests: a unit test for `SpanKind::parse` (valid values and rejected variants/casing) and a strict-mode test verifying unknown `tt.kind` errors; existing tests for missing and non-string `tt.kind` remain and continue to pass.

### Testing
- Ran `cargo fmt --check` and fixed formatting (succeeded).
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (succeeded).
- Ran the full test suite with features enabled using `cargo test --workspace --all-targets --all-features --locked` and all tests passed (succeeded).
- Ran `python3 scripts/validate_docs_contracts.py` and the docs contract validator succeeded (succeeded).
- Note: I ran the comprehensive test/build with all features enabled; I did not run a separate explicit build/test invocation with the `tokio` feature disabled as an independent verification step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ad71dd6a483309b25b5ae31e12c9b)