### PR TITLE
Tighten tracing recorder & Tokio session tests after RunBuilder migration

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -683,6 +683,7 @@ mod tests {
         });
         let imported = recorder.snapshot_run().unwrap();
         assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].request_id, "r1");
         assert!(imported
             .warnings()
             .iter()
@@ -794,7 +795,13 @@ mod tests {
             let _open =
                 tracing::info_span!("request", tt.kind = "request", tt.request_id = "r1").entered();
             let err = recorder.snapshot_run().unwrap_err();
-            assert!(matches!(err, ImportError::StrictViolation(_)));
+            match err {
+                ImportError::StrictViolation(msg) => {
+                    assert!(msg.contains("open candidate span(s)"));
+                    assert!(msg.contains("not converted into fabricated completions"));
+                }
+                _ => panic!("expected strict violation"),
+            }
         });
     }
 

--- a/tailtriage-tracing/tests/tokio_session.rs
+++ b/tailtriage-tracing/tests/tokio_session.rs
@@ -228,3 +228,73 @@ async fn record_runtime_snapshot_does_not_alter_tracing_events() {
     assert_eq!(run.stages.len(), 1);
     assert_eq!(run.queues.len(), 1);
 }
+
+#[tokio::test(flavor = "current_thread")]
+async fn snapshot_run_preserves_schema_v1_finalization_and_runtime_metadata() {
+    let session = TracingTokioSession::builder("svc")
+        .sampler_interval(Duration::from_millis(1))
+        .start()
+        .expect("start session");
+
+    let subscriber = tracing_subscriber::registry().with(session.layer());
+    tracing::subscriber::with_default(subscriber, || {
+        tracing::info_span!(
+            "req",
+            tt.kind = "request",
+            tt.request_id = "r-finalize",
+            tt.route = "/finalize"
+        )
+        .in_scope(|| {});
+    });
+
+    session.record_runtime_snapshot(RuntimeSnapshot {
+        at_unix_ms: unix_time_ms(),
+        alive_tasks: Some(1),
+        global_queue_depth: Some(1),
+        local_queue_depth: Some(1),
+        blocking_queue_depth: Some(1),
+        remote_schedule_count: Some(1),
+    });
+
+    let imported = session.snapshot_run().expect("snapshot run");
+    let run = imported.run();
+    assert_eq!(run.schema_version, 1);
+    assert_eq!(run.requests.len(), 1);
+    assert!(!run.runtime_snapshots.is_empty());
+    assert!(run.metadata.effective_tokio_sampler_config.is_some());
+    assert_eq!(
+        run.metadata.finalized_at_unix_ms,
+        Some(run.metadata.finished_at_unix_ms)
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn runtime_snapshot_truncation_propagates_to_imported_run() {
+    let session = TracingTokioSession::builder("svc")
+        .max_runtime_snapshots(1)
+        .start()
+        .expect("start session");
+
+    session.record_runtime_snapshot(RuntimeSnapshot {
+        at_unix_ms: unix_time_ms(),
+        alive_tasks: Some(1),
+        global_queue_depth: Some(1),
+        local_queue_depth: Some(1),
+        blocking_queue_depth: Some(1),
+        remote_schedule_count: Some(1),
+    });
+    session.record_runtime_snapshot(RuntimeSnapshot {
+        at_unix_ms: unix_time_ms().saturating_add(1),
+        alive_tasks: Some(2),
+        global_queue_depth: Some(2),
+        local_queue_depth: Some(2),
+        blocking_queue_depth: Some(2),
+        remote_schedule_count: Some(2),
+    });
+
+    let imported = session.snapshot_run().expect("snapshot run");
+    let run = imported.run();
+    assert_eq!(run.runtime_snapshots.len(), 1);
+    assert_eq!(run.truncation.dropped_runtime_snapshots, 1);
+    assert!(run.truncation.limits_hit);
+}


### PR DESCRIPTION
### Motivation
- Verify the live tracing recorder and `TracingTokioSession` behavior remained correct after converting tracing import to use `tailtriage_core::RunBuilder` and ensure schema v1 finalization semantics are preserved. 

### Description
- Strengthened recorder tests in `tailtriage-tracing` to assert first-N retention for completed spans and to assert the `ImportError::StrictViolation` message explicitly mentions open candidate spans are not converted into fabricated completions. 
- Added Tokio-session integration tests that assert runtime snapshot merge presence, propagation of `truncation.dropped_runtime_snapshots` and `truncation.limits_hit`, presence of `metadata.effective_tokio_sampler_config`, preservation of tracing events, and schema v1 finalization semantics (`finalized_at_unix_ms == Some(finished_at_unix_ms)`). 
- Changes are test-focused only and did not alter public APIs, runtime code, JSONL import shape, or `SCHEMA_VERSION`.
- Files changed: `tailtriage-tracing/src/recorder.rs` and `tailtriage-tracing/tests/tokio_session.rs`.

### Testing
- Ran `cargo fmt --check` which passed. 
- Ran `cargo test -p tailtriage-tracing --all-features` which passed (all tracing tests and tokio-session tests succeeded). 
- Ran `cargo test -p tailtriage-core` which passed. 
- Ran `cargo test -p tailtriage-cli --all-features` which passed. 
- Ran `cargo clippy -p tailtriage-tracing --all-targets --all-features -- -D warnings` which passed with no warnings. 

Confirmations:
- Live recorder warnings and truncation behavior remain preserved and continue to appear in both `ImportedRun::warnings()` and `run.metadata.lifecycle_warnings`. 
- Strict recorder mode still errors on open candidate spans with `ImportError::StrictViolation` and does not fabricate completions. 
- Recorder completed-span and open-span drops still emit lifecycle warnings and set `run.truncation.limits_hit = true`. 
- Plain tracing-only recorder/import output remains without runtime snapshots unless Tokio sampling or manual snapshots add them. 
- `TracingTokioSession` merging preserves tracing request/stage/queue evidence, merges deterministic runtime snapshots, propagates runtime truncation counters, includes `metadata.effective_tokio_sampler_config` when sampler runs, and preserves schema v1 finalization semantics. 
- `SCHEMA_VERSION` was not bumped (remains `1`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b77bf67e08330ba6911bc8b46d322)