### PR TITLE
Refine non-strict duplicate tt.request_id tracing import behavior

### DIFF
--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -244,12 +244,12 @@ where
             "{request_outcome_default_count} request span(s) missing optional '{TT_OUTCOME}'; assumed 'ok'"
         )));
     }
-    let requests: Vec<RequestEvent> = parsed_requests
+    let raw_requests: Vec<RequestEvent> = parsed_requests
         .into_iter()
         .map(|request| request.event)
         .collect();
-    let request_intervals = retained_request_intervals(
-        &requests,
+    let (requests, request_intervals) = retained_requests_and_intervals(
+        raw_requests,
         capture_limits.max_requests,
         options.strict_mode(),
         &mut warnings,
@@ -354,21 +354,23 @@ struct RequestInterval {
     finished_at_unix_ms: u64,
 }
 
-fn retained_request_intervals(
-    requests: &[RequestEvent],
+fn retained_requests_and_intervals(
+    requests: Vec<RequestEvent>,
     max_requests: usize,
     strict: bool,
     warnings: &mut Vec<ImportWarning>,
-) -> Result<BTreeMap<String, RequestInterval>, ImportError> {
+) -> Result<(Vec<RequestEvent>, BTreeMap<String, RequestInterval>), ImportError> {
+    let overflow_requests: Vec<RequestEvent> = requests.iter().skip(max_requests).cloned().collect();
     let mut intervals = BTreeMap::new();
-    for request in requests.iter().take(max_requests) {
+    let mut deduped_requests = Vec::with_capacity(requests.len());
+    for request in requests.into_iter().take(max_requests) {
         let request_id = request.request_id.as_str();
         if intervals.contains_key(request_id) {
             strict_or_warn(
                 strict,
                 warnings,
                 format!(
-                    "duplicate retained request_id '{request_id}' encountered during import; using first retained request interval"
+                    "input-quality warning: duplicate tt.request_id '{request_id}' encountered during tracing import; skipped later duplicate request event and retained first request interval; child stage/queue evidence outside the retained request interval may also be skipped"
                 ),
             )?;
             continue;
@@ -380,8 +382,10 @@ fn retained_request_intervals(
                 finished_at_unix_ms: request.finished_at_unix_ms,
             },
         );
+        deduped_requests.push(request);
     }
-    Ok(intervals)
+    deduped_requests.extend(overflow_requests);
+    Ok((deduped_requests, intervals))
 }
 
 struct ParsedStageEvent {
@@ -610,7 +614,7 @@ fn validated_duration_us(
 
 fn is_durable_conversion_warning(message: &str) -> bool {
     message.starts_with("skipped ")
-        || message.starts_with("duplicate retained request_id")
+        || message.starts_with("input-quality warning: duplicate tt.request_id")
         || message.starts_with("missing required field")
         || message.starts_with("invalid field")
         || message.starts_with("unknown tt.kind")
@@ -1140,28 +1144,61 @@ mod tests {
     }
 
     #[test]
-    fn duplicate_retained_request_ids_warn_non_strict_and_fail_strict() {
+    fn non_strict_duplicate_request_id_skips_later_request() {
         let spans = vec![
             SpanRecord::new("req-1", 100, 120)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "dup")
                 .field(TT_ROUTE, "/a"),
-            SpanRecord::new("req-2", 101, 121)
+            SpanRecord::new("req-2", 200, 240)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "dup")
                 .field(TT_ROUTE, "/b"),
+            SpanRecord::new("stage-later", 205, 235)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "dup")
+                .field(TT_STAGE, "db"),
         ];
-        let imported = run_from_span_records(spans.clone(), ImportOptions::new("svc")).unwrap();
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        let run = imported.run();
+        assert_eq!(run.requests.len(), 1);
+        assert_eq!(run.requests[0].request_id, "dup");
+        assert_eq!(run.requests[0].route, "/a");
+        assert!(run.stages.is_empty());
+        assert_eq!(run.truncation.dropped_requests, 0);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("duplicate tt.request_id 'dup'")));
         assert!(imported.warnings().iter().any(|w| w
             .message()
-            .contains("duplicate retained request_id 'dup' encountered during import")));
+            .contains("skipped later duplicate request event")));
+        assert!(imported.warnings().iter().any(|w| w.message().contains(
+            "child stage/queue evidence outside the retained request interval may also be skipped"
+        )));
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("skipped stage span 'db' for request_id 'dup' because interval [205, 235] falls outside request interval [100, 120]")));
         assert!(imported
             .run()
             .metadata
             .lifecycle_warnings
             .iter()
-            .any(|w| w.contains("duplicate retained request_id 'dup' encountered during import")));
+            .any(|w| w.contains("duplicate tt.request_id 'dup'")));
+    }
 
+    #[test]
+    fn strict_duplicate_request_id_fails() {
+        let spans = vec![
+            SpanRecord::new("req-1", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "dup")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("req-2", 200, 240)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "dup")
+                .field(TT_ROUTE, "/b"),
+        ];
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
         assert!(matches!(err, ImportError::StrictViolation(_)));
     }
@@ -1195,7 +1232,7 @@ mod tests {
         assert!(!imported
             .warnings()
             .iter()
-            .any(|w| w.message().contains("duplicate retained request_id")));
+            .any(|w| w.message().contains("duplicate tt.request_id")));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Duplicate `tt.request_id` events in tracing input were confusing: non-strict import previously retained multiple requests and produced unclear warnings and containment behavior. 
- The goal is to make non-strict behavior explicit and consistent: keep the first valid request event, skip later duplicates as an input-quality skip, and make child stage/queue containment evaluate against the retained-first request interval.
- Strict mode must continue to treat duplicate retained request IDs as an import failure (`ImportError::StrictViolation`).

### Description
- Replace the previous retained-interval-only flow with `retained_requests_and_intervals` that returns the deduplicated retained requests and a map of first-retained request intervals, applying duplicate handling before stage/queue containment filtering.
- In non-strict mode, skip later duplicate request events (retain the first) and emit an explicit input-quality warning whose text states the duplicate is an input-quality problem, the later duplicate was skipped, and that child stage/queue evidence outside the retained request interval may also be skipped.
- Preserve overflow semantics by keeping overflow requests after deduplication so capture-limit truncation counts remain correct and skipped-duplicate requests do not increment `truncation.dropped_requests`.
- Make the duplicate-warning prefix durable by adding the new prefix to the durable-warning classifier and attach these conversion warnings to run lifecycle warnings like other conversion warnings.
- Add focused tests `non_strict_duplicate_request_id_skips_later_request` and `strict_duplicate_request_id_fails` to assert retained-first behavior, skipped child evidence, zero `truncation.dropped_requests` for the skipped duplicate, and the exact expected warning wording.
- Code changes are in `tailtriage-tracing/src/lib.rs` (duplicate handling, warning text, durable-warning classification) and test updates live in the same module.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed.
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests passed, including the newly added tests `non_strict_duplicate_request_id_skips_later_request` and `strict_duplicate_request_id_fails`.
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1365fb94c88330a217f9871671afe8)