### PR TITLE
Enforce strict-mode failures for tracing recorder retention drops

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -340,6 +340,16 @@ fn imported_with_drop_warnings(
     let closed_missing_kind_samples = stats.closed_missing_kind_samples.as_slice();
     if options.strict_mode() {
         let mut messages = Vec::new();
+        if dropped_open_spans > 0 {
+            messages.push(format!(
+                "live recorder dropped {dropped_open_spans} candidate open span(s) because max_open_spans was reached; raise max_open_spans or reduce capture scope"
+            ));
+        }
+        if dropped_completed_spans > 0 {
+            messages.push(format!(
+                "live recorder dropped {dropped_completed_spans} completed span(s) because max_completed_spans was reached; raise max_completed_spans or reduce capture scope"
+            ));
+        }
         if open_candidate_count > 0 {
             messages.push(format!(
                 "live recorder observed {open_candidate_count} open candidate span(s) at snapshot/shutdown; incomplete spans are not converted into fabricated completions"
@@ -794,6 +804,116 @@ mod tests {
             .iter()
             .any(|w| w.contains("dropped 1 candidate spans")));
         assert!(imported.run().truncation.limits_hit);
+    }
+
+    #[test]
+    fn strict_mode_errors_when_max_open_spans_drops_candidate_spans() {
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .max_open_spans(0)
+            .build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/strict-open"
+            );
+            drop(span);
+        });
+        let err = recorder.snapshot_run().unwrap_err();
+        match err {
+            ImportError::StrictViolation(message) => {
+                assert!(message.contains("dropped 1 candidate open span(s)"));
+                assert!(message.contains("max_open_spans"));
+                assert!(message.contains("reduce capture scope"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn strict_mode_errors_when_max_completed_spans_drops_completed_spans() {
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .max_completed_spans(0)
+            .build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/checkout"
+            );
+            drop(span);
+        });
+        let err = recorder.snapshot_run().unwrap_err();
+        match err {
+            ImportError::StrictViolation(message) => {
+                assert!(message.contains("dropped 1 completed span(s)"));
+                assert!(message.contains("max_completed_spans"));
+                assert!(message.contains("reduce capture scope"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn non_strict_mode_reports_drop_warnings_and_truncation() {
+        let recorder_open_drop = TracingRecorder::builder("svc")
+            .max_open_spans(0)
+            .build();
+        let open_subscriber = tracing_subscriber::registry().with(recorder_open_drop.layer());
+        tracing::subscriber::with_default(open_subscriber, || {
+            let span = tracing::info_span!(
+                "request-open-drop",
+                tt.kind = "request",
+                tt.request_id = "r-open-drop",
+                tt.route = "/open"
+            );
+            drop(span);
+        });
+        let imported_open_drop = recorder_open_drop.snapshot_run().unwrap();
+        assert!(imported_open_drop
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("dropped 1 candidate spans")));
+        assert!(imported_open_drop
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|w| w.contains("dropped 1 candidate spans")));
+        assert!(imported_open_drop.run().truncation.limits_hit);
+
+        let recorder_completed_drop = TracingRecorder::builder("svc")
+            .max_completed_spans(0)
+            .build();
+        let completed_subscriber =
+            tracing_subscriber::registry().with(recorder_completed_drop.layer());
+        tracing::subscriber::with_default(completed_subscriber, || {
+            let span = tracing::info_span!(
+                "request-completed-drop",
+                tt.kind = "request",
+                tt.request_id = "r-completed-drop",
+                tt.route = "/completed"
+            );
+            drop(span);
+        });
+        let imported_completed_drop = recorder_completed_drop.snapshot_run().unwrap();
+        assert!(imported_completed_drop
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("dropped 1 completed spans")));
+        assert!(imported_completed_drop
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|w| w.contains("dropped 1 completed spans")));
+        assert!(imported_completed_drop.run().truncation.limits_hit);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Users who enable strict conversion expect any recorder data loss to fail import, but recorder retention drops were still treated as warnings causing a trust boundary gap.
- Preserve durable conversion-warning behavior introduced previously while making strict-mode semantics stricter for live recorder retention losses.

### Description
- Updated `imported_with_drop_warnings(...)` in `tailtriage-tracing/src/recorder.rs` so in `options.strict_mode()` it also checks `dropped_open_spans > 0` and `dropped_completed_spans > 0` and returns `ImportError::StrictViolation` when either is present. The messages name the dropped class, the limit hit (`max_open_spans` / `max_completed_spans`) and advise raising limits or reducing capture scope. 
- Kept existing strict aggregation: multiple strict causes (open candidates at snapshot/shutdown, closed-missing-`tt.kind`, and conversion strict violations) are combined into a single `StrictViolation` message. 
- Left non-strict path unchanged so retention drops still produce `ImportedRun` with `ImportedRun::warnings()`, durable entries in `run.metadata.lifecycle_warnings`, and `run.truncation.limits_hit = true` when limits were hit. 
- Single file changed: `tailtriage-tracing/src/recorder.rs` (tests added in same file). No dependencies or public Run schema changes.

### Testing
- New unit tests added in `tailtriage-tracing/src/recorder.rs`: `strict_mode_errors_when_max_open_spans_drops_candidate_spans`, `strict_mode_errors_when_max_completed_spans_drops_completed_spans`, and `non_strict_mode_reports_drop_warnings_and_truncation` and integrated with existing recorder tests.
- Commands run: `cargo fmt --check` (passed), `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (passed), `cargo test --workspace --all-targets --all-features --locked` (passed), and `python3 scripts/validate_docs_contracts.py` (passed).
- All tests in the workspace passed after the change.

Remaining risks / intentionally unchanged behavior
- Did not change `run_from_span_records`, analyzer behavior, Run schema, or JSONL strict/non-strict semantics (per task constraints).
- Did not add broader tracing backend features or new dependencies; change is narrowly scoped to recorder strict-mode semantics and tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dca13bdb8833088f4fc26b05114b3)