### PR TITLE
tracing: re-export DEFAULT_MAX_COMPLETED_CANDIDATE_SPANS and add live-API default test

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -103,7 +103,10 @@ Ordinary tracing log JSON (for example `fmt().json` output) is rejected by impor
 
 ## Retention and drop behavior
 
+- `DEFAULT_MAX_OPEN_SPANS` and `DEFAULT_MAX_COMPLETED_CANDIDATE_SPANS` are live-recorder memory caps for in-memory span tracking.
 - `max_open_spans` bounds in-flight span tracking.
+- `max_completed_candidate_spans` bounds retained raw completed candidate spans before semantic conversion.
+- Request/stage/queue semantic retention uses `CaptureMode`, `CaptureLimits`, and `CaptureLimitsOverride`.
 - `completed_span_jsonl_path(...)` writes retained valid completed-span JSONL on shutdown.
 - The completed-span JSONL is replayable into the same retained request/stage/queue evidence when imported with matching service metadata.
 - This completed-span JSONL is a narrow retained-evidence export, not a generic tracing log stream and not OTel/OTLP.

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -54,7 +54,8 @@ pub use jsonl::{
 #[cfg(feature = "live")]
 pub use recorder::{
     RecorderLimits, TailtriageLayer, TracingIntakeSession, TracingIntakeSessionBuilder,
-    TracingRecorder, TracingRecorderBuilder, DEFAULT_MAX_OPEN_SPANS,
+    TracingRecorder, TracingRecorderBuilder, DEFAULT_MAX_COMPLETED_CANDIDATE_SPANS,
+    DEFAULT_MAX_OPEN_SPANS,
 };
 pub use types::{FieldValue, ImportOptions, ImportWarning, ImportedRun, SpanKind, SpanRecord};
 

--- a/tailtriage-tracing/tests/live_api_defaults.rs
+++ b/tailtriage-tracing/tests/live_api_defaults.rs
@@ -1,0 +1,14 @@
+#![cfg(feature = "live")]
+
+#[test]
+fn crate_root_exports_live_recorder_default_limits_consistently() {
+    let defaults = tailtriage_tracing::RecorderLimits::default();
+    assert_eq!(
+        defaults.max_open_spans,
+        tailtriage_tracing::DEFAULT_MAX_OPEN_SPANS
+    );
+    assert_eq!(
+        defaults.max_completed_candidate_spans,
+        tailtriage_tracing::DEFAULT_MAX_COMPLETED_CANDIDATE_SPANS
+    );
+}


### PR DESCRIPTION
### Motivation

- Make the live-recorder memory default `DEFAULT_MAX_COMPLETED_CANDIDATE_SPANS` discoverable from the crate root alongside `DEFAULT_MAX_OPEN_SPANS` so public API consumers can find both defaults consistently.

### Description

- Re-exported `DEFAULT_MAX_COMPLETED_CANDIDATE_SPANS` from `tailtriage-tracing` crate root under the `live` feature next to `DEFAULT_MAX_OPEN_SPANS` by updating `tailtriage-tracing/src/lib.rs`.
- Updated `tailtriage-tracing/README.md` retention/drop behavior section to document both `DEFAULT_MAX_OPEN_SPANS` and `DEFAULT_MAX_COMPLETED_CANDIDATE_SPANS` as live-recorder memory caps and to clarify semantic request/stage/queue retention is controlled by `CaptureMode`/`CaptureLimits`/`CaptureLimitsOverride`.
- Added a small `live`-gated compile-time API test at `tailtriage-tracing/tests/live_api_defaults.rs` that references `tailtriage_tracing::DEFAULT_MAX_OPEN_SPANS`, `tailtriage_tracing::DEFAULT_MAX_COMPLETED_CANDIDATE_SPANS`, and `tailtriage_tracing::RecorderLimits::default()` and verifies the default fields equal those constants.
- No constant values were changed and no new dependencies were added.

### Testing

- Ran `cargo fmt --check` and it succeeded.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it succeeded with no warnings.
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests passed, including the new `live`-gated `crate_root_exports_live_recorder_default_limits_consistently` test.
- Ran `cargo doc --workspace --all-features --locked --no-deps` and documentation built successfully.
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a131f0f95d08330b5dc56db16b3a782)