### PR TITLE
Clean up duplicated rustdoc in tracing intake builder — final reconciliation pass

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -327,20 +327,17 @@ impl TracingIntakeSessionBuilder {
         self
     }
     /// Sets capture mode used to resolve live completed-evidence retention limits.
-    /// Sets capture mode used to resolve live completed-evidence retention limits.
     #[must_use]
     pub fn mode(mut self, mode: CaptureMode) -> Self {
         self.recorder_builder = self.recorder_builder.mode(mode);
         self
     }
     /// Sets base capture limits used for live completed-evidence retention.
-    /// Sets base capture limits used for live completed-evidence retention.
     #[must_use]
     pub fn capture_limits(mut self, capture_limits: CaptureLimits) -> Self {
         self.recorder_builder = self.recorder_builder.capture_limits(capture_limits);
         self
     }
-    /// Sets capture-limit overrides applied on top of the selected capture mode.
     /// Sets capture-limit overrides applied on top of the selected capture mode.
     #[must_use]
     pub fn capture_limits_override(mut self, override_limits: CaptureLimitsOverride) -> Self {


### PR DESCRIPTION
### Motivation
- Remove obvious aggregate-branch quality drift by deduplicating adjacent `///` rustdoc lines introduced in the tracing intake builder while preserving existing API behavior and docs-contract fidelity.

### Description
- Deleted duplicated adjacent rustdoc lines for `TracingIntakeSessionBuilder::mode`, `TracingIntakeSessionBuilder::capture_limits`, and `TracingIntakeSessionBuilder::capture_limits_override` in `tailtriage-tracing/src/recorder.rs` and verified no behavioral/API changes were made.

### Testing
- Re-ran the full reconciliation validation including `cargo fmt --check`, multiple `cargo check` configurations for `tailtriage-tracing`, `cargo clippy -D warnings`, `cargo test --workspace --all-features`, documentation builds, `python3 scripts/validate_docs_contracts.py`, tracing parity/retention parity demos, and the runtime-cost measurement and summary validation; all checks passed, with the runtime-cost summary emitting expected non-failing warning-band throughput notices.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11a110575c83309bed3c252bf6fb36)