### PR TITLE
tracing: split jsonl/live features and use core sink for run json writes

### DIFF
--- a/tailtriage-cli/Cargo.toml
+++ b/tailtriage-cli/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 tailtriage-core.workspace = true
 tailtriage-analyzer.workspace = true
-tailtriage-tracing.workspace = true
+tailtriage-tracing = { path = "../tailtriage-tracing", version = "0.2.0", default-features = false, features = ["jsonl"] }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -17,17 +17,19 @@ include = [
 ]
 
 [features]
-default = []
-tokio = ["dep:tailtriage-tokio", "dep:tokio"]
+default = ["jsonl"]
+jsonl = ["dep:serde_json"]
+live = ["jsonl", "dep:tracing", "dep:tracing-subscriber"]
+tokio = ["live", "dep:tailtriage-tokio", "dep:tokio"]
 
 [dependencies]
 tailtriage-core.workspace = true
 tailtriage-tokio = { workspace = true, optional = true }
 tokio = { version = "1", features = ["rt", "sync", "time"], optional = true }
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
+serde_json = { version = "1", optional = true }
+tracing = { version = "0.1", optional = true }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"], optional = true }
 
 [package.metadata.docs.rs]
 all-features = true
@@ -40,3 +42,15 @@ workspace = true
 tailtriage-analyzer.workspace = true
 futures-executor = "0.3"
 tempfile = "3"
+
+[[example]]
+name = "completed_span_jsonl_import"
+required-features = ["live"]
+
+[[example]]
+name = "live_recorder"
+required-features = ["live"]
+
+[[example]]
+name = "live_session_to_run"
+required-features = ["live"]

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -12,7 +12,15 @@ It is **not**:
 - an OTel/OTLP pipeline,
 - proof of root cause (output remains triage leads).
 
-## Recommended live session setup
+## Feature flags
+
+- Default (`jsonl`): typed records plus JSONL import APIs.
+- `live`: enables `TracingRecorder`, `TailtriageLayer`, and `TracingIntakeSession`.
+- `tokio`: enables `TracingTokioSession` (and includes `live`).
+
+CLI offline import workflows only need JSONL import support and do not require the live `tracing_subscriber` layer dependency.
+
+## Recommended live session setup (`live` feature)
 
 ```rust,no_run
 use tailtriage_tracing::TracingIntakeSession;

--- a/tailtriage-tracing/src/error.rs
+++ b/tailtriage-tracing/src/error.rs
@@ -39,6 +39,13 @@ pub enum ImportError {
         /// Actionable setup guidance for creating a persistable run artifact.
         guidance: String,
     },
+    /// Failed to write run JSON output via core sink.
+    RunJsonWrite {
+        /// Target output path.
+        path: String,
+        /// Underlying sink failure reason.
+        reason: String,
+    },
 }
 
 impl fmt::Display for ImportError {
@@ -60,6 +67,9 @@ impl fmt::Display for ImportError {
             Self::EmptyServiceName => write!(f, "service name must not be empty"),
             Self::InvalidRunEvent(message) => write!(f, "invalid run event: {message}"),
             Self::ZeroRequestArtifact { guidance } => write!(f, "{guidance}"),
+            Self::RunJsonWrite { path, reason } => {
+                write!(f, "failed to write run JSON at {path}: {reason}")
+            }
         }
     }
 }

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -4,9 +4,9 @@
 //! Tracing intake bridge types for tailtriage triage workflows.
 //!
 //! This crate provides semantic `tt.*` keys, typed [`SpanRecord`] intake,
-//! conversion to [`tailtriage_core::Run`] via [`run_from_span_records`],
-//! JSONL import via [`import_jsonl_reader`] and [`import_jsonl_path`], and
-//! live in-memory recording via [`TracingRecorder`] and [`TailtriageLayer`].
+//! and conversion to [`tailtriage_core::Run`] via [`run_from_span_records`].
+//! The `jsonl` feature adds JSONL import APIs.
+//! The `live` feature adds live in-memory recording APIs.
 //! It does not implement OpenTelemetry/OTLP and does not change analyzer behavior.
 //!
 //! # Example
@@ -29,7 +29,9 @@
 
 mod convention;
 mod error;
+#[cfg(feature = "jsonl")]
 mod jsonl;
+#[cfg(feature = "live")]
 mod recorder;
 #[cfg(feature = "tokio")]
 /// Optional Tokio runtime sampler coupling for tracing sessions.
@@ -45,9 +47,11 @@ pub use convention::{
     TT_DEPTH_AT_START, TT_KIND, TT_OUTCOME, TT_QUEUE, TT_REQUEST_ID, TT_ROUTE, TT_STAGE, TT_SUCCESS,
 };
 pub use error::ImportError;
+#[cfg(feature = "jsonl")]
 pub use jsonl::{
     import_jsonl_path, import_jsonl_path_with_mode, import_jsonl_reader, JsonlParseMode,
 };
+#[cfg(feature = "live")]
 pub use recorder::{
     RecorderLimits, TailtriageLayer, TracingIntakeSession, TracingIntakeSessionBuilder,
     TracingRecorder, TracingRecorderBuilder, DEFAULT_MAX_COMPLETED_SPANS, DEFAULT_MAX_OPEN_SPANS,

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -6,6 +6,7 @@ use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
+use tailtriage_core::{LocalJsonSink, RunSink};
 
 use tracing::field::{Field, Visit};
 use tracing::{Id, Subscriber};
@@ -293,17 +294,12 @@ impl TracingIntakeSession {
         let imported = self.recorder.shutdown()?;
         if let Some(path) = self.run_json_path {
             ensure_persistable_run_has_requests(imported.run())?;
-            let file = std::fs::File::create(&path).map_err(|err| ImportError::Io {
-                operation: "create run json path",
-                context: path.display().to_string(),
-                reason: err.to_string(),
-            })?;
-            serde_json::to_writer_pretty(file, imported.run()).map_err(|err| {
-                ImportError::InvalidField {
-                    field: "run_json_path",
+            LocalJsonSink::new(&path)
+                .write(imported.run())
+                .map_err(|err| ImportError::RunJsonWrite {
+                    path: path.display().to_string(),
                     reason: err.to_string(),
-                }
-            })?;
+                })?;
         }
         Ok(imported)
     }

--- a/tailtriage-tracing/tests/equivalence.rs
+++ b/tailtriage-tracing/tests/equivalence.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "live")]
+
 mod support;
 
 use support::equivalence_harness::assert_deterministic_span_import_full_parity;


### PR DESCRIPTION
### Motivation
- Remove duplicated Run JSON writing logic in `tailtriage-tracing` by reusing the robust writer in `tailtriage-core` to ensure consistent temp-file/flush/sync/rename semantics. 
- Reduce dependency weight for CLI/offline JSONL import users by making live `tracing`/`tracing-subscriber` and `serde_json` optional and feature-gating live APIs. 
- Preserve the existing persisted-artifact guard so zero-request runs never create or modify output files. 
- Keep docs and examples buildable in no-default and jsonl-only configurations.

### Description
- Replaced direct `File::create` + `serde_json::to_writer_pretty` in `TracingIntakeSession::shutdown()` with `tailtriage_core::LocalJsonSink::new(&path).write(imported.run())`, and retained the `ensure_persistable_run_has_requests(...)` check before attempting any write. 
- Added `ImportError::RunJsonWrite { path: String, reason: String }` and map core `SinkError` into it so errors include the target path and sink failure reason. 
- Split `tailtriage-tracing` features and made deps optional: `default = ["jsonl"]`, `jsonl = ["dep:serde_json"]`, `live = ["jsonl", "dep:tracing", "dep:tracing-subscriber"]`, and `tokio = ["live", "dep:tailtriage-tokio", "dep:tokio"]`. 
- Feature-gated modules and re-exports so JSONL APIs are behind `feature = "jsonl"`, live recorder/session APIs are behind `feature = "live"`, and the Tokio session module is behind `feature = "tokio"`; also updated `tailtriage-cli` to depend on `tailtriage-tracing` with `default-features = false, features = ["jsonl"]`. 
- Updated `tailtriage-tracing/README.md` to be feature-aware and added `required-features = ["live"]` for live examples, and gated a live integration test with `#![cfg(feature = "live")]`.

### Testing
- Ran formatting and static checks with `cargo fmt --check` and they passed. 
- Built `tailtriage-tracing` in multiple feature configurations with `cargo check -p tailtriage-tracing --no-default-features --locked`, `--features jsonl`, `--features live`, and `--features tokio` and all succeeded. 
- Built docs with `cargo doc -p tailtriage-tracing --no-default-features --locked --no-deps` and `--features jsonl` and both succeeded. 
- Ran full workspace validation including `cargo clippy --workspace --all-targets --all-features --locked -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, and `python3 scripts/validate_docs_contracts.py`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a100b5bf4fc833099d82f7ab399657a)