### PR TITLE
Validate tracing import tt.outcome values and enforce bounded labels

### DIFF
--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -1030,6 +1030,89 @@ fn import_tracing_json_persists_optional_default_assumption_warnings_in_run_arti
     assert_eq!(report.request_count, 1);
 }
 
+#[test]
+fn import_tracing_json_invalid_outcome_non_strict_warns_and_fails_zero_request() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, invalid_outcome_only_fixture()).expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("warning:"));
+    assert!(stderr.contains(
+        "invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'sucess'"
+    ));
+    assert!(stderr.contains("zero request events"));
+}
+
+#[test]
+fn import_tracing_json_invalid_outcome_strict_fails_with_message() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, invalid_outcome_only_fixture()).expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--strict")
+        .output()
+        .expect("cli should run");
+
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains(
+        "invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'sucess'"
+    ));
+}
+
+#[test]
+fn import_tracing_json_valid_outcomes_import_successfully() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, valid_outcomes_fixture()).expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+    assert!(output.status.success(), "cli failed: {output:?}");
+
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
+        .expect("imported run should load in cli loader");
+    let outcomes = loaded
+        .run
+        .requests
+        .iter()
+        .map(|request| request.outcome.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        outcomes,
+        vec!["ok", "error", "timeout", "cancelled", "rejected"]
+    );
+}
+
 fn valid_cli_artifact_with_requests() -> &'static str {
     r#"{"schema_version":1,"metadata":{"run_id":"r1","service_name":"svc","service_version":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"mode":"light","host":null,"pid":null,"lifecycle_warnings":[],"unfinished_requests":{"count":0,"sample":[]}},"requests":[{"request_id":"req1","route":"/","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":10,"outcome":"ok"}],"stages":[],"queues":[],"inflight":[],"runtime_snapshots":[]}"#
 }
@@ -1108,5 +1191,19 @@ fn only_missing_kind_tailtriage_spans_fixture() -> &'static str {
 fn mixed_valid_and_unknown_kind_fixture() -> &'static str {
     r#"{"span":{"name":"unknown","started_at_unix_ms":1000,"finished_at_unix_ms":1005,"fields":{"tt.kind":"mystery"}}}
 {"span":{"name":"http.request","started_at_unix_ms":1020,"finished_at_unix_ms":1032,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout","tt.outcome":"ok"}}}
+"#
+}
+
+fn invalid_outcome_only_fixture() -> &'static str {
+    r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"sucess"}}}
+"#
+}
+
+fn valid_outcomes_fixture() -> &'static str {
+    r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"http.request-1","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}
+{"format":"tailtriage.tracing-span.v1","span":{"name":"http.request-2","started_at_unix_ms":1010,"finished_at_unix_ms":1020,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout","tt.outcome":"error"}}}
+{"format":"tailtriage.tracing-span.v1","span":{"name":"http.request-3","started_at_unix_ms":1020,"finished_at_unix_ms":1030,"fields":{"tt.kind":"request","tt.request_id":"req-3","tt.route":"/checkout","tt.outcome":"timeout"}}}
+{"format":"tailtriage.tracing-span.v1","span":{"name":"http.request-4","started_at_unix_ms":1030,"finished_at_unix_ms":1040,"fields":{"tt.kind":"request","tt.request_id":"req-4","tt.route":"/checkout","tt.outcome":"cancelled"}}}
+{"format":"tailtriage.tracing-span.v1","span":{"name":"http.request-5","started_at_unix_ms":1040,"finished_at_unix_ms":1050,"fields":{"tt.kind":"request","tt.request_id":"req-5","tt.route":"/checkout","tt.outcome":"rejected"}}}
 "#
 }

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -104,7 +104,7 @@ Ordinary tracing log JSON (for example `fmt().json` output) is rejected by impor
 
 | Span kind | Required fields | Optional fields |
 | --- | --- | --- |
-| request | `tt.kind="request"`, `tt.request_id`, `tt.route` | `tt.outcome` |
+| request | `tt.kind="request"`, `tt.request_id`, `tt.route` | `tt.outcome` (`ok`, `error`, `timeout`, `cancelled`, or `rejected`) |
 | stage | `tt.kind="stage"`, `tt.request_id`, `tt.stage` | `tt.success` |
 | queue | `tt.kind="queue"`, `tt.request_id`, `tt.queue` | `tt.depth_at_start` |
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -108,6 +108,8 @@ Ordinary tracing log JSON (for example `fmt().json` output) is rejected by impor
 | stage | `tt.kind="stage"`, `tt.request_id`, `tt.stage` | `tt.success` |
 | queue | `tt.kind="queue"`, `tt.request_id`, `tt.queue` | `tt.depth_at_start` |
 
+Missing request `tt.outcome` defaults to `ok` with a warning.
+
 ## Strict vs non-strict
 
 - Strict mode: malformed/incomplete `tt.*` span records fail import/session conversion.

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -701,6 +701,9 @@ fn strict_or_warn(
     Ok(())
 }
 
+const ACCEPTED_OUTCOME_LABELS: [&str; 5] = ["ok", "error", "timeout", "cancelled", "rejected"];
+const ACCEPTED_OUTCOME_LABELS_CSV: &str = "ok,error,timeout,cancelled,rejected";
+
 fn parse_outcome(
     span: &SpanRecord,
     strict: bool,
@@ -708,7 +711,21 @@ fn parse_outcome(
 ) -> Result<Option<(String, bool)>, ImportError> {
     match get_string_field_state(span, TT_OUTCOME) {
         StringFieldState::Missing => Ok(Some(("ok".to_owned(), true))),
-        StringFieldState::Value(value) => Ok(Some((value.to_owned(), false))),
+        StringFieldState::Value(value) => {
+            if ACCEPTED_OUTCOME_LABELS.contains(&value) {
+                Ok(Some((value.to_owned(), false)))
+            } else {
+                strict_or_warn(
+                    strict,
+                    warnings,
+                    format!(
+                        "invalid field '{TT_OUTCOME}' in span '{}': expected one of {ACCEPTED_OUTCOME_LABELS_CSV}, got '{value}'",
+                        span.name()
+                    ),
+                )?;
+                Ok(None)
+            }
+        }
         StringFieldState::InvalidType => {
             strict_or_warn(
                 strict,
@@ -1834,6 +1851,115 @@ mod tests {
             run_from_span_records(vec![bad_outcome], ImportOptions::new("svc").strict(true))
                 .is_err()
         );
+    }
+
+    #[test]
+    fn accepted_request_outcomes_are_retained_exactly() {
+        let spans = ACCEPTED_OUTCOME_LABELS
+            .iter()
+            .enumerate()
+            .map(|(idx, outcome)| {
+                SpanRecord::new("req", idx as u64 + 1, idx as u64 + 2)
+                    .field(TT_KIND, "request")
+                    .field(TT_REQUEST_ID, format!("r{idx}"))
+                    .field(TT_ROUTE, "/")
+                    .field(TT_OUTCOME, *outcome)
+            })
+            .collect::<Vec<_>>();
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        let retained = imported
+            .run()
+            .requests
+            .iter()
+            .map(|request| request.outcome.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(retained, ACCEPTED_OUTCOME_LABELS);
+    }
+
+    #[test]
+    fn missing_outcome_defaults_ok_and_warns() {
+        let spans = vec![SpanRecord::new("req", 1, 2)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].outcome, "ok");
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("missing optional 'tt.outcome'; assumed 'ok'")));
+    }
+
+    #[test]
+    fn invalid_outcome_non_strict_skips_request_and_warns() {
+        let spans = vec![SpanRecord::new("http.request", 1, 2)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")
+            .field(TT_OUTCOME, "sucess")];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.warnings().iter().any(|w| w.message().contains(
+            "invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'sucess'"
+        )));
+    }
+
+    #[test]
+    fn invalid_outcome_strict_fails() {
+        let spans = vec![SpanRecord::new("http.request", 1, 2)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")
+            .field(TT_OUTCOME, "sucess")];
+        let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(err.to_string().contains(
+            "invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'sucess'"
+        ));
+    }
+
+    #[test]
+    fn invalid_outcome_with_whitespace_is_rejected() {
+        let spans = vec![SpanRecord::new("http.request", 1, 2)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")
+            .field(TT_OUTCOME, "ok ")];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.warnings().iter().any(|w| w.message().contains(
+            "invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'ok '"
+        )));
+    }
+
+    #[test]
+    fn invalid_outcome_skips_child_spans_via_existing_correlation_logic() {
+        let spans = vec![
+            SpanRecord::new("http.request", 1_000, 2_000)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/")
+                .field(TT_OUTCOME, "sucess"),
+            SpanRecord::new("db.stage", 1_100, 1_200)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db")
+                .field(TT_SUCCESS, true),
+            SpanRecord::new("worker.queue", 1_300, 1_350)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "worker"),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.run().stages.is_empty());
+        assert!(imported.run().queues.is_empty());
+        assert!(imported.warnings().iter().any(|w| w.message().contains(
+            "skipped stage span for request_id 'r1' because no retained request event was imported"
+        )));
+        assert!(imported.warnings().iter().any(|w| w.message().contains(
+            "skipped queue span for request_id 'r1' because no retained request event was imported"
+        )));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent arbitrary strings from being treated as request outcomes by restricting `tt.outcome` to the five canonical labels used by the analyzer and UI. 
- Centralize the accepted labels so parsing, warnings, and tests cannot drift out of sync. 
- Preserve existing non-strict defaulting behavior for missing `tt.outcome` while making invalid values explicit error/warning cases.

### Description
- Add `ACCEPTED_OUTCOME_LABELS` and `ACCEPTED_OUTCOME_LABELS_CSV` and update `parse_outcome` to accept only `ok`, `error`, `timeout`, `cancelled`, and `rejected`, emitting the required invalid-value message shape when violated. 
- In non-strict mode invalid outcomes produce a warning and skip the request span, while strict mode returns `ImportError::StrictViolation(...)`, leaving child-stage/queue handling to the existing correlation filtering. 
- Add unit tests in `tailtriage-tracing/src/lib.rs` covering accepted values, missing-default behavior, non-strict/strict invalid handling, whitespace rejection, and child-span skipping for dropped requests. 
- Add CLI boundary tests in `tailtriage-cli/tests/cli_boundary.rs` for invalid outcomes (non-strict and `--strict`) and a fixture exercising successful import of all valid outcomes. 
- Update `tailtriage-tracing/README.md` to document the exact accepted `tt.outcome` labels.

### Testing
- Ran formatting, linting, unit and integration tests, and docs contract validation using: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, and `python3 scripts/validate_docs_contracts.py`; all commands completed successfully. 
- `cargo fmt --check` passed with no diffs after fixes. 
- `cargo clippy ... -D warnings` completed without warnings. 
- `cargo test ...` ran the full workspace and all tests passed (including the new tracing unit tests and CLI boundary tests). 
- `python3 scripts/validate_docs_contracts.py` succeeded and validated the updated docs contract.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1419cb8668833081573bd23ea8e3ea)