### PR TITLE
Include runtime lifecycle warnings in ImportedRun warnings

### DIFF
--- a/tailtriage-tracing/src/tokio.rs
+++ b/tailtriage-tracing/src/tokio.rs
@@ -7,7 +7,9 @@ use tailtriage_core::{
 };
 use tailtriage_tokio::{RuntimeSampler, SamplerStartError};
 
-use crate::{ImportError, ImportedRun, RecorderLimits, TailtriageLayer, TracingRecorder};
+use crate::{
+    ImportError, ImportWarning, ImportedRun, RecorderLimits, TailtriageLayer, TracingRecorder,
+};
 
 /// Error returned when starting [`TracingTokioSession`].
 #[derive(Debug)]
@@ -229,7 +231,7 @@ impl TracingTokioSessionBuilder {
 }
 
 fn merge_runtime_data(imported: ImportedRun, runtime_run: &Run) -> ImportedRun {
-    let (mut tracing_run, warnings) = imported.into_parts();
+    let (mut tracing_run, mut warnings) = imported.into_parts();
     tracing_run
         .runtime_snapshots
         .clone_from(&runtime_run.runtime_snapshots);
@@ -271,6 +273,9 @@ fn merge_runtime_data(imported: ImportedRun, runtime_run: &Run) -> ImportedRun {
                 .metadata
                 .lifecycle_warnings
                 .push(warning.clone());
+        }
+        if !warnings.iter().any(|entry| entry.message() == warning) {
+            warnings.push(ImportWarning::new(warning.clone()));
         }
     }
     ImportedRun::new(tracing_run, warnings)
@@ -478,6 +483,43 @@ mod tests {
         assert_eq!(
             run.metadata.finalized_at_unix_ms,
             Some(run.metadata.finished_at_unix_ms)
+        );
+    }
+
+    #[test]
+    fn merge_runtime_data_merges_runtime_lifecycle_warnings_into_metadata_and_imported_warnings() {
+        let tracing_run = empty_run("tracing");
+        let mut runtime_run = empty_run("runtime");
+        runtime_run.metadata.lifecycle_warnings = vec!["runtime-warning".into()];
+
+        let merged = merge_runtime_data(ImportedRun::new(tracing_run, vec![]), &runtime_run);
+        let run = merged.run();
+        let warnings = merged.warnings();
+
+        assert_eq!(run.metadata.lifecycle_warnings, vec!["runtime-warning"]);
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].message(), "runtime-warning");
+    }
+
+    #[test]
+    fn merge_runtime_data_deduplicates_imported_warnings_by_message() {
+        let tracing_run = empty_run("tracing");
+        let mut runtime_run = empty_run("runtime");
+        runtime_run.metadata.lifecycle_warnings = vec!["duplicate-warning".into()];
+
+        let merged = merge_runtime_data(
+            ImportedRun::new(
+                tracing_run,
+                vec![crate::ImportWarning::new("duplicate-warning")],
+            ),
+            &runtime_run,
+        );
+        let warnings = merged.warnings();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].message(), "duplicate-warning");
+        assert_eq!(
+            merged.run().metadata.lifecycle_warnings,
+            vec!["duplicate-warning"]
         );
     }
 }


### PR DESCRIPTION
### Motivation
- `merge_runtime_data` previously copied runtime lifecycle warnings into `run.metadata.lifecycle_warnings` but did not expose those warnings through the `ImportedRun::warnings()` API, causing library users to miss runtime-side non-fatal warnings.
- The change ensures that all non-fatal warnings relevant to a returned `Run` are visible to callers via `ImportedRun::warnings()` while preserving existing metadata behavior.

### Description
- Updated `tailtriage-tracing/src/tokio.rs` and `merge_runtime_data` to also append runtime lifecycle warnings to the imported `warnings` vector as `ImportWarning::new(...)` when merging a `Run` from the runtime collector.
- Made the imported `warnings` vector mutable and deduplicate by warning message string using `warnings.iter().any(|entry| entry.message() == warning)` before pushing a new `ImportWarning`.
- Kept existing behavior that always preserves runtime lifecycle warnings in `run.metadata.lifecycle_warnings` and did not change other runtime snapshot merge semantics.
- Added unit tests in `tailtriage-tracing/src/tokio.rs` to verify that runtime warnings are merged into both metadata and `ImportedRun::warnings()` and that duplicate messages are not duplicated in `ImportedRun::warnings()`.

### Testing
- Ran `cargo fmt --check` which succeeded.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which succeeded with no warnings.
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests passed, including the new tests `merge_runtime_data_merges_runtime_lifecycle_warnings_into_metadata_and_imported_warnings` and `merge_runtime_data_deduplicates_imported_warnings_by_message`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12ebf6508c83308daeb7ba2881fc24)