### PR TITLE
Fix tailtriage-tracing live recorder default API consistency

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -103,11 +103,13 @@ Ordinary tracing log JSON (for example `fmt().json` output) is rejected by impor
 
 ## Retention and drop behavior
 
+- `DEFAULT_MAX_OPEN_SPANS` and `DEFAULT_MAX_COMPLETED_CANDIDATE_SPANS` are the default live-recorder memory caps for in-flight and completed-candidate span buffers.
 - `max_open_spans` bounds in-flight span tracking.
 - `completed_span_jsonl_path(...)` writes retained valid completed-span JSONL on shutdown.
 - The completed-span JSONL is replayable into the same retained request/stage/queue evidence when imported with matching service metadata.
 - This completed-span JSONL is a narrow retained-evidence export, not a generic tracing log stream and not OTel/OTLP.
 - Warnings and lifecycle warnings indicate evidence may be incomplete when limits are hit or writer issues occur.
+- Request/stage/queue semantic retention uses `CaptureMode`, `CaptureLimits`, and `CaptureLimitsOverride`.
 
 ## Runtime-pressure limitation
 

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -54,7 +54,8 @@ pub use jsonl::{
 #[cfg(feature = "live")]
 pub use recorder::{
     RecorderLimits, TailtriageLayer, TracingIntakeSession, TracingIntakeSessionBuilder,
-    TracingRecorder, TracingRecorderBuilder, DEFAULT_MAX_OPEN_SPANS,
+    TracingRecorder, TracingRecorderBuilder, DEFAULT_MAX_COMPLETED_CANDIDATE_SPANS,
+    DEFAULT_MAX_OPEN_SPANS,
 };
 pub use types::{FieldValue, ImportOptions, ImportWarning, ImportedRun, SpanKind, SpanRecord};
 

--- a/tailtriage-tracing/tests/public_api_live_defaults.rs
+++ b/tailtriage-tracing/tests/public_api_live_defaults.rs
@@ -1,0 +1,14 @@
+#![cfg(feature = "live")]
+
+#[test]
+fn crate_root_reexports_live_recorder_defaults_consistently() {
+    let limits = tailtriage_tracing::RecorderLimits::default();
+    assert_eq!(
+        limits.max_open_spans,
+        tailtriage_tracing::DEFAULT_MAX_OPEN_SPANS
+    );
+    assert_eq!(
+        limits.max_completed_candidate_spans,
+        tailtriage_tracing::DEFAULT_MAX_COMPLETED_CANDIDATE_SPANS
+    );
+}


### PR DESCRIPTION
### Motivation
- Make the live recorder default for `max_completed_candidate_spans` discoverable from the crate root so public API and docs consistently expose both live-recorder memory knobs.

### Description
- Re-export `DEFAULT_MAX_COMPLETED_CANDIDATE_SPANS` from `tailtriage-tracing` crate root under the `live` feature next to `DEFAULT_MAX_OPEN_SPANS` (`tailtriage-tracing/src/lib.rs`).
- Update `tailtriage-tracing/README.md` retention/drop behavior to mention both `DEFAULT_MAX_OPEN_SPANS` and `DEFAULT_MAX_COMPLETED_CANDIDATE_SPANS` and clarify that these are live-recorder memory caps while request/stage/queue retention is governed by `CaptureMode`/`CaptureLimits`/`CaptureLimitsOverride`.
- Add a small compile-time API test `tailtriage-tracing/tests/public_api_live_defaults.rs` that references `tailtriage_tracing::DEFAULT_MAX_OPEN_SPANS`, `tailtriage_tracing::DEFAULT_MAX_COMPLETED_CANDIDATE_SPANS`, and `tailtriage_tracing::RecorderLimits::default()` and verifies the defaults match the constants.

### Testing
- Ran formatting and linters: `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, both succeeded.
- Ran unit and integration tests: `cargo test --workspace --all-targets --all-features --locked`, all tests passed (including the new API test).
- Built docs: `cargo doc --workspace --all-features --locked --no-deps`, succeeded.
- Validated docs contract: `python3 scripts/validate_docs_contracts.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a131f0f95d08330b5dc56db16b3a782)