### PR TITLE
Harden tracing import duration semantics with tolerance and strict enforcement

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -99,6 +99,7 @@ Ordinary tracing log JSON (for example `fmt().json` output) is rejected by impor
 
 - Strict mode: malformed/incomplete `tt.*` span records fail import/session conversion.
 - Non-strict mode: malformed/incomplete records are warned and skipped where implemented.
+- Duration consistency tolerance: when a completed span includes `duration_us`, import compares it to `(finished_at_unix_ms - started_at_unix_ms) * 1000`. Differences up to `2_000` microseconds use `duration_us`; larger mismatches warn and fall back to derived duration in non-strict mode, and fail import in strict mode.
 
 ## Retention and drop behavior
 
@@ -121,4 +122,3 @@ For `TracingTokioSession`, runtime snapshot retention also uses the same core ca
 
 - `tailtriage-tracing/examples/live_session_to_run.rs`
 - `tailtriage-tracing/examples/completed_span_jsonl_import.rs`
-

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -914,29 +914,31 @@ mod tests {
     }
 
     #[test]
-    fn normalized_duration_us_overrides_derived_latency() {
+    fn normalized_duration_us_mismatch_warns_and_falls_back_to_derived_latency() {
         let input = r#"
 {"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":1234,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
 {"span":{"name":"st","started_at_unix_ms":11,"finished_at_unix_ms":18,"duration_us":1234,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
 {"span":{"name":"q","started_at_unix_ms":10,"finished_at_unix_ms":11,"duration_us":1234,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":3}}}
 "#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests[0].latency_us, 1234);
-        assert_eq!(imported.run().stages[0].latency_us, 1234);
-        assert_eq!(imported.run().queues[0].wait_us, 1234);
+        assert_eq!(imported.run().requests[0].latency_us, 10_000);
+        assert_eq!(imported.run().stages[0].latency_us, 7_000);
+        assert_eq!(imported.run().queues[0].wait_us, 1_234);
+        assert_eq!(imported.warnings().len(), 4);
     }
 
     #[test]
-    fn normalized_zero_duration_us_is_accepted_for_positive_timestamp_spans() {
+    fn normalized_duration_us_within_tolerance_is_accepted_for_positive_timestamp_spans() {
         let input = r#"
-{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":0,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
-{"span":{"name":"st","started_at_unix_ms":11,"finished_at_unix_ms":18,"duration_us":0,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
-{"span":{"name":"q","started_at_unix_ms":10,"finished_at_unix_ms":11,"duration_us":0,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":3}}}
+{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":11999,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
+{"span":{"name":"st","started_at_unix_ms":11,"finished_at_unix_ms":18,"duration_us":8999,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
+{"span":{"name":"q","started_at_unix_ms":10,"finished_at_unix_ms":11,"duration_us":2999,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":3}}}
 "#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests[0].latency_us, 0);
-        assert_eq!(imported.run().stages[0].latency_us, 0);
-        assert_eq!(imported.run().queues[0].wait_us, 0);
+        assert_eq!(imported.run().requests[0].latency_us, 11_999);
+        assert_eq!(imported.run().stages[0].latency_us, 8_999);
+        assert_eq!(imported.run().queues[0].wait_us, 2_999);
+        assert_eq!(imported.warnings().len(), 2);
     }
 
     #[test]
@@ -1007,17 +1009,17 @@ mod tests {
     }
 
     #[test]
-    fn normalized_duration_us_from_outer_fields_still_overrides_derived_latency() {
+    fn normalized_duration_us_from_outer_fields_mismatch_falls_back_to_derived_latency() {
         let input = r#"{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":1234},"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/outer"}}"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests[0].latency_us, 1234);
+        assert_eq!(imported.run().requests[0].latency_us, 10_000);
     }
 
     #[test]
-    fn normalized_duration_us_from_top_level_tt_keys_still_overrides_derived_latency() {
+    fn normalized_duration_us_from_top_level_tt_keys_mismatch_falls_back_to_derived_latency() {
         let input = r#"{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":1234},"tt.kind":"request","tt.request_id":"r1","tt.route":"/top"}"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests[0].latency_us, 1234);
+        assert_eq!(imported.run().requests[0].latency_us, 10_000);
     }
 
     #[test]

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -58,6 +58,8 @@ pub use recorder::{
 };
 pub use types::{FieldValue, ImportOptions, ImportWarning, ImportedRun, SpanKind, SpanRecord};
 
+const DURATION_TOLERANCE_US: u64 = 2_000;
+
 /// Ensures a run is suitable for persisted Run JSON artifacts intended for CLI analysis.
 ///
 /// # Errors
@@ -165,10 +167,11 @@ where
                             kind: None,
                             started_at_unix_ms: span.started_at_unix_ms(),
                             finished_at_unix_ms: span.finished_at_unix_ms(),
-                            latency_us: span.duration_us_ref().unwrap_or(
-                                (span.finished_at_unix_ms() - span.started_at_unix_ms())
-                                    .saturating_mul(1000),
-                            ),
+                            latency_us: validated_duration_us(
+                                &span,
+                                options.strict_mode(),
+                                &mut warnings,
+                            )?,
                             outcome,
                         },
                         outcome_defaulted,
@@ -192,10 +195,11 @@ where
                             stage,
                             started_at_unix_ms: span.started_at_unix_ms(),
                             finished_at_unix_ms: span.finished_at_unix_ms(),
-                            latency_us: span.duration_us_ref().unwrap_or(
-                                (span.finished_at_unix_ms() - span.started_at_unix_ms())
-                                    .saturating_mul(1000),
-                            ),
+                            latency_us: validated_duration_us(
+                                &span,
+                                options.strict_mode(),
+                                &mut warnings,
+                            )?,
                             success,
                         },
                         success_defaulted: matches!(success_field, OptionalField::Missing),
@@ -218,10 +222,11 @@ where
                         queue,
                         waited_from_unix_ms: span.started_at_unix_ms(),
                         waited_until_unix_ms: span.finished_at_unix_ms(),
-                        wait_us: span.duration_us_ref().unwrap_or(
-                            (span.finished_at_unix_ms() - span.started_at_unix_ms())
-                                .saturating_mul(1000),
-                        ),
+                        wait_us: validated_duration_us(
+                            &span,
+                            options.strict_mode(),
+                            &mut warnings,
+                        )?,
                         depth_at_start,
                     });
                 }
@@ -532,6 +537,36 @@ fn span_has_tailtriage_field(span: &SpanRecord) -> bool {
     span.fields().keys().any(|key| key.starts_with("tt."))
 }
 
+fn validated_duration_us(
+    span: &SpanRecord,
+    strict: bool,
+    warnings: &mut Vec<ImportWarning>,
+) -> Result<u64, ImportError> {
+    let derived_us = (span.finished_at_unix_ms() - span.started_at_unix_ms()).saturating_mul(1_000);
+    match span.duration_us_ref() {
+        None => Ok(derived_us),
+        Some(duration_us) => {
+            let delta = duration_us.abs_diff(derived_us);
+            if delta <= DURATION_TOLERANCE_US {
+                Ok(duration_us)
+            } else {
+                strict_or_warn(
+                    strict,
+                    warnings,
+                    format!(
+                        "duration_us mismatch for span '{}': duration_us={} derived_us={} tolerance_us={}",
+                        span.name(),
+                        duration_us,
+                        derived_us,
+                        DURATION_TOLERANCE_US
+                    ),
+                )?;
+                Ok(derived_us)
+            }
+        }
+    }
+}
+
 fn required_string(
     span: &SpanRecord,
     key: &'static str,
@@ -568,6 +603,7 @@ fn is_durable_conversion_warning(message: &str) -> bool {
         || message.starts_with("missing required field")
         || message.starts_with("invalid field")
         || message.starts_with("unknown tt.kind")
+        || message.starts_with("duration_us mismatch for span")
         || message.contains("missing optional 'tt.outcome'; assumed 'ok'")
         || message.contains("missing optional 'tt.success'; assumed true")
 }
@@ -1814,37 +1850,130 @@ mod tests {
     }
 
     #[test]
-    fn span_duration_us_is_used_for_stage_latency() {
+    fn contradictory_request_duration_warns_and_uses_derived_us_non_strict() {
+        let spans = vec![SpanRecord::new("req", 100, 110)
+            .duration_us(1)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests[0].latency_us, 10_000);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("duration_us mismatch for span 'req'")));
+        assert!(imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|w| w.contains("duration_us=1") && w.contains("derived_us=10000")));
+    }
+
+    #[test]
+    fn contradictory_stage_duration_warns_and_uses_derived_us_non_strict() {
         let spans = vec![
-            SpanRecord::new("req", 99, 101)
+            SpanRecord::new("req", 99, 120)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/"),
-            SpanRecord::new("stage", 100, 100)
-                .duration_us(123)
+            SpanRecord::new("stage", 100, 108)
+                .duration_us(1)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_STAGE, "db"),
         ];
-        let run = run_from_span_records(spans, ImportOptions::new("svc"))
-            .unwrap()
-            .run()
-            .clone();
-        assert_eq!(run.stages[0].latency_us, 123);
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().stages[0].latency_us, 8_000);
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("duration_us mismatch for span 'stage'")));
     }
 
     #[test]
-    fn span_duration_us_is_used_for_request_latency() {
-        let spans = vec![SpanRecord::new("req", 100, 100)
-            .duration_us(456)
+    fn contradictory_queue_duration_warns_and_uses_derived_us_non_strict() {
+        let spans = vec![
+            SpanRecord::new("req", 99, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/"),
+            SpanRecord::new("queue", 100, 107)
+                .duration_us(1)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().queues[0].wait_us, 7_000);
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("duration_us mismatch for span 'queue'")));
+    }
+
+    #[test]
+    fn strict_mode_rejects_contradictory_request_duration() {
+        let spans = vec![SpanRecord::new("req", 100, 110)
+            .duration_us(1)
             .field(TT_KIND, "request")
             .field(TT_REQUEST_ID, "r1")
             .field(TT_ROUTE, "/a")];
-        let run = run_from_span_records(spans, ImportOptions::new("svc"))
-            .unwrap()
-            .run()
-            .clone();
-        assert_eq!(run.requests[0].latency_us, 456);
+        assert!(matches!(
+            run_from_span_records(spans, ImportOptions::new("svc").strict(true)),
+            Err(ImportError::StrictViolation(message)) if message.contains("duration_us mismatch")
+        ));
+    }
+
+    #[test]
+    fn strict_mode_rejects_contradictory_stage_duration() {
+        let spans = vec![
+            SpanRecord::new("req", 99, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/"),
+            SpanRecord::new("stage", 100, 108)
+                .duration_us(1)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+        ];
+        assert!(matches!(
+            run_from_span_records(spans, ImportOptions::new("svc").strict(true)),
+            Err(ImportError::StrictViolation(message)) if message.contains("duration_us mismatch")
+        ));
+    }
+
+    #[test]
+    fn strict_mode_rejects_contradictory_queue_duration() {
+        let spans = vec![
+            SpanRecord::new("req", 99, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/"),
+            SpanRecord::new("queue", 100, 107)
+                .duration_us(1)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+        assert!(matches!(
+            run_from_span_records(spans, ImportOptions::new("svc").strict(true)),
+            Err(ImportError::StrictViolation(message)) if message.contains("duration_us mismatch")
+        ));
+    }
+
+    #[test]
+    fn duration_us_within_tolerance_is_accepted() {
+        let spans = vec![SpanRecord::new("req", 100, 110)
+            .duration_us(11_500)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests[0].latency_us, 11_500);
+        assert!(!imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("duration_us mismatch")));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Avoid internally contradictory Run artifacts when a span's explicit `duration_us` disagrees with its wall-clock timestamps by enforcing a clear reconciliation policy. 
- Ensure request latency, stage latency, and queue wait values are consistent and observable as durable lifecycle warnings when applicable. 
- Preserve monotonic recording behavior for live recorder spans while validating wall-clock mismatches at conversion time.

### Description
- Add `DURATION_TOLERANCE_US = 2_000` and a private helper `validated_duration_us(span, strict, warnings)` in `tailtriage-tracing/src/lib.rs` that derives `derived_us = (finished_at_unix_ms - started_at_unix_ms) * 1000`, uses `duration_us` if absent, accepts `duration_us` when within tolerance, and otherwise emits a named mismatch warning (non-strict) or returns `ImportError::StrictViolation` (strict).
- Replace direct `span.duration_us_ref().unwrap_or(...)` uses with `validated_duration_us` for `RequestEvent.latency_us`, `StageEvent.latency_us`, and `QueueEvent.wait_us` so the rule is applied consistently.
- Ensure mismatch warnings include span name, `duration_us`, `derived_us`, and the tolerance, and add them to `run.metadata.lifecycle_warnings` by updating durable warning detection (`is_durable_conversion_warning`).
- Update `tailtriage-tracing/README.md` documenting the 2_000µs tolerance and the strict/non-strict handling behavior.
- Update and add unit tests in `tailtriage-tracing` and JSONL tests to cover contradictory and within-tolerance cases, and leave live recorder duration recording unchanged (monotonic elapsed values remain the source while conversion validates wall-clock consistency).

### Testing
- Ran formatting check with `cargo fmt --check` and it passed. 
- Ran lints with `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed. 
- Ran the full test suite with `cargo test --workspace --all-targets --all-features --locked` and all tests passed. 
- Ran docs contract validation `python3 scripts/validate_docs_contracts.py` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12c20970548330b31905e162525ede)