### PR TITLE
Persist durable tracing import conversion warnings in Run lifecycle metadata

### DIFF
--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -488,6 +488,53 @@ fn import_tracing_json_warns_for_tt_fields_missing_kind_and_still_writes_run() {
     assert!(stderr.contains("warning:"));
     assert!(stderr.contains("missing required field 'tt.kind'"));
     assert!(run_path.exists(), "run output should be written");
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
+        .expect("imported run should load in cli loader");
+    let warning_matches = loaded
+        .run
+        .metadata
+        .lifecycle_warnings
+        .iter()
+        .filter(|warning| warning.as_str() == "missing required field 'tt.kind' in span 'oops'")
+        .count();
+    assert_eq!(warning_matches, 1);
+}
+
+#[test]
+fn import_tracing_json_persists_unknown_kind_warning_in_run_artifact() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, mixed_valid_and_unknown_kind_fixture())
+        .expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+
+    assert!(
+        output.status.success(),
+        "cli unexpectedly failed: {output:?}"
+    );
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("warning:"));
+    assert!(stderr.contains("unknown tt.kind 'mystery' in span 'unknown'"));
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
+        .expect("imported run should load in cli loader");
+    let warning_matches = loaded
+        .run
+        .metadata
+        .lifecycle_warnings
+        .iter()
+        .filter(|warning| warning.as_str() == "unknown tt.kind 'mystery' in span 'unknown'")
+        .count();
+    assert_eq!(warning_matches, 1);
 }
 
 fn valid_cli_artifact_with_requests() -> &'static str {
@@ -549,5 +596,11 @@ fn mixed_valid_and_missing_kind_fixture() -> &'static str {
 fn only_missing_kind_tailtriage_spans_fixture() -> &'static str {
     r#"{"span":{"name":"oops-1","started_at_unix_ms":1000,"finished_at_unix_ms":1005,"fields":{"tt.request_id":"req-0","tt.route":"/oops"}}}
 {"span":{"name":"oops-2","started_at_unix_ms":1010,"finished_at_unix_ms":1015,"fields":{"tt.request_id":"req-1","tt.route":"/oops2"}}}
+"#
+}
+
+fn mixed_valid_and_unknown_kind_fixture() -> &'static str {
+    r#"{"span":{"name":"unknown","started_at_unix_ms":1000,"finished_at_unix_ms":1005,"fields":{"tt.kind":"mystery"}}}
+{"span":{"name":"http.request","started_at_unix_ms":1020,"finished_at_unix_ms":1032,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout","tt.outcome":"ok"}}}
 "#
 }

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -664,10 +664,16 @@ mod tests {
     }
 
     #[test]
-    fn conversion_warnings_are_not_duplicated_in_lifecycle_warnings() {
-        let input = r#"{"span":{"name":"unknown","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"mystery"}}}"#;
+    fn unknown_kind_warning_is_durable_once_with_valid_request_present() {
+        let input = r#"
+{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok","tt.outcome":"ok"}}}
+{"span":{"name":"unknown","started_at_unix_ms":3,"finished_at_unix_ms":4,"fields":{"tt.kind":"mystery"}}}
+"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        let warning_message = imported.warnings()[0].message().to_owned();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.warnings().len(), 1);
+        let warning_message = "unknown tt.kind 'mystery' in span 'unknown'";
+        assert_eq!(imported.warnings()[0].message(), warning_message);
         let matches = imported
             .run()
             .metadata

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -664,6 +664,21 @@ mod tests {
     }
 
     #[test]
+    fn conversion_warnings_are_not_duplicated_in_lifecycle_warnings() {
+        let input = r#"{"span":{"name":"unknown","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"mystery"}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        let warning_message = imported.warnings()[0].message().to_owned();
+        let matches = imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .filter(|warning| warning.as_str() == warning_message)
+            .count();
+        assert_eq!(matches, 1);
+    }
+
+    #[test]
     fn tt_fields_without_kind_warn_non_strict_and_error_strict() {
         let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.request_id":"r1","tt.route":"/ok"}}}"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -234,12 +234,6 @@ where
         ToOwned::to_owned,
     );
 
-    let lifecycle_warnings = warnings
-        .iter()
-        .filter(|warning| is_lifecycle_warning(warning.message()))
-        .map(|w| w.message().to_owned())
-        .collect::<Vec<_>>();
-
     let mut builder_options = RunBuilderOptions::new(options.service_name())
         .run_id(run_id)
         .mode(CaptureMode::Light)
@@ -284,11 +278,8 @@ where
     for queue in queues {
         run_builder.push_queue(queue);
     }
-    for warning in &lifecycle_warnings {
-        run_builder.add_lifecycle_warning(warning.clone());
-    }
-
-    let run = run_builder.finish();
+    let mut run = run_builder.finish();
+    attach_durable_conversion_warnings(&mut run, &warnings);
 
     Ok(ImportedRun::new(run, warnings))
 }
@@ -363,10 +354,26 @@ fn required_string(
     }
 }
 
-fn is_lifecycle_warning(message: &str) -> bool {
+fn is_durable_conversion_warning(message: &str) -> bool {
     message.starts_with("skipped span")
         || message.starts_with("missing required field")
         || message.starts_with("invalid field")
+        || message.starts_with("unknown tt.kind")
+}
+
+fn attach_durable_conversion_warnings(run: &mut tailtriage_core::Run, warnings: &[ImportWarning]) {
+    for warning in warnings {
+        let message = warning.message();
+        if is_durable_conversion_warning(message)
+            && !run
+                .metadata
+                .lifecycle_warnings
+                .iter()
+                .any(|existing| existing == message)
+        {
+            run.metadata.lifecycle_warnings.push(message.to_owned());
+        }
+    }
 }
 
 fn strict_or_warn(
@@ -573,6 +580,12 @@ mod tests {
         let spans = vec![SpanRecord::new("x", 1, 2).field(TT_KIND, "wat")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.warnings().len(), 1);
+        assert!(imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|warning| warning.contains("unknown tt.kind 'wat'")));
     }
 
     #[test]
@@ -641,6 +654,7 @@ mod tests {
             .iter()
             .any(|m| m.contains("2 stage span(s) missing optional 'tt.success'; assumed true")));
         assert!(!msgs.iter().any(|m| m.contains("tt.depth_at_start")));
+        assert!(imported.run().metadata.lifecycle_warnings.is_empty());
     }
 
     #[test]
@@ -744,7 +758,7 @@ mod tests {
     }
 
     #[test]
-    fn unknown_kind_does_not_affect_metadata_bounds_and_lifecycle_warning() {
+    fn unknown_kind_does_not_affect_metadata_bounds_and_is_durable_lifecycle_warning() {
         let spans = vec![
             SpanRecord::new("unknown", 1, 1_000).field(TT_KIND, "wat"),
             SpanRecord::new("req", 10, 20)
@@ -760,7 +774,7 @@ mod tests {
             .metadata
             .lifecycle_warnings
             .iter()
-            .all(|w| !w.contains("unknown tt.kind")));
+            .any(|w| w.contains("unknown tt.kind")));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Conversion warnings from tracing imports (skipped/malformed/unknown `tt.*` spans) were returned in `ImportedRun::warnings()` but not reliably persisted into `run.metadata.lifecycle_warnings`, causing lost trust-relevant signals in saved Run artifacts.
- Ensure that warnings which indicate skipped, malformed, incomplete, invalid, or unknown tailtriage-tagged evidence are durable in the Run metadata so CLI and later analysis agree on what was dropped.

### Description
- Added `is_durable_conversion_warning` and replaced the prior narrow lifecycle filter with this clearer predicate that includes `unknown tt.kind` and other skip/error patterns. 
- Persist durable conversion warnings after `RunBuilder::finish()` via `attach_durable_conversion_warnings`, deduplicating against existing lifecycle warnings. 
- Kept aggregate benign defaults (missing optional `tt.outcome` / `tt.success`) as non-durable import warnings only, per guidance. 
- Added and adjusted tests to verify: unknown `tt.kind` is emitted and durably persisted, missing required fields produce durable lifecycle warnings, benign optional-default warnings are not persisted, and JSONL import does not duplicate lifecycle warnings. 
- Did not change strict-mode semantics, analyzer behavior, or the Run schema.

### Testing
- Ran formatting/lint/test and docs validation: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, and `python3 scripts/validate_docs_contracts.py`; all succeeded. 
- Unit tests added/updated in `tailtriage-tracing` verify durable persistence and non-duplication of conversion warnings and passed under the workspace test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dbec243288330b14c12aaad3f1179)