### PR TITLE
Fix TT_SUCCESS rustdoc to describe stage success

### DIFF
--- a/tailtriage-tracing/src/convention.rs
+++ b/tailtriage-tracing/src/convention.rs
@@ -14,7 +14,7 @@ pub const TT_QUEUE: &str = "tt.queue";
 pub const TT_DEPTH_AT_START: &str = "tt.depth_at_start";
 /// Field key for request outcome label.
 pub const TT_OUTCOME: &str = "tt.outcome";
-/// Field key for boolean request success.
+/// Field key for boolean stage success.
 pub const TT_SUCCESS: &str = "tt.success";
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation
- Correct an incorrect rustdoc that described `tt.success` as request success so docs/rustdoc match the intended field ownership and README/conversion behavior.

### Description
- Update `tailtriage-tracing/src/convention.rs` rustdoc for `TT_SUCCESS` from "Field key for boolean request success." to "Field key for boolean stage success.".
- Searched the repository for `TT_SUCCESS`, `tt.success`, `request success`, `boolean request success`, `stage success`, and `tt.outcome` and confirmed the only stale wording was the rustdoc above; other docs (including `tailtriage-tracing/README.md`) already describe `tt.outcome` as the request field and `tt.success` as the stage field.
- Files changed: `tailtriage-tracing/src/convention.rs`.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed.
- Ran `cargo test --workspace --all-targets --all-features --locked` and observed an existing, unrelated failing analyzer test (`tailtriage-analyzer::end_to_end_capture_analysis::queue_and_stage_data_drives_ranked_suspects`) that predates and is unrelated to this docs-only change; all other tests passed.
- Ran `python3 scripts/validate_docs_contracts.py` and it passed.
- No behavioral, schema, conversion, analyzer, JSONL import, or live-recorder strict/non-strict semantics were changed, and this change preserves the semantics introduced by PR #696 and PR #700.
- Remaining risk: the workspace currently has a pre-existing failing analyzer end-to-end test which may cause CI to report non-green despite this docs-only fix; the failure is unrelated to the change made here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dd15132908330b722fd932a1d3dcd)