### PR TITLE
Reject blank tracing service names at live builder setup time

### DIFF
--- a/demos/demo_support/src/lib.rs
+++ b/demos/demo_support/src/lib.rs
@@ -282,7 +282,9 @@ impl DemoInstrumentation {
                         max_runtime_snapshots: None,
                     });
                 }
-                let recorder = builder.build();
+                let recorder = builder
+                    .build()
+                    .map_err(|e| anyhow::anyhow!("invalid tracing recorder config: {e}"))?;
                 let subscriber = tracing_subscriber::registry().with(recorder.layer());
                 // Demo binaries run one instrumentation backend per process, so installing a
                 // global subscriber is acceptable here. Do not reuse this helper in libraries

--- a/demos/runtime_cost/src/main.rs
+++ b/demos/runtime_cost/src/main.rs
@@ -300,7 +300,9 @@ fn build_backend(cli: &Cli) -> anyhow::Result<Backend> {
                 if cli.mode.uses_drop_path_limits() {
                     b = b.max_open_spans(64);
                 }
-                let rec = b.build();
+                let rec = b
+                    .build()
+                    .map_err(|e| anyhow!("invalid tracing recorder config: {e}"))?;
                 // One mode runs per process in this demo, so process-global subscriber init is acceptable.
                 tracing::subscriber::set_global_default(
                     tracing_subscriber::registry().with(rec.layer()),

--- a/tailtriage-tracing/examples/live_recorder.rs
+++ b/tailtriage-tracing/examples/live_recorder.rs
@@ -9,7 +9,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .service_version("example")
         .run_id("live-recorder-example")
         .strict(false)
-        .build();
+        .build()
+        .expect("valid tracing recorder builder");
 
     let subscriber = tracing_subscriber::registry().with(recorder.layer());
 

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -13,7 +13,8 @@ use tracing_subscriber::layer::{Context, Layer};
 
 use crate::{
     duration_within_tolerance, ensure_persistable_run_has_requests, run_from_span_records,
-    FieldValue, ImportError, ImportOptions, ImportedRun, SpanRecord, TT_KIND,
+    validate_service_name, FieldValue, ImportError, ImportOptions, ImportedRun, SpanRecord,
+    TT_KIND,
 };
 
 /// In-memory recorder for completed tracing spans with `tt.*` fields.
@@ -484,7 +485,7 @@ impl TracingIntakeSessionBuilder {
     ///
     /// Returns an error when required recorder configuration is invalid.
     pub fn build(self) -> Result<TracingIntakeSession, ImportError> {
-        let recorder = self.recorder_builder.build();
+        let recorder = self.recorder_builder.build()?;
         Ok(TracingIntakeSession {
             recorder,
             completed_span_jsonl_path: self.completed_span_jsonl_path,
@@ -540,13 +541,17 @@ impl TracingRecorderBuilder {
     }
 
     /// Builds a recorder instance.
-    #[must_use]
-    pub fn build(self) -> TracingRecorder {
-        TracingRecorder {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ImportError::EmptyServiceName`] when the configured service name is blank or whitespace-only.
+    pub fn build(self) -> Result<TracingRecorder, ImportError> {
+        validate_service_name(self.options.service_name())?;
+        Ok(TracingRecorder {
             state: Arc::new(Mutex::new(RecorderState::default())),
             options: self.options,
             limits: self.limits,
-        }
+        })
     }
     /// Sets live recorder memory limits.
     #[must_use]
@@ -1029,7 +1034,10 @@ mod tests {
     use tracing_subscriber::prelude::*;
 
     fn with_recorder<T>(f: impl FnOnce(&TracingRecorder) -> T) -> T {
-        let recorder = TracingRecorder::builder("svc").run_id("rid").build();
+        let recorder = TracingRecorder::builder("svc")
+            .run_id("rid")
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || f(&recorder))
     }
@@ -1147,7 +1155,9 @@ mod tests {
             assert_eq!(snapshot.run().requests[0].route, "/checkout");
         });
 
-        let recorder = TracingRecorder::builder("svc").build();
+        let recorder = TracingRecorder::builder("svc")
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let span = tracing::info_span!(
@@ -1169,7 +1179,8 @@ mod tests {
             .service_version("1.2.3")
             .run_id("run-42")
             .strict(false)
-            .build();
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let span = tracing::info_span!(
@@ -1189,7 +1200,10 @@ mod tests {
 
     #[test]
     fn strict_mode_errors_on_malformed_request() {
-        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let span = tracing::info_span!("request", tt.kind = "request", tt.request_id = "r1");
@@ -1303,7 +1317,8 @@ mod tests {
     fn completed_candidate_cap_emits_warning_and_sets_limits_hit_non_strict() {
         let recorder = TracingRecorder::builder("svc")
             .max_completed_candidate_spans(1)
-            .build();
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let span1 = tracing::info_span!(
@@ -1345,7 +1360,8 @@ mod tests {
         let recorder = TracingRecorder::builder("svc")
             .strict(true)
             .max_completed_candidate_spans(1)
-            .build();
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let span1 = tracing::info_span!(
@@ -1380,7 +1396,8 @@ mod tests {
                 max_requests: 1,
                 ..CaptureMode::Light.core_defaults()
             })
-            .build();
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             drop(tracing::info_span!(
@@ -1410,7 +1427,8 @@ mod tests {
         let recorder = TracingRecorder::builder("svc")
             .strict(true)
             .max_open_spans(1)
-            .build();
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let span1 = tracing::info_span!(
@@ -1451,7 +1469,8 @@ mod tests {
                 max_queues: 1,
                 ..tailtriage_core::CaptureMode::Light.core_defaults()
             })
-            .build();
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let malformed =
@@ -1481,7 +1500,8 @@ mod tests {
     fn incomplete_request_does_not_consume_completed_candidate_cap_in_non_strict_mode() {
         let recorder = TracingRecorder::builder("svc")
             .max_completed_candidate_spans(1)
-            .build();
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             drop(tracing::info_span!(
@@ -1513,7 +1533,8 @@ mod tests {
     fn incomplete_stage_does_not_consume_completed_candidate_cap_in_non_strict_mode() {
         let recorder = TracingRecorder::builder("svc")
             .max_completed_candidate_spans(2)
-            .build();
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let request = tracing::info_span!(
@@ -1558,7 +1579,8 @@ mod tests {
     fn incomplete_queue_does_not_consume_completed_candidate_cap_in_non_strict_mode() {
         let recorder = TracingRecorder::builder("svc")
             .max_completed_candidate_spans(2)
-            .build();
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let request = tracing::info_span!(
@@ -1603,7 +1625,8 @@ mod tests {
     fn invalid_numeric_required_fields_do_not_consume_completed_candidate_cap() {
         let recorder = TracingRecorder::builder("svc")
             .max_completed_candidate_spans(1)
-            .build();
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             drop(tracing::info_span!(
@@ -1636,7 +1659,8 @@ mod tests {
     fn invalid_numeric_stage_does_not_consume_completed_candidate_cap() {
         let recorder = TracingRecorder::builder("svc")
             .max_completed_candidate_spans(2)
-            .build();
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let request = tracing::info_span!(
@@ -1677,7 +1701,8 @@ mod tests {
     fn invalid_numeric_queue_does_not_consume_completed_candidate_cap() {
         let recorder = TracingRecorder::builder("svc")
             .max_completed_candidate_spans(2)
-            .build();
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let request = tracing::info_span!(
@@ -1722,7 +1747,8 @@ mod tests {
                 max_stages: 1,
                 ..CaptureMode::Light.core_defaults()
             })
-            .build();
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             drop(tracing::info_span!(
@@ -1758,7 +1784,8 @@ mod tests {
                 max_queues: 1,
                 ..CaptureMode::Light.core_defaults()
             })
-            .build();
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             drop(tracing::info_span!(
@@ -1788,7 +1815,10 @@ mod tests {
 
     #[test]
     fn strict_mode_fails_for_malformed_request_span() {
-        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             drop(tracing::info_span!(
@@ -1803,7 +1833,10 @@ mod tests {
 
     #[test]
     fn strict_mode_fails_for_invalid_numeric_request_route() {
-        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             drop(tracing::info_span!(
@@ -1824,7 +1857,10 @@ mod tests {
 
     #[test]
     fn strict_mode_fails_for_malformed_stage_span() {
-        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let request = tracing::info_span!(
@@ -1846,7 +1882,10 @@ mod tests {
 
     #[test]
     fn strict_mode_fails_for_invalid_numeric_stage_field() {
-        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let request = tracing::info_span!(
@@ -1874,7 +1913,10 @@ mod tests {
 
     #[test]
     fn strict_mode_fails_for_malformed_queue_span() {
-        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let request = tracing::info_span!(
@@ -1896,7 +1938,10 @@ mod tests {
 
     #[test]
     fn strict_mode_fails_for_invalid_numeric_queue_field() {
-        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let request = tracing::info_span!(
@@ -1924,7 +1969,10 @@ mod tests {
 
     #[test]
     fn strict_mode_fails_for_orphan_stage_span() {
-        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             drop(tracing::info_span!(
@@ -1940,7 +1988,10 @@ mod tests {
 
     #[test]
     fn strict_mode_fails_for_orphan_queue_span() {
-        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             drop(tracing::info_span!(
@@ -1956,7 +2007,10 @@ mod tests {
 
     #[test]
     fn open_span_saturation_emits_warning_and_sets_limits_hit() {
-        let recorder = TracingRecorder::builder("svc").max_open_spans(1).build();
+        let recorder = TracingRecorder::builder("svc")
+            .max_open_spans(1)
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let span1 = tracing::info_span!(
@@ -1999,7 +2053,8 @@ mod tests {
                 max_queues: 1,
                 ..tailtriage_core::CaptureMode::Light.core_defaults()
             })
-            .build();
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let _open_1 = tracing::info_span!(
@@ -2053,7 +2108,10 @@ mod tests {
 
     #[test]
     fn unrelated_spans_do_not_consume_open_limit() {
-        let recorder = TracingRecorder::builder("svc").max_open_spans(1).build();
+        let recorder = TracingRecorder::builder("svc")
+            .max_open_spans(1)
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let unrelated = tracing::info_span!("ordinary", foo = 1_u64);
@@ -2073,9 +2131,18 @@ mod tests {
     }
 
     #[test]
-    fn empty_service_name_builder_errors_on_snapshot() {
-        let recorder = TracingRecorder::builder(" ").build();
-        let err = recorder.snapshot_run().unwrap_err();
+    fn tracing_recorder_builder_rejects_blank_service_name() {
+        let err = TracingRecorder::builder("   ")
+            .build()
+            .expect_err("blank service name must fail recorder builder");
+        assert!(matches!(err, ImportError::EmptyServiceName));
+    }
+
+    #[test]
+    fn tracing_intake_session_builder_rejects_blank_service_name() {
+        let err = TracingIntakeSession::builder("   ")
+            .build()
+            .expect_err("blank service name must fail intake session builder");
         assert!(matches!(err, ImportError::EmptyServiceName));
     }
 
@@ -2196,7 +2263,10 @@ mod tests {
 
     #[test]
     fn closed_candidate_missing_tt_kind_errors_strict() {
-        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let span = tracing::info_span!(
@@ -2221,7 +2291,10 @@ mod tests {
 
     #[test]
     fn closed_candidate_missing_tt_kind_shutdown_errors_strict() {
-        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let span = tracing::info_span!(
@@ -2246,7 +2319,10 @@ mod tests {
 
     #[test]
     fn strict_mode_reports_open_and_closed_missing_kind_causes_together() {
-        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let _open = tracing::info_span!(
@@ -2290,7 +2366,10 @@ mod tests {
     }
     #[test]
     fn strict_mode_rejects_open_candidate_spans_without_fabricating_completions() {
-        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         let err = tracing::subscriber::with_default(subscriber, || {
             let _open_guard = tracing::info_span!(
@@ -2341,7 +2420,10 @@ mod tests {
 
     #[test]
     fn open_candidate_span_errors_in_strict_mode() {
-        let recorder = TracingRecorder::builder("svc").strict(true).build();
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .expect("valid tracing recorder builder");
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
             let _open =

--- a/tailtriage-tracing/src/tokio.rs
+++ b/tailtriage-tracing/src/tokio.rs
@@ -15,7 +15,9 @@ use crate::{
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum TracingTokioSessionStartError {
-    /// Underlying tracing recorder setup failed.
+    /// Tracing recorder import configuration is invalid.
+    Import(ImportError),
+    /// Underlying runtime collector setup failed.
     Build(BuildError),
     /// Tokio runtime sampler failed to start.
     SamplerStart(SamplerStartError),
@@ -24,6 +26,7 @@ pub enum TracingTokioSessionStartError {
 impl core::fmt::Display for TracingTokioSessionStartError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
+            Self::Import(err) => write!(f, "invalid tracing recorder configuration: {err}"),
             Self::Build(err) => write!(f, "failed to build tailtriage runtime collector: {err}"),
             Self::SamplerStart(err) => write!(f, "failed to start Tokio runtime sampler: {err}"),
         }
@@ -189,11 +192,14 @@ impl TracingTokioSessionBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`TracingTokioSessionStartError`] when runtime collector build fails,
-    /// when sampler interval is zero, or when there is no active Tokio runtime.
+    /// Returns [`TracingTokioSessionStartError`] when tracing import configuration is invalid,
+    /// when runtime collector build fails, when sampler interval is zero, or when there is no active Tokio runtime.
     pub fn start(self) -> Result<TracingTokioSession, TracingTokioSessionStartError> {
         let resolved_limits = self.recorder_builder.resolved_capture_limits();
-        let recorder = self.recorder_builder.build();
+        let recorder = self
+            .recorder_builder
+            .build()
+            .map_err(TracingTokioSessionStartError::Import)?;
         let sink = MemorySink::new();
         let builder = Tailtriage::builder("tailtriage-tracing-runtime")
             .sink(sink)

--- a/tailtriage-tracing/tests/support/equivalence_harness.rs
+++ b/tailtriage-tracing/tests/support/equivalence_harness.rs
@@ -297,7 +297,9 @@ fn live_tracing_run() -> (Run, Vec<String>) {
 }
 
 fn tracing_run_with_queue(queue_name: &str) -> (Run, Vec<String>) {
-    let recorder = TracingRecorder::builder("svc").build();
+    let recorder = TracingRecorder::builder("svc")
+        .build()
+        .expect("valid tracing recorder builder");
     let subscriber = tracing_subscriber::registry().with(recorder.layer());
     tracing::subscriber::with_default(subscriber, || {
         block_on(async {

--- a/tailtriage-tracing/tests/tokio_session.rs
+++ b/tailtriage-tracing/tests/tokio_session.rs
@@ -97,6 +97,17 @@ async fn zero_sampler_interval_fails_clearly() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn tracing_tokio_session_start_rejects_blank_service_name() {
+    let err = TracingTokioSession::builder("   ")
+        .start()
+        .expect_err("blank service name must fail before sampler setup");
+    assert!(matches!(
+        err,
+        TracingTokioSessionStartError::Import(tailtriage_tracing::ImportError::EmptyServiceName)
+    ));
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn runtime_merge_keeps_tracing_requests() {
     let session = TracingTokioSession::builder("svc")
         .sampler_interval(Duration::from_millis(1))


### PR DESCRIPTION
### Motivation

- Ensure invalid service-name metadata is rejected early during live tracing setup so captures, samplers, and runtime collectors are not started with blank/whitespace service names.
- Make setup failures explicit and fail-fast so downstream runtime/sampler work is not attempted when import configuration is invalid.

### Description

- Make `TracingRecorderBuilder::build()` fallible by changing its signature to `pub fn build(self) -> Result<TracingRecorder, ImportError>` and validate the configured service name using the existing `validate_service_name` helper, returning `ImportError::EmptyServiceName` for blank/whitespace names.
- Propagate recorder build failures in `TracingIntakeSessionBuilder::build()` so intake session construction returns `Err(ImportError::EmptyServiceName)` for whitespace-only service names.
- Add `TracingTokioSessionStartError::Import(ImportError)` and map recorder/import configuration validation failures in `TracingTokioSessionBuilder::start()` to `TracingTokioSessionStartError::Import`, rejecting blank/whitespace service names before building the runtime collector or starting the sampler; preserve `Build(BuildError)` and `SamplerStart(SamplerStartError)` for their original, narrow failure classes.
- Update rustdoc for the affected builder/start methods to state that invalid service metadata fails at build/start time.
- Update all call sites, examples, and test helpers that previously used `.build()` on the recorder builder so they handle the new `Result` (using `.expect(...)` or `?` as appropriate).
- Add focused tests `tracing_recorder_builder_rejects_blank_service_name`, `tracing_intake_session_builder_rejects_blank_service_name`, and `tracing_tokio_session_start_rejects_blank_service_name` which use whitespace-only service names and assert the specific error variants.

### Testing

- Builder signatures changed: Yes; `TracingRecorderBuilder::build()` now returns `Result<TracingRecorder, ImportError>`.
- All call sites updated: Yes; examples, demos, tests and support harnesses referencing `TracingRecorder::builder(...).build()` were updated to handle the fallible result.
- Tests added: Yes; `tracing_recorder_builder_rejects_blank_service_name`, `tracing_intake_session_builder_rejects_blank_service_name`, and `tracing_tokio_session_start_rejects_blank_service_name` were added to validate whitespace-only inputs.
- Commands run and results: ran `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, and `python3 scripts/validate_docs_contracts.py`, and all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13451d0ca08330951c344f98f39487)