### PR TITLE
Tighten runtime-cost smoke to enforce tracing/native parity thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,7 @@ jobs:
             --requests 1200 \
             --concurrency 32 \
             --work-ms 4 \
-            --rounds 2 \
+            --rounds 4 \
             --warmup-rounds 1 \
             --artifact-dir demos/runtime_cost/artifacts/ci-smoke
 
@@ -301,4 +301,3 @@ jobs:
           python3 scripts/validate_runtime_cost_summary.py \
             --raw demos/runtime_cost/artifacts/ci-smoke/runtime-cost-raw.jsonl \
             --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json
-

--- a/docs/runtime-cost.md
+++ b/docs/runtime-cost.md
@@ -60,7 +60,7 @@ python3 scripts/measure_runtime_cost.py \
   --requests 1200 \
   --concurrency 32 \
   --work-ms 4 \
-  --rounds 2 \
+  --rounds 4 \
   --warmup-rounds 1 \
   --artifact-dir demos/runtime_cost/artifacts/ci-smoke
 python3 scripts/validate_runtime_cost_summary.py \
@@ -68,7 +68,17 @@ python3 scripts/validate_runtime_cost_summary.py \
   --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json
 ```
 
-This is a bounded diagnostic sanity check only. It enforces broad catastrophic-regression checks and required tracing evidence shape, not rigorous performance benchmarking. CI validates runtime-cost output in-place and does not upload runtime-cost artifacts by default. Full runtime-cost measurement remains a local/developer-run path via the canonical command above. Results remain machine/workload/profile scoped.
+This is a bounded runtime-cost smoke for regression triage, not a rigorous benchmark. It enforces required tracing evidence shape plus tracing/native parity hard thresholds:
+
+- tracing/native p95 ratio must be `<= 1.25x`
+- tracing/native throughput ratio must be `>= 0.75x`
+
+The same tracing/native pairs emit non-failing warnings when movement exceeds a 5% parity band:
+
+- p95 ratio warning when `> 1.05x`
+- throughput ratio warning when `< 0.95x`
+
+Minor movement inside that warning band is treated as parity, not as a reason to change the default recommendation. Native remains the default instrumentation path because it is direct, explicit, and complete. Tracing remains a first-class intake bridge for users already using tracing or preferring span-shaped instrumentation, and should remain close to native in cost. CI validates runtime-cost output in-place and does not upload runtime-cost artifacts by default. Full runtime-cost measurement remains a local/developer-run path via the canonical command above. Results remain machine/workload/profile scoped.
 
 ## Inputs and knobs
 
@@ -97,7 +107,7 @@ Per-mode records now include instrumentation family (`baseline` / `native` / `tr
 - Use **Post-limit / drop-path overhead** only for intentionally saturated-limit behavior.
 
 If `measurement_quality` reports noisy/unstable, rerun on a quieter machine state before drawing stronger conclusions.
-Numbers are directional and machine/workload/profile scoped; broad thresholds are intended only to catch catastrophic regressions.
+Numbers are directional and machine/workload/profile scoped. CI parity thresholds are bounded smoke checks, not universal performance guarantees.
 
 ## Semantics reminder
 

--- a/scripts/measure_runtime_cost.py
+++ b/scripts/measure_runtime_cost.py
@@ -51,6 +51,9 @@ QUALITY_NOISY = "noisy"
 QUALITY_UNSTABLE = "unstable"
 QUALITY_INSUFFICIENT_DATA = "insufficient_data"
 MIN_ROUNDS_FOR_STABLE = 4
+TRACING_NATIVE_PARITY_LATENCY_P95_HARD_LIMIT = 1.25
+TRACING_NATIVE_PARITY_THROUGHPUT_HARD_FLOOR = 0.75
+TRACING_NATIVE_PARITY_SOFT_WARNING_BAND = 0.05
 
 DELTA_VS_BASELINE_MODE_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("Baked-in overhead", ("baked_in_no_request_context",)),
@@ -58,6 +61,22 @@ DELTA_VS_BASELINE_MODE_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("Tokio mode overhead", TOKIO_SAMPLER_MODES),
     ("Post-limit / drop-path overhead", SATURATED_DROP_PATH_MODES),
 )
+TRACING_NATIVE_PARITY_RATIO_CHECKS: tuple[tuple[str, str], ...] = (
+    ("tracing_light_vs_core_light_latency_p95", "latency_p95"),
+    ("tracing_light_vs_core_light_throughput", "throughput"),
+    ("tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95", "latency_p95"),
+    ("tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput", "throughput"),
+    ("tracing_light_drop_path_vs_core_light_drop_path_latency_p95", "latency_p95"),
+    ("tracing_light_drop_path_vs_core_light_drop_path_throughput", "throughput"),
+)
+TRACING_NATIVE_PARITY_WARNING_LABELS = {
+    "tracing_light_vs_core_light_latency_p95": "tracing_light",
+    "tracing_light_vs_core_light_throughput": "tracing_light",
+    "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": "tracing_light_tokio_sampler",
+    "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": "tracing_light_tokio_sampler",
+    "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": "tracing_light_drop_path",
+    "tracing_light_drop_path_vs_core_light_drop_path_throughput": "tracing_light_drop_path",
+}
 
 
 def parse_args() -> argparse.Namespace:
@@ -367,40 +386,36 @@ def _validate_sanity(summary: dict) -> None:
     if abs_m["tracing_light_drop_path"]["drop_path_signal_present_rounds"] <= 0:
         raise SystemExit("tracing_light_drop_path must include drop-path signal")
     ratios = summary["tracing_vs_native_ratios"]
-    required_ratio_keys = (
-        "tracing_light_vs_core_light_latency_p95",
-        "tracing_light_vs_core_light_throughput",
-        "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95",
-        "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput",
-        "tracing_light_drop_path_vs_core_light_drop_path_latency_p95",
-        "tracing_light_drop_path_vs_core_light_drop_path_throughput",
-    )
-    for key in required_ratio_keys:
+    for key, _kind in TRACING_NATIVE_PARITY_RATIO_CHECKS:
         value = ratios.get(key)
         if value is None:
             raise SystemExit(f"{key} is required and cannot be null (likely zero/missing denominator)")
         if value != value or value in (float("inf"), float("-inf")):
             raise SystemExit(f"{key} must be finite (not NaN or infinity)")
-    if ratios["tracing_light_vs_core_light_latency_p95"] > 20:
-        raise SystemExit("tracing_light_vs_core_light_latency_p95 exceeds catastrophic threshold (>20x)")
-    if ratios["tracing_light_vs_core_light_throughput"] < 0.05:
-        raise SystemExit("tracing_light_vs_core_light_throughput is below catastrophic threshold (<0.05x)")
-    if ratios["tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95"] > 20:
-        raise SystemExit(
-            "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95 exceeds catastrophic threshold (>20x)"
-        )
-    if ratios["tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput"] < 0.05:
-        raise SystemExit(
-            "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput is below catastrophic threshold (<0.05x)"
-        )
-    if ratios["tracing_light_drop_path_vs_core_light_drop_path_latency_p95"] > 20:
-        raise SystemExit(
-            "tracing_light_drop_path_vs_core_light_drop_path_latency_p95 exceeds catastrophic threshold (>20x)"
-        )
-    if ratios["tracing_light_drop_path_vs_core_light_drop_path_throughput"] < 0.05:
-        raise SystemExit(
-            "tracing_light_drop_path_vs_core_light_drop_path_throughput is below catastrophic threshold (<0.05x)"
-        )
+    if summary.get("measured_rounds", MIN_ROUNDS_FOR_STABLE) < MIN_ROUNDS_FOR_STABLE:
+        raise SystemExit(f"measured rounds must be >= {MIN_ROUNDS_FOR_STABLE} for CI smoke validation")
+    for key, kind in TRACING_NATIVE_PARITY_RATIO_CHECKS:
+        value = ratios[key]
+        if kind == "latency_p95":
+            if value > TRACING_NATIVE_PARITY_LATENCY_P95_HARD_LIMIT:
+                raise SystemExit(
+                    f"{key} exceeds parity threshold (>{TRACING_NATIVE_PARITY_LATENCY_P95_HARD_LIMIT:.2f}x)"
+                )
+            if value > (1.0 + TRACING_NATIVE_PARITY_SOFT_WARNING_BAND):
+                print(
+                    f"WARNING: {TRACING_NATIVE_PARITY_WARNING_LABELS[key]} p95 is {value:.2f}x native; within hard threshold but above 5% warning band",
+                    file=sys.stderr,
+                )
+        else:
+            if value < TRACING_NATIVE_PARITY_THROUGHPUT_HARD_FLOOR:
+                raise SystemExit(
+                    f"{key} is below parity threshold (<{TRACING_NATIVE_PARITY_THROUGHPUT_HARD_FLOOR:.2f}x)"
+                )
+            if value < (1.0 - TRACING_NATIVE_PARITY_SOFT_WARNING_BAND):
+                print(
+                    f"WARNING: {TRACING_NATIVE_PARITY_WARNING_LABELS[key]} throughput is {value:.2f}x native; within hard threshold but below 5% warning band",
+                    file=sys.stderr,
+                )
 
 
 def build_release_binary(root_dir: Path) -> Path:

--- a/scripts/tests/test_measure_runtime_cost.py
+++ b/scripts/tests/test_measure_runtime_cost.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import json
+import contextlib
+import io
 import tempfile
 import unittest
 from pathlib import Path
@@ -159,14 +161,14 @@ class RuntimeCostSummaryTests(unittest.TestCase):
             self.assertEqual(drop_summary["limit_reached_rounds"], 4)
             self.assertGreater(drop_summary["dropped_requests"]["mean"], 0)
 
-    def test_sanity_fails_on_catastrophic_latency_ratio(self) -> None:
+    def test_sanity_fails_when_latency_ratio_exceeds_parity_threshold(self) -> None:
         summary = {"absolute_metrics": {m: {"throughput_rps": {"median": 10.0}, "latency_p95_ms": {"median": 2.0},
                                             "run_requests": {"median": 1}, "run_stages": {"median": 1}, "run_queues": {"median": 1},
                                             "runtime_snapshots": {"median": 0},
                                             "effective_tokio_sampler_config_present_rounds": 0,
                                             "drop_path_signal_present_rounds": 0} for m in measure_runtime_cost.MODES},
                    "tracing_vs_native_ratios": {
-                       "tracing_light_vs_core_light_latency_p95": 25.0,
+                       "tracing_light_vs_core_light_latency_p95": 1.26,
                        "tracing_light_vs_core_light_throughput": 0.5,
                        "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.0,
                        "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 1.0,
@@ -179,7 +181,7 @@ class RuntimeCostSummaryTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             measure_runtime_cost._validate_sanity(summary)
 
-    def test_sanity_fails_on_catastrophic_throughput_ratio(self) -> None:
+    def test_sanity_fails_when_throughput_ratio_is_below_parity_threshold(self) -> None:
         summary = {"absolute_metrics": {m: {"throughput_rps": {"median": 10.0}, "latency_p95_ms": {"median": 2.0},
                                             "run_requests": {"median": 1}, "run_stages": {"median": 1}, "run_queues": {"median": 1},
                                             "runtime_snapshots": {"median": 0},
@@ -187,7 +189,7 @@ class RuntimeCostSummaryTests(unittest.TestCase):
                                             "drop_path_signal_present_rounds": 0} for m in measure_runtime_cost.MODES},
                    "tracing_vs_native_ratios": {
                        "tracing_light_vs_core_light_latency_p95": 1.0,
-                       "tracing_light_vs_core_light_throughput": 0.01,
+                       "tracing_light_vs_core_light_throughput": 0.74,
                        "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.0,
                        "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 1.0,
                        "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.0,
@@ -206,17 +208,40 @@ class RuntimeCostSummaryTests(unittest.TestCase):
                                             "effective_tokio_sampler_config_present_rounds": 0,
                                             "drop_path_signal_present_rounds": 0} for m in measure_runtime_cost.MODES},
                    "tracing_vs_native_ratios": {
-                       "tracing_light_vs_core_light_latency_p95": 2.0,
+                       "tracing_light_vs_core_light_latency_p95": 1.05,
                        "tracing_light_vs_core_light_throughput": 0.8,
-                       "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 2.0,
+                       "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.05,
                        "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 0.8,
-                       "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 2.0,
+                       "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.05,
                        "tracing_light_drop_path_vs_core_light_drop_path_throughput": 0.8,
                    }}
         summary["absolute_metrics"]["tracing_light_tokio_sampler"]["runtime_snapshots"]["median"] = 1
         summary["absolute_metrics"]["tracing_light_tokio_sampler"]["effective_tokio_sampler_config_present_rounds"] = 1
         summary["absolute_metrics"]["tracing_light_drop_path"]["drop_path_signal_present_rounds"] = 1
         measure_runtime_cost._validate_sanity(summary)
+
+    def test_sanity_warns_for_soft_latency_band_but_does_not_fail(self) -> None:
+        summary = {"absolute_metrics": {m: {"throughput_rps": {"median": 10.0}, "latency_p95_ms": {"median": 2.0},
+                                            "run_requests": {"median": 1}, "run_stages": {"median": 1}, "run_queues": {"median": 1},
+                                            "runtime_snapshots": {"median": 0},
+                                            "effective_tokio_sampler_config_present_rounds": 0,
+                                            "drop_path_signal_present_rounds": 0} for m in measure_runtime_cost.MODES},
+                   "measured_rounds": 4,
+                   "tracing_vs_native_ratios": {
+                       "tracing_light_vs_core_light_latency_p95": 1.07,
+                       "tracing_light_vs_core_light_throughput": 0.96,
+                       "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.0,
+                       "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 1.0,
+                       "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.0,
+                       "tracing_light_drop_path_vs_core_light_drop_path_throughput": 1.0,
+                   }}
+        summary["absolute_metrics"]["tracing_light_tokio_sampler"]["runtime_snapshots"]["median"] = 1
+        summary["absolute_metrics"]["tracing_light_tokio_sampler"]["effective_tokio_sampler_config_present_rounds"] = 1
+        summary["absolute_metrics"]["tracing_light_drop_path"]["drop_path_signal_present_rounds"] = 1
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            measure_runtime_cost._validate_sanity(summary)
+        self.assertIn("WARNING: tracing_light p95 is 1.07x native", stderr.getvalue())
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_validate_runtime_cost_summary.py
+++ b/scripts/tests/test_validate_runtime_cost_summary.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import contextlib
+import io
 import math
 import tempfile
 import unittest
@@ -36,6 +38,7 @@ class ValidateRuntimeCostSummaryTests(unittest.TestCase):
         abs_metrics["tracing_light_tokio_sampler"]["effective_tokio_sampler_config_present_rounds"] = 1
         abs_metrics["tracing_light_drop_path"]["drop_path_signal_present_rounds"] = 1
         return {
+            "measured_rounds": 4,
             "absolute_metrics": abs_metrics,
             "tracing_vs_native_ratios": {
                 "tracing_light_vs_core_light_latency_p95": 1.0,
@@ -43,7 +46,7 @@ class ValidateRuntimeCostSummaryTests(unittest.TestCase):
                 "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.1,
                 "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 0.8,
                 "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.2,
-                "tracing_light_drop_path_vs_core_light_drop_path_throughput": 0.7,
+                "tracing_light_drop_path_vs_core_light_drop_path_throughput": 0.8,
             },
         }
 
@@ -100,6 +103,29 @@ class ValidateRuntimeCostSummaryTests(unittest.TestCase):
     def test_missing_required_ratio_key_fails(self) -> None:
         summary = self._summary()
         del summary["tracing_vs_native_ratios"]["tracing_light_drop_path_vs_core_light_drop_path_throughput"]
+        raw, summ, tmp = self._write(summary)
+        with tmp, self.assertRaises(SystemExit):
+            validate_runtime_cost_summary.validate(raw, summ)
+
+    def test_warning_band_throughput_warns_but_passes(self) -> None:
+        summary = self._summary()
+        summary["tracing_vs_native_ratios"]["tracing_light_vs_core_light_throughput"] = 0.93
+        raw, summ, tmp = self._write(summary)
+        stderr = io.StringIO()
+        with tmp, contextlib.redirect_stderr(stderr):
+            validate_runtime_cost_summary.validate(raw, summ)
+        self.assertIn("WARNING: tracing_light throughput is 0.93x native", stderr.getvalue())
+
+    def test_missing_ratio_value_fails(self) -> None:
+        summary = self._summary()
+        summary["tracing_vs_native_ratios"]["tracing_light_vs_core_light_latency_p95"] = None
+        raw, summ, tmp = self._write(summary)
+        with tmp, self.assertRaises(SystemExit):
+            validate_runtime_cost_summary.validate(raw, summ)
+
+    def test_insufficient_measured_rounds_fails(self) -> None:
+        summary = self._summary()
+        summary["measured_rounds"] = 2
         raw, summ, tmp = self._write(summary)
         with tmp, self.assertRaises(SystemExit):
             validate_runtime_cost_summary.validate(raw, summ)


### PR DESCRIPTION
### Motivation
- Improve runtime-cost CI so tracing vs native is checked as a meaningful parity gate instead of only catching catastrophic regressions. 
- Raise measurement quality for CI smoke to reduce `insufficient_data` classifications while keeping the smoke bounded and fast.

### Description
- Increase CI smoke measured rounds from `--rounds 2` to `--rounds 4` (warmup stays `--warmup-rounds 1`) in `.github/workflows/ci.yml` and docs/CI command. 
- Replace the prior catastrophic 20x/0.05x checks with named parity constants in `scripts/measure_runtime_cost.py`: p95 hard limit `1.25x`, throughput hard floor `0.75x`, and a soft warning band of `5%` (`0.05`) that emits non-failing warnings when crossed. 
- Enforce minimum measured rounds (`>= 4`) for the CI smoke path, preserve required evidence-shape checks and finite-ratio validation, and emit stable/noisy warnings but do not fail purely on “noisy”. 
- Update unit tests under `scripts/tests/` to exercise new pass/fail/warn cases and update `docs/runtime-cost.md` to document the new smoke configuration and parity semantics.

### Testing
- Files changed: `.github/workflows/ci.yml`, `scripts/measure_runtime_cost.py`, `scripts/tests/test_measure_runtime_cost.py`, `scripts/tests/test_validate_runtime_cost_summary.py`, `docs/runtime-cost.md`.
- New hard thresholds: `tracing/native p95 <= 1.25x` and `tracing/native throughput >= 0.75x` and soft warning band = `5%` (warn when p95 > `1.05x` or throughput < `0.95x`).
- CI smoke rounds changed to 4 measured rounds: Yes (`--rounds 4`, `--warmup-rounds 1`).
- Local bounded smoke run (requested command) produced tracing/native median ratios: `tracing_light_vs_core_light_latency_p95 = 0.9997x`, `tracing_light_vs_core_light_throughput = 0.9564x`, `tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95 = 0.9947x`, `tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput = 0.9644x`, `tracing_light_drop_path_vs_core_light_drop_path_latency_p95 = 0.9871x`, `tracing_light_drop_path_vs_core_light_drop_path_throughput = 1.0049x`, and `measurement_quality = noisy` (warning printed but not failed).
- Validation commands run and results: `cargo fmt --check` (ok), `python3 -m unittest scripts.tests.test_measure_runtime_cost scripts.tests.test_validate_runtime_cost_summary` (all tests passed), `python3 scripts/measure_runtime_cost.py --requests 1200 --concurrency 32 --work-ms 4 --rounds 4 --warmup-rounds 1 --artifact-dir demos/runtime_cost/artifacts/ci-smoke` (ran, summary produced; measurement quality reported `noisy`), `python3 scripts/validate_runtime_cost_summary.py --raw demos/runtime_cost/artifacts/ci-smoke/runtime-cost-raw.jsonl --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json` (validator passed), and `python3 scripts/validate_docs_contracts.py` (docs contract validated successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c34a8a89c8330a07a85bbc88f6af8)