### PR TITLE
Fix duplicate-request outcome-default warning ordering and add tracing install guidance

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -55,6 +55,7 @@ B) Direct Run JSON path with async span instrumentation (`live` feature required
 
 ```bash
 cargo add tailtriage-tracing --features live
+cargo add tracing tracing-subscriber
 ```
 
 
@@ -101,6 +102,7 @@ Tokio runtime sampler coupling via `TracingTokioSession` requires the `tokio` fe
 
 ```bash
 cargo add tailtriage-tracing --features tokio
+cargo add tracing tracing-subscriber
 ```
 
 For the full tracing setup details and both flows, see `tailtriage-tracing/README.md`.

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -20,6 +20,22 @@ It is **not**:
 
 CLI offline import workflows only need JSONL import support and do not require the live `tracing_subscriber` layer dependency.
 
+Install for live session intake:
+
+```bash
+cargo add tailtriage-tracing --features live
+cargo add tracing tracing-subscriber
+```
+
+`tailtriage-tracing` enables its own optional dependencies for selected features, but applications that directly call `tracing::...` or `tracing_subscriber::...` APIs should also depend on `tracing` and `tracing-subscriber`.
+
+If using `TracingTokioSession`:
+
+```bash
+cargo add tailtriage-tracing --features tokio
+cargo add tracing tracing-subscriber
+```
+
 ## Recommended live session setup (`live` feature)
 
 ```rust,no_run

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -234,6 +234,12 @@ where
     }
     let mode = options.mode_value();
     let capture_limits = options.resolved_capture_limits();
+    dedupe_retained_requests(
+        &mut parsed_requests,
+        capture_limits.max_requests,
+        options.strict_mode(),
+        &mut warnings,
+    )?;
     let request_outcome_default_count = parsed_requests
         .iter()
         .take(capture_limits.max_requests)
@@ -244,16 +250,10 @@ where
             "{request_outcome_default_count} request span(s) missing optional '{TT_OUTCOME}'; assumed 'ok'"
         )));
     }
-    let mut requests: Vec<RequestEvent> = parsed_requests
+    let requests: Vec<RequestEvent> = parsed_requests
         .into_iter()
         .map(|request| request.event)
         .collect();
-    dedupe_retained_requests(
-        &mut requests,
-        capture_limits.max_requests,
-        options.strict_mode(),
-        &mut warnings,
-    )?;
     let request_intervals = retained_request_intervals(&requests, capture_limits.max_requests);
     filter_correlated_parsed_stages(
         &mut parsed_stages,
@@ -356,7 +356,7 @@ struct RequestInterval {
 }
 
 fn dedupe_retained_requests(
-    requests: &mut Vec<RequestEvent>,
+    requests: &mut Vec<ParsedRequestEvent>,
     max_requests: usize,
     strict: bool,
     warnings: &mut Vec<ImportWarning>,
@@ -368,13 +368,13 @@ fn dedupe_retained_requests(
             retained.push(request);
             continue;
         }
-        if !seen.insert(request.request_id.clone()) {
+        if !seen.insert(request.event.request_id.clone()) {
             strict_or_warn(
                 strict,
                 warnings,
                 format!(
                     "duplicate tt.request_id '{}' is an input-quality problem; skipped later duplicate request event; child stage/queue evidence outside the retained first request interval may also be skipped",
-                    request.request_id
+                    request.event.request_id
                 ),
             )?;
             continue;
@@ -1196,6 +1196,36 @@ mod tests {
             .lifecycle_warnings
             .iter()
             .any(|w| w.contains("duplicate tt.request_id 'dup' is an input-quality problem")));
+    }
+
+    #[test]
+    fn non_strict_skipped_duplicate_missing_outcome_does_not_warn_outcome_defaulted() {
+        let spans = vec![
+            SpanRecord::new("req-1", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "dup")
+                .field(TT_ROUTE, "/a")
+                .field(TT_OUTCOME, "ok"),
+            SpanRecord::new("req-2", 200, 260)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "dup")
+                .field(TT_ROUTE, "/b"),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        let run = imported.run();
+        assert_eq!(run.requests.len(), 1);
+        assert_eq!(run.requests[0].route, "/a");
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("duplicate tt.request_id 'dup' is an input-quality problem")));
+        assert!(imported.warnings().iter().all(|w| !w
+            .message()
+            .contains("missing optional 'tt.outcome'; assumed 'ok'")));
+        assert!(run
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .all(|w| !w.contains("missing optional 'tt.outcome'; assumed 'ok'")));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent misleading `tt.outcome` default warnings emitted for later duplicate request spans that are ultimately skipped in non-strict import mode.
- Make live tracing install guidance explicit that applications which call `tracing::...` or `tracing_subscriber::...` directly must also depend on `tracing` and `tracing-subscriber` when using the `live`/`tokio` features of `tailtriage-tracing`.

### Description
- Adjusted tracing import flow in `tailtriage-tracing/src/lib.rs` so duplicate deduplication runs on `Vec<ParsedRequestEvent>` (preserving `ParsedRequestEvent { event, outcome_defaulted }`) before counting missing `tt.outcome` defaults, then convert retained parsed requests into `Vec<RequestEvent>` for downstream processing, preserving strict/non-strict duplicate semantics.
- Changed `dedupe_retained_requests` to accept `&mut Vec<ParsedRequestEvent>` and use `request.event.request_id` for duplicate detection and warning text.
- Added regression test `non_strict_skipped_duplicate_missing_outcome_does_not_warn_outcome_defaulted` to the existing tracing import tests to assert retained-first semantics, durable duplicate warning presence, and absence of misleading `missing optional 'tt.outcome'; assumed 'ok'` warnings for skipped duplicates.
- Updated docs to include explicit install snippets for live/tokio tracing session users so examples show both `cargo add tailtriage-tracing --features live|tokio` and `cargo add tracing tracing-subscriber`.
- Files changed: `tailtriage-tracing/src/lib.rs`, `docs/user-guide.md`, `tailtriage-tracing/README.md`.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed without warnings.
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests including the new regression test passed.
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed.

Behavior notes: duplicate warning durability and strict-mode duplicate failure (`ImportError::StrictViolation`) are unchanged, but default-outcome warning aggregation now counts only retained request events after dedupe so skipped later-duplicate requests no longer cause misleading default-outcome warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13e768f07083309596cbe9642ba84d)