### PR TITLE
Harden tracing import duration consistency with tolerance + strict enforcement

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -99,6 +99,7 @@ Ordinary tracing log JSON (for example `fmt().json` output) is rejected by impor
 
 - Strict mode: malformed/incomplete `tt.*` span records fail import/session conversion.
 - Non-strict mode: malformed/incomplete records are warned and skipped where implemented.
+- Duration consistency rule: conversion derives duration from wall-clock bounds as `(finished_at_unix_ms - started_at_unix_ms) * 1000`. If optional `duration_us` differs by more than `2_000` microseconds, non-strict conversion warns and uses the derived duration, while strict conversion fails.
 
 ## Retention and drop behavior
 
@@ -121,4 +122,3 @@ For `TracingTokioSession`, runtime snapshot retention also uses the same core ca
 
 - `tailtriage-tracing/examples/live_session_to_run.rs`
 - `tailtriage-tracing/examples/completed_span_jsonl_import.rs`
-

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -914,28 +914,31 @@ mod tests {
     }
 
     #[test]
-    fn normalized_duration_us_overrides_derived_latency() {
+    fn normalized_contradictory_duration_us_warns_and_uses_derived_latency() {
         let input = r#"
 {"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":1234,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
 {"span":{"name":"st","started_at_unix_ms":11,"finished_at_unix_ms":18,"duration_us":1234,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
 {"span":{"name":"q","started_at_unix_ms":10,"finished_at_unix_ms":11,"duration_us":1234,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":3}}}
 "#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests[0].latency_us, 1234);
-        assert_eq!(imported.run().stages[0].latency_us, 1234);
+        assert_eq!(imported.run().requests[0].latency_us, 10_000);
+        assert_eq!(imported.run().stages[0].latency_us, 7_000);
         assert_eq!(imported.run().queues[0].wait_us, 1234);
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("duration_us mismatch exceeds tolerance")));
     }
 
     #[test]
-    fn normalized_zero_duration_us_is_accepted_for_positive_timestamp_spans() {
+    fn normalized_zero_duration_us_outside_tolerance_uses_derived_latency() {
         let input = r#"
 {"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":0,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
 {"span":{"name":"st","started_at_unix_ms":11,"finished_at_unix_ms":18,"duration_us":0,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
 {"span":{"name":"q","started_at_unix_ms":10,"finished_at_unix_ms":11,"duration_us":0,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":3}}}
 "#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests[0].latency_us, 0);
-        assert_eq!(imported.run().stages[0].latency_us, 0);
+        assert_eq!(imported.run().requests[0].latency_us, 10_000);
+        assert_eq!(imported.run().stages[0].latency_us, 7_000);
         assert_eq!(imported.run().queues[0].wait_us, 0);
     }
 
@@ -1007,17 +1010,17 @@ mod tests {
     }
 
     #[test]
-    fn normalized_duration_us_from_outer_fields_still_overrides_derived_latency() {
+    fn normalized_duration_us_from_outer_fields_uses_derived_when_outside_tolerance() {
         let input = r#"{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":1234},"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/outer"}}"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests[0].latency_us, 1234);
+        assert_eq!(imported.run().requests[0].latency_us, 10_000);
     }
 
     #[test]
-    fn normalized_duration_us_from_top_level_tt_keys_still_overrides_derived_latency() {
+    fn normalized_duration_us_from_top_level_tt_keys_uses_derived_when_outside_tolerance() {
         let input = r#"{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":1234},"tt.kind":"request","tt.request_id":"r1","tt.route":"/top"}"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests[0].latency_us, 1234);
+        assert_eq!(imported.run().requests[0].latency_us, 10_000);
     }
 
     #[test]

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -165,10 +165,11 @@ where
                             kind: None,
                             started_at_unix_ms: span.started_at_unix_ms(),
                             finished_at_unix_ms: span.finished_at_unix_ms(),
-                            latency_us: span.duration_us_ref().unwrap_or(
-                                (span.finished_at_unix_ms() - span.started_at_unix_ms())
-                                    .saturating_mul(1000),
-                            ),
+                            latency_us: validated_duration_us(
+                                &span,
+                                options.strict_mode(),
+                                &mut warnings,
+                            )?,
                             outcome,
                         },
                         outcome_defaulted,
@@ -192,10 +193,11 @@ where
                             stage,
                             started_at_unix_ms: span.started_at_unix_ms(),
                             finished_at_unix_ms: span.finished_at_unix_ms(),
-                            latency_us: span.duration_us_ref().unwrap_or(
-                                (span.finished_at_unix_ms() - span.started_at_unix_ms())
-                                    .saturating_mul(1000),
-                            ),
+                            latency_us: validated_duration_us(
+                                &span,
+                                options.strict_mode(),
+                                &mut warnings,
+                            )?,
                             success,
                         },
                         success_defaulted: matches!(success_field, OptionalField::Missing),
@@ -218,10 +220,11 @@ where
                         queue,
                         waited_from_unix_ms: span.started_at_unix_ms(),
                         waited_until_unix_ms: span.finished_at_unix_ms(),
-                        wait_us: span.duration_us_ref().unwrap_or(
-                            (span.finished_at_unix_ms() - span.started_at_unix_ms())
-                                .saturating_mul(1000),
-                        ),
+                        wait_us: validated_duration_us(
+                            &span,
+                            options.strict_mode(),
+                            &mut warnings,
+                        )?,
                         depth_at_start,
                     });
                 }
@@ -562,12 +565,37 @@ fn required_string(
     }
 }
 
+fn validated_duration_us(
+    span: &SpanRecord,
+    strict: bool,
+    warnings: &mut Vec<ImportWarning>,
+) -> Result<u64, ImportError> {
+    const DURATION_TOLERANCE_US: u64 = 2_000;
+    let derived_us = (span.finished_at_unix_ms() - span.started_at_unix_ms()).saturating_mul(1000);
+    let Some(duration_us) = span.duration_us_ref() else {
+        return Ok(derived_us);
+    };
+    let diff_us = duration_us.abs_diff(derived_us);
+    if diff_us <= DURATION_TOLERANCE_US {
+        return Ok(duration_us);
+    }
+    let message = format!(
+        "span '{}' duration_us mismatch exceeds tolerance: duration_us={} derived_us={} tolerance_us={DURATION_TOLERANCE_US}",
+        span.name(),
+        duration_us,
+        derived_us
+    );
+    strict_or_warn(strict, warnings, message)?;
+    Ok(derived_us)
+}
+
 fn is_durable_conversion_warning(message: &str) -> bool {
     message.starts_with("skipped ")
         || message.starts_with("duplicate retained request_id")
         || message.starts_with("missing required field")
         || message.starts_with("invalid field")
         || message.starts_with("unknown tt.kind")
+        || message.contains("duration_us mismatch exceeds tolerance")
         || message.contains("missing optional 'tt.outcome'; assumed 'ok'")
         || message.contains("missing optional 'tt.success'; assumed true")
 }
@@ -1814,37 +1842,128 @@ mod tests {
     }
 
     #[test]
-    fn span_duration_us_is_used_for_stage_latency() {
+    fn contradictory_request_duration_warns_and_uses_derived_us_in_non_strict_mode() {
+        let spans = vec![SpanRecord::new("req", 100, 101)
+            .duration_us(50_000)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests[0].latency_us, 1_000);
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("duration_us mismatch exceeds tolerance")));
+        assert!(imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|w| w.contains("duration_us mismatch exceeds tolerance")));
+    }
+
+    #[test]
+    fn contradictory_stage_duration_warns_and_uses_derived_us_in_non_strict_mode() {
         let spans = vec![
             SpanRecord::new("req", 99, 101)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/"),
             SpanRecord::new("stage", 100, 100)
-                .duration_us(123)
+                .duration_us(9_999)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_STAGE, "db"),
         ];
-        let run = run_from_span_records(spans, ImportOptions::new("svc"))
-            .unwrap()
-            .run()
-            .clone();
-        assert_eq!(run.stages[0].latency_us, 123);
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().stages[0].latency_us, 0);
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("duration_us mismatch exceeds tolerance")));
     }
 
     #[test]
-    fn span_duration_us_is_used_for_request_latency() {
-        let spans = vec![SpanRecord::new("req", 100, 100)
-            .duration_us(456)
+    fn contradictory_queue_duration_warns_and_uses_derived_us_in_non_strict_mode() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 110)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("q", 101, 102)
+                .duration_us(99_000)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().queues[0].wait_us, 1_000);
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("duration_us mismatch exceeds tolerance")));
+    }
+
+    #[test]
+    fn strict_mode_rejects_contradictory_request_duration() {
+        let spans = vec![SpanRecord::new("req", 100, 101)
+            .duration_us(40_000)
             .field(TT_KIND, "request")
             .field(TT_REQUEST_ID, "r1")
             .field(TT_ROUTE, "/a")];
-        let run = run_from_span_records(spans, ImportOptions::new("svc"))
-            .unwrap()
-            .run()
-            .clone();
-        assert_eq!(run.requests[0].latency_us, 456);
+        assert!(matches!(
+            run_from_span_records(spans, ImportOptions::new("svc").strict(true)),
+            Err(ImportError::StrictViolation(_))
+        ));
+    }
+
+    #[test]
+    fn strict_mode_rejects_contradictory_stage_duration() {
+        let spans = vec![
+            SpanRecord::new("req", 99, 101)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/"),
+            SpanRecord::new("stage", 100, 100)
+                .duration_us(9_999)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+        ];
+        assert!(matches!(
+            run_from_span_records(spans, ImportOptions::new("svc").strict(true)),
+            Err(ImportError::StrictViolation(_))
+        ));
+    }
+
+    #[test]
+    fn strict_mode_rejects_contradictory_queue_duration() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 110)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("q", 101, 102)
+                .duration_us(99_000)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+        assert!(matches!(
+            run_from_span_records(spans, ImportOptions::new("svc").strict(true)),
+            Err(ImportError::StrictViolation(_))
+        ));
+    }
+
+    #[test]
+    fn duration_us_within_2000_microseconds_is_accepted() {
+        let spans = vec![SpanRecord::new("req", 100, 101)
+            .duration_us(2_999)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests[0].latency_us, 2_999);
+        assert!(!imported.warnings().iter().any(|w| w
+            .message()
+            .contains("duration_us mismatch exceeds tolerance")));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent inconsistent Run artifacts that can occur when an optional `duration_us` disagrees with the wall-clock timestamps on a span.  
- Make import behavior deterministic and auditable by deriving duration from timestamps and enforcing a bounded tolerance for `duration_us` overrides.  

### Description
- Add a private helper `validated_duration_us(span, strict, warnings)` in `tailtriage-tracing/src/lib.rs` that derives `derived_us = (finished_at_unix_ms - started_at_unix_ms) * 1000`, uses `derived_us` when `duration_us` is absent, accepts `duration_us` when within a `2_000` microsecond tolerance, warns and falls back to `derived_us` in non-strict mode when outside the tolerance, and returns `ImportError::StrictViolation` in strict mode.  
- Wire the helper into all three conversion branches so the same rule applies to `RequestEvent.latency_us`, `StageEvent.latency_us`, and `QueueEvent.wait_us`.  
- Ensure non-strict mismatch warnings name the span and include `duration_us`, `derived_us`, and the tolerance, and persist those warnings to `run.metadata.lifecycle_warnings` by updating the durable-warning classification (`is_durable_conversion_warning`).  
- Update `tailtriage-tracing/README.md` to document the 2_000 microsecond tolerance and conversion rule.  
- Add/adjust tests in `tailtriage-tracing` covering contradictory request/stage/queue durations (non-strict warns + uses derived), strict-mode rejections for contradictions, and acceptance when `duration_us` is within the 2_000 µs tolerance; update JSONL normalization tests to match the new rules.  

### Testing
- Added unit tests in `tailtriage-tracing` for contradictory durations and tolerance-edge cases and updated JSONL tests; the new tests exercise request/stage/queue conversion branches and strict vs non-strict behavior.  
- Ran repository validation and verification which all succeeded: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, and `python3 scripts/validate_docs_contracts.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12c20970548330b31905e162525ede)