### PR TITLE
Persist durable tracing import conversion warnings in Run lifecycle metadata

### DIFF
--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -645,6 +645,27 @@ mod tests {
     }
 
     #[test]
+    fn unknown_tt_kind_warning_is_durable_without_lifecycle_duplicates() {
+        let input = r#"
+{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok","tt.outcome":"ok"}}}
+{"span":{"name":"unknown","started_at_unix_ms":3,"finished_at_unix_ms":4,"fields":{"tt.kind":"mystery","tt.request_id":"r2"}}}
+"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        let warning = imported
+            .warnings()
+            .iter()
+            .find(|w| w.message().contains("unknown tt.kind"))
+            .expect("unknown kind warning");
+        let durable_count = imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .filter(|msg| msg.as_str() == warning.message())
+            .count();
+        assert_eq!(durable_count, 1);
+    }
+    #[test]
     fn conversion_warnings_still_follow_existing_lifecycle_policy() {
         let input = r#"
 {"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok","tt.outcome":"ok"}}}

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -234,12 +234,6 @@ where
         ToOwned::to_owned,
     );
 
-    let lifecycle_warnings = warnings
-        .iter()
-        .filter(|warning| is_lifecycle_warning(warning.message()))
-        .map(|w| w.message().to_owned())
-        .collect::<Vec<_>>();
-
     let mut builder_options = RunBuilderOptions::new(options.service_name())
         .run_id(run_id)
         .mode(CaptureMode::Light)
@@ -284,11 +278,8 @@ where
     for queue in queues {
         run_builder.push_queue(queue);
     }
-    for warning in &lifecycle_warnings {
-        run_builder.add_lifecycle_warning(warning.clone());
-    }
-
-    let run = run_builder.finish();
+    let mut run = run_builder.finish();
+    attach_durable_conversion_warnings(&mut run, &warnings);
 
     Ok(ImportedRun::new(run, warnings))
 }
@@ -363,10 +354,28 @@ fn required_string(
     }
 }
 
-fn is_lifecycle_warning(message: &str) -> bool {
+fn is_durable_conversion_warning(message: &str) -> bool {
     message.starts_with("skipped span")
         || message.starts_with("missing required field")
         || message.starts_with("invalid field")
+        || message.starts_with("unknown tt.kind")
+}
+
+fn attach_durable_conversion_warnings(run: &mut tailtriage_core::Run, warnings: &[ImportWarning]) {
+    for warning in warnings {
+        let message = warning.message();
+        if !is_durable_conversion_warning(message) {
+            continue;
+        }
+        if !run
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|existing| existing == message)
+        {
+            run.metadata.lifecycle_warnings.push(message.to_owned());
+        }
+    }
 }
 
 fn strict_or_warn(
@@ -744,7 +753,7 @@ mod tests {
     }
 
     #[test]
-    fn unknown_kind_does_not_affect_metadata_bounds_and_lifecycle_warning() {
+    fn unknown_kind_is_persisted_as_durable_lifecycle_warning() {
         let spans = vec![
             SpanRecord::new("unknown", 1, 1_000).field(TT_KIND, "wat"),
             SpanRecord::new("req", 10, 20)
@@ -760,7 +769,7 @@ mod tests {
             .metadata
             .lifecycle_warnings
             .iter()
-            .all(|w| !w.contains("unknown tt.kind")));
+            .any(|w| w.contains("unknown tt.kind")));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Conversion warnings for skipped/malformed `tt.*` spans must be persisted into the saved `Run` so CLI/analysis consumers can trust that tailtriage-tagged evidence was skipped or malformed. 
- The previous `is_lifecycle_warning` filter was too narrow and excluded important cases like unknown `tt.kind`, causing one-off stderr hints to be lost from the artifact. 
- Deduplicate durable lifecycle warnings to avoid noisy repeated messages in `run.metadata.lifecycle_warnings`. 
- Preserve existing semantics for benign aggregate defaults and strict-mode failure behavior. 

### Description
- Replaced the narrow `is_lifecycle_warning` predicate with `is_durable_conversion_warning` and included `unknown tt.kind` as durable evidence of skipped `tt.*` spans. 
- Attach durable conversion warnings after `RunBuilder::finish()` via `attach_durable_conversion_warnings(run, &warnings)`, deduplicating against existing `run.metadata.lifecycle_warnings`. 
- Kept JSONL parse-warning attachment logic in `import_jsonl_reader` unchanged and ensured parse warnings are not double-added. 
- Added/updated tests: a JSONL test `unknown_tt_kind_warning_is_durable_without_lifecycle_duplicates` and a tracing conversion test `unknown_kind_is_persisted_as_durable_lifecycle_warning`, plus existing tests exercise missing/invalid-field durability and deduplication. 
- Did not change analyzer behavior, `Run` schema, or strict-mode semantics, and left aggregate optional-default warnings (e.g., missing `tt.outcome`/`tt.success`) non-durable. 

### Testing
- Ran `cargo fmt --check`, which passed. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, which passed. 
- Ran full test suite with `cargo test --workspace --all-targets --all-features --locked`, and all tests passed. 
- Ran `python3 scripts/validate_docs_contracts.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dbec243288330b14c12aaad3f1179)