### PR TITLE
Deduplicate tracing intake builder rustdoc comments and validate aggregate branch

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -327,20 +327,17 @@ impl TracingIntakeSessionBuilder {
         self
     }
     /// Sets capture mode used to resolve live completed-evidence retention limits.
-    /// Sets capture mode used to resolve live completed-evidence retention limits.
     #[must_use]
     pub fn mode(mut self, mode: CaptureMode) -> Self {
         self.recorder_builder = self.recorder_builder.mode(mode);
         self
     }
     /// Sets base capture limits used for live completed-evidence retention.
-    /// Sets base capture limits used for live completed-evidence retention.
     #[must_use]
     pub fn capture_limits(mut self, capture_limits: CaptureLimits) -> Self {
         self.recorder_builder = self.recorder_builder.capture_limits(capture_limits);
         self
     }
-    /// Sets capture-limit overrides applied on top of the selected capture mode.
     /// Sets capture-limit overrides applied on top of the selected capture mode.
     #[must_use]
     pub fn capture_limits_override(mut self, override_limits: CaptureLimitsOverride) -> Self {


### PR DESCRIPTION
### Motivation
- Remove obvious quality drift introduced by the aggregate branch by deduplicating repeated rustdoc lines in the tracing intake builder while keeping all API behavior unchanged.

### Description
- Removed adjacent duplicate `///` rustdoc lines for `mode`, `capture_limits`, and `capture_limits_override` in `tailtriage-tracing/src/recorder.rs` and ran a repository scan for similar adjacent-duplicate comment patterns (no other duplicates required changes); no public API or behavior was altered and docs still describe unsupported ordinary `fmt().json` input and retained capture-limit semantics.

### Testing
- Ran the full automated validation suite including `cargo fmt --check`, targeted `cargo check` combinations for `tailtriage-tracing`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-targets --all-features`, `cargo doc` permutations, `python3 scripts/validate_docs_contracts.py`, parity validations (`python3 scripts/demo_tool.py validate-tracing-retention-parity --profile release` and `python3 scripts/demo_tool.py validate-tracing-parity all --profile release`), and the runtime-cost smoke measurement and summary validation; all commands completed successfully and CI/validation gates passed (the runtime-cost script reported warning-band noisy measurements, which are informational and not failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11a110575c83309bed3c252bf6fb36)