### PR TITLE
tracing: remove duplicated intake builder rustdoc comments and run aggregate validation

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -327,20 +327,17 @@ impl TracingIntakeSessionBuilder {
         self
     }
     /// Sets capture mode used to resolve live completed-evidence retention limits.
-    /// Sets capture mode used to resolve live completed-evidence retention limits.
     #[must_use]
     pub fn mode(mut self, mode: CaptureMode) -> Self {
         self.recorder_builder = self.recorder_builder.mode(mode);
         self
     }
     /// Sets base capture limits used for live completed-evidence retention.
-    /// Sets base capture limits used for live completed-evidence retention.
     #[must_use]
     pub fn capture_limits(mut self, capture_limits: CaptureLimits) -> Self {
         self.recorder_builder = self.recorder_builder.capture_limits(capture_limits);
         self
     }
-    /// Sets capture-limit overrides applied on top of the selected capture mode.
     /// Sets capture-limit overrides applied on top of the selected capture mode.
     #[must_use]
     pub fn capture_limits_override(mut self, override_limits: CaptureLimitsOverride) -> Self {


### PR DESCRIPTION
### Motivation
- Clean up duplicated adjacent rustdoc lines introduced in the aggregate branch for `TracingIntakeSessionBuilder` and ensure the aggregate PR head satisfies the accepted prompt outcomes and repo guardrails without changing API behavior. 

### Description
- Removed the duplicated `///` lines above `TracingIntakeSessionBuilder::mode`, `::capture_limits`, and `::capture_limits_override`, scanned Rust sources to clear other adjacent-duplicate `///` occurrences, and ensured no behavioral or public-API changes were made (no OTel/OTLP or analyzer semantic changes). 

### Testing
- Ran the full validation matrix including `cargo fmt --check`, `cargo check` for tracing with feature permutations, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-targets --all-features`, `cargo doc` variants, `python3 scripts/validate_docs_contracts.py`, tracing parity and retention parity demos via `python3 scripts/demo_tool.py`, and the runtime-cost smoke and summary validation (`python3 scripts/measure_runtime_cost.py` and `python3 scripts/validate_runtime_cost_summary.py`), with all checks passing except the runtime-cost smoke which completed with warning-band/noisy-quality notices but stayed within hard-gated thresholds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11a110575c83309bed3c252bf6fb36)