### PR TITLE
Align tracing docs integration and docs.rs surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,6 +233,7 @@ Expected workspace members:
 - `tailtriage-axum`
 - `tailtriage-analyzer`
 - `tailtriage-cli`
+- `tailtriage-tracing`
 
 Possible directories:
 

--- a/tailtriage-analyzer/README.md
+++ b/tailtriage-analyzer/README.md
@@ -22,7 +22,7 @@ Suspects are investigation leads, not proof of root cause.
 cargo add tailtriage-analyzer
 ```
 
-You also need a capture crate that provides `tailtriage_core::Run`, such as `tailtriage` or `tailtriage-core`.
+You also need a capture crate that provides `tailtriage_core::Run`, such as `tailtriage`, `tailtriage-core`, or `tailtriage-tracing`.
 
 ## How to obtain a `Run`
 
@@ -30,7 +30,7 @@ You also need a capture crate that provides `tailtriage_core::Run`, such as `tai
 
 Typical flow:
 
-- capture/integration crates (`tailtriage`, `tailtriage-core`, `tailtriage-controller`, `tailtriage-tokio`, `tailtriage-axum`) produce completed runs or saved artifacts
+- capture/integration crates (`tailtriage`, `tailtriage-core`, `tailtriage-controller`, `tailtriage-tokio`, `tailtriage-axum`, `tailtriage-tracing`) produce completed runs or saved artifacts
 - `tailtriage-analyzer` analyzes completed in-memory runs or stable snapshots in process
 - `tailtriage-cli` loads saved artifacts from disk and invokes `tailtriage-analyzer`
 

--- a/tailtriage-axum/README.md
+++ b/tailtriage-axum/README.md
@@ -123,3 +123,4 @@ If you do not use Axum, this crate is not the right abstraction boundary.
 - `tailtriage-tokio`: runtime-pressure sampling
 - `tailtriage-analyzer`: in-process analysis/report generation for completed runs
 - `tailtriage-cli`: command-line analysis of saved run artifacts
+- `tailtriage-tracing`: optional tracing intake bridge that can produce standard `Run` artifacts for the same analyzer/CLI workflow

--- a/tailtriage-controller/README.md
+++ b/tailtriage-controller/README.md
@@ -211,3 +211,4 @@ Optional table. If present, `kind` is required.
 - `tailtriage-axum`: Axum request-boundary integration
 - `tailtriage-analyzer`: in-process analysis/report generation for completed runs
 - `tailtriage-cli`: command-line analysis of saved run artifacts
+- `tailtriage-tracing`: optional tracing intake bridge that can also produce `Run` artifacts for the same analyzer/CLI workflow

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -177,3 +177,4 @@ This crate does not provide:
 - analysis/report generation
 
 Use sibling crates for those surfaces: `tailtriage-controller`, `tailtriage-tokio`, `tailtriage-axum`, `tailtriage-analyzer`, and `tailtriage-cli`.
+For teams already emitting Rust `tracing` spans, `tailtriage-tracing` can import tracing-shaped request/stage/queue evidence into standard `tailtriage_core::Run` values.

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -42,6 +42,7 @@ Examples:
 - active bounded sections as in-flight evidence
 
 This crate does not change core request lifecycle semantics.
+Runtime-pressure evidence still depends on runtime snapshots captured by the sampler; tracing spans alone do not provide Tokio executor/blocking queue-depth fields.
 
 ## When to choose this crate
 
@@ -350,3 +351,4 @@ For those surfaces, use:
 - `tailtriage-axum`: Axum middleware/extractor integration
 - `tailtriage-analyzer`: in-process analysis/report generation for completed runs
 - `tailtriage-cli`: command-line analysis of saved run artifacts
+- `tailtriage-tracing`: optional tracing intake bridge; combine with runtime sampling when executor/blocking-pressure separation is required

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -31,6 +31,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
 
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]

--- a/tailtriage-tracing/LICENSE
+++ b/tailtriage-tracing/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Sebastian
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tailtriage/README.md
+++ b/tailtriage/README.md
@@ -99,6 +99,7 @@ Choose a focused crate only when you need a narrower boundary:
 - `tailtriage-controller`: repeated bounded windows
 - `tailtriage-tokio`: runtime-pressure sampling and Tokio primitive helper trait (`TokioRequestHandleExt`)
 - `tailtriage-axum`: Axum request-boundary wiring
+- `tailtriage-tracing`: optional narrow tracing intake bridge for teams already emitting Rust `tracing` spans; converts tracing-shaped evidence into standard `tailtriage_core::Run` values
 
 ## Feature flags
 
@@ -127,3 +128,4 @@ If you want a smaller core-only dependency surface, use `tailtriage-core` direct
 - `tailtriage-axum`: Axum request-boundary integration
 - `tailtriage-analyzer`: in-process analysis/report generation for completed runs
 - `tailtriage-cli`: command-line analysis of saved run artifacts
+- `tailtriage-tracing`: optional tracing intake bridge (JSONL import + live recorder) that produces standard `tailtriage_core::Run` values for the same analyzer/CLI workflow


### PR DESCRIPTION
### Motivation
- Ensure the repository guidance and crate READMEs truthfully reflect the new optional `tailtriage-tracing` intake surface without changing the product positioning of `tailtriage` as the default entry point. 
- Make the published docs.rs surface for `tailtriage-tracing` match the README-described feature-gated API (Tokio coupling) so docs.rs users see the documented surface. 
- Fix a packaging mismatch by ensuring the crate `include` list is coherent (LICENSE present) and avoid misleading consumers about what the tracing crate provides. 

### Description
- Add `tailtriage-tracing` to the expected workspace members in `AGENTS.md` so repository guidance matches the actual workspace. 
- Update `tailtriage/README.md`, `tailtriage-analyzer/README.md`, `tailtriage-core/README.md`, `tailtriage-controller/README.md`, `tailtriage-tokio/README.md`, and `tailtriage-axum/README.md` with minimal, consistent mentions that `tailtriage-tracing` is an optional, narrow tracing intake bridge that converts tracing-shaped evidence into standard `tailtriage_core::Run` values while preserving runtime-pressure caveats and keeping `tailtriage` as the recommended default. 
- Make the `tailtriage-tracing` crate package coherent by adding a crate-local `LICENSE` file and updating `tailtriage-tracing/Cargo.toml` `[package.metadata.docs.rs]` to `all-features = true` so docs.rs builds the documented, feature-gated Tokio coupling surface. 
- Keep all changes narrowly scoped to docs, package metadata, and licensing; no analyzer, capture, or runtime behavior was altered and the wording preserves triage framing (evidence-ranked suspects, next checks, and runtime-snapshot caveats). 

### Testing
- Ran `cargo fmt --check` and it passed. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed. 
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests passed. 
- Ran `python3 scripts/validate_docs_contracts.py` and the docs contract validation passed. 
- Ran `python3 -m unittest scripts.tests.test_validate_docs_contracts` and the test suite passed. 
- Built docs with `cargo doc -p tailtriage-tracing --all-features --no-deps` and the crate docs generated successfully. 
- Remaining limitations: none identified in this scoped docs and packaging pass; the tracing crate is still explicitly documented as optional and not a tracing backend or OTel/OTLP exporter.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b0d2cfab883308fa72efc4f61f50c)