### PR TITLE
Propagate TracingTokioSession capture mode into runtime sampler metadata

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -495,6 +495,12 @@ impl TracingIntakeSessionBuilder {
 }
 
 impl TracingRecorderBuilder {
+    /// Returns configured capture mode.
+    #[must_use]
+    pub fn mode_value(&self) -> CaptureMode {
+        self.options.mode_value()
+    }
+
     /// Returns capture limits resolved from configured mode/base/override settings.
     #[must_use]
     pub fn resolved_capture_limits(&self) -> CaptureLimits {

--- a/tailtriage-tracing/src/tokio.rs
+++ b/tailtriage-tracing/src/tokio.rs
@@ -196,6 +196,7 @@ impl TracingTokioSessionBuilder {
     /// when runtime collector build fails, when sampler interval is zero,
     /// or when there is no active Tokio runtime.
     pub fn start(self) -> Result<TracingTokioSession, TracingTokioSessionStartError> {
+        let selected_mode = self.recorder_builder.mode_value();
         let resolved_limits = self.recorder_builder.resolved_capture_limits();
         let recorder = self
             .recorder_builder
@@ -206,6 +207,10 @@ impl TracingTokioSessionBuilder {
             .sink(sink)
             .strict_lifecycle(false)
             .capture_limits(resolved_limits);
+        let builder = match selected_mode {
+            CaptureMode::Light => builder.light(),
+            CaptureMode::Investigation => builder.investigation(),
+        };
         if let Some(interval) = self.sampler_interval {
             if interval.is_zero() {
                 return Err(TracingTokioSessionStartError::SamplerStart(
@@ -293,9 +298,10 @@ fn merge_runtime_data(imported: ImportedRun, runtime_run: &Run) -> ImportedRun {
 
 #[cfg(test)]
 mod tests {
-    use super::merge_runtime_data;
+    use super::{merge_runtime_data, TracingTokioSession};
     use crate::{ImportWarning, ImportedRun};
-    use tailtriage_core::{MemorySink, RuntimeSnapshot, Tailtriage};
+    use std::time::Duration;
+    use tailtriage_core::{CaptureMode, MemorySink, RuntimeSnapshot, Tailtriage};
 
     fn empty_run(service_name: &str) -> tailtriage_core::Run {
         Tailtriage::builder(service_name)
@@ -543,6 +549,64 @@ mod tests {
                 ImportWarning::new("existing-warning"),
                 ImportWarning::new("unique-warning"),
             ]
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tracing_tokio_session_investigation_mode_propagates_to_sampler_metadata() {
+        let session = TracingTokioSession::builder("svc")
+            .mode(CaptureMode::Investigation)
+            .sampler_interval(Duration::from_millis(5))
+            .start()
+            .expect("start session");
+        let imported_run = session.shutdown().await.expect("shutdown session");
+        let (run, _warnings) = imported_run.into_parts();
+        let core_config = run
+            .metadata
+            .effective_core_config
+            .expect("effective core config");
+        let sampler_config = run
+            .metadata
+            .effective_tokio_sampler_config
+            .expect("effective tokio sampler config");
+        assert_eq!(run.metadata.mode, CaptureMode::Investigation);
+        assert_eq!(core_config.mode, CaptureMode::Investigation);
+        assert_eq!(sampler_config.inherited_mode, CaptureMode::Investigation);
+        assert_eq!(sampler_config.resolved_mode, CaptureMode::Investigation);
+        assert_eq!(sampler_config.explicit_mode_override, None);
+        assert_eq!(sampler_config.resolved_sampler_cadence_ms, 5);
+        assert!(
+            sampler_config.resolved_runtime_snapshot_retention
+                <= core_config.capture_limits.max_runtime_snapshots
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tracing_tokio_session_light_mode_sampler_metadata_stays_light() {
+        let session = TracingTokioSession::builder("svc")
+            .mode(CaptureMode::Light)
+            .sampler_interval(Duration::from_millis(5))
+            .start()
+            .expect("start session");
+        let imported_run = session.shutdown().await.expect("shutdown session");
+        let (run, _warnings) = imported_run.into_parts();
+        let core_config = run
+            .metadata
+            .effective_core_config
+            .expect("effective core config");
+        let sampler_config = run
+            .metadata
+            .effective_tokio_sampler_config
+            .expect("effective tokio sampler config");
+        assert_eq!(run.metadata.mode, CaptureMode::Light);
+        assert_eq!(core_config.mode, CaptureMode::Light);
+        assert_eq!(sampler_config.inherited_mode, CaptureMode::Light);
+        assert_eq!(sampler_config.resolved_mode, CaptureMode::Light);
+        assert_eq!(sampler_config.explicit_mode_override, None);
+        assert_eq!(sampler_config.resolved_sampler_cadence_ms, 5);
+        assert!(
+            sampler_config.resolved_runtime_snapshot_retention
+                <= core_config.capture_limits.max_runtime_snapshots
         );
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure the capture `mode` selected on `TracingTokioSessionBuilder` consistently drives runtime collector selection and the `RuntimeSampler` metadata so sampler behavior and reported metadata match the tracing session mode.

### Description
- Read the configured capture mode from the tracing recorder builder and apply it to the internal `Tailtriage` builder using existing `light()` / `investigation()` helpers so the internal runtime collector is built with the selected mode.
- Add a minimal `TracingRecorderBuilder::mode_value()` accessor to expose the already-configured capture mode for session startup wiring without adding a broader API surface.
- Keep `RuntimeSampler` mode inheritance from the internal collector (no explicit sampler mode override), and let `.sampler_interval(...)` only override cadence not mode; ensure sampler retention is still bounded by resolved capture limits.
- Add two focused Tokio-session tests that verify mode propagation and sampler metadata for both `Investigation` and `Light` modes.

### Testing
- Files changed: `tailtriage-tracing/src/tokio.rs`, `tailtriage-tracing/src/recorder.rs`.
- Tests added: `tracing_tokio_session_investigation_mode_propagates_to_sampler_metadata` and `tracing_tokio_session_light_mode_sampler_metadata_stays_light` (under the existing `#[cfg(test)]` module in `tokio.rs`).
- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed.
- Ran `cargo test --workspace --all-targets --all-features --locked` and all workspace tests passed.
- Ran `python3 scripts/validate_docs_contracts.py` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a134f225c848330a1749b149fe35e3b)