### PR TITLE
Unify TracingTokioSession runtime snapshot retention with core capture limits

### DIFF
--- a/demos/runtime_cost/src/main.rs
+++ b/demos/runtime_cost/src/main.rs
@@ -276,9 +276,19 @@ fn build_backend(cli: &Cli) -> anyhow::Result<Backend> {
         }
         InstrumentationKind::Tracing => {
             if cli.mode.uses_runtime_sampler() {
-                let session = TracingTokioSession::builder("runtime_cost_demo")
-                    .strict(false)
-                    .start()?;
+                let mut session_builder =
+                    TracingTokioSession::builder("runtime_cost_demo").strict(false);
+                if cli.mode.uses_drop_path_limits() {
+                    session_builder =
+                        session_builder.capture_limits_override(CaptureLimitsOverride {
+                            max_requests: Some(64),
+                            max_stages: Some(64),
+                            max_queues: Some(64),
+                            max_inflight_snapshots: Some(64),
+                            max_runtime_snapshots: Some(64),
+                        });
+                }
+                let session = session_builder.start()?;
                 // One mode runs per process in this demo, so process-global subscriber init is acceptable.
                 tracing::subscriber::set_global_default(
                     tracing_subscriber::registry().with(session.layer()),

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -168,6 +168,8 @@ Important limits for production interpretation:
 * without runtime snapshots, executor-pressure and blocking-pool suspects can be weaker or absent
 * runtime-pressure evidence remains Tokio-specific and requires runtime snapshots or Tokio sampler coupling
 
+`TracingTokioSession` uses the same core capture-limit model as native Tokio sampling for runtime snapshot retention. There is no tracing-specific `max_runtime_snapshots(...)` builder method; configure explicit caps with `capture_limits_override(CaptureLimitsOverride { max_runtime_snapshots: Some(...), ..Default::default() })`. Tracing-only runs still do not fabricate runtime snapshots, so runtime-pressure evidence requires Tokio session/runtime sampler coupling.
+
 Treat tracing-based reports the same way as other reports: evidence-ranked suspects and next checks are triage leads, not proof.
 
 ## Artifact sizing and retention expectations

--- a/docs/runtime-cost.md
+++ b/docs/runtime-cost.md
@@ -104,6 +104,7 @@ Numbers are directional and machine/workload/profile scoped; this bounded smoke 
 ## Semantics reminder
 
 - `CaptureMode` changes retention defaults; it does not auto-start the runtime sampler.
+- In tracing Tokio-session modes, runtime snapshot retention is configured through the same core capture-limit model (`mode`/`capture_limits`/`capture_limits_override`) used by native sampling paths.
 - Tracing modes measure tailtriage semantic `tt.*` tracing spans (not OTel/OTLP export).
 - Tracing spans alone do not imply runtime-pressure evidence; runtime-pressure evidence requires Tokio-session runtime snapshots.
 - Post-limit overhead improvements come from cheaper drop-path handling after limits are hit, while preserving drop counters and truncation visibility.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -292,6 +292,7 @@ Key constraints:
 - start inside an active Tokio runtime
 - one successful sampler start per run
 - runtime snapshot retention is bounded by core limits
+- Tokio tracing sessions use the same core `CaptureMode`/`CaptureLimits`/`CaptureLimitsOverride` model (no tracing-specific retention knob)
 - some runtime fields require `tokio_unstable`
 
 Sampler details: [tailtriage-tokio/README.md](../tailtriage-tokio/README.md)

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -111,6 +111,12 @@ Arbitrary `tracing_subscriber::fmt().json()` log JSON is rejected by import. Imp
 Tracing intake import and native capture share the same CaptureMode/CaptureLimits semantics for request/stage/queue evidence retention. Offline tracing JSONL import does not fabricate runtime snapshots. Runtime-pressure evidence still requires runtime snapshots/Tokio sampler coupling.
 Persisted Run JSON artifacts intended for `tailtriage analyze` require at least one completed request span event. Library snapshots taken before completed requests may still be zero-request for inspection.
 
+For `TracingTokioSession`, runtime snapshot retention also uses the same core capture-limit model:
+
+- configure retention with `mode(...)`, `capture_limits(...)`, or `capture_limits_override(...)`
+- there is no tracing-specific `.max_runtime_snapshots(...)` session builder method
+- tracing-only runs still do not fabricate runtime snapshots
+
 ## Examples
 
 - `tailtriage-tracing/examples/live_session_to_run.rs`

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -418,6 +418,12 @@ impl TracingIntakeSessionBuilder {
 }
 
 impl TracingRecorderBuilder {
+    /// Returns capture limits resolved from configured mode/base/override settings.
+    #[must_use]
+    pub fn resolved_capture_limits(&self) -> CaptureLimits {
+        self.options.resolved_capture_limits()
+    }
+
     /// Sets service version metadata for converted run output.
     #[must_use]
     pub fn service_version(mut self, service_version: impl Into<String>) -> Self {

--- a/tailtriage-tracing/src/tokio.rs
+++ b/tailtriage-tracing/src/tokio.rs
@@ -53,7 +53,6 @@ impl std::error::Error for TracingTokioSessionShutdownError {}
 pub struct TracingTokioSessionBuilder {
     recorder_builder: crate::TracingRecorderBuilder,
     sampler_interval: Option<Duration>,
-    max_runtime_snapshots: Option<usize>,
 }
 
 /// Combined tracing and Tokio runtime sampler session.
@@ -70,7 +69,6 @@ impl TracingTokioSession {
         TracingTokioSessionBuilder {
             recorder_builder: TracingRecorder::builder(service_name),
             sampler_interval: None,
-            max_runtime_snapshots: None,
         }
     }
 
@@ -169,13 +167,6 @@ impl TracingTokioSessionBuilder {
         self.sampler_interval = Some(sampler_interval);
         self
     }
-    /// Sets runtime sampler retention cap for runtime snapshots.
-    #[must_use]
-    pub fn max_runtime_snapshots(mut self, max_runtime_snapshots: usize) -> Self {
-        self.max_runtime_snapshots = Some(max_runtime_snapshots);
-        self
-    }
-
     /// Builds the session and starts Tokio runtime sampling.
     ///
     /// # Errors
@@ -183,23 +174,19 @@ impl TracingTokioSessionBuilder {
     /// Returns [`TracingTokioSessionStartError`] when runtime collector build fails,
     /// when sampler interval is zero, or when there is no active Tokio runtime.
     pub fn start(self) -> Result<TracingTokioSession, TracingTokioSessionStartError> {
+        let resolved_limits = self.recorder_builder.resolved_capture_limits();
         let recorder = self.recorder_builder.build();
         let sink = MemorySink::new();
-        let mut builder = Tailtriage::builder("tailtriage-tracing-runtime")
+        let builder = Tailtriage::builder("tailtriage-tracing-runtime")
             .sink(sink)
-            .strict_lifecycle(false);
+            .strict_lifecycle(false)
+            .capture_limits(resolved_limits);
         if let Some(interval) = self.sampler_interval {
             if interval.is_zero() {
                 return Err(TracingTokioSessionStartError::SamplerStart(
                     SamplerStartError::ZeroInterval,
                 ));
             }
-        }
-        if let Some(limit) = self.max_runtime_snapshots {
-            builder = builder.capture_limits_override(CaptureLimitsOverride {
-                max_runtime_snapshots: Some(limit),
-                ..CaptureLimitsOverride::default()
-            });
         }
         let runtime_collector = Arc::new(
             builder
@@ -212,11 +199,8 @@ impl TracingTokioSessionBuilder {
         } else {
             sampler_builder
         };
-        let sampler_builder = if let Some(limit) = self.max_runtime_snapshots {
-            sampler_builder.max_runtime_snapshots(limit)
-        } else {
-            sampler_builder
-        };
+        let sampler_builder =
+            sampler_builder.max_runtime_snapshots(resolved_limits.max_runtime_snapshots);
         let sampler = sampler_builder
             .start()
             .map_err(TracingTokioSessionStartError::SamplerStart)?;

--- a/tailtriage-tracing/tests/tokio_session.rs
+++ b/tailtriage-tracing/tests/tokio_session.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use tailtriage_core::{unix_time_ms, RuntimeSnapshot};
+use tailtriage_core::{unix_time_ms, CaptureLimitsOverride, RuntimeSnapshot};
 use tailtriage_tokio::SamplerStartError;
 use tailtriage_tracing::tokio::{TracingTokioSession, TracingTokioSessionStartError};
 use tracing_subscriber::prelude::*;
@@ -244,7 +244,10 @@ async fn record_runtime_snapshot_does_not_alter_tracing_events() {
 #[tokio::test(flavor = "current_thread")]
 async fn runtime_snapshot_truncation_propagates_to_imported_run() {
     let session = TracingTokioSession::builder("svc")
-        .max_runtime_snapshots(1)
+        .capture_limits_override(CaptureLimitsOverride {
+            max_runtime_snapshots: Some(1),
+            ..CaptureLimitsOverride::default()
+        })
         .start()
         .expect("start session");
     session.record_runtime_snapshot(RuntimeSnapshot {
@@ -269,4 +272,35 @@ async fn runtime_snapshot_truncation_propagates_to_imported_run() {
     assert_eq!(run.runtime_snapshots.len(), 1);
     assert_eq!(run.truncation.dropped_runtime_snapshots, 1);
     assert!(run.truncation.limits_hit);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn capture_limits_override_controls_sampler_and_collector_retention() {
+    let session = TracingTokioSession::builder("svc")
+        .capture_limits_override(CaptureLimitsOverride {
+            max_runtime_snapshots: Some(2),
+            ..CaptureLimitsOverride::default()
+        })
+        .start()
+        .expect("start session");
+    for idx in 0_u64..5 {
+        session.record_runtime_snapshot(RuntimeSnapshot {
+            at_unix_ms: unix_time_ms().saturating_add(idx),
+            alive_tasks: Some(idx),
+            global_queue_depth: Some(idx),
+            local_queue_depth: Some(idx),
+            blocking_queue_depth: Some(idx),
+            remote_schedule_count: Some(idx),
+        });
+    }
+    let run = session.snapshot_run().expect("snapshot run").run().clone();
+    assert!(run.runtime_snapshots.len() <= 2);
+    assert!(run.truncation.dropped_runtime_snapshots > 0);
+    assert_eq!(
+        run.metadata
+            .effective_tokio_sampler_config
+            .expect("tokio sampler metadata")
+            .resolved_runtime_snapshot_retention,
+        2
+    );
 }


### PR DESCRIPTION
### Motivation
- Reduce API surface and avoid dual retention knobs by making TracingTokioSession use the same core `CaptureMode` / `CaptureLimits` / `CaptureLimitsOverride` model as native sampling. 
- Ensure the internal runtime collector and the Tokio `RuntimeSampler` always agree on `max_runtime_snapshots` so truncation/dropped counts and sampler metadata remain consistent. 
- Preserve existing session semantics (merge behavior, shutdown ordering, strict/non-strict behavior) while centralizing retention configuration.

### Description
- Removed the tracing-specific `TracingTokioSessionBuilder::max_runtime_snapshots(...)` builder method and forwarded `mode(...)`, `capture_limits(...)`, and `capture_limits_override(...)` through the existing `TracingRecorderBuilder` API. 
- Added `TracingRecorderBuilder::resolved_capture_limits()` to expose the recorder’s resolved `CaptureLimits` for session startup and used that resolved value to configure the internal `Tailtriage` collector (`.capture_limits(...)`) and the `RuntimeSampler` (`.max_runtime_snapshots(...)`) so both use the same effective retention. 
- Kept `max_open_spans(...)` as a tracing-specific recorder limit and preserved `TracingTokioSession::snapshot_run()` and `shutdown()` semantics and merged-run metadata preservation. 
- Updated demos and examples (notably `demos/runtime_cost` and Tokio example) to stop calling the removed tracing-specific API and to use `capture_limits_override(...)` when a runtime snapshot cap is desired. 
- Updated docs (`tailtriage-tracing/README.md`, `docs/user-guide.md`, `docs/runtime-cost.md`) to state that Tokio tracing sessions use the core capture-limit model, that there is no tracing-specific `max_runtime_snapshots` builder method, and that tracing-only runs do not fabricate runtime snapshots. 
- Updated/added Tokio-session tests to configure retention through `CaptureLimitsOverride` and to assert retained snapshot count, dropped runtime-snapshot counts, and sampler metadata agreement.

### Testing
- Ran `cargo fmt --check` and it succeeded. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it succeeded. 
- Ran `cargo test --workspace --all-targets --all-features --locked` and the full test suite passed, including the updated Tokio session tests (the new `capture_limits_override_controls_sampler_and_collector_retention` test and the runtime truncation assertions). 
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1095fc86708330a5e4f13972efdff0)