### PR TITLE
runtime_cost: skip analysis for zero-request native runs

### DIFF
--- a/demos/runtime_cost/src/main.rs
+++ b/demos/runtime_cost/src/main.rs
@@ -181,16 +181,7 @@ async fn main() -> anyhow::Result<()> {
     let finalize_start = Instant::now();
     let (run, artifact_path) = finalize_backend_and_write_artifact(&cli, &mut backend).await?;
     let artifact_finalize_ms = finalize_start.elapsed().as_secs_f64() * 1000.0;
-    let analyze_start = Instant::now();
-    let (analyze_ms, report_render_ms) = if let Some(ref run_value) = run {
-        let report = try_analyze_run(run_value, AnalyzeOptions::default())?;
-        let analyze_ms = analyze_start.elapsed().as_secs_f64() * 1000.0;
-        let render_start = Instant::now();
-        black_box(render_json_pretty(&report)?);
-        (analyze_ms, render_start.elapsed().as_secs_f64() * 1000.0)
-    } else {
-        (0.0, 0.0)
-    };
+    let (analyze_ms, report_render_ms) = analyze_and_render_timing(run.as_ref())?;
     latencies.sort_unstable();
     let truncation = run.as_ref().map(|r| TruncationMeasurement {
         dropped_requests: r.truncation.dropped_requests,
@@ -454,6 +445,22 @@ async fn tracing_request(sem: Arc<Semaphore>, work: Duration, idx: usize) {
     .await;
 }
 
+fn analyze_and_render_timing(run: Option<&Run>) -> anyhow::Result<(f64, f64)> {
+    let Some(run_value) = run else {
+        return Ok((0.0, 0.0));
+    };
+    if run_value.requests.is_empty() {
+        return Ok((0.0, 0.0));
+    }
+
+    let analyze_start = Instant::now();
+    let report = try_analyze_run(run_value, AnalyzeOptions::default())?;
+    let analyze_ms = analyze_start.elapsed().as_secs_f64() * 1000.0;
+    let render_start = Instant::now();
+    black_box(render_json_pretty(&report)?);
+    Ok((analyze_ms, render_start.elapsed().as_secs_f64() * 1000.0))
+}
+
 fn parse_cli() -> anyhow::Result<Cli> {
     let mut mode = None;
     let mut requests = DEFAULT_REQUESTS;
@@ -563,6 +570,41 @@ mod tests {
         assert_eq!(
             PathBuf::from(artifact_path),
             output_dir.join("run-core_light.json")
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn baked_in_no_request_context_finalizes_without_analysis_input() {
+        let output_dir = std::env::temp_dir().join(format!(
+            "tailtriage-runtime-cost-test-no-request-{}",
+            std::process::id()
+        ));
+        let cli = Cli {
+            mode: Mode::BakedInNoRequestContext,
+            requests: 1,
+            concurrency: 1,
+            work_ms: 1,
+            output_dir: output_dir.clone(),
+        };
+        std::fs::create_dir_all(&output_dir).expect("create output dir");
+        let mut backend = build_backend(&cli).expect("build backend");
+        let (latencies, _) = run_requests(&cli, &backend).await.expect("run requests");
+        assert_eq!(latencies.len(), 1);
+
+        let (run, artifact_path) = finalize_backend_and_write_artifact(&cli, &mut backend)
+            .await
+            .expect("finalize and write");
+        let run = run.expect("native run should exist");
+        assert!(run.requests.is_empty());
+        let (analyze_ms, report_render_ms) =
+            analyze_and_render_timing(Some(&run)).expect("analyze timing");
+        assert_eq!(analyze_ms, 0.0);
+        assert_eq!(report_render_ms, 0.0);
+
+        let artifact_path = artifact_path.expect("artifact path should exist");
+        assert_eq!(
+            PathBuf::from(artifact_path),
+            output_dir.join("run-baked_in_no_request_context.json")
         );
     }
 


### PR DESCRIPTION
### Motivation
- Fix a regression where `baked_in_no_request_context` finalizes a native `Run` with zero request events and then calls the analyzer/renderer, which requires at least one request event. 
- Preserve `baked_in_no_request_context` as a real native finalization mode so artifact finalization cost remains measured. 
- Ensure the runtime-cost demo does not fail when a finalized run intentionally omits request-context instrumentation.

### Description
- Add a helper `analyze_and_render_timing` that returns `(0.0, 0.0)` when `run` is `None` or `run.requests.is_empty()` and otherwise times `try_analyze_run` and `render_json_pretty` for the run. 
- Replace the inline analyze/render timing in `main` with a call to `analyze_and_render_timing(run.as_ref())`. 
- Keep `Mode::BakedInNoRequestContext` behavior unchanged and do not add request/stage/queue instrumentation for that mode. 
- Add a focused unit test in `demos/runtime_cost/src/main.rs` proving `Mode::BakedInNoRequestContext` can finalize, produce zero requests, write the artifact, and yields `analyze_ms == 0.0` and `report_render_ms == 0.0`.

### Testing
- Ran `cargo fmt --check` which passed. 
- Ran `cargo test -p runtime_cost --all-targets` which passed (all demo unit tests passed including the new test). 
- Ran `python3 -m unittest scripts.tests.test_measure_runtime_cost` which passed. 
- Ran `python3 -m unittest scripts.tests.test_validate_runtime_cost_summary` which passed. 
- Note: the earlier `cargo test -p runtime-cost-demo --all-targets` command does not match a workspace package; the demo package is named `runtime_cost` so tests were run against `runtime_cost`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d6a5acfa88330bf9d9a5423f8455d)