### PR TITLE
Docs & packaging: integrate optional tailtriage-tracing intake and fix docs.rs/package include

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,6 +233,7 @@ Expected workspace members:
 - `tailtriage-axum`
 - `tailtriage-analyzer`
 - `tailtriage-cli`
+- `tailtriage-tracing`
 
 Possible directories:
 

--- a/tailtriage-analyzer/README.md
+++ b/tailtriage-analyzer/README.md
@@ -30,7 +30,7 @@ You also need a capture crate that provides `tailtriage_core::Run`, such as `tai
 
 Typical flow:
 
-- capture/integration crates (`tailtriage`, `tailtriage-core`, `tailtriage-controller`, `tailtriage-tokio`, `tailtriage-axum`) produce completed runs or saved artifacts
+- capture/integration crates (`tailtriage`, `tailtriage-core`, `tailtriage-controller`, `tailtriage-tokio`, `tailtriage-axum`, `tailtriage-tracing`) produce completed runs or saved artifacts
 - `tailtriage-analyzer` analyzes completed in-memory runs or stable snapshots in process
 - `tailtriage-cli` loads saved artifacts from disk and invokes `tailtriage-analyzer`
 

--- a/tailtriage-axum/README.md
+++ b/tailtriage-axum/README.md
@@ -123,3 +123,4 @@ If you do not use Axum, this crate is not the right abstraction boundary.
 - `tailtriage-tokio`: runtime-pressure sampling
 - `tailtriage-analyzer`: in-process analysis/report generation for completed runs
 - `tailtriage-cli`: command-line analysis of saved run artifacts
+- `tailtriage-tracing`: optional tracing intake bridge that converts tracing-shaped evidence into standard `tailtriage_core::Run` values

--- a/tailtriage-controller/README.md
+++ b/tailtriage-controller/README.md
@@ -211,3 +211,4 @@ Optional table. If present, `kind` is required.
 - `tailtriage-axum`: Axum request-boundary integration
 - `tailtriage-analyzer`: in-process analysis/report generation for completed runs
 - `tailtriage-cli`: command-line analysis of saved run artifacts
+- `tailtriage-tracing`: optional tracing intake bridge that converts tracing-shaped evidence into standard `tailtriage_core::Run` values

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -350,3 +350,4 @@ For those surfaces, use:
 - `tailtriage-axum`: Axum middleware/extractor integration
 - `tailtriage-analyzer`: in-process analysis/report generation for completed runs
 - `tailtriage-cli`: command-line analysis of saved run artifacts
+- `tailtriage-tracing`: optional tracing intake bridge that converts tracing-shaped evidence into standard `tailtriage_core::Run` values

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["asynchronous", "development-tools::debugging", "development-tools
 include = [
   "Cargo.toml",
   "README.md",
-  "LICENSE",
   "src/**",
   "examples/**",
 ]
@@ -31,6 +30,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
 
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]

--- a/tailtriage/README.md
+++ b/tailtriage/README.md
@@ -99,6 +99,7 @@ Choose a focused crate only when you need a narrower boundary:
 - `tailtriage-controller`: repeated bounded windows
 - `tailtriage-tokio`: runtime-pressure sampling and Tokio primitive helper trait (`TokioRequestHandleExt`)
 - `tailtriage-axum`: Axum request-boundary wiring
+- `tailtriage-tracing`: optional narrow tracing intake bridge for teams already emitting Rust `tracing` spans; converts tracing-shaped evidence into standard `tailtriage_core::Run` values
 
 ## Feature flags
 
@@ -127,3 +128,4 @@ If you want a smaller core-only dependency surface, use `tailtriage-core` direct
 - `tailtriage-axum`: Axum request-boundary integration
 - `tailtriage-analyzer`: in-process analysis/report generation for completed runs
 - `tailtriage-cli`: command-line analysis of saved run artifacts
+- `tailtriage-tracing`: optional tracing intake bridge that converts tracing-shaped request/stage/queue evidence into standard `tailtriage_core::Run` values


### PR DESCRIPTION
### Motivation

- Bring repository guidance and published docs into factual alignment now that `tailtriage-tracing` ships in the workspace. 
- Keep `tailtriage` as the recommended default onboarding path while documenting the new optional tracing intake bridge and preserving runtime-snapshot caveats.

### Description

- Add `tailtriage-tracing` to the Expected workspace members list in `AGENTS.md` so repo guidance matches the actual workspace surface. 
- Update `tailtriage/README.md` to mention `tailtriage-tracing` as an optional, narrow tracing intake bridge that converts tracing-shaped evidence into `tailtriage_core::Run` values while keeping `tailtriage` as the primary entry point. 
- Update `tailtriage-analyzer/README.md` to list `tailtriage-tracing` among crates that can produce completed `Run` artifacts while preserving the analyzer boundary (it does not capture or load from disk). 
- Add minimal, non-invasive related-crate mentions of `tailtriage-tracing` in `tailtriage-controller/README.md`, `tailtriage-tokio/README.md`, and `tailtriage-axum/README.md` without implying new integration behaviors. 
- Fix `tailtriage-tracing/Cargo.toml` packaging and docs surface by removing a non-existent crate-local `LICENSE` entry from `include` and adding `all-features = true` to `[package.metadata.docs.rs]` so docs.rs builds the feature-gated public surface documented in the README.

### Testing

- Ran `cargo fmt --check` and it succeeded. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it succeeded. 
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests passed. 
- Ran `python3 scripts/validate_docs_contracts.py` and the docs contract validation succeeded. 
- Ran `python3 -m unittest scripts.tests.test_validate_docs_contracts` and the unit tests all passed. 
- Built documentation with `cargo doc -p tailtriage-tracing --all-features --no-deps` and rustdoc completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b0d2cfab883308fa72efc4f61f50c)