### PR TITLE
CLI: default tracing import to stable wrapper; replace `auto` with `compatible`

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Offline import expects completed `tt.*` span JSONL (not arbitrary tracing log JS
 
 - Offline JSONL import:
   ```bash
-  tailtriage import tracing-json completed-spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json
+  tailtriage import tracing-json completed-spans.jsonl --service checkout --output tailtriage-run.json
   tailtriage analyze tailtriage-run.json
   ```
 - Live session path: first install `tailtriage-tracing` with `live` (`cargo add tailtriage-tracing --features live`), then add `tailtriage_tracing::TracingIntakeSession` and `session.layer()` beside your existing subscriber setup.
@@ -241,7 +241,7 @@ tailtriage analyze tailtriage-run.json --format json
 Import completed tracing span records (JSONL) into a Run artifact first when needed:
 
 ```bash
-tailtriage import tracing-json completed-spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json
+tailtriage import tracing-json completed-spans.jsonl --service checkout --output tailtriage-run.json
 ```
 
 `tailtriage import tracing-json` writes **Run JSON** (capture artifact and CLI input), not Report JSON. Use `--strict` to fail on malformed/incomplete `tt.*` spans; without `--strict`, malformed `tt.*` spans are skipped and surfaced as `warning: ...` lines on stderr. Arbitrary `tracing_subscriber::fmt().json()` log JSON is not imported, and timing is not guessed from line receive time: completed spans must include explicit unix-ms start/end timestamps. Persisted Run JSON intended for `tailtriage analyze` must include at least one completed request event; in-process library snapshots may still be zero-request for inspection.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -45,7 +45,7 @@ cargo add tailtriage-tracing
 A) Completed-span JSONL intake path:
 
 ```bash
-tailtriage import tracing-json completed-spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json
+tailtriage import tracing-json completed-spans.jsonl --service checkout --output tailtriage-run.json
 tailtriage analyze tailtriage-run.json
 ```
 

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -45,13 +45,19 @@ tailtriage analyze tailtriage-run.json --format json
 Import completed `tt.*` tracing span JSONL into Run JSON:
 
 ```bash
-tailtriage import tracing-json spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json
+tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json
 ```
 
 With optional metadata flags, strict validation, and explicit format:
 
 ```bash
-tailtriage import tracing-json spans.jsonl --input-format tailtriage-span-jsonl --service checkout --output tailtriage-run.json --service-version v1 --run-id run-42 --strict
+tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json --service-version v1 --run-id run-42 --strict
+```
+
+Compatibility-mode import for older normalized input shapes:
+
+```bash
+tailtriage import tracing-json spans.jsonl --input-format compatible --service checkout --output tailtriage-run.json
 ```
 
 
@@ -64,12 +70,12 @@ Recommended stable input format is the tailtriage wrapper JSONL shape:
 ```
 
 `--input-format` values:
-- `auto`
-- `tailtriage-span-jsonl`
+- `tailtriage-span-jsonl` (default stable wrapper-only format)
+- `compatible`
 
 Behavior:
-- `tailtriage-span-jsonl` enforces wrapper-only parsing.
-- `auto` keeps compatibility parsing for older normalized shapes and rejects ordinary tracing log JSON (including `fmt().json` output) early with setup guidance; timing is not guessed from JSONL line receive time.
+- `tailtriage-span-jsonl` enforces wrapper-only parsing for `{"format":"tailtriage.tracing-span.v1","span":{...}}`.
+- `compatible` keeps compatibility parsing for pre-stable/internal normalized shapes and rejects ordinary tracing log JSON (including `fmt().json` output) early with setup guidance; timing is not guessed from JSONL line receive time.
 
 After import, run analysis separately:
 
@@ -85,7 +91,7 @@ When paths include spaces, quote them in shell usage:
 tailtriage import tracing-json "fixtures/tracing spans.jsonl" --service checkout --output "runs/imported run.json"
 ```
 
-The command imports completed `tt.*` tracing span records in the documented JSONL shape and writes pretty Run JSON (`serde_json::to_writer_pretty`), not Report JSON. Import warnings are printed to stderr as `warning: ...`. Analysis is a separate step: `tailtriage analyze tailtriage-run.json`.
+The command imports completed `tt.*` tracing span records in the documented JSONL shape and writes Run JSON through the normal local JSON artifact writer, not Report JSON. Import warnings are printed to stderr as `warning: ...`. Analysis is a separate step: `tailtriage analyze tailtriage-run.json`.
 Tracing import and native capture share the same CaptureMode/CaptureLimits semantics for request/stage/queue evidence retention. Offline CLI tracing import exposes request/stage/queue limit overrides because those are the evidence types it imports. It intentionally does not expose runtime-snapshot or in-flight-snapshot limit flags because this import path does not ingest those evidence types. Tracing-only imports do not fabricate runtime snapshots; executor/blocking-pressure interpretation remains limited unless runtime snapshots are also captured (for example via Tokio runtime sampling).
 Malformed JSON input remains fatal. In non-strict mode, syntactically valid malformed/incomplete `tt.*` records are skipped with `warning: ...` lines.
 `--service` must not be empty or whitespace.

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -12,7 +12,7 @@ use tailtriage_tracing::{
 
 #[derive(Debug, Parser)]
 #[command(name = "tailtriage")]
-#[command(about = "Analyze tailtriage run artifacts", version)]
+#[command(about = "Import and analyze tailtriage run artifacts", version)]
 struct Cli {
     #[command(subcommand)]
     command: Command,
@@ -67,8 +67,8 @@ enum ImportCommand {
         /// Fail on malformed/incomplete tailtriage spans.
         #[arg(long)]
         strict: bool,
-        /// Input format mode.
-        #[arg(long, value_enum, default_value_t = TracingInputFormat::Auto)]
+        /// Input format. Defaults to the stable tailtriage wrapper JSONL format.
+        #[arg(long, value_enum, default_value_t = TracingInputFormat::TailtriageSpanJsonl)]
         input_format: TracingInputFormat,
         /// Import capture mode semantics for request/stage/queue retention.
         #[arg(long, value_enum, default_value_t = ImportCaptureMode::Light)]
@@ -86,8 +86,10 @@ enum ImportCommand {
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 enum TracingInputFormat {
-    Auto,
+    /// Stable wrapper-only format: {"format":"tailtriage.tracing-span.v1","span":{...}}.
     TailtriageSpanJsonl,
+    /// Compatibility parser for pre-stable/internal normalized completed-span shapes; not arbitrary tracing log JSON.
+    Compatible,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -148,7 +150,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 options = options.capture_limits_override(capture_limits_override);
 
-                if matches!(input_format, TracingInputFormat::Auto)
+                if matches!(input_format, TracingInputFormat::Compatible)
                     && input_looks_like_tracing_fmt_json(&spans_jsonl)?
                 {
                     return Err(std::io::Error::new(
@@ -161,7 +163,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                     TracingInputFormat::TailtriageSpanJsonl => {
                         JsonlParseMode::TailtriageWrapperOnly
                     }
-                    TracingInputFormat::Auto => JsonlParseMode::Compatible,
+                    TracingInputFormat::Compatible => JsonlParseMode::Compatible,
                 };
                 let imported = import_jsonl_path_with_mode(spans_jsonl, options, parse_mode)?;
                 for warning in imported.warnings() {
@@ -212,7 +214,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn tracing_json_setup_guidance() -> &'static str {
-    "the file looks like ordinary tracing log JSON, not completed tailtriage span JSONL. tailtriage requires completed spans with literal dotted tt.* keys and explicit unix-ms start/end timestamps. Recommended setup: TracingIntakeSession::builder(...).completed_span_jsonl_path(...). Then run: tailtriage import tracing-json <completed-spans.jsonl> --input-format tailtriage-span-jsonl --service <service> --output <run-json>"
+    "the file looks like ordinary tracing log JSON, not completed tailtriage span JSONL. tailtriage requires completed spans with literal dotted tt.* keys and explicit unix-ms start/end timestamps. Recommended setup: TracingIntakeSession::builder(...).completed_span_jsonl_path(...). Then run: tailtriage import tracing-json <completed-spans.jsonl> --input-format compatible --service <service> --output <run-json>"
 }
 
 fn input_looks_like_tracing_fmt_json(path: &std::path::Path) -> Result<bool, std::io::Error> {

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -309,6 +309,8 @@ fn import_tracing_json_capture_limit_overrides_apply() {
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--service")
         .arg("checkout")
         .arg("--output")
@@ -375,7 +377,7 @@ fn import_tracing_json_rejects_inert_inflight_snapshot_flags() {
 }
 
 #[test]
-fn import_tracing_json_input_format_tailtriage_wrapper_only_accepts_fixture() {
+fn import_tracing_json_default_wrapper_only_accepts_fixture() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
@@ -385,8 +387,6 @@ fn import_tracing_json_input_format_tailtriage_wrapper_only_accepts_fixture() {
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
-        .arg("--input-format")
-        .arg("tailtriage-span-jsonl")
         .arg("--service")
         .arg("checkout")
         .arg("--output")
@@ -407,7 +407,7 @@ fn import_tracing_json_input_format_tailtriage_wrapper_only_accepts_fixture() {
 }
 
 #[test]
-fn import_tracing_json_input_format_tailtriage_wrapper_only_rejects_unwrapped() {
+fn import_tracing_json_default_wrapper_only_rejects_unwrapped() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
@@ -416,8 +416,6 @@ fn import_tracing_json_input_format_tailtriage_wrapper_only_rejects_unwrapped() 
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
-        .arg("--input-format")
-        .arg("tailtriage-span-jsonl")
         .arg("--service")
         .arg("checkout")
         .arg("--output")
@@ -432,7 +430,7 @@ fn import_tracing_json_input_format_tailtriage_wrapper_only_rejects_unwrapped() 
 }
 
 #[test]
-fn import_tracing_json_auto_rejects_fmt_json_with_guidance() {
+fn import_tracing_json_compatible_rejects_fmt_json_with_guidance() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("fmt.jsonl");
     let run_path = dir.path().join("run.json");
@@ -441,6 +439,8 @@ fn import_tracing_json_auto_rejects_fmt_json_with_guidance() {
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--service")
         .arg("checkout")
         .arg("--output")
@@ -453,12 +453,12 @@ fn import_tracing_json_auto_rejects_fmt_json_with_guidance() {
     assert!(stderr.contains("literal dotted tt.* keys"));
     assert!(stderr.contains("explicit unix-ms start/end timestamps"));
     assert!(stderr.contains("TracingIntakeSession"));
-    assert!(stderr.contains("tailtriage-span-jsonl"));
+    assert!(stderr.contains("--input-format compatible"));
     assert!(!run_path.exists());
 }
 
 #[test]
-fn import_tracing_json_auto_accepts_fmt_like_record_with_top_level_explicit_timestamps() {
+fn import_tracing_json_compatible_accepts_fmt_like_record_with_top_level_explicit_timestamps() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("compatible.jsonl");
     let run_path = dir.path().join("run.json");
@@ -471,6 +471,8 @@ fn import_tracing_json_auto_accepts_fmt_like_record_with_top_level_explicit_time
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--service")
         .arg("checkout")
         .arg("--output")
@@ -488,7 +490,7 @@ fn import_tracing_json_auto_accepts_fmt_like_record_with_top_level_explicit_time
 }
 
 #[test]
-fn import_tracing_json_auto_accepts_fmt_like_record_with_nested_explicit_timestamps() {
+fn import_tracing_json_compatible_accepts_fmt_like_record_with_nested_explicit_timestamps() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("compatible.jsonl");
     let run_path = dir.path().join("run.json");
@@ -501,6 +503,8 @@ fn import_tracing_json_auto_accepts_fmt_like_record_with_nested_explicit_timesta
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--service")
         .arg("checkout")
         .arg("--output")
@@ -527,8 +531,9 @@ fn import_tracing_json_help_shows_only_live_input_format_values() {
         .expect("cli should run");
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("auto"));
+    assert!(stdout.contains("compatible"));
     assert!(stdout.contains("tailtriage-span-jsonl"));
+    assert!(!stdout.contains("auto"));
     assert!(!stdout.contains("tracing-subscriber-fmt-json"));
 }
 
@@ -544,6 +549,8 @@ fn import_tracing_json_strict_fails_on_incomplete_tailtriage_span() {
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--service")
         .arg("checkout")
         .arg("--output")
@@ -576,6 +583,8 @@ fn import_tracing_json_non_strict_writes_output_and_emits_warning_to_stderr() {
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--service")
         .arg("checkout")
         .arg("--output")
@@ -605,6 +614,8 @@ fn import_tracing_json_writes_metadata_flags_into_run_json() {
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--service")
         .arg("checkout")
         .arg("--service-version")
@@ -638,6 +649,8 @@ fn import_tracing_json_accepts_paths_with_spaces() {
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--service")
         .arg("checkout")
         .arg("--output")
@@ -731,6 +744,8 @@ fn import_tracing_json_fails_when_only_tt_spans_are_missing_kind() {
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--service")
         .arg("checkout")
         .arg("--output")
@@ -756,6 +771,8 @@ fn import_tracing_json_warns_for_tt_fields_missing_kind_and_still_writes_run() {
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--service")
         .arg("checkout")
         .arg("--output")
@@ -793,6 +810,8 @@ fn import_tracing_json_persists_unknown_kind_warning_in_run_artifact() {
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--service")
         .arg("checkout")
         .arg("--output")
@@ -829,6 +848,8 @@ fn import_tracing_json_persists_optional_default_assumption_warnings_in_run_arti
         .arg("import")
         .arg("tracing-json")
         .arg(&spans_path)
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--service")
         .arg("checkout")
         .arg("--output")
@@ -943,4 +964,38 @@ fn mixed_valid_and_unknown_kind_fixture() -> &'static str {
     r#"{"span":{"name":"unknown","started_at_unix_ms":1000,"finished_at_unix_ms":1005,"fields":{"tt.kind":"mystery"}}}
 {"span":{"name":"http.request","started_at_unix_ms":1020,"finished_at_unix_ms":1032,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout","tt.outcome":"ok"}}}
 "#
+}
+
+#[test]
+fn top_level_help_includes_import_and_analyze() {
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("--help")
+        .output()
+        .expect("cli should run");
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Import and analyze tailtriage run artifacts"));
+}
+
+#[test]
+fn import_tracing_json_rejects_auto_input_format_value() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, complete_span_jsonl_fixture()).expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--input-format")
+        .arg("auto")
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("invalid value 'auto'"));
 }

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -82,7 +82,6 @@ Use `completed_span_jsonl_path(...)` when you want an offline import workflow:
 
 ```bash
 tailtriage import tracing-json target/tailtriage-examples/checkout.spans.jsonl \
-  --input-format tailtriage-span-jsonl \
   --service checkout-service \
   --output target/tailtriage-examples/checkout.run.json
 


### PR DESCRIPTION
### Motivation

- Make the CLI input-format surface explicit and stable by promoting the wrapper-only format to the default and removing the hidden/ambiguous `auto` value so stale docs/scripts fail loudly. 
- Ensure the ordinary `tracing_subscriber::fmt().json()` sniff/rejection logic only runs in a compatibility mode, so wrapper-only parsing is strict and actionable. 
- Align docs, examples, and tests with the new default and the new public `compatible` value. 

### Description

- Changed the top-level clap about text from `Analyze tailtriage run artifacts` to `Import and analyze tailtriage run artifacts` in `tailtriage-cli/src/main.rs`. 
- Replaced the `TracingInputFormat` enum to expose `TailtriageSpanJsonl` and `Compatible` (removed `Auto`) and made `TailtriageSpanJsonl` the `clap` default. 
- Updated parsing: `TailtriageSpanJsonl` -> `JsonlParseMode::TailtriageWrapperOnly`, `Compatible` -> `JsonlParseMode::Compatible`, and moved tracing-log sniff/rejection so it runs only when `TracingInputFormat::Compatible` is selected. 
- Updated CLI docs and examples in `tailtriage-cli/README.md`, root `README.md`, `docs/user-guide.md`, and `tailtriage-tracing/README.md` to omit `--input-format` for stable wrapper examples and show `--input-format compatible` for compatibility examples, and replaced the `serde_json::to_writer_pretty` implementation-detail wording with "writes Run JSON through the normal local JSON artifact writer." 
- Added/updated CLI boundary tests in `tailtriage-cli/tests/cli_boundary.rs` so help text, default-wrapper behavior, compatibility behavior, and explicit rejection of `--input-format auto` are enforced. 

### Testing

- Ran `cargo fmt --check` and it succeeded. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it succeeded with no warnings. 
- Ran `cargo test --workspace --all-targets --all-features --locked` and the full test suite passed (unit, integration, and CLI boundary tests all succeeded). 
- Ran `python3 scripts/validate_docs_contracts.py` and it reported `docs contracts validated successfully`.

Exact commands run and results:
- `cargo fmt --check` — exited successfully (no formatting issues).
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — completed successfully (no warnings).
- `cargo test --workspace --all-targets --all-features --locked` — completed successfully (all tests passed).
- `python3 scripts/validate_docs_contracts.py` — completed successfully (`docs contracts validated successfully`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13f797728c8330b5ccf0a645e6b9b6)