### PR TITLE
Align tracing offline import mode/limit semantics with native capture

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -497,6 +497,10 @@ Do not treat one report as final proof.
 - Import expects completed `tt.*` span JSONL input (stable wrapper format), not arbitrary tracing log JSON.
 - Arbitrary tracing log JSON (for example plain `tracing_subscriber::fmt().json()` output) is not import input.
 - Import writes Run JSON; analysis is a separate `tailtriage analyze` step.
+- Tracing import and native capture use the same `CaptureMode` and `CaptureLimits` semantics for request/stage/queue evidence retention.
+- Offline CLI import exposes `--mode`, `--max-requests`, `--max-stages`, and `--max-queues` for imported evidence retention controls.
+- Offline CLI import does not expose runtime/in-flight snapshot limit flags on this path because tracing JSONL import does not import those evidence types.
+- Imported run metadata records selected mode and resolved effective limits for this path, with strict lifecycle retained as `false` for import semantics.
 - Timing is not guessed from line receive time; completed span records must carry explicit unix-ms start/end timestamps.
 - Persisted Run JSON artifacts intended for `tailtriage analyze` require at least one completed request event.
 - Library snapshots may still be zero-request when used for non-persisted inspection during active captures.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -40,10 +40,12 @@ A) Completed-span JSONL intake path:
 
 ```bash
 tailtriage import tracing-json completed-spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json
+# optional: investigation defaults + request/stage/queue retention overrides
+tailtriage import tracing-json completed-spans.jsonl --service checkout --output tailtriage-run.json --mode investigation --max-requests 20000 --max-stages 120000 --max-queues 120000
 tailtriage analyze tailtriage-run.json
 ```
 
-`tailtriage import tracing-json` writes Run artifact JSON (not Report JSON), and analysis remains a separate step after import. Use the documented stable wrapper JSONL shape from `tailtriage-tracing` (`{"format":"tailtriage.tracing-span.v1","span":{...}}`). `--strict` fails on malformed or incomplete `tt.*` spans; non-strict mode skips malformed `tt.*` spans and prints `warning: ...` messages. Tracing-only runs do not fabricate runtime snapshots, and runtime-pressure evidence remains Tokio-specific.
+`tailtriage import tracing-json` writes Run artifact JSON (not Report JSON), and analysis remains a separate step after import. Use the documented stable wrapper JSONL shape from `tailtriage-tracing` (`{"format":"tailtriage.tracing-span.v1","span":{...}}`). `--strict` fails on malformed or incomplete `tt.*` spans; non-strict mode skips malformed `tt.*` spans and prints `warning: ...` messages. Import uses the same `CaptureMode` + `CaptureLimits` semantics as native capture for request/stage/queue retention, with selected mode and resolved limits recorded in imported run metadata. Offline tracing import exposes request/stage/queue limit overrides because those evidence types are imported on this path; it does not expose runtime/in-flight snapshot limit flags because those evidence types are not imported here. Tracing-only runs do not fabricate runtime snapshots, and runtime-pressure evidence remains Tokio-specific.
 
 B) Direct Run JSON path with async span instrumentation:
 

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -46,6 +46,9 @@ Import completed `tt.*` tracing span JSONL into Run JSON:
 
 ```bash
 tailtriage import tracing-json spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json
+# investigation-mode defaults + request/stage/queue retention overrides
+tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json \
+  --mode investigation --max-requests 20000 --max-stages 120000 --max-queues 120000
 ```
 
 With optional metadata flags, strict validation, and explicit format:
@@ -56,6 +59,9 @@ tailtriage import tracing-json spans.jsonl --input-format tailtriage-span-jsonl 
 
 
 `tailtriage import tracing-json` imports **completed `tt.*` tracing span JSONL** into **Run JSON** (not Report JSON).
+Import uses the same `CaptureMode` + `CaptureLimits` semantics as native capture for request/stage/queue retention, and imported run metadata records the selected mode plus resolved effective limits.
+Offline tracing import exposes `--max-requests`, `--max-stages`, and `--max-queues` because those evidence types are imported on this path.
+It intentionally does **not** expose runtime/in-flight snapshot limit flags for this path because offline tracing JSONL import does not import runtime snapshots or in-flight snapshots.
 
 Recommended stable input format is the tailtriage wrapper JSONL shape:
 

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -66,10 +66,36 @@ enum ImportCommand {
         /// Fail on malformed/incomplete tailtriage spans.
         #[arg(long)]
         strict: bool,
+        /// Capture mode used to resolve default retention limits.
+        #[arg(long, value_enum, default_value_t = CliCaptureMode::Light)]
+        mode: CliCaptureMode,
+        /// Override maximum retained request events.
+        #[arg(long)]
+        max_requests: Option<usize>,
+        /// Override maximum retained stage events.
+        #[arg(long)]
+        max_stages: Option<usize>,
+        /// Override maximum retained queue events.
+        #[arg(long)]
+        max_queues: Option<usize>,
         /// Input format mode.
         #[arg(long, value_enum, default_value_t = TracingInputFormat::Auto)]
         input_format: TracingInputFormat,
     },
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum CliCaptureMode {
+    Light,
+    Investigation,
+}
+
+impl From<CliCaptureMode> for tailtriage_core::CaptureMode {
+    fn from(value: CliCaptureMode) -> Self {
+        match value {
+            CliCaptureMode::Light => tailtriage_core::CaptureMode::Light,
+            CliCaptureMode::Investigation => tailtriage_core::CaptureMode::Investigation,
+        }
+    }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 enum TracingInputFormat {
@@ -95,9 +121,22 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 service_version,
                 run_id,
                 strict,
+                mode,
+                max_requests,
+                max_stages,
+                max_queues,
                 input_format,
             } => {
-                let mut options = ImportOptions::new(service).strict(strict);
+                let mut options = ImportOptions::new(service)
+                    .strict(strict)
+                    .mode(mode.into())
+                    .capture_limits_override(tailtriage_core::CaptureLimitsOverride {
+                        max_requests,
+                        max_stages,
+                        max_queues,
+                        max_runtime_snapshots: None,
+                        max_inflight_snapshots: None,
+                    });
                 if let Some(service_version) = service_version {
                     options = options.service_version(service_version);
                 }

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -405,7 +405,70 @@ fn import_tracing_json_help_shows_only_live_input_format_values() {
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains("auto"));
     assert!(stdout.contains("tailtriage-span-jsonl"));
+    assert!(stdout.contains("light"));
+    assert!(stdout.contains("investigation"));
+    assert!(stdout.contains("--max-requests"));
+    assert!(stdout.contains("--max-stages"));
+    assert!(stdout.contains("--max-queues"));
+    assert!(!stdout.contains("--max-runtime-snapshots"));
+    assert!(!stdout.contains("--max-inflight-snapshots"));
     assert!(!stdout.contains("tracing-subscriber-fmt-json"));
+}
+
+#[test]
+fn import_tracing_json_mode_investigation_sets_metadata_mode() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, complete_span_jsonl_fixture()).expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--mode")
+        .arg("investigation")
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+    assert!(output.status.success(), "cli failed: {output:?}");
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path).unwrap();
+    assert_eq!(
+        loaded.run.metadata.mode,
+        tailtriage_core::CaptureMode::Investigation
+    );
+}
+
+#[test]
+fn import_tracing_json_limit_overrides_set_effective_core_limits() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, complete_span_jsonl_fixture()).expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--max-requests")
+        .arg("7")
+        .arg("--max-stages")
+        .arg("8")
+        .arg("--max-queues")
+        .arg("9")
+        .output()
+        .expect("cli should run");
+    assert!(output.status.success(), "cli failed: {output:?}");
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path).unwrap();
+    let effective = loaded.run.metadata.effective_core_config.unwrap();
+    assert_eq!(effective.capture_limits.max_requests, 7);
+    assert_eq!(effective.capture_limits.max_stages, 8);
+    assert_eq!(effective.capture_limits.max_queues, 9);
 }
 
 #[test]

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -62,6 +62,8 @@ Use `run_json_path(...)` when you want to skip a separate import step:
 tailtriage analyze target/tailtriage-examples/checkout.run.json
 ```
 
+Offline tracing import uses the same `CaptureMode` and `CaptureLimits` semantics as native capture for request/stage/queue evidence retention, and imported run metadata records selected mode plus resolved effective limits.
+
 ## Completed-span JSONL path
 
 Use `completed_span_jsonl_path(...)` when you want an offline import workflow:

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -40,7 +40,7 @@ mod types;
 
 use std::collections::BTreeSet;
 use tailtriage_core::{
-    BuildError, CaptureMode, QueueEvent, RequestEvent, RunBuilder, RunBuilderOptions, StageEvent,
+    BuildError, QueueEvent, RequestEvent, RunBuilder, RunBuilderOptions, StageEvent,
 };
 
 pub use convention::{
@@ -228,7 +228,8 @@ where
             }
         }
     }
-    let capture_limits = CaptureMode::Light.core_defaults();
+    let mode = options.mode_value();
+    let capture_limits = options.resolved_capture_limits();
     let request_outcome_default_count = parsed_requests
         .iter()
         .take(capture_limits.max_requests)
@@ -284,7 +285,7 @@ where
 
     let mut builder_options = RunBuilderOptions::new(options.service_name())
         .run_id(run_id)
-        .mode(CaptureMode::Light)
+        .mode(mode)
         .capture_limits(capture_limits)
         .strict_lifecycle(false)
         .started_at_unix_ms(started_at_unix_ms)
@@ -641,6 +642,7 @@ fn parse_depth_at_start(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tailtriage_core::{CaptureLimitsOverride, CaptureMode};
 
     #[test]
     fn span_kind_parser_accepts_supported_values_only() {
@@ -944,6 +946,76 @@ mod tests {
         assert_eq!(run.truncation.dropped_queues, 1);
         assert_eq!(run.metadata.started_at_unix_ms, 100);
         assert_eq!(run.metadata.finished_at_unix_ms, 120);
+    }
+
+    #[test]
+    fn run_from_span_records_uses_configured_mode_and_resolved_limits() {
+        let spans = vec![
+            SpanRecord::new("req-1", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a")
+                .field(TT_OUTCOME, "ok"),
+            SpanRecord::new("req-2", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r2")
+                .field(TT_ROUTE, "/b")
+                .field(TT_OUTCOME, "ok"),
+            SpanRecord::new("stage-1", 101, 110)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "s1")
+                .field(TT_SUCCESS, true),
+            SpanRecord::new("stage-2", 101, 110)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "s2")
+                .field(TT_SUCCESS, true),
+            SpanRecord::new("queue-1", 101, 110)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "q1"),
+            SpanRecord::new("queue-2", 101, 110)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "q2"),
+        ];
+        let options = ImportOptions::new("svc")
+            .mode(CaptureMode::Investigation)
+            .capture_limits_override(CaptureLimitsOverride {
+                max_requests: Some(1),
+                max_stages: Some(1),
+                max_queues: Some(1),
+                max_runtime_snapshots: None,
+                max_inflight_snapshots: None,
+            });
+        let imported = run_from_span_records(spans, options).unwrap();
+        let run = imported.run();
+        assert_eq!(run.metadata.mode, CaptureMode::Investigation);
+        assert_eq!(run.requests.len(), 1);
+        assert_eq!(run.stages.len(), 1);
+        assert_eq!(run.queues.len(), 1);
+        assert_eq!(run.truncation.dropped_requests, 1);
+        assert_eq!(run.truncation.dropped_stages, 1);
+        assert_eq!(run.truncation.dropped_queues, 1);
+        assert_eq!(
+            run.metadata.effective_core_config.expect("effective core"),
+            tailtriage_core::EffectiveCoreConfig {
+                mode: CaptureMode::Investigation,
+                capture_limits: tailtriage_core::CaptureLimits {
+                    max_requests: 1,
+                    max_stages: 1,
+                    max_queues: 1,
+                    max_runtime_snapshots: CaptureMode::Investigation
+                        .core_defaults()
+                        .max_runtime_snapshots,
+                    max_inflight_snapshots: CaptureMode::Investigation
+                        .core_defaults()
+                        .max_inflight_snapshots,
+                },
+                strict_lifecycle: false,
+            }
+        );
     }
 
     #[test]

--- a/tailtriage-tracing/src/types.rs
+++ b/tailtriage-tracing/src/types.rs
@@ -182,6 +182,9 @@ pub struct ImportOptions {
     service_version: Option<String>,
     run_id: Option<String>,
     strict: bool,
+    mode: tailtriage_core::CaptureMode,
+    capture_limits: Option<tailtriage_core::CaptureLimits>,
+    capture_limits_override: tailtriage_core::CaptureLimitsOverride,
 }
 
 impl ImportOptions {
@@ -192,6 +195,9 @@ impl ImportOptions {
             service_version: None,
             run_id: None,
             strict: false,
+            mode: tailtriage_core::CaptureMode::Light,
+            capture_limits: None,
+            capture_limits_override: tailtriage_core::CaptureLimitsOverride::default(),
         }
     }
 
@@ -214,6 +220,56 @@ impl ImportOptions {
     pub fn service_version(mut self, service_version: impl Into<String>) -> Self {
         self.service_version = Some(service_version.into());
         self
+    }
+    /// Sets capture mode.
+    #[must_use]
+    pub fn mode(mut self, mode: tailtriage_core::CaptureMode) -> Self {
+        self.mode = mode;
+        self
+    }
+    /// Sets full capture limits override.
+    #[must_use]
+    pub fn capture_limits(mut self, capture_limits: tailtriage_core::CaptureLimits) -> Self {
+        self.capture_limits = Some(capture_limits);
+        self
+    }
+    /// Sets additive capture limit overrides.
+    #[must_use]
+    pub fn capture_limits_override(
+        mut self,
+        capture_limits_override: tailtriage_core::CaptureLimitsOverride,
+    ) -> Self {
+        self.capture_limits_override = tailtriage_core::CaptureLimitsOverride {
+            max_requests: capture_limits_override
+                .max_requests
+                .or(self.capture_limits_override.max_requests),
+            max_stages: capture_limits_override
+                .max_stages
+                .or(self.capture_limits_override.max_stages),
+            max_queues: capture_limits_override
+                .max_queues
+                .or(self.capture_limits_override.max_queues),
+            max_runtime_snapshots: capture_limits_override
+                .max_runtime_snapshots
+                .or(self.capture_limits_override.max_runtime_snapshots),
+            max_inflight_snapshots: capture_limits_override
+                .max_inflight_snapshots
+                .or(self.capture_limits_override.max_inflight_snapshots),
+        };
+        self
+    }
+    /// Returns resolved capture limits.
+    #[must_use]
+    pub fn resolved_capture_limits(&self) -> tailtriage_core::CaptureLimits {
+        self.capture_limits.unwrap_or_else(|| {
+            self.capture_limits_override
+                .apply(self.mode.core_defaults())
+        })
+    }
+    /// Returns selected capture mode.
+    #[must_use]
+    pub fn mode_value(&self) -> tailtriage_core::CaptureMode {
+        self.mode
     }
 
     /// Returns service name.
@@ -344,12 +400,67 @@ mod tests {
         let options = ImportOptions::new("checkout-service")
             .service_version("1.2.3")
             .run_id("run-123")
-            .strict(true);
+            .strict(true)
+            .mode(tailtriage_core::CaptureMode::Investigation);
 
         assert_eq!(options.service_name(), "checkout-service");
         assert_eq!(options.service_version_ref(), Some("1.2.3"));
         assert_eq!(options.run_id_ref(), Some("run-123"));
         assert!(options.strict_mode());
+        assert_eq!(
+            options.mode_value(),
+            tailtriage_core::CaptureMode::Investigation
+        );
+    }
+
+    #[test]
+    fn import_options_defaults_resolve_light_defaults() {
+        let options = ImportOptions::new("svc");
+        assert_eq!(options.mode_value(), tailtriage_core::CaptureMode::Light);
+        assert_eq!(
+            options.resolved_capture_limits(),
+            tailtriage_core::CaptureMode::Light.core_defaults()
+        );
+    }
+
+    #[test]
+    fn import_options_full_capture_limits_override_wins() {
+        let full = tailtriage_core::CaptureLimits {
+            max_requests: 1,
+            max_stages: 2,
+            max_queues: 3,
+            max_runtime_snapshots: 4,
+            max_inflight_snapshots: 5,
+        };
+        let options = ImportOptions::new("svc")
+            .mode(tailtriage_core::CaptureMode::Investigation)
+            .capture_limits_override(tailtriage_core::CaptureLimitsOverride {
+                max_requests: Some(1000),
+                max_stages: Some(1000),
+                max_queues: Some(1000),
+                max_runtime_snapshots: Some(1000),
+                max_inflight_snapshots: Some(1000),
+            })
+            .capture_limits(full);
+        assert_eq!(options.resolved_capture_limits(), full);
+    }
+
+    #[test]
+    fn import_options_additive_override_applies_on_mode_defaults() {
+        let options = ImportOptions::new("svc")
+            .mode(tailtriage_core::CaptureMode::Investigation)
+            .capture_limits_override(tailtriage_core::CaptureLimitsOverride {
+                max_requests: Some(11),
+                max_stages: Some(22),
+                max_queues: Some(33),
+                max_runtime_snapshots: None,
+                max_inflight_snapshots: None,
+            });
+        let mut expected = tailtriage_core::CaptureMode::Investigation.core_defaults();
+        expected.max_requests = 11;
+        expected.max_stages = 22;
+        expected.max_queues = 33;
+        assert_eq!(options.resolved_capture_limits(), expected);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Ensure offline tracing JSONL import uses the same CaptureMode + CaptureLimits semantics as native capture so retention/truncation behavior and imported Run metadata are consistent across capture paths.
- Expose only meaningful CLI overrides for the offline import path (request/stage/queue) and avoid exposing inert runtime/in-flight snapshot flags that the JSONL import does not use.
- Preserve import semantics (strict lifecycle false) while allowing users to request investigation-mode defaults or override limits to match native behavior for analysis parity.

### Description
- Extended `tailtriage-tracing::ImportOptions` to carry core capture configuration: `mode: CaptureMode`, `capture_limits: Option<CaptureLimits>`, and `capture_limits_override: CaptureLimitsOverride` with defaults (`Light`, `None`, `CaptureLimitsOverride::default()`).
- Added builder/accessor methods on `ImportOptions`: `mode(...)`, `capture_limits(...)`, `capture_limits_override(...)`, `resolved_capture_limits()`, and `mode_value()` with resolution semantics matching native capture (explicit `capture_limits` wins; otherwise apply overrides on `mode.core_defaults()`).
- Updated `run_from_span_records` to use `options.mode_value()` and `options.resolved_capture_limits()` instead of hard-coded light defaults, to apply truncation/retention and to record selected `mode` and the effective core config (resolved capture limits + `strict_lifecycle: false`) into imported Run metadata.
- Added CLI flags to `tailtriage import tracing-json`: `--mode <light|investigation>`, `--max-requests`, `--max-stages`, and `--max-queues`, implemented with a small CLI-local `CliCaptureMode` mapped into `tailtriage_core::CaptureMode`, and applied via `CaptureLimitsOverride` (no `clap` added to core). The CLI intentionally does not expose `--max-runtime-snapshots` or `--max-inflight-snapshots` for offline tracing import.
- Updated documentation: `tailtriage-tracing/README.md`, `tailtriage-cli/README.md`, `docs/user-guide.md`, and `docs/operations.md` to state that tracing import and native capture share the same `CaptureMode`/`CaptureLimits` semantics for request/stage/queue evidence, to document the offline CLI flags exposed, and to explain why runtime/in-flight snapshot flags are not present for this path.
- Added/updated unit and CLI tests exercising `ImportOptions` resolution, full/override/additive behaviors, `run_from_span_records` truncation/metadata under small limits, `--mode investigation`, and the `--max-requests/--max-stages/--max-queues` CLI flags plus absence of runtime/in-flight flags in help output.

### Testing
- Ran `cargo fmt --check`, which passed.
- Attempted `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, which surfaced pre-existing `clippy::large_enum_variant` warnings in `demo-support`; this is unrelated to the changes in this PR and blocked a full workspace clippy run (no core code modifications were made to address that warning in this change).
- Ran focused package tests `cargo test -p tailtriage-tracing -p tailtriage-cli --all-targets --all-features --locked`, and all tests passed for those packages (new and updated unit/CLI tests succeeded).
- Ran full-workspace tests and docs validation (`python3 scripts/validate_docs_contracts.py`) as part of verification; the docs contract validator passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1018baf4cc83308e8959b88a244abb)