### PR TITLE
Tracing intake: add TracingIntakeSession, stable completed-span JSONL, and tighten CLI import semantics

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -110,11 +110,19 @@ Keep the optional tracing intake path clear for teams already using Rust `tracin
 
 Near-term tasks:
 
-- document offline JSONL import and live in-memory recorder usage in public docs
+- keep docs aligned to the implemented tracing-intake path:
+  - `TracingIntakeSession` as the primary live setup
+  - stable completed-span JSONL wrapper (`tailtriage.tracing-span.v1`)
+  - CLI `--input-format` guardrails (`auto`, `tailtriage-span-jsonl`, `tracing-subscriber-fmt-json`)
+  - golden wrapper fixture, examples, and contract tests for request/stage/queue + duration preservation
 - keep positioning explicit: tracing intake converts tracing-shaped evidence into standard Runs for the existing analyzer
 - preserve bounded claims: no tracing backend semantics, no OTel/OTLP, no observability-platform expansion
 - keep runtime-pressure guidance explicit: tracing-only imports usually lack runtime snapshots, so Tokio sampling remains the path for runtime-pressure evidence
-- keep CI readiness explicit: tracing parity is gated once on Ubuntu extended release; runtime-cost is gated by bounded smoke sanity checks on Ubuntu extended release (one warmup round plus the measured-round count shown in `.github/workflows/ci.yml`, validated in-place without artifact upload)
+
+Current scope notes:
+- arbitrary `tracing_subscriber::fmt().json()` log parsing remains intentionally unsupported
+- OTel/OTLP remains out of scope
+- runtime-pressure evidence still requires runtime snapshots / Tokio sampler coupling
 
 ## Near-term sequencing
 

--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ If your service already emits `tracing` spans, use `tailtriage-tracing` as a nar
 
 - Offline JSONL import:
   ```bash
-  tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json
+  tailtriage import tracing-json completed-spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json
   tailtriage analyze tailtriage-run.json
   ```
-- Live in-memory import: `tailtriage_tracing::TracingRecorder`
+- Live session path: add `tailtriage_tracing::TracingIntakeSession` and `session.layer()` beside your existing subscriber setup.
 
 Both paths convert tracing-shaped evidence into standard `tailtriage_core::Run` data and feed the same analyzer/report workflow (evidence-ranked suspects and next checks). Runtime-pressure evidence still requires runtime snapshots (for example via the Tokio sampler).
 
@@ -239,7 +239,7 @@ tailtriage analyze tailtriage-run.json --format json
 Import completed tracing span records (JSONL) into a Run artifact first when needed:
 
 ```bash
-tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json
+tailtriage import tracing-json completed-spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json
 ```
 
 `tailtriage import tracing-json` writes **Run JSON** (capture artifact and CLI input), not Report JSON. Use `--strict` to fail on malformed/incomplete `tt.*` spans; without `--strict`, malformed `tt.*` spans are skipped and surfaced as `warning: ...` lines on stderr.

--- a/SPEC.md
+++ b/SPEC.md
@@ -160,11 +160,17 @@ Analyzer configuration contract:
 
 `tailtriage-tracing` is an optional integration surface for services that already emit Rust `tracing` spans.
 
-- converts tracing-shaped request/stage/queue evidence into standard `Run` values
-- supports offline JSONL import and a live in-memory `TracingRecorder`
-- reuses the same analyzer/report workflow as native capture artifacts
-- does not alter analyzer semantics
-- does not provide OTel/OTLP or a tracing backend
+- primary live path is `TracingIntakeSession` / `TracingIntakeSessionBuilder`; users add `session.layer()` beside their existing `tracing_subscriber` setup
+- live session output can write standard Run JSON on shutdown via `run_json_path(...)`
+- live session output can stream stable completed-span JSONL as spans close via `completed_span_jsonl_path(...)`
+- stable completed-span JSONL wrapper format is:
+  `{"format":"tailtriage.tracing-span.v1","span":{...}}`
+- CLI imports that wrapper shape with:
+  `tailtriage import tracing-json <completed-spans.jsonl> --input-format tailtriage-span-jsonl --service <service> --output <run.json>`
+- tracing intake converts request/stage/queue evidence into the same standard `Run` schema; analyzer semantics remain unchanged
+- `tracing_subscriber::fmt().json()` arbitrary log scraping is intentionally unsupported
+- tracing-only intake does not fabricate runtime-pressure evidence without runtime snapshots / Tokio sampler coupling
+- OTel/OTLP and tracing backend behavior are out of scope
 
 ### 5.10 Analyzer CLI (`tailtriage-cli`)
 

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -35,6 +35,15 @@ Normal CI keeps deterministic diagnostics and docs contracts as gates but does n
 | Collector-limit stress | Yes (smoke profile + summary validation) | bounded drop/truncation/warning/downgrade behavior under stress | zero drops under all load |
 | Real-service validation | No (planned) | future curated real-service truth checks when artifacts exist | current real-service validation coverage |
 
+Tracing-intake contract coverage is currently validated by unit/package tests and examples that exercise:
+- stable wrapper fixture (`tailtriage.tracing-span.v1`)
+- wrapper-only import mode and compatible-mode behavior
+- CLI `--input-format` guardrails
+- `TracingIntakeSession` request/stage/queue capture and conversion
+- example compile/run coverage under package example tests
+
+These checks validate conversion correctness and user-facing guardrails for triage intake. They do not validate production root-cause truth, do not claim arbitrary `tracing_subscriber::fmt().json()` import support, do not claim OTel/OTLP support, and do not claim runtime-pressure diagnosis from tracing-only intake without runtime snapshots/Tokio sampler coupling.
+
 ## Deterministic corpus validation
 The deterministic benchmark validates:
 - evidence-ranked suspect correctness against corpus labels

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ Most users should start with `tailtriage`.
 - [`tailtriage-axum`](../tailtriage-axum/README.md) — Axum middleware/extractor integration.
 - [`tailtriage-analyzer`](../tailtriage-analyzer/README.md) — in-process analysis of completed runs.
 - [`tailtriage-cli`](../tailtriage-cli/README.md) — command-line analysis of saved run artifacts.
-- [`tailtriage-tracing`](../tailtriage-tracing/README.md) — narrow tracing intake bridge for JSONL import and a live in-memory recorder; converts tracing-shaped spans into standard `tailtriage_core::Run` values (no OTel/OTLP).
+- [`tailtriage-tracing`](../tailtriage-tracing/README.md) — narrow tracing intake bridge built around `TracingIntakeSession`; writes Run JSON or stable completed-span JSONL (`{"format":"tailtriage.tracing-span.v1","span":{...}}`), converts tracing-shaped spans into standard `tailtriage_core::Run`, and intentionally does not support generic fmt JSON scraping or OTel/OTLP.
 
 ## Capture and analysis workflow
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -69,7 +69,7 @@ Consumes run artifacts from disk, validates schema/loader rules, invokes `tailtr
 ### `tailtriage-tracing`
 
 A narrow intake bridge for tracing-shaped completed spans and live `tt.*` span recording.
-It converts/imports tracing intake into standard core `Run` artifacts, does not implement OpenTelemetry/OTLP, and does not change analyzer behavior.
+It converts/imports tracing intake into standard core `Run` artifacts, including stable completed-span JSONL as an intermediate input format (`tailtriage.tracing-span.v1`), does not implement OpenTelemetry/OTLP, and does not change Run schema or analyzer behavior.
 
 ## Relationship model
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -488,3 +488,14 @@ A practical production loop:
 Treat the workflow as iterative triage.
 
 Do not treat one report as final proof.
+
+
+## Tracing intake operations
+
+- Completed-span JSONL can grow with captured completed spans; size outputs accordingly.
+- `completed_span_jsonl_path(...)` output files are created or truncated when the session is built.
+- Configure `max_open_spans` and `max_completed_spans` to keep memory bounded.
+- Completed-span JSONL streaming happens before in-memory `max_completed_spans` retention, so the file can preserve spans beyond in-memory retained completed spans.
+- Import warnings and lifecycle warnings mean evidence may be incomplete and should be treated as triage caveats.
+- Tracing-only intake does not provide runtime-pressure evidence by itself; runtime-pressure evidence still requires runtime snapshots/Tokio sampler coupling.
+- Treat tracing-import output like all tailtriage output: evidence-ranked suspects and next checks are leads, not proof of root cause.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -36,16 +36,16 @@ The `controller` and `tokio` namespaces are available with default features; `ax
 
 If you already instrument request/stage/queue work with Rust `tracing`, use `tailtriage-tracing` as an intake path into the same triage workflow.
 
-Offline JSONL import:
+A) Completed-span JSONL intake path:
 
 ```bash
 tailtriage import tracing-json completed-spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json
 tailtriage analyze tailtriage-run.json
 ```
 
-`tailtriage import tracing-json` writes Run artifact JSON (not Report JSON), and analysis remains a separate step after import. Use the documented completed-span JSONL shape from `tailtriage-tracing` (normalized literal dotted `tt.*` keys). `--strict` fails on malformed or incomplete `tt.*` spans; non-strict mode skips malformed `tt.*` spans and prints `warning: ...` messages. Tracing-only runs do not fabricate runtime snapshots, and runtime-pressure evidence remains Tokio-specific.
+`tailtriage import tracing-json` writes Run artifact JSON (not Report JSON), and analysis remains a separate step after import. Use the documented stable wrapper JSONL shape from `tailtriage-tracing` (`{"format":"tailtriage.tracing-span.v1","span":{...}}`). `--strict` fails on malformed or incomplete `tt.*` spans; non-strict mode skips malformed `tt.*` spans and prints `warning: ...` messages. Tracing-only runs do not fabricate runtime snapshots, and runtime-pressure evidence remains Tokio-specific.
 
-Live tracing session path:
+B) Direct Run JSON path:
 
 ```rust,no_run
 use tailtriage_tracing::TracingIntakeSession;
@@ -53,7 +53,7 @@ use tracing_subscriber::prelude::*;
 
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
 let session = TracingIntakeSession::builder("checkout-service")
-    .completed_span_jsonl_path("target/tailtriage-examples/checkout.spans.jsonl")
+    .run_json_path("target/tailtriage-examples/checkout.run.json")
     .build()?;
 let subscriber = tracing_subscriber::registry().with(session.layer());
 tracing::subscriber::with_default(subscriber, || {
@@ -64,9 +64,15 @@ session.shutdown()?;
 # }
 ```
 
-Use `.instrument(...)` for async work; `snapshot_run()` is the non-consuming inspection API, while `shutdown()` consumes the recorder handle for finalization.
+Then analyze directly:
 
-This live path supports in-process diagnosis without writing an intermediate Run file.
+```bash
+tailtriage analyze target/tailtriage-examples/checkout.run.json
+```
+
+Use `.instrument(...)` for async work; `snapshot_run()` is the non-consuming inspection API, while `shutdown()` finalizes the session.
+
+For the full tracing setup details and both flows, see `tailtriage-tracing/README.md`.
 
 ## 2) Core workflow: capture -> analyze -> next check -> re-run
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -32,55 +32,38 @@ cargo add tailtriage --features axum
 
 The `controller` and `tokio` namespaces are available with default features; `axum` remains opt-in.
 
-### Using existing tracing spans
+### Already using tracing?
 
 If you already instrument request/stage/queue work with Rust `tracing`, use `tailtriage-tracing` as an intake path into the same triage workflow.
 
 Offline JSONL import:
 
 ```bash
-tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json
+tailtriage import tracing-json completed-spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json
 tailtriage analyze tailtriage-run.json
 ```
 
 `tailtriage import tracing-json` writes Run artifact JSON (not Report JSON), and analysis remains a separate step after import. Use the documented completed-span JSONL shape from `tailtriage-tracing` (normalized literal dotted `tt.*` keys). `--strict` fails on malformed or incomplete `tt.*` spans; non-strict mode skips malformed `tt.*` spans and prints `warning: ...` messages. Tracing-only runs do not fabricate runtime snapshots, and runtime-pressure evidence remains Tokio-specific.
 
-Live in-memory recorder:
+Live tracing session path:
 
 ```rust,no_run
-use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
-use tailtriage_tracing::TracingRecorder;
-use tracing::Instrument;
+use tailtriage_tracing::TracingIntakeSession;
 use tracing_subscriber::prelude::*;
 
-async fn handle_request() {
-    let request = tracing::info_span!(
-        "http.request",
-        tt.kind = "request",
-        tt.request_id = "req-1",
-        tt.route = "/checkout"
-    );
-    async {
-        // request work goes here
-    }
-    .instrument(request)
-    .await;
-}
-
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
-let recorder = TracingRecorder::builder("checkout-service").build();
-let subscriber = tracing_subscriber::registry().with(recorder.layer());
-
+let session = TracingIntakeSession::builder("checkout-service")
+    .completed_span_jsonl_path("target/tailtriage-examples/checkout.spans.jsonl")
+    .build()?;
+let subscriber = tracing_subscriber::registry().with(session.layer());
 tracing::subscriber::with_default(subscriber, || {
-    // run `handle_request()` on your async runtime
+    let _request = tracing::info_span!("request", tt.kind = "request", tt.request_id = "req-1", tt.route = "/checkout");
 });
-
-let imported = recorder.shutdown()?;
-let report = analyze_run(imported.run(), AnalyzeOptions::default());
-# let _ = report;
+session.shutdown()?;
 # Ok(())
 # }
 ```
+
 Use `.instrument(...)` for async work; `snapshot_run()` is the non-consuming inspection API, while `shutdown()` consumes the recorder handle for finalization.
 
 This live path supports in-process diagnosis without writing an intermediate Run file.

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -48,11 +48,38 @@ Import completed tracing span records from JSONL into Run JSON:
 tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json
 ```
 
-With optional metadata flags and strict validation:
+With optional metadata flags, strict validation, and explicit format:
 
 ```bash
-tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json --service-version v1 --run-id run-42 --strict
+tailtriage import tracing-json spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json --service-version v1 --run-id run-42 --strict
 ```
+
+
+`tailtriage import tracing-json` imports **completed tracing span records** into **Run JSON** (not Report JSON).
+
+Recommended stable input format is the tailtriage wrapper JSONL shape:
+
+```json
+{"format":"tailtriage.tracing-span.v1","span":{...}}
+```
+
+`--input-format` values:
+- `auto`
+- `tailtriage-span-jsonl`
+- `tracing-subscriber-fmt-json`
+
+Behavior:
+- `tailtriage-span-jsonl` enforces wrapper-only parsing.
+- `auto` keeps compatibility parsing for older normalized shapes and rejects likely ordinary `tracing_subscriber::fmt().json()` logs with setup guidance.
+- `tracing-subscriber-fmt-json` intentionally fails with setup guidance in the current product scope.
+
+After import, run analysis separately:
+
+```bash
+tailtriage analyze tailtriage-run.json
+```
+
+Zero-request imports fail by design (the CLI loader requires at least one request).
 
 When paths include spaces, quote them in shell usage:
 

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -45,7 +45,7 @@ tailtriage analyze tailtriage-run.json --format json
 Import completed tracing span records from JSONL into Run JSON:
 
 ```bash
-tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json
+tailtriage import tracing-json spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json
 ```
 
 With optional metadata flags, strict validation, and explicit format:

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -63,7 +63,16 @@ enum ImportCommand {
         /// Fail on malformed/incomplete tailtriage spans.
         #[arg(long)]
         strict: bool,
+        /// Input format mode.
+        #[arg(long, value_enum, default_value_t = TracingInputFormat::Auto)]
+        input_format: TracingInputFormat,
     },
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum TracingInputFormat {
+    Auto,
+    TailtriageSpanJsonl,
+    TracingSubscriberFmtJson,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -84,6 +93,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 service_version,
                 run_id,
                 strict,
+                input_format,
             } => {
                 let mut options = ImportOptions::new(service).strict(strict);
                 if let Some(service_version) = service_version {
@@ -93,6 +103,9 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                     options = options.run_id(run_id);
                 }
 
+                if matches!(input_format, TracingInputFormat::TracingSubscriberFmtJson) {
+                    return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "tracing-subscriber fmt JSON logs do not include completed-span start/end timestamps needed by tailtriage. Recommended path: configure tailtriage_tracing::TracingIntakeSession (or TracingRecorder layer) to emit completed-span JSONL, then run: tailtriage import tracing-json <spans.jsonl> --input-format tailtriage-span-jsonl --service <service> --output <run.json>").into());
+                }
                 let imported = import_jsonl_path(spans_jsonl, options)?;
                 for warning in imported.warnings() {
                     eprintln!("warning: {}", warning.message());
@@ -100,7 +113,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 if imported.run().requests.is_empty() {
                     return Err(std::io::Error::new(
                         std::io::ErrorKind::InvalidData,
-                        "tracing import produced zero request events; tailtriage analyze requires at least one request event",
+                        "tracing import produced zero request events; tailtriage requires completed tt.request spans (tt.kind=request, tt.request_id, tt.route) with start/end timestamps. Hint: use tailtriage_tracing::TracingIntakeSession and import completed-span JSONL.",
                     )
                     .into());
                 }

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -4,7 +4,7 @@ use clap::{Parser, ValueEnum};
 use tailtriage_analyzer::{render_json_pretty, render_text, try_analyze_run};
 use tailtriage_cli::artifact::load_run_artifact;
 use tailtriage_cli::{analyzer_options_help_text, build_analyze_options};
-use tailtriage_tracing::{import_jsonl_path, ImportOptions};
+use tailtriage_tracing::{import_jsonl_path_with_mode, ImportOptions, JsonlParseMode};
 
 #[derive(Debug, Parser)]
 #[command(name = "tailtriage")]
@@ -121,7 +121,15 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                     )
                     .into());
                 }
-                let imported = import_jsonl_path(spans_jsonl, options)?;
+                let parse_mode = match input_format {
+                    TracingInputFormat::TailtriageSpanJsonl => {
+                        JsonlParseMode::TailtriageWrapperOnly
+                    }
+                    TracingInputFormat::Auto | TracingInputFormat::TracingSubscriberFmtJson => {
+                        JsonlParseMode::Compatible
+                    }
+                };
+                let imported = import_jsonl_path_with_mode(spans_jsonl, options, parse_mode)?;
                 for warning in imported.warnings() {
                     eprintln!("warning: {}", warning.message());
                 }

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -104,7 +104,22 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 }
 
                 if matches!(input_format, TracingInputFormat::TracingSubscriberFmtJson) {
-                    return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "tracing-subscriber fmt JSON logs do not include completed-span start/end timestamps needed by tailtriage. Recommended path: configure tailtriage_tracing::TracingIntakeSession (or TracingRecorder layer) to emit completed-span JSONL, then run: tailtriage import tracing-json <spans.jsonl> --input-format tailtriage-span-jsonl --service <service> --output <run.json>").into());
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        tracing_json_setup_guidance(),
+                    )
+                    .into());
+                }
+                if matches!(
+                    input_format,
+                    TracingInputFormat::Auto | TracingInputFormat::TailtriageSpanJsonl
+                ) && input_looks_like_tracing_fmt_json(&spans_jsonl)?
+                {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        tracing_json_setup_guidance(),
+                    )
+                    .into());
                 }
                 let imported = import_jsonl_path(spans_jsonl, options)?;
                 for warning in imported.warnings() {
@@ -113,7 +128,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 if imported.run().requests.is_empty() {
                     return Err(std::io::Error::new(
                         std::io::ErrorKind::InvalidData,
-                        "tracing import produced zero request events; tailtriage requires completed tt.request spans (tt.kind=request, tt.request_id, tt.route) with start/end timestamps. Hint: use tailtriage_tracing::TracingIntakeSession and import completed-span JSONL.",
+                        "tracing import produced zero request events; tailtriage requires completed tt.request spans (tt.kind=request, tt.request_id, tt.route) with start/end timestamps. Configure TracingIntakeSession::builder(...).completed_span_jsonl_path(...) then run: tailtriage import tracing-json <completed-spans.jsonl> --input-format tailtriage-span-jsonl --service <service> --output <run-json>",
                     )
                     .into());
                 }
@@ -159,6 +174,40 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+fn tracing_json_setup_guidance() -> &'static str {
+    "ordinary tracing_subscriber::fmt().json() logs are not the supported primary import format. tailtriage needs completed tt.* span records with start/end timestamps. Recommended setup: TracingIntakeSession::builder(...).completed_span_jsonl_path(...). Then import with: tailtriage import tracing-json <completed-spans.jsonl> --input-format tailtriage-span-jsonl --service <service> --output <run-json>"
+}
+
+fn input_looks_like_tracing_fmt_json(path: &std::path::Path) -> Result<bool, std::io::Error> {
+    let contents = std::fs::read_to_string(path)?;
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) {
+            let has_span_timestamps =
+                value
+                    .get("span")
+                    .and_then(|s| s.as_object())
+                    .is_some_and(|span| {
+                        span.contains_key("started_at_unix_ms")
+                            || span.contains_key("start_unix_ms")
+                            || span.contains_key("finished_at_unix_ms")
+                            || span.contains_key("end_unix_ms")
+                    });
+            let looks_like_fmt = value.get("timestamp").is_some()
+                && value.get("level").is_some()
+                && value.get("target").is_some();
+            if looks_like_fmt && !has_span_timestamps {
+                return Ok(true);
+            }
+        }
+        break;
+    }
+    Ok(false)
 }
 
 fn main() {

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -251,6 +251,53 @@ fn import_tracing_json_writes_run_json_analyzable_by_existing_apis() {
 }
 
 #[test]
+fn import_tracing_json_input_format_tailtriage_wrapper_only_rejects_unwrapped() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, one_valid_request_span_fixture()).expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--input-format")
+        .arg("tailtriage-span-jsonl")
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("tailtriage.tracing-span.v1") || stderr.contains("stable wrapper"));
+    assert!(!run_path.exists());
+}
+
+#[test]
+fn import_tracing_json_input_format_fmt_json_fails_with_guidance() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("fmt.jsonl");
+    std::fs::write(&spans_path, r#"{"timestamp":"2026-01-01T00:00:00Z","level":"INFO","target":"svc","fields":{"message":"close"}}"#).unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--input-format")
+        .arg("tracing-subscriber-fmt-json")
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(dir.path().join("run.json"))
+        .output()
+        .expect("cli should run");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("TracingIntakeSession"));
+    assert!(stderr.contains("tailtriage-span-jsonl"));
+}
+
+#[test]
 fn import_tracing_json_strict_fails_on_incomplete_tailtriage_span() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
@@ -612,9 +659,9 @@ fn valid_cli_artifact_with_empty_requests() -> &'static str {
 }
 
 fn complete_span_jsonl_fixture() -> &'static str {
-    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}
-{"span":{"name":"db.stage","started_at_unix_ms":1002,"finished_at_unix_ms":1006,"fields":{"tt.kind":"stage","tt.request_id":"req-1","tt.stage":"db","tt.success":true}}}
-{"span":{"name":"admission.queue","started_at_unix_ms":1000,"finished_at_unix_ms":1002,"fields":{"tt.kind":"queue","tt.request_id":"req-1","tt.queue":"admission"}}}
+    r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}
+{"format":"tailtriage.tracing-span.v1","span":{"name":"db.stage","started_at_unix_ms":1002,"finished_at_unix_ms":1006,"fields":{"tt.kind":"stage","tt.request_id":"req-1","tt.stage":"db","tt.success":true}}}
+{"format":"tailtriage.tracing-span.v1","span":{"name":"admission.queue","started_at_unix_ms":1000,"finished_at_unix_ms":1002,"fields":{"tt.kind":"queue","tt.request_id":"req-1","tt.queue":"admission"}}}
 "#
 }
 

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -684,10 +684,7 @@ fn valid_cli_artifact_with_empty_requests() -> &'static str {
 }
 
 fn complete_span_jsonl_fixture() -> &'static str {
-    r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}
-{"format":"tailtriage.tracing-span.v1","span":{"name":"db.stage","started_at_unix_ms":1002,"finished_at_unix_ms":1006,"fields":{"tt.kind":"stage","tt.request_id":"req-1","tt.stage":"db","tt.success":true}}}
-{"format":"tailtriage.tracing-span.v1","span":{"name":"admission.queue","started_at_unix_ms":1000,"finished_at_unix_ms":1002,"fields":{"tt.kind":"queue","tt.request_id":"req-1","tt.queue":"admission"}}}
-"#
+    include_str!("../../tailtriage-tracing/tests/fixtures/tailtriage-span-v1.jsonl")
 }
 
 fn incomplete_tailtriage_span_fixture() -> &'static str {

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -298,6 +298,31 @@ fn import_tracing_json_input_format_fmt_json_fails_with_guidance() {
 }
 
 #[test]
+fn import_tracing_json_auto_rejects_fmt_json_with_guidance() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("fmt.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, r#"{"timestamp":"2026-01-01T00:00:00Z","level":"INFO","target":"svc","fields":{"message":"close"}}"#).unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("tracing_subscriber::fmt().json()"));
+    assert!(stderr.contains("completed tt.*") || stderr.contains("completed tt.* span records"));
+    assert!(stderr.contains("TracingIntakeSession"));
+    assert!(stderr.contains("tailtriage-span-jsonl"));
+    assert!(!run_path.exists());
+}
+
+#[test]
 fn import_tracing_json_strict_fails_on_incomplete_tailtriage_span() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -251,6 +251,38 @@ fn import_tracing_json_writes_run_json_analyzable_by_existing_apis() {
 }
 
 #[test]
+fn import_tracing_json_input_format_tailtriage_wrapper_only_accepts_fixture() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, complete_span_jsonl_fixture()).expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--input-format")
+        .arg("tailtriage-span-jsonl")
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+
+    assert!(output.status.success(), "cli failed: {output:?}");
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
+        .expect("imported run should load in cli loader");
+    assert_eq!(loaded.run.requests.len(), 1);
+    assert_eq!(loaded.run.stages.len(), 1);
+    assert_eq!(loaded.run.queues.len(), 1);
+    let report = analyze_run(&loaded.run, AnalyzeOptions::default());
+    assert_eq!(report.request_count, 1);
+}
+
+#[test]
 fn import_tracing_json_input_format_tailtriage_wrapper_only_rejects_unwrapped() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -1,186 +1,102 @@
 # tailtriage-tracing
 
-`tailtriage-tracing` is a focused intake bridge surface for tracing-shaped completed spans that are assembled into standard `tailtriage_core::Run` artifacts through core-owned completed-run assembly.
+`tailtriage-tracing` is a narrow tracing intake bridge for completed `tt.*` spans.
 
-This crate is intentionally narrow:
+It helps existing `tracing` users produce standard `tailtriage_core::Run` artifacts by:
+- writing Run JSON on shutdown, and/or
+- streaming stable completed-span JSONL as spans close.
 
-- It defines semantic convention keys (`tt.*`) for triage-oriented span fields.
-- It defines typed intake records and import option/result types.
-- It converts typed `SpanRecord` values with `run_from_span_records`.
-- It imports JSONL from readers/paths when records contain completed span timing (`import_jsonl_reader` / `import_jsonl_path`).
-- It provides an in-process `tracing_subscriber::Layer` recorder (`TracingRecorder`) for completed `tt.*` spans.
-- It optionally couples live tracing intake with Tokio runtime snapshots via `tokio::TracingTokioSession`.
-- It does **not** implement OpenTelemetry or OTLP.
-- It does **not** change `tailtriage-analyzer`.
+It is **not**:
+- an observability backend,
+- generic tracing log scraping,
+- an OTel/OTLP pipeline,
+- proof of root cause (output remains triage leads).
 
-JSONL import, typed `SpanRecord` import, and live recorder intake all produce standard `tailtriage_core::Run` values for the same analyzer/report workflow via core-owned completed-run assembly. Completed tracing import output follows the same bounded retention/truncation semantics as core-built runs.
-
-## JSONL import support in this phase
-
-Public APIs:
-
-- `import_jsonl_reader(reader, options)`
-- `import_jsonl_path(path, options)`
-
-### Canonical JSONL shape (stable authoring contract)
-
-Recommended normalized line shape for tests and integrations:
-
-```json
-{
-  "span": {
-    "name": "http.request",
-    "started_at_unix_ms": 1700000000000,
-    "finished_at_unix_ms": 1700000000120,
-    "duration_us": 120000,
-    "fields": {
-      "tt.kind": "request",
-      "tt.request_id": "req-42",
-      "tt.route": "/checkout",
-      "tt.outcome": "ok"
-    }
-  }
-}
-```
-
-Notes:
-
-- Importer accepts `started_at_unix_ms`/`finished_at_unix_ms` and aliases `start_unix_ms`/`end_unix_ms`.
-- `duration_us` is optional and must be an unsigned microseconds value. When present, it overrides derived `(finished-start)` duration for request latency, stage latency, and queue wait.
-- Start/end unix-ms timestamps are still required even when `duration_us` is present.
-- In this phase, normalized shape uses **literal dotted keys** inside `fields` (for example `"tt.kind"` and `"tt.request_id"`), not nested objects that require flattening.
-- Importer reads `tt.*` fields from `fields`, `span.fields`, or top-level `tt.*` keys when present.
-- Scalars can be strings, bools, numbers, or null.
-- Empty lines are ignored.
-- Malformed JSON line input is an import error in both strict and non-strict mode.
-- In non-strict mode, syntactically valid but malformed/incomplete `tt.*` records are skipped with warnings.
-- In strict mode, malformed/incomplete `tt.*` records are import errors.
-- Tolerant import of close-event-like records is best-effort compatibility only; it is not the preferred/stable authoring format.
-
-CLI import for the same shape:
-
-```bash
-tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json
-tailtriage analyze tailtriage-run.json
-```
-
-## tracing-subscriber JSON caveat
-
-Direct `tracing-subscriber` JSON output can vary by formatter configuration. In
-this phase, the importer supports:
-
-- normalized completed-span JSONL (shape above), and
-- close-event-like records only when they include explicit start/end unix-ms timestamps.
-
-Close-event-like records require explicit unix-ms start/end timestamps; timing is not guessed from line receive time, and broad compatibility with arbitrary tracing JSON is not claimed.
-
-## Field convention
-
-Use literal dotted `tt.*` keys inside the span `fields` object. The table below
-describes the stable field contract used by import and live recording.
-
-| Field | Required for span kind | Expected type | Default | Meaning |
-| --- | --- | --- | --- | --- |
-| `tt.kind` | request, stage, queue | string (`"request"`, `"stage"`, `"queue"`) | none | Identifies the triage span kind. |
-| `tt.request_id` | request, stage, queue | string | none | Correlates request, stage, and queue spans into one request flow. |
-| `tt.route` | request | string | none | Logical request route/name used for request-level grouping. |
-| `tt.stage` | stage | string | none | Stage label for downstream-stage evidence. |
-| `tt.queue` | queue | string | none | Queue label for queue-wait evidence. |
-| `tt.outcome` | request (optional) | string | `ok` (with aggregate importer warning) | Optional completion outcome label (for example `ok`/`error`). |
-| `tt.success` | stage (optional) | bool | `true` (with aggregate importer warning) | Optional normalized success flag. |
-| `tt.depth_at_start` | queue (optional) | unsigned integer | omitted when unknown (no warning) | Queue depth snapshot when queued work started waiting. |
-
-
-## Live tracing recorder
+## Recommended live session setup
 
 ```rust,no_run
-use tracing::Instrument;
+use tailtriage_tracing::TracingIntakeSession;
 use tracing_subscriber::prelude::*;
-use tailtriage_tracing::TracingRecorder;
 
-async fn handle_request() {
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let session = TracingIntakeSession::builder("checkout-service")
+    .run_json_path("target/tailtriage-examples/checkout.run.json")
+    .completed_span_jsonl_path("target/tailtriage-examples/checkout.spans.jsonl")
+    .build()?;
+
+let subscriber = tracing_subscriber::registry().with(session.layer());
+tracing::subscriber::with_default(subscriber, || {
     let request = tracing::info_span!(
-        "http.request",
+        "request",
         tt.kind = "request",
-        tt.request_id = "req-42",
+        tt.request_id = "req-1",
         tt.route = "/checkout",
         tt.outcome = "ok"
     );
-    async {
-        // request work goes here
-    }
-    .instrument(request)
-    .await;
-}
-
-# fn main() -> Result<(), tailtriage_tracing::ImportError> {
-let recorder = TracingRecorder::builder("checkout-service")
-    .service_version("1.2.3")
-    .run_id("run-42")
-    .strict(false)
-    .build();
-
-let subscriber = tracing_subscriber::registry().with(recorder.layer());
-tracing::subscriber::with_default(subscriber, || {
-    // run `handle_request()` on your async runtime
+    let _entered = request.enter();
 });
 
-let imported = recorder.shutdown()?;
-let run = imported.run();
-# let _ = run;
+session.shutdown()?;
 # Ok(())
 # }
 ```
 
-## Live recorder tracking rule
+## Direct Run JSON path
 
-For live recording, a span is tracked only when **at least one `tt.*` field is
-declared at span creation time**.
+Use `run_json_path(...)` when you want to skip a separate import step:
 
-- If a span has no `tt.*` field at creation, later `record(...)` calls are ignored
-  by this recorder.
-- `tt.kind` may be filled later only when a `tt.*` field was declared initially
-  (for example with `tracing::field::Empty`).
-- Record `tt.*` values as typed scalar fields (string/bool/number), not only
-  debug-formatted values.
-
-Minimal pattern:
-
-```rust
-let span = tracing::info_span!(
-    "db.stage",
-    tt.kind = tracing::field::Empty,
-    tt.request_id = "req-42",
-    tt.stage = "postgres.query"
-);
-span.record("tt.kind", "stage");
+```bash
+tailtriage analyze target/tailtriage-examples/checkout.run.json
 ```
 
-The live recorder is bounded by default (`DEFAULT_MAX_OPEN_SPANS`, `DEFAULT_MAX_COMPLETED_SPANS`), and limits are configurable via `TracingRecorder::builder(...).max_open_spans(...)`, `.max_completed_spans(...)`, or `.limits(RecorderLimits { ... })`. In non-strict mode, retention drops are reported as import warnings and `run.truncation.limits_hit = true`; in strict mode, retention drops fail import with a strict violation so dropped `tt.*` evidence is not silently accepted.
+## Completed-span JSONL path
 
-Use `#[tracing::instrument(fields(...))]` or `.instrument(...)` so span fields attach to async work correctly.
-Do not hold a manual entered-span guard across `.await`; async spans may enter/exit many times, and this recorder finalizes completed work on `on_close` (drop), not enter/exit transitions.
-Use `snapshot_run()` for non-consuming inspection, and `shutdown()` when finalizing via a consumed recorder handle.
-Live recorder latency/wait precision uses monotonic elapsed duration (`duration_us`) captured at close time.
+Use `completed_span_jsonl_path(...)` when you want an offline import workflow:
 
-Tracing-only import/recording provides request, stage, and queue evidence. It
-does not fabricate executor-pressure or blocking-pool-pressure evidence.
-Runtime-pressure evidence still requires tailtriage runtime snapshots (for
-example the Tokio sampler).
+```bash
+tailtriage import tracing-json target/tailtriage-examples/checkout.spans.jsonl \
+  --input-format tailtriage-span-jsonl \
+  --service checkout-service \
+  --output target/tailtriage-examples/checkout.run.json
 
+tailtriage analyze target/tailtriage-examples/checkout.run.json
+```
 
+## Stable JSONL wrapper format
 
-## Optional Tokio runtime sampler coupling
+Stable completed-span JSONL records use this wrapper:
 
-When the optional `tokio` feature is enabled, the crate exposes
-`tokio::TracingTokioSession` for applications that already run inside a Tokio
-runtime. This session combines tracing request/stage/queue evidence with
-tailtriage Tokio runtime snapshots in one standard run artifact.
+```json
+{"format":"tailtriage.tracing-span.v1","span":{...}}
+```
 
-Base `TracingRecorder` usage remains available without Tokio. This crate is
-still not an OTel/OTLP exporter and not a tracing backend.
+`format` is a wrapper-level field (not a `SpanRecord` field).
+
+## `tt.*` field convention
+
+| Span kind | Required fields | Optional fields |
+| --- | --- | --- |
+| request | `tt.kind="request"`, `tt.request_id`, `tt.route` | `tt.outcome` |
+| stage | `tt.kind="stage"`, `tt.request_id`, `tt.stage` | `tt.success` |
+| queue | `tt.kind="queue"`, `tt.request_id`, `tt.queue` | `tt.depth_at_start` |
+
+## Strict vs non-strict
+
+- Strict mode: malformed/incomplete `tt.*` span records fail import/session conversion.
+- Non-strict mode: malformed/incomplete records are warned and skipped where implemented.
+
+## Retention and drop behavior
+
+- `max_open_spans` bounds in-flight span tracking.
+- `max_completed_spans` bounds in-memory completed-span retention.
+- Completed-span JSONL streaming happens before in-memory completed-span retention is applied.
+- Warnings and lifecycle warnings indicate evidence may be incomplete when limits are hit or writer issues occur.
+
+## Runtime-pressure limitation
+
+Tracing-only intake does not fabricate runtime snapshots. Runtime-pressure evidence still requires runtime snapshots/Tokio sampler coupling.
 
 ## Examples
 
-- `examples/live_recorder.rs`: records one request span, one queue span, and one stage span with `TracingRecorder`, imports a run, and renders analyzer suspects and next checks.
-- `examples/tracing_spans.jsonl`: normalized completed-span JSONL fixture importable via `import_jsonl_path` or CLI `tailtriage import tracing-json`.
+- `tailtriage-tracing/examples/live_session_to_run.rs`
+- `tailtriage-tracing/examples/completed_span_jsonl_import.rs`

--- a/tailtriage-tracing/examples/completed_span_jsonl_import.rs
+++ b/tailtriage-tracing/examples/completed_span_jsonl_import.rs
@@ -1,0 +1,48 @@
+use std::error::Error;
+
+use tailtriage_tracing::TracingIntakeSession;
+use tracing_subscriber::prelude::*;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let spans_path = std::path::PathBuf::from("target/tailtriage-examples/completed-spans.jsonl");
+    std::fs::create_dir_all(spans_path.parent().expect("parent path exists"))?;
+
+    let session = TracingIntakeSession::builder("checkout-service")
+        .completed_span_jsonl_path(&spans_path)
+        .build()?;
+
+    let subscriber = tracing_subscriber::registry().with(session.layer());
+    tracing::subscriber::with_default(subscriber, || {
+        let request = tracing::info_span!(
+            "http.request",
+            tt.kind = "request",
+            tt.request_id = "req-1",
+            tt.route = "/checkout",
+            tt.outcome = "ok"
+        );
+        let _request_guard = request.enter();
+        let _queue_guard = tracing::info_span!(
+            "admission.queue",
+            tt.kind = "queue",
+            tt.request_id = "req-1",
+            tt.queue = "admission",
+            tt.depth_at_start = 5_u64
+        )
+        .entered();
+        let _stage_guard = tracing::info_span!(
+            "db.stage",
+            tt.kind = "stage",
+            tt.request_id = "req-1",
+            tt.stage = "db",
+            tt.success = true
+        )
+        .entered();
+    });
+
+    session.shutdown()?;
+    println!("wrote completed spans to: {}", spans_path.display());
+    // Import + analyze with:
+    // tailtriage import tracing-json target/tailtriage-examples/completed-spans.jsonl --input-format tailtriage-span-jsonl --service checkout-service --output target/tailtriage-examples/run.json
+    // tailtriage analyze target/tailtriage-examples/run.json
+    Ok(())
+}

--- a/tailtriage-tracing/examples/live_session_to_run.rs
+++ b/tailtriage-tracing/examples/live_session_to_run.rs
@@ -1,0 +1,49 @@
+use std::error::Error;
+
+use tailtriage_tracing::TracingIntakeSession;
+use tracing_subscriber::prelude::*;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let run_path = std::path::PathBuf::from("target/tailtriage-examples/live-session-run.json");
+    std::fs::create_dir_all(run_path.parent().expect("parent path exists"))?;
+
+    let session = TracingIntakeSession::builder("checkout-service")
+        .run_json_path(&run_path)
+        .build()?;
+
+    let subscriber = tracing_subscriber::registry().with(session.layer());
+    tracing::subscriber::with_default(subscriber, || {
+        let request = tracing::info_span!(
+            "http.request",
+            tt.kind = "request",
+            tt.request_id = "req-1",
+            tt.route = "/checkout",
+            tt.outcome = "ok"
+        );
+        let _request_guard = request.enter();
+
+        let queue = tracing::info_span!(
+            "admission.queue",
+            tt.kind = "queue",
+            tt.request_id = "req-1",
+            tt.queue = "admission",
+            tt.depth_at_start = 3_u64
+        );
+        let _queue_guard = queue.enter();
+
+        let stage = tracing::info_span!(
+            "db.stage",
+            tt.kind = "stage",
+            tt.request_id = "req-1",
+            tt.stage = "db",
+            tt.success = true
+        );
+        let _stage_guard = stage.enter();
+    });
+
+    session.shutdown()?;
+    println!("wrote run JSON to: {}", run_path.display());
+    // Analyze with:
+    // tailtriage analyze target/tailtriage-examples/live-session-run.json
+    Ok(())
+}

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -96,22 +96,42 @@ pub fn import_jsonl_path(
     import_jsonl_reader(file, options)
 }
 
+#[derive(serde::Deserialize)]
+struct WrappedSpanRecord {
+    format: String,
+    span: SpanRecord,
+}
+
 fn parse_record(
     line_no: usize,
     value: &Value,
     strict: bool,
     warnings: &mut Vec<crate::ImportWarning>,
 ) -> Result<Option<SpanRecord>, ImportError> {
-    if let Ok(span) = serde_json::from_value::<SpanRecord>(value.clone()) {
-        if span.format_ref().is_none() || span.format_ref() == Some("tailtriage.tracing-span.v1") {
-            return Ok(Some(span));
+    if let Ok(wrapped) = serde_json::from_value::<WrappedSpanRecord>(value.clone()) {
+        if wrapped.format == "tailtriage.tracing-span.v1" {
+            return Ok(Some(wrapped.span));
         }
+        let message = format!(
+            "line {line_no}: unsupported span format marker '{}'",
+            wrapped.format
+        );
+        if strict {
+            return Err(ImportError::StrictViolation(message));
+        }
+        warnings.push(crate::ImportWarning::new(message));
+        return Ok(None);
+    }
+    if value.get("format").is_some() && value.get("span").is_some() {
         let message = format!("line {line_no}: unsupported span format marker");
         if strict {
             return Err(ImportError::StrictViolation(message));
         }
         warnings.push(crate::ImportWarning::new(message));
         return Ok(None);
+    }
+    if let Ok(span) = serde_json::from_value::<SpanRecord>(value.clone()) {
+        return Ok(Some(span));
     }
     if let Some(field_name) = first_non_scalar_tailtriage_field(value) {
         let message = format!(

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -1270,6 +1270,23 @@ mod tests {
     }
 
     #[test]
+    fn wrapper_fixture_uses_duration_us_fields() {
+        let imported = import_jsonl_reader_with_mode(
+            Cursor::new(include_str!("../tests/fixtures/tailtriage-span-v1.jsonl")),
+            ImportOptions::new("svc"),
+            JsonlParseMode::TailtriageWrapperOnly,
+        )
+        .unwrap();
+        let run = imported.run();
+        assert_eq!(run.requests.len(), 1);
+        assert_eq!(run.requests[0].latency_us, 30_000);
+        assert_eq!(run.stages.len(), 1);
+        assert_eq!(run.stages[0].latency_us, 10_000);
+        assert_eq!(run.queues.len(), 1);
+        assert_eq!(run.queues[0].wait_us, 4_000);
+    }
+
+    #[test]
     fn empty_service_name_is_rejected_for_jsonl_import() {
         let err = import_jsonl_reader(Cursor::new(""), ImportOptions::new("")).unwrap_err();
         assert!(matches!(err, ImportError::EmptyServiceName));

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -136,12 +136,6 @@ pub fn import_jsonl_path_with_mode(
     import_jsonl_reader_with_mode(file, options, mode)
 }
 
-#[derive(serde::Deserialize)]
-struct WrappedSpanRecord {
-    format: String,
-    span: SpanRecord,
-}
-
 #[allow(clippy::too_many_lines)]
 fn parse_record(
     line_no: usize,
@@ -150,27 +144,54 @@ fn parse_record(
     warnings: &mut Vec<crate::ImportWarning>,
     mode: JsonlParseMode,
 ) -> Result<Option<SpanRecord>, ImportError> {
-    if let Ok(wrapped) = serde_json::from_value::<WrappedSpanRecord>(value.clone()) {
-        if wrapped.format == "tailtriage.tracing-span.v1" {
-            return Ok(Some(wrapped.span));
+    if let Some(obj) = value.as_object() {
+        if let (Some(format), Some(span_value)) = (obj.get("format"), obj.get("span")) {
+            let Some(format_marker) = format.as_str() else {
+                let message = format!(
+                    "line {line_no}: invalid field 'format': expected string format marker"
+                );
+                if strict {
+                    return Err(ImportError::StrictViolation(message));
+                }
+                warnings.push(crate::ImportWarning::new(message));
+                return Ok(None);
+            };
+
+            if format_marker != "tailtriage.tracing-span.v1" {
+                let message =
+                    format!("line {line_no}: unsupported span format marker '{format_marker}'");
+                if strict {
+                    return Err(ImportError::StrictViolation(message));
+                }
+                warnings.push(crate::ImportWarning::new(message));
+                return Ok(None);
+            }
+
+            let Some(_) = span_value.as_object() else {
+                let message = format!(
+                    "line {line_no}: invalid field 'span': expected completed span object for tailtriage.tracing-span.v1"
+                );
+                if strict {
+                    return Err(ImportError::StrictViolation(message));
+                }
+                warnings.push(crate::ImportWarning::new(message));
+                return Ok(None);
+            };
+
+            return match serde_json::from_value::<SpanRecord>(span_value.clone()) {
+                Ok(span) => Ok(Some(span)),
+                Err(err) => {
+                    let message =
+                        format!("line {line_no}: invalid tailtriage.tracing-span.v1 span: {err}");
+                    if strict {
+                        Err(ImportError::StrictViolation(message))
+                    } else {
+                        warnings.push(crate::ImportWarning::new(message));
+                        Ok(None)
+                    }
+                }
+            };
         }
-        let message = format!(
-            "line {line_no}: unsupported span format marker '{}'",
-            wrapped.format
-        );
-        if strict {
-            return Err(ImportError::StrictViolation(message));
-        }
-        warnings.push(crate::ImportWarning::new(message));
-        return Ok(None);
-    }
-    if value.get("format").is_some() && value.get("span").is_some() {
-        let message = format!("line {line_no}: unsupported span format marker");
-        if strict {
-            return Err(ImportError::StrictViolation(message));
-        }
-        warnings.push(crate::ImportWarning::new(message));
-        return Ok(None);
     }
     if matches!(mode, JsonlParseMode::TailtriageWrapperOnly) {
         let message = format!(
@@ -1137,6 +1158,107 @@ mod tests {
             .warnings()
             .iter()
             .any(|w| w.message().contains("v2") || w.message().contains("unsupported")));
+    }
+
+    #[test]
+    fn wrapper_v1_with_bad_span_timestamp_reports_invalid_span_not_marker() {
+        let input = r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req","started_at_unix_ms":"bad","finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
+        let err = import_jsonl_reader_with_mode(
+            Cursor::new(input),
+            ImportOptions::new("svc").strict(true),
+            JsonlParseMode::TailtriageWrapperOnly,
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(msg.contains("tailtriage.tracing-span.v1"));
+        assert!(msg.contains("started_at_unix_ms") || msg.contains("expected"));
+        assert!(!msg.contains("unsupported span format marker"));
+
+        let imported = import_jsonl_reader_with_mode(
+            Cursor::new(input),
+            ImportOptions::new("svc"),
+            JsonlParseMode::TailtriageWrapperOnly,
+        )
+        .unwrap();
+        assert_eq!(imported.run().requests.len(), 0);
+        assert_eq!(imported.warnings().len(), 1);
+        assert!(!imported.warnings()[0]
+            .message()
+            .contains("unsupported span format marker"));
+    }
+
+    #[test]
+    fn wrapper_v1_with_missing_required_span_field_reports_invalid_span() {
+        let input = r#"{"format":"tailtriage.tracing-span.v1","span":{"started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
+        let err = import_jsonl_reader_with_mode(
+            Cursor::new(input),
+            ImportOptions::new("svc").strict(true),
+            JsonlParseMode::TailtriageWrapperOnly,
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(msg.contains("span") || msg.contains("name"));
+        assert!(!msg.contains("unsupported span format marker"));
+
+        let imported = import_jsonl_reader_with_mode(
+            Cursor::new(input),
+            ImportOptions::new("svc"),
+            JsonlParseMode::TailtriageWrapperOnly,
+        )
+        .unwrap();
+        assert_eq!(imported.run().requests.len(), 0);
+        assert_eq!(imported.warnings().len(), 1);
+    }
+
+    #[test]
+    fn wrapper_v1_with_non_object_span_reports_invalid_span_field() {
+        let input = r#"{"format":"tailtriage.tracing-span.v1","span":"not an object"}"#;
+        let err = import_jsonl_reader_with_mode(
+            Cursor::new(input),
+            ImportOptions::new("svc").strict(true),
+            JsonlParseMode::TailtriageWrapperOnly,
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(
+            msg.contains("invalid field 'span'") || msg.contains("expected completed span object")
+        );
+        assert!(!msg.contains("unsupported span format marker"));
+
+        let imported = import_jsonl_reader_with_mode(
+            Cursor::new(input),
+            ImportOptions::new("svc"),
+            JsonlParseMode::TailtriageWrapperOnly,
+        )
+        .unwrap();
+        assert_eq!(imported.run().requests.len(), 0);
+        assert_eq!(imported.warnings().len(), 1);
+    }
+
+    #[test]
+    fn wrapper_with_non_string_format_reports_invalid_format_field() {
+        let input = r#"{"format":1,"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
+        let err = import_jsonl_reader_with_mode(
+            Cursor::new(input),
+            ImportOptions::new("svc").strict(true),
+            JsonlParseMode::TailtriageWrapperOnly,
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(msg.contains("format") && msg.contains("expected string"));
+
+        let imported = import_jsonl_reader_with_mode(
+            Cursor::new(input),
+            ImportOptions::new("svc"),
+            JsonlParseMode::TailtriageWrapperOnly,
+        )
+        .unwrap();
+        assert_eq!(imported.run().requests.len(), 0);
+        assert_eq!(imported.warnings().len(), 1);
     }
 
     #[test]

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -1287,6 +1287,39 @@ mod tests {
     }
 
     #[test]
+    fn wrapper_fixture_imports_request_stage_queue() {
+        let imported = import_jsonl_reader_with_mode(
+            Cursor::new(include_str!("../tests/fixtures/tailtriage-span-v1.jsonl")),
+            ImportOptions::new("svc"),
+            JsonlParseMode::TailtriageWrapperOnly,
+        )
+        .unwrap();
+        let run = imported.run();
+        assert_eq!(run.requests.len(), 1);
+        assert_eq!(run.stages.len(), 1);
+        assert_eq!(run.queues.len(), 1);
+        assert_eq!(run.requests[0].request_id, "req-1");
+        assert_eq!(run.requests[0].route, "/checkout");
+        assert_eq!(run.stages[0].stage, "db");
+        assert_eq!(run.queues[0].queue, "admission");
+        assert_eq!(run.queues[0].depth_at_start, Some(7));
+    }
+
+    #[test]
+    fn wrapper_fixture_preserves_duration_us() {
+        let imported = import_jsonl_reader_with_mode(
+            Cursor::new(include_str!("../tests/fixtures/tailtriage-span-v1.jsonl")),
+            ImportOptions::new("svc"),
+            JsonlParseMode::TailtriageWrapperOnly,
+        )
+        .unwrap();
+        let run = imported.run();
+        assert_eq!(run.requests[0].latency_us, 30_000);
+        assert_eq!(run.stages[0].latency_us, 10_000);
+        assert_eq!(run.queues[0].wait_us, 4_000);
+    }
+
+    #[test]
     fn empty_service_name_is_rejected_for_jsonl_import() {
         let err = import_jsonl_reader(Cursor::new(""), ImportOptions::new("")).unwrap_err();
         assert!(matches!(err, ImportError::EmptyServiceName));

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -102,6 +102,17 @@ fn parse_record(
     strict: bool,
     warnings: &mut Vec<crate::ImportWarning>,
 ) -> Result<Option<SpanRecord>, ImportError> {
+    if let Ok(span) = serde_json::from_value::<SpanRecord>(value.clone()) {
+        if span.format_ref().is_none() || span.format_ref() == Some("tailtriage.tracing-span.v1") {
+            return Ok(Some(span));
+        }
+        let message = format!("line {line_no}: unsupported span format marker");
+        if strict {
+            return Err(ImportError::StrictViolation(message));
+        }
+        warnings.push(crate::ImportWarning::new(message));
+        return Ok(None);
+    }
     if let Some(field_name) = first_non_scalar_tailtriage_field(value) {
         let message = format!(
             "line {line_no}: invalid field '{field_name}': expected scalar tt.* value in JSONL record"

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -1077,6 +1077,27 @@ mod tests {
     }
 
     #[test]
+    fn wrapper_only_mode_accepts_wrapper_and_rejects_unwrapped() {
+        let wrapped = r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
+        let imported = import_jsonl_reader_with_mode(
+            Cursor::new(wrapped),
+            ImportOptions::new("svc"),
+            JsonlParseMode::TailtriageWrapperOnly,
+        )
+        .unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+
+        let unwrapped = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
+        let err = import_jsonl_reader_with_mode(
+            Cursor::new(unwrapped),
+            ImportOptions::new("svc").strict(true),
+            JsonlParseMode::TailtriageWrapperOnly,
+        )
+        .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
     fn empty_service_name_is_rejected_for_jsonl_import() {
         let err = import_jsonl_reader(Cursor::new(""), ImportOptions::new("")).unwrap_err();
         assert!(matches!(err, ImportError::EmptyServiceName));

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -24,6 +24,31 @@ pub fn import_jsonl_reader<R: Read>(
     reader: R,
     options: ImportOptions,
 ) -> Result<ImportedRun, ImportError> {
+    import_jsonl_reader_with_mode(reader, options, JsonlParseMode::Compatible)
+}
+
+/// Parse mode for tracing JSONL import.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JsonlParseMode {
+    /// Accept stable wrapper records plus compatibility legacy shapes.
+    Compatible,
+    /// Accept only the stable wrapper shape `{"format":"tailtriage.tracing-span.v1","span":{...}}`.
+    TailtriageWrapperOnly,
+}
+
+/// Imports newline-delimited JSON records from a reader with an explicit parse mode.
+///
+/// # Errors
+///
+/// Returns [`ImportError::Io`] for reader I/O failures,
+/// [`ImportError::MalformedJsonLine`] for malformed non-empty JSONL lines,
+/// and existing field/conversion errors for malformed tailtriage span records
+/// or strict conversion violations surfaced by [`run_from_span_records`].
+pub fn import_jsonl_reader_with_mode<R: Read>(
+    reader: R,
+    options: ImportOptions,
+    mode: JsonlParseMode,
+) -> Result<ImportedRun, ImportError> {
     let mut spans = Vec::new();
     let mut parse_warnings = Vec::new();
     let reader = BufReader::new(reader);
@@ -46,7 +71,7 @@ pub fn import_jsonl_reader<R: Read>(
                 reason: err.to_string(),
             })?;
 
-        if let Some(span) = parse_record(line_no + 1, &value, strict, &mut parse_warnings)? {
+        if let Some(span) = parse_record(line_no + 1, &value, strict, &mut parse_warnings, mode)? {
             spans.push(span);
         }
     }
@@ -87,13 +112,28 @@ pub fn import_jsonl_path(
     path: impl AsRef<Path>,
     options: ImportOptions,
 ) -> Result<ImportedRun, ImportError> {
+    import_jsonl_path_with_mode(path, options, JsonlParseMode::Compatible)
+}
+
+/// Imports newline-delimited JSON records from a filesystem path with an explicit parse mode.
+///
+/// # Errors
+///
+/// Returns [`ImportError::Io`] for path open/read failures,
+/// [`ImportError::MalformedJsonLine`] for malformed non-empty JSON lines,
+/// and strict/field errors for invalid span records.
+pub fn import_jsonl_path_with_mode(
+    path: impl AsRef<Path>,
+    options: ImportOptions,
+    mode: JsonlParseMode,
+) -> Result<ImportedRun, ImportError> {
     let path_ref = path.as_ref();
     let file = std::fs::File::open(path_ref).map_err(|err| ImportError::Io {
         operation: "open jsonl path",
         context: path_ref.display().to_string(),
         reason: err.to_string(),
     })?;
-    import_jsonl_reader(file, options)
+    import_jsonl_reader_with_mode(file, options, mode)
 }
 
 #[derive(serde::Deserialize)]
@@ -102,11 +142,13 @@ struct WrappedSpanRecord {
     span: SpanRecord,
 }
 
+#[allow(clippy::too_many_lines)]
 fn parse_record(
     line_no: usize,
     value: &Value,
     strict: bool,
     warnings: &mut Vec<crate::ImportWarning>,
+    mode: JsonlParseMode,
 ) -> Result<Option<SpanRecord>, ImportError> {
     if let Ok(wrapped) = serde_json::from_value::<WrappedSpanRecord>(value.clone()) {
         if wrapped.format == "tailtriage.tracing-span.v1" {
@@ -124,6 +166,16 @@ fn parse_record(
     }
     if value.get("format").is_some() && value.get("span").is_some() {
         let message = format!("line {line_no}: unsupported span format marker");
+        if strict {
+            return Err(ImportError::StrictViolation(message));
+        }
+        warnings.push(crate::ImportWarning::new(message));
+        return Ok(None);
+    }
+    if matches!(mode, JsonlParseMode::TailtriageWrapperOnly) {
+        let message = format!(
+            "line {line_no}: expected stable wrapper shape {{\"format\":\"tailtriage.tracing-span.v1\",\"span\":{{...}}}}"
+        );
         if strict {
             return Err(ImportError::StrictViolation(message));
         }

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -1098,6 +1098,56 @@ mod tests {
     }
 
     #[test]
+    fn wrapper_only_non_strict_unwrapped_warns_and_skips() {
+        let unwrapped = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
+        let imported = import_jsonl_reader_with_mode(
+            Cursor::new(unwrapped),
+            ImportOptions::new("svc"),
+            JsonlParseMode::TailtriageWrapperOnly,
+        )
+        .unwrap();
+        assert_eq!(imported.run().requests.len(), 0);
+        assert!(!imported.warnings().is_empty());
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("tailtriage.tracing-span.v1")));
+    }
+
+    #[test]
+    fn wrapper_only_unsupported_marker_strict_errors_and_non_strict_warns() {
+        let v2 = r#"{"format":"tailtriage.tracing-span.v2","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
+        let err = import_jsonl_reader_with_mode(
+            Cursor::new(v2),
+            ImportOptions::new("svc").strict(true),
+            JsonlParseMode::TailtriageWrapperOnly,
+        )
+        .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(err.to_string().contains("v2") || err.to_string().contains("unsupported"));
+
+        let imported = import_jsonl_reader_with_mode(
+            Cursor::new(v2),
+            ImportOptions::new("svc"),
+            JsonlParseMode::TailtriageWrapperOnly,
+        )
+        .unwrap();
+        assert_eq!(imported.run().requests.len(), 0);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("v2") || w.message().contains("unsupported")));
+    }
+
+    #[test]
+    fn compatible_mode_accepts_old_normalized_shape() {
+        let unwrapped = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
+        let imported =
+            import_jsonl_reader(Cursor::new(unwrapped), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+    }
+
+    #[test]
     fn empty_service_name_is_rejected_for_jsonl_import() {
         let err = import_jsonl_reader(Cursor::new(""), ImportOptions::new("")).unwrap_err();
         assert!(matches!(err, ImportError::EmptyServiceName));

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -1270,23 +1270,6 @@ mod tests {
     }
 
     #[test]
-    fn wrapper_fixture_uses_duration_us_fields() {
-        let imported = import_jsonl_reader_with_mode(
-            Cursor::new(include_str!("../tests/fixtures/tailtriage-span-v1.jsonl")),
-            ImportOptions::new("svc"),
-            JsonlParseMode::TailtriageWrapperOnly,
-        )
-        .unwrap();
-        let run = imported.run();
-        assert_eq!(run.requests.len(), 1);
-        assert_eq!(run.requests[0].latency_us, 30_000);
-        assert_eq!(run.stages.len(), 1);
-        assert_eq!(run.stages[0].latency_us, 10_000);
-        assert_eq!(run.queues.len(), 1);
-        assert_eq!(run.queues[0].wait_us, 4_000);
-    }
-
-    #[test]
     fn wrapper_fixture_imports_request_stage_queue() {
         let imported = import_jsonl_reader_with_mode(
             Cursor::new(include_str!("../tests/fixtures/tailtriage-span-v1.jsonl")),

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -45,7 +45,9 @@ pub use convention::{
     TT_DEPTH_AT_START, TT_KIND, TT_OUTCOME, TT_QUEUE, TT_REQUEST_ID, TT_ROUTE, TT_STAGE, TT_SUCCESS,
 };
 pub use error::ImportError;
-pub use jsonl::{import_jsonl_path, import_jsonl_reader};
+pub use jsonl::{
+    import_jsonl_path, import_jsonl_path_with_mode, import_jsonl_reader, JsonlParseMode,
+};
 pub use recorder::{
     RecorderLimits, TailtriageLayer, TracingIntakeSession, TracingIntakeSessionBuilder,
     TracingRecorder, TracingRecorderBuilder, DEFAULT_MAX_COMPLETED_SPANS, DEFAULT_MAX_OPEN_SPANS,

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -47,8 +47,8 @@ pub use convention::{
 pub use error::ImportError;
 pub use jsonl::{import_jsonl_path, import_jsonl_reader};
 pub use recorder::{
-    RecorderLimits, TailtriageLayer, TracingRecorder, TracingRecorderBuilder,
-    DEFAULT_MAX_COMPLETED_SPANS, DEFAULT_MAX_OPEN_SPANS,
+    RecorderLimits, TailtriageLayer, TracingIntakeSession, TracingIntakeSessionBuilder,
+    TracingRecorder, TracingRecorderBuilder, DEFAULT_MAX_COMPLETED_SPANS, DEFAULT_MAX_OPEN_SPANS,
 };
 pub use types::{FieldValue, ImportOptions, ImportWarning, ImportedRun, SpanKind, SpanRecord};
 

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -1568,4 +1568,161 @@ mod tests {
         let lines: Vec<_> = raw.lines().filter(|l| !l.trim().is_empty()).collect();
         assert_eq!(lines.len(), 1);
     }
+
+    #[test]
+    fn intake_session_emits_wrapper_shape_and_round_trips_wrapper_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let spans_path = dir.path().join("spans.jsonl");
+        let session = TracingIntakeSession::builder("svc")
+            .completed_span_jsonl_path(&spans_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            );
+            drop(span);
+        });
+        session.snapshot_run().unwrap();
+        let raw = std::fs::read_to_string(&spans_path).unwrap();
+        let lines: Vec<_> = raw.lines().filter(|l| !l.trim().is_empty()).collect();
+        assert_eq!(lines.len(), 1);
+        let value: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(value["format"], "tailtriage.tracing-span.v1");
+        assert!(value["span"].is_object());
+        assert_eq!(value["span"]["name"], "request");
+        assert!(value["span"]["started_at_unix_ms"].is_number());
+        assert!(value["span"]["finished_at_unix_ms"].is_number());
+        assert!(value["span"]["duration_us"].is_number());
+        assert_eq!(value["span"]["fields"]["tt.kind"], "request");
+        assert_eq!(value["span"]["fields"]["tt.request_id"], "r1");
+        assert_eq!(value["span"]["fields"]["tt.route"], "/a");
+
+        let imported = crate::jsonl::import_jsonl_path_with_mode(
+            &spans_path,
+            ImportOptions::new("svc"),
+            crate::jsonl::JsonlParseMode::TailtriageWrapperOnly,
+        )
+        .unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].request_id, "r1");
+        assert_eq!(imported.run().requests[0].route, "/a");
+    }
+
+    #[test]
+    fn streaming_jsonl_is_independent_of_in_memory_completed_retention() {
+        let dir = tempfile::tempdir().unwrap();
+        let spans_path = dir.path().join("spans.jsonl");
+        let session = TracingIntakeSession::builder("svc")
+            .completed_span_jsonl_path(&spans_path)
+            .max_completed_spans(1)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            ));
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r2",
+                tt.route = "/b"
+            ));
+        });
+        let snapshot = session.snapshot_run().unwrap();
+        assert_eq!(snapshot.run().requests.len(), 1);
+        assert!(snapshot
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("dropped 1 completed spans")));
+        let raw = std::fs::read_to_string(&spans_path).unwrap();
+        let lines: Vec<_> = raw.lines().filter(|l| !l.trim().is_empty()).collect();
+        assert_eq!(lines.len(), 2);
+        let imported = crate::jsonl::import_jsonl_path_with_mode(
+            &spans_path,
+            ImportOptions::new("svc"),
+            crate::jsonl::JsonlParseMode::TailtriageWrapperOnly,
+        )
+        .unwrap();
+        assert_eq!(imported.run().requests.len(), 2);
+        let ids: Vec<_> = imported
+            .run()
+            .requests
+            .iter()
+            .map(|r| r.request_id.as_str())
+            .collect();
+        assert!(ids.contains(&"r1"));
+        assert!(ids.contains(&"r2"));
+    }
+
+    #[test]
+    fn intake_session_build_writer_open_failure_returns_io() {
+        let dir = tempfile::tempdir().unwrap();
+        let bad_path = dir.path().join("missing").join("spans.jsonl");
+        let err = TracingIntakeSession::builder("svc")
+            .completed_span_jsonl_path(&bad_path)
+            .build()
+            .unwrap_err();
+        assert!(matches!(err, ImportError::Io { .. }));
+        assert!(err.to_string().contains("spans.jsonl"));
+    }
+
+    #[test]
+    fn intake_session_run_json_path_writes_valid_run_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_path = dir.path().join("run.json");
+        let session = TracingIntakeSession::builder("svc")
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            ));
+        });
+        session.shutdown().unwrap();
+        assert!(run_path.exists());
+        let run: tailtriage_core::Run =
+            serde_json::from_slice(&std::fs::read(&run_path).unwrap()).unwrap();
+        assert_eq!(run.requests.len(), 1);
+    }
+
+    #[test]
+    fn unrelated_spans_are_ignored_by_completed_span_jsonl_writer() {
+        let dir = tempfile::tempdir().unwrap();
+        let spans_path = dir.path().join("spans.jsonl");
+        let session = TracingIntakeSession::builder("svc")
+            .completed_span_jsonl_path(&spans_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!("unrelated", user = 1_u64));
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            ));
+        });
+        session.shutdown().unwrap();
+        let raw = std::fs::read_to_string(&spans_path).unwrap();
+        let lines: Vec<_> = raw.lines().filter(|l| !l.trim().is_empty()).collect();
+        assert_eq!(lines.len(), 1);
+        let line = lines[0];
+        assert!(line.contains("\"tt.request_id\":\"r1\""));
+        assert!(!line.contains("unrelated"));
+    }
 }

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -237,7 +237,30 @@ impl TracingRecorder {
 }
 
 impl TracingIntakeSession {
-    /// Creates a builder with required service name metadata.
+    /// Creates a tracing intake session builder with required service metadata.
+    ///
+    /// ```no_run
+    /// use tailtriage_tracing::TracingIntakeSession;
+    /// use tracing_subscriber::prelude::*;
+    ///
+    /// let session = TracingIntakeSession::builder("checkout")
+    ///     .completed_span_jsonl_path("completed-spans.jsonl")
+    ///     .build()
+    ///     .expect("session should build");
+    ///
+    /// let subscriber = tracing_subscriber::registry().with(session.layer());
+    /// tracing::subscriber::with_default(subscriber, || {
+    ///     let span = tracing::info_span!(
+    ///         "request",
+    ///         tt.kind = "request",
+    ///         tt.request_id = "r1",
+    ///         tt.route = "/checkout"
+    ///     );
+    ///     drop(span);
+    /// });
+    ///
+    /// let _ = session.shutdown().expect("shutdown should succeed");
+    /// ```
     pub fn builder(service_name: impl Into<String>) -> TracingIntakeSessionBuilder {
         TracingIntakeSessionBuilder {
             recorder_builder: TracingRecorder::builder(service_name),
@@ -323,10 +346,10 @@ impl TracingIntakeSessionBuilder {
         self
     }
     /// Enables completed-span JSONL output at the given path.
-    #[must_use]
     ///
-    /// Records are appended as spans close using the stable wrapper shape
-    /// `{"format":"tailtriage.tracing-span.v1","span":{...}}`.
+    /// Writes completed spans as spans close using the stable wrapper shape.
+    /// The file is created or truncated when the session is built.
+    #[must_use]
     pub fn completed_span_jsonl_path(mut self, path: impl AsRef<Path>) -> Self {
         self.completed_span_jsonl_path = Some(path.as_ref().to_path_buf());
         self
@@ -367,25 +390,22 @@ impl TracingIntakeSessionBuilder {
 }
 
 impl TracingRecorderBuilder {
-    /// Sets service version metadata.
-    #[must_use]
     /// Sets service version metadata for converted run output.
+    #[must_use]
     pub fn service_version(mut self, service_version: impl Into<String>) -> Self {
         self.options = self.options.service_version(service_version);
         self
     }
 
-    /// Sets explicit run-id metadata.
-    #[must_use]
     /// Sets explicit run id metadata for converted run output.
+    #[must_use]
     pub fn run_id(mut self, run_id: impl Into<String>) -> Self {
         self.options = self.options.run_id(run_id);
         self
     }
 
-    /// Enables or disables strict conversion mode.
-    #[must_use]
     /// Enables or disables strict mode for conversion warnings.
+    #[must_use]
     pub fn strict(mut self, strict: bool) -> Self {
         self.options = self.options.strict(strict);
         self
@@ -400,9 +420,8 @@ impl TracingRecorderBuilder {
             limits: self.limits,
         }
     }
-    /// Sets both open/completed in-memory span retention limits.
-    #[must_use]
     /// Sets open/completed in-memory retention limits.
+    #[must_use]
     pub fn limits(mut self, limits: RecorderLimits) -> Self {
         self.limits = limits;
         self
@@ -1517,5 +1536,36 @@ mod tests {
                 .message()
                 .contains("open candidate span(s) at snapshot/shutdown")));
         });
+    }
+
+    #[test]
+    fn intake_session_wrapper_jsonl_and_truncate_behavior() {
+        let dir = tempfile::tempdir().unwrap();
+        let spans_path = dir.path().join("spans.jsonl");
+        std::fs::write(
+            &spans_path,
+            r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"old","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"old","tt.route":"/old"}}}"#,
+        )
+        .unwrap();
+        let session = TracingIntakeSession::builder("svc")
+            .completed_span_jsonl_path(&spans_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            );
+            drop(span);
+        });
+        let imported = session.shutdown().unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        let raw = std::fs::read_to_string(&spans_path).unwrap();
+        assert!(!raw.contains("\"old\""));
+        let lines: Vec<_> = raw.lines().filter(|l| !l.trim().is_empty()).collect();
+        assert_eq!(lines.len(), 1);
     }
 }

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -92,6 +92,7 @@ struct RecorderState {
     closed_missing_kind_spans: u64,
     closed_missing_kind_samples: Vec<ClosedMissingKindSample>,
     writer_failure: Option<String>,
+    completed_span_writer_path: Option<PathBuf>,
     completed_span_writer: Option<BufWriter<std::fs::File>>,
 }
 
@@ -200,11 +201,24 @@ impl TracingRecorder {
     fn flush_completed_span_writer(&self) -> Result<(), ImportError> {
         let mut state = lock_state(&self.state);
         if let Some(writer) = state.completed_span_writer.as_mut() {
-            writer.flush().map_err(|err| ImportError::Io {
-                operation: "flush completed span jsonl writer",
-                context: "completed-span-jsonl".to_owned(),
-                reason: err.to_string(),
-            })?;
+            if let Err(err) = writer.flush() {
+                let msg = format_writer_failure(
+                    "flush",
+                    state.completed_span_writer_path.as_deref(),
+                    &err,
+                );
+                state.writer_failure = Some(msg.clone());
+                if self.options.strict_mode() {
+                    return Err(ImportError::Io {
+                        operation: "flush completed span jsonl writer",
+                        context: state.completed_span_writer_path.as_ref().map_or_else(
+                            || "completed-span-jsonl".to_owned(),
+                            |p| p.display().to_string(),
+                        ),
+                        reason: err.to_string(),
+                    });
+                }
+            }
         }
         Ok(())
     }
@@ -272,44 +286,44 @@ impl TracingIntakeSession {
     }
 }
 impl TracingIntakeSessionBuilder {
-    #[must_use]
     /// Enables or disables strict mode for conversion warnings.
+    #[must_use]
     pub fn strict(mut self, strict: bool) -> Self {
         self.recorder_builder = self.recorder_builder.strict(strict);
         self
     }
-    #[must_use]
     /// Sets service version metadata for converted run output.
+    #[must_use]
     pub fn service_version(mut self, service_version: impl Into<String>) -> Self {
         self.recorder_builder = self.recorder_builder.service_version(service_version);
         self
     }
-    #[must_use]
     /// Sets explicit run id metadata for converted run output.
+    #[must_use]
     pub fn run_id(mut self, run_id: impl Into<String>) -> Self {
         self.recorder_builder = self.recorder_builder.run_id(run_id);
         self
     }
-    #[must_use]
     /// Sets open/completed in-memory retention limits.
+    #[must_use]
     pub fn limits(mut self, limits: RecorderLimits) -> Self {
         self.recorder_builder = self.recorder_builder.limits(limits);
         self
     }
-    #[must_use]
     /// Sets maximum concurrently tracked open candidate spans.
+    #[must_use]
     pub fn max_open_spans(mut self, v: usize) -> Self {
         self.recorder_builder = self.recorder_builder.max_open_spans(v);
         self
     }
-    #[must_use]
     /// Sets maximum retained completed candidate spans in memory.
+    #[must_use]
     pub fn max_completed_spans(mut self, v: usize) -> Self {
         self.recorder_builder = self.recorder_builder.max_completed_spans(v);
         self
     }
-    #[must_use]
     /// Enables completed-span JSONL output at the given path.
+    #[must_use]
     ///
     /// Records are appended as spans close using the stable wrapper shape
     /// `{"format":"tailtriage.tracing-span.v1","span":{...}}`.
@@ -317,8 +331,8 @@ impl TracingIntakeSessionBuilder {
         self.completed_span_jsonl_path = Some(path.as_ref().to_path_buf());
         self
     }
-    #[must_use]
     /// Enables Run JSON output on shutdown at the given path.
+    #[must_use]
     pub fn run_json_path(mut self, path: impl AsRef<Path>) -> Self {
         self.run_json_path = Some(path.as_ref().to_path_buf());
         self
@@ -333,7 +347,8 @@ impl TracingIntakeSessionBuilder {
         if let Some(path) = self.completed_span_jsonl_path {
             let file = OpenOptions::new()
                 .create(true)
-                .append(true)
+                .write(true)
+                .truncate(true)
                 .open(&path)
                 .map_err(|err| ImportError::Io {
                     operation: "open completed span jsonl path",
@@ -342,6 +357,7 @@ impl TracingIntakeSessionBuilder {
                 })?;
             let mut state = lock_state(&recorder.state);
             state.completed_span_writer = Some(BufWriter::new(file));
+            state.completed_span_writer_path = Some(path);
         }
         Ok(TracingIntakeSession {
             recorder,
@@ -498,11 +514,19 @@ where
                     Ok(()) => match writer.write_all(b"\n") {
                         Ok(()) => {}
                         Err(err) => {
-                            state.writer_failure = Some(err.to_string());
+                            state.writer_failure = Some(format_writer_failure(
+                                "write newline",
+                                state.completed_span_writer_path.as_deref(),
+                                &err,
+                            ));
                         }
                     },
                     Err(err) => {
-                        state.writer_failure = Some(err.to_string());
+                        state.writer_failure = Some(format_writer_failure(
+                            "write span record",
+                            state.completed_span_writer_path.as_deref(),
+                            &err,
+                        ));
                     }
                 }
             }
@@ -519,6 +543,15 @@ fn metadata_has_tailtriage_field(metadata: &tracing::Metadata<'_>) -> bool {
         .fields()
         .iter()
         .any(|f| f.name().starts_with("tt."))
+}
+
+fn format_writer_failure(
+    operation: &str,
+    path: Option<&Path>,
+    err: &dyn std::error::Error,
+) -> String {
+    let path_text = path.map_or_else(|| "<unknown>".to_owned(), |p| p.display().to_string());
+    format!("completed-span JSONL writer failed to {operation} at {path_text}: {err}")
 }
 fn fields_have_tailtriage_key(fields: &BTreeMap<String, FieldValue>) -> bool {
     fields.keys().any(|k| k.starts_with("tt."))

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -231,7 +231,6 @@ impl TracingRecorder {
     ///
     /// Returns [`ImportError`] when strict conversion fails.
     pub fn shutdown(self) -> Result<ImportedRun, ImportError> {
-        self.flush_completed_span_writer()?;
         self.snapshot_run()
     }
 }
@@ -282,7 +281,6 @@ impl TracingIntakeSession {
     ///
     /// Returns an error when strict conversion fails.
     pub fn snapshot_run(&self) -> Result<ImportedRun, ImportError> {
-        self.recorder.flush_completed_span_writer()?;
         self.recorder.snapshot_run()
     }
     /// Finalizes intake and optionally writes run JSON when configured.

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -1,6 +1,9 @@
 use std::collections::BTreeMap;
 use std::fmt;
 use std::fmt::Write as _;
+use std::fs::OpenOptions;
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -18,6 +21,21 @@ pub struct TracingRecorder {
     state: Arc<Mutex<RecorderState>>,
     options: ImportOptions,
     limits: RecorderLimits,
+}
+/// High-level tracing intake session for first-time users.
+#[derive(Debug, Clone)]
+#[allow(missing_docs)]
+pub struct TracingIntakeSession {
+    recorder: TracingRecorder,
+    run_json_path: Option<PathBuf>,
+}
+/// Builder for [`TracingIntakeSession`].
+#[derive(Debug, Clone)]
+#[allow(missing_docs)]
+pub struct TracingIntakeSessionBuilder {
+    recorder_builder: TracingRecorderBuilder,
+    completed_span_jsonl_path: Option<PathBuf>,
+    run_json_path: Option<PathBuf>,
 }
 
 /// Builder for [`TracingRecorder`].
@@ -63,6 +81,8 @@ struct RecorderState {
     dropped_completed_spans: u64,
     closed_missing_kind_spans: u64,
     closed_missing_kind_samples: Vec<ClosedMissingKindSample>,
+    writer_failure: Option<String>,
+    completed_span_writer: Option<BufWriter<std::fs::File>>,
 }
 
 #[derive(Debug)]
@@ -98,6 +118,7 @@ struct SnapshotStats {
     open_samples: Vec<OpenSpanSample>,
     closed_missing_kind_spans: u64,
     closed_missing_kind_samples: Vec<ClosedMissingKindSample>,
+    writer_failure: Option<String>,
 }
 fn lock_state(state: &Arc<Mutex<RecorderState>>) -> std::sync::MutexGuard<'_, RecorderState> {
     match state.lock() {
@@ -158,6 +179,7 @@ impl TracingRecorder {
                     open_samples: samples,
                     closed_missing_kind_spans: state.closed_missing_kind_spans,
                     closed_missing_kind_samples: state.closed_missing_kind_samples.clone(),
+                    writer_failure: state.writer_failure.clone(),
                 },
             )
         };
@@ -173,6 +195,120 @@ impl TracingRecorder {
     /// Returns [`ImportError`] when strict conversion fails.
     pub fn shutdown(self) -> Result<ImportedRun, ImportError> {
         self.snapshot_run()
+    }
+}
+
+#[allow(missing_docs)]
+impl TracingIntakeSession {
+    /// Creates a builder with required service name metadata.
+    pub fn builder(service_name: impl Into<String>) -> TracingIntakeSessionBuilder {
+        TracingIntakeSessionBuilder {
+            recorder_builder: TracingRecorder::builder(service_name),
+            completed_span_jsonl_path: None,
+            run_json_path: None,
+        }
+    }
+    #[must_use]
+    pub fn layer(&self) -> TailtriageLayer {
+        self.recorder.layer()
+    }
+    /// Returns a non-consuming imported snapshot of completed spans.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when strict conversion fails.
+    pub fn snapshot_run(&self) -> Result<ImportedRun, ImportError> {
+        self.recorder.snapshot_run()
+    }
+    /// Finalizes intake and optionally writes run JSON when configured.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when conversion fails or when configured run-json output cannot be written.
+    pub fn shutdown(self) -> Result<ImportedRun, ImportError> {
+        let imported = self.recorder.shutdown()?;
+        if let Some(path) = self.run_json_path {
+            let file = std::fs::File::create(&path).map_err(|err| ImportError::Io {
+                operation: "create run json path",
+                context: path.display().to_string(),
+                reason: err.to_string(),
+            })?;
+            serde_json::to_writer_pretty(file, imported.run()).map_err(|err| {
+                ImportError::InvalidField {
+                    field: "run_json_path",
+                    reason: err.to_string(),
+                }
+            })?;
+        }
+        Ok(imported)
+    }
+}
+#[allow(missing_docs)]
+impl TracingIntakeSessionBuilder {
+    #[must_use]
+    pub fn strict(mut self, strict: bool) -> Self {
+        self.recorder_builder = self.recorder_builder.strict(strict);
+        self
+    }
+    #[must_use]
+    pub fn service_version(mut self, service_version: impl Into<String>) -> Self {
+        self.recorder_builder = self.recorder_builder.service_version(service_version);
+        self
+    }
+    #[must_use]
+    pub fn run_id(mut self, run_id: impl Into<String>) -> Self {
+        self.recorder_builder = self.recorder_builder.run_id(run_id);
+        self
+    }
+    #[must_use]
+    pub fn limits(mut self, limits: RecorderLimits) -> Self {
+        self.recorder_builder = self.recorder_builder.limits(limits);
+        self
+    }
+    #[must_use]
+    pub fn max_open_spans(mut self, v: usize) -> Self {
+        self.recorder_builder = self.recorder_builder.max_open_spans(v);
+        self
+    }
+    #[must_use]
+    pub fn max_completed_spans(mut self, v: usize) -> Self {
+        self.recorder_builder = self.recorder_builder.max_completed_spans(v);
+        self
+    }
+    #[must_use]
+    pub fn completed_span_jsonl_path(mut self, path: impl AsRef<Path>) -> Self {
+        self.completed_span_jsonl_path = Some(path.as_ref().to_path_buf());
+        self
+    }
+    #[must_use]
+    pub fn run_json_path(mut self, path: impl AsRef<Path>) -> Self {
+        self.run_json_path = Some(path.as_ref().to_path_buf());
+        self
+    }
+    /// Builds a tracing intake session and opens optional outputs.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the completed-span JSONL path cannot be opened.
+    pub fn build(self) -> Result<TracingIntakeSession, ImportError> {
+        let recorder = self.recorder_builder.build();
+        if let Some(path) = self.completed_span_jsonl_path {
+            let file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)
+                .map_err(|err| ImportError::Io {
+                    operation: "open completed span jsonl path",
+                    context: path.display().to_string(),
+                    reason: err.to_string(),
+                })?;
+            let mut state = lock_state(&recorder.state);
+            state.completed_span_writer = Some(BufWriter::new(file));
+        }
+        Ok(TracingIntakeSession {
+            recorder,
+            run_json_path: self.run_json_path,
+        })
     }
 }
 
@@ -311,6 +447,20 @@ where
             for (k, v) in open.fields {
                 record = record.field(k, v);
             }
+            record = record.format("tailtriage.tracing-span.v1");
+            if let Some(writer) = state.completed_span_writer.as_mut() {
+                match serde_json::to_writer(&mut *writer, &record) {
+                    Ok(()) => match writer.write_all(b"\n") {
+                        Ok(()) => {}
+                        Err(err) => {
+                            state.writer_failure = Some(err.to_string());
+                        }
+                    },
+                    Err(err) => {
+                        state.writer_failure = Some(err.to_string());
+                    }
+                }
+            }
             if state.completed.len() >= self.limits.max_completed_spans {
                 state.dropped_completed_spans = state.dropped_completed_spans.saturating_add(1);
                 return;
@@ -356,6 +506,11 @@ fn push_strict_recorder_messages(
         messages.push(format!(
             "live recorder dropped {} completed span(s) because max_completed_spans={} was reached; raise max_completed_spans or reduce capture scope",
             stats.dropped_completed_spans, limits.max_completed_spans
+        ));
+    }
+    if let Some(reason) = &stats.writer_failure {
+        messages.push(format!(
+            "live recorder failed writing completed-span JSONL output: {reason}"
         ));
     }
 }
@@ -434,6 +589,11 @@ fn append_non_strict_drop_warnings(
     if stats.dropped_open_spans > 0 || stats.dropped_completed_spans > 0 {
         run.truncation.limits_hit = true;
     }
+    if let Some(reason) = &stats.writer_failure {
+        let msg = format!("live recorder failed writing completed-span JSONL output: {reason}");
+        run.metadata.lifecycle_warnings.push(msg.clone());
+        warnings.push(crate::ImportWarning::new(msg));
+    }
 }
 
 fn imported_with_drop_warnings(
@@ -464,6 +624,7 @@ fn imported_with_drop_warnings(
         && stats.dropped_completed_spans == 0
         && stats.open_candidate_count == 0
         && stats.closed_missing_kind_spans == 0
+        && stats.writer_failure.is_none()
     {
         return Ok(imported);
     }

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -22,16 +22,26 @@ pub struct TracingRecorder {
     options: ImportOptions,
     limits: RecorderLimits,
 }
-/// High-level tracing intake session for first-time users.
+/// High-level tracing intake bridge for completed `tt.*` spans.
+///
+/// A session attaches to an existing `tracing_subscriber` registry via [`Self::layer`],
+/// captures completed `tt.*` spans, and converts them into standard `tailtriage_core::Run`
+/// artifacts through [`Self::snapshot_run`] or [`Self::shutdown`].
+///
+/// When configured, the session emits stable completed-span JSONL records in the
+/// wrapper form `{"format":"tailtriage.tracing-span.v1","span":{...}}` and can
+/// optionally write a Run JSON file on shutdown.
+///
+/// This API is intentionally a tracing intake bridge; it does not implement OTel/OTLP.
+/// Tracing-only evidence does not fabricate runtime-pressure snapshots, and suspects
+/// in resulting diagnosis reports remain triage leads rather than root-cause proof.
 #[derive(Debug, Clone)]
-#[allow(missing_docs)]
 pub struct TracingIntakeSession {
     recorder: TracingRecorder,
     run_json_path: Option<PathBuf>,
 }
 /// Builder for [`TracingIntakeSession`].
 #[derive(Debug, Clone)]
-#[allow(missing_docs)]
 pub struct TracingIntakeSessionBuilder {
     recorder_builder: TracingRecorderBuilder,
     completed_span_jsonl_path: Option<PathBuf>,
@@ -153,6 +163,7 @@ impl TracingRecorder {
     ///
     /// Returns [`ImportError`] when strict conversion fails.
     pub fn snapshot_run(&self) -> Result<ImportedRun, ImportError> {
+        self.flush_completed_span_writer()?;
         let (spans, stats) = {
             let state = lock_state(&self.state);
             let mut samples = Vec::new();
@@ -186,6 +197,18 @@ impl TracingRecorder {
         imported_with_drop_warnings(spans, self.options.clone(), &stats, self.limits)
     }
 
+    fn flush_completed_span_writer(&self) -> Result<(), ImportError> {
+        let mut state = lock_state(&self.state);
+        if let Some(writer) = state.completed_span_writer.as_mut() {
+            writer.flush().map_err(|err| ImportError::Io {
+                operation: "flush completed span jsonl writer",
+                context: "completed-span-jsonl".to_owned(),
+                reason: err.to_string(),
+            })?;
+        }
+        Ok(())
+    }
+
     /// Consumes this recorder handle and returns a final imported run snapshot.
     ///
     /// Span completion is driven by span close/drop, not enter/exit.
@@ -194,11 +217,11 @@ impl TracingRecorder {
     ///
     /// Returns [`ImportError`] when strict conversion fails.
     pub fn shutdown(self) -> Result<ImportedRun, ImportError> {
+        self.flush_completed_span_writer()?;
         self.snapshot_run()
     }
 }
 
-#[allow(missing_docs)]
 impl TracingIntakeSession {
     /// Creates a builder with required service name metadata.
     pub fn builder(service_name: impl Into<String>) -> TracingIntakeSessionBuilder {
@@ -208,6 +231,10 @@ impl TracingIntakeSession {
             run_json_path: None,
         }
     }
+    /// Returns a `tracing_subscriber` layer for this intake session.
+    ///
+    /// Add this layer beside your existing subscriber layers; this does not replace
+    /// your tracing pipeline.
     #[must_use]
     pub fn layer(&self) -> TailtriageLayer {
         self.recorder.layer()
@@ -218,6 +245,7 @@ impl TracingIntakeSession {
     ///
     /// Returns an error when strict conversion fails.
     pub fn snapshot_run(&self) -> Result<ImportedRun, ImportError> {
+        self.recorder.flush_completed_span_writer()?;
         self.recorder.snapshot_run()
     }
     /// Finalizes intake and optionally writes run JSON when configured.
@@ -243,44 +271,54 @@ impl TracingIntakeSession {
         Ok(imported)
     }
 }
-#[allow(missing_docs)]
 impl TracingIntakeSessionBuilder {
     #[must_use]
+    /// Enables or disables strict mode for conversion warnings.
     pub fn strict(mut self, strict: bool) -> Self {
         self.recorder_builder = self.recorder_builder.strict(strict);
         self
     }
     #[must_use]
+    /// Sets service version metadata for converted run output.
     pub fn service_version(mut self, service_version: impl Into<String>) -> Self {
         self.recorder_builder = self.recorder_builder.service_version(service_version);
         self
     }
     #[must_use]
+    /// Sets explicit run id metadata for converted run output.
     pub fn run_id(mut self, run_id: impl Into<String>) -> Self {
         self.recorder_builder = self.recorder_builder.run_id(run_id);
         self
     }
     #[must_use]
+    /// Sets open/completed in-memory retention limits.
     pub fn limits(mut self, limits: RecorderLimits) -> Self {
         self.recorder_builder = self.recorder_builder.limits(limits);
         self
     }
     #[must_use]
+    /// Sets maximum concurrently tracked open candidate spans.
     pub fn max_open_spans(mut self, v: usize) -> Self {
         self.recorder_builder = self.recorder_builder.max_open_spans(v);
         self
     }
     #[must_use]
+    /// Sets maximum retained completed candidate spans in memory.
     pub fn max_completed_spans(mut self, v: usize) -> Self {
         self.recorder_builder = self.recorder_builder.max_completed_spans(v);
         self
     }
     #[must_use]
+    /// Enables completed-span JSONL output at the given path.
+    ///
+    /// Records are appended as spans close using the stable wrapper shape
+    /// `{"format":"tailtriage.tracing-span.v1","span":{...}}`.
     pub fn completed_span_jsonl_path(mut self, path: impl AsRef<Path>) -> Self {
         self.completed_span_jsonl_path = Some(path.as_ref().to_path_buf());
         self
     }
     #[must_use]
+    /// Enables Run JSON output on shutdown at the given path.
     pub fn run_json_path(mut self, path: impl AsRef<Path>) -> Self {
         self.run_json_path = Some(path.as_ref().to_path_buf());
         self
@@ -315,6 +353,7 @@ impl TracingIntakeSessionBuilder {
 impl TracingRecorderBuilder {
     /// Sets service version metadata.
     #[must_use]
+    /// Sets service version metadata for converted run output.
     pub fn service_version(mut self, service_version: impl Into<String>) -> Self {
         self.options = self.options.service_version(service_version);
         self
@@ -322,6 +361,7 @@ impl TracingRecorderBuilder {
 
     /// Sets explicit run-id metadata.
     #[must_use]
+    /// Sets explicit run id metadata for converted run output.
     pub fn run_id(mut self, run_id: impl Into<String>) -> Self {
         self.options = self.options.run_id(run_id);
         self
@@ -329,6 +369,7 @@ impl TracingRecorderBuilder {
 
     /// Enables or disables strict conversion mode.
     #[must_use]
+    /// Enables or disables strict mode for conversion warnings.
     pub fn strict(mut self, strict: bool) -> Self {
         self.options = self.options.strict(strict);
         self
@@ -345,6 +386,7 @@ impl TracingRecorderBuilder {
     }
     /// Sets both open/completed in-memory span retention limits.
     #[must_use]
+    /// Sets open/completed in-memory retention limits.
     pub fn limits(mut self, limits: RecorderLimits) -> Self {
         self.limits = limits;
         self
@@ -447,9 +489,12 @@ where
             for (k, v) in open.fields {
                 record = record.field(k, v);
             }
-            record = record.format("tailtriage.tracing-span.v1");
             if let Some(writer) = state.completed_span_writer.as_mut() {
-                match serde_json::to_writer(&mut *writer, &record) {
+                let wrapped = serde_json::json!({
+                    "format": "tailtriage.tracing-span.v1",
+                    "span": record,
+                });
+                match serde_json::to_writer(&mut *writer, &wrapped) {
                     Ok(()) => match writer.write_all(b"\n") {
                         Ok(()) => {}
                         Err(err) => {

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -1725,4 +1725,43 @@ mod tests {
         assert!(line.contains("\"tt.request_id\":\"r1\""));
         assert!(!line.contains("unrelated"));
     }
+
+    #[test]
+    fn intake_session_captures_request_stage_queue() {
+        let session = TracingIntakeSession::builder("svc").build().unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "req-1",
+                tt.route = "/checkout",
+                tt.outcome = "ok"
+            ));
+            drop(tracing::info_span!(
+                "stage",
+                tt.kind = "stage",
+                tt.request_id = "req-1",
+                tt.stage = "db",
+                tt.success = true
+            ));
+            drop(tracing::info_span!(
+                "queue",
+                tt.kind = "queue",
+                tt.request_id = "req-1",
+                tt.queue = "admission",
+                tt.depth_at_start = 7_u64
+            ));
+        });
+        let snapshot = session.snapshot_run().unwrap();
+        let run = snapshot.run();
+        assert_eq!(run.requests.len(), 1);
+        assert_eq!(run.stages.len(), 1);
+        assert_eq!(run.queues.len(), 1);
+        assert!(run.runtime_snapshots.is_empty());
+        assert_eq!(run.requests[0].route, "/checkout");
+        assert_eq!(run.stages[0].stage, "db");
+        assert_eq!(run.queues[0].queue, "admission");
+        assert_eq!(run.queues[0].depth_at_start, Some(7));
+    }
 }

--- a/tailtriage-tracing/src/types.rs
+++ b/tailtriage-tracing/src/types.rs
@@ -86,8 +86,6 @@ impl From<f64> for FieldValue {
 /// A tracing-shaped finished span record ready for intake conversion.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SpanRecord {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    format: Option<String>,
     id: Option<String>,
     parent_id: Option<String>,
     name: String,
@@ -102,7 +100,6 @@ impl SpanRecord {
     /// Creates a new span record with required timing fields.
     pub fn new(name: impl Into<String>, started_at_unix_ms: u64, finished_at_unix_ms: u64) -> Self {
         Self {
-            format: None,
             id: None,
             parent_id: None,
             name: name.into(),
@@ -137,12 +134,6 @@ impl SpanRecord {
     #[must_use]
     pub fn duration_us(mut self, duration_us: u64) -> Self {
         self.duration_us = Some(duration_us);
-        self
-    }
-    /// Sets stable on-disk format marker.
-    #[must_use]
-    pub fn format(mut self, format: impl Into<String>) -> Self {
-        self.format = Some(format.into());
         self
     }
 
@@ -180,11 +171,6 @@ impl SpanRecord {
     #[must_use]
     pub fn duration_us_ref(&self) -> Option<u64> {
         self.duration_us
-    }
-    /// Returns optional format marker.
-    #[must_use]
-    pub fn format_ref(&self) -> Option<&str> {
-        self.format.as_deref()
     }
 }
 

--- a/tailtriage-tracing/src/types.rs
+++ b/tailtriage-tracing/src/types.rs
@@ -86,6 +86,8 @@ impl From<f64> for FieldValue {
 /// A tracing-shaped finished span record ready for intake conversion.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SpanRecord {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    format: Option<String>,
     id: Option<String>,
     parent_id: Option<String>,
     name: String,
@@ -100,6 +102,7 @@ impl SpanRecord {
     /// Creates a new span record with required timing fields.
     pub fn new(name: impl Into<String>, started_at_unix_ms: u64, finished_at_unix_ms: u64) -> Self {
         Self {
+            format: None,
             id: None,
             parent_id: None,
             name: name.into(),
@@ -134,6 +137,12 @@ impl SpanRecord {
     #[must_use]
     pub fn duration_us(mut self, duration_us: u64) -> Self {
         self.duration_us = Some(duration_us);
+        self
+    }
+    /// Sets stable on-disk format marker.
+    #[must_use]
+    pub fn format(mut self, format: impl Into<String>) -> Self {
+        self.format = Some(format.into());
         self
     }
 
@@ -171,6 +180,11 @@ impl SpanRecord {
     #[must_use]
     pub fn duration_us_ref(&self) -> Option<u64> {
         self.duration_us
+    }
+    /// Returns optional format marker.
+    #[must_use]
+    pub fn format_ref(&self) -> Option<&str> {
+        self.format.as_deref()
     }
 }
 

--- a/tailtriage-tracing/tests/fixtures/tailtriage-span-v1.jsonl
+++ b/tailtriage-tracing/tests/fixtures/tailtriage-span-v1.jsonl
@@ -1,0 +1,3 @@
+{"format":"tailtriage.tracing-span.v1","span":{"name":"http.request","started_at_unix_ms":1700000000000,"finished_at_unix_ms":1700000000030,"duration_us":30000,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}
+{"format":"tailtriage.tracing-span.v1","span":{"name":"db.stage","started_at_unix_ms":1700000000005,"finished_at_unix_ms":1700000000015,"duration_us":10000,"fields":{"tt.kind":"stage","tt.request_id":"req-1","tt.stage":"db","tt.success":true}}}
+{"format":"tailtriage.tracing-span.v1","span":{"name":"admission.queue","started_at_unix_ms":1700000000000,"finished_at_unix_ms":1700000000004,"duration_us":4000,"fields":{"tt.kind":"queue","tt.request_id":"req-1","tt.queue":"admission","tt.depth_at_start":7}}}


### PR DESCRIPTION
### Motivation

- This is the merge-readiness hardening pass on top of #547’s tracing-intake bridge.
- The original tracing import surface could be read as supporting arbitrary structured tracing JSON, but reliable tailtriage import requires completed span records with explicit start/end timing.
- This change makes the tracing intake contract explicit and gives existing Rust `tracing` users a first-class `tracing_subscriber` layer/session so they can emit tailtriage-ready artifacts without duplicating instrumentation.
- The goal is to reduce adoption friction while avoiding misleading claims about generic log scraping, OpenTelemetry/OTLP, or broader observability-platform behavior.

### User-facing adoption path

Recommended path for existing `tracing` users:

1. Keep existing spans.
2. Add literal dotted `tt.*` fields to request/stage/queue spans.
3. Add `TracingIntakeSession::builder(...).build()?` and `session.layer()` beside the existing `tracing_subscriber` setup.
4. Either:
   - write Run JSON directly with `run_json_path(...)`, then run `tailtriage analyze <run.json>`; or
   - write completed-span JSONL with `completed_span_jsonl_path(...)`, then run:

   ```bash
   tailtriage import tracing-json <completed-spans.jsonl> \
     --input-format tailtriage-span-jsonl \
     --service <service> \
     --output <run.json>

   tailtriage analyze <run.json>
   ```

### Description

* Added `TracingIntakeSession` and `TracingIntakeSessionBuilder` as the high-level tracing intake API over the existing recorder.

  * Exposes `layer()`, `snapshot_run()`, and `shutdown()`.
  * Supports builder options including `strict(bool)`, `service_version(...)`, `run_id(...)`, `limits(RecorderLimits)`, `max_open_spans(usize)`, `max_completed_spans(usize)`, `completed_span_jsonl_path(path)`, and `run_json_path(path)`.
  * The session can write Run JSON on shutdown and/or stream completed-span JSONL as spans close.

* Introduced the stable completed-span JSONL wrapper format:

  ```json
  {"format":"tailtriage.tracing-span.v1","span":{...}}
  ```

  This is the preferred offline import contract. The `format` marker belongs to the wrapper, not to `SpanRecord`.

* Added explicit JSONL parse modes:

  * `JsonlParseMode::Compatible` keeps compatibility with older normalized shapes where appropriate.
  * `JsonlParseMode::TailtriageWrapperOnly` accepts only the stable wrapper format.
  * `import_jsonl_path_with_mode(...)` exposes explicit parser behavior.

* Implemented completed-span JSONL streaming on span close.

  * Output files configured through `completed_span_jsonl_path(...)` are created or truncated when the session is built.
  * JSONL writing happens before in-memory `max_completed_spans` retention is applied, so file output can preserve completed spans even when retained in-memory spans are capped.
  * Writer failures are surfaced as strict errors or non-strict warnings/lifecycle warnings rather than panics.

* Tightened CLI import semantics.

  * `tailtriage import tracing-json` gained `--input-format auto|tailtriage-span-jsonl|tracing-subscriber-fmt-json`.
  * `auto` keeps compatibility parsing and rejects likely ordinary `tracing_subscriber::fmt().json()` logs with setup guidance.
  * `tailtriage-span-jsonl` enforces the stable wrapper-only contract.
  * `tracing-subscriber-fmt-json` intentionally fails with guidance instead of pretending arbitrary fmt JSON logs are supported.
  * Zero-request imports still fail and include a setup hint pointing users to `TracingIntakeSession`.

### Tests, fixtures, and examples

* Added a stable golden fixture:

  * `tailtriage-tracing/tests/fixtures/tailtriage-span-v1.jsonl`
  * covers request, stage, and queue wrapper records with deterministic timestamps and `duration_us`.

* Added/updated tracing intake tests for:

  * live `TracingRecorder` / `TracingIntakeSession` span capture
  * request-only and request + stage + queue conversion
  * strict and non-strict malformed span behavior
  * open-span and completed-span retention warnings
  * completed-span JSONL wrapper emission
  * completed-span JSONL truncation behavior
  * retention-independent JSONL streaming
  * wrapper-only JSONL parse mode behavior
  * compatible parsing for older normalized shapes
  * duration preservation from `duration_us`
  * unrelated span filtering
  * writer-open failure behavior

* Added/updated CLI boundary tests for:

  * importing stable wrapper JSONL in default `auto` mode
  * importing stable wrapper JSONL with `--input-format tailtriage-span-jsonl`
  * rejecting unwrapped normalized JSONL under `--input-format tailtriage-span-jsonl`
  * failing explicit `--input-format tracing-subscriber-fmt-json` with setup guidance
  * rejecting likely fmt JSON in default `auto` mode with setup guidance
  * preserving zero-request failure behavior
  * producing Run JSON that the existing analyzer can consume

* Added examples:

  * `tailtriage-tracing/examples/live_session_to_run.rs`
  * `tailtriage-tracing/examples/completed_span_jsonl_import.rs`

### Documentation and validation wording

* Updated public docs to teach one coherent tracing adoption path:

  * root `README.md`
  * `docs/README.md`
  * `docs/user-guide.md`
  * `docs/operations.md`
  * `docs/architecture.md`
  * `tailtriage-cli/README.md`
  * `tailtriage-tracing/README.md`
  * `SPEC.md`
  * `IMPLEMENTATION_PLAN.md`
  * `VALIDATION.md`

* Docs now distinguish:

  * direct Run JSON output via `run_json_path(...)`
  * completed-span JSONL output via `completed_span_jsonl_path(...)` + CLI import
  * stable wrapper JSONL from ordinary formatted tracing logs

* Validation wording now covers tracing-intake contract tests and keeps claims bounded:

  * conversion and guardrail correctness are tested;
  * production root-cause truth is not claimed;
  * arbitrary fmt JSON import is not claimed;
  * OTel/OTLP is not claimed;
  * runtime-pressure evidence still requires runtime snapshots/Tokio sampler coupling.

### Benefit over #547

Compared with #547, this PR turns the tracing bridge from a mostly normalized-import/recorder surface into a user-friendly, reliable adoption path:

* users get a first-class `TracingIntakeSession` instead of starting from lower-level recorder/import APIs;
* the offline file contract is explicit and stable (`tailtriage.tracing-span.v1` wrapper JSONL);
* CLI import no longer overpromises arbitrary tracing JSON support;
* likely `tracing_subscriber::fmt().json()` input fails with actionable guidance instead of producing confusing empty/partial imports;
* completed-span JSONL streaming is independent of in-memory retention;
* writer failures and retention drops are surfaced through strict errors or non-strict warnings;
* docs, examples, fixtures, and tests now align with the intended product story.

### Public API changes

* Added:

  * `TracingIntakeSession`
  * `TracingIntakeSessionBuilder`
  * `JsonlParseMode`
  * `import_jsonl_path_with_mode(...)`

* No `SpanRecord::format(...)` or `SpanRecord::format_ref()` public API is added. The stable format marker lives in the JSONL wrapper.

### Remaining limitations

* Arbitrary `tracing_subscriber::fmt().json()` log import is intentionally unsupported in this PR. Use `TracingIntakeSession` to emit completed-span JSONL instead.
* OpenTelemetry/OTLP remains out of scope.
* Tracing-only intake does not fabricate runtime-pressure evidence. Runtime-pressure evidence still requires runtime snapshots/Tokio sampler coupling.
* Analyzer semantics and the Run schema are unchanged.

### Checks

Expected final checks for this stacked PR:

* `python3 scripts/validate_docs_contracts.py`
* `python3 -m unittest scripts.tests.test_validate_docs_contracts`
* `cargo fmt --check`
* `cargo test --workspace --all-targets --all-features --locked`
* `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
* `cargo test -p tailtriage-tracing --examples --all-features` if examples are not otherwise covered by the workspace command