### PR TITLE
Remove duplicated rustdoc comments in tracing recorder (reconciliation for PR #724)

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -327,20 +327,17 @@ impl TracingIntakeSessionBuilder {
         self
     }
     /// Sets capture mode used to resolve live completed-evidence retention limits.
-    /// Sets capture mode used to resolve live completed-evidence retention limits.
     #[must_use]
     pub fn mode(mut self, mode: CaptureMode) -> Self {
         self.recorder_builder = self.recorder_builder.mode(mode);
         self
     }
     /// Sets base capture limits used for live completed-evidence retention.
-    /// Sets base capture limits used for live completed-evidence retention.
     #[must_use]
     pub fn capture_limits(mut self, capture_limits: CaptureLimits) -> Self {
         self.recorder_builder = self.recorder_builder.capture_limits(capture_limits);
         self
     }
-    /// Sets capture-limit overrides applied on top of the selected capture mode.
     /// Sets capture-limit overrides applied on top of the selected capture mode.
     #[must_use]
     pub fn capture_limits_override(mut self, override_limits: CaptureLimitsOverride) -> Self {


### PR DESCRIPTION
### Motivation
- Clean up obvious documentation-quality drift introduced by the aggregate branch by removing duplicated adjacent rustdoc lines in the tracing intake recorder without changing API behavior.

### Description
- Remove duplicated `///` lines in `tailtriage-tracing/src/recorder.rs` for the `TracingIntakeSessionBuilder` methods `mode`, `capture_limits`, and `capture_limits_override`, and scan the repo for other identical adjacent rustdoc duplicates (no behavioral changes were made).

### Testing
- Re-ran the full validation set including `cargo fmt --check`, `cargo check` (multiple feature permutations), `cargo clippy -- -D warnings`, `cargo test --workspace --all-features --locked`, `cargo doc` permutations, `python3 scripts/validate_docs_contracts.py`, tracing parity/retention demo validations, and the runtime-cost smoke measurements (the runtime-cost smoke completed with expected warning-band notices).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11a110575c83309bed3c252bf6fb36)