### PR TITLE
Add fixed 2 ms tolerance for tracing child span containment

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -115,6 +115,8 @@ Missing request `tt.outcome` defaults to `ok` with a warning.
 - Strict mode: malformed/incomplete `tt.*` span records fail import/session conversion.
 - Non-strict mode: malformed/incomplete records are warned and skipped where implemented.
 - Duration consistency rule: conversion derives duration from wall-clock bounds as `(finished_at_unix_ms - started_at_unix_ms) * 1000`. If optional `duration_us` differs by more than `2_000` microseconds, non-strict conversion warns and uses the derived duration, while strict conversion fails.
+- Child stage/queue containment rule: stage and queue intervals may extend up to 2 ms outside the retained parent request interval before being skipped or causing strict failure.
+- Containment tolerance is fixed at 2 ms in this release and is not configurable.
 
 ## Retention and drop behavior
 

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -431,14 +431,17 @@ fn filter_correlated_parsed_stages(
             )?;
             continue;
         };
-        if stage.event.started_at_unix_ms < interval.started_at_unix_ms
-            || stage.event.finished_at_unix_ms > interval.finished_at_unix_ms
-        {
+        if !interval_within_request_with_tolerance(
+            stage.event.started_at_unix_ms,
+            stage.event.finished_at_unix_ms,
+            interval.started_at_unix_ms,
+            interval.finished_at_unix_ms,
+        ) {
             strict_or_warn(
                 strict,
                 warnings,
                 format!(
-                    "skipped stage span '{}' for request_id '{}' because interval [{}, {}] falls outside request interval [{}, {}]",
+                    "skipped stage span '{}' for request_id '{}' because interval [{}, {}] falls outside request interval [{}, {}] beyond tolerance_ms={TRACE_TIME_TOLERANCE_MS}",
                     stage.event.stage,
                     stage.event.request_id,
                     stage.event.started_at_unix_ms,
@@ -474,14 +477,17 @@ fn filter_correlated_queues(
             )?;
             continue;
         };
-        if queue.waited_from_unix_ms < interval.started_at_unix_ms
-            || queue.waited_until_unix_ms > interval.finished_at_unix_ms
-        {
+        if !interval_within_request_with_tolerance(
+            queue.waited_from_unix_ms,
+            queue.waited_until_unix_ms,
+            interval.started_at_unix_ms,
+            interval.finished_at_unix_ms,
+        ) {
             strict_or_warn(
                 strict,
                 warnings,
                 format!(
-                    "skipped queue span '{}' for request_id '{}' because interval [{}, {}] falls outside request interval [{}, {}]",
+                    "skipped queue span '{}' for request_id '{}' because interval [{}, {}] falls outside request interval [{}, {}] beyond tolerance_ms={TRACE_TIME_TOLERANCE_MS}",
                     queue.queue,
                     queue.request_id,
                     queue.waited_from_unix_ms,
@@ -584,7 +590,19 @@ fn required_string(
     }
 }
 
-pub(crate) const DURATION_TOLERANCE_US: u64 = 2_000;
+pub(crate) const TRACE_TIME_TOLERANCE_US: u64 = 2_000;
+pub(crate) const TRACE_TIME_TOLERANCE_MS: u64 = TRACE_TIME_TOLERANCE_US / 1_000;
+pub(crate) const DURATION_TOLERANCE_US: u64 = TRACE_TIME_TOLERANCE_US;
+
+fn interval_within_request_with_tolerance(
+    child_start_ms: u64,
+    child_finish_ms: u64,
+    request_start_ms: u64,
+    request_finish_ms: u64,
+) -> bool {
+    child_start_ms.saturating_add(TRACE_TIME_TOLERANCE_MS) >= request_start_ms
+        && child_finish_ms <= request_finish_ms.saturating_add(TRACE_TIME_TOLERANCE_MS)
+}
 
 pub(crate) fn duration_within_tolerance(
     duration_us: u64,
@@ -985,7 +1003,7 @@ mod tests {
     }
 
     #[test]
-    fn non_strict_stage_before_request_start_is_skipped_and_warning_is_durable() {
+    fn non_strict_stage_starts_1ms_before_request_is_retained() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
                 .field(TT_KIND, "request")
@@ -997,8 +1015,24 @@ mod tests {
                 .field(TT_STAGE, "db"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().stages.len(), 1);
+    }
+
+    #[test]
+    fn non_strict_stage_starts_3ms_before_request_is_skipped_and_warning_is_durable() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("stage", 97, 110)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(imported.run().stages.is_empty());
-        let warning = "skipped stage span 'db' for request_id 'r1' because interval [99, 110] falls outside request interval [100, 120]";
+        let warning = "skipped stage span 'db' for request_id 'r1' because interval [97, 110] falls outside request interval [100, 120] beyond tolerance_ms=2";
         assert!(imported
             .warnings()
             .iter()
@@ -1018,14 +1052,14 @@ mod tests {
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/a"),
-            SpanRecord::new("stage", 110, 121)
+            SpanRecord::new("stage", 110, 123)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_STAGE, "db"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(imported.run().stages.is_empty());
-        let warning = "skipped stage span 'db' for request_id 'r1' because interval [110, 121] falls outside request interval [100, 120]";
+        let warning = "skipped stage span 'db' for request_id 'r1' because interval [110, 123] falls outside request interval [100, 120] beyond tolerance_ms=2";
         assert!(imported
             .warnings()
             .iter()
@@ -1039,34 +1073,7 @@ mod tests {
     }
 
     #[test]
-    fn non_strict_queue_before_request_start_is_skipped_and_warning_is_durable() {
-        let spans = vec![
-            SpanRecord::new("req", 100, 120)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
-            SpanRecord::new("queue", 99, 110)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "permits"),
-        ];
-        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().queues.is_empty());
-        let warning = "skipped queue span 'permits' for request_id 'r1' because interval [99, 110] falls outside request interval [100, 120]";
-        assert!(imported
-            .warnings()
-            .iter()
-            .any(|w| w.message().contains(warning)));
-        assert!(imported
-            .run()
-            .metadata
-            .lifecycle_warnings
-            .iter()
-            .any(|w| w.contains(warning)));
-    }
-
-    #[test]
-    fn non_strict_queue_after_request_finish_is_skipped_and_warning_is_durable() {
+    fn non_strict_queue_ends_1ms_after_request_is_retained() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
                 .field(TT_KIND, "request")
@@ -1078,8 +1085,24 @@ mod tests {
                 .field(TT_QUEUE, "permits"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().queues.len(), 1);
+    }
+
+    #[test]
+    fn non_strict_queue_ends_3ms_after_request_is_skipped_and_warning_is_durable() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("queue", 110, 123)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(imported.run().queues.is_empty());
-        let warning = "skipped queue span 'permits' for request_id 'r1' because interval [110, 121] falls outside request interval [100, 120]";
+        let warning = "skipped queue span 'permits' for request_id 'r1' because interval [110, 123] falls outside request interval [100, 120] beyond tolerance_ms=2";
         assert!(imported
             .warnings()
             .iter()
@@ -1099,7 +1122,7 @@ mod tests {
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/a"),
-            SpanRecord::new("stage", 99, 110)
+            SpanRecord::new("stage", 97, 110)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_STAGE, "db"),
@@ -1115,7 +1138,7 @@ mod tests {
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/a"),
-            SpanRecord::new("queue", 99, 110)
+            SpanRecord::new("queue", 110, 123)
                 .field(TT_KIND, "queue")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_QUEUE, "permits"),


### PR DESCRIPTION
### Motivation
- Exact containment checks for child `stage`/`queue` spans were brittle against millisecond export/close skew and caused valid child spans to be dropped or to fail strict import. 
- Introduce a small fixed tolerance so real-world exported spans that are off by a couple of ms still correlate as expected while preserving strict-mode failure semantics. 

### Description
- Add shared tracing timing tolerance constants: `TRACE_TIME_TOLERANCE_US = 2_000` and `TRACE_TIME_TOLERANCE_MS = TRACE_TIME_TOLERANCE_US / 1_000`, and reuse the same tolerance for `DURATION_TOLERANCE_US`. 
- Add helper `interval_within_request_with_tolerance(...)` that implements a fixed 2 ms containment slack when checking child span intervals against retained request intervals. 
- Replace exact containment checks in `filter_correlated_parsed_stages(...)` and `filter_correlated_queues(...)` to use the new helper. 
- Update skipped-child warning text to include the tolerance (keeps the durable `skipped ` prefix) using wording like: `... falls outside request interval [...] beyond tolerance_ms=2`. 
- Update and expand unit tests in `tailtriage-tracing/src/lib.rs` to cover: stage starting 1 ms before request (retained), queue ending 1 ms after request (retained), stage starting 3 ms before request (skipped and warns non-strict / strict fails), queue ending 3 ms after request (skipped and warns non-strict / strict fails), and preserve existing exact-containment cases. 
- Document the new fixed containment rule in `tailtriage-tracing/README.md`, explicitly noting the 2 ms tolerance is fixed and not configurable in this release. 

### Testing
- Ran `cargo fmt --check` (initial run reported formatting diffs), then ran `cargo fmt` and re-ran `cargo fmt --check`, which passed. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, which completed with no warnings. 
- Ran `cargo test --workspace --all-targets --all-features --locked`, and all unit/integration tests completed successfully (tests covering the new ±1ms retained and ±3ms skip/strict-fail cases passed). 
- Ran `python3 scripts/validate_docs_contracts.py`, which reported `docs contracts validated successfully`. 

Commands run (exact):
- `cargo fmt --check` (initial diff -> formatting applied)
- `cargo fmt`
- `cargo fmt --check` (passed)
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (passed)
- `cargo test --workspace --all-targets --all-features --locked` (passed)
- `python3 scripts/validate_docs_contracts.py` (`docs contracts validated successfully`)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14263c691083309c333f95424d730c)