### PR TITLE
CLI: Use LocalJsonSink to write imported Run JSON

### DIFF
--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -5,7 +5,7 @@ use clap::{Parser, ValueEnum};
 use tailtriage_analyzer::{render_json_pretty, render_text, try_analyze_run};
 use tailtriage_cli::artifact::load_run_artifact;
 use tailtriage_cli::{analyzer_options_help_text, build_analyze_options};
-use tailtriage_core::{CaptureLimitsOverride, CaptureMode};
+use tailtriage_core::{CaptureLimitsOverride, CaptureMode, LocalJsonSink, RunSink};
 use tailtriage_tracing::{
     ensure_persistable_run_has_requests, import_jsonl_path_with_mode, ImportOptions, JsonlParseMode,
 };
@@ -169,8 +169,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 ensure_persistable_run_has_requests(imported.run())?;
 
-                let file = std::fs::File::create(&output)?;
-                serde_json::to_writer_pretty(file, imported.run())?;
+                LocalJsonSink::new(&output).write(imported.run())?;
             }
         },
         Command::Analyze {


### PR DESCRIPTION
### Motivation
- Prevent partial/truncated run artifacts when importing tracing JSON by using the same robust core writer path as native capture instead of `File::create` + `serde_json::to_writer_pretty`.

### Description
- Replace the direct `File::create(&output)` + `serde_json::to_writer_pretty(...)` write in the `tailtriage import tracing-json` flow with `LocalJsonSink::new(&output).write(imported.run())` in `tailtriage-cli/src/main.rs`.
- Import `LocalJsonSink` and the `RunSink` trait from `tailtriage_core` so `write(...)` is available.
- Preserve the pre-write guard `ensure_persistable_run_has_requests(imported.run())` and the existing stderr warning emission, and keep stdout empty on success.

### Testing
- Ran `cargo fmt --check` which succeeded.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which succeeded.
- Ran `cargo test --workspace --all-targets --all-features --locked`; most tests including the CLI boundary tests (notably `import_tracing_json_accepts_paths_with_spaces`) passed, but the full test run failed due to an unrelated existing failing test `tailtriage-tracing::recorder::tests::intake_session_captures_request_stage_queue`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12cf513ee48330b50fe42b17eb451b)