### PR TITLE
Validate RunBuilder timestamp ordering with explicit BuildError variants

### DIFF
--- a/tailtriage-core/src/config.rs
+++ b/tailtriage-core/src/config.rs
@@ -208,12 +208,40 @@ impl Config {
 pub enum BuildError {
     /// Service name was empty.
     EmptyServiceName,
+    /// Run finish timestamp was earlier than start timestamp.
+    InvalidRunTimeBounds {
+        /// Start timestamp provided for run metadata.
+        started_at_unix_ms: u64,
+        /// Finish timestamp provided for run metadata.
+        finished_at_unix_ms: u64,
+    },
+    /// Run finalization timestamp was earlier than finish timestamp.
+    InvalidFinalizationTime {
+        /// Finish timestamp provided for run metadata.
+        finished_at_unix_ms: u64,
+        /// Finalization timestamp provided for run metadata.
+        finalized_at_unix_ms: u64,
+    },
 }
 
 impl std::fmt::Display for BuildError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::EmptyServiceName => write!(f, "service_name cannot be empty"),
+            Self::InvalidRunTimeBounds {
+                started_at_unix_ms,
+                finished_at_unix_ms,
+            } => write!(
+                f,
+                "invalid run time bounds: finish ({finished_at_unix_ms}) must be >= start ({started_at_unix_ms})"
+            ),
+            Self::InvalidFinalizationTime {
+                finished_at_unix_ms,
+                finalized_at_unix_ms,
+            } => write!(
+                f,
+                "invalid finalization time: finalized ({finalized_at_unix_ms}) must be >= finish ({finished_at_unix_ms})"
+            ),
         }
     }
 }

--- a/tailtriage-core/src/run_builder.rs
+++ b/tailtriage-core/src/run_builder.rs
@@ -141,7 +141,10 @@ impl RunBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`BuildError::EmptyServiceName`] when the service name is blank.
+    /// Returns [`BuildError::EmptyServiceName`] when the service name is blank,
+    /// [`BuildError::InvalidRunTimeBounds`] when finish is earlier than start,
+    /// and [`BuildError::InvalidFinalizationTime`] when finalization is earlier
+    /// than finish.
     pub fn new(options: RunBuilderOptions) -> Result<Self, BuildError> {
         if options.service_name.trim().is_empty() {
             return Err(BuildError::EmptyServiceName);
@@ -154,8 +157,20 @@ impl RunBuilder {
         let ts = unix_time_ms();
         let started_at_unix_ms = options.started_at_unix_ms.unwrap_or(ts);
         let finished_at_unix_ms = options.finished_at_unix_ms.unwrap_or(ts);
-        let finalized_at_unix_ms =
-            Some(options.finalized_at_unix_ms.unwrap_or(finished_at_unix_ms));
+        let finalized_at_unix_ms = options.finalized_at_unix_ms.unwrap_or(finished_at_unix_ms);
+
+        if finished_at_unix_ms < started_at_unix_ms {
+            return Err(BuildError::InvalidRunTimeBounds {
+                started_at_unix_ms,
+                finished_at_unix_ms,
+            });
+        }
+        if finalized_at_unix_ms < finished_at_unix_ms {
+            return Err(BuildError::InvalidFinalizationTime {
+                finished_at_unix_ms,
+                finalized_at_unix_ms,
+            });
+        }
 
         Ok(Self {
             run: Run::new(RunMetadata {
@@ -164,7 +179,7 @@ impl RunBuilder {
                 service_version: options.service_version,
                 started_at_unix_ms,
                 finished_at_unix_ms,
-                finalized_at_unix_ms,
+                finalized_at_unix_ms: Some(finalized_at_unix_ms),
                 mode,
                 effective_core_config: Some(EffectiveCoreConfig {
                     mode,

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -1011,11 +1011,79 @@ fn run_builder_defaults_host_and_pid_to_none() {
 }
 
 #[test]
-fn run_builder_default_finalized_timestamp_is_some() {
+fn run_builder_valid_explicit_timestamps_pass() {
+    let run = crate::RunBuilder::new(
+        crate::RunBuilderOptions::new("svc")
+            .started_at_unix_ms(100)
+            .finished_at_unix_ms(150)
+            .finalized_at_unix_ms(200),
+    )
+    .expect("ok")
+    .finish();
+    assert_eq!(run.metadata.started_at_unix_ms, 100);
+    assert_eq!(run.metadata.finished_at_unix_ms, 150);
+    assert_eq!(run.metadata.finalized_at_unix_ms, Some(200));
+}
+
+#[test]
+fn run_builder_equal_timestamp_bounds_pass() {
+    let run = crate::RunBuilder::new(
+        crate::RunBuilderOptions::new("svc")
+            .started_at_unix_ms(100)
+            .finished_at_unix_ms(100)
+            .finalized_at_unix_ms(100),
+    )
+    .expect("ok")
+    .finish();
+    assert_eq!(run.metadata.started_at_unix_ms, 100);
+    assert_eq!(run.metadata.finished_at_unix_ms, 100);
+    assert_eq!(run.metadata.finalized_at_unix_ms, Some(100));
+}
+
+#[test]
+fn run_builder_rejects_finished_before_started() {
+    let err = crate::RunBuilder::new(
+        crate::RunBuilderOptions::new("svc")
+            .started_at_unix_ms(100)
+            .finished_at_unix_ms(99),
+    )
+    .expect_err("should fail");
+    assert_eq!(
+        err,
+        BuildError::InvalidRunTimeBounds {
+            started_at_unix_ms: 100,
+            finished_at_unix_ms: 99
+        }
+    );
+}
+
+#[test]
+fn run_builder_rejects_finalized_before_finished() {
+    let err = crate::RunBuilder::new(
+        crate::RunBuilderOptions::new("svc")
+            .started_at_unix_ms(100)
+            .finished_at_unix_ms(200)
+            .finalized_at_unix_ms(199),
+    )
+    .expect_err("should fail");
+    assert_eq!(
+        err,
+        BuildError::InvalidFinalizationTime {
+            finished_at_unix_ms: 200,
+            finalized_at_unix_ms: 199
+        }
+    );
+}
+
+#[test]
+fn run_builder_default_timestamps_produce_valid_finalized_run() {
     let run = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc"))
         .expect("ok")
         .finish();
-    assert!(run.metadata.finalized_at_unix_ms.is_some());
+    let finalized_at_unix_ms = run.metadata.finalized_at_unix_ms;
+    assert!(finalized_at_unix_ms.is_some());
+    assert!(run.metadata.finished_at_unix_ms >= run.metadata.started_at_unix_ms);
+    assert!(finalized_at_unix_ms.expect("present") >= run.metadata.finished_at_unix_ms);
 }
 
 #[test]
@@ -1033,10 +1101,14 @@ fn run_builder_defaults_finalized_timestamp_to_finished_timestamp() {
 
 #[test]
 fn run_builder_preserves_explicit_finalized_timestamp() {
-    let run =
-        crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").finalized_at_unix_ms(777))
-            .expect("ok")
-            .finish();
+    let run = crate::RunBuilder::new(
+        crate::RunBuilderOptions::new("svc")
+            .started_at_unix_ms(700)
+            .finished_at_unix_ms(700)
+            .finalized_at_unix_ms(777),
+    )
+    .expect("ok")
+    .finish();
     assert_eq!(run.metadata.finalized_at_unix_ms, Some(777));
 }
 

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -255,6 +255,9 @@ where
 
     let mut run_builder = RunBuilder::new(builder_options).map_err(|err| match err {
         BuildError::EmptyServiceName => ImportError::EmptyServiceName,
+        BuildError::InvalidRunTimeBounds { .. } | BuildError::InvalidFinalizationTime { .. } => {
+            ImportError::StrictViolation(err.to_string())
+        }
     })?;
 
     for request in requests {


### PR DESCRIPTION
### Motivation
- Make `RunBuilder` / `RunBuilderOptions` a robust public API by validating resolved run metadata timestamps before constructing a `Run` artifact.
- Surface distinct errors for the two ordering problems so callers can distinguish `finished < started` from `finalized < finished` programmatically.

### Description
- Added two public `BuildError` variants in `tailtriage-core::config`: `InvalidRunTimeBounds { started_at_unix_ms: u64, finished_at_unix_ms: u64 }` and `InvalidFinalizationTime { finished_at_unix_ms: u64, finalized_at_unix_ms: u64 }`, with clear `Display` messages describing the required ordering.
- Implemented timestamp validation inside `RunBuilder::new` (after defaulting timestamps and before `Run` construction) so `RunBuilder::new` returns the appropriate `BuildError` when `finished_at_unix_ms < started_at_unix_ms` or when `finalized_at_unix_ms < finished_at_unix_ms` while preserving existing default timestamp semantics (single `ts` default, `finalized_at_unix_ms` defaults to `finished_at_unix_ms`, and metadata output keeps `finalized_at_unix_ms: Some(...)`).
- Updated downstream mapping in `tailtriage-tracing` to match the new `BuildError` variants exhaustively and map invalid-order variants to an `ImportError::StrictViolation` with the error string so import paths handle the new cases cleanly.
- Added focused `tailtriage-core` unit tests that assert valid explicit timestamps, equal bounds, both invalid-order error cases (with preserved values), and default timestamp behavior still produces a finalized run.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed.
- Ran `cargo test -p tailtriage-core --all-targets` and all tests passed.
- Ran `cargo test -p tailtriage-tracing --all-targets --all-features` and all tests passed.
- Ran `cargo test --workspace --all-targets --all-features --locked` and all workspace tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d79a172f8833084cabb3024d55894)