### PR TITLE
Make RunBuilder push APIs validate event shape and return Result

### DIFF
--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -172,12 +172,12 @@ Override limits with:
 Most users should use `Tailtriage::builder(...)` for live request instrumentation.
 Use `RunBuilder` only when you already have completed request, stage, queue, in-flight, or runtime evidence and need to assemble a standard `Run` artifact.
 
-`RunBuilder` is intended for import/conversion paths. It does not perform live lifecycle tracking. It applies the same bounded retention/truncation semantics as live core capture, so events beyond configured `CaptureLimits` are dropped and `Run.truncation` counters are updated. For assembled/imported artifacts, host and pid default to `None`, and generated run IDs use the same core run-id semantics as live capture.
+`RunBuilder` is intended for import/conversion paths. It does not perform live lifecycle tracking. `RunBuilder::new` validates top-level run timestamp ordering. Each `push_*` call validates event/snapshot shape before retention is applied. It applies the same bounded retention/truncation semantics as live core capture, so events beyond configured `CaptureLimits` are dropped without error and `Run.truncation` counters are updated. `RunBuilder` does not validate cross-event correlation (for example a stage without a matching request) and does not synthesize lifecycle completions. For assembled/imported artifacts, host and pid default to `None`, and generated run IDs use the same core run-id semantics as live capture.
 
 ```rust,no_run
 use tailtriage_core::{RequestEvent, RunBuilder, RunBuilderOptions};
 
-fn assemble_run() -> Result<(), tailtriage_core::BuildError> {
+fn assemble_run() -> Result<(), Box<dyn std::error::Error>> {
     let mut builder = RunBuilder::new(RunBuilderOptions::new("checkout-service"))?;
     builder.push_request(RequestEvent {
         request_id: "req-1".into(),
@@ -187,7 +187,7 @@ fn assemble_run() -> Result<(), tailtriage_core::BuildError> {
         finished_at_unix_ms: 2,
         latency_us: 1_000,
         outcome: "ok".into(),
-    });
+    })?;
 
     let run = builder.finish();
     assert_eq!(run.requests.len(), 1);

--- a/tailtriage-core/src/lib.rs
+++ b/tailtriage-core/src/lib.rs
@@ -48,7 +48,7 @@ pub use events::{
     RunEndReason, RunMetadata, RuntimeSnapshot, StageEvent, TruncationSummary,
     UnfinishedRequestSample, UnfinishedRequests, SCHEMA_VERSION,
 };
-pub use run_builder::{RunBuilder, RunBuilderOptions};
+pub use run_builder::{RunBuilder, RunBuilderEventError, RunBuilderOptions};
 pub use sink::{DiscardSink, LocalJsonSink, MemorySink, RunSink, SinkError};
 pub use time::{system_time_to_unix_ms, unix_time_ms};
 pub use timers::{InflightGuard, QueueTimer, StageTimer};

--- a/tailtriage-core/src/run_builder.rs
+++ b/tailtriage-core/src/run_builder.rs
@@ -3,6 +3,7 @@ use crate::{
     EffectiveCoreConfig, EffectiveTokioSamplerConfig, InFlightSnapshot, QueueEvent, RequestEvent,
     Run, RunEndReason, RunMetadata, RuntimeSnapshot, StageEvent, UnfinishedRequests,
 };
+use core::fmt;
 
 /// Options for assembling a completed [`Run`] artifact.
 ///
@@ -122,6 +123,36 @@ impl RunBuilderOptions {
     }
 }
 
+/// Validation error returned when a pushed event or snapshot has invalid shape.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RunBuilderEventError {
+    /// A field value on an event/snapshot failed validation.
+    InvalidEvent {
+        /// Event/snapshot type name.
+        event: &'static str,
+        /// Invalid field name.
+        field: &'static str,
+        /// Human-readable validation reason.
+        reason: String,
+    },
+}
+
+impl fmt::Display for RunBuilderEventError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidEvent {
+                event,
+                field,
+                reason,
+            } => {
+                write!(f, "invalid {event}.{field}: {reason}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RunBuilderEventError {}
+
 /// Advanced/import API for completed-run artifact assembly.
 ///
 /// [`RunBuilder`] assembles a finalized [`Run`] from already measured evidence.
@@ -207,46 +238,81 @@ impl RunBuilder {
     ///
     /// The event is retained only while request capture-limit capacity remains;
     /// otherwise it is dropped and `truncation.dropped_requests` is updated.
-    pub fn push_request(&mut self, event: RequestEvent) {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RunBuilderEventError`] when the event has invalid shape.
+    pub fn push_request(&mut self, event: RequestEvent) -> Result<(), RunBuilderEventError> {
+        validate_request_event(&event)?;
         let _ = crate::retention::push_request_bounded(&mut self.run, self.capture_limits, event);
+        Ok(())
     }
     /// Appends a stage event.
     ///
     /// The event is retained only while stage capture-limit capacity remains;
     /// otherwise it is dropped and `truncation.dropped_stages` is updated.
-    pub fn push_stage(&mut self, event: StageEvent) {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RunBuilderEventError`] when the event has invalid shape.
+    pub fn push_stage(&mut self, event: StageEvent) -> Result<(), RunBuilderEventError> {
+        validate_stage_event(&event)?;
         let _ = crate::retention::push_stage_bounded(&mut self.run, self.capture_limits, event);
+        Ok(())
     }
     /// Appends a queue event.
     ///
     /// The event is retained only while queue capture-limit capacity remains;
     /// otherwise it is dropped and `truncation.dropped_queues` is updated.
-    pub fn push_queue(&mut self, event: QueueEvent) {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RunBuilderEventError`] when the event has invalid shape.
+    pub fn push_queue(&mut self, event: QueueEvent) -> Result<(), RunBuilderEventError> {
+        validate_queue_event(&event)?;
         let _ = crate::retention::push_queue_bounded(&mut self.run, self.capture_limits, event);
+        Ok(())
     }
     /// Appends an in-flight snapshot.
     ///
     /// The snapshot is retained only while in-flight snapshot capture-limit
     /// capacity remains; otherwise it is dropped and
     /// `truncation.dropped_inflight_snapshots` is updated.
-    pub fn push_inflight_snapshot(&mut self, snapshot: InFlightSnapshot) {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RunBuilderEventError`] when the snapshot has invalid shape.
+    pub fn push_inflight_snapshot(
+        &mut self,
+        snapshot: InFlightSnapshot,
+    ) -> Result<(), RunBuilderEventError> {
+        validate_inflight_snapshot(&snapshot)?;
         let _ = crate::retention::push_inflight_snapshot_bounded(
             &mut self.run,
             self.capture_limits,
             snapshot,
         );
+        Ok(())
     }
     /// Appends a runtime snapshot.
     ///
     /// The snapshot is retained only while runtime snapshot capture-limit
     /// capacity remains; otherwise it is dropped and
     /// `truncation.dropped_runtime_snapshots` is updated.
-    pub fn push_runtime_snapshot(&mut self, snapshot: RuntimeSnapshot) {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RunBuilderEventError`] when the snapshot has invalid shape.
+    pub fn push_runtime_snapshot(
+        &mut self,
+        snapshot: RuntimeSnapshot,
+    ) -> Result<(), RunBuilderEventError> {
         let _ = crate::retention::push_runtime_snapshot_bounded(
             &mut self.run,
             self.capture_limits,
             snapshot,
         );
+        Ok(())
     }
     /// Adds one lifecycle warning string.
     pub fn add_lifecycle_warning(&mut self, warning: impl Into<String>) {
@@ -274,4 +340,115 @@ impl RunBuilder {
     pub fn finish(self) -> Run {
         self.run
     }
+}
+
+fn invalid_event(
+    event: &'static str,
+    field: &'static str,
+    reason: impl Into<String>,
+) -> RunBuilderEventError {
+    RunBuilderEventError::InvalidEvent {
+        event,
+        field,
+        reason: reason.into(),
+    }
+}
+
+fn validate_request_event(event: &RequestEvent) -> Result<(), RunBuilderEventError> {
+    if event.request_id.trim().is_empty() {
+        return Err(invalid_event(
+            "RequestEvent",
+            "request_id",
+            "must not be empty",
+        ));
+    }
+    if event.route.trim().is_empty() {
+        return Err(invalid_event("RequestEvent", "route", "must not be empty"));
+    }
+    if event.finished_at_unix_ms < event.started_at_unix_ms {
+        return Err(invalid_event(
+            "RequestEvent",
+            "finished_at_unix_ms",
+            "must be >= started_at_unix_ms",
+        ));
+    }
+    if event.outcome.trim().is_empty() {
+        return Err(invalid_event(
+            "RequestEvent",
+            "outcome",
+            "must not be empty",
+        ));
+    }
+    if event.finished_at_unix_ms > event.started_at_unix_ms && event.latency_us == 0 {
+        return Err(invalid_event(
+            "RequestEvent",
+            "latency_us",
+            "must be > 0 when finished_at_unix_ms > started_at_unix_ms",
+        ));
+    }
+    Ok(())
+}
+fn validate_stage_event(event: &StageEvent) -> Result<(), RunBuilderEventError> {
+    if event.request_id.trim().is_empty() {
+        return Err(invalid_event(
+            "StageEvent",
+            "request_id",
+            "must not be empty",
+        ));
+    }
+    if event.stage.trim().is_empty() {
+        return Err(invalid_event("StageEvent", "stage", "must not be empty"));
+    }
+    if event.finished_at_unix_ms < event.started_at_unix_ms {
+        return Err(invalid_event(
+            "StageEvent",
+            "finished_at_unix_ms",
+            "must be >= started_at_unix_ms",
+        ));
+    }
+    if event.finished_at_unix_ms > event.started_at_unix_ms && event.latency_us == 0 {
+        return Err(invalid_event(
+            "StageEvent",
+            "latency_us",
+            "must be > 0 when finished_at_unix_ms > started_at_unix_ms",
+        ));
+    }
+    Ok(())
+}
+fn validate_queue_event(event: &QueueEvent) -> Result<(), RunBuilderEventError> {
+    if event.request_id.trim().is_empty() {
+        return Err(invalid_event(
+            "QueueEvent",
+            "request_id",
+            "must not be empty",
+        ));
+    }
+    if event.queue.trim().is_empty() {
+        return Err(invalid_event("QueueEvent", "queue", "must not be empty"));
+    }
+    if event.waited_until_unix_ms < event.waited_from_unix_ms {
+        return Err(invalid_event(
+            "QueueEvent",
+            "waited_until_unix_ms",
+            "must be >= waited_from_unix_ms",
+        ));
+    }
+    if event.waited_until_unix_ms > event.waited_from_unix_ms && event.wait_us == 0 {
+        return Err(invalid_event(
+            "QueueEvent",
+            "wait_us",
+            "must be > 0 when waited_until_unix_ms > waited_from_unix_ms",
+        ));
+    }
+    Ok(())
+}
+fn validate_inflight_snapshot(snapshot: &InFlightSnapshot) -> Result<(), RunBuilderEventError> {
+    if snapshot.gauge.trim().is_empty() {
+        return Err(invalid_event(
+            "InFlightSnapshot",
+            "gauge",
+            "must not be empty",
+        ));
+    }
+    Ok(())
 }

--- a/tailtriage-core/src/run_builder.rs
+++ b/tailtriage-core/src/run_builder.rs
@@ -302,7 +302,10 @@ impl RunBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`RunBuilderEventError`] when the snapshot has invalid shape.
+    /// Currently returns `Ok(())` for all runtime snapshots. The `Result`
+    /// keeps this API consistent with other [`RunBuilder`] push methods and
+    /// leaves room for future runtime snapshot validation without changing
+    /// the method shape.
     pub fn push_runtime_snapshot(
         &mut self,
         snapshot: RuntimeSnapshot,

--- a/tailtriage-core/src/run_builder.rs
+++ b/tailtriage-core/src/run_builder.rs
@@ -379,13 +379,6 @@ fn validate_request_event(event: &RequestEvent) -> Result<(), RunBuilderEventErr
             "must not be empty",
         ));
     }
-    if event.finished_at_unix_ms > event.started_at_unix_ms && event.latency_us == 0 {
-        return Err(invalid_event(
-            "RequestEvent",
-            "latency_us",
-            "must be > 0 when finished_at_unix_ms > started_at_unix_ms",
-        ));
-    }
     Ok(())
 }
 fn validate_stage_event(event: &StageEvent) -> Result<(), RunBuilderEventError> {
@@ -406,13 +399,6 @@ fn validate_stage_event(event: &StageEvent) -> Result<(), RunBuilderEventError> 
             "must be >= started_at_unix_ms",
         ));
     }
-    if event.finished_at_unix_ms > event.started_at_unix_ms && event.latency_us == 0 {
-        return Err(invalid_event(
-            "StageEvent",
-            "latency_us",
-            "must be > 0 when finished_at_unix_ms > started_at_unix_ms",
-        ));
-    }
     Ok(())
 }
 fn validate_queue_event(event: &QueueEvent) -> Result<(), RunBuilderEventError> {
@@ -431,13 +417,6 @@ fn validate_queue_event(event: &QueueEvent) -> Result<(), RunBuilderEventError> 
             "QueueEvent",
             "waited_until_unix_ms",
             "must be >= waited_from_unix_ms",
-        ));
-    }
-    if event.waited_until_unix_ms > event.waited_from_unix_ms && event.wait_us == 0 {
-        return Err(invalid_event(
-            "QueueEvent",
-            "wait_us",
-            "must be > 0 when waited_until_unix_ms > waited_from_unix_ms",
         ));
     }
     Ok(())

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -1510,6 +1510,10 @@ fn run_builder_event_validation_rejects_invalid_shapes() {
     assert!(builder.push_request(request).is_ok());
 
     let mut stage = test_stage_event("req", "stage");
+    stage.request_id = " ".into();
+    assert!(builder.push_stage(stage).is_err());
+
+    let mut stage = test_stage_event("req", "stage");
     stage.stage = " ".into();
     assert!(builder.push_stage(stage).is_err());
 
@@ -1523,6 +1527,10 @@ fn run_builder_event_validation_rejects_invalid_shapes() {
     stage.finished_at_unix_ms = 4;
     stage.latency_us = 0;
     assert!(builder.push_stage(stage).is_ok());
+
+    let mut queue = test_queue_event("req", "queue");
+    queue.request_id = " ".into();
+    assert!(builder.push_queue(queue).is_err());
 
     let mut queue = test_queue_event("req", "queue");
     queue.queue = " ".into();

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -1504,12 +1504,6 @@ fn run_builder_event_validation_rejects_invalid_shapes() {
     assert!(builder.push_request(request).is_err());
 
     let mut request = test_request_event("req");
-    request.started_at_unix_ms = 1;
-    request.finished_at_unix_ms = 2;
-    request.latency_us = 0;
-    assert!(builder.push_request(request).is_err());
-
-    let mut request = test_request_event("req");
     request.started_at_unix_ms = 2;
     request.finished_at_unix_ms = 2;
     request.latency_us = 0;
@@ -1524,6 +1518,12 @@ fn run_builder_event_validation_rejects_invalid_shapes() {
     stage.finished_at_unix_ms = 7;
     assert!(builder.push_stage(stage).is_err());
 
+    let mut stage = test_stage_event("req", "stage");
+    stage.started_at_unix_ms = 3;
+    stage.finished_at_unix_ms = 4;
+    stage.latency_us = 0;
+    assert!(builder.push_stage(stage).is_ok());
+
     let mut queue = test_queue_event("req", "queue");
     queue.queue = " ".into();
     assert!(builder.push_queue(queue).is_err());
@@ -1533,6 +1533,12 @@ fn run_builder_event_validation_rejects_invalid_shapes() {
     queue.waited_until_unix_ms = 2;
     assert!(builder.push_queue(queue).is_err());
 
+    let mut queue = test_queue_event("req", "queue");
+    queue.waited_from_unix_ms = 5;
+    queue.waited_until_unix_ms = 6;
+    queue.wait_us = 0;
+    assert!(builder.push_queue(queue).is_ok());
+
     assert!(builder
         .push_inflight_snapshot(crate::InFlightSnapshot {
             gauge: " ".into(),
@@ -1540,4 +1546,27 @@ fn run_builder_event_validation_rejects_invalid_shapes() {
             count: 1,
         })
         .is_err());
+}
+
+#[test]
+fn run_builder_accepts_zero_duration_with_positive_timestamp_span() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+
+    let mut request = test_request_event("req");
+    request.started_at_unix_ms = 1;
+    request.finished_at_unix_ms = 2;
+    request.latency_us = 0;
+    assert!(builder.push_request(request).is_ok());
+
+    let mut stage = test_stage_event("req", "stage");
+    stage.started_at_unix_ms = 3;
+    stage.finished_at_unix_ms = 4;
+    stage.latency_us = 0;
+    assert!(builder.push_stage(stage).is_ok());
+
+    let mut queue = test_queue_event("req", "queue");
+    queue.waited_from_unix_ms = 5;
+    queue.waited_until_unix_ms = 6;
+    queue.wait_us = 0;
+    assert!(builder.push_queue(queue).is_ok());
 }

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -949,15 +949,17 @@ fn run_builder_creates_empty_run_with_explicit_metadata() {
             .run_end_reason(crate::RunEndReason::Shutdown),
     )
     .expect("builder should succeed");
-    builder.push_request(crate::RequestEvent {
-        request_id: "r1".into(),
-        route: "/x".into(),
-        kind: None,
-        started_at_unix_ms: 1,
-        finished_at_unix_ms: 2,
-        latency_us: 10,
-        outcome: "ok".into(),
-    });
+    builder
+        .push_request(crate::RequestEvent {
+            request_id: "r1".into(),
+            route: "/x".into(),
+            kind: None,
+            started_at_unix_ms: 1,
+            finished_at_unix_ms: 2,
+            latency_us: 10,
+            outcome: "ok".into(),
+        })
+        .expect("ok");
     let run = builder.finish();
 
     assert_eq!(run.metadata.service_name, "payments");
@@ -1223,8 +1225,12 @@ fn run_builder_applies_request_limit_and_updates_truncation() {
     let mut builder =
         crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").capture_limits(limits))
             .expect("ok");
-    builder.push_request(test_request_event("req-1"));
-    builder.push_request(test_request_event("req-2"));
+    builder
+        .push_request(test_request_event("req-1"))
+        .expect("ok");
+    builder
+        .push_request(test_request_event("req-2"))
+        .expect("ok");
     let run = builder.finish();
     assert_eq!(run.requests.len(), 1);
     assert_eq!(run.requests[0].request_id, "req-1");
@@ -1249,8 +1255,12 @@ fn run_builder_applies_stage_limit_and_updates_truncation() {
     let mut builder =
         crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").capture_limits(limits))
             .expect("ok");
-    builder.push_stage(test_stage_event("req-1", "stage-1"));
-    builder.push_stage(test_stage_event("req-2", "stage-2"));
+    builder
+        .push_stage(test_stage_event("req-1", "stage-1"))
+        .expect("ok");
+    builder
+        .push_stage(test_stage_event("req-2", "stage-2"))
+        .expect("ok");
     let run = builder.finish();
     assert_eq!(run.stages.len(), 1);
     assert_eq!(run.stages[0].stage, "stage-1");
@@ -1275,8 +1285,12 @@ fn run_builder_applies_queue_limit_and_updates_truncation() {
     let mut builder =
         crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").capture_limits(limits))
             .expect("ok");
-    builder.push_queue(test_queue_event("req-1", "queue-1"));
-    builder.push_queue(test_queue_event("req-2", "queue-2"));
+    builder
+        .push_queue(test_queue_event("req-1", "queue-1"))
+        .expect("ok");
+    builder
+        .push_queue(test_queue_event("req-2", "queue-2"))
+        .expect("ok");
     let run = builder.finish();
     assert_eq!(run.queues.len(), 1);
     assert_eq!(run.queues[0].queue, "queue-1");
@@ -1301,16 +1315,20 @@ fn run_builder_applies_inflight_snapshot_limit_and_updates_truncation() {
     let mut builder =
         crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").capture_limits(limits))
             .expect("ok");
-    builder.push_inflight_snapshot(crate::InFlightSnapshot {
-        gauge: "g".to_string(),
-        at_unix_ms: 7,
-        count: 1,
-    });
-    builder.push_inflight_snapshot(crate::InFlightSnapshot {
-        gauge: "g".to_string(),
-        at_unix_ms: 8,
-        count: 2,
-    });
+    builder
+        .push_inflight_snapshot(crate::InFlightSnapshot {
+            gauge: "g".to_string(),
+            at_unix_ms: 7,
+            count: 1,
+        })
+        .expect("ok");
+    builder
+        .push_inflight_snapshot(crate::InFlightSnapshot {
+            gauge: "g".to_string(),
+            at_unix_ms: 8,
+            count: 2,
+        })
+        .expect("ok");
     let run = builder.finish();
     assert_eq!(run.inflight.len(), 1);
     assert_eq!(run.inflight[0].count, 1);
@@ -1335,22 +1353,26 @@ fn run_builder_applies_runtime_snapshot_limit_and_updates_truncation() {
     let mut builder =
         crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").capture_limits(limits))
             .expect("ok");
-    builder.push_runtime_snapshot(crate::RuntimeSnapshot {
-        at_unix_ms: 9,
-        alive_tasks: Some(1),
-        global_queue_depth: Some(2),
-        local_queue_depth: Some(3),
-        blocking_queue_depth: Some(4),
-        remote_schedule_count: Some(5),
-    });
-    builder.push_runtime_snapshot(crate::RuntimeSnapshot {
-        at_unix_ms: 10,
-        alive_tasks: Some(2),
-        global_queue_depth: Some(3),
-        local_queue_depth: Some(4),
-        blocking_queue_depth: Some(5),
-        remote_schedule_count: Some(6),
-    });
+    builder
+        .push_runtime_snapshot(crate::RuntimeSnapshot {
+            at_unix_ms: 9,
+            alive_tasks: Some(1),
+            global_queue_depth: Some(2),
+            local_queue_depth: Some(3),
+            blocking_queue_depth: Some(4),
+            remote_schedule_count: Some(5),
+        })
+        .expect("ok");
+    builder
+        .push_runtime_snapshot(crate::RuntimeSnapshot {
+            at_unix_ms: 10,
+            alive_tasks: Some(2),
+            global_queue_depth: Some(3),
+            local_queue_depth: Some(4),
+            blocking_queue_depth: Some(5),
+            remote_schedule_count: Some(6),
+        })
+        .expect("ok");
     let run = builder.finish();
     assert_eq!(run.runtime_snapshots.len(), 1);
     assert_eq!(run.runtime_snapshots[0].at_unix_ms, 9);
@@ -1375,22 +1397,32 @@ fn run_builder_does_not_report_truncation_within_limits() {
     let mut builder =
         crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").capture_limits(limits))
             .expect("ok");
-    builder.push_request(test_request_event("req-1"));
-    builder.push_stage(test_stage_event("req-1", "stage-1"));
-    builder.push_queue(test_queue_event("req-1", "queue-1"));
-    builder.push_inflight_snapshot(crate::InFlightSnapshot {
-        gauge: "g".to_string(),
-        at_unix_ms: 11,
-        count: 1,
-    });
-    builder.push_runtime_snapshot(crate::RuntimeSnapshot {
-        at_unix_ms: 12,
-        alive_tasks: Some(1),
-        global_queue_depth: Some(1),
-        local_queue_depth: Some(1),
-        blocking_queue_depth: Some(1),
-        remote_schedule_count: Some(1),
-    });
+    builder
+        .push_request(test_request_event("req-1"))
+        .expect("ok");
+    builder
+        .push_stage(test_stage_event("req-1", "stage-1"))
+        .expect("ok");
+    builder
+        .push_queue(test_queue_event("req-1", "queue-1"))
+        .expect("ok");
+    builder
+        .push_inflight_snapshot(crate::InFlightSnapshot {
+            gauge: "g".to_string(),
+            at_unix_ms: 11,
+            count: 1,
+        })
+        .expect("ok");
+    builder
+        .push_runtime_snapshot(crate::RuntimeSnapshot {
+            at_unix_ms: 12,
+            alive_tasks: Some(1),
+            global_queue_depth: Some(1),
+            local_queue_depth: Some(1),
+            blocking_queue_depth: Some(1),
+            remote_schedule_count: Some(1),
+        })
+        .expect("ok");
     let run = builder.finish();
     assert_eq!(run.requests.len(), 1);
     assert_eq!(run.stages.len(), 1);
@@ -1413,11 +1445,99 @@ fn run_builder_uses_mode_default_limits_when_limits_not_explicit() {
         crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").mode(CaptureMode::Light))
             .expect("ok");
     for i in 0..(default_limits.max_requests + 2) {
-        builder.push_request(test_request_event(&format!("req-{}", i + 1)));
+        builder
+            .push_request(test_request_event(&format!("req-{}", i + 1)))
+            .expect("ok");
     }
     let run = builder.finish();
     assert_eq!(run.requests.len(), default_limits.max_requests);
     assert_eq!(run.truncation.dropped_requests, 2);
     assert!(run.truncation.limits_hit);
     assert!(run.truncation.is_truncated());
+}
+
+#[test]
+fn run_builder_valid_pushes_return_ok() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+    assert!(builder.push_request(test_request_event("req")).is_ok());
+    assert!(builder.push_stage(test_stage_event("req", "db")).is_ok());
+    assert!(builder
+        .push_queue(test_queue_event("req", "permits"))
+        .is_ok());
+    assert!(builder
+        .push_inflight_snapshot(crate::InFlightSnapshot {
+            gauge: "inflight".into(),
+            at_unix_ms: 1,
+            count: 1,
+        })
+        .is_ok());
+    assert!(builder
+        .push_runtime_snapshot(crate::RuntimeSnapshot {
+            at_unix_ms: 0,
+            alive_tasks: None,
+            global_queue_depth: None,
+            local_queue_depth: None,
+            blocking_queue_depth: None,
+            remote_schedule_count: None,
+        })
+        .is_ok());
+}
+
+#[test]
+fn run_builder_event_validation_rejects_invalid_shapes() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+    let mut request = test_request_event("req");
+    request.request_id = " ".into();
+    assert!(builder.push_request(request).is_err());
+
+    let mut request = test_request_event("req");
+    request.route = "\t".into();
+    assert!(builder.push_request(request).is_err());
+
+    let mut request = test_request_event("req");
+    request.started_at_unix_ms = 5;
+    request.finished_at_unix_ms = 4;
+    assert!(builder.push_request(request).is_err());
+
+    let mut request = test_request_event("req");
+    request.outcome = " ".into();
+    assert!(builder.push_request(request).is_err());
+
+    let mut request = test_request_event("req");
+    request.started_at_unix_ms = 1;
+    request.finished_at_unix_ms = 2;
+    request.latency_us = 0;
+    assert!(builder.push_request(request).is_err());
+
+    let mut request = test_request_event("req");
+    request.started_at_unix_ms = 2;
+    request.finished_at_unix_ms = 2;
+    request.latency_us = 0;
+    assert!(builder.push_request(request).is_ok());
+
+    let mut stage = test_stage_event("req", "stage");
+    stage.stage = " ".into();
+    assert!(builder.push_stage(stage).is_err());
+
+    let mut stage = test_stage_event("req", "stage");
+    stage.started_at_unix_ms = 8;
+    stage.finished_at_unix_ms = 7;
+    assert!(builder.push_stage(stage).is_err());
+
+    let mut queue = test_queue_event("req", "queue");
+    queue.queue = " ".into();
+    assert!(builder.push_queue(queue).is_err());
+
+    let mut queue = test_queue_event("req", "queue");
+    queue.waited_from_unix_ms = 3;
+    queue.waited_until_unix_ms = 2;
+    assert!(builder.push_queue(queue).is_err());
+
+    assert!(builder
+        .push_inflight_snapshot(crate::InFlightSnapshot {
+            gauge: " ".into(),
+            at_unix_ms: 1,
+            count: 1,
+        })
+        .is_err());
 }

--- a/tailtriage-tracing/src/error.rs
+++ b/tailtriage-tracing/src/error.rs
@@ -32,6 +32,8 @@ pub enum ImportError {
     StrictViolation(String),
     /// Service name was empty or whitespace-only.
     EmptyServiceName,
+    /// Imported run event failed `tailtriage-core` run-builder validation.
+    InvalidRunEvent(String),
 }
 
 impl fmt::Display for ImportError {
@@ -51,6 +53,7 @@ impl fmt::Display for ImportError {
             }
             Self::StrictViolation(message) => write!(f, "strict import violation: {message}"),
             Self::EmptyServiceName => write!(f, "service name must not be empty"),
+            Self::InvalidRunEvent(message) => write!(f, "invalid run event: {message}"),
         }
     }
 }

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -821,6 +821,19 @@ mod tests {
     }
 
     #[test]
+    fn normalized_zero_duration_us_is_accepted_for_positive_timestamp_spans() {
+        let input = r#"
+{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":0,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
+{"span":{"name":"st","started_at_unix_ms":11,"finished_at_unix_ms":18,"duration_us":0,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
+{"span":{"name":"q","started_at_unix_ms":10,"finished_at_unix_ms":11,"duration_us":0,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":3}}}
+"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests[0].latency_us, 0);
+        assert_eq!(imported.run().stages[0].latency_us, 0);
+        assert_eq!(imported.run().queues[0].wait_us, 0);
+    }
+
+    #[test]
     fn normalized_request_fields_import_from_outer_fields() {
         let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2},"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/outer"}}"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -270,13 +270,19 @@ where
     })?;
 
     for request in requests {
-        run_builder.push_request(request);
+        run_builder
+            .push_request(request)
+            .map_err(|err| ImportError::InvalidRunEvent(err.to_string()))?;
     }
     for stage in stages {
-        run_builder.push_stage(stage);
+        run_builder
+            .push_stage(stage)
+            .map_err(|err| ImportError::InvalidRunEvent(err.to_string()))?;
     }
     for queue in queues {
-        run_builder.push_queue(queue);
+        run_builder
+            .push_queue(queue)
+            .map_err(|err| ImportError::InvalidRunEvent(err.to_string()))?;
     }
     let mut run = run_builder.finish();
     attach_durable_conversion_warnings(&mut run, &warnings);


### PR DESCRIPTION
### Motivation
- Ensure `RunBuilder` is a safe public assembly API that rejects malformed pushed events while preserving existing public schemas and retention semantics.
- Prevent callers from silently inserting invalid event shapes into assembled `Run` artifacts without changing event struct visibility or `RunBuilder` naming.

### Description
- Added a public `RunBuilderEventError` (`Debug`, `Clone`, `PartialEq`, `Eq`) with `Display` and `std::error::Error` impls and re-exported it from the `tailtriage-core` crate root.
- Converted `RunBuilder` push APIs to return `Result<(), RunBuilderEventError>` for `push_request`, `push_stage`, `push_queue`, `push_inflight_snapshot`, and `push_runtime_snapshot`, and implemented per-type validation helpers enforcing the requested rules (request/stage/queue/inflight validations; runtime snapshots remain permissive and accept `at_unix_ms = 0`).
- Kept retention overflow non-error behavior (dropped items still return `Ok(())` and update `Run.truncation`), did not perform cross-event correlation or synthesize completions, and did not change public JSON schema or event field visibility.
- Updated `tailtriage-tracing` import flow to map builder validation failures into `ImportError::InvalidRunEvent(String)` and adjusted `ImportError` accordingly.
- Updated rustdoc for `RunBuilder` push methods and the `tailtriage-core/README.md` advanced `RunBuilder` section to document the new validation boundary and non-goals, and added/updated focused tests to cover valid/invalid pushes and retention overflow semantics.

### Testing
- Ran `cargo fmt --check` successfully.
- Ran `cargo test -p tailtriage-core --all-targets` and `cargo test -p tailtriage-tracing --all-targets --all-features`, and all tests passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and fixed issues until it passed.
- Ran `python3 scripts/validate_docs_contracts.py` and validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0df2fe5a9483309ae16cc1830330a8)