### PR TITLE
Split tailtriage-tracing live features and reuse core Run JSON sink

### DIFF
--- a/tailtriage-cli/Cargo.toml
+++ b/tailtriage-cli/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 tailtriage-core.workspace = true
 tailtriage-analyzer.workspace = true
-tailtriage-tracing.workspace = true
+tailtriage-tracing = { version = "0.2.0", path = "../tailtriage-tracing", default-features = false, features = ["jsonl"] }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -17,17 +17,19 @@ include = [
 ]
 
 [features]
-default = []
-tokio = ["dep:tailtriage-tokio", "dep:tokio"]
+default = ["jsonl"]
+jsonl = ["dep:serde_json"]
+live = ["jsonl", "dep:tracing", "dep:tracing-subscriber"]
+tokio = ["live", "dep:tailtriage-tokio", "dep:tokio"]
 
 [dependencies]
 tailtriage-core.workspace = true
 tailtriage-tokio = { workspace = true, optional = true }
 tokio = { version = "1", features = ["rt", "sync", "time"], optional = true }
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
+serde_json = { version = "1", optional = true }
+tracing = { version = "0.1", optional = true }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"], optional = true }
 
 [package.metadata.docs.rs]
 all-features = true
@@ -40,3 +42,15 @@ workspace = true
 tailtriage-analyzer.workspace = true
 futures-executor = "0.3"
 tempfile = "3"
+
+[[example]]
+name = "live_session_to_run"
+required-features = ["live"]
+
+[[example]]
+name = "completed_span_jsonl_import"
+required-features = ["live"]
+
+[[example]]
+name = "live_recorder"
+required-features = ["live"]

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -12,7 +12,15 @@ It is **not**:
 - an OTel/OTLP pipeline,
 - proof of root cause (output remains triage leads).
 
-## Recommended live session setup
+## Feature flags
+
+- default (`jsonl`): typed span records plus JSONL import (`import_jsonl_reader`/`import_jsonl_path`).
+- `live`: enables live tracing capture (`TracingRecorder`, `TailtriageLayer`, `TracingIntakeSession`).
+- `tokio`: enables Tokio sampler coupling (`TracingTokioSession`).
+
+This keeps offline JSONL import paths (including CLI import usage) independent from the live `tracing_subscriber` layer dependency.
+
+## Recommended live session setup (`live` feature)
 
 ```rust,no_run
 use tailtriage_tracing::TracingIntakeSession;

--- a/tailtriage-tracing/src/error.rs
+++ b/tailtriage-tracing/src/error.rs
@@ -39,6 +39,13 @@ pub enum ImportError {
         /// Actionable setup guidance for creating a persistable run artifact.
         guidance: String,
     },
+    /// Writing Run JSON output via the core sink failed.
+    RunJsonWrite {
+        /// Target file path.
+        path: String,
+        /// Underlying sink failure reason.
+        reason: String,
+    },
 }
 
 impl fmt::Display for ImportError {
@@ -60,6 +67,9 @@ impl fmt::Display for ImportError {
             Self::EmptyServiceName => write!(f, "service name must not be empty"),
             Self::InvalidRunEvent(message) => write!(f, "invalid run event: {message}"),
             Self::ZeroRequestArtifact { guidance } => write!(f, "{guidance}"),
+            Self::RunJsonWrite { path, reason } => {
+                write!(f, "failed to write run json to {path}: {reason}")
+            }
         }
     }
 }

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -3,10 +3,10 @@
 
 //! Tracing intake bridge types for tailtriage triage workflows.
 //!
-//! This crate provides semantic `tt.*` keys, typed [`SpanRecord`] intake,
-//! conversion to [`tailtriage_core::Run`] via [`run_from_span_records`],
-//! JSONL import via [`import_jsonl_reader`] and [`import_jsonl_path`], and
-//! live in-memory recording via [`TracingRecorder`] and [`TailtriageLayer`].
+//! This crate provides semantic `tt.*` keys, typed `SpanRecord` intake,
+//! conversion to `tailtriage_core::Run` via `run_from_span_records`,
+//! JSONL import via `import_jsonl_reader` and `import_jsonl_path` (`jsonl` feature),
+//! and live in-memory recording via `TracingRecorder` and `TailtriageLayer` (`live` feature).
 //! It does not implement OpenTelemetry/OTLP and does not change analyzer behavior.
 //!
 //! # Example
@@ -29,7 +29,9 @@
 
 mod convention;
 mod error;
+#[cfg(feature = "jsonl")]
 mod jsonl;
+#[cfg(feature = "live")]
 mod recorder;
 #[cfg(feature = "tokio")]
 /// Optional Tokio runtime sampler coupling for tracing sessions.
@@ -45,9 +47,11 @@ pub use convention::{
     TT_DEPTH_AT_START, TT_KIND, TT_OUTCOME, TT_QUEUE, TT_REQUEST_ID, TT_ROUTE, TT_STAGE, TT_SUCCESS,
 };
 pub use error::ImportError;
+#[cfg(feature = "jsonl")]
 pub use jsonl::{
     import_jsonl_path, import_jsonl_path_with_mode, import_jsonl_reader, JsonlParseMode,
 };
+#[cfg(feature = "live")]
 pub use recorder::{
     RecorderLimits, TailtriageLayer, TracingIntakeSession, TracingIntakeSessionBuilder,
     TracingRecorder, TracingRecorderBuilder, DEFAULT_MAX_COMPLETED_SPANS, DEFAULT_MAX_OPEN_SPANS,

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
+use tailtriage_core::{LocalJsonSink, RunSink};
 use tracing::field::{Field, Visit};
 use tracing::{Id, Subscriber};
 use tracing_subscriber::layer::{Context, Layer};
@@ -293,17 +294,12 @@ impl TracingIntakeSession {
         let imported = self.recorder.shutdown()?;
         if let Some(path) = self.run_json_path {
             ensure_persistable_run_has_requests(imported.run())?;
-            let file = std::fs::File::create(&path).map_err(|err| ImportError::Io {
-                operation: "create run json path",
-                context: path.display().to_string(),
-                reason: err.to_string(),
-            })?;
-            serde_json::to_writer_pretty(file, imported.run()).map_err(|err| {
-                ImportError::InvalidField {
-                    field: "run_json_path",
+            LocalJsonSink::new(&path)
+                .write(imported.run())
+                .map_err(|err| ImportError::RunJsonWrite {
+                    path: path.display().to_string(),
                     reason: err.to_string(),
-                }
-            })?;
+                })?;
         }
         Ok(imported)
     }


### PR DESCRIPTION
### Motivation
- Remove duplicated Run JSON write logic in `tailtriage-tracing` and reuse the robust core writer to ensure consistent temp-file/flush/sync/rename semantics.
- Keep offline JSONL import users lightweight by preventing the live `tracing`/`tracing-subscriber` dependencies from being pulled in for CLI-only import flows.
- Ensure the zero-request persisted-artifact guard runs before any write attempt so no files are created or modified on empty runs.

### Description
- Replaced direct `File::create` + `serde_json::to_writer_pretty` in `TracingIntakeSession::shutdown()` with `tailtriage_core::LocalJsonSink` and `RunSink::write`, preserving the pre-write `ensure_persistable_run_has_requests(...)` check so no sink activity occurs on zero-request runs.
- Added `ImportError::RunJsonWrite { path: String, reason: String }` and mapped sink `SinkError` failures into this variant so error messages include the target path and sink failure reason.
- Split `tailtriage-tracing` features and made heavier deps optional: `default = ["jsonl"]`, `jsonl = ["dep:serde_json"]`, `live = ["jsonl", "dep:tracing", "dep:tracing-subscriber"]`, and `tokio = ["live", "dep:tailtriage-tokio", "dep:tokio"]` while keeping `serde` as a normal dependency.
- Gate modules and public re-exports so `jsonl` APIs are behind `feature = "jsonl"`, live recorder/session APIs are behind `feature = "live"`, and Tokio session APIs remain behind `feature = "tokio"`.
- Updated `tailtriage-cli` to depend on `tailtriage-tracing` as `default-features = false, features = ["jsonl"]` so CLI offline imports do not pull in live tracing crates, and added `required-features` to live examples.
- Adjusted crate README and top-level lib docs to be feature-aware and avoid broken rustdoc links under no-default or jsonl-only builds.

### Testing
- Ran `cargo fmt --check`, which succeeded.
- Ran `cargo check -p tailtriage-tracing` in combinations `--no-default-features`, `--no-default-features --features jsonl`, `--no-default-features --features live`, and `--no-default-features --features tokio`, all of which succeeded.
- Generated docs with `cargo doc -p tailtriage-tracing --no-default-features` and with `--features jsonl`, both of which succeeded.
- Ran full workspace `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and `cargo test --workspace --all-targets --all-features --locked`, and both completed with no failures.
- Ran `python3 scripts/validate_docs_contracts.py`, which validated successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a100b5bf4fc833099d82f7ab399657a)