### PR TITLE
Tighten tracing import format UX and persisted run safeguards

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -113,7 +113,7 @@ Near-term tasks:
 - keep docs aligned to the implemented tracing-intake path:
   - `TracingIntakeSession` as the primary live setup
   - stable completed-span JSONL wrapper (`tailtriage.tracing-span.v1`)
-  - CLI `--input-format` guardrails (`auto`, `tailtriage-span-jsonl`, `tracing-subscriber-fmt-json`)
+  - CLI `--input-format` guardrails (`auto`, `tailtriage-span-jsonl`)
   - golden wrapper fixture, examples, and contract tests for request/stage/queue + duration preservation
 - keep positioning explicit: tracing intake converts tracing-shaped evidence into standard Runs for the existing analyzer
 - preserve bounded claims: no tracing backend semantics, no OTel/OTLP, no observability-platform expansion

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -43,7 +43,7 @@ tailtriage import tracing-json completed-spans.jsonl --input-format tailtriage-s
 tailtriage analyze tailtriage-run.json
 ```
 
-`tailtriage import tracing-json` writes Run artifact JSON (not Report JSON), and analysis remains a separate step after import. Use the documented stable wrapper JSONL shape from `tailtriage-tracing` (`{"format":"tailtriage.tracing-span.v1","span":{...}}`). `--strict` fails on malformed or incomplete `tt.*` spans; non-strict mode skips malformed `tt.*` spans and prints `warning: ...` messages. Tracing-only runs do not fabricate runtime snapshots, and runtime-pressure evidence remains Tokio-specific.
+`tailtriage import tracing-json` writes Run artifact JSON (not Report JSON), and analysis remains a separate step after import. Use the documented stable wrapper JSONL shape from `tailtriage-tracing` (`{"format":"tailtriage.tracing-span.v1","span":{...}}`). Arbitrary `tracing_subscriber::fmt().json()` logs are not imported. `--strict` fails on malformed or incomplete `tt.*` spans; non-strict mode skips malformed `tt.*` spans and prints `warning: ...` messages. Import does not guess timing from line receive time; completed spans must provide explicit unix-ms start/end timestamps. Tracing-only runs do not fabricate runtime snapshots, and runtime-pressure evidence remains Tokio-specific.
 
 B) Direct Run JSON path:
 
@@ -342,3 +342,6 @@ Semantics notes:
 - [Diagnostics guide](diagnostics.md)
 - [Getting started demos](getting-started-demo.md)
 - [Architecture](architecture.md)
+
+
+Stage and queue spans use their own `tt.stage` / `tt.queue` fields around the awaited work they measure.

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -55,7 +55,7 @@ tailtriage import tracing-json spans.jsonl --input-format tailtriage-span-jsonl 
 ```
 
 
-`tailtriage import tracing-json` imports **completed tracing span records** into **Run JSON** (not Report JSON).
+`tailtriage import tracing-json` imports **completed `tt.*` tracing span JSONL records** into **Run JSON** (not Report JSON). Analysis is a separate step.
 
 Recommended stable input format is the tailtriage wrapper JSONL shape:
 
@@ -66,12 +66,10 @@ Recommended stable input format is the tailtriage wrapper JSONL shape:
 `--input-format` values:
 - `auto`
 - `tailtriage-span-jsonl`
-- `tracing-subscriber-fmt-json`
 
 Behavior:
 - `tailtriage-span-jsonl` enforces wrapper-only parsing.
 - `auto` keeps compatibility parsing for older normalized shapes and rejects likely ordinary `tracing_subscriber::fmt().json()` logs with setup guidance.
-- `tracing-subscriber-fmt-json` intentionally fails with setup guidance in the current product scope.
 
 After import, run analysis separately:
 
@@ -285,3 +283,6 @@ Use capture-side crates for that:
 - `tailtriage-controller`: repeated bounded windows
 - `tailtriage-tokio`: runtime-pressure sampling
 - `tailtriage-axum`: Axum request-boundary integration
+
+
+Auto mode rejects ordinary `tracing_subscriber::fmt().json()` logs early with guidance. Import does not guess timing from line receive time; it requires explicit unix-ms start/end timestamps on completed spans.

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -1,3 +1,4 @@
+use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 
 use clap::{Parser, ValueEnum};
@@ -43,7 +44,7 @@ enum Command {
 
 #[derive(Debug, clap::Subcommand)]
 enum ImportCommand {
-    /// Import completed tracing span records from JSONL into run JSON.
+    /// Import completed tt.* tracing span JSONL into tailtriage Run JSON.
     TracingJson {
         /// Path to newline-delimited JSON span records.
         #[arg(value_name = "SPANS_JSONL")]
@@ -72,7 +73,6 @@ enum ImportCommand {
 enum TracingInputFormat {
     Auto,
     TailtriageSpanJsonl,
-    TracingSubscriberFmtJson,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -103,17 +103,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                     options = options.run_id(run_id);
                 }
 
-                if matches!(input_format, TracingInputFormat::TracingSubscriberFmtJson) {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::InvalidInput,
-                        tracing_json_setup_guidance(),
-                    )
-                    .into());
-                }
-                if matches!(
-                    input_format,
-                    TracingInputFormat::Auto | TracingInputFormat::TailtriageSpanJsonl
-                ) && input_looks_like_tracing_fmt_json(&spans_jsonl)?
+                if matches!(input_format, TracingInputFormat::Auto)
+                    && input_looks_like_tracing_fmt_json(&spans_jsonl)?
                 {
                     return Err(std::io::Error::new(
                         std::io::ErrorKind::InvalidInput,
@@ -125,21 +116,13 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                     TracingInputFormat::TailtriageSpanJsonl => {
                         JsonlParseMode::TailtriageWrapperOnly
                     }
-                    TracingInputFormat::Auto | TracingInputFormat::TracingSubscriberFmtJson => {
-                        JsonlParseMode::Compatible
-                    }
+                    TracingInputFormat::Auto => JsonlParseMode::Compatible,
                 };
                 let imported = import_jsonl_path_with_mode(spans_jsonl, options, parse_mode)?;
                 for warning in imported.warnings() {
                     eprintln!("warning: {}", warning.message());
                 }
-                if imported.run().requests.is_empty() {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        "tracing import produced zero request events; tailtriage requires completed tt.request spans (tt.kind=request, tt.request_id, tt.route) with start/end timestamps. Configure TracingIntakeSession::builder(...).completed_span_jsonl_path(...) then run: tailtriage import tracing-json <completed-spans.jsonl> --input-format tailtriage-span-jsonl --service <service> --output <run-json>",
-                    )
-                    .into());
-                }
+                tailtriage_tracing::ensure_persistable_run_has_requests(imported.run())?;
 
                 let file = std::fs::File::create(&output)?;
                 serde_json::to_writer_pretty(file, imported.run())?;
@@ -185,12 +168,14 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn tracing_json_setup_guidance() -> &'static str {
-    "ordinary tracing_subscriber::fmt().json() logs are not the supported primary import format. tailtriage needs completed tt.* span records with start/end timestamps. Recommended setup: TracingIntakeSession::builder(...).completed_span_jsonl_path(...). Then import with: tailtriage import tracing-json <completed-spans.jsonl> --input-format tailtriage-span-jsonl --service <service> --output <run-json>"
+    "the file looks like ordinary tracing log JSON, not completed tailtriage span JSONL. tailtriage requires completed spans with literal dotted tt.* keys and explicit unix-ms start/end timestamps. Recommended path: TracingIntakeSession::builder(...).completed_span_jsonl_path(...); then run tailtriage import tracing-json <completed-spans.jsonl> --input-format tailtriage-span-jsonl --service <service> --output <run-json>"
 }
 
 fn input_looks_like_tracing_fmt_json(path: &std::path::Path) -> Result<bool, std::io::Error> {
-    let contents = std::fs::read_to_string(path)?;
-    for line in contents.lines() {
+    let file = std::fs::File::open(path)?;
+    let reader = BufReader::new(file);
+    for line_result in reader.lines() {
+        let line = line_result?;
         let trimmed = line.trim();
         if trimmed.is_empty() {
             continue;
@@ -209,11 +194,9 @@ fn input_looks_like_tracing_fmt_json(path: &std::path::Path) -> Result<bool, std
             let looks_like_fmt = value.get("timestamp").is_some()
                 && value.get("level").is_some()
                 && value.get("target").is_some();
-            if looks_like_fmt && !has_span_timestamps {
-                return Ok(true);
-            }
+            return Ok(looks_like_fmt && !has_span_timestamps);
         }
-        break;
+        return Ok(false);
     }
     Ok(false)
 }

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -307,26 +307,18 @@ fn import_tracing_json_input_format_tailtriage_wrapper_only_rejects_unwrapped() 
 }
 
 #[test]
-fn import_tracing_json_input_format_fmt_json_fails_with_guidance() {
-    let dir = tempfile::tempdir().expect("tempdir should build");
-    let spans_path = dir.path().join("fmt.jsonl");
-    std::fs::write(&spans_path, r#"{"timestamp":"2026-01-01T00:00:00Z","level":"INFO","target":"svc","fields":{"message":"close"}}"#).unwrap();
+fn import_tracing_json_no_dead_input_format_option_is_advertised() {
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
         .arg("tracing-json")
-        .arg(&spans_path)
-        .arg("--input-format")
-        .arg("tracing-subscriber-fmt-json")
-        .arg("--service")
-        .arg("checkout")
-        .arg("--output")
-        .arg(dir.path().join("run.json"))
+        .arg("--help")
         .output()
         .expect("cli should run");
-    assert!(!output.status.success());
-    let stderr = String::from_utf8(output.stderr).unwrap();
-    assert!(stderr.contains("TracingIntakeSession"));
-    assert!(stderr.contains("tailtriage-span-jsonl"));
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("auto"));
+    assert!(stdout.contains("tailtriage-span-jsonl"));
+    assert!(!stdout.contains("tracing-subscriber-fmt-json"));
 }
 
 #[test]
@@ -347,11 +339,42 @@ fn import_tracing_json_auto_rejects_fmt_json_with_guidance() {
         .expect("cli should run");
     assert!(!output.status.success());
     let stderr = String::from_utf8(output.stderr).unwrap();
-    assert!(stderr.contains("tracing_subscriber::fmt().json()"));
-    assert!(stderr.contains("completed tt.*") || stderr.contains("completed tt.* span records"));
+    assert!(stderr.contains("ordinary tracing log JSON"));
+    assert!(
+        stderr.contains("completed tailtriage span JSONL")
+            || stderr.contains("literal dotted tt.* keys")
+    );
     assert!(stderr.contains("TracingIntakeSession"));
     assert!(stderr.contains("tailtriage-span-jsonl"));
     assert!(!run_path.exists());
+}
+
+#[test]
+fn import_tracing_json_explicit_tailtriage_span_jsonl_does_not_run_fmt_sniff() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(
+        &spans_path,
+        r#"{"timestamp":"2026-01-01T00:00:00Z","level":"INFO","target":"svc","fields":{"message":"close"}}"#,
+    )
+    .unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--input-format")
+        .arg("tailtriage-span-jsonl")
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(!stderr.contains("ordinary tracing log JSON"));
+    assert!(stderr.contains("tailtriage.tracing-span.v1") || stderr.contains("stable wrapper"));
 }
 
 #[test]
@@ -515,7 +538,7 @@ fn import_tracing_json_fails_when_only_unrelated_lines_are_present() {
         .expect("cli should run");
     assert!(!output.status.success(), "cli unexpectedly succeeded");
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
-    assert!(stderr.contains("zero request events"));
+    assert!(stderr.contains("persisted Run JSON artifacts intended for tailtriage analyze require at least one completed tt.kind=\"request\" span"));
     assert!(!run_path.exists(), "run output should not be written");
 }
 
@@ -538,7 +561,7 @@ fn import_tracing_json_fails_when_non_strict_skips_all_malformed_tt_spans() {
     assert!(!output.status.success(), "cli unexpectedly succeeded");
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
     assert!(stderr.contains("warning:"));
-    assert!(stderr.contains("zero request events"));
+    assert!(stderr.contains("persisted Run JSON artifacts intended for tailtriage analyze require at least one completed tt.kind=\"request\" span"));
     assert!(!run_path.exists(), "run output should not be written");
 }
 
@@ -563,7 +586,7 @@ fn import_tracing_json_fails_when_only_tt_spans_are_missing_kind() {
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
     assert!(stderr.contains("warning:"));
     assert!(stderr.contains("missing required field 'tt.kind'"));
-    assert!(stderr.contains("zero request events"));
+    assert!(stderr.contains("persisted Run JSON artifacts intended for tailtriage analyze require at least one completed tt.kind=\"request\" span"));
     assert!(!run_path.exists(), "run output should not be written");
 }
 

--- a/tailtriage-tracing/src/error.rs
+++ b/tailtriage-tracing/src/error.rs
@@ -34,6 +34,11 @@ pub enum ImportError {
     EmptyServiceName,
     /// Imported run event failed `tailtriage-core` run-builder validation.
     InvalidRunEvent(String),
+    /// Persisted Run JSON artifact is empty and cannot be analyzed by tailtriage CLI.
+    ZeroRequestArtifact {
+        /// Actionable guidance to produce at least one completed request span.
+        guidance: String,
+    },
 }
 
 impl fmt::Display for ImportError {
@@ -54,6 +59,7 @@ impl fmt::Display for ImportError {
             Self::StrictViolation(message) => write!(f, "strict import violation: {message}"),
             Self::EmptyServiceName => write!(f, "service name must not be empty"),
             Self::InvalidRunEvent(message) => write!(f, "invalid run event: {message}"),
+            Self::ZeroRequestArtifact { guidance } => write!(f, "{guidance}"),
         }
     }
 }

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -388,6 +388,20 @@ fn filter_correlated_queues(
     Ok(())
 }
 
+/// Ensures a Run JSON artifact intended for persistence is analyzable by `tailtriage analyze`.
+///
+/// # Errors
+///
+/// Returns [`ImportError::ZeroRequestArtifact`] when the run has zero request events.
+pub fn ensure_persistable_run_has_requests(run: &tailtriage_core::Run) -> Result<(), ImportError> {
+    if run.requests.is_empty() {
+        return Err(ImportError::ZeroRequestArtifact {
+            guidance: "persisted Run JSON artifacts intended for tailtriage analyze require at least one completed tt.kind=\"request\" span with tt.request_id, tt.route, and explicit unix-ms timing fields (start/end)".to_owned(),
+        });
+    }
+    Ok(())
+}
+
 fn validate_service_name(service_name: &str) -> Result<(), ImportError> {
     if service_name.trim().is_empty() {
         return Err(ImportError::EmptyServiceName);
@@ -1390,5 +1404,31 @@ mod tests {
     fn empty_service_name_is_rejected() {
         let err = run_from_span_records(Vec::new(), ImportOptions::new(" ")).unwrap_err();
         assert!(matches!(err, ImportError::EmptyServiceName));
+    }
+}
+
+#[cfg(test)]
+mod persistable_run_tests {
+    use super::*;
+
+    #[test]
+    fn ensure_persistable_run_has_requests_ok_when_run_has_request() {
+        let imported = run_from_span_records(
+            [SpanRecord::new("request", 1, 2)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/")],
+            ImportOptions::new("svc"),
+        )
+        .expect("import should succeed");
+        assert!(ensure_persistable_run_has_requests(imported.run()).is_ok());
+    }
+
+    #[test]
+    fn ensure_persistable_run_has_requests_err_when_run_has_no_requests() {
+        let imported =
+            run_from_span_records([], ImportOptions::new("svc")).expect("import should succeed");
+        let err = ensure_persistable_run_has_requests(imported.run()).expect_err("should fail");
+        assert!(matches!(err, ImportError::ZeroRequestArtifact { .. }));
     }
 }

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -12,7 +12,8 @@ use tracing::{Id, Subscriber};
 use tracing_subscriber::layer::{Context, Layer};
 
 use crate::{
-    run_from_span_records, FieldValue, ImportError, ImportOptions, ImportedRun, SpanRecord, TT_KIND,
+    ensure_persistable_run_has_requests, run_from_span_records, FieldValue, ImportError,
+    ImportOptions, ImportedRun, SpanRecord, TT_KIND,
 };
 
 /// In-memory recorder for completed tracing spans with `tt.*` fields.
@@ -291,6 +292,7 @@ impl TracingIntakeSession {
     pub fn shutdown(self) -> Result<ImportedRun, ImportError> {
         let imported = self.recorder.shutdown()?;
         if let Some(path) = self.run_json_path {
+            ensure_persistable_run_has_requests(imported.run())?;
             let file = std::fs::File::create(&path).map_err(|err| ImportError::Io {
                 operation: "create run json path",
                 context: path.display().to_string(),
@@ -1695,6 +1697,35 @@ mod tests {
         let run: tailtriage_core::Run =
             serde_json::from_slice(&std::fs::read(&run_path).unwrap()).unwrap();
         assert_eq!(run.requests.len(), 1);
+    }
+
+    #[test]
+    fn intake_session_run_json_path_zero_requests_does_not_create_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_path = dir.path().join("run.json");
+        let session = TracingIntakeSession::builder("svc")
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let err = session.shutdown().unwrap_err();
+        assert!(matches!(err, ImportError::ZeroRequestArtifact { .. }));
+        assert!(!run_path.exists());
+    }
+
+    #[test]
+    fn intake_session_run_json_path_zero_requests_keeps_existing_file_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_path = dir.path().join("run.json");
+        std::fs::write(&run_path, "sentinel").unwrap();
+        let before = std::fs::read(&run_path).unwrap();
+        let session = TracingIntakeSession::builder("svc")
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let err = session.shutdown().unwrap_err();
+        assert!(matches!(err, ImportError::ZeroRequestArtifact { .. }));
+        let after = std::fs::read(&run_path).unwrap();
+        assert_eq!(before, after);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Make tracing intake clear and safe by only accepting completed `tt.*` span JSONL as an import source and rejecting ordinary `tracing_subscriber::fmt().json()` logs with actionable guidance. 
- Prevent the CLI or `TracingIntakeSession::shutdown()` from creating or overwriting persisted Run JSON artifacts that contain zero requests, since such artifacts are not analyzable by `tailtriage analyze`.

### Description
- Removed the dead `tracing-subscriber-fmt-json` `--input-format` option and now advertise/accept only `auto` and `tailtriage-span-jsonl` in the CLI, and updated the `tracing-json` subcommand help to say it imports completed `tt.*` tracing span JSONL into Run JSON. 
- Made format sniffing streaming and auto-only by changing `input_looks_like_tracing_fmt_json` to use `BufReader`, read line-by-line, return after the first non-empty line, and only call the helper when `--input-format auto`. 
- Improved the auto-mode rejection message so it precisely explains the file looks like ordinary tracing log JSON (not completed tailtriage span JSONL), states the required shape (literal dotted `tt.*` keys and unix-ms start/end timestamps), and recommends `TracingIntakeSession::builder(...).completed_span_jsonl_path(...)` then `tailtriage import tracing-json <completed-spans.jsonl> --input-format tailtriage-span-jsonl --service <service> --output <run-json>`. 
- Added a shared persisted-artifact guard in `tailtriage-tracing`: `pub fn ensure_persistable_run_has_requests(run: &tailtriage_core::Run) -> Result<(), ImportError>` and a new error variant `ImportError::ZeroRequestArtifact { guidance: String }`. 
- Wired the helper into the CLI import path (called before writing `--output`) and into `TracingIntakeSession::shutdown()` (called before creating/writing the configured `run_json_path`), so shutdown/import refuse to create/overwrite files when the resulting run has zero requests. 
- Updated and added tests and examples: CLI tests to cover explicit `tailtriage-span-jsonl` mode, auto-mode sniffing failure guidance, advertising only implemented input formats, and zero-request output refusal without file creation; tracing session tests to assert `run_json_path(...)` refuses to create/overwrite on zero-request shutdown; unit tests for `ensure_persistable_run_has_requests`. 
- Updated docs and README entries (`tailtriage-cli/README.md`, `tailtriage-tracing/README.md`, `docs/user-guide.md`, `docs/operations.md`, `IMPLEMENTATION_PLAN.md`) to consistently state: tracing import expects completed `tt.*` span JSONL, import writes Run JSON (analysis is a separate step), arbitrary fmt JSON is not imported, timing must be explicit, and tracing-only runs do not fabricate runtime snapshots.

### Testing
- Ran `cargo fmt --check` and fixed formatting (passed). 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and addressed warnings (passed). 
- Ran `python3 scripts/validate_docs_contracts.py` (docs contract validation passed). 
- Ran the test suite and updated tests during the rollout: CLI boundary tests covering tracing import behavior and tracing-session tests were added/updated; failing assertions discovered during iteration were corrected and re-run; the modified `tailtriage-cli` and `tailtriage-tracing` tests covering the new behaviors (explicit-format import, auto-mode fmt JSON rejection guidance, sniff-path behavior, zero-request refusal and file-safety) pass after the fixes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f59bd5f7083308700b21165b793f5)