### PR TITLE
Add fixed 2ms tracing child containment tolerance

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -115,6 +115,8 @@ Missing request `tt.outcome` defaults to `ok` with a warning.
 - Strict mode: malformed/incomplete `tt.*` span records fail import/session conversion.
 - Non-strict mode: malformed/incomplete records are warned and skipped where implemented.
 - Duration consistency rule: conversion derives duration from wall-clock bounds as `(finished_at_unix_ms - started_at_unix_ms) * 1000`. If optional `duration_us` differs by more than `2_000` microseconds, non-strict conversion warns and uses the derived duration, while strict conversion fails.
+- Child stage/queue containment rule: conversion allows a fixed ±2 ms boundary tolerance when checking child stage/queue intervals against retained request intervals to absorb timestamp precision/export skew.
+- Child containment tolerance is fixed in this release (`2 ms`) and is not configurable via CLI or API.
 
 ## Retention and drop behavior
 

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -431,14 +431,17 @@ fn filter_correlated_parsed_stages(
             )?;
             continue;
         };
-        if stage.event.started_at_unix_ms < interval.started_at_unix_ms
-            || stage.event.finished_at_unix_ms > interval.finished_at_unix_ms
-        {
+        if !interval_within_request_with_tolerance(
+            stage.event.started_at_unix_ms,
+            stage.event.finished_at_unix_ms,
+            interval.started_at_unix_ms,
+            interval.finished_at_unix_ms,
+        ) {
             strict_or_warn(
                 strict,
                 warnings,
                 format!(
-                    "skipped stage span '{}' for request_id '{}' because interval [{}, {}] falls outside request interval [{}, {}]",
+                    "skipped stage span '{}' for request_id '{}' because interval [{}, {}] falls outside request interval [{}, {}] beyond tolerance_ms={TRACE_TIME_TOLERANCE_MS}",
                     stage.event.stage,
                     stage.event.request_id,
                     stage.event.started_at_unix_ms,
@@ -474,14 +477,17 @@ fn filter_correlated_queues(
             )?;
             continue;
         };
-        if queue.waited_from_unix_ms < interval.started_at_unix_ms
-            || queue.waited_until_unix_ms > interval.finished_at_unix_ms
-        {
+        if !interval_within_request_with_tolerance(
+            queue.waited_from_unix_ms,
+            queue.waited_until_unix_ms,
+            interval.started_at_unix_ms,
+            interval.finished_at_unix_ms,
+        ) {
             strict_or_warn(
                 strict,
                 warnings,
                 format!(
-                    "skipped queue span '{}' for request_id '{}' because interval [{}, {}] falls outside request interval [{}, {}]",
+                    "skipped queue span '{}' for request_id '{}' because interval [{}, {}] falls outside request interval [{}, {}] beyond tolerance_ms={TRACE_TIME_TOLERANCE_MS}",
                     queue.queue,
                     queue.request_id,
                     queue.waited_from_unix_ms,
@@ -584,7 +590,8 @@ fn required_string(
     }
 }
 
-pub(crate) const DURATION_TOLERANCE_US: u64 = 2_000;
+pub(crate) const TRACE_TIME_TOLERANCE_US: u64 = 2_000;
+pub(crate) const TRACE_TIME_TOLERANCE_MS: u64 = TRACE_TIME_TOLERANCE_US / 1_000;
 
 pub(crate) fn duration_within_tolerance(
     duration_us: u64,
@@ -594,7 +601,17 @@ pub(crate) fn duration_within_tolerance(
     let derived_us = finished_at_unix_ms
         .saturating_sub(started_at_unix_ms)
         .saturating_mul(1000);
-    duration_us.abs_diff(derived_us) <= DURATION_TOLERANCE_US
+    duration_us.abs_diff(derived_us) <= TRACE_TIME_TOLERANCE_US
+}
+
+fn interval_within_request_with_tolerance(
+    child_start_ms: u64,
+    child_finish_ms: u64,
+    request_start_ms: u64,
+    request_finish_ms: u64,
+) -> bool {
+    child_start_ms.saturating_add(TRACE_TIME_TOLERANCE_MS) >= request_start_ms
+        && child_finish_ms <= request_finish_ms.saturating_add(TRACE_TIME_TOLERANCE_MS)
 }
 
 fn validated_duration_us(
@@ -617,7 +634,7 @@ fn validated_duration_us(
         return Ok(duration_us);
     }
     let message = format!(
-        "span '{}' duration_us mismatch exceeds tolerance: duration_us={} derived_us={} tolerance_us={DURATION_TOLERANCE_US}",
+        "span '{}' duration_us mismatch exceeds tolerance: duration_us={} derived_us={} tolerance_us={TRACE_TIME_TOLERANCE_US}",
         span.name(),
         duration_us,
         derived_us
@@ -985,7 +1002,7 @@ mod tests {
     }
 
     #[test]
-    fn non_strict_stage_before_request_start_is_skipped_and_warning_is_durable() {
+    fn non_strict_stage_one_ms_before_request_start_is_retained() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
                 .field(TT_KIND, "request")
@@ -997,22 +1014,15 @@ mod tests {
                 .field(TT_STAGE, "db"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().stages.is_empty());
-        let warning = "skipped stage span 'db' for request_id 'r1' because interval [99, 110] falls outside request interval [100, 120]";
+        assert_eq!(imported.run().stages.len(), 1);
         assert!(imported
             .warnings()
             .iter()
-            .any(|w| w.message().contains(warning)));
-        assert!(imported
-            .run()
-            .metadata
-            .lifecycle_warnings
-            .iter()
-            .any(|w| w.contains(warning)));
+            .all(|w| !w.message().contains("skipped stage span 'db'")));
     }
 
     #[test]
-    fn non_strict_stage_after_request_finish_is_skipped_and_warning_is_durable() {
+    fn non_strict_stage_one_ms_after_request_finish_is_retained() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
                 .field(TT_KIND, "request")
@@ -1024,49 +1034,15 @@ mod tests {
                 .field(TT_STAGE, "db"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().stages.is_empty());
-        let warning = "skipped stage span 'db' for request_id 'r1' because interval [110, 121] falls outside request interval [100, 120]";
+        assert_eq!(imported.run().stages.len(), 1);
         assert!(imported
             .warnings()
             .iter()
-            .any(|w| w.message().contains(warning)));
-        assert!(imported
-            .run()
-            .metadata
-            .lifecycle_warnings
-            .iter()
-            .any(|w| w.contains(warning)));
+            .all(|w| !w.message().contains("skipped stage span 'db'")));
     }
 
     #[test]
-    fn non_strict_queue_before_request_start_is_skipped_and_warning_is_durable() {
-        let spans = vec![
-            SpanRecord::new("req", 100, 120)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
-            SpanRecord::new("queue", 99, 110)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "permits"),
-        ];
-        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().queues.is_empty());
-        let warning = "skipped queue span 'permits' for request_id 'r1' because interval [99, 110] falls outside request interval [100, 120]";
-        assert!(imported
-            .warnings()
-            .iter()
-            .any(|w| w.message().contains(warning)));
-        assert!(imported
-            .run()
-            .metadata
-            .lifecycle_warnings
-            .iter()
-            .any(|w| w.contains(warning)));
-    }
-
-    #[test]
-    fn non_strict_queue_after_request_finish_is_skipped_and_warning_is_durable() {
+    fn non_strict_queue_ends_one_ms_after_request_finish_is_retained() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
                 .field(TT_KIND, "request")
@@ -1078,8 +1054,28 @@ mod tests {
                 .field(TT_QUEUE, "permits"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().queues.is_empty());
-        let warning = "skipped queue span 'permits' for request_id 'r1' because interval [110, 121] falls outside request interval [100, 120]";
+        assert_eq!(imported.run().queues.len(), 1);
+        assert!(imported
+            .warnings()
+            .iter()
+            .all(|w| !w.message().contains("skipped queue span 'permits'")));
+    }
+
+    #[test]
+    fn non_strict_stage_three_ms_before_request_start_is_skipped_and_warning_is_durable() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("stage", 97, 110)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().stages.is_empty());
+        let warning = "skipped stage span 'db' for request_id 'r1' because interval [97, 110] falls outside request interval [100, 120] beyond tolerance_ms=2";
         assert!(imported
             .warnings()
             .iter()
@@ -1093,13 +1089,13 @@ mod tests {
     }
 
     #[test]
-    fn strict_mode_fails_for_out_of_window_stage() {
+    fn strict_mode_fails_for_stage_three_ms_before_request_start() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/a"),
-            SpanRecord::new("stage", 99, 110)
+            SpanRecord::new("stage", 97, 110)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_STAGE, "db"),
@@ -1109,13 +1105,40 @@ mod tests {
     }
 
     #[test]
-    fn strict_mode_fails_for_out_of_window_queue() {
+    fn non_strict_queue_three_ms_after_request_finish_is_skipped_and_warning_is_durable() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/a"),
-            SpanRecord::new("queue", 99, 110)
+            SpanRecord::new("queue", 110, 123)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().queues.is_empty());
+        let warning = "skipped queue span 'permits' for request_id 'r1' because interval [110, 123] falls outside request interval [100, 120] beyond tolerance_ms=2";
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains(warning)));
+        assert!(imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|w| w.contains(warning)));
+    }
+
+    #[test]
+    fn strict_mode_fails_for_queue_three_ms_after_request_finish() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("queue", 110, 123)
                 .field(TT_KIND, "queue")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_QUEUE, "permits"),


### PR DESCRIPTION
### Motivation
- Child stage/queue spans were being rejected when their timestamps fell very slightly outside request intervals due to millisecond precision and export ordering skew, making tracing import brittle.
- Use a single, explicit tolerance so duration consistency and child-span containment use the same fixed timing budget.

### Description
- Introduced `TRACE_TIME_TOLERANCE_US = 2_000` and derived `TRACE_TIME_TOLERANCE_MS` and switched duration checks to use the new constant.
- Added `interval_within_request_with_tolerance(...)` and applied it to both `filter_correlated_parsed_stages(...)` and `filter_correlated_queues(...)` to allow a 2 ms containment tolerance when correlating child spans to retained requests.
- Updated skipped child-span warning text to include the `beyond tolerance_ms=2` phrase while preserving the leading `skipped ` prefix so the warning classifier remains durable.
- Added/adjusted unit tests in `tailtriage-tracing/src/lib.rs` to cover: 1 ms-before/start and 1 ms-after/finish cases retained, 3 ms boundary cases skipped (non-strict warns and strict errors), and preserved existing exact-containment behavior.
- Updated `tailtriage-tracing/README.md` to document the fixed 2 ms child containment tolerance and explicitly state it is not configurable in this release.

### Testing
- Ran `cargo fmt --check`, which succeeded with no formatting changes reported.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, which completed successfully with no warnings (clippy passed).
- Ran `cargo test --workspace --all-targets --all-features --locked`, which completed successfully and all tests passed (test suites ran to completion with no failures).
- Ran `python3 scripts/validate_docs_contracts.py`, which printed `docs contracts validated successfully` and exited successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14263c691083309c333f95424d730c)