### PR TITLE
Make malformed tt.* imports visible and document default assumptions

### DIFF
--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -313,6 +313,56 @@ fn import_tracing_json_non_strict_writes_output_and_emits_warning_to_stderr() {
 }
 
 #[test]
+fn import_tracing_json_warns_for_tt_fields_missing_kind_but_writes_output_when_valid_exists() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, valid_plus_missing_kind_fixture()).expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+
+    assert!(output.status.success(), "cli failed: {output:?}");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("warning:"));
+    assert!(stderr.contains("missing required field 'tt.kind'"));
+    assert!(run_path.exists(), "run output should be written");
+}
+
+#[test]
+fn import_tracing_json_fails_when_only_tt_fields_missing_kind() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, missing_kind_tt_span_fixture()).expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("warning:"));
+    assert!(stderr.contains("missing required field 'tt.kind'"));
+    assert!(stderr.contains("zero request events"));
+    assert!(!run_path.exists(), "run output should not be written");
+}
+#[test]
 fn import_tracing_json_writes_metadata_flags_into_run_json() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
@@ -462,7 +512,7 @@ fn valid_cli_artifact_with_empty_requests() -> &'static str {
 }
 
 fn complete_span_jsonl_fixture() -> &'static str {
-    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.success":true}}}
+    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}
 {"span":{"name":"db.stage","started_at_unix_ms":1002,"finished_at_unix_ms":1006,"fields":{"tt.kind":"stage","tt.request_id":"req-1","tt.stage":"db","tt.success":true}}}
 {"span":{"name":"admission.queue","started_at_unix_ms":1000,"finished_at_unix_ms":1002,"fields":{"tt.kind":"queue","tt.request_id":"req-1","tt.queue":"admission"}}}
 "#
@@ -474,16 +524,26 @@ fn incomplete_tailtriage_span_fixture() -> &'static str {
 }
 
 fn one_valid_request_span_fixture() -> &'static str {
-    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.success":true}}}
+    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}
 "#
 }
 
+fn missing_kind_tt_span_fixture() -> &'static str {
+    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.request_id":"req-bad","tt.route":"/checkout"}}}
+"#
+}
+
+fn valid_plus_missing_kind_fixture() -> &'static str {
+    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}
+{"span":{"name":"http.request","started_at_unix_ms":1011,"finished_at_unix_ms":1020,"fields":{"tt.request_id":"req-bad","tt.route":"/checkout"}}}
+"#
+}
 fn malformed_tailtriage_span_fixture() -> &'static str {
     r#"{"span":{"name":"req","started_at_unix_ms":"bad","finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#
 }
 
 fn mixed_valid_and_incomplete_request_span_fixture() -> &'static str {
     r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1"}}}
-{"span":{"name":"http.request","started_at_unix_ms":1020,"finished_at_unix_ms":1032,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout","tt.success":true}}}
+{"span":{"name":"http.request","started_at_unix_ms":1020,"finished_at_unix_ms":1032,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout","tt.outcome":"ok"}}}
 "#
 }

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -36,7 +36,8 @@ Recommended normalized line shape for tests and integrations:
     "fields": {
       "tt.kind": "request",
       "tt.request_id": "req-42",
-      "tt.route": "/checkout"
+      "tt.route": "/checkout",
+      "tt.outcome": "ok"
     }
   }
 }
@@ -85,9 +86,9 @@ describes the stable field contract used by import and live recording.
 | `tt.route` | request | string | none | Logical request route/name used for request-level grouping. |
 | `tt.stage` | stage | string | none | Stage label for downstream-stage evidence. |
 | `tt.queue` | queue | string | none | Queue label for queue-wait evidence. |
-| `tt.outcome` | none (optional) | string | none | Optional completion outcome label (for example `ok`/`error`). |
-| `tt.success` | none (optional) | bool | none | Optional normalized success flag. |
-| `tt.depth_at_start` | queue | unsigned integer | omitted when unknown | Queue depth snapshot when queued work started waiting. |
+| `tt.outcome` | request | string | `ok` when omitted | Optional request outcome label; importer emits one aggregate warning when defaulted. |
+| `tt.success` | stage | bool | `true` when omitted | Optional stage success flag; importer emits one aggregate warning when defaulted. |
+| `tt.depth_at_start` | queue | unsigned integer | omitted when unknown | Queue depth snapshot when queued work started waiting; no warning when absent. |
 
 
 ## Live tracing recorder

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -584,7 +584,7 @@ mod tests {
     #[test]
     fn parse_warnings_are_persisted_to_run_lifecycle_warnings() {
         let input = r#"
-{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok"}}}
+{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok","tt.outcome":"ok"}}}
 {"span":{"name":"broken","fields":{"tt.kind":"request","tt.request_id":"r2","tt.route":"/broken"}}}
 "#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
@@ -603,7 +603,7 @@ mod tests {
     #[test]
     fn conversion_warnings_still_follow_existing_lifecycle_policy() {
         let input = r#"
-{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok"}}}
+{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok","tt.outcome":"ok"}}}
 {"span":{"name":"req2","started_at_unix_ms":3,"finished_at_unix_ms":4,"fields":{"tt.kind":"request","tt.request_id":"r2"}}}
 "#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
@@ -622,7 +622,7 @@ mod tests {
     #[test]
     fn unrelated_malformed_normalized_span_does_not_create_lifecycle_warning() {
         let input = r#"
-{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok"}}}
+{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok","tt.outcome":"ok"}}}
 {"span":{"name":"other","id":123,"started_at_unix_ms":3,"finished_at_unix_ms":4}}
 "#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
@@ -825,6 +825,45 @@ mod tests {
         assert!(imported.warnings().is_empty());
     }
 
+    #[test]
+    fn normalized_tt_fields_without_kind_warn_non_strict_and_error_strict() {
+        let input = r#"{"span":{"name":"http.request","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.request_id":"r1","tt.route":"/checkout"}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("missing required field 'tt.kind' in span 'http.request'")));
+
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+            .unwrap_err();
+        assert!(
+            matches!(err, ImportError::StrictViolation(msg) if msg.contains("missing required field 'tt.kind'"))
+        );
+    }
+
+    #[test]
+    fn jsonl_missing_outcome_and_success_warn_once_each() {
+        let input = r#"
+{"span":{"name":"req-1","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
+{"span":{"name":"req-2","started_at_unix_ms":3,"finished_at_unix_ms":4,"fields":{"tt.kind":"request","tt.request_id":"r2","tt.route":"/b"}}}
+{"span":{"name":"st-1","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
+{"span":{"name":"st-2","started_at_unix_ms":3,"finished_at_unix_ms":4,"fields":{"tt.kind":"stage","tt.request_id":"r2","tt.stage":"cache"}}}
+"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        let msgs: Vec<String> = imported
+            .warnings()
+            .iter()
+            .map(|warning| warning.message().to_owned())
+            .collect();
+        assert_eq!(msgs.iter().filter(|m| m.contains("tt.outcome")).count(), 1);
+        assert_eq!(msgs.iter().filter(|m| m.contains("tt.success")).count(), 1);
+        assert!(msgs
+            .iter()
+            .any(|m| m.contains("2 request span(s) missing optional 'tt.outcome'; assumed 'ok'")));
+        assert!(msgs
+            .iter()
+            .any(|m| m.contains("2 stage span(s) missing optional 'tt.success'; assumed true")));
+    }
     #[test]
     fn empty_service_name_is_rejected_for_jsonl_import() {
         let err = import_jsonl_reader(Cursor::new(""), ImportOptions::new("")).unwrap_err();

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -53,7 +53,7 @@ pub use types::{FieldValue, ImportOptions, ImportWarning, ImportedRun, SpanKind,
 
 /// Converts in-memory tracing span records into a `tailtriage_core::Run`.
 ///
-/// Spans without [`TT_KIND`] are ignored silently. In non-strict mode, malformed
+/// Spans without any `tt.*` fields are ignored silently. In non-strict mode, malformed
 /// `tt.*` spans are skipped and surfaced as warnings. In strict mode, the first
 /// malformed `tt.*` span returns an [`ImportError`].
 /// # Errors
@@ -75,10 +75,25 @@ where
     let mut queues = Vec::new();
     let mut min_start: Option<u64> = None;
     let mut max_finish: Option<u64> = None;
+    let mut missing_outcome_defaults = 0_u64;
+    let mut missing_success_defaults = 0_u64;
 
     for span in spans {
         let kind = match get_string_field_state(&span, TT_KIND) {
-            StringFieldState::Missing => continue,
+            StringFieldState::Missing => {
+                if !span_has_tailtriage_field(&span) {
+                    continue;
+                }
+                strict_or_warn(
+                    options.strict_mode(),
+                    &mut warnings,
+                    format!(
+                        "missing required field '{TT_KIND}' in span '{}'",
+                        span.name()
+                    ),
+                )?;
+                continue;
+            }
             StringFieldState::Value(kind) => {
                 let Some(kind) = SpanKind::parse(kind) else {
                     strict_or_warn(
@@ -120,7 +135,12 @@ where
                     required_string(&span, TT_REQUEST_ID, options.strict_mode(), &mut warnings)?;
                 let route = required_string(&span, TT_ROUTE, options.strict_mode(), &mut warnings)?;
                 if let (Some(request_id), Some(route)) = (request_id, route) {
-                    let Some(outcome) = parse_outcome(&span, options.strict_mode(), &mut warnings)?
+                    let Some(outcome) = parse_outcome(
+                        &span,
+                        options.strict_mode(),
+                        &mut warnings,
+                        &mut missing_outcome_defaults,
+                    )?
                     else {
                         continue;
                     };
@@ -144,8 +164,12 @@ where
                     required_string(&span, TT_REQUEST_ID, options.strict_mode(), &mut warnings)?;
                 let stage = required_string(&span, TT_STAGE, options.strict_mode(), &mut warnings)?;
                 if let (Some(request_id), Some(stage)) = (request_id, stage) {
-                    let success = match parse_success(&span, options.strict_mode(), &mut warnings)?
-                    {
+                    let success = match parse_success(
+                        &span,
+                        options.strict_mode(),
+                        &mut warnings,
+                        &mut missing_success_defaults,
+                    )? {
                         OptionalField::Missing => true,
                         OptionalField::Value(success) => success,
                         OptionalField::Invalid => continue,
@@ -190,6 +214,17 @@ where
                 }
             }
         }
+    }
+
+    if missing_outcome_defaults > 0 {
+        warnings.push(ImportWarning::new(format!(
+            "{missing_outcome_defaults} request span(s) missing optional '{TT_OUTCOME}'; assumed 'ok'"
+        )));
+    }
+    if missing_success_defaults > 0 {
+        warnings.push(ImportWarning::new(format!(
+            "{missing_success_defaults} stage span(s) missing optional '{TT_SUCCESS}'; assumed true"
+        )));
     }
 
     let started_at_unix_ms = min_start.unwrap_or_else(tailtriage_core::unix_time_ms);
@@ -276,6 +311,10 @@ fn get_string_field_state<'a>(span: &'a SpanRecord, key: &str) -> StringFieldSta
     }
 }
 
+fn span_has_tailtriage_field(span: &SpanRecord) -> bool {
+    span.fields().keys().any(|key| key.starts_with("tt."))
+}
+
 fn required_string(
     span: &SpanRecord,
     key: &'static str,
@@ -328,9 +367,13 @@ fn parse_outcome(
     span: &SpanRecord,
     strict: bool,
     warnings: &mut Vec<ImportWarning>,
+    missing_outcome_defaults: &mut u64,
 ) -> Result<Option<String>, ImportError> {
     match get_string_field_state(span, TT_OUTCOME) {
-        StringFieldState::Missing => Ok(Some("ok".to_owned())),
+        StringFieldState::Missing => {
+            *missing_outcome_defaults = missing_outcome_defaults.saturating_add(1);
+            Ok(Some("ok".to_owned()))
+        }
         StringFieldState::Value(value) => Ok(Some(value.to_owned())),
         StringFieldState::InvalidType => {
             strict_or_warn(
@@ -350,6 +393,7 @@ fn parse_success(
     span: &SpanRecord,
     strict: bool,
     warnings: &mut Vec<ImportWarning>,
+    missing_success_defaults: &mut u64,
 ) -> Result<OptionalField<bool>, ImportError> {
     match span.fields().get(TT_SUCCESS) {
         Some(FieldValue::Bool(value)) => Ok(OptionalField::Value(*value)),
@@ -363,7 +407,10 @@ fn parse_success(
             strict_or_warn(strict, warnings, format!("invalid field '{TT_SUCCESS}' in span '{}': expected bool or 'true'/'false' string", span.name()))?;
             Ok(OptionalField::Invalid)
         }
-        None => Ok(OptionalField::Missing),
+        None => {
+            *missing_success_defaults = missing_success_defaults.saturating_add(1);
+            Ok(OptionalField::Missing)
+        }
     }
 }
 
@@ -465,7 +512,8 @@ mod tests {
             SpanRecord::new("req", 1, 2)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/"),
+                .field(TT_ROUTE, "/")
+                .field(TT_OUTCOME, "ok"),
             SpanRecord::new("st", 1, 2)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, "r1")
@@ -518,10 +566,33 @@ mod tests {
     }
 
     #[test]
-    fn span_without_kind_ignored_silently() {
+    fn span_without_tt_fields_is_ignored_silently() {
         let spans = vec![SpanRecord::new("x", 1, 2).field("a", "b")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(imported.warnings().is_empty());
+    }
+
+    #[test]
+    fn tt_fields_without_kind_warn_non_strict_and_skip() {
+        let spans = vec![SpanRecord::new("http.request", 1, 2)
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("missing required field 'tt.kind' in span 'http.request'")));
+    }
+
+    #[test]
+    fn tt_fields_without_kind_error_in_strict_mode() {
+        let spans = vec![SpanRecord::new("http.request", 1, 2)
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")];
+        let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
+        assert!(
+            matches!(err, ImportError::StrictViolation(msg) if msg.contains("missing required field 'tt.kind'"))
+        );
     }
 
     #[test]
@@ -614,7 +685,8 @@ mod tests {
             SpanRecord::new("req", 10, 20)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/"),
+                .field(TT_ROUTE, "/")
+                .field(TT_OUTCOME, "ok"),
         ];
         let run = run_from_span_records(spans, ImportOptions::new("svc"))
             .unwrap()
@@ -631,7 +703,8 @@ mod tests {
             SpanRecord::new("req", 10, 20)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/"),
+                .field(TT_ROUTE, "/")
+                .field(TT_OUTCOME, "ok"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().metadata.started_at_unix_ms, 10);
@@ -687,7 +760,8 @@ mod tests {
             SpanRecord::new("req", 10, 20)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/"),
+                .field(TT_ROUTE, "/")
+                .field(TT_OUTCOME, "ok"),
             SpanRecord::new("st", 1, 1_000)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, "r1")
@@ -707,7 +781,8 @@ mod tests {
             SpanRecord::new("req", 10, 20)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/"),
+                .field(TT_ROUTE, "/")
+                .field(TT_OUTCOME, "ok"),
             SpanRecord::new("st", 1, 1_000)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, "r1")
@@ -723,7 +798,8 @@ mod tests {
             SpanRecord::new("req", 10, 20)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/"),
+                .field(TT_ROUTE, "/")
+                .field(TT_OUTCOME, "ok"),
             SpanRecord::new("q", 1, 1_000)
                 .field(TT_KIND, "queue")
                 .field(TT_REQUEST_ID, "r1")
@@ -743,7 +819,8 @@ mod tests {
             SpanRecord::new("req", 10, 20)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/"),
+                .field(TT_ROUTE, "/")
+                .field(TT_OUTCOME, "ok"),
             SpanRecord::new("q", 1, 1_000)
                 .field(TT_KIND, "queue")
                 .field(TT_REQUEST_ID, "r1")
@@ -803,6 +880,48 @@ mod tests {
         assert_eq!(run.requests[0].latency_us, 456);
     }
 
+    #[test]
+    fn missing_outcome_and_success_emit_aggregate_warnings() {
+        let spans = vec![
+            SpanRecord::new("req-1", 1, 2)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/"),
+            SpanRecord::new("req-2", 3, 4)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r2")
+                .field(TT_ROUTE, "/"),
+            SpanRecord::new("st-1", 1, 2)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+            SpanRecord::new("st-2", 3, 4)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r2")
+                .field(TT_STAGE, "db"),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("2 request span(s) missing optional 'tt.outcome'; assumed 'ok'")));
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("2 stage span(s) missing optional 'tt.success'; assumed true")));
+    }
+
+    #[test]
+    fn missing_queue_depth_has_no_warning() {
+        let spans = vec![SpanRecord::new("q", 1, 2)
+            .field(TT_KIND, "queue")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_QUEUE, "permits")];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().queues[0].depth_at_start, None);
+        assert!(imported
+            .warnings()
+            .iter()
+            .all(|w| !w.message().contains("tt.depth_at_start")));
+    }
     #[test]
     fn empty_service_name_is_rejected() {
         let err = run_from_span_records(Vec::new(), ImportOptions::new(" ")).unwrap_err();

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -496,7 +496,8 @@ mod tests {
                 "request",
                 tt.kind = "request",
                 tt.request_id = "r1",
-                tt.route = "/a"
+                tt.route = "/a",
+                tt.outcome = "ok"
             );
             drop(span);
             let run = recorder.snapshot_run().unwrap();
@@ -542,6 +543,7 @@ mod tests {
                 tt.kind = "request",
                 tt.request_id = "r1",
                 tt.route = "/a",
+                tt.outcome = "ok",
                 tt.outcome = tracing::field::Empty
             );
             span.record("tt.outcome", "timeout");
@@ -734,7 +736,8 @@ mod tests {
                 "request",
                 tt.kind = "request",
                 tt.request_id = "r1",
-                tt.route = "/a"
+                tt.route = "/a",
+                tt.outcome = "ok"
             );
             drop(span1);
             let span2 = tracing::info_span!(
@@ -770,7 +773,8 @@ mod tests {
                 "request",
                 tt.kind = "request",
                 tt.request_id = "r1",
-                tt.route = "/a"
+                tt.route = "/a",
+                tt.outcome = "ok"
             );
             let span2 = tracing::info_span!(
                 "request",
@@ -806,7 +810,8 @@ mod tests {
                 "request",
                 tt.kind = "request",
                 tt.request_id = "r1",
-                tt.route = "/a"
+                tt.route = "/a",
+                tt.outcome = "ok"
             );
             drop(request);
             drop(unrelated);

--- a/tailtriage-tracing/tests/support/equivalence_harness.rs
+++ b/tailtriage-tracing/tests/support/equivalence_harness.rs
@@ -306,7 +306,8 @@ fn tracing_run_with_queue(queue_name: &str) -> (Run, Vec<String>) {
                     "request",
                     tt.kind = "request",
                     tt.request_id = id,
-                    tt.route = "/checkout"
+                    tt.route = "/checkout",
+                    tt.outcome = "ok"
                 );
                 {
                     let _request_guard = request.enter();


### PR DESCRIPTION
### Motivation
- Spans containing any `tt.*` fields should be treated as user-intended tailtriage input and must not be silently discarded when malformed. 
- The importer made interpretive assumptions about missing status fields (`tt.outcome`, `tt.success`) without surfacing those assumptions to users. 
- CLI/JSONL/live recorder surfaces should be consistent so first-time users are not surprised by silent drops or noisy warnings.

### Description
- Change `run_from_span_records` to treat spans with no `tt.*` fields as still ignored, but to detect any span that contains `tt.*` fields and is missing `tt.kind` and then either warn-and-skip in non-strict mode or return `ImportError::StrictViolation` in strict mode. 
- Add `span_has_tailtriage_field` helper to detect `tt.*` presence and update missing-`tt.kind` handling to include span name in messages. 
- Make status-default assumptions explicit: missing request `tt.outcome` defaults to `"ok"` and missing stage `tt.success` defaults to `true`, and emit one concise aggregate warning per import for each defaulted field type while keeping `tt.depth_at_start` omission silent. 
- Update docs (`tailtriage-tracing/README.md`) to document the defaults and warning semantics and update examples/fixtures so recommended examples include explicit `tt.outcome` and `tt.success`. 
- Add and update unit/integration tests covering typed conversion behavior, JSONL import cases, and CLI boundary behaviors (including mixed valid+malformed input and all-malformed input cases). 
- Keep the tracing bridge design and analyzer behavior unchanged and do not alter Run schema, CLI shape, or add dependencies.

### Testing
- Ran `cargo fmt --check` which succeeded. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which succeeded. 
- Ran full test suite with `cargo test --workspace --all-targets --all-features --locked` which succeeded. 
- Ran docs contract validator `python3 scripts/validate_docs_contracts.py` which succeeded. 
- New/updated tests include typed conversion tests for missing `tt.kind` behavior and aggregate default warnings, JSONL tests for the same cases and de-duplication of warnings, and CLI boundary tests that assert warning visibility and correct success/failure behavior; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cbe8da2fc833083cbff7827926bcc)