### PR TITLE
Fix tracing intake silent-loss blockers in PR #547 follow-up

### DIFF
--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -139,7 +139,19 @@ fn parse_record(
     }
 
     match parse_close_event_shape(value) {
-        Ok(result) => Ok(result),
+        Ok(Some(result)) => Ok(Some(result)),
+        Ok(None) if has_tt => {
+            let message = format!(
+                "line {line_no}: tailtriage JSONL record must use normalized span shape or supported close-event shape with explicit timestamps"
+            );
+            if strict {
+                Err(ImportError::StrictViolation(message))
+            } else {
+                warnings.push(crate::ImportWarning::new(message));
+                Ok(None)
+            }
+        }
+        Ok(None) => Ok(None),
         Err(err) if has_tt => {
             let message = format!("line {line_no}: {err}");
             if strict {
@@ -770,6 +782,47 @@ mod tests {
         let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
             .unwrap_err();
         assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn top_level_tt_record_without_span_shape_warns_non_strict() {
+        let input = r#"{"tt.kind":"request","tt.request_id":"r1","tt.route":"/checkout"}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.run().stages.is_empty());
+        assert!(imported.run().queues.is_empty());
+        assert_eq!(imported.warnings().len(), 1);
+        let msg = imported.warnings()[0].message();
+        assert!(msg.contains("line 1"));
+        assert!(msg.contains("normalized span shape") || msg.contains("explicit timestamps"));
+        assert!(imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|w| w == msg));
+    }
+
+    #[test]
+    fn top_level_tt_record_without_span_shape_errors_strict() {
+        let input = r#"{"tt.kind":"request","tt.request_id":"r1","tt.route":"/checkout"}"#;
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+            .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(
+            err.to_string().contains("normalized span shape")
+                || err.to_string().contains("explicit timestamps")
+        );
+    }
+
+    #[test]
+    fn unrelated_top_level_json_record_still_ignored() {
+        let input = r#"{"message":"ordinary log","level":"info","request_id":"r1"}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.run().stages.is_empty());
+        assert!(imported.run().queues.is_empty());
+        assert!(imported.warnings().is_empty());
     }
 
     #[test]

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -338,15 +338,21 @@ fn imported_with_drop_warnings(
     let open_samples = stats.open_samples.as_slice();
     let closed_missing_kind_spans = stats.closed_missing_kind_spans;
     let closed_missing_kind_samples = stats.closed_missing_kind_samples.as_slice();
-    if options.strict_mode() && (open_candidate_count > 0 || closed_missing_kind_spans > 0) {
-        return Err(ImportError::StrictViolation(format!(
-            "live recorder observed {open_candidate_count} open candidate span(s) at snapshot/shutdown; incomplete spans are not converted into fabricated completions"
-        )));
-    }
-    if options.strict_mode() && closed_missing_kind_spans > 0 {
-        return Err(ImportError::StrictViolation(format!(
-            "live recorder closed {closed_missing_kind_spans} candidate span(s) missing tt.kind; closed candidate spans without tt.kind are not converted"
-        )));
+    if options.strict_mode() {
+        let mut messages = Vec::new();
+        if open_candidate_count > 0 {
+            messages.push(format!(
+                "live recorder observed {open_candidate_count} open candidate span(s) at snapshot/shutdown; incomplete spans are not converted into fabricated completions"
+            ));
+        }
+        if closed_missing_kind_spans > 0 {
+            messages.push(format!(
+                "live recorder closed {closed_missing_kind_spans} candidate span(s) missing tt.kind; closed candidate spans without tt.kind are not converted"
+            ));
+        }
+        if !messages.is_empty() {
+            return Err(ImportError::StrictViolation(messages.join("; ")));
+        }
     }
     let imported = run_from_span_records(spans, options)?;
     if dropped_open_spans == 0
@@ -861,10 +867,9 @@ mod tests {
         match err {
             ImportError::StrictViolation(message) => {
                 assert!(
-                    message.contains("tt.kind")
-                        || message.contains("closed")
-                        || message.contains("open candidate")
+                    message.contains("missing tt.kind") || message.contains("closed candidate")
                 );
+                assert!(!message.contains("0 open candidate span(s)"));
             }
             other => panic!("unexpected error: {other:?}"),
         }
@@ -884,7 +889,47 @@ mod tests {
             drop(span);
         });
         let err = recorder.shutdown().unwrap_err();
-        assert!(matches!(err, ImportError::StrictViolation(_)));
+        match err {
+            ImportError::StrictViolation(message) => {
+                assert!(
+                    message.contains("missing tt.kind") || message.contains("closed candidate")
+                );
+                assert!(!message.contains("0 open candidate span(s)"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn strict_mode_reports_open_and_closed_missing_kind_causes_together() {
+        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let _open = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r-open",
+                tt.route = "/open"
+            )
+            .entered();
+            let closed_missing_kind = tracing::info_span!(
+                "stage.db",
+                tt.kind = tracing::field::Empty,
+                tt.request_id = "r-closed"
+            );
+            drop(closed_missing_kind);
+
+            let err = recorder.snapshot_run().unwrap_err();
+            match err {
+                ImportError::StrictViolation(message) => {
+                    assert!(message.contains("open candidate span(s)"));
+                    assert!(
+                        message.contains("missing tt.kind") || message.contains("closed candidate")
+                    );
+                }
+                other => panic!("unexpected error: {other:?}"),
+            }
+        });
     }
 
     #[test]

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -61,6 +61,8 @@ struct RecorderState {
     completed: Vec<SpanRecord>,
     dropped_open_spans: u64,
     dropped_completed_spans: u64,
+    closed_missing_kind_spans: u64,
+    closed_missing_kind_samples: Vec<ClosedMissingKindSample>,
 }
 
 #[derive(Debug)]
@@ -82,6 +84,21 @@ struct OpenSpanSample {
     tt_request_id: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+struct ClosedMissingKindSample {
+    name: String,
+    span_id: Option<String>,
+    tt_request_id: Option<String>,
+}
+
+struct SnapshotStats {
+    dropped_open_spans: u64,
+    dropped_completed_spans: u64,
+    open_candidate_count: u64,
+    open_samples: Vec<OpenSpanSample>,
+    closed_missing_kind_spans: u64,
+    closed_missing_kind_samples: Vec<ClosedMissingKindSample>,
+}
 fn lock_state(state: &Arc<Mutex<RecorderState>>) -> std::sync::MutexGuard<'_, RecorderState> {
     match state.lock() {
         Ok(guard) => guard,
@@ -113,13 +130,7 @@ impl TracingRecorder {
     ///
     /// Returns [`ImportError`] when strict conversion fails.
     pub fn snapshot_run(&self) -> Result<ImportedRun, ImportError> {
-        let (
-            spans,
-            dropped_open_spans,
-            dropped_completed_spans,
-            open_candidate_count,
-            open_samples,
-        ) = {
+        let (spans, stats) = {
             let state = lock_state(&self.state);
             let mut samples = Vec::new();
             let mut count = 0_u64;
@@ -138,20 +149,17 @@ impl TracingRecorder {
             }
             (
                 state.completed.clone(),
-                state.dropped_open_spans,
-                state.dropped_completed_spans,
-                count,
-                samples,
+                SnapshotStats {
+                    dropped_open_spans: state.dropped_open_spans,
+                    dropped_completed_spans: state.dropped_completed_spans,
+                    open_candidate_count: count,
+                    open_samples: samples,
+                    closed_missing_kind_spans: state.closed_missing_kind_spans,
+                    closed_missing_kind_samples: state.closed_missing_kind_samples.clone(),
+                },
             )
         };
-        imported_with_drop_warnings(
-            spans,
-            self.options.clone(),
-            dropped_open_spans,
-            dropped_completed_spans,
-            open_candidate_count,
-            &open_samples,
-        )
+        imported_with_drop_warnings(spans, self.options.clone(), &stats)
     }
 
     /// Converts currently completed spans into an imported run.
@@ -267,6 +275,21 @@ where
         let mut state = lock_state(&self.state);
         if let Some(open) = state.open.remove(&id.into_u64()) {
             if !open.fields.contains_key(TT_KIND) {
+                if open.is_tt_candidate {
+                    state.closed_missing_kind_spans =
+                        state.closed_missing_kind_spans.saturating_add(1);
+                    if state.closed_missing_kind_samples.len() < 3 {
+                        state
+                            .closed_missing_kind_samples
+                            .push(ClosedMissingKindSample {
+                                name: open.name.clone(),
+                                span_id: open.id.clone(),
+                                tt_request_id: scalar_field_string(
+                                    open.fields.get("tt.request_id"),
+                                ),
+                            });
+                    }
+                }
                 return;
             }
             let mut record = SpanRecord::new(
@@ -307,18 +330,30 @@ fn fields_have_tailtriage_key(fields: &BTreeMap<String, FieldValue>) -> bool {
 fn imported_with_drop_warnings(
     spans: Vec<SpanRecord>,
     options: ImportOptions,
-    dropped_open_spans: u64,
-    dropped_completed_spans: u64,
-    open_candidate_count: u64,
-    open_samples: &[OpenSpanSample],
+    stats: &SnapshotStats,
 ) -> Result<ImportedRun, ImportError> {
-    if options.strict_mode() && open_candidate_count > 0 {
+    let dropped_open_spans = stats.dropped_open_spans;
+    let dropped_completed_spans = stats.dropped_completed_spans;
+    let open_candidate_count = stats.open_candidate_count;
+    let open_samples = stats.open_samples.as_slice();
+    let closed_missing_kind_spans = stats.closed_missing_kind_spans;
+    let closed_missing_kind_samples = stats.closed_missing_kind_samples.as_slice();
+    if options.strict_mode() && (open_candidate_count > 0 || closed_missing_kind_spans > 0) {
         return Err(ImportError::StrictViolation(format!(
             "live recorder observed {open_candidate_count} open candidate span(s) at snapshot/shutdown; incomplete spans are not converted into fabricated completions"
         )));
     }
+    if options.strict_mode() && closed_missing_kind_spans > 0 {
+        return Err(ImportError::StrictViolation(format!(
+            "live recorder closed {closed_missing_kind_spans} candidate span(s) missing tt.kind; closed candidate spans without tt.kind are not converted"
+        )));
+    }
     let imported = run_from_span_records(spans, options)?;
-    if dropped_open_spans == 0 && dropped_completed_spans == 0 && open_candidate_count == 0 {
+    if dropped_open_spans == 0
+        && dropped_completed_spans == 0
+        && open_candidate_count == 0
+        && closed_missing_kind_spans == 0
+    {
         return Ok(imported);
     }
     let (mut run, mut warnings) = imported.into_parts();
@@ -335,6 +370,29 @@ fn imported_with_drop_warnings(
                         sample.name,
                         sample.span_id.as_deref().unwrap_or("-"),
                         sample.tt_kind.as_deref().unwrap_or("-"),
+                        sample.tt_request_id.as_deref().unwrap_or("-")
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("; ");
+            let _ = write!(&mut msg, "; samples: {sample_text}");
+        }
+        run.metadata.lifecycle_warnings.push(msg.clone());
+        warnings.push(crate::ImportWarning::new(msg));
+    }
+
+    if closed_missing_kind_spans > 0 {
+        let mut msg = format!(
+            "live recorder closed {closed_missing_kind_spans} candidate span(s) missing tt.kind; closed candidate spans without tt.kind are not converted"
+        );
+        if !closed_missing_kind_samples.is_empty() {
+            let sample_text = closed_missing_kind_samples
+                .iter()
+                .map(|sample| {
+                    format!(
+                        "name={}, id={}, tt.request_id={}",
+                        sample.name,
+                        sample.span_id.as_deref().unwrap_or("-"),
                         sample.tt_request_id.as_deref().unwrap_or("-")
                     )
                 })
@@ -759,6 +817,88 @@ mod tests {
         assert!(matches!(err, ImportError::EmptyServiceName));
     }
 
+    #[test]
+    fn closed_candidate_missing_tt_kind_warns_non_strict() {
+        with_recorder(|recorder| {
+            let span = tracing::info_span!(
+                "http.request",
+                tt.kind = tracing::field::Empty,
+                tt.request_id = "r1",
+                tt.route = "/checkout"
+            );
+            drop(span);
+            let imported = recorder.snapshot_run().unwrap();
+            assert!(imported.run().requests.is_empty());
+            assert!(imported.run().stages.is_empty());
+            assert!(imported.run().queues.is_empty());
+            assert_eq!(imported.warnings().len(), 1);
+            let msg = imported.warnings()[0].message();
+            assert!(msg.contains("missing tt.kind"));
+            assert!(msg.contains("http.request") || msg.contains("r1"));
+            assert!(imported
+                .run()
+                .metadata
+                .lifecycle_warnings
+                .iter()
+                .any(|w| w == msg));
+        });
+    }
+
+    #[test]
+    fn closed_candidate_missing_tt_kind_errors_strict() {
+        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!(
+                "http.request",
+                tt.kind = tracing::field::Empty,
+                tt.request_id = "r1",
+                tt.route = "/checkout"
+            );
+            drop(span);
+        });
+        let err = recorder.snapshot_run().unwrap_err();
+        match err {
+            ImportError::StrictViolation(message) => {
+                assert!(
+                    message.contains("tt.kind")
+                        || message.contains("closed")
+                        || message.contains("open candidate")
+                );
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn closed_candidate_missing_tt_kind_shutdown_errors_strict() {
+        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!(
+                "http.request",
+                tt.kind = tracing::field::Empty,
+                tt.request_id = "r1",
+                tt.route = "/checkout"
+            );
+            drop(span);
+        });
+        let err = recorder.shutdown().unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn unrelated_closed_span_still_ignored_without_warning() {
+        with_recorder(|recorder| {
+            let span = tracing::info_span!("ordinary", user_id = 7_u64);
+            drop(span);
+            let imported = recorder.snapshot_run().unwrap();
+            assert!(imported.run().requests.is_empty());
+            assert!(imported.run().stages.is_empty());
+            assert!(imported.run().queues.is_empty());
+            assert!(imported.warnings().is_empty());
+        });
+    }
     #[test]
     fn strict_mode_rejects_open_candidate_spans_without_fabricating_completions() {
         let recorder = TracingRecorder::builder("svc").strict(true).build();


### PR DESCRIPTION
### Motivation

- Two silent-loss gaps were found in tracing intake: closed live-recorder candidate spans that never receive a final `tt.kind` were discarded silently, and JSONL lines with top-level `tt.*` keys but no supported span/close-event shape were ignored without feedback.
- The intent is to surface these problems as warnings in non-strict mode and as strict import errors in strict mode, while preserving existing semantics (no fabricated completions, no schema bump, no analyzer/CLI behavioral drift). 

### Description

- Files changed: `tailtriage-tracing/src/recorder.rs` and `tailtriage-tracing/src/jsonl.rs`.
- Live recorder (recorder.rs): added accounting for closed-but-missing-`tt.kind` candidates (`closed_missing_kind_spans`) and a bounded sample list (`closed_missing_kind_samples`), capture on `on_close`, and inclusion of these stats in the snapshot path via a `SnapshotStats` struct; non-strict snapshots append lifecycle warnings (and persist them to `run.metadata.lifecycle_warnings`), strict mode returns `ImportError::StrictViolation`; no request/stage/queue completions are fabricated.
- JSONL parser (jsonl.rs): updated `parse_record` so that when `value_has_tailtriage_field` is true but neither normalized `span` nor supported close-event shape is matched, the code now emits a line-aware import warning and skips the record in non-strict mode and returns `ImportError::StrictViolation` in strict mode, with a clear explanatory message about the supported shapes and explicit timestamps.
- Tests: added recorder tests covering closed-candidate missing-`tt.kind` behavior (non-strict warning + lifecycle persistence, strict errors for `snapshot_run()` and `shutdown()`, unrelated closed spans still ignored) and JSONL tests covering top-level `tt.*` unsupported-shape warning/error and unrelated top-level-record ignore; preserved and ran all existing normalized/close-event shape tests.
- Scope constraints preserved: no public API redesign, no Run schema bump, no analyzer changes, no new dependencies, and no fabricated completions.

### Testing

- Ran `cargo fmt --check` and `cargo clippy -p tailtriage-tracing --all-targets --all-features -- -D warnings` and both passed.
- Ran unit tests: `cargo test -p tailtriage-tracing --all-features` and `cargo test -p tailtriage-cli --all-features` and all tests passed (new recorder/jsonl tests included and green).
- Ran docs contract validation: `python3 scripts/validate_docs_contracts.py` and it passed.
- Ran tracing parity demo validation: `python3 scripts/demo_tool.py validate-tracing-parity all --profile release` and it completed successfully.

All automated checks listed above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c2187b5588330a53c6fd29b0fc7d5)