### PR TITLE
Add ExpectedTailtriageWrapper error and narrow CLI wrapper guidance

### DIFF
--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -262,13 +262,7 @@ fn tracing_json_setup_guidance() -> &'static str {
 
 fn should_append_wrapper_guidance(input_format: TracingInputFormat, err: &ImportError) -> bool {
     matches!(input_format, TracingInputFormat::TailtriageSpanJsonl)
-        && matches!(
-            err,
-            ImportError::MissingField(_)
-                | ImportError::InvalidField { .. }
-                | ImportError::StrictViolation(_)
-                | ImportError::InvalidRunEvent(_)
-        )
+        && matches!(err, ImportError::ExpectedTailtriageWrapper { .. })
 }
 
 fn wrapper_only_rejection_guidance() -> &'static str {

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -436,8 +436,76 @@ fn import_tracing_json_input_format_tailtriage_wrapper_only_rejects_unwrapped() 
     assert!(!output.status.success());
     let stderr = String::from_utf8(output.stderr).unwrap();
     assert!(stderr.contains("tailtriage.tracing-span.v1") || stderr.contains("stable wrapper"));
+    assert!(stderr.contains("tracing_subscriber::fmt().json() logs are unsupported"));
     assert!(!stderr.contains("ordinary tracing log JSON"));
     assert!(!run_path.exists());
+}
+
+#[test]
+fn import_tracing_json_default_wrapper_mode_rejects_wrong_wrapper_format_with_guidance() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, r#"{"format":"tailtriage.tracing-span.v2","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#).unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("tailtriage.tracing-span.v1"));
+}
+
+#[test]
+fn import_tracing_json_default_wrapper_mode_semantic_missing_route_no_wrapper_guidance() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1"}}}"#).unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--strict")
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("tt.route") || stderr.contains("missing required field"));
+    assert!(!stderr.contains("tracing_subscriber::fmt().json()"));
+}
+
+#[test]
+fn import_tracing_json_default_wrapper_mode_semantic_invalid_kind_type_no_wrapper_guidance() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":1,"tt.request_id":"r1","tt.route":"/a"}}}"#).unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--strict")
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("tt.kind") || stderr.contains("invalid field"));
+    assert!(!stderr.contains("tracing_subscriber::fmt().json()"));
 }
 
 #[test]

--- a/tailtriage-tracing/src/error.rs
+++ b/tailtriage-tracing/src/error.rs
@@ -19,6 +19,11 @@ pub enum ImportError {
         /// Underlying JSON parser error text.
         reason: String,
     },
+    /// JSONL input did not match the stable tailtriage wrapper shape required by wrapper-only mode.
+    ExpectedTailtriageWrapper {
+        /// Human-readable reason the wrapper shape was rejected.
+        reason: String,
+    },
     /// Required field or option is missing.
     MissingField(&'static str),
     /// Field value had an invalid type or invalid content.
@@ -58,6 +63,9 @@ impl fmt::Display for ImportError {
             } => write!(f, "io error while {operation} ({context}): {reason}"),
             Self::MalformedJsonLine { line, reason } => {
                 write!(f, "malformed JSONL at line {line}: {reason}")
+            }
+            Self::ExpectedTailtriageWrapper { reason } => {
+                write!(f, "expected tailtriage wrapper JSONL record: {reason}")
             }
             Self::MissingField(field) => write!(f, "missing required field: {field}"),
             Self::InvalidField { field, reason } => {

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -151,7 +151,11 @@ fn parse_record(
                     "line {line_no}: invalid field 'format': expected string format marker"
                 );
                 if strict {
-                    return Err(ImportError::StrictViolation(message));
+                    return Err(if matches!(mode, JsonlParseMode::TailtriageWrapperOnly) {
+                        ImportError::ExpectedTailtriageWrapper { reason: message }
+                    } else {
+                        ImportError::StrictViolation(message)
+                    });
                 }
                 warnings.push(crate::ImportWarning::new(message));
                 return Ok(None);
@@ -161,7 +165,11 @@ fn parse_record(
                 let message =
                     format!("line {line_no}: unsupported span format marker '{format_marker}'");
                 if strict {
-                    return Err(ImportError::StrictViolation(message));
+                    return Err(if matches!(mode, JsonlParseMode::TailtriageWrapperOnly) {
+                        ImportError::ExpectedTailtriageWrapper { reason: message }
+                    } else {
+                        ImportError::StrictViolation(message)
+                    });
                 }
                 warnings.push(crate::ImportWarning::new(message));
                 return Ok(None);
@@ -172,7 +180,11 @@ fn parse_record(
                     "line {line_no}: missing field 'span' for tailtriage.tracing-span.v1 wrapper"
                 );
                 if strict {
-                    return Err(ImportError::StrictViolation(message));
+                    return Err(if matches!(mode, JsonlParseMode::TailtriageWrapperOnly) {
+                        ImportError::ExpectedTailtriageWrapper { reason: message }
+                    } else {
+                        ImportError::StrictViolation(message)
+                    });
                 }
                 warnings.push(crate::ImportWarning::new(message));
                 return Ok(None);
@@ -183,7 +195,11 @@ fn parse_record(
                     "line {line_no}: invalid field 'span': expected completed span object for tailtriage.tracing-span.v1"
                 );
                 if strict {
-                    return Err(ImportError::StrictViolation(message));
+                    return Err(if matches!(mode, JsonlParseMode::TailtriageWrapperOnly) {
+                        ImportError::ExpectedTailtriageWrapper { reason: message }
+                    } else {
+                        ImportError::StrictViolation(message)
+                    });
                 }
                 warnings.push(crate::ImportWarning::new(message));
                 return Ok(None);
@@ -209,7 +225,7 @@ fn parse_record(
             "line {line_no}: expected stable wrapper shape {{\"format\":\"tailtriage.tracing-span.v1\",\"span\":{{...}}}}"
         );
         if strict {
-            return Err(ImportError::StrictViolation(message));
+            return Err(ImportError::ExpectedTailtriageWrapper { reason: message });
         }
         warnings.push(crate::ImportWarning::new(message));
         return Ok(None);
@@ -1129,7 +1145,19 @@ mod tests {
             JsonlParseMode::TailtriageWrapperOnly,
         )
         .unwrap_err();
-        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
+    }
+
+    #[test]
+    fn wrapper_only_mode_missing_span_strict_returns_expected_wrapper_error() {
+        let missing_span = r#"{"format":"tailtriage.tracing-span.v1"}"#;
+        let err = import_jsonl_reader_with_mode(
+            Cursor::new(missing_span),
+            ImportOptions::new("svc").strict(true),
+            JsonlParseMode::TailtriageWrapperOnly,
+        )
+        .unwrap_err();
+        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
     }
 
     #[test]
@@ -1158,7 +1186,7 @@ mod tests {
             JsonlParseMode::TailtriageWrapperOnly,
         )
         .unwrap_err();
-        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
         assert!(err.to_string().contains("v2") || err.to_string().contains("unsupported"));
 
         let imported = import_jsonl_reader_with_mode(
@@ -1335,7 +1363,7 @@ mod tests {
         )
         .unwrap_err();
         let msg = err.to_string();
-        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
         assert!(
             msg.contains("invalid field 'span'") || msg.contains("expected completed span object")
         );
@@ -1361,7 +1389,7 @@ mod tests {
         )
         .unwrap_err();
         let msg = err.to_string();
-        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
         assert!(msg.contains("format") && msg.contains("expected string"));
 
         let imported = import_jsonl_reader_with_mode(


### PR DESCRIPTION
### Motivation
- Prevent the CLI from appending wrapper-shape guidance when import failures are actually semantic/field errors inside a valid wrapper record.
- Provide a precise import error for wrapper-only mode so guidance is shown only for true wrapper-shape/input-format mismatches.

### Description
- Add a new `ImportError::ExpectedTailtriageWrapper { reason: String }` variant and `Display` arm in `tailtriage-tracing/src/error.rs` to represent wrapper-shape mismatches explicitly.
- Update wrapper-only JSONL parsing in `tailtriage-tracing/src/jsonl.rs` so it returns `ExpectedTailtriageWrapper` only for top-level wrapper-shape failures (missing/invalid `format`, wrong marker, missing/non-object `span`, raw/unwrapped records, or ordinary tracing log JSON), while preserving existing semantic/strict paths (`StrictViolation`, `InvalidField`, etc.) for tt.* content errors.
- Change `should_append_wrapper_guidance(...)` in `tailtriage-cli/src/main.rs` to append guidance only when `input_format == TracingInputFormat::TailtriageSpanJsonl` and the error is `ImportError::ExpectedTailtriageWrapper { .. }`.
- Keep existing `ensure_persistable_run_has_requests(...)` special-case behavior unchanged.
- Add/update unit tests in `tailtriage-tracing` to assert wrapper-only mode returns `ExpectedTailtriageWrapper` for unwrapped input, wrong `format`, missing `span`, preserves malformed JSON as `MalformedJsonLine`, and preserves semantic error paths for wrapper-shaped records with bad `tt.*` content.
- Add/update CLI boundary tests in `tailtriage-cli/tests/cli_boundary.rs` to verify guidance appears for wrapper-shape mismatches and does not appear for semantic failures inside a valid wrapper.

### Testing
- Searches performed (no public `auto` reintroduced; wrapper examples remain documented):
  - `rg -n -- '--input-format auto'` → no matches.
  - `rg -n 'TracingInputFormat::Auto'` → no matches.
  - `rg -n '`auto`'` → no matches.
  - `rg -n 'auto mode'` → no matches.
  - `rg -n -- '--input-format tailtriage-span-jsonl'` → no matches (docs/examples use implicit/default wrapper or `compatible` where appropriate).
  - `rg -n 'tailtriage import tracing-json'` → matches only in docs/examples/help as expected.
- Files changed: `tailtriage-tracing/src/error.rs`, `tailtriage-tracing/src/jsonl.rs`, `tailtriage-cli/src/main.rs`, `tailtriage-cli/tests/cli_boundary.rs`.
- Commands run and results:
  - `cargo fmt --check` → initially reported formatting diffs; `cargo fmt` was run to apply changes and final `cargo fmt --check` passed.
  - `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` → passed (no warnings).
  - `cargo test --workspace --all-targets --all-features --locked` → passed (all workspace tests passed in final run).
  - `python3 scripts/validate_docs_contracts.py` → passed (docs contracts validated successfully).
- Unit tests added/updated and their behavior: tracing JSONL tests now assert `ExpectedTailtriageWrapper` for wrapper-shape mismatch cases, `MalformedJsonLine` preserved for malformed JSON, and semantic errors still surface without wrapper guidance; CLI boundary tests validate guidance presence/absence accordingly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a140683bebc8330bd81fbea48cf1b4e)