### PR TITLE
Harden tracing JSONL wrapper marker validation in compatible mode

### DIFF
--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -145,7 +145,10 @@ fn parse_record(
     mode: JsonlParseMode,
 ) -> Result<Option<SpanRecord>, ImportError> {
     if let Some(obj) = value.as_object() {
-        if let (Some(format), Some(span_value)) = (obj.get("format"), obj.get("span")) {
+        if obj.contains_key("format") {
+            let Some(format) = obj.get("format") else {
+                unreachable!("contains_key(\"format\") guarantees key presence");
+            };
             let Some(format_marker) = format.as_str() else {
                 let message = format!(
                     "line {line_no}: invalid field 'format': expected string format marker"
@@ -166,6 +169,17 @@ fn parse_record(
                 warnings.push(crate::ImportWarning::new(message));
                 return Ok(None);
             }
+
+            let Some(span_value) = obj.get("span") else {
+                let message = format!(
+                    "line {line_no}: missing field 'span' for tailtriage.tracing-span.v1 wrapper"
+                );
+                if strict {
+                    return Err(ImportError::StrictViolation(message));
+                }
+                warnings.push(crate::ImportWarning::new(message));
+                return Ok(None);
+            };
 
             let Some(_) = span_value.as_object() else {
                 let message = format!(
@@ -1262,6 +1276,66 @@ mod tests {
         .unwrap();
         assert_eq!(imported.run().requests.len(), 0);
         assert_eq!(imported.warnings().len(), 1);
+    }
+
+    #[test]
+    fn compatible_mode_wrapper_marker_errors_warn_non_strict_and_fail_strict() {
+        let cases = [
+            (
+                r#"{"format":"tailtriage.tracing-span.v1"}"#,
+                "missing field 'span'",
+            ),
+            (
+                r#"{"format":"tailtriage.tracing-span.v1","span":"not an object"}"#,
+                "invalid field 'span'",
+            ),
+            (
+                r#"{"format":1,"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#,
+                "invalid field 'format'",
+            ),
+            (
+                r#"{"format":"tailtriage.tracing-span.v2","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#,
+                "unsupported span format marker",
+            ),
+        ];
+
+        for (idx, (input, expected_msg_fragment)) in cases.iter().enumerate() {
+            let imported =
+                import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+            assert_eq!(
+                imported.run().requests.len(),
+                0,
+                "case {idx} unexpectedly imported requests"
+            );
+            assert_eq!(
+                imported.warnings().len(),
+                1,
+                "case {idx} expected one parse warning"
+            );
+            let warning = imported.warnings()[0].message();
+            assert!(
+                warning.contains(expected_msg_fragment),
+                "case {idx} warning '{warning}' did not include '{expected_msg_fragment}'"
+            );
+            assert!(
+                warning.contains("line 1"),
+                "case {idx} warning '{warning}' should include line number"
+            );
+
+            let err =
+                import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+                    .unwrap_err();
+            assert!(matches!(err, ImportError::StrictViolation(_)));
+            let msg = err.to_string();
+            assert!(
+                msg.contains(expected_msg_fragment),
+                "case {idx} strict error '{msg}' did not include '{expected_msg_fragment}'"
+            );
+            assert!(
+                msg.contains("line 1"),
+                "case {idx} strict error '{msg}' should include line number"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent records that include a `format` marker from being silently treated as unrelated noise in compatible mode by treating any record with a `format` field as an attempted wrapper.
- Make error/warning semantics explicit and consistent for malformed wrapper markers so compatible-mode users get actionable warnings while `strict` users get hard failures.

### Description
- Change `parse_record` in `tailtriage-tracing/src/jsonl.rs` to enter wrapper validation whenever the JSON object `contains_key("format")` rather than only when both `format` and `span` are present. 
- Add explicit handling for missing `span` when `format == "tailtriage.tracing-span.v1"` that emits a line-numbered warning in non-strict mode and returns `ImportError::StrictViolation` in strict mode. 
- Preserve existing checks and behavior for non-string `format`, unsupported format markers, and non-object `span`, keeping existing valid wrapper behavior and legacy compatible parsing for records that do not include `format`. 
- Add a test matrix verifying the following scenarios: missing `span`, non-object `span`, non-string `format`, and unsupported `format` marker, and assert that each case warns+skips in non-strict mode and fails in strict mode; keep legacy-shape compatibility tests intact.

### Testing
- Ran `cargo fmt --check` which passed. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which passed with no warnings. 
- Ran `cargo test --workspace --all-targets --all-features --locked` and the full test suite passed (all tests OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12e172b93c83308fb7891ce1d7319d)