### PR TITLE
Propagate TracingTokioSession capture mode into runtime sampler metadata

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -495,6 +495,12 @@ impl TracingIntakeSessionBuilder {
 }
 
 impl TracingRecorderBuilder {
+    /// Returns currently selected capture mode.
+    #[must_use]
+    pub fn selected_mode(&self) -> CaptureMode {
+        self.options.mode_value()
+    }
+
     /// Returns capture limits resolved from configured mode/base/override settings.
     #[must_use]
     pub fn resolved_capture_limits(&self) -> CaptureLimits {

--- a/tailtriage-tracing/src/tokio.rs
+++ b/tailtriage-tracing/src/tokio.rs
@@ -196,16 +196,22 @@ impl TracingTokioSessionBuilder {
     /// when runtime collector build fails, when sampler interval is zero,
     /// or when there is no active Tokio runtime.
     pub fn start(self) -> Result<TracingTokioSession, TracingTokioSessionStartError> {
+        let selected_mode = self.recorder_builder.selected_mode();
         let resolved_limits = self.recorder_builder.resolved_capture_limits();
         let recorder = self
             .recorder_builder
             .build()
             .map_err(TracingTokioSessionStartError::Import)?;
         let sink = MemorySink::new();
-        let builder = Tailtriage::builder("tailtriage-tracing-runtime")
-            .sink(sink)
-            .strict_lifecycle(false)
-            .capture_limits(resolved_limits);
+        let builder = match selected_mode {
+            CaptureMode::Light => Tailtriage::builder("tailtriage-tracing-runtime").light(),
+            CaptureMode::Investigation => {
+                Tailtriage::builder("tailtriage-tracing-runtime").investigation()
+            }
+        }
+        .sink(sink)
+        .strict_lifecycle(false)
+        .capture_limits(resolved_limits);
         if let Some(interval) = self.sampler_interval {
             if interval.is_zero() {
                 return Err(TracingTokioSessionStartError::SamplerStart(
@@ -293,9 +299,11 @@ fn merge_runtime_data(imported: ImportedRun, runtime_run: &Run) -> ImportedRun {
 
 #[cfg(test)]
 mod tests {
-    use super::merge_runtime_data;
+    use std::time::Duration;
+
+    use super::{merge_runtime_data, TracingTokioSession};
     use crate::{ImportWarning, ImportedRun};
-    use tailtriage_core::{MemorySink, RuntimeSnapshot, Tailtriage};
+    use tailtriage_core::{CaptureMode, MemorySink, RuntimeSnapshot, Tailtriage};
 
     fn empty_run(service_name: &str) -> tailtriage_core::Run {
         Tailtriage::builder(service_name)
@@ -543,6 +551,72 @@ mod tests {
                 ImportWarning::new("existing-warning"),
                 ImportWarning::new("unique-warning"),
             ]
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tracing_tokio_session_investigation_mode_propagates_to_sampler_metadata() {
+        let session = TracingTokioSession::builder("svc")
+            .mode(CaptureMode::Investigation)
+            .sampler_interval(Duration::from_millis(5))
+            .start()
+            .expect("start session");
+        let (run, _warnings) = session
+            .shutdown()
+            .await
+            .expect("shutdown session")
+            .into_parts();
+        let effective_core_config = run
+            .metadata
+            .effective_core_config
+            .expect("effective core config");
+        let sampler_config = run
+            .metadata
+            .effective_tokio_sampler_config
+            .expect("effective sampler config");
+
+        assert_eq!(run.metadata.mode, CaptureMode::Investigation);
+        assert_eq!(effective_core_config.mode, CaptureMode::Investigation);
+        assert_eq!(sampler_config.inherited_mode, CaptureMode::Investigation);
+        assert_eq!(sampler_config.resolved_mode, CaptureMode::Investigation);
+        assert_eq!(sampler_config.explicit_mode_override, None);
+        assert_eq!(sampler_config.resolved_sampler_cadence_ms, 5);
+        assert!(
+            sampler_config.resolved_runtime_snapshot_retention
+                <= effective_core_config.capture_limits.max_runtime_snapshots
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tracing_tokio_session_light_mode_sampler_metadata_stays_light() {
+        let session = TracingTokioSession::builder("svc")
+            .mode(CaptureMode::Light)
+            .sampler_interval(Duration::from_millis(5))
+            .start()
+            .expect("start session");
+        let (run, _warnings) = session
+            .shutdown()
+            .await
+            .expect("shutdown session")
+            .into_parts();
+        let effective_core_config = run
+            .metadata
+            .effective_core_config
+            .expect("effective core config");
+        let sampler_config = run
+            .metadata
+            .effective_tokio_sampler_config
+            .expect("effective sampler config");
+
+        assert_eq!(run.metadata.mode, CaptureMode::Light);
+        assert_eq!(effective_core_config.mode, CaptureMode::Light);
+        assert_eq!(sampler_config.inherited_mode, CaptureMode::Light);
+        assert_eq!(sampler_config.resolved_mode, CaptureMode::Light);
+        assert_eq!(sampler_config.explicit_mode_override, None);
+        assert_eq!(sampler_config.resolved_sampler_cadence_ms, 5);
+        assert!(
+            sampler_config.resolved_runtime_snapshot_retention
+                <= effective_core_config.capture_limits.max_runtime_snapshots
         );
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure the `CaptureMode` selected on `TracingTokioSessionBuilder` consistently controls tracing conversion retention, the internal runtime collector mode, and the metadata exposed by the Tokio `RuntimeSampler` so run outputs reflect the selected capture fidelity.

### Description
- Add a minimal accessor `TracingRecorderBuilder::selected_mode()` and use it in `TracingTokioSession::start()` to read the configured mode without widening the public API surface.
- Map the selected mode into the core collector builder by calling `.light()` or `.investigation()` on `Tailtriage::builder("tailtriage-tracing-runtime")` before setting sink/limits so the internal collector's selected mode matches the recorder mode.
- Preserve `RuntimeSampler` inheritance semantics by continuing to build the sampler from the collector (no explicit sampler `mode(...)` override) while allowing `sampler_interval(...)` to override only cadence and bounding runtime snapshot retention with the resolved capture limits.
- Add two focused tests validating mode propagation and sampler metadata: `tracing_tokio_session_investigation_mode_propagates_to_sampler_metadata` and `tracing_tokio_session_light_mode_sampler_metadata_stays_light`.

### Testing
- Files changed: `tailtriage-tracing/src/tokio.rs`, `tailtriage-tracing/src/recorder.rs`.
- Tests added: `tracing_tokio_session_investigation_mode_propagates_to_sampler_metadata` and `tracing_tokio_session_light_mode_sampler_metadata_stays_light` (both under `tailtriage-tracing/src/tokio.rs` test module).
- Commands run and results: `cargo fmt --check` (succeeded), `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (succeeded), `cargo test --workspace --all-targets --all-features --locked` (succeeded; all tests passed), and `python3 scripts/validate_docs_contracts.py` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a134f225c848330a1749b149fe35e3b)