### PR TITLE
Validate tracing import tt.outcome values

### DIFF
--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -906,6 +906,96 @@ fn import_tracing_json_fails_when_only_tt_spans_are_missing_kind() {
 }
 
 #[test]
+fn import_tracing_json_invalid_outcome_non_strict_warns_and_fails_zero_request_artifact() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, invalid_outcome_only_fixture()).expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--input-format")
+        .arg("compatible")
+        .output()
+        .expect("cli should run");
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains(
+        "invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'sucess'"
+    ));
+    assert!(stderr.contains("zero request events"));
+    assert!(!run_path.exists(), "run output should not be written");
+}
+
+#[test]
+fn import_tracing_json_invalid_outcome_strict_fails_with_invalid_outcome_message() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, invalid_outcome_only_fixture()).expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--strict")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--input-format")
+        .arg("compatible")
+        .output()
+        .expect("cli should run");
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains(
+        "invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'sucess'"
+    ));
+    assert!(!run_path.exists(), "run output should not be written");
+}
+
+#[test]
+fn import_tracing_json_valid_outcomes_import_successfully() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, all_valid_outcomes_fixture()).expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--input-format")
+        .arg("compatible")
+        .output()
+        .expect("cli should run");
+    assert!(
+        output.status.success(),
+        "cli unexpectedly failed: {output:?}"
+    );
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
+        .expect("imported run should load in cli loader");
+    let outcomes: Vec<&str> = loaded
+        .run
+        .requests
+        .iter()
+        .map(|request| request.outcome.as_str())
+        .collect();
+    assert_eq!(
+        outcomes,
+        vec!["ok", "error", "timeout", "cancelled", "rejected"]
+    );
+}
+
+#[test]
 fn import_tracing_json_warns_for_tt_fields_missing_kind_and_still_writes_run() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
@@ -1070,6 +1160,20 @@ fn incomplete_tailtriage_span_fixture() -> &'static str {
 
 fn one_valid_request_span_fixture() -> &'static str {
     r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}
+"#
+}
+
+fn invalid_outcome_only_fixture() -> &'static str {
+    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"sucess"}}}
+"#
+}
+
+fn all_valid_outcomes_fixture() -> &'static str {
+    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}
+{"span":{"name":"http.request","started_at_unix_ms":1011,"finished_at_unix_ms":1020,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout","tt.outcome":"error"}}}
+{"span":{"name":"http.request","started_at_unix_ms":1021,"finished_at_unix_ms":1030,"fields":{"tt.kind":"request","tt.request_id":"req-3","tt.route":"/checkout","tt.outcome":"timeout"}}}
+{"span":{"name":"http.request","started_at_unix_ms":1031,"finished_at_unix_ms":1040,"fields":{"tt.kind":"request","tt.request_id":"req-4","tt.route":"/checkout","tt.outcome":"cancelled"}}}
+{"span":{"name":"http.request","started_at_unix_ms":1041,"finished_at_unix_ms":1050,"fields":{"tt.kind":"request","tt.request_id":"req-5","tt.route":"/checkout","tt.outcome":"rejected"}}}
 "#
 }
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -108,6 +108,9 @@ Ordinary tracing log JSON (for example `fmt().json` output) is rejected by impor
 | stage | `tt.kind="stage"`, `tt.request_id`, `tt.stage` | `tt.success` |
 | queue | `tt.kind="queue"`, `tt.request_id`, `tt.queue` | `tt.depth_at_start` |
 
+Request `tt.outcome` accepts only: `ok`, `error`, `timeout`, `cancelled`, `rejected`.
+Missing `tt.outcome` defaults to `ok` with a warning.
+
 ## Strict vs non-strict
 
 - Strict mode: malformed/incomplete `tt.*` span records fail import/session conversion.

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -585,6 +585,8 @@ fn required_string(
 }
 
 pub(crate) const DURATION_TOLERANCE_US: u64 = 2_000;
+const ACCEPTED_OUTCOME_LABELS: [&str; 5] = ["ok", "error", "timeout", "cancelled", "rejected"];
+const ACCEPTED_OUTCOME_LABELS_CSV: &str = "ok,error,timeout,cancelled,rejected";
 
 pub(crate) fn duration_within_tolerance(
     duration_us: u64,
@@ -708,7 +710,21 @@ fn parse_outcome(
 ) -> Result<Option<(String, bool)>, ImportError> {
     match get_string_field_state(span, TT_OUTCOME) {
         StringFieldState::Missing => Ok(Some(("ok".to_owned(), true))),
-        StringFieldState::Value(value) => Ok(Some((value.to_owned(), false))),
+        StringFieldState::Value(value) => {
+            if ACCEPTED_OUTCOME_LABELS.contains(&value) {
+                Ok(Some((value.to_owned(), false)))
+            } else {
+                strict_or_warn(
+                    strict,
+                    warnings,
+                    format!(
+                        "invalid field '{TT_OUTCOME}' in span '{}': expected one of {ACCEPTED_OUTCOME_LABELS_CSV}, got '{value}'",
+                        span.name()
+                    ),
+                )?;
+                Ok(None)
+            }
+        }
         StringFieldState::InvalidType => {
             strict_or_warn(
                 strict,
@@ -1834,6 +1850,97 @@ mod tests {
             run_from_span_records(vec![bad_outcome], ImportOptions::new("svc").strict(true))
                 .is_err()
         );
+    }
+
+    #[test]
+    fn request_outcome_accepts_only_supported_values() {
+        for outcome in ACCEPTED_OUTCOME_LABELS {
+            let spans = vec![SpanRecord::new("req", 1, 2)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/")
+                .field(TT_OUTCOME, outcome)];
+            let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+            assert_eq!(imported.run().requests.len(), 1);
+            assert_eq!(imported.run().requests[0].outcome, outcome);
+        }
+    }
+
+    #[test]
+    fn missing_request_outcome_defaults_to_ok_with_warning() {
+        let spans = vec![SpanRecord::new("req", 1, 2)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests[0].outcome, "ok");
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("missing optional 'tt.outcome'; assumed 'ok'")));
+    }
+
+    #[test]
+    fn invalid_outcome_non_strict_warns_and_skips_request() {
+        let bad = SpanRecord::new("http.request", 1, 2)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")
+            .field(TT_OUTCOME, "sucess");
+        let imported = run_from_span_records(vec![bad], ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.warnings().iter().any(|w| w.message().contains(
+            "invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'sucess'"
+        )));
+    }
+
+    #[test]
+    fn invalid_outcome_strict_fails() {
+        let bad = SpanRecord::new("http.request", 1, 2)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")
+            .field(TT_OUTCOME, "bad");
+        let err =
+            run_from_span_records(vec![bad], ImportOptions::new("svc").strict(true)).unwrap_err();
+        assert!(
+            matches!(err, ImportError::StrictViolation(message) if message.contains("invalid field 'tt.outcome'"))
+        );
+    }
+
+    #[test]
+    fn invalid_outcome_with_whitespace_is_rejected() {
+        let bad = SpanRecord::new("http.request", 1, 2)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")
+            .field(TT_OUTCOME, "ok ");
+        let imported = run_from_span_records(vec![bad], ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("got 'ok '")));
+    }
+
+    #[test]
+    fn invalid_outcome_request_causes_child_spans_to_skip_via_correlation_behavior() {
+        let spans = vec![
+            SpanRecord::new("http.request", 10, 20)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/")
+                .field(TT_OUTCOME, "sucess"),
+            SpanRecord::new("stage", 11, 12)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.run().stages.is_empty());
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("no retained request event was imported")));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Enforce the tracing convention that request `tt.outcome` only accepts the explicit labels used by triage logic so parsing, warnings, and errors are deterministic and cannot drift. 
- Preserve existing behavior for missing outcomes (default to `ok` and emit the aggregated warning) while making invalid labels surfaced precisely and handled by strict/non-strict modes.

### Description
- Added shared constants `ACCEPTED_OUTCOME_LABELS` and `ACCEPTED_OUTCOME_LABELS_CSV` in `tailtriage-tracing/src/lib.rs` and updated `parse_outcome` to accept only those five exact values: `ok`, `error`, `timeout`, `cancelled`, `rejected`.
- Invalid non-string outcome still triggers the existing invalid-type handling, invalid recognized-string outcome now in non-strict mode emits a warning with the invalid value, span name, and accepted CSV and skips the request, and in strict mode returns `ImportError::StrictViolation(...)` with the same message shape.
- Added unit tests in `tailtriage-tracing/src/lib.rs` that verify accepted outcomes, missing defaulting-with-warning, non-strict skip + warning on invalid labels, strict-mode failure, rejection of whitespace variants, and that child spans are skipped via existing correlation logic when the request is skipped.
- Added CLI boundary tests in `tailtriage-cli/tests/cli_boundary.rs` to validate non-strict invalid-outcome warning + zero-request artifact behavior, strict-mode failure with the invalid message, and successful import of all valid outcomes; and updated `tailtriage-tracing/README.md` to document the accepted values and missing-default behavior.

### Testing
- Ran `cargo fmt --check` which initially reported formatting diffs, then ran `cargo fmt` to apply formatting fixes, and rechecked formatting successfully (exit code 0).
- Ran the combined verification command `cargo fmt --check && cargo clippy --workspace --all-targets --all-features --locked -- -D warnings && cargo test --workspace --all-targets --all-features --locked && python3 scripts/validate_docs_contracts.py` and it completed successfully with `cargo clippy` reporting no warnings and `cargo test` finishing with all tests passing (no failures), and `python3 scripts/validate_docs_contracts.py` validating the docs contract.
- The added unit tests and CLI boundary tests ran as part of `cargo test` and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1419cb8668833081573bd23ea8e3ea)