### PR TITLE
Prevent incomplete closed candidate spans from consuming raw completed cap

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -99,6 +99,8 @@ struct RecorderState {
     closed_unknown_kind_spans: u64,
     closed_malformed_kind_spans: u64,
     closed_kind_samples: Vec<ClosedKindIssueSample>,
+    closed_incomplete_candidate_spans: u64,
+    closed_incomplete_candidate_samples: Vec<ClosedKindIssueSample>,
 }
 
 #[derive(Debug)]
@@ -138,6 +140,8 @@ struct SnapshotStats {
     closed_unknown_kind_spans: u64,
     closed_malformed_kind_spans: u64,
     closed_kind_samples: Vec<ClosedKindIssueSample>,
+    closed_incomplete_candidate_spans: u64,
+    closed_incomplete_candidate_samples: Vec<ClosedKindIssueSample>,
 }
 fn lock_state(state: &Arc<Mutex<RecorderState>>) -> std::sync::MutexGuard<'_, RecorderState> {
     match state.lock() {
@@ -200,6 +204,10 @@ impl TracingRecorder {
                     closed_unknown_kind_spans: state.closed_unknown_kind_spans,
                     closed_malformed_kind_spans: state.closed_malformed_kind_spans,
                     closed_kind_samples: state.closed_kind_samples.clone(),
+                    closed_incomplete_candidate_spans: state.closed_incomplete_candidate_spans,
+                    closed_incomplete_candidate_samples: state
+                        .closed_incomplete_candidate_samples
+                        .clone(),
                 },
             )
         };
@@ -617,6 +625,11 @@ where
                 record_invalid_kind_issue(&mut state, &open, reason);
                 return;
             }
+            let kind = kind.expect("validated above");
+            if let Some(reason) = precheck_required_fields(kind, &open.fields) {
+                record_incomplete_candidate_issue(&mut state, &open, kind, reason);
+                return;
+            }
             let mut record = SpanRecord::new(
                 open.name,
                 open.started_at_unix_ms,
@@ -641,6 +654,67 @@ where
                 state.completed.push(record);
             }
         }
+    }
+}
+fn precheck_required_fields(
+    kind: &str,
+    fields: &BTreeMap<String, FieldValue>,
+) -> Option<&'static str> {
+    match kind {
+        "request" => require_string_field(fields, "tt.request_id")
+            .or_else(|| require_string_field(fields, "tt.route")),
+        "stage" => require_string_field(fields, "tt.request_id")
+            .or_else(|| require_string_field(fields, "tt.stage")),
+        "queue" => require_string_field(fields, "tt.request_id")
+            .or_else(|| require_string_field(fields, "tt.queue")),
+        _ => None,
+    }
+}
+
+fn require_string_field(
+    fields: &BTreeMap<String, FieldValue>,
+    field_name: &'static str,
+) -> Option<&'static str> {
+    match fields.get(field_name) {
+        None => Some(match field_name {
+            "tt.request_id" => "missing required field tt.request_id",
+            "tt.route" => "missing required field tt.route",
+            "tt.stage" => "missing required field tt.stage",
+            "tt.queue" => "missing required field tt.queue",
+            _ => "missing required field",
+        }),
+        Some(FieldValue::String(_)) => None,
+        Some(_) => Some(match field_name {
+            "tt.request_id" => "invalid required field tt.request_id: expected string",
+            "tt.route" => "invalid required field tt.route: expected string",
+            "tt.stage" => "invalid required field tt.stage: expected string",
+            "tt.queue" => "invalid required field tt.queue: expected string",
+            _ => "invalid required field: expected string",
+        }),
+    }
+}
+
+fn record_incomplete_candidate_issue(
+    state: &mut RecorderState,
+    open: &OpenSpan,
+    kind: &'static str,
+    reason: &'static str,
+) {
+    state.closed_incomplete_candidate_spans =
+        state.closed_incomplete_candidate_spans.saturating_add(1);
+    if state.closed_incomplete_candidate_samples.len() < 16 {
+        state
+            .closed_incomplete_candidate_samples
+            .push(ClosedKindIssueSample {
+                name: open.name.clone(),
+                span_id: open.id.clone(),
+                tt_request_id: match open.fields.get("tt.request_id") {
+                    Some(FieldValue::String(v)) => Some(v.clone()),
+                    _ => None,
+                },
+                tt_kind: Some(kind.to_owned()),
+                reason,
+            });
     }
 }
 fn record_invalid_kind_issue(state: &mut RecorderState, open: &OpenSpan, reason: &'static str) {
@@ -720,6 +794,12 @@ fn push_strict_recorder_messages(
             stats.closed_malformed_kind_spans
         ));
     }
+    if stats.closed_incomplete_candidate_spans > 0 {
+        messages.push(format!(
+            "live recorder closed {} candidate span(s) with incomplete required fields for tt.kind=request|stage|queue; these spans are not converted",
+            stats.closed_incomplete_candidate_spans
+        ));
+    }
     if stats.dropped_open_spans > 0 {
         messages.push(format!(
             "live recorder dropped {} open candidate span(s) because max_open_spans={} was reached; raise max_open_spans or reduce capture scope",
@@ -797,6 +877,11 @@ fn append_non_strict_drop_warnings(
         run.metadata.lifecycle_warnings.push(msg.clone());
         warnings.push(crate::ImportWarning::new(msg));
     }
+    if stats.closed_incomplete_candidate_spans > 0 {
+        let msg = format_incomplete_closed_candidate_message(stats);
+        run.metadata.lifecycle_warnings.push(msg.clone());
+        warnings.push(crate::ImportWarning::new(msg));
+    }
     if stats.dropped_open_spans > 0 {
         let msg = format!(
             "live recorder dropped {} candidate spans because max_open_spans was reached",
@@ -816,6 +901,32 @@ fn append_non_strict_drop_warnings(
     if stats.dropped_open_spans > 0 || stats.dropped_completed_candidate_spans > 0 {
         run.truncation.limits_hit = true;
     }
+}
+
+fn format_incomplete_closed_candidate_message(stats: &SnapshotStats) -> String {
+    let mut msg = format!(
+        "live recorder closed {} candidate span(s) with incomplete required fields for tt.kind=request|stage|queue; these spans are not converted",
+        stats.closed_incomplete_candidate_spans
+    );
+    if !stats.closed_incomplete_candidate_samples.is_empty() {
+        let sample_text = stats
+            .closed_incomplete_candidate_samples
+            .iter()
+            .map(|sample| {
+                format!(
+                    "reason={}, name={}, id={}, tt.kind={}, tt.request_id={}",
+                    sample.reason,
+                    sample.name,
+                    sample.span_id.as_deref().unwrap_or("-"),
+                    sample.tt_kind.as_deref().unwrap_or("-"),
+                    sample.tt_request_id.as_deref().unwrap_or("-")
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("; ");
+        let _ = write!(&mut msg, "; samples: {sample_text}");
+    }
+    msg
 }
 
 fn imported_with_drop_warnings(
@@ -848,6 +959,7 @@ fn imported_with_drop_warnings(
         && stats.closed_missing_kind_spans == 0
         && stats.closed_unknown_kind_spans == 0
         && stats.closed_malformed_kind_spans == 0
+        && stats.closed_incomplete_candidate_spans == 0
     {
         return Ok(imported);
     }
@@ -1359,19 +1471,16 @@ mod tests {
         );
         match err {
             ImportError::StrictViolation(message) => {
-                assert!(message.contains("tt.route"));
+                assert!(message.contains("incomplete required fields"));
             }
             other => panic!("unexpected error: {other:?}"),
         }
     }
 
     #[test]
-    fn malformed_request_does_not_consume_request_retention_in_non_strict_mode() {
+    fn incomplete_request_does_not_consume_completed_candidate_cap_in_non_strict_mode() {
         let recorder = TracingRecorder::builder("svc")
-            .capture_limits(CaptureLimits {
-                max_requests: 1,
-                ..CaptureMode::Light.core_defaults()
-            })
+            .max_completed_candidate_spans(1)
             .build();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
@@ -1390,26 +1499,23 @@ mod tests {
         let imported = recorder.snapshot_run().unwrap();
         assert_eq!(imported.run().requests.len(), 1);
         assert_eq!(imported.run().requests[0].request_id, "r-good");
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("incomplete required fields")));
+        assert!(!imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("max_completed_candidate_spans")));
     }
 
     #[test]
-    fn malformed_stage_does_not_consume_stage_retention_in_non_strict_mode() {
+    fn incomplete_stage_does_not_consume_completed_candidate_cap_in_non_strict_mode() {
         let recorder = TracingRecorder::builder("svc")
-            .capture_limits(CaptureLimits {
-                max_requests: 1,
-                max_stages: 1,
-                ..CaptureMode::Light.core_defaults()
-            })
+            .max_completed_candidate_spans(1)
             .build();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
-            let request = tracing::info_span!(
-                "request-valid",
-                tt.kind = "request",
-                tt.request_id = "r1",
-                tt.route = "/ok"
-            );
-            let _request_guard = request.enter();
             drop(tracing::info_span!(
                 "stage-malformed",
                 tt.kind = "stage",
@@ -1423,28 +1529,24 @@ mod tests {
             ));
         });
         let imported = recorder.snapshot_run().unwrap();
-        assert_eq!(imported.run().stages.len(), 1);
-        assert_eq!(imported.run().stages[0].request_id, "r1");
+        assert_eq!(imported.run().stages.len(), 0);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("incomplete required fields")));
+        assert!(!imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("max_completed_candidate_spans")));
     }
 
     #[test]
-    fn malformed_queue_does_not_consume_queue_retention_in_non_strict_mode() {
+    fn incomplete_queue_does_not_consume_completed_candidate_cap_in_non_strict_mode() {
         let recorder = TracingRecorder::builder("svc")
-            .capture_limits(CaptureLimits {
-                max_requests: 1,
-                max_queues: 1,
-                ..CaptureMode::Light.core_defaults()
-            })
+            .max_completed_candidate_spans(1)
             .build();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
-            let request = tracing::info_span!(
-                "request-valid",
-                tt.kind = "request",
-                tt.request_id = "r1",
-                tt.route = "/ok"
-            );
-            let _request_guard = request.enter();
             drop(tracing::info_span!(
                 "queue-malformed",
                 tt.kind = "queue",
@@ -1458,8 +1560,112 @@ mod tests {
             ));
         });
         let imported = recorder.snapshot_run().unwrap();
-        assert_eq!(imported.run().queues.len(), 1);
-        assert_eq!(imported.run().queues[0].request_id, "r1");
+        assert_eq!(imported.run().queues.len(), 0);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("incomplete required fields")));
+        assert!(!imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("max_completed_candidate_spans")));
+    }
+
+    #[test]
+    fn invalid_numeric_required_fields_do_not_consume_completed_candidate_cap() {
+        let recorder = TracingRecorder::builder("svc")
+            .max_completed_candidate_spans(1)
+            .build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request-invalid",
+                tt.kind = "request",
+                tt.request_id = "r-bad",
+                tt.route = 7_u64
+            ));
+            drop(tracing::info_span!(
+                "request-valid",
+                tt.kind = "request",
+                tt.request_id = "r-good",
+                tt.route = "/ok"
+            ));
+        });
+        let imported = recorder.snapshot_run().unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].request_id, "r-good");
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("invalid required field tt.route")));
+        assert!(!imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("max_completed_candidate_spans")));
+    }
+
+    #[test]
+    fn invalid_numeric_stage_does_not_consume_completed_candidate_cap() {
+        let recorder = TracingRecorder::builder("svc")
+            .max_completed_candidate_spans(1)
+            .build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "stage-invalid",
+                tt.kind = "stage",
+                tt.request_id = "r1",
+                tt.stage = 7_u64
+            ));
+            drop(tracing::info_span!(
+                "stage-valid",
+                tt.kind = "stage",
+                tt.request_id = "r1",
+                tt.stage = "db"
+            ));
+        });
+        let imported = recorder.snapshot_run().unwrap();
+        assert_eq!(imported.run().stages.len(), 0);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("invalid required field tt.stage")));
+        assert!(!imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("max_completed_candidate_spans")));
+    }
+
+    #[test]
+    fn invalid_numeric_queue_does_not_consume_completed_candidate_cap() {
+        let recorder = TracingRecorder::builder("svc")
+            .max_completed_candidate_spans(1)
+            .build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "queue-invalid",
+                tt.kind = "queue",
+                tt.request_id = "r1",
+                tt.queue = 7_u64
+            ));
+            drop(tracing::info_span!(
+                "queue-valid",
+                tt.kind = "queue",
+                tt.request_id = "r1",
+                tt.queue = "db-pool"
+            ));
+        });
+        let imported = recorder.snapshot_run().unwrap();
+        assert_eq!(imported.run().queues.len(), 0);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("invalid required field tt.queue")));
+        assert!(!imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("max_completed_candidate_spans")));
     }
 
     #[test]
@@ -1550,6 +1756,27 @@ mod tests {
     }
 
     #[test]
+    fn strict_mode_fails_for_invalid_numeric_request_route() {
+        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request-invalid-route",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = 1_u64
+            ));
+        });
+        let err = recorder.snapshot_run().unwrap_err();
+        match err {
+            ImportError::StrictViolation(message) => {
+                assert!(message.contains("incomplete required fields"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
     fn strict_mode_fails_for_malformed_stage_span() {
         let recorder = TracingRecorder::builder("svc").strict(true).build();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
@@ -1572,6 +1799,34 @@ mod tests {
     }
 
     #[test]
+    fn strict_mode_fails_for_invalid_numeric_stage_field() {
+        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let request = tracing::info_span!(
+                "request-valid",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/ok"
+            );
+            let _request_guard = request.enter();
+            drop(tracing::info_span!(
+                "stage-invalid",
+                tt.kind = "stage",
+                tt.request_id = "r1",
+                tt.stage = 2_u64
+            ));
+        });
+        let err = recorder.snapshot_run().unwrap_err();
+        match err {
+            ImportError::StrictViolation(message) => {
+                assert!(message.contains("incomplete required fields"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
     fn strict_mode_fails_for_malformed_queue_span() {
         let recorder = TracingRecorder::builder("svc").strict(true).build();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
@@ -1591,6 +1846,34 @@ mod tests {
         });
         let err = recorder.snapshot_run().unwrap_err();
         assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn strict_mode_fails_for_invalid_numeric_queue_field() {
+        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let request = tracing::info_span!(
+                "request-valid",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/ok"
+            );
+            let _request_guard = request.enter();
+            drop(tracing::info_span!(
+                "queue-invalid",
+                tt.kind = "queue",
+                tt.request_id = "r1",
+                tt.queue = 3_u64
+            ));
+        });
+        let err = recorder.snapshot_run().unwrap_err();
+        match err {
+            ImportError::StrictViolation(message) => {
+                assert!(message.contains("incomplete required fields"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
     }
 
     #[test]

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -1512,12 +1512,19 @@ mod tests {
     #[test]
     fn incomplete_stage_does_not_consume_completed_candidate_cap_in_non_strict_mode() {
         let recorder = TracingRecorder::builder("svc")
-            .max_completed_candidate_spans(1)
+            .max_completed_candidate_spans(2)
             .build();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
+            let request = tracing::info_span!(
+                "request-valid",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/ok"
+            );
+            let _request_guard = request.enter();
             drop(tracing::info_span!(
-                "stage-malformed",
+                "stage-missing-field",
                 tt.kind = "stage",
                 tt.request_id = "r1"
             ));
@@ -1529,11 +1536,18 @@ mod tests {
             ));
         });
         let imported = recorder.snapshot_run().unwrap();
-        assert_eq!(imported.run().stages.len(), 0);
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().stages.len(), 1);
+        assert_eq!(imported.run().stages[0].request_id, "r1");
+        assert_eq!(imported.run().stages[0].stage, "db");
         assert!(imported
             .warnings()
             .iter()
             .any(|w| w.message().contains("incomplete required fields")));
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("missing required field tt.stage")));
         assert!(!imported
             .warnings()
             .iter()
@@ -1543,12 +1557,19 @@ mod tests {
     #[test]
     fn incomplete_queue_does_not_consume_completed_candidate_cap_in_non_strict_mode() {
         let recorder = TracingRecorder::builder("svc")
-            .max_completed_candidate_spans(1)
+            .max_completed_candidate_spans(2)
             .build();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
+            let request = tracing::info_span!(
+                "request-valid",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/ok"
+            );
+            let _request_guard = request.enter();
             drop(tracing::info_span!(
-                "queue-malformed",
+                "queue-missing-field",
                 tt.kind = "queue",
                 tt.request_id = "r1"
             ));
@@ -1560,11 +1581,18 @@ mod tests {
             ));
         });
         let imported = recorder.snapshot_run().unwrap();
-        assert_eq!(imported.run().queues.len(), 0);
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().queues.len(), 1);
+        assert_eq!(imported.run().queues[0].request_id, "r1");
+        assert_eq!(imported.run().queues[0].queue, "db-pool");
         assert!(imported
             .warnings()
             .iter()
             .any(|w| w.message().contains("incomplete required fields")));
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("missing required field tt.queue")));
         assert!(!imported
             .warnings()
             .iter()
@@ -1607,10 +1635,17 @@ mod tests {
     #[test]
     fn invalid_numeric_stage_does_not_consume_completed_candidate_cap() {
         let recorder = TracingRecorder::builder("svc")
-            .max_completed_candidate_spans(1)
+            .max_completed_candidate_spans(2)
             .build();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
+            let request = tracing::info_span!(
+                "request-valid",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/ok"
+            );
+            let _request_guard = request.enter();
             drop(tracing::info_span!(
                 "stage-invalid",
                 tt.kind = "stage",
@@ -1625,7 +1660,9 @@ mod tests {
             ));
         });
         let imported = recorder.snapshot_run().unwrap();
-        assert_eq!(imported.run().stages.len(), 0);
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().stages.len(), 1);
+        assert_eq!(imported.run().stages[0].stage, "db");
         assert!(imported
             .warnings()
             .iter()
@@ -1639,10 +1676,17 @@ mod tests {
     #[test]
     fn invalid_numeric_queue_does_not_consume_completed_candidate_cap() {
         let recorder = TracingRecorder::builder("svc")
-            .max_completed_candidate_spans(1)
+            .max_completed_candidate_spans(2)
             .build();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
+            let request = tracing::info_span!(
+                "request-valid",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/ok"
+            );
+            let _request_guard = request.enter();
             drop(tracing::info_span!(
                 "queue-invalid",
                 tt.kind = "queue",
@@ -1657,7 +1701,9 @@ mod tests {
             ));
         });
         let imported = recorder.snapshot_run().unwrap();
-        assert_eq!(imported.run().queues.len(), 0);
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().queues.len(), 1);
+        assert_eq!(imported.run().queues[0].queue, "db-pool");
         assert!(imported
             .warnings()
             .iter()


### PR DESCRIPTION
### Motivation
- Avoid malformed but kind-valid closed spans from filling the recorder's raw completed-candidate buffer and causing later valid spans to be dropped before semantic conversion.
- Provide observable counters and samples so incomplete closed candidates are counted and surfaced separately from kind errors and raw-cap drops.

### Description
- Add `closed_incomplete_candidate_spans: u64` and sampled `closed_incomplete_candidate_samples: Vec<ClosedKindIssueSample>` to `RecorderState` and `SnapshotStats` to track incomplete closed candidates.
- Add a cheap kind-specific precheck in `TailtriageLayer::on_close` (after `tt.kind` classification and before enforcing `max_completed_candidate_spans`) that requires string-typed fields per kind (`request`: `tt.request_id` and `tt.route`; `stage`: `tt.request_id` and `tt.stage`; `queue`: `tt.request_id` and `tt.queue`), and treat missing/non-string values as incomplete.
- When the precheck fails, increment the new counter, sample up to 16 examples with reason text, and return without pushing the span into `state.completed` or incrementing `dropped_completed_candidate_spans`.
- Surface incomplete-closed-candidate information in strict-mode recorder messages and append a non-strict lifecycle warning + samples into `run.metadata.lifecycle_warnings`, while keeping orphan/out-of-window validation inside `run_from_span_records`.
- Add and update unit tests covering missing and non-string required fields for request/stage/queue, strict-mode failures for those cases, and retention behavior around `max_completed_candidate_spans` to ensure incomplete closed candidates do not consume the raw-cap.

### Testing
- Added and ran unit tests that exercise: malformed/ missing `tt.route|tt.stage|tt.queue`, numeric (non-string) required fields, non-strict retention behavior with `max_completed_candidate_spans=1`, strict-mode failures for each incomplete case, and that orphan/out-of-window cases continue to be handled by conversion validation.
- Ran repository validation and tooling: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, and `python3 scripts/demo_tool.py validate-tracing-retention-parity --profile release`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a130b14953483308f6bc8e6d5325160)