### PR TITLE
Write completed-span JSONL from retained Run evidence at shutdown

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -4,7 +4,7 @@
 
 It helps existing `tracing` users produce standard `tailtriage_core::Run` artifacts by:
 - writing Run JSON on shutdown, and/or
-- streaming stable completed-span JSONL as spans close.
+- writing stable completed-span JSONL from retained valid evidence on shutdown.
 
 It is **not**:
 - an observability backend,
@@ -104,7 +104,7 @@ Ordinary tracing log JSON (for example `fmt().json` output) is rejected by impor
 ## Retention and drop behavior
 
 - `max_open_spans` bounds in-flight span tracking.
-- Completed-span JSONL streaming happens before in-memory completed-span retention is applied.
+- Completed-span JSONL is written on shutdown from the same retained, semantically valid request/stage/queue evidence present in the final imported Run.
 - Warnings and lifecycle warnings indicate evidence may be incomplete when limits are hit or writer issues occur.
 
 ## Runtime-pressure limitation

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::fmt::Write as _;
 use std::fs::OpenOptions;
-use std::io::{BufWriter, Write};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -40,6 +40,7 @@ pub struct TracingRecorder {
 #[derive(Debug, Clone)]
 pub struct TracingIntakeSession {
     recorder: TracingRecorder,
+    completed_span_jsonl_path: Option<PathBuf>,
     run_json_path: Option<PathBuf>,
 }
 /// Builder for [`TracingIntakeSession`].
@@ -99,9 +100,6 @@ struct RecorderState {
     closed_unknown_kind_spans: u64,
     closed_malformed_kind_spans: u64,
     closed_kind_samples: Vec<ClosedKindIssueSample>,
-    writer_failure: Option<String>,
-    completed_span_writer_path: Option<PathBuf>,
-    completed_span_writer: Option<BufWriter<std::fs::File>>,
 }
 
 #[derive(Debug)]
@@ -141,7 +139,6 @@ struct SnapshotStats {
     closed_unknown_kind_spans: u64,
     closed_malformed_kind_spans: u64,
     closed_kind_samples: Vec<ClosedKindIssueSample>,
-    writer_failure: Option<String>,
 }
 fn lock_state(state: &Arc<Mutex<RecorderState>>) -> std::sync::MutexGuard<'_, RecorderState> {
     match state.lock() {
@@ -176,7 +173,6 @@ impl TracingRecorder {
     ///
     /// Returns [`ImportError`] when strict conversion fails.
     pub fn snapshot_run(&self) -> Result<ImportedRun, ImportError> {
-        self.flush_completed_span_writer()?;
         let (spans, stats) = {
             let state = lock_state(&self.state);
             let mut samples = Vec::new();
@@ -205,36 +201,10 @@ impl TracingRecorder {
                     closed_unknown_kind_spans: state.closed_unknown_kind_spans,
                     closed_malformed_kind_spans: state.closed_malformed_kind_spans,
                     closed_kind_samples: state.closed_kind_samples.clone(),
-                    writer_failure: state.writer_failure.clone(),
                 },
             )
         };
         imported_with_drop_warnings(spans, self.options.clone(), &stats, self.limits)
-    }
-
-    fn flush_completed_span_writer(&self) -> Result<(), ImportError> {
-        let mut state = lock_state(&self.state);
-        if let Some(writer) = state.completed_span_writer.as_mut() {
-            if let Err(err) = writer.flush() {
-                let msg = format_writer_failure(
-                    "flush",
-                    state.completed_span_writer_path.as_deref(),
-                    &err,
-                );
-                state.writer_failure = Some(msg.clone());
-                if self.options.strict_mode() {
-                    return Err(ImportError::Io {
-                        operation: "flush completed span jsonl writer",
-                        context: state.completed_span_writer_path.as_ref().map_or_else(
-                            || "completed-span-jsonl".to_owned(),
-                            |p| p.display().to_string(),
-                        ),
-                        reason: err.to_string(),
-                    });
-                }
-            }
-        }
-        Ok(())
     }
 
     /// Consumes this recorder handle and returns a final imported run snapshot.
@@ -303,17 +273,29 @@ impl TracingIntakeSession {
     ///
     /// Returns an error when conversion fails or when configured run-json output cannot be written.
     pub fn shutdown(self) -> Result<ImportedRun, ImportError> {
+        let strict_mode = self.recorder.options.strict_mode();
         let imported = self.recorder.shutdown()?;
+        let (mut run, mut warnings) = imported.into_parts();
+        if let Some(path) = &self.completed_span_jsonl_path {
+            if let Err(err) = write_retained_completed_span_jsonl(path, &run) {
+                if strict_mode {
+                    return Err(err);
+                }
+                let msg = err.to_string();
+                run.metadata.lifecycle_warnings.push(msg.clone());
+                warnings.push(crate::ImportWarning::new(msg));
+            }
+        }
         if let Some(path) = self.run_json_path {
-            ensure_persistable_run_has_requests(imported.run())?;
+            ensure_persistable_run_has_requests(&run)?;
             LocalJsonSink::new(&path)
-                .write(imported.run())
+                .write(&run)
                 .map_err(|err| ImportError::RunJsonWrite {
                     path: path.display().to_string(),
                     reason: err.to_string(),
                 })?;
         }
-        Ok(imported)
+        Ok(ImportedRun::new(run, warnings))
     }
 }
 impl TracingIntakeSessionBuilder {
@@ -378,8 +360,7 @@ impl TracingIntakeSessionBuilder {
     }
     /// Enables completed-span JSONL output at the given path.
     ///
-    /// Writes completed spans as spans close using the stable wrapper shape.
-    /// The file is created or truncated when the session is built.
+    /// Writes retained, semantically valid completed-span JSONL at shutdown.
     #[must_use]
     pub fn completed_span_jsonl_path(mut self, path: impl AsRef<Path>) -> Self {
         self.completed_span_jsonl_path = Some(path.as_ref().to_path_buf());
@@ -395,26 +376,12 @@ impl TracingIntakeSessionBuilder {
     ///
     /// # Errors
     ///
-    /// Returns an error when the completed-span JSONL path cannot be opened.
+    /// Returns an error when service metadata/configuration is invalid.
     pub fn build(self) -> Result<TracingIntakeSession, ImportError> {
         let recorder = self.recorder_builder.build();
-        if let Some(path) = self.completed_span_jsonl_path {
-            let file = OpenOptions::new()
-                .create(true)
-                .write(true)
-                .truncate(true)
-                .open(&path)
-                .map_err(|err| ImportError::Io {
-                    operation: "open completed span jsonl path",
-                    context: path.display().to_string(),
-                    reason: err.to_string(),
-                })?;
-            let mut state = lock_state(&recorder.state);
-            state.completed_span_writer = Some(BufWriter::new(file));
-            state.completed_span_writer_path = Some(path);
-        }
         Ok(TracingIntakeSession {
             recorder,
+            completed_span_jsonl_path: self.completed_span_jsonl_path,
             run_json_path: self.run_json_path,
         })
     }
@@ -569,31 +536,6 @@ where
             for (k, v) in open.fields {
                 record = record.field(k, v);
             }
-            if let Some(writer) = state.completed_span_writer.as_mut() {
-                let wrapped = serde_json::json!({
-                    "format": "tailtriage.tracing-span.v1",
-                    "span": record,
-                });
-                match serde_json::to_writer(&mut *writer, &wrapped) {
-                    Ok(()) => match writer.write_all(b"\n") {
-                        Ok(()) => {}
-                        Err(err) => {
-                            state.writer_failure = Some(format_writer_failure(
-                                "write newline",
-                                state.completed_span_writer_path.as_deref(),
-                                &err,
-                            ));
-                        }
-                    },
-                    Err(err) => {
-                        state.writer_failure = Some(format_writer_failure(
-                            "write span record",
-                            state.completed_span_writer_path.as_deref(),
-                            &err,
-                        ));
-                    }
-                }
-            }
             if state.completed.len() >= self.limits.max_completed_candidate_spans {
                 state.dropped_completed_candidate_spans =
                     state.dropped_completed_candidate_spans.saturating_add(1);
@@ -647,16 +589,86 @@ fn metadata_has_tailtriage_field(metadata: &tracing::Metadata<'_>) -> bool {
         .any(|f| f.name().starts_with("tt."))
 }
 
-fn format_writer_failure(
-    operation: &str,
-    path: Option<&Path>,
-    err: &dyn std::error::Error,
-) -> String {
-    let path_text = path.map_or_else(|| "<unknown>".to_owned(), |p| p.display().to_string());
-    format!("completed-span JSONL writer failed to {operation} at {path_text}: {err}")
-}
 fn fields_have_tailtriage_key(fields: &BTreeMap<String, FieldValue>) -> bool {
     fields.keys().any(|k| k.starts_with("tt."))
+}
+
+fn write_retained_completed_span_jsonl(
+    path: &Path,
+    run: &tailtriage_core::Run,
+) -> Result<(), ImportError> {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(path)
+        .map_err(|err| ImportError::Io {
+            operation: "open completed span jsonl path",
+            context: path.display().to_string(),
+            reason: err.to_string(),
+        })?;
+    for span in retained_span_records_from_run(run) {
+        let wrapped = serde_json::json!({"format":"tailtriage.tracing-span.v1","span":span});
+        serde_json::to_writer(&mut file, &wrapped).map_err(|err| ImportError::Io {
+            operation: "write completed span jsonl record",
+            context: path.display().to_string(),
+            reason: err.to_string(),
+        })?;
+        file.write_all(b"\n").map_err(|err| ImportError::Io {
+            operation: "write completed span jsonl newline",
+            context: path.display().to_string(),
+            reason: err.to_string(),
+        })?;
+    }
+    Ok(())
+}
+
+fn retained_span_records_from_run(run: &tailtriage_core::Run) -> Vec<SpanRecord> {
+    let mut out = Vec::new();
+    for req in &run.requests {
+        out.push(
+            SpanRecord::new(
+                "tt.request",
+                req.started_at_unix_ms,
+                req.finished_at_unix_ms,
+            )
+            .duration_us(req.latency_us)
+            .field(TT_KIND, "request")
+            .field("tt.request_id", req.request_id.clone())
+            .field("tt.route", req.route.clone())
+            .field("tt.outcome", req.outcome.clone()),
+        );
+    }
+    for stage in &run.stages {
+        out.push(
+            SpanRecord::new(
+                "tt.stage",
+                stage.started_at_unix_ms,
+                stage.finished_at_unix_ms,
+            )
+            .duration_us(stage.latency_us)
+            .field(TT_KIND, "stage")
+            .field("tt.request_id", stage.request_id.clone())
+            .field("tt.stage", stage.stage.clone())
+            .field("tt.success", stage.success),
+        );
+    }
+    for queue in &run.queues {
+        let mut span = SpanRecord::new(
+            "tt.queue",
+            queue.waited_from_unix_ms,
+            queue.waited_until_unix_ms,
+        )
+        .duration_us(queue.wait_us)
+        .field(TT_KIND, "queue")
+        .field("tt.request_id", queue.request_id.clone())
+        .field("tt.queue", queue.queue.clone());
+        if let Some(depth) = queue.depth_at_start {
+            span = span.field("tt.depth_at_start", depth);
+        }
+        out.push(span);
+    }
+    out
 }
 
 fn push_strict_recorder_messages(
@@ -698,11 +710,6 @@ fn push_strict_recorder_messages(
         messages.push(format!(
             "live recorder dropped {} completed candidate span(s) because max_completed_candidate_spans={} was reached; this is a raw closed-span memory cap before semantic conversion, not request/stage/queue CaptureLimits; raise max_completed_candidate_spans, snapshot/shutdown sooner, or reduce capture scope",
             stats.dropped_completed_candidate_spans, limits.max_completed_candidate_spans
-        ));
-    }
-    if let Some(reason) = &stats.writer_failure {
-        messages.push(format!(
-            "live recorder failed writing completed-span JSONL output: {reason}"
         ));
     }
 }
@@ -789,11 +796,6 @@ fn append_non_strict_drop_warnings(
     if stats.dropped_open_spans > 0 || stats.dropped_completed_candidate_spans > 0 {
         run.truncation.limits_hit = true;
     }
-    if let Some(reason) = &stats.writer_failure {
-        let msg = format!("live recorder failed writing completed-span JSONL output: {reason}");
-        run.metadata.lifecycle_warnings.push(msg.clone());
-        warnings.push(crate::ImportWarning::new(msg));
-    }
 }
 
 fn imported_with_drop_warnings(
@@ -826,7 +828,6 @@ fn imported_with_drop_warnings(
         && stats.closed_missing_kind_spans == 0
         && stats.closed_unknown_kind_spans == 0
         && stats.closed_malformed_kind_spans == 0
-        && stats.writer_failure.is_none()
     {
         return Ok(imported);
     }
@@ -2066,14 +2067,15 @@ mod tests {
             );
             drop(span);
         });
-        session.snapshot_run().unwrap();
+        assert!(std::fs::read_to_string(&spans_path).is_err());
+        session.shutdown().unwrap();
         let raw = std::fs::read_to_string(&spans_path).unwrap();
         let lines: Vec<_> = raw.lines().filter(|l| !l.trim().is_empty()).collect();
         assert_eq!(lines.len(), 1);
         let value: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
         assert_eq!(value["format"], "tailtriage.tracing-span.v1");
         assert!(value["span"].is_object());
-        assert_eq!(value["span"]["name"], "request");
+        assert_eq!(value["span"]["name"], "tt.request");
         assert!(value["span"]["started_at_unix_ms"].is_number());
         assert!(value["span"]["finished_at_unix_ms"].is_number());
         assert!(value["span"]["duration_us"].is_number());
@@ -2093,7 +2095,7 @@ mod tests {
     }
 
     #[test]
-    fn streaming_jsonl_is_independent_of_in_memory_completed_retention() {
+    fn completed_span_jsonl_matches_retained_run_after_limits() {
         let dir = tempfile::tempdir().unwrap();
         let spans_path = dir.path().join("spans.jsonl");
         let session = TracingIntakeSession::builder("svc")
@@ -2121,39 +2123,35 @@ mod tests {
                 tt.route = "/b"
             ));
         });
-        let snapshot = session.snapshot_run().unwrap();
+        let snapshot = session.shutdown().unwrap();
         assert_eq!(snapshot.run().requests.len(), 1);
         assert_eq!(snapshot.run().truncation.dropped_requests, 1);
         let raw = std::fs::read_to_string(&spans_path).unwrap();
         let lines: Vec<_> = raw.lines().filter(|l| !l.trim().is_empty()).collect();
-        assert_eq!(lines.len(), 2);
+        assert_eq!(lines.len(), 1);
         let imported = crate::jsonl::import_jsonl_path_with_mode(
             &spans_path,
             ImportOptions::new("svc"),
             crate::jsonl::JsonlParseMode::TailtriageWrapperOnly,
         )
         .unwrap();
-        assert_eq!(imported.run().requests.len(), 2);
-        let ids: Vec<_> = imported
-            .run()
-            .requests
-            .iter()
-            .map(|r| r.request_id.as_str())
-            .collect();
-        assert!(ids.contains(&"r1"));
-        assert!(ids.contains(&"r2"));
+        assert_eq!(imported.run().requests.len(), snapshot.run().requests.len());
+        assert_eq!(imported.run().stages.len(), snapshot.run().stages.len());
+        assert_eq!(imported.run().queues.len(), snapshot.run().queues.len());
     }
 
     #[test]
-    fn intake_session_build_writer_open_failure_returns_io() {
+    fn intake_session_completed_jsonl_write_failure_returns_io_in_strict_mode() {
         let dir = tempfile::tempdir().unwrap();
         let bad_path = dir.path().join("missing").join("spans.jsonl");
-        let err = TracingIntakeSession::builder("svc")
+        let session = TracingIntakeSession::builder("svc")
             .completed_span_jsonl_path(&bad_path)
+            .strict(true)
             .build()
-            .unwrap_err();
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        let err = tracing::subscriber::with_default(subscriber, || session.shutdown()).unwrap_err();
         assert!(matches!(err, ImportError::Io { .. }));
-        assert!(err.to_string().contains("spans.jsonl"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent pre-retention streaming of completed-span JSONL that could contain spans later dropped by retention, which confused users when both `completed_span_jsonl_path` and `run_json_path` were configured.
- Ensure the JSONL output matches the final, semantically validated `Run` artifact so it is replayable and consistent with what `tailtriage` analyzes.

### Description
- Removed on-close streaming: `TailtriageLayer::on_close` no longer writes JSONL; it only buffers closed candidate `SpanRecord`s in memory for later conversion and retention.
- Emit JSONL at shutdown: `TracingIntakeSession::shutdown` now writes `completed_span_jsonl_path` using retained, semantically valid evidence reconstructed from the final imported `Run` and using create+truncate semantics.
- Reconstruct retained spans: Implemented `retained_span_records_from_run` to synthesize `SpanRecord`s from `Run` events with the stable wrapper shape `{"format":"tailtriage.tracing-span.v1","span":{...}}` and mapped fields/timestamps/durations for `tt.request`, `tt.stage`, and `tt.queue` as specified.
- Snapshot immutability: `snapshot_run` remains read-only and does not create or mutate the completed-span JSONL file; only `shutdown` writes the file.
- Error handling: completed-span JSONL write failures propagate as `ImportError::Io` in strict mode; in non-strict mode an `ImportWarning` is appended and a `metadata.lifecycle_warnings` entry is added to the `Run`.
- Docs update: updated `tailtriage-tracing/README.md` to state JSONL is written on shutdown from retained valid evidence and removed prior wording that implied pre-retention streaming.
- Tests updated: recorder tests modified to assert shutdown-time JSONL behavior, parity between JSONL re-import and retained `Run` under tight limits, exclusion of malformed/orphan spans from JSONL, file-truncate/round-trip expectations, and strict-mode write error behavior.

### Testing
- Ran formatting, linting, full workspace tests, and docs contract validation: `cargo fmt --check` (passed), `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (passed), `cargo test --workspace --all-targets --all-features --locked` (passed), and `python3 scripts/validate_docs_contracts.py` (passed).
- Exercised and updated unit tests in `tailtriage-tracing` covering: shutdown JSONL emission and wrapper shape, retained-count parity between `Run` and JSONL re-import under limits, malformed/orphan spans excluded from output, `snapshot_run` does not mutate the JSONL file, and strict-mode failure semantics when JSONL cannot be written; all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12d21354708330a134faf72df35d7c)