### PR TITLE
Retain/replay completed-span JSONL from final Run at shutdown

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -4,7 +4,7 @@
 
 It helps existing `tracing` users produce standard `tailtriage_core::Run` artifacts by:
 - writing Run JSON on shutdown, and/or
-- streaming stable completed-span JSONL as spans close.
+- writing retained valid completed-span JSONL at shutdown for replay workflows.
 
 It is **not**:
 - an observability backend,
@@ -104,7 +104,7 @@ Ordinary tracing log JSON (for example `fmt().json` output) is rejected by impor
 ## Retention and drop behavior
 
 - `max_open_spans` bounds in-flight span tracking.
-- Completed-span JSONL streaming happens before in-memory completed-span retention is applied.
+- Completed-span JSONL is written at shutdown from retained semantically valid request/stage/queue evidence in the imported Run.
 - Warnings and lifecycle warnings indicate evidence may be incomplete when limits are hit or writer issues occur.
 
 ## Runtime-pressure limitation

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::fmt::Write as _;
 use std::fs::OpenOptions;
-use std::io::{BufWriter, Write};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -40,6 +40,7 @@ pub struct TracingRecorder {
 #[derive(Debug, Clone)]
 pub struct TracingIntakeSession {
     recorder: TracingRecorder,
+    completed_span_jsonl_path: Option<PathBuf>,
     run_json_path: Option<PathBuf>,
 }
 /// Builder for [`TracingIntakeSession`].
@@ -100,8 +101,6 @@ struct RecorderState {
     closed_malformed_kind_spans: u64,
     closed_kind_samples: Vec<ClosedKindIssueSample>,
     writer_failure: Option<String>,
-    completed_span_writer_path: Option<PathBuf>,
-    completed_span_writer: Option<BufWriter<std::fs::File>>,
 }
 
 #[derive(Debug)]
@@ -176,7 +175,6 @@ impl TracingRecorder {
     ///
     /// Returns [`ImportError`] when strict conversion fails.
     pub fn snapshot_run(&self) -> Result<ImportedRun, ImportError> {
-        self.flush_completed_span_writer()?;
         let (spans, stats) = {
             let state = lock_state(&self.state);
             let mut samples = Vec::new();
@@ -210,31 +208,6 @@ impl TracingRecorder {
             )
         };
         imported_with_drop_warnings(spans, self.options.clone(), &stats, self.limits)
-    }
-
-    fn flush_completed_span_writer(&self) -> Result<(), ImportError> {
-        let mut state = lock_state(&self.state);
-        if let Some(writer) = state.completed_span_writer.as_mut() {
-            if let Err(err) = writer.flush() {
-                let msg = format_writer_failure(
-                    "flush",
-                    state.completed_span_writer_path.as_deref(),
-                    &err,
-                );
-                state.writer_failure = Some(msg.clone());
-                if self.options.strict_mode() {
-                    return Err(ImportError::Io {
-                        operation: "flush completed span jsonl writer",
-                        context: state.completed_span_writer_path.as_ref().map_or_else(
-                            || "completed-span-jsonl".to_owned(),
-                            |p| p.display().to_string(),
-                        ),
-                        reason: err.to_string(),
-                    });
-                }
-            }
-        }
-        Ok(())
     }
 
     /// Consumes this recorder handle and returns a final imported run snapshot.
@@ -303,7 +276,20 @@ impl TracingIntakeSession {
     ///
     /// Returns an error when conversion fails or when configured run-json output cannot be written.
     pub fn shutdown(self) -> Result<ImportedRun, ImportError> {
-        let imported = self.recorder.shutdown()?;
+        let strict_mode = self.recorder.options.strict_mode();
+        let mut imported = self.recorder.shutdown()?;
+        if let Some(path) = &self.completed_span_jsonl_path {
+            if let Err(err) = write_completed_span_jsonl_from_run(imported.run(), path) {
+                if strict_mode {
+                    return Err(err);
+                }
+                let msg = err.to_string();
+                let (mut run, mut warnings) = imported.into_parts();
+                run.metadata.lifecycle_warnings.push(msg.clone());
+                warnings.push(crate::ImportWarning::new(msg));
+                imported = ImportedRun::new(run, warnings);
+            }
+        }
         if let Some(path) = self.run_json_path {
             ensure_persistable_run_has_requests(imported.run())?;
             LocalJsonSink::new(&path)
@@ -378,8 +364,7 @@ impl TracingIntakeSessionBuilder {
     }
     /// Enables completed-span JSONL output at the given path.
     ///
-    /// Writes completed spans as spans close using the stable wrapper shape.
-    /// The file is created or truncated when the session is built.
+    /// Writes retained valid completed spans on shutdown using the stable wrapper shape.
     #[must_use]
     pub fn completed_span_jsonl_path(mut self, path: impl AsRef<Path>) -> Self {
         self.completed_span_jsonl_path = Some(path.as_ref().to_path_buf());
@@ -391,30 +376,15 @@ impl TracingIntakeSessionBuilder {
         self.run_json_path = Some(path.as_ref().to_path_buf());
         self
     }
-    /// Builds a tracing intake session and opens optional outputs.
+    /// Builds a tracing intake session.
     ///
     /// # Errors
     ///
-    /// Returns an error when the completed-span JSONL path cannot be opened.
     pub fn build(self) -> Result<TracingIntakeSession, ImportError> {
         let recorder = self.recorder_builder.build();
-        if let Some(path) = self.completed_span_jsonl_path {
-            let file = OpenOptions::new()
-                .create(true)
-                .write(true)
-                .truncate(true)
-                .open(&path)
-                .map_err(|err| ImportError::Io {
-                    operation: "open completed span jsonl path",
-                    context: path.display().to_string(),
-                    reason: err.to_string(),
-                })?;
-            let mut state = lock_state(&recorder.state);
-            state.completed_span_writer = Some(BufWriter::new(file));
-            state.completed_span_writer_path = Some(path);
-        }
         Ok(TracingIntakeSession {
             recorder,
+            completed_span_jsonl_path: self.completed_span_jsonl_path,
             run_json_path: self.run_json_path,
         })
     }
@@ -569,31 +539,6 @@ where
             for (k, v) in open.fields {
                 record = record.field(k, v);
             }
-            if let Some(writer) = state.completed_span_writer.as_mut() {
-                let wrapped = serde_json::json!({
-                    "format": "tailtriage.tracing-span.v1",
-                    "span": record,
-                });
-                match serde_json::to_writer(&mut *writer, &wrapped) {
-                    Ok(()) => match writer.write_all(b"\n") {
-                        Ok(()) => {}
-                        Err(err) => {
-                            state.writer_failure = Some(format_writer_failure(
-                                "write newline",
-                                state.completed_span_writer_path.as_deref(),
-                                &err,
-                            ));
-                        }
-                    },
-                    Err(err) => {
-                        state.writer_failure = Some(format_writer_failure(
-                            "write span record",
-                            state.completed_span_writer_path.as_deref(),
-                            &err,
-                        ));
-                    }
-                }
-            }
             if state.completed.len() >= self.limits.max_completed_candidate_spans {
                 state.dropped_completed_candidate_spans =
                     state.dropped_completed_candidate_spans.saturating_add(1);
@@ -647,13 +592,95 @@ fn metadata_has_tailtriage_field(metadata: &tracing::Metadata<'_>) -> bool {
         .any(|f| f.name().starts_with("tt."))
 }
 
-fn format_writer_failure(
-    operation: &str,
-    path: Option<&Path>,
-    err: &dyn std::error::Error,
-) -> String {
-    let path_text = path.map_or_else(|| "<unknown>".to_owned(), |p| p.display().to_string());
-    format!("completed-span JSONL writer failed to {operation} at {path_text}: {err}")
+fn write_completed_span_jsonl_from_run(
+    run: &tailtriage_core::Run,
+    path: &Path,
+) -> Result<(), ImportError> {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(path)
+        .map_err(|err| ImportError::Io {
+            operation: "open completed span jsonl path",
+            context: path.display().to_string(),
+            reason: err.to_string(),
+        })?;
+    for req in &run.requests {
+        let span = SpanRecord::new(
+            "tt.request",
+            req.started_at_unix_ms,
+            req.finished_at_unix_ms,
+        )
+        .duration_us(req.latency_us)
+        .field("tt.kind", "request")
+        .field("tt.request_id", req.request_id.as_str())
+        .field("tt.route", req.route.clone())
+        .field("tt.outcome", req.outcome.clone());
+        let wrapped = serde_json::json!({"format":"tailtriage.tracing-span.v1","span": span});
+        serde_json::to_writer(&mut file, &wrapped).map_err(|err| ImportError::Io {
+            operation: "write completed span jsonl record",
+            context: path.display().to_string(),
+            reason: err.to_string(),
+        })?;
+        file.write_all(b"\n").map_err(|err| ImportError::Io {
+            operation: "write completed span jsonl newline",
+            context: path.display().to_string(),
+            reason: err.to_string(),
+        })?;
+    }
+    for stage in &run.stages {
+        let span = SpanRecord::new(
+            "tt.stage",
+            stage.started_at_unix_ms,
+            stage.finished_at_unix_ms,
+        )
+        .duration_us(stage.latency_us)
+        .field("tt.kind", "stage")
+        .field("tt.request_id", stage.request_id.as_str())
+        .field("tt.stage", stage.stage.clone())
+        .field("tt.success", stage.success);
+        let wrapped = serde_json::json!({"format":"tailtriage.tracing-span.v1","span": span});
+        serde_json::to_writer(&mut file, &wrapped).map_err(|err| ImportError::Io {
+            operation: "write completed span jsonl record",
+            context: path.display().to_string(),
+            reason: err.to_string(),
+        })?;
+        file.write_all(b"\n").map_err(|err| ImportError::Io {
+            operation: "write completed span jsonl newline",
+            context: path.display().to_string(),
+            reason: err.to_string(),
+        })?;
+    }
+    for queue in &run.queues {
+        let mut span = SpanRecord::new(
+            "tt.queue",
+            queue.waited_from_unix_ms,
+            queue.waited_until_unix_ms,
+        )
+        .duration_us(queue.wait_us)
+        .field("tt.kind", "queue")
+        .field("tt.request_id", queue.request_id.as_str())
+        .field("tt.queue", queue.queue.clone());
+        if let Some(depth) = queue.depth_at_start {
+            span = span.field("tt.depth_at_start", depth);
+        }
+        let wrapped = serde_json::json!({
+            "format":"tailtriage.tracing-span.v1",
+            "span": span
+        });
+        serde_json::to_writer(&mut file, &wrapped).map_err(|err| ImportError::Io {
+            operation: "write completed span jsonl record",
+            context: path.display().to_string(),
+            reason: err.to_string(),
+        })?;
+        file.write_all(b"\n").map_err(|err| ImportError::Io {
+            operation: "write completed span jsonl newline",
+            context: path.display().to_string(),
+            reason: err.to_string(),
+        })?;
+    }
+    Ok(())
 }
 fn fields_have_tailtriage_key(fields: &BTreeMap<String, FieldValue>) -> bool {
     fields.keys().any(|k| k.starts_with("tt."))
@@ -2067,13 +2094,15 @@ mod tests {
             drop(span);
         });
         session.snapshot_run().unwrap();
+        assert!(!spans_path.exists());
+        let _ = session.shutdown().unwrap();
         let raw = std::fs::read_to_string(&spans_path).unwrap();
         let lines: Vec<_> = raw.lines().filter(|l| !l.trim().is_empty()).collect();
         assert_eq!(lines.len(), 1);
         let value: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
         assert_eq!(value["format"], "tailtriage.tracing-span.v1");
         assert!(value["span"].is_object());
-        assert_eq!(value["span"]["name"], "request");
+        assert_eq!(value["span"]["name"], "tt.request");
         assert!(value["span"]["started_at_unix_ms"].is_number());
         assert!(value["span"]["finished_at_unix_ms"].is_number());
         assert!(value["span"]["duration_us"].is_number());
@@ -2093,7 +2122,7 @@ mod tests {
     }
 
     #[test]
-    fn streaming_jsonl_is_independent_of_in_memory_completed_retention() {
+    fn shutdown_jsonl_matches_retained_run_counts() {
         let dir = tempfile::tempdir().unwrap();
         let spans_path = dir.path().join("spans.jsonl");
         let session = TracingIntakeSession::builder("svc")
@@ -2124,36 +2153,32 @@ mod tests {
         let snapshot = session.snapshot_run().unwrap();
         assert_eq!(snapshot.run().requests.len(), 1);
         assert_eq!(snapshot.run().truncation.dropped_requests, 1);
-        let raw = std::fs::read_to_string(&spans_path).unwrap();
-        let lines: Vec<_> = raw.lines().filter(|l| !l.trim().is_empty()).collect();
-        assert_eq!(lines.len(), 2);
+        let _ = session.shutdown().unwrap();
         let imported = crate::jsonl::import_jsonl_path_with_mode(
             &spans_path,
             ImportOptions::new("svc"),
             crate::jsonl::JsonlParseMode::TailtriageWrapperOnly,
         )
         .unwrap();
-        assert_eq!(imported.run().requests.len(), 2);
-        let ids: Vec<_> = imported
-            .run()
-            .requests
-            .iter()
-            .map(|r| r.request_id.as_str())
-            .collect();
-        assert!(ids.contains(&"r1"));
-        assert!(ids.contains(&"r2"));
+        assert_eq!(imported.run().requests.len(), snapshot.run().requests.len());
+        assert_eq!(imported.run().stages.len(), snapshot.run().stages.len());
+        assert_eq!(imported.run().queues.len(), snapshot.run().queues.len());
     }
 
     #[test]
-    fn intake_session_build_writer_open_failure_returns_io() {
+    fn intake_session_shutdown_writer_open_failure_returns_io_or_warning() {
         let dir = tempfile::tempdir().unwrap();
         let bad_path = dir.path().join("missing").join("spans.jsonl");
-        let err = TracingIntakeSession::builder("svc")
+        let session = TracingIntakeSession::builder("svc")
             .completed_span_jsonl_path(&bad_path)
+            .strict(false)
             .build()
-            .unwrap_err();
-        assert!(matches!(err, ImportError::Io { .. }));
-        assert!(err.to_string().contains("spans.jsonl"));
+            .unwrap();
+        let imported = session.shutdown().unwrap();
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("open completed span jsonl path")));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent confusion where completed-span JSONL previously streamed on span close could contain spans that were later dropped by retention/validation, so the on-disk JSONL must match the final persisted Run. 
- Provide a replayable, semantically valid completed-span JSONL artifact that reflects the same retained request/stage/queue evidence used by `tailtriage` analysis.

### Description
- Removed streaming writes from `TailtriageLayer::on_close` and kept closed `SpanRecord` values in memory for later conversion and retention. 
- Added shutdown-time JSONL emission in `TracingIntakeSession::shutdown` that reconstructs span wrapper records from the final retained `Run` and writes to `completed_span_jsonl_path` with create/truncate semantics. 
- Ensured `snapshot_run` is read-only and does not create/flush/mutate the completed-span JSONL file; only `shutdown` writes the file. 
- Preserved the stable wrapper `{"format":"tailtriage.tracing-span.v1","span":{...}}` and implemented span reconstruction rules: request => `tt.request` (`duration_us = latency_us`), stage => `tt.stage` (`duration_us = latency_us`), queue => `tt.queue` (`duration_us = wait_us`, optional `tt.depth_at_start`). 
- Non-strict write failures add an `ImportWarning` and push a `metadata.lifecycle_warnings` entry while strict mode returns an `ImportError::Io` (or equivalent). 
- Updated docs in `tailtriage-tracing/README.md` to state completed-span JSONL is written on shutdown from retained valid evidence and removed prior pre-retention streaming wording. 

### Testing
- Ran formatter, linter, full test suite, and docs validator: `cargo fmt --check` passed, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` passed, `cargo test --workspace --all-targets --all-features --locked` passed, and `python3 scripts/validate_docs_contracts.py` passed. 
- Exercised and updated `tailtriage-tracing` unit tests around the intake session to verify: shutdown JSONL create/truncate behavior and wrapper shape, snapshot non-mutation, retained-count parity between `snapshot_run()` and JSONL re-import under tiny limits, and non-strict shutdown-write warning behavior; the modified test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12d21354708330a134faf72df35d7c)