### PR TITLE
tailtriage-core: add narrow completed-run RunBuilder API

### DIFF
--- a/tailtriage-core/src/lib.rs
+++ b/tailtriage-core/src/lib.rs
@@ -29,6 +29,7 @@
 mod collector;
 mod config;
 mod events;
+mod run_builder;
 mod sink;
 mod time;
 mod timers;
@@ -46,6 +47,7 @@ pub use events::{
     RunEndReason, RunMetadata, RuntimeSnapshot, StageEvent, TruncationSummary,
     UnfinishedRequestSample, UnfinishedRequests, SCHEMA_VERSION,
 };
+pub use run_builder::{RunBuilder, RunBuilderOptions};
 pub use sink::{DiscardSink, LocalJsonSink, MemorySink, RunSink, SinkError};
 pub use time::{system_time_to_unix_ms, unix_time_ms};
 pub use timers::{InflightGuard, QueueTimer, StageTimer};

--- a/tailtriage-core/src/run_builder.rs
+++ b/tailtriage-core/src/run_builder.rs
@@ -1,0 +1,214 @@
+use crate::{
+    unix_time_ms, BuildError, CaptureLimits, CaptureMode, EffectiveCoreConfig,
+    EffectiveTokioSamplerConfig, InFlightSnapshot, QueueEvent, RequestEvent, Run, RunEndReason,
+    RunMetadata, RuntimeSnapshot, StageEvent, UnfinishedRequests,
+};
+
+/// Options for assembling a completed [`Run`] artifact in `tailtriage-core`.
+///
+/// This API is intended for completed evidence assembly flows (for example,
+/// import/conversion paths) rather than normal live request instrumentation.
+#[derive(Debug, Clone)]
+pub struct RunBuilderOptions {
+    service_name: String,
+    service_version: Option<String>,
+    run_id: Option<String>,
+    mode: Option<CaptureMode>,
+    capture_limits: Option<CaptureLimits>,
+    strict_lifecycle: bool,
+    started_at_unix_ms: Option<u64>,
+    finished_at_unix_ms: Option<u64>,
+    finalized_at_unix_ms: Option<u64>,
+    host: Option<String>,
+    pid: Option<u32>,
+    run_end_reason: Option<RunEndReason>,
+}
+
+impl RunBuilderOptions {
+    /// Creates options for a completed run assembly with a required service name.
+    #[must_use]
+    pub fn new(service_name: impl Into<String>) -> Self {
+        Self {
+            service_name: service_name.into(),
+            service_version: None,
+            run_id: None,
+            mode: None,
+            capture_limits: None,
+            strict_lifecycle: false,
+            started_at_unix_ms: None,
+            finished_at_unix_ms: None,
+            finalized_at_unix_ms: None,
+            host: None,
+            pid: None,
+            run_end_reason: None,
+        }
+    }
+
+    /// Sets an optional service version.
+    #[must_use]
+    pub fn service_version(mut self, service_version: impl Into<String>) -> Self {
+        self.service_version = Some(service_version.into());
+        self
+    }
+    /// Sets an explicit run identifier.
+    #[must_use]
+    pub fn run_id(mut self, run_id: impl Into<String>) -> Self {
+        self.run_id = Some(run_id.into());
+        self
+    }
+    /// Sets the capture mode used for effective core configuration.
+    #[must_use]
+    pub fn mode(mut self, mode: CaptureMode) -> Self {
+        self.mode = Some(mode);
+        self
+    }
+    /// Sets explicit effective capture limits.
+    #[must_use]
+    pub fn capture_limits(mut self, capture_limits: CaptureLimits) -> Self {
+        self.capture_limits = Some(capture_limits);
+        self
+    }
+    /// Sets strict lifecycle value recorded in effective core configuration.
+    #[must_use]
+    pub fn strict_lifecycle(mut self, strict_lifecycle: bool) -> Self {
+        self.strict_lifecycle = strict_lifecycle;
+        self
+    }
+    /// Sets explicit start timestamp in unix milliseconds.
+    #[must_use]
+    pub fn started_at_unix_ms(mut self, started_at_unix_ms: u64) -> Self {
+        self.started_at_unix_ms = Some(started_at_unix_ms);
+        self
+    }
+    /// Sets explicit finish timestamp in unix milliseconds.
+    #[must_use]
+    pub fn finished_at_unix_ms(mut self, finished_at_unix_ms: u64) -> Self {
+        self.finished_at_unix_ms = Some(finished_at_unix_ms);
+        self
+    }
+    /// Sets explicit finalization timestamp in unix milliseconds.
+    #[must_use]
+    pub fn finalized_at_unix_ms(mut self, finalized_at_unix_ms: u64) -> Self {
+        self.finalized_at_unix_ms = Some(finalized_at_unix_ms);
+        self
+    }
+    /// Sets an optional hostname.
+    #[must_use]
+    pub fn host(mut self, host: impl Into<String>) -> Self {
+        self.host = Some(host.into());
+        self
+    }
+    /// Sets an optional process identifier.
+    #[must_use]
+    pub fn pid(mut self, pid: u32) -> Self {
+        self.pid = Some(pid);
+        self
+    }
+    /// Sets an explicit run end reason.
+    #[must_use]
+    pub fn run_end_reason(mut self, run_end_reason: RunEndReason) -> Self {
+        self.run_end_reason = Some(run_end_reason);
+        self
+    }
+}
+
+/// Builder for assembling a completed [`Run`] value from already-captured evidence.
+#[derive(Debug, Clone)]
+pub struct RunBuilder {
+    run: Run,
+}
+
+impl RunBuilder {
+    /// Creates a completed-run builder from [`RunBuilderOptions`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BuildError::EmptyServiceName`] when the configured service name is blank.
+    pub fn new(options: RunBuilderOptions) -> Result<Self, BuildError> {
+        if options.service_name.trim().is_empty() {
+            return Err(BuildError::EmptyServiceName);
+        }
+
+        let mode = options.mode.unwrap_or(CaptureMode::Light);
+        let now_ms = unix_time_ms();
+        let started_at_unix_ms = options.started_at_unix_ms.unwrap_or(now_ms);
+        let finished_at_unix_ms = options.finished_at_unix_ms.unwrap_or(now_ms);
+        let finalized_at_unix_ms = Some(options.finalized_at_unix_ms.unwrap_or(now_ms));
+        let capture_limits = options
+            .capture_limits
+            .unwrap_or_else(|| mode.core_defaults());
+
+        let metadata = RunMetadata {
+            run_id: options.run_id.unwrap_or_else(generate_run_id),
+            service_name: options.service_name,
+            service_version: options.service_version,
+            started_at_unix_ms,
+            finished_at_unix_ms,
+            finalized_at_unix_ms,
+            mode,
+            effective_core_config: Some(EffectiveCoreConfig {
+                mode,
+                capture_limits,
+                strict_lifecycle: options.strict_lifecycle,
+            }),
+            effective_tokio_sampler_config: None,
+            host: options.host,
+            pid: options.pid,
+            lifecycle_warnings: Vec::new(),
+            unfinished_requests: UnfinishedRequests::default(),
+            run_end_reason: options.run_end_reason,
+        };
+
+        Ok(Self {
+            run: Run::new(metadata),
+        })
+    }
+
+    /// Appends a request event.
+    pub fn push_request(&mut self, event: RequestEvent) {
+        self.run.requests.push(event);
+    }
+    /// Appends a stage event.
+    pub fn push_stage(&mut self, event: StageEvent) {
+        self.run.stages.push(event);
+    }
+    /// Appends a queue event.
+    pub fn push_queue(&mut self, event: QueueEvent) {
+        self.run.queues.push(event);
+    }
+    /// Appends an in-flight snapshot.
+    pub fn push_inflight_snapshot(&mut self, snapshot: InFlightSnapshot) {
+        self.run.inflight.push(snapshot);
+    }
+    /// Appends a runtime snapshot.
+    pub fn push_runtime_snapshot(&mut self, snapshot: RuntimeSnapshot) {
+        self.run.runtime_snapshots.push(snapshot);
+    }
+    /// Adds a lifecycle warning string.
+    pub fn add_lifecycle_warning(&mut self, warning: impl Into<String>) {
+        self.run.metadata.lifecycle_warnings.push(warning.into());
+    }
+    /// Sets unfinished request summary metadata.
+    pub fn set_unfinished_requests(&mut self, unfinished_requests: UnfinishedRequests) {
+        self.run.metadata.unfinished_requests = unfinished_requests;
+    }
+    /// Sets effective Tokio runtime sampler metadata.
+    pub fn set_effective_tokio_sampler_config(&mut self, config: EffectiveTokioSamplerConfig) {
+        self.run.metadata.effective_tokio_sampler_config = Some(config);
+    }
+    /// Sets run end reason only when absent.
+    pub fn set_run_end_reason_if_absent(&mut self, run_end_reason: RunEndReason) {
+        if self.run.metadata.run_end_reason.is_none() {
+            self.run.metadata.run_end_reason = Some(run_end_reason);
+        }
+    }
+    /// Finishes assembly and returns a completed/finalized [`Run`].
+    #[must_use]
+    pub fn finish(self) -> Run {
+        self.run
+    }
+}
+
+fn generate_run_id() -> String {
+    format!("run-{}", uuid::Uuid::new_v4())
+}

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -924,3 +924,172 @@ fn dropping_unfinished_completion_panics_in_debug() {
         "unfinished completion should panic in debug"
     );
 }
+
+#[test]
+fn run_builder_creates_empty_run_with_explicit_metadata() {
+    let options = crate::RunBuilderOptions::new("checkout-service")
+        .service_version("1.2.3")
+        .run_id("run-explicit")
+        .mode(CaptureMode::Investigation)
+        .capture_limits(CaptureLimits {
+            max_requests: 1,
+            max_stages: 2,
+            max_queues: 3,
+            max_inflight_snapshots: 4,
+            max_runtime_snapshots: 5,
+        })
+        .strict_lifecycle(true)
+        .started_at_unix_ms(10)
+        .finished_at_unix_ms(20)
+        .finalized_at_unix_ms(30)
+        .host("host-a")
+        .pid(1234)
+        .run_end_reason(crate::RunEndReason::Shutdown);
+
+    let run = crate::RunBuilder::new(options)
+        .expect("run builder should succeed")
+        .finish();
+
+    assert_eq!(run.schema_version, crate::SCHEMA_VERSION);
+    assert_eq!(run.metadata.service_name, "checkout-service");
+    assert_eq!(run.metadata.service_version.as_deref(), Some("1.2.3"));
+    assert_eq!(run.metadata.run_id, "run-explicit");
+    assert_eq!(run.metadata.mode, CaptureMode::Investigation);
+    assert_eq!(run.metadata.started_at_unix_ms, 10);
+    assert_eq!(run.metadata.finished_at_unix_ms, 20);
+    assert_eq!(run.metadata.finalized_at_unix_ms, Some(30));
+    assert_eq!(run.metadata.host.as_deref(), Some("host-a"));
+    assert_eq!(run.metadata.pid, Some(1234));
+    assert_eq!(
+        run.metadata.run_end_reason,
+        Some(crate::RunEndReason::Shutdown)
+    );
+    assert_eq!(
+        run.metadata
+            .effective_core_config
+            .expect("effective core config should be present")
+            .capture_limits,
+        CaptureLimits {
+            max_requests: 1,
+            max_stages: 2,
+            max_queues: 3,
+            max_inflight_snapshots: 4,
+            max_runtime_snapshots: 5,
+        }
+    );
+    assert!(run.requests.is_empty());
+    assert!(run.stages.is_empty());
+    assert!(run.queues.is_empty());
+    assert!(run.inflight.is_empty());
+    assert!(run.runtime_snapshots.is_empty());
+}
+
+#[test]
+fn run_builder_rejects_blank_service_name() {
+    let err = crate::RunBuilder::new(crate::RunBuilderOptions::new("   "))
+        .expect_err("blank service name should fail");
+    assert_eq!(err, BuildError::EmptyServiceName);
+}
+
+#[test]
+fn run_builder_generated_default_run_ids_are_unique() {
+    let first = crate::RunBuilder::new(crate::RunBuilderOptions::new("checkout-service"))
+        .expect("first builder should succeed")
+        .finish();
+    let second = crate::RunBuilder::new(crate::RunBuilderOptions::new("checkout-service"))
+        .expect("second builder should succeed")
+        .finish();
+
+    assert_ne!(first.metadata.run_id, second.metadata.run_id);
+}
+
+#[test]
+fn run_builder_default_metadata_host_and_pid_are_none() {
+    let run = crate::RunBuilder::new(crate::RunBuilderOptions::new("checkout-service"))
+        .expect("builder should succeed")
+        .finish();
+
+    assert!(run.metadata.host.is_none());
+    assert!(run.metadata.pid.is_none());
+}
+
+#[test]
+fn run_builder_default_finalized_timestamp_is_some() {
+    let run = crate::RunBuilder::new(crate::RunBuilderOptions::new("checkout-service"))
+        .expect("builder should succeed")
+        .finish();
+
+    assert!(run.metadata.finalized_at_unix_ms.is_some());
+}
+
+#[test]
+fn run_builder_explicit_finalized_timestamp_is_preserved() {
+    let run = crate::RunBuilder::new(
+        crate::RunBuilderOptions::new("checkout-service").finalized_at_unix_ms(42),
+    )
+    .expect("builder should succeed")
+    .finish();
+
+    assert_eq!(run.metadata.finalized_at_unix_ms, Some(42));
+}
+
+#[test]
+fn run_builder_strict_lifecycle_is_preserved_in_effective_config() {
+    let run = crate::RunBuilder::new(
+        crate::RunBuilderOptions::new("checkout-service").strict_lifecycle(true),
+    )
+    .expect("builder should succeed")
+    .finish();
+
+    assert!(
+        run.metadata
+            .effective_core_config
+            .expect("effective core config should be present")
+            .strict_lifecycle
+    );
+}
+
+#[test]
+fn run_builder_run_end_reason_if_absent_is_not_overwritten() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("checkout-service"))
+        .expect("builder should succeed");
+    builder.set_run_end_reason_if_absent(crate::RunEndReason::Shutdown);
+    builder.set_run_end_reason_if_absent(crate::RunEndReason::ManualDisarm);
+    let run = builder.finish();
+
+    assert_eq!(
+        run.metadata.run_end_reason,
+        Some(crate::RunEndReason::Shutdown)
+    );
+}
+
+#[test]
+fn run_builder_lifecycle_warnings_are_preserved() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("checkout-service"))
+        .expect("builder should succeed");
+    builder.add_lifecycle_warning("warning-a");
+    builder.add_lifecycle_warning("warning-b");
+
+    let run = builder.finish();
+    assert_eq!(
+        run.metadata.lifecycle_warnings,
+        vec!["warning-a".to_string(), "warning-b".to_string()]
+    );
+}
+
+#[test]
+fn run_builder_unfinished_requests_are_preserved() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("checkout-service"))
+        .expect("builder should succeed");
+    let unfinished = crate::UnfinishedRequests {
+        count: 2,
+        sample: vec![crate::UnfinishedRequestSample {
+            request_id: "req-1".to_string(),
+            route: "/checkout".to_string(),
+        }],
+    };
+    builder.set_unfinished_requests(unfinished.clone());
+    let run = builder.finish();
+
+    assert_eq!(run.metadata.unfinished_requests, unfinished);
+}


### PR DESCRIPTION
### Motivation
- Provide a small, focused API for assembling a completed/finalized `Run` artifact in `tailtriage-core` for import/conversion or offline assembly without changing live instrumentation or tracing integration.
- Keep the core crate responsible for run-shape and metadata defaults so downstream integration code can produce consistent artifacts.

### Description
- Add a new module `tailtriage-core/src/run_builder.rs` that defines `RunBuilderOptions` (private fields, compact setters) and `RunBuilder` for completed-run assembly.  
- `RunBuilderOptions` exposes `new(service_name: impl Into<String>)` plus setters for `service_version`, `run_id`, `mode`, `capture_limits`, `strict_lifecycle`, `started_at_unix_ms`, `finished_at_unix_ms`, `finalized_at_unix_ms`, `host`, `pid`, and `run_end_reason`.
- `RunBuilder::new(options) -> Result<Self, BuildError>` enforces non-blank service names (`BuildError::EmptyServiceName`), defaults `mode` to `CaptureMode::Light`, defaults capture limits to `mode.core_defaults()`, leaves `strict_lifecycle` false by default, uses `None` for host/pid by default, generates a run ID when absent, and seeds start/finish/finalized timestamps with a single current unix-ms value when not provided; `finish()` returns the finalized `Run`.
- Provide mutation/push APIs on `RunBuilder` for assembling evidence: `push_request(RequestEvent)`, `push_stage(StageEvent)`, `push_queue(QueueEvent)`, `push_inflight_snapshot(InFlightSnapshot)`, `push_runtime_snapshot(RuntimeSnapshot)`, `add_lifecycle_warning(impl Into<String>)`, `set_unfinished_requests(UnfinishedRequests)`, `set_effective_tokio_sampler_config(EffectiveTokioSamplerConfig)`, and `set_run_end_reason_if_absent(RunEndReason)`.
- Export `RunBuilder` and `RunBuilderOptions` from `tailtriage-core/src/lib.rs` and add rustdoc positioning this API as completed-evidence assembly (not for normal live instrumentation).
- Keep scope narrow: no changes to `tailtriage-tracing`, no new dependencies, and no analyzer behavior changes.

### Testing
- Ran `cargo fmt --check` which passed.  
- Ran `cargo test -p tailtriage-core` and all unit tests passed (new focused tests added and existing tests remained green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b14789e14833092200885f9732b3b)