### PR TITLE
docs: document core completed-run assembly and update tracing intake README

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,6 +43,7 @@ Owns the core capture model:
 - queue/stage/inflight instrumentation wrappers
 - run artifact schema and sink behavior
 - capture limits/truncation accounting
+- completed-run assembly for import/adaptation bridges (with the same bounded retention/truncation semantics as live capture)
 
 ### `tailtriage-tokio`
 
@@ -51,6 +52,11 @@ Adds optional runtime-pressure snapshots to the same run artifact via `RuntimeSa
 ### `tailtriage-axum`
 
 Adds optional Axum request-boundary ergonomics (middleware + extractor).
+
+### `tailtriage-tracing`
+
+A narrow intake bridge for tracing-shaped completed spans and live `tt.*` span recording.
+It converts/imports tracing evidence into standard core `Run` artifacts, does not implement OpenTelemetry/OTLP, and does not change analyzer behavior.
 
 ### `tailtriage-analyzer`
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -13,14 +13,18 @@ This crate is intentionally narrow:
 - It does **not** implement OpenTelemetry or OTLP.
 - It does **not** change `tailtriage-analyzer`.
 
-Both JSONL import and live recorder intake produce standard `tailtriage_core::Run` values for the same analyzer/report workflow.
+JSONL import, typed `SpanRecord` import, and live recorder intake all assemble standard `tailtriage_core::Run` artifacts through core-owned completed-run assembly.
+Completed tracing import output follows the same bounded retention/truncation semantics as core-built runs.
 
 ## JSONL import support in this phase
 
 Public APIs:
 
+- `run_from_span_records(records, options)`
 - `import_jsonl_reader(reader, options)`
 - `import_jsonl_path(path, options)`
+- `TracingRecorder`
+- optional `tokio::TracingTokioSession`
 
 ### Canonical JSONL shape (stable authoring contract)
 


### PR DESCRIPTION
### Motivation
- Finish documentation and PR-description cleanup for the RunBuilder + tracing import refactor so crate roles and the public tracing intake story accurately reflect the current implementation and retention semantics.

### Description
- Updated `tailtriage-tracing/README.md` to state that JSONL import, typed `SpanRecord` import, and live recorder intake assemble standard `tailtriage_core::Run` artifacts via core-owned completed-run assembly, added the explicit public-API list (`run_from_span_records`, `import_jsonl_reader`, `import_jsonl_path`, `TracingRecorder`, optional `tokio::TracingTokioSession`), and noted that completed tracing import follows the same bounded retention/truncation semantics as core-built runs. (file changed)
- Updated `docs/architecture.md` to state that `tailtriage-core` owns completed-run assembly for import/adaptation bridges and to add a concise `tailtriage-tracing` crate-role section clarifying its narrow intake scope and non-goals (no OTel/OTLP, no analyzer behavior change). (file changed)
- Updated the PR #662 description to reflect the implemented core `RunBuilder` + shared truncation helper, the tracing import/refactor (`run_from_span_records` using core assembly), preserved schema v1 finalization semantics, strengthened recorder/Tokio session tests, and docs updates; no runtime behavior changes or schema bump. Files changed: `tailtriage-tracing/README.md`, `docs/architecture.md`; no Rust code behavior changes were made.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo test -p tailtriage-core` and unit/doc tests passed (66 tests + 8 doc-tests passed).
- Ran `cargo test -p tailtriage-tracing --all-features` and package tests and integration equivalence/tokio-session tests passed (95 tests + additional test suites passed).
- Ran `cargo test -p tailtriage-cli --all-features` and all tests passed.
- Ran `cargo clippy -p tailtriage-tracing --all-targets --all-features -- -D warnings` and it passed with no warnings.
- Ran `python3 scripts/validate_docs_contracts.py` and docs contracts validated successfully.

Notes: `SCHEMA_VERSION` was not bumped and no code changes were introduced; this change is documentation and PR-description alignment only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bf3694e648330a2f87628f2f95ee8)