### PR TITLE
Tighten runtime-cost CI tracing/native parity gate and warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,7 @@ jobs:
             --requests 1200 \
             --concurrency 32 \
             --work-ms 4 \
-            --rounds 2 \
+            --rounds 4 \
             --warmup-rounds 1 \
             --artifact-dir demos/runtime_cost/artifacts/ci-smoke
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,8 +273,8 @@ jobs:
         run: python3 scripts/check_demo_fixture_drift.py --profile ${{ matrix.profile }}
 
       - name: Validate tracing parity across all demos
-        if: matrix.os == 'ubuntu-latest' && matrix.profile == 'release' && matrix.extended
-        run: python3 scripts/demo_tool.py validate-tracing-parity all --profile release
+        if: matrix.os == 'ubuntu-latest' && matrix.profile == 'dev' && matrix.extended
+        run: python3 scripts/demo_tool.py validate-tracing-parity all --profile dev
 
       - name: Validate runtime-cost script unit tests
         if: matrix.os == 'ubuntu-latest' && matrix.profile == 'dev' && matrix.extended
@@ -288,7 +288,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.profile == 'release' && matrix.extended
         run: |
           python3 scripts/measure_runtime_cost.py \
-            --requests 1200 \
+            --requests 4000 \
             --concurrency 32 \
             --work-ms 4 \
             --rounds 4 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,8 +273,8 @@ jobs:
         run: python3 scripts/check_demo_fixture_drift.py --profile ${{ matrix.profile }}
 
       - name: Validate tracing parity across all demos
-        if: matrix.os == 'ubuntu-latest' && matrix.profile == 'dev' && matrix.extended
-        run: python3 scripts/demo_tool.py validate-tracing-parity all --profile dev
+        if: matrix.os == 'ubuntu-latest' && matrix.profile == 'release' && matrix.extended
+        run: python3 scripts/demo_tool.py validate-tracing-parity all --profile release
 
       - name: Validate runtime-cost script unit tests
         if: matrix.os == 'ubuntu-latest' && matrix.profile == 'dev' && matrix.extended
@@ -288,7 +288,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.profile == 'release' && matrix.extended
         run: |
           python3 scripts/measure_runtime_cost.py \
-            --requests 4000 \
+            --requests 2000 \
             --concurrency 32 \
             --work-ms 4 \
             --rounds 4 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,7 +288,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.profile == 'release' && matrix.extended
         run: |
           python3 scripts/measure_runtime_cost.py \
-            --requests 2000 \
+            --requests 4000 \
             --concurrency 32 \
             --work-ms 4 \
             --rounds 4 \
@@ -301,4 +301,3 @@ jobs:
           python3 scripts/validate_runtime_cost_summary.py \
             --raw demos/runtime_cost/artifacts/ci-smoke/runtime-cost-raw.jsonl \
             --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json
-

--- a/docs/runtime-cost.md
+++ b/docs/runtime-cost.md
@@ -57,7 +57,7 @@ CI runs one bounded runtime-cost smoke on the Ubuntu extended release leg:
 
 ```bash
 python3 scripts/measure_runtime_cost.py \
-  --requests 1200 \
+  --requests 4000 \
   --concurrency 32 \
   --work-ms 4 \
   --rounds 4 \
@@ -68,7 +68,7 @@ python3 scripts/validate_runtime_cost_summary.py \
   --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json
 ```
 
-This is a bounded diagnostic sanity check only. It enforces tracing/native parity hard checks (p95 <= 1.25x native and throughput >= 0.75x native), a 5% soft warning band (p95 > 1.05x or throughput < 0.95x), and required tracing evidence shape, not rigorous performance benchmarking. CI validates runtime-cost output in-place and does not upload runtime-cost artifacts by default. Full runtime-cost measurement remains a local/developer-run path via the canonical command above. Results remain machine/workload/profile scoped.
+This is a bounded diagnostic sanity check only. It enforces tracing/native parity hard checks (p95 <= 1.25x native and throughput >= 0.75x native), a 10% soft warning band (p95 > 1.10x or throughput < 0.90x), and required tracing evidence shape, not rigorous performance benchmarking. CI validates runtime-cost output in-place and does not upload runtime-cost artifacts by default. Full runtime-cost measurement remains a local/developer-run path via the canonical command above. Results remain machine/workload/profile scoped.
 
 ## Inputs and knobs
 
@@ -96,8 +96,9 @@ Per-mode records now include instrumentation family (`baseline` / `native` / `tr
 - Use **Incremental runtime sampler overhead** to isolate sampler contribution from same-mode core baselines.
 - Use **Post-limit / drop-path overhead** only for intentionally saturated-limit behavior.
 
-If `measurement_quality` reports noisy/unstable, rerun on a quieter machine state before drawing stronger conclusions.
-Numbers are directional and machine/workload/profile scoped; broad thresholds are intended only to catch catastrophic regressions.
+If `measurement_quality` reports noisy/unstable, CI reports warnings but does not fail solely for that quality classification; rerun on a quieter machine state before drawing stronger conclusions.
+If `measurement_quality` is `insufficient_data` after expected measured rounds, CI fails.
+Numbers are directional and machine/workload/profile scoped; this bounded smoke catches meaningful regressions, not rigorous benchmark conclusions.
 
 ## Semantics reminder
 
@@ -111,4 +112,4 @@ Numbers are directional and machine/workload/profile scoped; broad thresholds ar
 Use `python3 scripts/run_operational_validation.py --domain runtime-cost` for manual/local runtime-cost validation that emits JSONL records, stable summary JSON, and an optional scorecard. Results are machine/workload/profile scoped and should be treated as measurements, not universal guarantees. Missing metrics are emitted as `null` rather than guessed.
 
 
-Native remains the default instrumentation path because it is direct, explicit, and complete. Tracing is a first-class intake bridge for teams already instrumented with tracing or preferring span-shaped instrumentation. Small wins/losses inside the 5% warning band are treated as parity, not as a reason to change the default recommendation.
+Native remains the default instrumentation path because it is direct, explicit, and complete. Tracing is a first-class intake bridge for teams already instrumented with tracing or preferring span-shaped instrumentation. Small wins/losses inside the 10% warning band are treated as parity, not as a reason to change the default recommendation.

--- a/docs/runtime-cost.md
+++ b/docs/runtime-cost.md
@@ -68,7 +68,7 @@ python3 scripts/validate_runtime_cost_summary.py \
   --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json
 ```
 
-This is a bounded diagnostic sanity check only. It enforces tracing/native parity hard checks (p95 <= 1.25x native and throughput >= 0.75x native), a 10% soft warning band (p95 > 1.10x or throughput < 0.90x), and required tracing evidence shape, not rigorous performance benchmarking. CI validates runtime-cost output in-place and does not upload runtime-cost artifacts by default. Full runtime-cost measurement remains a local/developer-run path via the canonical command above. Results remain machine/workload/profile scoped.
+This is a bounded diagnostic sanity check only. It enforces tracing/native parity hard checks (p95 <= 1.10x native and throughput >= 0.90x native), a 2% soft warning band (p95 > 1.02x or throughput < 0.98x), and required tracing evidence shape, not rigorous performance benchmarking. CI validates runtime-cost output in-place and does not upload runtime-cost artifacts by default. CI logs print compact runtime-cost tables by default, while full JSON remains in artifacts (`runtime-cost-summary.json`) and can be printed locally with `--print-json`. Full runtime-cost measurement remains a local/developer-run path via the canonical command above. Results remain machine/workload/profile scoped.
 
 ## Inputs and knobs
 
@@ -79,6 +79,7 @@ CLI options (with equivalent env vars):
 - `--work-ms` (`WORK_MS`, default `3`)
 - `--warmup-rounds` (`WARMUP_ROUNDS`, default `2`)
 - `--rounds` (`ROUNDS`, default `6`)
+- `--print-json` (print full summary JSON after compact report)
 
 ## Artifacts emitted
 
@@ -112,4 +113,4 @@ Numbers are directional and machine/workload/profile scoped; this bounded smoke 
 Use `python3 scripts/run_operational_validation.py --domain runtime-cost` for manual/local runtime-cost validation that emits JSONL records, stable summary JSON, and an optional scorecard. Results are machine/workload/profile scoped and should be treated as measurements, not universal guarantees. Missing metrics are emitted as `null` rather than guessed.
 
 
-Native remains the default instrumentation path because it is direct, explicit, and complete. Tracing is a first-class intake bridge for teams already instrumented with tracing or preferring span-shaped instrumentation. Small wins/losses inside the 10% warning band are treated as parity, not as a reason to change the default recommendation.
+Native remains the default instrumentation path because it is direct, explicit, and complete. Tracing is a first-class intake bridge for teams already instrumented with tracing or preferring span-shaped instrumentation. Small wins/losses inside the 2% warning band are treated as parity, not as a reason to change the default recommendation.

--- a/docs/runtime-cost.md
+++ b/docs/runtime-cost.md
@@ -60,7 +60,7 @@ python3 scripts/measure_runtime_cost.py \
   --requests 1200 \
   --concurrency 32 \
   --work-ms 4 \
-  --rounds 2 \
+  --rounds 4 \
   --warmup-rounds 1 \
   --artifact-dir demos/runtime_cost/artifacts/ci-smoke
 python3 scripts/validate_runtime_cost_summary.py \
@@ -68,7 +68,7 @@ python3 scripts/validate_runtime_cost_summary.py \
   --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json
 ```
 
-This is a bounded diagnostic sanity check only. It enforces broad catastrophic-regression checks and required tracing evidence shape, not rigorous performance benchmarking. CI validates runtime-cost output in-place and does not upload runtime-cost artifacts by default. Full runtime-cost measurement remains a local/developer-run path via the canonical command above. Results remain machine/workload/profile scoped.
+This is a bounded diagnostic sanity check only. It enforces tracing/native parity hard checks (p95 <= 1.25x native and throughput >= 0.75x native), a 5% soft warning band (p95 > 1.05x or throughput < 0.95x), and required tracing evidence shape, not rigorous performance benchmarking. CI validates runtime-cost output in-place and does not upload runtime-cost artifacts by default. Full runtime-cost measurement remains a local/developer-run path via the canonical command above. Results remain machine/workload/profile scoped.
 
 ## Inputs and knobs
 
@@ -109,3 +109,6 @@ Numbers are directional and machine/workload/profile scoped; broad thresholds ar
 ## Operational validation runner
 
 Use `python3 scripts/run_operational_validation.py --domain runtime-cost` for manual/local runtime-cost validation that emits JSONL records, stable summary JSON, and an optional scorecard. Results are machine/workload/profile scoped and should be treated as measurements, not universal guarantees. Missing metrics are emitted as `null` rather than guessed.
+
+
+Native remains the default instrumentation path because it is direct, explicit, and complete. Tracing is a first-class intake bridge for teams already instrumented with tracing or preferring span-shaped instrumentation. Small wins/losses inside the 5% warning band are treated as parity, not as a reason to change the default recommendation.

--- a/scripts/measure_runtime_cost.py
+++ b/scripts/measure_runtime_cost.py
@@ -51,6 +51,9 @@ QUALITY_NOISY = "noisy"
 QUALITY_UNSTABLE = "unstable"
 QUALITY_INSUFFICIENT_DATA = "insufficient_data"
 MIN_ROUNDS_FOR_STABLE = 4
+TRACING_PARITY_P95_HARD_LIMIT = 1.25
+TRACING_PARITY_THROUGHPUT_HARD_FLOOR = 0.75
+TRACING_PARITY_SOFT_WARNING_BAND = 0.05
 
 DELTA_VS_BASELINE_MODE_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("Baked-in overhead", ("baked_in_no_request_context",)),
@@ -381,26 +384,48 @@ def _validate_sanity(summary: dict) -> None:
             raise SystemExit(f"{key} is required and cannot be null (likely zero/missing denominator)")
         if value != value or value in (float("inf"), float("-inf")):
             raise SystemExit(f"{key} must be finite (not NaN or infinity)")
-    if ratios["tracing_light_vs_core_light_latency_p95"] > 20:
-        raise SystemExit("tracing_light_vs_core_light_latency_p95 exceeds catastrophic threshold (>20x)")
-    if ratios["tracing_light_vs_core_light_throughput"] < 0.05:
-        raise SystemExit("tracing_light_vs_core_light_throughput is below catastrophic threshold (<0.05x)")
-    if ratios["tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95"] > 20:
-        raise SystemExit(
-            "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95 exceeds catastrophic threshold (>20x)"
-        )
-    if ratios["tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput"] < 0.05:
-        raise SystemExit(
-            "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput is below catastrophic threshold (<0.05x)"
-        )
-    if ratios["tracing_light_drop_path_vs_core_light_drop_path_latency_p95"] > 20:
-        raise SystemExit(
-            "tracing_light_drop_path_vs_core_light_drop_path_latency_p95 exceeds catastrophic threshold (>20x)"
-        )
-    if ratios["tracing_light_drop_path_vs_core_light_drop_path_throughput"] < 0.05:
-        raise SystemExit(
-            "tracing_light_drop_path_vs_core_light_drop_path_throughput is below catastrophic threshold (<0.05x)"
-        )
+
+    warnings = evaluate_tracing_parity(ratios)
+    for warning in warnings:
+        print(f"WARNING: {warning}", file=sys.stderr)
+
+
+def evaluate_tracing_parity(ratios: dict[str, float]) -> list[str]:
+    warnings: list[str] = []
+    pairs = (
+        ("tracing_light", "tracing_light_vs_core_light_latency_p95", "tracing_light_vs_core_light_throughput"),
+        (
+            "tracing_light_tokio_sampler",
+            "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95",
+            "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput",
+        ),
+        (
+            "tracing_light_drop_path",
+            "tracing_light_drop_path_vs_core_light_drop_path_latency_p95",
+            "tracing_light_drop_path_vs_core_light_drop_path_throughput",
+        ),
+    )
+
+    for mode_label, latency_key, throughput_key in pairs:
+        latency_ratio = ratios[latency_key]
+        if latency_ratio > TRACING_PARITY_P95_HARD_LIMIT:
+            raise SystemExit(f"{latency_key} exceeds parity threshold (>{TRACING_PARITY_P95_HARD_LIMIT}x)")
+        if latency_ratio > (1.0 + TRACING_PARITY_SOFT_WARNING_BAND):
+            warnings.append(
+                f"{mode_label} p95 is {latency_ratio:.2f}x native; "
+                "within hard threshold but above 5% warning band"
+            )
+
+        throughput_ratio = ratios[throughput_key]
+        if throughput_ratio < TRACING_PARITY_THROUGHPUT_HARD_FLOOR:
+            raise SystemExit(f"{throughput_key} is below parity threshold (<{TRACING_PARITY_THROUGHPUT_HARD_FLOOR}x)")
+        if throughput_ratio < (1.0 - TRACING_PARITY_SOFT_WARNING_BAND):
+            warnings.append(
+                f"{mode_label} throughput is {throughput_ratio:.2f}x native; "
+                "within hard threshold but below 5% warning band"
+            )
+
+    return warnings
 
 
 def build_release_binary(root_dir: Path) -> Path:

--- a/scripts/measure_runtime_cost.py
+++ b/scripts/measure_runtime_cost.py
@@ -51,9 +51,9 @@ QUALITY_NOISY = "noisy"
 QUALITY_UNSTABLE = "unstable"
 QUALITY_INSUFFICIENT_DATA = "insufficient_data"
 MIN_ROUNDS_FOR_STABLE = 4
-TRACING_PARITY_P95_HARD_LIMIT = 1.25
-TRACING_PARITY_THROUGHPUT_HARD_FLOOR = 0.75
-TRACING_PARITY_SOFT_WARNING_BAND = 0.10
+TRACING_PARITY_P95_HARD_LIMIT = 1.10
+TRACING_PARITY_THROUGHPUT_HARD_FLOOR = 0.90
+TRACING_PARITY_SOFT_WARNING_BAND = 0.02
 
 DELTA_VS_BASELINE_MODE_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("Baked-in overhead", ("baked_in_no_request_context",)),
@@ -76,6 +76,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--work-ms", type=int, default=int(os.environ.get("WORK_MS", str(DEFAULT_WORK_MS))))
     parser.add_argument("--rounds", type=int, default=int(os.environ.get("ROUNDS", str(DEFAULT_ROUNDS))))
     parser.add_argument("--warmup-rounds", type=int, default=int(os.environ.get("WARMUP_ROUNDS", str(DEFAULT_WARMUP_ROUNDS))))
+    parser.add_argument(
+        "--print-json",
+        action="store_true",
+        help="Print the full summary JSON in addition to the compact report.",
+    )
     return parser.parse_args()
 
 
@@ -413,7 +418,7 @@ def evaluate_tracing_parity(ratios: dict[str, float]) -> list[str]:
         if latency_ratio > (1.0 + TRACING_PARITY_SOFT_WARNING_BAND):
             warnings.append(
                 f"{mode_label} p95 is {latency_ratio:.2f}x native; "
-                "within hard threshold but above 10% warning band"
+                "within hard threshold but above 2% warning band"
             )
 
         throughput_ratio = ratios[throughput_key]
@@ -422,7 +427,7 @@ def evaluate_tracing_parity(ratios: dict[str, float]) -> list[str]:
         if throughput_ratio < (1.0 - TRACING_PARITY_SOFT_WARNING_BAND):
             warnings.append(
                 f"{mode_label} throughput is {throughput_ratio:.2f}x native; "
-                "within hard threshold but below 10% warning band"
+                "within hard threshold but below 2% warning band"
             )
 
     return warnings
@@ -482,6 +487,10 @@ def run_mode(binary_path: Path, mode: str, args: argparse.Namespace, artifact_di
     return json.loads(output[-1])
 
 
+def ratio_text(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:.2f}x"
+
+
 def main() -> None:
     args = parse_args()
     if args.requests <= 0 or args.concurrency <= 0 or args.work_ms <= 0:
@@ -528,7 +537,7 @@ def main() -> None:
         for reason in summary["stability_warning"] or []:
             print(f" - {reason}", file=sys.stderr)
 
-    print(json.dumps(summary, indent=2))
+    parity_warnings = evaluate_tracing_parity(summary.get("tracing_vs_native_ratios", {}))
     ratios = summary.get("tracing_vs_native_ratios", {})
     rows = (
         (
@@ -547,14 +556,56 @@ def main() -> None:
             ratios.get("tracing_light_drop_path_vs_core_light_drop_path_throughput"),
         ),
     )
-    print("| comparison | p95 ratio | throughput ratio |")
-    print("|---|---:|---:|")
+    print("Runtime-cost CI smoke summary")
+    print(
+        "requests="
+        f"{summary['requests']} concurrency={summary['concurrency']} work_ms={summary['work_ms']} "
+        f"warmup_rounds={summary['warmup_rounds']} measured_rounds={summary['measured_rounds']} "
+        f"quality={summary['measurement_quality']}"
+    )
+    print()
+    print("GATED tracing/native runtime-path ratios")
+    print("| comparison | p95 ratio | throughput ratio | status |")
+    print("|---|---:|---:|---|")
     for name, p95_ratio, throughput_ratio in rows:
         p95_text = "n/a" if p95_ratio is None else f"{p95_ratio:.2f}x"
         throughput_text = "n/a" if throughput_ratio is None else f"{throughput_ratio:.2f}x"
-        print(f"| {name} | {p95_text} | {throughput_text} |")
+        status = "ok"
+        if (p95_ratio is not None and p95_ratio > TRACING_PARITY_P95_HARD_LIMIT) or (
+            throughput_ratio is not None and throughput_ratio < TRACING_PARITY_THROUGHPUT_HARD_FLOOR
+        ):
+            status = "fail"
+        elif (p95_ratio is not None and p95_ratio > (1.0 + TRACING_PARITY_SOFT_WARNING_BAND)) or (
+            throughput_ratio is not None and throughput_ratio < (1.0 - TRACING_PARITY_SOFT_WARNING_BAND)
+        ):
+            status = "warn"
+        print(f"| {name} | {p95_text} | {throughput_text} | {status} |")
+    print()
+    print("Informational post-run ratios")
+    print("| comparison | ratio |")
+    print("|---|---:|")
+    print(f"| tracing finalize / native finalize | {ratio_text(ratios.get('tracing_finalize_vs_native_finalize'))} |")
+    print(f"| tracing analyze / native analyze | {ratio_text(ratios.get('tracing_analyze_vs_native_analyze'))} |")
+    print(f"| tracing render / native render | {ratio_text(ratios.get('tracing_render_vs_native_render'))} |")
+    print()
+    print("Warnings")
+    if parity_warnings:
+        for warning in parity_warnings:
+            print(f"- WARNING: {warning}")
+    if summary["measurement_quality"] != QUALITY_STABLE:
+        print(
+            f"- WARNING: measurement quality is {summary['measurement_quality']}; rerun on a quieter machine for stronger conclusions."
+        )
+        for reason in summary["stability_warning"] or []:
+            print(f"- {reason}")
+    if not parity_warnings and summary["measurement_quality"] == QUALITY_STABLE:
+        print("- none")
+    print()
+    print("Artifacts")
     print(f"raw results: {raw_path}")
     print(f"summary: {summary_path}")
+    if args.print_json:
+        print(json.dumps(summary, indent=2))
 
 
 if __name__ == "__main__":

--- a/scripts/measure_runtime_cost.py
+++ b/scripts/measure_runtime_cost.py
@@ -53,7 +53,7 @@ QUALITY_INSUFFICIENT_DATA = "insufficient_data"
 MIN_ROUNDS_FOR_STABLE = 4
 TRACING_PARITY_P95_HARD_LIMIT = 1.25
 TRACING_PARITY_THROUGHPUT_HARD_FLOOR = 0.75
-TRACING_PARITY_SOFT_WARNING_BAND = 0.05
+TRACING_PARITY_SOFT_WARNING_BAND = 0.10
 
 DELTA_VS_BASELINE_MODE_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("Baked-in overhead", ("baked_in_no_request_context",)),
@@ -413,7 +413,7 @@ def evaluate_tracing_parity(ratios: dict[str, float]) -> list[str]:
         if latency_ratio > (1.0 + TRACING_PARITY_SOFT_WARNING_BAND):
             warnings.append(
                 f"{mode_label} p95 is {latency_ratio:.2f}x native; "
-                "within hard threshold but above 5% warning band"
+                "within hard threshold but above 10% warning band"
             )
 
         throughput_ratio = ratios[throughput_key]
@@ -422,7 +422,7 @@ def evaluate_tracing_parity(ratios: dict[str, float]) -> list[str]:
         if throughput_ratio < (1.0 - TRACING_PARITY_SOFT_WARNING_BAND):
             warnings.append(
                 f"{mode_label} throughput is {throughput_ratio:.2f}x native; "
-                "within hard threshold but below 5% warning band"
+                "within hard threshold but below 10% warning band"
             )
 
     return warnings

--- a/scripts/tests/test_measure_runtime_cost.py
+++ b/scripts/tests/test_measure_runtime_cost.py
@@ -207,11 +207,11 @@ class RuntimeCostSummaryTests(unittest.TestCase):
                                             "drop_path_signal_present_rounds": 0} for m in measure_runtime_cost.MODES},
                    "tracing_vs_native_ratios": {
                        "tracing_light_vs_core_light_latency_p95": 1.10,
-                       "tracing_light_vs_core_light_throughput": 0.8,
+                       "tracing_light_vs_core_light_throughput": 0.9,
                        "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.10,
-                       "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 0.8,
+                       "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 0.9,
                        "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.10,
-                       "tracing_light_drop_path_vs_core_light_drop_path_throughput": 0.8,
+                       "tracing_light_drop_path_vs_core_light_drop_path_throughput": 0.9,
                    }}
         summary["absolute_metrics"]["tracing_light_tokio_sampler"]["runtime_snapshots"]["median"] = 1
         summary["absolute_metrics"]["tracing_light_tokio_sampler"]["effective_tokio_sampler_config_present_rounds"] = 1
@@ -220,25 +220,47 @@ class RuntimeCostSummaryTests(unittest.TestCase):
 
     def test_parity_warning_for_latency_above_soft_band(self) -> None:
         warnings = measure_runtime_cost.evaluate_tracing_parity({
-            "tracing_light_vs_core_light_latency_p95": 1.11,
+            "tracing_light_vs_core_light_latency_p95": 1.03,
             "tracing_light_vs_core_light_throughput": 1.0,
             "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.0,
             "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 1.0,
             "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.0,
             "tracing_light_drop_path_vs_core_light_drop_path_throughput": 1.0,
         })
-        self.assertTrue(any("tracing_light p95 is 1.11x native" in w for w in warnings))
+        self.assertTrue(any("tracing_light p95 is 1.03x native" in w for w in warnings))
+
+    def test_parity_no_warning_for_latency_at_or_below_soft_band(self) -> None:
+        warnings = measure_runtime_cost.evaluate_tracing_parity({
+            "tracing_light_vs_core_light_latency_p95": 1.02,
+            "tracing_light_vs_core_light_throughput": 1.0,
+            "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.02,
+            "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 1.0,
+            "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.02,
+            "tracing_light_drop_path_vs_core_light_drop_path_throughput": 1.0,
+        })
+        self.assertEqual(warnings, [])
 
     def test_parity_warning_for_throughput_below_soft_band(self) -> None:
         warnings = measure_runtime_cost.evaluate_tracing_parity({
             "tracing_light_vs_core_light_latency_p95": 1.0,
-            "tracing_light_vs_core_light_throughput": 0.89,
+            "tracing_light_vs_core_light_throughput": 0.97,
             "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.0,
             "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 1.0,
             "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.0,
             "tracing_light_drop_path_vs_core_light_drop_path_throughput": 1.0,
         })
-        self.assertTrue(any("tracing_light throughput is 0.89x native" in w for w in warnings))
+        self.assertTrue(any("tracing_light throughput is 0.97x native" in w for w in warnings))
+
+    def test_parity_no_warning_for_throughput_at_or_above_soft_band(self) -> None:
+        warnings = measure_runtime_cost.evaluate_tracing_parity({
+            "tracing_light_vs_core_light_latency_p95": 1.0,
+            "tracing_light_vs_core_light_throughput": 0.98,
+            "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.0,
+            "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 0.98,
+            "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.0,
+            "tracing_light_drop_path_vs_core_light_drop_path_throughput": 0.98,
+        })
+        self.assertEqual(warnings, [])
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_measure_runtime_cost.py
+++ b/scripts/tests/test_measure_runtime_cost.py
@@ -159,14 +159,14 @@ class RuntimeCostSummaryTests(unittest.TestCase):
             self.assertEqual(drop_summary["limit_reached_rounds"], 4)
             self.assertGreater(drop_summary["dropped_requests"]["mean"], 0)
 
-    def test_sanity_fails_on_catastrophic_latency_ratio(self) -> None:
+    def test_sanity_fails_on_parity_latency_ratio(self) -> None:
         summary = {"absolute_metrics": {m: {"throughput_rps": {"median": 10.0}, "latency_p95_ms": {"median": 2.0},
                                             "run_requests": {"median": 1}, "run_stages": {"median": 1}, "run_queues": {"median": 1},
                                             "runtime_snapshots": {"median": 0},
                                             "effective_tokio_sampler_config_present_rounds": 0,
                                             "drop_path_signal_present_rounds": 0} for m in measure_runtime_cost.MODES},
                    "tracing_vs_native_ratios": {
-                       "tracing_light_vs_core_light_latency_p95": 25.0,
+                       "tracing_light_vs_core_light_latency_p95": 1.26,
                        "tracing_light_vs_core_light_throughput": 0.5,
                        "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.0,
                        "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 1.0,
@@ -179,7 +179,7 @@ class RuntimeCostSummaryTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             measure_runtime_cost._validate_sanity(summary)
 
-    def test_sanity_fails_on_catastrophic_throughput_ratio(self) -> None:
+    def test_sanity_fails_on_parity_throughput_ratio(self) -> None:
         summary = {"absolute_metrics": {m: {"throughput_rps": {"median": 10.0}, "latency_p95_ms": {"median": 2.0},
                                             "run_requests": {"median": 1}, "run_stages": {"median": 1}, "run_queues": {"median": 1},
                                             "runtime_snapshots": {"median": 0},
@@ -187,7 +187,7 @@ class RuntimeCostSummaryTests(unittest.TestCase):
                                             "drop_path_signal_present_rounds": 0} for m in measure_runtime_cost.MODES},
                    "tracing_vs_native_ratios": {
                        "tracing_light_vs_core_light_latency_p95": 1.0,
-                       "tracing_light_vs_core_light_throughput": 0.01,
+                       "tracing_light_vs_core_light_throughput": 0.74,
                        "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.0,
                        "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 1.0,
                        "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.0,
@@ -206,17 +206,39 @@ class RuntimeCostSummaryTests(unittest.TestCase):
                                             "effective_tokio_sampler_config_present_rounds": 0,
                                             "drop_path_signal_present_rounds": 0} for m in measure_runtime_cost.MODES},
                    "tracing_vs_native_ratios": {
-                       "tracing_light_vs_core_light_latency_p95": 2.0,
+                       "tracing_light_vs_core_light_latency_p95": 1.10,
                        "tracing_light_vs_core_light_throughput": 0.8,
-                       "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 2.0,
+                       "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.10,
                        "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 0.8,
-                       "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 2.0,
+                       "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.10,
                        "tracing_light_drop_path_vs_core_light_drop_path_throughput": 0.8,
                    }}
         summary["absolute_metrics"]["tracing_light_tokio_sampler"]["runtime_snapshots"]["median"] = 1
         summary["absolute_metrics"]["tracing_light_tokio_sampler"]["effective_tokio_sampler_config_present_rounds"] = 1
         summary["absolute_metrics"]["tracing_light_drop_path"]["drop_path_signal_present_rounds"] = 1
         measure_runtime_cost._validate_sanity(summary)
+
+    def test_parity_warning_for_latency_above_soft_band(self) -> None:
+        warnings = measure_runtime_cost.evaluate_tracing_parity({
+            "tracing_light_vs_core_light_latency_p95": 1.07,
+            "tracing_light_vs_core_light_throughput": 1.0,
+            "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.0,
+            "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 1.0,
+            "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.0,
+            "tracing_light_drop_path_vs_core_light_drop_path_throughput": 1.0,
+        })
+        self.assertTrue(any("tracing_light p95 is 1.07x native" in w for w in warnings))
+
+    def test_parity_warning_for_throughput_below_soft_band(self) -> None:
+        warnings = measure_runtime_cost.evaluate_tracing_parity({
+            "tracing_light_vs_core_light_latency_p95": 1.0,
+            "tracing_light_vs_core_light_throughput": 0.93,
+            "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.0,
+            "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 1.0,
+            "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.0,
+            "tracing_light_drop_path_vs_core_light_drop_path_throughput": 1.0,
+        })
+        self.assertTrue(any("tracing_light throughput is 0.93x native" in w for w in warnings))
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_measure_runtime_cost.py
+++ b/scripts/tests/test_measure_runtime_cost.py
@@ -220,25 +220,25 @@ class RuntimeCostSummaryTests(unittest.TestCase):
 
     def test_parity_warning_for_latency_above_soft_band(self) -> None:
         warnings = measure_runtime_cost.evaluate_tracing_parity({
-            "tracing_light_vs_core_light_latency_p95": 1.07,
+            "tracing_light_vs_core_light_latency_p95": 1.11,
             "tracing_light_vs_core_light_throughput": 1.0,
             "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.0,
             "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 1.0,
             "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.0,
             "tracing_light_drop_path_vs_core_light_drop_path_throughput": 1.0,
         })
-        self.assertTrue(any("tracing_light p95 is 1.07x native" in w for w in warnings))
+        self.assertTrue(any("tracing_light p95 is 1.11x native" in w for w in warnings))
 
     def test_parity_warning_for_throughput_below_soft_band(self) -> None:
         warnings = measure_runtime_cost.evaluate_tracing_parity({
             "tracing_light_vs_core_light_latency_p95": 1.0,
-            "tracing_light_vs_core_light_throughput": 0.93,
+            "tracing_light_vs_core_light_throughput": 0.89,
             "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.0,
             "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 1.0,
             "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.0,
             "tracing_light_drop_path_vs_core_light_drop_path_throughput": 1.0,
         })
-        self.assertTrue(any("tracing_light throughput is 0.93x native" in w for w in warnings))
+        self.assertTrue(any("tracing_light throughput is 0.89x native" in w for w in warnings))
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_validate_runtime_cost_summary.py
+++ b/scripts/tests/test_validate_runtime_cost_summary.py
@@ -36,6 +36,8 @@ class ValidateRuntimeCostSummaryTests(unittest.TestCase):
         abs_metrics["tracing_light_tokio_sampler"]["effective_tokio_sampler_config_present_rounds"] = 1
         abs_metrics["tracing_light_drop_path"]["drop_path_signal_present_rounds"] = 1
         return {
+            "measured_rounds": 4,
+            "measurement_quality": "noisy",
             "absolute_metrics": abs_metrics,
             "tracing_vs_native_ratios": {
                 "tracing_light_vs_core_light_latency_p95": 1.0,
@@ -43,7 +45,7 @@ class ValidateRuntimeCostSummaryTests(unittest.TestCase):
                 "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.1,
                 "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 0.8,
                 "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.2,
-                "tracing_light_drop_path_vs_core_light_drop_path_throughput": 0.7,
+                "tracing_light_drop_path_vs_core_light_drop_path_throughput": 0.8,
             },
         }
 
@@ -100,6 +102,20 @@ class ValidateRuntimeCostSummaryTests(unittest.TestCase):
     def test_missing_required_ratio_key_fails(self) -> None:
         summary = self._summary()
         del summary["tracing_vs_native_ratios"]["tracing_light_drop_path_vs_core_light_drop_path_throughput"]
+        raw, summ, tmp = self._write(summary)
+        with tmp, self.assertRaises(SystemExit):
+            validate_runtime_cost_summary.validate(raw, summ)
+
+    def test_fewer_measured_rounds_fails(self) -> None:
+        summary = self._summary()
+        summary["measured_rounds"] = 2
+        raw, summ, tmp = self._write(summary)
+        with tmp, self.assertRaises(SystemExit):
+            validate_runtime_cost_summary.validate(raw, summ)
+
+    def test_insufficient_data_quality_fails(self) -> None:
+        summary = self._summary()
+        summary["measurement_quality"] = "insufficient_data"
         raw, summ, tmp = self._write(summary)
         with tmp, self.assertRaises(SystemExit):
             validate_runtime_cost_summary.validate(raw, summ)

--- a/scripts/tests/test_validate_runtime_cost_summary.py
+++ b/scripts/tests/test_validate_runtime_cost_summary.py
@@ -41,11 +41,11 @@ class ValidateRuntimeCostSummaryTests(unittest.TestCase):
             "absolute_metrics": abs_metrics,
             "tracing_vs_native_ratios": {
                 "tracing_light_vs_core_light_latency_p95": 1.0,
-                "tracing_light_vs_core_light_throughput": 0.9,
-                "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.1,
-                "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 0.8,
-                "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.2,
-                "tracing_light_drop_path_vs_core_light_drop_path_throughput": 0.8,
+                "tracing_light_vs_core_light_throughput": 0.97,
+                "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.03,
+                "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 0.97,
+                "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.03,
+                "tracing_light_drop_path_vs_core_light_drop_path_throughput": 0.97,
             },
         }
 

--- a/scripts/validate_runtime_cost_summary.py
+++ b/scripts/validate_runtime_cost_summary.py
@@ -13,7 +13,7 @@ SCRIPTS_DIR = Path(__file__).resolve().parent
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
-from measure_runtime_cost import MODES, _validate_sanity
+from measure_runtime_cost import MIN_ROUNDS_FOR_STABLE, MODES, QUALITY_INSUFFICIENT_DATA, _validate_sanity
 
 
 def parse_args() -> argparse.Namespace:
@@ -44,6 +44,16 @@ def validate(raw_path: Path, summary_path: Path) -> None:
 
     if "tracing_vs_native_ratios" not in summary:
         raise SystemExit("summary missing tracing_vs_native_ratios")
+
+    measured_rounds = summary.get("measured_rounds")
+    if not isinstance(measured_rounds, int) or measured_rounds < MIN_ROUNDS_FOR_STABLE:
+        raise SystemExit(
+            f"measured_rounds must be >= {MIN_ROUNDS_FOR_STABLE} for CI smoke validation (found: {measured_rounds})"
+        )
+
+    measurement_quality = summary.get("measurement_quality")
+    if measurement_quality == QUALITY_INSUFFICIENT_DATA:
+        raise SystemExit("measurement_quality is insufficient_data after expected measured rounds")
 
     _validate_sanity(summary)
 


### PR DESCRIPTION
### Motivation

- Replace the overly-permissive catastrophic runtime-cost gate with a practical tracing/native parity gate.
- Improve CI runtime-cost signal by using more measured work while keeping the check bounded.
- Keep runtime-cost validation as a smoke/regression check, not a rigorous benchmark.
- Improve CI log readability by printing compact runtime-cost tables instead of dumping the full JSON summary by default.

### Description

- Tightened tracing/native runtime-cost hard gates:
  - p95 latency ratio must be `<= 1.10x`
  - throughput ratio must be `>= 0.90x`
- Added a 2% non-failing warning band:
  - warn when p95 latency ratio is `> 1.02x`
  - warn when throughput ratio is `< 0.98x`
- Increased the CI runtime-cost workload while keeping it in the existing Ubuntu release leg:
  - `--requests 4000`
  - `--concurrency 32`
  - `--work-ms 4`
  - `--rounds 4`
  - `--warmup-rounds 1`
- Kept tracing parity validation on the Ubuntu release leg using `--profile release`.
- Added compact runtime-cost CI output:
  - gated tracing/native runtime-path ratios table
  - informational post-run ratios table
  - warnings section for parity and measurement-quality warnings
  - artifact path summary
- Stopped printing the full JSON summary by default.
- Added `--print-json` to print the full JSON summary when needed locally.
- Preserved full raw and summary artifacts:
  - `runtime-cost-raw.jsonl`
  - `runtime-cost-summary.json`
- Preserved existing required evidence-shape checks:
  - tracing modes must record request/stage/queue evidence
  - tracing Tokio sampler mode must include runtime snapshots and sampler metadata
  - tracing drop-path mode must include drop-path signal
  - required ratios must be present and finite
- Kept measurement-quality policy:
  - `noisy` and `unstable` remain nonfatal
  - `insufficient_data` after expected measured rounds is fatal
- Updated runtime-cost docs and tests for the new thresholds, workload, compact output, and `--print-json`.

Files changed:
- `.github/workflows/ci.yml`
- `docs/runtime-cost.md`
- `scripts/measure_runtime_cost.py`
- `scripts/validate_runtime_cost_summary.py`
- `scripts/tests/test_measure_runtime_cost.py`
- `scripts/tests/test_validate_runtime_cost_summary.py`

### Testing

- `cargo fmt --check`
- `python3 -m unittest scripts.tests.test_measure_runtime_cost scripts.tests.test_validate_runtime_cost_summary`
- `python3 scripts/demo_tool.py validate-tracing-parity all --profile release`
- `python3 scripts/measure_runtime_cost.py --requests 4000 --concurrency 32 --work-ms 4 --rounds 4 --warmup-rounds 1 --artifact-dir demos/runtime_cost/artifacts/ci-smoke`
- `python3 scripts/validate_runtime_cost_summary.py --raw demos/runtime_cost/artifacts/ci-smoke/runtime-cost-raw.jsonl --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json`
- `python3 scripts/measure_runtime_cost.py --requests 4000 --concurrency 32 --work-ms 4 --rounds 4 --warmup-rounds 1 --artifact-dir demos/runtime_cost/artifacts/ci-smoke-json --print-json`
- `python3 scripts/validate_docs_contracts.py`

### CI status

- CI is green on current head.
- Ubuntu release runs:
  - tracing parity across all demos
  - runtime-cost smoke
  - runtime-cost summary validation
- Ubuntu dev runs:
  - runtime-cost script unit tests
  - runtime-cost summary validator unit tests
- No separate runtime-cost CI leg was added.