### PR TITLE
Propagate TracingTokioSession capture mode into runtime sampler metadata

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -495,6 +495,12 @@ impl TracingIntakeSessionBuilder {
 }
 
 impl TracingRecorderBuilder {
+    /// Returns selected capture mode for import conversion semantics.
+    #[must_use]
+    pub(crate) fn selected_mode(&self) -> CaptureMode {
+        self.options.mode_value()
+    }
+
     /// Returns capture limits resolved from configured mode/base/override settings.
     #[must_use]
     pub fn resolved_capture_limits(&self) -> CaptureLimits {

--- a/tailtriage-tracing/src/tokio.rs
+++ b/tailtriage-tracing/src/tokio.rs
@@ -196,6 +196,7 @@ impl TracingTokioSessionBuilder {
     /// when runtime collector build fails, when sampler interval is zero,
     /// or when there is no active Tokio runtime.
     pub fn start(self) -> Result<TracingTokioSession, TracingTokioSessionStartError> {
+        let mode = self.recorder_builder.selected_mode();
         let resolved_limits = self.recorder_builder.resolved_capture_limits();
         let recorder = self
             .recorder_builder
@@ -206,6 +207,10 @@ impl TracingTokioSessionBuilder {
             .sink(sink)
             .strict_lifecycle(false)
             .capture_limits(resolved_limits);
+        let builder = match mode {
+            CaptureMode::Light => builder.light(),
+            CaptureMode::Investigation => builder.investigation(),
+        };
         if let Some(interval) = self.sampler_interval {
             if interval.is_zero() {
                 return Err(TracingTokioSessionStartError::SamplerStart(
@@ -295,7 +300,8 @@ fn merge_runtime_data(imported: ImportedRun, runtime_run: &Run) -> ImportedRun {
 mod tests {
     use super::merge_runtime_data;
     use crate::{ImportWarning, ImportedRun};
-    use tailtriage_core::{MemorySink, RuntimeSnapshot, Tailtriage};
+    use std::time::Duration;
+    use tailtriage_core::{CaptureMode, MemorySink, RuntimeSnapshot, Tailtriage};
 
     fn empty_run(service_name: &str) -> tailtriage_core::Run {
         Tailtriage::builder(service_name)
@@ -543,6 +549,76 @@ mod tests {
                 ImportWarning::new("existing-warning"),
                 ImportWarning::new("unique-warning"),
             ]
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tracing_tokio_session_investigation_mode_propagates_to_sampler_metadata() {
+        let session = super::TracingTokioSession::builder("svc")
+            .mode(CaptureMode::Investigation)
+            .sampler_interval(Duration::from_millis(5))
+            .start()
+            .expect("start tracing tokio session");
+
+        let run = session
+            .shutdown()
+            .await
+            .expect("shutdown tracing tokio session");
+        let effective_core = run
+            .run()
+            .metadata
+            .effective_core_config
+            .expect("effective core config metadata");
+        let sampler_config = run
+            .run()
+            .metadata
+            .effective_tokio_sampler_config
+            .expect("effective sampler metadata");
+
+        assert_eq!(run.run().metadata.mode, CaptureMode::Investigation);
+        assert_eq!(effective_core.mode, CaptureMode::Investigation);
+        assert_eq!(sampler_config.inherited_mode, CaptureMode::Investigation);
+        assert_eq!(sampler_config.resolved_mode, CaptureMode::Investigation);
+        assert_eq!(sampler_config.explicit_mode_override, None);
+        assert_eq!(sampler_config.resolved_sampler_cadence_ms, 5);
+        assert!(
+            sampler_config.resolved_runtime_snapshot_retention
+                <= effective_core.capture_limits.max_runtime_snapshots
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tracing_tokio_session_light_mode_sampler_metadata_stays_light() {
+        let session = super::TracingTokioSession::builder("svc")
+            .mode(CaptureMode::Light)
+            .sampler_interval(Duration::from_millis(5))
+            .start()
+            .expect("start tracing tokio session");
+
+        let run = session
+            .shutdown()
+            .await
+            .expect("shutdown tracing tokio session");
+        let effective_core = run
+            .run()
+            .metadata
+            .effective_core_config
+            .expect("effective core config metadata");
+        let sampler_config = run
+            .run()
+            .metadata
+            .effective_tokio_sampler_config
+            .expect("effective sampler metadata");
+
+        assert_eq!(run.run().metadata.mode, CaptureMode::Light);
+        assert_eq!(effective_core.mode, CaptureMode::Light);
+        assert_eq!(sampler_config.inherited_mode, CaptureMode::Light);
+        assert_eq!(sampler_config.resolved_mode, CaptureMode::Light);
+        assert_eq!(sampler_config.explicit_mode_override, None);
+        assert_eq!(sampler_config.resolved_sampler_cadence_ms, 5);
+        assert!(
+            sampler_config.resolved_runtime_snapshot_retention
+                <= effective_core.capture_limits.max_runtime_snapshots
         );
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure the `CaptureMode` selected on `TracingTokioSessionBuilder` consistently influences tracing conversion retention, the internal `Tailtriage` runtime collector mode, and the `RuntimeSampler` metadata so sampler behavior and run metadata align with the session mode.

### Description
- Read the recorder-selected mode via a minimal crate-private accessor `TracingRecorderBuilder::selected_mode()` and map it to the core `Tailtriage` builder mode (`.light()` / `.investigation()`) before building the internal runtime collector in `TracingTokioSession::start` so the collector's selected mode matches the session mode. (files changed: `tailtriage-tracing/src/tokio.rs`, `tailtriage-tracing/src/recorder.rs`).
- Preserve existing `RuntimeSampler` inheritance behavior so the sampler inherits mode from the internal collector rather than forcing an explicit sampler mode override, and keep `sampler_interval(...)` as a cadence-only override while clamping retention by core capture limits. (file: `tailtriage-tokio` behavior unchanged).
- Add focused tests exercising end-to-end metadata without waiting for ticks: `tracing_tokio_session_investigation_mode_propagates_to_sampler_metadata` and `tracing_tokio_session_light_mode_sampler_metadata_stays_light` under the existing `#[cfg(test)]` module, using `#[tokio::test(flavor = "current_thread")]` and `sampler_interval(Duration::from_millis(5))` to assert metadata invariants. (tests added in `tailtriage-tracing/src/tokio.rs`).

### Testing
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, and `python3 scripts/validate_docs_contracts.py`, and all commands completed successfully. 
- Unit tests added: `tracing_tokio_session_investigation_mode_propagates_to_sampler_metadata` and `tracing_tokio_session_light_mode_sampler_metadata_stays_light`, and the full test suite passed with these tests included.
- Files changed: `tailtriage-tracing/src/tokio.rs`, `tailtriage-tracing/src/recorder.rs`.
- Tests added: the two focused Tokio-session tests listed above (both passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a134f225c848330a1749b149fe35e3b)