### PR TITLE
Harden tracing duration import consistency

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -102,6 +102,9 @@ Ordinary tracing log JSON (for example `fmt().json` output) is rejected by impor
 
 ## Retention and drop behavior
 
+Duration fields are validated during conversion: `derived_us = (finished_at_unix_ms - started_at_unix_ms) * 1000`. If `duration_us` is absent, import uses `derived_us`. If `duration_us` differs by at most `2_000` microseconds, import keeps `duration_us`; otherwise non-strict mode warns and uses `derived_us`, while strict mode fails conversion.
+
+
 - `max_open_spans` bounds in-flight span tracking.
 - Completed-span JSONL streaming happens before in-memory completed-span retention is applied.
 - Warnings and lifecycle warnings indicate evidence may be incomplete when limits are hit or writer issues occur.

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -914,28 +914,28 @@ mod tests {
     }
 
     #[test]
-    fn normalized_duration_us_overrides_derived_latency() {
+    fn normalized_duration_us_beyond_tolerance_uses_derived_latency() {
         let input = r#"
 {"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":1234,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
 {"span":{"name":"st","started_at_unix_ms":11,"finished_at_unix_ms":18,"duration_us":1234,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
 {"span":{"name":"q","started_at_unix_ms":10,"finished_at_unix_ms":11,"duration_us":1234,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":3}}}
 "#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests[0].latency_us, 1234);
-        assert_eq!(imported.run().stages[0].latency_us, 1234);
-        assert_eq!(imported.run().queues[0].wait_us, 1234);
+        assert_eq!(imported.run().requests[0].latency_us, 10_000);
+        assert_eq!(imported.run().stages[0].latency_us, 7_000);
+        assert_eq!(imported.run().queues[0].wait_us, 1_234);
     }
 
     #[test]
-    fn normalized_zero_duration_us_is_accepted_for_positive_timestamp_spans() {
+    fn normalized_zero_duration_us_beyond_tolerance_uses_derived_latency() {
         let input = r#"
 {"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":0,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
 {"span":{"name":"st","started_at_unix_ms":11,"finished_at_unix_ms":18,"duration_us":0,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
 {"span":{"name":"q","started_at_unix_ms":10,"finished_at_unix_ms":11,"duration_us":0,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":3}}}
 "#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests[0].latency_us, 0);
-        assert_eq!(imported.run().stages[0].latency_us, 0);
+        assert_eq!(imported.run().requests[0].latency_us, 10_000);
+        assert_eq!(imported.run().stages[0].latency_us, 7_000);
         assert_eq!(imported.run().queues[0].wait_us, 0);
     }
 
@@ -1007,17 +1007,17 @@ mod tests {
     }
 
     #[test]
-    fn normalized_duration_us_from_outer_fields_still_overrides_derived_latency() {
+    fn normalized_duration_us_from_outer_fields_beyond_tolerance_uses_derived_latency() {
         let input = r#"{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":1234},"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/outer"}}"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests[0].latency_us, 1234);
+        assert_eq!(imported.run().requests[0].latency_us, 10_000);
     }
 
     #[test]
-    fn normalized_duration_us_from_top_level_tt_keys_still_overrides_derived_latency() {
+    fn normalized_duration_us_from_top_level_tt_keys_beyond_tolerance_uses_derived_latency() {
         let input = r#"{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":1234},"tt.kind":"request","tt.request_id":"r1","tt.route":"/top"}"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests[0].latency_us, 1234);
+        assert_eq!(imported.run().requests[0].latency_us, 10_000);
     }
 
     #[test]

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -165,10 +165,11 @@ where
                             kind: None,
                             started_at_unix_ms: span.started_at_unix_ms(),
                             finished_at_unix_ms: span.finished_at_unix_ms(),
-                            latency_us: span.duration_us_ref().unwrap_or(
-                                (span.finished_at_unix_ms() - span.started_at_unix_ms())
-                                    .saturating_mul(1000),
-                            ),
+                            latency_us: validated_duration_us(
+                                &span,
+                                options.strict_mode(),
+                                &mut warnings,
+                            )?,
                             outcome,
                         },
                         outcome_defaulted,
@@ -192,10 +193,11 @@ where
                             stage,
                             started_at_unix_ms: span.started_at_unix_ms(),
                             finished_at_unix_ms: span.finished_at_unix_ms(),
-                            latency_us: span.duration_us_ref().unwrap_or(
-                                (span.finished_at_unix_ms() - span.started_at_unix_ms())
-                                    .saturating_mul(1000),
-                            ),
+                            latency_us: validated_duration_us(
+                                &span,
+                                options.strict_mode(),
+                                &mut warnings,
+                            )?,
                             success,
                         },
                         success_defaulted: matches!(success_field, OptionalField::Missing),
@@ -218,10 +220,11 @@ where
                         queue,
                         waited_from_unix_ms: span.started_at_unix_ms(),
                         waited_until_unix_ms: span.finished_at_unix_ms(),
-                        wait_us: span.duration_us_ref().unwrap_or(
-                            (span.finished_at_unix_ms() - span.started_at_unix_ms())
-                                .saturating_mul(1000),
-                        ),
+                        wait_us: validated_duration_us(
+                            &span,
+                            options.strict_mode(),
+                            &mut warnings,
+                        )?,
                         depth_at_start,
                     });
                 }
@@ -342,6 +345,34 @@ where
     attach_durable_conversion_warnings(&mut run, &warnings);
 
     Ok(ImportedRun::new(run, warnings))
+}
+
+const DURATION_TOLERANCE_US: u64 = 2_000;
+
+fn validated_duration_us(
+    span: &SpanRecord,
+    strict: bool,
+    warnings: &mut Vec<ImportWarning>,
+) -> Result<u64, ImportError> {
+    let derived_us = (span.finished_at_unix_ms() - span.started_at_unix_ms()).saturating_mul(1000);
+    let Some(duration_us) = span.duration_us_ref() else {
+        return Ok(derived_us);
+    };
+
+    if duration_us.abs_diff(derived_us) <= DURATION_TOLERANCE_US {
+        return Ok(duration_us);
+    }
+
+    strict_or_warn(
+        strict,
+        warnings,
+        format!(
+            "span '{}' duration_us ({duration_us}) differs from derived_us ({derived_us}) beyond tolerance_us ({DURATION_TOLERANCE_US}); using derived_us",
+            span.name()
+        ),
+    )?;
+
+    Ok(derived_us)
 }
 
 #[derive(Clone, Copy)]
@@ -570,6 +601,7 @@ fn is_durable_conversion_warning(message: &str) -> bool {
         || message.starts_with("unknown tt.kind")
         || message.contains("missing optional 'tt.outcome'; assumed 'ok'")
         || message.contains("missing optional 'tt.success'; assumed true")
+        || message.contains("differs from derived_us")
 }
 
 fn attach_durable_conversion_warnings(run: &mut tailtriage_core::Run, warnings: &[ImportWarning]) {
@@ -1814,37 +1846,112 @@ mod tests {
     }
 
     #[test]
-    fn span_duration_us_is_used_for_stage_latency() {
+    fn contradictory_request_duration_warns_and_uses_derived_us_non_strict() {
+        let spans = vec![SpanRecord::new("req", 100, 101)
+            .duration_us(9_999)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests[0].latency_us, 1_000);
+        assert!(imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|w| w.contains("duration_us (9999)")
+                && w.contains("derived_us (1000)")
+                && w.contains("tolerance_us (2000)")));
+    }
+
+    #[test]
+    fn contradictory_stage_duration_warns_and_uses_derived_us_non_strict() {
         let spans = vec![
             SpanRecord::new("req", 99, 101)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/"),
-            SpanRecord::new("stage", 100, 100)
-                .duration_us(123)
+            SpanRecord::new("stage", 100, 101)
+                .duration_us(10_000)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_STAGE, "db"),
         ];
-        let run = run_from_span_records(spans, ImportOptions::new("svc"))
-            .unwrap()
-            .run()
-            .clone();
-        assert_eq!(run.stages[0].latency_us, 123);
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().stages[0].latency_us, 1_000);
     }
 
     #[test]
-    fn span_duration_us_is_used_for_request_latency() {
-        let spans = vec![SpanRecord::new("req", 100, 100)
-            .duration_us(456)
+    fn contradictory_queue_duration_warns_and_uses_derived_us_non_strict() {
+        let spans = vec![
+            SpanRecord::new("req", 99, 101)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/"),
+            SpanRecord::new("queue", 100, 101)
+                .duration_us(10_000)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().queues[0].wait_us, 1_000);
+    }
+
+    #[test]
+    fn strict_mode_rejects_contradictory_request_duration() {
+        let spans = vec![SpanRecord::new("req", 100, 101)
+            .duration_us(9_999)
             .field(TT_KIND, "request")
             .field(TT_REQUEST_ID, "r1")
             .field(TT_ROUTE, "/a")];
-        let run = run_from_span_records(spans, ImportOptions::new("svc"))
-            .unwrap()
-            .run()
-            .clone();
-        assert_eq!(run.requests[0].latency_us, 456);
+        let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn strict_mode_rejects_contradictory_stage_duration() {
+        let spans = vec![
+            SpanRecord::new("req", 99, 101)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/"),
+            SpanRecord::new("stage", 100, 101)
+                .duration_us(10_000)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+        ];
+        let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn strict_mode_rejects_contradictory_queue_duration() {
+        let spans = vec![
+            SpanRecord::new("req", 99, 101)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/"),
+            SpanRecord::new("queue", 100, 101)
+                .duration_us(10_000)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+        let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn duration_us_within_2000_microseconds_is_accepted() {
+        let spans = vec![SpanRecord::new("req", 100, 101)
+            .duration_us(2_999)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests[0].latency_us, 2_999);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Prevent internally contradictory Run artifacts when a span-provided `duration_us` disagrees with wall-clock timestamps by reconciling the two sources deterministically and consistently.

### Description

- Add `DURATION_TOLERANCE_US = 2_000` and a private helper `validated_duration_us(span, strict, warnings)` in `tailtriage-tracing/src/lib.rs` that computes `derived_us = (finished_at_unix_ms - started_at_unix_ms) * 1000` and applies the tolerance/strict rules when `duration_us` is present.
- Use the helper for `RequestEvent.latency_us`, `StageEvent.latency_us`, and `QueueEvent.wait_us` so all three conversion branches follow the same logic (`run_from_span_records` conversion updated to call `validated_duration_us`).
- Emit a non-strict warning containing the span name, `duration_us`, `derived_us`, and the tolerance when the mismatch exceeds the tolerance, and make those warnings durable by updating `is_durable_conversion_warning` and reusing `attach_durable_conversion_warnings`.
- Document the 2,000 microsecond tolerance and behavior in `tailtriage-tracing/README.md` and update JSONL-related tests to reflect the new semantics (tests in `tailtriage-tracing/src/lib.rs` and `tailtriage-tracing/src/jsonl.rs`).

### Testing

- Ran formatting check: `cargo fmt --check` (passed).
- Ran linting: `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (passed).
- Ran unit/integration tests: `cargo test --workspace --all-targets --all-features --locked` and targeted tracing tests (passed); new/updated tests verify non-strict warnings + derived fallback for request/stage/queue, strict-mode rejections, and acceptance within the `2_000` microsecond tolerance.
- Ran docs contract validator: `python3 scripts/validate_docs_contracts.py` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12c20970548330b31905e162525ede)