### PR TITLE
Validate RunBuilder timestamp ordering with explicit BuildError variants

### DIFF
--- a/tailtriage-core/src/config.rs
+++ b/tailtriage-core/src/config.rs
@@ -208,12 +208,40 @@ impl Config {
 pub enum BuildError {
     /// Service name was empty.
     EmptyServiceName,
+    /// Finished timestamp was earlier than start timestamp.
+    InvalidRunTimeBounds {
+        /// Start timestamp in unix milliseconds.
+        started_at_unix_ms: u64,
+        /// Finish timestamp in unix milliseconds.
+        finished_at_unix_ms: u64,
+    },
+    /// Finalization timestamp was earlier than finished timestamp.
+    InvalidFinalizationTime {
+        /// Finish timestamp in unix milliseconds.
+        finished_at_unix_ms: u64,
+        /// Finalization timestamp in unix milliseconds.
+        finalized_at_unix_ms: u64,
+    },
 }
 
 impl std::fmt::Display for BuildError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::EmptyServiceName => write!(f, "service_name cannot be empty"),
+            Self::InvalidRunTimeBounds {
+                started_at_unix_ms,
+                finished_at_unix_ms,
+            } => write!(
+                f,
+                "invalid run timestamps: finished_at_unix_ms ({finished_at_unix_ms}) must be >= started_at_unix_ms ({started_at_unix_ms})"
+            ),
+            Self::InvalidFinalizationTime {
+                finished_at_unix_ms,
+                finalized_at_unix_ms,
+            } => write!(
+                f,
+                "invalid finalization timestamp: finalized_at_unix_ms ({finalized_at_unix_ms}) must be >= finished_at_unix_ms ({finished_at_unix_ms})"
+            ),
         }
     }
 }

--- a/tailtriage-core/src/run_builder.rs
+++ b/tailtriage-core/src/run_builder.rs
@@ -142,6 +142,12 @@ impl RunBuilder {
     /// # Errors
     ///
     /// Returns [`BuildError::EmptyServiceName`] when the service name is blank.
+    ///
+    /// Returns [`BuildError::InvalidRunTimeBounds`] when finished timestamp is
+    /// earlier than start timestamp.
+    ///
+    /// Returns [`BuildError::InvalidFinalizationTime`] when finalization
+    /// timestamp is earlier than finished timestamp.
     pub fn new(options: RunBuilderOptions) -> Result<Self, BuildError> {
         if options.service_name.trim().is_empty() {
             return Err(BuildError::EmptyServiceName);
@@ -154,8 +160,23 @@ impl RunBuilder {
         let ts = unix_time_ms();
         let started_at_unix_ms = options.started_at_unix_ms.unwrap_or(ts);
         let finished_at_unix_ms = options.finished_at_unix_ms.unwrap_or(ts);
-        let finalized_at_unix_ms =
-            Some(options.finalized_at_unix_ms.unwrap_or(finished_at_unix_ms));
+        let finalized_at_unix_ms_value =
+            options.finalized_at_unix_ms.unwrap_or(finished_at_unix_ms);
+        let finalized_at_unix_ms = Some(finalized_at_unix_ms_value);
+
+        if finished_at_unix_ms < started_at_unix_ms {
+            return Err(BuildError::InvalidRunTimeBounds {
+                started_at_unix_ms,
+                finished_at_unix_ms,
+            });
+        }
+
+        if finalized_at_unix_ms_value < finished_at_unix_ms {
+            return Err(BuildError::InvalidFinalizationTime {
+                finished_at_unix_ms,
+                finalized_at_unix_ms: finalized_at_unix_ms_value,
+            });
+        }
 
         Ok(Self {
             run: Run::new(RunMetadata {

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -1045,6 +1045,22 @@ fn run_builder_preserves_explicit_finalized_timestamp() {
 }
 
 #[test]
+fn run_builder_preserves_explicit_timestamps_exactly() {
+    let run = crate::RunBuilder::new(
+        crate::RunBuilderOptions::new("svc")
+            .started_at_unix_ms(100)
+            .finished_at_unix_ms(150)
+            .finalized_at_unix_ms(200),
+    )
+    .expect("ok")
+    .finish();
+
+    assert_eq!(run.metadata.started_at_unix_ms, 100);
+    assert_eq!(run.metadata.finished_at_unix_ms, 150);
+    assert_eq!(run.metadata.finalized_at_unix_ms, Some(200));
+}
+
+#[test]
 fn run_builder_allows_equal_timestamp_bounds() {
     let run = crate::RunBuilder::new(
         crate::RunBuilderOptions::new("svc")

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -1033,13 +1033,82 @@ fn run_builder_defaults_finalized_timestamp_to_finished_timestamp() {
 
 #[test]
 fn run_builder_preserves_explicit_finalized_timestamp() {
-    let run =
-        crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").finalized_at_unix_ms(777))
-            .expect("ok")
-            .finish();
+    let run = crate::RunBuilder::new(
+        crate::RunBuilderOptions::new("svc")
+            .started_at_unix_ms(100)
+            .finished_at_unix_ms(200)
+            .finalized_at_unix_ms(777),
+    )
+    .expect("ok")
+    .finish();
     assert_eq!(run.metadata.finalized_at_unix_ms, Some(777));
 }
 
+#[test]
+fn run_builder_allows_equal_timestamp_bounds() {
+    let run = crate::RunBuilder::new(
+        crate::RunBuilderOptions::new("svc")
+            .started_at_unix_ms(100)
+            .finished_at_unix_ms(100)
+            .finalized_at_unix_ms(100),
+    )
+    .expect("ok")
+    .finish();
+
+    assert_eq!(run.metadata.started_at_unix_ms, 100);
+    assert_eq!(run.metadata.finished_at_unix_ms, 100);
+    assert_eq!(run.metadata.finalized_at_unix_ms, Some(100));
+}
+
+#[test]
+fn run_builder_rejects_finished_before_started() {
+    let err = crate::RunBuilder::new(
+        crate::RunBuilderOptions::new("svc")
+            .started_at_unix_ms(100)
+            .finished_at_unix_ms(99),
+    )
+    .expect_err("should fail");
+
+    assert_eq!(
+        err,
+        BuildError::InvalidRunTimeBounds {
+            started_at_unix_ms: 100,
+            finished_at_unix_ms: 99
+        }
+    );
+}
+
+#[test]
+fn run_builder_rejects_finalized_before_finished() {
+    let err = crate::RunBuilder::new(
+        crate::RunBuilderOptions::new("svc")
+            .started_at_unix_ms(100)
+            .finished_at_unix_ms(150)
+            .finalized_at_unix_ms(149),
+    )
+    .expect_err("should fail");
+
+    assert_eq!(
+        err,
+        BuildError::InvalidFinalizationTime {
+            finished_at_unix_ms: 150,
+            finalized_at_unix_ms: 149
+        }
+    );
+}
+
+#[test]
+fn run_builder_default_timestamps_produce_valid_finalized_run() {
+    let run = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc"))
+        .expect("ok")
+        .finish();
+
+    assert!(run.metadata.finalized_at_unix_ms.is_some());
+    assert!(run.metadata.finished_at_unix_ms >= run.metadata.started_at_unix_ms);
+    assert!(
+        run.metadata.finalized_at_unix_ms.expect("finalized") >= run.metadata.finished_at_unix_ms
+    );
+}
 #[test]
 fn run_builder_strict_lifecycle_in_effective_core_config() {
     let run = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").strict_lifecycle(true))

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -255,6 +255,24 @@ where
 
     let mut run_builder = RunBuilder::new(builder_options).map_err(|err| match err {
         BuildError::EmptyServiceName => ImportError::EmptyServiceName,
+        BuildError::InvalidRunTimeBounds {
+            started_at_unix_ms,
+            finished_at_unix_ms,
+        } => ImportError::InvalidField {
+            field: "tt.finished_at_unix_ms",
+            reason: format!(
+                "finished_at_unix_ms ({finished_at_unix_ms}) must be >= started_at_unix_ms ({started_at_unix_ms})"
+            ),
+        },
+        BuildError::InvalidFinalizationTime {
+            finished_at_unix_ms,
+            finalized_at_unix_ms,
+        } => ImportError::InvalidField {
+            field: "tt.finalized_at_unix_ms",
+            reason: format!(
+                "finalized_at_unix_ms ({finalized_at_unix_ms}) must be >= finished_at_unix_ms ({finished_at_unix_ms})"
+            ),
+        },
     })?;
 
     for request in requests {


### PR DESCRIPTION
### Motivation
- Prevent constructing `Run` artifacts with inconsistent timestamps by validating resolved metadata timestamps in `RunBuilder::new` before assembly. 
- Provide clear, distinguishable error variants so callers can map and report specific timestamp ordering problems. 

### Description
- Add two explicit public `BuildError` variants in `tailtriage-core/src/config.rs`: `InvalidRunTimeBounds { started_at_unix_ms: u64, finished_at_unix_ms: u64 }` and `InvalidFinalizationTime { finished_at_unix_ms: u64, finalized_at_unix_ms: u64 }`, keeping `BuildError` `Clone`/`PartialEq`/`Eq` for public API use. 
- Implement clear `Display` messages for both new variants that include the relevant timestamp values and state the ordering constraint. 
- In `tailtriage-core/src/run_builder.rs`, after resolving defaults (single `ts = unix_time_ms()` and defaulting `started`, `finished`, and `finalized` as before), validate ordering and return the corresponding `BuildError` when `finished < started` or `finalized < finished`, while preserving the existing default-finalization semantics. 
- Update `tailtriage-tracing/src/lib.rs` to exhaustively map the new `BuildError` variants to `ImportError::InvalidField` with descriptive `field` and `reason` so downstream matching is exhaustive and user-facing import errors remain clear. 
- Add focused unit tests in `tailtriage-core` covering valid explicit timestamps, equal bounds, `finished < started` rejection, `finalized < finished` rejection, and default-timestamp finalization guarantees. 

### Testing
- Ran formatting and linting: `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, and they passed. 
- Ran unit tests for core and tracing: `cargo test -p tailtriage-core --all-targets` and `cargo test -p tailtriage-tracing --all-targets --all-features`, and they passed. 
- Ran full workspace tests: `cargo test --workspace --all-targets --all-features --locked`, and they passed. 

All commands succeeded; no failing commands to report.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d79a172f8833084cabb3024d55894)