### PR TITLE
Propagate TracingTokioSession capture mode into runtime sampler metadata

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -495,6 +495,12 @@ impl TracingIntakeSessionBuilder {
 }
 
 impl TracingRecorderBuilder {
+    /// Returns configured capture mode.
+    #[must_use]
+    pub fn configured_mode(&self) -> CaptureMode {
+        self.options.mode_value()
+    }
+
     /// Returns capture limits resolved from configured mode/base/override settings.
     #[must_use]
     pub fn resolved_capture_limits(&self) -> CaptureLimits {

--- a/tailtriage-tracing/src/tokio.rs
+++ b/tailtriage-tracing/src/tokio.rs
@@ -196,6 +196,7 @@ impl TracingTokioSessionBuilder {
     /// when runtime collector build fails, when sampler interval is zero,
     /// or when there is no active Tokio runtime.
     pub fn start(self) -> Result<TracingTokioSession, TracingTokioSessionStartError> {
+        let mode = self.recorder_builder.configured_mode();
         let resolved_limits = self.recorder_builder.resolved_capture_limits();
         let recorder = self
             .recorder_builder
@@ -204,8 +205,12 @@ impl TracingTokioSessionBuilder {
         let sink = MemorySink::new();
         let builder = Tailtriage::builder("tailtriage-tracing-runtime")
             .sink(sink)
-            .strict_lifecycle(false)
-            .capture_limits(resolved_limits);
+            .strict_lifecycle(false);
+        let builder = match mode {
+            CaptureMode::Light => builder.light(),
+            CaptureMode::Investigation => builder.investigation(),
+        }
+        .capture_limits(resolved_limits);
         if let Some(interval) = self.sampler_interval {
             if interval.is_zero() {
                 return Err(TracingTokioSessionStartError::SamplerStart(
@@ -293,9 +298,10 @@ fn merge_runtime_data(imported: ImportedRun, runtime_run: &Run) -> ImportedRun {
 
 #[cfg(test)]
 mod tests {
-    use super::merge_runtime_data;
+    use super::{merge_runtime_data, TracingTokioSession};
     use crate::{ImportWarning, ImportedRun};
-    use tailtriage_core::{MemorySink, RuntimeSnapshot, Tailtriage};
+    use std::time::Duration;
+    use tailtriage_core::{CaptureMode, MemorySink, RuntimeSnapshot, Tailtriage};
 
     fn empty_run(service_name: &str) -> tailtriage_core::Run {
         Tailtriage::builder(service_name)
@@ -543,6 +549,66 @@ mod tests {
                 ImportWarning::new("existing-warning"),
                 ImportWarning::new("unique-warning"),
             ]
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tracing_tokio_session_investigation_mode_propagates_to_sampler_metadata() {
+        let session = TracingTokioSession::builder("svc")
+            .mode(CaptureMode::Investigation)
+            .sampler_interval(Duration::from_millis(5))
+            .start()
+            .expect("start tracing tokio session");
+
+        let imported = session.shutdown().await.expect("shutdown session");
+        let run = imported.run();
+        let core = run
+            .metadata
+            .effective_core_config
+            .expect("effective core config is present");
+        let sampler = run
+            .metadata
+            .effective_tokio_sampler_config
+            .expect("effective tokio sampler config is present");
+        assert_eq!(run.metadata.mode, CaptureMode::Investigation);
+        assert_eq!(core.mode, CaptureMode::Investigation);
+        assert_eq!(sampler.inherited_mode, CaptureMode::Investigation);
+        assert_eq!(sampler.resolved_mode, CaptureMode::Investigation);
+        assert_eq!(sampler.explicit_mode_override, None);
+        assert_eq!(sampler.resolved_sampler_cadence_ms, 5);
+        assert!(
+            sampler.resolved_runtime_snapshot_retention
+                <= core.capture_limits.max_runtime_snapshots
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tracing_tokio_session_light_mode_sampler_metadata_stays_light() {
+        let session = TracingTokioSession::builder("svc")
+            .mode(CaptureMode::Light)
+            .sampler_interval(Duration::from_millis(5))
+            .start()
+            .expect("start tracing tokio session");
+
+        let imported = session.shutdown().await.expect("shutdown session");
+        let run = imported.run();
+        let core = run
+            .metadata
+            .effective_core_config
+            .expect("effective core config is present");
+        let sampler = run
+            .metadata
+            .effective_tokio_sampler_config
+            .expect("effective tokio sampler config is present");
+        assert_eq!(run.metadata.mode, CaptureMode::Light);
+        assert_eq!(core.mode, CaptureMode::Light);
+        assert_eq!(sampler.inherited_mode, CaptureMode::Light);
+        assert_eq!(sampler.resolved_mode, CaptureMode::Light);
+        assert_eq!(sampler.explicit_mode_override, None);
+        assert_eq!(sampler.resolved_sampler_cadence_ms, 5);
+        assert!(
+            sampler.resolved_runtime_snapshot_retention
+                <= core.capture_limits.max_runtime_snapshots
         );
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure the `CaptureMode` selected on `TracingTokioSessionBuilder` consistently controls tracing conversion retention, the internal runtime collector mode, and the `RuntimeSampler` metadata so sampler behavior and reported metadata match the session mode.

### Description
- Apply the recorder-configured mode into the internal collector builder by calling `Tailtriage::builder(...).light()` or `.investigation()` before `capture_limits(...)` so the collector mode matches the session `mode` selection.
- Let the `RuntimeSampler` continue to inherit mode from the internal runtime collector while preserving explicit cadence overrides via `.sampler_interval(...)` and bounding runtime snapshot retention with the resolved core limits (`max_runtime_snapshots`).
- Add a minimal accessor `TracingRecorderBuilder::configured_mode()` to expose the selected mode to the Tokio session startup path without adding a broad API surface.
- Add two focused tests in the tracing Tokio test module to validate metadata propagation and invariants: `tracing_tokio_session_investigation_mode_propagates_to_sampler_metadata` and `tracing_tokio_session_light_mode_sampler_metadata_stays_light`.
- Files changed: `tailtriage-tracing/src/tokio.rs`, `tailtriage-tracing/src/recorder.rs`.
- Tests added: `tracing_tokio_session_investigation_mode_propagates_to_sampler_metadata`, `tracing_tokio_session_light_mode_sampler_metadata_stays_light` (both under `tailtriage-tracing/src/tokio.rs` test module).

### Testing
- Ran `cargo fmt --check` — passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — passed.
- Ran `cargo test --workspace --all-targets --all-features --locked` — passed (all tests successful, including the two new Tokio-session tests).
- Ran `python3 scripts/validate_docs_contracts.py` — passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a134f225c848330a1749b149fe35e3b)