### PR TITLE
CLI: make wrapper JSONL the default input format and replace `auto` with `compatible`

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Offline import expects completed `tt.*` span JSONL (not arbitrary tracing log JS
 
 - Offline JSONL import:
   ```bash
-  tailtriage import tracing-json completed-spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json
+  tailtriage import tracing-json completed-spans.jsonl --service checkout --output tailtriage-run.json
   tailtriage analyze tailtriage-run.json
   ```
 - Live session path: first install `tailtriage-tracing` with `live` (`cargo add tailtriage-tracing --features live`), then add `tailtriage_tracing::TracingIntakeSession` and `session.layer()` beside your existing subscriber setup.
@@ -241,7 +241,7 @@ tailtriage analyze tailtriage-run.json --format json
 Import completed tracing span records (JSONL) into a Run artifact first when needed:
 
 ```bash
-tailtriage import tracing-json completed-spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json
+tailtriage import tracing-json completed-spans.jsonl --service checkout --output tailtriage-run.json
 ```
 
 `tailtriage import tracing-json` writes **Run JSON** (capture artifact and CLI input), not Report JSON. Use `--strict` to fail on malformed/incomplete `tt.*` spans; without `--strict`, malformed `tt.*` spans are skipped and surfaced as `warning: ...` lines on stderr. Arbitrary `tracing_subscriber::fmt().json()` log JSON is not imported, and timing is not guessed from line receive time: completed spans must include explicit unix-ms start/end timestamps. Persisted Run JSON intended for `tailtriage analyze` must include at least one completed request event; in-process library snapshots may still be zero-request for inspection.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -45,7 +45,7 @@ cargo add tailtriage-tracing
 A) Completed-span JSONL intake path:
 
 ```bash
-tailtriage import tracing-json completed-spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json
+tailtriage import tracing-json completed-spans.jsonl --service checkout --output tailtriage-run.json
 tailtriage analyze tailtriage-run.json
 ```
 

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -45,13 +45,13 @@ tailtriage analyze tailtriage-run.json --format json
 Import completed `tt.*` tracing span JSONL into Run JSON:
 
 ```bash
-tailtriage import tracing-json spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json
+tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json
 ```
 
 With optional metadata flags, strict validation, and explicit format:
 
 ```bash
-tailtriage import tracing-json spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json --service-version v1 --run-id run-42 --strict
+tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json --service-version v1 --run-id run-42 --strict
 ```
 
 
@@ -64,12 +64,12 @@ Recommended stable input format is the tailtriage wrapper JSONL shape:
 ```
 
 `--input-format` values:
-- `auto`
 - `tailtriage-span-jsonl`
+- `compatible`
 
 Behavior:
 - `tailtriage-span-jsonl` enforces wrapper-only parsing.
-- `auto` keeps compatibility parsing for older normalized shapes and rejects ordinary tracing log JSON (including `fmt().json` output) early with setup guidance; timing is not guessed from JSONL line receive time.
+- `compatible` keeps compatibility parsing for older normalized shapes and rejects ordinary tracing log JSON (including `fmt().json` output) early with setup guidance; timing is not guessed from JSONL line receive time.
 
 After import, run analysis separately:
 
@@ -85,7 +85,7 @@ When paths include spaces, quote them in shell usage:
 tailtriage import tracing-json "fixtures/tracing spans.jsonl" --service checkout --output "runs/imported run.json"
 ```
 
-The command imports completed `tt.*` tracing span records in the documented JSONL shape and writes pretty Run JSON (`serde_json::to_writer_pretty`), not Report JSON. Import warnings are printed to stderr as `warning: ...`. Analysis is a separate step: `tailtriage analyze tailtriage-run.json`.
+The command imports completed `tt.*` tracing span records in the documented JSONL shape and writes Run JSON through the normal local JSON artifact writer, not Report JSON. Import warnings are printed to stderr as `warning: ...`. Analysis is a separate step: `tailtriage analyze tailtriage-run.json`.
 Tracing import and native capture share the same CaptureMode/CaptureLimits semantics for request/stage/queue evidence retention. Offline CLI tracing import exposes request/stage/queue limit overrides because those are the evidence types it imports. It intentionally does not expose runtime-snapshot or in-flight-snapshot limit flags because this import path does not ingest those evidence types. Tracing-only imports do not fabricate runtime snapshots; executor/blocking-pressure interpretation remains limited unless runtime snapshots are also captured (for example via Tokio runtime sampling).
 Malformed JSON input remains fatal. In non-strict mode, syntactically valid malformed/incomplete `tt.*` records are skipped with `warning: ...` lines.
 `--service` must not be empty or whitespace.

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -12,7 +12,7 @@ use tailtriage_tracing::{
 
 #[derive(Debug, Parser)]
 #[command(name = "tailtriage")]
-#[command(about = "Analyze tailtriage run artifacts", version)]
+#[command(about = "Import and analyze tailtriage run artifacts", version)]
 struct Cli {
     #[command(subcommand)]
     command: Command,
@@ -67,8 +67,8 @@ enum ImportCommand {
         /// Fail on malformed/incomplete tailtriage spans.
         #[arg(long)]
         strict: bool,
-        /// Input format mode.
-        #[arg(long, value_enum, default_value_t = TracingInputFormat::Auto)]
+        /// Input format. Defaults to the stable tailtriage wrapper JSONL format.
+        #[arg(long, value_enum, default_value_t = TracingInputFormat::TailtriageSpanJsonl)]
         input_format: TracingInputFormat,
         /// Import capture mode semantics for request/stage/queue retention.
         #[arg(long, value_enum, default_value_t = ImportCaptureMode::Light)]
@@ -86,8 +86,10 @@ enum ImportCommand {
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 enum TracingInputFormat {
-    Auto,
+    /// Stable wrapper-only format, {"format":"tailtriage.tracing-span.v1","span":{...}}.
     TailtriageSpanJsonl,
+    /// Compatibility parser for pre-stable/internal normalized completed-span shapes; not arbitrary tracing log JSON.
+    Compatible,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -148,7 +150,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 options = options.capture_limits_override(capture_limits_override);
 
-                if matches!(input_format, TracingInputFormat::Auto)
+                if matches!(input_format, TracingInputFormat::Compatible)
                     && input_looks_like_tracing_fmt_json(&spans_jsonl)?
                 {
                     return Err(std::io::Error::new(
@@ -161,7 +163,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                     TracingInputFormat::TailtriageSpanJsonl => {
                         JsonlParseMode::TailtriageWrapperOnly
                     }
-                    TracingInputFormat::Auto => JsonlParseMode::Compatible,
+                    TracingInputFormat::Compatible => JsonlParseMode::Compatible,
                 };
                 let imported = import_jsonl_path_with_mode(spans_jsonl, options, parse_mode)?;
                 for warning in imported.warnings() {
@@ -212,7 +214,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn tracing_json_setup_guidance() -> &'static str {
-    "the file looks like ordinary tracing log JSON, not completed tailtriage span JSONL. tailtriage requires completed spans with literal dotted tt.* keys and explicit unix-ms start/end timestamps. Recommended setup: TracingIntakeSession::builder(...).completed_span_jsonl_path(...). Then run: tailtriage import tracing-json <completed-spans.jsonl> --input-format tailtriage-span-jsonl --service <service> --output <run-json>"
+    "the file looks like ordinary tracing log JSON, not completed tailtriage span JSONL. tailtriage requires completed spans with literal dotted tt.* keys and explicit unix-ms start/end timestamps. Recommended setup: TracingIntakeSession::builder(...).completed_span_jsonl_path(...). Then run: tailtriage import tracing-json <completed-spans.jsonl> --service <service> --output <run-json>"
 }
 
 fn input_looks_like_tracing_fmt_json(path: &std::path::Path) -> Result<bool, std::io::Error> {

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -309,6 +309,8 @@ fn import_tracing_json_capture_limit_overrides_apply() {
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--service")
         .arg("checkout")
         .arg("--output")
@@ -407,7 +409,7 @@ fn import_tracing_json_input_format_tailtriage_wrapper_only_accepts_fixture() {
 }
 
 #[test]
-fn import_tracing_json_input_format_tailtriage_wrapper_only_rejects_unwrapped() {
+fn import_tracing_json_default_wrapper_only_rejects_unwrapped() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
@@ -416,8 +418,6 @@ fn import_tracing_json_input_format_tailtriage_wrapper_only_rejects_unwrapped() 
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
-        .arg("--input-format")
-        .arg("tailtriage-span-jsonl")
         .arg("--service")
         .arg("checkout")
         .arg("--output")
@@ -432,7 +432,7 @@ fn import_tracing_json_input_format_tailtriage_wrapper_only_rejects_unwrapped() 
 }
 
 #[test]
-fn import_tracing_json_auto_rejects_fmt_json_with_guidance() {
+fn import_tracing_json_compatible_rejects_fmt_json_with_guidance() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("fmt.jsonl");
     let run_path = dir.path().join("run.json");
@@ -441,6 +441,8 @@ fn import_tracing_json_auto_rejects_fmt_json_with_guidance() {
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--service")
         .arg("checkout")
         .arg("--output")
@@ -453,12 +455,12 @@ fn import_tracing_json_auto_rejects_fmt_json_with_guidance() {
     assert!(stderr.contains("literal dotted tt.* keys"));
     assert!(stderr.contains("explicit unix-ms start/end timestamps"));
     assert!(stderr.contains("TracingIntakeSession"));
-    assert!(stderr.contains("tailtriage-span-jsonl"));
+    assert!(!stderr.contains("tailtriage-span-jsonl"));
     assert!(!run_path.exists());
 }
 
 #[test]
-fn import_tracing_json_auto_accepts_fmt_like_record_with_top_level_explicit_timestamps() {
+fn import_tracing_json_default_wrapper_only_rejects_fmt_like_record() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("compatible.jsonl");
     let run_path = dir.path().join("run.json");
@@ -477,18 +479,17 @@ fn import_tracing_json_auto_accepts_fmt_like_record_with_top_level_explicit_time
         .arg(&run_path)
         .output()
         .expect("cli should run");
-    assert!(output.status.success(), "cli failed: {output:?}");
+    assert!(
+        !output.status.success(),
+        "cli unexpectedly succeeded: {output:?}"
+    );
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
-    assert!(!stderr.contains("ordinary tracing log JSON"));
-    assert!(run_path.exists(), "run json should be written");
-
-    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
-        .expect("imported run should load in cli loader");
-    assert_eq!(loaded.run.requests.len(), 1);
+    assert!(stderr.contains("tailtriage.tracing-span.v1") || stderr.contains("stable wrapper"));
+    assert!(!run_path.exists(), "run json should not be written");
 }
 
 #[test]
-fn import_tracing_json_auto_accepts_fmt_like_record_with_nested_explicit_timestamps() {
+fn import_tracing_json_compatible_accepts_fmt_like_record_with_nested_explicit_timestamps() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("compatible.jsonl");
     let run_path = dir.path().join("run.json");
@@ -501,6 +502,8 @@ fn import_tracing_json_auto_accepts_fmt_like_record_with_nested_explicit_timesta
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--service")
         .arg("checkout")
         .arg("--output")
@@ -527,9 +530,37 @@ fn import_tracing_json_help_shows_only_live_input_format_values() {
         .expect("cli should run");
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("auto"));
+    assert!(stdout.contains("compatible"));
     assert!(stdout.contains("tailtriage-span-jsonl"));
+    assert!(!stdout.contains("auto"));
     assert!(!stdout.contains("tracing-subscriber-fmt-json"));
+}
+
+#[test]
+fn top_level_help_includes_updated_about_text() {
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("--help")
+        .output()
+        .expect("cli should run");
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Import and analyze tailtriage run artifacts"));
+}
+
+#[test]
+fn import_tracing_json_rejects_auto_input_format_value() {
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg("--input-format")
+        .arg("auto")
+        .arg("--help")
+        .output()
+        .expect("cli should run");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("invalid value"));
+    assert!(stderr.contains("compatible"));
 }
 
 #[test]
@@ -544,6 +575,8 @@ fn import_tracing_json_strict_fails_on_incomplete_tailtriage_span() {
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--service")
         .arg("checkout")
         .arg("--output")
@@ -576,6 +609,8 @@ fn import_tracing_json_non_strict_writes_output_and_emits_warning_to_stderr() {
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--service")
         .arg("checkout")
         .arg("--output")
@@ -605,6 +640,8 @@ fn import_tracing_json_writes_metadata_flags_into_run_json() {
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--service")
         .arg("checkout")
         .arg("--service-version")
@@ -638,6 +675,8 @@ fn import_tracing_json_accepts_paths_with_spaces() {
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--service")
         .arg("checkout")
         .arg("--output")
@@ -731,6 +770,8 @@ fn import_tracing_json_fails_when_only_tt_spans_are_missing_kind() {
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--service")
         .arg("checkout")
         .arg("--output")
@@ -756,6 +797,8 @@ fn import_tracing_json_warns_for_tt_fields_missing_kind_and_still_writes_run() {
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--service")
         .arg("checkout")
         .arg("--output")
@@ -793,6 +836,8 @@ fn import_tracing_json_persists_unknown_kind_warning_in_run_artifact() {
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--service")
         .arg("checkout")
         .arg("--output")
@@ -829,6 +874,8 @@ fn import_tracing_json_persists_optional_default_assumption_warnings_in_run_arti
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--service")
         .arg("checkout")
         .arg("--output")

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -82,7 +82,6 @@ Use `completed_span_jsonl_path(...)` when you want an offline import workflow:
 
 ```bash
 tailtriage import tracing-json target/tailtriage-examples/checkout.spans.jsonl \
-  --input-format tailtriage-span-jsonl \
   --service checkout-service \
   --output target/tailtriage-examples/checkout.run.json
 


### PR DESCRIPTION
### Motivation
- Make the stable wrapper-only import the default, loudly remove the legacy `auto` token, and ensure compatibility parsing is explicit so stale scripts/docs fail fast.
- Ensure wrapper-only mode stays strict and actionable while preserving a compatibility mode for older normalized shapes.
- Update top-level CLI help and examples to reflect the new default and avoid recommending an explicit `--input-format` when using the stable wrapper format.

### Description
- Changed top-level clap about text from `Analyze tailtriage run artifacts` to `Import and analyze tailtriage run artifacts` in `tailtriage-cli/src/main.rs`.
- Replaced the `TracingInputFormat` enum to remove `Auto` and expose `TailtriageSpanJsonl` and `Compatible`, added doc comments for both variants, and updated the `--input-format` flag doc to state the default is the stable wrapper JSONL format.
- Made `TailtriageSpanJsonl` the default `--input-format` and mapped parse behavior so `TailtriageSpanJsonl` -> `JsonlParseMode::TailtriageWrapperOnly` and `Compatible` -> `JsonlParseMode::Compatible`.
- Restricted the ordinary tracing-log sniff/rejection logic to run only when `--input-format compatible` is selected (so wrapper-only mode rejects non-wrapper input via wrapper-only parser and emits actionable guidance).
- Removed the `auto` alias so `--input-format auto` is invalid and fails at parse-time.
- Updated docs and examples to omit `--input-format` for stable wrapper examples, show `--input-format compatible` only for compatibility examples, and reworded an implementation-detail line to say the CLI "writes Run JSON through the normal local JSON artifact writer" instead of referencing `serde_json::to_writer_pretty`.
- Updated and added CLI boundary tests to validate: top-level help text, default wrapper import behavior, default rejection of unwrapped/normalized input, compatibility success for normalized input, and that `--input-format auto` is rejected; updated fixture-based tests to pass `compatible` where appropriate.
- Files changed include `tailtriage-cli/src/main.rs`, `tailtriage-cli/tests/cli_boundary.rs`, `tailtriage-cli/README.md`, `README.md`, `docs/user-guide.md`, and `tailtriage-tracing/README.md`.

### Testing
- Ran formatting, linting, test suite, and docs contract validation and all succeeded:
  - `cargo fmt --check` — succeeded.
  - `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — succeeded.
  - `cargo test --workspace --all-targets --all-features --locked` — succeeded (unit and integration tests, including updated CLI boundary tests).
  - `python3 scripts/validate_docs_contracts.py` — succeeded (docs contracts validated successfully).
- Key test-targets exercised include the CLI boundary tests that confirm the new default and explicit `compatible` behavior and that `auto` is rejected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13f797728c8330b5ccf0a645e6b9b6)