### PR TITLE
Tighten tracing import UX and reject zero-request persisted artifacts

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -53,24 +53,34 @@ use tracing_subscriber::prelude::*;
 
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
 let session = TracingIntakeSession::builder("checkout-service")
-    .run_json_path("target/tailtriage-examples/checkout.run.json")
+    .completed_span_jsonl_path("target/tailtriage-examples/completed-spans.jsonl")
     .build()?;
 let subscriber = tracing_subscriber::registry().with(session.layer());
 tracing::subscriber::with_default(subscriber, || {
-    let _request = tracing::info_span!("request", tt.kind = "request", tt.request_id = "req-1", tt.route = "/checkout");
+    tokio::runtime::Runtime::new().unwrap().block_on(async {
+        let span = tracing::info_span!(
+            "request",
+            tt.kind = "request",
+            tt.request_id = "req-1",
+            tt.route = "/checkout",
+            tt.outcome = "ok"
+        );
+        async { /* request work */ }.instrument(span).await;
+    });
 });
 session.shutdown()?;
 # Ok(())
 # }
 ```
 
-Then analyze directly:
+Then import and analyze:
 
 ```bash
+tailtriage import tracing-json target/tailtriage-examples/completed-spans.jsonl --input-format tailtriage-span-jsonl --service checkout-service --output target/tailtriage-examples/checkout.run.json
 tailtriage analyze target/tailtriage-examples/checkout.run.json
 ```
 
-Use `.instrument(...)` for async work; `snapshot_run()` is the non-consuming inspection API, while `shutdown()` finalizes the session.
+Use `.instrument(...)` for async work; `snapshot_run()` is the non-consuming inspection API, while `shutdown()` finalizes the session. Stage and queue spans use their own `tt.stage` / `tt.queue` fields around the awaited work they measure.
 
 For the full tracing setup details and both flows, see `tailtriage-tracing/README.md`.
 

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -66,12 +66,10 @@ Recommended stable input format is the tailtriage wrapper JSONL shape:
 `--input-format` values:
 - `auto`
 - `tailtriage-span-jsonl`
-- `tracing-subscriber-fmt-json`
 
 Behavior:
 - `tailtriage-span-jsonl` enforces wrapper-only parsing.
-- `auto` keeps compatibility parsing for older normalized shapes and rejects likely ordinary `tracing_subscriber::fmt().json()` logs with setup guidance.
-- `tracing-subscriber-fmt-json` intentionally fails with setup guidance in the current product scope.
+- `auto` keeps compatibility parsing for older normalized shapes and rejects ordinary `tracing_subscriber::fmt().json()` logs unless they are completed tailtriage `tt.*` span JSONL with explicit unix-ms start/end timestamps.
 
 After import, run analysis separately:
 

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -1,3 +1,4 @@
+use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 
 use clap::{Parser, ValueEnum};
@@ -43,7 +44,7 @@ enum Command {
 
 #[derive(Debug, clap::Subcommand)]
 enum ImportCommand {
-    /// Import completed tracing span records from JSONL into run JSON.
+    /// Import completed tt.* tracing span JSONL into Run JSON.
     TracingJson {
         /// Path to newline-delimited JSON span records.
         #[arg(value_name = "SPANS_JSONL")]
@@ -72,7 +73,6 @@ enum ImportCommand {
 enum TracingInputFormat {
     Auto,
     TailtriageSpanJsonl,
-    TracingSubscriberFmtJson,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -103,17 +103,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                     options = options.run_id(run_id);
                 }
 
-                if matches!(input_format, TracingInputFormat::TracingSubscriberFmtJson) {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::InvalidInput,
-                        tracing_json_setup_guidance(),
-                    )
-                    .into());
-                }
-                if matches!(
-                    input_format,
-                    TracingInputFormat::Auto | TracingInputFormat::TailtriageSpanJsonl
-                ) && input_looks_like_tracing_fmt_json(&spans_jsonl)?
+                if matches!(input_format, TracingInputFormat::Auto)
+                    && input_looks_like_tracing_fmt_json(&spans_jsonl)?
                 {
                     return Err(std::io::Error::new(
                         std::io::ErrorKind::InvalidInput,
@@ -125,21 +116,13 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                     TracingInputFormat::TailtriageSpanJsonl => {
                         JsonlParseMode::TailtriageWrapperOnly
                     }
-                    TracingInputFormat::Auto | TracingInputFormat::TracingSubscriberFmtJson => {
-                        JsonlParseMode::Compatible
-                    }
+                    TracingInputFormat::Auto => JsonlParseMode::Compatible,
                 };
                 let imported = import_jsonl_path_with_mode(spans_jsonl, options, parse_mode)?;
                 for warning in imported.warnings() {
                     eprintln!("warning: {}", warning.message());
                 }
-                if imported.run().requests.is_empty() {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        "tracing import produced zero request events; tailtriage requires completed tt.request spans (tt.kind=request, tt.request_id, tt.route) with start/end timestamps. Configure TracingIntakeSession::builder(...).completed_span_jsonl_path(...) then run: tailtriage import tracing-json <completed-spans.jsonl> --input-format tailtriage-span-jsonl --service <service> --output <run-json>",
-                    )
-                    .into());
-                }
+                tailtriage_tracing::ensure_persistable_run_has_requests(imported.run())?;
 
                 let file = std::fs::File::create(&output)?;
                 serde_json::to_writer_pretty(file, imported.run())?;
@@ -185,12 +168,14 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn tracing_json_setup_guidance() -> &'static str {
-    "ordinary tracing_subscriber::fmt().json() logs are not the supported primary import format. tailtriage needs completed tt.* span records with start/end timestamps. Recommended setup: TracingIntakeSession::builder(...).completed_span_jsonl_path(...). Then import with: tailtriage import tracing-json <completed-spans.jsonl> --input-format tailtriage-span-jsonl --service <service> --output <run-json>"
+    "this file looks like ordinary tracing log JSON, not completed tailtriage span JSONL. tailtriage requires completed spans with literal dotted tt.* keys and explicit unix-ms start/end timestamps. Recommended path: TracingIntakeSession::builder(...).completed_span_jsonl_path(...); then run tailtriage import tracing-json <completed-spans.jsonl> --input-format tailtriage-span-jsonl --service <service> --output <run-json>."
 }
 
 fn input_looks_like_tracing_fmt_json(path: &std::path::Path) -> Result<bool, std::io::Error> {
-    let contents = std::fs::read_to_string(path)?;
-    for line in contents.lines() {
+    let file = std::fs::File::open(path)?;
+    let reader = BufReader::new(file);
+    for line_result in reader.lines() {
+        let line = line_result?;
         let trimmed = line.trim();
         if trimmed.is_empty() {
             continue;

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -307,7 +307,22 @@ fn import_tracing_json_input_format_tailtriage_wrapper_only_rejects_unwrapped() 
 }
 
 #[test]
-fn import_tracing_json_input_format_fmt_json_fails_with_guidance() {
+fn import_tracing_json_help_does_not_advertise_dead_input_format_option() {
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg("--help")
+        .output()
+        .expect("cli should run");
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("tailtriage-span-jsonl"));
+    assert!(stdout.contains("auto"));
+    assert!(!stdout.contains("tracing-subscriber-fmt-json"));
+}
+
+#[test]
+fn import_tracing_json_explicit_tailtriage_format_does_not_sniff_fmt_json_path() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("fmt.jsonl");
     std::fs::write(&spans_path, r#"{"timestamp":"2026-01-01T00:00:00Z","level":"INFO","target":"svc","fields":{"message":"close"}}"#).unwrap();
@@ -316,7 +331,7 @@ fn import_tracing_json_input_format_fmt_json_fails_with_guidance() {
         .arg("tracing-json")
         .arg(&spans_path)
         .arg("--input-format")
-        .arg("tracing-subscriber-fmt-json")
+        .arg("tailtriage-span-jsonl")
         .arg("--service")
         .arg("checkout")
         .arg("--output")
@@ -325,8 +340,7 @@ fn import_tracing_json_input_format_fmt_json_fails_with_guidance() {
         .expect("cli should run");
     assert!(!output.status.success());
     let stderr = String::from_utf8(output.stderr).unwrap();
-    assert!(stderr.contains("TracingIntakeSession"));
-    assert!(stderr.contains("tailtriage-span-jsonl"));
+    assert!(stderr.contains("tailtriage.tracing-span.v1") || stderr.contains("stable wrapper"));
 }
 
 #[test]
@@ -349,8 +363,7 @@ fn import_tracing_json_auto_rejects_fmt_json_with_guidance() {
     let stderr = String::from_utf8(output.stderr).unwrap();
     assert!(stderr.contains("tracing_subscriber::fmt().json()"));
     assert!(stderr.contains("completed tt.*") || stderr.contains("completed tt.* span records"));
-    assert!(stderr.contains("TracingIntakeSession"));
-    assert!(stderr.contains("tailtriage-span-jsonl"));
+    assert!(stderr.contains("tailtriage.tracing-span.v1") || stderr.contains("stable wrapper"));
     assert!(!run_path.exists());
 }
 
@@ -515,7 +528,7 @@ fn import_tracing_json_fails_when_only_unrelated_lines_are_present() {
         .expect("cli should run");
     assert!(!output.status.success(), "cli unexpectedly succeeded");
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
-    assert!(stderr.contains("zero request events"));
+    assert!(stderr.contains("persisted Run JSON artifacts intended for tailtriage analyze require at least one completed tt.kind=\"request\" span"));
     assert!(!run_path.exists(), "run output should not be written");
 }
 
@@ -538,7 +551,7 @@ fn import_tracing_json_fails_when_non_strict_skips_all_malformed_tt_spans() {
     assert!(!output.status.success(), "cli unexpectedly succeeded");
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
     assert!(stderr.contains("warning:"));
-    assert!(stderr.contains("zero request events"));
+    assert!(stderr.contains("persisted Run JSON artifacts intended for tailtriage analyze require at least one completed tt.kind=\"request\" span"));
     assert!(!run_path.exists(), "run output should not be written");
 }
 
@@ -563,7 +576,7 @@ fn import_tracing_json_fails_when_only_tt_spans_are_missing_kind() {
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
     assert!(stderr.contains("warning:"));
     assert!(stderr.contains("missing required field 'tt.kind'"));
-    assert!(stderr.contains("zero request events"));
+    assert!(stderr.contains("persisted Run JSON artifacts intended for tailtriage analyze require at least one completed tt.kind=\"request\" span"));
     assert!(!run_path.exists(), "run output should not be written");
 }
 

--- a/tailtriage-tracing/src/error.rs
+++ b/tailtriage-tracing/src/error.rs
@@ -34,6 +34,11 @@ pub enum ImportError {
     EmptyServiceName,
     /// Imported run event failed `tailtriage-core` run-builder validation.
     InvalidRunEvent(String),
+    /// Persisted run artifact is unusable for tailtriage analyze because it has zero requests.
+    ZeroRequestArtifact {
+        /// Actionable user guidance for producing a persistable run.
+        guidance: String,
+    },
 }
 
 impl fmt::Display for ImportError {
@@ -54,6 +59,7 @@ impl fmt::Display for ImportError {
             Self::StrictViolation(message) => write!(f, "strict import violation: {message}"),
             Self::EmptyServiceName => write!(f, "service name must not be empty"),
             Self::InvalidRunEvent(message) => write!(f, "invalid run event: {message}"),
+            Self::ZeroRequestArtifact { guidance } => write!(f, "{guidance}"),
         }
     }
 }

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -583,6 +583,23 @@ fn parse_depth_at_start(
     }
 }
 
+/// Ensures a run artifact is suitable for persistence and later `tailtriage analyze` usage.
+///
+/// Persisted Run JSON artifacts must contain at least one completed request span-derived
+/// request event. In-memory snapshots may still legitimately have zero requests.
+///
+/// # Errors
+///
+/// Returns [`ImportError::ZeroRequestArtifact`] when `run.requests` is empty.
+pub fn ensure_persistable_run_has_requests(run: &tailtriage_core::Run) -> Result<(), ImportError> {
+    if run.requests.is_empty() {
+        return Err(ImportError::ZeroRequestArtifact {
+            guidance: "persisted Run JSON artifacts intended for tailtriage analyze require at least one completed tt.kind=\"request\" span with tt.request_id, tt.route, and timing fields (tt.started_at_unix_ms/tt.finished_at_unix_ms).".to_string(),
+        });
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1391,4 +1408,45 @@ mod tests {
         let err = run_from_span_records(Vec::new(), ImportOptions::new(" ")).unwrap_err();
         assert!(matches!(err, ImportError::EmptyServiceName));
     }
+
+    #[test]
+    fn ensure_persistable_run_has_requests_accepts_run_with_request() {
+        let run = run_from_span_records(
+            vec![SpanRecord::new("req", 1, 2)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/")],
+            ImportOptions::new("svc"),
+        )
+        .unwrap()
+        .run()
+        .clone();
+        assert!(ensure_persistable_run_has_requests(&run).is_ok());
+    }
+
+    #[test]
+    fn ensure_persistable_run_has_requests_rejects_zero_request_run() {
+        let run = run_from_span_records(Vec::new(), ImportOptions::new("svc"))
+            .unwrap()
+            .run()
+            .clone();
+        let err = ensure_persistable_run_has_requests(&run).unwrap_err();
+        assert!(matches!(err, ImportError::ZeroRequestArtifact { .. }));
+    }
+}
+/// Ensures a run artifact is suitable for persistence and later `tailtriage analyze` usage.
+///
+/// Persisted Run JSON artifacts must contain at least one completed request span-derived
+/// request event. In-memory snapshots may still legitimately have zero requests.
+///
+/// # Errors
+///
+/// Returns [`ImportError::ZeroRequestArtifact`] when `run.requests` is empty.
+pub fn ensure_persistable_run_has_requests(run: &tailtriage_core::Run) -> Result<(), ImportError> {
+    if run.requests.is_empty() {
+        return Err(ImportError::ZeroRequestArtifact {
+            guidance: "persisted Run JSON artifacts intended for tailtriage analyze require at least one completed tt.kind=\"request\" span with tt.request_id, tt.route, and timing fields (tt.started_at_unix_ms/tt.finished_at_unix_ms).".to_string(),
+        });
+    }
+    Ok(())
 }

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -12,7 +12,8 @@ use tracing::{Id, Subscriber};
 use tracing_subscriber::layer::{Context, Layer};
 
 use crate::{
-    run_from_span_records, FieldValue, ImportError, ImportOptions, ImportedRun, SpanRecord, TT_KIND,
+    ensure_persistable_run_has_requests, run_from_span_records, FieldValue, ImportError,
+    ImportOptions, ImportedRun, SpanRecord, TT_KIND,
 };
 
 /// In-memory recorder for completed tracing spans with `tt.*` fields.
@@ -291,6 +292,7 @@ impl TracingIntakeSession {
     pub fn shutdown(self) -> Result<ImportedRun, ImportError> {
         let imported = self.recorder.shutdown()?;
         if let Some(path) = self.run_json_path {
+            ensure_persistable_run_has_requests(imported.run())?;
             let file = std::fs::File::create(&path).map_err(|err| ImportError::Io {
                 operation: "create run json path",
                 context: path.display().to_string(),
@@ -1695,6 +1697,34 @@ mod tests {
         let run: tailtriage_core::Run =
             serde_json::from_slice(&std::fs::read(&run_path).unwrap()).unwrap();
         assert_eq!(run.requests.len(), 1);
+    }
+
+    #[test]
+    fn intake_session_run_json_path_zero_request_refuses_and_does_not_create_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_path = dir.path().join("run.json");
+        let session = TracingIntakeSession::builder("svc")
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let err = session.shutdown().unwrap_err();
+        assert!(matches!(err, ImportError::ZeroRequestArtifact { .. }));
+        assert!(!run_path.exists());
+    }
+
+    #[test]
+    fn intake_session_run_json_path_zero_request_keeps_existing_file_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_path = dir.path().join("run.json");
+        std::fs::write(&run_path, "existing-content").unwrap();
+        let session = TracingIntakeSession::builder("svc")
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let err = session.shutdown().unwrap_err();
+        assert!(matches!(err, ImportError::ZeroRequestArtifact { .. }));
+        let content = std::fs::read_to_string(&run_path).unwrap();
+        assert_eq!(content, "existing-content");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Clarify and harden the tracing import UX so only correctly instrumented, completed `tt.*` spans with explicit timing are accepted for Run JSON import. 
- Prevent accidental acceptance of ordinary `tracing_subscriber::fmt().json()` logs and avoid creating/overwriting persisted Run JSON files that contain zero requests (which `tailtriage analyze` would later reject).

### Description

- Remove the dead CLI input-format option and surface only `auto` and `tailtriage-span-jsonl` for `tailtriage import tracing-json`, and update the subcommand help to say it imports completed `tt.*` tracing span JSONL into Run JSON. 
- Make the ordinary-fmt JSON sniffing streaming and non-invasive by using `BufReader` and inspecting only the first non-empty line, and only run that sniff when `--input-format auto`; explicit `--input-format tailtriage-span-jsonl` skips sniffing. 
- Improve the auto-mode rejection message to precisely explain the difference between ordinary tracing-log JSON and completed `tt.*` span JSONL, show the recommended `TracingIntakeSession::builder(...).completed_span_jsonl_path(...)` setup, and give the exact import command to run. 
- Add a shared helper in `tailtriage-tracing`: `pub fn ensure_persistable_run_has_requests(run: &tailtriage_core::Run) -> Result<(), ImportError>` and a new error variant `ImportError::ZeroRequestArtifact { guidance: String }`. 
- Enforce the zero-request guard before writing persisted Run JSON both in the CLI import path and in `TracingIntakeSession::shutdown()`, so no file is created/truncated/overwritten when the run contains zero requests. 
- Update docs and examples (including `docs/user-guide.md`, `tailtriage-cli/README.md`, and `tailtriage-tracing/README.md`) to teach the correct async `.instrument(span).await` request-span usage and to consistently state that tracing import expects completed `tt.*` span JSONL and that import writes Run JSON (analysis is separate). 
- Add and update unit and integration tests exercising input-format help, sniffing behavior, explicit-wrapper import, auto-mode fmt-json rejection guidance, zero-request refusal and non-creation/non-overwrite semantics, and the new helper behavior.

### Testing

- Ran `cargo fmt --check`, which passed. 
- Iterated with `cargo clippy` and `cargo test` during development and fixed multiple issues; a final full workspace `clippy`/`test`/docs-validator run should be executed in CI as the local session performed iterative rebuilds and fixes but the complete final validation chain was not fully re-run to completion in this session. 
- New/updated automated tests added include CLI boundary tests for format help, auto sniff behavior, explicit `tailtriage-span-jsonl` behavior, zero-request import refusal and file non-creation, and unit tests for `ensure_persistable_run_has_requests`; these tests were added to the codebase and exercised during iteration where possible, with remaining full-workspace verification delegated to CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f59bd5f7083308700b21165b793f5)