### PR TITLE
Use robust core sink for `tailtriage import tracing-json` artifact writes

### DIFF
--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -5,7 +5,7 @@ use clap::{Parser, ValueEnum};
 use tailtriage_analyzer::{render_json_pretty, render_text, try_analyze_run};
 use tailtriage_cli::artifact::load_run_artifact;
 use tailtriage_cli::{analyzer_options_help_text, build_analyze_options};
-use tailtriage_core::{CaptureLimitsOverride, CaptureMode};
+use tailtriage_core::{CaptureLimitsOverride, CaptureMode, LocalJsonSink, RunSink};
 use tailtriage_tracing::{
     ensure_persistable_run_has_requests, import_jsonl_path_with_mode, ImportOptions, JsonlParseMode,
 };
@@ -169,8 +169,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 ensure_persistable_run_has_requests(imported.run())?;
 
-                let file = std::fs::File::create(&output)?;
-                serde_json::to_writer_pretty(file, imported.run())?;
+                LocalJsonSink::new(&output).write(imported.run())?;
             }
         },
         Command::Analyze {

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -251,6 +251,33 @@ fn import_tracing_json_writes_run_json_analyzable_by_existing_apis() {
 }
 
 #[test]
+fn import_tracing_json_accepts_output_path_with_spaces() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run artifact with spaces.json");
+    std::fs::write(&spans_path, complete_span_jsonl_fixture()).expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+
+    assert!(output.status.success(), "cli failed: {output:?}");
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
+        .expect("imported run should load from path with spaces");
+    let report = analyze_run(&loaded.run, AnalyzeOptions::default());
+    assert_eq!(report.request_count, 1);
+}
+
+#[test]
 fn import_tracing_json_mode_investigation_sets_run_metadata_mode() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");


### PR DESCRIPTION
### Motivation
- Prevent possible truncation/partial-file artifacts when the CLI imports runs by reusing the same robust core writer used by native capture rather than writing with `File::create` + `serde_json::to_writer_pretty`.
- Keep the CLI import persistence semantics aligned with the core capture path so import artifacts are written atomically and consistently.

### Description
- Replaced the direct `File::create` + `serde_json::to_writer_pretty` write in `tailtriage-cli/src/main.rs` with `LocalJsonSink::new(&output).write(imported.run())` to use the core sink API.
- Brought `LocalJsonSink` and `RunSink` into scope via `use tailtriage_core::{..., LocalJsonSink, RunSink};` so the `write` method resolves.
- Preserved existing flow: `ensure_persistable_run_has_requests(imported.run())` still runs before writing and warnings are printed to stderr prior to the write, and successful import still emits no stdout.
- Added a focused CLI boundary test in `tailtriage-cli/tests/cli_boundary.rs` to confirm import succeeds when the output path contains spaces and re-ran the existing import-related CLI tests.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed with no warnings.
- Ran `cargo test --workspace --all-targets --all-features --locked` and the full test suite passed, including the updated CLI boundary tests (all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12cf3f88d883308cf22b1e8e610421)