### PR TITLE
Add fixed 2ms tolerance for tracing child span containment

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -115,6 +115,7 @@ Missing request `tt.outcome` defaults to `ok` with a warning.
 - Strict mode: malformed/incomplete `tt.*` span records fail import/session conversion.
 - Non-strict mode: malformed/incomplete records are warned and skipped where implemented.
 - Duration consistency rule: conversion derives duration from wall-clock bounds as `(finished_at_unix_ms - started_at_unix_ms) * 1000`. If optional `duration_us` differs by more than `2_000` microseconds, non-strict conversion warns and uses the derived duration, while strict conversion fails.
+- Child stage/queue containment rule: correlated child intervals are retained when they fall within the retained request interval with a fixed `2 ms` tolerance for exported timestamp precision and close-order skew. This tolerance is not configurable in this release.
 
 ## Retention and drop behavior
 

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -431,14 +431,17 @@ fn filter_correlated_parsed_stages(
             )?;
             continue;
         };
-        if stage.event.started_at_unix_ms < interval.started_at_unix_ms
-            || stage.event.finished_at_unix_ms > interval.finished_at_unix_ms
-        {
+        if !interval_within_request_with_tolerance(
+            stage.event.started_at_unix_ms,
+            stage.event.finished_at_unix_ms,
+            interval.started_at_unix_ms,
+            interval.finished_at_unix_ms,
+        ) {
             strict_or_warn(
                 strict,
                 warnings,
                 format!(
-                    "skipped stage span '{}' for request_id '{}' because interval [{}, {}] falls outside request interval [{}, {}]",
+                    "skipped stage span '{}' for request_id '{}' because interval [{}, {}] falls outside request interval [{}, {}] beyond tolerance_ms={TRACE_TIME_TOLERANCE_MS}",
                     stage.event.stage,
                     stage.event.request_id,
                     stage.event.started_at_unix_ms,
@@ -474,14 +477,17 @@ fn filter_correlated_queues(
             )?;
             continue;
         };
-        if queue.waited_from_unix_ms < interval.started_at_unix_ms
-            || queue.waited_until_unix_ms > interval.finished_at_unix_ms
-        {
+        if !interval_within_request_with_tolerance(
+            queue.waited_from_unix_ms,
+            queue.waited_until_unix_ms,
+            interval.started_at_unix_ms,
+            interval.finished_at_unix_ms,
+        ) {
             strict_or_warn(
                 strict,
                 warnings,
                 format!(
-                    "skipped queue span '{}' for request_id '{}' because interval [{}, {}] falls outside request interval [{}, {}]",
+                    "skipped queue span '{}' for request_id '{}' because interval [{}, {}] falls outside request interval [{}, {}] beyond tolerance_ms={TRACE_TIME_TOLERANCE_MS}",
                     queue.queue,
                     queue.request_id,
                     queue.waited_from_unix_ms,
@@ -584,7 +590,18 @@ fn required_string(
     }
 }
 
-pub(crate) const DURATION_TOLERANCE_US: u64 = 2_000;
+pub(crate) const TRACE_TIME_TOLERANCE_US: u64 = 2_000;
+pub(crate) const TRACE_TIME_TOLERANCE_MS: u64 = TRACE_TIME_TOLERANCE_US / 1_000;
+
+fn interval_within_request_with_tolerance(
+    child_start_ms: u64,
+    child_finish_ms: u64,
+    request_start_ms: u64,
+    request_finish_ms: u64,
+) -> bool {
+    child_start_ms.saturating_add(TRACE_TIME_TOLERANCE_MS) >= request_start_ms
+        && child_finish_ms <= request_finish_ms.saturating_add(TRACE_TIME_TOLERANCE_MS)
+}
 
 pub(crate) fn duration_within_tolerance(
     duration_us: u64,
@@ -594,7 +611,7 @@ pub(crate) fn duration_within_tolerance(
     let derived_us = finished_at_unix_ms
         .saturating_sub(started_at_unix_ms)
         .saturating_mul(1000);
-    duration_us.abs_diff(derived_us) <= DURATION_TOLERANCE_US
+    duration_us.abs_diff(derived_us) <= TRACE_TIME_TOLERANCE_US
 }
 
 fn validated_duration_us(
@@ -617,7 +634,7 @@ fn validated_duration_us(
         return Ok(duration_us);
     }
     let message = format!(
-        "span '{}' duration_us mismatch exceeds tolerance: duration_us={} derived_us={} tolerance_us={DURATION_TOLERANCE_US}",
+        "span '{}' duration_us mismatch exceeds tolerance: duration_us={} derived_us={} tolerance_us={TRACE_TIME_TOLERANCE_US}",
         span.name(),
         duration_us,
         derived_us
@@ -985,7 +1002,7 @@ mod tests {
     }
 
     #[test]
-    fn non_strict_stage_before_request_start_is_skipped_and_warning_is_durable() {
+    fn non_strict_stage_before_request_start_within_tolerance_is_retained() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
                 .field(TT_KIND, "request")
@@ -997,22 +1014,15 @@ mod tests {
                 .field(TT_STAGE, "db"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().stages.is_empty());
-        let warning = "skipped stage span 'db' for request_id 'r1' because interval [99, 110] falls outside request interval [100, 120]";
-        assert!(imported
+        assert_eq!(imported.run().stages.len(), 1);
+        assert!(!imported
             .warnings()
             .iter()
-            .any(|w| w.message().contains(warning)));
-        assert!(imported
-            .run()
-            .metadata
-            .lifecycle_warnings
-            .iter()
-            .any(|w| w.contains(warning)));
+            .any(|w| w.message().starts_with("skipped stage span")));
     }
 
     #[test]
-    fn non_strict_stage_after_request_finish_is_skipped_and_warning_is_durable() {
+    fn non_strict_stage_after_request_finish_within_tolerance_is_retained() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
                 .field(TT_KIND, "request")
@@ -1024,22 +1034,15 @@ mod tests {
                 .field(TT_STAGE, "db"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().stages.is_empty());
-        let warning = "skipped stage span 'db' for request_id 'r1' because interval [110, 121] falls outside request interval [100, 120]";
-        assert!(imported
+        assert_eq!(imported.run().stages.len(), 1);
+        assert!(!imported
             .warnings()
             .iter()
-            .any(|w| w.message().contains(warning)));
-        assert!(imported
-            .run()
-            .metadata
-            .lifecycle_warnings
-            .iter()
-            .any(|w| w.contains(warning)));
+            .any(|w| w.message().starts_with("skipped stage span")));
     }
 
     #[test]
-    fn non_strict_queue_before_request_start_is_skipped_and_warning_is_durable() {
+    fn non_strict_queue_before_request_start_within_tolerance_is_retained() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
                 .field(TT_KIND, "request")
@@ -1051,8 +1054,48 @@ mod tests {
                 .field(TT_QUEUE, "permits"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().queues.len(), 1);
+        assert!(!imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().starts_with("skipped queue span")));
+    }
+
+    #[test]
+    fn non_strict_queue_after_request_finish_within_tolerance_is_retained() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("queue", 110, 121)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().queues.len(), 1);
+        assert!(!imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().starts_with("skipped queue span")));
+    }
+
+    #[test]
+    fn non_strict_queue_after_request_finish_beyond_tolerance_is_skipped_and_warning_is_durable() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("queue", 110, 123)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(imported.run().queues.is_empty());
-        let warning = "skipped queue span 'permits' for request_id 'r1' because interval [99, 110] falls outside request interval [100, 120]";
+        let warning = "skipped queue span 'permits' for request_id 'r1' because interval [110, 123] falls outside request interval [100, 120] beyond tolerance_ms=2";
         assert!(imported
             .warnings()
             .iter()
@@ -1066,20 +1109,20 @@ mod tests {
     }
 
     #[test]
-    fn non_strict_queue_after_request_finish_is_skipped_and_warning_is_durable() {
+    fn non_strict_stage_before_request_start_beyond_tolerance_is_skipped_and_warning_is_durable() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/a"),
-            SpanRecord::new("queue", 110, 121)
-                .field(TT_KIND, "queue")
+            SpanRecord::new("stage", 97, 110)
+                .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "permits"),
+                .field(TT_STAGE, "db"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().queues.is_empty());
-        let warning = "skipped queue span 'permits' for request_id 'r1' because interval [110, 121] falls outside request interval [100, 120]";
+        assert!(imported.run().stages.is_empty());
+        let warning = "skipped stage span 'db' for request_id 'r1' because interval [97, 110] falls outside request interval [100, 120] beyond tolerance_ms=2";
         assert!(imported
             .warnings()
             .iter()
@@ -1099,7 +1142,7 @@ mod tests {
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/a"),
-            SpanRecord::new("stage", 99, 110)
+            SpanRecord::new("stage", 97, 110)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_STAGE, "db"),
@@ -1115,7 +1158,7 @@ mod tests {
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/a"),
-            SpanRecord::new("queue", 99, 110)
+            SpanRecord::new("queue", 99, 123)
                 .field(TT_KIND, "queue")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_QUEUE, "permits"),


### PR DESCRIPTION
### Motivation
- Child stage/queue span containment checks were too brittle because exported span timestamps and close/export ordering can differ by a few milliseconds, causing valid child spans to be dropped or trigger strict failures.
- Introduce a small, well-defined tolerance so real-world tracing exports are resilient without changing public APIs or adding knobs.

### Description
- Introduced generalized tracing timing tolerance constants `TRACE_TIME_TOLERANCE_US` and `TRACE_TIME_TOLERANCE_MS` and aligned duration-consistency checks to use the same 2 ms value.
- Added helper `interval_within_request_with_tolerance(...)` and applied it to both `filter_correlated_parsed_stages(...)` and `filter_correlated_queues(...)` to allow ±2 ms containment tolerance for child spans.
- Updated skipped child-span warning messages to include `beyond tolerance_ms=2` while preserving the `skipped ` prefix so durable warning classification remains unchanged.
- Added and updated unit tests in `tailtriage-tracing` to cover within-tolerance retention, beyond-tolerance skipping with durable warnings, and strict-mode failures, and updated the README to document the fixed 2 ms non-configurable containment tolerance.

### Testing
- Ran `cargo fmt --check` and it succeeded after formatting changes were applied.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it completed with no warnings.
- Ran `cargo test --workspace --all-targets --all-features --locked` and the full workspace test suite passed (including the updated `tailtriage-tracing` tests covering within-tolerance retention, beyond-tolerance skipping/warnings, and strict-mode failures).
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14263c691083309c333f95424d730c)