### PR TITLE
Harden tracing JSONL wrapper parsing for format-marker error cases

### DIFF
--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -145,7 +145,7 @@ fn parse_record(
     mode: JsonlParseMode,
 ) -> Result<Option<SpanRecord>, ImportError> {
     if let Some(obj) = value.as_object() {
-        if let (Some(format), Some(span_value)) = (obj.get("format"), obj.get("span")) {
+        if let Some(format) = obj.get("format") {
             let Some(format_marker) = format.as_str() else {
                 let message = format!(
                     "line {line_no}: invalid field 'format': expected string format marker"
@@ -166,6 +166,17 @@ fn parse_record(
                 warnings.push(crate::ImportWarning::new(message));
                 return Ok(None);
             }
+
+            let Some(span_value) = obj.get("span") else {
+                let message = format!(
+                    "line {line_no}: missing field 'span': expected completed span object for tailtriage.tracing-span.v1"
+                );
+                if strict {
+                    return Err(ImportError::StrictViolation(message));
+                }
+                warnings.push(crate::ImportWarning::new(message));
+                return Ok(None);
+            };
 
             let Some(_) = span_value.as_object() else {
                 let message = format!(
@@ -1262,6 +1273,74 @@ mod tests {
         .unwrap();
         assert_eq!(imported.run().requests.len(), 0);
         assert_eq!(imported.warnings().len(), 1);
+    }
+
+    #[test]
+    fn wrapper_v1_missing_span_warns_non_strict_and_errors_strict() {
+        let input = r#"{"format":"tailtriage.tracing-span.v1"}"#;
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+            .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(err.to_string().contains("line 1"));
+        assert!(err.to_string().contains("missing field 'span'"));
+
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.warnings().iter().any(
+            |w| w.message().contains("line 1") && w.message().contains("missing field 'span'")
+        ));
+    }
+
+    #[test]
+    fn wrapper_v1_non_object_span_warns_non_strict_and_errors_strict() {
+        let input = r#"{"format":"tailtriage.tracing-span.v1","span":"nope"}"#;
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+            .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(err.to_string().contains("line 1"));
+        assert!(err.to_string().contains("invalid field 'span'"));
+
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.warnings().iter().any(
+            |w| w.message().contains("line 1") && w.message().contains("invalid field 'span'")
+        ));
+    }
+
+    #[test]
+    fn wrapper_with_non_string_format_warns_non_strict_and_errors_strict() {
+        let input = r#"{"format":false}"#;
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+            .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(err.to_string().contains("line 1"));
+        assert!(err.to_string().contains("invalid field 'format'"));
+
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("line 1")
+                && w.message().contains("invalid field 'format'")));
+    }
+
+    #[test]
+    fn wrapper_with_unsupported_format_warns_non_strict_and_errors_strict() {
+        let input = r#"{"format":"tailtriage.tracing-span.v2"}"#;
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+            .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(err.to_string().contains("line 1"));
+        assert!(err.to_string().contains("unsupported span format marker"));
+
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("line 1")
+                && w.message().contains("unsupported span format marker")));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Ensure any record that includes a `format` key is treated as an attempted tailtriage wrapper instead of being silently ignored as unrelated noise.
- Make wrapper validation precise so compatible mode does not accidentally accept or ignore malformed wrapper-like records.
- Provide clear, line-numbered warnings in non-strict mode and deterministic failures in strict mode to help callers diagnose malformed wrapper records.

### Description
- Change `parse_record` in `tailtriage-tracing/src/jsonl.rs` to begin wrapper validation whenever the JSON object contains a `format` key (i.e. treat `format` presence as an attempted wrapper parse) instead of requiring both `format` and `span` to be present.
- Add explicit handling and messages for these wrapper error cases: non-string `format`, unsupported `format` string, missing `span` when `format == "tailtriage.tracing-span.v1"`, and non-object `span` when `format == "tailtriage.tracing-span.v1"` (non-strict: warning + skip; strict: return `ImportError::StrictViolation`).
- Preserve existing valid wrapper parsing behavior and the legacy-compatible normalized/close-event parsing for records without `format` unchanged.
- Add unit tests (in the `jsonl` tests) covering: `format` present with missing `span`, `format` present with non-object `span`, non-string `format`, and unsupported `format` marker, asserting warning-and-skip in non-strict mode and strict failures in strict mode.

### Testing
- Ran `cargo fmt --check` and formatting passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and linting passed with no warnings.
- Ran the full test suite with `cargo test --workspace --all-targets --all-features --locked` and all tests passed including the newly added `jsonl` tests (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12e172b93c83308fb7891ce1d7319d)