### PR TITLE
docs: tighten tracing-intake bridge wording and docs consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Add `tailtriage-analyzer` when you want to analyze a completed Run inside Rust c
 
 ### Already using tracing?
 
-If your service already emits `tracing` spans, use `tailtriage-tracing` as a narrow intake path.
+If your service already emits `tracing` spans, use `tailtriage-tracing` as a narrow tracing-intake bridge into standard `Run` artifacts.
 
 - Offline JSONL import:
   ```bash

--- a/SPEC.md
+++ b/SPEC.md
@@ -158,7 +158,7 @@ Analyzer configuration contract:
 
 ### 5.9 Optional tracing intake (`tailtriage-tracing`)
 
-`tailtriage-tracing` is an optional integration surface for services that already emit Rust `tracing` spans.
+`tailtriage-tracing` is an optional narrow tracing-intake bridge for services that already emit Rust `tracing` spans.
 
 - converts tracing-shaped request/stage/queue evidence into standard `Run` values
 - supports offline JSONL import and a live in-memory `TracingRecorder`

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ Most users should start with `tailtriage`.
 - [`tailtriage-axum`](../tailtriage-axum/README.md) — Axum middleware/extractor integration.
 - [`tailtriage-analyzer`](../tailtriage-analyzer/README.md) — in-process analysis of completed runs.
 - [`tailtriage-cli`](../tailtriage-cli/README.md) — command-line analysis of saved run artifacts.
-- [`tailtriage-tracing`](../tailtriage-tracing/README.md) — tracing intake for JSONL import and a live in-memory recorder; converts tracing-shaped spans into standard `tailtriage_core::Run` values (no OTel/OTLP).
+- [`tailtriage-tracing`](../tailtriage-tracing/README.md) — narrow tracing-intake bridge for JSONL import and a live in-memory recorder; converts tracing-shaped spans into standard `tailtriage_core::Run` values (no OTel/OTLP).
 
 ## Capture and analysis workflow
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -158,7 +158,7 @@ Prefer moderate intervals and bounded runs before increasing density.
 
 ## Operating with tracing-based runs
 
-Tracing-based imports can still provide useful request, stage, and queue evidence for triage.
+Tracing-based imports are a narrow tracing-intake bridge and can still provide useful request, stage, and queue evidence for triage.
 
 Important limits for production interpretation:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -34,7 +34,7 @@ The `controller` and `tokio` namespaces are available with default features; `ax
 
 ### Using existing tracing spans
 
-If you already instrument request/stage/queue work with Rust `tracing`, use `tailtriage-tracing` as an intake path into the same triage workflow.
+If you already instrument request/stage/queue work with Rust `tracing`, use `tailtriage-tracing` as a narrow tracing-intake bridge into the same triage workflow.
 
 Offline JSONL import:
 


### PR DESCRIPTION
### Motivation
- Ensure the tracing intake addition has a single coherent public story and that public docs do not imply OTLP/back-end, distributed-tracing diagnosis, or observability-platform replacement.

### Description
- Tighten wording across public docs to present `tailtriage-tracing` as a "narrow tracing-intake bridge" rather than a generic integration surface. Files changed: `README.md`, `docs/README.md`, `docs/user-guide.md`, `docs/operations.md`, and `SPEC.md`.
- Preserve and clarify existing semantics: `tailtriage import tracing-json` writes Run JSON (not Report JSON), tracing-only imports do not fabricate runtime-pressure evidence, and runtime-pressure evidence requires explicit Tokio runtime snapshots/sampler.
- No code, feature, or dependency changes were introduced; this is strictly documentation and phrasing cleanup to keep the public product boundary tight.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed with no warnings.
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests passed.
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed.
- Ran `python3 scripts/demo_tool.py validate-tracing-parity all --profile release` and tracing-parity validations passed for the demo scenarios.
- Ran `python3 scripts/measure_runtime_cost.py --requests 1200 --concurrency 32 --work-ms 4 --rounds 2 --warmup-rounds 1 --artifact-dir demos/runtime_cost/artifacts/ci-smoke` and the smoke measurement completed successfully but reported `measurement_quality: insufficient_data` (expected for the bounded CI-smoke profile using only 2 measured rounds).
- Ran `python3 scripts/validate_runtime_cost_summary.py --raw demos/runtime_cost/artifacts/ci-smoke/runtime-cost-raw.jsonl --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json` and validation passed.
- Remaining limitation: the runtime-cost smoke intentionally uses fewer measured rounds than the full stability profile, so `measurement_quality: insufficient_data` is expected and documented; no other validation failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ae1567d1483309a044757a8d76d93)