### PR TITLE
docs: finalize RunBuilder + tracing import wording and update PR description

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,6 +43,7 @@ Owns the core capture model:
 - queue/stage/inflight instrumentation wrappers
 - run artifact schema and sink behavior
 - capture limits/truncation accounting
+- completed-run assembly for import/adaptation bridges, with the same core truncation semantics
 
 ### `tailtriage-tokio`
 
@@ -60,6 +61,11 @@ Owns in-process analysis/report generation from completed runs:
 - `analyze_run` entry point
 - `render_text` human-readable rendering
 - analyzer-owned Report JSON rendering (`render_json`, `render_json_pretty`)
+
+
+### `tailtriage-tracing`
+
+A narrow tracing intake bridge for completed tracing-shaped spans and live `tt.*` span recording. It converts/imports tracing intake into standard core `Run` artifacts, does not implement OpenTelemetry/OTLP, and does not change analyzer behavior.
 
 ### `tailtriage-cli`
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -13,7 +13,9 @@ This crate is intentionally narrow:
 - It does **not** implement OpenTelemetry or OTLP.
 - It does **not** change `tailtriage-analyzer`.
 
-Both JSONL import and live recorder intake produce standard `tailtriage_core::Run` values for the same analyzer/report workflow.
+JSONL import, typed `SpanRecord` import via `run_from_span_records`, and live recorder intake all assemble standard `tailtriage_core::Run` artifacts through core-owned completed-run assembly. Completed tracing import output follows the same bounded retention/truncation semantics as core-built runs.
+
+Use these user-facing APIs for tracing intake workflows: `run_from_span_records`, `import_jsonl_reader`, `import_jsonl_path`, `TracingRecorder`, and optional `tokio::TracingTokioSession`.
 
 ## JSONL import support in this phase
 


### PR DESCRIPTION
### Motivation
- Finish documentation and PR-description cleanup for the RunBuilder + tracing import refactor so docs accurately reflect that completed-run assembly is core-owned and that tracing import and recorder now use that assembly path.

### Description
- Updated `tailtriage-tracing/README.md` to state that JSONL import, typed `SpanRecord` import via `run_from_span_records`, and live recorder intake all assemble standard `tailtriage_core::Run` artifacts through core-owned completed-run assembly, to list the user-facing tracing intake APIs, and to note that completed tracing import follows the same bounded retention/truncation semantics as core-built runs. 
- Updated `docs/architecture.md` to add that `tailtriage-core` owns completed-run assembly for import/adaptation bridges and to add a concise `tailtriage-tracing` crate-role description that it is a narrow intake bridge, does not implement OpenTelemetry/OTLP, and does not change analyzer behavior. 
- Files changed: `tailtriage-tracing/README.md`, `docs/architecture.md`; no runtime/code logic changes were made and `SCHEMA_VERSION` was not bumped; the PR description/body was prepared to match the new scope and testing notes.

### Testing
- Ran `cargo fmt --check` and it passed. 
- Ran `cargo test -p tailtriage-core` and `cargo test -p tailtriage-tracing --all-features` and `cargo test -p tailtriage-cli --all-features`, and all tests passed. 
- Ran `cargo clippy -p tailtriage-tracing --all-targets --all-features -- -D warnings` and it passed with no warnings. 
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed. 
- CI was reported green at commit `058cd89ceda819e84c99bf060b344d068e3986bd` prior to these doc edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bf3694e648330a2f87628f2f95ee8)