### PR TITLE
Align completed-span JSONL output with retained shutdown run

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -162,7 +162,7 @@ Analyzer configuration contract:
 
 - primary live path is `TracingIntakeSession` / `TracingIntakeSessionBuilder`; users add `session.layer()` beside their existing `tracing_subscriber` setup
 - live session output can write standard Run JSON on shutdown via `run_json_path(...)`
-- live session output can stream stable completed-span JSONL as spans close via `completed_span_jsonl_path(...)`
+- live session output can write stable completed-span JSONL on shutdown via `completed_span_jsonl_path(...)`, using retained semantically valid request/stage/queue evidence
 - stable completed-span JSONL wrapper format is:
   `{"format":"tailtriage.tracing-span.v1","span":{...}}`
 - CLI imports that wrapper shape with:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -503,9 +503,9 @@ Do not treat one report as final proof.
 - Persisted Run JSON artifacts intended for `tailtriage analyze` require at least one completed request event.
 - Library snapshots may still be zero-request when used for non-persisted inspection during active captures.
 - Completed-span JSONL can grow with captured completed spans; size outputs accordingly.
-- `completed_span_jsonl_path(...)` output files are created or truncated when the session is built.
+- `completed_span_jsonl_path(...)` output files are created/truncated and written at shutdown.
 - Configure `max_open_spans`` to keep memory bounded.
-- Completed-span JSONL streaming happens before in-memory core CaptureLimits retention, so the file can preserve spans beyond in-memory retained completed spans.
+- Completed-span JSONL is written from retained, semantically valid request/stage/queue evidence in the finalized Run, so the file reflects Run retention rather than a pre-retention stream.
 - Import warnings and lifecycle warnings mean evidence may be incomplete and should be treated as triage caveats.
 - Tracing import and native capture share `CaptureMode` and `CaptureLimits` semantics for request/stage/queue retention. Offline CLI tracing import exposes only request/stage/queue limit overrides because those are the evidence types imported on this path; runtime/in-flight snapshot limit flags are intentionally not exposed because these evidence types are not imported. Tracing-only runs do not fabricate runtime snapshots; runtime-pressure evidence remains Tokio-specific and requires runtime snapshots/Tokio sampler coupling.
 - Treat tracing-import output like all tailtriage output: evidence-ranked suspects and next checks are leads, not proof of root cause.

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -4,7 +4,7 @@
 
 It helps existing `tracing` users produce standard `tailtriage_core::Run` artifacts by:
 - writing Run JSON on shutdown, and/or
-- streaming stable completed-span JSONL as spans close.
+- writing retained, semantically valid completed-span JSONL on shutdown.
 
 It is **not**:
 - an observability backend,
@@ -104,7 +104,7 @@ Ordinary tracing log JSON (for example `fmt().json` output) is rejected by impor
 ## Retention and drop behavior
 
 - `max_open_spans` bounds in-flight span tracking.
-- Completed-span JSONL streaming happens before in-memory completed-span retention is applied.
+- Completed-span JSONL is written on shutdown from the same retained, semantically valid request/stage/queue evidence present in the finalized imported Run.
 - Warnings and lifecycle warnings indicate evidence may be incomplete when limits are hit or writer issues occur.
 
 ## Runtime-pressure limitation

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -1,8 +1,7 @@
 use std::collections::BTreeMap;
 use std::fmt;
 use std::fmt::Write as _;
-use std::fs::OpenOptions;
-use std::io::{BufWriter, Write};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -40,6 +39,7 @@ pub struct TracingRecorder {
 #[derive(Debug, Clone)]
 pub struct TracingIntakeSession {
     recorder: TracingRecorder,
+    completed_span_jsonl_path: Option<PathBuf>,
     run_json_path: Option<PathBuf>,
 }
 /// Builder for [`TracingIntakeSession`].
@@ -100,8 +100,6 @@ struct RecorderState {
     closed_malformed_kind_spans: u64,
     closed_kind_samples: Vec<ClosedKindIssueSample>,
     writer_failure: Option<String>,
-    completed_span_writer_path: Option<PathBuf>,
-    completed_span_writer: Option<BufWriter<std::fs::File>>,
 }
 
 #[derive(Debug)]
@@ -176,7 +174,6 @@ impl TracingRecorder {
     ///
     /// Returns [`ImportError`] when strict conversion fails.
     pub fn snapshot_run(&self) -> Result<ImportedRun, ImportError> {
-        self.flush_completed_span_writer()?;
         let (spans, stats) = {
             let state = lock_state(&self.state);
             let mut samples = Vec::new();
@@ -210,31 +207,6 @@ impl TracingRecorder {
             )
         };
         imported_with_drop_warnings(spans, self.options.clone(), &stats, self.limits)
-    }
-
-    fn flush_completed_span_writer(&self) -> Result<(), ImportError> {
-        let mut state = lock_state(&self.state);
-        if let Some(writer) = state.completed_span_writer.as_mut() {
-            if let Err(err) = writer.flush() {
-                let msg = format_writer_failure(
-                    "flush",
-                    state.completed_span_writer_path.as_deref(),
-                    &err,
-                );
-                state.writer_failure = Some(msg.clone());
-                if self.options.strict_mode() {
-                    return Err(ImportError::Io {
-                        operation: "flush completed span jsonl writer",
-                        context: state.completed_span_writer_path.as_ref().map_or_else(
-                            || "completed-span-jsonl".to_owned(),
-                            |p| p.display().to_string(),
-                        ),
-                        reason: err.to_string(),
-                    });
-                }
-            }
-        }
-        Ok(())
     }
 
     /// Consumes this recorder handle and returns a final imported run snapshot.
@@ -303,18 +275,112 @@ impl TracingIntakeSession {
     ///
     /// Returns an error when conversion fails or when configured run-json output cannot be written.
     pub fn shutdown(self) -> Result<ImportedRun, ImportError> {
+        let strict_mode = self.recorder.options.strict_mode();
         let imported = self.recorder.shutdown()?;
+        let (mut run, mut warnings) = imported.into_parts();
+        if let Some(path) = &self.completed_span_jsonl_path {
+            if let Err(err) = write_completed_span_jsonl_from_run(&run, path) {
+                if strict_mode {
+                    return Err(err);
+                }
+                let msg = err.to_string();
+                run.metadata.lifecycle_warnings.push(msg.clone());
+                warnings.push(crate::ImportWarning::new(msg));
+            }
+        }
         if let Some(path) = self.run_json_path {
-            ensure_persistable_run_has_requests(imported.run())?;
+            ensure_persistable_run_has_requests(&run)?;
             LocalJsonSink::new(&path)
-                .write(imported.run())
+                .write(&run)
                 .map_err(|err| ImportError::RunJsonWrite {
                     path: path.display().to_string(),
                     reason: err.to_string(),
                 })?;
         }
-        Ok(imported)
+        Ok(ImportedRun::new(run, warnings))
     }
+}
+
+fn write_completed_span_jsonl_from_run(
+    run: &tailtriage_core::Run,
+    path: &Path,
+) -> Result<(), ImportError> {
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(path)
+        .map_err(|err| ImportError::Io {
+            operation: "open completed span jsonl path",
+            context: path.display().to_string(),
+            reason: err.to_string(),
+        })?;
+    for span in retained_span_records_from_run(run) {
+        let wrapped = serde_json::json!({ "format": "tailtriage.tracing-span.v1", "span": span });
+        serde_json::to_writer(&mut file, &wrapped).map_err(|err| ImportError::Io {
+            operation: "write completed span jsonl record",
+            context: path.display().to_string(),
+            reason: err.to_string(),
+        })?;
+        file.write_all(b"\n").map_err(|err| ImportError::Io {
+            operation: "write completed span jsonl newline",
+            context: path.display().to_string(),
+            reason: err.to_string(),
+        })?;
+    }
+    file.flush().map_err(|err| ImportError::Io {
+        operation: "flush completed span jsonl file",
+        context: path.display().to_string(),
+        reason: err.to_string(),
+    })?;
+    Ok(())
+}
+
+fn retained_span_records_from_run(run: &tailtriage_core::Run) -> Vec<SpanRecord> {
+    let mut spans = Vec::new();
+    for req in &run.requests {
+        let span = SpanRecord::new(
+            "tt.request",
+            req.started_at_unix_ms,
+            req.finished_at_unix_ms,
+        )
+        .duration_us(req.latency_us)
+        .field("tt.kind", "request")
+        .field("tt.request_id", req.request_id.clone())
+        .field("tt.route", req.route.clone())
+        .field("tt.outcome", req.outcome.clone());
+        spans.push(span);
+    }
+    for stage in &run.stages {
+        spans.push(
+            SpanRecord::new(
+                "tt.stage",
+                stage.started_at_unix_ms,
+                stage.finished_at_unix_ms,
+            )
+            .duration_us(stage.latency_us)
+            .field("tt.kind", "stage")
+            .field("tt.request_id", stage.request_id.clone())
+            .field("tt.stage", stage.stage.clone())
+            .field("tt.success", stage.success),
+        );
+    }
+    for queue in &run.queues {
+        let mut span = SpanRecord::new(
+            "tt.queue",
+            queue.waited_from_unix_ms,
+            queue.waited_until_unix_ms,
+        )
+        .duration_us(queue.wait_us)
+        .field("tt.kind", "queue")
+        .field("tt.request_id", queue.request_id.clone())
+        .field("tt.queue", queue.queue.clone());
+        if let Some(depth) = queue.depth_at_start {
+            span = span.field("tt.depth_at_start", depth);
+        }
+        spans.push(span);
+    }
+    spans
 }
 impl TracingIntakeSessionBuilder {
     /// Enables or disables strict mode for conversion warnings.
@@ -378,8 +444,7 @@ impl TracingIntakeSessionBuilder {
     }
     /// Enables completed-span JSONL output at the given path.
     ///
-    /// Writes completed spans as spans close using the stable wrapper shape.
-    /// The file is created or truncated when the session is built.
+    /// Writes retained valid completed spans on shutdown using the stable wrapper shape.
     #[must_use]
     pub fn completed_span_jsonl_path(mut self, path: impl AsRef<Path>) -> Self {
         self.completed_span_jsonl_path = Some(path.as_ref().to_path_buf());
@@ -398,23 +463,9 @@ impl TracingIntakeSessionBuilder {
     /// Returns an error when the completed-span JSONL path cannot be opened.
     pub fn build(self) -> Result<TracingIntakeSession, ImportError> {
         let recorder = self.recorder_builder.build();
-        if let Some(path) = self.completed_span_jsonl_path {
-            let file = OpenOptions::new()
-                .create(true)
-                .write(true)
-                .truncate(true)
-                .open(&path)
-                .map_err(|err| ImportError::Io {
-                    operation: "open completed span jsonl path",
-                    context: path.display().to_string(),
-                    reason: err.to_string(),
-                })?;
-            let mut state = lock_state(&recorder.state);
-            state.completed_span_writer = Some(BufWriter::new(file));
-            state.completed_span_writer_path = Some(path);
-        }
         Ok(TracingIntakeSession {
             recorder,
+            completed_span_jsonl_path: self.completed_span_jsonl_path,
             run_json_path: self.run_json_path,
         })
     }
@@ -569,31 +620,6 @@ where
             for (k, v) in open.fields {
                 record = record.field(k, v);
             }
-            if let Some(writer) = state.completed_span_writer.as_mut() {
-                let wrapped = serde_json::json!({
-                    "format": "tailtriage.tracing-span.v1",
-                    "span": record,
-                });
-                match serde_json::to_writer(&mut *writer, &wrapped) {
-                    Ok(()) => match writer.write_all(b"\n") {
-                        Ok(()) => {}
-                        Err(err) => {
-                            state.writer_failure = Some(format_writer_failure(
-                                "write newline",
-                                state.completed_span_writer_path.as_deref(),
-                                &err,
-                            ));
-                        }
-                    },
-                    Err(err) => {
-                        state.writer_failure = Some(format_writer_failure(
-                            "write span record",
-                            state.completed_span_writer_path.as_deref(),
-                            &err,
-                        ));
-                    }
-                }
-            }
             if state.completed.len() >= self.limits.max_completed_candidate_spans {
                 state.dropped_completed_candidate_spans =
                     state.dropped_completed_candidate_spans.saturating_add(1);
@@ -647,14 +673,6 @@ fn metadata_has_tailtriage_field(metadata: &tracing::Metadata<'_>) -> bool {
         .any(|f| f.name().starts_with("tt."))
 }
 
-fn format_writer_failure(
-    operation: &str,
-    path: Option<&Path>,
-    err: &dyn std::error::Error,
-) -> String {
-    let path_text = path.map_or_else(|| "<unknown>".to_owned(), |p| p.display().to_string());
-    format!("completed-span JSONL writer failed to {operation} at {path_text}: {err}")
-}
 fn fields_have_tailtriage_key(fields: &BTreeMap<String, FieldValue>) -> bool {
     fields.keys().any(|k| k.starts_with("tt."))
 }
@@ -2066,14 +2084,16 @@ mod tests {
             );
             drop(span);
         });
-        session.snapshot_run().unwrap();
+        assert!(session.snapshot_run().is_ok());
+        assert!(!spans_path.exists());
+        let _ = session.shutdown().unwrap();
         let raw = std::fs::read_to_string(&spans_path).unwrap();
         let lines: Vec<_> = raw.lines().filter(|l| !l.trim().is_empty()).collect();
         assert_eq!(lines.len(), 1);
         let value: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
         assert_eq!(value["format"], "tailtriage.tracing-span.v1");
         assert!(value["span"].is_object());
-        assert_eq!(value["span"]["name"], "request");
+        assert_eq!(value["span"]["name"], "tt.request");
         assert!(value["span"]["started_at_unix_ms"].is_number());
         assert!(value["span"]["finished_at_unix_ms"].is_number());
         assert!(value["span"]["duration_us"].is_number());
@@ -2093,7 +2113,7 @@ mod tests {
     }
 
     #[test]
-    fn streaming_jsonl_is_independent_of_in_memory_completed_retention() {
+    fn completed_jsonl_matches_retained_run_counts() {
         let dir = tempfile::tempdir().unwrap();
         let spans_path = dir.path().join("spans.jsonl");
         let session = TracingIntakeSession::builder("svc")
@@ -2124,34 +2144,28 @@ mod tests {
         let snapshot = session.snapshot_run().unwrap();
         assert_eq!(snapshot.run().requests.len(), 1);
         assert_eq!(snapshot.run().truncation.dropped_requests, 1);
-        let raw = std::fs::read_to_string(&spans_path).unwrap();
-        let lines: Vec<_> = raw.lines().filter(|l| !l.trim().is_empty()).collect();
-        assert_eq!(lines.len(), 2);
+        session.shutdown().unwrap();
         let imported = crate::jsonl::import_jsonl_path_with_mode(
             &spans_path,
             ImportOptions::new("svc"),
             crate::jsonl::JsonlParseMode::TailtriageWrapperOnly,
         )
         .unwrap();
-        assert_eq!(imported.run().requests.len(), 2);
-        let ids: Vec<_> = imported
-            .run()
-            .requests
-            .iter()
-            .map(|r| r.request_id.as_str())
-            .collect();
-        assert!(ids.contains(&"r1"));
-        assert!(ids.contains(&"r2"));
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().stages.len(), 0);
+        assert_eq!(imported.run().queues.len(), 0);
     }
 
     #[test]
-    fn intake_session_build_writer_open_failure_returns_io() {
+    fn intake_session_write_failure_returns_io_on_shutdown() {
         let dir = tempfile::tempdir().unwrap();
         let bad_path = dir.path().join("missing").join("spans.jsonl");
-        let err = TracingIntakeSession::builder("svc")
+        let session = TracingIntakeSession::builder("svc")
             .completed_span_jsonl_path(&bad_path)
+            .strict(true)
             .build()
-            .unwrap_err();
+            .unwrap();
+        let err = session.shutdown().unwrap_err();
         assert!(matches!(err, ImportError::Io { .. }));
         assert!(err.to_string().contains("spans.jsonl"));
     }
@@ -2235,17 +2249,67 @@ mod tests {
     }
 
     #[test]
+    fn completed_jsonl_excludes_malformed_and_orphan_stage_queue_spans() {
+        let dir = tempfile::tempdir().unwrap();
+        let spans_path = dir.path().join("spans.jsonl");
+        let session = TracingIntakeSession::builder("svc")
+            .completed_span_jsonl_path(&spans_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "bad-kind",
+                tt.kind = tracing::field::Empty,
+                tt.request_id = "bad-1",
+                tt.route = "/bad"
+            ));
+            drop(tracing::info_span!(
+                "orphan-stage",
+                tt.kind = "stage",
+                tt.request_id = "missing-req",
+                tt.stage = "db",
+                tt.success = true
+            ));
+            drop(tracing::info_span!(
+                "orphan-queue",
+                tt.kind = "queue",
+                tt.request_id = "missing-req",
+                tt.queue = "permits"
+            ));
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/ok",
+                tt.outcome = "ok"
+            ));
+        });
+        let _ = session.shutdown().unwrap();
+        let imported = crate::jsonl::import_jsonl_path_with_mode(
+            &spans_path,
+            ImportOptions::new("svc"),
+            crate::jsonl::JsonlParseMode::TailtriageWrapperOnly,
+        )
+        .unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().stages.len(), 0);
+        assert_eq!(imported.run().queues.len(), 0);
+    }
+
+    #[test]
     fn intake_session_captures_request_stage_queue() {
         let session = TracingIntakeSession::builder("svc").build().unwrap();
         let subscriber = tracing_subscriber::registry().with(session.layer());
         tracing::subscriber::with_default(subscriber, || {
-            drop(tracing::info_span!(
+            let req = tracing::info_span!(
                 "request",
                 tt.kind = "request",
                 tt.request_id = "req-1",
                 tt.route = "/checkout",
                 tt.outcome = "ok"
-            ));
+            );
+            let req_guard = req.enter();
             drop(tracing::info_span!(
                 "stage",
                 tt.kind = "stage",
@@ -2260,6 +2324,7 @@ mod tests {
                 tt.queue = "admission",
                 tt.depth_at_start = 7_u64
             ));
+            drop(req_guard);
         });
         let snapshot = session.snapshot_run().unwrap();
         let run = snapshot.run();

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -99,7 +99,6 @@ struct RecorderState {
     closed_unknown_kind_spans: u64,
     closed_malformed_kind_spans: u64,
     closed_kind_samples: Vec<ClosedKindIssueSample>,
-    writer_failure: Option<String>,
 }
 
 #[derive(Debug)]
@@ -139,7 +138,6 @@ struct SnapshotStats {
     closed_unknown_kind_spans: u64,
     closed_malformed_kind_spans: u64,
     closed_kind_samples: Vec<ClosedKindIssueSample>,
-    writer_failure: Option<String>,
 }
 fn lock_state(state: &Arc<Mutex<RecorderState>>) -> std::sync::MutexGuard<'_, RecorderState> {
     match state.lock() {
@@ -202,7 +200,6 @@ impl TracingRecorder {
                     closed_unknown_kind_spans: state.closed_unknown_kind_spans,
                     closed_malformed_kind_spans: state.closed_malformed_kind_spans,
                     closed_kind_samples: state.closed_kind_samples.clone(),
-                    writer_failure: state.writer_failure.clone(),
                 },
             )
         };
@@ -456,11 +453,11 @@ impl TracingIntakeSessionBuilder {
         self.run_json_path = Some(path.as_ref().to_path_buf());
         self
     }
-    /// Builds a tracing intake session and opens optional outputs.
+    /// Builds a tracing intake session.
     ///
     /// # Errors
     ///
-    /// Returns an error when the completed-span JSONL path cannot be opened.
+    /// Returns an error when required recorder configuration is invalid.
     pub fn build(self) -> Result<TracingIntakeSession, ImportError> {
         let recorder = self.recorder_builder.build();
         Ok(TracingIntakeSession {
@@ -718,11 +715,6 @@ fn push_strict_recorder_messages(
             stats.dropped_completed_candidate_spans, limits.max_completed_candidate_spans
         ));
     }
-    if let Some(reason) = &stats.writer_failure {
-        messages.push(format!(
-            "live recorder failed writing completed-span JSONL output: {reason}"
-        ));
-    }
 }
 
 fn append_non_strict_drop_warnings(
@@ -807,11 +799,6 @@ fn append_non_strict_drop_warnings(
     if stats.dropped_open_spans > 0 || stats.dropped_completed_candidate_spans > 0 {
         run.truncation.limits_hit = true;
     }
-    if let Some(reason) = &stats.writer_failure {
-        let msg = format!("live recorder failed writing completed-span JSONL output: {reason}");
-        run.metadata.lifecycle_warnings.push(msg.clone());
-        warnings.push(crate::ImportWarning::new(msg));
-    }
 }
 
 fn imported_with_drop_warnings(
@@ -844,7 +831,6 @@ fn imported_with_drop_warnings(
         && stats.closed_missing_kind_spans == 0
         && stats.closed_unknown_kind_spans == 0
         && stats.closed_malformed_kind_spans == 0
-        && stats.writer_failure.is_none()
     {
         return Ok(imported);
     }
@@ -2168,6 +2154,49 @@ mod tests {
         let err = session.shutdown().unwrap_err();
         assert!(matches!(err, ImportError::Io { .. }));
         assert!(err.to_string().contains("spans.jsonl"));
+    }
+
+    #[test]
+    fn intake_session_non_strict_write_failure_adds_warning_and_keeps_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let bad_path = dir.path().join("missing").join("spans.jsonl");
+        let session = TracingIntakeSession::builder("svc")
+            .completed_span_jsonl_path(&bad_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/ok"
+            ));
+        });
+
+        let imported = session.shutdown().unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].request_id, "r1");
+
+        let warning = imported
+            .warnings()
+            .iter()
+            .map(crate::ImportWarning::message)
+            .find(|m| m.contains("completed span jsonl") || m.contains("spans.jsonl"))
+            .expect("non-strict shutdown should include completed-span JSONL write warning");
+        assert!(
+            warning.contains("completed span jsonl") || warning.contains("spans.jsonl"),
+            "warning should contain completed-span JSONL context: {warning}"
+        );
+        assert!(
+            imported
+                .run()
+                .metadata
+                .lifecycle_warnings
+                .iter()
+                .any(|m| m == warning),
+            "lifecycle warnings should contain the same completed-span JSONL write warning"
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Prevent completed-span JSONL from containing pre-retention spans that are absent from the final imported `Run`, which confused users when both `completed_span_jsonl_path` and `run_json_path` were configured.
- Ensure the JSONL is replayable and matches the semantically retained request/stage/queue evidence present in the finalized `Run`.

### Description

- Removed streaming writes from `TailtriageLayer::on_close` and retained closed `SpanRecord` candidates in-memory for semantic conversion instead of emitting them on close.
- Added `completed_span_jsonl_path` to `TracingIntakeSession` and perform create/truncate + write of completed-span JSONL during `TracingIntakeSession::shutdown`, using only evidence retained in the final imported `Run`.
- Reconstruct completed-span wrapper records from the retained `Run` events (preserving the wrapper shape `{"format":"tailtriage.tracing-span.v1","span":{...}}`) with these mappings: request -> `tt.request` (fields: `tt.kind`,`tt.request_id`,`tt.route`,`tt.outcome`, `started_at_unix_ms`,`finished_at_unix_ms`,`duration_us`), stage -> `tt.stage` (fields: `tt.kind`,`tt.request_id`,`tt.stage`,`tt.success`, timestamps/duration), queue -> `tt.queue` (fields: `tt.kind`,`tt.request_id`,`tt.queue`, optional `tt.depth_at_start`, `waited_from_unix_ms`,`waited_until_unix_ms`,`wait_us`).
- Made sure `snapshot_run()` does not create or mutate the completed-span JSONL file; only `shutdown()` writes it.
- Implemented strict vs non-strict write behavior: write failures in strict mode return an `ImportError::Io`, while non-strict mode records an `ImportWarning` and appends a `metadata.lifecycle_warnings` entry.
- Updated docs and examples to state that `completed_span_jsonl_path` writes retained, semantically valid completed-span JSONL on shutdown (removed statements implying pre-retention streaming).
- Added and updated unit tests in `tailtriage-tracing` to verify shutdown-only writing, parity with retained run counts, exclusion of malformed and orphaned spans, and strict/non-strict write-failure behavior.

### Testing

- Ran formatting, linting, full test suite, and docs contract validation: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, and `python3 scripts/validate_docs_contracts.py`.
- All checks passed: clippy warnings were resolved and the full test suite passed locally, and `scripts/validate_docs_contracts.py` validated updated docs.
- Added tests exercising retained JSONL parity, malformed/orphan exclusion, snapshot non-mutation, and shutdown write-failure handling; those tests passed as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12d21354708330a134faf72df35d7c)