### PR TITLE
Make tracing shutdown output writes atomic and pre-validated

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -4,7 +4,7 @@ use std::fmt::Write as _;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tailtriage_core::{CaptureLimits, CaptureLimitsOverride, CaptureMode, LocalJsonSink, RunSink};
 
 use tracing::field::{Field, Visit};
@@ -323,48 +323,60 @@ fn write_completed_span_jsonl_from_run(
             context: temp_path.display().to_string(),
             reason: err.to_string(),
         })?;
+    let cleanup_temp_file = |operation: &'static str, context: String, reason: String| {
+        let _ = std::fs::remove_file(&temp_path);
+        ImportError::Io {
+            operation,
+            context,
+            reason,
+        }
+    };
     for span in retained_span_records_from_run(run) {
         let wrapped = serde_json::json!({ "format": "tailtriage.tracing-span.v1", "span": span });
-        serde_json::to_writer(&mut file, &wrapped).map_err(|err| ImportError::Io {
-            operation: "write completed span jsonl record",
-            context: temp_path.display().to_string(),
-            reason: err.to_string(),
+        serde_json::to_writer(&mut file, &wrapped).map_err(|err| {
+            cleanup_temp_file(
+                "write completed span jsonl record",
+                temp_path.display().to_string(),
+                err.to_string(),
+            )
         })?;
-        file.write_all(b"\n").map_err(|err| ImportError::Io {
-            operation: "write completed span jsonl newline",
-            context: temp_path.display().to_string(),
-            reason: err.to_string(),
+        file.write_all(b"\n").map_err(|err| {
+            cleanup_temp_file(
+                "write completed span jsonl newline",
+                temp_path.display().to_string(),
+                err.to_string(),
+            )
         })?;
     }
-    if let Err(err) = file.flush() {
-        let _ = std::fs::remove_file(&temp_path);
-        return Err(ImportError::Io {
-            operation: "flush completed span jsonl file",
-            context: temp_path.display().to_string(),
-            reason: err.to_string(),
-        });
-    }
+    file.flush().map_err(|err| {
+        cleanup_temp_file(
+            "flush completed span jsonl file",
+            temp_path.display().to_string(),
+            err.to_string(),
+        )
+    })?;
     drop(file);
-    if let Err(err) = std::fs::rename(&temp_path, path) {
-        let _ = std::fs::remove_file(&temp_path);
-        return Err(ImportError::Io {
-            operation: "rename completed span jsonl temp file",
-            context: format!("{} -> {}", temp_path.display(), path.display()),
-            reason: err.to_string(),
-        });
-    }
+    std::fs::rename(&temp_path, path).map_err(|err| {
+        cleanup_temp_file(
+            "rename completed span jsonl temp file",
+            format!("{} -> {}", temp_path.display(), path.display()),
+            err.to_string(),
+        )
+    })?;
     Ok(())
 }
 
 fn completed_span_jsonl_temp_path(path: &Path) -> PathBuf {
     let file_name = path.file_name().map_or_else(
         || "completed-spans.jsonl".to_string(),
-        |n| n.to_string_lossy().into_owned(),
+        |name| name.to_string_lossy().into_owned(),
     );
+    let nanos_since_unix_epoch = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
     let temp_name = format!(
-        ".{file_name}.tailtriage-tmp-{}-{}",
+        ".{file_name}.tailtriage-tmp-{}-{nanos_since_unix_epoch}",
         std::process::id(),
-        tailtriage_core::unix_time_ms()
     );
     path.with_file_name(temp_name)
 }

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -283,6 +283,9 @@ impl TracingIntakeSession {
         let strict_mode = self.recorder.options.strict_mode();
         let imported = self.recorder.shutdown()?;
         let (mut run, mut warnings) = imported.into_parts();
+        if self.run_json_path.is_some() {
+            ensure_persistable_run_has_requests(&run)?;
+        }
         if let Some(path) = &self.completed_span_jsonl_path {
             if let Err(err) = write_completed_span_jsonl_from_run(&run, path) {
                 if strict_mode {
@@ -294,7 +297,6 @@ impl TracingIntakeSession {
             }
         }
         if let Some(path) = self.run_json_path {
-            ensure_persistable_run_has_requests(&run)?;
             LocalJsonSink::new(&path)
                 .write(&run)
                 .map_err(|err| ImportError::RunJsonWrite {
@@ -310,35 +312,61 @@ fn write_completed_span_jsonl_from_run(
     run: &tailtriage_core::Run,
     path: &Path,
 ) -> Result<(), ImportError> {
+    let temp_path = completed_span_jsonl_temp_path(path);
     let mut file = std::fs::OpenOptions::new()
         .create(true)
         .write(true)
         .truncate(true)
-        .open(path)
+        .open(&temp_path)
         .map_err(|err| ImportError::Io {
             operation: "open completed span jsonl path",
-            context: path.display().to_string(),
+            context: temp_path.display().to_string(),
             reason: err.to_string(),
         })?;
     for span in retained_span_records_from_run(run) {
         let wrapped = serde_json::json!({ "format": "tailtriage.tracing-span.v1", "span": span });
         serde_json::to_writer(&mut file, &wrapped).map_err(|err| ImportError::Io {
             operation: "write completed span jsonl record",
-            context: path.display().to_string(),
+            context: temp_path.display().to_string(),
             reason: err.to_string(),
         })?;
         file.write_all(b"\n").map_err(|err| ImportError::Io {
             operation: "write completed span jsonl newline",
-            context: path.display().to_string(),
+            context: temp_path.display().to_string(),
             reason: err.to_string(),
         })?;
     }
-    file.flush().map_err(|err| ImportError::Io {
-        operation: "flush completed span jsonl file",
-        context: path.display().to_string(),
-        reason: err.to_string(),
-    })?;
+    if let Err(err) = file.flush() {
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(ImportError::Io {
+            operation: "flush completed span jsonl file",
+            context: temp_path.display().to_string(),
+            reason: err.to_string(),
+        });
+    }
+    drop(file);
+    if let Err(err) = std::fs::rename(&temp_path, path) {
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(ImportError::Io {
+            operation: "rename completed span jsonl temp file",
+            context: format!("{} -> {}", temp_path.display(), path.display()),
+            reason: err.to_string(),
+        });
+    }
     Ok(())
+}
+
+fn completed_span_jsonl_temp_path(path: &Path) -> PathBuf {
+    let file_name = path.file_name().map_or_else(
+        || "completed-spans.jsonl".to_string(),
+        |n| n.to_string_lossy().into_owned(),
+    );
+    let temp_name = format!(
+        ".{file_name}.tailtriage-tmp-{}-{}",
+        std::process::id(),
+        tailtriage_core::unix_time_ms()
+    );
+    path.with_file_name(temp_name)
 }
 
 fn retained_span_records_from_run(run: &tailtriage_core::Run) -> Vec<SpanRecord> {
@@ -2688,6 +2716,50 @@ mod tests {
         let err = session.shutdown().unwrap_err();
         assert!(matches!(err, ImportError::ZeroRequestArtifact { .. }));
         assert_eq!(std::fs::read_to_string(&run_path).unwrap(), "keep-me");
+    }
+
+    #[test]
+    fn shutdown_with_both_outputs_and_zero_requests_writes_no_final_artifacts() {
+        let dir = tempfile::tempdir().unwrap();
+        let spans_path = dir.path().join("spans.jsonl");
+        let run_path = dir.path().join("run.json");
+        let session = TracingIntakeSession::builder("svc")
+            .completed_span_jsonl_path(&spans_path)
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let err = session.shutdown().unwrap_err();
+        assert!(matches!(err, ImportError::ZeroRequestArtifact { .. }));
+        assert!(!spans_path.exists());
+        assert!(!run_path.exists());
+    }
+
+    #[test]
+    fn completed_span_jsonl_success_writes_final_wrapper_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let spans_path = dir.path().join("spans.jsonl");
+        let session = TracingIntakeSession::builder("svc")
+            .completed_span_jsonl_path(&spans_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            ));
+        });
+
+        session.shutdown().unwrap();
+        assert!(spans_path.exists());
+        let raw = std::fs::read_to_string(&spans_path).unwrap();
+        let lines: Vec<_> = raw.lines().filter(|line| !line.trim().is_empty()).collect();
+        assert_eq!(lines.len(), 1);
+        let value: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(value["format"], "tailtriage.tracing-span.v1");
+        assert!(value["span"].is_object());
     }
 
     #[test]

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -323,46 +323,50 @@ fn write_completed_span_jsonl_from_run(
             context: temp_path.display().to_string(),
             reason: err.to_string(),
         })?;
-    let cleanup_temp_file = |operation: &'static str, context: String, reason: String| {
+
+    let write_result = (|| -> Result<(), ImportError> {
+        for span in retained_span_records_from_run(run) {
+            let wrapped =
+                serde_json::json!({ "format": "tailtriage.tracing-span.v1", "span": span });
+
+            serde_json::to_writer(&mut file, &wrapped).map_err(|err| ImportError::Io {
+                operation: "write completed span jsonl record",
+                context: temp_path.display().to_string(),
+                reason: err.to_string(),
+            })?;
+
+            file.write_all(b"\n").map_err(|err| ImportError::Io {
+                operation: "write completed span jsonl newline",
+                context: temp_path.display().to_string(),
+                reason: err.to_string(),
+            })?;
+        }
+
+        file.flush().map_err(|err| ImportError::Io {
+            operation: "flush completed span jsonl file",
+            context: temp_path.display().to_string(),
+            reason: err.to_string(),
+        })?;
+
+        Ok(())
+    })();
+
+    drop(file);
+
+    if let Err(err) = write_result {
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(err);
+    }
+
+    std::fs::rename(&temp_path, path).map_err(|err| {
         let _ = std::fs::remove_file(&temp_path);
         ImportError::Io {
-            operation,
-            context,
-            reason,
+            operation: "rename completed span jsonl temp file",
+            context: format!("{} -> {}", temp_path.display(), path.display()),
+            reason: err.to_string(),
         }
-    };
-    for span in retained_span_records_from_run(run) {
-        let wrapped = serde_json::json!({ "format": "tailtriage.tracing-span.v1", "span": span });
-        serde_json::to_writer(&mut file, &wrapped).map_err(|err| {
-            cleanup_temp_file(
-                "write completed span jsonl record",
-                temp_path.display().to_string(),
-                err.to_string(),
-            )
-        })?;
-        file.write_all(b"\n").map_err(|err| {
-            cleanup_temp_file(
-                "write completed span jsonl newline",
-                temp_path.display().to_string(),
-                err.to_string(),
-            )
-        })?;
-    }
-    file.flush().map_err(|err| {
-        cleanup_temp_file(
-            "flush completed span jsonl file",
-            temp_path.display().to_string(),
-            err.to_string(),
-        )
     })?;
-    drop(file);
-    std::fs::rename(&temp_path, path).map_err(|err| {
-        cleanup_temp_file(
-            "rename completed span jsonl temp file",
-            format!("{} -> {}", temp_path.display(), path.display()),
-            err.to_string(),
-        )
-    })?;
+
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation
- Prevent shutdown from leaving partially-written final-path artifacts when Run JSON output would fail validation, while preserving existing in-process `snapshot_run()` behavior. 
- Ensure completed-span JSONL final-path files are written atomically to avoid partial artifacts on writer failures.

### Description
- Validate persistability up-front in `TracingIntakeSession::shutdown()` by calling `ensure_persistable_run_has_requests(&run)` when `run_json_path` is configured before writing any configured outputs. 
- Keep `snapshot_run()` unchanged so zero-request in-process snapshots remain available for inspection. 
- Emit completed-span JSONL via a temp file in the same directory: write -> flush -> rename to final path, with best-effort temp-file cleanup on flush/rename errors. 
- Preserve existing strict/non-strict semantics for completed-span JSONL writer errors (strict returns error, non-strict converts it to lifecycle warnings). 
- Continue using `LocalJsonSink` for Run JSON writes (no changes to `LocalJsonSink`). 
- Added the helper `completed_span_jsonl_temp_path()` to build a same-directory temp filename and best-effort cleanup logic on failure.

### Testing
- Added `shutdown_with_both_outputs_and_zero_requests_writes_no_final_artifacts` which configures both `.completed_span_jsonl_path(...)` and `.run_json_path(...)`, records no request spans, asserts `shutdown()` returns `ImportError::ZeroRequestArtifact`, and asserts neither final path exists. 
- Added `completed_span_jsonl_success_writes_final_wrapper_file` which verifies a normal request span leads to a final JSONL file with the stable wrapper shape after `shutdown()`. 
- Ran required validations and test suite: `cargo fmt --check` (passed), `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (passed), `cargo test --workspace --all-targets --all-features --locked` (passed), and `python3 scripts/validate_docs_contracts.py` (passed). 

Output-order changes: persistability (`ensure_persistable_run_has_requests`) is now performed before any configured output writes when `run_json_path` is set. 
Temp-file rename: completed-span JSONL now writes to a temp file in the same directory and renames it to the final path only after successful write+flush. 
Tests added: `shutdown_with_both_outputs_and_zero_requests_writes_no_final_artifacts`, `completed_span_jsonl_success_writes_final_wrapper_file`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13522bd25c8330b7576811255be02a)