### PR TITLE
Use RunBuilder for tracing imports and preserve schema-v1 finalization

### DIFF
--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -37,8 +37,7 @@ pub mod tokio;
 mod types;
 
 use tailtriage_core::{
-    CaptureMode, EffectiveCoreConfig, QueueEvent, RequestEvent, Run, RunMetadata, StageEvent,
-    TruncationSummary, UnfinishedRequests, SCHEMA_VERSION,
+    BuildError, CaptureMode, QueueEvent, RequestEvent, RunBuilder, RunBuilderOptions, StageEvent,
 };
 
 pub use convention::{
@@ -69,7 +68,6 @@ pub fn run_from_span_records<I>(
 where
     I: IntoIterator<Item = SpanRecord>,
 {
-    validate_service_name(options.service_name())?;
     let mut warnings = Vec::new();
     let mut requests = Vec::new();
     let mut stages = Vec::new();
@@ -200,52 +198,40 @@ where
         ToOwned::to_owned,
     );
 
-    let lifecycle_warnings = warnings
+    let mut builder_options = RunBuilderOptions::new(options.service_name())
+        .run_id(run_id)
+        .mode(CaptureMode::Light)
+        .capture_limits(CaptureMode::Light.core_defaults())
+        .strict_lifecycle(false)
+        .started_at_unix_ms(started_at_unix_ms)
+        .finished_at_unix_ms(finished_at_unix_ms)
+        .finalized_at_unix_ms(finished_at_unix_ms);
+    if let Some(service_version) = options.service_version_ref() {
+        builder_options = builder_options.service_version(service_version.to_owned());
+    }
+    let mut builder = RunBuilder::new(builder_options).map_err(|error| match error {
+        BuildError::EmptyServiceName => ImportError::EmptyServiceName,
+    })?;
+
+    for warning in warnings
         .iter()
-        .filter(|warning| is_lifecycle_warning(warning.message()))
-        .map(|w| w.message().to_owned())
-        .collect::<Vec<_>>();
+        .filter(|w| is_lifecycle_warning(w.message()))
+    {
+        builder.add_lifecycle_warning(warning.message());
+    }
+    for request in requests {
+        builder.push_request(request);
+    }
+    for stage in stages {
+        builder.push_stage(stage);
+    }
+    for queue in queues {
+        builder.push_queue(queue);
+    }
 
-    let metadata = RunMetadata {
-        run_id,
-        service_name: options.service_name().to_owned(),
-        service_version: options.service_version_ref().map(ToOwned::to_owned),
-        started_at_unix_ms,
-        finished_at_unix_ms,
-        finalized_at_unix_ms: Some(finished_at_unix_ms),
-        mode: CaptureMode::Light,
-        effective_core_config: Some(EffectiveCoreConfig {
-            mode: CaptureMode::Light,
-            capture_limits: CaptureMode::Light.core_defaults(),
-            strict_lifecycle: false,
-        }),
-        effective_tokio_sampler_config: None,
-        host: None,
-        pid: None,
-        lifecycle_warnings,
-        unfinished_requests: UnfinishedRequests::default(),
-        run_end_reason: None,
-    };
-
-    let run = Run {
-        schema_version: SCHEMA_VERSION,
-        metadata,
-        requests,
-        stages,
-        queues,
-        inflight: Vec::new(),
-        runtime_snapshots: Vec::new(),
-        truncation: TruncationSummary::default(),
-    };
+    let run = builder.finish();
 
     Ok(ImportedRun::new(run, warnings))
-}
-
-fn validate_service_name(service_name: &str) -> Result<(), ImportError> {
-    if service_name.trim().is_empty() {
-        return Err(ImportError::EmptyServiceName);
-    }
-    Ok(())
 }
 
 fn update_min_max(min_start: &mut Option<u64>, max_finish: &mut Option<u64>, span: &SpanRecord) {
@@ -546,6 +532,66 @@ mod tests {
         assert_eq!(
             imported.run().metadata.finished_at_unix_ms,
             imported.run().metadata.started_at_unix_ms
+        );
+    }
+
+    #[test]
+    fn run_from_span_records_uses_schema_v1_finalization_semantics() {
+        let spans = vec![SpanRecord::new("req", 10, 20)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+        let run = run_from_span_records(spans, ImportOptions::new("svc"))
+            .unwrap()
+            .run()
+            .clone();
+        assert_eq!(run.metadata.started_at_unix_ms, 10);
+        assert_eq!(run.metadata.finished_at_unix_ms, 20);
+        assert_eq!(run.metadata.finalized_at_unix_ms, Some(20));
+    }
+
+    #[test]
+    fn run_from_span_records_preserves_computed_import_run_id() {
+        let spans = vec![SpanRecord::new("req", 10, 20)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+        let run = run_from_span_records(spans, ImportOptions::new("svc"))
+            .unwrap()
+            .run()
+            .clone();
+        assert_eq!(run.metadata.run_id, "tracing-import-10-20");
+    }
+
+    #[test]
+    fn run_from_span_records_preserves_explicit_import_run_id() {
+        let spans = vec![SpanRecord::new("req", 10, 20)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+        let run = run_from_span_records(spans, ImportOptions::new("svc").run_id("explicit-id"))
+            .unwrap()
+            .run()
+            .clone();
+        assert_eq!(run.metadata.run_id, "explicit-id");
+    }
+
+    #[test]
+    fn run_from_span_records_empty_input_uses_equal_start_finish_finalized() {
+        let run = run_from_span_records(Vec::new(), ImportOptions::new("svc"))
+            .unwrap()
+            .run()
+            .clone();
+        assert!(run.requests.is_empty());
+        assert!(run.stages.is_empty());
+        assert!(run.queues.is_empty());
+        assert_eq!(
+            run.metadata.finished_at_unix_ms,
+            run.metadata.started_at_unix_ms
+        );
+        assert_eq!(
+            run.metadata.finalized_at_unix_ms,
+            Some(run.metadata.finished_at_unix_ms)
         );
     }
 


### PR DESCRIPTION
### Motivation
- Replace manual tracing-side construction of completed `Run` artifacts with the shared `tailtriage_core::RunBuilder` to centralize metadata defaults, truncation behavior, and retention logic.
- Preserve existing tracing import semantics and schema v1 finalization behavior so imported artifacts remain compatible with existing consumers and the v1 migration plan is not started.

### Description
- Reworked `run_from_span_records` to build a `RunBuilderOptions` and construct a `RunBuilder`, passing explicit `run_id`, `started_at_unix_ms`, `finished_at_unix_ms`, and `finalized_at_unix_ms` so schema v1 finalization semantics (`finished_at_unix_ms == finalized_at_unix_ms` for finalized artifacts) are preserved.
- Pushed parsed events into the builder with `push_request`, `push_stage`, and `push_queue`, and added lifecycle warnings via `add_lifecycle_warning`, instead of assembling `Run`, `RunMetadata`, `EffectiveCoreConfig`, `TruncationSummary`, `inflight`, and `runtime_snapshots` manually.
- Mapped core `BuildError::EmptyServiceName` to `ImportError::EmptyServiceName` and preserved `ImportOptions` run-id behavior by explicitly passing either the provided `run_id` or the computed `tracing-import-{started}-{finished}` to the builder.
- Changed file: `tailtriage-tracing/src/lib.rs`, and added unit tests that assert finalization semantics, computed and explicit run-id preservation, and empty-input start/finish/finalized equality.

### Testing
- Ran `cargo fmt --check` and the check passed.
- Ran `cargo test -p tailtriage-tracing --all-features` and all unit and integration tests under that package passed.
- Ran `cargo test -p tailtriage-cli --all-features` and `cargo test -p tailtriage-core` and both test suites passed.
- Ran `cargo clippy -p tailtriage-tracing --all-targets --all-features -- -D warnings` and the lint pass completed with no warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b67d815d483308abfeb7719c19035)