### PR TITLE
Enforce strict recorder retention-drop failures

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -148,6 +148,7 @@ span.record("tt.kind", "stage");
 ```
 
 The live recorder is bounded by default (`DEFAULT_MAX_OPEN_SPANS`, `DEFAULT_MAX_COMPLETED_SPANS`), and limits are configurable via `TracingRecorder::builder(...).max_open_spans(...)`, `.max_completed_spans(...)`, or `.limits(RecorderLimits { ... })`.
+In non-strict mode, recorder retention drops are returned as import warnings and set `run.truncation.limits_hit = true`; in strict mode, recorder retention drops are import errors so dropped `tt.*` evidence cannot be treated as a successful import.
 
 Use `#[tracing::instrument(fields(...))]` or `.instrument(...)` so span fields attach to async work correctly.
 Do not hold a manual entered-span guard across `.await`; async spans may enter/exit many times, and this recorder finalizes completed work on `on_close` (drop), not enter/exit transitions.

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -340,6 +340,16 @@ fn imported_with_drop_warnings(
     let closed_missing_kind_samples = stats.closed_missing_kind_samples.as_slice();
     if options.strict_mode() {
         let mut messages = Vec::new();
+        if dropped_open_spans > 0 {
+            messages.push(format!(
+                "live recorder dropped {dropped_open_spans} candidate open span(s) because max_open_spans was reached; raise max_open_spans or reduce capture scope"
+            ));
+        }
+        if dropped_completed_spans > 0 {
+            messages.push(format!(
+                "live recorder dropped {dropped_completed_spans} completed span(s) because max_completed_spans was reached; raise max_completed_spans or reduce capture scope"
+            ));
+        }
         if open_candidate_count > 0 {
             messages.push(format!(
                 "live recorder observed {open_candidate_count} open candidate span(s) at snapshot/shutdown; incomplete spans are not converted into fabricated completions"
@@ -794,6 +804,113 @@ mod tests {
             .iter()
             .any(|w| w.contains("dropped 1 candidate spans")));
         assert!(imported.run().truncation.limits_hit);
+    }
+
+    #[test]
+    fn strict_mode_errors_when_max_open_spans_drops_candidate_spans() {
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .max_open_spans(0)
+            .build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            );
+            drop(span);
+        });
+        let err = recorder.snapshot_run().unwrap_err();
+        match err {
+            ImportError::StrictViolation(message) => {
+                assert!(message.contains("candidate open span(s)"));
+                assert!(message.contains("max_open_spans"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn strict_mode_errors_when_max_completed_spans_drops_completed_spans() {
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .max_completed_spans(0)
+            .build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/checkout"
+            );
+            drop(span);
+        });
+        let err = recorder.shutdown().unwrap_err();
+        match err {
+            ImportError::StrictViolation(message) => {
+                assert!(message.contains("completed span(s)"));
+                assert!(message.contains("max_completed_spans"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn non_strict_mode_reports_drop_warnings_and_truncation() {
+        let recorder = TracingRecorder::builder("svc")
+            .max_open_spans(1)
+            .max_completed_spans(0)
+            .build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let open1 = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r-open-1",
+                tt.route = "/open-1"
+            );
+            let open2 = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r-open-2",
+                tt.route = "/open-2"
+            );
+            let completed = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r-done",
+                tt.route = "/done"
+            );
+            drop(completed);
+
+            drop(open1);
+            drop(open2);
+        });
+        let imported = recorder.snapshot_run().unwrap();
+        assert!(imported.run().truncation.limits_hit);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("max_open_spans was reached")));
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("max_completed_spans was reached")));
+        assert!(imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|w| w.contains("max_open_spans was reached")));
+        assert!(imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|w| w.contains("max_completed_spans was reached")));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Users running the live `TracingRecorder` in strict mode must not be able to import a `Run` when the recorder silently dropped `tt.*` evidence due to retention limits. 
- The recorder already reports open-at-snapshot and closed-missing-`tt.kind` strict violations, but retained-drop (bounded retention) cases were only warnings and thus broke the strict trust boundary. 

### Description
- Added strict-mode checks in `imported_with_drop_warnings(...)` to return `ImportError::StrictViolation` when `dropped_open_spans > 0` or `dropped_completed_spans > 0`, with actionable messages referencing `max_open_spans` / `max_completed_spans` and guidance to raise limits or reduce capture scope. 
- Kept non-strict behavior unchanged so dropped spans still produce warnings, are appended to `run.metadata.lifecycle_warnings`, and set `run.truncation.limits_hit = true`; durable conversion-warning semantics from prior work are preserved. 
- Files changed: `tailtriage-tracing/src/recorder.rs` and `tailtriage-tracing/README.md`. 
- Tests added/updated: `strict_mode_errors_when_max_open_spans_drops_candidate_spans`, `strict_mode_errors_when_max_completed_spans_drops_completed_spans`, and `non_strict_mode_reports_drop_warnings_and_truncation` (added to recorder unit tests). 

### Testing
- Ran `cargo fmt --check` which passed, and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which passed. 
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests passed (the tailored failing test was fixed during development). 
- Ran `python3 scripts/validate_docs_contracts.py` which passed. 
- Remaining notes: no `TracingTokioSession`-specific propagation test was added because strict recorder errors surface through shared import paths and existing session tests remained green, and PR #696’s durable conversion-warning behavior was intentionally left unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dca13bdb8833088f4fc26b05114b3)