### PR TITLE
Fix CLI input-format surface and top-level help for tracing import

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -113,7 +113,7 @@ Near-term tasks:
 - keep docs aligned to the implemented tracing-intake path:
   - `TracingIntakeSession` as the primary live setup
   - stable completed-span JSONL wrapper (`tailtriage.tracing-span.v1`)
-  - CLI `--input-format` guardrails (`auto`, `tailtriage-span-jsonl`)
+  - CLI `--input-format` guardrails (`compatible`, `tailtriage-span-jsonl`)
   - golden wrapper fixture, examples, and contract tests for request/stage/queue + duration preservation
 - keep positioning explicit: tracing intake converts tracing-shaped evidence into standard Runs for the existing analyzer
 - preserve bounded claims: no tracing backend semantics, no OTel/OTLP, no observability-platform expansion

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Offline import expects completed `tt.*` span JSONL (not arbitrary tracing log JS
 
 - Offline JSONL import:
   ```bash
-  tailtriage import tracing-json completed-spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json
+  tailtriage import tracing-json completed-spans.jsonl --service checkout --output tailtriage-run.json
   tailtriage analyze tailtriage-run.json
   ```
 - Live session path: first install `tailtriage-tracing` with `live` (`cargo add tailtriage-tracing --features live`), then add `tailtriage_tracing::TracingIntakeSession` and `session.layer()` beside your existing subscriber setup.
@@ -241,7 +241,7 @@ tailtriage analyze tailtriage-run.json --format json
 Import completed tracing span records (JSONL) into a Run artifact first when needed:
 
 ```bash
-tailtriage import tracing-json completed-spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json
+tailtriage import tracing-json completed-spans.jsonl --service checkout --output tailtriage-run.json
 ```
 
 `tailtriage import tracing-json` writes **Run JSON** (capture artifact and CLI input), not Report JSON. Use `--strict` to fail on malformed/incomplete `tt.*` spans; without `--strict`, malformed `tt.*` spans are skipped and surfaced as `warning: ...` lines on stderr. Arbitrary `tracing_subscriber::fmt().json()` log JSON is not imported, and timing is not guessed from line receive time: completed spans must include explicit unix-ms start/end timestamps. Persisted Run JSON intended for `tailtriage analyze` must include at least one completed request event; in-process library snapshots may still be zero-request for inspection.

--- a/SPEC.md
+++ b/SPEC.md
@@ -166,7 +166,7 @@ Analyzer configuration contract:
 - stable completed-span JSONL wrapper format is:
   `{"format":"tailtriage.tracing-span.v1","span":{...}}`
 - CLI imports that wrapper shape with:
-  `tailtriage import tracing-json <completed-spans.jsonl>  --service <service> --output <run.json>`
+  `tailtriage import tracing-json <completed-spans.jsonl> --service <service> --output <run.json>`
 - tracing intake converts request/stage/queue evidence into the same standard `Run` schema; analyzer semantics remain unchanged
 - `tracing_subscriber::fmt().json()` arbitrary log scraping is intentionally unsupported
 - tracing-only intake does not fabricate runtime-pressure evidence without runtime snapshots / Tokio sampler coupling

--- a/SPEC.md
+++ b/SPEC.md
@@ -166,7 +166,7 @@ Analyzer configuration contract:
 - stable completed-span JSONL wrapper format is:
   `{"format":"tailtriage.tracing-span.v1","span":{...}}`
 - CLI imports that wrapper shape with:
-  `tailtriage import tracing-json <completed-spans.jsonl> --input-format tailtriage-span-jsonl --service <service> --output <run.json>`
+  `tailtriage import tracing-json <completed-spans.jsonl>  --service <service> --output <run.json>`
 - tracing intake converts request/stage/queue evidence into the same standard `Run` schema; analyzer semantics remain unchanged
 - `tracing_subscriber::fmt().json()` arbitrary log scraping is intentionally unsupported
 - tracing-only intake does not fabricate runtime-pressure evidence without runtime snapshots / Tokio sampler coupling

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -45,7 +45,7 @@ cargo add tailtriage-tracing
 A) Completed-span JSONL intake path:
 
 ```bash
-tailtriage import tracing-json completed-spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json
+tailtriage import tracing-json completed-spans.jsonl --service checkout --output tailtriage-run.json
 tailtriage analyze tailtriage-run.json
 ```
 

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -45,13 +45,13 @@ tailtriage analyze tailtriage-run.json --format json
 Import completed `tt.*` tracing span JSONL into Run JSON:
 
 ```bash
-tailtriage import tracing-json spans.jsonl  --service checkout --output tailtriage-run.json
+tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json
 ```
 
 With optional metadata flags, strict validation, and explicit format:
 
 ```bash
-tailtriage import tracing-json spans.jsonl  --service checkout --output tailtriage-run.json --service-version v1 --run-id run-42 --strict
+tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json --service-version v1 --run-id run-42 --strict
 ```
 
 

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -45,13 +45,13 @@ tailtriage analyze tailtriage-run.json --format json
 Import completed `tt.*` tracing span JSONL into Run JSON:
 
 ```bash
-tailtriage import tracing-json spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json
+tailtriage import tracing-json spans.jsonl  --service checkout --output tailtriage-run.json
 ```
 
 With optional metadata flags, strict validation, and explicit format:
 
 ```bash
-tailtriage import tracing-json spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json --service-version v1 --run-id run-42 --strict
+tailtriage import tracing-json spans.jsonl  --service checkout --output tailtriage-run.json --service-version v1 --run-id run-42 --strict
 ```
 
 
@@ -64,12 +64,12 @@ Recommended stable input format is the tailtriage wrapper JSONL shape:
 ```
 
 `--input-format` values:
-- `auto`
 - `tailtriage-span-jsonl`
+- `compatible`
 
 Behavior:
 - `tailtriage-span-jsonl` enforces wrapper-only parsing.
-- `auto` keeps compatibility parsing for older normalized shapes and rejects ordinary tracing log JSON (including `fmt().json` output) early with setup guidance; timing is not guessed from JSONL line receive time.
+- `compatible` keeps compatibility parsing for pre-stable/internal normalized shapes and rejects ordinary tracing log JSON (including `fmt().json` output) early with setup guidance; timing is not guessed from JSONL line receive time.
 
 After import, run analysis separately:
 
@@ -85,7 +85,7 @@ When paths include spaces, quote them in shell usage:
 tailtriage import tracing-json "fixtures/tracing spans.jsonl" --service checkout --output "runs/imported run.json"
 ```
 
-The command imports completed `tt.*` tracing span records in the documented JSONL shape and writes pretty Run JSON (`serde_json::to_writer_pretty`), not Report JSON. Import warnings are printed to stderr as `warning: ...`. Analysis is a separate step: `tailtriage analyze tailtriage-run.json`.
+The command imports completed `tt.*` tracing span records in the documented JSONL shape and writes Run JSON through the normal local JSON artifact writer, not Report JSON. Import warnings are printed to stderr as `warning: ...`. Analysis is a separate step: `tailtriage analyze tailtriage-run.json`.
 Tracing import and native capture share the same CaptureMode/CaptureLimits semantics for request/stage/queue evidence retention. Offline CLI tracing import exposes request/stage/queue limit overrides because those are the evidence types it imports. It intentionally does not expose runtime-snapshot or in-flight-snapshot limit flags because this import path does not ingest those evidence types. Tracing-only imports do not fabricate runtime snapshots; executor/blocking-pressure interpretation remains limited unless runtime snapshots are also captured (for example via Tokio runtime sampling).
 Malformed JSON input remains fatal. In non-strict mode, syntactically valid malformed/incomplete `tt.*` records are skipped with `warning: ...` lines.
 `--service` must not be empty or whitespace.

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -12,7 +12,7 @@ use tailtriage_tracing::{
 
 #[derive(Debug, Parser)]
 #[command(name = "tailtriage")]
-#[command(about = "Analyze tailtriage run artifacts", version)]
+#[command(about = "Import and analyze tailtriage run artifacts", version)]
 struct Cli {
     #[command(subcommand)]
     command: Command,
@@ -67,8 +67,8 @@ enum ImportCommand {
         /// Fail on malformed/incomplete tailtriage spans.
         #[arg(long)]
         strict: bool,
-        /// Input format mode.
-        #[arg(long, value_enum, default_value_t = TracingInputFormat::Auto)]
+        /// Input format. Defaults to the stable tailtriage wrapper JSONL format.
+        #[arg(long, value_enum, default_value_t = TracingInputFormat::TailtriageSpanJsonl)]
         input_format: TracingInputFormat,
         /// Import capture mode semantics for request/stage/queue retention.
         #[arg(long, value_enum, default_value_t = ImportCaptureMode::Light)]
@@ -86,8 +86,10 @@ enum ImportCommand {
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 enum TracingInputFormat {
-    Auto,
+    /// Stable wrapper-only format: {"format":"tailtriage.tracing-span.v1","span":{...}}.
     TailtriageSpanJsonl,
+    /// Compatibility parser for pre-stable/internal normalized completed-span shapes; not arbitrary tracing log JSON.
+    Compatible,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -128,49 +130,19 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 max_requests,
                 max_stages,
                 max_queues,
-            } => {
-                let mut options = ImportOptions::new(service).strict(strict).mode(mode.into());
-                if let Some(service_version) = service_version {
-                    options = options.service_version(service_version);
-                }
-                if let Some(run_id) = run_id {
-                    options = options.run_id(run_id);
-                }
-                let mut capture_limits_override = CaptureLimitsOverride::default();
-                if let Some(max_requests) = max_requests {
-                    capture_limits_override.max_requests = Some(max_requests);
-                }
-                if let Some(max_stages) = max_stages {
-                    capture_limits_override.max_stages = Some(max_stages);
-                }
-                if let Some(max_queues) = max_queues {
-                    capture_limits_override.max_queues = Some(max_queues);
-                }
-                options = options.capture_limits_override(capture_limits_override);
-
-                if matches!(input_format, TracingInputFormat::Auto)
-                    && input_looks_like_tracing_fmt_json(&spans_jsonl)?
-                {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::InvalidInput,
-                        tracing_json_setup_guidance(),
-                    )
-                    .into());
-                }
-                let parse_mode = match input_format {
-                    TracingInputFormat::TailtriageSpanJsonl => {
-                        JsonlParseMode::TailtriageWrapperOnly
-                    }
-                    TracingInputFormat::Auto => JsonlParseMode::Compatible,
-                };
-                let imported = import_jsonl_path_with_mode(spans_jsonl, options, parse_mode)?;
-                for warning in imported.warnings() {
-                    eprintln!("warning: {}", warning.message());
-                }
-                ensure_persistable_run_has_requests(imported.run())?;
-
-                LocalJsonSink::new(&output).write(imported.run())?;
-            }
+            } => import_tracing_json(
+                spans_jsonl,
+                service,
+                &output,
+                service_version,
+                run_id,
+                strict,
+                input_format,
+                mode,
+                max_requests,
+                max_stages,
+                max_queues,
+            )?,
         },
         Command::Analyze {
             run_json,
@@ -211,8 +183,84 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
+fn import_tracing_json(
+    spans_jsonl: PathBuf,
+    service: String,
+    output: &PathBuf,
+    service_version: Option<String>,
+    run_id: Option<String>,
+    strict: bool,
+    input_format: TracingInputFormat,
+    mode: ImportCaptureMode,
+    max_requests: Option<usize>,
+    max_stages: Option<usize>,
+    max_queues: Option<usize>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut options = ImportOptions::new(service).strict(strict).mode(mode.into());
+    if let Some(service_version) = service_version {
+        options = options.service_version(service_version);
+    }
+    if let Some(run_id) = run_id {
+        options = options.run_id(run_id);
+    }
+    let mut capture_limits_override = CaptureLimitsOverride::default();
+    if let Some(max_requests) = max_requests {
+        capture_limits_override.max_requests = Some(max_requests);
+    }
+    if let Some(max_stages) = max_stages {
+        capture_limits_override.max_stages = Some(max_stages);
+    }
+    if let Some(max_queues) = max_queues {
+        capture_limits_override.max_queues = Some(max_queues);
+    }
+    options = options.capture_limits_override(capture_limits_override);
+
+    if matches!(input_format, TracingInputFormat::Compatible)
+        && input_looks_like_tracing_fmt_json(&spans_jsonl)?
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            tracing_json_setup_guidance(),
+        )
+        .into());
+    }
+    let parse_mode = match input_format {
+        TracingInputFormat::TailtriageSpanJsonl => JsonlParseMode::TailtriageWrapperOnly,
+        TracingInputFormat::Compatible => JsonlParseMode::Compatible,
+    };
+    let imported =
+        import_jsonl_path_with_mode(spans_jsonl, options, parse_mode).map_err(|err| {
+            if matches!(input_format, TracingInputFormat::TailtriageSpanJsonl) {
+                let message = format!("{err}\n{}", wrapper_only_rejection_guidance());
+                Box::<dyn std::error::Error>::from(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    message,
+                ))
+            } else {
+                Box::<dyn std::error::Error>::from(err)
+            }
+        })?;
+    for warning in imported.warnings() {
+        eprintln!("warning: {}", warning.message());
+    }
+    if let Err(err) = ensure_persistable_run_has_requests(imported.run()) {
+        if matches!(input_format, TracingInputFormat::TailtriageSpanJsonl) {
+            let message = format!("{err}\n{}", wrapper_only_rejection_guidance());
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, message).into());
+        }
+        return Err(err.into());
+    }
+    LocalJsonSink::new(output).write(imported.run())?;
+    Ok(())
+}
+
 fn tracing_json_setup_guidance() -> &'static str {
-    "the file looks like ordinary tracing log JSON, not completed tailtriage span JSONL. tailtriage requires completed spans with literal dotted tt.* keys and explicit unix-ms start/end timestamps. Recommended setup: TracingIntakeSession::builder(...).completed_span_jsonl_path(...). Then run: tailtriage import tracing-json <completed-spans.jsonl> --input-format tailtriage-span-jsonl --service <service> --output <run-json>"
+    "the file looks like ordinary tracing log JSON, not completed tailtriage span JSONL. tailtriage requires completed spans with literal dotted tt.* keys and explicit unix-ms start/end timestamps. Stable import expects wrapper JSONL records shaped like {\"format\":\"tailtriage.tracing-span.v1\",\"span\":{...}}. Ordinary tracing_subscriber::fmt().json() logs are unsupported. Recommended setup: TracingIntakeSession::builder(...).completed_span_jsonl_path(...). Then run: tailtriage import tracing-json <completed-spans.jsonl> --service <service> --output <run-json>"
+}
+
+fn wrapper_only_rejection_guidance() -> &'static str {
+    "stable import expects wrapper JSONL records shaped like {\"format\":\"tailtriage.tracing-span.v1\",\"span\":{...}}. Ordinary tracing_subscriber::fmt().json() logs are unsupported. Use --input-format compatible only for pre-stable/internal normalized completed-span shapes."
 }
 
 fn input_looks_like_tracing_fmt_json(path: &std::path::Path) -> Result<bool, std::io::Error> {

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -7,7 +7,8 @@ use tailtriage_cli::artifact::load_run_artifact;
 use tailtriage_cli::{analyzer_options_help_text, build_analyze_options};
 use tailtriage_core::{CaptureLimitsOverride, CaptureMode, LocalJsonSink, RunSink};
 use tailtriage_tracing::{
-    ensure_persistable_run_has_requests, import_jsonl_path_with_mode, ImportOptions, JsonlParseMode,
+    ensure_persistable_run_has_requests, import_jsonl_path_with_mode, ImportError, ImportOptions,
+    JsonlParseMode,
 };
 
 #[derive(Debug, Parser)]
@@ -231,7 +232,7 @@ fn import_tracing_json(
     };
     let imported =
         import_jsonl_path_with_mode(spans_jsonl, options, parse_mode).map_err(|err| {
-            if matches!(input_format, TracingInputFormat::TailtriageSpanJsonl) {
+            if should_append_wrapper_guidance(input_format, &err) {
                 let message = format!("{err}\n{}", wrapper_only_rejection_guidance());
                 Box::<dyn std::error::Error>::from(std::io::Error::new(
                     std::io::ErrorKind::InvalidInput,
@@ -257,6 +258,17 @@ fn import_tracing_json(
 
 fn tracing_json_setup_guidance() -> &'static str {
     "the file looks like ordinary tracing log JSON, not completed tailtriage span JSONL. tailtriage requires completed spans with literal dotted tt.* keys and explicit unix-ms start/end timestamps. Stable import expects wrapper JSONL records shaped like {\"format\":\"tailtriage.tracing-span.v1\",\"span\":{...}}. Ordinary tracing_subscriber::fmt().json() logs are unsupported. Recommended setup: TracingIntakeSession::builder(...).completed_span_jsonl_path(...). Then run: tailtriage import tracing-json <completed-spans.jsonl> --service <service> --output <run-json>"
+}
+
+fn should_append_wrapper_guidance(input_format: TracingInputFormat, err: &ImportError) -> bool {
+    matches!(input_format, TracingInputFormat::TailtriageSpanJsonl)
+        && matches!(
+            err,
+            ImportError::MissingField(_)
+                | ImportError::InvalidField { .. }
+                | ImportError::StrictViolation(_)
+                | ImportError::InvalidRunEvent(_)
+        )
 }
 
 fn wrapper_only_rejection_guidance() -> &'static str {

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -262,13 +262,7 @@ fn tracing_json_setup_guidance() -> &'static str {
 
 fn should_append_wrapper_guidance(input_format: TracingInputFormat, err: &ImportError) -> bool {
     matches!(input_format, TracingInputFormat::TailtriageSpanJsonl)
-        && matches!(
-            err,
-            ImportError::MissingField(_)
-                | ImportError::InvalidField { .. }
-                | ImportError::StrictViolation(_)
-                | ImportError::InvalidRunEvent(_)
-        )
+        && matches!(err, ImportError::ExpectedTailtriageWrapper { .. })
 }
 
 fn wrapper_only_rejection_guidance() -> &'static str {

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -441,6 +441,54 @@ fn import_tracing_json_input_format_tailtriage_wrapper_only_rejects_unwrapped() 
 }
 
 #[test]
+fn import_tracing_json_default_wrapper_mode_missing_input_does_not_append_wrapper_guidance() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let missing_spans_path = dir.path().join("missing-spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&missing_spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains(&missing_spans_path.display().to_string())
+            || stderr.contains("No such file")
+    );
+    assert!(!stderr.contains("tailtriage.tracing-span.v1"));
+    assert!(!stderr.contains("tracing_subscriber::fmt().json()"));
+}
+
+#[test]
+fn import_tracing_json_default_wrapper_mode_malformed_json_does_not_append_wrapper_guidance() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("bad.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, "{\"format\":").expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("malformed JSONL"));
+    assert!(!stderr.contains("tailtriage.tracing-span.v1"));
+    assert!(!stderr.contains("tracing_subscriber::fmt().json()"));
+}
+
+#[test]
 fn import_tracing_json_default_rejects_fmt_json_with_guidance() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("fmt.jsonl");
@@ -734,6 +782,8 @@ fn import_tracing_json_fails_when_only_unrelated_lines_are_present() {
     assert!(!output.status.success(), "cli unexpectedly succeeded");
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
     assert!(stderr.contains("zero request events"));
+    assert!(stderr.contains("tailtriage.tracing-span.v1") || stderr.contains("stable wrapper"));
+    assert!(stderr.contains("tracing_subscriber::fmt().json() logs are unsupported"));
     assert!(!run_path.exists(), "run output should not be written");
 }
 

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -436,8 +436,76 @@ fn import_tracing_json_input_format_tailtriage_wrapper_only_rejects_unwrapped() 
     assert!(!output.status.success());
     let stderr = String::from_utf8(output.stderr).unwrap();
     assert!(stderr.contains("tailtriage.tracing-span.v1") || stderr.contains("stable wrapper"));
+    assert!(stderr.contains("tracing_subscriber::fmt().json() logs are unsupported"));
     assert!(!stderr.contains("ordinary tracing log JSON"));
     assert!(!run_path.exists());
+}
+
+#[test]
+fn import_tracing_json_default_wrapper_mode_rejects_wrong_wrapper_format_with_guidance() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, r#"{"format":"tailtriage.tracing-span.v2","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#).unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("tailtriage.tracing-span.v1"));
+}
+
+#[test]
+fn import_tracing_json_default_wrapper_mode_semantic_missing_route_no_wrapper_guidance() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1"}}}"#).unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--strict")
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("tt.route") || stderr.contains("missing required field"));
+    assert!(!stderr.contains("tracing_subscriber::fmt().json()"));
+}
+
+#[test]
+fn import_tracing_json_default_wrapper_mode_semantic_invalid_kind_type_no_wrapper_guidance() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":1,"tt.request_id":"r1","tt.route":"/a"}}}"#).unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--strict")
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("tt.kind") || stderr.contains("invalid field"));
+    assert!(!stderr.contains("tracing_subscriber::fmt().json()"));
 }
 
 #[test]

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -313,6 +313,8 @@ fn import_tracing_json_capture_limit_overrides_apply() {
         .arg("checkout")
         .arg("--output")
         .arg(&run_path)
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--max-requests")
         .arg("1")
         .arg("--max-stages")
@@ -375,6 +377,17 @@ fn import_tracing_json_rejects_inert_inflight_snapshot_flags() {
 }
 
 #[test]
+fn tailtriage_help_mentions_import_and_analyze_artifacts() {
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("--help")
+        .output()
+        .expect("cli should run");
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Import and analyze tailtriage run artifacts"));
+}
+
+#[test]
 fn import_tracing_json_input_format_tailtriage_wrapper_only_accepts_fixture() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
@@ -385,8 +398,6 @@ fn import_tracing_json_input_format_tailtriage_wrapper_only_accepts_fixture() {
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
-        .arg("--input-format")
-        .arg("tailtriage-span-jsonl")
         .arg("--service")
         .arg("checkout")
         .arg("--output")
@@ -416,8 +427,6 @@ fn import_tracing_json_input_format_tailtriage_wrapper_only_rejects_unwrapped() 
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
-        .arg("--input-format")
-        .arg("tailtriage-span-jsonl")
         .arg("--service")
         .arg("checkout")
         .arg("--output")
@@ -432,7 +441,7 @@ fn import_tracing_json_input_format_tailtriage_wrapper_only_rejects_unwrapped() 
 }
 
 #[test]
-fn import_tracing_json_auto_rejects_fmt_json_with_guidance() {
+fn import_tracing_json_default_rejects_fmt_json_with_guidance() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("fmt.jsonl");
     let run_path = dir.path().join("run.json");
@@ -449,16 +458,14 @@ fn import_tracing_json_auto_rejects_fmt_json_with_guidance() {
         .expect("cli should run");
     assert!(!output.status.success());
     let stderr = String::from_utf8(output.stderr).unwrap();
-    assert!(stderr.contains("ordinary tracing log JSON"));
-    assert!(stderr.contains("literal dotted tt.* keys"));
-    assert!(stderr.contains("explicit unix-ms start/end timestamps"));
-    assert!(stderr.contains("TracingIntakeSession"));
-    assert!(stderr.contains("tailtriage-span-jsonl"));
+    assert!(stderr.contains("stable wrapper shape"));
+    assert!(stderr.contains("tailtriage.tracing-span.v1"));
+    assert!(stderr.contains("tracing_subscriber::fmt().json() logs are unsupported"));
     assert!(!run_path.exists());
 }
 
 #[test]
-fn import_tracing_json_auto_accepts_fmt_like_record_with_top_level_explicit_timestamps() {
+fn import_tracing_json_compatible_accepts_fmt_like_record_with_top_level_explicit_timestamps() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("compatible.jsonl");
     let run_path = dir.path().join("run.json");
@@ -475,6 +482,8 @@ fn import_tracing_json_auto_accepts_fmt_like_record_with_top_level_explicit_time
         .arg("checkout")
         .arg("--output")
         .arg(&run_path)
+        .arg("--input-format")
+        .arg("compatible")
         .output()
         .expect("cli should run");
     assert!(output.status.success(), "cli failed: {output:?}");
@@ -488,7 +497,7 @@ fn import_tracing_json_auto_accepts_fmt_like_record_with_top_level_explicit_time
 }
 
 #[test]
-fn import_tracing_json_auto_accepts_fmt_like_record_with_nested_explicit_timestamps() {
+fn import_tracing_json_compatible_accepts_fmt_like_record_with_nested_explicit_timestamps() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("compatible.jsonl");
     let run_path = dir.path().join("run.json");
@@ -505,6 +514,8 @@ fn import_tracing_json_auto_accepts_fmt_like_record_with_nested_explicit_timesta
         .arg("checkout")
         .arg("--output")
         .arg(&run_path)
+        .arg("--input-format")
+        .arg("compatible")
         .output()
         .expect("cli should run");
     assert!(output.status.success(), "cli failed: {output:?}");
@@ -527,9 +538,30 @@ fn import_tracing_json_help_shows_only_live_input_format_values() {
         .expect("cli should run");
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("auto"));
+    assert!(stdout.contains("compatible"));
     assert!(stdout.contains("tailtriage-span-jsonl"));
     assert!(!stdout.contains("tracing-subscriber-fmt-json"));
+}
+
+#[test]
+fn import_tracing_json_auto_is_rejected() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, complete_span_jsonl_fixture()).expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--input-format")
+        .arg("auto")
+        .output()
+        .expect("cli should run");
+    assert!(!output.status.success());
 }
 
 #[test]
@@ -548,6 +580,8 @@ fn import_tracing_json_strict_fails_on_incomplete_tailtriage_span() {
         .arg("checkout")
         .arg("--output")
         .arg(&run_path)
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--strict")
         .output()
         .expect("cli should run");
@@ -580,6 +614,8 @@ fn import_tracing_json_non_strict_writes_output_and_emits_warning_to_stderr() {
         .arg("checkout")
         .arg("--output")
         .arg(&run_path)
+        .arg("--input-format")
+        .arg("compatible")
         .output()
         .expect("cli should run");
 
@@ -613,6 +649,8 @@ fn import_tracing_json_writes_metadata_flags_into_run_json() {
         .arg("run-42")
         .arg("--output")
         .arg(&run_path)
+        .arg("--input-format")
+        .arg("compatible")
         .output()
         .expect("cli should run");
 
@@ -642,6 +680,8 @@ fn import_tracing_json_accepts_paths_with_spaces() {
         .arg("checkout")
         .arg("--output")
         .arg(&run_path)
+        .arg("--input-format")
+        .arg("compatible")
         .output()
         .expect("cli should run");
 
@@ -735,6 +775,8 @@ fn import_tracing_json_fails_when_only_tt_spans_are_missing_kind() {
         .arg("checkout")
         .arg("--output")
         .arg(&run_path)
+        .arg("--input-format")
+        .arg("compatible")
         .output()
         .expect("cli should run");
     assert!(!output.status.success(), "cli unexpectedly succeeded");
@@ -760,6 +802,8 @@ fn import_tracing_json_warns_for_tt_fields_missing_kind_and_still_writes_run() {
         .arg("checkout")
         .arg("--output")
         .arg(&run_path)
+        .arg("--input-format")
+        .arg("compatible")
         .output()
         .expect("cli should run");
     assert!(
@@ -797,6 +841,8 @@ fn import_tracing_json_persists_unknown_kind_warning_in_run_artifact() {
         .arg("checkout")
         .arg("--output")
         .arg(&run_path)
+        .arg("--input-format")
+        .arg("compatible")
         .output()
         .expect("cli should run");
 
@@ -833,6 +879,8 @@ fn import_tracing_json_persists_optional_default_assumption_warnings_in_run_arti
         .arg("checkout")
         .arg("--output")
         .arg(&run_path)
+        .arg("--input-format")
+        .arg("compatible")
         .output()
         .expect("cli should run");
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -82,7 +82,6 @@ Use `completed_span_jsonl_path(...)` when you want an offline import workflow:
 
 ```bash
 tailtriage import tracing-json target/tailtriage-examples/checkout.spans.jsonl \
-  --input-format tailtriage-span-jsonl \
   --service checkout-service \
   --output target/tailtriage-examples/checkout.run.json
 

--- a/tailtriage-tracing/examples/completed_span_jsonl_import.rs
+++ b/tailtriage-tracing/examples/completed_span_jsonl_import.rs
@@ -42,7 +42,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     session.shutdown()?;
     println!("wrote completed spans to: {}", spans_path.display());
     // Import + analyze with:
-    // tailtriage import tracing-json target/tailtriage-examples/completed-spans.jsonl  --service checkout-service --output target/tailtriage-examples/run.json
+    // tailtriage import tracing-json target/tailtriage-examples/completed-spans.jsonl --service checkout-service --output target/tailtriage-examples/run.json
     // tailtriage analyze target/tailtriage-examples/run.json
     Ok(())
 }

--- a/tailtriage-tracing/examples/completed_span_jsonl_import.rs
+++ b/tailtriage-tracing/examples/completed_span_jsonl_import.rs
@@ -42,7 +42,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     session.shutdown()?;
     println!("wrote completed spans to: {}", spans_path.display());
     // Import + analyze with:
-    // tailtriage import tracing-json target/tailtriage-examples/completed-spans.jsonl --input-format tailtriage-span-jsonl --service checkout-service --output target/tailtriage-examples/run.json
+    // tailtriage import tracing-json target/tailtriage-examples/completed-spans.jsonl  --service checkout-service --output target/tailtriage-examples/run.json
     // tailtriage analyze target/tailtriage-examples/run.json
     Ok(())
 }

--- a/tailtriage-tracing/src/error.rs
+++ b/tailtriage-tracing/src/error.rs
@@ -19,6 +19,11 @@ pub enum ImportError {
         /// Underlying JSON parser error text.
         reason: String,
     },
+    /// JSONL input did not match the stable tailtriage wrapper shape required by wrapper-only mode.
+    ExpectedTailtriageWrapper {
+        /// Human-readable reason the wrapper shape was rejected.
+        reason: String,
+    },
     /// Required field or option is missing.
     MissingField(&'static str),
     /// Field value had an invalid type or invalid content.
@@ -58,6 +63,9 @@ impl fmt::Display for ImportError {
             } => write!(f, "io error while {operation} ({context}): {reason}"),
             Self::MalformedJsonLine { line, reason } => {
                 write!(f, "malformed JSONL at line {line}: {reason}")
+            }
+            Self::ExpectedTailtriageWrapper { reason } => {
+                write!(f, "expected tailtriage wrapper JSONL record: {reason}")
             }
             Self::MissingField(field) => write!(f, "missing required field: {field}"),
             Self::InvalidField { field, reason } => {

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -151,7 +151,11 @@ fn parse_record(
                     "line {line_no}: invalid field 'format': expected string format marker"
                 );
                 if strict {
-                    return Err(ImportError::StrictViolation(message));
+                    return Err(if matches!(mode, JsonlParseMode::TailtriageWrapperOnly) {
+                        ImportError::ExpectedTailtriageWrapper { reason: message }
+                    } else {
+                        ImportError::StrictViolation(message)
+                    });
                 }
                 warnings.push(crate::ImportWarning::new(message));
                 return Ok(None);
@@ -161,7 +165,11 @@ fn parse_record(
                 let message =
                     format!("line {line_no}: unsupported span format marker '{format_marker}'");
                 if strict {
-                    return Err(ImportError::StrictViolation(message));
+                    return Err(if matches!(mode, JsonlParseMode::TailtriageWrapperOnly) {
+                        ImportError::ExpectedTailtriageWrapper { reason: message }
+                    } else {
+                        ImportError::StrictViolation(message)
+                    });
                 }
                 warnings.push(crate::ImportWarning::new(message));
                 return Ok(None);
@@ -172,7 +180,11 @@ fn parse_record(
                     "line {line_no}: missing field 'span' for tailtriage.tracing-span.v1 wrapper"
                 );
                 if strict {
-                    return Err(ImportError::StrictViolation(message));
+                    return Err(if matches!(mode, JsonlParseMode::TailtriageWrapperOnly) {
+                        ImportError::ExpectedTailtriageWrapper { reason: message }
+                    } else {
+                        ImportError::StrictViolation(message)
+                    });
                 }
                 warnings.push(crate::ImportWarning::new(message));
                 return Ok(None);
@@ -183,7 +195,11 @@ fn parse_record(
                     "line {line_no}: invalid field 'span': expected completed span object for tailtriage.tracing-span.v1"
                 );
                 if strict {
-                    return Err(ImportError::StrictViolation(message));
+                    return Err(if matches!(mode, JsonlParseMode::TailtriageWrapperOnly) {
+                        ImportError::ExpectedTailtriageWrapper { reason: message }
+                    } else {
+                        ImportError::StrictViolation(message)
+                    });
                 }
                 warnings.push(crate::ImportWarning::new(message));
                 return Ok(None);
@@ -209,7 +225,7 @@ fn parse_record(
             "line {line_no}: expected stable wrapper shape {{\"format\":\"tailtriage.tracing-span.v1\",\"span\":{{...}}}}"
         );
         if strict {
-            return Err(ImportError::StrictViolation(message));
+            return Err(ImportError::ExpectedTailtriageWrapper { reason: message });
         }
         warnings.push(crate::ImportWarning::new(message));
         return Ok(None);
@@ -1129,7 +1145,19 @@ mod tests {
             JsonlParseMode::TailtriageWrapperOnly,
         )
         .unwrap_err();
-        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
+    }
+
+    #[test]
+    fn wrapper_only_mode_missing_span_strict_returns_expected_wrapper_error() {
+        let missing_span = r#"{"format":"tailtriage.tracing-span.v1"}"#;
+        let err = import_jsonl_reader_with_mode(
+            Cursor::new(missing_span),
+            ImportOptions::new("svc").strict(true),
+            JsonlParseMode::TailtriageWrapperOnly,
+        )
+        .unwrap_err();
+        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
     }
 
     #[test]
@@ -1158,7 +1186,7 @@ mod tests {
             JsonlParseMode::TailtriageWrapperOnly,
         )
         .unwrap_err();
-        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
         assert!(err.to_string().contains("v2") || err.to_string().contains("unsupported"));
 
         let imported = import_jsonl_reader_with_mode(
@@ -1335,7 +1363,7 @@ mod tests {
         )
         .unwrap_err();
         let msg = err.to_string();
-        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
         assert!(
             msg.contains("invalid field 'span'") || msg.contains("expected completed span object")
         );
@@ -1361,7 +1389,7 @@ mod tests {
         )
         .unwrap_err();
         let msg = err.to_string();
-        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
         assert!(msg.contains("format") && msg.contains("expected string"));
 
         let imported = import_jsonl_reader_with_mode(


### PR DESCRIPTION
### Motivation
- Make the CLI top-level help clearer about its dual import+analyze role. 
- Replace the unstable public `auto` input-format surface with an explicit `compatible` mode and make the stable wrapper-only format the default so callers and docs don't rely on heuristic behavior. 
- Ensure ordinary `tracing_subscriber::fmt().json()` logs are rejected loudly in the right mode and keep wrapper-only errors actionable. 
- Align docs, examples, and CLI boundary tests with the new public surface.

### Description
- Update top-level clap about text in `tailtriage-cli/src/main.rs` from "Analyze tailtriage run artifacts" to "Import and analyze tailtriage run artifacts". 
- Replace the `TracingInputFormat` enum so the public values are `TailtriageSpanJsonl` and `Compatible` (no `Auto`), add doc comments for both variants, and set `TailtriageSpanJsonl` as the default. 
- Change parsing logic so `TailtriageSpanJsonl` -> `JsonlParseMode::TailtriageWrapperOnly` and `Compatible` -> `JsonlParseMode::Compatible`, and run the ordinary tracing-log sniff/rejection only when `Compatible` is selected. 
- Remove any hidden `auto` alias so `--input-format auto` now fails; add a test to assert that. 
- Preserve (and improve) wrapper-only error messaging so wrapper-only failures append guidance showing the stable wrapper shape and explicitly state that `tracing_subscriber::fmt().json()` logs are unsupported. 
- Refactor the import handling into an `import_tracing_json` helper to keep the main function smaller and keep clippy happy. 
- Update docs and examples to remove `auto`, omit `--input-format` in stable-wrapper examples (since wrapper mode is now default), show `--input-format compatible` only for compatibility-mode examples, and reword implementation-detail references to say the CLI writes Run JSON through the normal local JSON artifact writer (not `serde_json::to_writer_pretty`). Files updated include `tailtriage-cli/README.md`, root `README.md`, `docs/user-guide.md`, `tailtriage-tracing/README.md`, and related examples. 
- Update CLI boundary tests in `tailtriage-cli/tests/cli_boundary.rs` to cover: new help text, default wrapper import success without `--input-format`, compatibility-mode success, default rejection of ordinary fmt-style tracing logs with actionable guidance, and explicit failure for `--input-format auto`.

### Testing
- Commands run:
  - `cargo fmt --check` — succeeded (no formatting changes required).
  - `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — succeeded (no lints/warnings remaining).
  - `cargo test --workspace --all-targets --all-features --locked` — succeeded (all tests, including updated CLI boundary tests, passed).
  - `python3 scripts/validate_docs_contracts.py` — succeeded (`docs contracts validated successfully`).
- Result: all automated checks and workspace tests passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13f797728c8330b5ccf0a645e6b9b6)