### PR TITLE
Optimize TracingRecorder span-key internals and tighten tt.kind edge-case tests

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -57,7 +57,7 @@ impl Default for RecorderLimits {
 
 #[derive(Debug, Default)]
 struct RecorderState {
-    open: BTreeMap<String, OpenSpan>,
+    open: BTreeMap<u64, OpenSpan>,
     completed: Vec<SpanRecord>,
     dropped_open_spans: u64,
     dropped_completed_spans: u64,
@@ -242,8 +242,9 @@ where
             state.dropped_open_spans = state.dropped_open_spans.saturating_add(1);
             return;
         }
+        let span_u64 = id.into_u64();
         let open_span = OpenSpan {
-            id: Some(id.into_u64().to_string()),
+            id: Some(span_u64.to_string()),
             parent_id,
             name: attrs.metadata().name().to_owned(),
             fields: visitor.fields,
@@ -251,14 +252,14 @@ where
             started_instant: Instant::now(),
             is_tt_candidate: metadata_candidate || initial_candidate,
         };
-        state.open.insert(id.into_u64().to_string(), open_span);
+        state.open.insert(span_u64, open_span);
     }
 
     fn on_record(&self, span_id: &Id, values: &tracing::span::Record<'_>, _ctx: Context<'_, S>) {
         let mut visitor = FieldVisitor::default();
         values.record(&mut visitor);
         let mut state = lock_state(&self.state);
-        let key = span_id.into_u64().to_string();
+        let key = span_id.into_u64();
         if let Some(span) = state.open.get_mut(&key) {
             span.fields.extend(visitor.fields);
         }
@@ -266,7 +267,7 @@ where
 
     fn on_close(&self, id: Id, _ctx: Context<'_, S>) {
         let mut state = lock_state(&self.state);
-        let key = id.into_u64().to_string();
+        let key = id.into_u64();
         if let Some(open) = state.open.remove(&key) {
             if !open.fields.contains_key(TT_KIND) {
                 return;
@@ -569,6 +570,40 @@ mod tests {
             let run = recorder.snapshot_run().unwrap();
             assert_eq!(run.run().requests.len(), 1);
             assert_eq!(run.run().requests[0].route, "/late-kind");
+        });
+    }
+
+    #[test]
+    fn non_candidate_span_with_non_tt_fields_is_not_tracked() {
+        with_recorder(|recorder| {
+            let span = tracing::info_span!("ordinary", user_id = 42_u64, outcome = "ok");
+            drop(span);
+
+            let run = recorder.snapshot_run().unwrap();
+            assert!(run.run().requests.is_empty());
+            assert!(run.run().stages.is_empty());
+            assert!(run.run().queues.is_empty());
+            assert!(run.warnings().is_empty());
+        });
+    }
+
+    #[test]
+    fn debug_formatted_tt_kind_is_not_promoted_to_valid_kind() {
+        with_recorder(|recorder| {
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = tracing::field::debug("request"),
+                tt.request_id = "r1",
+                tt.route = "/debug-kind"
+            );
+            drop(span);
+
+            let imported = recorder.snapshot_run().unwrap();
+            assert!(imported.run().requests.is_empty());
+            assert!(imported
+                .warnings()
+                .iter()
+                .any(|w| w.message().contains("unknown tt.kind")));
         });
     }
 


### PR DESCRIPTION
### Motivation
- Avoid needless allocation on hot span lifecycle callbacks by using the raw numeric span id for internal open-span bookkeeping instead of converting to `String` on every lookup/remove. 
- Make behavior around `tt.*` fields, especially `tt.kind`, explicit in tests so late-filled and debug-formatted cases are validated and documented. 
- Preserve the public usage story and existing retention/truncation semantics while removing an internal performance footgun.

### Description
- Changed `RecorderState.open` key type from `BTreeMap<String, OpenSpan>` to `BTreeMap<u64, OpenSpan>` and updated `on_new_span`, `on_record`, and `on_close` to use `Id::into_u64()` for insert/lookup/remove to avoid temporary `to_string()` allocations. 
- Preserved public output compatibility by continuing to store `SpanRecord` `id` and `parent_id` as strings when completing spans. 
- Added/updated recorder tests to cover the edge cases: `tt_kind_recorded_later_is_captured`, `non_candidate_span_with_non_tt_fields_is_not_tracked`, and `debug_formatted_tt_kind_is_not_promoted_to_valid_kind`. 
- Kept live-recorder semantics unchanged (bounded open/completed spans, drop/truncation counters and warnings, and strict-mode errors on open candidate spans); no new dependencies were added and the recorder was not broadened into a general tracing backend.

### Testing
- Ran `cargo fmt --check` which passed. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which passed. 
- Ran `cargo test --workspace --all-targets --all-features --locked` and all workspace tests passed (including the new recorder tests). 
- Ran `python3 scripts/validate_docs_contracts.py` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ade22d1ec8330bb4ef029e2298269)