### PR TITLE
Make malformed tt.* spans visible and surface importer defaults clearly

### DIFF
--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -438,6 +438,30 @@ fn import_tracing_json_fails_when_non_strict_skips_all_malformed_tt_spans() {
     assert!(!run_path.exists(), "run output should not be written");
 }
 
+#[test]
+fn import_tracing_json_warns_for_missing_kind_tt_span_and_succeeds_with_valid_request() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, valid_plus_missing_kind_span_fixture())
+        .expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+    assert!(output.status.success(), "cli failed: {output:?}");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("warning:"));
+    assert!(stderr.contains("missing required field 'tt.kind'"));
+    assert!(run_path.exists());
+}
+
 fn valid_cli_artifact_with_requests() -> &'static str {
     r#"{"schema_version":1,"metadata":{"run_id":"r1","service_name":"svc","service_version":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"mode":"light","host":null,"pid":null,"lifecycle_warnings":[],"unfinished_requests":{"count":0,"sample":[]}},"requests":[{"request_id":"req1","route":"/","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":10,"outcome":"ok"}],"stages":[],"queues":[],"inflight":[],"runtime_snapshots":[]}"#
 }
@@ -462,7 +486,7 @@ fn valid_cli_artifact_with_empty_requests() -> &'static str {
 }
 
 fn complete_span_jsonl_fixture() -> &'static str {
-    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.success":true}}}
+    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}
 {"span":{"name":"db.stage","started_at_unix_ms":1002,"finished_at_unix_ms":1006,"fields":{"tt.kind":"stage","tt.request_id":"req-1","tt.stage":"db","tt.success":true}}}
 {"span":{"name":"admission.queue","started_at_unix_ms":1000,"finished_at_unix_ms":1002,"fields":{"tt.kind":"queue","tt.request_id":"req-1","tt.queue":"admission"}}}
 "#
@@ -474,7 +498,7 @@ fn incomplete_tailtriage_span_fixture() -> &'static str {
 }
 
 fn one_valid_request_span_fixture() -> &'static str {
-    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.success":true}}}
+    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}
 "#
 }
 
@@ -484,6 +508,12 @@ fn malformed_tailtriage_span_fixture() -> &'static str {
 
 fn mixed_valid_and_incomplete_request_span_fixture() -> &'static str {
     r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1"}}}
-{"span":{"name":"http.request","started_at_unix_ms":1020,"finished_at_unix_ms":1032,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout","tt.success":true}}}
+{"span":{"name":"http.request","started_at_unix_ms":1020,"finished_at_unix_ms":1032,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout","tt.outcome":"ok"}}}
+"#
+}
+
+fn valid_plus_missing_kind_span_fixture() -> &'static str {
+    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}
+{"span":{"name":"bad.tt","started_at_unix_ms":1020,"finished_at_unix_ms":1032,"fields":{"tt.request_id":"req-2","tt.route":"/checkout"}}}
 "#
 }

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -85,9 +85,9 @@ describes the stable field contract used by import and live recording.
 | `tt.route` | request | string | none | Logical request route/name used for request-level grouping. |
 | `tt.stage` | stage | string | none | Stage label for downstream-stage evidence. |
 | `tt.queue` | queue | string | none | Queue label for queue-wait evidence. |
-| `tt.outcome` | none (optional) | string | none | Optional completion outcome label (for example `ok`/`error`). |
-| `tt.success` | none (optional) | bool | none | Optional normalized success flag. |
-| `tt.depth_at_start` | queue | unsigned integer | omitted when unknown | Queue depth snapshot when queued work started waiting. |
+| `tt.outcome` | request (optional) | string | defaults to `ok`; importer emits one aggregate warning per import | Optional request completion outcome label (for example `ok`/`error`). |
+| `tt.success` | stage (optional) | bool | defaults to `true`; importer emits one aggregate warning per import | Optional stage success flag. |
+| `tt.depth_at_start` | queue (optional) | unsigned integer | omitted when unknown; no warning when absent | Queue depth snapshot when queued work started waiting. |
 
 
 ## Live tracing recorder

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -826,6 +826,41 @@ mod tests {
     }
 
     #[test]
+    fn normalized_tt_fields_missing_kind_warn_and_skip_non_strict() {
+        let input = r#"{"span":{"name":"http.request","started_at_unix_ms":1,"finished_at_unix_ms":2},"fields":{"tt.request_id":"r1","tt.route":"/checkout"}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert_eq!(imported.warnings().len(), 1);
+        assert!(imported.warnings()[0]
+            .message()
+            .contains("missing required field 'tt.kind' in span 'http.request'"));
+    }
+
+    #[test]
+    fn normalized_tt_fields_missing_kind_error_strict() {
+        let input = r#"{"span":{"name":"http.request","started_at_unix_ms":1,"finished_at_unix_ms":2},"fields":{"tt.request_id":"r1","tt.route":"/checkout"}}"#;
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+            .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn aggregate_optional_default_warnings_are_not_spammy() {
+        let input = r#"{"span":{"name":"req1","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
+{"span":{"name":"req2","started_at_unix_ms":3,"finished_at_unix_ms":4,"fields":{"tt.kind":"request","tt.request_id":"r2","tt.route":"/b"}}}
+{"span":{"name":"st1","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
+{"span":{"name":"st2","started_at_unix_ms":3,"finished_at_unix_ms":4,"fields":{"tt.kind":"stage","tt.request_id":"r2","tt.stage":"cache"}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.warnings().len(), 2);
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("2 request span(s) missing optional 'tt.outcome'")));
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("2 stage span(s) missing optional 'tt.success'")));
+    }
+
+    #[test]
     fn empty_service_name_is_rejected_for_jsonl_import() {
         let err = import_jsonl_reader(Cursor::new(""), ImportOptions::new("")).unwrap_err();
         assert!(matches!(err, ImportError::EmptyServiceName));

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -53,7 +53,7 @@ pub use types::{FieldValue, ImportOptions, ImportWarning, ImportedRun, SpanKind,
 
 /// Converts in-memory tracing span records into a `tailtriage_core::Run`.
 ///
-/// Spans without [`TT_KIND`] are ignored silently. In non-strict mode, malformed
+/// Spans without `tt.*` fields are ignored silently. In non-strict mode, malformed
 /// `tt.*` spans are skipped and surfaced as warnings. In strict mode, the first
 /// malformed `tt.*` span returns an [`ImportError`].
 /// # Errors
@@ -75,10 +75,24 @@ where
     let mut queues = Vec::new();
     let mut min_start: Option<u64> = None;
     let mut max_finish: Option<u64> = None;
+    let mut request_outcome_default_count = 0_u64;
+    let mut stage_success_default_count = 0_u64;
 
     for span in spans {
         let kind = match get_string_field_state(&span, TT_KIND) {
-            StringFieldState::Missing => continue,
+            StringFieldState::Missing => {
+                if span_has_tailtriage_field(&span) {
+                    strict_or_warn(
+                        options.strict_mode(),
+                        &mut warnings,
+                        format!(
+                            "missing required field '{TT_KIND}' in span '{}'",
+                            span.name()
+                        ),
+                    )?;
+                }
+                continue;
+            }
             StringFieldState::Value(kind) => {
                 let Some(kind) = SpanKind::parse(kind) else {
                     strict_or_warn(
@@ -120,7 +134,12 @@ where
                     required_string(&span, TT_REQUEST_ID, options.strict_mode(), &mut warnings)?;
                 let route = required_string(&span, TT_ROUTE, options.strict_mode(), &mut warnings)?;
                 if let (Some(request_id), Some(route)) = (request_id, route) {
-                    let Some(outcome) = parse_outcome(&span, options.strict_mode(), &mut warnings)?
+                    let Some(outcome) = parse_outcome(
+                        &span,
+                        options.strict_mode(),
+                        &mut warnings,
+                        &mut request_outcome_default_count,
+                    )?
                     else {
                         continue;
                     };
@@ -144,8 +163,12 @@ where
                     required_string(&span, TT_REQUEST_ID, options.strict_mode(), &mut warnings)?;
                 let stage = required_string(&span, TT_STAGE, options.strict_mode(), &mut warnings)?;
                 if let (Some(request_id), Some(stage)) = (request_id, stage) {
-                    let success = match parse_success(&span, options.strict_mode(), &mut warnings)?
-                    {
+                    let success = match parse_success(
+                        &span,
+                        options.strict_mode(),
+                        &mut warnings,
+                        &mut stage_success_default_count,
+                    )? {
                         OptionalField::Missing => true,
                         OptionalField::Value(success) => success,
                         OptionalField::Invalid => continue,
@@ -190,6 +213,16 @@ where
                 }
             }
         }
+    }
+    if request_outcome_default_count > 0 {
+        warnings.push(ImportWarning::new(format!(
+            "{request_outcome_default_count} request span(s) missing optional '{TT_OUTCOME}'; assumed 'ok'"
+        )));
+    }
+    if stage_success_default_count > 0 {
+        warnings.push(ImportWarning::new(format!(
+            "{stage_success_default_count} stage span(s) missing optional '{TT_SUCCESS}'; assumed true"
+        )));
     }
 
     let started_at_unix_ms = min_start.unwrap_or_else(tailtriage_core::unix_time_ms);
@@ -254,6 +287,10 @@ fn update_min_max(min_start: &mut Option<u64>, max_finish: &mut Option<u64>, spa
     *max_finish = Some(max_finish.map_or(span.finished_at_unix_ms(), |current| {
         current.max(span.finished_at_unix_ms())
     }));
+}
+
+fn span_has_tailtriage_field(span: &SpanRecord) -> bool {
+    span.fields().keys().any(|key| key.starts_with("tt."))
 }
 
 enum StringFieldState<'a> {
@@ -328,9 +365,13 @@ fn parse_outcome(
     span: &SpanRecord,
     strict: bool,
     warnings: &mut Vec<ImportWarning>,
+    default_count: &mut u64,
 ) -> Result<Option<String>, ImportError> {
     match get_string_field_state(span, TT_OUTCOME) {
-        StringFieldState::Missing => Ok(Some("ok".to_owned())),
+        StringFieldState::Missing => {
+            *default_count += 1;
+            Ok(Some("ok".to_owned()))
+        }
         StringFieldState::Value(value) => Ok(Some(value.to_owned())),
         StringFieldState::InvalidType => {
             strict_or_warn(
@@ -350,6 +391,7 @@ fn parse_success(
     span: &SpanRecord,
     strict: bool,
     warnings: &mut Vec<ImportWarning>,
+    default_count: &mut u64,
 ) -> Result<OptionalField<bool>, ImportError> {
     match span.fields().get(TT_SUCCESS) {
         Some(FieldValue::Bool(value)) => Ok(OptionalField::Value(*value)),
@@ -363,7 +405,10 @@ fn parse_success(
             strict_or_warn(strict, warnings, format!("invalid field '{TT_SUCCESS}' in span '{}': expected bool or 'true'/'false' string", span.name()))?;
             Ok(OptionalField::Invalid)
         }
-        None => Ok(OptionalField::Missing),
+        None => {
+            *default_count += 1;
+            Ok(OptionalField::Missing)
+        }
     }
 }
 
@@ -522,6 +567,65 @@ mod tests {
         let spans = vec![SpanRecord::new("x", 1, 2).field("a", "b")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(imported.warnings().is_empty());
+    }
+
+    #[test]
+    fn span_with_tt_fields_but_missing_kind_warns_and_skips_non_strict() {
+        let spans = vec![SpanRecord::new("http.request", 1, 2)
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/checkout")];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert_eq!(imported.warnings().len(), 1);
+        assert!(imported.warnings()[0]
+            .message()
+            .contains("missing required field 'tt.kind' in span 'http.request'"));
+    }
+
+    #[test]
+    fn span_with_tt_fields_but_missing_kind_errors_in_strict_mode() {
+        let spans = vec![SpanRecord::new("http.request", 1, 2)
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/checkout")];
+        let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn missing_optional_defaults_emit_aggregate_warnings() {
+        let spans = vec![
+            SpanRecord::new("req-1", 1, 2)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/"),
+            SpanRecord::new("req-2", 3, 4)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r2")
+                .field(TT_ROUTE, "/"),
+            SpanRecord::new("st-1", 1, 2)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+            SpanRecord::new("st-2", 3, 4)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r2")
+                .field(TT_STAGE, "cache"),
+            SpanRecord::new("q-1", 1, 2)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "admission"),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests[0].outcome, "ok");
+        assert!(imported.run().stages[0].success);
+        assert_eq!(imported.run().queues[0].depth_at_start, None);
+        assert_eq!(imported.warnings().len(), 2);
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("2 request span(s) missing optional 'tt.outcome'")));
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("2 stage span(s) missing optional 'tt.success'")));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Avoid silently discarding user-intended `tt.*` tracing input when it is malformed, so imports are predictable and debuggable. 
- Preserve low-friction defaults for partial instrumentation while making interpretive assumptions explicit and observable. 
- Keep warning volume bounded on large imports by emitting concise aggregate warnings rather than per-span spam.

### Description

- Treat any span containing at least one `tt.*` field as user-intended tailtriage input and, if `tt.kind` is missing, then in non-strict mode `run_from_span_records` warns and skips the span and in strict mode it returns `ImportError::StrictViolation` (spans with no `tt.*` fields are still ignored silently). 
- Added `span_has_tailtriage_field` helper and updated `run_from_span_records` to surface missing-`tt.kind` cases and to keep existing malformed-field semantics (unknown kinds, invalid types) but surface them as warnings or strict errors. 
- Make importer defaults explicit and aggregate: missing request `tt.outcome` defaults to `"ok"` and missing stage `tt.success` defaults to `true`; the importer now emits one aggregate warning per import for each defaulted family (no warnings for missing `tt.depth_at_start`). 
- Small API/internal changes: `parse_outcome` and `parse_success` accept counters to accumulate default counts and return behavior unchanged otherwise. 
- Tests and fixtures: added unit tests for typed conversion behaviors, JSONL import tests for normalized `tt.*` records (missing-`tt.kind` handling and aggregate warnings), and CLI boundary tests and fixtures so the recommended examples include explicit `tt.outcome`/`tt.success` and a CLI test verifies warning visibility while still producing output when valid requests exist. 
- Docs: updated `tailtriage-tracing/README.md` field-convention table to document defaults and warning behavior for `tt.outcome`, `tt.success`, and `tt.depth_at_start` so importer assumptions are explicit to users.

### Testing

- Ran `cargo fmt --check` which succeeded. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which completed successfully. 
- Ran `cargo test --workspace --all-targets --all-features --locked`; an unrelated analyzer test (`queue_and_stage_data_drives_ranked_suspects`) failed once during the full workspace run due to non-determinism, and an immediate targeted rerun of the analyzer end-to-end tests (`cargo test -p tailtriage-analyzer --test end_to_end_capture_analysis`) passed; the added tracing/jsonl/CLI tests exercised the new behaviors. 
- Ran `python3 scripts/validate_docs_contracts.py` which passed and confirms docs remain within the repository validation contract.

The change preserves the tracing bridge design and analyzer behavior while making malformed `tt.*` input and importer assumptions visible and actionable to users.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cbe8da2fc833083cbff7827926bcc)