### PR TITLE
Persist durable tt.* conversion warnings in tracing-imported run metadata

### DIFF
--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -488,6 +488,45 @@ fn import_tracing_json_warns_for_tt_fields_missing_kind_and_still_writes_run() {
     assert!(stderr.contains("warning:"));
     assert!(stderr.contains("missing required field 'tt.kind'"));
     assert!(run_path.exists(), "run output should be written");
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
+        .expect("imported run should load in cli loader");
+    assert!(loaded
+        .run
+        .metadata
+        .lifecycle_warnings
+        .iter()
+        .any(|w| w.contains("missing required field 'tt.kind'")));
+}
+
+#[test]
+fn import_tracing_json_persists_unknown_kind_warning_to_run_artifact() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, mixed_valid_and_unknown_kind_fixture())
+        .expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+    assert!(
+        output.status.success(),
+        "cli unexpectedly failed: {output:?}"
+    );
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
+        .expect("imported run should load in cli loader");
+    assert!(loaded
+        .run
+        .metadata
+        .lifecycle_warnings
+        .iter()
+        .any(|w| w.contains("unknown tt.kind 'wat'")));
 }
 
 fn valid_cli_artifact_with_requests() -> &'static str {
@@ -542,6 +581,12 @@ fn mixed_valid_and_incomplete_request_span_fixture() -> &'static str {
 
 fn mixed_valid_and_missing_kind_fixture() -> &'static str {
     r#"{"span":{"name":"oops","started_at_unix_ms":1000,"finished_at_unix_ms":1005,"fields":{"tt.request_id":"req-0","tt.route":"/oops"}}}
+{"span":{"name":"http.request","started_at_unix_ms":1020,"finished_at_unix_ms":1032,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout","tt.outcome":"ok"}}}
+"#
+}
+
+fn mixed_valid_and_unknown_kind_fixture() -> &'static str {
+    r#"{"span":{"name":"oops","started_at_unix_ms":1000,"finished_at_unix_ms":1005,"fields":{"tt.kind":"wat","tt.request_id":"req-0"}}}
 {"span":{"name":"http.request","started_at_unix_ms":1020,"finished_at_unix_ms":1032,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout","tt.outcome":"ok"}}}
 "#
 }

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -664,6 +664,29 @@ mod tests {
     }
 
     #[test]
+    fn unknown_kind_warning_is_durable_in_jsonl_import() {
+        let input = r#"
+{"span":{"name":"bad","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"wat","tt.request_id":"r0"}}}
+{"span":{"name":"req","started_at_unix_ms":3,"finished_at_unix_ms":4,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok","tt.outcome":"ok"}}}
+"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        let warning = imported
+            .warnings()
+            .iter()
+            .find(|w| w.message().contains("unknown tt.kind"))
+            .expect("unknown kind warning should be emitted")
+            .message()
+            .to_owned();
+        assert!(imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|w| w == &warning));
+    }
+
+    #[test]
     fn tt_fields_without_kind_warn_non_strict_and_error_strict() {
         let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.request_id":"r1","tt.route":"/ok"}}}"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -236,7 +236,7 @@ where
 
     let lifecycle_warnings = warnings
         .iter()
-        .filter(|warning| is_lifecycle_warning(warning.message()))
+        .filter(|warning| is_durable_conversion_warning(warning.message()))
         .map(|w| w.message().to_owned())
         .collect::<Vec<_>>();
 
@@ -363,8 +363,9 @@ fn required_string(
     }
 }
 
-fn is_lifecycle_warning(message: &str) -> bool {
+fn is_durable_conversion_warning(message: &str) -> bool {
     message.starts_with("skipped span")
+        || message.starts_with("unknown tt.kind")
         || message.starts_with("missing required field")
         || message.starts_with("invalid field")
 }
@@ -760,7 +761,36 @@ mod tests {
             .metadata
             .lifecycle_warnings
             .iter()
-            .all(|w| !w.contains("unknown tt.kind")));
+            .any(|w| w.contains("unknown tt.kind")));
+    }
+
+    #[test]
+    fn optional_default_warnings_are_not_persisted_to_lifecycle_warnings() {
+        let spans = vec![
+            SpanRecord::new("req", 1, 2)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/"),
+            SpanRecord::new("st", 1, 2)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("missing optional 'tt.outcome'")));
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("missing optional 'tt.success'")));
+        assert!(imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .all(|w| !w.contains("missing optional")));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Some conversion warnings (e.g. skipped/malformed `tt.*` spans and unknown `tt.kind`) were only emitted to `ImportedRun::warnings()` and not persisted into `run.metadata.lifecycle_warnings`, causing later-run artifacts to lose trust-relevant import signals.
- CLI users saw warnings on stderr but the saved Run JSON could omit those durable signals, undermining reproducible triage and auditability.
- The change must persist trust-relevant conversion warnings while keeping benign aggregate optional-default messages non-durable and not changing strict-mode or analyzer semantics.

### Description
- Replace the narrow lifecycle predicate with a clearer helper `is_durable_conversion_warning(message: &str)` and use it when building `lifecycle_warnings` in `run_from_span_records`; the helper now includes `unknown tt.kind` along with skipped-span, missing required, and invalid-field messages. (See `tailtriage-tracing/src/lib.rs`.)
- Ensure durable conversion warnings are added to the `RunBuilder` via `run_builder.add_lifecycle_warning(...)` so they appear in `run.metadata.lifecycle_warnings` in the persisted Run artifact. (No Run schema changes.)
- Keep benign aggregate optional-default warnings (missing optional `tt.outcome` and `tt.success`) as non-durable warnings that remain in `ImportedRun::warnings()` only. 
- Add tests: a JSONL unit test asserting unknown `tt.kind` durability, unit tests confirming missing-required durability and that optional-default warnings are not persisted, and a CLI boundary test that verifies imported Run artifacts contain durable warnings for missing/unknown `tt.kind`. (Files touched: `tailtriage-tracing/src/lib.rs`, `tailtriage-tracing/src/jsonl.rs`, `tailtriage-cli/tests/cli_boundary.rs`.)
- Preserve strict-mode behavior: `strict_or_warn` still returns `ImportError::StrictViolation` when `strict` is enabled.

### Testing
- Ran `cargo fmt --check` and formatting succeeded.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` with no warnings.
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests passed.
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dbec243288330b14c12aaad3f1179)