### PR TITLE
docs: align tracing bridge docs with core run assembly

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,6 +42,7 @@ Owns the core capture model:
 - request lifecycle API (`StartedRequest`, `RequestHandle`, `RequestCompletion`)
 - queue/stage/inflight instrumentation wrappers
 - run artifact schema and sink behavior
+- completed-run assembly used by import/adaptation bridges
 - capture limits/truncation accounting
 
 ### `tailtriage-tokio`
@@ -64,6 +65,10 @@ Owns in-process analysis/report generation from completed runs:
 ### `tailtriage-cli`
 
 Consumes run artifacts from disk, validates schema/loader rules, invokes `tailtriage-analyzer`, and emits text/JSON output. CLI report rendering delegates to analyzer-owned renderers.
+
+### `tailtriage-tracing`
+
+Provides a narrow intake bridge for tracing-shaped completed spans and live `tt.*` span recording, converting both paths into standard core `Run` artifacts. It does not implement OpenTelemetry/OTLP and does not change analyzer behavior.
 
 ## Relationship model
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -13,7 +13,8 @@ This crate is intentionally narrow:
 - It does **not** implement OpenTelemetry or OTLP.
 - It does **not** change `tailtriage-analyzer`.
 
-Both JSONL import and live recorder intake produce standard `tailtriage_core::Run` values for the same analyzer/report workflow.
+JSONL import (`import_jsonl_reader` / `import_jsonl_path`), typed `SpanRecord` import (`run_from_span_records`), and live recorder intake (`TracingRecorder`, optionally `tokio::TracingTokioSession`) all assemble standard `tailtriage_core::Run` artifacts through core-owned completed-run assembly for the same analyzer/report workflow.
+Completed tracing import output follows the same bounded retention and truncation semantics as other core-built runs.
 
 ## JSONL import support in this phase
 


### PR DESCRIPTION
### Motivation
- Finish documentation and PR-description cleanup for the RunBuilder + tracing import refactor so the repo docs accurately describe how tracing import/recorder now assemble core `Run` artifacts. 
- Keep the public tracing user surface unchanged and emphasize that completed-run assembly and truncation/retention semantics are core-owned.

### Description
- Updated `tailtriage-tracing/README.md` to state that `import_jsonl_reader`/`import_jsonl_path`, `run_from_span_records`, and `TracingRecorder` (optionally `tokio::TracingTokioSession`) assemble standard `tailtriage_core::Run` artifacts via core-owned completed-run assembly and added a concise note that tracing imports follow the same bounded retention/truncation semantics as core-built runs. 
- Updated `docs/architecture.md` to note that `tailtriage-core` owns completed-run assembly for import/adaptation bridges and added a short `tailtriage-tracing` crate-role description clarifying its narrow intake role and non-OTLP stance. 
- No code changes were made and `SCHEMA_VERSION` was not bumped, and the user-facing tracing APIs remain `run_from_span_records`, `import_jsonl_reader`, `import_jsonl_path`, `TracingRecorder`, and optional `tokio::TracingTokioSession`.

### Testing
- Ran `cargo fmt --check` and it passed. 
- Ran `cargo test -p tailtriage-core`, `cargo test -p tailtriage-tracing --all-features`, and `cargo test -p tailtriage-cli --all-features`, and all test suites passed. 
- Ran `cargo clippy -p tailtriage-tracing --all-targets --all-features -- -D warnings` and it passed with no warnings. 
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bf3694e648330a2f87628f2f95ee8)