### PR TITLE
Refactor tracing Run JSON writing and split tracing features

### DIFF
--- a/tailtriage-cli/Cargo.toml
+++ b/tailtriage-cli/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 tailtriage-core.workspace = true
 tailtriage-analyzer.workspace = true
-tailtriage-tracing.workspace = true
+tailtriage-tracing = { workspace = true, default-features = false, features = ["jsonl"] }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -17,17 +17,19 @@ include = [
 ]
 
 [features]
-default = []
-tokio = ["dep:tailtriage-tokio", "dep:tokio"]
+default = ["jsonl"]
+jsonl = ["dep:serde_json"]
+live = ["jsonl", "dep:tracing", "dep:tracing-subscriber"]
+tokio = ["live", "dep:tailtriage-tokio", "dep:tokio"]
 
 [dependencies]
 tailtriage-core.workspace = true
 tailtriage-tokio = { workspace = true, optional = true }
 tokio = { version = "1", features = ["rt", "sync", "time"], optional = true }
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
+serde_json = { version = "1", optional = true }
+tracing = { version = "0.1", optional = true }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"], optional = true }
 
 [package.metadata.docs.rs]
 all-features = true
@@ -40,3 +42,15 @@ workspace = true
 tailtriage-analyzer.workspace = true
 futures-executor = "0.3"
 tempfile = "3"
+
+[[example]]
+name = "live_recorder"
+required-features = ["live"]
+
+[[example]]
+name = "live_session_to_run"
+required-features = ["live"]
+
+[[example]]
+name = "completed_span_jsonl_import"
+required-features = ["live"]

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -12,6 +12,15 @@ It is **not**:
 - an OTel/OTLP pipeline,
 - proof of root cause (output remains triage leads).
 
+
+## Features
+
+- Default (`jsonl`): typed span records plus JSONL import APIs for offline conversion.
+- `live`: enables `TracingRecorder`, `TailtriageLayer`, and `TracingIntakeSession` for live subscriber-layer recording.
+- `tokio`: enables `TracingTokioSession` (and includes `live`) for Tokio runtime sampler coupling.
+
+This split is dependency hygiene: CLI/offline JSONL import users do not need the live `tracing_subscriber` layer dependency path.
+
 ## Recommended live session setup
 
 ```rust,no_run

--- a/tailtriage-tracing/src/error.rs
+++ b/tailtriage-tracing/src/error.rs
@@ -35,6 +35,13 @@ pub enum ImportError {
     /// Imported run event failed `tailtriage-core` run-builder validation.
     InvalidRunEvent(String),
     /// Persistable run artifact is missing required completed request spans.
+    RunJsonWrite {
+        /// Destination path for the Run JSON artifact.
+        path: String,
+        /// Writer failure reason from core sink implementation.
+        reason: String,
+    },
+    /// Persistable run artifact is missing required completed request spans.
     ZeroRequestArtifact {
         /// Actionable setup guidance for creating a persistable run artifact.
         guidance: String,
@@ -59,6 +66,9 @@ impl fmt::Display for ImportError {
             Self::StrictViolation(message) => write!(f, "strict import violation: {message}"),
             Self::EmptyServiceName => write!(f, "service name must not be empty"),
             Self::InvalidRunEvent(message) => write!(f, "invalid run event: {message}"),
+            Self::RunJsonWrite { path, reason } => {
+                write!(f, "failed to write run json to {path}: {reason}")
+            }
             Self::ZeroRequestArtifact { guidance } => write!(f, "{guidance}"),
         }
     }

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -3,10 +3,10 @@
 
 //! Tracing intake bridge types for tailtriage triage workflows.
 //!
-//! This crate provides semantic `tt.*` keys, typed [`SpanRecord`] intake,
-//! conversion to [`tailtriage_core::Run`] via [`run_from_span_records`],
-//! JSONL import via [`import_jsonl_reader`] and [`import_jsonl_path`], and
-//! live in-memory recording via [`TracingRecorder`] and [`TailtriageLayer`].
+//! This crate provides semantic `tt.*` keys, typed `SpanRecord` intake,
+//! and conversion to `tailtriage_core::Run` via `run_from_span_records`.
+//! With the `jsonl` feature, it also provides JSONL import helpers.
+//! With the `live` feature, it also provides live in-memory recording helpers.
 //! It does not implement OpenTelemetry/OTLP and does not change analyzer behavior.
 //!
 //! # Example
@@ -29,7 +29,9 @@
 
 mod convention;
 mod error;
+#[cfg(feature = "jsonl")]
 mod jsonl;
+#[cfg(feature = "live")]
 mod recorder;
 #[cfg(feature = "tokio")]
 /// Optional Tokio runtime sampler coupling for tracing sessions.
@@ -45,9 +47,11 @@ pub use convention::{
     TT_DEPTH_AT_START, TT_KIND, TT_OUTCOME, TT_QUEUE, TT_REQUEST_ID, TT_ROUTE, TT_STAGE, TT_SUCCESS,
 };
 pub use error::ImportError;
+#[cfg(feature = "jsonl")]
 pub use jsonl::{
     import_jsonl_path, import_jsonl_path_with_mode, import_jsonl_reader, JsonlParseMode,
 };
+#[cfg(feature = "live")]
 pub use recorder::{
     RecorderLimits, TailtriageLayer, TracingIntakeSession, TracingIntakeSessionBuilder,
     TracingRecorder, TracingRecorderBuilder, DEFAULT_MAX_COMPLETED_SPANS, DEFAULT_MAX_OPEN_SPANS,

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -15,6 +15,7 @@ use crate::{
     ensure_persistable_run_has_requests, run_from_span_records, FieldValue, ImportError,
     ImportOptions, ImportedRun, SpanRecord, TT_KIND,
 };
+use tailtriage_core::{LocalJsonSink, RunSink};
 
 /// In-memory recorder for completed tracing spans with `tt.*` fields.
 #[derive(Debug, Clone)]
@@ -293,17 +294,12 @@ impl TracingIntakeSession {
         let imported = self.recorder.shutdown()?;
         if let Some(path) = self.run_json_path {
             ensure_persistable_run_has_requests(imported.run())?;
-            let file = std::fs::File::create(&path).map_err(|err| ImportError::Io {
-                operation: "create run json path",
-                context: path.display().to_string(),
-                reason: err.to_string(),
-            })?;
-            serde_json::to_writer_pretty(file, imported.run()).map_err(|err| {
-                ImportError::InvalidField {
-                    field: "run_json_path",
+            LocalJsonSink::new(&path)
+                .write(imported.run())
+                .map_err(|err| ImportError::RunJsonWrite {
+                    path: path.display().to_string(),
                     reason: err.to_string(),
-                }
-            })?;
+                })?;
         }
         Ok(imported)
     }


### PR DESCRIPTION
### Motivation

- Ensure tracing-produced Run JSON uses the same robust local-sink semantics as native capture and avoid duplicating temp-file/flush/rename logic in `tailtriage-tracing`.
- Keep the zero-request persisted-artifact guard strictly before any write attempt so no filesystem side-effects occur for non-persistable runs.
- Reduce dependency weight for offline/CLI JSONL import users by decoupling live `tracing`/`tracing-subscriber` from the JSONL import path.

### Description

- Replaced direct `File::create` + `serde_json::to_writer_pretty` in `TracingIntakeSession::shutdown()` with `tailtriage_core::LocalJsonSink` and call `LocalJsonSink::new(&path).write(imported.run())`, keeping `ensure_persistable_run_has_requests(...)` before the write attempt; sink errors are mapped into a new `ImportError::RunJsonWrite { path, reason }` variant so the displayed error includes the destination path and reason. (See `tailtriage-tracing/src/recorder.rs` and `tailtriage-tracing/src/error.rs`.)
- Feature-split `tailtriage-tracing` and made heavy runtime deps optional: `default = ["jsonl"]`, `jsonl = ["dep:serde_json"]`, `live = ["jsonl", "dep:tracing", "dep:tracing-subscriber"]`, `tokio = ["live", "dep:tailtriage-tokio", "dep:tokio"]`, and `serde_json`, `tracing`, `tracing-subscriber` are now optional dependencies; `serde` remains a normal dependency for typed types. (See `tailtriage-tracing/Cargo.toml`.)
- Gate crate surface and modules behind features: JSONL import APIs and `jsonl` module behind `feature = "jsonl"`, recorder/session/layer and live examples behind `feature = "live"`, and Tokio session behind `feature = "tokio"`. (See `tailtriage-tracing/src/lib.rs` and added example `required-features` in `Cargo.toml`.)
- Updated `tailtriage-cli` dependency on `tailtriage-tracing` to `default-features = false, features = ["jsonl"]` so CLI offline import users do not pull live tracing deps. (See `tailtriage-cli/Cargo.toml`.)
- Made README/rustdoc wording feature-aware to avoid broken rustdoc links under no-default / jsonl-only builds and added a short `Features` section that frames the split as dependency hygiene rather than a performance claim. (See `tailtriage-tracing/README.md`.)

### Testing

- Ran formatting check: `cargo fmt --check` and it passed.
- Built and documented `tailtriage-tracing` under the requested feature permutations and they all succeeded: `cargo check -p tailtriage-tracing --no-default-features --locked`, `--features jsonl`, `--features live`, and `--features tokio`, plus `cargo doc` for no-default and `--features jsonl`.
- Ran workspace static checks and tests: `cargo clippy --workspace --all-targets --all-features --locked -D warnings` and `cargo test --workspace --all-targets --all-features --locked`, and both completed successfully.
- Ran docs contract validator: `python3 scripts/validate_docs_contracts.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a100b5bf4fc833099d82f7ab399657a)