### PR TITLE
Harden tracing duration import validation semantics

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -99,6 +99,7 @@ Ordinary tracing log JSON (for example `fmt().json` output) is rejected by impor
 
 - Strict mode: malformed/incomplete `tt.*` span records fail import/session conversion.
 - Non-strict mode: malformed/incomplete records are warned and skipped where implemented.
+- `duration_us` validation uses a `2_000` microsecond tolerance against derived wall-clock duration (`(finished_at_unix_ms - started_at_unix_ms) * 1000`): absent `duration_us` uses the derived value, within tolerance keeps `duration_us`, and larger mismatch warns+falls back to derived (or fails in strict mode).
 
 ## Retention and drop behavior
 
@@ -121,4 +122,3 @@ For `TracingTokioSession`, runtime snapshot retention also uses the same core ca
 
 - `tailtriage-tracing/examples/live_session_to_run.rs`
 - `tailtriage-tracing/examples/completed_span_jsonl_import.rs`
-

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -914,29 +914,35 @@ mod tests {
     }
 
     #[test]
-    fn normalized_duration_us_overrides_derived_latency() {
+    fn normalized_duration_us_within_tolerance_is_preserved() {
         let input = r#"
-{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":1234,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
-{"span":{"name":"st","started_at_unix_ms":11,"finished_at_unix_ms":18,"duration_us":1234,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
-{"span":{"name":"q","started_at_unix_ms":10,"finished_at_unix_ms":11,"duration_us":1234,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":3}}}
+{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":10100,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
+{"span":{"name":"st","started_at_unix_ms":11,"finished_at_unix_ms":18,"duration_us":7100,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
+{"span":{"name":"q","started_at_unix_ms":10,"finished_at_unix_ms":11,"duration_us":1100,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":3}}}
 "#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests[0].latency_us, 1234);
-        assert_eq!(imported.run().stages[0].latency_us, 1234);
-        assert_eq!(imported.run().queues[0].wait_us, 1234);
+        assert_eq!(imported.run().requests[0].latency_us, 10100);
+        assert_eq!(imported.run().stages[0].latency_us, 7100);
+        assert_eq!(imported.run().queues[0].wait_us, 1100);
     }
 
     #[test]
-    fn normalized_zero_duration_us_is_accepted_for_positive_timestamp_spans() {
+    fn normalized_contradictory_duration_us_warns_and_uses_derived_non_strict() {
         let input = r#"
 {"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":0,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
 {"span":{"name":"st","started_at_unix_ms":11,"finished_at_unix_ms":18,"duration_us":0,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
 {"span":{"name":"q","started_at_unix_ms":10,"finished_at_unix_ms":11,"duration_us":0,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":3}}}
 "#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests[0].latency_us, 0);
-        assert_eq!(imported.run().stages[0].latency_us, 0);
+        assert_eq!(imported.run().requests[0].latency_us, 10_000);
+        assert_eq!(imported.run().stages[0].latency_us, 7_000);
         assert_eq!(imported.run().queues[0].wait_us, 0);
+        assert!(imported
+            .warnings()
+            .iter()
+            .filter(|warning| warning.message().contains("duration_us mismatch"))
+            .count()
+            >= 2);
     }
 
     #[test]
@@ -1007,17 +1013,17 @@ mod tests {
     }
 
     #[test]
-    fn normalized_duration_us_from_outer_fields_still_overrides_derived_latency() {
-        let input = r#"{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":1234},"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/outer"}}"#;
+    fn normalized_duration_us_from_outer_fields_within_tolerance_is_preserved() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":10100},"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/outer"}}"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests[0].latency_us, 1234);
+        assert_eq!(imported.run().requests[0].latency_us, 10100);
     }
 
     #[test]
-    fn normalized_duration_us_from_top_level_tt_keys_still_overrides_derived_latency() {
-        let input = r#"{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":1234},"tt.kind":"request","tt.request_id":"r1","tt.route":"/top"}"#;
+    fn normalized_duration_us_from_top_level_tt_keys_within_tolerance_is_preserved() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":10100},"tt.kind":"request","tt.request_id":"r1","tt.route":"/top"}"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests[0].latency_us, 1234);
+        assert_eq!(imported.run().requests[0].latency_us, 10100);
     }
 
     #[test]

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -39,6 +39,7 @@ pub mod tokio;
 mod types;
 
 use std::collections::BTreeMap;
+const DURATION_TOLERANCE_US: u64 = 2_000;
 use tailtriage_core::{
     BuildError, QueueEvent, RequestEvent, RunBuilder, RunBuilderOptions, StageEvent,
 };
@@ -165,10 +166,11 @@ where
                             kind: None,
                             started_at_unix_ms: span.started_at_unix_ms(),
                             finished_at_unix_ms: span.finished_at_unix_ms(),
-                            latency_us: span.duration_us_ref().unwrap_or(
-                                (span.finished_at_unix_ms() - span.started_at_unix_ms())
-                                    .saturating_mul(1000),
-                            ),
+                            latency_us: validated_duration_us(
+                                &span,
+                                options.strict_mode(),
+                                &mut warnings,
+                            )?,
                             outcome,
                         },
                         outcome_defaulted,
@@ -192,10 +194,11 @@ where
                             stage,
                             started_at_unix_ms: span.started_at_unix_ms(),
                             finished_at_unix_ms: span.finished_at_unix_ms(),
-                            latency_us: span.duration_us_ref().unwrap_or(
-                                (span.finished_at_unix_ms() - span.started_at_unix_ms())
-                                    .saturating_mul(1000),
-                            ),
+                            latency_us: validated_duration_us(
+                                &span,
+                                options.strict_mode(),
+                                &mut warnings,
+                            )?,
                             success,
                         },
                         success_defaulted: matches!(success_field, OptionalField::Missing),
@@ -218,10 +221,11 @@ where
                         queue,
                         waited_from_unix_ms: span.started_at_unix_ms(),
                         waited_until_unix_ms: span.finished_at_unix_ms(),
-                        wait_us: span.duration_us_ref().unwrap_or(
-                            (span.finished_at_unix_ms() - span.started_at_unix_ms())
-                                .saturating_mul(1000),
-                        ),
+                        wait_us: validated_duration_us(
+                            &span,
+                            options.strict_mode(),
+                            &mut warnings,
+                        )?,
                         depth_at_start,
                     });
                 }
@@ -483,6 +487,32 @@ fn validate_service_name(service_name: &str) -> Result<(), ImportError> {
     Ok(())
 }
 
+fn validated_duration_us(
+    span: &SpanRecord,
+    strict: bool,
+    warnings: &mut Vec<ImportWarning>,
+) -> Result<u64, ImportError> {
+    let derived_us = (span.finished_at_unix_ms() - span.started_at_unix_ms()).saturating_mul(1000);
+    let Some(duration_us) = span.duration_us_ref() else {
+        return Ok(derived_us);
+    };
+    if duration_us.abs_diff(derived_us) <= DURATION_TOLERANCE_US {
+        return Ok(duration_us);
+    }
+    let message = format!(
+        "span '{}' duration_us mismatch: duration_us={} derived_us={} exceeds tolerance_us={}",
+        span.name(),
+        duration_us,
+        derived_us,
+        DURATION_TOLERANCE_US
+    );
+    if strict {
+        return Err(ImportError::StrictViolation(message));
+    }
+    warnings.push(ImportWarning::new(message));
+    Ok(derived_us)
+}
+
 fn retained_event_time_bounds(
     requests: &[RequestEvent],
     stages: &[StageEvent],
@@ -570,6 +600,7 @@ fn is_durable_conversion_warning(message: &str) -> bool {
         || message.starts_with("unknown tt.kind")
         || message.contains("missing optional 'tt.outcome'; assumed 'ok'")
         || message.contains("missing optional 'tt.success'; assumed true")
+        || message.contains("duration_us mismatch:")
 }
 
 fn attach_durable_conversion_warnings(run: &mut tailtriage_core::Run, warnings: &[ImportWarning]) {
@@ -1814,37 +1845,130 @@ mod tests {
     }
 
     #[test]
-    fn span_duration_us_is_used_for_stage_latency() {
+    fn contradictory_stage_duration_warns_and_uses_derived_us_non_strict() {
         let spans = vec![
             SpanRecord::new("req", 99, 101)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/"),
-            SpanRecord::new("stage", 100, 100)
-                .duration_us(123)
+            SpanRecord::new("stage", 100, 101)
+                .duration_us(6_000)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_STAGE, "db"),
         ];
-        let run = run_from_span_records(spans, ImportOptions::new("svc"))
-            .unwrap()
-            .run()
-            .clone();
-        assert_eq!(run.stages[0].latency_us, 123);
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        let run = imported.run().clone();
+        assert_eq!(run.stages[0].latency_us, 1_000);
+        assert!(run.metadata.lifecycle_warnings.iter().any(|warning| {
+            warning.contains("span 'stage' duration_us mismatch: duration_us=6000 derived_us=1000")
+                && warning.contains("tolerance_us=2000")
+        }));
     }
 
     #[test]
-    fn span_duration_us_is_used_for_request_latency() {
-        let spans = vec![SpanRecord::new("req", 100, 100)
-            .duration_us(456)
+    fn contradictory_request_duration_warns_and_uses_derived_us_non_strict() {
+        let spans = vec![SpanRecord::new("req", 100, 101)
+            .duration_us(9_000)
             .field(TT_KIND, "request")
             .field(TT_REQUEST_ID, "r1")
             .field(TT_ROUTE, "/a")];
-        let run = run_from_span_records(spans, ImportOptions::new("svc"))
-            .unwrap()
-            .run()
-            .clone();
-        assert_eq!(run.requests[0].latency_us, 456);
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        let run = imported.run().clone();
+        assert_eq!(run.requests[0].latency_us, 1_000);
+        assert!(run.metadata.lifecycle_warnings.iter().any(|warning| {
+            warning.contains("span 'req' duration_us mismatch: duration_us=9000 derived_us=1000")
+                && warning.contains("tolerance_us=2000")
+        }));
+    }
+
+    #[test]
+    fn contradictory_queue_duration_warns_and_uses_derived_us_non_strict() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 110)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("queue", 101, 103)
+                .duration_us(100_000)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        let run = imported.run().clone();
+        assert_eq!(run.queues[0].wait_us, 2_000);
+        assert!(run.metadata.lifecycle_warnings.iter().any(|warning| {
+            warning
+                .contains("span 'queue' duration_us mismatch: duration_us=100000 derived_us=2000")
+                && warning.contains("tolerance_us=2000")
+        }));
+    }
+
+    #[test]
+    fn strict_mode_rejects_contradictory_request_duration() {
+        let spans = vec![SpanRecord::new("req", 100, 101)
+            .duration_us(9_000)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+        assert!(matches!(
+            run_from_span_records(spans, ImportOptions::new("svc").strict(true)),
+            Err(ImportError::StrictViolation(message)) if message.contains("duration_us mismatch")
+        ));
+    }
+
+    #[test]
+    fn strict_mode_rejects_contradictory_stage_duration() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 110)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("stage", 101, 102)
+                .duration_us(8_000)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+        ];
+        assert!(matches!(
+            run_from_span_records(spans, ImportOptions::new("svc").strict(true)),
+            Err(ImportError::StrictViolation(message)) if message.contains("duration_us mismatch")
+        ));
+    }
+
+    #[test]
+    fn strict_mode_rejects_contradictory_queue_duration() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 110)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("queue", 101, 103)
+                .duration_us(100_000)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+        assert!(matches!(
+            run_from_span_records(spans, ImportOptions::new("svc").strict(true)),
+            Err(ImportError::StrictViolation(message)) if message.contains("duration_us mismatch")
+        ));
+    }
+
+    #[test]
+    fn duration_us_within_tolerance_is_accepted() {
+        let spans = vec![SpanRecord::new("req", 100, 101)
+            .duration_us(2_999)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests[0].latency_us, 2_999);
+        assert!(imported
+            .warnings()
+            .iter()
+            .all(|warning| !warning.message().contains("duration_us mismatch")));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent internally contradictory Run artifacts when a span's `duration_us` disagrees with its wall-clock timestamps by enforcing a consistent validation rule during import.
- Preserve existing non-strict behavior (warn + fallback) while adding a strict-mode guard that fails on large mismatches.

### Description
- Add `DURATION_TOLERANCE_US: u64 = 2_000` and a private helper `validated_duration_us(span, strict, warnings) -> Result<u64, ImportError>` in `tailtriage-tracing/src/lib.rs` that derives `derived_us = (finished_at_unix_ms - started_at_unix_ms) * 1000`, uses `duration_us` when absent/within tolerance, warns+falls back to derived in non-strict mode when mismatch > tolerance, and returns `ImportError::StrictViolation` in strict mode.
- Replace direct `span.duration_us_ref().unwrap_or(...)` usage with the helper for `RequestEvent.latency_us`, `StageEvent.latency_us`, and `QueueEvent.wait_us` conversion paths.
- Extend `is_durable_conversion_warning` and the durable warning attachment flow so duration mismatch warnings are persisted to `run.metadata.lifecycle_warnings` using the existing durable-warning mechanism.
- Update/expand unit tests in `tailtriage-tracing` and JSONL import tests to cover: non-strict contradictory durations (warn + use derived), strict rejections for contradictory durations, and acceptance when `duration_us` is within the 2_000µs tolerance.
- Document the 2_000µs tolerance and the behavior in `tailtriage-tracing/README.md`.

### Testing
- Ran formatting and linting: `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (both passed).
- Ran the full test suite: `cargo test --workspace --all-targets --all-features --locked` (all tests passed after updates).
- Ran docs contract validation: `python3 scripts/validate_docs_contracts.py` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12c20970548330b31905e162525ede)