### PR TITLE
Skip analysis for zero-request runtime-cost runs

### DIFF
--- a/demos/runtime_cost/src/main.rs
+++ b/demos/runtime_cost/src/main.rs
@@ -181,13 +181,8 @@ async fn main() -> anyhow::Result<()> {
     let finalize_start = Instant::now();
     let (run, artifact_path) = finalize_backend_and_write_artifact(&cli, &mut backend).await?;
     let artifact_finalize_ms = finalize_start.elapsed().as_secs_f64() * 1000.0;
-    let analyze_start = Instant::now();
     let (analyze_ms, report_render_ms) = if let Some(ref run_value) = run {
-        let report = try_analyze_run(run_value, AnalyzeOptions::default())?;
-        let analyze_ms = analyze_start.elapsed().as_secs_f64() * 1000.0;
-        let render_start = Instant::now();
-        black_box(render_json_pretty(&report)?);
-        (analyze_ms, render_start.elapsed().as_secs_f64() * 1000.0)
+        analyze_and_render_if_requests(run_value)?
     } else {
         (0.0, 0.0)
     };
@@ -534,6 +529,18 @@ fn micros_to_millis_f64(m: u64) -> anyhow::Result<f64> {
     Ok(m.to_string().parse::<f64>()? / 1_000.0)
 }
 
+fn analyze_and_render_if_requests(run: &Run) -> anyhow::Result<(f64, f64)> {
+    if run.requests.is_empty() {
+        return Ok((0.0, 0.0));
+    }
+    let analyze_start = Instant::now();
+    let report = try_analyze_run(run, AnalyzeOptions::default())?;
+    let analyze_ms = analyze_start.elapsed().as_secs_f64() * 1000.0;
+    let render_start = Instant::now();
+    black_box(render_json_pretty(&report)?);
+    Ok((analyze_ms, render_start.elapsed().as_secs_f64() * 1000.0))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -564,6 +571,39 @@ mod tests {
             PathBuf::from(artifact_path),
             output_dir.join("run-core_light.json")
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn baked_in_no_request_context_finalizes_artifact_with_zero_requests() {
+        let output_dir = std::env::temp_dir().join(format!(
+            "tailtriage-runtime-cost-test-no-request-context-{}",
+            std::process::id()
+        ));
+        let cli = Cli {
+            mode: Mode::BakedInNoRequestContext,
+            requests: 1,
+            concurrency: 1,
+            work_ms: 1,
+            output_dir: output_dir.clone(),
+        };
+        std::fs::create_dir_all(&output_dir).expect("create output dir");
+        let mut backend = build_backend(&cli).expect("build backend");
+        let (latencies, _) = run_requests(&cli, &backend).await.expect("run requests");
+        assert_eq!(latencies.len(), 1);
+        let (run, artifact_path) = finalize_backend_and_write_artifact(&cli, &mut backend)
+            .await
+            .expect("finalize and write");
+        let run = run.expect("native run should exist");
+        assert!(run.requests.is_empty());
+        let artifact_path = artifact_path.expect("artifact path should exist");
+        assert_eq!(
+            PathBuf::from(artifact_path),
+            output_dir.join("run-baked_in_no_request_context.json")
+        );
+        let (analyze_ms, report_render_ms) =
+            analyze_and_render_if_requests(&run).expect("skip analysis for zero-request run");
+        assert_eq!(analyze_ms, 0.0);
+        assert_eq!(report_render_ms, 0.0);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The `baked_in_no_request_context` demo finalizes a native `Run` that can contain zero request events, and calling the analyzer on such a run is invalid and causes a regression. 
- The runtime-cost demo must still measure artifact finalization cost while avoiding analyzer/report rendering when there are no request events. 

### Description
- Add a guard that only runs analysis/rendering when `run.requests` is non-empty by factoring the logic into `analyze_and_render_if_requests(run: &Run) -> anyhow::Result<(f64, f64)>` inside `demos/runtime_cost/src/main.rs`. 
- When a run has zero requests the code now returns `(analyze_ms, report_render_ms) = (0.0, 0.0)` and skips `try_analyze_run` and `render_json_pretty`. 
- Preserve `baked_in_no_request_context` as a native finalize mode that still writes a finalized `Run` artifact and leaves the runtime-cost summary schema and the tracing/native gate thresholds unchanged. 
- Add a focused regression test `baked_in_no_request_context_finalizes_artifact_with_zero_requests` in `demos/runtime_cost/src/main.rs` that verifies the mode finalizes, writes the artifact `run-baked_in_no_request_context.json`, produces zero requests, and that the analysis/render step is skipped (observed as `0.0` timings). 

### Testing
- Ran `cargo fmt --check` and it passed. 
- Ran `cargo test -p runtime_cost --all-targets` and all unit tests passed (including the new regression test). 
- Ran `python3 -m unittest scripts.tests.test_measure_runtime_cost` and it passed. 
- Ran `python3 -m unittest scripts.tests.test_validate_runtime_cost_summary` and it passed. 
- The new test failed on the pre-fix version and passes with the changes, confirming the regression is fixed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d6a5acfa88330bf9d9a5423f8455d)