### PR TITLE
Expose DEFAULT_MAX_COMPLETED_CANDIDATE_SPANS from tailtriage-tracing crate root

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -103,7 +103,9 @@ Ordinary tracing log JSON (for example `fmt().json` output) is rejected by impor
 
 ## Retention and drop behavior
 
-- `max_open_spans` bounds in-flight span tracking.
+- Live-recorder memory caps use `DEFAULT_MAX_OPEN_SPANS` and `DEFAULT_MAX_COMPLETED_CANDIDATE_SPANS` by default.
+- `max_open_spans` bounds in-flight span tracking, and `max_completed_candidate_spans` bounds retained closed raw completed candidates before conversion.
+- Request/stage/queue semantic retention uses `CaptureMode`, `CaptureLimits`, and `CaptureLimitsOverride`.
 - `completed_span_jsonl_path(...)` writes retained valid completed-span JSONL on shutdown.
 - The completed-span JSONL is replayable into the same retained request/stage/queue evidence when imported with matching service metadata.
 - This completed-span JSONL is a narrow retained-evidence export, not a generic tracing log stream and not OTel/OTLP.

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -54,7 +54,8 @@ pub use jsonl::{
 #[cfg(feature = "live")]
 pub use recorder::{
     RecorderLimits, TailtriageLayer, TracingIntakeSession, TracingIntakeSessionBuilder,
-    TracingRecorder, TracingRecorderBuilder, DEFAULT_MAX_OPEN_SPANS,
+    TracingRecorder, TracingRecorderBuilder, DEFAULT_MAX_COMPLETED_CANDIDATE_SPANS,
+    DEFAULT_MAX_OPEN_SPANS,
 };
 pub use types::{FieldValue, ImportOptions, ImportWarning, ImportedRun, SpanKind, SpanRecord};
 

--- a/tailtriage-tracing/tests/live_recorder_defaults.rs
+++ b/tailtriage-tracing/tests/live_recorder_defaults.rs
@@ -1,0 +1,14 @@
+#![cfg(feature = "live")]
+
+#[test]
+fn crate_root_live_recorder_default_constants_match_default_limits() {
+    let limits = tailtriage_tracing::RecorderLimits::default();
+    assert_eq!(
+        limits.max_open_spans,
+        tailtriage_tracing::DEFAULT_MAX_OPEN_SPANS
+    );
+    assert_eq!(
+        limits.max_completed_candidate_spans,
+        tailtriage_tracing::DEFAULT_MAX_COMPLETED_CANDIDATE_SPANS
+    );
+}


### PR DESCRIPTION
### Motivation

- Make the live-recorder default for `max_completed_candidate_spans` discoverable from the crate root so public API and docs are consistent. 
- Document both live-recorder memory caps in the crate README so users understand what knobs control raw retained candidates versus semantic retention. 
- Add a compile-time API test to prevent regressions where crate-root re-exports diverge from the actual defaults.

### Description

- Re-exported `DEFAULT_MAX_COMPLETED_CANDIDATE_SPANS` alongside `DEFAULT_MAX_OPEN_SPANS` under the `live` feature in `tailtriage-tracing/src/lib.rs`. 
- Updated `tailtriage-tracing/README.md` retention/drop behavior to mention both `DEFAULT_MAX_OPEN_SPANS` and `DEFAULT_MAX_COMPLETED_CANDIDATE_SPANS`, and clarified that request/stage/queue retention is controlled by `CaptureMode`/`CaptureLimits`/`CaptureLimitsOverride`. 
- Added a `live`-gated API test at `tailtriage-tracing/tests/live_recorder_defaults.rs` that asserts `RecorderLimits::default()` fields equal the crate-root constants. 
- Did not change any constant values and added no new dependencies.

### Testing

- Ran `cargo fmt --check` and it succeeded. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed with no warnings. 
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests passed (including the new `live`-gated API test). 
- Ran `cargo doc --workspace --all-features --locked --no-deps` and documentation built successfully. 
- Ran `python3 scripts/validate_docs_contracts.py` and the docs contract validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a131f0f95d08330b5dc56db16b3a782)