### PR TITLE
Align tracing documentation and published crate surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,6 +233,7 @@ Expected workspace members:
 - `tailtriage-axum`
 - `tailtriage-analyzer`
 - `tailtriage-cli`
+- `tailtriage-tracing`
 
 Possible directories:
 

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -36,6 +36,7 @@ class ValidateDocsContractsTests(unittest.TestCase):
                 "tailtriage-axum/src/lib.rs",
                 "tailtriage-analyzer/src/lib.rs",
                 "tailtriage-cli/src/lib.rs",
+                "tailtriage-tracing/src/lib.rs",
             )
             paths = []
             for rel in rels:

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -23,6 +23,7 @@ ANALYZER_DOC_PATHS = (
     USER_GUIDE_PATH,
     REPO_ROOT / "tailtriage-analyzer" / "README.md",
     REPO_ROOT / "tailtriage-cli" / "README.md",
+    REPO_ROOT / "tailtriage-tracing" / "README.md",
 )
 DIAGNOSTIC_VALIDATION_PATH = REPO_ROOT / "docs" / "diagnostic-validation.md"
 CI_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
@@ -129,6 +130,7 @@ RUSTDOC_INCLUDE_CRATE_LIBS = (
     REPO_ROOT / "tailtriage-axum" / "src" / "lib.rs",
     REPO_ROOT / "tailtriage-analyzer" / "src" / "lib.rs",
     REPO_ROOT / "tailtriage-cli" / "src" / "lib.rs",
+    REPO_ROOT / "tailtriage-tracing" / "src" / "lib.rs",
 )
 
 ANALYZER_GROUPS = (

--- a/tailtriage-analyzer/README.md
+++ b/tailtriage-analyzer/README.md
@@ -22,7 +22,7 @@ Suspects are investigation leads, not proof of root cause.
 cargo add tailtriage-analyzer
 ```
 
-You also need a capture crate that provides `tailtriage_core::Run`, such as `tailtriage` or `tailtriage-core`.
+You also need a capture/intake crate that provides `tailtriage_core::Run`, such as `tailtriage`, `tailtriage-core`, or `tailtriage-tracing`.
 
 ## How to obtain a `Run`
 
@@ -30,7 +30,7 @@ You also need a capture crate that provides `tailtriage_core::Run`, such as `tai
 
 Typical flow:
 
-- capture/integration crates (`tailtriage`, `tailtriage-core`, `tailtriage-controller`, `tailtriage-tokio`, `tailtriage-axum`) produce completed runs or saved artifacts
+- capture/intake crates (`tailtriage`, `tailtriage-core`, `tailtriage-controller`, `tailtriage-tokio`, `tailtriage-axum`, `tailtriage-tracing`) produce completed runs or saved artifacts
 - `tailtriage-analyzer` analyzes completed in-memory runs or stable snapshots in process
 - `tailtriage-cli` loads saved artifacts from disk and invokes `tailtriage-analyzer`
 

--- a/tailtriage-axum/README.md
+++ b/tailtriage-axum/README.md
@@ -123,3 +123,4 @@ If you do not use Axum, this crate is not the right abstraction boundary.
 - `tailtriage-tokio`: runtime-pressure sampling
 - `tailtriage-analyzer`: in-process analysis/report generation for completed runs
 - `tailtriage-cli`: command-line analysis of saved run artifacts
+- `tailtriage-tracing`: optional tracing intake bridge for converting tracing-shaped evidence into `tailtriage_core::Run`

--- a/tailtriage-controller/README.md
+++ b/tailtriage-controller/README.md
@@ -211,3 +211,4 @@ Optional table. If present, `kind` is required.
 - `tailtriage-axum`: Axum request-boundary integration
 - `tailtriage-analyzer`: in-process analysis/report generation for completed runs
 - `tailtriage-cli`: command-line analysis of saved run artifacts
+- `tailtriage-tracing`: optional tracing intake bridge that converts tracing-shaped evidence into `tailtriage_core::Run`

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -176,4 +176,4 @@ This crate does not provide:
 - Axum middleware/extractors
 - analysis/report generation
 
-Use sibling crates for those surfaces: `tailtriage-controller`, `tailtriage-tokio`, `tailtriage-axum`, `tailtriage-analyzer`, and `tailtriage-cli`.
+Use sibling crates for those surfaces: `tailtriage-controller`, `tailtriage-tokio`, `tailtriage-axum`, `tailtriage-analyzer`, `tailtriage-cli`, and optional `tailtriage-tracing` intake when you already emit Rust `tracing` spans.

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -350,3 +350,4 @@ For those surfaces, use:
 - `tailtriage-axum`: Axum middleware/extractor integration
 - `tailtriage-analyzer`: in-process analysis/report generation for completed runs
 - `tailtriage-cli`: command-line analysis of saved run artifacts
+- `tailtriage-tracing`: optional tracing intake bridge; runtime-pressure evidence still depends on runtime snapshots

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -31,6 +31,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
 
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]

--- a/tailtriage-tracing/LICENSE
+++ b/tailtriage-tracing/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Sebastian
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tailtriage/README.md
+++ b/tailtriage/README.md
@@ -127,3 +127,4 @@ If you want a smaller core-only dependency surface, use `tailtriage-core` direct
 - `tailtriage-axum`: Axum request-boundary integration
 - `tailtriage-analyzer`: in-process analysis/report generation for completed runs
 - `tailtriage-cli`: command-line analysis of saved run artifacts
+- `tailtriage-tracing`: optional narrow tracing intake bridge for teams already emitting Rust `tracing` spans; converts tracing-shaped evidence into standard `tailtriage_core::Run` values


### PR DESCRIPTION
### Motivation
- Make the repository and public docs consistent with the newly added `tailtriage-tracing` crate so workspace guidance, READMEs, and published docs tell one coherent story.  
- Keep `tailtriage` as the recommended default entry point while documenting `tailtriage-tracing` as an optional, narrow tracing intake bridge that produces standard `tailtriage_core::Run` values.  
- Fix packaging/docs-surface mismatches (docs.rs metadata and crate `include` list) so published docs and package contents are truthful and buildable.

### Description
- Add `tailtriage-tracing` to the expected workspace members in `AGENTS.md` and add short, scoped mentions of the tracing intake in `tailtriage/README.md`, `tailtriage-analyzer/README.md`, `tailtriage-core/README.md`, `tailtriage-controller/README.md`, `tailtriage-tokio/README.md`, and `tailtriage-axum/README.md` so all READMEs agree tracing is optional and secondary.  
- Update `tailtriage-analyzer/README.md` to list `tailtriage-tracing` among crates that can produce completed `Run` values while preserving the analyzer’s boundary that it does not capture or load artifacts itself.  
- Adjust `tailtriage-tracing/Cargo.toml` `[package.metadata.docs.rs]` to include `all-features = true` so docs.rs will build the documented feature-gated API surface, and add a crate-local `tailtriage-tracing/LICENSE` to satisfy the `include = [

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b0d2cfab883308fa72efc4f61f50c)