### PR TITLE
Align completed-span JSONL with retained shutdown Run evidence

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -4,7 +4,7 @@
 
 It helps existing `tracing` users produce standard `tailtriage_core::Run` artifacts by:
 - writing Run JSON on shutdown, and/or
-- streaming stable completed-span JSONL as spans close.
+- writing stable completed-span JSONL on shutdown from retained, semantically valid request/stage/queue evidence.
 
 It is **not**:
 - an observability backend,
@@ -104,8 +104,9 @@ Ordinary tracing log JSON (for example `fmt().json` output) is rejected by impor
 ## Retention and drop behavior
 
 - `max_open_spans` bounds in-flight span tracking.
-- Completed-span JSONL streaming happens before in-memory completed-span retention is applied.
-- Warnings and lifecycle warnings indicate evidence may be incomplete when limits are hit or writer issues occur.
+- completed-span JSONL output is written on shutdown only, after semantic conversion and retention.
+- The JSONL file contains only retained valid request/stage/queue evidence that matches the final imported Run.
+- Warnings and lifecycle warnings indicate evidence may be incomplete when limits are hit or write issues occur.
 
 ## Runtime-pressure limitation
 

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::fmt::Write as _;
 use std::fs::OpenOptions;
-use std::io::{BufWriter, Write};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -40,6 +40,7 @@ pub struct TracingRecorder {
 #[derive(Debug, Clone)]
 pub struct TracingIntakeSession {
     recorder: TracingRecorder,
+    completed_span_jsonl_path: Option<PathBuf>,
     run_json_path: Option<PathBuf>,
 }
 /// Builder for [`TracingIntakeSession`].
@@ -100,8 +101,6 @@ struct RecorderState {
     closed_malformed_kind_spans: u64,
     closed_kind_samples: Vec<ClosedKindIssueSample>,
     writer_failure: Option<String>,
-    completed_span_writer_path: Option<PathBuf>,
-    completed_span_writer: Option<BufWriter<std::fs::File>>,
 }
 
 #[derive(Debug)]
@@ -176,7 +175,6 @@ impl TracingRecorder {
     ///
     /// Returns [`ImportError`] when strict conversion fails.
     pub fn snapshot_run(&self) -> Result<ImportedRun, ImportError> {
-        self.flush_completed_span_writer()?;
         let (spans, stats) = {
             let state = lock_state(&self.state);
             let mut samples = Vec::new();
@@ -210,31 +208,6 @@ impl TracingRecorder {
             )
         };
         imported_with_drop_warnings(spans, self.options.clone(), &stats, self.limits)
-    }
-
-    fn flush_completed_span_writer(&self) -> Result<(), ImportError> {
-        let mut state = lock_state(&self.state);
-        if let Some(writer) = state.completed_span_writer.as_mut() {
-            if let Err(err) = writer.flush() {
-                let msg = format_writer_failure(
-                    "flush",
-                    state.completed_span_writer_path.as_deref(),
-                    &err,
-                );
-                state.writer_failure = Some(msg.clone());
-                if self.options.strict_mode() {
-                    return Err(ImportError::Io {
-                        operation: "flush completed span jsonl writer",
-                        context: state.completed_span_writer_path.as_ref().map_or_else(
-                            || "completed-span-jsonl".to_owned(),
-                            |p| p.display().to_string(),
-                        ),
-                        reason: err.to_string(),
-                    });
-                }
-            }
-        }
-        Ok(())
     }
 
     /// Consumes this recorder handle and returns a final imported run snapshot.
@@ -303,7 +276,21 @@ impl TracingIntakeSession {
     ///
     /// Returns an error when conversion fails or when configured run-json output cannot be written.
     pub fn shutdown(self) -> Result<ImportedRun, ImportError> {
-        let imported = self.recorder.shutdown()?;
+        let strict_mode = self.recorder.options.strict_mode();
+        let mut imported = self.recorder.shutdown()?;
+        if let Some(path) = self.completed_span_jsonl_path {
+            if let Err(err) = write_completed_span_jsonl_from_run(&path, imported.run()) {
+                if strict_mode {
+                    return Err(err);
+                }
+                let msg =
+                    format!("live recorder failed writing completed-span JSONL output: {err}");
+                let (mut run, mut warnings) = imported.into_parts();
+                run.metadata.lifecycle_warnings.push(msg.clone());
+                warnings.push(crate::ImportWarning::new(msg));
+                imported = ImportedRun::new(run, warnings);
+            }
+        }
         if let Some(path) = self.run_json_path {
             ensure_persistable_run_has_requests(imported.run())?;
             LocalJsonSink::new(&path)
@@ -378,8 +365,7 @@ impl TracingIntakeSessionBuilder {
     }
     /// Enables completed-span JSONL output at the given path.
     ///
-    /// Writes completed spans as spans close using the stable wrapper shape.
-    /// The file is created or truncated when the session is built.
+    /// Writes retained valid completed spans on shutdown using the stable wrapper shape.
     #[must_use]
     pub fn completed_span_jsonl_path(mut self, path: impl AsRef<Path>) -> Self {
         self.completed_span_jsonl_path = Some(path.as_ref().to_path_buf());
@@ -391,30 +377,16 @@ impl TracingIntakeSessionBuilder {
         self.run_json_path = Some(path.as_ref().to_path_buf());
         self
     }
-    /// Builds a tracing intake session and opens optional outputs.
+    /// Builds a tracing intake session.
     ///
     /// # Errors
     ///
-    /// Returns an error when the completed-span JSONL path cannot be opened.
+    /// Returns an error when required recorder configuration is invalid.
     pub fn build(self) -> Result<TracingIntakeSession, ImportError> {
         let recorder = self.recorder_builder.build();
-        if let Some(path) = self.completed_span_jsonl_path {
-            let file = OpenOptions::new()
-                .create(true)
-                .write(true)
-                .truncate(true)
-                .open(&path)
-                .map_err(|err| ImportError::Io {
-                    operation: "open completed span jsonl path",
-                    context: path.display().to_string(),
-                    reason: err.to_string(),
-                })?;
-            let mut state = lock_state(&recorder.state);
-            state.completed_span_writer = Some(BufWriter::new(file));
-            state.completed_span_writer_path = Some(path);
-        }
         Ok(TracingIntakeSession {
             recorder,
+            completed_span_jsonl_path: self.completed_span_jsonl_path,
             run_json_path: self.run_json_path,
         })
     }
@@ -569,31 +541,6 @@ where
             for (k, v) in open.fields {
                 record = record.field(k, v);
             }
-            if let Some(writer) = state.completed_span_writer.as_mut() {
-                let wrapped = serde_json::json!({
-                    "format": "tailtriage.tracing-span.v1",
-                    "span": record,
-                });
-                match serde_json::to_writer(&mut *writer, &wrapped) {
-                    Ok(()) => match writer.write_all(b"\n") {
-                        Ok(()) => {}
-                        Err(err) => {
-                            state.writer_failure = Some(format_writer_failure(
-                                "write newline",
-                                state.completed_span_writer_path.as_deref(),
-                                &err,
-                            ));
-                        }
-                    },
-                    Err(err) => {
-                        state.writer_failure = Some(format_writer_failure(
-                            "write span record",
-                            state.completed_span_writer_path.as_deref(),
-                            &err,
-                        ));
-                    }
-                }
-            }
             if state.completed.len() >= self.limits.max_completed_candidate_spans {
                 state.dropped_completed_candidate_spans =
                     state.dropped_completed_candidate_spans.saturating_add(1);
@@ -647,13 +594,82 @@ fn metadata_has_tailtriage_field(metadata: &tracing::Metadata<'_>) -> bool {
         .any(|f| f.name().starts_with("tt."))
 }
 
-fn format_writer_failure(
-    operation: &str,
-    path: Option<&Path>,
-    err: &dyn std::error::Error,
-) -> String {
-    let path_text = path.map_or_else(|| "<unknown>".to_owned(), |p| p.display().to_string());
-    format!("completed-span JSONL writer failed to {operation} at {path_text}: {err}")
+fn write_completed_span_jsonl_from_run(
+    path: &Path,
+    run: &tailtriage_core::Run,
+) -> Result<(), ImportError> {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(path)
+        .map_err(|err| ImportError::Io {
+            operation: "open completed span jsonl path",
+            context: path.display().to_string(),
+            reason: err.to_string(),
+        })?;
+    for span in run
+        .requests
+        .iter()
+        .map(span_record_from_request)
+        .chain(run.stages.iter().map(span_record_from_stage))
+        .chain(run.queues.iter().map(span_record_from_queue))
+    {
+        let wrapped = serde_json::json!({ "format": "tailtriage.tracing-span.v1", "span": span });
+        serde_json::to_writer(&mut file, &wrapped).map_err(|err| ImportError::Io {
+            operation: "write completed span jsonl record",
+            context: path.display().to_string(),
+            reason: err.to_string(),
+        })?;
+        file.write_all(b"\n").map_err(|err| ImportError::Io {
+            operation: "write completed span jsonl newline",
+            context: path.display().to_string(),
+            reason: err.to_string(),
+        })?;
+    }
+    Ok(())
+}
+
+fn span_record_from_request(request: &tailtriage_core::RequestEvent) -> SpanRecord {
+    SpanRecord::new(
+        "tt.request",
+        request.started_at_unix_ms,
+        request.finished_at_unix_ms,
+    )
+    .duration_us(request.latency_us)
+    .field("tt.kind", "request")
+    .field("tt.request_id", request.request_id.clone())
+    .field("tt.route", request.route.clone())
+    .field("tt.outcome", request.outcome.clone())
+}
+
+fn span_record_from_stage(stage: &tailtriage_core::StageEvent) -> SpanRecord {
+    SpanRecord::new(
+        "tt.stage",
+        stage.started_at_unix_ms,
+        stage.finished_at_unix_ms,
+    )
+    .duration_us(stage.latency_us)
+    .field("tt.kind", "stage")
+    .field("tt.request_id", stage.request_id.clone())
+    .field("tt.stage", stage.stage.clone())
+    .field("tt.success", stage.success)
+}
+
+fn span_record_from_queue(queue: &tailtriage_core::QueueEvent) -> SpanRecord {
+    let mut span = SpanRecord::new(
+        "tt.queue",
+        queue.waited_from_unix_ms,
+        queue.waited_until_unix_ms,
+    )
+    .duration_us(queue.wait_us)
+    .field("tt.kind", "queue")
+    .field("tt.request_id", queue.request_id.clone())
+    .field("tt.queue", queue.queue.clone());
+    if let Some(depth) = queue.depth_at_start {
+        span = span.field("tt.depth_at_start", depth);
+    }
+    span
 }
 fn fields_have_tailtriage_key(fields: &BTreeMap<String, FieldValue>) -> bool {
     fields.keys().any(|k| k.starts_with("tt."))
@@ -2066,14 +2082,16 @@ mod tests {
             );
             drop(span);
         });
-        session.snapshot_run().unwrap();
+        assert!(session.snapshot_run().is_ok());
+        assert!(!spans_path.exists());
+        let _ = session.shutdown().unwrap();
         let raw = std::fs::read_to_string(&spans_path).unwrap();
         let lines: Vec<_> = raw.lines().filter(|l| !l.trim().is_empty()).collect();
         assert_eq!(lines.len(), 1);
         let value: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
         assert_eq!(value["format"], "tailtriage.tracing-span.v1");
         assert!(value["span"].is_object());
-        assert_eq!(value["span"]["name"], "request");
+        assert_eq!(value["span"]["name"], "tt.request");
         assert!(value["span"]["started_at_unix_ms"].is_number());
         assert!(value["span"]["finished_at_unix_ms"].is_number());
         assert!(value["span"]["duration_us"].is_number());
@@ -2093,7 +2111,7 @@ mod tests {
     }
 
     #[test]
-    fn streaming_jsonl_is_independent_of_in_memory_completed_retention() {
+    fn completed_span_jsonl_matches_retained_run_counts() {
         let dir = tempfile::tempdir().unwrap();
         let spans_path = dir.path().join("spans.jsonl");
         let session = TracingIntakeSession::builder("svc")
@@ -2121,37 +2139,42 @@ mod tests {
                 tt.route = "/b"
             ));
         });
-        let snapshot = session.snapshot_run().unwrap();
-        assert_eq!(snapshot.run().requests.len(), 1);
-        assert_eq!(snapshot.run().truncation.dropped_requests, 1);
-        let raw = std::fs::read_to_string(&spans_path).unwrap();
-        let lines: Vec<_> = raw.lines().filter(|l| !l.trim().is_empty()).collect();
-        assert_eq!(lines.len(), 2);
+        let imported_run = session.shutdown().unwrap();
+        assert_eq!(imported_run.run().requests.len(), 1);
+        assert_eq!(imported_run.run().truncation.dropped_requests, 1);
         let imported = crate::jsonl::import_jsonl_path_with_mode(
             &spans_path,
             ImportOptions::new("svc"),
             crate::jsonl::JsonlParseMode::TailtriageWrapperOnly,
         )
         .unwrap();
-        assert_eq!(imported.run().requests.len(), 2);
-        let ids: Vec<_> = imported
-            .run()
-            .requests
-            .iter()
-            .map(|r| r.request_id.as_str())
-            .collect();
-        assert!(ids.contains(&"r1"));
-        assert!(ids.contains(&"r2"));
+        assert_eq!(
+            imported.run().requests.len(),
+            imported_run.run().requests.len()
+        );
+        assert_eq!(imported.run().stages.len(), imported_run.run().stages.len());
+        assert_eq!(imported.run().queues.len(), imported_run.run().queues.len());
     }
 
     #[test]
-    fn intake_session_build_writer_open_failure_returns_io() {
+    fn completed_span_jsonl_write_failure_returns_io_in_strict_mode() {
         let dir = tempfile::tempdir().unwrap();
         let bad_path = dir.path().join("missing").join("spans.jsonl");
-        let err = TracingIntakeSession::builder("svc")
+        let session = TracingIntakeSession::builder("svc")
+            .strict(true)
             .completed_span_jsonl_path(&bad_path)
             .build()
-            .unwrap_err();
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            ));
+        });
+        let err = session.shutdown().unwrap_err();
         assert!(matches!(err, ImportError::Io { .. }));
         assert!(err.to_string().contains("spans.jsonl"));
     }
@@ -2232,6 +2255,42 @@ mod tests {
         let line = lines[0];
         assert!(line.contains("\"tt.request_id\":\"r1\""));
         assert!(!line.contains("unrelated"));
+    }
+
+    #[test]
+    fn malformed_and_orphan_spans_not_in_completed_span_jsonl() {
+        let dir = tempfile::tempdir().unwrap();
+        let spans_path = dir.path().join("spans.jsonl");
+        let session = TracingIntakeSession::builder("svc")
+            .completed_span_jsonl_path(&spans_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "bad",
+                tt.kind = 123_u64,
+                tt.request_id = "rbad"
+            ));
+            drop(tracing::info_span!(
+                "orphan-stage",
+                tt.kind = "stage",
+                tt.request_id = "missing",
+                tt.stage = "db",
+                tt.success = true
+            ));
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/ok"
+            ));
+        });
+        let _ = session.shutdown().unwrap();
+        let raw = std::fs::read_to_string(&spans_path).unwrap();
+        assert!(raw.contains("\"r1\""));
+        assert!(!raw.contains("\"rbad\""));
+        assert!(!raw.contains("\"missing\""));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The completed-span JSONL writer previously emitted spans at `TailtriageLayer::on_close` (pre-retention and pre-validation), which could produce JSONL containing spans that are not present in the final `Run` after retention and semantic conversion, causing confusion.  
- The desired behavior is that `completed_span_jsonl_path` must contain only the retained, semantically valid request/stage/queue evidence that appears in the final imported `Run` and be replayable via the existing JSONL importer.

### Description
- Removed per-span JSONL writes from `TailtriageLayer::on_close`; closed candidate `SpanRecord` values are still collected in memory (`state.completed`) but not streamed to disk.  
- Added a shutdown-time JSONL writer: `TracingIntakeSession::shutdown` calls `write_completed_span_jsonl_from_run(...)` after conversion/retention and before optionally writing `run_json_path`, using create/truncate semantics.  
- Reconstructs output `SpanRecord` values from the retained `Run` events and preserves the stable wrapper shape `{"format":"tailtriage.tracing-span.v1","span":{...}}`, with mapping rules: request → `tt.request`, stage → `tt.stage`, queue → `tt.queue` (timestamps and microsecond durations mapped from `Run` fields; `tt.depth_at_start` preserved for queues).  
- `snapshot_run()` is non-consuming and no longer creates or mutates the completed-span JSONL file; only `shutdown()` writes the file.  
- Write-failure behavior: in strict mode a completed-span JSONL write error returns an `ImportError::Io`, and in non-strict mode the failure is converted into an `ImportWarning` and a `metadata.lifecycle_warnings` entry on the returned `ImportedRun`.

### Testing
- Unit tests added/updated in `tailtriage-tracing` to assert that `snapshot_run()` does not create/mutate the JSONL, `shutdown()` writes the JSONL, malformed/orphan spans are excluded, and JSONL re-import counts match the retained `Run` under tight limits.  
- Ran repository validation: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, and `python3 scripts/validate_docs_contracts.py`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12d21354708330a134faf72df35d7c)