### PR TITLE
Validate tracing tt.outcome labels during import

### DIFF
--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -237,6 +237,8 @@ fn import_tracing_json_writes_run_json_analyzable_by_existing_apis() {
         .arg("checkout")
         .arg("--output")
         .arg(&run_path)
+        .arg("--input-format")
+        .arg("compatible")
         .output()
         .expect("cli should run");
 
@@ -265,6 +267,8 @@ fn import_tracing_json_writes_run_json_when_output_path_contains_spaces() {
         .arg("checkout")
         .arg("--output")
         .arg(&run_path)
+        .arg("--input-format")
+        .arg("compatible")
         .output()
         .expect("cli should run");
 
@@ -476,6 +480,8 @@ fn import_tracing_json_default_wrapper_mode_semantic_missing_route_no_wrapper_gu
         .arg("checkout")
         .arg("--output")
         .arg(&run_path)
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--strict")
         .output()
         .unwrap();
@@ -499,6 +505,8 @@ fn import_tracing_json_default_wrapper_mode_semantic_invalid_kind_type_no_wrappe
         .arg("checkout")
         .arg("--output")
         .arg(&run_path)
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--strict")
         .output()
         .unwrap();
@@ -879,6 +887,81 @@ fn import_tracing_json_fails_when_non_strict_skips_all_malformed_tt_spans() {
 }
 
 #[test]
+fn import_tracing_json_invalid_outcome_non_strict_warns_then_fails_zero_request_artifact() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, invalid_outcome_only_fixture()).expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("invalid field 'tt.outcome'"));
+    assert!(stderr.contains("expected one of ok,error,timeout,cancelled,rejected"));
+    assert!(stderr.contains("zero request events"));
+    assert!(!run_path.exists(), "run output should not be written");
+}
+
+#[test]
+fn import_tracing_json_invalid_outcome_strict_fails_with_invalid_outcome_message() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, invalid_outcome_only_fixture()).expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--strict")
+        .output()
+        .expect("cli should run");
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("invalid field 'tt.outcome'"));
+    assert!(stderr.contains("expected one of ok,error,timeout,cancelled,rejected"));
+    assert!(!run_path.exists(), "run output should not be written");
+}
+
+#[test]
+fn import_tracing_json_valid_outcomes_import_successfully() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, valid_outcomes_fixture()).expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--input-format")
+        .arg("compatible")
+        .output()
+        .expect("cli should run");
+    assert!(
+        output.status.success(),
+        "cli unexpectedly failed: {output:?}"
+    );
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
+        .expect("imported run should load in cli loader");
+    assert_eq!(loaded.run.requests.len(), 5);
+}
+
+#[test]
 fn import_tracing_json_fails_when_only_tt_spans_are_missing_kind() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
@@ -1108,5 +1191,19 @@ fn only_missing_kind_tailtriage_spans_fixture() -> &'static str {
 fn mixed_valid_and_unknown_kind_fixture() -> &'static str {
     r#"{"span":{"name":"unknown","started_at_unix_ms":1000,"finished_at_unix_ms":1005,"fields":{"tt.kind":"mystery"}}}
 {"span":{"name":"http.request","started_at_unix_ms":1020,"finished_at_unix_ms":1032,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout","tt.outcome":"ok"}}}
+"#
+}
+
+fn invalid_outcome_only_fixture() -> &'static str {
+    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"sucess"}}}
+"#
+}
+
+fn valid_outcomes_fixture() -> &'static str {
+    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}
+{"span":{"name":"http.request","started_at_unix_ms":1011,"finished_at_unix_ms":1020,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout","tt.outcome":"error"}}}
+{"span":{"name":"http.request","started_at_unix_ms":1021,"finished_at_unix_ms":1030,"fields":{"tt.kind":"request","tt.request_id":"req-3","tt.route":"/checkout","tt.outcome":"timeout"}}}
+{"span":{"name":"http.request","started_at_unix_ms":1031,"finished_at_unix_ms":1040,"fields":{"tt.kind":"request","tt.request_id":"req-4","tt.route":"/checkout","tt.outcome":"cancelled"}}}
+{"span":{"name":"http.request","started_at_unix_ms":1041,"finished_at_unix_ms":1050,"fields":{"tt.kind":"request","tt.request_id":"req-5","tt.route":"/checkout","tt.outcome":"rejected"}}}
 "#
 }

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -104,7 +104,7 @@ Ordinary tracing log JSON (for example `fmt().json` output) is rejected by impor
 
 | Span kind | Required fields | Optional fields |
 | --- | --- | --- |
-| request | `tt.kind="request"`, `tt.request_id`, `tt.route` | `tt.outcome` |
+| request | `tt.kind="request"`, `tt.request_id`, `tt.route` | `tt.outcome` (`ok` \| `error` \| `timeout` \| `cancelled` \| `rejected`) |
 | stage | `tt.kind="stage"`, `tt.request_id`, `tt.stage` | `tt.success` |
 | queue | `tt.kind="queue"`, `tt.request_id`, `tt.queue` | `tt.depth_at_start` |
 

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -59,6 +59,9 @@ pub use recorder::{
 };
 pub use types::{FieldValue, ImportOptions, ImportWarning, ImportedRun, SpanKind, SpanRecord};
 
+const ACCEPTED_OUTCOME_VALUES: [&str; 5] = ["ok", "error", "timeout", "cancelled", "rejected"];
+const ACCEPTED_OUTCOME_VALUES_CSV: &str = "ok,error,timeout,cancelled,rejected";
+
 /// Ensures a run is suitable for persisted Run JSON artifacts intended for CLI analysis.
 ///
 /// # Errors
@@ -708,7 +711,21 @@ fn parse_outcome(
 ) -> Result<Option<(String, bool)>, ImportError> {
     match get_string_field_state(span, TT_OUTCOME) {
         StringFieldState::Missing => Ok(Some(("ok".to_owned(), true))),
-        StringFieldState::Value(value) => Ok(Some((value.to_owned(), false))),
+        StringFieldState::Value(value) => {
+            if ACCEPTED_OUTCOME_VALUES.contains(&value) {
+                Ok(Some((value.to_owned(), false)))
+            } else {
+                strict_or_warn(
+                    strict,
+                    warnings,
+                    format!(
+                        "invalid field '{TT_OUTCOME}' in span '{}': expected one of {ACCEPTED_OUTCOME_VALUES_CSV}, got '{value}'",
+                        span.name()
+                    ),
+                )?;
+                Ok(None)
+            }
+        }
         StringFieldState::InvalidType => {
             strict_or_warn(
                 strict,
@@ -1834,6 +1851,102 @@ mod tests {
             run_from_span_records(vec![bad_outcome], ImportOptions::new("svc").strict(true))
                 .is_err()
         );
+    }
+
+    #[test]
+    fn request_outcome_accepts_only_supported_values() {
+        for accepted in ACCEPTED_OUTCOME_VALUES {
+            let span = SpanRecord::new("http.request", 10, 20)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/")
+                .field(TT_OUTCOME, accepted);
+            let imported = run_from_span_records(vec![span], ImportOptions::new("svc")).unwrap();
+            assert_eq!(imported.run().requests.len(), 1);
+            assert_eq!(imported.run().requests[0].outcome, accepted);
+        }
+    }
+
+    #[test]
+    fn request_outcome_missing_defaults_to_ok_with_warning() {
+        let span = SpanRecord::new("http.request", 10, 20)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/");
+        let imported = run_from_span_records(vec![span], ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].outcome, "ok");
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("missing optional 'tt.outcome'; assumed 'ok'")));
+    }
+
+    #[test]
+    fn invalid_request_outcome_non_strict_warns_and_skips_request() {
+        let span = SpanRecord::new("http.request", 10, 20)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")
+            .field(TT_OUTCOME, "sucess");
+        let imported = run_from_span_records(vec![span], ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        let warning = imported.warnings()[0].message();
+        assert!(warning.contains("got 'sucess'"));
+        assert!(warning.contains("span 'http.request'"));
+        assert!(warning.contains(ACCEPTED_OUTCOME_VALUES_CSV));
+    }
+
+    #[test]
+    fn invalid_request_outcome_strict_fails() {
+        let span = SpanRecord::new("http.request", 10, 20)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")
+            .field(TT_OUTCOME, "sucess");
+        let err =
+            run_from_span_records(vec![span], ImportOptions::new("svc").strict(true)).unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(err.to_string().contains(ACCEPTED_OUTCOME_VALUES_CSV));
+    }
+
+    #[test]
+    fn request_outcome_whitespace_is_invalid() {
+        let span = SpanRecord::new("http.request", 10, 20)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")
+            .field(TT_OUTCOME, "ok ");
+        let imported = run_from_span_records(vec![span], ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.warnings()[0].message().contains("got 'ok '"));
+    }
+
+    #[test]
+    fn invalid_request_outcome_skips_child_spans_via_correlation_logic() {
+        let spans = vec![
+            SpanRecord::new("http.request", 10, 20)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/")
+                .field(TT_OUTCOME, "bad"),
+            SpanRecord::new("db-stage", 11, 19)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db")
+                .field(TT_SUCCESS, true),
+            SpanRecord::new("queue-stage", 12, 18)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits")
+                .field(TT_DEPTH_AT_START, 4_u64),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.run().stages.is_empty());
+        assert!(imported.run().queues.is_empty());
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("no retained request event was imported")));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent arbitrary strings from being accepted for request `tt.outcome` and enforce a fixed, well-known set of outcome labels to avoid drift and incorrect downstream triage.
- Keep parsing, warning text, and tests tied to a single source of truth so behavior cannot diverge.

### Description
- Add a single shared allowlist `ACCEPTED_OUTCOME_VALUES` and `ACCEPTED_OUTCOME_VALUES_CSV` in `tailtriage-tracing/src/lib.rs` and use it to validate `tt.outcome` during import. 
- Make `tt.outcome` parsing accept only the exact labels `ok`, `error`, `timeout`, `cancelled`, `rejected`; missing `tt.outcome` still defaults to `ok` and preserves the existing missing-optional warning behavior. 
- On invalid `tt.outcome`, non-strict mode emits a lifecycle warning and the request span is skipped (child spans then follow existing correlation/drop logic), and strict mode returns `ImportError::StrictViolation(...)` with a diagnostic message including the invalid value, span name, and accepted values. 
- Add unit tests to `tailtriage-tracing/src/lib.rs` that cover the five accepted values, missing default behavior, strict/non-strict invalid handling, whitespace-rejection, and children being skipped when the parent request is skipped; add CLI boundary tests in `tailtriage-cli/tests/cli_boundary.rs` for non-strict warning + zero-request artifact, strict failure, and valid-outcome success; update tracing README documentation to list the accepted labels.

### Testing
- Commands run exactly as requested:
  - `cargo fmt --check` — passed.
  - `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — passed.
  - `cargo test --workspace --all-targets --all-features --locked` — executed but the workspace test run failed due to an unrelated analyzer integration test failing (`tailtriage-analyzer/tests/end_to_end_capture_analysis.rs::queue_and_stage_data_drives_ranked_suspects` expected `application_queue_saturation` but observed `downstream_stage_dominates`), so the full test sequence did not fully succeed.
  - `python3 scripts/validate_docs_contracts.py` — not reached in the chained run because the prior `cargo test` step failed.
- CLI-level verification (invoked directly while iterating) showed the expected invalid-outcome warning message shape when importing a single invalid span: `warning: invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'sucess'` and the CLI returned nonzero exit status for zero-request output cases.
- Summary: formatting and lints are clean; import parsing and tests for `tt.outcome` pass in the tracing crate and CLI boundary tests added, but the overall workspace test run failed because of an existing/non-deterministic analyzer test unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1419cb8668833081573bd23ea8e3ea)