### PR TITLE
fix(tracing): align TT_SUCCESS docs with stage-field ownership

### DIFF
--- a/tailtriage-tracing/src/convention.rs
+++ b/tailtriage-tracing/src/convention.rs
@@ -14,7 +14,7 @@ pub const TT_QUEUE: &str = "tt.queue";
 pub const TT_DEPTH_AT_START: &str = "tt.depth_at_start";
 /// Field key for request outcome label.
 pub const TT_OUTCOME: &str = "tt.outcome";
-/// Field key for boolean request success.
+/// Field key for boolean stage success.
 pub const TT_SUCCESS: &str = "tt.success";
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation
- Correct a stale rustdoc that implied `tt.success` was a request-level field so docs and rustdoc consistently teach that `tt.success` is a stage-level boolean.

### Description
- Changed the rustdoc in `tailtriage-tracing/src/convention.rs` to `/// Field key for boolean stage success.`.
- Searched the repository for `TT_SUCCESS`, `tt.success`, `request success`, `boolean request success`, `stage success`, and `tt.outcome` and confirmed no other public docs or rustdocs claim `tt.success` belongs to request spans.
- Made no changes to conversion logic, analyzer behavior, Run schema, JSONL import semantics, live-recorder strict/non-strict behavior, durable warning behavior, or dependencies.

### Testing
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, and `python3 scripts/validate_docs_contracts.py`, and all commands completed successfully.
- Files changed: `tailtriage-tracing/src/convention.rs`.
- Remaining risk: minimal because this is a single-line documentation correction and no executable behavior was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dd15132908330b722fd932a1d3dcd)