### PR TITLE
Fix retained completed-span JSONL replay safety for contradictory durations

### DIFF
--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -565,18 +565,31 @@ fn required_string(
     }
 }
 
+pub(crate) const DURATION_TOLERANCE_US: u64 = 2_000;
+
+pub(crate) fn duration_within_tolerance(
+    duration_us: u64,
+    started_at_unix_ms: u64,
+    finished_at_unix_ms: u64,
+) -> bool {
+    let derived_us = (finished_at_unix_ms - started_at_unix_ms).saturating_mul(1000);
+    duration_us.abs_diff(derived_us) <= DURATION_TOLERANCE_US
+}
+
 fn validated_duration_us(
     span: &SpanRecord,
     strict: bool,
     warnings: &mut Vec<ImportWarning>,
 ) -> Result<u64, ImportError> {
-    const DURATION_TOLERANCE_US: u64 = 2_000;
     let derived_us = (span.finished_at_unix_ms() - span.started_at_unix_ms()).saturating_mul(1000);
     let Some(duration_us) = span.duration_us_ref() else {
         return Ok(derived_us);
     };
-    let diff_us = duration_us.abs_diff(derived_us);
-    if diff_us <= DURATION_TOLERANCE_US {
+    if duration_within_tolerance(
+        duration_us,
+        span.started_at_unix_ms(),
+        span.finished_at_unix_ms(),
+    ) {
         return Ok(duration_us);
     }
     let message = format!(

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -12,8 +12,8 @@ use tracing::{Id, Subscriber};
 use tracing_subscriber::layer::{Context, Layer};
 
 use crate::{
-    ensure_persistable_run_has_requests, run_from_span_records, FieldValue, ImportError,
-    ImportOptions, ImportedRun, SpanRecord, TT_KIND,
+    duration_within_tolerance, ensure_persistable_run_has_requests, run_from_span_records,
+    FieldValue, ImportError, ImportOptions, ImportedRun, SpanRecord, TT_KIND,
 };
 
 /// In-memory recorder for completed tracing spans with `tt.*` fields.
@@ -341,26 +341,41 @@ fn retained_span_records_from_run(run: &tailtriage_core::Run) -> Vec<SpanRecord>
             req.started_at_unix_ms,
             req.finished_at_unix_ms,
         )
-        .duration_us(req.latency_us)
         .field("tt.kind", "request")
         .field("tt.request_id", req.request_id.clone())
         .field("tt.route", req.route.clone())
         .field("tt.outcome", req.outcome.clone());
+        let span = if duration_within_tolerance(
+            req.latency_us,
+            req.started_at_unix_ms,
+            req.finished_at_unix_ms,
+        ) {
+            span.duration_us(req.latency_us)
+        } else {
+            span
+        };
         spans.push(span);
     }
     for stage in &run.stages {
-        spans.push(
-            SpanRecord::new(
-                "tt.stage",
-                stage.started_at_unix_ms,
-                stage.finished_at_unix_ms,
-            )
-            .duration_us(stage.latency_us)
-            .field("tt.kind", "stage")
-            .field("tt.request_id", stage.request_id.clone())
-            .field("tt.stage", stage.stage.clone())
-            .field("tt.success", stage.success),
-        );
+        let stage_span = SpanRecord::new(
+            "tt.stage",
+            stage.started_at_unix_ms,
+            stage.finished_at_unix_ms,
+        )
+        .field("tt.kind", "stage")
+        .field("tt.request_id", stage.request_id.clone())
+        .field("tt.stage", stage.stage.clone())
+        .field("tt.success", stage.success);
+        let stage_span = if duration_within_tolerance(
+            stage.latency_us,
+            stage.started_at_unix_ms,
+            stage.finished_at_unix_ms,
+        ) {
+            stage_span.duration_us(stage.latency_us)
+        } else {
+            stage_span
+        };
+        spans.push(stage_span);
     }
     for queue in &run.queues {
         let mut span = SpanRecord::new(
@@ -368,10 +383,16 @@ fn retained_span_records_from_run(run: &tailtriage_core::Run) -> Vec<SpanRecord>
             queue.waited_from_unix_ms,
             queue.waited_until_unix_ms,
         )
-        .duration_us(queue.wait_us)
         .field("tt.kind", "queue")
         .field("tt.request_id", queue.request_id.clone())
         .field("tt.queue", queue.queue.clone());
+        if duration_within_tolerance(
+            queue.wait_us,
+            queue.waited_from_unix_ms,
+            queue.waited_until_unix_ms,
+        ) {
+            span = span.duration_us(queue.wait_us);
+        }
         if let Some(depth) = queue.depth_at_start {
             span = span.field("tt.depth_at_start", depth);
         }
@@ -2248,6 +2269,88 @@ mod tests {
         let err = session.shutdown().unwrap_err();
         assert!(matches!(err, ImportError::ZeroRequestArtifact { .. }));
         assert_eq!(std::fs::read_to_string(&run_path).unwrap(), "keep-me");
+    }
+
+    #[test]
+    fn retained_jsonl_omits_implausible_request_stage_queue_durations() {
+        let dir = tempfile::tempdir().unwrap();
+        let spans_path = dir.path().join("spans.jsonl");
+        let mut run = tailtriage_core::Tailtriage::builder("svc")
+            .sink(tailtriage_core::MemorySink::new())
+            .build()
+            .unwrap()
+            .snapshot();
+        run.requests.push(tailtriage_core::RequestEvent {
+            request_id: "r1".into(),
+            route: "/a".into(),
+            kind: None,
+            started_at_unix_ms: 100,
+            finished_at_unix_ms: 100,
+            latency_us: 50_000,
+            outcome: "ok".into(),
+        });
+        run.stages.push(tailtriage_core::StageEvent {
+            request_id: "r1".into(),
+            stage: "db".into(),
+            started_at_unix_ms: 100,
+            finished_at_unix_ms: 100,
+            latency_us: 50_000,
+            success: true,
+        });
+        run.queues.push(tailtriage_core::QueueEvent {
+            request_id: "r1".into(),
+            queue: "admission".into(),
+            waited_from_unix_ms: 100,
+            waited_until_unix_ms: 100,
+            wait_us: 50_000,
+            depth_at_start: None,
+        });
+
+        write_completed_span_jsonl_from_run(&run, &spans_path).unwrap();
+        let raw = std::fs::read_to_string(&spans_path).unwrap();
+        for line in raw.lines().filter(|l| !l.trim().is_empty()) {
+            let value: serde_json::Value = serde_json::from_str(line).unwrap();
+            assert_eq!(value["format"], "tailtriage.tracing-span.v1");
+            let kind = value["span"]["fields"]["tt.kind"].as_str().unwrap();
+            match kind {
+                "request" | "stage" | "queue" => {
+                    assert!(value["span"].get("duration_us").is_none());
+                }
+                other => panic!("unexpected kind in retained jsonl: {other}"),
+            }
+        }
+
+        let imported = crate::jsonl::import_jsonl_path_with_mode(
+            &spans_path,
+            ImportOptions::new("svc").strict(true),
+            crate::jsonl::JsonlParseMode::TailtriageWrapperOnly,
+        )
+        .unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().stages.len(), 1);
+        assert_eq!(imported.run().queues.len(), 1);
+    }
+
+    #[test]
+    fn retained_jsonl_preserves_duration_within_tolerance() {
+        let mut run = tailtriage_core::Tailtriage::builder("svc")
+            .sink(tailtriage_core::MemorySink::new())
+            .build()
+            .unwrap()
+            .snapshot();
+        run.requests.push(tailtriage_core::RequestEvent {
+            request_id: "r1".into(),
+            route: "/a".into(),
+            kind: None,
+            started_at_unix_ms: 100,
+            finished_at_unix_ms: 101,
+            latency_us: 1_500,
+            outcome: "ok".into(),
+        });
+
+        let spans = retained_span_records_from_run(&run);
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].duration_us_ref(), Some(1_500));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent retained completed-span JSONL emitted on shutdown from containing `duration_us` values that contradict millisecond start/end timestamps, which can cause importer strict-mode rejections.
- Align retained JSONL output with the repository claim that `completed_span_jsonl_path` writes replayable evidence without changing Run schema or analyzer behavior.

### Description
- Introduced a shared private plausibility contract in `tailtriage-tracing`: `pub(crate) const DURATION_TOLERANCE_US: u64 = 2_000` and `pub(crate) fn duration_within_tolerance(duration_us, started_at_unix_ms, finished_at_unix_ms) -> bool` placed in `src/lib.rs` and used across the crate.
- Updated `validated_duration_us` to call the new `duration_within_tolerance` helper instead of using its local constant.
- Updated `retained_span_records_from_run` in `src/recorder.rs` to only emit `.duration_us(...)` for request, stage, and queue spans when `duration_within_tolerance(...)` returns true; otherwise the `duration_us` field is omitted (no warning emitted), preserving the wrapper JSONL shape `{"format":"tailtriage.tracing-span.v1","span":{...}}`.
- Did not change the Run schema, analyzer behavior, or add any dependencies.

### Testing
- Ran formatting, linting, and tests: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, and `cargo test --workspace --all-targets --all-features --locked`, all of which completed successfully.
- Ran docs contract and demo parity validations: `python3 scripts/validate_docs_contracts.py` and `python3 scripts/demo_tool.py validate-tracing-retention-parity --profile release`, both succeeded.
- Added unit tests that verify implausible durations are omitted from retained JSONL, that strict wrapper-only import of that JSONL succeeds and preserves request/stage/queue counts, and that in-tolerance durations are preserved; these tests passed as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a130745d3d883308e5a9fdb5a9ee04d)