### PR TITLE
docs: clarify tracing feature-flag onboarding and TracingTokioSession bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Offline import expects completed `tt.*` span JSONL (not arbitrary tracing log JS
   tailtriage import tracing-json completed-spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json
   tailtriage analyze tailtriage-run.json
   ```
-- Live session path: add `tailtriage_tracing::TracingIntakeSession` and `session.layer()` beside your existing subscriber setup.
+- Live session path: install live intake support (`cargo add tailtriage-tracing --features live`), then add `tailtriage_tracing::TracingIntakeSession` and `session.layer()` beside your existing subscriber setup.
 
 Both paths convert tracing-shaped evidence into standard `tailtriage_core::Run` data and feed the same analyzer/report workflow (evidence-ranked suspects and next checks). Runtime-pressure evidence still requires runtime snapshots (for example via the Tokio sampler).
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -166,7 +166,7 @@ Important limits for production interpretation:
 * without runtime snapshots, executor-pressure and blocking-pool suspects can be weaker or absent
 * runtime-pressure evidence remains Tokio-specific and requires runtime snapshots or Tokio sampler coupling
 
-`TracingTokioSession` uses the same core capture-limit model as native Tokio sampling for runtime snapshot retention. There is no tracing-specific `max_runtime_snapshots(...)` builder method; configure explicit caps with `capture_limits_override(CaptureLimitsOverride { max_runtime_snapshots: Some(...), ..Default::default() })`. Tracing-only runs still do not fabricate runtime snapshots, so runtime-pressure evidence requires Tokio session/runtime sampler coupling.
+`TracingTokioSession` uses the same core capture-limit model as native Tokio sampling for runtime snapshot retention. Its run metadata time bounds cover both retained tracing evidence and retained runtime snapshots for bounded operational interpretation. There is no tracing-specific `max_runtime_snapshots(...)` builder method; configure explicit caps with `capture_limits_override(CaptureLimitsOverride { max_runtime_snapshots: Some(...), ..Default::default() })`. Tracing-only runs still do not fabricate runtime snapshots, so runtime-pressure evidence requires Tokio session/runtime sampler coupling.
 
 Treat tracing-based reports the same way as other reports: evidence-ranked suspects and next checks are triage leads, not proof.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -47,6 +47,12 @@ tailtriage analyze tailtriage-run.json
 
 B) Direct Run JSON path with async span instrumentation:
 
+Install live intake support:
+
+```bash
+cargo add tailtriage-tracing --features live
+```
+
 ```rust,no_run
 use tailtriage_tracing::TracingIntakeSession;
 use tracing::Instrument as _;
@@ -85,6 +91,14 @@ tailtriage analyze target/tailtriage-examples/checkout.run.json
 ```
 
 Use `.instrument(...)` for async work; `snapshot_run()` is the non-consuming inspection API, while `shutdown()` finalizes the session.
+
+For Tokio runtime sampler coupling with tracing intake, install the Tokio-enabled feature:
+
+```bash
+cargo add tailtriage-tracing --features tokio
+```
+
+Default `tailtriage-tracing` supports typed completed-span records plus JSONL import APIs. `live` is required for `TracingRecorder`, `TailtriageLayer`, and `TracingIntakeSession`. `tokio` is required for `TracingTokioSession`.
 
 For the full tracing setup details and both flows, see `tailtriage-tracing/README.md`.
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -118,6 +118,7 @@ Tracing intake import and native capture share the same CaptureMode/CaptureLimit
 Persisted Run JSON intended for `tailtriage analyze` must include at least one completed request event; in-process library snapshots may still be zero-request for inspection.
 
 For `TracingTokioSession`, runtime snapshot retention also uses the same core capture-limit model:
+Run metadata time bounds cover merged tracing evidence plus retained runtime snapshots, which helps bound triage interpretation without proving root cause.
 
 - configure retention with `mode(...)`, `capture_limits(...)`, or `capture_limits_override(...)`
 - there is no tracing-specific `.max_runtime_snapshots(...)` session builder method


### PR DESCRIPTION
### Motivation
- Make it explicit how to install live tracing intake and Tokio-enabled tracing support so users enable the correct feature flags before using live intake APIs. 
- Clarify the operational semantics of `TracingTokioSession` run metadata so users understand the bounded nature of merged tracing+runtime evidence without implying root-cause proof.

### Description
- Added explicit install guidance `cargo add tailtriage-tracing --features live` before the `TracingIntakeSession` example and `cargo add tailtriage-tracing --features tokio` for Tokio runtime sampler coupling in `docs/user-guide.md`.
- Documented the feature-flag distinction in `docs/user-guide.md`: default supports typed completed-span records + JSONL import, `live` enables `TracingRecorder`/`TailtriageLayer`/`TracingIntakeSession`, and `tokio` enables `TracingTokioSession`.
- Added a concise sentence in `tailtriage-tracing/README.md` that `TracingTokioSession` run metadata time bounds cover merged tracing evidence plus retained runtime snapshots while avoiding causal-proof language.
- Added a matching operational sentence in `docs/operations.md` that `TracingTokioSession` bounds cover both retained tracing evidence and retained runtime snapshots and kept all other operational constraints and distinctions unchanged.
- Files changed: `docs/user-guide.md`, `tailtriage-tracing/README.md`, `docs/operations.md`, and `README.md`.
- No behavior, dependency, or code changes were made and no new tracing sections were added elsewhere.

### Testing
- Ran `cargo fmt --check` which passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which passed.
- Ran `cargo test --workspace --all-targets --all-features --locked` which passed.
- Ran `python3 scripts/validate_docs_contracts.py` which passed and the docs validator was not changed.
- Result: all automated checks listed above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13cf006bec83309d9d1f389fc72113)