### PR TITLE
Skip runtime-cost analysis for zero-request runs

### DIFF
--- a/demos/runtime_cost/src/main.rs
+++ b/demos/runtime_cost/src/main.rs
@@ -181,16 +181,7 @@ async fn main() -> anyhow::Result<()> {
     let finalize_start = Instant::now();
     let (run, artifact_path) = finalize_backend_and_write_artifact(&cli, &mut backend).await?;
     let artifact_finalize_ms = finalize_start.elapsed().as_secs_f64() * 1000.0;
-    let analyze_start = Instant::now();
-    let (analyze_ms, report_render_ms) = if let Some(ref run_value) = run {
-        let report = try_analyze_run(run_value, AnalyzeOptions::default())?;
-        let analyze_ms = analyze_start.elapsed().as_secs_f64() * 1000.0;
-        let render_start = Instant::now();
-        black_box(render_json_pretty(&report)?);
-        (analyze_ms, render_start.elapsed().as_secs_f64() * 1000.0)
-    } else {
-        (0.0, 0.0)
-    };
+    let (analyze_ms, report_render_ms) = analyze_and_render_timings_for_run(run.as_ref())?;
     latencies.sort_unstable();
     let truncation = run.as_ref().map(|r| TruncationMeasurement {
         dropped_requests: r.truncation.dropped_requests,
@@ -566,6 +557,39 @@ mod tests {
         );
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn baked_in_no_request_context_finalizes_and_skips_analysis() {
+        let output_dir = std::env::temp_dir().join(format!(
+            "tailtriage-runtime-cost-no-request-context-test-{}",
+            std::process::id()
+        ));
+        let cli = Cli {
+            mode: Mode::BakedInNoRequestContext,
+            requests: 1,
+            concurrency: 1,
+            work_ms: 1,
+            output_dir: output_dir.clone(),
+        };
+        std::fs::create_dir_all(&output_dir).expect("create output dir");
+        let mut backend = build_backend(&cli).expect("build backend");
+        let (latencies, _) = run_requests(&cli, &backend).await.expect("run requests");
+        assert_eq!(latencies.len(), 1);
+        let (run, artifact_path) = finalize_backend_and_write_artifact(&cli, &mut backend)
+            .await
+            .expect("finalize and write");
+        let run = run.expect("native run should exist");
+        assert!(run.requests.is_empty());
+        let artifact_path = artifact_path.expect("artifact path should exist");
+        assert_eq!(
+            PathBuf::from(artifact_path),
+            output_dir.join("run-baked_in_no_request_context.json")
+        );
+        assert_eq!(
+            analyze_and_render_timings_for_run(Some(&run)).unwrap(),
+            (0.0, 0.0)
+        );
+    }
+
     #[test]
     fn mode_parse_accepts_tracing_modes() {
         assert_eq!(Mode::parse("tracing_light"), Some(Mode::TracingLight));
@@ -588,5 +612,21 @@ mod tests {
         assert_eq!(m.instrumentation(), InstrumentationKind::Tracing);
         assert!(m.uses_runtime_sampler());
         assert!(!m.uses_drop_path_limits());
+    }
+}
+
+fn analyze_and_render_timings_for_run(run: Option<&Run>) -> anyhow::Result<(f64, f64)> {
+    let analyze_start = Instant::now();
+    if let Some(run_value) = run {
+        if run_value.requests.is_empty() {
+            return Ok((0.0, 0.0));
+        }
+        let report = try_analyze_run(run_value, AnalyzeOptions::default())?;
+        let analyze_ms = analyze_start.elapsed().as_secs_f64() * 1000.0;
+        let render_start = Instant::now();
+        black_box(render_json_pretty(&report)?);
+        Ok((analyze_ms, render_start.elapsed().as_secs_f64() * 1000.0))
+    } else {
+        Ok((0.0, 0.0))
     }
 }


### PR DESCRIPTION
### Motivation
- The `baked_in_no_request_context` mode finalizes a native run but intentionally omits request-context instrumentation, producing runs with zero request events. 
- `tailtriage analyze` requires at least one request event and would fail or be inappropriate to run on zero-request runs, causing a runtime-cost demo regression. 
- The demo should still measure artifact finalization cost while avoiding analyzer/report rendering when there are no requests.

### Description
- Modify `demos/runtime_cost/src/main.rs` to route analyzer/report timing through a helper `analyze_and_render_timings_for_run` and skip analysis when `run.requests.is_empty()`, returning `(0.0, 0.0)` for `analyze_ms` and `report_render_ms`.
- Preserve `baked_in_no_request_context` as a real native finalization mode and continue writing its finalized run artifact file (no request/stage/queue instrumentation added).
- Add a focused test `baked_in_no_request_context_finalizes_and_skips_analysis` in `demos/runtime_cost/src/main.rs` that verifies the mode finalizes, writes `run-baked_in_no_request_context.json`, contains zero requests, and yields zero analyzer/render timings instead of failing.
- Keep runtime-cost summary schema and existing thresholds unchanged.

### Testing
- Ran `cargo fmt --check` and it succeeded.
- Ran `cargo test -p runtime_cost --all-targets` and the runtime-cost demo unit tests passed, including the new regression test.
- Ran `python3 -m unittest scripts.tests.test_measure_runtime_cost` and `python3 -m unittest scripts.tests.test_validate_runtime_cost_summary` and both test suites passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d6a5acfa88330bf9d9a5423f8455d)