### PR TITLE
Validate RunBuilder timestamp ordering in public API

### DIFF
--- a/tailtriage-core/src/config.rs
+++ b/tailtriage-core/src/config.rs
@@ -208,12 +208,40 @@ impl Config {
 pub enum BuildError {
     /// Service name was empty.
     EmptyServiceName,
+    /// Finished timestamp was earlier than started timestamp.
+    InvalidRunTimeBounds {
+        /// Run start timestamp in unix milliseconds.
+        started_at_unix_ms: u64,
+        /// Run finish timestamp in unix milliseconds.
+        finished_at_unix_ms: u64,
+    },
+    /// Finalized timestamp was earlier than finished timestamp.
+    InvalidFinalizationTime {
+        /// Run finish timestamp in unix milliseconds.
+        finished_at_unix_ms: u64,
+        /// Run finalization timestamp in unix milliseconds.
+        finalized_at_unix_ms: u64,
+    },
 }
 
 impl std::fmt::Display for BuildError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::EmptyServiceName => write!(f, "service_name cannot be empty"),
+            Self::InvalidRunTimeBounds {
+                started_at_unix_ms,
+                finished_at_unix_ms,
+            } => write!(
+                f,
+                "invalid run time bounds: finished_at_unix_ms ({finished_at_unix_ms}) must be >= started_at_unix_ms ({started_at_unix_ms})"
+            ),
+            Self::InvalidFinalizationTime {
+                finished_at_unix_ms,
+                finalized_at_unix_ms,
+            } => write!(
+                f,
+                "invalid finalization time: finalized_at_unix_ms ({finalized_at_unix_ms}) must be >= finished_at_unix_ms ({finished_at_unix_ms})"
+            ),
         }
     }
 }

--- a/tailtriage-core/src/run_builder.rs
+++ b/tailtriage-core/src/run_builder.rs
@@ -154,8 +154,21 @@ impl RunBuilder {
         let ts = unix_time_ms();
         let started_at_unix_ms = options.started_at_unix_ms.unwrap_or(ts);
         let finished_at_unix_ms = options.finished_at_unix_ms.unwrap_or(ts);
-        let finalized_at_unix_ms =
-            Some(options.finalized_at_unix_ms.unwrap_or(finished_at_unix_ms));
+        let finalized_at_unix_ms = options.finalized_at_unix_ms.unwrap_or(finished_at_unix_ms);
+
+        if finished_at_unix_ms < started_at_unix_ms {
+            return Err(BuildError::InvalidRunTimeBounds {
+                started_at_unix_ms,
+                finished_at_unix_ms,
+            });
+        }
+
+        if finalized_at_unix_ms < finished_at_unix_ms {
+            return Err(BuildError::InvalidFinalizationTime {
+                finished_at_unix_ms,
+                finalized_at_unix_ms,
+            });
+        }
 
         Ok(Self {
             run: Run::new(RunMetadata {
@@ -164,7 +177,7 @@ impl RunBuilder {
                 service_version: options.service_version,
                 started_at_unix_ms,
                 finished_at_unix_ms,
-                finalized_at_unix_ms,
+                finalized_at_unix_ms: Some(finalized_at_unix_ms),
                 mode,
                 effective_core_config: Some(EffectiveCoreConfig {
                     mode,

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -991,6 +991,86 @@ fn run_builder_rejects_blank_service_name() {
 }
 
 #[test]
+fn run_builder_valid_explicit_timestamps_are_preserved() {
+    let run = crate::RunBuilder::new(
+        crate::RunBuilderOptions::new("svc")
+            .started_at_unix_ms(100)
+            .finished_at_unix_ms(150)
+            .finalized_at_unix_ms(200),
+    )
+    .expect("valid timestamps should succeed")
+    .finish();
+
+    assert_eq!(run.metadata.started_at_unix_ms, 100);
+    assert_eq!(run.metadata.finished_at_unix_ms, 150);
+    assert_eq!(run.metadata.finalized_at_unix_ms, Some(200));
+}
+
+#[test]
+fn run_builder_equal_timestamp_bounds_are_valid() {
+    let run = crate::RunBuilder::new(
+        crate::RunBuilderOptions::new("svc")
+            .started_at_unix_ms(100)
+            .finished_at_unix_ms(100)
+            .finalized_at_unix_ms(100),
+    )
+    .expect("equal timestamps should succeed")
+    .finish();
+
+    assert_eq!(run.metadata.started_at_unix_ms, 100);
+    assert_eq!(run.metadata.finished_at_unix_ms, 100);
+    assert_eq!(run.metadata.finalized_at_unix_ms, Some(100));
+}
+
+#[test]
+fn run_builder_rejects_finished_before_started() {
+    let err = crate::RunBuilder::new(
+        crate::RunBuilderOptions::new("svc")
+            .started_at_unix_ms(100)
+            .finished_at_unix_ms(99),
+    )
+    .expect_err("invalid bounds should fail");
+
+    assert_eq!(
+        err,
+        BuildError::InvalidRunTimeBounds {
+            started_at_unix_ms: 100,
+            finished_at_unix_ms: 99
+        }
+    );
+}
+
+#[test]
+fn run_builder_rejects_finalized_before_finished() {
+    let err = crate::RunBuilder::new(
+        crate::RunBuilderOptions::new("svc")
+            .started_at_unix_ms(100)
+            .finished_at_unix_ms(150)
+            .finalized_at_unix_ms(149),
+    )
+    .expect_err("invalid finalization should fail");
+
+    assert_eq!(
+        err,
+        BuildError::InvalidFinalizationTime {
+            finished_at_unix_ms: 150,
+            finalized_at_unix_ms: 149
+        }
+    );
+}
+
+#[test]
+fn run_builder_default_timestamps_produce_valid_finalized_run() {
+    let run = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc"))
+        .expect("default timestamps should succeed")
+        .finish();
+
+    assert!(run.metadata.finalized_at_unix_ms.is_some());
+    assert!(run.metadata.finished_at_unix_ms >= run.metadata.started_at_unix_ms);
+    assert!(run.metadata.finalized_at_unix_ms.expect("some") >= run.metadata.finished_at_unix_ms);
+}
+
+#[test]
 fn run_builder_default_run_ids_are_unique() {
     let first = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc"))
         .expect("ok")
@@ -1033,10 +1113,14 @@ fn run_builder_defaults_finalized_timestamp_to_finished_timestamp() {
 
 #[test]
 fn run_builder_preserves_explicit_finalized_timestamp() {
-    let run =
-        crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").finalized_at_unix_ms(777))
-            .expect("ok")
-            .finish();
+    let run = crate::RunBuilder::new(
+        crate::RunBuilderOptions::new("svc")
+            .started_at_unix_ms(700)
+            .finished_at_unix_ms(750)
+            .finalized_at_unix_ms(777),
+    )
+    .expect("ok")
+    .finish();
     assert_eq!(run.metadata.finalized_at_unix_ms, Some(777));
 }
 

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -255,6 +255,12 @@ where
 
     let mut run_builder = RunBuilder::new(builder_options).map_err(|err| match err {
         BuildError::EmptyServiceName => ImportError::EmptyServiceName,
+        BuildError::InvalidRunTimeBounds { .. } | BuildError::InvalidFinalizationTime { .. } => {
+            ImportError::InvalidField {
+                field: "run metadata timestamps",
+                reason: err.to_string(),
+            }
+        }
     })?;
 
     for request in requests {


### PR DESCRIPTION
### Motivation
- Make `tailtriage_core::RunBuilder` / `RunBuilderOptions` a safe, stable public API by ensuring run metadata timestamps are ordered correctly and exposing clear, distinguishable errors for callers.
- Prevent consumer code from constructing finalized `Run` artifacts with inconsistent timestamps while preserving existing default timestamp semantics.

### Description
- Added two public `BuildError` variants in `tailtriage-core/src/config.rs`: `InvalidRunTimeBounds { started_at_unix_ms: u64, finished_at_unix_ms: u64 }` and `InvalidFinalizationTime { finished_at_unix_ms: u64, finalized_at_unix_ms: u64 }` with clear `Display` messages explaining the ordering requirements.
- Implemented validation in `RunBuilder::new` (in `tailtriage-core/src/run_builder.rs`) after resolving defaults and before `Run` construction to reject `finished_at_unix_ms < started_at_unix_ms` and `finalized_at_unix_ms < finished_at_unix_ms`, while keeping the prior default behavior (single `ts = unix_time_ms()`, defaults for start/finish/finalized, and `finalized_at_unix_ms` stored as `Some(...)`).
- Updated downstream mapping in `tailtriage-tracing/src/lib.rs` to handle the new `BuildError` variants exhaustively, mapping them to `ImportError::InvalidField` with a helpful reason string so pattern matches remain exhaustive and compile cleanly.
- Added focused unit tests in `tailtriage-core` that cover valid explicit timestamps, equal bounds, finished-before-started rejection, finalized-before-finished rejection, and default timestamps producing a valid finalized run.

### Testing
- Ran formatting, linting, and the requested test matrix: `cargo fmt --check` (passed), `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (passed), `cargo test -p tailtriage-core --all-targets` (passed), `cargo test -p tailtriage-tracing --all-targets --all-features` (passed), and `cargo test --workspace --all-targets --all-features --locked` (passed).
- All added and existing tests passed: final result `ok` for the specified crates and workspace tests. No failing command to report.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d79a172f8833084cabb3024d55894)