### PR TITLE
Validate RunBuilder timestamp ordering with explicit BuildError variants

### DIFF
--- a/tailtriage-core/src/config.rs
+++ b/tailtriage-core/src/config.rs
@@ -208,12 +208,40 @@ impl Config {
 pub enum BuildError {
     /// Service name was empty.
     EmptyServiceName,
+    /// Run finish timestamp was earlier than start timestamp.
+    InvalidRunTimeBounds {
+        /// Run start timestamp in unix milliseconds.
+        started_at_unix_ms: u64,
+        /// Run finish timestamp in unix milliseconds.
+        finished_at_unix_ms: u64,
+    },
+    /// Run finalization timestamp was earlier than finish timestamp.
+    InvalidFinalizationTime {
+        /// Run finish timestamp in unix milliseconds.
+        finished_at_unix_ms: u64,
+        /// Run finalization timestamp in unix milliseconds.
+        finalized_at_unix_ms: u64,
+    },
 }
 
 impl std::fmt::Display for BuildError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::EmptyServiceName => write!(f, "service_name cannot be empty"),
+            Self::InvalidRunTimeBounds {
+                started_at_unix_ms,
+                finished_at_unix_ms,
+            } => write!(
+                f,
+                "invalid run time bounds: finished_at_unix_ms ({finished_at_unix_ms}) must be >= started_at_unix_ms ({started_at_unix_ms})"
+            ),
+            Self::InvalidFinalizationTime {
+                finished_at_unix_ms,
+                finalized_at_unix_ms,
+            } => write!(
+                f,
+                "invalid finalization time: finalized_at_unix_ms ({finalized_at_unix_ms}) must be >= finished_at_unix_ms ({finished_at_unix_ms})"
+            ),
         }
     }
 }

--- a/tailtriage-core/src/run_builder.rs
+++ b/tailtriage-core/src/run_builder.rs
@@ -142,6 +142,12 @@ impl RunBuilder {
     /// # Errors
     ///
     /// Returns [`BuildError::EmptyServiceName`] when the service name is blank.
+    ///
+    /// Returns [`BuildError::InvalidRunTimeBounds`] when finish timestamp is
+    /// earlier than start timestamp.
+    ///
+    /// Returns [`BuildError::InvalidFinalizationTime`] when finalization
+    /// timestamp is earlier than finish timestamp.
     pub fn new(options: RunBuilderOptions) -> Result<Self, BuildError> {
         if options.service_name.trim().is_empty() {
             return Err(BuildError::EmptyServiceName);
@@ -154,8 +160,20 @@ impl RunBuilder {
         let ts = unix_time_ms();
         let started_at_unix_ms = options.started_at_unix_ms.unwrap_or(ts);
         let finished_at_unix_ms = options.finished_at_unix_ms.unwrap_or(ts);
-        let finalized_at_unix_ms =
-            Some(options.finalized_at_unix_ms.unwrap_or(finished_at_unix_ms));
+        let finalized_at_unix_ms = options.finalized_at_unix_ms.unwrap_or(finished_at_unix_ms);
+
+        if finished_at_unix_ms < started_at_unix_ms {
+            return Err(BuildError::InvalidRunTimeBounds {
+                started_at_unix_ms,
+                finished_at_unix_ms,
+            });
+        }
+        if finalized_at_unix_ms < finished_at_unix_ms {
+            return Err(BuildError::InvalidFinalizationTime {
+                finished_at_unix_ms,
+                finalized_at_unix_ms,
+            });
+        }
 
         Ok(Self {
             run: Run::new(RunMetadata {
@@ -164,7 +182,7 @@ impl RunBuilder {
                 service_version: options.service_version,
                 started_at_unix_ms,
                 finished_at_unix_ms,
-                finalized_at_unix_ms,
+                finalized_at_unix_ms: Some(finalized_at_unix_ms),
                 mode,
                 effective_core_config: Some(EffectiveCoreConfig {
                     mode,
@@ -252,5 +270,93 @@ impl RunBuilder {
     #[must_use]
     pub fn finish(self) -> Run {
         self.run
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{BuildError, RunBuilder, RunBuilderOptions};
+
+    #[test]
+    fn valid_explicit_timestamps_pass() {
+        let run = RunBuilder::new(
+            RunBuilderOptions::new("svc")
+                .started_at_unix_ms(100)
+                .finished_at_unix_ms(150)
+                .finalized_at_unix_ms(200),
+        )
+        .expect("valid timestamp ordering must build")
+        .finish();
+
+        assert_eq!(run.metadata.started_at_unix_ms, 100);
+        assert_eq!(run.metadata.finished_at_unix_ms, 150);
+        assert_eq!(run.metadata.finalized_at_unix_ms, Some(200));
+    }
+
+    #[test]
+    fn equal_bounds_pass() {
+        let run = RunBuilder::new(
+            RunBuilderOptions::new("svc")
+                .started_at_unix_ms(100)
+                .finished_at_unix_ms(100)
+                .finalized_at_unix_ms(100),
+        )
+        .expect("equal bounds must build")
+        .finish();
+
+        assert_eq!(run.metadata.started_at_unix_ms, 100);
+        assert_eq!(run.metadata.finished_at_unix_ms, 100);
+        assert_eq!(run.metadata.finalized_at_unix_ms, Some(100));
+    }
+
+    #[test]
+    fn finished_before_started_fails() {
+        let err = RunBuilder::new(
+            RunBuilderOptions::new("svc")
+                .started_at_unix_ms(100)
+                .finished_at_unix_ms(99),
+        )
+        .expect_err("finish before start must fail");
+
+        assert_eq!(
+            err,
+            BuildError::InvalidRunTimeBounds {
+                started_at_unix_ms: 100,
+                finished_at_unix_ms: 99,
+            }
+        );
+    }
+
+    #[test]
+    fn finalized_before_finished_fails() {
+        let err = RunBuilder::new(
+            RunBuilderOptions::new("svc")
+                .started_at_unix_ms(100)
+                .finished_at_unix_ms(150)
+                .finalized_at_unix_ms(149),
+        )
+        .expect_err("finalized before finished must fail");
+
+        assert_eq!(
+            err,
+            BuildError::InvalidFinalizationTime {
+                finished_at_unix_ms: 150,
+                finalized_at_unix_ms: 149,
+            }
+        );
+    }
+
+    #[test]
+    fn defaults_produce_valid_finalized_run() {
+        let run = RunBuilder::new(RunBuilderOptions::new("svc"))
+            .expect("default timestamps must build")
+            .finish();
+        let finalized_at = run
+            .metadata
+            .finalized_at_unix_ms
+            .expect("run builder always finalizes");
+
+        assert!(run.metadata.finished_at_unix_ms >= run.metadata.started_at_unix_ms);
+        assert!(finalized_at >= run.metadata.finished_at_unix_ms);
     }
 }

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -1033,10 +1033,14 @@ fn run_builder_defaults_finalized_timestamp_to_finished_timestamp() {
 
 #[test]
 fn run_builder_preserves_explicit_finalized_timestamp() {
-    let run =
-        crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").finalized_at_unix_ms(777))
-            .expect("ok")
-            .finish();
+    let run = crate::RunBuilder::new(
+        crate::RunBuilderOptions::new("svc")
+            .started_at_unix_ms(700)
+            .finished_at_unix_ms(750)
+            .finalized_at_unix_ms(777),
+    )
+    .expect("ok")
+    .finish();
     assert_eq!(run.metadata.finalized_at_unix_ms, Some(777));
 }
 

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -255,6 +255,24 @@ where
 
     let mut run_builder = RunBuilder::new(builder_options).map_err(|err| match err {
         BuildError::EmptyServiceName => ImportError::EmptyServiceName,
+        BuildError::InvalidRunTimeBounds {
+            started_at_unix_ms,
+            finished_at_unix_ms,
+        } => ImportError::InvalidField {
+            field: "tt.started_at_unix_ms/tt.finished_at_unix_ms",
+            reason: format!(
+                "finished_at_unix_ms ({finished_at_unix_ms}) must be >= started_at_unix_ms ({started_at_unix_ms})"
+            ),
+        },
+        BuildError::InvalidFinalizationTime {
+            finished_at_unix_ms,
+            finalized_at_unix_ms,
+        } => ImportError::InvalidField {
+            field: "tt.finished_at_unix_ms/tt.finalized_at_unix_ms",
+            reason: format!(
+                "finalized_at_unix_ms ({finalized_at_unix_ms}) must be >= finished_at_unix_ms ({finished_at_unix_ms})"
+            ),
+        },
     })?;
 
     for request in requests {


### PR DESCRIPTION
### Motivation
- Ensure `tailtriage_core::RunBuilder` is a stable public API by validating run metadata timestamps and surfacing clear, distinguishable errors for invalid bounds.
- Keep existing default timestamp semantics (single `ts = unix_time_ms()` source, started/finished/finalized defaults, finalized remains `Some(...)`) while preventing obviously inconsistent inputs from producing malformed runs.

### Description
- Added two explicit public `BuildError` variants in `tailtriage-core/src/config.rs`: `InvalidRunTimeBounds { started_at_unix_ms, finished_at_unix_ms }` and `InvalidFinalizationTime { finished_at_unix_ms, finalized_at_unix_ms }`, keeping `BuildError` `Debug/Clone/PartialEq/Eq` for public API use.
- Implemented clear `Display` messages for both new variants that include the relevant timestamp values and state the ordering requirement (`finish >= start`, `finalized >= finish`).
- Added timestamp validation inside `RunBuilder::new` (in `tailtriage-core/src/run_builder.rs`) after resolving defaults and before constructing `Run`, returning the new `BuildError` variants on violation while preserving existing defaults and `finalized_at_unix_ms: Some(...)` output behavior.
- Updated downstream mapping in `tailtriage-tracing/src/lib.rs` to exhaustively handle the new `BuildError` variants and convert them into `ImportError::InvalidField` with informative `field` and `reason` text.
- Added focused unit tests in `tailtriage-core` covering valid explicit timestamps, equal bounds, `finished < started`, `finalized < finished`, and default-timestamp validity, and adjusted one existing test to supply consistent timestamps so it remains valid under the new checks.

### Testing
- Ran formatting and linting: `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, both completed successfully.
- Ran crate/unit tests: `cargo test -p tailtriage-core --all-targets`, `cargo test -p tailtriage-tracing --all-targets --all-features`, and `cargo test --workspace --all-targets --all-features --locked`, all completed successfully with the new tests passing.
- No commands failed in the final validation; all checks and tests passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d79a172f8833084cabb3024d55894)