### PR TITLE
Refactor tracing import to use tailtriage-core RunBuilder

### DIFF
--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -37,8 +37,7 @@ pub mod tokio;
 mod types;
 
 use tailtriage_core::{
-    CaptureMode, EffectiveCoreConfig, QueueEvent, RequestEvent, Run, RunMetadata, StageEvent,
-    TruncationSummary, UnfinishedRequests, SCHEMA_VERSION,
+    BuildError, CaptureMode, QueueEvent, RequestEvent, RunBuilder, RunBuilderOptions, StageEvent,
 };
 
 pub use convention::{
@@ -206,37 +205,37 @@ where
         .map(|w| w.message().to_owned())
         .collect::<Vec<_>>();
 
-    let metadata = RunMetadata {
-        run_id,
-        service_name: options.service_name().to_owned(),
-        service_version: options.service_version_ref().map(ToOwned::to_owned),
-        started_at_unix_ms,
-        finished_at_unix_ms,
-        finalized_at_unix_ms: Some(finished_at_unix_ms),
-        mode: CaptureMode::Light,
-        effective_core_config: Some(EffectiveCoreConfig {
-            mode: CaptureMode::Light,
-            capture_limits: CaptureMode::Light.core_defaults(),
-            strict_lifecycle: false,
-        }),
-        effective_tokio_sampler_config: None,
-        host: None,
-        pid: None,
-        lifecycle_warnings,
-        unfinished_requests: UnfinishedRequests::default(),
-        run_end_reason: None,
-    };
+    let mut builder_options = RunBuilderOptions::new(options.service_name())
+        .run_id(run_id)
+        .mode(CaptureMode::Light)
+        .capture_limits(CaptureMode::Light.core_defaults())
+        .strict_lifecycle(false)
+        .started_at_unix_ms(started_at_unix_ms)
+        .finished_at_unix_ms(finished_at_unix_ms)
+        .finalized_at_unix_ms(finished_at_unix_ms);
 
-    let run = Run {
-        schema_version: SCHEMA_VERSION,
-        metadata,
-        requests,
-        stages,
-        queues,
-        inflight: Vec::new(),
-        runtime_snapshots: Vec::new(),
-        truncation: TruncationSummary::default(),
-    };
+    if let Some(service_version) = options.service_version_ref() {
+        builder_options = builder_options.service_version(service_version);
+    }
+
+    let mut run_builder = RunBuilder::new(builder_options).map_err(|err| match err {
+        BuildError::EmptyServiceName => ImportError::EmptyServiceName,
+    })?;
+
+    for request in requests {
+        run_builder.push_request(request);
+    }
+    for stage in stages {
+        run_builder.push_stage(stage);
+    }
+    for queue in queues {
+        run_builder.push_queue(queue);
+    }
+    for warning in &lifecycle_warnings {
+        run_builder.add_lifecycle_warning(warning.clone());
+    }
+
+    let run = run_builder.finish();
 
     Ok(ImportedRun::new(run, warnings))
 }
@@ -538,7 +537,7 @@ mod tests {
     }
 
     #[test]
-    fn empty_input_returns_valid_run_with_zero_events() {
+    fn run_from_span_records_empty_input_uses_equal_start_finish_finalized() {
         let imported = run_from_span_records(Vec::new(), ImportOptions::new("svc")).unwrap();
         assert!(imported.run().requests.is_empty());
         assert!(imported.run().stages.is_empty());
@@ -547,6 +546,51 @@ mod tests {
             imported.run().metadata.finished_at_unix_ms,
             imported.run().metadata.started_at_unix_ms
         );
+        assert_eq!(
+            imported.run().metadata.finalized_at_unix_ms,
+            Some(imported.run().metadata.finished_at_unix_ms)
+        );
+    }
+
+    #[test]
+    fn run_from_span_records_uses_schema_v1_finalization_semantics() {
+        let spans = vec![SpanRecord::new("req", 10, 20)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")];
+        let run = run_from_span_records(spans, ImportOptions::new("svc"))
+            .unwrap()
+            .run()
+            .clone();
+        assert_eq!(run.metadata.started_at_unix_ms, 10);
+        assert_eq!(run.metadata.finished_at_unix_ms, 20);
+        assert_eq!(run.metadata.finalized_at_unix_ms, Some(20));
+    }
+
+    #[test]
+    fn run_from_span_records_preserves_computed_import_run_id() {
+        let spans = vec![SpanRecord::new("req", 10, 20)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")];
+        let run = run_from_span_records(spans, ImportOptions::new("svc"))
+            .unwrap()
+            .run()
+            .clone();
+        assert_eq!(run.metadata.run_id, "tracing-import-10-20");
+    }
+
+    #[test]
+    fn run_from_span_records_preserves_explicit_import_run_id() {
+        let spans = vec![SpanRecord::new("req", 10, 20)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")];
+        let run = run_from_span_records(spans, ImportOptions::new("svc").run_id("explicit-run"))
+            .unwrap()
+            .run()
+            .clone();
+        assert_eq!(run.metadata.run_id, "explicit-run");
     }
 
     #[test]

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -537,6 +537,13 @@ mod tests {
     }
 
     #[test]
+    fn run_from_span_records_validates_service_name_before_strict_span_parsing() {
+        let spans = vec![SpanRecord::new("bad", 10, 20).field(TT_KIND, 123_u64)];
+        let err = run_from_span_records(spans, ImportOptions::new("   ").strict(true)).unwrap_err();
+        assert!(matches!(err, ImportError::EmptyServiceName));
+    }
+
+    #[test]
     fn run_from_span_records_empty_input_uses_equal_start_finish_finalized() {
         let imported = run_from_span_records(Vec::new(), ImportOptions::new("svc")).unwrap();
         assert!(imported.run().requests.is_empty());


### PR DESCRIPTION
### Motivation
- Consolidate run-assembly logic by using `tailtriage_core::RunBuilder` so tracing import reuses core truncation/metadata rules and avoids duplicating `Run`/`RunMetadata` construction. 
- Preserve existing tracing import semantics (strict/non-strict parsing, run-id/timestamp behavior, schema v1 finalization) while removing plumbing duplication.

### Description
- Reworked `run_from_span_records` to build output via `RunBuilderOptions` + `RunBuilder` and to push parsed events through `push_request`, `push_stage`, `push_queue` and `add_lifecycle_warning` instead of hand-assembling `Run` and `RunMetadata`.
- Removed tracing-side manual construction of `Run`, `RunMetadata`, `EffectiveCoreConfig`, `TruncationSummary`, and explicit empty `inflight`/`runtime_snapshots` setup; those are now produced by the core `RunBuilder` output.
- Preserved import semantics by explicitly passing `run_id`, `started_at_unix_ms`, `finished_at_unix_ms`, and `.finalized_at_unix_ms(finished_at_unix_ms)` to the `RunBuilderOptions`, and by mapping `BuildError::EmptyServiceName` to `ImportError::EmptyServiceName`.
- Added/updated unit tests to assert schema v1 finalization semantics, computed import run-id preservation, explicit run-id preservation, and empty-input start/finish/finalized equality; removed an obsolete test name and adjusted assertions accordingly.
- Files changed: `tailtriage-tracing/src/lib.rs`.

### Testing
- Ran formatting and lint: `cargo fmt --check` succeeded.
- Ran unit and integration tests: `cargo test -p tailtriage-tracing --all-features` (93 tests passed), `cargo test -p tailtriage-cli --all-features` (all tests passed), and `cargo test -p tailtriage-core` (all tests passed).
- Ran `cargo clippy -p tailtriage-tracing --all-targets --all-features -- -D warnings` and it passed with no warnings.
- All CI-local validation commands passed and the modified tests covering finalization and run-id behavior succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b67d815d483308abfeb7719c19035)