### PR TITLE
Refactor tracing run-json writing and split tracing features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,5 +44,5 @@ tailtriage-analyzer = { version = "0.2.0", path = "tailtriage-analyzer" }
 tailtriage-controller = { version = "0.2.0", path = "tailtriage-controller" }
 tailtriage-tokio = { version = "0.2.0", path = "tailtriage-tokio" }
 tailtriage-axum = { version = "0.2.0", path = "tailtriage-axum" }
-tailtriage-tracing = { version = "0.2.0", path = "tailtriage-tracing" }
+tailtriage-tracing = { version = "0.2.0", path = "tailtriage-tracing", default-features = false }
 demo-support = { version = "0.2.0", path = "demos/demo_support" }

--- a/tailtriage-cli/Cargo.toml
+++ b/tailtriage-cli/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 tailtriage-core.workspace = true
 tailtriage-analyzer.workspace = true
-tailtriage-tracing.workspace = true
+tailtriage-tracing = { workspace = true, default-features = false, features = ["jsonl"] }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -17,17 +17,19 @@ include = [
 ]
 
 [features]
-default = []
-tokio = ["dep:tailtriage-tokio", "dep:tokio"]
+default = ["jsonl"]
+jsonl = ["dep:serde_json"]
+live = ["jsonl", "dep:tracing", "dep:tracing-subscriber"]
+tokio = ["live", "dep:tailtriage-tokio", "dep:tokio"]
 
 [dependencies]
 tailtriage-core.workspace = true
 tailtriage-tokio = { workspace = true, optional = true }
 tokio = { version = "1", features = ["rt", "sync", "time"], optional = true }
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
+serde_json = { version = "1", optional = true }
+tracing = { version = "0.1", optional = true }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"], optional = true }
 
 [package.metadata.docs.rs]
 all-features = true
@@ -40,3 +42,15 @@ workspace = true
 tailtriage-analyzer.workspace = true
 futures-executor = "0.3"
 tempfile = "3"
+
+[[example]]
+name = "completed_span_jsonl_import"
+required-features = ["live"]
+
+[[example]]
+name = "live_recorder"
+required-features = ["live"]
+
+[[example]]
+name = "live_session_to_run"
+required-features = ["live"]

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -67,6 +67,15 @@ tailtriage import tracing-json target/tailtriage-examples/checkout.spans.jsonl \
 tailtriage analyze target/tailtriage-examples/checkout.run.json
 ```
 
+
+## Features
+
+- `default = ["jsonl"]`: typed intake types plus JSONL import APIs (`import_jsonl_reader`, `import_jsonl_path`, and strict/compatible parse mode helpers).
+- `live`: enables live tracing capture APIs (`TracingRecorder`, `TailtriageLayer`, `TracingIntakeSession`) and depends on `tracing` + `tracing-subscriber`.
+- `tokio`: enables `TracingTokioSession` runtime-sampler coupling on top of `live`.
+
+CLI offline import paths only need JSONL import support; they do not require the live `tracing_subscriber` layer dependency.
+
 ## Stable JSONL wrapper format
 
 Stable completed-span JSONL records use this wrapper:

--- a/tailtriage-tracing/src/error.rs
+++ b/tailtriage-tracing/src/error.rs
@@ -34,6 +34,13 @@ pub enum ImportError {
     EmptyServiceName,
     /// Imported run event failed `tailtriage-core` run-builder validation.
     InvalidRunEvent(String),
+    /// Writing run JSON output failed.
+    RunJsonWrite {
+        /// Target path.
+        path: String,
+        /// Underlying sink error text.
+        reason: String,
+    },
     /// Persistable run artifact is missing required completed request spans.
     ZeroRequestArtifact {
         /// Actionable setup guidance for creating a persistable run artifact.
@@ -59,6 +66,9 @@ impl fmt::Display for ImportError {
             Self::StrictViolation(message) => write!(f, "strict import violation: {message}"),
             Self::EmptyServiceName => write!(f, "service name must not be empty"),
             Self::InvalidRunEvent(message) => write!(f, "invalid run event: {message}"),
+            Self::RunJsonWrite { path, reason } => {
+                write!(f, "failed to write run json at {path}: {reason}")
+            }
             Self::ZeroRequestArtifact { guidance } => write!(f, "{guidance}"),
         }
     }

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -3,10 +3,10 @@
 
 //! Tracing intake bridge types for tailtriage triage workflows.
 //!
-//! This crate provides semantic `tt.*` keys, typed [`SpanRecord`] intake,
-//! conversion to [`tailtriage_core::Run`] via [`run_from_span_records`],
-//! JSONL import via [`import_jsonl_reader`] and [`import_jsonl_path`], and
-//! live in-memory recording via [`TracingRecorder`] and [`TailtriageLayer`].
+//! This crate provides semantic `tt.*` keys, typed `SpanRecord` intake,
+//! conversion to `tailtriage_core::Run` via `run_from_span_records`,
+//! JSONL import APIs (feature `jsonl`), and live in-memory recording APIs
+//! (feature `live`).
 //! It does not implement OpenTelemetry/OTLP and does not change analyzer behavior.
 //!
 //! # Example
@@ -29,7 +29,9 @@
 
 mod convention;
 mod error;
+#[cfg(feature = "jsonl")]
 mod jsonl;
+#[cfg(feature = "live")]
 mod recorder;
 #[cfg(feature = "tokio")]
 /// Optional Tokio runtime sampler coupling for tracing sessions.
@@ -45,9 +47,11 @@ pub use convention::{
     TT_DEPTH_AT_START, TT_KIND, TT_OUTCOME, TT_QUEUE, TT_REQUEST_ID, TT_ROUTE, TT_STAGE, TT_SUCCESS,
 };
 pub use error::ImportError;
+#[cfg(feature = "jsonl")]
 pub use jsonl::{
     import_jsonl_path, import_jsonl_path_with_mode, import_jsonl_reader, JsonlParseMode,
 };
+#[cfg(feature = "live")]
 pub use recorder::{
     RecorderLimits, TailtriageLayer, TracingIntakeSession, TracingIntakeSessionBuilder,
     TracingRecorder, TracingRecorderBuilder, DEFAULT_MAX_COMPLETED_SPANS, DEFAULT_MAX_OPEN_SPANS,

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
+use tailtriage_core::{LocalJsonSink, RunSink};
 use tracing::field::{Field, Visit};
 use tracing::{Id, Subscriber};
 use tracing_subscriber::layer::{Context, Layer};
@@ -293,17 +294,12 @@ impl TracingIntakeSession {
         let imported = self.recorder.shutdown()?;
         if let Some(path) = self.run_json_path {
             ensure_persistable_run_has_requests(imported.run())?;
-            let file = std::fs::File::create(&path).map_err(|err| ImportError::Io {
-                operation: "create run json path",
-                context: path.display().to_string(),
-                reason: err.to_string(),
-            })?;
-            serde_json::to_writer_pretty(file, imported.run()).map_err(|err| {
-                ImportError::InvalidField {
-                    field: "run_json_path",
+            LocalJsonSink::new(&path)
+                .write(imported.run())
+                .map_err(|err| ImportError::RunJsonWrite {
+                    path: path.display().to_string(),
                     reason: err.to_string(),
-                }
-            })?;
+                })?;
         }
         Ok(imported)
     }

--- a/tailtriage-tracing/tests/equivalence.rs
+++ b/tailtriage-tracing/tests/equivalence.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "live")]
+
 mod support;
 
 use support::equivalence_harness::assert_deterministic_span_import_full_parity;


### PR DESCRIPTION
### Motivation

- Consolidate Run JSON writing so tracing reuse the same robust sink semantics as native captures and avoid duplicated temp-file/flush/rename logic. 
- Reduce dependency weight for offline JSONL import users so `tailtriage-cli` can import JSONL without pulling `tracing` / `tracing-subscriber`.
- Keep existing persisted-artifact guardrails (no run JSON when there are zero request events) and preserve current writer semantics.

### Description

- Replaced direct `File::create` + `serde_json::to_writer_pretty` in `TracingIntakeSession::shutdown()` with the core writer via `tailtriage_core::LocalJsonSink` and `RunSink::write`, keeping the zero-request check (`ensure_persistable_run_has_requests`) before any write attempt. 
- Added `ImportError::RunJsonWrite { path: String, reason: String }` and map sink failures into that variant so errors include the target path and sink failure reason. 
- Made `serde_json`, `tracing`, and `tracing-subscriber` optional and split `tailtriage-tracing` features as requested: `default = [

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a100b5bf4fc833099d82f7ab399657a)