### PR TITLE
Make malformed tt.* spans visible and document importer default assumptions

### DIFF
--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -305,11 +305,41 @@ fn import_tracing_json_non_strict_writes_output_and_emits_warning_to_stderr() {
     assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
     assert!(stderr.contains("warning:"));
+    assert!(stderr.contains("tt.route"));
     assert!(run_path.exists(), "run output should be written");
 
     let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
         .expect("imported run should load in cli loader");
     assert_eq!(loaded.run.requests.len(), 1);
+}
+
+#[test]
+fn import_tracing_json_missing_tt_kind_tt_fields_warns_and_still_writes_when_valid_present() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(
+        &spans_path,
+        r#"{"span":{"name":"good","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok","tt.outcome":"ok"}}}
+{"span":{"name":"bad","started_at_unix_ms":3,"finished_at_unix_ms":4,"fields":{"tt.request_id":"r2","tt.route":"/broken"}}}
+"#,
+    )
+    .expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+    assert!(output.status.success());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("warning:"));
+    assert!(stderr.contains("missing required field 'tt.kind'"));
+    assert!(run_path.exists());
 }
 
 #[test]
@@ -462,7 +492,7 @@ fn valid_cli_artifact_with_empty_requests() -> &'static str {
 }
 
 fn complete_span_jsonl_fixture() -> &'static str {
-    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.success":true}}}
+    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}
 {"span":{"name":"db.stage","started_at_unix_ms":1002,"finished_at_unix_ms":1006,"fields":{"tt.kind":"stage","tt.request_id":"req-1","tt.stage":"db","tt.success":true}}}
 {"span":{"name":"admission.queue","started_at_unix_ms":1000,"finished_at_unix_ms":1002,"fields":{"tt.kind":"queue","tt.request_id":"req-1","tt.queue":"admission"}}}
 "#
@@ -474,7 +504,7 @@ fn incomplete_tailtriage_span_fixture() -> &'static str {
 }
 
 fn one_valid_request_span_fixture() -> &'static str {
-    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.success":true}}}
+    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}
 "#
 }
 
@@ -484,6 +514,6 @@ fn malformed_tailtriage_span_fixture() -> &'static str {
 
 fn mixed_valid_and_incomplete_request_span_fixture() -> &'static str {
     r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1"}}}
-{"span":{"name":"http.request","started_at_unix_ms":1020,"finished_at_unix_ms":1032,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout","tt.success":true}}}
+{"span":{"name":"http.request","started_at_unix_ms":1020,"finished_at_unix_ms":1032,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout","tt.outcome":"ok"}}}
 "#
 }

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -85,8 +85,8 @@ describes the stable field contract used by import and live recording.
 | `tt.route` | request | string | none | Logical request route/name used for request-level grouping. |
 | `tt.stage` | stage | string | none | Stage label for downstream-stage evidence. |
 | `tt.queue` | queue | string | none | Queue label for queue-wait evidence. |
-| `tt.outcome` | none (optional) | string | none | Optional completion outcome label (for example `ok`/`error`). |
-| `tt.success` | none (optional) | bool | none | Optional normalized success flag. |
+| `tt.outcome` | request (optional) | string | `ok` | Optional completion outcome label. When omitted, importer assumes `ok` and emits one aggregate warning. |
+| `tt.success` | stage (optional) | bool | `true` | Optional normalized success flag. When omitted, importer assumes `true` and emits one aggregate warning. |
 | `tt.depth_at_start` | queue | unsigned integer | omitted when unknown | Queue depth snapshot when queued work started waiting. |
 
 
@@ -110,10 +110,9 @@ tracing::subscriber::with_default(subscriber, || {
             tt.kind = "request",
             tt.request_id = "req-42",
             tt.route = "/checkout",
-            tt.outcome = tracing::field::Empty
+            tt.outcome = "ok"
         );
         let _entered = request.enter();
-        request.record("tt.outcome", "ok");
     }
 });
 

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -533,15 +533,41 @@ mod tests {
 
     #[test]
     fn incomplete_normalized_tt_kind_span_warns_non_strict_and_errors_strict() {
-        let input = r#"{"span":{"name":"req","fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.request_id":"r1","tt.route":"/a"}}}"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests.len(), 0);
         assert_eq!(imported.warnings().len(), 1);
-        assert!(imported.warnings()[0].message().contains("line 1"));
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("missing required field 'tt.kind'")));
 
         let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
             .unwrap_err();
         assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn aggregate_default_warnings_are_emitted_once_per_kind() {
+        let input = r#"
+{"span":{"name":"req1","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
+{"span":{"name":"req2","started_at_unix_ms":3,"finished_at_unix_ms":4,"fields":{"tt.kind":"request","tt.request_id":"r2","tt.route":"/b"}}}
+{"span":{"name":"st1","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
+{"span":{"name":"st2","started_at_unix_ms":3,"finished_at_unix_ms":4,"fields":{"tt.kind":"stage","tt.request_id":"r2","tt.stage":"cache"}}}
+"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        let messages = imported
+            .warnings()
+            .iter()
+            .map(|w| w.message().to_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(messages.len(), 2);
+        assert!(messages
+            .iter()
+            .any(|m| m.contains("2 request span(s) missing optional 'tt.outcome'")));
+        assert!(messages
+            .iter()
+            .any(|m| m.contains("2 stage span(s) missing optional 'tt.success'")));
     }
 
     #[test]
@@ -584,7 +610,7 @@ mod tests {
     #[test]
     fn parse_warnings_are_persisted_to_run_lifecycle_warnings() {
         let input = r#"
-{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok"}}}
+{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok","tt.outcome":"ok"}}}
 {"span":{"name":"broken","fields":{"tt.kind":"request","tt.request_id":"r2","tt.route":"/broken"}}}
 "#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
@@ -603,7 +629,7 @@ mod tests {
     #[test]
     fn conversion_warnings_still_follow_existing_lifecycle_policy() {
         let input = r#"
-{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok"}}}
+{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok","tt.outcome":"ok"}}}
 {"span":{"name":"req2","started_at_unix_ms":3,"finished_at_unix_ms":4,"fields":{"tt.kind":"request","tt.request_id":"r2"}}}
 "#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
@@ -622,7 +648,7 @@ mod tests {
     #[test]
     fn unrelated_malformed_normalized_span_does_not_create_lifecycle_warning() {
         let input = r#"
-{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok"}}}
+{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok","tt.outcome":"ok"}}}
 {"span":{"name":"other","id":123,"started_at_unix_ms":3,"finished_at_unix_ms":4}}
 "#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -75,10 +75,25 @@ where
     let mut queues = Vec::new();
     let mut min_start: Option<u64> = None;
     let mut max_finish: Option<u64> = None;
+    let mut missing_request_outcome = 0_u64;
+    let mut missing_stage_success = 0_u64;
 
     for span in spans {
+        let has_tailtriage_fields = span_has_tailtriage_field(&span);
         let kind = match get_string_field_state(&span, TT_KIND) {
-            StringFieldState::Missing => continue,
+            StringFieldState::Missing => {
+                if has_tailtriage_fields {
+                    strict_or_warn(
+                        options.strict_mode(),
+                        &mut warnings,
+                        format!(
+                            "missing required field '{TT_KIND}' in span '{}'",
+                            span.name()
+                        ),
+                    )?;
+                }
+                continue;
+            }
             StringFieldState::Value(kind) => {
                 let Some(kind) = SpanKind::parse(kind) else {
                     strict_or_warn(
@@ -120,10 +135,14 @@ where
                     required_string(&span, TT_REQUEST_ID, options.strict_mode(), &mut warnings)?;
                 let route = required_string(&span, TT_ROUTE, options.strict_mode(), &mut warnings)?;
                 if let (Some(request_id), Some(route)) = (request_id, route) {
-                    let Some(outcome) = parse_outcome(&span, options.strict_mode(), &mut warnings)?
-                    else {
+                    let (outcome, outcome_missing) =
+                        parse_outcome(&span, options.strict_mode(), &mut warnings)?;
+                    let Some(outcome) = outcome else {
                         continue;
                     };
+                    if outcome_missing {
+                        missing_request_outcome += 1;
+                    }
                     requests.push(RequestEvent {
                         request_id,
                         route,
@@ -144,12 +163,15 @@ where
                     required_string(&span, TT_REQUEST_ID, options.strict_mode(), &mut warnings)?;
                 let stage = required_string(&span, TT_STAGE, options.strict_mode(), &mut warnings)?;
                 if let (Some(request_id), Some(stage)) = (request_id, stage) {
-                    let success = match parse_success(&span, options.strict_mode(), &mut warnings)?
-                    {
-                        OptionalField::Missing => true,
-                        OptionalField::Value(success) => success,
-                        OptionalField::Invalid => continue,
-                    };
+                    let (success, success_missing) =
+                        match parse_success(&span, options.strict_mode(), &mut warnings)? {
+                            OptionalField::Missing => (true, true),
+                            OptionalField::Value(success) => (success, false),
+                            OptionalField::Invalid => continue,
+                        };
+                    if success_missing {
+                        missing_stage_success += 1;
+                    }
                     stages.push(StageEvent {
                         request_id,
                         stage,
@@ -190,6 +212,16 @@ where
                 }
             }
         }
+    }
+    if missing_request_outcome > 0 {
+        warnings.push(ImportWarning::new(format!(
+            "{missing_request_outcome} request span(s) missing optional '{TT_OUTCOME}'; assumed 'ok'"
+        )));
+    }
+    if missing_stage_success > 0 {
+        warnings.push(ImportWarning::new(format!(
+            "{missing_stage_success} stage span(s) missing optional '{TT_SUCCESS}'; assumed true"
+        )));
     }
 
     let started_at_unix_ms = min_start.unwrap_or_else(tailtriage_core::unix_time_ms);
@@ -275,6 +307,9 @@ fn get_string_field_state<'a>(span: &'a SpanRecord, key: &str) -> StringFieldSta
         None => StringFieldState::Missing,
     }
 }
+fn span_has_tailtriage_field(span: &SpanRecord) -> bool {
+    span.fields().keys().any(|key| key.starts_with("tt."))
+}
 
 fn required_string(
     span: &SpanRecord,
@@ -328,10 +363,10 @@ fn parse_outcome(
     span: &SpanRecord,
     strict: bool,
     warnings: &mut Vec<ImportWarning>,
-) -> Result<Option<String>, ImportError> {
+) -> Result<(Option<String>, bool), ImportError> {
     match get_string_field_state(span, TT_OUTCOME) {
-        StringFieldState::Missing => Ok(Some("ok".to_owned())),
-        StringFieldState::Value(value) => Ok(Some(value.to_owned())),
+        StringFieldState::Missing => Ok((Some("ok".to_owned()), true)),
+        StringFieldState::Value(value) => Ok((Some(value.to_owned()), false)),
         StringFieldState::InvalidType => {
             strict_or_warn(
                 strict,
@@ -341,7 +376,7 @@ fn parse_outcome(
                     span.name()
                 ),
             )?;
-            Ok(None)
+            Ok((None, false))
         }
     }
 }
@@ -475,13 +510,42 @@ mod tests {
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_QUEUE, "q1"),
         ];
-        let run = run_from_span_records(spans, ImportOptions::new("svc"))
-            .unwrap()
-            .run()
-            .clone();
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        let run = imported.run().clone();
         assert_eq!(run.requests[0].outcome, "ok");
         assert!(run.stages[0].success);
         assert_eq!(run.queues[0].depth_at_start, None);
+        assert_eq!(imported.warnings().len(), 2);
+    }
+
+    #[test]
+    fn non_tt_span_is_ignored_without_warning() {
+        let spans = vec![SpanRecord::new("other", 1, 2).field("http.method", "GET")];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.warnings().is_empty());
+    }
+
+    #[test]
+    fn tt_span_missing_kind_warns_and_skips_non_strict() {
+        let spans = vec![SpanRecord::new("http.request", 1, 2)
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert_eq!(imported.warnings().len(), 1);
+        assert!(imported.warnings()[0]
+            .message()
+            .contains("missing required field 'tt.kind'"));
+    }
+
+    #[test]
+    fn tt_span_missing_kind_errors_in_strict() {
+        let spans = vec![SpanRecord::new("http.request", 1, 2)
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+        let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
     }
 
     #[test]
@@ -614,7 +678,8 @@ mod tests {
             SpanRecord::new("req", 10, 20)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/"),
+                .field(TT_ROUTE, "/")
+                .field(TT_OUTCOME, "ok"),
         ];
         let run = run_from_span_records(spans, ImportOptions::new("svc"))
             .unwrap()
@@ -631,7 +696,8 @@ mod tests {
             SpanRecord::new("req", 10, 20)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/"),
+                .field(TT_ROUTE, "/")
+                .field(TT_OUTCOME, "ok"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().metadata.started_at_unix_ms, 10);
@@ -687,7 +753,8 @@ mod tests {
             SpanRecord::new("req", 10, 20)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/"),
+                .field(TT_ROUTE, "/")
+                .field(TT_OUTCOME, "ok"),
             SpanRecord::new("st", 1, 1_000)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, "r1")
@@ -707,7 +774,8 @@ mod tests {
             SpanRecord::new("req", 10, 20)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/"),
+                .field(TT_ROUTE, "/")
+                .field(TT_OUTCOME, "ok"),
             SpanRecord::new("st", 1, 1_000)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, "r1")
@@ -732,7 +800,7 @@ mod tests {
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().queues.len(), 0);
-        assert_eq!(imported.warnings().len(), 1);
+        assert_eq!(imported.warnings().len(), 2);
         assert_eq!(imported.run().metadata.started_at_unix_ms, 10);
         assert_eq!(imported.run().metadata.finished_at_unix_ms, 20);
     }

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -806,7 +806,8 @@ mod tests {
                 "request",
                 tt.kind = "request",
                 tt.request_id = "r1",
-                tt.route = "/a"
+                tt.route = "/a",
+                tt.outcome = "ok"
             );
             drop(request);
             drop(unrelated);


### PR DESCRIPTION
### Motivation
- Avoid silently discarding spans that clearly carry `tt.*` user intent by surfacing malformed tailtriage-tagged spans rather than ignoring them. 
- Make interpretive defaults (`tt.outcome` / `tt.success`) explicit to avoid surprising users and reduce onboarding friction. 
- Keep the existing tracing-bridge design and importer semantics but make assumptions and error/warning behavior visible and documented.

### Description
- Treat any span that contains at least one `tt.*` field as user-intended input by adding `span_has_tailtriage_field(span: &SpanRecord) -> bool` and using it to decide whether missing `tt.kind` is a conversion problem (not an unrelated span). 
- Change `run_from_span_records` so that: in non-strict mode a `tt.*` span missing `tt.kind` is skipped and an `ImportWarning` is emitted, and in strict mode the same case returns `ImportError::StrictViolation` with a message like `missing required field 'tt.kind' in span 'http.request'`. Ordinary spans with no `tt.*` fields are still ignored silently. 
- Preserve low-friction defaults but surface aggregate warnings per import: missing request `tt.outcome` defaults to `"ok"` and increments a counter so an aggregate warning is emitted once (`N request span(s) missing optional 'tt.outcome'; assumed 'ok'`); missing stage `tt.success` defaults to `true` and emits a single aggregate warning; missing `tt.depth_at_start` remains `None` without warning. 
- Update docs and examples in `tailtriage-tracing/README.md` to document the defaults and warning behavior and change the live/example fixtures to include explicit `tt.outcome` and `tt.success` so recommended examples import cleanly. 
- Add and update tests: typed conversion tests for non-`tt.*` silent ignore, missing-`tt.kind` warn vs strict error, aggregate default warnings; JSONL import tests for the same behaviors and for preserving lifecycle-warning policy; CLI boundary tests to assert warnings are printed to `stderr` and valid runs are written when mixed valid+malformed spans present.

### Testing
- Ran `cargo fmt --check` which passed. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which passed. 
- Ran the test suite: `cargo test --workspace --all-targets --all-features --locked` (including `-p tailtriage-tracing` and CLI boundary tests) and all tests passed. 
- Ran `python3 scripts/validate_docs_contracts.py` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cbe8da2fc833083cbff7827926bcc)