### PR TITLE
Narrow wrapper-only CLI guidance to wrapper-shape mismatches

### DIFF
--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -261,14 +261,21 @@ fn tracing_json_setup_guidance() -> &'static str {
 }
 
 fn should_append_wrapper_guidance(input_format: TracingInputFormat, err: &ImportError) -> bool {
-    matches!(input_format, TracingInputFormat::TailtriageSpanJsonl)
-        && matches!(
-            err,
-            ImportError::MissingField(_)
-                | ImportError::InvalidField { .. }
-                | ImportError::StrictViolation(_)
-                | ImportError::InvalidRunEvent(_)
-        )
+    if !matches!(input_format, TracingInputFormat::TailtriageSpanJsonl) {
+        return false;
+    }
+
+    match err {
+        ImportError::MissingField(field) => *field == "format" || *field == "span",
+        ImportError::InvalidField { field, reason } => {
+            (*field == "format" || *field == "span")
+                && (reason.contains("tailtriage.tracing-span.v1")
+                    || reason.contains("wrapper")
+                    || reason.contains("expected object")
+                    || reason.contains("expected string"))
+        }
+        _ => false,
+    }
 }
 
 fn wrapper_only_rejection_guidance() -> &'static str {

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -436,7 +436,7 @@ fn import_tracing_json_input_format_tailtriage_wrapper_only_rejects_unwrapped() 
     assert!(!output.status.success());
     let stderr = String::from_utf8(output.stderr).unwrap();
     assert!(stderr.contains("tailtriage.tracing-span.v1") || stderr.contains("stable wrapper"));
-    assert!(!stderr.contains("ordinary tracing log JSON"));
+    assert!(stderr.contains("tracing_subscriber::fmt().json() logs are unsupported"));
     assert!(!run_path.exists());
 }
 
@@ -509,6 +509,86 @@ fn import_tracing_json_default_rejects_fmt_json_with_guidance() {
     assert!(stderr.contains("stable wrapper shape"));
     assert!(stderr.contains("tailtriage.tracing-span.v1"));
     assert!(stderr.contains("tracing_subscriber::fmt().json() logs are unsupported"));
+    assert!(!run_path.exists());
+}
+
+#[test]
+fn import_tracing_json_default_wrapper_mode_wrong_wrapper_format_shows_wrapper_guidance() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("wrong-format.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(
+        &spans_path,
+        r#"{"format":"tailtriage.tracing-span.v2","span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout"}}}"#,
+    )
+    .expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("tailtriage.tracing-span.v1") || stderr.contains("stable wrapper"));
+    assert!(!run_path.exists());
+}
+
+#[test]
+fn import_tracing_json_default_wrapper_mode_strict_missing_route_does_not_append_wrapper_guidance()
+{
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("missing-route.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, strict_wrapper_missing_route_fixture())
+        .expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--strict")
+        .output()
+        .expect("cli should run");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("strict violation") || stderr.contains("missing required field"));
+    assert!(!stderr.contains("tailtriage.tracing-span.v1"));
+    assert!(!stderr.contains("tracing_subscriber::fmt().json()"));
+    assert!(!run_path.exists());
+}
+
+#[test]
+fn import_tracing_json_default_wrapper_mode_strict_invalid_kind_type_does_not_append_wrapper_guidance(
+) {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("invalid-kind.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, strict_wrapper_invalid_kind_type_fixture())
+        .expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--strict")
+        .output()
+        .expect("cli should run");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("strict violation") || stderr.contains("invalid field"));
+    assert!(!stderr.contains("tailtriage.tracing-span.v1"));
+    assert!(!stderr.contains("tracing_subscriber::fmt().json()"));
     assert!(!run_path.exists());
 }
 
@@ -1041,4 +1121,12 @@ fn mixed_valid_and_unknown_kind_fixture() -> &'static str {
     r#"{"span":{"name":"unknown","started_at_unix_ms":1000,"finished_at_unix_ms":1005,"fields":{"tt.kind":"mystery"}}}
 {"span":{"name":"http.request","started_at_unix_ms":1020,"finished_at_unix_ms":1032,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout","tt.outcome":"ok"}}}
 "#
+}
+
+fn strict_wrapper_missing_route_fixture() -> &'static str {
+    r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1"}}}"#
+}
+
+fn strict_wrapper_invalid_kind_type_fixture() -> &'static str {
+    r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":42,"tt.request_id":"req-1","tt.route":"/checkout"}}}"#
 }


### PR DESCRIPTION
### Motivation
- Prevent misleading wrapper-only CLI guidance from being appended for semantic/field-level errors that can occur inside a valid wrapper record, by only appending wrapper guidance when the error clearly indicates a top-level wrapper-shape mismatch; do not add a new `ImportError` variant.

### Description
- Replace `should_append_wrapper_guidance` in `tailtriage-cli/src/main.rs` with a conservative classifier that returns true only for `TracingInputFormat::TailtriageSpanJsonl` combined with `ImportError::MissingField(field)` when `field` is `"format"` or `"span"`, or `ImportError::InvalidField { field, reason }` when `field` is `"format"` or `"span"` and `reason` contains wrapper-specific tokens such as `tailtriage.tracing-span.v1`, `wrapper`, `expected object`, or `expected string`.
- Preserve the existing `ensure_persistable_run_has_requests(...)` special-case behavior that may append wrapper guidance for zero-request persisted-artifact rejection in default wrapper mode.
- Update `tailtriage-cli/tests/cli_boundary.rs` to add/adjust boundary tests so wrapper guidance is present for unwrapped/default-wrapper and wrong-wrapper-format inputs, and absent for strict semantic errors (missing `tt.route` and non-string `tt.kind`), plus add small strict-wrapper fixtures used by the new tests.
- No new dependencies, no new `ImportError` variants, and no changes to public CLI surface beyond adjusting when wrapper guidance is appended.

### Testing
- Searches performed: `rg -n -- '--input-format auto'` (no matches), `rg -n 'TracingInputFormat::Auto'` (no matches), `rg -n '\`auto\`'` (no matches), `rg -n 'auto mode'` (no matches), `rg -n -- '--input-format tailtriage-span-jsonl'` (no matches), and `rg -n 'tailtriage import tracing-json'` (matches found only in docs/readmes as expected).
- Files changed: `tailtriage-cli/src/main.rs` and `tailtriage-cli/tests/cli_boundary.rs`.
- Commands run and results: `cargo fmt --check` — passed; `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — passed; `cargo test --workspace --all-targets --all-features --locked` — passed (all tests green); `python3 scripts/validate_docs_contracts.py` — passed.
- CLI boundary tests added/updated and executed as part of `cargo test`, and the suite confirmed wrapper guidance appears only for wrapper-shape mismatch cases while strict semantic errors do not append wrapper guidance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14089cf770833096aee24e83f3e343)