### PR TITLE
Tighten recorder and Tokio session behavior coverage after RunBuilder import migration

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -683,6 +683,7 @@ mod tests {
         });
         let imported = recorder.snapshot_run().unwrap();
         assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].request_id, "r1");
         assert!(imported
             .warnings()
             .iter()
@@ -795,6 +796,9 @@ mod tests {
                 tracing::info_span!("request", tt.kind = "request", tt.request_id = "r1").entered();
             let err = recorder.snapshot_run().unwrap_err();
             assert!(matches!(err, ImportError::StrictViolation(_)));
+            assert!(err
+                .to_string()
+                .contains("incomplete spans are not converted into fabricated completions"));
         });
     }
 

--- a/tailtriage-tracing/tests/tokio_session.rs
+++ b/tailtriage-tracing/tests/tokio_session.rs
@@ -67,6 +67,10 @@ async fn session_merges_tracing_and_runtime() {
     assert_eq!(run.queues[0].depth_at_start, Some(2));
     assert!(!run.runtime_snapshots.is_empty());
     assert!(run.metadata.effective_tokio_sampler_config.is_some());
+    assert_eq!(
+        run.metadata.finalized_at_unix_ms,
+        Some(run.metadata.finished_at_unix_ms)
+    );
 }
 
 #[test]
@@ -227,4 +231,34 @@ async fn record_runtime_snapshot_does_not_alter_tracing_events() {
     assert_eq!(run.requests.len(), 1);
     assert_eq!(run.stages.len(), 1);
     assert_eq!(run.queues.len(), 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn max_runtime_snapshots_limit_propagates_to_merged_output() {
+    let session = TracingTokioSession::builder("svc")
+        .max_runtime_snapshots(1)
+        .start()
+        .expect("start session");
+    let at = unix_time_ms();
+    session.record_runtime_snapshot(RuntimeSnapshot {
+        at_unix_ms: at,
+        alive_tasks: Some(1),
+        global_queue_depth: Some(1),
+        local_queue_depth: Some(1),
+        blocking_queue_depth: Some(1),
+        remote_schedule_count: Some(1),
+    });
+    session.record_runtime_snapshot(RuntimeSnapshot {
+        at_unix_ms: at + 1,
+        alive_tasks: Some(2),
+        global_queue_depth: Some(2),
+        local_queue_depth: Some(2),
+        blocking_queue_depth: Some(2),
+        remote_schedule_count: Some(2),
+    });
+
+    let run = session.snapshot_run().expect("snapshot").run().clone();
+    assert_eq!(run.runtime_snapshots.len(), 1);
+    assert_eq!(run.truncation.dropped_runtime_snapshots, 1);
+    assert!(run.truncation.limits_hit);
 }


### PR DESCRIPTION
### Motivation
- PR #662 moved tracing import through `tailtriage_core::RunBuilder`, so we must verify live recorder and `TracingTokioSession` behavior remained unchanged and schema v1 semantics are preserved. 
- Keep behavior conservative: preserve lifecycle warnings, truncation semantics, strict-mode errors, and finalized-timestamp semantics for persisted artifacts.

### Description
- Tests only: strengthened recorder tests in `tailtriage-tracing/src/recorder.rs` to assert first-N retention on completed-span saturation and that strict-mode errors explicitly reject fabricated completions. 
- Tests only: strengthened `TracingTokioSession` tests in `tailtriage-tracing/tests/tokio_session.rs` to assert `finalized_at_unix_ms == Some(finished_at_unix_ms)` for merged shutdown output and to verify runtime-snapshot truncation (`max_runtime_snapshots(1)`) propagates into merged `Run.truncation` counters. 
- No production API or schema changes were made and `SCHEMA_VERSION` remains 1.

### Testing
- Files changed: `tailtriage-tracing/src/recorder.rs`, `tailtriage-tracing/tests/tokio_session.rs`.
- Code changes: tests only (no runtime/logic changes required).
- Confirmations: live recorder warnings and truncation behavior preserved; strict recorder still errors on open candidate spans without fabricating completions; completed/open span drops emit lifecycle warnings and set `run.truncation.limits_hit = true`; tracing-only imports still produce empty runtime snapshots; `TracingTokioSession` preserves tracing evidence, runtime snapshots, `metadata.effective_tokio_sampler_config`, runtime truncation counters, lifecycle-warning ordering/deduplication, and schema v1 finalization semantics; `record_runtime_snapshot` still merges deterministic snapshots into the imported run.
- Commands run and results (all succeeded):
  - `cargo fmt --check` — OK
  - `cargo test -p tailtriage-tracing --all-features` — OK (all tests passed)
  - `cargo test -p tailtriage-core` — OK (all tests passed)
  - `cargo test -p tailtriage-cli --all-features` — OK (all tests passed)
  - `cargo clippy -p tailtriage-tracing --all-targets --all-features -- -D warnings` — OK
- Schema version: not bumped (`SCHEMA_VERSION = 1`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b77bf67e08330ba6911bc8b46d322)