### PR TITLE
Strengthen recorder/session parity checks after RunBuilder tracing import migration

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -778,7 +778,7 @@ mod tests {
                 assert!(message.contains("open candidate span(s)"));
                 assert!(message.contains("not converted into fabricated completions"));
             }
-            other => panic!("unexpected error: {other}"),
+            other => panic!("unexpected error: {other:?}"),
         }
     }
 

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -694,6 +694,7 @@ mod tests {
             .iter()
             .any(|w| w.contains("dropped 1 completed spans")));
         assert!(imported.run().truncation.limits_hit);
+        assert_eq!(imported.run().requests[0].request_id, "r1");
     }
 
     #[test]
@@ -756,6 +757,29 @@ mod tests {
         let recorder = TracingRecorder::builder(" ").build();
         let err = recorder.snapshot_run().unwrap_err();
         assert!(matches!(err, ImportError::EmptyServiceName));
+    }
+
+    #[test]
+    fn strict_mode_rejects_open_candidate_spans_without_fabricating_completions() {
+        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        let err = tracing::subscriber::with_default(subscriber, || {
+            let _open_guard = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r-open",
+                tt.route = "/open"
+            )
+            .entered();
+            recorder.snapshot_run().expect_err("strict should reject")
+        });
+        match err {
+            ImportError::StrictViolation(message) => {
+                assert!(message.contains("open candidate span(s)"));
+                assert!(message.contains("not converted into fabricated completions"));
+            }
+            other => panic!("unexpected error: {other}"),
+        }
     }
 
     #[test]

--- a/tailtriage-tracing/tests/tokio_session.rs
+++ b/tailtriage-tracing/tests/tokio_session.rs
@@ -67,6 +67,10 @@ async fn session_merges_tracing_and_runtime() {
     assert_eq!(run.queues[0].depth_at_start, Some(2));
     assert!(!run.runtime_snapshots.is_empty());
     assert!(run.metadata.effective_tokio_sampler_config.is_some());
+    assert_eq!(
+        run.metadata.finalized_at_unix_ms,
+        Some(run.metadata.finished_at_unix_ms)
+    );
 }
 
 #[test]
@@ -153,6 +157,10 @@ async fn record_runtime_snapshot_is_visible_in_snapshot_run() {
     });
 
     let imported = session.snapshot_run().expect("snapshot run");
+    assert_eq!(
+        imported.run().metadata.finalized_at_unix_ms,
+        Some(imported.run().metadata.finished_at_unix_ms)
+    );
     assert!(imported
         .run()
         .runtime_snapshots
@@ -176,6 +184,10 @@ async fn record_runtime_snapshot_is_visible_in_shutdown_output() {
     });
 
     let imported = session.shutdown().await.expect("shutdown");
+    assert_eq!(
+        imported.run().metadata.finalized_at_unix_ms,
+        Some(imported.run().metadata.finished_at_unix_ms)
+    );
     assert!(imported
         .run()
         .runtime_snapshots
@@ -227,4 +239,34 @@ async fn record_runtime_snapshot_does_not_alter_tracing_events() {
     assert_eq!(run.requests.len(), 1);
     assert_eq!(run.stages.len(), 1);
     assert_eq!(run.queues.len(), 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn runtime_snapshot_truncation_propagates_to_imported_run() {
+    let session = TracingTokioSession::builder("svc")
+        .max_runtime_snapshots(1)
+        .start()
+        .expect("start session");
+    session.record_runtime_snapshot(RuntimeSnapshot {
+        at_unix_ms: unix_time_ms(),
+        alive_tasks: Some(1),
+        global_queue_depth: Some(1),
+        local_queue_depth: Some(1),
+        blocking_queue_depth: Some(1),
+        remote_schedule_count: Some(1),
+    });
+    session.record_runtime_snapshot(RuntimeSnapshot {
+        at_unix_ms: unix_time_ms().saturating_add(1),
+        alive_tasks: Some(2),
+        global_queue_depth: Some(2),
+        local_queue_depth: Some(2),
+        blocking_queue_depth: Some(2),
+        remote_schedule_count: Some(2),
+    });
+
+    let imported = session.snapshot_run().expect("snapshot run");
+    let run = imported.run();
+    assert_eq!(run.runtime_snapshots.len(), 1);
+    assert_eq!(run.truncation.dropped_runtime_snapshots, 1);
+    assert!(run.truncation.limits_hit);
 }


### PR DESCRIPTION
### Motivation
- After tracing import was migrated to use `tailtriage_core::RunBuilder`, tighten behavioral guards to ensure live recorder and `TracingTokioSession` semantics (warnings, truncation, and schema-v1 finalization) remained unchanged.
- Preserve conservative, compatibility-first behavior: no runtime model changes or schema bumping, only stronger tests to catch regressions from the migration.

### Description
- Added focused tests in `tailtriage-tracing` to validate live recorder behavior and Tokio session merging without touching production code. 
- Tests added/modified: `tailtriage-tracing/src/recorder.rs` (strict open-span rejection assertion and completed-span retention assertion) and `tailtriage-tracing/tests/tokio_session.rs` (schema-v1 finalization checks and runtime snapshot truncation propagation test).
- Tests assert that strict recorder mode returns `ImportError::StrictViolation` for open candidate spans and that recorder warnings appear in both `ImportedRun::warnings()` and `run.metadata.lifecycle_warnings` and that completed-span retention remains first-N.
- Tests assert `TracingTokioSession` preserves tracing events, merges runtime snapshots and `metadata.effective_tokio_sampler_config`, preserves runtime truncation counters, and enforces schema-v1 finalization semantics (`finalized_at_unix_ms == Some(finished_at_unix_ms)`).

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo test -p tailtriage-tracing --all-features` and all tests passed (95 passed, 0 failed) after test additions.
- Ran `cargo test -p tailtriage-core` and it passed (66 passed, 0 failed).
- Ran `cargo test -p tailtriage-cli --all-features` and it passed (all CLI tests passed).
- Ran `cargo clippy -p tailtriage-tracing --all-targets --all-features -- -D warnings` and it completed without warnings.

Files changed: `tailtriage-tracing/src/recorder.rs`, `tailtriage-tracing/tests/tokio_session.rs`.
Code changes: tests only, no production code changes.
Behavioral confirmations: live recorder warnings and truncation behavior preserved; strict-mode still rejects open candidate spans without fabricating completions; Tokio session runtime merge and truncation propagation preserved; schema version was not bumped (still v1).
Commands run and results: `cargo fmt --check` (ok), `cargo test -p tailtriage-tracing --all-features` (ok), `cargo test -p tailtriage-core` (ok), `cargo test -p tailtriage-cli --all-features` (ok), `cargo clippy -p tailtriage-tracing --all-targets --all-features -- -D warnings` (ok).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b77bf67e08330ba6911bc8b46d322)