### PR TITLE
Fix stale TT_SUCCESS wording to stage success

### DIFF
--- a/tailtriage-tracing/src/convention.rs
+++ b/tailtriage-tracing/src/convention.rs
@@ -14,7 +14,7 @@ pub const TT_QUEUE: &str = "tt.queue";
 pub const TT_DEPTH_AT_START: &str = "tt.depth_at_start";
 /// Field key for request outcome label.
 pub const TT_OUTCOME: &str = "tt.outcome";
-/// Field key for boolean request success.
+/// Field key for boolean stage success.
 pub const TT_SUCCESS: &str = "tt.success";
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation
- The rustdoc in `tailtriage-tracing/src/convention.rs` described `TT_SUCCESS` as request success, which is incorrect and conflicts with the README and conversion behavior that treat `tt.outcome` as the request outcome and `tt.success` as a stage-level flag. 

### Description
- Updated the `TT_SUCCESS` rustdoc in `tailtriage-tracing/src/convention.rs` to read `Field key for boolean stage success.`, audited the repository for `TT_SUCCESS`, `tt.success`, `tt.outcome`, `request success`, and `stage success`, and found/fixed this single stale occurrence in `tailtriage-tracing/src/convention.rs`; no code, conversion, analyzer, Run schema, JSONL import, or live-recorder strict/non-strict semantics were changed and the behavior introduced by #696 and #700 is preserved. 

### Testing
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, and `python3 scripts/validate_docs_contracts.py`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dd15132908330b722fd932a1d3dcd)