### PR TITLE
Tighten TracingRecorder internals and add edge-case recorder tests

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -57,7 +57,7 @@ impl Default for RecorderLimits {
 
 #[derive(Debug, Default)]
 struct RecorderState {
-    open: BTreeMap<String, OpenSpan>,
+    open: BTreeMap<u64, OpenSpan>,
     completed: Vec<SpanRecord>,
     dropped_open_spans: u64,
     dropped_completed_spans: u64,
@@ -251,23 +251,21 @@ where
             started_instant: Instant::now(),
             is_tt_candidate: metadata_candidate || initial_candidate,
         };
-        state.open.insert(id.into_u64().to_string(), open_span);
+        state.open.insert(id.into_u64(), open_span);
     }
 
     fn on_record(&self, span_id: &Id, values: &tracing::span::Record<'_>, _ctx: Context<'_, S>) {
         let mut visitor = FieldVisitor::default();
         values.record(&mut visitor);
         let mut state = lock_state(&self.state);
-        let key = span_id.into_u64().to_string();
-        if let Some(span) = state.open.get_mut(&key) {
+        if let Some(span) = state.open.get_mut(&span_id.into_u64()) {
             span.fields.extend(visitor.fields);
         }
     }
 
     fn on_close(&self, id: Id, _ctx: Context<'_, S>) {
         let mut state = lock_state(&self.state);
-        let key = id.into_u64().to_string();
-        if let Some(open) = state.open.remove(&key) {
+        if let Some(open) = state.open.remove(&id.into_u64()) {
             if !open.fields.contains_key(TT_KIND) {
                 return;
             }
@@ -569,6 +567,59 @@ mod tests {
             let run = recorder.snapshot_run().unwrap();
             assert_eq!(run.run().requests.len(), 1);
             assert_eq!(run.run().requests[0].route, "/late-kind");
+        });
+    }
+
+    #[test]
+    fn non_tailtriage_fields_do_not_make_span_candidate() {
+        with_recorder(|recorder| {
+            let span = tracing::info_span!(
+                "request",
+                http.method = "GET",
+                user_id = 42_u64,
+                error = tracing::field::Empty
+            );
+            drop(span);
+
+            let run = recorder.snapshot_run().unwrap();
+            assert!(run.run().requests.is_empty());
+            assert!(run.run().stages.is_empty());
+            assert!(run.run().queues.is_empty());
+            assert!(run.warnings().is_empty());
+        });
+    }
+
+    #[test]
+    fn debug_or_invalid_tt_kind_does_not_become_valid_kind() {
+        with_recorder(|recorder| {
+            let debug_kind = tracing::info_span!(
+                "debug-kind",
+                tt.kind = ?Some("request"),
+                tt.request_id = "r-debug",
+                tt.route = "/debug"
+            );
+            drop(debug_kind);
+
+            let numeric_kind = tracing::info_span!(
+                "numeric-kind",
+                tt.kind = 7_u64,
+                tt.request_id = "r-num",
+                tt.route = "/numeric"
+            );
+            drop(numeric_kind);
+
+            let run = recorder.snapshot_run().unwrap();
+            assert!(run.run().requests.is_empty());
+            assert!(run.run().stages.is_empty());
+            assert!(run.run().queues.is_empty());
+            assert!(run
+                .warnings()
+                .iter()
+                .any(|w| w.message().contains("unknown tt.kind 'Some(\"request\")'")));
+            assert!(run
+                .warnings()
+                .iter()
+                .any(|w| w.message().contains("tt.kind") && w.message().contains("numeric-kind")));
         });
     }
 


### PR DESCRIPTION
### Motivation
- Avoid unnecessary allocations during span lifecycle callbacks by using the raw `Id::into_u64()` for internal open-span keys while preserving the existing public `SpanRecord` string ids.
- Make recorder behavior around late/invalid `tt.kind` values explicit in tests so surprising debug-formatted or non-string `tt.kind` cases are covered and surface warnings via the existing import behavior.
- Keep the live recorder bounded and focused (no backend/store changes or new dependencies). 

### Description
- Changed internal open-span bookkeeping from `BTreeMap<String, OpenSpan>` to `BTreeMap<u64, OpenSpan>` and updated `on_new_span`, `on_record`, and `on_close` to insert/get/remove by `Id::into_u64()` to avoid temporary `String` allocations.
- Preserved public output compatibility by continuing to set `OpenSpan.id` and `OpenSpan.parent_id` as `String` values so finalized `SpanRecord` ids remain strings.
- Added/updated recorder unit tests to cover edge cases: `tt_kind_recorded_later_is_captured` (existing behavior retained), `non_tailtriage_fields_do_not_make_span_candidate` (spans without declared `tt.*` fields are not tracked), and `debug_or_invalid_tt_kind_does_not_become_valid_kind` (debug-formatted and numeric `tt.kind` do not silently become valid kinds and generate import warnings referencing the offending span).
- Did not add any dependencies or broaden the recorder into a general tracing store; retention/drop/warning/truncation behavior is unchanged.

### Testing
- Ran `cargo fmt --check` and formatting passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and the workspace passed with no clippy warnings.
- Ran `cargo test --workspace --all-targets --all-features --locked` and the full test suite passed; the new recorder tests pass.
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed.

All checks completed successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ade22d1ec8330bb4ef029e2298269)