### PR TITLE
Narrow wrapper-only CLI guidance to wrapper-shape import failures

### DIFF
--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -261,14 +261,30 @@ fn tracing_json_setup_guidance() -> &'static str {
 }
 
 fn should_append_wrapper_guidance(input_format: TracingInputFormat, err: &ImportError) -> bool {
-    matches!(input_format, TracingInputFormat::TailtriageSpanJsonl)
-        && matches!(
-            err,
-            ImportError::MissingField(_)
-                | ImportError::InvalidField { .. }
-                | ImportError::StrictViolation(_)
-                | ImportError::InvalidRunEvent(_)
-        )
+    if !matches!(input_format, TracingInputFormat::TailtriageSpanJsonl) {
+        return false;
+    }
+
+    match err {
+        ImportError::MissingField(field) => *field == "format" || *field == "span",
+        ImportError::InvalidField { field, reason } => {
+            (*field == "format" || *field == "span")
+                && (reason.contains("tailtriage.tracing-span.v1")
+                    || reason.contains("wrapper")
+                    || reason.contains("expected object")
+                    || reason.contains("expected string"))
+        }
+        ImportError::StrictViolation(message) => {
+            message.contains("expected stable wrapper shape")
+                || message.contains("unsupported span format marker")
+                || message.contains("missing field 'span' for tailtriage.tracing-span.v1 wrapper")
+                || message.contains(
+                    "invalid field 'span': expected completed span object for tailtriage.tracing-span.v1",
+                )
+                || message.contains("invalid field 'format': expected string format marker")
+        }
+        _ => false,
+    }
 }
 
 fn wrapper_only_rejection_guidance() -> &'static str {

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -513,6 +513,33 @@ fn import_tracing_json_default_rejects_fmt_json_with_guidance() {
 }
 
 #[test]
+fn import_tracing_json_default_wrapper_mode_wrong_top_level_format_includes_wrapper_guidance() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("wrong-format.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(
+        &spans_path,
+        r#"{"format":"wrong.format.marker","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok"}}}"#,
+    )
+    .unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("tailtriage.tracing-span.v1"));
+    assert!(stderr.contains("tracing_subscriber::fmt().json() logs are unsupported"));
+    assert!(!run_path.exists(), "run output should not be written");
+}
+
+#[test]
 fn import_tracing_json_compatible_accepts_fmt_like_record_with_top_level_explicit_timestamps() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("compatible.jsonl");
@@ -641,6 +668,70 @@ fn import_tracing_json_strict_fails_on_incomplete_tailtriage_span() {
         !run_path.exists(),
         "run output should not exist on strict failure"
     );
+}
+
+#[test]
+fn import_tracing_json_wrapper_mode_strict_missing_route_does_not_append_wrapper_guidance() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("missing-route.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(
+        &spans_path,
+        r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1"}}}"#,
+    )
+    .expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--strict")
+        .output()
+        .expect("cli should run");
+
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(
+        stderr.contains("missing required field"),
+        "stderr: {stderr}"
+    );
+    assert!(!stderr.contains("stable wrapper"));
+    assert!(!stderr.contains("tracing_subscriber::fmt().json()"));
+}
+
+#[test]
+fn import_tracing_json_wrapper_mode_strict_invalid_kind_type_does_not_append_wrapper_guidance() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("invalid-kind-type.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(
+        &spans_path,
+        r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":7,"tt.request_id":"r1","tt.route":"/ok"}}}"#,
+    )
+    .expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--strict")
+        .output()
+        .expect("cli should run");
+
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(
+        stderr.contains("invalid field 'tt.kind'"),
+        "stderr: {stderr}"
+    );
+    assert!(!stderr.contains("stable wrapper"));
+    assert!(!stderr.contains("tracing_subscriber::fmt().json()"));
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- The CLI was appending wrapper-only guidance too broadly for parsing errors that can equally arise from valid wrapper-shaped records with semantic tt.* problems, which misleads users about using `tracing_subscriber::fmt().json()` logs.
- The goal is to conservatively append the wrapper-shape guidance only when the import error clearly indicates a wrapper-level shape mismatch.

### Description
- Replaced `should_append_wrapper_guidance` in `tailtriage-cli/src/main.rs` with a narrow classifier that returns true only in `TracingInputFormat::TailtriageSpanJsonl` and when the `ImportError` specifically identifies top-level wrapper `format`/`span` shape issues (`MissingField("format"|"span")`, `InvalidField` for `format`/`span` with wrapper-specific reason text, or `StrictViolation` messages that indicate wrapper-shape problems).
- Kept existing fallback behavior for `ensure_persistable_run_has_requests(...)` unchanged so default wrapper-mode zero-request rejections still append wrapper guidance as before.
- Added/updated CLI boundary tests in `tailtriage-cli/tests/cli_boundary.rs` covering: unwrapped/fmt-like rejection with wrapper guidance; wrong top-level `format` marker includes wrapper guidance; valid wrapper shape but strict semantic missing-field or invalid-field type fail with semantic messages and do not include wrapper guidance.
- No new `ImportError` variant, input-format values, aliases, dependencies, or public CLI surface changes were introduced.

### Testing
- Searches performed: `--input-format auto`, `TracingInputFormat::Auto`, `` `auto` ``, `auto mode`, `--input-format tailtriage-span-jsonl`, and `tailtriage import tracing-json` were searched repository-wide to detect stale references.
- Files changed: `tailtriage-cli/src/main.rs` and `tailtriage-cli/tests/cli_boundary.rs`.
- Commands run and results: `cargo fmt --check` — passed; `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — passed; `cargo test --workspace --all-targets --all-features --locked` — passed; `python3 scripts/validate_docs_contracts.py` — passed.
- New/updated tests exercised: CLI boundary tests in `tailtriage-cli/tests/cli_boundary.rs` covering the four required scenarios (A–D) and all workspace tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14089cf770833096aee24e83f3e343)