### PR TITLE
Validate tt.outcome values in tracing import

### DIFF
--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -235,6 +235,8 @@ fn import_tracing_json_writes_run_json_analyzable_by_existing_apis() {
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--output")
         .arg(&run_path)
         .output()
@@ -263,6 +265,8 @@ fn import_tracing_json_writes_run_json_when_output_path_contains_spaces() {
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--output")
         .arg(&run_path)
         .output()
@@ -342,6 +346,8 @@ fn import_tracing_json_rejects_inert_runtime_snapshot_flags() {
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
+        .arg("--input-format")
+        .arg("compatible")
         .arg("--output")
         .arg(&run_path)
         .arg("--max-runtime-snapshots")
@@ -879,6 +885,94 @@ fn import_tracing_json_fails_when_non_strict_skips_all_malformed_tt_spans() {
 }
 
 #[test]
+fn import_tracing_json_non_strict_invalid_outcome_warns_and_zero_request_artifact_fails() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, invalid_outcome_only_fixture()).expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--input-format")
+        .arg("compatible")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("invalid field 'tt.outcome'"));
+    assert!(stderr.contains("expected one of ok,error,timeout,cancelled,rejected"));
+    assert!(stderr.contains("zero request events"));
+    assert!(!run_path.exists(), "run output should not be written");
+}
+
+#[test]
+fn import_tracing_json_strict_invalid_outcome_fails_with_message() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, invalid_outcome_only_fixture()).expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--input-format")
+        .arg("compatible")
+        .arg("--strict")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("invalid field 'tt.outcome'"));
+    assert!(stderr.contains("expected one of ok,error,timeout,cancelled,rejected"));
+    assert!(!run_path.exists(), "run output should not be written");
+}
+
+#[test]
+fn import_tracing_json_accepts_all_valid_outcomes() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, all_valid_outcomes_fixture()).expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--input-format")
+        .arg("compatible")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+    assert!(
+        output.status.success(),
+        "cli unexpectedly failed: {output:?}"
+    );
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
+        .expect("imported run should load in cli loader");
+    let outcomes: Vec<&str> = loaded
+        .run
+        .requests
+        .iter()
+        .map(|request| request.outcome.as_str())
+        .collect();
+    assert_eq!(
+        outcomes,
+        vec!["ok", "error", "timeout", "cancelled", "rejected"]
+    );
+}
+
+#[test]
 fn import_tracing_json_fails_when_only_tt_spans_are_missing_kind() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
@@ -1103,6 +1197,18 @@ fn only_missing_kind_tailtriage_spans_fixture() -> &'static str {
     r#"{"span":{"name":"oops-1","started_at_unix_ms":1000,"finished_at_unix_ms":1005,"fields":{"tt.request_id":"req-0","tt.route":"/oops"}}}
 {"span":{"name":"oops-2","started_at_unix_ms":1010,"finished_at_unix_ms":1015,"fields":{"tt.request_id":"req-1","tt.route":"/oops2"}}}
 "#
+}
+
+fn invalid_outcome_only_fixture() -> &'static str {
+    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"sucess"}}}"#
+}
+
+fn all_valid_outcomes_fixture() -> &'static str {
+    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-ok","tt.route":"/checkout","tt.outcome":"ok"}}}
+{"span":{"name":"http.request","started_at_unix_ms":1011,"finished_at_unix_ms":1020,"fields":{"tt.kind":"request","tt.request_id":"req-error","tt.route":"/checkout","tt.outcome":"error"}}}
+{"span":{"name":"http.request","started_at_unix_ms":1021,"finished_at_unix_ms":1030,"fields":{"tt.kind":"request","tt.request_id":"req-timeout","tt.route":"/checkout","tt.outcome":"timeout"}}}
+{"span":{"name":"http.request","started_at_unix_ms":1031,"finished_at_unix_ms":1040,"fields":{"tt.kind":"request","tt.request_id":"req-cancelled","tt.route":"/checkout","tt.outcome":"cancelled"}}}
+{"span":{"name":"http.request","started_at_unix_ms":1041,"finished_at_unix_ms":1050,"fields":{"tt.kind":"request","tt.request_id":"req-rejected","tt.route":"/checkout","tt.outcome":"rejected"}}}"#
 }
 
 fn mixed_valid_and_unknown_kind_fixture() -> &'static str {

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -108,6 +108,8 @@ Ordinary tracing log JSON (for example `fmt().json` output) is rejected by impor
 | stage | `tt.kind="stage"`, `tt.request_id`, `tt.stage` | `tt.success` |
 | queue | `tt.kind="queue"`, `tt.request_id`, `tt.queue` | `tt.depth_at_start` |
 
+`tt.outcome` accepts only: `ok`, `error`, `timeout`, `cancelled`, `rejected`. Missing `tt.outcome` defaults to `ok` with a warning.
+
 ## Strict vs non-strict
 
 - Strict mode: malformed/incomplete `tt.*` span records fail import/session conversion.

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -412,6 +412,9 @@ struct ParsedRequestEvent {
     outcome_defaulted: bool,
 }
 
+const ACCEPTED_OUTCOME_LABELS: [&str; 5] = ["ok", "error", "timeout", "cancelled", "rejected"];
+const ACCEPTED_OUTCOME_LABELS_DISPLAY: &str = "ok,error,timeout,cancelled,rejected";
+
 fn filter_correlated_parsed_stages(
     stages: &mut Vec<ParsedStageEvent>,
     request_intervals: &BTreeMap<String, RequestInterval>,
@@ -708,7 +711,21 @@ fn parse_outcome(
 ) -> Result<Option<(String, bool)>, ImportError> {
     match get_string_field_state(span, TT_OUTCOME) {
         StringFieldState::Missing => Ok(Some(("ok".to_owned(), true))),
-        StringFieldState::Value(value) => Ok(Some((value.to_owned(), false))),
+        StringFieldState::Value(value) => {
+            if ACCEPTED_OUTCOME_LABELS.contains(&value) {
+                Ok(Some((value.to_owned(), false)))
+            } else {
+                strict_or_warn(
+                    strict,
+                    warnings,
+                    format!(
+                        "invalid field '{TT_OUTCOME}' in span '{}': expected one of {ACCEPTED_OUTCOME_LABELS_DISPLAY}, got '{value}'",
+                        span.name()
+                    ),
+                )?;
+                Ok(None)
+            }
+        }
         StringFieldState::InvalidType => {
             strict_or_warn(
                 strict,
@@ -1834,6 +1851,87 @@ mod tests {
             run_from_span_records(vec![bad_outcome], ImportOptions::new("svc").strict(true))
                 .is_err()
         );
+    }
+
+    #[test]
+    fn request_outcome_accepts_all_supported_values() {
+        let spans: Vec<SpanRecord> = ACCEPTED_OUTCOME_LABELS
+            .iter()
+            .enumerate()
+            .map(|(index, outcome)| {
+                let start = 100 + (index as u64 * 10);
+                SpanRecord::new(format!("req-{outcome}"), start, start + 5)
+                    .field(TT_KIND, "request")
+                    .field(TT_REQUEST_ID, format!("r-{index}"))
+                    .field(TT_ROUTE, "/checkout")
+                    .field(TT_OUTCOME, *outcome)
+            })
+            .collect();
+
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        let retained: Vec<&str> = imported
+            .run()
+            .requests
+            .iter()
+            .map(|request| request.outcome.as_str())
+            .collect();
+        assert_eq!(retained, ACCEPTED_OUTCOME_LABELS);
+    }
+
+    #[test]
+    fn invalid_outcome_non_strict_skips_request_and_warns() {
+        let bad_outcome = "sucess";
+        let spans = vec![
+            SpanRecord::new("http.request", 100, 110)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r-1")
+                .field(TT_ROUTE, "/checkout")
+                .field(TT_OUTCOME, bad_outcome),
+            SpanRecord::new("db", 101, 109)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r-1")
+                .field(TT_STAGE, "db"),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.run().stages.is_empty());
+        assert!(imported.warnings().iter().any(|warning| warning.message().contains(
+            &format!(
+                "invalid field 'tt.outcome' in span 'http.request': expected one of {ACCEPTED_OUTCOME_LABELS_DISPLAY}, got '{bad_outcome}'"
+            )
+        )));
+    }
+
+    #[test]
+    fn invalid_outcome_strict_fails() {
+        let spans = vec![SpanRecord::new("http.request", 100, 110)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r-1")
+            .field(TT_ROUTE, "/checkout")
+            .field(TT_OUTCOME, "sucess")];
+        let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
+        match err {
+            ImportError::StrictViolation(message) => assert!(message.contains(&format!(
+                "expected one of {ACCEPTED_OUTCOME_LABELS_DISPLAY}, got 'sucess'"
+            ))),
+            _ => panic!("expected StrictViolation"),
+        }
+    }
+
+    #[test]
+    fn invalid_outcome_with_whitespace_is_rejected() {
+        let spans = vec![SpanRecord::new("http.request", 100, 110)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r-1")
+            .field(TT_ROUTE, "/checkout")
+            .field(TT_OUTCOME, "ok ")];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.warnings().iter().any(|warning| {
+            warning
+                .message()
+                .contains("expected one of ok,error,timeout,cancelled,rejected, got 'ok '")
+        }));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Prevent arbitrary strings from being accepted for request `tt.outcome` during tracing import and enforce the tracing convention's allowed labels. 
- Keep existing missing-outcome behavior (default to `ok` and aggregate warning) while making invalid values deterministic to aid triage and correlation. 
- Avoid duplicated accepted-value lists by centralizing the accepted labels so parsing, warning text, and tests cannot drift. 

### Description

- Added a single shared constant list `ACCEPTED_OUTCOME_LABELS` and a display string `ACCEPTED_OUTCOME_LABELS_DISPLAY` in `tailtriage-tracing/src/lib.rs` and updated `parse_outcome` to accept only `ok`, `error`, `timeout`, `cancelled`, `rejected`. 
- Retained the existing missing-`tt.outcome` behavior (defaults to `ok` and sets the aggregated missing-outcome warning). 
- On invalid `tt.outcome`, `parse_outcome` now: returns `ImportError::StrictViolation(...)` in strict mode and issues a warning + skips the request in non-strict mode; the warning text includes the invalid value, the span name, and the accepted values. 
- Added unit tests in `tailtriage-tracing/src/lib.rs` covering acceptance of the five values, missing/default behavior, strict and non-strict invalid handling, whitespace rejection, and child-span correlation behavior when a request is skipped. 
- Added CLI boundary tests in `tailtriage-cli/tests/cli_boundary.rs` to cover non-strict invalid outcome warning + zero-request artifact failure, strict-mode failure, and successful import of all valid outcomes, and updated fixtures used by those tests. 
- Updated `tailtriage-tracing/README.md` `tt.*` convention section to explicitly list the accepted `tt.outcome` values and defaulting behavior. 

### Testing

- Commands run:
  - `cargo fmt --check` — completed successfully (no formatting changes required after patch).
  - `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — completed successfully with no warnings.
  - `cargo test --workspace --all-targets --all-features --locked` — completed successfully; workspace tests passed (new and existing unit and integration tests executed, final run shows all tests passing).
  - `python3 scripts/validate_docs_contracts.py` — completed successfully and validated docs contracts.

- Automated test result summary: all invoked checks succeeded (format/lint/tests/docs validator exit code 0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1419cb8668833081573bd23ea8e3ea)