### PR TITLE
Use core RunSink path for `import tracing-json` output writes

### DIFF
--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -5,7 +5,7 @@ use clap::{Parser, ValueEnum};
 use tailtriage_analyzer::{render_json_pretty, render_text, try_analyze_run};
 use tailtriage_cli::artifact::load_run_artifact;
 use tailtriage_cli::{analyzer_options_help_text, build_analyze_options};
-use tailtriage_core::{CaptureLimitsOverride, CaptureMode};
+use tailtriage_core::{CaptureLimitsOverride, CaptureMode, LocalJsonSink, RunSink};
 use tailtriage_tracing::{
     ensure_persistable_run_has_requests, import_jsonl_path_with_mode, ImportOptions, JsonlParseMode,
 };
@@ -169,8 +169,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 ensure_persistable_run_has_requests(imported.run())?;
 
-                let file = std::fs::File::create(&output)?;
-                serde_json::to_writer_pretty(file, imported.run())?;
+                LocalJsonSink::new(&output).write(imported.run())?;
             }
         },
         Command::Analyze {


### PR DESCRIPTION
### Motivation
- Prevent partial/truncated run artifacts when importing tracing JSON by reusing the robust core writer used by native capture instead of creating and writing the file directly from the CLI.

### Description
- Replace direct `File::create` + `serde_json::to_writer_pretty` in the `tailtriage import tracing-json` path with `tailtriage_core::LocalJsonSink::new(&output).write(imported.run())` and import `LocalJsonSink` and `RunSink` so the `write` method is available.
- Preserve `ensure_persistable_run_has_requests(imported.run())` before writing and keep warnings printed to stderr and stdout empty on success.

### Testing
- Ran `cargo fmt --check` and it succeeded.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it succeeded.
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests passed, including the CLI boundary tests covering import behavior and the `import_tracing_json_accepts_paths_with_spaces` case.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12cf513ee48330b50fe42b17eb451b)