### PR TITLE
Make tracing shutdown outputs atomic for zero-request validation

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -283,6 +283,9 @@ impl TracingIntakeSession {
         let strict_mode = self.recorder.options.strict_mode();
         let imported = self.recorder.shutdown()?;
         let (mut run, mut warnings) = imported.into_parts();
+        if self.run_json_path.is_some() {
+            ensure_persistable_run_has_requests(&run)?;
+        }
         if let Some(path) = &self.completed_span_jsonl_path {
             if let Err(err) = write_completed_span_jsonl_from_run(&run, path) {
                 if strict_mode {
@@ -294,7 +297,6 @@ impl TracingIntakeSession {
             }
         }
         if let Some(path) = self.run_json_path {
-            ensure_persistable_run_has_requests(&run)?;
             LocalJsonSink::new(&path)
                 .write(&run)
                 .map_err(|err| ImportError::RunJsonWrite {
@@ -310,35 +312,60 @@ fn write_completed_span_jsonl_from_run(
     run: &tailtriage_core::Run,
     path: &Path,
 ) -> Result<(), ImportError> {
+    let temp_path = temporary_output_path(path);
     let mut file = std::fs::OpenOptions::new()
         .create(true)
         .write(true)
         .truncate(true)
-        .open(path)
+        .open(&temp_path)
         .map_err(|err| ImportError::Io {
             operation: "open completed span jsonl path",
-            context: path.display().to_string(),
+            context: temp_path.display().to_string(),
             reason: err.to_string(),
         })?;
     for span in retained_span_records_from_run(run) {
         let wrapped = serde_json::json!({ "format": "tailtriage.tracing-span.v1", "span": span });
         serde_json::to_writer(&mut file, &wrapped).map_err(|err| ImportError::Io {
             operation: "write completed span jsonl record",
-            context: path.display().to_string(),
+            context: temp_path.display().to_string(),
             reason: err.to_string(),
         })?;
         file.write_all(b"\n").map_err(|err| ImportError::Io {
             operation: "write completed span jsonl newline",
-            context: path.display().to_string(),
+            context: temp_path.display().to_string(),
             reason: err.to_string(),
         })?;
     }
     file.flush().map_err(|err| ImportError::Io {
         operation: "flush completed span jsonl file",
-        context: path.display().to_string(),
+        context: temp_path.display().to_string(),
         reason: err.to_string(),
     })?;
+    drop(file);
+    std::fs::rename(&temp_path, path).map_err(|err| {
+        let _ = std::fs::remove_file(&temp_path);
+        ImportError::Io {
+            operation: "rename completed span jsonl temp file into place",
+            context: format!("{} -> {}", temp_path.display(), path.display()),
+            reason: err.to_string(),
+        }
+    })?;
     Ok(())
+}
+
+fn temporary_output_path(path: &Path) -> PathBuf {
+    let parent = path
+        .parent()
+        .map_or_else(|| Path::new("."), std::convert::identity);
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("completed-spans.jsonl");
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    parent.join(format!(".{name}.tmp.{}.{}", std::process::id(), unique))
 }
 
 fn retained_span_records_from_run(run: &tailtriage_core::Run) -> Vec<SpanRecord> {
@@ -2688,6 +2715,51 @@ mod tests {
         let err = session.shutdown().unwrap_err();
         assert!(matches!(err, ImportError::ZeroRequestArtifact { .. }));
         assert_eq!(std::fs::read_to_string(&run_path).unwrap(), "keep-me");
+    }
+
+    #[test]
+    fn shutdown_with_both_outputs_and_zero_requests_writes_no_final_artifacts() {
+        let dir = tempfile::tempdir().unwrap();
+        let spans_path = dir.path().join("spans.jsonl");
+        let run_path = dir.path().join("run.json");
+        let session = TracingIntakeSession::builder("svc")
+            .completed_span_jsonl_path(&spans_path)
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+
+        let err = session.shutdown().unwrap_err();
+        assert!(matches!(err, ImportError::ZeroRequestArtifact { .. }));
+        assert!(!spans_path.exists());
+        assert!(!run_path.exists());
+    }
+
+    #[test]
+    fn completed_span_jsonl_success_writes_final_wrapper_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let spans_path = dir.path().join("spans.jsonl");
+        let session = TracingIntakeSession::builder("svc")
+            .completed_span_jsonl_path(&spans_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/ok"
+            ));
+        });
+
+        session.shutdown().unwrap();
+        assert!(spans_path.exists());
+        let raw = std::fs::read_to_string(&spans_path).unwrap();
+        let lines: Vec<_> = raw.lines().filter(|line| !line.trim().is_empty()).collect();
+        assert_eq!(lines.len(), 1);
+        let value: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(value["format"], "tailtriage.tracing-span.v1");
+        assert!(value["span"].is_object());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent shutdown from leaving partial/incorrect final artifacts when run validation fails for zero-request runs.
- Ensure configured outputs are only created when the final Run is persistable, while preserving `snapshot_run()` behavior. 
- Avoid destructive cleanup of user-provided final output paths and make completed-span JSONL publishing atomic.

### Description
- Call `ensure_persistable_run_has_requests(&run)` early in `TracingIntakeSession::shutdown()` when `run_json_path` is configured so validation happens before any configured files are written. 
- Switch completed-span JSONL output to write to a same-directory temporary file, flush, then `rename` the temp file into place, with best-effort temp cleanup on error. 
- Keep using `LocalJsonSink` for writing the Run JSON and preserve the existing strict/non-strict warning behavior for JSONL writer errors. 
- Add tests `shutdown_with_both_outputs_and_zero_requests_writes_no_final_artifacts` and `completed_span_jsonl_success_writes_final_wrapper_file` to validate zero-request behavior and successful atomic publish.

### Testing
- Ran `cargo fmt --check` and it passed. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed. 
- Ran the full test suite with `cargo test --workspace --all-targets --all-features --locked` and all tests passed (including the two new recorder tests). 
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13522bd25c8330b7576811255be02a)