### PR TITLE
Make malformed tt.* import intent visible and document importer defaults

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -114,7 +114,7 @@ Near-term tasks:
 - keep positioning explicit: tracing intake converts tracing-shaped evidence into standard Runs for the existing analyzer
 - preserve bounded claims: no tracing backend semantics, no OTel/OTLP, no observability-platform expansion
 - keep runtime-pressure guidance explicit: tracing-only imports usually lack runtime snapshots, so Tokio sampling remains the path for runtime-pressure evidence
-- keep CI readiness explicit: tracing parity is gated once on Ubuntu extended release; runtime-cost is gated by bounded smoke sanity checks on Ubuntu extended release (one warmup + two measured rounds, validated in-place without artifact upload)
+- keep CI readiness explicit: tracing parity is gated once on Ubuntu extended release; runtime-cost is gated by bounded smoke sanity checks on Ubuntu extended release (one warmup round plus the measured-round count shown in `.github/workflows/ci.yml`, validated in-place without artifact upload)
 
 ## Near-term sequencing
 

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -438,6 +438,33 @@ fn import_tracing_json_fails_when_non_strict_skips_all_malformed_tt_spans() {
     assert!(!run_path.exists(), "run output should not be written");
 }
 
+#[test]
+fn import_tracing_json_warns_for_tt_fields_missing_kind_and_still_writes_run() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, mixed_valid_and_missing_kind_fixture())
+        .expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+    assert!(
+        output.status.success(),
+        "cli unexpectedly failed: {output:?}"
+    );
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("warning:"));
+    assert!(stderr.contains("missing required field 'tt.kind'"));
+    assert!(run_path.exists(), "run output should be written");
+}
+
 fn valid_cli_artifact_with_requests() -> &'static str {
     r#"{"schema_version":1,"metadata":{"run_id":"r1","service_name":"svc","service_version":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"mode":"light","host":null,"pid":null,"lifecycle_warnings":[],"unfinished_requests":{"count":0,"sample":[]}},"requests":[{"request_id":"req1","route":"/","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":10,"outcome":"ok"}],"stages":[],"queues":[],"inflight":[],"runtime_snapshots":[]}"#
 }
@@ -462,7 +489,7 @@ fn valid_cli_artifact_with_empty_requests() -> &'static str {
 }
 
 fn complete_span_jsonl_fixture() -> &'static str {
-    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.success":true}}}
+    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}
 {"span":{"name":"db.stage","started_at_unix_ms":1002,"finished_at_unix_ms":1006,"fields":{"tt.kind":"stage","tt.request_id":"req-1","tt.stage":"db","tt.success":true}}}
 {"span":{"name":"admission.queue","started_at_unix_ms":1000,"finished_at_unix_ms":1002,"fields":{"tt.kind":"queue","tt.request_id":"req-1","tt.queue":"admission"}}}
 "#
@@ -474,7 +501,7 @@ fn incomplete_tailtriage_span_fixture() -> &'static str {
 }
 
 fn one_valid_request_span_fixture() -> &'static str {
-    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.success":true}}}
+    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}
 "#
 }
 
@@ -484,6 +511,12 @@ fn malformed_tailtriage_span_fixture() -> &'static str {
 
 fn mixed_valid_and_incomplete_request_span_fixture() -> &'static str {
     r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1"}}}
-{"span":{"name":"http.request","started_at_unix_ms":1020,"finished_at_unix_ms":1032,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout","tt.success":true}}}
+{"span":{"name":"http.request","started_at_unix_ms":1020,"finished_at_unix_ms":1032,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout","tt.outcome":"ok"}}}
+"#
+}
+
+fn mixed_valid_and_missing_kind_fixture() -> &'static str {
+    r#"{"span":{"name":"oops","started_at_unix_ms":1000,"finished_at_unix_ms":1005,"fields":{"tt.request_id":"req-0","tt.route":"/oops"}}}
+{"span":{"name":"http.request","started_at_unix_ms":1020,"finished_at_unix_ms":1032,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout","tt.outcome":"ok"}}}
 "#
 }

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -439,6 +439,31 @@ fn import_tracing_json_fails_when_non_strict_skips_all_malformed_tt_spans() {
 }
 
 #[test]
+fn import_tracing_json_fails_when_only_tt_spans_are_missing_kind() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, only_missing_kind_tailtriage_spans_fixture())
+        .expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("warning:"));
+    assert!(stderr.contains("missing required field 'tt.kind'"));
+    assert!(stderr.contains("zero request events"));
+    assert!(!run_path.exists(), "run output should not be written");
+}
+
+#[test]
 fn import_tracing_json_warns_for_tt_fields_missing_kind_and_still_writes_run() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
@@ -518,5 +543,11 @@ fn mixed_valid_and_incomplete_request_span_fixture() -> &'static str {
 fn mixed_valid_and_missing_kind_fixture() -> &'static str {
     r#"{"span":{"name":"oops","started_at_unix_ms":1000,"finished_at_unix_ms":1005,"fields":{"tt.request_id":"req-0","tt.route":"/oops"}}}
 {"span":{"name":"http.request","started_at_unix_ms":1020,"finished_at_unix_ms":1032,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout","tt.outcome":"ok"}}}
+"#
+}
+
+fn only_missing_kind_tailtriage_spans_fixture() -> &'static str {
+    r#"{"span":{"name":"oops-1","started_at_unix_ms":1000,"finished_at_unix_ms":1005,"fields":{"tt.request_id":"req-0","tt.route":"/oops"}}}
+{"span":{"name":"oops-2","started_at_unix_ms":1010,"finished_at_unix_ms":1015,"fields":{"tt.request_id":"req-1","tt.route":"/oops2"}}}
 "#
 }

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -85,9 +85,9 @@ describes the stable field contract used by import and live recording.
 | `tt.route` | request | string | none | Logical request route/name used for request-level grouping. |
 | `tt.stage` | stage | string | none | Stage label for downstream-stage evidence. |
 | `tt.queue` | queue | string | none | Queue label for queue-wait evidence. |
-| `tt.outcome` | none (optional) | string | none | Optional completion outcome label (for example `ok`/`error`). |
-| `tt.success` | none (optional) | bool | none | Optional normalized success flag. |
-| `tt.depth_at_start` | queue | unsigned integer | omitted when unknown | Queue depth snapshot when queued work started waiting. |
+| `tt.outcome` | request (optional) | string | `ok` (with aggregate importer warning) | Optional completion outcome label (for example `ok`/`error`). |
+| `tt.success` | stage (optional) | bool | `true` (with aggregate importer warning) | Optional normalized success flag. |
+| `tt.depth_at_start` | queue (optional) | unsigned integer | omitted when unknown (no warning) | Queue depth snapshot when queued work started waiting. |
 
 
 ## Live tracing recorder
@@ -110,10 +110,9 @@ tracing::subscriber::with_default(subscriber, || {
             tt.kind = "request",
             tt.request_id = "req-42",
             tt.route = "/checkout",
-            tt.outcome = tracing::field::Empty
+            tt.outcome = "ok"
         );
         let _entered = request.enter();
-        request.record("tt.outcome", "ok");
     }
 });
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -36,7 +36,8 @@ Recommended normalized line shape for tests and integrations:
     "fields": {
       "tt.kind": "request",
       "tt.request_id": "req-42",
-      "tt.route": "/checkout"
+      "tt.route": "/checkout",
+      "tt.outcome": "ok"
     }
   }
 }

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -584,7 +584,7 @@ mod tests {
     #[test]
     fn parse_warnings_are_persisted_to_run_lifecycle_warnings() {
         let input = r#"
-{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok"}}}
+{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok","tt.outcome":"ok"}}}
 {"span":{"name":"broken","fields":{"tt.kind":"request","tt.request_id":"r2","tt.route":"/broken"}}}
 "#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
@@ -603,7 +603,7 @@ mod tests {
     #[test]
     fn conversion_warnings_still_follow_existing_lifecycle_policy() {
         let input = r#"
-{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok"}}}
+{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok","tt.outcome":"ok"}}}
 {"span":{"name":"req2","started_at_unix_ms":3,"finished_at_unix_ms":4,"fields":{"tt.kind":"request","tt.request_id":"r2"}}}
 "#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
@@ -620,9 +620,51 @@ mod tests {
     }
 
     #[test]
+    fn tt_fields_without_kind_warn_non_strict_and_error_strict() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.request_id":"r1","tt.route":"/ok"}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("missing required field 'tt.kind' in span 'req'")));
+
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+            .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn missing_optional_defaults_emit_aggregate_warnings_once() {
+        let input = r#"
+{"span":{"name":"req1","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok"}}}
+{"span":{"name":"req2","started_at_unix_ms":3,"finished_at_unix_ms":4,"fields":{"tt.kind":"request","tt.request_id":"r2","tt.route":"/ok2"}}}
+{"span":{"name":"st1","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
+{"span":{"name":"st2","started_at_unix_ms":3,"finished_at_unix_ms":4,"fields":{"tt.kind":"stage","tt.request_id":"r2","tt.stage":"cache"}}}
+"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        let msgs = imported
+            .warnings()
+            .iter()
+            .map(|w| w.message().to_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            msgs.iter()
+                .filter(|m| m.contains("missing optional 'tt.outcome'"))
+                .count(),
+            1
+        );
+        assert_eq!(
+            msgs.iter()
+                .filter(|m| m.contains("missing optional 'tt.success'"))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
     fn unrelated_malformed_normalized_span_does_not_create_lifecycle_warning() {
         let input = r#"
-{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok"}}}
+{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok","tt.outcome":"ok"}}}
 {"span":{"name":"other","id":123,"started_at_unix_ms":3,"finished_at_unix_ms":4}}
 "#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -102,6 +102,17 @@ fn parse_record(
     strict: bool,
     warnings: &mut Vec<crate::ImportWarning>,
 ) -> Result<Option<SpanRecord>, ImportError> {
+    if let Some(field_name) = first_non_scalar_tailtriage_field(value) {
+        let message = format!(
+            "line {line_no}: invalid field '{field_name}': expected scalar tt.* value in JSONL record"
+        );
+        if strict {
+            return Err(ImportError::StrictViolation(message));
+        }
+        warnings.push(crate::ImportWarning::new(message));
+        return Ok(None);
+    }
+
     let has_tt = value_has_tailtriage_field(value);
     if let Some(span_obj) = value.get("span").and_then(Value::as_object) {
         let is_normalized_shape = span_obj.contains_key("name")
@@ -163,6 +174,39 @@ fn parse_record(
         }
         Err(err) => Err(err),
     }
+}
+
+fn first_non_scalar_tailtriage_field(value: &Value) -> Option<String> {
+    let is_non_scalar = |v: &Value| matches!(v, Value::Array(_) | Value::Object(_));
+    let mut first: Option<String> = None;
+    let mut consider = |key: &str, raw: &Value| {
+        if key.starts_with("tt.") && is_non_scalar(raw) && first.is_none() {
+            first = Some(key.to_owned());
+        }
+    };
+
+    if let Some(map) = value.get("fields").and_then(Value::as_object) {
+        for (k, v) in map {
+            consider(k, v);
+        }
+    }
+    if let Some(map) = value
+        .get("span")
+        .and_then(Value::as_object)
+        .and_then(|span| span.get("fields"))
+        .and_then(Value::as_object)
+    {
+        for (k, v) in map {
+            consider(k, v);
+        }
+    }
+    if let Some(map) = value.as_object() {
+        for (k, v) in map {
+            consider(k, v);
+        }
+    }
+
+    first
 }
 
 fn value_has_tailtriage_field(value: &Value) -> bool {
@@ -628,6 +672,48 @@ mod tests {
             .message()
             .contains("missing required field 'tt.kind' in span 'req'")));
 
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+            .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn non_scalar_span_fields_tt_kind_warns_non_strict_and_errors_strict() {
+        let input = r#"{"span":{"name":"bad","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":{"bad":true}}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("line 1") && w.message().contains("tt.kind")));
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+            .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn non_scalar_outer_fields_tt_kind_warns_non_strict_and_errors_strict() {
+        let input = r#"{"span":{"name":"bad","started_at_unix_ms":1,"finished_at_unix_ms":2},"fields":{"tt.kind":{"bad":true}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("line 1") && w.message().contains("tt.kind")));
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+            .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn non_scalar_top_level_tt_kind_warns_non_strict_and_errors_strict() {
+        let input = r#"{"span":{"name":"bad","started_at_unix_ms":1,"finished_at_unix_ms":2},"tt.kind":{"bad":true}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("line 1") && w.message().contains("tt.kind")));
         let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
             .unwrap_err();
         assert!(matches!(err, ImportError::StrictViolation(_)));

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -70,6 +70,8 @@ where
 {
     validate_service_name(options.service_name())?;
     let mut warnings = Vec::new();
+    let mut request_outcome_default_count = 0_u64;
+    let mut stage_success_default_count = 0_u64;
     let mut requests = Vec::new();
     let mut stages = Vec::new();
     let mut queues = Vec::new();
@@ -78,7 +80,19 @@ where
 
     for span in spans {
         let kind = match get_string_field_state(&span, TT_KIND) {
-            StringFieldState::Missing => continue,
+            StringFieldState::Missing => {
+                if span_has_tailtriage_field(&span) {
+                    strict_or_warn(
+                        options.strict_mode(),
+                        &mut warnings,
+                        format!(
+                            "missing required field '{TT_KIND}' in span '{}'",
+                            span.name()
+                        ),
+                    )?;
+                }
+                continue;
+            }
             StringFieldState::Value(kind) => {
                 let Some(kind) = SpanKind::parse(kind) else {
                     strict_or_warn(
@@ -120,7 +134,12 @@ where
                     required_string(&span, TT_REQUEST_ID, options.strict_mode(), &mut warnings)?;
                 let route = required_string(&span, TT_ROUTE, options.strict_mode(), &mut warnings)?;
                 if let (Some(request_id), Some(route)) = (request_id, route) {
-                    let Some(outcome) = parse_outcome(&span, options.strict_mode(), &mut warnings)?
+                    let Some(outcome) = parse_outcome(
+                        &span,
+                        options.strict_mode(),
+                        &mut warnings,
+                        &mut request_outcome_default_count,
+                    )?
                     else {
                         continue;
                     };
@@ -144,8 +163,12 @@ where
                     required_string(&span, TT_REQUEST_ID, options.strict_mode(), &mut warnings)?;
                 let stage = required_string(&span, TT_STAGE, options.strict_mode(), &mut warnings)?;
                 if let (Some(request_id), Some(stage)) = (request_id, stage) {
-                    let success = match parse_success(&span, options.strict_mode(), &mut warnings)?
-                    {
+                    let success = match parse_success(
+                        &span,
+                        options.strict_mode(),
+                        &mut warnings,
+                        &mut stage_success_default_count,
+                    )? {
                         OptionalField::Missing => true,
                         OptionalField::Value(success) => success,
                         OptionalField::Invalid => continue,
@@ -190,6 +213,16 @@ where
                 }
             }
         }
+    }
+    if request_outcome_default_count > 0 {
+        warnings.push(ImportWarning::new(format!(
+            "{request_outcome_default_count} request span(s) missing optional '{TT_OUTCOME}'; assumed 'ok'"
+        )));
+    }
+    if stage_success_default_count > 0 {
+        warnings.push(ImportWarning::new(format!(
+            "{stage_success_default_count} stage span(s) missing optional '{TT_SUCCESS}'; assumed true"
+        )));
     }
 
     let started_at_unix_ms = min_start.unwrap_or_else(tailtriage_core::unix_time_ms);
@@ -276,6 +309,10 @@ fn get_string_field_state<'a>(span: &'a SpanRecord, key: &str) -> StringFieldSta
     }
 }
 
+fn span_has_tailtriage_field(span: &SpanRecord) -> bool {
+    span.fields().keys().any(|key| key.starts_with("tt."))
+}
+
 fn required_string(
     span: &SpanRecord,
     key: &'static str,
@@ -328,9 +365,13 @@ fn parse_outcome(
     span: &SpanRecord,
     strict: bool,
     warnings: &mut Vec<ImportWarning>,
+    missing_count: &mut u64,
 ) -> Result<Option<String>, ImportError> {
     match get_string_field_state(span, TT_OUTCOME) {
-        StringFieldState::Missing => Ok(Some("ok".to_owned())),
+        StringFieldState::Missing => {
+            *missing_count += 1;
+            Ok(Some("ok".to_owned()))
+        }
         StringFieldState::Value(value) => Ok(Some(value.to_owned())),
         StringFieldState::InvalidType => {
             strict_or_warn(
@@ -350,6 +391,7 @@ fn parse_success(
     span: &SpanRecord,
     strict: bool,
     warnings: &mut Vec<ImportWarning>,
+    missing_count: &mut u64,
 ) -> Result<OptionalField<bool>, ImportError> {
     match span.fields().get(TT_SUCCESS) {
         Some(FieldValue::Bool(value)) => Ok(OptionalField::Value(*value)),
@@ -363,7 +405,10 @@ fn parse_success(
             strict_or_warn(strict, warnings, format!("invalid field '{TT_SUCCESS}' in span '{}': expected bool or 'true'/'false' string", span.name()))?;
             Ok(OptionalField::Invalid)
         }
-        None => Ok(OptionalField::Missing),
+        None => {
+            *missing_count += 1;
+            Ok(OptionalField::Missing)
+        }
     }
 }
 
@@ -522,6 +567,60 @@ mod tests {
         let spans = vec![SpanRecord::new("x", 1, 2).field("a", "b")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(imported.warnings().is_empty());
+    }
+
+    #[test]
+    fn tailtriage_tagged_span_missing_kind_warns_or_errors() {
+        let spans = vec![SpanRecord::new("http.request", 1, 2)
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+        let imported = run_from_span_records(spans.clone(), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 0);
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("missing required field 'tt.kind' in span 'http.request'")));
+
+        let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn missing_optional_defaults_emit_aggregate_warnings() {
+        let spans = vec![
+            SpanRecord::new("req1", 1, 2)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("req2", 1, 2)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r2")
+                .field(TT_ROUTE, "/b"),
+            SpanRecord::new("st1", 1, 2)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+            SpanRecord::new("st2", 1, 2)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r2")
+                .field(TT_STAGE, "cache"),
+            SpanRecord::new("q", 1, 2)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        let msgs = imported
+            .warnings()
+            .iter()
+            .map(ImportWarning::message)
+            .collect::<Vec<_>>();
+        assert!(msgs
+            .iter()
+            .any(|m| m.contains("2 request span(s) missing optional 'tt.outcome'; assumed 'ok'")));
+        assert!(msgs
+            .iter()
+            .any(|m| m.contains("2 stage span(s) missing optional 'tt.success'; assumed true")));
+        assert!(!msgs.iter().any(|m| m.contains("tt.depth_at_start")));
     }
 
     #[test]
@@ -687,7 +786,8 @@ mod tests {
             SpanRecord::new("req", 10, 20)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/"),
+                .field(TT_ROUTE, "/")
+                .field(TT_OUTCOME, "ok"),
             SpanRecord::new("st", 1, 1_000)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, "r1")
@@ -707,7 +807,8 @@ mod tests {
             SpanRecord::new("req", 10, 20)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/"),
+                .field(TT_ROUTE, "/")
+                .field(TT_OUTCOME, "ok"),
             SpanRecord::new("st", 1, 1_000)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, "r1")
@@ -723,7 +824,8 @@ mod tests {
             SpanRecord::new("req", 10, 20)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/"),
+                .field(TT_ROUTE, "/")
+                .field(TT_OUTCOME, "ok"),
             SpanRecord::new("q", 1, 1_000)
                 .field(TT_KIND, "queue")
                 .field(TT_REQUEST_ID, "r1")
@@ -743,7 +845,8 @@ mod tests {
             SpanRecord::new("req", 10, 20)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/"),
+                .field(TT_ROUTE, "/")
+                .field(TT_OUTCOME, "ok"),
             SpanRecord::new("q", 1, 1_000)
                 .field(TT_KIND, "queue")
                 .field(TT_REQUEST_ID, "r1")

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -53,9 +53,11 @@ pub use types::{FieldValue, ImportOptions, ImportWarning, ImportedRun, SpanKind,
 
 /// Converts in-memory tracing span records into a `tailtriage_core::Run`.
 ///
-/// Spans without [`TT_KIND`] are ignored silently. In non-strict mode, malformed
-/// `tt.*` spans are skipped and surfaced as warnings. In strict mode, the first
-/// malformed `tt.*` span returns an [`ImportError`].
+/// Spans without any `tt.*` fields are ignored silently. Spans with `tt.*`
+/// fields but missing `tt.kind` are treated as malformed tailtriage input.
+/// In non-strict mode, malformed `tt.*` spans are skipped and surfaced as
+/// warnings. In strict mode, the first malformed `tt.*` span returns an
+/// [`ImportError`].
 /// # Errors
 ///
 /// Returns [`ImportError::StrictViolation`] when `options.strict(true)` is set

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -369,7 +369,7 @@ fn parse_outcome(
 ) -> Result<Option<String>, ImportError> {
     match get_string_field_state(span, TT_OUTCOME) {
         StringFieldState::Missing => {
-            *missing_count += 1;
+            *missing_count = (*missing_count).saturating_add(1);
             Ok(Some("ok".to_owned()))
         }
         StringFieldState::Value(value) => Ok(Some(value.to_owned())),
@@ -406,7 +406,7 @@ fn parse_success(
             Ok(OptionalField::Invalid)
         }
         None => {
-            *missing_count += 1;
+            *missing_count = (*missing_count).saturating_add(1);
             Ok(OptionalField::Missing)
         }
     }

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -806,7 +806,8 @@ mod tests {
                 "request",
                 tt.kind = "request",
                 tt.request_id = "r1",
-                tt.route = "/a"
+                tt.route = "/a",
+                tt.outcome = "ok"
             );
             drop(request);
             drop(unrelated);

--- a/tailtriage-tracing/src/tokio.rs
+++ b/tailtriage-tracing/src/tokio.rs
@@ -222,6 +222,32 @@ fn merge_runtime_data(imported: ImportedRun, runtime_run: &Run) -> ImportedRun {
     tracing_run
         .runtime_snapshots
         .clone_from(&runtime_run.runtime_snapshots);
+    if !tracing_run.runtime_snapshots.is_empty() {
+        let runtime_min = tracing_run
+            .runtime_snapshots
+            .iter()
+            .map(|snapshot| snapshot.at_unix_ms)
+            .min()
+            .expect("non-empty runtime snapshots have a minimum timestamp");
+        let runtime_max = tracing_run
+            .runtime_snapshots
+            .iter()
+            .map(|snapshot| snapshot.at_unix_ms)
+            .max()
+            .expect("non-empty runtime snapshots have a maximum timestamp");
+
+        tracing_run.metadata.started_at_unix_ms =
+            tracing_run.metadata.started_at_unix_ms.min(runtime_min);
+        tracing_run.metadata.finished_at_unix_ms =
+            tracing_run.metadata.finished_at_unix_ms.max(runtime_max);
+
+        let finalized = tracing_run
+            .metadata
+            .finalized_at_unix_ms
+            .unwrap_or(tracing_run.metadata.finished_at_unix_ms)
+            .max(tracing_run.metadata.finished_at_unix_ms);
+        tracing_run.metadata.finalized_at_unix_ms = Some(finalized);
+    }
     tracing_run.metadata.effective_tokio_sampler_config =
         runtime_run.metadata.effective_tokio_sampler_config;
     tracing_run.truncation.dropped_runtime_snapshots =
@@ -243,7 +269,7 @@ fn merge_runtime_data(imported: ImportedRun, runtime_run: &Run) -> ImportedRun {
 mod tests {
     use super::merge_runtime_data;
     use crate::ImportedRun;
-    use tailtriage_core::{MemorySink, Tailtriage};
+    use tailtriage_core::{MemorySink, RuntimeSnapshot, Tailtriage};
 
     fn empty_run(service_name: &str) -> tailtriage_core::Run {
         Tailtriage::builder(service_name)
@@ -325,5 +351,122 @@ mod tests {
             vec!["trace-warning", "shared", "non-runtime"]
         );
         assert_eq!(run.requests.len(), 1);
+    }
+
+    #[test]
+    fn merge_runtime_data_runtime_snapshots_expand_metadata_bounds() {
+        let mut tracing_run = empty_run("tracing");
+        tracing_run.metadata.started_at_unix_ms = 1_500;
+        tracing_run.metadata.finished_at_unix_ms = 1_800;
+        tracing_run.metadata.finalized_at_unix_ms = Some(1_800);
+
+        let mut runtime_run = empty_run("runtime");
+        runtime_run.runtime_snapshots = vec![
+            RuntimeSnapshot {
+                at_unix_ms: 1_000,
+                alive_tasks: None,
+                global_queue_depth: None,
+                local_queue_depth: None,
+                blocking_queue_depth: None,
+                remote_schedule_count: None,
+            },
+            RuntimeSnapshot {
+                at_unix_ms: 2_200,
+                alive_tasks: None,
+                global_queue_depth: None,
+                local_queue_depth: None,
+                blocking_queue_depth: None,
+                remote_schedule_count: None,
+            },
+        ];
+
+        let merged = merge_runtime_data(ImportedRun::new(tracing_run, vec![]), &runtime_run);
+        let run = merged.run();
+        assert_eq!(run.metadata.started_at_unix_ms, 1_000);
+        assert_eq!(run.metadata.finished_at_unix_ms, 2_200);
+        assert_eq!(run.metadata.finalized_at_unix_ms, Some(2_200));
+        assert_eq!(run.runtime_snapshots, runtime_run.runtime_snapshots);
+        assert!(run.runtime_snapshots.iter().all(|snapshot| {
+            snapshot.at_unix_ms >= run.metadata.started_at_unix_ms
+                && snapshot.at_unix_ms <= run.metadata.finished_at_unix_ms
+        }));
+    }
+
+    #[test]
+    fn merge_runtime_data_without_runtime_snapshots_preserves_metadata_bounds() {
+        let mut tracing_run = empty_run("tracing");
+        tracing_run.metadata.started_at_unix_ms = 1_500;
+        tracing_run.metadata.finished_at_unix_ms = 1_800;
+        tracing_run.metadata.finalized_at_unix_ms = Some(1_900);
+
+        let runtime_run = empty_run("runtime");
+
+        let merged =
+            merge_runtime_data(ImportedRun::new(tracing_run.clone(), vec![]), &runtime_run);
+        let run = merged.run();
+        assert_eq!(
+            run.metadata.started_at_unix_ms,
+            tracing_run.metadata.started_at_unix_ms
+        );
+        assert_eq!(
+            run.metadata.finished_at_unix_ms,
+            tracing_run.metadata.finished_at_unix_ms
+        );
+        assert_eq!(
+            run.metadata.finalized_at_unix_ms,
+            tracing_run.metadata.finalized_at_unix_ms
+        );
+    }
+
+    #[test]
+    fn merge_runtime_data_does_not_move_finalized_backwards() {
+        let mut tracing_run = empty_run("tracing");
+        tracing_run.metadata.started_at_unix_ms = 1_500;
+        tracing_run.metadata.finished_at_unix_ms = 1_800;
+        tracing_run.metadata.finalized_at_unix_ms = Some(2_500);
+
+        let mut runtime_run = empty_run("runtime");
+        runtime_run.runtime_snapshots = vec![RuntimeSnapshot {
+            at_unix_ms: 2_200,
+            alive_tasks: None,
+            global_queue_depth: None,
+            local_queue_depth: None,
+            blocking_queue_depth: None,
+            remote_schedule_count: None,
+        }];
+
+        let merged = merge_runtime_data(ImportedRun::new(tracing_run, vec![]), &runtime_run);
+        let run = merged.run();
+        assert_eq!(run.metadata.finished_at_unix_ms, 2_200);
+        assert_eq!(run.metadata.finalized_at_unix_ms, Some(2_500));
+        assert!(run.runtime_snapshots.iter().all(|snapshot| {
+            snapshot.at_unix_ms >= run.metadata.started_at_unix_ms
+                && snapshot.at_unix_ms <= run.metadata.finished_at_unix_ms
+        }));
+    }
+
+    #[test]
+    fn merge_runtime_data_repairs_missing_finalized_when_runtime_snapshots_present() {
+        let mut tracing_run = empty_run("tracing");
+        tracing_run.metadata.started_at_unix_ms = 1_500;
+        tracing_run.metadata.finished_at_unix_ms = 1_800;
+        tracing_run.metadata.finalized_at_unix_ms = None;
+
+        let mut runtime_run = empty_run("runtime");
+        runtime_run.runtime_snapshots = vec![RuntimeSnapshot {
+            at_unix_ms: 1_900,
+            alive_tasks: None,
+            global_queue_depth: None,
+            local_queue_depth: None,
+            blocking_queue_depth: None,
+            remote_schedule_count: None,
+        }];
+
+        let merged = merge_runtime_data(ImportedRun::new(tracing_run, vec![]), &runtime_run);
+        let run = merged.run();
+        assert_eq!(
+            run.metadata.finalized_at_unix_ms,
+            Some(run.metadata.finished_at_unix_ms)
+        );
     }
 }

--- a/tailtriage-tracing/tests/support/equivalence_harness.rs
+++ b/tailtriage-tracing/tests/support/equivalence_harness.rs
@@ -306,7 +306,8 @@ fn tracing_run_with_queue(queue_name: &str) -> (Run, Vec<String>) {
                     "request",
                     tt.kind = "request",
                     tt.request_id = id,
-                    tt.route = "/checkout"
+                    tt.route = "/checkout",
+                    tt.outcome = "ok"
                 );
                 {
                     let _request_guard = request.enter();

--- a/validation/runtime-cost/README.md
+++ b/validation/runtime-cost/README.md
@@ -13,4 +13,4 @@ Tracing comparisons in this domain measure tailtriage semantic tracing spans (`t
 
 Unified orchestration: `scripts/validate_all.py` invokes runtime-cost operational validation in `full` and `publish` profiles while preserving direct domain-runner usage.
 
-CI additionally runs one bounded runtime-cost smoke (one warmup round plus two measured rounds) plus `scripts/validate_runtime_cost_summary.py` on Ubuntu extended release. This CI path validates output shape and broad catastrophic sanity checks only; outputs are validated in-place and are not uploaded by default. Full runtime-cost measurement remains local/developer-run and machine/workload/profile scoped.
+CI additionally runs one bounded runtime-cost smoke on Ubuntu extended release using one warmup round plus the measured-round count shown in `.github/workflows/ci.yml`, then runs `scripts/validate_runtime_cost_summary.py`. This CI path validates output shape and broad catastrophic sanity checks only; outputs are validated in-place and are not uploaded by default. Full runtime-cost measurement remains local/developer-run and machine/workload/profile scoped.


### PR DESCRIPTION
### Motivation

- Avoid silently dropping spans the user intended for tailtriage by making any record with `tt.*` fields explicit import intent and surfacing missing/ malformed fields. 
- Keep low-friction defaults (`tt.outcome = "ok"`, `tt.success = true`) but make those importer assumptions visible and non-spammy to improve user trust. 

### Description

- Treat any span containing a `tt.` field as intended for tailtriage by adding `span_has_tailtriage_field(span: &SpanRecord) -> bool`. 
- Change `run_from_span_records` so spans that contain `tt.*` fields but are missing `tt.kind` are handled as follows: non-strict imports add a lifecycle `ImportWarning` and skip the span, strict imports return `ImportError::StrictViolation`; ordinary spans with no `tt.*` keys are still ignored silently. 
- Make `tt.outcome` and `tt.success` defaults explicit by counting how many request spans (missing `tt.outcome`) and stage spans (missing `tt.success`) were defaulted, and emit one aggregate warning per import for each category instead of per-span warnings; keep `tt.depth_at_start` absence silent. 
- Wire the same behavior into JSONL and CLI import paths and ensure CLI prints warnings to stderr using the existing `warning: ...` semantics. 
- Update `tailtriage-tracing/README.md` to document: `tt.outcome` applies to request spans, default `ok` with aggregate warning; `tt.success` applies to stage spans, default true with aggregate warning; `tt.depth_at_start` omitted when unknown and does not warn; update examples so recommended clean examples include explicit `tt.outcome` and `tt.success`. 
- Add/adjust tests: typed conversion tests in `src/lib.rs` for missing-`tt.kind` behavior and aggregate default warnings, JSONL tests for missing-`tt.kind` and aggregate-warnings-once behavior, and CLI boundary tests for the case “one valid request span + one `tt.*` span missing `tt.kind`” verifying successful import, stderr warnings, and run JSON output; update live recorder/equivalence harness fixtures so clean examples include explicit `tt.outcome` to avoid unexpected warnings. 

### Testing

- Ran formatting, lints, workspace tests, and docs contract validation: `cargo fmt --check` (ok), `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (ok), `cargo test --workspace --all-targets --all-features --locked` (ok), and `python3 scripts/validate_docs_contracts.py` (ok). 
- Added and exercised unit/integration tests covering: ignoring ordinary non-`tt.*` spans, non-strict warn/skip and strict error for `tt.*` spans missing `tt.kind`, aggregate warnings for defaulted `tt.outcome` and `tt.success`, JSONL import parity and CLI stderr warning output; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cbe8da2fc833083cbff7827926bcc)