### PR TITLE
docs: clarify tracing feature flags and TracingTokioSession runtime bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Offline import expects completed `tt.*` span JSONL (not arbitrary tracing log JS
   tailtriage import tracing-json completed-spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json
   tailtriage analyze tailtriage-run.json
   ```
-- Live session path: add `tailtriage_tracing::TracingIntakeSession` and `session.layer()` beside your existing subscriber setup.
+- Live session path prerequisite: `cargo add tailtriage-tracing --features live`. Then add `tailtriage_tracing::TracingIntakeSession` and `session.layer()` beside your existing subscriber setup.
 
 Both paths convert tracing-shaped evidence into standard `tailtriage_core::Run` data and feed the same analyzer/report workflow (evidence-ranked suspects and next checks). Runtime-pressure evidence still requires runtime snapshots (for example via the Tokio sampler).
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -166,7 +166,7 @@ Important limits for production interpretation:
 * without runtime snapshots, executor-pressure and blocking-pool suspects can be weaker or absent
 * runtime-pressure evidence remains Tokio-specific and requires runtime snapshots or Tokio sampler coupling
 
-`TracingTokioSession` uses the same core capture-limit model as native Tokio sampling for runtime snapshot retention. There is no tracing-specific `max_runtime_snapshots(...)` builder method; configure explicit caps with `capture_limits_override(CaptureLimitsOverride { max_runtime_snapshots: Some(...), ..Default::default() })`. Tracing-only runs still do not fabricate runtime snapshots, so runtime-pressure evidence requires Tokio session/runtime sampler coupling.
+`TracingTokioSession` uses the same core capture-limit model as native Tokio sampling for runtime snapshot retention. Run metadata time bounds cover both retained tracing evidence and runtime snapshots for the captured run window. There is no tracing-specific `max_runtime_snapshots(...)` builder method; configure explicit caps with `capture_limits_override(CaptureLimitsOverride { max_runtime_snapshots: Some(...), ..Default::default() })`. Tracing-only runs still do not fabricate runtime snapshots, so runtime-pressure evidence requires Tokio session/runtime sampler coupling.
 
 Treat tracing-based reports the same way as other reports: evidence-ranked suspects and next checks are triage leads, not proof.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -47,6 +47,12 @@ tailtriage analyze tailtriage-run.json
 
 B) Direct Run JSON path with async span instrumentation:
 
+Install live tracing intake support:
+
+```bash
+cargo add tailtriage-tracing --features live
+```
+
 ```rust,no_run
 use tailtriage_tracing::TracingIntakeSession;
 use tracing::Instrument as _;
@@ -78,6 +84,14 @@ session.shutdown()?;
 
 Stage and queue spans use their own `tt.stage` / `tt.queue` fields around the awaited work they measure.
 
+
+Tokio runtime sampler coupling with `TracingTokioSession` needs the `tokio` feature:
+
+```bash
+cargo add tailtriage-tracing --features tokio
+```
+
+Default `tailtriage-tracing` supports typed records plus JSONL import. `live` enables `TracingRecorder`, `TailtriageLayer`, and `TracingIntakeSession`; `tokio` enables `TracingTokioSession`.
 Then analyze directly:
 
 ```bash

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -117,7 +117,7 @@ Ordinary tracing log JSON (for example `fmt().json` output) is rejected by impor
 Tracing intake import and native capture share the same CaptureMode/CaptureLimits semantics for request/stage/queue evidence retention. Offline tracing JSONL import does not fabricate runtime snapshots. Runtime-pressure evidence still requires runtime snapshots/Tokio sampler coupling.
 Persisted Run JSON intended for `tailtriage analyze` must include at least one completed request event; in-process library snapshots may still be zero-request for inspection.
 
-For `TracingTokioSession`, runtime snapshot retention also uses the same core capture-limit model:
+For `TracingTokioSession`, runtime snapshot retention also uses the same core capture-limit model, and run metadata time bounds cover merged tracing evidence plus retained runtime snapshots (triage evidence, not root-cause proof):
 
 - configure retention with `mode(...)`, `capture_limits(...)`, or `capture_limits_override(...)`
 - there is no tracing-specific `.max_runtime_snapshots(...)` session builder method


### PR DESCRIPTION
### Motivation

- Make tracing onboarding explicit about required feature flags so users can install the correct `tailtriage-tracing` features before using live/session APIs. 
- Clarify what `TracingTokioSession` run metadata covers so readers understand the bounded scope of merged tracing + runtime evidence without implying root-cause proof.

### Description

- Added explicit install instructions for live intake support with `cargo add tailtriage-tracing --features live` before the `TracingIntakeSession` snippet in `docs/user-guide.md` and `README.md`. 
- Added explicit install instruction for Tokio sampler coupling with `cargo add tailtriage-tracing --features tokio` and clarified feature split: default = typed records + JSONL import; `live` = `TracingRecorder`/`TailtriageLayer`/`TracingIntakeSession`; `tokio` = `TracingTokioSession`. 
- Added a concise bounded sentence to `tailtriage-tracing/README.md` that `TracingTokioSession` run metadata time bounds cover merged tracing evidence plus retained runtime snapshots and explicitly framed it as triage evidence (not root-cause proof). 
- Added one concise operational sentence to `docs/operations.md` stating `TracingTokioSession` run metadata bounds cover both retained tracing evidence and runtime snapshots for the captured run window. 
- Docs-only change, no behavioral or dependency changes, and the docs validator was not modified.

### Testing

- Ran `cargo fmt --check` and it passed. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed. 
- Ran `cargo test --workspace --all-targets --all-features --locked` and it failed due to an existing unit test failure in `tailtriage-tokio`: `helper_tests::stage_helpers_and_inflight_behave_and_preserve_results` (test failure unrelated to docs changes). 
- Ran `python3 scripts/validate_docs_contracts.py` and it passed. 

Files changed: `docs/user-guide.md`, `tailtriage-tracing/README.md`, `docs/operations.md`, and `README.md`. 
Docs validator changed: No.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13cf006bec83309d9d1f389fc72113)