### PR TITLE
RunBuilder: validate pushed events and make push APIs fallible

### DIFF
--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -172,12 +172,12 @@ Override limits with:
 Most users should use `Tailtriage::builder(...)` for live request instrumentation.
 Use `RunBuilder` only when you already have completed request, stage, queue, in-flight, or runtime evidence and need to assemble a standard `Run` artifact.
 
-`RunBuilder` is intended for import/conversion paths. It does not perform live lifecycle tracking. It applies the same bounded retention/truncation semantics as live core capture, so events beyond configured `CaptureLimits` are dropped and `Run.truncation` counters are updated. For assembled/imported artifacts, host and pid default to `None`, and generated run IDs use the same core run-id semantics as live capture.
+`RunBuilder` is intended for import/conversion paths. `RunBuilder::new(...)` validates top-level run timestamp ordering. Push methods validate event/snapshot shape and return errors for malformed fields. It does not perform cross-event correlation validation and does not synthesize missing lifecycle completions. It applies the same bounded retention/truncation semantics as live core capture, so events beyond configured `CaptureLimits` are dropped, `Run.truncation` counters are updated, and overflow remains non-error behavior. For assembled/imported artifacts, host and pid default to `None`, and generated run IDs use the same core run-id semantics as live capture.
 
 ```rust,no_run
 use tailtriage_core::{RequestEvent, RunBuilder, RunBuilderOptions};
 
-fn assemble_run() -> Result<(), tailtriage_core::BuildError> {
+fn assemble_run() -> Result<(), Box<dyn std::error::Error>> {
     let mut builder = RunBuilder::new(RunBuilderOptions::new("checkout-service"))?;
     builder.push_request(RequestEvent {
         request_id: "req-1".into(),
@@ -187,7 +187,7 @@ fn assemble_run() -> Result<(), tailtriage_core::BuildError> {
         finished_at_unix_ms: 2,
         latency_us: 1_000,
         outcome: "ok".into(),
-    });
+    })?;
 
     let run = builder.finish();
     assert_eq!(run.requests.len(), 1);

--- a/tailtriage-core/src/lib.rs
+++ b/tailtriage-core/src/lib.rs
@@ -48,7 +48,7 @@ pub use events::{
     RunEndReason, RunMetadata, RuntimeSnapshot, StageEvent, TruncationSummary,
     UnfinishedRequestSample, UnfinishedRequests, SCHEMA_VERSION,
 };
-pub use run_builder::{RunBuilder, RunBuilderOptions};
+pub use run_builder::{RunBuilder, RunBuilderEventError, RunBuilderOptions};
 pub use sink::{DiscardSink, LocalJsonSink, MemorySink, RunSink, SinkError};
 pub use time::{system_time_to_unix_ms, unix_time_ms};
 pub use timers::{InflightGuard, QueueTimer, StageTimer};

--- a/tailtriage-core/src/run_builder.rs
+++ b/tailtriage-core/src/run_builder.rs
@@ -3,6 +3,35 @@ use crate::{
     EffectiveCoreConfig, EffectiveTokioSamplerConfig, InFlightSnapshot, QueueEvent, RequestEvent,
     Run, RunEndReason, RunMetadata, RuntimeSnapshot, StageEvent, UnfinishedRequests,
 };
+use std::fmt;
+
+/// Validation error returned when pushing malformed run events/snapshots.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RunBuilderEventError {
+    /// Invalid event or snapshot shape field.
+    InvalidEvent {
+        /// Event/snapshot type name.
+        event: &'static str,
+        /// Invalid field name.
+        field: &'static str,
+        /// Validation reason.
+        reason: String,
+    },
+}
+
+impl fmt::Display for RunBuilderEventError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidEvent {
+                event,
+                field,
+                reason,
+            } => write!(f, "invalid {event}.{field}: {reason}"),
+        }
+    }
+}
+
+impl std::error::Error for RunBuilderEventError {}
 
 /// Options for assembling a completed [`Run`] artifact.
 ///
@@ -207,46 +236,81 @@ impl RunBuilder {
     ///
     /// The event is retained only while request capture-limit capacity remains;
     /// otherwise it is dropped and `truncation.dropped_requests` is updated.
-    pub fn push_request(&mut self, event: RequestEvent) {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RunBuilderEventError`] when the event shape is invalid.
+    pub fn push_request(&mut self, event: RequestEvent) -> Result<(), RunBuilderEventError> {
+        validate_request_event(&event)?;
         let _ = crate::retention::push_request_bounded(&mut self.run, self.capture_limits, event);
+        Ok(())
     }
     /// Appends a stage event.
     ///
     /// The event is retained only while stage capture-limit capacity remains;
     /// otherwise it is dropped and `truncation.dropped_stages` is updated.
-    pub fn push_stage(&mut self, event: StageEvent) {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RunBuilderEventError`] when the event shape is invalid.
+    pub fn push_stage(&mut self, event: StageEvent) -> Result<(), RunBuilderEventError> {
+        validate_stage_event(&event)?;
         let _ = crate::retention::push_stage_bounded(&mut self.run, self.capture_limits, event);
+        Ok(())
     }
     /// Appends a queue event.
     ///
     /// The event is retained only while queue capture-limit capacity remains;
     /// otherwise it is dropped and `truncation.dropped_queues` is updated.
-    pub fn push_queue(&mut self, event: QueueEvent) {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RunBuilderEventError`] when the event shape is invalid.
+    pub fn push_queue(&mut self, event: QueueEvent) -> Result<(), RunBuilderEventError> {
+        validate_queue_event(&event)?;
         let _ = crate::retention::push_queue_bounded(&mut self.run, self.capture_limits, event);
+        Ok(())
     }
     /// Appends an in-flight snapshot.
     ///
     /// The snapshot is retained only while in-flight snapshot capture-limit
     /// capacity remains; otherwise it is dropped and
     /// `truncation.dropped_inflight_snapshots` is updated.
-    pub fn push_inflight_snapshot(&mut self, snapshot: InFlightSnapshot) {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RunBuilderEventError`] when the snapshot shape is invalid.
+    pub fn push_inflight_snapshot(
+        &mut self,
+        snapshot: InFlightSnapshot,
+    ) -> Result<(), RunBuilderEventError> {
+        validate_inflight_snapshot(&snapshot)?;
         let _ = crate::retention::push_inflight_snapshot_bounded(
             &mut self.run,
             self.capture_limits,
             snapshot,
         );
+        Ok(())
     }
     /// Appends a runtime snapshot.
     ///
     /// The snapshot is retained only while runtime snapshot capture-limit
     /// capacity remains; otherwise it is dropped and
     /// `truncation.dropped_runtime_snapshots` is updated.
-    pub fn push_runtime_snapshot(&mut self, snapshot: RuntimeSnapshot) {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RunBuilderEventError`] when the snapshot shape is invalid.
+    pub fn push_runtime_snapshot(
+        &mut self,
+        snapshot: RuntimeSnapshot,
+    ) -> Result<(), RunBuilderEventError> {
         let _ = crate::retention::push_runtime_snapshot_bounded(
             &mut self.run,
             self.capture_limits,
             snapshot,
         );
+        Ok(())
     }
     /// Adds one lifecycle warning string.
     pub fn add_lifecycle_warning(&mut self, warning: impl Into<String>) {
@@ -274,4 +338,118 @@ impl RunBuilder {
     pub fn finish(self) -> Run {
         self.run
     }
+}
+
+fn invalid_event(
+    event: &'static str,
+    field: &'static str,
+    reason: impl Into<String>,
+) -> RunBuilderEventError {
+    RunBuilderEventError::InvalidEvent {
+        event,
+        field,
+        reason: reason.into(),
+    }
+}
+
+fn validate_request_event(event: &RequestEvent) -> Result<(), RunBuilderEventError> {
+    if event.request_id.trim().is_empty() {
+        return Err(invalid_event(
+            "RequestEvent",
+            "request_id",
+            "must not be blank",
+        ));
+    }
+    if event.route.trim().is_empty() {
+        return Err(invalid_event("RequestEvent", "route", "must not be blank"));
+    }
+    if event.finished_at_unix_ms < event.started_at_unix_ms {
+        return Err(invalid_event(
+            "RequestEvent",
+            "finished_at_unix_ms",
+            "must be greater than or equal to started_at_unix_ms",
+        ));
+    }
+    if event.outcome.trim().is_empty() {
+        return Err(invalid_event(
+            "RequestEvent",
+            "outcome",
+            "must not be blank",
+        ));
+    }
+    if event.finished_at_unix_ms > event.started_at_unix_ms && event.latency_us == 0 {
+        return Err(invalid_event(
+            "RequestEvent",
+            "latency_us",
+            "must be > 0 when finished_at_unix_ms > started_at_unix_ms",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_stage_event(event: &StageEvent) -> Result<(), RunBuilderEventError> {
+    if event.request_id.trim().is_empty() {
+        return Err(invalid_event(
+            "StageEvent",
+            "request_id",
+            "must not be blank",
+        ));
+    }
+    if event.stage.trim().is_empty() {
+        return Err(invalid_event("StageEvent", "stage", "must not be blank"));
+    }
+    if event.finished_at_unix_ms < event.started_at_unix_ms {
+        return Err(invalid_event(
+            "StageEvent",
+            "finished_at_unix_ms",
+            "must be greater than or equal to started_at_unix_ms",
+        ));
+    }
+    if event.finished_at_unix_ms > event.started_at_unix_ms && event.latency_us == 0 {
+        return Err(invalid_event(
+            "StageEvent",
+            "latency_us",
+            "must be > 0 when finished_at_unix_ms > started_at_unix_ms",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_queue_event(event: &QueueEvent) -> Result<(), RunBuilderEventError> {
+    if event.request_id.trim().is_empty() {
+        return Err(invalid_event(
+            "QueueEvent",
+            "request_id",
+            "must not be blank",
+        ));
+    }
+    if event.queue.trim().is_empty() {
+        return Err(invalid_event("QueueEvent", "queue", "must not be blank"));
+    }
+    if event.waited_until_unix_ms < event.waited_from_unix_ms {
+        return Err(invalid_event(
+            "QueueEvent",
+            "waited_until_unix_ms",
+            "must be greater than or equal to waited_from_unix_ms",
+        ));
+    }
+    if event.waited_until_unix_ms > event.waited_from_unix_ms && event.wait_us == 0 {
+        return Err(invalid_event(
+            "QueueEvent",
+            "wait_us",
+            "must be > 0 when waited_until_unix_ms > waited_from_unix_ms",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_inflight_snapshot(snapshot: &InFlightSnapshot) -> Result<(), RunBuilderEventError> {
+    if snapshot.gauge.trim().is_empty() {
+        return Err(invalid_event(
+            "InFlightSnapshot",
+            "gauge",
+            "must not be blank",
+        ));
+    }
+    Ok(())
 }

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -949,15 +949,17 @@ fn run_builder_creates_empty_run_with_explicit_metadata() {
             .run_end_reason(crate::RunEndReason::Shutdown),
     )
     .expect("builder should succeed");
-    builder.push_request(crate::RequestEvent {
-        request_id: "r1".into(),
-        route: "/x".into(),
-        kind: None,
-        started_at_unix_ms: 1,
-        finished_at_unix_ms: 2,
-        latency_us: 10,
-        outcome: "ok".into(),
-    });
+    builder
+        .push_request(crate::RequestEvent {
+            request_id: "r1".into(),
+            route: "/x".into(),
+            kind: None,
+            started_at_unix_ms: 1,
+            finished_at_unix_ms: 2,
+            latency_us: 10,
+            outcome: "ok".into(),
+        })
+        .expect("push should succeed");
     let run = builder.finish();
 
     assert_eq!(run.metadata.service_name, "payments");
@@ -1223,8 +1225,12 @@ fn run_builder_applies_request_limit_and_updates_truncation() {
     let mut builder =
         crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").capture_limits(limits))
             .expect("ok");
-    builder.push_request(test_request_event("req-1"));
-    builder.push_request(test_request_event("req-2"));
+    builder
+        .push_request(test_request_event("req-1"))
+        .expect("push should succeed");
+    builder
+        .push_request(test_request_event("req-2"))
+        .expect("push should succeed");
     let run = builder.finish();
     assert_eq!(run.requests.len(), 1);
     assert_eq!(run.requests[0].request_id, "req-1");
@@ -1249,8 +1255,12 @@ fn run_builder_applies_stage_limit_and_updates_truncation() {
     let mut builder =
         crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").capture_limits(limits))
             .expect("ok");
-    builder.push_stage(test_stage_event("req-1", "stage-1"));
-    builder.push_stage(test_stage_event("req-2", "stage-2"));
+    builder
+        .push_stage(test_stage_event("req-1", "stage-1"))
+        .expect("push should succeed");
+    builder
+        .push_stage(test_stage_event("req-2", "stage-2"))
+        .expect("push should succeed");
     let run = builder.finish();
     assert_eq!(run.stages.len(), 1);
     assert_eq!(run.stages[0].stage, "stage-1");
@@ -1275,8 +1285,12 @@ fn run_builder_applies_queue_limit_and_updates_truncation() {
     let mut builder =
         crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").capture_limits(limits))
             .expect("ok");
-    builder.push_queue(test_queue_event("req-1", "queue-1"));
-    builder.push_queue(test_queue_event("req-2", "queue-2"));
+    builder
+        .push_queue(test_queue_event("req-1", "queue-1"))
+        .expect("push should succeed");
+    builder
+        .push_queue(test_queue_event("req-2", "queue-2"))
+        .expect("push should succeed");
     let run = builder.finish();
     assert_eq!(run.queues.len(), 1);
     assert_eq!(run.queues[0].queue, "queue-1");
@@ -1301,16 +1315,20 @@ fn run_builder_applies_inflight_snapshot_limit_and_updates_truncation() {
     let mut builder =
         crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").capture_limits(limits))
             .expect("ok");
-    builder.push_inflight_snapshot(crate::InFlightSnapshot {
-        gauge: "g".to_string(),
-        at_unix_ms: 7,
-        count: 1,
-    });
-    builder.push_inflight_snapshot(crate::InFlightSnapshot {
-        gauge: "g".to_string(),
-        at_unix_ms: 8,
-        count: 2,
-    });
+    builder
+        .push_inflight_snapshot(crate::InFlightSnapshot {
+            gauge: "g".to_string(),
+            at_unix_ms: 7,
+            count: 1,
+        })
+        .expect("push should succeed");
+    builder
+        .push_inflight_snapshot(crate::InFlightSnapshot {
+            gauge: "g".to_string(),
+            at_unix_ms: 8,
+            count: 2,
+        })
+        .expect("push should succeed");
     let run = builder.finish();
     assert_eq!(run.inflight.len(), 1);
     assert_eq!(run.inflight[0].count, 1);
@@ -1335,22 +1353,26 @@ fn run_builder_applies_runtime_snapshot_limit_and_updates_truncation() {
     let mut builder =
         crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").capture_limits(limits))
             .expect("ok");
-    builder.push_runtime_snapshot(crate::RuntimeSnapshot {
-        at_unix_ms: 9,
-        alive_tasks: Some(1),
-        global_queue_depth: Some(2),
-        local_queue_depth: Some(3),
-        blocking_queue_depth: Some(4),
-        remote_schedule_count: Some(5),
-    });
-    builder.push_runtime_snapshot(crate::RuntimeSnapshot {
-        at_unix_ms: 10,
-        alive_tasks: Some(2),
-        global_queue_depth: Some(3),
-        local_queue_depth: Some(4),
-        blocking_queue_depth: Some(5),
-        remote_schedule_count: Some(6),
-    });
+    builder
+        .push_runtime_snapshot(crate::RuntimeSnapshot {
+            at_unix_ms: 9,
+            alive_tasks: Some(1),
+            global_queue_depth: Some(2),
+            local_queue_depth: Some(3),
+            blocking_queue_depth: Some(4),
+            remote_schedule_count: Some(5),
+        })
+        .expect("push should succeed");
+    builder
+        .push_runtime_snapshot(crate::RuntimeSnapshot {
+            at_unix_ms: 10,
+            alive_tasks: Some(2),
+            global_queue_depth: Some(3),
+            local_queue_depth: Some(4),
+            blocking_queue_depth: Some(5),
+            remote_schedule_count: Some(6),
+        })
+        .expect("push should succeed");
     let run = builder.finish();
     assert_eq!(run.runtime_snapshots.len(), 1);
     assert_eq!(run.runtime_snapshots[0].at_unix_ms, 9);
@@ -1375,22 +1397,32 @@ fn run_builder_does_not_report_truncation_within_limits() {
     let mut builder =
         crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").capture_limits(limits))
             .expect("ok");
-    builder.push_request(test_request_event("req-1"));
-    builder.push_stage(test_stage_event("req-1", "stage-1"));
-    builder.push_queue(test_queue_event("req-1", "queue-1"));
-    builder.push_inflight_snapshot(crate::InFlightSnapshot {
-        gauge: "g".to_string(),
-        at_unix_ms: 11,
-        count: 1,
-    });
-    builder.push_runtime_snapshot(crate::RuntimeSnapshot {
-        at_unix_ms: 12,
-        alive_tasks: Some(1),
-        global_queue_depth: Some(1),
-        local_queue_depth: Some(1),
-        blocking_queue_depth: Some(1),
-        remote_schedule_count: Some(1),
-    });
+    builder
+        .push_request(test_request_event("req-1"))
+        .expect("push should succeed");
+    builder
+        .push_stage(test_stage_event("req-1", "stage-1"))
+        .expect("push should succeed");
+    builder
+        .push_queue(test_queue_event("req-1", "queue-1"))
+        .expect("push should succeed");
+    builder
+        .push_inflight_snapshot(crate::InFlightSnapshot {
+            gauge: "g".to_string(),
+            at_unix_ms: 11,
+            count: 1,
+        })
+        .expect("push should succeed");
+    builder
+        .push_runtime_snapshot(crate::RuntimeSnapshot {
+            at_unix_ms: 12,
+            alive_tasks: Some(1),
+            global_queue_depth: Some(1),
+            local_queue_depth: Some(1),
+            blocking_queue_depth: Some(1),
+            remote_schedule_count: Some(1),
+        })
+        .expect("push should succeed");
     let run = builder.finish();
     assert_eq!(run.requests.len(), 1);
     assert_eq!(run.stages.len(), 1);
@@ -1413,11 +1445,89 @@ fn run_builder_uses_mode_default_limits_when_limits_not_explicit() {
         crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").mode(CaptureMode::Light))
             .expect("ok");
     for i in 0..(default_limits.max_requests + 2) {
-        builder.push_request(test_request_event(&format!("req-{}", i + 1)));
+        builder
+            .push_request(test_request_event(&format!("req-{}", i + 1)))
+            .expect("push should succeed");
     }
     let run = builder.finish();
     assert_eq!(run.requests.len(), default_limits.max_requests);
     assert_eq!(run.truncation.dropped_requests, 2);
     assert!(run.truncation.limits_hit);
     assert!(run.truncation.is_truncated());
+}
+
+#[test]
+fn run_builder_rejects_invalid_request_shapes() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+    let mut event = test_request_event("req-1");
+    event.request_id = "   ".into();
+    assert!(builder.push_request(event).is_err());
+
+    let mut event = test_request_event("req-1");
+    event.route = " ".into();
+    assert!(builder.push_request(event).is_err());
+
+    let mut event = test_request_event("req-1");
+    event.started_at_unix_ms = 2;
+    event.finished_at_unix_ms = 1;
+    assert!(builder.push_request(event).is_err());
+
+    let mut event = test_request_event("req-1");
+    event.outcome = String::new();
+    assert!(builder.push_request(event).is_err());
+
+    let mut event = test_request_event("req-1");
+    event.started_at_unix_ms = 1;
+    event.finished_at_unix_ms = 2;
+    event.latency_us = 0;
+    assert!(builder.push_request(event).is_err());
+
+    let mut event = test_request_event("req-1");
+    event.started_at_unix_ms = 1;
+    event.finished_at_unix_ms = 1;
+    event.latency_us = 0;
+    assert!(builder.push_request(event).is_ok());
+}
+
+#[test]
+fn run_builder_rejects_invalid_stage_queue_and_inflight_shapes() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+    let mut stage = test_stage_event("req-1", "stage");
+    stage.stage = " ".into();
+    assert!(builder.push_stage(stage).is_err());
+
+    let mut stage = test_stage_event("req-1", "stage");
+    stage.started_at_unix_ms = 4;
+    stage.finished_at_unix_ms = 3;
+    assert!(builder.push_stage(stage).is_err());
+
+    let mut queue = test_queue_event("req-1", "q");
+    queue.queue = String::new();
+    assert!(builder.push_queue(queue).is_err());
+
+    let mut queue = test_queue_event("req-1", "q");
+    queue.waited_from_unix_ms = 9;
+    queue.waited_until_unix_ms = 8;
+    assert!(builder.push_queue(queue).is_err());
+
+    let inflight = crate::InFlightSnapshot {
+        gauge: " ".into(),
+        at_unix_ms: 1,
+        count: 1,
+    };
+    assert!(builder.push_inflight_snapshot(inflight).is_err());
+}
+
+#[test]
+fn run_builder_accepts_runtime_snapshot_at_zero_timestamp() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+    let snapshot = crate::RuntimeSnapshot {
+        at_unix_ms: 0,
+        alive_tasks: None,
+        global_queue_depth: None,
+        local_queue_depth: None,
+        blocking_queue_depth: None,
+        remote_schedule_count: None,
+    };
+    assert!(builder.push_runtime_snapshot(snapshot).is_ok());
 }

--- a/tailtriage-tracing/src/error.rs
+++ b/tailtriage-tracing/src/error.rs
@@ -32,6 +32,8 @@ pub enum ImportError {
     StrictViolation(String),
     /// Service name was empty or whitespace-only.
     EmptyServiceName,
+    /// Run event failed `RunBuilder` shape validation.
+    InvalidRunEvent(String),
 }
 
 impl fmt::Display for ImportError {
@@ -51,6 +53,7 @@ impl fmt::Display for ImportError {
             }
             Self::StrictViolation(message) => write!(f, "strict import violation: {message}"),
             Self::EmptyServiceName => write!(f, "service name must not be empty"),
+            Self::InvalidRunEvent(message) => write!(f, "invalid run event: {message}"),
         }
     }
 }

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -270,13 +270,19 @@ where
     })?;
 
     for request in requests {
-        run_builder.push_request(request);
+        run_builder
+            .push_request(request)
+            .map_err(|err| ImportError::InvalidRunEvent(err.to_string()))?;
     }
     for stage in stages {
-        run_builder.push_stage(stage);
+        run_builder
+            .push_stage(stage)
+            .map_err(|err| ImportError::InvalidRunEvent(err.to_string()))?;
     }
     for queue in queues {
-        run_builder.push_queue(queue);
+        run_builder
+            .push_queue(queue)
+            .map_err(|err| ImportError::InvalidRunEvent(err.to_string()))?;
     }
     let mut run = run_builder.finish();
     attach_durable_conversion_warnings(&mut run, &warnings);


### PR DESCRIPTION
### Motivation
- Harden the completed-run assembly API so imported/assembled events are shape-validated before being retained in a `Run` artifact.
- Prevent downstream consumers from receiving obviously malformed `RequestEvent`/`StageEvent`/`QueueEvent`/`InFlightSnapshot` records while preserving existing retention/truncation semantics and public schema shape.

### Description
- Add a public `RunBuilderEventError` type and re-export it from `tailtriage-core` as `RunBuilderEventError` to report field-level push validation failures. 
- Make `RunBuilder` push methods fallible and signature-updated to return `Result<(), RunBuilderEventError>` for `push_request`, `push_stage`, `push_queue`, `push_inflight_snapshot`, and `push_runtime_snapshot` while keeping `RunBuilder` and `RunBuilderOptions` public and unchanged otherwise. 
- Implement per-event validation routines that enforce the requested rules for `RequestEvent`, `StageEvent`, `QueueEvent`, and `InFlightSnapshot` and keep runtime snapshots permissive (`at_unix_ms = 0` accepted), while leaving cross-event correlation and lifecycle synthesis out of scope. 
- Update `tailtriage-tracing` to map builder validation failures into `ImportError::InvalidRunEvent(String)` and update tests and call sites to handle or assert `Ok` results accordingly, and update docs/rustdoc to document the new validation boundary. 

### Testing
- Ran `cargo test -p tailtriage-core --all-targets` and all core unit tests passed. 
- Ran `cargo test -p tailtriage-tracing --all-targets --all-features` and all tracing-import tests passed. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and `cargo fmt --check` and both succeeded. 
- Ran `python3 scripts/validate_docs_contracts.py` and the docs contract validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0df2fe5a9483309ae16cc1830330a8)