### PR TITLE
docs: use service-safe global tracing subscriber setup

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -69,8 +69,10 @@ use tracing_subscriber::prelude::*;
 let session = TracingIntakeSession::builder("checkout-service")
     .run_json_path("target/tailtriage-examples/checkout.run.json")
     .build()?;
-let subscriber = tracing_subscriber::registry().with(session.layer());
-let _guard = tracing::subscriber::set_default(subscriber);
+tracing_subscriber::registry()
+    // Keep your existing subscriber layers and add tailtriage beside them.
+    .with(session.layer())
+    .init(); // Call once at application startup in standalone binaries.
 let span = tracing::info_span!(
     "request",
     tt.kind = "request",
@@ -89,6 +91,8 @@ session.shutdown()?;
 ```
 
 Stage and queue spans use their own `tt.stage` / `tt.queue` fields around the awaited work they measure.
+
+For reusable integrations, compose `session.layer()` with your existing layers and install that combined subscriber in the application's normal process-wide startup path (for example with `tracing::subscriber::set_global_default(...)` when you need explicit error handling). `set_default` is scoped to the current thread and guard lifetime; service startup should install the tailtriage layer in the process-wide subscriber setup.
 
 Then analyze directly:
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -48,8 +48,11 @@ let session = TracingIntakeSession::builder("checkout-service")
     .completed_span_jsonl_path("target/tailtriage-examples/checkout.spans.jsonl")
     .build()?;
 
-let subscriber = tracing_subscriber::registry().with(session.layer());
-let _guard = tracing::subscriber::set_default(subscriber);
+tracing_subscriber::registry()
+    // Keep existing layers (fmt/filter/telemetry) and add tailtriage beside them.
+    .with(session.layer())
+    .init(); // Startup-only in standalone binaries.
+
 let request = tracing::info_span!(
     "request",
     tt.kind = "request",
@@ -67,6 +70,10 @@ session.shutdown()?;
 #   Ok(())
 # }
 ```
+
+In reusable/library-style integration docs, compose `session.layer()` beside your existing subscriber layers and install the resulting subscriber in the application's normal process-wide setup (`.init()` at startup in standalone binaries, or `tracing::subscriber::set_global_default(...)` when startup needs explicit error handling).
+
+`set_default` is scoped to the current thread and guard lifetime; service startup should install the tailtriage layer in the process-wide subscriber setup.
 
 ## Direct Run JSON path
 


### PR DESCRIPTION
### Motivation
- The docs previously taught `tracing::subscriber::set_default(...)` as the primary live-session setup which is scoped to the current thread/guard lifetime and is fragile for Tokio multi-threaded services. 
- The primary live integration should show adding the `tailtriage` layer beside existing layers and installing it in the process-wide subscriber at startup to be service-safe. 

### Description
- Replaced thread-scoped `set_default` examples with a startup-time process-wide setup using `tracing_subscriber::registry().with(session.layer()).init()` in `tailtriage-tracing/README.md`. 
- Updated `docs/user-guide.md` to use the same service-safe `.init()` startup snippet and added guidance to compose `session.layer()` with existing layers and install the combined subscriber via the application’s normal process-wide setup (including mention of `tracing::subscriber::set_global_default(...)` when explicit error handling is required). 
- Added explicit wording that `set_default` is scoped/local/test-only and that the tailtriage layer is added beside, not replacing, the user’s tracing pipeline. 

### Testing
- Ran `cargo fmt --check` and it completed successfully with no formatting errors. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it completed successfully with no warnings. 
- Ran `cargo test --workspace --all-targets --all-features --locked` and the full workspace test suite completed successfully (all tests passed). 
- Ran `python3 scripts/validate_docs_contracts.py` and it reported `docs contracts validated successfully`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a142b6be7e48330b79d618ab1c1a01d)