### PR TITLE
Fail live tracing setup early for blank service names

### DIFF
--- a/demos/demo_support/src/lib.rs
+++ b/demos/demo_support/src/lib.rs
@@ -282,7 +282,9 @@ impl DemoInstrumentation {
                         max_runtime_snapshots: None,
                     });
                 }
-                let recorder = builder.build();
+                let recorder = builder.build().map_err(|err| {
+                    anyhow::anyhow!("invalid tracing recorder configuration: {err}")
+                })?;
                 let subscriber = tracing_subscriber::registry().with(recorder.layer());
                 // Demo binaries run one instrumentation backend per process, so installing a
                 // global subscriber is acceptable here. Do not reuse this helper in libraries

--- a/demos/runtime_cost/src/main.rs
+++ b/demos/runtime_cost/src/main.rs
@@ -300,7 +300,9 @@ fn build_backend(cli: &Cli) -> anyhow::Result<Backend> {
                 if cli.mode.uses_drop_path_limits() {
                     b = b.max_open_spans(64);
                 }
-                let rec = b.build();
+                let rec = b.build().map_err(|err| {
+                    anyhow::anyhow!("invalid tracing recorder configuration: {err}")
+                })?;
                 // One mode runs per process in this demo, so process-global subscriber init is acceptable.
                 tracing::subscriber::set_global_default(
                     tracing_subscriber::registry().with(rec.layer()),

--- a/tailtriage-tracing/examples/live_recorder.rs
+++ b/tailtriage-tracing/examples/live_recorder.rs
@@ -9,7 +9,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .service_version("example")
         .run_id("live-recorder-example")
         .strict(false)
-        .build();
+        .build()
+        .unwrap();
 
     let subscriber = tracing_subscriber::registry().with(recorder.layer());
 

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -483,8 +483,10 @@ impl TracingIntakeSessionBuilder {
     /// # Errors
     ///
     /// Returns an error when required recorder configuration is invalid.
+    ///
+    /// This fails when service metadata is blank or only whitespace.
     pub fn build(self) -> Result<TracingIntakeSession, ImportError> {
-        let recorder = self.recorder_builder.build();
+        let recorder = self.recorder_builder.build()?;
         Ok(TracingIntakeSession {
             recorder,
             completed_span_jsonl_path: self.completed_span_jsonl_path,
@@ -540,13 +542,19 @@ impl TracingRecorderBuilder {
     }
 
     /// Builds a recorder instance.
-    #[must_use]
-    pub fn build(self) -> TracingRecorder {
-        TracingRecorder {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ImportError::EmptyServiceName`] when service metadata is blank or only whitespace.
+    pub fn build(self) -> Result<TracingRecorder, ImportError> {
+        if self.options.service_name().trim().is_empty() {
+            return Err(ImportError::EmptyServiceName);
+        }
+        Ok(TracingRecorder {
             state: Arc::new(Mutex::new(RecorderState::default())),
             options: self.options,
             limits: self.limits,
-        }
+        })
     }
     /// Sets live recorder memory limits.
     #[must_use]
@@ -1029,7 +1037,10 @@ mod tests {
     use tracing_subscriber::prelude::*;
 
     fn with_recorder<T>(f: impl FnOnce(&TracingRecorder) -> T) -> T {
-        let recorder = TracingRecorder::builder("svc").run_id("rid").build();
+        let recorder = TracingRecorder::builder("svc")
+            .run_id("rid")
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || f(&recorder))
     }
@@ -1147,7 +1158,7 @@ mod tests {
             assert_eq!(snapshot.run().requests[0].route, "/checkout");
         });
 
-        let recorder = TracingRecorder::builder("svc").build();
+        let recorder = TracingRecorder::builder("svc").build().unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let span = tracing::info_span!(
@@ -1169,7 +1180,8 @@ mod tests {
             .service_version("1.2.3")
             .run_id("run-42")
             .strict(false)
-            .build();
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let span = tracing::info_span!(
@@ -1189,7 +1201,10 @@ mod tests {
 
     #[test]
     fn strict_mode_errors_on_malformed_request() {
-        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let span = tracing::info_span!("request", tt.kind = "request", tt.request_id = "r1");
@@ -1303,7 +1318,8 @@ mod tests {
     fn completed_candidate_cap_emits_warning_and_sets_limits_hit_non_strict() {
         let recorder = TracingRecorder::builder("svc")
             .max_completed_candidate_spans(1)
-            .build();
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let span1 = tracing::info_span!(
@@ -1345,7 +1361,8 @@ mod tests {
         let recorder = TracingRecorder::builder("svc")
             .strict(true)
             .max_completed_candidate_spans(1)
-            .build();
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let span1 = tracing::info_span!(
@@ -1380,7 +1397,8 @@ mod tests {
                 max_requests: 1,
                 ..CaptureMode::Light.core_defaults()
             })
-            .build();
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             drop(tracing::info_span!(
@@ -1410,7 +1428,8 @@ mod tests {
         let recorder = TracingRecorder::builder("svc")
             .strict(true)
             .max_open_spans(1)
-            .build();
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let span1 = tracing::info_span!(
@@ -1451,7 +1470,8 @@ mod tests {
                 max_queues: 1,
                 ..tailtriage_core::CaptureMode::Light.core_defaults()
             })
-            .build();
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let malformed =
@@ -1481,7 +1501,8 @@ mod tests {
     fn incomplete_request_does_not_consume_completed_candidate_cap_in_non_strict_mode() {
         let recorder = TracingRecorder::builder("svc")
             .max_completed_candidate_spans(1)
-            .build();
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             drop(tracing::info_span!(
@@ -1513,7 +1534,8 @@ mod tests {
     fn incomplete_stage_does_not_consume_completed_candidate_cap_in_non_strict_mode() {
         let recorder = TracingRecorder::builder("svc")
             .max_completed_candidate_spans(2)
-            .build();
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let request = tracing::info_span!(
@@ -1558,7 +1580,8 @@ mod tests {
     fn incomplete_queue_does_not_consume_completed_candidate_cap_in_non_strict_mode() {
         let recorder = TracingRecorder::builder("svc")
             .max_completed_candidate_spans(2)
-            .build();
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let request = tracing::info_span!(
@@ -1603,7 +1626,8 @@ mod tests {
     fn invalid_numeric_required_fields_do_not_consume_completed_candidate_cap() {
         let recorder = TracingRecorder::builder("svc")
             .max_completed_candidate_spans(1)
-            .build();
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             drop(tracing::info_span!(
@@ -1636,7 +1660,8 @@ mod tests {
     fn invalid_numeric_stage_does_not_consume_completed_candidate_cap() {
         let recorder = TracingRecorder::builder("svc")
             .max_completed_candidate_spans(2)
-            .build();
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let request = tracing::info_span!(
@@ -1677,7 +1702,8 @@ mod tests {
     fn invalid_numeric_queue_does_not_consume_completed_candidate_cap() {
         let recorder = TracingRecorder::builder("svc")
             .max_completed_candidate_spans(2)
-            .build();
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let request = tracing::info_span!(
@@ -1722,7 +1748,8 @@ mod tests {
                 max_stages: 1,
                 ..CaptureMode::Light.core_defaults()
             })
-            .build();
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             drop(tracing::info_span!(
@@ -1758,7 +1785,8 @@ mod tests {
                 max_queues: 1,
                 ..CaptureMode::Light.core_defaults()
             })
-            .build();
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             drop(tracing::info_span!(
@@ -1788,7 +1816,10 @@ mod tests {
 
     #[test]
     fn strict_mode_fails_for_malformed_request_span() {
-        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             drop(tracing::info_span!(
@@ -1803,7 +1834,10 @@ mod tests {
 
     #[test]
     fn strict_mode_fails_for_invalid_numeric_request_route() {
-        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             drop(tracing::info_span!(
@@ -1824,7 +1858,10 @@ mod tests {
 
     #[test]
     fn strict_mode_fails_for_malformed_stage_span() {
-        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let request = tracing::info_span!(
@@ -1846,7 +1883,10 @@ mod tests {
 
     #[test]
     fn strict_mode_fails_for_invalid_numeric_stage_field() {
-        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let request = tracing::info_span!(
@@ -1874,7 +1914,10 @@ mod tests {
 
     #[test]
     fn strict_mode_fails_for_malformed_queue_span() {
-        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let request = tracing::info_span!(
@@ -1896,7 +1939,10 @@ mod tests {
 
     #[test]
     fn strict_mode_fails_for_invalid_numeric_queue_field() {
-        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let request = tracing::info_span!(
@@ -1924,7 +1970,10 @@ mod tests {
 
     #[test]
     fn strict_mode_fails_for_orphan_stage_span() {
-        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             drop(tracing::info_span!(
@@ -1940,7 +1989,10 @@ mod tests {
 
     #[test]
     fn strict_mode_fails_for_orphan_queue_span() {
-        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             drop(tracing::info_span!(
@@ -1956,7 +2008,10 @@ mod tests {
 
     #[test]
     fn open_span_saturation_emits_warning_and_sets_limits_hit() {
-        let recorder = TracingRecorder::builder("svc").max_open_spans(1).build();
+        let recorder = TracingRecorder::builder("svc")
+            .max_open_spans(1)
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let span1 = tracing::info_span!(
@@ -1999,7 +2054,8 @@ mod tests {
                 max_queues: 1,
                 ..tailtriage_core::CaptureMode::Light.core_defaults()
             })
-            .build();
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let _open_1 = tracing::info_span!(
@@ -2053,7 +2109,10 @@ mod tests {
 
     #[test]
     fn unrelated_spans_do_not_consume_open_limit() {
-        let recorder = TracingRecorder::builder("svc").max_open_spans(1).build();
+        let recorder = TracingRecorder::builder("svc")
+            .max_open_spans(1)
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let unrelated = tracing::info_span!("ordinary", foo = 1_u64);
@@ -2073,9 +2132,14 @@ mod tests {
     }
 
     #[test]
-    fn empty_service_name_builder_errors_on_snapshot() {
-        let recorder = TracingRecorder::builder(" ").build();
-        let err = recorder.snapshot_run().unwrap_err();
+    fn tracing_recorder_builder_rejects_blank_service_name() {
+        let err = TracingRecorder::builder("   ").build().unwrap_err();
+        assert!(matches!(err, ImportError::EmptyServiceName));
+    }
+
+    #[test]
+    fn tracing_intake_session_builder_rejects_blank_service_name() {
+        let err = TracingIntakeSession::builder("   ").build().unwrap_err();
         assert!(matches!(err, ImportError::EmptyServiceName));
     }
 
@@ -2196,7 +2260,10 @@ mod tests {
 
     #[test]
     fn closed_candidate_missing_tt_kind_errors_strict() {
-        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let span = tracing::info_span!(
@@ -2221,7 +2288,10 @@ mod tests {
 
     #[test]
     fn closed_candidate_missing_tt_kind_shutdown_errors_strict() {
-        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let span = tracing::info_span!(
@@ -2246,7 +2316,10 @@ mod tests {
 
     #[test]
     fn strict_mode_reports_open_and_closed_missing_kind_causes_together() {
-        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let _open = tracing::info_span!(
@@ -2290,7 +2363,10 @@ mod tests {
     }
     #[test]
     fn strict_mode_rejects_open_candidate_spans_without_fabricating_completions() {
-        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         let err = tracing::subscriber::with_default(subscriber, || {
             let _open_guard = tracing::info_span!(
@@ -2341,7 +2417,10 @@ mod tests {
 
     #[test]
     fn open_candidate_span_errors_in_strict_mode() {
-        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let _open =

--- a/tailtriage-tracing/src/tokio.rs
+++ b/tailtriage-tracing/src/tokio.rs
@@ -15,7 +15,9 @@ use crate::{
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum TracingTokioSessionStartError {
-    /// Underlying tracing recorder setup failed.
+    /// Tracing recorder/import configuration failed validation.
+    Import(ImportError),
+    /// Internal runtime collector setup failed.
     Build(BuildError),
     /// Tokio runtime sampler failed to start.
     SamplerStart(SamplerStartError),
@@ -24,6 +26,9 @@ pub enum TracingTokioSessionStartError {
 impl core::fmt::Display for TracingTokioSessionStartError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
+            Self::Import(err) => {
+                write!(f, "failed to configure tracing recorder for startup: {err}")
+            }
             Self::Build(err) => write!(f, "failed to build tailtriage runtime collector: {err}"),
             Self::SamplerStart(err) => write!(f, "failed to start Tokio runtime sampler: {err}"),
         }
@@ -189,11 +194,14 @@ impl TracingTokioSessionBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`TracingTokioSessionStartError`] when runtime collector build fails,
-    /// when sampler interval is zero, or when there is no active Tokio runtime.
+    /// Returns [`TracingTokioSessionStartError`] when tracing recorder configuration is invalid,
+    /// when runtime collector build fails, when sampler interval is zero, or when there is no active Tokio runtime.
     pub fn start(self) -> Result<TracingTokioSession, TracingTokioSessionStartError> {
         let resolved_limits = self.recorder_builder.resolved_capture_limits();
-        let recorder = self.recorder_builder.build();
+        let recorder = self
+            .recorder_builder
+            .build()
+            .map_err(TracingTokioSessionStartError::Import)?;
         let sink = MemorySink::new();
         let builder = Tailtriage::builder("tailtriage-tracing-runtime")
             .sink(sink)
@@ -287,7 +295,8 @@ fn merge_runtime_data(imported: ImportedRun, runtime_run: &Run) -> ImportedRun {
 #[cfg(test)]
 mod tests {
     use super::merge_runtime_data;
-    use crate::{ImportWarning, ImportedRun};
+    use super::{TracingTokioSession, TracingTokioSessionStartError};
+    use crate::{ImportError, ImportWarning, ImportedRun};
     use tailtriage_core::{MemorySink, RuntimeSnapshot, Tailtriage};
 
     fn empty_run(service_name: &str) -> tailtriage_core::Run {
@@ -537,5 +546,16 @@ mod tests {
                 ImportWarning::new("unique-warning"),
             ]
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tracing_tokio_session_start_rejects_blank_service_name() {
+        let err = TracingTokioSession::builder("   ")
+            .start()
+            .expect_err("blank service name should fail before sampler startup");
+        assert!(matches!(
+            err,
+            TracingTokioSessionStartError::Import(ImportError::EmptyServiceName)
+        ));
     }
 }

--- a/tailtriage-tracing/tests/support/equivalence_harness.rs
+++ b/tailtriage-tracing/tests/support/equivalence_harness.rs
@@ -297,7 +297,7 @@ fn live_tracing_run() -> (Run, Vec<String>) {
 }
 
 fn tracing_run_with_queue(queue_name: &str) -> (Run, Vec<String>) {
-    let recorder = TracingRecorder::builder("svc").build();
+    let recorder = TracingRecorder::builder("svc").build().unwrap();
     let subscriber = tracing_subscriber::registry().with(recorder.layer());
     tracing::subscriber::with_default(subscriber, || {
         block_on(async {


### PR DESCRIPTION
### Motivation

- Prevent late failures and surprising runtime behavior by validating service-name metadata early during live tracing setup so blank or whitespace-only names fail at builder/start time. 
- Keep failures narrow and explicit (import/config validation) and ensure sampler/collector work is not started when the tracing configuration is invalid.

### Description

- Make `TracingRecorderBuilder::build()` fallible by changing its signature to `Result<TracingRecorder, ImportError>` and return `ImportError::EmptyServiceName` when `service_name().trim().is_empty()`.
- Propagate recorder validation to `TracingIntakeSessionBuilder::build()` so it returns an `Err(ImportError::EmptyServiceName)` for whitespace-only names, and add rustdoc notes that invalid service metadata fails at build time.
- Add `TracingTokioSessionStartError::Import(ImportError)` and validate the tracing recorder configuration in `TracingTokioSessionBuilder::start()` before building the runtime collector or starting the sampler, mapping recorder/import failures to the new `Import` start error; preserve `Build(BuildError)` and `SamplerStart(SamplerStartError)` for other failures, and update rustdocs accordingly.
- Update affected examples, demos and tests to handle the new fallible `build()` API (call sites now unwrap or propagate errors as appropriate), and add focused tests: `tracing_recorder_builder_rejects_blank_service_name`, `tracing_intake_session_builder_rejects_blank_service_name`, and `tracing_tokio_session_start_rejects_blank_service_name`.

### Testing

- Builder signatures changed: Yes; `TracingRecorderBuilder::build()` now returns `Result<TracingRecorder, ImportError>`.
- All call sites updated: Yes; updated direct call sites in `tailtriage-tracing` tests/examples and demo code paths (`tailtriage-tracing/examples/live_recorder.rs`, `tailtriage-tracing/tests/support/equivalence_harness.rs`, `demos/demo_support/src/lib.rs`, and `demos/runtime_cost/src/main.rs`) to handle the new signature.
- Tests added: Yes; `tracing_recorder_builder_rejects_blank_service_name`, `tracing_intake_session_builder_rejects_blank_service_name`, and `tracing_tokio_session_start_rejects_blank_service_name` were added and use whitespace-only inputs.
- Commands run and results: `cargo fmt --check` passed, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` passed, `cargo test --workspace --all-targets --all-features --locked` passed (all tests green), and `python3 scripts/validate_docs_contracts.py` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13451d0ca08330951c344f98f39487)