### PR TITLE
docs: clarify tailtriage-tracing intake, CLI import, and demo parity wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Add `tailtriage-analyzer` when you want to analyze a completed Run inside Rust c
 
 ### Already using tracing?
 
-If your service already emits `tracing` spans, use `tailtriage-tracing` as a narrow intake path.
+If your service already emits `tracing` spans, use `tailtriage-tracing` as a narrow tracing intake bridge.
 
 - Offline JSONL import:
   ```bash

--- a/demos/README.md
+++ b/demos/README.md
@@ -11,7 +11,7 @@ Check out [`../docs/getting-started-demo.md`](../docs/getting-started-demo.md) f
 ## Instrumentation mode note (request/stage/queue parity phase)
 
 - `queue_service`, `downstream_service`, `mixed_contention_service`, `cold_start_burst_service`, `db_pool_saturation_service`, `shared_state_lock_service`, and `retry_storm_service` accept `--instrumentation native|tracing` (default `native`).
-- This validates native-vs-tracing parity for request/stage evidence and queue evidence where applicable while still producing standard Run JSON for CLI analysis.
+- This validates native-vs-tracing semantic parity for request/stage evidence and queue evidence where applicable while still producing standard Run JSON for CLI analysis. Exact latency values and suspect scores are not expected to be identical across instrumentation modes.
 - Tracing inflight parity is out of scope for this phase.
 - `blocking_service` and `executor_pressure_service` also support `--instrumentation native|tracing`.
 - Runtime-sensitive tracing parity uses `TracingTokioSession` plus deterministic runtime snapshots recorded during workload execution.

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -60,7 +60,7 @@ When paths include spaces, quote them in shell usage:
 tailtriage import tracing-json "fixtures/tracing spans.jsonl" --service checkout --output "runs/imported run.json"
 ```
 
-The command imports completed tracing span records in the documented JSONL shape and writes pretty Run JSON (`serde_json::to_writer_pretty`), not Report JSON. Import warnings are printed to stderr as `warning: ...`. Analysis is a separate step: `tailtriage analyze tailtriage-run.json`.
+The command imports completed tracing span records in the documented JSONL shape and writes pretty Run JSON (`serde_json::to_writer_pretty`), not Report JSON. Import warnings are printed to stderr as `warning: ...`. Analysis is a separate step: `tailtriage analyze tailtriage-run.json`. Tracing-only imports do not fabricate runtime snapshots; executor-pressure and blocking-pool evidence stays limited unless runtime snapshots are present (for example from Tokio sampling).
 Malformed JSON input remains fatal. In non-strict mode, syntactically valid malformed/incomplete `tt.*` records are skipped with `warning: ...` lines.
 `--service` must not be empty or whitespace.
 Import fails when zero request events would be written (for example unrelated-only input or all-skipped malformed `tt.*` input), because `tailtriage analyze` requires at least one request in CLI-loaded run artifacts.


### PR DESCRIPTION
### Motivation
- Make the tracing-intake addition have a single coherent public story by avoiding wording that could imply backend/OTel behavior or full distributed-tracing diagnosis. 
- Ensure the CLI/import and demos correctly set expectations about what tracing-only imports provide (Run JSON, not Report JSON) and the limits of runtime-pressure evidence without runtime snapshots. 

### Description
- Updated top-level README wording to describe `tailtriage-tracing` as a narrow tracing intake bridge rather than a backend or platform path. (file: `README.md`).
- Tightened demo wording to state parity is semantic and to explicitly note that exact latency values and suspect scores are not expected to match across instrumentation modes. (file: `demos/README.md`).
- Clarified CLI import docs so `tailtriage import tracing-json` is documented as writing Run JSON (capture artifact / CLI input) and not Report JSON, and added an explicit caveat that tracing-only imports do not fabricate runtime snapshots so executor/blocking evidence is limited unless runtime snapshots (for example from the Tokio sampler) are present. (file: `tailtriage-cli/README.md`).
- No code features, dependencies, or public API surfaces were changed; this is a docs-only cleanup to align public messaging with the product boundaries defined for the tracing intake addition. (files changed: `README.md`, `demos/README.md`, `tailtriage-cli/README.md`).

### Testing
- Ran `cargo fmt --check` and it succeeded.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it completed with no warnings (success).
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests passed (success).
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed (success).
- Ran `python3 scripts/demo_tool.py validate-tracing-parity all --profile release` and tracing parity validation passed for the demo scenarios (success).
- Ran `python3 scripts/measure_runtime_cost.py --requests 1200 --concurrency 32 --work-ms 4 --rounds 2 --warmup-rounds 1 --artifact-dir demos/runtime_cost/artifacts/ci-smoke` and the measurement completed; the run reported `measurement_quality: insufficient_data` due to the bounded CI-smoke rounds (expected for this smoke profile) (completed with stability warning).
- Ran `python3 scripts/validate_runtime_cost_summary.py --raw demos/runtime_cost/artifacts/ci-smoke/runtime-cost-raw.jsonl --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json` and validation passed (success).

Remaining limitations
- The runtime-cost smoke run reported `measurement_quality: insufficient_data` because the supplied smoke-profile used only 2 measured rounds (below the stable threshold); this is expected for the CI-smoke command profile used here and not a functional failure. 
- All requested validation commands were executed; no required commands were skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ae1567d1483309a044757a8d76d93)