### PR TITLE
core: add completed-run RunBuilder API in tailtriage-core

### DIFF
--- a/tailtriage-core/src/lib.rs
+++ b/tailtriage-core/src/lib.rs
@@ -29,6 +29,7 @@
 mod collector;
 mod config;
 mod events;
+mod run_builder;
 mod sink;
 mod time;
 mod timers;
@@ -46,6 +47,7 @@ pub use events::{
     RunEndReason, RunMetadata, RuntimeSnapshot, StageEvent, TruncationSummary,
     UnfinishedRequestSample, UnfinishedRequests, SCHEMA_VERSION,
 };
+pub use run_builder::{RunBuilder, RunBuilderOptions};
 pub use sink::{DiscardSink, LocalJsonSink, MemorySink, RunSink, SinkError};
 pub use time::{system_time_to_unix_ms, unix_time_ms};
 pub use timers::{InflightGuard, QueueTimer, StageTimer};

--- a/tailtriage-core/src/run_builder.rs
+++ b/tailtriage-core/src/run_builder.rs
@@ -1,0 +1,209 @@
+use crate::{
+    unix_time_ms, BuildError, CaptureLimits, CaptureMode, EffectiveCoreConfig,
+    EffectiveTokioSamplerConfig, InFlightSnapshot, QueueEvent, RequestEvent, Run, RunEndReason,
+    RunMetadata, RuntimeSnapshot, StageEvent, UnfinishedRequests,
+};
+
+/// Options used to initialize a [`RunBuilder`].
+///
+/// This API is intended for assembling a completed evidence artifact from
+/// already-collected events. It is not the normal live instrumentation path;
+/// use [`crate::Tailtriage`] for request-lifecycle capture.
+#[derive(Debug, Clone)]
+pub struct RunBuilderOptions {
+    service_name: String,
+    service_version: Option<String>,
+    run_id: Option<String>,
+    mode: CaptureMode,
+    capture_limits: Option<CaptureLimits>,
+    strict_lifecycle: bool,
+    started_at_unix_ms: Option<u64>,
+    finished_at_unix_ms: Option<u64>,
+    finalized_at_unix_ms: Option<u64>,
+    host: Option<String>,
+    pid: Option<u32>,
+    run_end_reason: Option<RunEndReason>,
+}
+
+impl RunBuilderOptions {
+    /// Creates options with a required service name.
+    #[must_use]
+    pub fn new(service_name: impl Into<String>) -> Self {
+        Self {
+            service_name: service_name.into(),
+            service_version: None,
+            run_id: None,
+            mode: CaptureMode::Light,
+            capture_limits: None,
+            strict_lifecycle: false,
+            started_at_unix_ms: None,
+            finished_at_unix_ms: None,
+            finalized_at_unix_ms: None,
+            host: None,
+            pid: None,
+            run_end_reason: None,
+        }
+    }
+
+    /// Sets optional service version metadata.
+    #[must_use]
+    pub fn service_version(mut self, service_version: impl Into<String>) -> Self {
+        self.service_version = Some(service_version.into());
+        self
+    }
+    /// Sets an explicit run identifier.
+    #[must_use]
+    pub fn run_id(mut self, run_id: impl Into<String>) -> Self {
+        self.run_id = Some(run_id.into());
+        self
+    }
+    /// Sets the capture mode recorded in metadata.
+    #[must_use]
+    pub fn mode(mut self, mode: CaptureMode) -> Self {
+        self.mode = mode;
+        self
+    }
+    /// Sets full effective capture limits recorded in metadata.
+    #[must_use]
+    pub fn capture_limits(mut self, capture_limits: CaptureLimits) -> Self {
+        self.capture_limits = Some(capture_limits);
+        self
+    }
+    /// Sets strict lifecycle metadata in effective core config.
+    #[must_use]
+    pub fn strict_lifecycle(mut self, strict_lifecycle: bool) -> Self {
+        self.strict_lifecycle = strict_lifecycle;
+        self
+    }
+    /// Sets run start timestamp in milliseconds since epoch UTC.
+    #[must_use]
+    pub fn started_at_unix_ms(mut self, started_at_unix_ms: u64) -> Self {
+        self.started_at_unix_ms = Some(started_at_unix_ms);
+        self
+    }
+    /// Sets run finish timestamp in milliseconds since epoch UTC.
+    #[must_use]
+    pub fn finished_at_unix_ms(mut self, finished_at_unix_ms: u64) -> Self {
+        self.finished_at_unix_ms = Some(finished_at_unix_ms);
+        self
+    }
+    /// Sets run finalization timestamp in milliseconds since epoch UTC.
+    #[must_use]
+    pub fn finalized_at_unix_ms(mut self, finalized_at_unix_ms: u64) -> Self {
+        self.finalized_at_unix_ms = Some(finalized_at_unix_ms);
+        self
+    }
+    /// Sets optional host metadata.
+    #[must_use]
+    pub fn host(mut self, host: impl Into<String>) -> Self {
+        self.host = Some(host.into());
+        self
+    }
+    /// Sets optional process identifier metadata.
+    #[must_use]
+    pub fn pid(mut self, pid: u32) -> Self {
+        self.pid = Some(pid);
+        self
+    }
+    /// Sets optional run end reason metadata.
+    #[must_use]
+    pub fn run_end_reason(mut self, run_end_reason: RunEndReason) -> Self {
+        self.run_end_reason = Some(run_end_reason);
+        self
+    }
+}
+
+/// Builder for assembling a completed [`Run`] artifact from pre-collected evidence.
+#[derive(Debug)]
+pub struct RunBuilder {
+    run: Run,
+}
+
+impl RunBuilder {
+    /// Creates a new completed-run builder from options.
+    ///
+    /// Returns [`BuildError::EmptyServiceName`] when `service_name` is blank.
+    pub fn new(options: RunBuilderOptions) -> Result<Self, BuildError> {
+        if options.service_name.trim().is_empty() {
+            return Err(BuildError::EmptyServiceName);
+        }
+        let now = unix_time_ms();
+        let started_at_unix_ms = options.started_at_unix_ms.unwrap_or(now);
+        let finished_at_unix_ms = options.finished_at_unix_ms.unwrap_or(now);
+        let finalized_at_unix_ms = Some(options.finalized_at_unix_ms.unwrap_or(now));
+        let effective_core = EffectiveCoreConfig {
+            mode: options.mode,
+            capture_limits: options
+                .capture_limits
+                .unwrap_or_else(|| options.mode.core_defaults()),
+            strict_lifecycle: options.strict_lifecycle,
+        };
+
+        Ok(Self {
+            run: Run::new(RunMetadata {
+                run_id: options.run_id.unwrap_or_else(generate_run_id),
+                service_name: options.service_name,
+                service_version: options.service_version,
+                started_at_unix_ms,
+                finished_at_unix_ms,
+                finalized_at_unix_ms,
+                mode: options.mode,
+                effective_core_config: Some(effective_core),
+                effective_tokio_sampler_config: None,
+                host: options.host,
+                pid: options.pid,
+                lifecycle_warnings: Vec::new(),
+                unfinished_requests: UnfinishedRequests::default(),
+                run_end_reason: options.run_end_reason,
+            }),
+        })
+    }
+
+    /// Appends one request event.
+    pub fn push_request(&mut self, event: RequestEvent) {
+        self.run.requests.push(event);
+    }
+    /// Appends one stage event.
+    pub fn push_stage(&mut self, event: StageEvent) {
+        self.run.stages.push(event);
+    }
+    /// Appends one queue event.
+    pub fn push_queue(&mut self, event: QueueEvent) {
+        self.run.queues.push(event);
+    }
+    /// Appends one in-flight snapshot.
+    pub fn push_inflight_snapshot(&mut self, snapshot: InFlightSnapshot) {
+        self.run.inflight.push(snapshot);
+    }
+    /// Appends one runtime snapshot.
+    pub fn push_runtime_snapshot(&mut self, snapshot: RuntimeSnapshot) {
+        self.run.runtime_snapshots.push(snapshot);
+    }
+    /// Records one lifecycle warning string.
+    pub fn add_lifecycle_warning(&mut self, warning: impl Into<String>) {
+        self.run.metadata.lifecycle_warnings.push(warning.into());
+    }
+    /// Replaces unfinished-request metadata.
+    pub fn set_unfinished_requests(&mut self, unfinished_requests: UnfinishedRequests) {
+        self.run.metadata.unfinished_requests = unfinished_requests;
+    }
+    /// Sets effective Tokio runtime sampler configuration metadata.
+    pub fn set_effective_tokio_sampler_config(&mut self, config: EffectiveTokioSamplerConfig) {
+        self.run.metadata.effective_tokio_sampler_config = Some(config);
+    }
+    /// Sets run end reason only when metadata does not already have one.
+    pub fn set_run_end_reason_if_absent(&mut self, run_end_reason: RunEndReason) {
+        if self.run.metadata.run_end_reason.is_none() {
+            self.run.metadata.run_end_reason = Some(run_end_reason);
+        }
+    }
+    /// Finalizes builder assembly and returns the completed run artifact.
+    #[must_use]
+    pub fn finish(self) -> Run {
+        self.run
+    }
+}
+
+fn generate_run_id() -> String {
+    format!("run-{}", uuid::Uuid::new_v4())
+}

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -924,3 +924,153 @@ fn dropping_unfinished_completion_panics_in_debug() {
         "unfinished completion should panic in debug"
     );
 }
+
+#[test]
+fn run_builder_creates_empty_run_with_explicit_metadata() {
+    let limits = CaptureLimits {
+        max_requests: 10,
+        max_stages: 20,
+        max_queues: 30,
+        max_inflight_snapshots: 40,
+        max_runtime_snapshots: 50,
+    };
+    let run = crate::RunBuilder::new(
+        crate::RunBuilderOptions::new("payments")
+            .service_version("1.2.3")
+            .run_id("run-explicit")
+            .mode(CaptureMode::Investigation)
+            .capture_limits(limits)
+            .strict_lifecycle(true)
+            .started_at_unix_ms(1)
+            .finished_at_unix_ms(2)
+            .finalized_at_unix_ms(3)
+            .host("host-a")
+            .pid(42),
+    )
+    .expect("builder should succeed")
+    .finish();
+
+    assert_eq!(run.requests.len(), 0);
+    assert_eq!(run.stages.len(), 0);
+    assert_eq!(run.queues.len(), 0);
+    assert_eq!(run.inflight.len(), 0);
+    assert_eq!(run.runtime_snapshots.len(), 0);
+    assert_eq!(run.metadata.service_name, "payments");
+    assert_eq!(run.metadata.service_version.as_deref(), Some("1.2.3"));
+    assert_eq!(run.metadata.run_id, "run-explicit");
+    assert_eq!(run.metadata.started_at_unix_ms, 1);
+    assert_eq!(run.metadata.finished_at_unix_ms, 2);
+    assert_eq!(run.metadata.finalized_at_unix_ms, Some(3));
+    assert_eq!(run.metadata.mode, CaptureMode::Investigation);
+    assert_eq!(
+        run.metadata
+            .effective_core_config
+            .expect("effective core config should exist")
+            .capture_limits,
+        limits
+    );
+    assert_eq!(run.metadata.host.as_deref(), Some("host-a"));
+    assert_eq!(run.metadata.pid, Some(42));
+}
+
+#[test]
+fn run_builder_rejects_blank_service_name() {
+    let err = crate::RunBuilder::new(crate::RunBuilderOptions::new("  "))
+        .expect_err("blank service name should fail");
+    assert_eq!(err, BuildError::EmptyServiceName);
+}
+
+#[test]
+fn run_builder_generated_default_run_ids_are_unique() {
+    let first = crate::RunBuilder::new(crate::RunBuilderOptions::new("payments"))
+        .expect("first builder should succeed")
+        .finish();
+    let second = crate::RunBuilder::new(crate::RunBuilderOptions::new("payments"))
+        .expect("second builder should succeed")
+        .finish();
+    assert_ne!(first.metadata.run_id, second.metadata.run_id);
+}
+
+#[test]
+fn run_builder_defaults_host_and_pid_to_none() {
+    let run = crate::RunBuilder::new(crate::RunBuilderOptions::new("payments"))
+        .expect("builder should succeed")
+        .finish();
+    assert_eq!(run.metadata.host, None);
+    assert_eq!(run.metadata.pid, None);
+}
+
+#[test]
+fn run_builder_defaults_finalized_timestamp() {
+    let run = crate::RunBuilder::new(crate::RunBuilderOptions::new("payments"))
+        .expect("builder should succeed")
+        .finish();
+    assert!(run.metadata.finalized_at_unix_ms.is_some());
+}
+
+#[test]
+fn run_builder_preserves_explicit_finalized_timestamp() {
+    let run = crate::RunBuilder::new(
+        crate::RunBuilderOptions::new("payments").finalized_at_unix_ms(12345),
+    )
+    .expect("builder should succeed")
+    .finish();
+    assert_eq!(run.metadata.finalized_at_unix_ms, Some(12345));
+}
+
+#[test]
+fn run_builder_strict_lifecycle_in_effective_core_config() {
+    let run =
+        crate::RunBuilder::new(crate::RunBuilderOptions::new("payments").strict_lifecycle(true))
+            .expect("builder should succeed")
+            .finish();
+    assert!(
+        run.metadata
+            .effective_core_config
+            .expect("effective core config should exist")
+            .strict_lifecycle
+    );
+}
+
+#[test]
+fn run_builder_run_end_reason_set_if_absent() {
+    let mut builder = crate::RunBuilder::new(
+        crate::RunBuilderOptions::new("payments").run_end_reason(crate::RunEndReason::Shutdown),
+    )
+    .expect("builder should succeed");
+    builder.set_run_end_reason_if_absent(crate::RunEndReason::ManualDisarm);
+    let run = builder.finish();
+    assert_eq!(
+        run.metadata.run_end_reason,
+        Some(crate::RunEndReason::Shutdown)
+    );
+}
+
+#[test]
+fn run_builder_lifecycle_warnings_are_preserved() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("payments"))
+        .expect("builder should succeed");
+    builder.add_lifecycle_warning("warning-a");
+    builder.add_lifecycle_warning("warning-b");
+    let run = builder.finish();
+    assert_eq!(
+        run.metadata.lifecycle_warnings,
+        vec!["warning-a", "warning-b"]
+    );
+}
+
+#[test]
+fn run_builder_unfinished_requests_are_preserved() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("payments"))
+        .expect("builder should succeed");
+    builder.set_unfinished_requests(crate::UnfinishedRequests {
+        count: 1,
+        sample: vec![crate::UnfinishedRequestSample {
+            request_id: "req-1".to_string(),
+            route: "/checkout".to_string(),
+        }],
+    });
+    let run = builder.finish();
+    assert_eq!(run.metadata.unfinished_requests.count, 1);
+    assert_eq!(run.metadata.unfinished_requests.sample.len(), 1);
+}


### PR DESCRIPTION
### Motivation

- Provide a narrow, core-owned API for assembling a completed/finalized `Run` artifact from pre-collected evidence so downstream crates can create typed run artifacts without using live `Tailtriage` instrumentation yet.  

### Description

- Add `tailtriage-core/src/run_builder.rs` with `RunBuilderOptions` (private fields, compact setter API) and `RunBuilder` for completed-run assembly.  
- Export `RunBuilder` and `RunBuilderOptions` from `tailtriage-core/src/lib.rs`.  
- `RunBuilderOptions` exposes `new(service_name: impl Into<String>)` and setters for `service_version`, `run_id`, `mode`, `capture_limits`, `strict_lifecycle`, `started_at_unix_ms`, `finished_at_unix_ms`, `finalized_at_unix_ms`, `host`, `pid`, and `run_end_reason`; fields remain private.  
- `RunBuilder::new(options) -> Result<Self, BuildError>` rejects blank service names with `BuildError::EmptyServiceName`, applies defaults (`CaptureMode::Light`, mode `core_defaults()` for limits, `strict_lifecycle = false`, host/pid `None`, generated run id, and unified current timestamps when timestamps are omitted), exposes push/mutation methods (`push_request`, `push_stage`, `push_queue`, `push_inflight_snapshot`, `push_runtime_snapshot`, `add_lifecycle_warning`, `set_unfinished_requests`, `set_effective_tokio_sampler_config`, `set_run_end_reason_if_absent`) and `finish(self) -> Run`.  
- Public rustdoc positions the API as completed-evidence assembly rather than live instrumentation.  

### Testing

- Ran `cargo fmt --check` (succeeded).  
- Ran `cargo test -p tailtriage-core` (succeeded).  
- Added focused unit tests in `tailtriage-core/src/tests.rs` exercising: explicit metadata assembly (`run_builder_creates_empty_run_with_explicit_metadata`), blank-service validation (`run_builder_rejects_blank_service_name`), generated run-id uniqueness (`run_builder_generated_default_run_ids_are_unique`), default host/pid `None` (`run_builder_defaults_host_and_pid_to_none`), finalized timestamp behavior (`run_builder_defaults_finalized_timestamp`, `run_builder_preserves_explicit_finalized_timestamp`), strict lifecycle propagation (`run_builder_strict_lifecycle_in_effective_core_config`), run-end-reason set-if-absent (`run_builder_run_end_reason_set_if_absent`), lifecycle warnings preservation (`run_builder_lifecycle_warnings_are_preserved`), and unfinished-requests preservation (`run_builder_unfinished_requests_are_preserved`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b14789e14833092200885f9732b3b)