### PR TITLE
Enforce native/tracing parity and add tiny-limit retention parity CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,6 +275,9 @@ jobs:
       - name: Validate tracing parity across all demos
         if: matrix.os == 'ubuntu-latest' && matrix.profile == 'release' && matrix.extended
         run: python3 scripts/demo_tool.py validate-tracing-parity all --profile release
+      - name: Validate tracing tiny-limit retention parity
+        if: matrix.os == 'ubuntu-latest' && matrix.profile == 'release' && matrix.extended
+        run: python3 scripts/demo_tool.py validate-tracing-retention-parity --profile release
 
       - name: Validate runtime-cost script unit tests
         if: matrix.os == 'ubuntu-latest' && matrix.profile == 'dev' && matrix.extended

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -19,6 +19,8 @@ This repository includes an initial deterministic validation corpus for controll
 | `scripts/run_diagnostic_matrix.py` | Repeated controlled demo runs | No, local/manual | No |
 | `scripts/run_mitigation_matrix.py` | Baseline vs mitigated evidence-movement checks | No, local/manual | No |
 | `scripts/run_operational_validation.py` | Runtime-cost and collector-limit operational validation | Manual/local; some narrower smoke checks exist elsewhere | No |
+| `scripts/demo_tool.py validate-tracing-parity all` | Native/tracing parity gate for artifact shape, route/evidence coverage, effective core config, and runtime-sampler metadata expectations | Yes (Ubuntu release extended CI leg) | No |
+| `scripts/demo_tool.py validate-tracing-retention-parity` | Tiny-limit native/tracing parity gate for exact retention and truncation behavior under shared core capture config | Yes (Ubuntu release extended CI leg) | No |
 | `scripts/validate_all.py` | Optional orchestration wrapper over existing validation tracks | No single source of truth; local/manual wrapper | Local outputs only |
 
 Normal CI keeps deterministic diagnostics and docs contracts as gates but does not publish durable scorecards. Durable scorecard publication remains limited to the manual/tag snapshot workflow.
@@ -43,6 +45,8 @@ Tracing-intake contract coverage is currently validated by unit/package tests an
 - example compile/run coverage under package example tests
 
 These checks validate conversion correctness and user-facing guardrails for triage intake. They do not validate production root-cause truth, do not claim arbitrary `tracing_subscriber::fmt().json()` import support, do not claim OTel/OTLP support, and do not claim runtime-pressure diagnosis from tracing-only intake without runtime snapshots/Tokio sampler coupling.
+
+CI tracing parity gates enforce bounded parity semantics only: artifact shape, effective core capture config, expected evidence presence, runtime-sampler metadata for runtime-sensitive tracing scenarios, and exact tiny-limit truncation parity. They do not prove universal production performance or root-cause certainty.
 
 ## Deterministic corpus validation
 The deterministic benchmark validates:

--- a/docs/runtime-cost.md
+++ b/docs/runtime-cost.md
@@ -68,7 +68,7 @@ python3 scripts/validate_runtime_cost_summary.py \
   --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json
 ```
 
-This is a bounded diagnostic sanity check only. It enforces tracing/native parity hard checks (p95 <= 1.10x native and throughput >= 0.90x native), a 2% soft warning band (p95 > 1.02x or throughput < 0.98x), and required tracing evidence shape, not rigorous performance benchmarking. CI validates runtime-cost output in-place and does not upload runtime-cost artifacts by default. CI logs print compact runtime-cost tables by default, while full JSON remains in artifacts (`runtime-cost-summary.json`) and can be printed locally with `--print-json`. Full runtime-cost measurement remains a local/developer-run path via the canonical command above. Results remain machine/workload/profile scoped.
+This is a bounded diagnostic sanity check only. It enforces tracing/native parity hard checks (p95 <= 1.10x native and throughput >= 0.90x native), a 2% soft warning band (p95 > 1.02x or throughput < 0.98x), and required tracing evidence shape, not rigorous performance benchmarking. Runtime-cost tracing modes and native modes use the same core capture mode/limit configuration model (`mode` + `capture_limits`) for retained request/stage/queue evidence. CI validates runtime-cost output in-place and does not upload runtime-cost artifacts by default. CI logs print compact runtime-cost tables by default, while full JSON remains in artifacts (`runtime-cost-summary.json`) and can be printed locally with `--print-json`. Full runtime-cost measurement remains a local/developer-run path via the canonical command above. Results remain machine/workload/profile scoped.
 
 ## Inputs and knobs
 

--- a/scripts/demo_tool.py
+++ b/scripts/demo_tool.py
@@ -764,6 +764,8 @@ def validate_retry_storm(root_dir: Path, *, profile: str = "dev") -> None:
 
 PARITY_SCENARIOS = ["queue", "downstream", "mixed", "cold-start", "db-pool", "shared-lock", "retry-storm", "blocking", "executor", "all"]
 
+SHARED_PARITY_LIMITS = {"mode": "light", "max_requests": 3, "max_stages": 3, "max_queues": 3}
+
 def _artifact_prefix(mode: str, instrumentation: str) -> str:
     return f"{mode}-{instrumentation}"
 
@@ -771,6 +773,33 @@ def _artifact_prefix(mode: str, instrumentation: str) -> str:
 def _load_run(path: Path) -> dict:
     with path.open("r", encoding="utf-8") as handle:
         return json.load(handle)
+
+
+def _parity_fail(*, scenario: str, instrumentation: str, artifact_path: Path, field: str, expected: object, actual: object) -> None:
+    raise SystemExit(
+        f"parity check failed scenario={scenario} instrumentation={instrumentation} "
+        f"artifact={artifact_path} field={field} expected={expected!r} actual={actual!r}"
+    )
+
+
+def _assert_equal(
+    *,
+    scenario: str,
+    instrumentation: str,
+    artifact_path: Path,
+    field: str,
+    expected: object,
+    actual: object,
+) -> None:
+    if expected != actual:
+        _parity_fail(
+            scenario=scenario,
+            instrumentation=instrumentation,
+            artifact_path=artifact_path,
+            field=field,
+            expected=expected,
+            actual=actual,
+        )
 
 
 def _tracing_parity_config(root_dir: Path, scenario: str) -> dict:
@@ -889,7 +918,13 @@ def validate_tracing_parity(root_dir: Path, scenario: str, *, profile: str = "de
                 analysis_path,
                 mode_arg,
                 profile=profile,
-                extra_demo_args=["--instrumentation", instrumentation],
+                extra_demo_args=[
+                    "--instrumentation", instrumentation,
+                    "--capture-mode", SHARED_PARITY_LIMITS["mode"],
+                    "--max-requests", str(SHARED_PARITY_LIMITS["max_requests"]),
+                    "--max-stages", str(SHARED_PARITY_LIMITS["max_stages"]),
+                    "--max-queues", str(SHARED_PARITY_LIMITS["max_queues"]),
+                ],
             )
 
     expected_files = [
@@ -1028,6 +1063,48 @@ def validate_tracing_parity(root_dir: Path, scenario: str, *, profile: str = "de
         f"tracing parity validation passed for {scenario}: "
         f"baseline kind={expected_kind}, tracing p95 {before_tracing['p95_latency_us']}us -> {after_tracing['p95_latency_us']}us"
     )
+
+
+def validate_tracing_retention_parity(root_dir: Path, *, profile: str = "dev") -> None:
+    scenario = "queue"
+    config = _tracing_parity_config(root_dir, scenario)
+    demo_manifest = config["demo_manifest"]
+    artifact_dir = config["artifact_dir"]
+    cli_manifest = root_dir / "tailtriage-cli/Cargo.toml"
+    for instrumentation in ("native", "tracing"):
+        run_path = artifact_dir / f"retention-{instrumentation}-run.json"
+        analysis_path = artifact_dir / f"retention-{instrumentation}-analysis.json"
+        run_and_analyze(
+            demo_manifest,
+            cli_manifest,
+            run_path,
+            analysis_path,
+            "baseline",
+            profile=profile,
+            extra_demo_args=[
+                "--instrumentation", instrumentation,
+                "--capture-mode", "light",
+                "--max-requests", "3",
+                "--max-stages", "3",
+                "--max-queues", "3",
+            ],
+        )
+    native_path = artifact_dir / "retention-native-run.json"
+    tracing_path = artifact_dir / "retention-tracing-run.json"
+    native = _load_run(native_path)
+    tracing = _load_run(tracing_path)
+    for field, n, t in (
+        ("requests.len", len(native.get("requests", [])), len(tracing.get("requests", []))),
+        ("stages.len", len(native.get("stages", [])), len(tracing.get("stages", []))),
+        ("queues.len", len(native.get("queues", [])), len(tracing.get("queues", []))),
+        ("truncation.dropped_requests", (native.get("truncation") or {}).get("dropped_requests"), (tracing.get("truncation") or {}).get("dropped_requests")),
+        ("truncation.dropped_stages", (native.get("truncation") or {}).get("dropped_stages"), (tracing.get("truncation") or {}).get("dropped_stages")),
+        ("truncation.dropped_queues", (native.get("truncation") or {}).get("dropped_queues"), (tracing.get("truncation") or {}).get("dropped_queues")),
+        ("truncation.limits_hit", sorted((native.get("truncation") or {}).get("limits_hit") or []), sorted((tracing.get("truncation") or {}).get("limits_hit") or [])),
+        ("metadata.effective_core_config", native.get("metadata", {}).get("effective_core_config"), tracing.get("metadata", {}).get("effective_core_config")),
+    ):
+        _assert_equal(scenario=scenario, instrumentation="tracing", artifact_path=tracing_path, field=field, expected=n, actual=t)
+    print("tracing retention parity validation passed")
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Unified tailtriage demo run/validate tool.")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -1096,6 +1173,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parity_parser.add_argument("scenario", choices=PARITY_SCENARIOS)
     parity_parser.add_argument("--profile", choices=PROFILE_CHOICES, default="dev")
     parity_parser.add_argument("--release", action="store_const", const="release", dest="profile")
+    retention_parser = subparsers.add_parser(
+        "validate-tracing-retention-parity",
+        help="Run exact retention/truncation parity checks for tiny capture limits.",
+    )
+    retention_parser.add_argument("--profile", choices=PROFILE_CHOICES, default="dev")
+    retention_parser.add_argument("--release", action="store_const", const="release", dest="profile")
 
     return parser.parse_args(argv)
 
@@ -1161,6 +1244,9 @@ def main(argv: list[str] | None = None) -> None:
 
     if args.command == "validate-tracing-parity":
         validate_tracing_parity(root_dir, args.scenario, profile=args.profile)
+        return
+    if args.command == "validate-tracing-retention-parity":
+        validate_tracing_retention_parity(root_dir, profile=args.profile)
         return
 
     if args.scenario == "queue":

--- a/scripts/tests/test_demo_scripts.py
+++ b/scripts/tests/test_demo_scripts.py
@@ -161,6 +161,27 @@ class DemoWrapperTests(unittest.TestCase):
         self.assertEqual(args.command, "validate-tracing-parity")
         self.assertEqual(args.scenario, "all")
 
+    def test_parse_args_accepts_validate_tracing_retention_parity(self) -> None:
+        args = parse_args(["validate-tracing-retention-parity", "--profile", "release"])
+        self.assertEqual(args.command, "validate-tracing-retention-parity")
+        self.assertEqual(args.profile, "release")
+
+    def test_parity_fail_message_includes_expected_fields(self) -> None:
+        with self.assertRaises(SystemExit) as cm:
+            demo_tool._assert_equal(
+                scenario="queue",
+                instrumentation="tracing",
+                artifact_path=Path("/tmp/a.json"),
+                field="metadata.mode",
+                expected="light",
+                actual="investigation",
+            )
+        msg = str(cm.exception)
+        self.assertIn("scenario=queue", msg)
+        self.assertIn("field=metadata.mode", msg)
+        self.assertIn("expected='light'", msg)
+        self.assertIn("actual='investigation'", msg)
+
     def test_queue_score_increase_allowed_with_material_p95_drop_and_nonworsening_queue_evidence(self) -> None:
         before = {
             "primary_suspect": {"kind": "application_queue_saturation", "score": 95},


### PR DESCRIPTION
### Motivation

- Parity between native and tracing capture must be enforced (not just documented) for shared capture config, retention/truncation behavior, runtime-sampler evidence, and artifact semantics.  
- Provide a deterministic tiny-limit parity path that requires exact retention/truncation/effective-core-config equality to catch drift in conversion/retention logic.  
- Make parity checks CI-gated on the existing Ubuntu release extended leg so divergences are caught during PR validation.  

### Description

- Added structured parity assertion helpers in `scripts/demo_tool.py` (`_assert_equal`, `_parity_fail`) that produce failure messages including `scenario`, `instrumentation`, `artifact_path`, `field`, `expected`, and `actual`.  
- Updated `validate-tracing-parity` to pass shared capture arguments (`--capture-mode`, `--max-requests`, `--max-stages`, `--max-queues`) into both native and tracing runs so both modes use the same core capture semantics; latency/score comparisons remain tolerant.  
- Implemented a new `validate-tracing-retention-parity` command in `scripts/demo_tool.py` that runs a deterministic tiny-limit scenario (`mode=light`, `max_requests=3`, `max_stages=3`, `max_queues=3`) for both native and tracing instrumentation and requires exact equality for retained request/stage/queue counts, dropped counters, `truncation.limits_hit`, and `metadata.effective_core_config` while still running the analyzer on both artifacts.  
- Added CLI wiring and main-dispatch for the new command and added tests in `scripts/tests/test_demo_scripts.py` for argument parsing and parity-failure message shape.  
- Wired the new tiny-limit retention parity check into the existing Ubuntu release extended CI leg in `.github/workflows/ci.yml` (no new matrix job).  
- Updated validation guidance in `VALIDATION.md` and runtime-cost wording in `docs/runtime-cost.md` to explicitly describe what parity checks are CI-gated and to state that runtime-cost modes use the same capture-mode/limit model for retention evidence.  

### Testing

- Ran the demo script unit tests with `python3 -m unittest scripts.tests.test_demo_scripts`, which passed (`Ran 29 tests — OK`).  
- New parity helpers are covered by unit tests verifying argument parsing and that parity failure messages include `scenario`, `field`, `expected`, and `actual`.  
- The new tiny-limit parity command is CI-gated (Ubuntu release extended leg) and will run during PR validation to catch parity regressions; local execution is available via `python3 scripts/demo_tool.py validate-tracing-retention-parity --profile release`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10cbbd6050833098ab9718fe7ca893)