### PR TITLE
Fix duplicate-request default-outcome warnings and tracing install guidance

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -55,6 +55,7 @@ B) Direct Run JSON path with async span instrumentation (`live` feature required
 
 ```bash
 cargo add tailtriage-tracing --features live
+cargo add tracing tracing-subscriber
 ```
 
 
@@ -101,6 +102,7 @@ Tokio runtime sampler coupling via `TracingTokioSession` requires the `tokio` fe
 
 ```bash
 cargo add tailtriage-tracing --features tokio
+cargo add tracing tracing-subscriber
 ```
 
 For the full tracing setup details and both flows, see `tailtriage-tracing/README.md`.

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -20,6 +20,13 @@ It is **not**:
 
 CLI offline import workflows only need JSONL import support and do not require the live `tracing_subscriber` layer dependency.
 
+If your application code uses `tracing::...` and `tracing_subscriber::...` directly, add those crates in addition to enabling `tailtriage-tracing` features:
+
+```bash
+cargo add tailtriage-tracing --features live
+cargo add tracing tracing-subscriber
+```
+
 ## Recommended live session setup (`live` feature)
 
 ```rust,no_run
@@ -118,6 +125,11 @@ Tracing intake import and native capture share the same CaptureMode/CaptureLimit
 Persisted Run JSON intended for `tailtriage analyze` must include at least one completed request event; in-process library snapshots may still be zero-request for inspection.
 
 For `TracingTokioSession`, runtime snapshot retention also uses the same core capture-limit model. Run metadata time bounds cover merged retained tracing evidence plus retained runtime snapshots, which supports triage interpretation but is not root-cause proof:
+
+```bash
+cargo add tailtriage-tracing --features tokio
+cargo add tracing tracing-subscriber
+```
 
 - configure retention with `mode(...)`, `capture_limits(...)`, or `capture_limits_override(...)`
 - there is no tracing-specific `.max_runtime_snapshots(...)` session builder method

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -234,6 +234,12 @@ where
     }
     let mode = options.mode_value();
     let capture_limits = options.resolved_capture_limits();
+    dedupe_retained_parsed_requests(
+        &mut parsed_requests,
+        capture_limits.max_requests,
+        options.strict_mode(),
+        &mut warnings,
+    )?;
     let request_outcome_default_count = parsed_requests
         .iter()
         .take(capture_limits.max_requests)
@@ -244,16 +250,10 @@ where
             "{request_outcome_default_count} request span(s) missing optional '{TT_OUTCOME}'; assumed 'ok'"
         )));
     }
-    let mut requests: Vec<RequestEvent> = parsed_requests
+    let requests: Vec<RequestEvent> = parsed_requests
         .into_iter()
         .map(|request| request.event)
         .collect();
-    dedupe_retained_requests(
-        &mut requests,
-        capture_limits.max_requests,
-        options.strict_mode(),
-        &mut warnings,
-    )?;
     let request_intervals = retained_request_intervals(&requests, capture_limits.max_requests);
     filter_correlated_parsed_stages(
         &mut parsed_stages,
@@ -355,8 +355,8 @@ struct RequestInterval {
     finished_at_unix_ms: u64,
 }
 
-fn dedupe_retained_requests(
-    requests: &mut Vec<RequestEvent>,
+fn dedupe_retained_parsed_requests(
+    requests: &mut Vec<ParsedRequestEvent>,
     max_requests: usize,
     strict: bool,
     warnings: &mut Vec<ImportWarning>,
@@ -368,13 +368,13 @@ fn dedupe_retained_requests(
             retained.push(request);
             continue;
         }
-        if !seen.insert(request.request_id.clone()) {
+        if !seen.insert(request.event.request_id.clone()) {
             strict_or_warn(
                 strict,
                 warnings,
                 format!(
                     "duplicate tt.request_id '{}' is an input-quality problem; skipped later duplicate request event; child stage/queue evidence outside the retained first request interval may also be skipped",
-                    request.request_id
+                    request.event.request_id
                 ),
             )?;
             continue;
@@ -1212,6 +1212,37 @@ mod tests {
         ];
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
         assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn non_strict_skipped_duplicate_missing_outcome_does_not_warn_outcome_defaulted() {
+        let spans = vec![
+            SpanRecord::new("req-1", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "dup")
+                .field(TT_ROUTE, "/a")
+                .field(TT_OUTCOME, "ok"),
+            SpanRecord::new("req-2", 200, 260)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "dup")
+                .field(TT_ROUTE, "/b"),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        let run = imported.run();
+        assert_eq!(run.requests.len(), 1);
+        assert_eq!(run.requests[0].route, "/a");
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("duplicate tt.request_id 'dup' is an input-quality problem")));
+        assert!(!imported.warnings().iter().any(|w| w
+            .message()
+            .contains("missing optional 'tt.outcome'; assumed 'ok'")));
+        assert!(!imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|w| w.contains("missing optional 'tt.outcome'; assumed 'ok'")));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent misleading aggregate `tt.outcome` default warnings that were produced when a later non-strict duplicate (which is skipped) lacked `tt.outcome` and caused an inaccurate warning for the retained import. 
- Make live tracing install guidance explicit for applications that reference `tracing` / `tracing-subscriber` directly so users add the crates they need in addition to enabling `tailtriage-tracing` features.

### Description
- Dedupe parsing: run deduplication on `Vec<ParsedRequestEvent>` by adding `dedupe_retained_parsed_requests` and performing dedupe before computing aggregate `tt.outcome` default counts, then convert retained parsed requests to `Vec<RequestEvent>` for downstream use. 
- Warning semantics: compute `tt.outcome` default warnings only from retained/eligible parsed request events after duplicate filtering so skipped duplicates do not produce misleading default-outcome warnings. 
- Tests: add `non_strict_skipped_duplicate_missing_outcome_does_not_warn_outcome_defaulted` regression test to assert the first duplicate is retained, duplicate warning remains durable, and no `missing optional 'tt.outcome'; assumed 'ok'` aggregate warning is emitted. 
- Docs: update `docs/user-guide.md` and `tailtriage-tracing/README.md` to show explicit install lines for live/tokio flows (`cargo add tailtriage-tracing --features live|tokio` plus `cargo add tracing tracing-subscriber`) and clarify that applications using `tracing::...` or `tracing_subscriber::...` directly must depend on those crates.

### Testing
- Ran `cargo fmt --check` which succeeded. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which succeeded with no warnings. 
- Ran `cargo test --workspace --all-targets --all-features --locked` which succeeded (all tests passed, including the new regression test). 
- Ran `python3 scripts/validate_docs_contracts.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13e768f07083309596cbe9642ba84d)