### PR TITLE
core: add RunBuilder for assembling finalized Run artifacts

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,6 +43,7 @@ Owns the core capture model:
 - queue/stage/inflight instrumentation wrappers
 - run artifact schema and sink behavior
 - capture limits/truncation accounting
+- completed-run assembly used by import/adaptation bridges
 
 ### `tailtriage-tokio`
 
@@ -64,6 +65,11 @@ Owns in-process analysis/report generation from completed runs:
 ### `tailtriage-cli`
 
 Consumes run artifacts from disk, validates schema/loader rules, invokes `tailtriage-analyzer`, and emits text/JSON output. CLI report rendering delegates to analyzer-owned renderers.
+
+### `tailtriage-tracing`
+
+A narrow intake bridge for tracing-shaped completed spans and live `tt.*` span recording.
+It converts/imports tracing intake into standard core `Run` artifacts, does not implement OpenTelemetry/OTLP, and does not change analyzer behavior.
 
 ## Relationship model
 

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -177,19 +177,22 @@ Use `RunBuilder` only when you already have completed request, stage, queue, in-
 ```rust,no_run
 use tailtriage_core::{RequestEvent, RunBuilder, RunBuilderOptions};
 
-let mut builder = RunBuilder::new(RunBuilderOptions::new("checkout-service"))?;
-builder.push_request(RequestEvent {
-    request_id: "req-1".into(),
-    route: "/test".into(),
-    kind: Some("http".into()),
-    started_at_unix_ms: 1,
-    finished_at_unix_ms: 2,
-    latency_us: 1_000,
-    outcome: "ok".into(),
-});
-let run = builder.finish();
-assert_eq!(run.requests.len(), 1);
-# Ok::<(), tailtriage_core::BuildError>(())
+fn assemble_run() -> Result<(), tailtriage_core::BuildError> {
+    let mut builder = RunBuilder::new(RunBuilderOptions::new("checkout-service"))?;
+    builder.push_request(RequestEvent {
+        request_id: "req-1".into(),
+        route: "/test".into(),
+        kind: Some("http".into()),
+        started_at_unix_ms: 1,
+        finished_at_unix_ms: 2,
+        latency_us: 1_000,
+        outcome: "ok".into(),
+    });
+
+    let run = builder.finish();
+    assert_eq!(run.requests.len(), 1);
+    Ok(())
+}
 ```
 
 ## What this crate does not do

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -167,6 +167,31 @@ Override limits with:
 - `capture_limits(...)` (full override)
 - `capture_limits_override(...)` (field-level override)
 
+## Advanced: assembling completed run artifacts
+
+Most users should use `Tailtriage::builder(...)` for live request instrumentation.
+Use `RunBuilder` only when you already have completed request, stage, queue, in-flight, or runtime evidence and need to assemble a standard `Run` artifact.
+
+`RunBuilder` is intended for import/conversion paths. It does not perform live lifecycle tracking. It applies the same bounded retention/truncation semantics as live core capture, so events beyond configured `CaptureLimits` are dropped and `Run.truncation` counters are updated. For assembled/imported artifacts, host and pid default to `None`, and generated run IDs use the same core run-id semantics as live capture.
+
+```rust,no_run
+use tailtriage_core::{RequestEvent, RunBuilder, RunBuilderOptions};
+
+let mut builder = RunBuilder::new(RunBuilderOptions::new("checkout-service"))?;
+builder.push_request(RequestEvent {
+    request_id: "req-1".into(),
+    route: "/test".into(),
+    kind: Some("http".into()),
+    started_at_unix_ms: 1,
+    finished_at_unix_ms: 2,
+    latency_us: 1_000,
+    outcome: "ok".into(),
+});
+let run = builder.finish();
+assert_eq!(run.requests.len(), 1);
+# Ok::<(), tailtriage_core::BuildError>(())
+```
+
 ## What this crate does not do
 
 This crate does not provide:

--- a/tailtriage-core/src/collector.rs
+++ b/tailtriage-core/src/collector.rs
@@ -460,14 +460,9 @@ impl Tailtriage {
         let mut notify_limits_hit = false;
         {
             let mut run = lock_run(&self.run);
-            if run.runtime_snapshots.len() >= self.limits.max_runtime_snapshots {
-                run.truncation.limits_hit = true;
-                run.truncation.dropped_runtime_snapshots =
-                    run.truncation.dropped_runtime_snapshots.saturating_add(1);
+            if crate::retention::push_runtime_snapshot_bounded(&mut run, self.limits, snapshot) {
                 self.truncation_state.runtime_snapshots.mark_saturated();
                 notify_limits_hit = true;
-            } else {
-                run.runtime_snapshots.push(snapshot);
             }
         }
         if notify_limits_hit {
@@ -510,13 +505,9 @@ impl Tailtriage {
         let mut notify_limits_hit = false;
         {
             let mut run = lock_run(&self.run);
-            if run.stages.len() >= self.limits.max_stages {
-                run.truncation.limits_hit = true;
-                run.truncation.dropped_stages = run.truncation.dropped_stages.saturating_add(1);
+            if crate::retention::push_stage_bounded(&mut run, self.limits, event) {
                 self.truncation_state.stages.mark_saturated();
                 notify_limits_hit = true;
-            } else {
-                run.stages.push(event);
             }
         }
         if notify_limits_hit {
@@ -534,13 +525,9 @@ impl Tailtriage {
         let mut notify_limits_hit = false;
         {
             let mut run = lock_run(&self.run);
-            if run.queues.len() >= self.limits.max_queues {
-                run.truncation.limits_hit = true;
-                run.truncation.dropped_queues = run.truncation.dropped_queues.saturating_add(1);
+            if crate::retention::push_queue_bounded(&mut run, self.limits, event) {
                 self.truncation_state.queues.mark_saturated();
                 notify_limits_hit = true;
-            } else {
-                run.queues.push(event);
             }
         }
         if notify_limits_hit {
@@ -558,14 +545,9 @@ impl Tailtriage {
         let mut notify_limits_hit = false;
         {
             let mut run = lock_run(&self.run);
-            if run.inflight.len() >= self.limits.max_inflight_snapshots {
-                run.truncation.limits_hit = true;
-                run.truncation.dropped_inflight_snapshots =
-                    run.truncation.dropped_inflight_snapshots.saturating_add(1);
+            if crate::retention::push_inflight_snapshot_bounded(&mut run, self.limits, snapshot) {
                 self.truncation_state.inflight.mark_saturated();
                 notify_limits_hit = true;
-            } else {
-                run.inflight.push(snapshot);
             }
         }
         if notify_limits_hit {
@@ -583,13 +565,9 @@ impl Tailtriage {
         let mut notify_limits_hit = false;
         {
             let mut run = lock_run(&self.run);
-            if run.requests.len() >= self.limits.max_requests {
-                run.truncation.limits_hit = true;
-                run.truncation.dropped_requests = run.truncation.dropped_requests.saturating_add(1);
+            if crate::retention::push_request_bounded(&mut run, self.limits, event) {
                 self.truncation_state.requests.mark_saturated();
                 notify_limits_hit = true;
-            } else {
-                run.requests.push(event);
             }
         }
         if notify_limits_hit {

--- a/tailtriage-core/src/collector.rs
+++ b/tailtriage-core/src/collector.rs
@@ -905,7 +905,7 @@ pub(crate) fn duration_to_us(duration: Duration) -> u64 {
     duration.as_micros().try_into().unwrap_or(u64::MAX)
 }
 
-fn generate_run_id() -> String {
+pub(crate) fn generate_run_id() -> String {
     format!("run-{}", uuid::Uuid::new_v4())
 }
 

--- a/tailtriage-core/src/lib.rs
+++ b/tailtriage-core/src/lib.rs
@@ -29,6 +29,7 @@
 mod collector;
 mod config;
 mod events;
+mod run_builder;
 mod sink;
 mod time;
 mod timers;
@@ -46,6 +47,7 @@ pub use events::{
     RunEndReason, RunMetadata, RuntimeSnapshot, StageEvent, TruncationSummary,
     UnfinishedRequestSample, UnfinishedRequests, SCHEMA_VERSION,
 };
+pub use run_builder::{RunBuilder, RunBuilderOptions};
 pub use sink::{DiscardSink, LocalJsonSink, MemorySink, RunSink, SinkError};
 pub use time::{system_time_to_unix_ms, unix_time_ms};
 pub use timers::{InflightGuard, QueueTimer, StageTimer};

--- a/tailtriage-core/src/lib.rs
+++ b/tailtriage-core/src/lib.rs
@@ -29,6 +29,7 @@
 mod collector;
 mod config;
 mod events;
+mod retention;
 mod run_builder;
 mod sink;
 mod time;

--- a/tailtriage-core/src/retention.rs
+++ b/tailtriage-core/src/retention.rs
@@ -1,0 +1,72 @@
+use crate::{
+    CaptureLimits, InFlightSnapshot, QueueEvent, RequestEvent, Run, RuntimeSnapshot, StageEvent,
+};
+
+pub(crate) fn push_request_bounded(
+    run: &mut Run,
+    limits: CaptureLimits,
+    event: RequestEvent,
+) -> bool {
+    if run.requests.len() < limits.max_requests {
+        run.requests.push(event);
+        return false;
+    }
+
+    run.truncation.limits_hit = true;
+    run.truncation.dropped_requests = run.truncation.dropped_requests.saturating_add(1);
+    true
+}
+
+pub(crate) fn push_stage_bounded(run: &mut Run, limits: CaptureLimits, event: StageEvent) -> bool {
+    if run.stages.len() < limits.max_stages {
+        run.stages.push(event);
+        return false;
+    }
+
+    run.truncation.limits_hit = true;
+    run.truncation.dropped_stages = run.truncation.dropped_stages.saturating_add(1);
+    true
+}
+
+pub(crate) fn push_queue_bounded(run: &mut Run, limits: CaptureLimits, event: QueueEvent) -> bool {
+    if run.queues.len() < limits.max_queues {
+        run.queues.push(event);
+        return false;
+    }
+
+    run.truncation.limits_hit = true;
+    run.truncation.dropped_queues = run.truncation.dropped_queues.saturating_add(1);
+    true
+}
+
+pub(crate) fn push_inflight_snapshot_bounded(
+    run: &mut Run,
+    limits: CaptureLimits,
+    snapshot: InFlightSnapshot,
+) -> bool {
+    if run.inflight.len() < limits.max_inflight_snapshots {
+        run.inflight.push(snapshot);
+        return false;
+    }
+
+    run.truncation.limits_hit = true;
+    run.truncation.dropped_inflight_snapshots =
+        run.truncation.dropped_inflight_snapshots.saturating_add(1);
+    true
+}
+
+pub(crate) fn push_runtime_snapshot_bounded(
+    run: &mut Run,
+    limits: CaptureLimits,
+    snapshot: RuntimeSnapshot,
+) -> bool {
+    if run.runtime_snapshots.len() < limits.max_runtime_snapshots {
+        run.runtime_snapshots.push(snapshot);
+        return false;
+    }
+
+    run.truncation.limits_hit = true;
+    run.truncation.dropped_runtime_snapshots =
+        run.truncation.dropped_runtime_snapshots.saturating_add(1);
+    true
+}

--- a/tailtriage-core/src/run_builder.rs
+++ b/tailtriage-core/src/run_builder.rs
@@ -154,7 +154,8 @@ impl RunBuilder {
         let ts = unix_time_ms();
         let started_at_unix_ms = options.started_at_unix_ms.unwrap_or(ts);
         let finished_at_unix_ms = options.finished_at_unix_ms.unwrap_or(ts);
-        let finalized_at_unix_ms = Some(options.finalized_at_unix_ms.unwrap_or(ts));
+        let finalized_at_unix_ms =
+            Some(options.finalized_at_unix_ms.unwrap_or(finished_at_unix_ms));
 
         Ok(Self {
             run: Run::new(RunMetadata {

--- a/tailtriage-core/src/run_builder.rs
+++ b/tailtriage-core/src/run_builder.rs
@@ -121,6 +121,7 @@ impl RunBuilderOptions {
 #[derive(Debug)]
 pub struct RunBuilder {
     run: Run,
+    capture_limits: CaptureLimits,
 }
 
 impl RunBuilder {
@@ -164,28 +165,37 @@ impl RunBuilder {
                 unfinished_requests: UnfinishedRequests::default(),
                 run_end_reason: options.run_end_reason,
             }),
+            capture_limits,
         })
     }
 
     /// Appends a request event.
     pub fn push_request(&mut self, event: RequestEvent) {
-        self.run.requests.push(event);
+        let _ = crate::retention::push_request_bounded(&mut self.run, self.capture_limits, event);
     }
     /// Appends a stage event.
     pub fn push_stage(&mut self, event: StageEvent) {
-        self.run.stages.push(event);
+        let _ = crate::retention::push_stage_bounded(&mut self.run, self.capture_limits, event);
     }
     /// Appends a queue event.
     pub fn push_queue(&mut self, event: QueueEvent) {
-        self.run.queues.push(event);
+        let _ = crate::retention::push_queue_bounded(&mut self.run, self.capture_limits, event);
     }
     /// Appends an in-flight snapshot.
     pub fn push_inflight_snapshot(&mut self, snapshot: InFlightSnapshot) {
-        self.run.inflight.push(snapshot);
+        let _ = crate::retention::push_inflight_snapshot_bounded(
+            &mut self.run,
+            self.capture_limits,
+            snapshot,
+        );
     }
     /// Appends a runtime snapshot.
     pub fn push_runtime_snapshot(&mut self, snapshot: RuntimeSnapshot) {
-        self.run.runtime_snapshots.push(snapshot);
+        let _ = crate::retention::push_runtime_snapshot_bounded(
+            &mut self.run,
+            self.capture_limits,
+            snapshot,
+        );
     }
     /// Adds one lifecycle warning string.
     pub fn add_lifecycle_warning(&mut self, warning: impl Into<String>) {

--- a/tailtriage-core/src/run_builder.rs
+++ b/tailtriage-core/src/run_builder.rs
@@ -6,9 +6,18 @@ use crate::{
 
 /// Options for assembling a completed [`Run`] artifact.
 ///
-/// This API is intended for completed evidence assembly (for example, importing
-/// or adapting already-collected run evidence). For normal live instrumentation,
-/// use [`crate::Tailtriage`] and its request lifecycle APIs.
+/// This API is for completed evidence assembly (for example, import/conversion
+/// paths), not live request instrumentation. Normal live instrumentation should
+/// use [`crate::Tailtriage::builder`].
+///
+/// When omitted:
+/// - mode defaults to [`CaptureMode::Light`]
+/// - capture limits default to `mode.core_defaults()`
+/// - host and pid remain `None`
+/// - run id uses the same core run-id generator as live capture
+/// - timestamps are filled from one captured current unix-ms value
+///
+/// `finalized_at_unix_ms` is always `Some(...)` for [`RunBuilder`] output.
 #[derive(Debug, Clone)]
 pub struct RunBuilderOptions {
     service_name: String,
@@ -113,11 +122,14 @@ impl RunBuilderOptions {
     }
 }
 
-/// Completed-run artifact assembler.
+/// Advanced/import API for completed-run artifact assembly.
 ///
-/// Use this when you already have request/stage/queue/runtime evidence and need
-/// to assemble a finalized [`Run`] value. This is not the normal live
-/// instrumentation path.
+/// [`RunBuilder`] assembles a finalized [`Run`] from already measured evidence.
+/// It does not perform live request lifecycle tracking.
+///
+/// Push methods use first-N retention through the same bounded
+/// retention/truncation helper used by the live collector. Overflow items are
+/// dropped and reflected in [`Run::truncation`].
 #[derive(Debug)]
 pub struct RunBuilder {
     run: Run,
@@ -170,18 +182,31 @@ impl RunBuilder {
     }
 
     /// Appends a request event.
+    ///
+    /// The event is retained only while request capture-limit capacity remains;
+    /// otherwise it is dropped and `truncation.dropped_requests` is updated.
     pub fn push_request(&mut self, event: RequestEvent) {
         let _ = crate::retention::push_request_bounded(&mut self.run, self.capture_limits, event);
     }
     /// Appends a stage event.
+    ///
+    /// The event is retained only while stage capture-limit capacity remains;
+    /// otherwise it is dropped and `truncation.dropped_stages` is updated.
     pub fn push_stage(&mut self, event: StageEvent) {
         let _ = crate::retention::push_stage_bounded(&mut self.run, self.capture_limits, event);
     }
     /// Appends a queue event.
+    ///
+    /// The event is retained only while queue capture-limit capacity remains;
+    /// otherwise it is dropped and `truncation.dropped_queues` is updated.
     pub fn push_queue(&mut self, event: QueueEvent) {
         let _ = crate::retention::push_queue_bounded(&mut self.run, self.capture_limits, event);
     }
     /// Appends an in-flight snapshot.
+    ///
+    /// The snapshot is retained only while in-flight snapshot capture-limit
+    /// capacity remains; otherwise it is dropped and
+    /// `truncation.dropped_inflight_snapshots` is updated.
     pub fn push_inflight_snapshot(&mut self, snapshot: InFlightSnapshot) {
         let _ = crate::retention::push_inflight_snapshot_bounded(
             &mut self.run,
@@ -190,6 +215,10 @@ impl RunBuilder {
         );
     }
     /// Appends a runtime snapshot.
+    ///
+    /// The snapshot is retained only while runtime snapshot capture-limit
+    /// capacity remains; otherwise it is dropped and
+    /// `truncation.dropped_runtime_snapshots` is updated.
     pub fn push_runtime_snapshot(&mut self, snapshot: RuntimeSnapshot) {
         let _ = crate::retention::push_runtime_snapshot_bounded(
             &mut self.run,
@@ -215,7 +244,10 @@ impl RunBuilder {
             self.run.metadata.run_end_reason = Some(reason);
         }
     }
-    /// Finalizes builder ownership and returns the completed run artifact.
+    /// Consumes the builder and returns the assembled finalized [`Run`].
+    ///
+    /// This does not perform lifecycle validation or synthesize missing
+    /// completions.
     #[must_use]
     pub fn finish(self) -> Run {
         self.run

--- a/tailtriage-core/src/run_builder.rs
+++ b/tailtriage-core/src/run_builder.rs
@@ -1,0 +1,213 @@
+use crate::{
+    collector::generate_run_id, unix_time_ms, BuildError, CaptureLimits, CaptureMode,
+    EffectiveCoreConfig, EffectiveTokioSamplerConfig, InFlightSnapshot, QueueEvent, RequestEvent,
+    Run, RunEndReason, RunMetadata, RuntimeSnapshot, StageEvent, UnfinishedRequests,
+};
+
+/// Options for assembling a completed [`Run`] artifact.
+///
+/// This API is intended for completed evidence assembly (for example, importing
+/// or adapting already-collected run evidence). For normal live instrumentation,
+/// use [`crate::Tailtriage`] and its request lifecycle APIs.
+#[derive(Debug, Clone)]
+pub struct RunBuilderOptions {
+    service_name: String,
+    service_version: Option<String>,
+    run_id: Option<String>,
+    mode: Option<CaptureMode>,
+    capture_limits: Option<CaptureLimits>,
+    strict_lifecycle: bool,
+    started_at_unix_ms: Option<u64>,
+    finished_at_unix_ms: Option<u64>,
+    finalized_at_unix_ms: Option<u64>,
+    host: Option<String>,
+    pid: Option<u32>,
+    run_end_reason: Option<RunEndReason>,
+}
+
+impl RunBuilderOptions {
+    /// Creates options with a required service name.
+    #[must_use]
+    pub fn new(service_name: impl Into<String>) -> Self {
+        Self {
+            service_name: service_name.into(),
+            service_version: None,
+            run_id: None,
+            mode: None,
+            capture_limits: None,
+            strict_lifecycle: false,
+            started_at_unix_ms: None,
+            finished_at_unix_ms: None,
+            finalized_at_unix_ms: None,
+            host: None,
+            pid: None,
+            run_end_reason: None,
+        }
+    }
+
+    /// Sets optional service version metadata.
+    #[must_use]
+    pub fn service_version(mut self, service_version: impl Into<String>) -> Self {
+        self.service_version = Some(service_version.into());
+        self
+    }
+    /// Sets a caller-provided run identifier.
+    #[must_use]
+    pub fn run_id(mut self, run_id: impl Into<String>) -> Self {
+        self.run_id = Some(run_id.into());
+        self
+    }
+    /// Sets capture mode.
+    #[must_use]
+    pub fn mode(mut self, mode: CaptureMode) -> Self {
+        self.mode = Some(mode);
+        self
+    }
+    /// Sets effective capture limits for this completed run artifact.
+    #[must_use]
+    pub fn capture_limits(mut self, capture_limits: CaptureLimits) -> Self {
+        self.capture_limits = Some(capture_limits);
+        self
+    }
+    /// Sets strict lifecycle flag recorded in effective core config.
+    #[must_use]
+    pub const fn strict_lifecycle(mut self, strict_lifecycle: bool) -> Self {
+        self.strict_lifecycle = strict_lifecycle;
+        self
+    }
+    /// Sets start timestamp in unix milliseconds.
+    #[must_use]
+    pub const fn started_at_unix_ms(mut self, started_at_unix_ms: u64) -> Self {
+        self.started_at_unix_ms = Some(started_at_unix_ms);
+        self
+    }
+    /// Sets finish timestamp in unix milliseconds.
+    #[must_use]
+    pub const fn finished_at_unix_ms(mut self, finished_at_unix_ms: u64) -> Self {
+        self.finished_at_unix_ms = Some(finished_at_unix_ms);
+        self
+    }
+    /// Sets finalization timestamp in unix milliseconds.
+    #[must_use]
+    pub const fn finalized_at_unix_ms(mut self, finalized_at_unix_ms: u64) -> Self {
+        self.finalized_at_unix_ms = Some(finalized_at_unix_ms);
+        self
+    }
+    /// Sets optional host metadata.
+    #[must_use]
+    pub fn host(mut self, host: impl Into<String>) -> Self {
+        self.host = Some(host.into());
+        self
+    }
+    /// Sets optional process identifier metadata.
+    #[must_use]
+    pub const fn pid(mut self, pid: u32) -> Self {
+        self.pid = Some(pid);
+        self
+    }
+    /// Sets optional run-end reason metadata.
+    #[must_use]
+    pub const fn run_end_reason(mut self, run_end_reason: RunEndReason) -> Self {
+        self.run_end_reason = Some(run_end_reason);
+        self
+    }
+}
+
+/// Completed-run artifact assembler.
+///
+/// Use this when you already have request/stage/queue/runtime evidence and need
+/// to assemble a finalized [`Run`] value. This is not the normal live
+/// instrumentation path.
+#[derive(Debug)]
+pub struct RunBuilder {
+    run: Run,
+}
+
+impl RunBuilder {
+    /// Creates a new completed-run builder from [`RunBuilderOptions`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BuildError::EmptyServiceName`] when the service name is blank.
+    pub fn new(options: RunBuilderOptions) -> Result<Self, BuildError> {
+        if options.service_name.trim().is_empty() {
+            return Err(BuildError::EmptyServiceName);
+        }
+
+        let mode = options.mode.unwrap_or(CaptureMode::Light);
+        let capture_limits = options
+            .capture_limits
+            .unwrap_or_else(|| mode.core_defaults());
+        let ts = unix_time_ms();
+        let started_at_unix_ms = options.started_at_unix_ms.unwrap_or(ts);
+        let finished_at_unix_ms = options.finished_at_unix_ms.unwrap_or(ts);
+        let finalized_at_unix_ms = Some(options.finalized_at_unix_ms.unwrap_or(ts));
+
+        Ok(Self {
+            run: Run::new(RunMetadata {
+                run_id: options.run_id.unwrap_or_else(generate_run_id),
+                service_name: options.service_name,
+                service_version: options.service_version,
+                started_at_unix_ms,
+                finished_at_unix_ms,
+                finalized_at_unix_ms,
+                mode,
+                effective_core_config: Some(EffectiveCoreConfig {
+                    mode,
+                    capture_limits,
+                    strict_lifecycle: options.strict_lifecycle,
+                }),
+                effective_tokio_sampler_config: None,
+                host: options.host,
+                pid: options.pid,
+                lifecycle_warnings: Vec::new(),
+                unfinished_requests: UnfinishedRequests::default(),
+                run_end_reason: options.run_end_reason,
+            }),
+        })
+    }
+
+    /// Appends a request event.
+    pub fn push_request(&mut self, event: RequestEvent) {
+        self.run.requests.push(event);
+    }
+    /// Appends a stage event.
+    pub fn push_stage(&mut self, event: StageEvent) {
+        self.run.stages.push(event);
+    }
+    /// Appends a queue event.
+    pub fn push_queue(&mut self, event: QueueEvent) {
+        self.run.queues.push(event);
+    }
+    /// Appends an in-flight snapshot.
+    pub fn push_inflight_snapshot(&mut self, snapshot: InFlightSnapshot) {
+        self.run.inflight.push(snapshot);
+    }
+    /// Appends a runtime snapshot.
+    pub fn push_runtime_snapshot(&mut self, snapshot: RuntimeSnapshot) {
+        self.run.runtime_snapshots.push(snapshot);
+    }
+    /// Adds one lifecycle warning string.
+    pub fn add_lifecycle_warning(&mut self, warning: impl Into<String>) {
+        self.run.metadata.lifecycle_warnings.push(warning.into());
+    }
+    /// Sets unfinished-request metadata.
+    pub fn set_unfinished_requests(&mut self, unfinished: UnfinishedRequests) {
+        self.run.metadata.unfinished_requests = unfinished;
+    }
+    /// Sets effective Tokio sampler configuration metadata.
+    pub fn set_effective_tokio_sampler_config(&mut self, config: EffectiveTokioSamplerConfig) {
+        self.run.metadata.effective_tokio_sampler_config = Some(config);
+    }
+    /// Sets run-end reason only when absent.
+    pub fn set_run_end_reason_if_absent(&mut self, reason: RunEndReason) {
+        if self.run.metadata.run_end_reason.is_none() {
+            self.run.metadata.run_end_reason = Some(reason);
+        }
+    }
+    /// Finalizes builder ownership and returns the completed run artifact.
+    #[must_use]
+    pub fn finish(self) -> Run {
+        self.run
+    }
+}

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -924,3 +924,157 @@ fn dropping_unfinished_completion_panics_in_debug() {
         "unfinished completion should panic in debug"
     );
 }
+
+#[test]
+fn run_builder_creates_empty_run_with_explicit_metadata() {
+    let limits = CaptureLimits {
+        max_requests: 10,
+        max_stages: 20,
+        max_queues: 30,
+        max_inflight_snapshots: 40,
+        max_runtime_snapshots: 50,
+    };
+    let mut builder = crate::RunBuilder::new(
+        crate::RunBuilderOptions::new("payments")
+            .service_version("1.2.3")
+            .run_id("run-explicit")
+            .mode(CaptureMode::Investigation)
+            .capture_limits(limits)
+            .strict_lifecycle(true)
+            .started_at_unix_ms(100)
+            .finished_at_unix_ms(200)
+            .finalized_at_unix_ms(300)
+            .host("svc-host")
+            .pid(42)
+            .run_end_reason(crate::RunEndReason::Shutdown),
+    )
+    .expect("builder should succeed");
+    builder.push_request(crate::RequestEvent {
+        request_id: "r1".into(),
+        route: "/x".into(),
+        kind: None,
+        started_at_unix_ms: 1,
+        finished_at_unix_ms: 2,
+        latency_us: 10,
+        outcome: "ok".into(),
+    });
+    let run = builder.finish();
+
+    assert_eq!(run.metadata.service_name, "payments");
+    assert_eq!(run.metadata.service_version.as_deref(), Some("1.2.3"));
+    assert_eq!(run.metadata.run_id, "run-explicit");
+    assert_eq!(run.metadata.started_at_unix_ms, 100);
+    assert_eq!(run.metadata.finished_at_unix_ms, 200);
+    assert_eq!(run.metadata.finalized_at_unix_ms, Some(300));
+    assert_eq!(run.metadata.mode, CaptureMode::Investigation);
+    assert_eq!(run.metadata.host.as_deref(), Some("svc-host"));
+    assert_eq!(run.metadata.pid, Some(42));
+    assert_eq!(
+        run.metadata.run_end_reason,
+        Some(crate::RunEndReason::Shutdown)
+    );
+    assert_eq!(run.requests.len(), 1);
+    assert_eq!(
+        run.metadata.effective_core_config.expect("present"),
+        crate::EffectiveCoreConfig {
+            mode: CaptureMode::Investigation,
+            capture_limits: limits,
+            strict_lifecycle: true
+        }
+    );
+}
+
+#[test]
+fn run_builder_rejects_blank_service_name() {
+    let err = crate::RunBuilder::new(crate::RunBuilderOptions::new("  ")).expect_err("should fail");
+    assert_eq!(err, BuildError::EmptyServiceName);
+}
+
+#[test]
+fn run_builder_default_run_ids_are_unique() {
+    let first = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc"))
+        .expect("ok")
+        .finish();
+    let second = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc"))
+        .expect("ok")
+        .finish();
+    assert_ne!(first.metadata.run_id, second.metadata.run_id);
+}
+
+#[test]
+fn run_builder_defaults_host_and_pid_to_none() {
+    let run = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc"))
+        .expect("ok")
+        .finish();
+    assert!(run.metadata.host.is_none());
+    assert!(run.metadata.pid.is_none());
+}
+
+#[test]
+fn run_builder_default_finalized_timestamp_is_some() {
+    let run = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc"))
+        .expect("ok")
+        .finish();
+    assert!(run.metadata.finalized_at_unix_ms.is_some());
+}
+
+#[test]
+fn run_builder_preserves_explicit_finalized_timestamp() {
+    let run =
+        crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").finalized_at_unix_ms(777))
+            .expect("ok")
+            .finish();
+    assert_eq!(run.metadata.finalized_at_unix_ms, Some(777));
+}
+
+#[test]
+fn run_builder_strict_lifecycle_in_effective_core_config() {
+    let run = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").strict_lifecycle(true))
+        .expect("ok")
+        .finish();
+    assert!(
+        run.metadata
+            .effective_core_config
+            .expect("present")
+            .strict_lifecycle
+    );
+}
+
+#[test]
+fn run_builder_set_run_end_reason_if_absent_only_sets_once() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+    builder.set_run_end_reason_if_absent(crate::RunEndReason::Shutdown);
+    builder.set_run_end_reason_if_absent(crate::RunEndReason::ManualDisarm);
+    let run = builder.finish();
+    assert_eq!(
+        run.metadata.run_end_reason,
+        Some(crate::RunEndReason::Shutdown)
+    );
+}
+
+#[test]
+fn run_builder_preserves_lifecycle_warnings() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+    builder.add_lifecycle_warning("warning-1");
+    builder.add_lifecycle_warning("warning-2");
+    let run = builder.finish();
+    assert_eq!(
+        run.metadata.lifecycle_warnings,
+        vec!["warning-1", "warning-2"]
+    );
+}
+
+#[test]
+fn run_builder_preserves_unfinished_requests() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+    builder.set_unfinished_requests(crate::UnfinishedRequests {
+        count: 2,
+        sample: vec![crate::UnfinishedRequestSample {
+            request_id: "a".into(),
+            route: "/r".into(),
+        }],
+    });
+    let run = builder.finish();
+    assert_eq!(run.metadata.unfinished_requests.count, 2);
+    assert_eq!(run.metadata.unfinished_requests.sample.len(), 1);
+}

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -1136,6 +1136,7 @@ fn run_builder_applies_request_limit_and_updates_truncation() {
     assert_eq!(run.truncation.dropped_inflight_snapshots, 0);
     assert_eq!(run.truncation.dropped_runtime_snapshots, 0);
     assert!(run.truncation.limits_hit);
+    assert!(run.truncation.is_truncated());
 }
 
 #[test]
@@ -1161,6 +1162,7 @@ fn run_builder_applies_stage_limit_and_updates_truncation() {
     assert_eq!(run.truncation.dropped_inflight_snapshots, 0);
     assert_eq!(run.truncation.dropped_runtime_snapshots, 0);
     assert!(run.truncation.limits_hit);
+    assert!(run.truncation.is_truncated());
 }
 
 #[test]
@@ -1186,6 +1188,7 @@ fn run_builder_applies_queue_limit_and_updates_truncation() {
     assert_eq!(run.truncation.dropped_inflight_snapshots, 0);
     assert_eq!(run.truncation.dropped_runtime_snapshots, 0);
     assert!(run.truncation.limits_hit);
+    assert!(run.truncation.is_truncated());
 }
 
 #[test]
@@ -1219,6 +1222,7 @@ fn run_builder_applies_inflight_snapshot_limit_and_updates_truncation() {
     assert_eq!(run.truncation.dropped_queues, 0);
     assert_eq!(run.truncation.dropped_runtime_snapshots, 0);
     assert!(run.truncation.limits_hit);
+    assert!(run.truncation.is_truncated());
 }
 
 #[test]
@@ -1258,6 +1262,7 @@ fn run_builder_applies_runtime_snapshot_limit_and_updates_truncation() {
     assert_eq!(run.truncation.dropped_queues, 0);
     assert_eq!(run.truncation.dropped_inflight_snapshots, 0);
     assert!(run.truncation.limits_hit);
+    assert!(run.truncation.is_truncated());
 }
 
 #[test]
@@ -1316,4 +1321,5 @@ fn run_builder_uses_mode_default_limits_when_limits_not_explicit() {
     assert_eq!(run.requests.len(), default_limits.max_requests);
     assert_eq!(run.truncation.dropped_requests, 2);
     assert!(run.truncation.limits_hit);
+    assert!(run.truncation.is_truncated());
 }

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -1078,3 +1078,242 @@ fn run_builder_preserves_unfinished_requests() {
     assert_eq!(run.metadata.unfinished_requests.count, 2);
     assert_eq!(run.metadata.unfinished_requests.sample.len(), 1);
 }
+
+fn test_request_event(request_id: &str) -> crate::RequestEvent {
+    crate::RequestEvent {
+        request_id: request_id.to_string(),
+        route: "/test".to_string(),
+        kind: None,
+        started_at_unix_ms: 1,
+        finished_at_unix_ms: 2,
+        latency_us: 10,
+        outcome: "ok".to_string(),
+    }
+}
+
+fn test_stage_event(request_id: &str, stage: &str) -> crate::StageEvent {
+    crate::StageEvent {
+        request_id: request_id.to_string(),
+        stage: stage.to_string(),
+        started_at_unix_ms: 3,
+        finished_at_unix_ms: 4,
+        latency_us: 11,
+        success: true,
+    }
+}
+
+fn test_queue_event(request_id: &str, queue: &str) -> crate::QueueEvent {
+    crate::QueueEvent {
+        request_id: request_id.to_string(),
+        queue: queue.to_string(),
+        waited_from_unix_ms: 5,
+        waited_until_unix_ms: 6,
+        wait_us: 12,
+        depth_at_start: Some(1),
+    }
+}
+
+#[test]
+fn run_builder_applies_request_limit_and_updates_truncation() {
+    let limits = CaptureLimits {
+        max_requests: 1,
+        max_stages: 10,
+        max_queues: 10,
+        max_inflight_snapshots: 10,
+        max_runtime_snapshots: 10,
+    };
+    let mut builder =
+        crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").capture_limits(limits))
+            .expect("ok");
+    builder.push_request(test_request_event("req-1"));
+    builder.push_request(test_request_event("req-2"));
+    let run = builder.finish();
+    assert_eq!(run.requests.len(), 1);
+    assert_eq!(run.requests[0].request_id, "req-1");
+    assert_eq!(run.truncation.dropped_requests, 1);
+    assert_eq!(run.truncation.dropped_stages, 0);
+    assert_eq!(run.truncation.dropped_queues, 0);
+    assert_eq!(run.truncation.dropped_inflight_snapshots, 0);
+    assert_eq!(run.truncation.dropped_runtime_snapshots, 0);
+    assert!(run.truncation.limits_hit);
+}
+
+#[test]
+fn run_builder_applies_stage_limit_and_updates_truncation() {
+    let limits = CaptureLimits {
+        max_requests: 10,
+        max_stages: 1,
+        max_queues: 10,
+        max_inflight_snapshots: 10,
+        max_runtime_snapshots: 10,
+    };
+    let mut builder =
+        crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").capture_limits(limits))
+            .expect("ok");
+    builder.push_stage(test_stage_event("req-1", "stage-1"));
+    builder.push_stage(test_stage_event("req-2", "stage-2"));
+    let run = builder.finish();
+    assert_eq!(run.stages.len(), 1);
+    assert_eq!(run.stages[0].stage, "stage-1");
+    assert_eq!(run.truncation.dropped_stages, 1);
+    assert_eq!(run.truncation.dropped_requests, 0);
+    assert_eq!(run.truncation.dropped_queues, 0);
+    assert_eq!(run.truncation.dropped_inflight_snapshots, 0);
+    assert_eq!(run.truncation.dropped_runtime_snapshots, 0);
+    assert!(run.truncation.limits_hit);
+}
+
+#[test]
+fn run_builder_applies_queue_limit_and_updates_truncation() {
+    let limits = CaptureLimits {
+        max_requests: 10,
+        max_stages: 10,
+        max_queues: 1,
+        max_inflight_snapshots: 10,
+        max_runtime_snapshots: 10,
+    };
+    let mut builder =
+        crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").capture_limits(limits))
+            .expect("ok");
+    builder.push_queue(test_queue_event("req-1", "queue-1"));
+    builder.push_queue(test_queue_event("req-2", "queue-2"));
+    let run = builder.finish();
+    assert_eq!(run.queues.len(), 1);
+    assert_eq!(run.queues[0].queue, "queue-1");
+    assert_eq!(run.truncation.dropped_queues, 1);
+    assert_eq!(run.truncation.dropped_requests, 0);
+    assert_eq!(run.truncation.dropped_stages, 0);
+    assert_eq!(run.truncation.dropped_inflight_snapshots, 0);
+    assert_eq!(run.truncation.dropped_runtime_snapshots, 0);
+    assert!(run.truncation.limits_hit);
+}
+
+#[test]
+fn run_builder_applies_inflight_snapshot_limit_and_updates_truncation() {
+    let limits = CaptureLimits {
+        max_requests: 10,
+        max_stages: 10,
+        max_queues: 10,
+        max_inflight_snapshots: 1,
+        max_runtime_snapshots: 10,
+    };
+    let mut builder =
+        crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").capture_limits(limits))
+            .expect("ok");
+    builder.push_inflight_snapshot(crate::InFlightSnapshot {
+        gauge: "g".to_string(),
+        at_unix_ms: 7,
+        count: 1,
+    });
+    builder.push_inflight_snapshot(crate::InFlightSnapshot {
+        gauge: "g".to_string(),
+        at_unix_ms: 8,
+        count: 2,
+    });
+    let run = builder.finish();
+    assert_eq!(run.inflight.len(), 1);
+    assert_eq!(run.inflight[0].count, 1);
+    assert_eq!(run.truncation.dropped_inflight_snapshots, 1);
+    assert_eq!(run.truncation.dropped_requests, 0);
+    assert_eq!(run.truncation.dropped_stages, 0);
+    assert_eq!(run.truncation.dropped_queues, 0);
+    assert_eq!(run.truncation.dropped_runtime_snapshots, 0);
+    assert!(run.truncation.limits_hit);
+}
+
+#[test]
+fn run_builder_applies_runtime_snapshot_limit_and_updates_truncation() {
+    let limits = CaptureLimits {
+        max_requests: 10,
+        max_stages: 10,
+        max_queues: 10,
+        max_inflight_snapshots: 10,
+        max_runtime_snapshots: 1,
+    };
+    let mut builder =
+        crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").capture_limits(limits))
+            .expect("ok");
+    builder.push_runtime_snapshot(crate::RuntimeSnapshot {
+        at_unix_ms: 9,
+        alive_tasks: Some(1),
+        global_queue_depth: Some(2),
+        local_queue_depth: Some(3),
+        blocking_queue_depth: Some(4),
+        remote_schedule_count: Some(5),
+    });
+    builder.push_runtime_snapshot(crate::RuntimeSnapshot {
+        at_unix_ms: 10,
+        alive_tasks: Some(2),
+        global_queue_depth: Some(3),
+        local_queue_depth: Some(4),
+        blocking_queue_depth: Some(5),
+        remote_schedule_count: Some(6),
+    });
+    let run = builder.finish();
+    assert_eq!(run.runtime_snapshots.len(), 1);
+    assert_eq!(run.runtime_snapshots[0].at_unix_ms, 9);
+    assert_eq!(run.truncation.dropped_runtime_snapshots, 1);
+    assert_eq!(run.truncation.dropped_requests, 0);
+    assert_eq!(run.truncation.dropped_stages, 0);
+    assert_eq!(run.truncation.dropped_queues, 0);
+    assert_eq!(run.truncation.dropped_inflight_snapshots, 0);
+    assert!(run.truncation.limits_hit);
+}
+
+#[test]
+fn run_builder_does_not_report_truncation_within_limits() {
+    let limits = CaptureLimits {
+        max_requests: 10,
+        max_stages: 10,
+        max_queues: 10,
+        max_inflight_snapshots: 10,
+        max_runtime_snapshots: 10,
+    };
+    let mut builder =
+        crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").capture_limits(limits))
+            .expect("ok");
+    builder.push_request(test_request_event("req-1"));
+    builder.push_stage(test_stage_event("req-1", "stage-1"));
+    builder.push_queue(test_queue_event("req-1", "queue-1"));
+    builder.push_inflight_snapshot(crate::InFlightSnapshot {
+        gauge: "g".to_string(),
+        at_unix_ms: 11,
+        count: 1,
+    });
+    builder.push_runtime_snapshot(crate::RuntimeSnapshot {
+        at_unix_ms: 12,
+        alive_tasks: Some(1),
+        global_queue_depth: Some(1),
+        local_queue_depth: Some(1),
+        blocking_queue_depth: Some(1),
+        remote_schedule_count: Some(1),
+    });
+    let run = builder.finish();
+    assert_eq!(run.requests.len(), 1);
+    assert_eq!(run.stages.len(), 1);
+    assert_eq!(run.queues.len(), 1);
+    assert_eq!(run.inflight.len(), 1);
+    assert_eq!(run.runtime_snapshots.len(), 1);
+    assert_eq!(run.truncation.dropped_requests, 0);
+    assert_eq!(run.truncation.dropped_stages, 0);
+    assert_eq!(run.truncation.dropped_queues, 0);
+    assert_eq!(run.truncation.dropped_inflight_snapshots, 0);
+    assert_eq!(run.truncation.dropped_runtime_snapshots, 0);
+    assert!(!run.truncation.limits_hit);
+    assert!(!run.truncation.is_truncated());
+}
+
+#[test]
+fn run_builder_uses_mode_default_limits_when_limits_not_explicit() {
+    let default_limits = CaptureMode::Light.core_defaults();
+    let mut builder =
+        crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").mode(CaptureMode::Light))
+            .expect("ok");
+    for i in 0..(default_limits.max_requests + 2) {
+        builder.push_request(test_request_event(&format!("req-{}", i + 1)));
+    }
+    let run = builder.finish();
+    assert_eq!(run.requests.len(), default_limits.max_requests);
+    assert_eq!(run.truncation.dropped_requests, 2);
+    assert!(run.truncation.limits_hit);
+}

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -1019,6 +1019,19 @@ fn run_builder_default_finalized_timestamp_is_some() {
 }
 
 #[test]
+fn run_builder_defaults_finalized_timestamp_to_finished_timestamp() {
+    let run = crate::RunBuilder::new(
+        crate::RunBuilderOptions::new("svc")
+            .started_at_unix_ms(100)
+            .finished_at_unix_ms(200),
+    )
+    .expect("ok")
+    .finish();
+    assert_eq!(run.metadata.finished_at_unix_ms, 200);
+    assert_eq!(run.metadata.finalized_at_unix_ms, Some(200));
+}
+
+#[test]
 fn run_builder_preserves_explicit_finalized_timestamp() {
     let run =
         crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").finalized_at_unix_ms(777))

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -1,19 +1,19 @@
 # tailtriage-tracing
 
-`tailtriage-tracing` is a focused intake bridge surface for tracing-shaped span
-records that can be converted into `tailtriage_core::Run` inputs.
+`tailtriage-tracing` is a focused intake bridge surface for tracing-shaped completed spans that are assembled into standard `tailtriage_core::Run` artifacts through core-owned completed-run assembly.
 
 This crate is intentionally narrow:
 
 - It defines semantic convention keys (`tt.*`) for triage-oriented span fields.
 - It defines typed intake records and import option/result types.
 - It converts typed `SpanRecord` values with `run_from_span_records`.
-- It imports JSONL from readers/paths when records contain completed span timing.
-- It provides an in-process `tracing_subscriber::Layer` recorder for completed `tt.*` spans.
+- It imports JSONL from readers/paths when records contain completed span timing (`import_jsonl_reader` / `import_jsonl_path`).
+- It provides an in-process `tracing_subscriber::Layer` recorder (`TracingRecorder`) for completed `tt.*` spans.
+- It optionally couples live tracing intake with Tokio runtime snapshots via `tokio::TracingTokioSession`.
 - It does **not** implement OpenTelemetry or OTLP.
 - It does **not** change `tailtriage-analyzer`.
 
-Both JSONL import and live recorder intake produce standard `tailtriage_core::Run` values for the same analyzer/report workflow.
+JSONL import, typed `SpanRecord` import, and live recorder intake all produce standard `tailtriage_core::Run` values for the same analyzer/report workflow via core-owned completed-run assembly. Completed tracing import output follows the same bounded retention/truncation semantics as core-built runs.
 
 ## JSONL import support in this phase
 

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -37,8 +37,7 @@ pub mod tokio;
 mod types;
 
 use tailtriage_core::{
-    CaptureMode, EffectiveCoreConfig, QueueEvent, RequestEvent, Run, RunMetadata, StageEvent,
-    TruncationSummary, UnfinishedRequests, SCHEMA_VERSION,
+    BuildError, CaptureMode, QueueEvent, RequestEvent, RunBuilder, RunBuilderOptions, StageEvent,
 };
 
 pub use convention::{
@@ -206,37 +205,37 @@ where
         .map(|w| w.message().to_owned())
         .collect::<Vec<_>>();
 
-    let metadata = RunMetadata {
-        run_id,
-        service_name: options.service_name().to_owned(),
-        service_version: options.service_version_ref().map(ToOwned::to_owned),
-        started_at_unix_ms,
-        finished_at_unix_ms,
-        finalized_at_unix_ms: Some(finished_at_unix_ms),
-        mode: CaptureMode::Light,
-        effective_core_config: Some(EffectiveCoreConfig {
-            mode: CaptureMode::Light,
-            capture_limits: CaptureMode::Light.core_defaults(),
-            strict_lifecycle: false,
-        }),
-        effective_tokio_sampler_config: None,
-        host: None,
-        pid: None,
-        lifecycle_warnings,
-        unfinished_requests: UnfinishedRequests::default(),
-        run_end_reason: None,
-    };
+    let mut builder_options = RunBuilderOptions::new(options.service_name())
+        .run_id(run_id)
+        .mode(CaptureMode::Light)
+        .capture_limits(CaptureMode::Light.core_defaults())
+        .strict_lifecycle(false)
+        .started_at_unix_ms(started_at_unix_ms)
+        .finished_at_unix_ms(finished_at_unix_ms)
+        .finalized_at_unix_ms(finished_at_unix_ms);
 
-    let run = Run {
-        schema_version: SCHEMA_VERSION,
-        metadata,
-        requests,
-        stages,
-        queues,
-        inflight: Vec::new(),
-        runtime_snapshots: Vec::new(),
-        truncation: TruncationSummary::default(),
-    };
+    if let Some(service_version) = options.service_version_ref() {
+        builder_options = builder_options.service_version(service_version);
+    }
+
+    let mut run_builder = RunBuilder::new(builder_options).map_err(|err| match err {
+        BuildError::EmptyServiceName => ImportError::EmptyServiceName,
+    })?;
+
+    for request in requests {
+        run_builder.push_request(request);
+    }
+    for stage in stages {
+        run_builder.push_stage(stage);
+    }
+    for queue in queues {
+        run_builder.push_queue(queue);
+    }
+    for warning in &lifecycle_warnings {
+        run_builder.add_lifecycle_warning(warning.clone());
+    }
+
+    let run = run_builder.finish();
 
     Ok(ImportedRun::new(run, warnings))
 }
@@ -538,7 +537,14 @@ mod tests {
     }
 
     #[test]
-    fn empty_input_returns_valid_run_with_zero_events() {
+    fn run_from_span_records_validates_service_name_before_strict_span_parsing() {
+        let spans = vec![SpanRecord::new("bad", 10, 20).field(TT_KIND, 123_u64)];
+        let err = run_from_span_records(spans, ImportOptions::new("   ").strict(true)).unwrap_err();
+        assert!(matches!(err, ImportError::EmptyServiceName));
+    }
+
+    #[test]
+    fn run_from_span_records_empty_input_uses_equal_start_finish_finalized() {
         let imported = run_from_span_records(Vec::new(), ImportOptions::new("svc")).unwrap();
         assert!(imported.run().requests.is_empty());
         assert!(imported.run().stages.is_empty());
@@ -547,6 +553,51 @@ mod tests {
             imported.run().metadata.finished_at_unix_ms,
             imported.run().metadata.started_at_unix_ms
         );
+        assert_eq!(
+            imported.run().metadata.finalized_at_unix_ms,
+            Some(imported.run().metadata.finished_at_unix_ms)
+        );
+    }
+
+    #[test]
+    fn run_from_span_records_uses_schema_v1_finalization_semantics() {
+        let spans = vec![SpanRecord::new("req", 10, 20)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")];
+        let run = run_from_span_records(spans, ImportOptions::new("svc"))
+            .unwrap()
+            .run()
+            .clone();
+        assert_eq!(run.metadata.started_at_unix_ms, 10);
+        assert_eq!(run.metadata.finished_at_unix_ms, 20);
+        assert_eq!(run.metadata.finalized_at_unix_ms, Some(20));
+    }
+
+    #[test]
+    fn run_from_span_records_preserves_computed_import_run_id() {
+        let spans = vec![SpanRecord::new("req", 10, 20)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")];
+        let run = run_from_span_records(spans, ImportOptions::new("svc"))
+            .unwrap()
+            .run()
+            .clone();
+        assert_eq!(run.metadata.run_id, "tracing-import-10-20");
+    }
+
+    #[test]
+    fn run_from_span_records_preserves_explicit_import_run_id() {
+        let spans = vec![SpanRecord::new("req", 10, 20)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")];
+        let run = run_from_span_records(spans, ImportOptions::new("svc").run_id("explicit-run"))
+            .unwrap()
+            .run()
+            .clone();
+        assert_eq!(run.metadata.run_id, "explicit-run");
     }
 
     #[test]

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -694,6 +694,7 @@ mod tests {
             .iter()
             .any(|w| w.contains("dropped 1 completed spans")));
         assert!(imported.run().truncation.limits_hit);
+        assert_eq!(imported.run().requests[0].request_id, "r1");
     }
 
     #[test]
@@ -756,6 +757,29 @@ mod tests {
         let recorder = TracingRecorder::builder(" ").build();
         let err = recorder.snapshot_run().unwrap_err();
         assert!(matches!(err, ImportError::EmptyServiceName));
+    }
+
+    #[test]
+    fn strict_mode_rejects_open_candidate_spans_without_fabricating_completions() {
+        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        let err = tracing::subscriber::with_default(subscriber, || {
+            let _open_guard = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r-open",
+                tt.route = "/open"
+            )
+            .entered();
+            recorder.snapshot_run().expect_err("strict should reject")
+        });
+        match err {
+            ImportError::StrictViolation(message) => {
+                assert!(message.contains("open candidate span(s)"));
+                assert!(message.contains("not converted into fabricated completions"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
     }
 
     #[test]

--- a/tailtriage-tracing/tests/tokio_session.rs
+++ b/tailtriage-tracing/tests/tokio_session.rs
@@ -67,6 +67,10 @@ async fn session_merges_tracing_and_runtime() {
     assert_eq!(run.queues[0].depth_at_start, Some(2));
     assert!(!run.runtime_snapshots.is_empty());
     assert!(run.metadata.effective_tokio_sampler_config.is_some());
+    assert_eq!(
+        run.metadata.finalized_at_unix_ms,
+        Some(run.metadata.finished_at_unix_ms)
+    );
 }
 
 #[test]
@@ -153,6 +157,10 @@ async fn record_runtime_snapshot_is_visible_in_snapshot_run() {
     });
 
     let imported = session.snapshot_run().expect("snapshot run");
+    assert_eq!(
+        imported.run().metadata.finalized_at_unix_ms,
+        Some(imported.run().metadata.finished_at_unix_ms)
+    );
     assert!(imported
         .run()
         .runtime_snapshots
@@ -176,6 +184,10 @@ async fn record_runtime_snapshot_is_visible_in_shutdown_output() {
     });
 
     let imported = session.shutdown().await.expect("shutdown");
+    assert_eq!(
+        imported.run().metadata.finalized_at_unix_ms,
+        Some(imported.run().metadata.finished_at_unix_ms)
+    );
     assert!(imported
         .run()
         .runtime_snapshots
@@ -227,4 +239,34 @@ async fn record_runtime_snapshot_does_not_alter_tracing_events() {
     assert_eq!(run.requests.len(), 1);
     assert_eq!(run.stages.len(), 1);
     assert_eq!(run.queues.len(), 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn runtime_snapshot_truncation_propagates_to_imported_run() {
+    let session = TracingTokioSession::builder("svc")
+        .max_runtime_snapshots(1)
+        .start()
+        .expect("start session");
+    session.record_runtime_snapshot(RuntimeSnapshot {
+        at_unix_ms: unix_time_ms(),
+        alive_tasks: Some(1),
+        global_queue_depth: Some(1),
+        local_queue_depth: Some(1),
+        blocking_queue_depth: Some(1),
+        remote_schedule_count: Some(1),
+    });
+    session.record_runtime_snapshot(RuntimeSnapshot {
+        at_unix_ms: unix_time_ms().saturating_add(1),
+        alive_tasks: Some(2),
+        global_queue_depth: Some(2),
+        local_queue_depth: Some(2),
+        blocking_queue_depth: Some(2),
+        remote_schedule_count: Some(2),
+    });
+
+    let imported = session.snapshot_run().expect("snapshot run");
+    let run = imported.run();
+    assert_eq!(run.runtime_snapshots.len(), 1);
+    assert_eq!(run.truncation.dropped_runtime_snapshots, 1);
+    assert!(run.truncation.limits_hit);
 }


### PR DESCRIPTION
### Motivation

- Provide a narrow, core-owned API to assemble completed `Run` artifacts from already-collected evidence, such as import/adaptation paths, without expanding the normal live instrumentation surface.
- Keep completed-run assembly consistent with `tailtriage-core` schema, metadata defaults, bounded retention, and truncation semantics.
- Remove duplicate completed-run assembly from `tailtriage-tracing` so tracing import/live recorder output is built through the same core path.
- Preserve schema v1 finalization compatibility while deferring the schema-vNext cleanup from issue #321.

### Description

- Added `tailtriage-core/src/run_builder.rs` with `RunBuilderOptions` and `RunBuilder` for advanced completed-run artifact assembly.
  - `RunBuilderOptions` uses private fields and fluent setters.
  - `RunBuilder::new(options) -> Result<Self, BuildError>` validates blank service names and applies core defaults.
  - `RunBuilder` supports pushing request, stage, queue, in-flight, and runtime evidence, plus lifecycle warnings, unfinished-request metadata, Tokio sampler metadata, and run-end reason.
- Added a private `tailtriage-core/src/retention.rs` helper and routed both the live collector and `RunBuilder` through the same first-N bounded retention/truncation behavior.
- Updated `RunBuilder` timestamp behavior to preserve schema v1 finalized-artifact semantics:
  - generated completed runs have `finalized_at_unix_ms = Some(...)`
  - when finish time is explicit and finalization is omitted, finalization defaults to finish time
  - schema version remains unchanged
- Updated `tailtriage-tracing::run_from_span_records` to use core `RunBuilder` instead of manually constructing `Run`, `RunMetadata`, `EffectiveCoreConfig`, and truncation state.
- Preserved tracing import behavior:
  - deterministic `tracing-import-{started_at}-{finished_at}` run IDs when no explicit run ID is supplied
  - explicit import run IDs and service version metadata
  - schema v1 finalization semantics
  - strict/non-strict malformed span handling
  - lifecycle warnings
  - empty input behavior
  - plain tracing import without fabricated runtime or in-flight evidence
- Strengthened live recorder and Tokio session coverage:
  - recorder open/completed span warning paths
  - truncation propagation
  - strict open-span rejection without fabricated completions
  - Tokio runtime snapshot merge behavior
  - runtime snapshot truncation propagation
- Updated docs:
  - `tailtriage-core` documents `RunBuilder` as an advanced completed-run assembly API, not the normal live instrumentation path.
  - `tailtriage-tracing` now states tracing import/live recorder intake produces standard core-built `Run` artifacts.
  - architecture docs now list core-owned completed-run assembly and the tracing intake bridge role.

### Schema compatibility

- Did **not** bump `SCHEMA_VERSION`.
- Did **not** remove `finished_at_unix_ms`.
- Preserved schema v1 semantics:
  - active live snapshots remain unfinalized with `finalized_at_unix_ms == None`
  - finalized artifacts keep `finalized_at_unix_ms == Some(finished_at_unix_ms)`

### Testing

- `cargo fmt --check`
- `cargo test -p tailtriage-core`
- `cargo test -p tailtriage-tracing --all-features`
- `cargo test -p tailtriage-cli --all-features`
- `cargo clippy -p tailtriage-tracing --all-targets --all-features -- -D warnings`
- `python3 scripts/validate_docs_contracts.py`
- CI: full workflow expected to cover workspace cargo checks, docs contracts, tracing parity, and runtime-cost smoke.