### PR TITLE
Fix TT_SUCCESS rustdoc to describe stage success

### DIFF
--- a/tailtriage-tracing/src/convention.rs
+++ b/tailtriage-tracing/src/convention.rs
@@ -14,7 +14,7 @@ pub const TT_QUEUE: &str = "tt.queue";
 pub const TT_DEPTH_AT_START: &str = "tt.depth_at_start";
 /// Field key for request outcome label.
 pub const TT_OUTCOME: &str = "tt.outcome";
-/// Field key for boolean request success.
+/// Field key for boolean stage success.
 pub const TT_SUCCESS: &str = "tt.success";
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation
- Correct a misleading rustdoc that described `TT_SUCCESS` as request success so field ownership documentation matches the README and conversion behavior.

### Description
- Modified `tailtriage-tracing/src/convention.rs` to change the `TT_SUCCESS` doc comment from “Field key for boolean request success.” to “Field key for boolean stage success.”; verified `tt.outcome` remains the request outcome and `tt.success` remains the stage-level boolean and no code, conversion, analyzer, Run schema, JSONL import, or strict/non-strict/durable-warning semantics were changed.

### Testing
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, and `python3 scripts/validate_docs_contracts.py` and all completed successfully; remaining risk is negligible because this is a one-line documentation fix (no behavior changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dd15132908330b722fd932a1d3dcd)