### PR TITLE
Align offline tracing import mode/limits semantics with native capture

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -159,6 +159,7 @@ Prefer moderate intervals and bounded runs before increasing density.
 ## Operating with tracing-based runs
 
 Tracing import expects completed `tt.*` span JSONL, not arbitrary `tracing_subscriber::fmt().json()` or ordinary tracing log JSON. Import writes Run JSON (not Report JSON), and analysis is a separate step after import (`tailtriage analyze`). Timing is not guessed from line receive time, so completed spans must include explicit unix-ms start/end timestamps.
+Tracing import and native capture use the same `CaptureMode` and `CaptureLimits` semantics for request/stage/queue retention in the resulting Run metadata and drop accounting. Offline CLI tracing import exposes request/stage/queue override flags (`--max-requests`, `--max-stages`, `--max-queues`) because those are the imported evidence types. It intentionally does not expose runtime/in-flight snapshot limit flags because this path does not import runtime or in-flight snapshot evidence.
 
 Persisted Run JSON artifacts intended for `tailtriage analyze` require at least one completed request event. Library snapshots may still be zero-request for inspection during active captures.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -43,7 +43,7 @@ tailtriage import tracing-json completed-spans.jsonl --input-format tailtriage-s
 tailtriage analyze tailtriage-run.json
 ```
 
-`tailtriage import tracing-json` writes Run artifact JSON (not Report JSON), and analysis remains a separate step after import. Use the documented stable wrapper JSONL shape from `tailtriage-tracing` (`{"format":"tailtriage.tracing-span.v1","span":{...}}`). `--strict` fails on malformed or incomplete `tt.*` spans; non-strict mode skips malformed `tt.*` spans and prints `warning: ...` messages. Tracing-only runs do not fabricate runtime snapshots, and runtime-pressure evidence remains Tokio-specific.
+`tailtriage import tracing-json` writes Run artifact JSON (not Report JSON), and analysis remains a separate step after import. Use the documented stable wrapper JSONL shape from `tailtriage-tracing` (`{"format":"tailtriage.tracing-span.v1","span":{...}}`). `--strict` fails on malformed or incomplete `tt.*` spans; non-strict mode skips malformed `tt.*` spans and prints `warning: ...` messages. Tracing import and native capture share the same `CaptureMode`/`CaptureLimits` semantics for request/stage/queue retention. Offline CLI import exposes `--mode`, `--max-requests`, `--max-stages`, and `--max-queues`; it does not expose runtime/in-flight snapshot limit flags because that import path does not ingest runtime/in-flight snapshot evidence. Tracing-only runs do not fabricate runtime snapshots, and runtime-pressure evidence remains Tokio-specific.
 
 B) Direct Run JSON path with async span instrumentation:
 

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -54,6 +54,13 @@ With optional metadata flags, strict validation, and explicit format:
 tailtriage import tracing-json spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json --service-version v1 --run-id run-42 --strict
 ```
 
+Choose import retention semantics and override request/stage/queue limits:
+
+```bash
+tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json \
+  --mode investigation --max-requests 5000 --max-stages 20000 --max-queues 20000
+```
+
 
 `tailtriage import tracing-json` imports **completed `tt.*` tracing span JSONL** into **Run JSON** (not Report JSON).
 
@@ -87,6 +94,7 @@ tailtriage import tracing-json "fixtures/tracing spans.jsonl" --service checkout
 
 The command imports completed `tt.*` tracing span records in the documented JSONL shape and writes pretty Run JSON (`serde_json::to_writer_pretty`), not Report JSON. Import warnings are printed to stderr as `warning: ...`. Analysis is a separate step: `tailtriage analyze tailtriage-run.json`.
 Tracing-only imports provide request/stage/queue intake but do not fabricate runtime snapshots; executor/blocking-pressure interpretation remains limited unless runtime snapshots are also captured (for example via Tokio runtime sampling).
+Tracing import and native capture use the same `CaptureMode` and `CaptureLimits` semantics for request/stage/queue evidence retention. Offline import exposes `--max-requests`, `--max-stages`, and `--max-queues` because those are the imported evidence types. Offline import intentionally does not expose runtime/in-flight snapshot limit flags because this path does not import those evidence types.
 Malformed JSON input remains fatal. In non-strict mode, syntactically valid malformed/incomplete `tt.*` records are skipped with `warning: ...` lines.
 `--service` must not be empty or whitespace.
 Import fails when zero request events would be written (for example unrelated-only input or all-skipped malformed `tt.*` input), because `tailtriage analyze` requires at least one request in CLI-loaded run artifacts.

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -5,6 +5,7 @@ use clap::{Parser, ValueEnum};
 use tailtriage_analyzer::{render_json_pretty, render_text, try_analyze_run};
 use tailtriage_cli::artifact::load_run_artifact;
 use tailtriage_cli::{analyzer_options_help_text, build_analyze_options};
+use tailtriage_core::{CaptureLimitsOverride, CaptureMode};
 use tailtriage_tracing::{
     ensure_persistable_run_has_requests, import_jsonl_path_with_mode, ImportOptions, JsonlParseMode,
 };
@@ -69,12 +70,39 @@ enum ImportCommand {
         /// Input format mode.
         #[arg(long, value_enum, default_value_t = TracingInputFormat::Auto)]
         input_format: TracingInputFormat,
+        /// Capture mode for offline import retention semantics.
+        #[arg(long, value_enum, default_value_t = TracingImportMode::Light)]
+        mode: TracingImportMode,
+        /// Maximum retained request events.
+        #[arg(long)]
+        max_requests: Option<usize>,
+        /// Maximum retained stage events.
+        #[arg(long)]
+        max_stages: Option<usize>,
+        /// Maximum retained queue events.
+        #[arg(long)]
+        max_queues: Option<usize>,
     },
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 enum TracingInputFormat {
     Auto,
     TailtriageSpanJsonl,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum TracingImportMode {
+    Light,
+    Investigation,
+}
+
+impl From<TracingImportMode> for CaptureMode {
+    fn from(value: TracingImportMode) -> Self {
+        match value {
+            TracingImportMode::Light => CaptureMode::Light,
+            TracingImportMode::Investigation => CaptureMode::Investigation,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -96,8 +124,20 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 run_id,
                 strict,
                 input_format,
+                mode,
+                max_requests,
+                max_stages,
+                max_queues,
             } => {
-                let mut options = ImportOptions::new(service).strict(strict);
+                let mut options = ImportOptions::new(service)
+                    .strict(strict)
+                    .mode(mode.into())
+                    .capture_limits_override(CaptureLimitsOverride {
+                        max_requests,
+                        max_stages,
+                        max_queues,
+                        ..CaptureLimitsOverride::default()
+                    });
                 if let Some(service_version) = service_version {
                     options = options.service_version(service_version);
                 }

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
-use tailtriage_core::Run;
+use tailtriage_core::{CaptureMode, Run};
 
 #[test]
 fn cli_json_output_is_valid_report_json() {
@@ -248,6 +248,83 @@ fn import_tracing_json_writes_run_json_analyzable_by_existing_apis() {
         .expect("imported run should load in cli loader");
     let report = analyze_run(&loaded.run, AnalyzeOptions::default());
     assert_eq!(report.request_count, 1);
+}
+
+#[test]
+fn import_tracing_json_mode_investigation_sets_run_mode_metadata() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, complete_span_jsonl_fixture()).expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--mode")
+        .arg("investigation")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+    assert!(output.status.success(), "cli failed: {output:?}");
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path).expect("load run");
+    assert_eq!(loaded.run.metadata.mode, CaptureMode::Investigation);
+}
+
+#[test]
+fn import_tracing_json_limit_overrides_apply_to_retained_evidence() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(
+        &spans_path,
+        concat!(
+            "{\"format\":\"tailtriage.tracing-span.v1\",\"span\":{\"name\":\"req1\",\"started_at_unix_ms\":1,\"finished_at_unix_ms\":2,\"fields\":{\"tt.kind\":\"request\",\"tt.request_id\":\"r1\",\"tt.route\":\"/a\"}}}\n",
+            "{\"format\":\"tailtriage.tracing-span.v1\",\"span\":{\"name\":\"req2\",\"started_at_unix_ms\":3,\"finished_at_unix_ms\":4,\"fields\":{\"tt.kind\":\"request\",\"tt.request_id\":\"r2\",\"tt.route\":\"/b\"}}}\n",
+            "{\"format\":\"tailtriage.tracing-span.v1\",\"span\":{\"name\":\"st1\",\"started_at_unix_ms\":1,\"finished_at_unix_ms\":2,\"fields\":{\"tt.kind\":\"stage\",\"tt.request_id\":\"r1\",\"tt.stage\":\"db\"}}}\n",
+            "{\"format\":\"tailtriage.tracing-span.v1\",\"span\":{\"name\":\"st2\",\"started_at_unix_ms\":1,\"finished_at_unix_ms\":2,\"fields\":{\"tt.kind\":\"stage\",\"tt.request_id\":\"r1\",\"tt.stage\":\"cache\"}}}\n",
+            "{\"format\":\"tailtriage.tracing-span.v1\",\"span\":{\"name\":\"q1\",\"started_at_unix_ms\":1,\"finished_at_unix_ms\":2,\"fields\":{\"tt.kind\":\"queue\",\"tt.request_id\":\"r1\",\"tt.queue\":\"permits\"}}}\n",
+            "{\"format\":\"tailtriage.tracing-span.v1\",\"span\":{\"name\":\"q2\",\"started_at_unix_ms\":1,\"finished_at_unix_ms\":2,\"fields\":{\"tt.kind\":\"queue\",\"tt.request_id\":\"r1\",\"tt.queue\":\"dbpool\"}}}\n"
+        ),
+    )
+    .expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--max-requests")
+        .arg("1")
+        .arg("--max-stages")
+        .arg("1")
+        .arg("--max-queues")
+        .arg("1")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+    assert!(output.status.success(), "cli failed: {output:?}");
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path).expect("load run");
+    assert_eq!(loaded.run.requests.len(), 1);
+    assert_eq!(loaded.run.stages.len(), 1);
+    assert_eq!(loaded.run.queues.len(), 1);
+}
+
+#[test]
+fn import_tracing_json_has_no_runtime_snapshot_limit_flag() {
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg("--help")
+        .output()
+        .expect("cli should run");
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("utf8");
+    assert!(!stdout.contains("--max-runtime-snapshots"));
+    assert!(!stdout.contains("--max-inflight-snapshots"));
 }
 
 #[test]

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -70,6 +70,7 @@ Use `completed_span_jsonl_path(...)` when you want an offline import workflow:
 tailtriage import tracing-json target/tailtriage-examples/checkout.spans.jsonl \
   --input-format tailtriage-span-jsonl \
   --service checkout-service \
+  --mode light \
   --output target/tailtriage-examples/checkout.run.json
 
 tailtriage analyze target/tailtriage-examples/checkout.run.json
@@ -101,6 +102,13 @@ Arbitrary `tracing_subscriber::fmt().json()` log JSON is rejected by import. Imp
 - Non-strict mode: malformed/incomplete records are warned and skipped where implemented.
 
 ## Retention and drop behavior
+
+Offline tracing import resolves mode/limits with the same semantics as native capture:
+- mode selects the base `CaptureLimits` defaults,
+- explicit full `capture_limits` wins when set,
+- additive overrides apply on top of mode defaults when full limits are not set.
+
+CLI import exposes request/stage/queue overrides only (`--max-requests`, `--max-stages`, `--max-queues`) because offline JSONL import in this path imports those evidence types and does not import runtime or in-flight snapshots.
 
 - `max_open_spans` bounds in-flight span tracking.
 - `max_completed_spans` bounds in-memory completed-span retention.

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -40,7 +40,7 @@ mod types;
 
 use std::collections::BTreeSet;
 use tailtriage_core::{
-    BuildError, CaptureMode, QueueEvent, RequestEvent, RunBuilder, RunBuilderOptions, StageEvent,
+    BuildError, QueueEvent, RequestEvent, RunBuilder, RunBuilderOptions, StageEvent,
 };
 
 pub use convention::{
@@ -228,7 +228,8 @@ where
             }
         }
     }
-    let capture_limits = CaptureMode::Light.core_defaults();
+    let mode = options.mode_value();
+    let capture_limits = options.resolved_capture_limits();
     let request_outcome_default_count = parsed_requests
         .iter()
         .take(capture_limits.max_requests)
@@ -284,7 +285,7 @@ where
 
     let mut builder_options = RunBuilderOptions::new(options.service_name())
         .run_id(run_id)
-        .mode(CaptureMode::Light)
+        .mode(mode)
         .capture_limits(capture_limits)
         .strict_lifecycle(false)
         .started_at_unix_ms(started_at_unix_ms)
@@ -641,6 +642,7 @@ fn parse_depth_at_start(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tailtriage_core::{CaptureLimits, CaptureMode};
 
     #[test]
     fn span_kind_parser_accepts_supported_values_only() {
@@ -659,6 +661,62 @@ mod tests {
             .field(TT_ROUTE, "/a")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).expect("ok");
         assert_eq!(imported.run().requests.len(), 1);
+    }
+
+    #[test]
+    fn run_from_span_records_uses_resolved_limits_and_mode_metadata() {
+        let spans = vec![
+            SpanRecord::new("req1", 100, 200)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("req2", 110, 210)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r2")
+                .field(TT_ROUTE, "/b"),
+            SpanRecord::new("st1", 120, 130)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+            SpanRecord::new("st2", 121, 131)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "cache"),
+            SpanRecord::new("q1", 140, 150)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+            SpanRecord::new("q2", 141, 151)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "dbpool"),
+        ];
+        let limits = CaptureLimits {
+            max_requests: 1,
+            max_stages: 1,
+            max_queues: 1,
+            max_inflight_snapshots: 1000,
+            max_runtime_snapshots: 1000,
+        };
+        let run = run_from_span_records(
+            spans,
+            ImportOptions::new("svc")
+                .mode(CaptureMode::Investigation)
+                .capture_limits(limits),
+        )
+        .unwrap()
+        .run()
+        .clone();
+        assert_eq!(run.requests.len(), 1);
+        assert_eq!(run.stages.len(), 1);
+        assert_eq!(run.queues.len(), 1);
+        assert_eq!(run.truncation.dropped_requests, 1);
+        assert_eq!(run.truncation.dropped_stages, 1);
+        assert_eq!(run.truncation.dropped_queues, 1);
+        assert_eq!(run.metadata.mode, CaptureMode::Investigation);
+        let effective = run.metadata.effective_core_config.expect("effective core");
+        assert_eq!(effective.capture_limits, limits);
+        assert!(!effective.strict_lifecycle);
     }
 
     #[test]

--- a/tailtriage-tracing/src/types.rs
+++ b/tailtriage-tracing/src/types.rs
@@ -182,6 +182,9 @@ pub struct ImportOptions {
     service_version: Option<String>,
     run_id: Option<String>,
     strict: bool,
+    mode: tailtriage_core::CaptureMode,
+    capture_limits: Option<tailtriage_core::CaptureLimits>,
+    capture_limits_override: tailtriage_core::CaptureLimitsOverride,
 }
 
 impl ImportOptions {
@@ -192,6 +195,9 @@ impl ImportOptions {
             service_version: None,
             run_id: None,
             strict: false,
+            mode: tailtriage_core::CaptureMode::Light,
+            capture_limits: None,
+            capture_limits_override: tailtriage_core::CaptureLimitsOverride::default(),
         }
     }
 
@@ -214,6 +220,45 @@ impl ImportOptions {
     pub fn service_version(mut self, service_version: impl Into<String>) -> Self {
         self.service_version = Some(service_version.into());
         self
+    }
+
+    /// Sets capture mode for import semantics.
+    #[must_use]
+    pub fn mode(mut self, mode: tailtriage_core::CaptureMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    /// Sets full capture limits override.
+    #[must_use]
+    pub fn capture_limits(mut self, capture_limits: tailtriage_core::CaptureLimits) -> Self {
+        self.capture_limits = Some(capture_limits);
+        self
+    }
+
+    /// Sets additive capture limit overrides.
+    #[must_use]
+    pub fn capture_limits_override(
+        mut self,
+        capture_limits_override: tailtriage_core::CaptureLimitsOverride,
+    ) -> Self {
+        self.capture_limits_override = capture_limits_override;
+        self
+    }
+
+    /// Returns selected capture mode.
+    #[must_use]
+    pub fn mode_value(&self) -> tailtriage_core::CaptureMode {
+        self.mode
+    }
+
+    /// Returns resolved capture limits matching native resolution semantics.
+    #[must_use]
+    pub fn resolved_capture_limits(&self) -> tailtriage_core::CaptureLimits {
+        self.capture_limits.unwrap_or_else(|| {
+            self.capture_limits_override
+                .apply(self.mode.core_defaults())
+        })
     }
 
     /// Returns service name.
@@ -304,6 +349,7 @@ impl ImportedRun {
 mod tests {
     use super::*;
     use crate::{TT_DEPTH_AT_START, TT_KIND, TT_SUCCESS};
+    use tailtriage_core::{CaptureLimits, CaptureLimitsOverride, CaptureMode};
 
     #[test]
     fn span_record_builder_stores_fields() {
@@ -350,6 +396,50 @@ mod tests {
         assert_eq!(options.service_version_ref(), Some("1.2.3"));
         assert_eq!(options.run_id_ref(), Some("run-123"));
         assert!(options.strict_mode());
+    }
+
+    #[test]
+    fn import_options_capture_defaults_and_overrides() {
+        let defaults = ImportOptions::new("svc");
+        assert_eq!(defaults.mode_value(), CaptureMode::Light);
+        assert_eq!(
+            defaults.resolved_capture_limits(),
+            CaptureMode::Light.core_defaults()
+        );
+
+        let inv = ImportOptions::new("svc").mode(CaptureMode::Investigation);
+        assert_eq!(
+            inv.resolved_capture_limits(),
+            CaptureMode::Investigation.core_defaults()
+        );
+
+        let full = CaptureLimits {
+            max_requests: 1,
+            max_stages: 2,
+            max_queues: 3,
+            max_inflight_snapshots: 4,
+            max_runtime_snapshots: 5,
+        };
+        let full_wins = ImportOptions::new("svc")
+            .mode(CaptureMode::Investigation)
+            .capture_limits_override(CaptureLimitsOverride {
+                max_requests: Some(999),
+                ..CaptureLimitsOverride::default()
+            })
+            .capture_limits(full);
+        assert_eq!(full_wins.resolved_capture_limits(), full);
+
+        let additive = ImportOptions::new("svc")
+            .capture_limits_override(CaptureLimitsOverride {
+                max_requests: Some(7),
+                max_stages: Some(8),
+                max_queues: Some(9),
+                ..CaptureLimitsOverride::default()
+            })
+            .resolved_capture_limits();
+        assert_eq!(additive.max_requests, 7);
+        assert_eq!(additive.max_stages, 8);
+        assert_eq!(additive.max_queues, 9);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Make offline tracing JSONL import use the same capture-mode and capture-limits semantics as native in-process capture so retention/truncation behavior, metadata, and drop accounting are consistent across ingestion paths.

### Description
- Extended `ImportOptions` (in `tailtriage-tracing`) with `mode: CaptureMode`, optional full `capture_limits: Option<CaptureLimits>`, and `capture_limits_override: CaptureLimitsOverride`, plus builder-style setters `mode`, `capture_limits`, `capture_limits_override`, and accessors `mode_value` and `resolved_capture_limits` that resolve the final limits using native semantics (full override wins; otherwise additive override applied to `mode.core_defaults()`).
- Updated `run_from_span_records` to use `options.mode_value()` and `options.resolved_capture_limits()` (removed hard-coded light defaults), applied the resolved limits to truncation/retention logic, and recorded selected `mode` and effective core config (resolved limits + `strict_lifecycle=false`) into the built Run metadata.
- Added CLI flags for offline import in `tailtriage-cli`: `--mode <light|investigation>`, `--max-requests`, `--max-stages`, and `--max-queues`; these map into `ImportOptions` via a small CLI-local enum and `CaptureLimitsOverride` without adding `clap` to `tailtriage-core` or exposing runtime/in-flight snapshot flags.
- Updated docs (`tailtriage-tracing/README.md`, `tailtriage-cli/README.md`, `docs/user-guide.md`, `docs/operations.md`) to state that tracing import and native capture share `CaptureMode`/`CaptureLimits` semantics for request/stage/queue retention and that offline import only exposes meaningful request/stage/queue overrides (no runtime/in-flight snapshot limit flags).
- Added unit and CLI tests covering `ImportOptions` resolution, `run_from_span_records` behavior with small limits and metadata, CLI `--mode investigation`, CLI `--max-requests`, `--max-stages`, `--max-queues`, and help absence of runtime/in-flight flags.

### Testing
- Ran targeted tests and validations: `cargo test -p tailtriage-tracing -p tailtriage-cli --all-targets --all-features --locked` passed (all new and updated unit/CLI tests passed). 
- Ran `cargo fmt --check` (ok) and `python3 scripts/validate_docs_contracts.py` (ok).
- Attempting the full workspace `cargo clippy --workspace --all-targets --all-features --locked -D warnings` surfaced a pre-existing unrelated `clippy::large_enum_variant` issue in `demos/demo_support` and failed; this is not introduced by these changes and does not block the focused package tests exercised above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1018baf4cc83308e8959b88a244abb)