### PR TITLE
docs: align tracing README & architecture with RunBuilder-based completed-run assembly

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,6 +43,7 @@ Owns the core capture model:
 - queue/stage/inflight instrumentation wrappers
 - run artifact schema and sink behavior
 - capture limits/truncation accounting
+- completed-run assembly used by import/adaptation bridges
 
 ### `tailtriage-tokio`
 
@@ -64,6 +65,11 @@ Owns in-process analysis/report generation from completed runs:
 ### `tailtriage-cli`
 
 Consumes run artifacts from disk, validates schema/loader rules, invokes `tailtriage-analyzer`, and emits text/JSON output. CLI report rendering delegates to analyzer-owned renderers.
+
+### `tailtriage-tracing`
+
+A narrow intake bridge for tracing-shaped completed spans and live `tt.*` span recording.
+It converts/imports tracing intake into standard core `Run` artifacts, does not implement OpenTelemetry/OTLP, and does not change analyzer behavior.
 
 ## Relationship model
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -1,19 +1,19 @@
 # tailtriage-tracing
 
-`tailtriage-tracing` is a focused intake bridge surface for tracing-shaped span
-records that can be converted into `tailtriage_core::Run` inputs.
+`tailtriage-tracing` is a focused intake bridge surface for tracing-shaped completed spans that are assembled into standard `tailtriage_core::Run` artifacts through core-owned completed-run assembly.
 
 This crate is intentionally narrow:
 
 - It defines semantic convention keys (`tt.*`) for triage-oriented span fields.
 - It defines typed intake records and import option/result types.
 - It converts typed `SpanRecord` values with `run_from_span_records`.
-- It imports JSONL from readers/paths when records contain completed span timing.
-- It provides an in-process `tracing_subscriber::Layer` recorder for completed `tt.*` spans.
+- It imports JSONL from readers/paths when records contain completed span timing (`import_jsonl_reader` / `import_jsonl_path`).
+- It provides an in-process `tracing_subscriber::Layer` recorder (`TracingRecorder`) for completed `tt.*` spans.
+- It optionally couples live tracing intake with Tokio runtime snapshots via `tokio::TracingTokioSession`.
 - It does **not** implement OpenTelemetry or OTLP.
 - It does **not** change `tailtriage-analyzer`.
 
-Both JSONL import and live recorder intake produce standard `tailtriage_core::Run` values for the same analyzer/report workflow.
+JSONL import, typed `SpanRecord` import, and live recorder intake all produce standard `tailtriage_core::Run` values for the same analyzer/report workflow via core-owned completed-run assembly. Completed tracing import output follows the same bounded retention/truncation semantics as core-built runs.
 
 ## JSONL import support in this phase
 


### PR DESCRIPTION
### Motivation
- Finish documentation and PR-description cleanup to reflect that tracing import and live recorder now assemble completed `Run` artifacts via core-owned `RunBuilder` instead of exposing `RunBuilder` as the primary tracing surface. 
- Keep user-facing tracing APIs and existing caveats accurate while preserving core truncation/retention semantics and schema v1 finalization behavior.

### Description
- Updated `tailtriage-tracing/README.md` to state that JSONL import, typed `SpanRecord` import, and live recorder intake assemble standard `tailtriage_core::Run` artifacts through core-owned completed-run assembly, and to keep the user-facing intake surface as `run_from_span_records`, `import_jsonl_reader`, `import_jsonl_path`, `TracingRecorder`, and optional `tokio::TracingTokioSession`.
- Added an architecture note in `docs/architecture.md` that `tailtriage-core` owns completed-run assembly for import/adaptation bridges and added a concise `tailtriage-tracing` crate-role section describing tracing as a narrow intake bridge that converts to standard core `Run` artifacts and does not change analyzer behavior.
- Updated the PR #662 description to reflect the actual changes: added core `RunBuilder`/`RunBuilderOptions`, shared bounded retention/truncation helper, `tailtriage-tracing::run_from_span_records` using core RunBuilder, preserved schema v1 finalization semantics, strengthened recorder and Tokio session tests, and docs updates.
- Files changed: `tailtriage-tracing/README.md`, `docs/architecture.md`; no production code changes were made and `SCHEMA_VERSION` was not bumped.

### Testing
- Ran formatting and tests: `cargo fmt --check`, `cargo test -p tailtriage-core`, `cargo test -p tailtriage-tracing --all-features`, and `cargo test -p tailtriage-cli --all-features`, all of which completed successfully.
- Ran lints and docs validation: `cargo clippy -p tailtriage-tracing --all-targets --all-features -- -D warnings` and `python3 scripts/validate_docs_contracts.py`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bf3694e648330a2f87628f2f95ee8)