### PR TITLE
Make RunBuilder push APIs fallible with event-shape validation

### DIFF
--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -177,7 +177,7 @@ Use `RunBuilder` only when you already have completed request, stage, queue, in-
 ```rust,no_run
 use tailtriage_core::{RequestEvent, RunBuilder, RunBuilderOptions};
 
-fn assemble_run() -> Result<(), tailtriage_core::BuildError> {
+fn assemble_run() -> Result<(), Box<dyn std::error::Error>> {
     let mut builder = RunBuilder::new(RunBuilderOptions::new("checkout-service"))?;
     builder.push_request(RequestEvent {
         request_id: "req-1".into(),
@@ -187,13 +187,15 @@ fn assemble_run() -> Result<(), tailtriage_core::BuildError> {
         finished_at_unix_ms: 2,
         latency_us: 1_000,
         outcome: "ok".into(),
-    });
+    })?;
 
     let run = builder.finish();
     assert_eq!(run.requests.len(), 1);
     Ok(())
 }
 ```
+
+`RunBuilder::new(...)` validates top-level run timestamp ordering and service-name presence. Push methods validate event shape. Retention overflow is not an error: over-limit items are dropped and `Run.truncation` counters are updated. `RunBuilder` does not validate cross-event correlation (for example, stage/queue events without matching request events remain allowed) and does not synthesize missing lifecycle completions.
 
 ## What this crate does not do
 

--- a/tailtriage-core/src/lib.rs
+++ b/tailtriage-core/src/lib.rs
@@ -48,7 +48,7 @@ pub use events::{
     RunEndReason, RunMetadata, RuntimeSnapshot, StageEvent, TruncationSummary,
     UnfinishedRequestSample, UnfinishedRequests, SCHEMA_VERSION,
 };
-pub use run_builder::{RunBuilder, RunBuilderOptions};
+pub use run_builder::{RunBuilder, RunBuilderEventError, RunBuilderOptions};
 pub use sink::{DiscardSink, LocalJsonSink, MemorySink, RunSink, SinkError};
 pub use time::{system_time_to_unix_ms, unix_time_ms};
 pub use timers::{InflightGuard, QueueTimer, StageTimer};

--- a/tailtriage-core/src/run_builder.rs
+++ b/tailtriage-core/src/run_builder.rs
@@ -3,6 +3,35 @@ use crate::{
     EffectiveCoreConfig, EffectiveTokioSamplerConfig, InFlightSnapshot, QueueEvent, RequestEvent,
     Run, RunEndReason, RunMetadata, RuntimeSnapshot, StageEvent, UnfinishedRequests,
 };
+use core::fmt;
+
+/// Error returned when [`RunBuilder`] rejects an invalid pushed event shape.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RunBuilderEventError {
+    /// Event payload had invalid or inconsistent field values.
+    InvalidEvent {
+        /// Event type name.
+        event: &'static str,
+        /// Field that failed validation.
+        field: &'static str,
+        /// Human-readable validation failure reason.
+        reason: String,
+    },
+}
+
+impl fmt::Display for RunBuilderEventError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidEvent {
+                event,
+                field,
+                reason,
+            } => write!(f, "invalid {event} event field `{field}`: {reason}"),
+        }
+    }
+}
+
+impl std::error::Error for RunBuilderEventError {}
 
 /// Options for assembling a completed [`Run`] artifact.
 ///
@@ -207,46 +236,86 @@ impl RunBuilder {
     ///
     /// The event is retained only while request capture-limit capacity remains;
     /// otherwise it is dropped and `truncation.dropped_requests` is updated.
-    pub fn push_request(&mut self, event: RequestEvent) {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RunBuilderEventError`] when required request fields are blank,
+    /// timestamp order is invalid, or latency is inconsistent with timestamp span.
+    pub fn push_request(&mut self, event: RequestEvent) -> Result<(), RunBuilderEventError> {
+        validate_request_event(&event)?;
         let _ = crate::retention::push_request_bounded(&mut self.run, self.capture_limits, event);
+        Ok(())
     }
     /// Appends a stage event.
     ///
     /// The event is retained only while stage capture-limit capacity remains;
     /// otherwise it is dropped and `truncation.dropped_stages` is updated.
-    pub fn push_stage(&mut self, event: StageEvent) {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RunBuilderEventError`] when required stage fields are blank,
+    /// timestamp order is invalid, or latency is inconsistent with timestamp span.
+    pub fn push_stage(&mut self, event: StageEvent) -> Result<(), RunBuilderEventError> {
+        validate_stage_event(&event)?;
         let _ = crate::retention::push_stage_bounded(&mut self.run, self.capture_limits, event);
+        Ok(())
     }
     /// Appends a queue event.
     ///
     /// The event is retained only while queue capture-limit capacity remains;
     /// otherwise it is dropped and `truncation.dropped_queues` is updated.
-    pub fn push_queue(&mut self, event: QueueEvent) {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RunBuilderEventError`] when required queue fields are blank,
+    /// wait timestamp order is invalid, or wait duration is inconsistent.
+    pub fn push_queue(&mut self, event: QueueEvent) -> Result<(), RunBuilderEventError> {
+        validate_queue_event(&event)?;
         let _ = crate::retention::push_queue_bounded(&mut self.run, self.capture_limits, event);
+        Ok(())
     }
     /// Appends an in-flight snapshot.
     ///
     /// The snapshot is retained only while in-flight snapshot capture-limit
     /// capacity remains; otherwise it is dropped and
     /// `truncation.dropped_inflight_snapshots` is updated.
-    pub fn push_inflight_snapshot(&mut self, snapshot: InFlightSnapshot) {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RunBuilderEventError`] when `gauge` is blank.
+    pub fn push_inflight_snapshot(
+        &mut self,
+        snapshot: InFlightSnapshot,
+    ) -> Result<(), RunBuilderEventError> {
+        validate_inflight_snapshot(&snapshot)?;
         let _ = crate::retention::push_inflight_snapshot_bounded(
             &mut self.run,
             self.capture_limits,
             snapshot,
         );
+        Ok(())
     }
     /// Appends a runtime snapshot.
     ///
     /// The snapshot is retained only while runtime snapshot capture-limit
     /// capacity remains; otherwise it is dropped and
     /// `truncation.dropped_runtime_snapshots` is updated.
-    pub fn push_runtime_snapshot(&mut self, snapshot: RuntimeSnapshot) {
+    ///
+    /// This method does not validate optional metric fields.
+    ///
+    /// # Errors
+    ///
+    /// This currently returns `Ok(())` for all runtime snapshots.
+    pub fn push_runtime_snapshot(
+        &mut self,
+        snapshot: RuntimeSnapshot,
+    ) -> Result<(), RunBuilderEventError> {
         let _ = crate::retention::push_runtime_snapshot_bounded(
             &mut self.run,
             self.capture_limits,
             snapshot,
         );
+        Ok(())
     }
     /// Adds one lifecycle warning string.
     pub fn add_lifecycle_warning(&mut self, warning: impl Into<String>) {
@@ -274,4 +343,108 @@ impl RunBuilder {
     pub fn finish(self) -> Run {
         self.run
     }
+}
+
+fn invalid_event(
+    event: &'static str,
+    field: &'static str,
+    reason: impl Into<String>,
+) -> RunBuilderEventError {
+    RunBuilderEventError::InvalidEvent {
+        event,
+        field,
+        reason: reason.into(),
+    }
+}
+
+fn validate_request_event(event: &RequestEvent) -> Result<(), RunBuilderEventError> {
+    if event.request_id.trim().is_empty() {
+        return Err(invalid_event("request", "request_id", "must not be blank"));
+    }
+    if event.route.trim().is_empty() {
+        return Err(invalid_event("request", "route", "must not be blank"));
+    }
+    if event.finished_at_unix_ms < event.started_at_unix_ms {
+        return Err(invalid_event(
+            "request",
+            "finished_at_unix_ms",
+            format!(
+                "{} must be >= started_at_unix_ms ({})",
+                event.finished_at_unix_ms, event.started_at_unix_ms
+            ),
+        ));
+    }
+    if event.outcome.trim().is_empty() {
+        return Err(invalid_event("request", "outcome", "must not be blank"));
+    }
+    if event.finished_at_unix_ms > event.started_at_unix_ms && event.latency_us == 0 {
+        return Err(invalid_event(
+            "request",
+            "latency_us",
+            "must be > 0 when finished_at_unix_ms > started_at_unix_ms",
+        ));
+    }
+    Ok(())
+}
+fn validate_stage_event(event: &StageEvent) -> Result<(), RunBuilderEventError> {
+    if event.request_id.trim().is_empty() {
+        return Err(invalid_event("stage", "request_id", "must not be blank"));
+    }
+    if event.stage.trim().is_empty() {
+        return Err(invalid_event("stage", "stage", "must not be blank"));
+    }
+    if event.finished_at_unix_ms < event.started_at_unix_ms {
+        return Err(invalid_event(
+            "stage",
+            "finished_at_unix_ms",
+            format!(
+                "{} must be >= started_at_unix_ms ({})",
+                event.finished_at_unix_ms, event.started_at_unix_ms
+            ),
+        ));
+    }
+    if event.finished_at_unix_ms > event.started_at_unix_ms && event.latency_us == 0 {
+        return Err(invalid_event(
+            "stage",
+            "latency_us",
+            "must be > 0 when finished_at_unix_ms > started_at_unix_ms",
+        ));
+    }
+    Ok(())
+}
+fn validate_queue_event(event: &QueueEvent) -> Result<(), RunBuilderEventError> {
+    if event.request_id.trim().is_empty() {
+        return Err(invalid_event("queue", "request_id", "must not be blank"));
+    }
+    if event.queue.trim().is_empty() {
+        return Err(invalid_event("queue", "queue", "must not be blank"));
+    }
+    if event.waited_until_unix_ms < event.waited_from_unix_ms {
+        return Err(invalid_event(
+            "queue",
+            "waited_until_unix_ms",
+            format!(
+                "{} must be >= waited_from_unix_ms ({})",
+                event.waited_until_unix_ms, event.waited_from_unix_ms
+            ),
+        ));
+    }
+    if event.waited_until_unix_ms > event.waited_from_unix_ms && event.wait_us == 0 {
+        return Err(invalid_event(
+            "queue",
+            "wait_us",
+            "must be > 0 when waited_until_unix_ms > waited_from_unix_ms",
+        ));
+    }
+    Ok(())
+}
+fn validate_inflight_snapshot(snapshot: &InFlightSnapshot) -> Result<(), RunBuilderEventError> {
+    if snapshot.gauge.trim().is_empty() {
+        return Err(invalid_event(
+            "inflight_snapshot",
+            "gauge",
+            "must not be blank",
+        ));
+    }
+    Ok(())
 }

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -949,15 +949,17 @@ fn run_builder_creates_empty_run_with_explicit_metadata() {
             .run_end_reason(crate::RunEndReason::Shutdown),
     )
     .expect("builder should succeed");
-    builder.push_request(crate::RequestEvent {
-        request_id: "r1".into(),
-        route: "/x".into(),
-        kind: None,
-        started_at_unix_ms: 1,
-        finished_at_unix_ms: 2,
-        latency_us: 10,
-        outcome: "ok".into(),
-    });
+    builder
+        .push_request(crate::RequestEvent {
+            request_id: "r1".into(),
+            route: "/x".into(),
+            kind: None,
+            started_at_unix_ms: 1,
+            finished_at_unix_ms: 2,
+            latency_us: 10,
+            outcome: "ok".into(),
+        })
+        .expect("valid event");
     let run = builder.finish();
 
     assert_eq!(run.metadata.service_name, "payments");
@@ -1212,6 +1214,89 @@ fn test_queue_event(request_id: &str, queue: &str) -> crate::QueueEvent {
 }
 
 #[test]
+fn run_builder_valid_pushes_return_ok() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+    assert!(builder.push_request(test_request_event("req-1")).is_ok());
+    assert!(builder
+        .push_stage(test_stage_event("req-1", "stage-1"))
+        .is_ok());
+    assert!(builder
+        .push_queue(test_queue_event("req-1", "queue-1"))
+        .is_ok());
+    assert!(builder
+        .push_inflight_snapshot(crate::InFlightSnapshot {
+            gauge: "g".into(),
+            at_unix_ms: 1,
+            count: 1
+        })
+        .is_ok());
+    assert!(builder
+        .push_runtime_snapshot(crate::RuntimeSnapshot {
+            at_unix_ms: 0,
+            alive_tasks: None,
+            global_queue_depth: None,
+            local_queue_depth: None,
+            blocking_queue_depth: None,
+            remote_schedule_count: None
+        })
+        .is_ok());
+}
+
+#[test]
+fn run_builder_request_validation_rules() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+    let mut event = test_request_event("req-1");
+    event.request_id = "   ".into();
+    assert!(builder.push_request(event).is_err());
+    let mut event = test_request_event("req-1");
+    event.route = " ".into();
+    assert!(builder.push_request(event).is_err());
+    let mut event = test_request_event("req-1");
+    event.started_at_unix_ms = 10;
+    event.finished_at_unix_ms = 9;
+    assert!(builder.push_request(event).is_err());
+    let mut event = test_request_event("req-1");
+    event.outcome = String::new();
+    assert!(builder.push_request(event).is_err());
+    let mut event = test_request_event("req-1");
+    event.started_at_unix_ms = 10;
+    event.finished_at_unix_ms = 11;
+    event.latency_us = 0;
+    assert!(builder.push_request(event).is_err());
+    let mut event = test_request_event("req-1");
+    event.started_at_unix_ms = 10;
+    event.finished_at_unix_ms = 10;
+    event.latency_us = 0;
+    assert!(builder.push_request(event).is_ok());
+}
+
+#[test]
+fn run_builder_stage_queue_and_inflight_validation_rules() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+    let mut stage = test_stage_event("req-1", " ");
+    assert!(builder.push_stage(stage).is_err());
+    stage = test_stage_event("req-1", "s");
+    stage.started_at_unix_ms = 2;
+    stage.finished_at_unix_ms = 1;
+    assert!(builder.push_stage(stage).is_err());
+
+    let mut queue = test_queue_event("req-1", " ");
+    assert!(builder.push_queue(queue).is_err());
+    queue = test_queue_event("req-1", "q");
+    queue.waited_from_unix_ms = 2;
+    queue.waited_until_unix_ms = 1;
+    assert!(builder.push_queue(queue).is_err());
+
+    assert!(builder
+        .push_inflight_snapshot(crate::InFlightSnapshot {
+            gauge: " ".into(),
+            at_unix_ms: 1,
+            count: 1
+        })
+        .is_err());
+}
+
+#[test]
 fn run_builder_applies_request_limit_and_updates_truncation() {
     let limits = CaptureLimits {
         max_requests: 1,
@@ -1223,8 +1308,12 @@ fn run_builder_applies_request_limit_and_updates_truncation() {
     let mut builder =
         crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").capture_limits(limits))
             .expect("ok");
-    builder.push_request(test_request_event("req-1"));
-    builder.push_request(test_request_event("req-2"));
+    builder
+        .push_request(test_request_event("req-1"))
+        .expect("valid event");
+    builder
+        .push_request(test_request_event("req-2"))
+        .expect("valid event");
     let run = builder.finish();
     assert_eq!(run.requests.len(), 1);
     assert_eq!(run.requests[0].request_id, "req-1");
@@ -1249,8 +1338,12 @@ fn run_builder_applies_stage_limit_and_updates_truncation() {
     let mut builder =
         crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").capture_limits(limits))
             .expect("ok");
-    builder.push_stage(test_stage_event("req-1", "stage-1"));
-    builder.push_stage(test_stage_event("req-2", "stage-2"));
+    builder
+        .push_stage(test_stage_event("req-1", "stage-1"))
+        .expect("valid event");
+    builder
+        .push_stage(test_stage_event("req-2", "stage-2"))
+        .expect("valid event");
     let run = builder.finish();
     assert_eq!(run.stages.len(), 1);
     assert_eq!(run.stages[0].stage, "stage-1");
@@ -1275,8 +1368,12 @@ fn run_builder_applies_queue_limit_and_updates_truncation() {
     let mut builder =
         crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").capture_limits(limits))
             .expect("ok");
-    builder.push_queue(test_queue_event("req-1", "queue-1"));
-    builder.push_queue(test_queue_event("req-2", "queue-2"));
+    builder
+        .push_queue(test_queue_event("req-1", "queue-1"))
+        .expect("valid event");
+    builder
+        .push_queue(test_queue_event("req-2", "queue-2"))
+        .expect("valid event");
     let run = builder.finish();
     assert_eq!(run.queues.len(), 1);
     assert_eq!(run.queues[0].queue, "queue-1");
@@ -1301,16 +1398,20 @@ fn run_builder_applies_inflight_snapshot_limit_and_updates_truncation() {
     let mut builder =
         crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").capture_limits(limits))
             .expect("ok");
-    builder.push_inflight_snapshot(crate::InFlightSnapshot {
-        gauge: "g".to_string(),
-        at_unix_ms: 7,
-        count: 1,
-    });
-    builder.push_inflight_snapshot(crate::InFlightSnapshot {
-        gauge: "g".to_string(),
-        at_unix_ms: 8,
-        count: 2,
-    });
+    builder
+        .push_inflight_snapshot(crate::InFlightSnapshot {
+            gauge: "g".to_string(),
+            at_unix_ms: 7,
+            count: 1,
+        })
+        .expect("valid event");
+    builder
+        .push_inflight_snapshot(crate::InFlightSnapshot {
+            gauge: "g".to_string(),
+            at_unix_ms: 8,
+            count: 2,
+        })
+        .expect("valid event");
     let run = builder.finish();
     assert_eq!(run.inflight.len(), 1);
     assert_eq!(run.inflight[0].count, 1);
@@ -1335,22 +1436,26 @@ fn run_builder_applies_runtime_snapshot_limit_and_updates_truncation() {
     let mut builder =
         crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").capture_limits(limits))
             .expect("ok");
-    builder.push_runtime_snapshot(crate::RuntimeSnapshot {
-        at_unix_ms: 9,
-        alive_tasks: Some(1),
-        global_queue_depth: Some(2),
-        local_queue_depth: Some(3),
-        blocking_queue_depth: Some(4),
-        remote_schedule_count: Some(5),
-    });
-    builder.push_runtime_snapshot(crate::RuntimeSnapshot {
-        at_unix_ms: 10,
-        alive_tasks: Some(2),
-        global_queue_depth: Some(3),
-        local_queue_depth: Some(4),
-        blocking_queue_depth: Some(5),
-        remote_schedule_count: Some(6),
-    });
+    builder
+        .push_runtime_snapshot(crate::RuntimeSnapshot {
+            at_unix_ms: 9,
+            alive_tasks: Some(1),
+            global_queue_depth: Some(2),
+            local_queue_depth: Some(3),
+            blocking_queue_depth: Some(4),
+            remote_schedule_count: Some(5),
+        })
+        .expect("valid event");
+    builder
+        .push_runtime_snapshot(crate::RuntimeSnapshot {
+            at_unix_ms: 10,
+            alive_tasks: Some(2),
+            global_queue_depth: Some(3),
+            local_queue_depth: Some(4),
+            blocking_queue_depth: Some(5),
+            remote_schedule_count: Some(6),
+        })
+        .expect("valid event");
     let run = builder.finish();
     assert_eq!(run.runtime_snapshots.len(), 1);
     assert_eq!(run.runtime_snapshots[0].at_unix_ms, 9);
@@ -1375,22 +1480,32 @@ fn run_builder_does_not_report_truncation_within_limits() {
     let mut builder =
         crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").capture_limits(limits))
             .expect("ok");
-    builder.push_request(test_request_event("req-1"));
-    builder.push_stage(test_stage_event("req-1", "stage-1"));
-    builder.push_queue(test_queue_event("req-1", "queue-1"));
-    builder.push_inflight_snapshot(crate::InFlightSnapshot {
-        gauge: "g".to_string(),
-        at_unix_ms: 11,
-        count: 1,
-    });
-    builder.push_runtime_snapshot(crate::RuntimeSnapshot {
-        at_unix_ms: 12,
-        alive_tasks: Some(1),
-        global_queue_depth: Some(1),
-        local_queue_depth: Some(1),
-        blocking_queue_depth: Some(1),
-        remote_schedule_count: Some(1),
-    });
+    builder
+        .push_request(test_request_event("req-1"))
+        .expect("valid event");
+    builder
+        .push_stage(test_stage_event("req-1", "stage-1"))
+        .expect("valid event");
+    builder
+        .push_queue(test_queue_event("req-1", "queue-1"))
+        .expect("valid event");
+    builder
+        .push_inflight_snapshot(crate::InFlightSnapshot {
+            gauge: "g".to_string(),
+            at_unix_ms: 11,
+            count: 1,
+        })
+        .expect("valid event");
+    builder
+        .push_runtime_snapshot(crate::RuntimeSnapshot {
+            at_unix_ms: 12,
+            alive_tasks: Some(1),
+            global_queue_depth: Some(1),
+            local_queue_depth: Some(1),
+            blocking_queue_depth: Some(1),
+            remote_schedule_count: Some(1),
+        })
+        .expect("valid event");
     let run = builder.finish();
     assert_eq!(run.requests.len(), 1);
     assert_eq!(run.stages.len(), 1);
@@ -1413,7 +1528,9 @@ fn run_builder_uses_mode_default_limits_when_limits_not_explicit() {
         crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").mode(CaptureMode::Light))
             .expect("ok");
     for i in 0..(default_limits.max_requests + 2) {
-        builder.push_request(test_request_event(&format!("req-{}", i + 1)));
+        builder
+            .push_request(test_request_event(&format!("req-{}", i + 1)))
+            .expect("valid event");
     }
     let run = builder.finish();
     assert_eq!(run.requests.len(), default_limits.max_requests);

--- a/tailtriage-tracing/src/error.rs
+++ b/tailtriage-tracing/src/error.rs
@@ -32,6 +32,8 @@ pub enum ImportError {
     StrictViolation(String),
     /// Service name was empty or whitespace-only.
     EmptyServiceName,
+    /// `RunBuilder` rejected an imported event payload as invalid.
+    InvalidRunEvent(String),
 }
 
 impl fmt::Display for ImportError {
@@ -51,6 +53,7 @@ impl fmt::Display for ImportError {
             }
             Self::StrictViolation(message) => write!(f, "strict import violation: {message}"),
             Self::EmptyServiceName => write!(f, "service name must not be empty"),
+            Self::InvalidRunEvent(message) => write!(f, "invalid run event: {message}"),
         }
     }
 }

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -270,13 +270,19 @@ where
     })?;
 
     for request in requests {
-        run_builder.push_request(request);
+        run_builder
+            .push_request(request)
+            .map_err(|err| ImportError::InvalidRunEvent(err.to_string()))?;
     }
     for stage in stages {
-        run_builder.push_stage(stage);
+        run_builder
+            .push_stage(stage)
+            .map_err(|err| ImportError::InvalidRunEvent(err.to_string()))?;
     }
     for queue in queues {
-        run_builder.push_queue(queue);
+        run_builder
+            .push_queue(queue)
+            .map_err(|err| ImportError::InvalidRunEvent(err.to_string()))?;
     }
     let mut run = run_builder.finish();
     attach_durable_conversion_warnings(&mut run, &warnings);


### PR DESCRIPTION
### Motivation

- Harden the completed-run assembly API so malformed imported events are rejected at push time while preserving existing `RunBuilder::new` timestamp checks.
- Preserve public schemas and retention semantics so imports can be partial and truncation remains non-error behavior.

### Description

- Added a public `RunBuilderEventError` (`Debug`, `Clone`, `PartialEq`, `Eq`) with `Display` and `std::error::Error` implementations and re-exported it from `tailtriage-core` via `pub use run_builder::{RunBuilder, RunBuilderEventError, RunBuilderOptions}`.
- Made `RunBuilder` push APIs fallible: `push_request`, `push_stage`, `push_queue`, `push_inflight_snapshot`, and `push_runtime_snapshot` now return `Result<(), RunBuilderEventError>` and perform per-event validation (request, stage, queue, inflight rules as specified), while `RuntimeSnapshot` remains permissive (accepts `at_unix_ms = 0` and does not validate optional metrics).
- Kept retention/first-N overflow behavior unchanged so drops update `Run.truncation` and still return `Ok(())` from push methods on overflow; no cross-event correlation or lifecycle synthesis was added.
- Updated `tailtriage-tracing` import path to map `RunBuilderEventError` into `ImportError::InvalidRunEvent(String)` and updated relevant tests and call sites to handle the new `Result` returns.
- Documented the validation and non-goals in the `tailtriage-core/README.md` `RunBuilder` section and added focused unit tests covering valid pushes, rejection cases, equal-timestamp allowances, runtime-snapshot acceptance, and truncation behavior.

### Testing

- Ran formatting and lint/validation: `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` succeeded.
- Ran unit tests: `cargo test -p tailtriage-core --all-targets` and `cargo test -p tailtriage-tracing --all-targets --all-features` both succeeded (all tests passed).
- Ran docs contract validation: `python3 scripts/validate_docs_contracts.py` succeeded.
- All of the above completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0df2fe5a9483309ae16cc1830330a8)