### PR TITLE
Harden tracing JSONL wrapper parsing for format-marked records

### DIFF
--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -145,7 +145,7 @@ fn parse_record(
     mode: JsonlParseMode,
 ) -> Result<Option<SpanRecord>, ImportError> {
     if let Some(obj) = value.as_object() {
-        if let (Some(format), Some(span_value)) = (obj.get("format"), obj.get("span")) {
+        if let Some(format) = obj.get("format") {
             let Some(format_marker) = format.as_str() else {
                 let message = format!(
                     "line {line_no}: invalid field 'format': expected string format marker"
@@ -166,6 +166,17 @@ fn parse_record(
                 warnings.push(crate::ImportWarning::new(message));
                 return Ok(None);
             }
+
+            let Some(span_value) = obj.get("span") else {
+                let message = format!(
+                    "line {line_no}: missing field 'span' for tailtriage.tracing-span.v1 wrapper"
+                );
+                if strict {
+                    return Err(ImportError::StrictViolation(message));
+                }
+                warnings.push(crate::ImportWarning::new(message));
+                return Ok(None);
+            };
 
             let Some(_) = span_value.as_object() else {
                 let message = format!(
@@ -1161,6 +1172,105 @@ mod tests {
             .warnings()
             .iter()
             .any(|w| w.message().contains("v2") || w.message().contains("unsupported")));
+    }
+
+    #[test]
+    fn compatible_mode_wrapper_marker_missing_span_warns_non_strict_and_errors_strict() {
+        let missing_span = r#"{"format":"tailtriage.tracing-span.v1"}"#;
+        let imported =
+            import_jsonl_reader(Cursor::new(missing_span), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.run().stages.is_empty());
+        assert!(imported.run().queues.is_empty());
+        assert_eq!(imported.warnings().len(), 1);
+        assert!(imported.warnings()[0].message().contains("line 1"));
+        assert!(imported.warnings()[0]
+            .message()
+            .contains("missing field 'span'"));
+
+        let err = import_jsonl_reader(
+            Cursor::new(missing_span),
+            ImportOptions::new("svc").strict(true),
+        )
+        .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(err.to_string().contains("line 1"));
+        assert!(err.to_string().contains("missing field 'span'"));
+    }
+
+    #[test]
+    fn compatible_mode_wrapper_marker_non_object_span_warns_non_strict_and_errors_strict() {
+        let span_not_object = r#"{"format":"tailtriage.tracing-span.v1","span":"not an object"}"#;
+        let imported =
+            import_jsonl_reader(Cursor::new(span_not_object), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.run().stages.is_empty());
+        assert!(imported.run().queues.is_empty());
+        assert_eq!(imported.warnings().len(), 1);
+        assert!(imported.warnings()[0].message().contains("line 1"));
+        assert!(imported.warnings()[0]
+            .message()
+            .contains("invalid field 'span'"));
+
+        let err = import_jsonl_reader(
+            Cursor::new(span_not_object),
+            ImportOptions::new("svc").strict(true),
+        )
+        .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(err.to_string().contains("line 1"));
+        assert!(err.to_string().contains("invalid field 'span'"));
+    }
+
+    #[test]
+    fn compatible_mode_wrapper_marker_non_string_format_warns_non_strict_and_errors_strict() {
+        let format_not_string = r#"{"format":1,"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
+        let imported =
+            import_jsonl_reader(Cursor::new(format_not_string), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.run().stages.is_empty());
+        assert!(imported.run().queues.is_empty());
+        assert_eq!(imported.warnings().len(), 1);
+        assert!(imported.warnings()[0].message().contains("line 1"));
+        assert!(imported.warnings()[0]
+            .message()
+            .contains("expected string format marker"));
+
+        let err = import_jsonl_reader(
+            Cursor::new(format_not_string),
+            ImportOptions::new("svc").strict(true),
+        )
+        .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(err.to_string().contains("line 1"));
+        assert!(err.to_string().contains("expected string format marker"));
+    }
+
+    #[test]
+    fn compatible_mode_wrapper_marker_unsupported_format_warns_non_strict_and_errors_strict() {
+        let unsupported_format = r#"{"format":"tailtriage.tracing-span.v2","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
+        let imported =
+            import_jsonl_reader(Cursor::new(unsupported_format), ImportOptions::new("svc"))
+                .unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.run().stages.is_empty());
+        assert!(imported.run().queues.is_empty());
+        assert_eq!(imported.warnings().len(), 1);
+        assert!(imported.warnings()[0].message().contains("line 1"));
+        assert!(imported.warnings()[0]
+            .message()
+            .contains("unsupported span format marker"));
+        assert!(imported.warnings()[0].message().contains("v2"));
+
+        let err = import_jsonl_reader(
+            Cursor::new(unsupported_format),
+            ImportOptions::new("svc").strict(true),
+        )
+        .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(err.to_string().contains("line 1"));
+        assert!(err.to_string().contains("unsupported span format marker"));
+        assert!(err.to_string().contains("v2"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Ensure any JSON record that includes a `format` field is treated as an attempted tailtriage wrapper so malformed wrapper attempts are not silently treated as unrelated noise in compatible mode.
- Provide precise, line-numbered diagnostics and strict/non-strict behavior for malformed wrapper attempts to make imports deterministic and debuggable.

### Description
- Change `parse_record` in `tailtriage-tracing/src/jsonl.rs` so wrapper validation begins whenever an object contains `format` (checked with `obj.get("format")`) instead of only when both `format` and `span` are present.
- Enforce the specified strict/non-strict semantics with clear messages and line numbers for: non-string `format`, unsupported `format` values, missing `span` when `format == "tailtriage.tracing-span.v1"`, and non-object `span` for `tailtriage.tracing-span.v1`.
- Preserve existing valid wrapper parsing, compatible legacy-shape parsing for records without `format`, and `TailtriageWrapperOnly` mode behavior for non-wrapper records.
- Add unit tests in `tailtriage-tracing/src/jsonl.rs` covering: missing `span`, non-object `span`, non-string `format`, and unsupported `format` marker, verifying non-strict mode emits warnings (no imported events) and strict mode raises `ImportError::StrictViolation`.

### Testing
- Ran `cargo fmt --check` which passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which passed with no warnings.
- Ran `cargo test --workspace --all-targets --all-features --locked` and the full workspace test suite passed (all relevant new and existing tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12e172b93c83308fb7891ce1d7319d)