### PR TITLE
Add fixed 2ms tolerance for child span containment

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -115,6 +115,8 @@ Missing request `tt.outcome` defaults to `ok` with a warning.
 - Strict mode: malformed/incomplete `tt.*` span records fail import/session conversion.
 - Non-strict mode: malformed/incomplete records are warned and skipped where implemented.
 - Duration consistency rule: conversion derives duration from wall-clock bounds as `(finished_at_unix_ms - started_at_unix_ms) * 1000`. If optional `duration_us` differs by more than `2_000` microseconds, non-strict conversion warns and uses the derived duration, while strict conversion fails.
+- Child stage/queue containment uses a fixed `2` ms tolerance when checking whether child intervals fall inside retained request intervals.
+- That `2` ms containment tolerance is not configurable in this release (no CLI/API knob).
 
 ## Retention and drop behavior
 

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -412,6 +412,16 @@ struct ParsedRequestEvent {
     outcome_defaulted: bool,
 }
 
+fn interval_within_request_with_tolerance(
+    child_start_ms: u64,
+    child_finish_ms: u64,
+    request_start_ms: u64,
+    request_finish_ms: u64,
+) -> bool {
+    child_start_ms.saturating_add(TRACE_TIME_TOLERANCE_MS) >= request_start_ms
+        && child_finish_ms <= request_finish_ms.saturating_add(TRACE_TIME_TOLERANCE_MS)
+}
+
 fn filter_correlated_parsed_stages(
     stages: &mut Vec<ParsedStageEvent>,
     request_intervals: &BTreeMap<String, RequestInterval>,
@@ -431,14 +441,17 @@ fn filter_correlated_parsed_stages(
             )?;
             continue;
         };
-        if stage.event.started_at_unix_ms < interval.started_at_unix_ms
-            || stage.event.finished_at_unix_ms > interval.finished_at_unix_ms
-        {
+        if !interval_within_request_with_tolerance(
+            stage.event.started_at_unix_ms,
+            stage.event.finished_at_unix_ms,
+            interval.started_at_unix_ms,
+            interval.finished_at_unix_ms,
+        ) {
             strict_or_warn(
                 strict,
                 warnings,
                 format!(
-                    "skipped stage span '{}' for request_id '{}' because interval [{}, {}] falls outside request interval [{}, {}]",
+                    "skipped stage span '{}' for request_id '{}' because interval [{}, {}] falls outside request interval [{}, {}] beyond tolerance_ms={TRACE_TIME_TOLERANCE_MS}",
                     stage.event.stage,
                     stage.event.request_id,
                     stage.event.started_at_unix_ms,
@@ -474,14 +487,17 @@ fn filter_correlated_queues(
             )?;
             continue;
         };
-        if queue.waited_from_unix_ms < interval.started_at_unix_ms
-            || queue.waited_until_unix_ms > interval.finished_at_unix_ms
-        {
+        if !interval_within_request_with_tolerance(
+            queue.waited_from_unix_ms,
+            queue.waited_until_unix_ms,
+            interval.started_at_unix_ms,
+            interval.finished_at_unix_ms,
+        ) {
             strict_or_warn(
                 strict,
                 warnings,
                 format!(
-                    "skipped queue span '{}' for request_id '{}' because interval [{}, {}] falls outside request interval [{}, {}]",
+                    "skipped queue span '{}' for request_id '{}' because interval [{}, {}] falls outside request interval [{}, {}] beyond tolerance_ms={TRACE_TIME_TOLERANCE_MS}",
                     queue.queue,
                     queue.request_id,
                     queue.waited_from_unix_ms,
@@ -584,7 +600,8 @@ fn required_string(
     }
 }
 
-pub(crate) const DURATION_TOLERANCE_US: u64 = 2_000;
+pub(crate) const TRACE_TIME_TOLERANCE_US: u64 = 2_000;
+pub(crate) const TRACE_TIME_TOLERANCE_MS: u64 = TRACE_TIME_TOLERANCE_US / 1_000;
 
 pub(crate) fn duration_within_tolerance(
     duration_us: u64,
@@ -594,7 +611,7 @@ pub(crate) fn duration_within_tolerance(
     let derived_us = finished_at_unix_ms
         .saturating_sub(started_at_unix_ms)
         .saturating_mul(1000);
-    duration_us.abs_diff(derived_us) <= DURATION_TOLERANCE_US
+    duration_us.abs_diff(derived_us) <= TRACE_TIME_TOLERANCE_US
 }
 
 fn validated_duration_us(
@@ -617,7 +634,7 @@ fn validated_duration_us(
         return Ok(duration_us);
     }
     let message = format!(
-        "span '{}' duration_us mismatch exceeds tolerance: duration_us={} derived_us={} tolerance_us={DURATION_TOLERANCE_US}",
+        "span '{}' duration_us mismatch exceeds tolerance: duration_us={} derived_us={} tolerance_us={TRACE_TIME_TOLERANCE_US}",
         span.name(),
         duration_us,
         derived_us
@@ -991,14 +1008,14 @@ mod tests {
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/a"),
-            SpanRecord::new("stage", 99, 110)
+            SpanRecord::new("stage", 97, 110)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_STAGE, "db"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(imported.run().stages.is_empty());
-        let warning = "skipped stage span 'db' for request_id 'r1' because interval [99, 110] falls outside request interval [100, 120]";
+        let warning = "skipped stage span 'db' for request_id 'r1' because interval [97, 110] falls outside request interval [100, 120] beyond tolerance_ms=2";
         assert!(imported
             .warnings()
             .iter()
@@ -1018,14 +1035,14 @@ mod tests {
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/a"),
-            SpanRecord::new("stage", 110, 121)
+            SpanRecord::new("stage", 110, 123)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_STAGE, "db"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(imported.run().stages.is_empty());
-        let warning = "skipped stage span 'db' for request_id 'r1' because interval [110, 121] falls outside request interval [100, 120]";
+        let warning = "skipped stage span 'db' for request_id 'r1' because interval [110, 123] falls outside request interval [100, 120] beyond tolerance_ms=2";
         assert!(imported
             .warnings()
             .iter()
@@ -1045,14 +1062,14 @@ mod tests {
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/a"),
-            SpanRecord::new("queue", 99, 110)
+            SpanRecord::new("queue", 97, 110)
                 .field(TT_KIND, "queue")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_QUEUE, "permits"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(imported.run().queues.is_empty());
-        let warning = "skipped queue span 'permits' for request_id 'r1' because interval [99, 110] falls outside request interval [100, 120]";
+        let warning = "skipped queue span 'permits' for request_id 'r1' because interval [97, 110] falls outside request interval [100, 120] beyond tolerance_ms=2";
         assert!(imported
             .warnings()
             .iter()
@@ -1072,14 +1089,14 @@ mod tests {
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/a"),
-            SpanRecord::new("queue", 110, 121)
+            SpanRecord::new("queue", 110, 123)
                 .field(TT_KIND, "queue")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_QUEUE, "permits"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(imported.run().queues.is_empty());
-        let warning = "skipped queue span 'permits' for request_id 'r1' because interval [110, 121] falls outside request interval [100, 120]";
+        let warning = "skipped queue span 'permits' for request_id 'r1' because interval [110, 123] falls outside request interval [100, 120] beyond tolerance_ms=2";
         assert!(imported
             .warnings()
             .iter()
@@ -1099,7 +1116,7 @@ mod tests {
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/a"),
-            SpanRecord::new("stage", 99, 110)
+            SpanRecord::new("stage", 97, 110)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_STAGE, "db"),
@@ -1115,13 +1132,45 @@ mod tests {
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/a"),
-            SpanRecord::new("queue", 99, 110)
+            SpanRecord::new("queue", 110, 123)
                 .field(TT_KIND, "queue")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_QUEUE, "permits"),
         ];
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
         assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn stage_starting_1ms_before_request_is_retained_with_tolerance() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("stage", 99, 110)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().stages.len(), 1);
+    }
+
+    #[test]
+    fn queue_ending_1ms_after_request_is_retained_with_tolerance() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("queue", 110, 121)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().queues.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Exact containment checks for retained stage/queue spans were brittle against real exported span timing jitter and millisecond-level close/export ordering skew. 
- A small fixed tolerance improves robustness when matching child spans to retained request intervals without changing capture semantics.
- Keep duration-consistency behavior unchanged while reusing the same tolerance value for both duration and containment checks.

### Description
- Introduced tracing timing tolerance constants `TRACE_TIME_TOLERANCE_US = 2_000` and `TRACE_TIME_TOLERANCE_MS = TRACE_TIME_TOLERANCE_US / 1_000` and replaced the previous duration-only constant. 
- Added helper `interval_within_request_with_tolerance(child_start_ms, child_finish_ms, request_start_ms, request_finish_ms)` and used it in both `filter_correlated_parsed_stages(...)` and `filter_correlated_queues(...)` to accept child intervals that fall just outside request bounds within the 2 ms tolerance. 
- Updated skipped child-span warning messages to preserve the durable `skipped ` prefix and to include the new wording `beyond tolerance_ms=2` so warnings remain durable and informative. 
- Kept duration consistency checks using the same tolerance value (`TRACE_TIME_TOLERANCE_US`) and updated the message that reports duration mismatch to reference the new constant. 
- Updated and added unit tests for the tolerant behavior: stage starting 1 ms before request retained, queue ending 1 ms after request retained, stage/queue 3 ms out-of-window skipped with non-strict warnings, strict mode fails for 3 ms out-of-window, and existing exact-containment cases still pass. 
- Documented the fixed 2 ms containment tolerance in `tailtriage-tracing/README.md` and explicitly noted it is not configurable in this release.

### Testing
- Ran `cargo fmt --check` and it completed with exit status 0 (no formatting changes required). 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it completed successfully with no warnings (clippy exited 0). 
- Ran `cargo test --workspace --all-targets --all-features --locked` and the entire test suite completed successfully with all tests passing (workspace tests passed; no failures). 
- Ran `python3 scripts/validate_docs_contracts.py` and it printed `docs contracts validated successfully` and exited 0.

Commands run and results (exact):
- `cargo fmt --check` — completed successfully (exit 0, no output). 
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — completed successfully (compilation and checks finished, exit 0). 
- `cargo test --workspace --all-targets --all-features --locked` — completed successfully; workspace tests passed (no failing tests). 
- `python3 scripts/validate_docs_contracts.py` — output: `docs contracts validated successfully` (exit 0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14263c691083309c333f95424d730c)