### PR TITLE
Use tailtriage-core RunBuilder in tracing span import

### DIFF
--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -37,8 +37,7 @@ pub mod tokio;
 mod types;
 
 use tailtriage_core::{
-    CaptureMode, EffectiveCoreConfig, QueueEvent, RequestEvent, Run, RunMetadata, StageEvent,
-    TruncationSummary, UnfinishedRequests, SCHEMA_VERSION,
+    BuildError, CaptureMode, QueueEvent, RequestEvent, RunBuilder, RunBuilderOptions, StageEvent,
 };
 
 pub use convention::{
@@ -69,11 +68,10 @@ pub fn run_from_span_records<I>(
 where
     I: IntoIterator<Item = SpanRecord>,
 {
-    validate_service_name(options.service_name())?;
     let mut warnings = Vec::new();
-    let mut requests = Vec::new();
-    let mut stages = Vec::new();
-    let mut queues = Vec::new();
+    let mut request_events = Vec::new();
+    let mut stage_events = Vec::new();
+    let mut queue_events = Vec::new();
     let mut min_start: Option<u64> = None;
     let mut max_finish: Option<u64> = None;
 
@@ -125,7 +123,7 @@ where
                     else {
                         continue;
                     };
-                    requests.push(RequestEvent {
+                    request_events.push(RequestEvent {
                         request_id,
                         route,
                         kind: None,
@@ -151,7 +149,7 @@ where
                         OptionalField::Value(success) => success,
                         OptionalField::Invalid => continue,
                     };
-                    stages.push(StageEvent {
+                    stage_events.push(StageEvent {
                         request_id,
                         stage,
                         started_at_unix_ms: span.started_at_unix_ms(),
@@ -176,7 +174,7 @@ where
                             OptionalField::Value(depth) => Some(depth),
                             OptionalField::Invalid => continue,
                         };
-                    queues.push(QueueEvent {
+                    queue_events.push(QueueEvent {
                         request_id,
                         queue,
                         waited_from_unix_ms: span.started_at_unix_ms(),
@@ -200,52 +198,40 @@ where
         ToOwned::to_owned,
     );
 
-    let lifecycle_warnings = warnings
+    let mut builder_options = RunBuilderOptions::new(options.service_name())
+        .run_id(run_id)
+        .mode(CaptureMode::Light)
+        .capture_limits(CaptureMode::Light.core_defaults())
+        .strict_lifecycle(false)
+        .started_at_unix_ms(started_at_unix_ms)
+        .finished_at_unix_ms(finished_at_unix_ms)
+        .finalized_at_unix_ms(finished_at_unix_ms);
+    if let Some(service_version) = options.service_version_ref() {
+        builder_options = builder_options.service_version(service_version.to_owned());
+    }
+    let mut run_builder = RunBuilder::new(builder_options).map_err(|error| match error {
+        BuildError::EmptyServiceName => ImportError::EmptyServiceName,
+    })?;
+
+    for warning in warnings
         .iter()
         .filter(|warning| is_lifecycle_warning(warning.message()))
-        .map(|w| w.message().to_owned())
-        .collect::<Vec<_>>();
+    {
+        run_builder.add_lifecycle_warning(warning.message().to_owned());
+    }
+    for request in request_events {
+        run_builder.push_request(request);
+    }
+    for stage in stage_events {
+        run_builder.push_stage(stage);
+    }
+    for queue in queue_events {
+        run_builder.push_queue(queue);
+    }
 
-    let metadata = RunMetadata {
-        run_id,
-        service_name: options.service_name().to_owned(),
-        service_version: options.service_version_ref().map(ToOwned::to_owned),
-        started_at_unix_ms,
-        finished_at_unix_ms,
-        finalized_at_unix_ms: Some(finished_at_unix_ms),
-        mode: CaptureMode::Light,
-        effective_core_config: Some(EffectiveCoreConfig {
-            mode: CaptureMode::Light,
-            capture_limits: CaptureMode::Light.core_defaults(),
-            strict_lifecycle: false,
-        }),
-        effective_tokio_sampler_config: None,
-        host: None,
-        pid: None,
-        lifecycle_warnings,
-        unfinished_requests: UnfinishedRequests::default(),
-        run_end_reason: None,
-    };
-
-    let run = Run {
-        schema_version: SCHEMA_VERSION,
-        metadata,
-        requests,
-        stages,
-        queues,
-        inflight: Vec::new(),
-        runtime_snapshots: Vec::new(),
-        truncation: TruncationSummary::default(),
-    };
+    let run = run_builder.finish();
 
     Ok(ImportedRun::new(run, warnings))
-}
-
-fn validate_service_name(service_name: &str) -> Result<(), ImportError> {
-    if service_name.trim().is_empty() {
-        return Err(ImportError::EmptyServiceName);
-    }
-    Ok(())
 }
 
 fn update_min_max(min_start: &mut Option<u64>, max_finish: &mut Option<u64>, span: &SpanRecord) {
@@ -538,7 +524,7 @@ mod tests {
     }
 
     #[test]
-    fn empty_input_returns_valid_run_with_zero_events() {
+    fn run_from_span_records_empty_input_uses_equal_start_finish_finalized() {
         let imported = run_from_span_records(Vec::new(), ImportOptions::new("svc")).unwrap();
         assert!(imported.run().requests.is_empty());
         assert!(imported.run().stages.is_empty());
@@ -546,6 +532,10 @@ mod tests {
         assert_eq!(
             imported.run().metadata.finished_at_unix_ms,
             imported.run().metadata.started_at_unix_ms
+        );
+        assert_eq!(
+            imported.run().metadata.finalized_at_unix_ms,
+            Some(imported.run().metadata.finished_at_unix_ms)
         );
     }
 
@@ -571,6 +561,47 @@ mod tests {
             .clone();
         assert_eq!(run.metadata.started_at_unix_ms, 10);
         assert_eq!(run.metadata.finished_at_unix_ms, 20);
+    }
+
+    #[test]
+    fn run_from_span_records_uses_schema_v1_finalization_semantics() {
+        let spans = vec![SpanRecord::new("req", 10, 20)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")];
+        let run = run_from_span_records(spans, ImportOptions::new("svc"))
+            .unwrap()
+            .run()
+            .clone();
+        assert_eq!(run.metadata.started_at_unix_ms, 10);
+        assert_eq!(run.metadata.finished_at_unix_ms, 20);
+        assert_eq!(run.metadata.finalized_at_unix_ms, Some(20));
+    }
+
+    #[test]
+    fn run_from_span_records_preserves_computed_import_run_id() {
+        let spans = vec![SpanRecord::new("req", 10, 20)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")];
+        let run = run_from_span_records(spans, ImportOptions::new("svc"))
+            .unwrap()
+            .run()
+            .clone();
+        assert_eq!(run.metadata.run_id, "tracing-import-10-20");
+    }
+
+    #[test]
+    fn run_from_span_records_preserves_explicit_import_run_id() {
+        let spans = vec![SpanRecord::new("req", 10, 20)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")];
+        let run = run_from_span_records(spans, ImportOptions::new("svc").run_id("explicit-id"))
+            .unwrap()
+            .run()
+            .clone();
+        assert_eq!(run.metadata.run_id, "explicit-id");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Centralize finalized `Run` assembly in `tailtriage-core` to avoid duplicated metadata/truncation logic in the tracing import path and to reuse the `RunBuilder` retention/truncation behavior.
- Preserve existing `tt.*` tracing import semantics and schema v1 finalization compatibility while making the tracing crate a thin parser that pushes parsed events into core.

### Description
- Reworked `run_from_span_records` to build output via `tailtriage_core::RunBuilderOptions` + `tailtriage_core::RunBuilder` and to push parsed events with `push_request` / `push_stage` / `push_queue` and lifecycle warnings with `add_lifecycle_warning`.
- Removed tracing-side manual construction of `Run`, `RunMetadata`, `EffectiveCoreConfig`, `TruncationSummary`, empty `inflight` / `runtime_snapshots` and direct `schema_version` assignment; the core builder now produces the final `Run`.
- Preserved import metadata and semantics by explicitly passing `mode = CaptureMode::Light`, `capture_limits = CaptureMode::Light.core_defaults()`, `strict_lifecycle = false`, explicit `started_at_unix_ms` / `finished_at_unix_ms`, and `finalized_at_unix_ms(finished_at_unix_ms)`; preserved run-id behavior by forwarding either `ImportOptions::run_id` or the computed `tracing-import-{start}-{finish}` into `RunBuilderOptions::run_id`.
- Files changed: `tailtriage-tracing/src/lib.rs` (parsing logic, builder usage, and tests updated/added for run-id and finalization semantics).

### Testing
- Ran formatting and linters with `cargo fmt --check` and `cargo clippy -p tailtriage-tracing --all-targets --all-features -- -D warnings`, and both passed.
- Ran test suites with `cargo test -p tailtriage-tracing --all-features`, `cargo test -p tailtriage-cli --all-features`, and `cargo test -p tailtriage-core`, and all tests passed locally (new/updated tracing tests passed as well).
- Added/updated unit tests in `tailtriage-tracing` for `run_from_span_records_uses_schema_v1_finalization_semantics`, `run_from_span_records_preserves_computed_import_run_id`, `run_from_span_records_preserves_explicit_import_run_id`, and `run_from_span_records_empty_input_uses_equal_start_finish_finalized`, and they succeeded in the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b67d815d483308abfeb7719c19035)