### PR TITLE
Tighten runtime-cost smoke to enforce tracing/native parity thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,7 @@ jobs:
             --requests 1200 \
             --concurrency 32 \
             --work-ms 4 \
-            --rounds 2 \
+            --rounds 4 \
             --warmup-rounds 1 \
             --artifact-dir demos/runtime_cost/artifacts/ci-smoke
 

--- a/docs/runtime-cost.md
+++ b/docs/runtime-cost.md
@@ -60,7 +60,7 @@ python3 scripts/measure_runtime_cost.py \
   --requests 1200 \
   --concurrency 32 \
   --work-ms 4 \
-  --rounds 2 \
+  --rounds 4 \
   --warmup-rounds 1 \
   --artifact-dir demos/runtime_cost/artifacts/ci-smoke
 python3 scripts/validate_runtime_cost_summary.py \
@@ -68,7 +68,19 @@ python3 scripts/validate_runtime_cost_summary.py \
   --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json
 ```
 
-This is a bounded diagnostic sanity check only. It enforces broad catastrophic-regression checks and required tracing evidence shape, not rigorous performance benchmarking. CI validates runtime-cost output in-place and does not upload runtime-cost artifacts by default. Full runtime-cost measurement remains a local/developer-run path via the canonical command above. Results remain machine/workload/profile scoped.
+This is a bounded diagnostic sanity check only. It enforces tracing/native parity hard thresholds, required tracing evidence shape, and finite/missing-metric validation, not rigorous performance benchmarking.
+
+Hard tracing/native parity thresholds in CI smoke:
+
+- `tracing_*_vs_core_*_latency_p95 <= 1.25x`
+- `tracing_*_vs_core_*_throughput >= 0.75x`
+
+Soft warning band (non-failing):
+
+- p95 ratio warning when `> 1.05x`
+- throughput ratio warning when `< 0.95x`
+
+Minor wins/losses inside the warning band are treated as parity; they are not a reason to change the default recommendation. Native remains the default instrumentation path because it is direct, explicit, and complete. Tracing remains a first-class intake bridge for users already using tracing or preferring span-shaped instrumentation, and should remain close to native in cost. CI validates runtime-cost output in-place and does not upload runtime-cost artifacts by default. Full runtime-cost measurement remains a local/developer-run path via the canonical command above. Results remain machine/workload/profile scoped.
 
 ## Inputs and knobs
 
@@ -97,7 +109,7 @@ Per-mode records now include instrumentation family (`baseline` / `native` / `tr
 - Use **Post-limit / drop-path overhead** only for intentionally saturated-limit behavior.
 
 If `measurement_quality` reports noisy/unstable, rerun on a quieter machine state before drawing stronger conclusions.
-Numbers are directional and machine/workload/profile scoped; broad thresholds are intended only to catch catastrophic regressions.
+Numbers are directional and machine/workload/profile scoped; CI smoke remains a bounded regression check rather than a rigorous benchmark.
 
 ## Semantics reminder
 

--- a/scripts/measure_runtime_cost.py
+++ b/scripts/measure_runtime_cost.py
@@ -52,6 +52,10 @@ QUALITY_UNSTABLE = "unstable"
 QUALITY_INSUFFICIENT_DATA = "insufficient_data"
 MIN_ROUNDS_FOR_STABLE = 4
 
+TRACING_NATIVE_P95_HARD_LIMIT = 1.25
+TRACING_NATIVE_THROUGHPUT_HARD_FLOOR = 0.75
+TRACING_NATIVE_SOFT_WARNING_BAND = 0.05
+
 DELTA_VS_BASELINE_MODE_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("Baked-in overhead", ("baked_in_no_request_context",)),
     ("Core mode overhead", UNSATURATED_CORE_MODES),
@@ -350,6 +354,13 @@ def summarize(raw_path: Path, summary_path: Path) -> dict:
 
 
 def _validate_sanity(summary: dict) -> None:
+    measured_rounds = summary.get("measured_rounds")
+    if measured_rounds is None or measured_rounds < MIN_ROUNDS_FOR_STABLE:
+        raise SystemExit(
+            f"measured_rounds must be >= {MIN_ROUNDS_FOR_STABLE} for runtime-cost CI smoke "
+            f"(got {measured_rounds})"
+        )
+
     abs_m = summary["absolute_metrics"]
     required = ("core_light", "tracing_light", "tracing_light_tokio_sampler")
     for mode in MODES:
@@ -381,26 +392,61 @@ def _validate_sanity(summary: dict) -> None:
             raise SystemExit(f"{key} is required and cannot be null (likely zero/missing denominator)")
         if value != value or value in (float("inf"), float("-inf")):
             raise SystemExit(f"{key} must be finite (not NaN or infinity)")
-    if ratios["tracing_light_vs_core_light_latency_p95"] > 20:
-        raise SystemExit("tracing_light_vs_core_light_latency_p95 exceeds catastrophic threshold (>20x)")
-    if ratios["tracing_light_vs_core_light_throughput"] < 0.05:
-        raise SystemExit("tracing_light_vs_core_light_throughput is below catastrophic threshold (<0.05x)")
-    if ratios["tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95"] > 20:
-        raise SystemExit(
-            "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95 exceeds catastrophic threshold (>20x)"
-        )
-    if ratios["tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput"] < 0.05:
-        raise SystemExit(
-            "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput is below catastrophic threshold (<0.05x)"
-        )
-    if ratios["tracing_light_drop_path_vs_core_light_drop_path_latency_p95"] > 20:
-        raise SystemExit(
-            "tracing_light_drop_path_vs_core_light_drop_path_latency_p95 exceeds catastrophic threshold (>20x)"
-        )
-    if ratios["tracing_light_drop_path_vs_core_light_drop_path_throughput"] < 0.05:
-        raise SystemExit(
-            "tracing_light_drop_path_vs_core_light_drop_path_throughput is below catastrophic threshold (<0.05x)"
-        )
+
+    latency_keys = (
+        "tracing_light_vs_core_light_latency_p95",
+        "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95",
+        "tracing_light_drop_path_vs_core_light_drop_path_latency_p95",
+    )
+    throughput_keys = (
+        "tracing_light_vs_core_light_throughput",
+        "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput",
+        "tracing_light_drop_path_vs_core_light_drop_path_throughput",
+    )
+
+    for key in latency_keys:
+        ratio = ratios[key]
+        if ratio > TRACING_NATIVE_P95_HARD_LIMIT:
+            raise SystemExit(f"{key} exceeds parity threshold (>{TRACING_NATIVE_P95_HARD_LIMIT}x)")
+
+    for key in throughput_keys:
+        ratio = ratios[key]
+        if ratio < TRACING_NATIVE_THROUGHPUT_HARD_FLOOR:
+            raise SystemExit(f"{key} is below parity threshold (<{TRACING_NATIVE_THROUGHPUT_HARD_FLOOR}x)")
+
+    soft_latency_limit = 1.0 + TRACING_NATIVE_SOFT_WARNING_BAND
+    soft_throughput_floor = 1.0 - TRACING_NATIVE_SOFT_WARNING_BAND
+    soft_warning_messages: list[str] = []
+
+    warning_names = (
+        ("tracing_light", "tracing_light_vs_core_light_latency_p95", "tracing_light_vs_core_light_throughput"),
+        (
+            "tracing_light_tokio_sampler",
+            "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95",
+            "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput",
+        ),
+        (
+            "tracing_light_drop_path",
+            "tracing_light_drop_path_vs_core_light_drop_path_latency_p95",
+            "tracing_light_drop_path_vs_core_light_drop_path_throughput",
+        ),
+    )
+
+    for mode_name, latency_key, throughput_key in warning_names:
+        latency_ratio = ratios[latency_key]
+        throughput_ratio = ratios[throughput_key]
+        if latency_ratio > soft_latency_limit:
+            soft_warning_messages.append(
+                f"WARNING: {mode_name} p95 is {latency_ratio:.2f}x native; "
+                "within hard threshold but above 5% warning band"
+            )
+        if throughput_ratio < soft_throughput_floor:
+            soft_warning_messages.append(
+                f"WARNING: {mode_name} throughput is {throughput_ratio:.2f}x native; "
+                "within hard threshold but below 5% warning band"
+            )
+
+    summary["parity_warnings"] = soft_warning_messages
 
 
 def build_release_binary(root_dir: Path) -> Path:
@@ -495,6 +541,10 @@ def main() -> None:
                 raw_file.write(json.dumps(measurement) + "\n")
 
     summary = summarize(raw_path, summary_path)
+    parity_warnings = summary.get("parity_warnings") or []
+    for warning in parity_warnings:
+        print(warning, file=sys.stderr)
+
     if summary["measurement_quality"] != QUALITY_STABLE:
         print(
             f"WARNING: measurement quality is {summary['measurement_quality']}; rerun on a quieter machine for stronger conclusions.",

--- a/scripts/tests/test_measure_runtime_cost.py
+++ b/scripts/tests/test_measure_runtime_cost.py
@@ -159,14 +159,14 @@ class RuntimeCostSummaryTests(unittest.TestCase):
             self.assertEqual(drop_summary["limit_reached_rounds"], 4)
             self.assertGreater(drop_summary["dropped_requests"]["mean"], 0)
 
-    def test_sanity_fails_on_catastrophic_latency_ratio(self) -> None:
-        summary = {"absolute_metrics": {m: {"throughput_rps": {"median": 10.0}, "latency_p95_ms": {"median": 2.0},
+    def test_sanity_fails_on_parity_latency_ratio(self) -> None:
+        summary = {"measured_rounds": 4, "absolute_metrics": {m: {"throughput_rps": {"median": 10.0}, "latency_p95_ms": {"median": 2.0},
                                             "run_requests": {"median": 1}, "run_stages": {"median": 1}, "run_queues": {"median": 1},
                                             "runtime_snapshots": {"median": 0},
                                             "effective_tokio_sampler_config_present_rounds": 0,
                                             "drop_path_signal_present_rounds": 0} for m in measure_runtime_cost.MODES},
                    "tracing_vs_native_ratios": {
-                       "tracing_light_vs_core_light_latency_p95": 25.0,
+                       "tracing_light_vs_core_light_latency_p95": 1.26,
                        "tracing_light_vs_core_light_throughput": 0.5,
                        "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.0,
                        "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 1.0,
@@ -179,15 +179,15 @@ class RuntimeCostSummaryTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             measure_runtime_cost._validate_sanity(summary)
 
-    def test_sanity_fails_on_catastrophic_throughput_ratio(self) -> None:
-        summary = {"absolute_metrics": {m: {"throughput_rps": {"median": 10.0}, "latency_p95_ms": {"median": 2.0},
+    def test_sanity_fails_on_parity_throughput_ratio(self) -> None:
+        summary = {"measured_rounds": 4, "absolute_metrics": {m: {"throughput_rps": {"median": 10.0}, "latency_p95_ms": {"median": 2.0},
                                             "run_requests": {"median": 1}, "run_stages": {"median": 1}, "run_queues": {"median": 1},
                                             "runtime_snapshots": {"median": 0},
                                             "effective_tokio_sampler_config_present_rounds": 0,
                                             "drop_path_signal_present_rounds": 0} for m in measure_runtime_cost.MODES},
                    "tracing_vs_native_ratios": {
                        "tracing_light_vs_core_light_latency_p95": 1.0,
-                       "tracing_light_vs_core_light_throughput": 0.01,
+                       "tracing_light_vs_core_light_throughput": 0.74,
                        "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.0,
                        "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 1.0,
                        "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.0,
@@ -199,24 +199,61 @@ class RuntimeCostSummaryTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             measure_runtime_cost._validate_sanity(summary)
 
-    def test_sanity_passes_for_reasonable_tracing_ratios(self) -> None:
-        summary = {"absolute_metrics": {m: {"throughput_rps": {"median": 10.0}, "latency_p95_ms": {"median": 2.0},
+    def test_sanity_passes_for_inbound_parity_ratios(self) -> None:
+        summary = {"measured_rounds": 4, "absolute_metrics": {m: {"throughput_rps": {"median": 10.0}, "latency_p95_ms": {"median": 2.0},
                                             "run_requests": {"median": 1}, "run_stages": {"median": 1}, "run_queues": {"median": 1},
                                             "runtime_snapshots": {"median": 0},
                                             "effective_tokio_sampler_config_present_rounds": 0,
                                             "drop_path_signal_present_rounds": 0} for m in measure_runtime_cost.MODES},
                    "tracing_vs_native_ratios": {
-                       "tracing_light_vs_core_light_latency_p95": 2.0,
-                       "tracing_light_vs_core_light_throughput": 0.8,
-                       "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 2.0,
-                       "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 0.8,
-                       "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 2.0,
-                       "tracing_light_drop_path_vs_core_light_drop_path_throughput": 0.8,
+                       "tracing_light_vs_core_light_latency_p95": 1.02,
+                       "tracing_light_vs_core_light_throughput": 0.98,
+                       "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.03,
+                       "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 0.97,
+                       "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.01,
+                       "tracing_light_drop_path_vs_core_light_drop_path_throughput": 0.99,
                    }}
         summary["absolute_metrics"]["tracing_light_tokio_sampler"]["runtime_snapshots"]["median"] = 1
         summary["absolute_metrics"]["tracing_light_tokio_sampler"]["effective_tokio_sampler_config_present_rounds"] = 1
         summary["absolute_metrics"]["tracing_light_drop_path"]["drop_path_signal_present_rounds"] = 1
         measure_runtime_cost._validate_sanity(summary)
+
+    def test_sanity_warns_without_failing_for_soft_band_movement(self) -> None:
+        summary = {"measured_rounds": 4, "absolute_metrics": {m: {"throughput_rps": {"median": 10.0}, "latency_p95_ms": {"median": 2.0},
+                                            "run_requests": {"median": 1}, "run_stages": {"median": 1}, "run_queues": {"median": 1},
+                                            "runtime_snapshots": {"median": 0},
+                                            "effective_tokio_sampler_config_present_rounds": 0,
+                                            "drop_path_signal_present_rounds": 0} for m in measure_runtime_cost.MODES},
+                   "tracing_vs_native_ratios": {
+                       "tracing_light_vs_core_light_latency_p95": 1.07,
+                       "tracing_light_vs_core_light_throughput": 0.93,
+                       "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.02,
+                       "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 0.96,
+                       "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.01,
+                       "tracing_light_drop_path_vs_core_light_drop_path_throughput": 0.99,
+                   }}
+        summary["absolute_metrics"]["tracing_light_tokio_sampler"]["runtime_snapshots"]["median"] = 1
+        summary["absolute_metrics"]["tracing_light_tokio_sampler"]["effective_tokio_sampler_config_present_rounds"] = 1
+        summary["absolute_metrics"]["tracing_light_drop_path"]["drop_path_signal_present_rounds"] = 1
+        measure_runtime_cost._validate_sanity(summary)
+        self.assertTrue(summary.get("parity_warnings"))
+
+    def test_sanity_fails_when_measured_rounds_below_minimum(self) -> None:
+        summary = {"measured_rounds": 2, "absolute_metrics": {m: {"throughput_rps": {"median": 10.0}, "latency_p95_ms": {"median": 2.0},
+                                            "run_requests": {"median": 1}, "run_stages": {"median": 1}, "run_queues": {"median": 1},
+                                            "runtime_snapshots": {"median": 0},
+                                            "effective_tokio_sampler_config_present_rounds": 0,
+                                            "drop_path_signal_present_rounds": 0} for m in measure_runtime_cost.MODES},
+                   "tracing_vs_native_ratios": {
+                       "tracing_light_vs_core_light_latency_p95": 1.0,
+                       "tracing_light_vs_core_light_throughput": 1.0,
+                       "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.0,
+                       "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 1.0,
+                       "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.0,
+                       "tracing_light_drop_path_vs_core_light_drop_path_throughput": 1.0,
+                   }}
+        with self.assertRaises(SystemExit):
+            measure_runtime_cost._validate_sanity(summary)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_validate_runtime_cost_summary.py
+++ b/scripts/tests/test_validate_runtime_cost_summary.py
@@ -36,6 +36,7 @@ class ValidateRuntimeCostSummaryTests(unittest.TestCase):
         abs_metrics["tracing_light_tokio_sampler"]["effective_tokio_sampler_config_present_rounds"] = 1
         abs_metrics["tracing_light_drop_path"]["drop_path_signal_present_rounds"] = 1
         return {
+            "measured_rounds": 4,
             "absolute_metrics": abs_metrics,
             "tracing_vs_native_ratios": {
                 "tracing_light_vs_core_light_latency_p95": 1.0,
@@ -43,7 +44,7 @@ class ValidateRuntimeCostSummaryTests(unittest.TestCase):
                 "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.1,
                 "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 0.8,
                 "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.2,
-                "tracing_light_drop_path_vs_core_light_drop_path_throughput": 0.7,
+                "tracing_light_drop_path_vs_core_light_drop_path_throughput": 0.8,
             },
         }
 
@@ -100,6 +101,35 @@ class ValidateRuntimeCostSummaryTests(unittest.TestCase):
     def test_missing_required_ratio_key_fails(self) -> None:
         summary = self._summary()
         del summary["tracing_vs_native_ratios"]["tracing_light_drop_path_vs_core_light_drop_path_throughput"]
+        raw, summ, tmp = self._write(summary)
+        with tmp, self.assertRaises(SystemExit):
+            validate_runtime_cost_summary.validate(raw, summ)
+
+    def test_soft_warning_band_does_not_fail(self) -> None:
+        summary = self._summary()
+        summary["tracing_vs_native_ratios"]["tracing_light_vs_core_light_latency_p95"] = 1.07
+        summary["tracing_vs_native_ratios"]["tracing_light_vs_core_light_throughput"] = 0.93
+        raw, summ, tmp = self._write(summary)
+        with tmp:
+            validate_runtime_cost_summary.validate(raw, summ)
+
+    def test_parity_latency_hard_limit_fails(self) -> None:
+        summary = self._summary()
+        summary["tracing_vs_native_ratios"]["tracing_light_vs_core_light_latency_p95"] = 1.26
+        raw, summ, tmp = self._write(summary)
+        with tmp, self.assertRaises(SystemExit):
+            validate_runtime_cost_summary.validate(raw, summ)
+
+    def test_parity_throughput_hard_floor_fails(self) -> None:
+        summary = self._summary()
+        summary["tracing_vs_native_ratios"]["tracing_light_vs_core_light_throughput"] = 0.74
+        raw, summ, tmp = self._write(summary)
+        with tmp, self.assertRaises(SystemExit):
+            validate_runtime_cost_summary.validate(raw, summ)
+
+    def test_insufficient_measured_rounds_fails(self) -> None:
+        summary = self._summary()
+        summary["measured_rounds"] = 2
         raw, summ, tmp = self._write(summary)
         with tmp, self.assertRaises(SystemExit):
             validate_runtime_cost_summary.validate(raw, summ)

--- a/scripts/validate_runtime_cost_summary.py
+++ b/scripts/validate_runtime_cost_summary.py
@@ -47,6 +47,9 @@ def validate(raw_path: Path, summary_path: Path) -> None:
 
     _validate_sanity(summary)
 
+    for warning in summary.get("parity_warnings") or []:
+        print(warning)
+
 
 def main() -> None:
     args = parse_args()


### PR DESCRIPTION
### Motivation
- Replace very-wide catastrophic tracing/native checks with a meaningful parity gate that catches regressions while surfacing modest moves as warnings. 
- Improve CI measurement quality for parity checks by increasing measured rounds from `2` to `4` (keep `--warmup-rounds 1`) so variance classification is more meaningful. 
- Preserve existing evidence-shape and finite-ratio checks while failing on missing/invalid metrics or truly out-of-bounds parity. 

### Description
- Increase CI smoke measured rounds to `--rounds 4 --warmup-rounds 1` (workflow and docs updated). 
- Add named parity constants in `scripts/measure_runtime_cost.py`: `TRACING_NATIVE_P95_HARD_LIMIT = 1.25`, `TRACING_NATIVE_THROUGHPUT_HARD_FLOOR = 0.75`, and `TRACING_NATIVE_SOFT_WARNING_BAND = 0.05`. 
- Replace old catastrophic thresholds with hard parity checks on the six tracing/native ratio keys (p95 <= 1.25x; throughput >= 0.75x) and emit non-failing soft warnings when p95 > 1.05x or throughput < 0.95x. 
- Enforce `measured_rounds >= 4` for CI smoke summaries and keep all required evidence-shape validations (request/stage/queue evidence, sampler snapshots/metadata, drop-path signal, finite ratios). 
- Print `parity_warnings` from the summary in the validator and add/extend unit tests to cover parity pass/fail/warning/missing-ratio/insufficient-rounds cases. 
- Files changed: `.github/workflows/ci.yml`, `docs/runtime-cost.md`, `scripts/measure_runtime_cost.py`, `scripts/validate_runtime_cost_summary.py`, `scripts/tests/test_measure_runtime_cost.py`, and `scripts/tests/test_validate_runtime_cost_summary.py`. 

### Testing
- Formatting and unit tests: ran `cargo fmt --check` and `python3 -m unittest scripts.tests.test_measure_runtime_cost scripts.tests.test_validate_runtime_cost_summary`, and all tests passed. 
- CI-smoke measurement: ran `python3 scripts/measure_runtime_cost.py --requests 1200 --concurrency 32 --work-ms 4 --rounds 4 --warmup-rounds 1 --artifact-dir demos/runtime_cost/artifacts/ci-smoke` which produced a summary and emitted parity warnings but did not fail. 
- Summary validation and docs contract: ran `python3 scripts/validate_runtime_cost_summary.py --raw demos/runtime_cost/artifacts/ci-smoke/runtime-cost-raw.jsonl --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json` and `python3 scripts/validate_docs_contracts.py`, both succeeded. 
- Measured tracing/native ratios from the local CI-smoke run: `tracing_light / core_light` p95 `0.999x`, throughput `0.923x`; `tracing_light_tokio_sampler / core_light_tokio_sampler` p95 `0.975x`, throughput `0.957x`; `tracing_light_drop_path / core_light_drop_path` p95 `1.028x`, throughput `0.977x`. 
- Measurement quality observed: `measurement_quality = noisy` (the run printed stability warnings but noisy quality is not a CI failure under this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c34a8a89c8330a07a85bbc88f6af8)