### PR TITLE
Expose DEFAULT_MAX_COMPLETED_CANDIDATE_SPANS at crate root

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -103,8 +103,9 @@ Ordinary tracing log JSON (for example `fmt().json` output) is rejected by impor
 
 ## Retention and drop behavior
 
-- `max_open_spans` bounds in-flight span tracking.
+- Live-recorder memory caps default to `DEFAULT_MAX_OPEN_SPANS` (in-flight span tracking) and `DEFAULT_MAX_COMPLETED_CANDIDATE_SPANS` (closed raw completed candidate retention).
 - `completed_span_jsonl_path(...)` writes retained valid completed-span JSONL on shutdown.
+- Request/stage/queue semantic retention uses `CaptureMode`, `CaptureLimits`, and `CaptureLimitsOverride` during conversion.
 - The completed-span JSONL is replayable into the same retained request/stage/queue evidence when imported with matching service metadata.
 - This completed-span JSONL is a narrow retained-evidence export, not a generic tracing log stream and not OTel/OTLP.
 - Warnings and lifecycle warnings indicate evidence may be incomplete when limits are hit or writer issues occur.

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -54,7 +54,8 @@ pub use jsonl::{
 #[cfg(feature = "live")]
 pub use recorder::{
     RecorderLimits, TailtriageLayer, TracingIntakeSession, TracingIntakeSessionBuilder,
-    TracingRecorder, TracingRecorderBuilder, DEFAULT_MAX_OPEN_SPANS,
+    TracingRecorder, TracingRecorderBuilder, DEFAULT_MAX_COMPLETED_CANDIDATE_SPANS,
+    DEFAULT_MAX_OPEN_SPANS,
 };
 pub use types::{FieldValue, ImportOptions, ImportWarning, ImportedRun, SpanKind, SpanRecord};
 

--- a/tailtriage-tracing/tests/live_defaults_api.rs
+++ b/tailtriage-tracing/tests/live_defaults_api.rs
@@ -1,0 +1,14 @@
+#![cfg(feature = "live")]
+
+#[test]
+fn recorder_limit_defaults_match_public_constants() {
+    let defaults = tailtriage_tracing::RecorderLimits::default();
+    assert_eq!(
+        defaults.max_open_spans,
+        tailtriage_tracing::DEFAULT_MAX_OPEN_SPANS
+    );
+    assert_eq!(
+        defaults.max_completed_candidate_spans,
+        tailtriage_tracing::DEFAULT_MAX_COMPLETED_CANDIDATE_SPANS
+    );
+}


### PR DESCRIPTION
### Motivation

- Make the live-recorder default for closed completed-candidate span retention discoverable from the crate root so public API surface is consistent with `RecorderLimits::default()` and `DEFAULT_MAX_OPEN_SPANS`.

### Description

- Re-exported `DEFAULT_MAX_COMPLETED_CANDIDATE_SPANS` alongside `DEFAULT_MAX_OPEN_SPANS` in `tailtriage-tracing/src/lib.rs` under `#[cfg(feature = "live")]` so both defaults are reachable as `tailtriage_tracing::...`.
- Updated `tailtriage-tracing/README.md` retention/drop behavior to document both `DEFAULT_MAX_OPEN_SPANS` and `DEFAULT_MAX_COMPLETED_CANDIDATE_SPANS` and clarified that request/stage/queue semantic retention is controlled by `CaptureMode`/`CaptureLimits`/`CaptureLimitsOverride`.
- Added a small compile-time API test at `tailtriage-tracing/tests/live_defaults_api.rs` (live feature gated) that asserts `RecorderLimits::default()` fields equal the two public constants, and made no changes to the constant values or dependencies.

### Testing

- Ran `cargo fmt --check` and it succeeded.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it succeeded with no warnings.
- Ran `cargo test --workspace --all-targets --all-features --locked`, `cargo doc --workspace --all-features --locked --no-deps`, and `python3 scripts/validate_docs_contracts.py`, and all completed successfully with the new test passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a131f0f95d08330b5dc56db16b3a782)