### PR TITLE
Align tracing JSONL import mode/limits with native capture semantics

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -505,5 +505,5 @@ Do not treat one report as final proof.
 - Configure `max_open_spans` and `max_completed_spans` to keep memory bounded.
 - Completed-span JSONL streaming happens before in-memory `max_completed_spans` retention, so the file can preserve spans beyond in-memory retained completed spans.
 - Import warnings and lifecycle warnings mean evidence may be incomplete and should be treated as triage caveats.
-- Tracing-only runs do not fabricate runtime snapshots; runtime-pressure evidence remains Tokio-specific and requires runtime snapshots/Tokio sampler coupling.
+- Tracing-only runs do not fabricate runtime snapshots; runtime-pressure evidence remains Tokio-specific and requires runtime snapshots/Tokio sampler coupling. Offline tracing import uses the same `CaptureMode` + `CaptureLimits` semantics as native capture for request/stage/queue retention, including optional `--mode` and request/stage/queue limit overrides only.
 - Treat tracing-import output like all tailtriage output: evidence-ranked suspects and next checks are leads, not proof of root cause.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -43,7 +43,7 @@ tailtriage import tracing-json completed-spans.jsonl --input-format tailtriage-s
 tailtriage analyze tailtriage-run.json
 ```
 
-`tailtriage import tracing-json` writes Run artifact JSON (not Report JSON), and analysis remains a separate step after import. Use the documented stable wrapper JSONL shape from `tailtriage-tracing` (`{"format":"tailtriage.tracing-span.v1","span":{...}}`). `--strict` fails on malformed or incomplete `tt.*` spans; non-strict mode skips malformed `tt.*` spans and prints `warning: ...` messages. Tracing-only runs do not fabricate runtime snapshots, and runtime-pressure evidence remains Tokio-specific.
+`tailtriage import tracing-json` writes Run artifact JSON (not Report JSON), and analysis remains a separate step after import. Use the documented stable wrapper JSONL shape from `tailtriage-tracing` (`{"format":"tailtriage.tracing-span.v1","span":{...}}`). `--strict` fails on malformed or incomplete `tt.*` spans; non-strict mode skips malformed `tt.*` spans and prints `warning: ...` messages. Tracing-only runs do not fabricate runtime snapshots, and runtime-pressure evidence remains Tokio-specific. Offline tracing import and native capture share the same `CaptureMode`/`CaptureLimits` semantics for request/stage/queue evidence retention (`--mode`, `--max-requests`, `--max-stages`, `--max-queues`). Offline tracing import does not expose runtime/in-flight snapshot limit flags because those evidence types are not imported in this path.
 
 B) Direct Run JSON path with async span instrumentation:
 

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -45,13 +45,13 @@ tailtriage analyze tailtriage-run.json --format json
 Import completed `tt.*` tracing span JSONL into Run JSON:
 
 ```bash
-tailtriage import tracing-json spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json
+tailtriage import tracing-json spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json --mode light
 ```
 
 With optional metadata flags, strict validation, and explicit format:
 
 ```bash
-tailtriage import tracing-json spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json --service-version v1 --run-id run-42 --strict
+tailtriage import tracing-json spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json --mode light --service-version v1 --run-id run-42 --strict --mode investigation --max-requests 2000 --max-stages 16000 --max-queues 16000
 ```
 
 
@@ -283,3 +283,6 @@ Use capture-side crates for that:
 - `tailtriage-controller`: repeated bounded windows
 - `tailtriage-tokio`: runtime-pressure sampling
 - `tailtriage-axum`: Axum request-boundary integration
+
+
+Offline `tracing-json` import now uses the same `CaptureMode` and `CaptureLimits` semantics as native capture for request/stage/queue evidence retention. CLI import exposes `--mode <light|investigation>`, `--max-requests`, `--max-stages`, and `--max-queues`. It intentionally does not expose `--max-runtime-snapshots` or `--max-inflight-snapshots` because this offline tracing JSONL path does not import runtime snapshots or in-flight snapshots.

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -5,6 +5,7 @@ use clap::{Parser, ValueEnum};
 use tailtriage_analyzer::{render_json_pretty, render_text, try_analyze_run};
 use tailtriage_cli::artifact::load_run_artifact;
 use tailtriage_cli::{analyzer_options_help_text, build_analyze_options};
+use tailtriage_core::{CaptureLimitsOverride, CaptureMode};
 use tailtriage_tracing::{
     ensure_persistable_run_has_requests, import_jsonl_path_with_mode, ImportOptions, JsonlParseMode,
 };
@@ -66,10 +67,36 @@ enum ImportCommand {
         /// Fail on malformed/incomplete tailtriage spans.
         #[arg(long)]
         strict: bool,
+        /// Capture mode for imported run metadata and default retention limits.
+        #[arg(long, value_enum, default_value_t = ImportCaptureMode::Light)]
+        mode: ImportCaptureMode,
+        /// Override max retained requests for imported evidence.
+        #[arg(long, value_name = "N")]
+        max_requests: Option<usize>,
+        /// Override max retained stages for imported evidence.
+        #[arg(long, value_name = "N")]
+        max_stages: Option<usize>,
+        /// Override max retained queues for imported evidence.
+        #[arg(long, value_name = "N")]
+        max_queues: Option<usize>,
         /// Input format mode.
         #[arg(long, value_enum, default_value_t = TracingInputFormat::Auto)]
         input_format: TracingInputFormat,
     },
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum ImportCaptureMode {
+    Light,
+    Investigation,
+}
+
+impl ImportCaptureMode {
+    fn into_core(self) -> CaptureMode {
+        match self {
+            Self::Light => CaptureMode::Light,
+            Self::Investigation => CaptureMode::Investigation,
+        }
+    }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 enum TracingInputFormat {
@@ -95,9 +122,21 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 service_version,
                 run_id,
                 strict,
+                mode,
+                max_requests,
+                max_stages,
+                max_queues,
                 input_format,
             } => {
-                let mut options = ImportOptions::new(service).strict(strict);
+                let mut options = ImportOptions::new(service)
+                    .strict(strict)
+                    .mode(mode.into_core())
+                    .capture_limits_override(CaptureLimitsOverride {
+                        max_requests,
+                        max_stages,
+                        max_queues,
+                        ..CaptureLimitsOverride::default()
+                    });
                 if let Some(service_version) = service_version {
                     options = options.service_version(service_version);
                 }

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -740,6 +740,75 @@ fn import_tracing_json_persists_optional_default_assumption_warnings_in_run_arti
     assert_eq!(report.request_count, 1);
 }
 
+#[test]
+fn import_tracing_json_accepts_mode_investigation() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, missing_optional_defaults_fixture()).expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .args(["import", "tracing-json"])
+        .arg(&spans_path)
+        .args(["--service", "checkout", "--output"])
+        .arg(&run_path)
+        .args(["--mode", "investigation"])
+        .output()
+        .expect("cli should run");
+    assert!(
+        output.status.success(),
+        "cli unexpectedly failed: {output:?}"
+    );
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path).unwrap();
+    assert_eq!(
+        loaded.run.metadata.mode,
+        tailtriage_core::CaptureMode::Investigation
+    );
+}
+
+#[test]
+fn import_tracing_json_applies_request_stage_queue_limit_overrides() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, overflow_spans_fixture()).expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .args(["import", "tracing-json"])
+        .arg(&spans_path)
+        .args(["--service", "checkout", "--output"])
+        .arg(&run_path)
+        .args([
+            "--max-requests",
+            "1",
+            "--max-stages",
+            "1",
+            "--max-queues",
+            "1",
+        ])
+        .output()
+        .expect("cli should run");
+    assert!(
+        output.status.success(),
+        "cli unexpectedly failed: {output:?}"
+    );
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path).unwrap();
+    assert_eq!(loaded.run.requests.len(), 1);
+    assert_eq!(loaded.run.stages.len(), 1);
+    assert_eq!(loaded.run.queues.len(), 1);
+}
+
+#[test]
+fn import_tracing_json_does_not_expose_runtime_or_inflight_limit_flags() {
+    for flag in ["--max-runtime-snapshots", "--max-inflight-snapshots"] {
+        let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+            .args(["import", "tracing-json", "--help"])
+            .output()
+            .expect("help should run");
+        assert!(output.status.success());
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        assert!(!stdout.contains(flag), "unexpected flag in help: {flag}");
+    }
+}
+
 fn valid_cli_artifact_with_requests() -> &'static str {
     r#"{"schema_version":1,"metadata":{"run_id":"r1","service_name":"svc","service_version":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"mode":"light","host":null,"pid":null,"lifecycle_warnings":[],"unfinished_requests":{"count":0,"sample":[]}},"requests":[{"request_id":"req1","route":"/","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":10,"outcome":"ok"}],"stages":[],"queues":[],"inflight":[],"runtime_snapshots":[]}"#
 }
@@ -747,6 +816,16 @@ fn valid_cli_artifact_with_requests() -> &'static str {
 fn missing_optional_defaults_fixture() -> &'static str {
     r#"{"span":{"name":"request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout"}}}
 {"span":{"name":"stage","started_at_unix_ms":1001,"finished_at_unix_ms":1009,"fields":{"tt.kind":"stage","tt.request_id":"req-1","tt.stage":"db"}}}
+"#
+}
+
+fn overflow_spans_fixture() -> &'static str {
+    r#"{"span":{"name":"request-1","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/a","tt.outcome":"ok"}}}
+{"span":{"name":"request-2","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/b","tt.outcome":"ok"}}}
+{"span":{"name":"stage-1","started_at_unix_ms":1001,"finished_at_unix_ms":1009,"fields":{"tt.kind":"stage","tt.request_id":"req-1","tt.stage":"db","tt.success":true}}}
+{"span":{"name":"stage-2","started_at_unix_ms":1001,"finished_at_unix_ms":1009,"fields":{"tt.kind":"stage","tt.request_id":"req-1","tt.stage":"cache","tt.success":true}}}
+{"span":{"name":"queue-1","started_at_unix_ms":1001,"finished_at_unix_ms":1009,"fields":{"tt.kind":"queue","tt.request_id":"req-1","tt.queue":"q1"}}}
+{"span":{"name":"queue-2","started_at_unix_ms":1001,"finished_at_unix_ms":1009,"fields":{"tt.kind":"queue","tt.request_id":"req-1","tt.queue":"q2"}}}
 "#
 }
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -116,3 +116,6 @@ Persisted Run JSON artifacts intended for `tailtriage analyze` require at least 
 
 - `tailtriage-tracing/examples/live_session_to_run.rs`
 - `tailtriage-tracing/examples/completed_span_jsonl_import.rs`
+
+
+`ImportOptions` uses the same core capture configuration semantics as native capture: select `CaptureMode` and optionally apply full `capture_limits(...)` or additive `capture_limits_override(...)`. For tracing import, those semantics apply to request/stage/queue evidence retention in imported runs.

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -40,7 +40,7 @@ mod types;
 
 use std::collections::BTreeSet;
 use tailtriage_core::{
-    BuildError, CaptureMode, QueueEvent, RequestEvent, RunBuilder, RunBuilderOptions, StageEvent,
+    BuildError, QueueEvent, RequestEvent, RunBuilder, RunBuilderOptions, StageEvent,
 };
 
 pub use convention::{
@@ -228,7 +228,8 @@ where
             }
         }
     }
-    let capture_limits = CaptureMode::Light.core_defaults();
+    let mode = options.mode_value();
+    let capture_limits = options.resolved_capture_limits();
     let request_outcome_default_count = parsed_requests
         .iter()
         .take(capture_limits.max_requests)
@@ -284,7 +285,7 @@ where
 
     let mut builder_options = RunBuilderOptions::new(options.service_name())
         .run_id(run_id)
-        .mode(CaptureMode::Light)
+        .mode(mode)
         .capture_limits(capture_limits)
         .strict_lifecycle(false)
         .started_at_unix_ms(started_at_unix_ms)
@@ -641,6 +642,7 @@ fn parse_depth_at_start(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tailtriage_core::CaptureMode;
 
     #[test]
     fn span_kind_parser_accepts_supported_values_only() {
@@ -944,6 +946,62 @@ mod tests {
         assert_eq!(run.truncation.dropped_queues, 1);
         assert_eq!(run.metadata.started_at_unix_ms, 100);
         assert_eq!(run.metadata.finished_at_unix_ms, 120);
+    }
+
+    #[test]
+    fn run_from_span_records_respects_resolved_limits_and_metadata_config() {
+        let spans = vec![
+            SpanRecord::new("req-1", 100, 110)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("req-2", 100, 110)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r2")
+                .field(TT_ROUTE, "/b"),
+            SpanRecord::new("stage-1", 101, 109)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+            SpanRecord::new("stage-2", 101, 109)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "cache"),
+            SpanRecord::new("queue-1", 101, 109)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "db-pool"),
+            SpanRecord::new("queue-2", 101, 109)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "http"),
+        ];
+        let imported = run_from_span_records(
+            spans,
+            ImportOptions::new("svc")
+                .mode(CaptureMode::Investigation)
+                .capture_limits(tailtriage_core::CaptureLimits {
+                    max_requests: 1,
+                    max_stages: 1,
+                    max_queues: 1,
+                    max_runtime_snapshots: 500,
+                    max_inflight_snapshots: 500,
+                }),
+        )
+        .unwrap();
+        let run = imported.run();
+        assert_eq!(run.requests.len(), 1);
+        assert_eq!(run.stages.len(), 1);
+        assert_eq!(run.queues.len(), 1);
+        assert_eq!(run.truncation.dropped_requests, 1);
+        assert_eq!(run.truncation.dropped_stages, 1);
+        assert_eq!(run.truncation.dropped_queues, 1);
+        assert_eq!(run.metadata.mode, CaptureMode::Investigation);
+        let cfg = run.metadata.effective_core_config.as_ref().unwrap();
+        assert_eq!(cfg.capture_limits.max_requests, 1);
+        assert_eq!(cfg.capture_limits.max_stages, 1);
+        assert_eq!(cfg.capture_limits.max_queues, 1);
+        assert!(!cfg.strict_lifecycle);
     }
 
     #[test]

--- a/tailtriage-tracing/src/types.rs
+++ b/tailtriage-tracing/src/types.rs
@@ -182,6 +182,9 @@ pub struct ImportOptions {
     service_version: Option<String>,
     run_id: Option<String>,
     strict: bool,
+    mode: tailtriage_core::CaptureMode,
+    capture_limits: Option<tailtriage_core::CaptureLimits>,
+    capture_limits_override: tailtriage_core::CaptureLimitsOverride,
 }
 
 impl ImportOptions {
@@ -192,6 +195,9 @@ impl ImportOptions {
             service_version: None,
             run_id: None,
             strict: false,
+            mode: tailtriage_core::CaptureMode::Light,
+            capture_limits: None,
+            capture_limits_override: tailtriage_core::CaptureLimitsOverride::default(),
         }
     }
 
@@ -216,6 +222,30 @@ impl ImportOptions {
         self
     }
 
+    /// Sets capture mode for imported run metadata/default limits.
+    #[must_use]
+    pub fn mode(mut self, mode: tailtriage_core::CaptureMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    /// Sets full capture limits override for imported runs.
+    #[must_use]
+    pub fn capture_limits(mut self, capture_limits: tailtriage_core::CaptureLimits) -> Self {
+        self.capture_limits = Some(capture_limits);
+        self
+    }
+
+    /// Sets additive capture-limits override for imported runs.
+    #[must_use]
+    pub fn capture_limits_override(
+        mut self,
+        capture_limits_override: tailtriage_core::CaptureLimitsOverride,
+    ) -> Self {
+        self.capture_limits_override = capture_limits_override;
+        self
+    }
+
     /// Returns service name.
     #[must_use]
     pub fn service_name(&self) -> &str {
@@ -235,6 +265,21 @@ impl ImportOptions {
     #[must_use]
     pub fn strict_mode(&self) -> bool {
         self.strict
+    }
+
+    /// Returns selected capture mode.
+    #[must_use]
+    pub fn mode_value(&self) -> tailtriage_core::CaptureMode {
+        self.mode
+    }
+
+    /// Returns resolved capture limits.
+    #[must_use]
+    pub fn resolved_capture_limits(&self) -> tailtriage_core::CaptureLimits {
+        self.capture_limits.unwrap_or_else(|| {
+            self.capture_limits_override
+                .apply(self.mode.core_defaults())
+        })
     }
 }
 
@@ -350,6 +395,61 @@ mod tests {
         assert_eq!(options.service_version_ref(), Some("1.2.3"));
         assert_eq!(options.run_id_ref(), Some("run-123"));
         assert!(options.strict_mode());
+    }
+
+    #[test]
+    fn import_options_default_resolution_uses_light_defaults() {
+        let options = ImportOptions::new("checkout-service");
+        assert_eq!(options.mode_value(), tailtriage_core::CaptureMode::Light);
+        assert_eq!(
+            options.resolved_capture_limits(),
+            tailtriage_core::CaptureMode::Light.core_defaults()
+        );
+    }
+
+    #[test]
+    fn import_options_mode_investigation_uses_investigation_defaults() {
+        let options = ImportOptions::new("checkout-service")
+            .mode(tailtriage_core::CaptureMode::Investigation);
+        assert_eq!(
+            options.resolved_capture_limits(),
+            tailtriage_core::CaptureMode::Investigation.core_defaults()
+        );
+    }
+
+    #[test]
+    fn import_options_full_capture_limits_override_wins() {
+        let full = tailtriage_core::CaptureLimits {
+            max_requests: 1,
+            max_stages: 2,
+            max_queues: 3,
+            max_runtime_snapshots: 777,
+            max_inflight_snapshots: 888,
+        };
+        let options = ImportOptions::new("checkout-service")
+            .capture_limits_override(tailtriage_core::CaptureLimitsOverride {
+                max_requests: Some(99),
+                ..tailtriage_core::CaptureLimitsOverride::default()
+            })
+            .capture_limits(full);
+        assert_eq!(options.resolved_capture_limits(), full);
+    }
+
+    #[test]
+    fn import_options_additive_capture_limits_override_applies() {
+        let options = ImportOptions::new("checkout-service")
+            .mode(tailtriage_core::CaptureMode::Investigation)
+            .capture_limits_override(tailtriage_core::CaptureLimitsOverride {
+                max_requests: Some(11),
+                max_stages: Some(12),
+                max_queues: Some(13),
+                ..tailtriage_core::CaptureLimitsOverride::default()
+            });
+        let mut expected = tailtriage_core::CaptureMode::Investigation.core_defaults();
+        expected.max_requests = 11;
+        expected.max_stages = 12;
+        expected.max_queues = 13;
+        assert_eq!(options.resolved_capture_limits(), expected);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Make offline tracing JSONL import use the same CaptureMode and CaptureLimits semantics as native capture so imported Run artifacts reflect the same retention and metadata behavior as live capture, without changing live recorder retention.
- Expose only meaningful CLI flags for offline import (request/stage/queue limits) and avoid exposing runtime/in-flight snapshot flags that would be inert for this import path.

### Description
- Extended `ImportOptions` in `tailtriage-tracing` with `mode: CaptureMode`, `capture_limits: Option<CaptureLimits>`, and `capture_limits_override: CaptureLimitsOverride` and added builder-style methods `mode(...)`, `capture_limits(...)`, `capture_limits_override(...)`, plus accessors `mode_value()` and `resolved_capture_limits()`; resolution matches native semantics where `capture_limits` wins, otherwise `capture_limits_override` is applied to `mode.core_defaults()`.
- Updated `run_from_span_records` to use `options.mode_value()` and `options.resolved_capture_limits()` instead of hard-coded light defaults, apply truncation/retention using the resolved limits, and record the selected `mode` and effective core config in run metadata while keeping `strict_lifecycle(false)` for import.
- Added CLI offline import flags in `tailtriage-cli`: `--mode <light|investigation>` (CLI-local enum mapped to `tailtriage_core::CaptureMode`) and override flags `--max-requests`, `--max-stages`, and `--max-queues` which are applied via `CaptureLimitsOverride`; intentionally did not add `--max-runtime-snapshots` or `--max-inflight-snapshots` to offline import.
- Updated docs (`tailtriage-tracing/README.md`, `tailtriage-cli/README.md`, `docs/user-guide.md`, `docs/operations.md`) to state that tracing import and native capture share the same `CaptureMode`/`CaptureLimits` semantics for request/stage/queue retention and to explain why offline import only exposes request/stage/queue overrides.
- Added unit and integration tests: `ImportOptions` default/mode/override resolution tests, a `run_from_span_records` limits-and-metadata test, and CLI tests for `--mode investigation`, `--max-requests`/`--max-stages`/`--max-queues`, and absence of `--max-runtime-snapshots`/`--max-inflight-snapshots` in import help.

### Testing
- Ran `cargo fmt --check` (passed).
- Attempted workspace `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, which failed due to an existing unrelated `clippy::large_enum_variant` warning in `demos/demo_support` (this is pre-existing and not caused by these changes).
- Ran targeted and workspace tests: `cargo test -p tailtriage-tracing -p tailtriage-cli --all-targets --all-features --locked` and full suite runs exercised the modified packages; added tests passed (tracing and CLI tests included), and the docs contract validator `python3 scripts/validate_docs_contracts.py` passed.
- Summary: new import behavior and tests pass; one unrelated workspace clippy lint remains blocking a strict `-D warnings` clippy run across the whole workspace.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1018baf4cc83308e8959b88a244abb)