### PR TITLE
docs: align VALIDATION.md runtime-cost row with CI hard-gate semantics

### DIFF
--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -31,7 +31,7 @@ Normal CI keeps deterministic diagnostics and docs contracts as gates but does n
 | Deterministic corpus | Yes in normal CI and in `validation-snapshot.yml` | bounded analyzer/report behavior on committed fixtures | production root cause certainty or universal accuracy |
 | Repeated-run matrix | No (manual/local) | stability metrics across repeated controlled runs on one machine/workload profile | universal stability across production environments |
 | Mitigation matrix | No (manual/local) | baseline vs mitigated movement checks for next-check usefulness | formal causal proof |
-| Runtime-cost measurement | Partially (non-blocking measure in CI) | overhead measurement under documented synthetic workloads | universal production overhead guarantees |
+| Runtime-cost measurement | Yes (bounded hard-gated smoke in CI) + manual/local deeper runs | overhead measurement under documented synthetic workloads | universal production overhead guarantees |
 | Collector-limit stress | Yes (smoke profile + summary validation) | bounded drop/truncation/warning/downgrade behavior under stress | zero drops under all load |
 | Real-service validation | No (planned) | future curated real-service truth checks when artifacts exist | current real-service validation coverage |
 


### PR DESCRIPTION
### Motivation
- Fix a stale validation-map wording that described runtime-cost as a partially non-blocking CI measure so the docs reflect that CI runs a bounded hard-gated runtime-cost smoke check while deeper runs remain manual/local.

### Description
- Replace the Runtime-cost measurement row in `VALIDATION.md` with: `Yes (bounded hard-gated smoke in CI) + manual/local deeper runs`, with no changes to code, analyzer behavior, Run schema, runtime-cost thresholds, or crate names.

### Testing
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, `python3 scripts/validate_docs_contracts.py`, `python3 scripts/demo_tool.py validate-tracing-parity all --profile release`, and `python3 scripts/measure_runtime_cost.py --requests 1200 --concurrency 32 --work-ms 4 --rounds 2 --warmup-rounds 1 --artifact-dir demos/runtime_cost/artifacts/final-smoke`, all of which succeeded; running `python3 scripts/validate_runtime_cost_summary.py --raw demos/runtime_cost/artifacts/final-smoke/runtime-cost-raw.jsonl --summary demos/runtime_cost/artifacts/final-smoke/runtime-cost-summary.json` failed with the expected validator error `measured_rounds must be >= 4 for CI smoke validation (found: 2)` and was intentionally not changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d96afed488330a15d7a4081dbdc1b)