### PR TITLE
Fix duplicate-request outcome-warning ordering and clarify tracing install docs

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -55,6 +55,7 @@ B) Direct Run JSON path with async span instrumentation (`live` feature required
 
 ```bash
 cargo add tailtriage-tracing --features live
+cargo add tracing tracing-subscriber
 ```
 
 
@@ -101,6 +102,7 @@ Tokio runtime sampler coupling via `TracingTokioSession` requires the `tokio` fe
 
 ```bash
 cargo add tailtriage-tracing --features tokio
+cargo add tracing tracing-subscriber
 ```
 
 For the full tracing setup details and both flows, see `tailtriage-tracing/README.md`.

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -20,6 +20,20 @@ It is **not**:
 
 CLI offline import workflows only need JSONL import support and do not require the live `tracing_subscriber` layer dependency.
 
+For live tracing intake sessions, `tailtriage-tracing` enables optional dependencies behind feature flags, but applications that call `tracing::...` or `tracing_subscriber::...` directly still need explicit app dependencies:
+
+```bash
+cargo add tailtriage-tracing --features live
+cargo add tracing tracing-subscriber
+```
+
+If you use Tokio runtime sampler coupling via `TracingTokioSession`, use:
+
+```bash
+cargo add tailtriage-tracing --features tokio
+cargo add tracing tracing-subscriber
+```
+
 ## Recommended live session setup (`live` feature)
 
 ```rust,no_run

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -234,6 +234,12 @@ where
     }
     let mode = options.mode_value();
     let capture_limits = options.resolved_capture_limits();
+    dedupe_retained_requests(
+        &mut parsed_requests,
+        capture_limits.max_requests,
+        options.strict_mode(),
+        &mut warnings,
+    )?;
     let request_outcome_default_count = parsed_requests
         .iter()
         .take(capture_limits.max_requests)
@@ -244,16 +250,10 @@ where
             "{request_outcome_default_count} request span(s) missing optional '{TT_OUTCOME}'; assumed 'ok'"
         )));
     }
-    let mut requests: Vec<RequestEvent> = parsed_requests
+    let requests: Vec<RequestEvent> = parsed_requests
         .into_iter()
         .map(|request| request.event)
         .collect();
-    dedupe_retained_requests(
-        &mut requests,
-        capture_limits.max_requests,
-        options.strict_mode(),
-        &mut warnings,
-    )?;
     let request_intervals = retained_request_intervals(&requests, capture_limits.max_requests);
     filter_correlated_parsed_stages(
         &mut parsed_stages,
@@ -356,7 +356,7 @@ struct RequestInterval {
 }
 
 fn dedupe_retained_requests(
-    requests: &mut Vec<RequestEvent>,
+    requests: &mut Vec<ParsedRequestEvent>,
     max_requests: usize,
     strict: bool,
     warnings: &mut Vec<ImportWarning>,
@@ -368,13 +368,13 @@ fn dedupe_retained_requests(
             retained.push(request);
             continue;
         }
-        if !seen.insert(request.request_id.clone()) {
+        if !seen.insert(request.event.request_id.clone()) {
             strict_or_warn(
                 strict,
                 warnings,
                 format!(
                     "duplicate tt.request_id '{}' is an input-quality problem; skipped later duplicate request event; child stage/queue evidence outside the retained first request interval may also be skipped",
-                    request.request_id
+                    request.event.request_id
                 ),
             )?;
             continue;
@@ -1196,6 +1196,36 @@ mod tests {
             .lifecycle_warnings
             .iter()
             .any(|w| w.contains("duplicate tt.request_id 'dup' is an input-quality problem")));
+    }
+
+    #[test]
+    fn non_strict_skipped_duplicate_missing_outcome_does_not_warn_outcome_defaulted() {
+        let spans = vec![
+            SpanRecord::new("req-1", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "dup")
+                .field(TT_ROUTE, "/a")
+                .field(TT_OUTCOME, "ok"),
+            SpanRecord::new("req-2", 200, 260)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "dup")
+                .field(TT_ROUTE, "/b"),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        let run = imported.run();
+        assert_eq!(run.requests.len(), 1);
+        assert_eq!(run.requests[0].route, "/a");
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("duplicate tt.request_id 'dup' is an input-quality problem")));
+        assert!(!imported.warnings().iter().any(|w| w
+            .message()
+            .contains("missing optional 'tt.outcome'; assumed 'ok'")));
+        assert!(!run
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|w| w.contains("missing optional 'tt.outcome'; assumed 'ok'")));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Avoid misleading warnings where a later non-strict duplicate request (skipped) could still cause an aggregate "missing optional 'tt.outcome'" warning. 
- Make live tracing install guidance explicit for applications that call `tracing::...` or `tracing_subscriber::...` directly so users know they must depend on those crates.

### Description
- Move deduplication to operate on `Vec<ParsedRequestEvent>` so duplicate handling runs before counting outcome-defaulted requests, and update `dedupe_retained_requests` to accept `ParsedRequestEvent` instead of `RequestEvent` to preserve `outcome_defaulted` semantics. 
- Preserve strict-mode behavior and duplicate-warning durability while ensuring later skipped duplicates are not counted toward the `tt.outcome` default-warning aggregate. 
- Add test `non_strict_skipped_duplicate_missing_outcome_does_not_warn_outcome_defaulted` to assert the skipped duplicate does not trigger an outcome-default warning while duplicate warnings remain. 
- Update docs to include explicit install commands for direct `tracing` / `tracing-subscriber` usage in both `live` and `tokio` feature flows and add a short note in the tracing crate README clarifying that applications using `tracing::...` must depend on those crates.
- Files changed: `tailtriage-tracing/src/lib.rs`, `docs/user-guide.md`, and `tailtriage-tracing/README.md`.

### Testing
- Ran `cargo fmt --check` (fixed formatting then re-checked) and the workspace is formatted correctly. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it completed with no warnings. 
- Ran `cargo test --workspace --all-targets --all-features --locked` and the full test suite (including the new regression test) passed. 
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13e768f07083309596cbe9642ba84d)