### PR TITLE
docs: finalize tracing intake wording and parity notes for PR 547

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Add `tailtriage-analyzer` when you want to analyze a completed Run inside Rust c
 
 ### Already using tracing?
 
-If your service already emits `tracing` spans, use `tailtriage-tracing` as a narrow intake path.
+If your service already emits `tracing` spans, use `tailtriage-tracing` as a narrow tracing intake bridge.
 
 - Offline JSONL import:
   ```bash

--- a/demos/README.md
+++ b/demos/README.md
@@ -17,6 +17,7 @@ Check out [`../docs/getting-started-demo.md`](../docs/getting-started-demo.md) f
 - Runtime-sensitive tracing parity uses `TracingTokioSession` plus deterministic runtime snapshots recorded during workload execution.
 - CI-facing tracing parity coverage gates once on Ubuntu extended release via `python3 scripts/demo_tool.py validate-tracing-parity all --profile release`.
 - Tracing spans alone do not infer runtime pressure; runtime-sensitive parity relies on those recorded snapshots.
+- Demo parity is semantic parity (request/stage/queue evidence shape and diagnosis direction), not exact latency or suspect-score equality.
 - Tracing inflight remains out of scope unless explicitly implemented.
 - This tracing demo mode is not OTel/OTLP and not an observability backend.
 - Suspects in parity runs remain triage leads, not proof of root cause.

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ Most users should start with `tailtriage`.
 - [`tailtriage-axum`](../tailtriage-axum/README.md) — Axum middleware/extractor integration.
 - [`tailtriage-analyzer`](../tailtriage-analyzer/README.md) — in-process analysis of completed runs.
 - [`tailtriage-cli`](../tailtriage-cli/README.md) — command-line analysis of saved run artifacts.
-- [`tailtriage-tracing`](../tailtriage-tracing/README.md) — tracing intake for JSONL import and a live in-memory recorder; converts tracing-shaped spans into standard `tailtriage_core::Run` values (no OTel/OTLP).
+- [`tailtriage-tracing`](../tailtriage-tracing/README.md) — narrow tracing intake bridge for JSONL import and a live in-memory recorder; converts tracing-shaped spans into standard `tailtriage_core::Run` values (no OTel/OTLP).
 
 ## Capture and analysis workflow
 

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -61,6 +61,7 @@ tailtriage import tracing-json "fixtures/tracing spans.jsonl" --service checkout
 ```
 
 The command imports completed tracing span records in the documented JSONL shape and writes pretty Run JSON (`serde_json::to_writer_pretty`), not Report JSON. Import warnings are printed to stderr as `warning: ...`. Analysis is a separate step: `tailtriage analyze tailtriage-run.json`.
+Tracing-only imports provide request/stage/queue intake but do not fabricate runtime snapshots; executor/blocking-pressure interpretation remains limited unless runtime snapshots are also captured (for example via Tokio runtime sampling).
 Malformed JSON input remains fatal. In non-strict mode, syntactically valid malformed/incomplete `tt.*` records are skipped with `warning: ...` lines.
 `--service` must not be empty or whitespace.
 Import fails when zero request events would be written (for example unrelated-only input or all-skipped malformed `tt.*` input), because `tailtriage analyze` requires at least one request in CLI-loaded run artifacts.


### PR DESCRIPTION
### Motivation
- Make the tracing intake addition have one coherent, narrow public story and eliminate wording that could imply OTLP/OpenTelemetry support, distributed-tracing diagnosis, or observability-backend replacement.
- Ensure CLI import and demo wording clearly state that `tailtriage import tracing-json` writes Run JSON and that tracing-only inputs lack runtime-pressure snapshots unless explicit runtime sampling is captured.
- Prevent demo/docs readers from interpreting demo parity as exact latency/score equality or treating runtime-cost numbers as universal production guarantees.

### Description
- Updated user-facing docs to consistently describe `tailtriage-tracing` as a narrow tracing intake bridge and to preserve the product boundary (no OTel/OTLP, no tracing backend), touching `README.md` and `docs/README.md`.
- Clarified demo parity wording to state parity is semantic (request/stage/queue evidence shape and diagnosis direction) and not exact latency or suspect-score equality in `demos/README.md`.
- Strengthened the CLI import contract in `tailtriage-cli/README.md` to explicitly state `tailtriage import tracing-json` writes Run JSON (not Report JSON) and that tracing-only imports do not fabricate runtime snapshots so executor/blocking interpretation is limited without runtime sampling.
- This changes only documentation files: `README.md`, `docs/README.md`, `demos/README.md`, and `tailtriage-cli/README.md`, with no code, no new features, and no dependency changes.

### Testing
- Ran formatting and lints: `cargo fmt --check` succeeded and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` succeeded with no warnings.
- Ran unit and integration tests: `cargo test --workspace --all-targets --all-features --locked` completed successfully (all tests passed).
- Validated docs contract: `python3 scripts/validate_docs_contracts.py` succeeded.
- Ran tracing parity demos: `python3 scripts/demo_tool.py validate-tracing-parity all --profile release` completed and reported parity validation passed for demo scenarios.
- Measured runtime cost smoke run: `python3 scripts/measure_runtime_cost.py --requests 1200 --concurrency 32 --work-ms 4 --rounds 2 --warmup-rounds 1 --artifact-dir demos/runtime_cost/artifacts/ci-smoke` completed and produced artifacts but reported `measurement_quality: insufficient_data` because only 2 measured rounds were used (< required 4 for stable classification); `python3 scripts/validate_runtime_cost_summary.py --raw demos/runtime_cost/artifacts/ci-smoke/runtime-cost-raw.jsonl --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json` also completed.

Remaining limitations / notes
- All requested validation commands were executed; the only notable limitation is that the runtime-cost smoke invocation intentionally ran fewer measured rounds and therefore reported `measurement_quality: insufficient_data` (rerun on a quieter machine with >= 4 measured rounds for stable classification).
- No code or API behavior was changed; this PR is a docs-only sweep to align public wording with the product boundary for the tracing intake addition.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ae1567d1483309a044757a8d76d93)