### PR TITLE
Tighten runtime-cost smoke into tracing/native parity gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,7 @@ jobs:
             --requests 1200 \
             --concurrency 32 \
             --work-ms 4 \
-            --rounds 2 \
+            --rounds 4 \
             --warmup-rounds 1 \
             --artifact-dir demos/runtime_cost/artifacts/ci-smoke
 
@@ -301,4 +301,3 @@ jobs:
           python3 scripts/validate_runtime_cost_summary.py \
             --raw demos/runtime_cost/artifacts/ci-smoke/runtime-cost-raw.jsonl \
             --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json
-

--- a/docs/runtime-cost.md
+++ b/docs/runtime-cost.md
@@ -60,7 +60,7 @@ python3 scripts/measure_runtime_cost.py \
   --requests 1200 \
   --concurrency 32 \
   --work-ms 4 \
-  --rounds 2 \
+  --rounds 4 \
   --warmup-rounds 1 \
   --artifact-dir demos/runtime_cost/artifacts/ci-smoke
 python3 scripts/validate_runtime_cost_summary.py \
@@ -68,7 +68,22 @@ python3 scripts/validate_runtime_cost_summary.py \
   --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json
 ```
 
-This is a bounded diagnostic sanity check only. It enforces broad catastrophic-regression checks and required tracing evidence shape, not rigorous performance benchmarking. CI validates runtime-cost output in-place and does not upload runtime-cost artifacts by default. Full runtime-cost measurement remains a local/developer-run path via the canonical command above. Results remain machine/workload/profile scoped.
+This is a bounded diagnostic sanity check only. It enforces required tracing evidence shape plus bounded tracing/native parity checks, not rigorous performance benchmarking. CI validates runtime-cost output in-place and does not upload runtime-cost artifacts by default. Full runtime-cost measurement remains a local/developer-run path via the canonical command above. Results remain machine/workload/profile scoped.
+
+Hard tracing/native parity thresholds enforced in CI smoke:
+
+- p95 latency ratio must be `<= 1.25x` native for:
+  - `tracing_light / core_light`
+  - `tracing_light_tokio_sampler / core_light_tokio_sampler`
+  - `tracing_light_drop_path / core_light_drop_path`
+- throughput ratio must be `>= 0.75x` native for the same three pairs
+
+Soft warning band (does not fail CI):
+
+- warning when tracing p95 ratio is `> 1.05x` native
+- warning when tracing throughput ratio is `< 0.95x` native
+
+Minor wins/losses inside this ±5% band are treated as parity. Native remains the default instrumentation path because it is direct, explicit, and complete. Tracing remains a first-class intake bridge for users already using tracing or preferring span-shaped instrumentation, and is expected to stay close to native in cost.
 
 ## Inputs and knobs
 
@@ -97,7 +112,7 @@ Per-mode records now include instrumentation family (`baseline` / `native` / `tr
 - Use **Post-limit / drop-path overhead** only for intentionally saturated-limit behavior.
 
 If `measurement_quality` reports noisy/unstable, rerun on a quieter machine state before drawing stronger conclusions.
-Numbers are directional and machine/workload/profile scoped; broad thresholds are intended only to catch catastrophic regressions.
+Numbers are directional and machine/workload/profile scoped; CI smoke is a bounded regression gate, not a rigorous benchmark.
 
 ## Semantics reminder
 

--- a/scripts/measure_runtime_cost.py
+++ b/scripts/measure_runtime_cost.py
@@ -51,6 +51,9 @@ QUALITY_NOISY = "noisy"
 QUALITY_UNSTABLE = "unstable"
 QUALITY_INSUFFICIENT_DATA = "insufficient_data"
 MIN_ROUNDS_FOR_STABLE = 4
+TRACING_NATIVE_PARITY_LATENCY_P95_HARD_LIMIT = 1.25
+TRACING_NATIVE_PARITY_THROUGHPUT_HARD_FLOOR = 0.75
+TRACING_NATIVE_PARITY_SOFT_WARNING_DELTA = 0.05
 
 DELTA_VS_BASELINE_MODE_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("Baked-in overhead", ("baked_in_no_request_context",)),
@@ -350,6 +353,14 @@ def summarize(raw_path: Path, summary_path: Path) -> dict:
 
 
 def _validate_sanity(summary: dict) -> None:
+    measured_rounds = summary.get("measured_rounds")
+    if not isinstance(measured_rounds, int):
+        raise SystemExit("summary missing measured_rounds")
+    if measured_rounds < MIN_ROUNDS_FOR_STABLE:
+        raise SystemExit(
+            f"measured rounds below required minimum ({measured_rounds} < {MIN_ROUNDS_FOR_STABLE})"
+        )
+
     abs_m = summary["absolute_metrics"]
     required = ("core_light", "tracing_light", "tracing_light_tokio_sampler")
     for mode in MODES:
@@ -381,26 +392,46 @@ def _validate_sanity(summary: dict) -> None:
             raise SystemExit(f"{key} is required and cannot be null (likely zero/missing denominator)")
         if value != value or value in (float("inf"), float("-inf")):
             raise SystemExit(f"{key} must be finite (not NaN or infinity)")
-    if ratios["tracing_light_vs_core_light_latency_p95"] > 20:
-        raise SystemExit("tracing_light_vs_core_light_latency_p95 exceeds catastrophic threshold (>20x)")
-    if ratios["tracing_light_vs_core_light_throughput"] < 0.05:
-        raise SystemExit("tracing_light_vs_core_light_throughput is below catastrophic threshold (<0.05x)")
-    if ratios["tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95"] > 20:
-        raise SystemExit(
-            "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95 exceeds catastrophic threshold (>20x)"
-        )
-    if ratios["tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput"] < 0.05:
-        raise SystemExit(
-            "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput is below catastrophic threshold (<0.05x)"
-        )
-    if ratios["tracing_light_drop_path_vs_core_light_drop_path_latency_p95"] > 20:
-        raise SystemExit(
-            "tracing_light_drop_path_vs_core_light_drop_path_latency_p95 exceeds catastrophic threshold (>20x)"
-        )
-    if ratios["tracing_light_drop_path_vs_core_light_drop_path_throughput"] < 0.05:
-        raise SystemExit(
-            "tracing_light_drop_path_vs_core_light_drop_path_throughput is below catastrophic threshold (<0.05x)"
-        )
+    parity_pairs = (
+        ("tracing_light", "tracing_light_vs_core_light_latency_p95", "tracing_light_vs_core_light_throughput"),
+        (
+            "tracing_light_tokio_sampler",
+            "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95",
+            "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput",
+        ),
+        (
+            "tracing_light_drop_path",
+            "tracing_light_drop_path_vs_core_light_drop_path_latency_p95",
+            "tracing_light_drop_path_vs_core_light_drop_path_throughput",
+        ),
+    )
+    for label, latency_key, throughput_key in parity_pairs:
+        latency_ratio = ratios[latency_key]
+        throughput_ratio = ratios[throughput_key]
+        if latency_ratio > TRACING_NATIVE_PARITY_LATENCY_P95_HARD_LIMIT:
+            raise SystemExit(
+                f"{latency_key} exceeds parity threshold (>{TRACING_NATIVE_PARITY_LATENCY_P95_HARD_LIMIT}x)"
+            )
+        if throughput_ratio < TRACING_NATIVE_PARITY_THROUGHPUT_HARD_FLOOR:
+            raise SystemExit(
+                f"{throughput_key} is below parity threshold (<{TRACING_NATIVE_PARITY_THROUGHPUT_HARD_FLOOR}x)"
+            )
+        if latency_ratio > (1.0 + TRACING_NATIVE_PARITY_SOFT_WARNING_DELTA):
+            print(
+                (
+                    f"WARNING: {label} p95 is {latency_ratio:.2f}x native; within hard threshold "
+                    f"but above {TRACING_NATIVE_PARITY_SOFT_WARNING_DELTA:.0%} warning band"
+                ),
+                file=sys.stderr,
+            )
+        if throughput_ratio < (1.0 - TRACING_NATIVE_PARITY_SOFT_WARNING_DELTA):
+            print(
+                (
+                    f"WARNING: {label} throughput is {throughput_ratio:.2f}x native; within hard threshold "
+                    f"but below {TRACING_NATIVE_PARITY_SOFT_WARNING_DELTA:.0%} warning band"
+                ),
+                file=sys.stderr,
+            )
 
 
 def build_release_binary(root_dir: Path) -> Path:

--- a/scripts/tests/test_measure_runtime_cost.py
+++ b/scripts/tests/test_measure_runtime_cost.py
@@ -160,13 +160,13 @@ class RuntimeCostSummaryTests(unittest.TestCase):
             self.assertGreater(drop_summary["dropped_requests"]["mean"], 0)
 
     def test_sanity_fails_on_catastrophic_latency_ratio(self) -> None:
-        summary = {"absolute_metrics": {m: {"throughput_rps": {"median": 10.0}, "latency_p95_ms": {"median": 2.0},
+        summary = {"measured_rounds": 4, "absolute_metrics": {m: {"throughput_rps": {"median": 10.0}, "latency_p95_ms": {"median": 2.0},
                                             "run_requests": {"median": 1}, "run_stages": {"median": 1}, "run_queues": {"median": 1},
                                             "runtime_snapshots": {"median": 0},
                                             "effective_tokio_sampler_config_present_rounds": 0,
                                             "drop_path_signal_present_rounds": 0} for m in measure_runtime_cost.MODES},
                    "tracing_vs_native_ratios": {
-                       "tracing_light_vs_core_light_latency_p95": 25.0,
+                       "tracing_light_vs_core_light_latency_p95": 1.26,
                        "tracing_light_vs_core_light_throughput": 0.5,
                        "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.0,
                        "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 1.0,
@@ -180,14 +180,14 @@ class RuntimeCostSummaryTests(unittest.TestCase):
             measure_runtime_cost._validate_sanity(summary)
 
     def test_sanity_fails_on_catastrophic_throughput_ratio(self) -> None:
-        summary = {"absolute_metrics": {m: {"throughput_rps": {"median": 10.0}, "latency_p95_ms": {"median": 2.0},
+        summary = {"measured_rounds": 4, "absolute_metrics": {m: {"throughput_rps": {"median": 10.0}, "latency_p95_ms": {"median": 2.0},
                                             "run_requests": {"median": 1}, "run_stages": {"median": 1}, "run_queues": {"median": 1},
                                             "runtime_snapshots": {"median": 0},
                                             "effective_tokio_sampler_config_present_rounds": 0,
                                             "drop_path_signal_present_rounds": 0} for m in measure_runtime_cost.MODES},
                    "tracing_vs_native_ratios": {
                        "tracing_light_vs_core_light_latency_p95": 1.0,
-                       "tracing_light_vs_core_light_throughput": 0.01,
+                       "tracing_light_vs_core_light_throughput": 0.74,
                        "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.0,
                        "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 1.0,
                        "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.0,
@@ -200,23 +200,40 @@ class RuntimeCostSummaryTests(unittest.TestCase):
             measure_runtime_cost._validate_sanity(summary)
 
     def test_sanity_passes_for_reasonable_tracing_ratios(self) -> None:
-        summary = {"absolute_metrics": {m: {"throughput_rps": {"median": 10.0}, "latency_p95_ms": {"median": 2.0},
+        summary = {"measured_rounds": 4, "absolute_metrics": {m: {"throughput_rps": {"median": 10.0}, "latency_p95_ms": {"median": 2.0},
                                             "run_requests": {"median": 1}, "run_stages": {"median": 1}, "run_queues": {"median": 1},
                                             "runtime_snapshots": {"median": 0},
                                             "effective_tokio_sampler_config_present_rounds": 0,
                                             "drop_path_signal_present_rounds": 0} for m in measure_runtime_cost.MODES},
                    "tracing_vs_native_ratios": {
-                       "tracing_light_vs_core_light_latency_p95": 2.0,
-                       "tracing_light_vs_core_light_throughput": 0.8,
-                       "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 2.0,
-                       "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 0.8,
-                       "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 2.0,
-                       "tracing_light_drop_path_vs_core_light_drop_path_throughput": 0.8,
+                       "tracing_light_vs_core_light_latency_p95": 1.02,
+                       "tracing_light_vs_core_light_throughput": 0.99,
+                       "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.03,
+                       "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 0.98,
+                       "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.04,
+                       "tracing_light_drop_path_vs_core_light_drop_path_throughput": 0.97,
                    }}
         summary["absolute_metrics"]["tracing_light_tokio_sampler"]["runtime_snapshots"]["median"] = 1
         summary["absolute_metrics"]["tracing_light_tokio_sampler"]["effective_tokio_sampler_config_present_rounds"] = 1
         summary["absolute_metrics"]["tracing_light_drop_path"]["drop_path_signal_present_rounds"] = 1
         measure_runtime_cost._validate_sanity(summary)
+
+    def test_sanity_fails_when_measured_rounds_below_minimum(self) -> None:
+        summary = {"measured_rounds": 2, "absolute_metrics": {m: {"throughput_rps": {"median": 10.0}, "latency_p95_ms": {"median": 2.0},
+                                            "run_requests": {"median": 1}, "run_stages": {"median": 1}, "run_queues": {"median": 1},
+                                            "runtime_snapshots": {"median": 0},
+                                            "effective_tokio_sampler_config_present_rounds": 0,
+                                            "drop_path_signal_present_rounds": 0} for m in measure_runtime_cost.MODES},
+                   "tracing_vs_native_ratios": {
+                       "tracing_light_vs_core_light_latency_p95": 1.0,
+                       "tracing_light_vs_core_light_throughput": 1.0,
+                       "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.0,
+                       "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 1.0,
+                       "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.0,
+                       "tracing_light_drop_path_vs_core_light_drop_path_throughput": 1.0,
+                   }}
+        with self.assertRaises(SystemExit):
+            measure_runtime_cost._validate_sanity(summary)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_validate_runtime_cost_summary.py
+++ b/scripts/tests/test_validate_runtime_cost_summary.py
@@ -36,6 +36,7 @@ class ValidateRuntimeCostSummaryTests(unittest.TestCase):
         abs_metrics["tracing_light_tokio_sampler"]["effective_tokio_sampler_config_present_rounds"] = 1
         abs_metrics["tracing_light_drop_path"]["drop_path_signal_present_rounds"] = 1
         return {
+            "measured_rounds": 4,
             "absolute_metrics": abs_metrics,
             "tracing_vs_native_ratios": {
                 "tracing_light_vs_core_light_latency_p95": 1.0,
@@ -43,7 +44,7 @@ class ValidateRuntimeCostSummaryTests(unittest.TestCase):
                 "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_latency_p95": 1.1,
                 "tracing_light_tokio_sampler_vs_core_light_tokio_sampler_throughput": 0.8,
                 "tracing_light_drop_path_vs_core_light_drop_path_latency_p95": 1.2,
-                "tracing_light_drop_path_vs_core_light_drop_path_throughput": 0.7,
+                "tracing_light_drop_path_vs_core_light_drop_path_throughput": 0.8,
             },
         }
 
@@ -100,6 +101,34 @@ class ValidateRuntimeCostSummaryTests(unittest.TestCase):
     def test_missing_required_ratio_key_fails(self) -> None:
         summary = self._summary()
         del summary["tracing_vs_native_ratios"]["tracing_light_drop_path_vs_core_light_drop_path_throughput"]
+        raw, summ, tmp = self._write(summary)
+        with tmp, self.assertRaises(SystemExit):
+            validate_runtime_cost_summary.validate(raw, summ)
+
+    def test_over_hard_parity_latency_fails(self) -> None:
+        summary = self._summary()
+        summary["tracing_vs_native_ratios"]["tracing_light_vs_core_light_latency_p95"] = 1.3
+        raw, summ, tmp = self._write(summary)
+        with tmp, self.assertRaises(SystemExit):
+            validate_runtime_cost_summary.validate(raw, summ)
+
+    def test_below_hard_parity_throughput_fails(self) -> None:
+        summary = self._summary()
+        summary["tracing_vs_native_ratios"]["tracing_light_vs_core_light_throughput"] = 0.7
+        raw, summ, tmp = self._write(summary)
+        with tmp, self.assertRaises(SystemExit):
+            validate_runtime_cost_summary.validate(raw, summ)
+
+    def test_null_required_ratio_fails(self) -> None:
+        summary = self._summary()
+        summary["tracing_vs_native_ratios"]["tracing_light_vs_core_light_throughput"] = None
+        raw, summ, tmp = self._write(summary)
+        with tmp, self.assertRaises(SystemExit):
+            validate_runtime_cost_summary.validate(raw, summ)
+
+    def test_insufficient_measured_rounds_fails(self) -> None:
+        summary = self._summary()
+        summary["measured_rounds"] = 2
         raw, summ, tmp = self._write(summary)
         with tmp, self.assertRaises(SystemExit):
             validate_runtime_cost_summary.validate(raw, summ)


### PR DESCRIPTION
### Motivation
- Improve CI runtime-cost smoke so tracing vs native costs are enforced as a meaningful parity gate (bounded regression) rather than only catastrophic thresholds. 
- Make the CI smoke more statistically useful by increasing measured rounds to reduce `insufficient_data` false positives while keeping the bounded workload shape.

### Description
- Replace the old catastrophic 20x/0.05 checks with named parity constants and hard gates of p95 latency ratio `<= 1.25x` and throughput ratio `>= 0.75x`, and add a non-failing 5% soft warning band (`>1.05x` p95 or `<0.95x` throughput). 
- Require `measured_rounds` to be present and `>= 4` for this CI smoke and fail early on missing/invalid metrics while preserving all existing evidence-shape checks (request/stage/queue, runtime snapshots, sampler metadata, drop-path signal, finite ratios). 
- Change CI smoke rounds to `--rounds 4 --warmup-rounds 1` while keeping `--requests 1200 --concurrency 32 --work-ms 4`, update docs accordingly, and add/adjust unit tests for the new validator logic. 
- Files changed: `.github/workflows/ci.yml`, `docs/runtime-cost.md`, `scripts/measure_runtime_cost.py`, `scripts/tests/test_measure_runtime_cost.py`, and `scripts/tests/test_validate_runtime_cost_summary.py`.

### Testing
- Unit tests: ran `python3 -m unittest scripts.tests.test_measure_runtime_cost scripts.tests.test_validate_runtime_cost_summary` and they passed. 
- CI smoke measurement: ran `python3 scripts/measure_runtime_cost.py --requests 1200 --concurrency 32 --work-ms 4 --rounds 4 --warmup-rounds 1 --artifact-dir demos/runtime_cost/artifacts/ci-smoke` and it completed and wrote `runtime-cost-summary.json`. 
- Validator: ran `python3 scripts/validate_runtime_cost_summary.py --raw demos/runtime_cost/artifacts/ci-smoke/runtime-cost-raw.jsonl --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json` and it passed (hard parity checks satisfied). 
- Docs contract: ran `python3 scripts/validate_docs_contracts.py` and it passed.

Additional requested details
- New hard thresholds: p95 latency ratio hard limit = `1.25x`, throughput ratio hard floor = `0.75x`.
- Soft warning band: ±5% (warnings when p95 `> 1.05x` or throughput `< 0.95x`).
- CI runtime-cost rounds changed to 4 (warmup remains 1). 
- Measured tracing/native ratios from the local smoke run: `tracing_light / core_light` p95 = `0.9915x`, throughput = `0.9678x`; `tracing_light_tokio_sampler / core_light_tokio_sampler` p95 = `0.9848x`, throughput = `0.9750x`; `tracing_light_drop_path / core_light_drop_path` p95 = `1.0349x`, throughput = `0.9709x`.
- `measurement_quality` observed in the local run: `noisy` (not treated as a hard failure per this change set).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c34a8a89c8330a07a85bbc88f6af8)