### PR TITLE
Fix duplicate-outcome warning ordering and complete tracing install guidance

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -55,6 +55,7 @@ B) Direct Run JSON path with async span instrumentation (`live` feature required
 
 ```bash
 cargo add tailtriage-tracing --features live
+cargo add tracing tracing-subscriber
 ```
 
 
@@ -101,6 +102,7 @@ Tokio runtime sampler coupling via `TracingTokioSession` requires the `tokio` fe
 
 ```bash
 cargo add tailtriage-tracing --features tokio
+cargo add tracing tracing-subscriber
 ```
 
 For the full tracing setup details and both flows, see `tailtriage-tracing/README.md`.

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -20,6 +20,20 @@ It is **not**:
 
 CLI offline import workflows only need JSONL import support and do not require the live `tracing_subscriber` layer dependency.
 
+For direct `tracing::...` / `tracing_subscriber::...` usage in application code, add those crates explicitly:
+
+```bash
+cargo add tailtriage-tracing --features live
+cargo add tracing tracing-subscriber
+```
+
+If you use `TracingTokioSession`, install with the Tokio coupling feature and the direct tracing crates:
+
+```bash
+cargo add tailtriage-tracing --features tokio
+cargo add tracing tracing-subscriber
+```
+
 ## Recommended live session setup (`live` feature)
 
 ```rust,no_run

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -234,6 +234,12 @@ where
     }
     let mode = options.mode_value();
     let capture_limits = options.resolved_capture_limits();
+    dedupe_retained_requests(
+        &mut parsed_requests,
+        capture_limits.max_requests,
+        options.strict_mode(),
+        &mut warnings,
+    )?;
     let request_outcome_default_count = parsed_requests
         .iter()
         .take(capture_limits.max_requests)
@@ -244,16 +250,10 @@ where
             "{request_outcome_default_count} request span(s) missing optional '{TT_OUTCOME}'; assumed 'ok'"
         )));
     }
-    let mut requests: Vec<RequestEvent> = parsed_requests
+    let requests: Vec<RequestEvent> = parsed_requests
         .into_iter()
         .map(|request| request.event)
         .collect();
-    dedupe_retained_requests(
-        &mut requests,
-        capture_limits.max_requests,
-        options.strict_mode(),
-        &mut warnings,
-    )?;
     let request_intervals = retained_request_intervals(&requests, capture_limits.max_requests);
     filter_correlated_parsed_stages(
         &mut parsed_stages,
@@ -356,7 +356,7 @@ struct RequestInterval {
 }
 
 fn dedupe_retained_requests(
-    requests: &mut Vec<RequestEvent>,
+    requests: &mut Vec<ParsedRequestEvent>,
     max_requests: usize,
     strict: bool,
     warnings: &mut Vec<ImportWarning>,
@@ -368,13 +368,13 @@ fn dedupe_retained_requests(
             retained.push(request);
             continue;
         }
-        if !seen.insert(request.request_id.clone()) {
+        if !seen.insert(request.event.request_id.clone()) {
             strict_or_warn(
                 strict,
                 warnings,
                 format!(
                     "duplicate tt.request_id '{}' is an input-quality problem; skipped later duplicate request event; child stage/queue evidence outside the retained first request interval may also be skipped",
-                    request.request_id
+                    request.event.request_id
                 ),
             )?;
             continue;
@@ -1196,6 +1196,37 @@ mod tests {
             .lifecycle_warnings
             .iter()
             .any(|w| w.contains("duplicate tt.request_id 'dup' is an input-quality problem")));
+    }
+
+    #[test]
+    fn non_strict_skipped_duplicate_missing_outcome_does_not_warn_outcome_defaulted() {
+        let spans = vec![
+            SpanRecord::new("req-1", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "dup")
+                .field(TT_ROUTE, "/a")
+                .field(TT_OUTCOME, "ok"),
+            SpanRecord::new("req-2", 200, 260)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "dup")
+                .field(TT_ROUTE, "/b"),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        let run = imported.run();
+
+        assert_eq!(run.requests.len(), 1);
+        assert_eq!(run.requests[0].route, "/a");
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("duplicate tt.request_id 'dup' is an input-quality problem")));
+        assert!(imported.warnings().iter().all(|w| !w
+            .message()
+            .contains("missing optional 'tt.outcome'; assumed 'ok'")));
+        assert!(run
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .all(|w| !w.contains("missing optional 'tt.outcome'; assumed 'ok'")));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent misleading `tt.outcome` default warnings when a later duplicate request (skipped in non-strict mode) is the only span missing `tt.outcome`.
- Make install guidance explicit for applications that use `tracing::...` or `tracing_subscriber::...` directly when using the live tracing intake features.
- Keep the change narrow: no analyzer behavior changes, no tracing import redesign, and preserve strict/non-strict duplicate semantics.

### Description
- Move duplicate-request deduplication to operate on `Vec<ParsedRequestEvent>` before aggregating missing-`tt.outcome` counts, and then convert retained parsed requests into `Vec<RequestEvent>` for run building, so skipped duplicates do not inflate default-outcome warnings.
- Change `dedupe_retained_requests` to accept `&mut Vec<ParsedRequestEvent>` and dedupe by `request.event.request_id` while preserving strict-mode `ImportError::StrictViolation` behavior and durable non-strict duplicate warnings.
- Add a regression test `non_strict_skipped_duplicate_missing_outcome_does_not_warn_outcome_defaulted` that verifies the first duplicate is retained, later duplicate is skipped, duplicate warning is present, and no `missing optional 'tt.outcome'; assumed 'ok'` warning appears for the retained run or lifecycle warnings.
- Update docs to show that applications using the live `TracingIntakeSession` or `TracingTokioSession` directly should also add `tracing` and `tracing-subscriber` as dependencies; keep the narrow tracing-intake bridge wording and avoid expanding product scope.

### Testing
- Files changed: `tailtriage-tracing/src/lib.rs`, `docs/user-guide.md`, and `tailtriage-tracing/README.md`.
- Duplicate-warning behavior changed: the missing-`tt.outcome` aggregation now runs after deduplication so skipped later duplicates do not trigger the `missing optional 'tt.outcome'; assumed 'ok'` warning, while strict duplicate failure and non-strict duplicate warning durability remain unchanged.
- Tests added/updated: added `non_strict_skipped_duplicate_missing_outcome_does_not_warn_outcome_defaulted`; existing duplicate tests were left intact and continue to assert durable duplicate warnings, `truncation.dropped_requests == 0`, and child-evidence skipping outside retained intervals.
- Commands run and results: `cargo fmt --check` (passed), `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (passed), `cargo test --workspace --all-targets --all-features --locked` (passed), and `python3 scripts/validate_docs_contracts.py` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13e768f07083309596cbe9642ba84d)