### PR TITLE
Tighten tracing import formats and zero-request persistence guards

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -49,20 +49,32 @@ B) Direct Run JSON path:
 
 ```rust,no_run
 use tailtriage_tracing::TracingIntakeSession;
+use tracing::Instrument;
 use tracing_subscriber::prelude::*;
 
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
+# async fn do_checkout() {}
+# async fn main_async() -> Result<(), Box<dyn std::error::Error>> {
 let session = TracingIntakeSession::builder("checkout-service")
     .run_json_path("target/tailtriage-examples/checkout.run.json")
     .build()?;
 let subscriber = tracing_subscriber::registry().with(session.layer());
-tracing::subscriber::with_default(subscriber, || {
-    let _request = tracing::info_span!("request", tt.kind = "request", tt.request_id = "req-1", tt.route = "/checkout");
-});
+tracing::subscriber::with_default(subscriber, || async {
+    let span = tracing::info_span!(
+        "request",
+        tt.kind = "request",
+        tt.request_id = "req-1",
+        tt.route = "/checkout",
+        tt.outcome = "ok"
+    );
+    do_checkout().instrument(span).await;
+})
+.await;
 session.shutdown()?;
 # Ok(())
 # }
 ```
+
+Stage and queue spans use their own `tt.stage` / `tt.queue` fields around the awaited work they measure.
 
 Then analyze directly:
 

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -66,12 +66,10 @@ Recommended stable input format is the tailtriage wrapper JSONL shape:
 `--input-format` values:
 - `auto`
 - `tailtriage-span-jsonl`
-- `tracing-subscriber-fmt-json`
 
 Behavior:
 - `tailtriage-span-jsonl` enforces wrapper-only parsing.
 - `auto` keeps compatibility parsing for older normalized shapes and rejects likely ordinary `tracing_subscriber::fmt().json()` logs with setup guidance.
-- `tracing-subscriber-fmt-json` intentionally fails with setup guidance in the current product scope.
 
 After import, run analysis separately:
 

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -1,10 +1,13 @@
+use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 
 use clap::{Parser, ValueEnum};
 use tailtriage_analyzer::{render_json_pretty, render_text, try_analyze_run};
 use tailtriage_cli::artifact::load_run_artifact;
 use tailtriage_cli::{analyzer_options_help_text, build_analyze_options};
-use tailtriage_tracing::{import_jsonl_path_with_mode, ImportOptions, JsonlParseMode};
+use tailtriage_tracing::{
+    ensure_persistable_run_has_requests, import_jsonl_path_with_mode, ImportOptions, JsonlParseMode,
+};
 
 #[derive(Debug, Parser)]
 #[command(name = "tailtriage")]
@@ -43,7 +46,7 @@ enum Command {
 
 #[derive(Debug, clap::Subcommand)]
 enum ImportCommand {
-    /// Import completed tracing span records from JSONL into run JSON.
+    /// Import completed `tt.*` tracing span JSONL into Run JSON.
     TracingJson {
         /// Path to newline-delimited JSON span records.
         #[arg(value_name = "SPANS_JSONL")]
@@ -72,7 +75,6 @@ enum ImportCommand {
 enum TracingInputFormat {
     Auto,
     TailtriageSpanJsonl,
-    TracingSubscriberFmtJson,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -103,17 +105,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                     options = options.run_id(run_id);
                 }
 
-                if matches!(input_format, TracingInputFormat::TracingSubscriberFmtJson) {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::InvalidInput,
-                        tracing_json_setup_guidance(),
-                    )
-                    .into());
-                }
-                if matches!(
-                    input_format,
-                    TracingInputFormat::Auto | TracingInputFormat::TailtriageSpanJsonl
-                ) && input_looks_like_tracing_fmt_json(&spans_jsonl)?
+                if matches!(input_format, TracingInputFormat::Auto)
+                    && input_looks_like_tracing_fmt_json(&spans_jsonl)?
                 {
                     return Err(std::io::Error::new(
                         std::io::ErrorKind::InvalidInput,
@@ -125,21 +118,13 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                     TracingInputFormat::TailtriageSpanJsonl => {
                         JsonlParseMode::TailtriageWrapperOnly
                     }
-                    TracingInputFormat::Auto | TracingInputFormat::TracingSubscriberFmtJson => {
-                        JsonlParseMode::Compatible
-                    }
+                    TracingInputFormat::Auto => JsonlParseMode::Compatible,
                 };
                 let imported = import_jsonl_path_with_mode(spans_jsonl, options, parse_mode)?;
                 for warning in imported.warnings() {
                     eprintln!("warning: {}", warning.message());
                 }
-                if imported.run().requests.is_empty() {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        "tracing import produced zero request events; tailtriage requires completed tt.request spans (tt.kind=request, tt.request_id, tt.route) with start/end timestamps. Configure TracingIntakeSession::builder(...).completed_span_jsonl_path(...) then run: tailtriage import tracing-json <completed-spans.jsonl> --input-format tailtriage-span-jsonl --service <service> --output <run-json>",
-                    )
-                    .into());
-                }
+                ensure_persistable_run_has_requests(imported.run())?;
 
                 let file = std::fs::File::create(&output)?;
                 serde_json::to_writer_pretty(file, imported.run())?;
@@ -185,12 +170,18 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn tracing_json_setup_guidance() -> &'static str {
-    "ordinary tracing_subscriber::fmt().json() logs are not the supported primary import format. tailtriage needs completed tt.* span records with start/end timestamps. Recommended setup: TracingIntakeSession::builder(...).completed_span_jsonl_path(...). Then import with: tailtriage import tracing-json <completed-spans.jsonl> --input-format tailtriage-span-jsonl --service <service> --output <run-json>"
+    "input appears to be ordinary tracing log JSON, not completed tailtriage span JSONL. tailtriage requires completed spans with literal dotted tt.* keys and explicit unix-ms start/end timestamps. Recommended path: TracingIntakeSession::builder(...).completed_span_jsonl_path(...). Then run: tailtriage import tracing-json <completed-spans.jsonl> --input-format tailtriage-span-jsonl --service <service> --output <run-json>"
 }
 
 fn input_looks_like_tracing_fmt_json(path: &std::path::Path) -> Result<bool, std::io::Error> {
-    let contents = std::fs::read_to_string(path)?;
-    for line in contents.lines() {
+    let file = std::fs::File::open(path)?;
+    let mut reader = BufReader::new(file);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        if reader.read_line(&mut line)? == 0 {
+            return Ok(false);
+        }
         let trimmed = line.trim();
         if trimmed.is_empty() {
             continue;
@@ -209,13 +200,10 @@ fn input_looks_like_tracing_fmt_json(path: &std::path::Path) -> Result<bool, std
             let looks_like_fmt = value.get("timestamp").is_some()
                 && value.get("level").is_some()
                 && value.get("target").is_some();
-            if looks_like_fmt && !has_span_timestamps {
-                return Ok(true);
-            }
+            return Ok(looks_like_fmt && !has_span_timestamps);
         }
-        break;
+        return Ok(false);
     }
-    Ok(false)
 }
 
 fn main() {

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -307,29 +307,55 @@ fn import_tracing_json_input_format_tailtriage_wrapper_only_rejects_unwrapped() 
 }
 
 #[test]
-fn import_tracing_json_input_format_fmt_json_fails_with_guidance() {
+fn import_tracing_json_help_lists_only_live_input_formats() {
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg("--help")
+        .output()
+        .expect("cli should run");
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("tailtriage-span-jsonl"));
+    assert!(stdout.contains("auto"));
+    assert!(!stdout.contains("tracing-subscriber-fmt-json"));
+}
+
+#[test]
+fn import_tracing_json_explicit_wrapper_mode_does_not_sniff_fmt_json() {
     let dir = tempfile::tempdir().expect("tempdir should build");
-    let spans_path = dir.path().join("fmt.jsonl");
-    std::fs::write(&spans_path, r#"{"timestamp":"2026-01-01T00:00:00Z","level":"INFO","target":"svc","fields":{"message":"close"}}"#).unwrap();
+    let spans_path = dir.path().join("fmt_then_wrapper.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(
+        &spans_path,
+        format!(
+            "{{\"timestamp\":\"2026-01-01T00:00:00Z\",\"level\":\"INFO\",\"target\":\"svc\"}}\n{}",
+            complete_span_jsonl_fixture()
+        ),
+    )
+    .unwrap();
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
         .arg("--input-format")
-        .arg("tracing-subscriber-fmt-json")
+        .arg("tailtriage-span-jsonl")
         .arg("--service")
         .arg("checkout")
         .arg("--output")
-        .arg(dir.path().join("run.json"))
+        .arg(&run_path)
         .output()
         .expect("cli should run");
-    assert!(!output.status.success());
     let stderr = String::from_utf8(output.stderr).unwrap();
-    assert!(stderr.contains("TracingIntakeSession"));
-    assert!(stderr.contains("tailtriage-span-jsonl"));
+    assert!(
+        !output.status.success() || run_path.exists(),
+        "expected either parse failure or successful import"
+    );
+    assert!(!stderr.contains("ordinary tracing log JSON"));
 }
 
 #[test]
+
 fn import_tracing_json_auto_rejects_fmt_json_with_guidance() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("fmt.jsonl");
@@ -347,8 +373,8 @@ fn import_tracing_json_auto_rejects_fmt_json_with_guidance() {
         .expect("cli should run");
     assert!(!output.status.success());
     let stderr = String::from_utf8(output.stderr).unwrap();
-    assert!(stderr.contains("tracing_subscriber::fmt().json()"));
-    assert!(stderr.contains("completed tt.*") || stderr.contains("completed tt.* span records"));
+    assert!(stderr.contains("ordinary tracing log JSON"));
+    assert!(stderr.contains("completed tailtriage span JSONL"));
     assert!(stderr.contains("TracingIntakeSession"));
     assert!(stderr.contains("tailtriage-span-jsonl"));
     assert!(!run_path.exists());
@@ -515,7 +541,7 @@ fn import_tracing_json_fails_when_only_unrelated_lines_are_present() {
         .expect("cli should run");
     assert!(!output.status.success(), "cli unexpectedly succeeded");
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
-    assert!(stderr.contains("zero request events"));
+    assert!(stderr.contains("zero-request run artifact is not persistable"));
     assert!(!run_path.exists(), "run output should not be written");
 }
 
@@ -538,7 +564,7 @@ fn import_tracing_json_fails_when_non_strict_skips_all_malformed_tt_spans() {
     assert!(!output.status.success(), "cli unexpectedly succeeded");
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
     assert!(stderr.contains("warning:"));
-    assert!(stderr.contains("zero request events"));
+    assert!(stderr.contains("zero-request run artifact is not persistable"));
     assert!(!run_path.exists(), "run output should not be written");
 }
 
@@ -563,7 +589,7 @@ fn import_tracing_json_fails_when_only_tt_spans_are_missing_kind() {
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
     assert!(stderr.contains("warning:"));
     assert!(stderr.contains("missing required field 'tt.kind'"));
-    assert!(stderr.contains("zero request events"));
+    assert!(stderr.contains("zero-request run artifact is not persistable"));
     assert!(!run_path.exists(), "run output should not be written");
 }
 

--- a/tailtriage-tracing/src/error.rs
+++ b/tailtriage-tracing/src/error.rs
@@ -34,6 +34,11 @@ pub enum ImportError {
     EmptyServiceName,
     /// Imported run event failed `tailtriage-core` run-builder validation.
     InvalidRunEvent(String),
+    /// Persisted Run JSON artifact is invalid for CLI analysis because it has zero requests.
+    ZeroRequestArtifact {
+        /// Actionable guidance for producing a persistable Run artifact.
+        guidance: String,
+    },
 }
 
 impl fmt::Display for ImportError {
@@ -54,6 +59,12 @@ impl fmt::Display for ImportError {
             Self::StrictViolation(message) => write!(f, "strict import violation: {message}"),
             Self::EmptyServiceName => write!(f, "service name must not be empty"),
             Self::InvalidRunEvent(message) => write!(f, "invalid run event: {message}"),
+            Self::ZeroRequestArtifact { guidance } => {
+                write!(
+                    f,
+                    "zero-request run artifact is not persistable: {guidance}"
+                )
+            }
         }
     }
 }

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -388,6 +388,20 @@ fn filter_correlated_queues(
     Ok(())
 }
 
+/// Ensures a Run artifact is persistable for later `tailtriage analyze` usage.
+///
+/// # Errors
+///
+/// Returns [`ImportError::ZeroRequestArtifact`] when the run has no completed
+/// request events.
+pub fn ensure_persistable_run_has_requests(run: &tailtriage_core::Run) -> Result<(), ImportError> {
+    if run.requests.is_empty() {
+        return Err(ImportError::ZeroRequestArtifact {
+            guidance: "persisted Run JSON artifacts intended for tailtriage analyze require at least one completed tt.kind=\"request\" span with tt.request_id, tt.route, and explicit unix-ms timing fields".to_owned(),
+        });
+    }
+    Ok(())
+}
 fn validate_service_name(service_name: &str) -> Result<(), ImportError> {
     if service_name.trim().is_empty() {
         return Err(ImportError::EmptyServiceName);
@@ -586,6 +600,7 @@ fn parse_depth_at_start(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tailtriage_core::{CaptureMode, RequestEvent, RunBuilder, RunBuilderOptions};
 
     #[test]
     fn span_kind_parser_accepts_supported_values_only() {
@@ -1390,5 +1405,41 @@ mod tests {
     fn empty_service_name_is_rejected() {
         let err = run_from_span_records(Vec::new(), ImportOptions::new(" ")).unwrap_err();
         assert!(matches!(err, ImportError::EmptyServiceName));
+    }
+
+    #[test]
+    fn ensure_persistable_run_has_requests_ok_for_non_empty_run() {
+        let mut builder = RunBuilder::new(
+            RunBuilderOptions::new("svc")
+                .run_id("r1")
+                .mode(CaptureMode::Light),
+        )
+        .unwrap();
+        builder
+            .push_request(RequestEvent {
+                request_id: "req-1".into(),
+                route: "/x".into(),
+                kind: None,
+                started_at_unix_ms: 1,
+                finished_at_unix_ms: 2,
+                latency_us: 1000,
+                outcome: "ok".into(),
+            })
+            .unwrap();
+        let run = builder.finish();
+        assert!(ensure_persistable_run_has_requests(&run).is_ok());
+    }
+
+    #[test]
+    fn ensure_persistable_run_has_requests_errors_for_zero_request_run() {
+        let run = RunBuilder::new(
+            RunBuilderOptions::new("svc")
+                .run_id("r1")
+                .mode(CaptureMode::Light),
+        )
+        .unwrap()
+        .finish();
+        let err = ensure_persistable_run_has_requests(&run).unwrap_err();
+        assert!(matches!(err, ImportError::ZeroRequestArtifact { .. }));
     }
 }

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -12,7 +12,8 @@ use tracing::{Id, Subscriber};
 use tracing_subscriber::layer::{Context, Layer};
 
 use crate::{
-    run_from_span_records, FieldValue, ImportError, ImportOptions, ImportedRun, SpanRecord, TT_KIND,
+    ensure_persistable_run_has_requests, run_from_span_records, FieldValue, ImportError,
+    ImportOptions, ImportedRun, SpanRecord, TT_KIND,
 };
 
 /// In-memory recorder for completed tracing spans with `tt.*` fields.
@@ -291,6 +292,7 @@ impl TracingIntakeSession {
     pub fn shutdown(self) -> Result<ImportedRun, ImportError> {
         let imported = self.recorder.shutdown()?;
         if let Some(path) = self.run_json_path {
+            ensure_persistable_run_has_requests(imported.run())?;
             let file = std::fs::File::create(&path).map_err(|err| ImportError::Io {
                 operation: "create run json path",
                 context: path.display().to_string(),
@@ -1697,6 +1699,32 @@ mod tests {
         assert_eq!(run.requests.len(), 1);
     }
 
+    #[test]
+    fn intake_session_run_json_path_rejects_zero_request_without_creating_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_path = dir.path().join("run.json");
+        let session = TracingIntakeSession::builder("svc")
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let err = session.shutdown().unwrap_err();
+        assert!(matches!(err, ImportError::ZeroRequestArtifact { .. }));
+        assert!(!run_path.exists());
+    }
+
+    #[test]
+    fn intake_session_run_json_path_rejects_zero_request_without_overwriting_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_path = dir.path().join("run.json");
+        std::fs::write(&run_path, "keep-me").unwrap();
+        let session = TracingIntakeSession::builder("svc")
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let err = session.shutdown().unwrap_err();
+        assert!(matches!(err, ImportError::ZeroRequestArtifact { .. }));
+        assert_eq!(std::fs::read_to_string(&run_path).unwrap(), "keep-me");
+    }
     #[test]
     fn unrelated_spans_are_ignored_by_completed_span_jsonl_writer() {
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
### Motivation

- Make tracing import adoption clear and safe by only accepting completed `tt.*` span JSONL and by surfacing an actionable error when users accidentally feed ordinary `tracing_subscriber::fmt().json()` logs.
- Avoid inefficient/fragile format sniffing that reads entire files and instead detect fmt-json conservatively and streamingly in `auto` mode only.
- Prevent the CLI and live session helpers from persisting Run JSON artifacts that contain zero requests because such artifacts are not analyzable by `tailtriage analyze`.

### Description

- Removed the dead CLI input-format variant `TracingSubscriberFmtJson` and its code-path so `--input-format` only advertises `auto` and `tailtriage-span-jsonl`, and updated the `tracing-json` help text to say it imports completed `tt.*` tracing span JSONL into Run JSON. (`tailtriage-cli/src/main.rs`).
- Replaced full-file sniffing with a streaming first-non-empty-line check using `BufReader` and `read_line`, and invoke that sniff only when `--input-format auto`; explicit `--input-format tailtriage-span-jsonl` no longer triggers sniffing. The sniffer rejects likely ordinary fmt JSON when it lacks completed-span timestamps and returns a precise actionable guidance string. (`tailtriage-cli/src/main.rs`).
- Added `pub fn ensure_persistable_run_has_requests(run: &tailtriage_core::Run) -> Result<(), ImportError>` and new `ImportError::ZeroRequestArtifact { guidance: String }` in `tailtriage-tracing`, with an actionable guidance string; wired this helper into the CLI import path and `TracingIntakeSession::shutdown()` so persisted Run JSON is rejected when it contains zero requests and no file create/overwrite occurs. (`tailtriage-tracing/src/lib.rs`, `tailtriage-tracing/src/error.rs`, `tailtriage-tracing/src/recorder.rs`, `tailtriage-cli/src/main.rs`).
- Preserved `snapshot_run()` behavior for library inspection (it may still return zero-request `ImportedRun`), but prevented persisted outputs from being created/overwritten for zero-request runs. (`TracingRecorder::snapshot_run()` / `TracingIntakeSession::shutdown()`).
- Updated docs and examples to teach correct async `tracing` usage using `.instrument(span).await` and to consistently state that import expects completed `tt.*` span JSONL, writes Run JSON (not Report JSON), and that runtime-pressure evidence is Tokio-specific. (updated `docs/user-guide.md`, `tailtriage-cli/README.md`, `tailtriage-tracing/README.md`).
- Added and updated tests to cover: declared input formats in help output, streaming sniffing behavior in `auto`, explicit wrapper mode bypasses sniffing, fmt-json auto rejection with actionable guidance, wrapper-only import behavior, and zero-request persistency rejection behavior for both CLI import and `TracingIntakeSession::shutdown()`; plus unit tests for `ensure_persistable_run_has_requests`. (tests under `tailtriage-cli/tests/` and `tailtriage-tracing/tests/`).

### Testing

- Ran formatting and lints: `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and they passed.
- Ran the full test suite: `cargo test --workspace --all-targets --all-features --locked` and all tests passed; updated and new tests covering CLI boundary cases and tracing session behavior passed.
- Ran the docs contract validator: `python3 scripts/validate_docs_contracts.py` and it passed.
- Key tests added/updated: CLI tests for `--input-format tailtriage-span-jsonl`, `auto` sniffing rejection of ordinary fmt JSON, explicit wrapper mode not sniffing, help output listing only live formats, and CLI refusal to write zero-request output; tracing session tests ensure `TracingIntakeSession::shutdown()` refuses zero-request `run_json_path` and does not create or overwrite files; unit tests for `ensure_persistable_run_has_requests` for both non-empty and zero-request runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f59bd5f7083308700b21165b793f5)