### PR TITLE
Include merged runtime lifecycle warnings in ImportedRun::warnings

### DIFF
--- a/tailtriage-tracing/src/tokio.rs
+++ b/tailtriage-tracing/src/tokio.rs
@@ -7,7 +7,9 @@ use tailtriage_core::{
 };
 use tailtriage_tokio::{RuntimeSampler, SamplerStartError};
 
-use crate::{ImportError, ImportedRun, RecorderLimits, TailtriageLayer, TracingRecorder};
+use crate::{
+    ImportError, ImportWarning, ImportedRun, RecorderLimits, TailtriageLayer, TracingRecorder,
+};
 
 /// Error returned when starting [`TracingTokioSession`].
 #[derive(Debug)]
@@ -229,7 +231,7 @@ impl TracingTokioSessionBuilder {
 }
 
 fn merge_runtime_data(imported: ImportedRun, runtime_run: &Run) -> ImportedRun {
-    let (mut tracing_run, warnings) = imported.into_parts();
+    let (mut tracing_run, mut warnings) = imported.into_parts();
     tracing_run
         .runtime_snapshots
         .clone_from(&runtime_run.runtime_snapshots);
@@ -272,6 +274,12 @@ fn merge_runtime_data(imported: ImportedRun, runtime_run: &Run) -> ImportedRun {
                 .lifecycle_warnings
                 .push(warning.clone());
         }
+        if !warnings
+            .iter()
+            .any(|import_warning| import_warning.message() == warning)
+        {
+            warnings.push(ImportWarning::new(warning.clone()));
+        }
     }
     ImportedRun::new(tracing_run, warnings)
 }
@@ -279,7 +287,7 @@ fn merge_runtime_data(imported: ImportedRun, runtime_run: &Run) -> ImportedRun {
 #[cfg(test)]
 mod tests {
     use super::merge_runtime_data;
-    use crate::ImportedRun;
+    use crate::{ImportWarning, ImportedRun};
     use tailtriage_core::{MemorySink, RuntimeSnapshot, Tailtriage};
 
     fn empty_run(service_name: &str) -> tailtriage_core::Run {
@@ -478,6 +486,56 @@ mod tests {
         assert_eq!(
             run.metadata.finalized_at_unix_ms,
             Some(run.metadata.finished_at_unix_ms)
+        );
+    }
+
+    #[test]
+    fn merge_runtime_data_adds_runtime_lifecycle_warning_to_metadata_and_import_warnings() {
+        let tracing_run = empty_run("tracing");
+        let mut runtime_run = empty_run("runtime");
+        runtime_run.metadata.lifecycle_warnings = vec!["runtime-warning".into()];
+
+        let merged = merge_runtime_data(ImportedRun::new(tracing_run, vec![]), &runtime_run);
+        assert_eq!(
+            merged.run().metadata.lifecycle_warnings,
+            vec!["runtime-warning"]
+        );
+        assert_eq!(
+            merged.warnings(),
+            &[ImportWarning::new("runtime-warning".to_string())]
+        );
+    }
+
+    #[test]
+    fn merge_runtime_data_deduplicates_warning_messages_in_imported_run_warnings() {
+        let tracing_run = empty_run("tracing");
+        let mut runtime_run = empty_run("runtime");
+        runtime_run.metadata.lifecycle_warnings = vec![
+            "shared-warning".into(),
+            "shared-warning".into(),
+            "unique-warning".into(),
+        ];
+        let existing_warnings = vec![
+            ImportWarning::new("shared-warning"),
+            ImportWarning::new("existing-warning"),
+        ];
+
+        let merged = merge_runtime_data(
+            ImportedRun::new(tracing_run, existing_warnings),
+            &runtime_run,
+        );
+
+        assert_eq!(
+            merged.run().metadata.lifecycle_warnings,
+            vec!["shared-warning", "unique-warning"]
+        );
+        assert_eq!(
+            merged.warnings(),
+            &[
+                ImportWarning::new("shared-warning"),
+                ImportWarning::new("existing-warning"),
+                ImportWarning::new("unique-warning"),
+            ]
         );
     }
 }


### PR DESCRIPTION
### Motivation
- Previously `merge_runtime_data` copied runtime lifecycle warnings into `Run.metadata.lifecycle_warnings` but did not propagate them into the `ImportedRun::warnings()` list, causing library users to miss non-fatal runtime-side warnings when inspecting the imported warnings vector.

### Description
- Update `tailtriage-tracing/src/tokio.rs::merge_runtime_data` to import `ImportWarning` and make the imported `warnings` vector mutable so runtime lifecycle warnings can also be appended as `ImportWarning::new(...)` when merged.
- Add a message-based deduplication check so the same lifecycle warning string is not added twice to `ImportedRun::warnings()` while preserving the metadata lifecycle warnings list unchanged.
- Keep existing runtime snapshot merge semantics intact (snapshot copy, metadata bounds/finalized logic, truncation/limits handling) and do not remove metadata lifecycle warnings.
- Add unit tests to verify that runtime lifecycle warnings are merged into `run.metadata.lifecycle_warnings`, appear in `ImportedRun::warnings()`, and are not duplicated in the imported warnings list.

### Testing
- Ran `cargo fmt --check` which succeeded without changes required.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which completed with no warnings.
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests (including the new unit tests) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12ebf6508c83308daeb7ba2881fc24)