### PR TITLE
docs: clarify tracing feature-flag onboarding and TracingTokioSession bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Offline import expects completed `tt.*` span JSONL (not arbitrary tracing log JS
   tailtriage import tracing-json completed-spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json
   tailtriage analyze tailtriage-run.json
   ```
-- Live session path: add `tailtriage_tracing::TracingIntakeSession` and `session.layer()` beside your existing subscriber setup.
+- Live session path: first install `tailtriage-tracing` with `live` (`cargo add tailtriage-tracing --features live`), then add `tailtriage_tracing::TracingIntakeSession` and `session.layer()` beside your existing subscriber setup.
 
 Both paths convert tracing-shaped evidence into standard `tailtriage_core::Run` data and feed the same analyzer/report workflow (evidence-ranked suspects and next checks). Runtime-pressure evidence still requires runtime snapshots (for example via the Tokio sampler).
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -166,7 +166,7 @@ Important limits for production interpretation:
 * without runtime snapshots, executor-pressure and blocking-pool suspects can be weaker or absent
 * runtime-pressure evidence remains Tokio-specific and requires runtime snapshots or Tokio sampler coupling
 
-`TracingTokioSession` uses the same core capture-limit model as native Tokio sampling for runtime snapshot retention. There is no tracing-specific `max_runtime_snapshots(...)` builder method; configure explicit caps with `capture_limits_override(CaptureLimitsOverride { max_runtime_snapshots: Some(...), ..Default::default() })`. Tracing-only runs still do not fabricate runtime snapshots, so runtime-pressure evidence requires Tokio session/runtime sampler coupling.
+`TracingTokioSession` uses the same core capture-limit model as native Tokio sampling for runtime snapshot retention. For `TracingTokioSession`, run metadata time bounds cover both retained tracing evidence and retained runtime snapshots. There is no tracing-specific `max_runtime_snapshots(...)` builder method; configure explicit caps with `capture_limits_override(CaptureLimitsOverride { max_runtime_snapshots: Some(...), ..Default::default() })`. Tracing-only runs still do not fabricate runtime snapshots, so runtime-pressure evidence requires Tokio session/runtime sampler coupling.
 
 Treat tracing-based reports the same way as other reports: evidence-ranked suspects and next checks are triage leads, not proof.
 
@@ -506,4 +506,5 @@ Do not treat one report as final proof.
 - Completed-span JSONL is a narrow retained-evidence export, not a generic tracing log stream and not OTel/OTLP.
 - Import warnings and lifecycle warnings mean evidence may be incomplete and should be treated as triage caveats.
 - Tracing import and native capture share `CaptureMode` and `CaptureLimits` semantics for request/stage/queue retention. Offline CLI tracing import exposes only request/stage/queue limit overrides because those are the evidence types imported on this path; runtime/in-flight snapshot limit flags are intentionally not exposed because these evidence types are not imported. Tracing-only runs do not fabricate runtime snapshots; runtime-pressure evidence remains Tokio-specific and requires runtime snapshots/Tokio sampler coupling.
+- For `TracingTokioSession`, run metadata time bounds cover both retained tracing evidence and retained runtime snapshots.
 - Treat tracing-import output like all tailtriage output: evidence-ranked suspects and next checks are leads, not proof of root cause.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -36,6 +36,12 @@ The `controller` and `tokio` namespaces are available with default features; `ax
 
 If you already instrument request/stage/queue work with Rust `tracing`, use `tailtriage-tracing` as an intake path into the same triage workflow.
 
+Install for typed records plus JSONL import APIs (default feature set):
+
+```bash
+cargo add tailtriage-tracing
+```
+
 A) Completed-span JSONL intake path:
 
 ```bash
@@ -45,7 +51,12 @@ tailtriage analyze tailtriage-run.json
 
 `tailtriage import tracing-json` writes Run artifact JSON (not Report JSON), and analysis remains a separate step after import. Use the documented stable wrapper JSONL shape from `tailtriage-tracing` (`{"format":"tailtriage.tracing-span.v1","span":{...}}`). `--strict` fails on malformed or incomplete `tt.*` spans; non-strict mode skips malformed `tt.*` spans and prints `warning: ...` messages. Tracing import and native capture use the same `CaptureMode`/`CaptureLimits` semantics for request/stage/queue retention. Offline import exposes `--mode <light|investigation>` plus `--max-requests`, `--max-stages`, and `--max-queues` because those are the imported evidence types. It does not expose runtime/in-flight snapshot limit flags because those evidence types are not imported by this path. Tracing-only runs do not fabricate runtime snapshots, and runtime-pressure evidence remains Tokio-specific. Persisted Run JSON intended for `tailtriage analyze` must include at least one completed request event; in-process library snapshots may still be zero-request for inspection.
 
-B) Direct Run JSON path with async span instrumentation:
+B) Direct Run JSON path with async span instrumentation (`live` feature required):
+
+```bash
+cargo add tailtriage-tracing --features live
+```
+
 
 ```rust,no_run
 use tailtriage_tracing::TracingIntakeSession;
@@ -85,6 +96,12 @@ tailtriage analyze target/tailtriage-examples/checkout.run.json
 ```
 
 Use `.instrument(...)` for async work; `snapshot_run()` is the non-consuming inspection API, while `shutdown()` finalizes the session.
+
+Tokio runtime sampler coupling via `TracingTokioSession` requires the `tokio` feature:
+
+```bash
+cargo add tailtriage-tracing --features tokio
+```
 
 For the full tracing setup details and both flows, see `tailtriage-tracing/README.md`.
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -117,7 +117,7 @@ Ordinary tracing log JSON (for example `fmt().json` output) is rejected by impor
 Tracing intake import and native capture share the same CaptureMode/CaptureLimits semantics for request/stage/queue evidence retention. Offline tracing JSONL import does not fabricate runtime snapshots. Runtime-pressure evidence still requires runtime snapshots/Tokio sampler coupling.
 Persisted Run JSON intended for `tailtriage analyze` must include at least one completed request event; in-process library snapshots may still be zero-request for inspection.
 
-For `TracingTokioSession`, runtime snapshot retention also uses the same core capture-limit model:
+For `TracingTokioSession`, runtime snapshot retention also uses the same core capture-limit model. Run metadata time bounds cover merged retained tracing evidence plus retained runtime snapshots, which supports triage interpretation but is not root-cause proof:
 
 - configure retention with `mode(...)`, `capture_limits(...)`, or `capture_limits_override(...)`
 - there is no tracing-specific `.max_runtime_snapshots(...)` session builder method


### PR DESCRIPTION
### Motivation

- Make tracing onboarding explicit so integrators know which `tailtriage-tracing` feature enables which live/runtime coupling behavior. 
- Document that `TracingTokioSession` merges retained tracing evidence and runtime snapshots into the run metadata time bounds so users understand the limited scope of runtime-pressure evidence. 
- Preserve existing operational guardrails about Run vs Report JSON, separate analysis, no fabricated runtime snapshots for tracing-only runs, Tokio-specific runtime-pressure evidence, and that suspects are triage leads not proof.

### Description

- Added explicit install guidance in `docs/user-guide.md` for default `tailtriage-tracing` (`cargo add tailtriage-tracing`), the `live` feature required for `TracingIntakeSession`/`TracingRecorder`/`TailtriageLayer` (`cargo add tailtriage-tracing --features live`), and the `tokio` feature required for `TracingTokioSession` (`cargo add tailtriage-tracing --features tokio`).
- Clarified feature-role distinctions so the docs state the default feature supports typed records plus JSONL import, `live` enables the live recorder and layer, and `tokio` enables `TracingTokioSession` (which includes `live`).
- Added one concise sentence to `tailtriage-tracing/README.md` explaining that `TracingTokioSession` run metadata time bounds cover merged retained tracing evidence plus retained runtime snapshots while avoiding any root-cause proof language.
- Added a concise operational sentence to `docs/operations.md` noting that for `TracingTokioSession` run metadata bounds cover both retained tracing evidence and retained runtime snapshots and left the rest of the operational guidance unchanged.

### Testing

- Files changed: `docs/user-guide.md`, `tailtriage-tracing/README.md`, `docs/operations.md`, and `README.md`.
- Docs validator changed?: `scripts/validate_docs_contracts.py` was not modified and the docs validator was not changed.
- Commands run: `cargo fmt --check` (passed), `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (passed), `cargo test --workspace --all-targets --all-features --locked` (passed), and `python3 scripts/validate_docs_contracts.py` (passed).
- Automated test result: full workspace build, clippy, test suite, and docs contract validation all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13cf006bec83309d9d1f389fc72113)