### PR TITLE
Filter orphan tracing stage/queue spans and simplify tokio README section

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -172,47 +172,13 @@ example the Tokio sampler).
 
 ## Optional Tokio runtime sampler coupling
 
-Enable the optional `tokio` feature when you want one standard run that combines:
+When the optional `tokio` feature is enabled, the crate exposes
+`tokio::TracingTokioSession` for applications that already run inside a Tokio
+runtime. This session combines tracing request/stage/queue evidence with
+tailtriage Tokio runtime snapshots in one standard run artifact.
 
-- tracing request/stage/queue evidence, and
-- Tokio runtime-pressure snapshots from `tailtriage-tokio::RuntimeSampler`.
-
-This is optional. Base `TracingRecorder` usage stays available without Tokio.
-
-```rust
-# #[cfg(feature = "tokio")]
-# {
-use std::time::Duration;
-use tailtriage_tracing::tokio::TracingTokioSession;
-use tracing_subscriber::prelude::*;
-
-# #[tokio::main(flavor = "current_thread")]
-# async fn main() -> Result<(), Box<dyn std::error::Error>> {
-let session = TracingTokioSession::builder("checkout-service")
-    .service_version("1.2.3")
-    .sampler_interval(Duration::from_millis(200))
-    .max_runtime_snapshots(2_000)
-    .start()?;
-
-let subscriber = tracing_subscriber::registry().with(session.layer());
-tracing::subscriber::with_default(subscriber, || {
-    tracing::info_span!(
-        "http.request",
-        tt.kind = "request",
-        tt.request_id = "req-42",
-        tt.route = "/checkout"
-    )
-    .in_scope(|| {});
-});
-
-let imported = session.shutdown().await?;
-assert!(!imported.run().runtime_snapshots.is_empty());
-# Ok(())
-# }
-# }
-```
-
-This crate is still not an OTel/OTLP exporter and not a tracing backend.
+Base `TracingRecorder` usage remains available without Tokio. This crate is
+still not an OTel/OTLP exporter and not a tracing backend.
 
 ## Examples
 

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -569,7 +569,8 @@ mod tests {
 
     #[test]
     fn close_event_shape_with_explicit_timestamps_is_supported() {
-        let input = r#"{"event":"close","span":{"name":"st","fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}},"started_at_unix_ms":5,"finished_at_unix_ms":8}"#;
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":10,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
+{"event":"close","span":{"name":"st","fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}},"started_at_unix_ms":5,"finished_at_unix_ms":8}"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().stages.len(), 1);
         assert_eq!(imported.run().stages[0].stage, "db");
@@ -590,7 +591,8 @@ mod tests {
 
     #[test]
     fn close_event_shape_with_nested_span_timestamps_is_supported() {
-        let input = r#"{"event":"close","span":{"name":"st","started_at_unix_ms":5,"finished_at_unix_ms":8,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}"#;
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":10,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
+{"event":"close","span":{"name":"st","started_at_unix_ms":5,"finished_at_unix_ms":8,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().stages.len(), 1);
         assert_eq!(imported.run().stages[0].stage, "db");
@@ -851,7 +853,8 @@ mod tests {
 
     #[test]
     fn normalized_stage_fields_import_from_outer_fields() {
-        let input = r#"{"span":{"name":"st","started_at_unix_ms":1,"finished_at_unix_ms":2},"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}"#;
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2},"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}
+{"span":{"name":"st","started_at_unix_ms":1,"finished_at_unix_ms":2},"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().stages.len(), 1);
         assert_eq!(imported.run().stages[0].stage, "db");
@@ -859,7 +862,8 @@ mod tests {
 
     #[test]
     fn normalized_stage_fields_import_from_top_level_tt_keys() {
-        let input = r#"{"span":{"name":"st","started_at_unix_ms":1,"finished_at_unix_ms":2},"tt.kind":"stage","tt.request_id":"r1","tt.stage":"cache"}"#;
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2},"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}
+{"span":{"name":"st","started_at_unix_ms":1,"finished_at_unix_ms":2},"tt.kind":"stage","tt.request_id":"r1","tt.stage":"cache"}"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().stages.len(), 1);
         assert_eq!(imported.run().stages[0].stage, "cache");
@@ -867,7 +871,8 @@ mod tests {
 
     #[test]
     fn normalized_queue_fields_import_from_outer_fields() {
-        let input = r#"{"span":{"name":"q","started_at_unix_ms":1,"finished_at_unix_ms":2},"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":3}}"#;
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2},"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}
+{"span":{"name":"q","started_at_unix_ms":1,"finished_at_unix_ms":2},"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":3}}"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().queues.len(), 1);
         assert_eq!(imported.run().queues[0].depth_at_start, Some(3));
@@ -875,7 +880,8 @@ mod tests {
 
     #[test]
     fn normalized_queue_fields_import_from_top_level_tt_keys() {
-        let input = r#"{"span":{"name":"q","started_at_unix_ms":1,"finished_at_unix_ms":2},"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":7}"#;
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2},"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}
+{"span":{"name":"q","started_at_unix_ms":1,"finished_at_unix_ms":2},"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":7}"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().queues.len(), 1);
         assert_eq!(imported.run().queues[0].depth_at_start, Some(7));

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -36,6 +36,7 @@ mod recorder;
 pub mod tokio;
 mod types;
 
+use std::collections::BTreeSet;
 use tailtriage_core::{
     BuildError, CaptureMode, QueueEvent, RequestEvent, RunBuilder, RunBuilderOptions, StageEvent,
 };
@@ -227,6 +228,21 @@ where
         )));
     }
 
+    let capture_limits = CaptureMode::Light.core_defaults();
+    let retained_request_ids = retained_request_ids(&requests, capture_limits.max_requests);
+    filter_correlated_stages(
+        &mut stages,
+        &retained_request_ids,
+        options.strict_mode(),
+        &mut warnings,
+    )?;
+    filter_correlated_queues(
+        &mut queues,
+        &retained_request_ids,
+        options.strict_mode(),
+        &mut warnings,
+    )?;
+
     let started_at_unix_ms = min_start.unwrap_or_else(tailtriage_core::unix_time_ms);
     let finished_at_unix_ms = max_finish.unwrap_or(started_at_unix_ms);
     let run_id = options.run_id_ref().map_or_else(
@@ -237,7 +253,7 @@ where
     let mut builder_options = RunBuilderOptions::new(options.service_name())
         .run_id(run_id)
         .mode(CaptureMode::Light)
-        .capture_limits(CaptureMode::Light.core_defaults())
+        .capture_limits(capture_limits)
         .strict_lifecycle(false)
         .started_at_unix_ms(started_at_unix_ms)
         .finished_at_unix_ms(finished_at_unix_ms)
@@ -288,6 +304,64 @@ where
     attach_durable_conversion_warnings(&mut run, &warnings);
 
     Ok(ImportedRun::new(run, warnings))
+}
+
+fn retained_request_ids(requests: &[RequestEvent], max_requests: usize) -> BTreeSet<String> {
+    requests
+        .iter()
+        .take(max_requests)
+        .map(|request| request.request_id.clone())
+        .collect()
+}
+
+fn filter_correlated_stages(
+    stages: &mut Vec<StageEvent>,
+    retained_request_ids: &BTreeSet<String>,
+    strict: bool,
+    warnings: &mut Vec<ImportWarning>,
+) -> Result<(), ImportError> {
+    let mut filtered = Vec::with_capacity(stages.len());
+    for stage in stages.drain(..) {
+        if retained_request_ids.contains(&stage.request_id) {
+            filtered.push(stage);
+        } else {
+            strict_or_warn(
+                strict,
+                warnings,
+                format!(
+                    "skipped stage span for request_id '{}' because no retained request event was imported",
+                    stage.request_id
+                ),
+            )?;
+        }
+    }
+    *stages = filtered;
+    Ok(())
+}
+
+fn filter_correlated_queues(
+    queues: &mut Vec<QueueEvent>,
+    retained_request_ids: &BTreeSet<String>,
+    strict: bool,
+    warnings: &mut Vec<ImportWarning>,
+) -> Result<(), ImportError> {
+    let mut filtered = Vec::with_capacity(queues.len());
+    for queue in queues.drain(..) {
+        if retained_request_ids.contains(&queue.request_id) {
+            filtered.push(queue);
+        } else {
+            strict_or_warn(
+                strict,
+                warnings,
+                format!(
+                    "skipped queue span for request_id '{}' because no retained request event was imported",
+                    queue.request_id
+                ),
+            )?;
+        }
+    }
+    *queues = filtered;
+    Ok(())
 }
 
 fn validate_service_name(service_name: &str) -> Result<(), ImportError> {
@@ -361,7 +435,7 @@ fn required_string(
 }
 
 fn is_durable_conversion_warning(message: &str) -> bool {
-    message.starts_with("skipped span")
+    message.starts_with("skipped ")
         || message.starts_with("missing required field")
         || message.starts_with("invalid field")
         || message.starts_with("unknown tt.kind")
@@ -536,6 +610,129 @@ mod tests {
             .unwrap()
             .run()
             .clone();
+        assert_eq!(run.queues.len(), 1);
+    }
+
+    #[test]
+    fn non_strict_orphan_stage_is_skipped_and_warning_is_durable() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("st", 102, 119)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r-orphan")
+                .field(TT_STAGE, "db"),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().stages.len(), 0);
+        let warning = "skipped stage span for request_id 'r-orphan' because no retained request event was imported";
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains(warning)));
+        assert!(imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|w| w.contains(warning)));
+    }
+
+    #[test]
+    fn strict_orphan_stage_fails() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("st", 102, 119)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r-orphan")
+                .field(TT_STAGE, "db"),
+        ];
+        let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
+        match err {
+            ImportError::StrictViolation(message) => {
+                assert!(message.contains("no retained request event"));
+            }
+            _ => panic!("expected StrictViolation"),
+        }
+    }
+
+    #[test]
+    fn non_strict_orphan_queue_is_skipped_and_warning_is_durable() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("q", 102, 119)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r-orphan")
+                .field(TT_QUEUE, "permits"),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().queues.len(), 0);
+        let warning = "skipped queue span for request_id 'r-orphan' because no retained request event was imported";
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains(warning)));
+        assert!(imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|w| w.contains(warning)));
+    }
+
+    #[test]
+    fn strict_orphan_queue_fails() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("q", 102, 119)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r-orphan")
+                .field(TT_QUEUE, "permits"),
+        ];
+        let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
+        match err {
+            ImportError::StrictViolation(message) => {
+                assert!(message.contains("no retained request event"));
+            }
+            _ => panic!("expected StrictViolation"),
+        }
+    }
+
+    #[test]
+    fn matched_request_stage_queue_are_retained() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("st", 105, 115)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+            SpanRecord::new("q", 102, 103)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+        let run = run_from_span_records(spans, ImportOptions::new("svc"))
+            .unwrap()
+            .run()
+            .clone();
+        assert_eq!(run.requests.len(), 1);
+        assert_eq!(run.stages.len(), 1);
         assert_eq!(run.queues.len(), 1);
     }
 
@@ -921,6 +1118,10 @@ mod tests {
     #[test]
     fn valid_optional_fields_are_applied() {
         let spans = vec![
+            SpanRecord::new("req", 1, 2)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/"),
             SpanRecord::new("st", 10, 20)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, "r1")
@@ -942,11 +1143,17 @@ mod tests {
 
     #[test]
     fn span_duration_us_is_used_for_stage_latency() {
-        let spans = vec![SpanRecord::new("stage", 100, 100)
-            .duration_us(123)
-            .field(TT_KIND, "stage")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_STAGE, "db")];
+        let spans = vec![
+            SpanRecord::new("req", 99, 101)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/"),
+            SpanRecord::new("stage", 100, 100)
+                .duration_us(123)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+        ];
         let run = run_from_span_records(spans, ImportOptions::new("svc"))
             .unwrap()
             .run()

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -74,12 +74,9 @@ where
     validate_service_name(options.service_name())?;
     let mut warnings = Vec::new();
     let mut request_outcome_default_count = 0_u64;
-    let mut stage_success_default_count = 0_u64;
     let mut requests = Vec::new();
-    let mut stages = Vec::new();
+    let mut parsed_stages = Vec::new();
     let mut queues = Vec::new();
-    let mut min_start: Option<u64> = None;
-    let mut max_finish: Option<u64> = None;
 
     for span in spans {
         let kind = match get_string_field_state(&span, TT_KIND) {
@@ -158,7 +155,6 @@ where
                         ),
                         outcome,
                     });
-                    update_min_max(&mut min_start, &mut max_finish, &span);
                 }
             }
             SpanKind::Stage => {
@@ -166,28 +162,26 @@ where
                     required_string(&span, TT_REQUEST_ID, options.strict_mode(), &mut warnings)?;
                 let stage = required_string(&span, TT_STAGE, options.strict_mode(), &mut warnings)?;
                 if let (Some(request_id), Some(stage)) = (request_id, stage) {
-                    let success = match parse_success(
-                        &span,
-                        options.strict_mode(),
-                        &mut warnings,
-                        &mut stage_success_default_count,
-                    )? {
+                    let success_field = parse_success(&span, options.strict_mode(), &mut warnings)?;
+                    let success = match success_field {
                         OptionalField::Missing => true,
                         OptionalField::Value(success) => success,
                         OptionalField::Invalid => continue,
                     };
-                    stages.push(StageEvent {
-                        request_id,
-                        stage,
-                        started_at_unix_ms: span.started_at_unix_ms(),
-                        finished_at_unix_ms: span.finished_at_unix_ms(),
-                        latency_us: span.duration_us_ref().unwrap_or(
-                            (span.finished_at_unix_ms() - span.started_at_unix_ms())
-                                .saturating_mul(1000),
-                        ),
-                        success,
+                    parsed_stages.push(ParsedStageEvent {
+                        event: StageEvent {
+                            request_id,
+                            stage,
+                            started_at_unix_ms: span.started_at_unix_ms(),
+                            finished_at_unix_ms: span.finished_at_unix_ms(),
+                            latency_us: span.duration_us_ref().unwrap_or(
+                                (span.finished_at_unix_ms() - span.started_at_unix_ms())
+                                    .saturating_mul(1000),
+                            ),
+                            success,
+                        },
+                        success_defaulted: matches!(success_field, OptionalField::Missing),
                     });
-                    update_min_max(&mut min_start, &mut max_finish, &span);
                 }
             }
             SpanKind::Queue => {
@@ -212,7 +206,6 @@ where
                         ),
                         depth_at_start,
                     });
-                    update_min_max(&mut min_start, &mut max_finish, &span);
                 }
             }
         }
@@ -222,16 +215,10 @@ where
             "{request_outcome_default_count} request span(s) missing optional '{TT_OUTCOME}'; assumed 'ok'"
         )));
     }
-    if stage_success_default_count > 0 {
-        warnings.push(ImportWarning::new(format!(
-            "{stage_success_default_count} stage span(s) missing optional '{TT_SUCCESS}'; assumed true"
-        )));
-    }
-
     let capture_limits = CaptureMode::Light.core_defaults();
     let retained_request_ids = retained_request_ids(&requests, capture_limits.max_requests);
-    filter_correlated_stages(
-        &mut stages,
+    filter_correlated_parsed_stages(
+        &mut parsed_stages,
         &retained_request_ids,
         options.strict_mode(),
         &mut warnings,
@@ -242,9 +229,22 @@ where
         options.strict_mode(),
         &mut warnings,
     )?;
+    let stage_success_default_count = parsed_stages
+        .iter()
+        .filter(|stage| stage.success_defaulted)
+        .count();
+    if stage_success_default_count > 0 {
+        warnings.push(ImportWarning::new(format!(
+            "{stage_success_default_count} stage span(s) missing optional '{TT_SUCCESS}'; assumed true"
+        )));
+    }
+    let stages: Vec<StageEvent> = parsed_stages.into_iter().map(|stage| stage.event).collect();
 
-    let started_at_unix_ms = min_start.unwrap_or_else(tailtriage_core::unix_time_ms);
-    let finished_at_unix_ms = max_finish.unwrap_or(started_at_unix_ms);
+    let (started_at_unix_ms, finished_at_unix_ms) =
+        retained_event_time_bounds(&requests, &stages, &queues).unwrap_or_else(|| {
+            let now = tailtriage_core::unix_time_ms();
+            (now, now)
+        });
     let run_id = options.run_id_ref().map_or_else(
         || format!("tracing-import-{started_at_unix_ms}-{finished_at_unix_ms}"),
         ToOwned::to_owned,
@@ -314,15 +314,20 @@ fn retained_request_ids(requests: &[RequestEvent], max_requests: usize) -> BTree
         .collect()
 }
 
-fn filter_correlated_stages(
-    stages: &mut Vec<StageEvent>,
+struct ParsedStageEvent {
+    event: StageEvent,
+    success_defaulted: bool,
+}
+
+fn filter_correlated_parsed_stages(
+    stages: &mut Vec<ParsedStageEvent>,
     retained_request_ids: &BTreeSet<String>,
     strict: bool,
     warnings: &mut Vec<ImportWarning>,
 ) -> Result<(), ImportError> {
     let mut filtered = Vec::with_capacity(stages.len());
     for stage in stages.drain(..) {
-        if retained_request_ids.contains(&stage.request_id) {
+        if retained_request_ids.contains(&stage.event.request_id) {
             filtered.push(stage);
         } else {
             strict_or_warn(
@@ -330,7 +335,7 @@ fn filter_correlated_stages(
                 warnings,
                 format!(
                     "skipped stage span for request_id '{}' because no retained request event was imported",
-                    stage.request_id
+                    stage.event.request_id
                 ),
             )?;
         }
@@ -371,13 +376,29 @@ fn validate_service_name(service_name: &str) -> Result<(), ImportError> {
     Ok(())
 }
 
-fn update_min_max(min_start: &mut Option<u64>, max_finish: &mut Option<u64>, span: &SpanRecord) {
-    *min_start = Some(min_start.map_or(span.started_at_unix_ms(), |current| {
-        current.min(span.started_at_unix_ms())
-    }));
-    *max_finish = Some(max_finish.map_or(span.finished_at_unix_ms(), |current| {
-        current.max(span.finished_at_unix_ms())
-    }));
+fn retained_event_time_bounds(
+    requests: &[RequestEvent],
+    stages: &[StageEvent],
+    queues: &[QueueEvent],
+) -> Option<(u64, u64)> {
+    let request_bounds = requests
+        .iter()
+        .map(|request| (request.started_at_unix_ms, request.finished_at_unix_ms));
+    let stage_bounds = stages
+        .iter()
+        .map(|stage| (stage.started_at_unix_ms, stage.finished_at_unix_ms));
+    let queue_bounds = queues
+        .iter()
+        .map(|queue| (queue.waited_from_unix_ms, queue.waited_until_unix_ms));
+    request_bounds.chain(stage_bounds).chain(queue_bounds).fold(
+        None,
+        |acc: Option<(u64, u64)>, (start, finish)| {
+            Some(match acc {
+                Some((min_start, max_finish)) => (min_start.min(start), max_finish.max(finish)),
+                None => (start, finish),
+            })
+        },
+    )
 }
 
 enum StringFieldState<'a> {
@@ -500,7 +521,6 @@ fn parse_success(
     span: &SpanRecord,
     strict: bool,
     warnings: &mut Vec<ImportWarning>,
-    missing_count: &mut u64,
 ) -> Result<OptionalField<bool>, ImportError> {
     match span.fields().get(TT_SUCCESS) {
         Some(FieldValue::Bool(value)) => Ok(OptionalField::Value(*value)),
@@ -514,10 +534,7 @@ fn parse_success(
             strict_or_warn(strict, warnings, format!("invalid field '{TT_SUCCESS}' in span '{}': expected bool or 'true'/'false' string", span.name()))?;
             Ok(OptionalField::Invalid)
         }
-        None => {
-            *missing_count = (*missing_count).saturating_add(1);
-            Ok(OptionalField::Missing)
-        }
+        None => Ok(OptionalField::Missing),
     }
 }
 
@@ -642,6 +659,38 @@ mod tests {
     }
 
     #[test]
+    fn orphan_stage_does_not_affect_retained_bounds_or_default_stage_success_warning() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("st", 1, 1_000_000)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r-orphan")
+                .field(TT_STAGE, "db"),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        let run = imported.run();
+        assert_eq!(run.requests.len(), 1);
+        assert_eq!(run.stages.len(), 0);
+        assert_eq!(run.metadata.started_at_unix_ms, 100);
+        assert_eq!(run.metadata.finished_at_unix_ms, 120);
+        assert!(run.metadata.run_id.contains("tracing-import-100-120"));
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("skipped stage span for request_id 'r-orphan'")));
+        assert!(imported.warnings().iter().all(|w| !w
+            .message()
+            .contains("missing optional 'tt.success'; assumed true")));
+        assert!(run
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .all(|w| !w.contains("missing optional 'tt.success'; assumed true")));
+    }
+
+    #[test]
     fn strict_orphan_stage_fails() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
@@ -709,6 +758,27 @@ mod tests {
             }
             _ => panic!("expected StrictViolation"),
         }
+    }
+
+    #[test]
+    fn orphan_queue_does_not_affect_retained_bounds_or_default_run_id() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("q", 1, 1_000_000)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r-orphan")
+                .field(TT_QUEUE, "permits"),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        let run = imported.run();
+        assert_eq!(run.requests.len(), 1);
+        assert_eq!(run.queues.len(), 0);
+        assert_eq!(run.metadata.started_at_unix_ms, 100);
+        assert_eq!(run.metadata.finished_at_unix_ms, 120);
+        assert!(run.metadata.run_id.contains("tracing-import-100-120"));
     }
 
     #[test]

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -73,8 +73,7 @@ where
 {
     validate_service_name(options.service_name())?;
     let mut warnings = Vec::new();
-    let mut request_outcome_default_count = 0_u64;
-    let mut requests = Vec::new();
+    let mut parsed_requests = Vec::new();
     let mut parsed_stages = Vec::new();
     let mut queues = Vec::new();
 
@@ -134,26 +133,25 @@ where
                     required_string(&span, TT_REQUEST_ID, options.strict_mode(), &mut warnings)?;
                 let route = required_string(&span, TT_ROUTE, options.strict_mode(), &mut warnings)?;
                 if let (Some(request_id), Some(route)) = (request_id, route) {
-                    let Some(outcome) = parse_outcome(
-                        &span,
-                        options.strict_mode(),
-                        &mut warnings,
-                        &mut request_outcome_default_count,
-                    )?
+                    let Some((outcome, outcome_defaulted)) =
+                        parse_outcome(&span, options.strict_mode(), &mut warnings)?
                     else {
                         continue;
                     };
-                    requests.push(RequestEvent {
-                        request_id,
-                        route,
-                        kind: None,
-                        started_at_unix_ms: span.started_at_unix_ms(),
-                        finished_at_unix_ms: span.finished_at_unix_ms(),
-                        latency_us: span.duration_us_ref().unwrap_or(
-                            (span.finished_at_unix_ms() - span.started_at_unix_ms())
-                                .saturating_mul(1000),
-                        ),
-                        outcome,
+                    parsed_requests.push(ParsedRequestEvent {
+                        event: RequestEvent {
+                            request_id,
+                            route,
+                            kind: None,
+                            started_at_unix_ms: span.started_at_unix_ms(),
+                            finished_at_unix_ms: span.finished_at_unix_ms(),
+                            latency_us: span.duration_us_ref().unwrap_or(
+                                (span.finished_at_unix_ms() - span.started_at_unix_ms())
+                                    .saturating_mul(1000),
+                            ),
+                            outcome,
+                        },
+                        outcome_defaulted,
                     });
                 }
             }
@@ -210,12 +208,21 @@ where
             }
         }
     }
+    let capture_limits = CaptureMode::Light.core_defaults();
+    let request_outcome_default_count = parsed_requests
+        .iter()
+        .take(capture_limits.max_requests)
+        .filter(|request| request.outcome_defaulted)
+        .count();
     if request_outcome_default_count > 0 {
         warnings.push(ImportWarning::new(format!(
             "{request_outcome_default_count} request span(s) missing optional '{TT_OUTCOME}'; assumed 'ok'"
         )));
     }
-    let capture_limits = CaptureMode::Light.core_defaults();
+    let requests: Vec<RequestEvent> = parsed_requests
+        .into_iter()
+        .map(|request| request.event)
+        .collect();
     let retained_request_ids = retained_request_ids(&requests, capture_limits.max_requests);
     filter_correlated_parsed_stages(
         &mut parsed_stages,
@@ -231,6 +238,7 @@ where
     )?;
     let stage_success_default_count = parsed_stages
         .iter()
+        .take(capture_limits.max_stages)
         .filter(|stage| stage.success_defaulted)
         .count();
     if stage_success_default_count > 0 {
@@ -239,12 +247,16 @@ where
         )));
     }
     let stages: Vec<StageEvent> = parsed_stages.into_iter().map(|stage| stage.event).collect();
+    let retained_requests = &requests[..requests.len().min(capture_limits.max_requests)];
+    let retained_stages = &stages[..stages.len().min(capture_limits.max_stages)];
+    let retained_queues = &queues[..queues.len().min(capture_limits.max_queues)];
 
     let (started_at_unix_ms, finished_at_unix_ms) =
-        retained_event_time_bounds(&requests, &stages, &queues).unwrap_or_else(|| {
-            let now = tailtriage_core::unix_time_ms();
-            (now, now)
-        });
+        retained_event_time_bounds(retained_requests, retained_stages, retained_queues)
+            .unwrap_or_else(|| {
+                let now = tailtriage_core::unix_time_ms();
+                (now, now)
+            });
     let run_id = options.run_id_ref().map_or_else(
         || format!("tracing-import-{started_at_unix_ms}-{finished_at_unix_ms}"),
         ToOwned::to_owned,
@@ -317,6 +329,11 @@ fn retained_request_ids(requests: &[RequestEvent], max_requests: usize) -> BTree
 struct ParsedStageEvent {
     event: StageEvent,
     success_defaulted: bool,
+}
+
+struct ParsedRequestEvent {
+    event: RequestEvent,
+    outcome_defaulted: bool,
 }
 
 fn filter_correlated_parsed_stages(
@@ -495,14 +512,10 @@ fn parse_outcome(
     span: &SpanRecord,
     strict: bool,
     warnings: &mut Vec<ImportWarning>,
-    missing_count: &mut u64,
-) -> Result<Option<String>, ImportError> {
+) -> Result<Option<(String, bool)>, ImportError> {
     match get_string_field_state(span, TT_OUTCOME) {
-        StringFieldState::Missing => {
-            *missing_count = (*missing_count).saturating_add(1);
-            Ok(Some("ok".to_owned()))
-        }
-        StringFieldState::Value(value) => Ok(Some(value.to_owned())),
+        StringFieldState::Missing => Ok(Some(("ok".to_owned(), true))),
+        StringFieldState::Value(value) => Ok(Some((value.to_owned(), false))),
         StringFieldState::InvalidType => {
             strict_or_warn(
                 strict,
@@ -779,6 +792,132 @@ mod tests {
         assert_eq!(run.metadata.started_at_unix_ms, 100);
         assert_eq!(run.metadata.finished_at_unix_ms, 120);
         assert!(run.metadata.run_id.contains("tracing-import-100-120"));
+    }
+
+    #[test]
+    fn overflow_request_does_not_affect_metadata_bounds_or_run_id() {
+        let limits = CaptureMode::Light.core_defaults();
+        let mut spans = Vec::new();
+        for index in 0..limits.max_requests {
+            spans.push(
+                SpanRecord::new(format!("req-{index}"), 100, 120)
+                    .field(TT_KIND, "request")
+                    .field(TT_REQUEST_ID, format!("r{index}"))
+                    .field(TT_ROUTE, "/a")
+                    .field(TT_OUTCOME, "ok"),
+            );
+        }
+        spans.push(
+            SpanRecord::new("overflow", 1, 1_000_000)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r-overflow")
+                .field(TT_ROUTE, "/overflow"),
+        );
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        let run = imported.run();
+        assert_eq!(run.requests.len(), limits.max_requests);
+        assert_eq!(run.truncation.dropped_requests, 1);
+        assert_eq!(run.metadata.started_at_unix_ms, 100);
+        assert_eq!(run.metadata.finished_at_unix_ms, 120);
+        assert!(run.metadata.run_id.contains("tracing-import-100-120"));
+        assert!(!imported.warnings().iter().any(|w| w
+            .message()
+            .contains("missing optional 'tt.outcome'; assumed 'ok'")));
+    }
+
+    #[test]
+    fn overflow_stage_does_not_affect_metadata_bounds_or_success_warning() {
+        let limits = CaptureMode::Light.core_defaults();
+        let mut spans = vec![SpanRecord::new("req", 100, 120)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")
+            .field(TT_OUTCOME, "ok")];
+        for index in 0..limits.max_stages {
+            spans.push(
+                SpanRecord::new(format!("stage-{index}"), 101, 110)
+                    .field(TT_KIND, "stage")
+                    .field(TT_REQUEST_ID, "r1")
+                    .field(TT_STAGE, format!("s{index}"))
+                    .field(TT_SUCCESS, true),
+            );
+        }
+        spans.push(
+            SpanRecord::new("overflow-stage", 1, 1_000_000)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "overflow-stage"),
+        );
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        let run = imported.run();
+        assert_eq!(run.stages.len(), limits.max_stages);
+        assert_eq!(run.truncation.dropped_stages, 1);
+        assert_eq!(run.metadata.started_at_unix_ms, 100);
+        assert_eq!(run.metadata.finished_at_unix_ms, 120);
+        assert!(!imported.warnings().iter().any(|w| w
+            .message()
+            .contains("missing optional 'tt.success'; assumed true")));
+    }
+
+    #[test]
+    fn overflow_queue_does_not_affect_metadata_bounds() {
+        let limits = CaptureMode::Light.core_defaults();
+        let mut spans = vec![SpanRecord::new("req", 100, 120)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")
+            .field(TT_OUTCOME, "ok")];
+        for index in 0..limits.max_queues {
+            spans.push(
+                SpanRecord::new(format!("queue-{index}"), 101, 110)
+                    .field(TT_KIND, "queue")
+                    .field(TT_REQUEST_ID, "r1")
+                    .field(TT_QUEUE, format!("q{index}")),
+            );
+        }
+        spans.push(
+            SpanRecord::new("overflow-queue", 1, 1_000_000)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "overflow-queue"),
+        );
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        let run = imported.run();
+        assert_eq!(run.queues.len(), limits.max_queues);
+        assert_eq!(run.truncation.dropped_queues, 1);
+        assert_eq!(run.metadata.started_at_unix_ms, 100);
+        assert_eq!(run.metadata.finished_at_unix_ms, 120);
+    }
+
+    #[test]
+    fn retained_request_missing_outcome_still_warns() {
+        let spans = vec![SpanRecord::new("req", 100, 120)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("missing optional 'tt.outcome'; assumed 'ok'")));
+    }
+
+    #[test]
+    fn retained_stage_missing_success_still_warns() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a")
+                .field(TT_OUTCOME, "ok"),
+            SpanRecord::new("stage", 105, 115)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("missing optional 'tt.success'; assumed true")));
     }
 
     #[test]

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -555,6 +555,13 @@ mod tests {
     #[test]
     fn stage_span_collected() {
         with_recorder(|recorder| {
+            let request = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            );
+            drop(request);
             let span = tracing::info_span!(
                 "stage",
                 tt.kind = "stage",
@@ -570,6 +577,13 @@ mod tests {
     #[test]
     fn queue_span_collected() {
         with_recorder(|recorder| {
+            let request = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            );
+            drop(request);
             let span = tracing::info_span!(
                 "queue",
                 tt.kind = "queue",


### PR DESCRIPTION
### Motivation

- Prevent malformed or orphaned tracing stage/queue spans from creating misleading downstream-stage evidence by ensuring only stages/queues correlated to retained requests are imported. 
- Avoid teaching Tokio macro usage in the README and remove a timing-sensitive runnable example that imposes hidden dependency expectations on users. 

### Description

- Replace the Tokio macro-based example in `tailtriage-tracing/README.md` with concise prose that documents the optional `tokio::TracingTokioSession`, clarifies it is for apps already running in Tokio, and reiterates the crate is not an OTel/OTLP exporter or tracing backend. 
- In `run_from_span_records`, compute `capture_limits` once from `CaptureMode::Light.core_defaults()` and build the set of retained request IDs from `requests.iter().take(capture_limits.max_requests)`. 
- Add `retained_request_ids`, `filter_correlated_stages`, and `filter_correlated_queues` helpers to drop stage/queue events whose `request_id` is not in the retained set, returning `ImportError::StrictViolation` in strict mode and adding an `ImportWarning` (durable in `run.metadata.lifecycle_warnings`) in non-strict mode; exact warning shapes are used (for example: `skipped stage span for request_id 'r-orphan' because no retained request event was imported`). 
- Broaden durable-warning matching to preserve skip warnings by changing `is_durable_conversion_warning` to recognize messages starting with `"skipped "`. 
- Add regression tests covering non-strict skip + durable warning and strict failure for orphan stage and queue spans, and add a matched request/stage/queue test to confirm retained conversion remains unchanged; update affected `jsonl` and recorder tests to include correlated request spans where needed. 

### Testing

- Ran `cargo fmt --check` and it passed. 
- Ran `cargo clippy -p tailtriage-tracing --all-targets --all-features --locked -- -D warnings` and it passed. 
- Ran `cargo test -p tailtriage-tracing --all-targets --all-features --locked` and all tests passed. 
- Ran full workspace linters and tests (`cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and `cargo test --workspace --all-targets --all-features --locked`) and they passed. 
- Ran `python3 scripts/validate_docs_contracts.py` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eb5685ae48330b62dba894c421ff6)