### PR TITLE
Align TracingTokioSession runtime retention with core capture limits

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -418,6 +418,12 @@ impl TracingIntakeSessionBuilder {
 }
 
 impl TracingRecorderBuilder {
+    /// Returns resolved capture limits after applying mode/base/override configuration.
+    #[must_use]
+    pub fn resolved_capture_limits(&self) -> CaptureLimits {
+        self.options.resolved_capture_limits()
+    }
+
     /// Sets service version metadata for converted run output.
     #[must_use]
     pub fn service_version(mut self, service_version: impl Into<String>) -> Self {

--- a/tailtriage-tracing/src/tokio.rs
+++ b/tailtriage-tracing/src/tokio.rs
@@ -53,7 +53,6 @@ impl std::error::Error for TracingTokioSessionShutdownError {}
 pub struct TracingTokioSessionBuilder {
     recorder_builder: crate::TracingRecorderBuilder,
     sampler_interval: Option<Duration>,
-    max_runtime_snapshots: Option<usize>,
 }
 
 /// Combined tracing and Tokio runtime sampler session.
@@ -70,7 +69,6 @@ impl TracingTokioSession {
         TracingTokioSessionBuilder {
             recorder_builder: TracingRecorder::builder(service_name),
             sampler_interval: None,
-            max_runtime_snapshots: None,
         }
     }
 
@@ -169,13 +167,6 @@ impl TracingTokioSessionBuilder {
         self.sampler_interval = Some(sampler_interval);
         self
     }
-    /// Sets runtime sampler retention cap for runtime snapshots.
-    #[must_use]
-    pub fn max_runtime_snapshots(mut self, max_runtime_snapshots: usize) -> Self {
-        self.max_runtime_snapshots = Some(max_runtime_snapshots);
-        self
-    }
-
     /// Builds the session and starts Tokio runtime sampling.
     ///
     /// # Errors
@@ -183,23 +174,19 @@ impl TracingTokioSessionBuilder {
     /// Returns [`TracingTokioSessionStartError`] when runtime collector build fails,
     /// when sampler interval is zero, or when there is no active Tokio runtime.
     pub fn start(self) -> Result<TracingTokioSession, TracingTokioSessionStartError> {
+        let resolved_capture_limits = self.recorder_builder.resolved_capture_limits();
         let recorder = self.recorder_builder.build();
         let sink = MemorySink::new();
-        let mut builder = Tailtriage::builder("tailtriage-tracing-runtime")
+        let builder = Tailtriage::builder("tailtriage-tracing-runtime")
             .sink(sink)
-            .strict_lifecycle(false);
+            .strict_lifecycle(false)
+            .capture_limits(resolved_capture_limits);
         if let Some(interval) = self.sampler_interval {
             if interval.is_zero() {
                 return Err(TracingTokioSessionStartError::SamplerStart(
                     SamplerStartError::ZeroInterval,
                 ));
             }
-        }
-        if let Some(limit) = self.max_runtime_snapshots {
-            builder = builder.capture_limits_override(CaptureLimitsOverride {
-                max_runtime_snapshots: Some(limit),
-                ..CaptureLimitsOverride::default()
-            });
         }
         let runtime_collector = Arc::new(
             builder
@@ -212,11 +199,8 @@ impl TracingTokioSessionBuilder {
         } else {
             sampler_builder
         };
-        let sampler_builder = if let Some(limit) = self.max_runtime_snapshots {
-            sampler_builder.max_runtime_snapshots(limit)
-        } else {
-            sampler_builder
-        };
+        let sampler_builder =
+            sampler_builder.max_runtime_snapshots(resolved_capture_limits.max_runtime_snapshots);
         let sampler = sampler_builder
             .start()
             .map_err(TracingTokioSessionStartError::SamplerStart)?;

--- a/tailtriage-tracing/tests/tokio_session.rs
+++ b/tailtriage-tracing/tests/tokio_session.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use tailtriage_core::{unix_time_ms, RuntimeSnapshot};
+use tailtriage_core::{unix_time_ms, CaptureLimitsOverride, RuntimeSnapshot};
 use tailtriage_tokio::SamplerStartError;
 use tailtriage_tracing::tokio::{TracingTokioSession, TracingTokioSessionStartError};
 use tracing_subscriber::prelude::*;
@@ -244,7 +244,10 @@ async fn record_runtime_snapshot_does_not_alter_tracing_events() {
 #[tokio::test(flavor = "current_thread")]
 async fn runtime_snapshot_truncation_propagates_to_imported_run() {
     let session = TracingTokioSession::builder("svc")
-        .max_runtime_snapshots(1)
+        .capture_limits_override(CaptureLimitsOverride {
+            max_runtime_snapshots: Some(1),
+            ..CaptureLimitsOverride::default()
+        })
         .start()
         .expect("start session");
     session.record_runtime_snapshot(RuntimeSnapshot {
@@ -269,4 +272,44 @@ async fn runtime_snapshot_truncation_propagates_to_imported_run() {
     assert_eq!(run.runtime_snapshots.len(), 1);
     assert_eq!(run.truncation.dropped_runtime_snapshots, 1);
     assert!(run.truncation.limits_hit);
+    assert_eq!(
+        run.metadata
+            .effective_tokio_sampler_config
+            .as_ref()
+            .expect("sampler metadata present")
+            .resolved_runtime_snapshot_retention,
+        1
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn capture_limits_override_caps_sampler_and_collector_together() {
+    let session = TracingTokioSession::builder("svc")
+        .capture_limits_override(CaptureLimitsOverride {
+            max_runtime_snapshots: Some(2),
+            ..CaptureLimitsOverride::default()
+        })
+        .start()
+        .expect("start session");
+    for i in 0..4_u64 {
+        session.record_runtime_snapshot(RuntimeSnapshot {
+            at_unix_ms: unix_time_ms().saturating_add(i),
+            alive_tasks: Some(i),
+            global_queue_depth: Some(i),
+            local_queue_depth: Some(i),
+            blocking_queue_depth: Some(i),
+            remote_schedule_count: Some(i),
+        });
+    }
+    let run = session.shutdown().await.expect("shutdown").run().clone();
+    assert!(run.runtime_snapshots.len() <= 2);
+    assert!(run.truncation.dropped_runtime_snapshots > 0);
+    assert_eq!(
+        run.metadata
+            .effective_tokio_sampler_config
+            .as_ref()
+            .expect("sampler metadata present")
+            .resolved_runtime_snapshot_retention,
+        2
+    );
 }


### PR DESCRIPTION
### Motivation
- Unify runtime snapshot retention configuration so `TracingTokioSession` uses the same `CaptureMode` / `CaptureLimits` / `CaptureLimitsOverride` model as other capture paths instead of a tracing-specific knob. 
- Ensure the internal runtime collector and the Tokio runtime sampler agree on the resolved `max_runtime_snapshots` and that merged runs carry correct sampler metadata and truncation evidence.

### Description
- Removed the tracing-specific builder method `TracingTokioSessionBuilder::max_runtime_snapshots(...)` and kept tracing-specific `max_open_spans(...)` only for span-tracking needs. 
- Added `TracingRecorderBuilder::resolved_capture_limits()` to expose the recorder/options-resolved `CaptureLimits` to the Tokio session setup. 
- Wired session startup to resolve capture limits once and apply them to the internal runtime collector via `Tailtriage::builder(...).capture_limits(...)` and to the runtime sampler via `RuntimeSampler::builder(...).max_runtime_snapshots(...)` so both use the same effective `max_runtime_snapshots`. 
- Updated tests and example usage to use `capture_limits_override(...)` for runtime snapshot retention and added assertions that retained snapshot counts, `truncation.dropped_runtime_snapshots`, and `metadata.effective_tokio_sampler_config.resolved_runtime_snapshot_retention` reflect the resolved cap. 

### Testing
- Ran formatting and linting with `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, which completed successfully. 
- Ran the full test matrix with `cargo test --workspace --all-targets --all-features --locked`, including updated Tokio-session tests (e.g. `capture_limits_override_caps_sampler_and_collector_together`), and all tests passed. 
- Ran `python3 scripts/validate_docs_contracts.py` and the docs contract validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1095fc86708330a5e4f13972efdff0)