### PR TITLE
core: add completed-run assembly API (RunBuilder)

### DIFF
--- a/tailtriage-core/src/lib.rs
+++ b/tailtriage-core/src/lib.rs
@@ -29,6 +29,7 @@
 mod collector;
 mod config;
 mod events;
+mod run_builder;
 mod sink;
 mod time;
 mod timers;
@@ -46,6 +47,7 @@ pub use events::{
     RunEndReason, RunMetadata, RuntimeSnapshot, StageEvent, TruncationSummary,
     UnfinishedRequestSample, UnfinishedRequests, SCHEMA_VERSION,
 };
+pub use run_builder::{RunBuilder, RunBuilderOptions};
 pub use sink::{DiscardSink, LocalJsonSink, MemorySink, RunSink, SinkError};
 pub use time::{system_time_to_unix_ms, unix_time_ms};
 pub use timers::{InflightGuard, QueueTimer, StageTimer};

--- a/tailtriage-core/src/run_builder.rs
+++ b/tailtriage-core/src/run_builder.rs
@@ -1,0 +1,210 @@
+use crate::{
+    unix_time_ms, BuildError, CaptureLimits, CaptureMode, EffectiveCoreConfig,
+    EffectiveTokioSamplerConfig, InFlightSnapshot, QueueEvent, RequestEvent, Run, RunEndReason,
+    RunMetadata, RuntimeSnapshot, StageEvent, UnfinishedRequests,
+};
+
+/// Options for assembling a completed [`Run`] artifact.
+///
+/// This API is intended for completed evidence assembly (for example import or
+/// conversion pipelines), not live request instrumentation.
+#[derive(Debug, Clone)]
+pub struct RunBuilderOptions {
+    service_name: String,
+    service_version: Option<String>,
+    run_id: Option<String>,
+    mode: Option<CaptureMode>,
+    capture_limits: Option<CaptureLimits>,
+    strict_lifecycle: bool,
+    started_at_unix_ms: Option<u64>,
+    finished_at_unix_ms: Option<u64>,
+    finalized_at_unix_ms: Option<u64>,
+    host: Option<String>,
+    pid: Option<u32>,
+    run_end_reason: Option<RunEndReason>,
+}
+
+impl RunBuilderOptions {
+    /// Creates a new options set for one assembled run.
+    #[must_use]
+    pub fn new(service_name: impl Into<String>) -> Self {
+        Self {
+            service_name: service_name.into(),
+            service_version: None,
+            run_id: None,
+            mode: None,
+            capture_limits: None,
+            strict_lifecycle: false,
+            started_at_unix_ms: None,
+            finished_at_unix_ms: None,
+            finalized_at_unix_ms: None,
+            host: None,
+            pid: None,
+            run_end_reason: None,
+        }
+    }
+
+    /// Sets an optional service version.
+    #[must_use]
+    pub fn service_version(mut self, service_version: impl Into<String>) -> Self {
+        self.service_version = Some(service_version.into());
+        self
+    }
+    /// Sets an explicit run identifier.
+    #[must_use]
+    pub fn run_id(mut self, run_id: impl Into<String>) -> Self {
+        self.run_id = Some(run_id.into());
+        self
+    }
+    /// Sets capture mode recorded in metadata.
+    #[must_use]
+    pub fn mode(mut self, mode: CaptureMode) -> Self {
+        self.mode = Some(mode);
+        self
+    }
+    /// Sets effective capture limits recorded in metadata.
+    #[must_use]
+    pub fn capture_limits(mut self, capture_limits: CaptureLimits) -> Self {
+        self.capture_limits = Some(capture_limits);
+        self
+    }
+    /// Sets strict lifecycle flag recorded in effective core config.
+    #[must_use]
+    pub fn strict_lifecycle(mut self, strict_lifecycle: bool) -> Self {
+        self.strict_lifecycle = strict_lifecycle;
+        self
+    }
+    /// Sets capture start timestamp in unix milliseconds.
+    #[must_use]
+    pub fn started_at_unix_ms(mut self, started_at_unix_ms: u64) -> Self {
+        self.started_at_unix_ms = Some(started_at_unix_ms);
+        self
+    }
+    /// Sets capture finish timestamp in unix milliseconds.
+    #[must_use]
+    pub fn finished_at_unix_ms(mut self, finished_at_unix_ms: u64) -> Self {
+        self.finished_at_unix_ms = Some(finished_at_unix_ms);
+        self
+    }
+    /// Sets run finalization timestamp in unix milliseconds.
+    #[must_use]
+    pub fn finalized_at_unix_ms(mut self, finalized_at_unix_ms: u64) -> Self {
+        self.finalized_at_unix_ms = Some(finalized_at_unix_ms);
+        self
+    }
+    /// Sets optional host metadata.
+    #[must_use]
+    pub fn host(mut self, host: impl Into<String>) -> Self {
+        self.host = Some(host.into());
+        self
+    }
+    /// Sets optional process id metadata.
+    #[must_use]
+    pub fn pid(mut self, pid: u32) -> Self {
+        self.pid = Some(pid);
+        self
+    }
+    /// Sets optional run end reason metadata.
+    #[must_use]
+    pub fn run_end_reason(mut self, run_end_reason: RunEndReason) -> Self {
+        self.run_end_reason = Some(run_end_reason);
+        self
+    }
+}
+
+/// Builder for assembling a completed [`Run`] artifact.
+///
+/// Unlike [`crate::Tailtriage`], this type does not perform live request
+/// lifecycle tracking; it only assembles finalized evidence.
+#[derive(Debug, Clone)]
+pub struct RunBuilder {
+    run: Run,
+}
+
+impl RunBuilder {
+    /// Creates a new completed-run builder from options.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BuildError::EmptyServiceName`] when `service_name` is blank.
+    pub fn new(options: RunBuilderOptions) -> Result<Self, BuildError> {
+        if options.service_name.trim().is_empty() {
+            return Err(BuildError::EmptyServiceName);
+        }
+
+        let mode = options.mode.unwrap_or(CaptureMode::Light);
+        let capture_limits = options.capture_limits.unwrap_or(mode.core_defaults());
+        let now = unix_time_ms();
+
+        Ok(Self {
+            run: Run::new(RunMetadata {
+                run_id: options.run_id.unwrap_or_else(generate_run_id),
+                service_name: options.service_name,
+                service_version: options.service_version,
+                started_at_unix_ms: options.started_at_unix_ms.unwrap_or(now),
+                finished_at_unix_ms: options.finished_at_unix_ms.unwrap_or(now),
+                finalized_at_unix_ms: Some(options.finalized_at_unix_ms.unwrap_or(now)),
+                mode,
+                effective_core_config: Some(EffectiveCoreConfig {
+                    mode,
+                    capture_limits,
+                    strict_lifecycle: options.strict_lifecycle,
+                }),
+                effective_tokio_sampler_config: None,
+                host: options.host,
+                pid: options.pid,
+                lifecycle_warnings: Vec::new(),
+                unfinished_requests: UnfinishedRequests::default(),
+                run_end_reason: options.run_end_reason,
+            }),
+        })
+    }
+
+    /// Appends one request event.
+    pub fn push_request(&mut self, event: RequestEvent) {
+        self.run.requests.push(event);
+    }
+    /// Appends one stage event.
+    pub fn push_stage(&mut self, event: StageEvent) {
+        self.run.stages.push(event);
+    }
+    /// Appends one queue event.
+    pub fn push_queue(&mut self, event: QueueEvent) {
+        self.run.queues.push(event);
+    }
+    /// Appends one in-flight snapshot.
+    pub fn push_inflight_snapshot(&mut self, snapshot: InFlightSnapshot) {
+        self.run.inflight.push(snapshot);
+    }
+    /// Appends one runtime snapshot.
+    pub fn push_runtime_snapshot(&mut self, snapshot: RuntimeSnapshot) {
+        self.run.runtime_snapshots.push(snapshot);
+    }
+    /// Adds one lifecycle warning string.
+    pub fn add_lifecycle_warning(&mut self, warning: impl Into<String>) {
+        self.run.metadata.lifecycle_warnings.push(warning.into());
+    }
+    /// Replaces unfinished request summary metadata.
+    pub fn set_unfinished_requests(&mut self, unfinished: UnfinishedRequests) {
+        self.run.metadata.unfinished_requests = unfinished;
+    }
+    /// Sets effective Tokio sampler configuration metadata.
+    pub fn set_effective_tokio_sampler_config(&mut self, config: EffectiveTokioSamplerConfig) {
+        self.run.metadata.effective_tokio_sampler_config = Some(config);
+    }
+    /// Sets run end reason only when metadata does not already have one.
+    pub fn set_run_end_reason_if_absent(&mut self, reason: RunEndReason) {
+        if self.run.metadata.run_end_reason.is_none() {
+            self.run.metadata.run_end_reason = Some(reason);
+        }
+    }
+    /// Finishes assembly and returns the completed run artifact.
+    #[must_use]
+    pub fn finish(self) -> Run {
+        self.run
+    }
+}
+
+fn generate_run_id() -> String {
+    format!("run-{}", uuid::Uuid::new_v4())
+}

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -924,3 +924,164 @@ fn dropping_unfinished_completion_panics_in_debug() {
         "unfinished completion should panic in debug"
     );
 }
+
+#[test]
+fn run_builder_creates_empty_run_with_explicit_metadata() {
+    let options = crate::RunBuilderOptions::new("payments")
+        .service_version("1.2.3")
+        .run_id("run-explicit")
+        .mode(CaptureMode::Investigation)
+        .capture_limits(CaptureLimits {
+            max_requests: 1,
+            max_stages: 2,
+            max_queues: 3,
+            max_inflight_snapshots: 4,
+            max_runtime_snapshots: 5,
+        })
+        .strict_lifecycle(true)
+        .started_at_unix_ms(10)
+        .finished_at_unix_ms(20)
+        .finalized_at_unix_ms(30)
+        .host("host-a")
+        .pid(42);
+
+    let run = crate::RunBuilder::new(options)
+        .expect("builder should succeed")
+        .finish();
+
+    assert_eq!(run.requests.len(), 0);
+    assert_eq!(run.stages.len(), 0);
+    assert_eq!(run.queues.len(), 0);
+    assert_eq!(run.inflight.len(), 0);
+    assert_eq!(run.runtime_snapshots.len(), 0);
+    assert_eq!(run.metadata.service_name, "payments");
+    assert_eq!(run.metadata.service_version.as_deref(), Some("1.2.3"));
+    assert_eq!(run.metadata.run_id, "run-explicit");
+    assert_eq!(run.metadata.mode, CaptureMode::Investigation);
+    assert_eq!(run.metadata.started_at_unix_ms, 10);
+    assert_eq!(run.metadata.finished_at_unix_ms, 20);
+    assert_eq!(run.metadata.finalized_at_unix_ms, Some(30));
+    assert_eq!(run.metadata.host.as_deref(), Some("host-a"));
+    assert_eq!(run.metadata.pid, Some(42));
+    assert_eq!(
+        run.metadata
+            .effective_core_config
+            .expect("effective core config should be present")
+            .capture_limits,
+        CaptureLimits {
+            max_requests: 1,
+            max_stages: 2,
+            max_queues: 3,
+            max_inflight_snapshots: 4,
+            max_runtime_snapshots: 5,
+        }
+    );
+}
+
+#[test]
+fn run_builder_rejects_blank_service_name() {
+    let err = crate::RunBuilder::new(crate::RunBuilderOptions::new("   "))
+        .expect_err("blank service_name should fail");
+    assert_eq!(err, BuildError::EmptyServiceName);
+}
+
+#[test]
+fn run_builder_generated_default_run_ids_are_unique() {
+    let first = crate::RunBuilder::new(crate::RunBuilderOptions::new("payments"))
+        .expect("first builder should succeed")
+        .finish();
+    let second = crate::RunBuilder::new(crate::RunBuilderOptions::new("payments"))
+        .expect("second builder should succeed")
+        .finish();
+    assert_ne!(first.metadata.run_id, second.metadata.run_id);
+}
+
+#[test]
+fn run_builder_defaults_host_and_pid_to_none() {
+    let run = crate::RunBuilder::new(crate::RunBuilderOptions::new("payments"))
+        .expect("builder should succeed")
+        .finish();
+    assert!(run.metadata.host.is_none());
+    assert!(run.metadata.pid.is_none());
+}
+
+#[test]
+fn run_builder_default_finalized_timestamp_is_some() {
+    let run = crate::RunBuilder::new(crate::RunBuilderOptions::new("payments"))
+        .expect("builder should succeed")
+        .finish();
+    assert!(run.metadata.finalized_at_unix_ms.is_some());
+}
+
+#[test]
+fn run_builder_preserves_explicit_finalized_timestamp() {
+    let run =
+        crate::RunBuilder::new(crate::RunBuilderOptions::new("payments").finalized_at_unix_ms(123))
+            .expect("builder should succeed")
+            .finish();
+    assert_eq!(run.metadata.finalized_at_unix_ms, Some(123));
+}
+
+#[test]
+fn run_builder_strict_lifecycle_appears_in_effective_core_config() {
+    let run =
+        crate::RunBuilder::new(crate::RunBuilderOptions::new("payments").strict_lifecycle(true))
+            .expect("builder should succeed")
+            .finish();
+
+    assert!(
+        run.metadata
+            .effective_core_config
+            .expect("effective core config should be present")
+            .strict_lifecycle
+    );
+}
+
+#[test]
+fn run_builder_run_end_reason_is_set_if_absent_and_not_overwritten() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("payments"))
+        .expect("builder should succeed");
+    builder.set_run_end_reason_if_absent(crate::RunEndReason::ManualDisarm);
+    builder.set_run_end_reason_if_absent(crate::RunEndReason::Shutdown);
+
+    let run = builder.finish();
+    assert_eq!(
+        run.metadata.run_end_reason,
+        Some(crate::RunEndReason::ManualDisarm)
+    );
+}
+
+#[test]
+fn run_builder_lifecycle_warnings_are_preserved() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("payments"))
+        .expect("builder should succeed");
+    builder.add_lifecycle_warning("warning-1");
+    builder.add_lifecycle_warning("warning-2");
+
+    let run = builder.finish();
+    assert_eq!(
+        run.metadata.lifecycle_warnings,
+        vec!["warning-1", "warning-2"]
+    );
+}
+
+#[test]
+fn run_builder_unfinished_requests_are_preserved() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("payments"))
+        .expect("builder should succeed");
+    builder.set_unfinished_requests(crate::UnfinishedRequests {
+        count: 2,
+        sample: vec![crate::UnfinishedRequestSample {
+            request_id: "req-1".to_string(),
+            route: "/x".to_string(),
+        }],
+    });
+
+    let run = builder.finish();
+    assert_eq!(run.metadata.unfinished_requests.count, 2);
+    assert_eq!(run.metadata.unfinished_requests.sample.len(), 1);
+    assert_eq!(
+        run.metadata.unfinished_requests.sample[0].request_id,
+        "req-1"
+    );
+}


### PR DESCRIPTION
### Motivation
- Provide a narrow, public API for assembling a completed/finalized `Run` artifact in `tailtriage-core` for import/conversion and evidence assembly workflows without touching live tracing integration yet.

### Description
- Add `tailtriage-core/src/run_builder.rs` implementing `RunBuilderOptions` (private fields + compact setter API) and `RunBuilder` that assembles a finalized `Run` from provided options and appended events.
- Export `RunBuilder` and `RunBuilderOptions` from `tailtriage-core/src/lib.rs` so they are part of the public core surface.
- `RunBuilderOptions::new(service_name)` plus setters for `service_version`, `run_id`, `mode`, `capture_limits`, `strict_lifecycle`, `started_at_unix_ms`, `finished_at_unix_ms`, `finalized_at_unix_ms`, `host`, `pid`, and `run_end_reason` are provided.
- `RunBuilder::new(options) -> Result<Self, BuildError>` validates non-empty service name, applies default `CaptureMode::Light`, uses mode `core_defaults()` for default limits, generates run IDs when absent, and sets timestamps (started/finished/finalized) using current unix-ms when not provided; `finish()` returns the finalized `Run`.
- Provide push/mutation methods: `push_request`, `push_stage`, `push_queue`, `push_inflight_snapshot`, `push_runtime_snapshot`, `add_lifecycle_warning`, `set_unfinished_requests`, `set_effective_tokio_sampler_config`, `set_run_end_reason_if_absent`, and `finish`.
- Document every public item with rustdoc and position the API as completed-evidence assembly (not live instrumentation).
- Add focused unit tests in `tailtriage-core/src/tests.rs` covering explicit metadata, blank-service rejection, generated run-id uniqueness, host/pid defaults, finalized timestamp behavior, strict-lifecycle propagation, run-end-reason set-if-absent semantics, lifecycle warnings, and unfinished-requests preservation.

### Testing
- Ran `cargo fmt --check` which succeeded.
- Ran `cargo test -p tailtriage-core`; unit tests and doctests completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b14789e14833092200885f9732b3b)