### PR TITLE
docs: teach service-safe global subscriber setup for live tracing intake

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -69,8 +69,12 @@ use tracing_subscriber::prelude::*;
 let session = TracingIntakeSession::builder("checkout-service")
     .run_json_path("target/tailtriage-examples/checkout.run.json")
     .build()?;
-let subscriber = tracing_subscriber::registry().with(session.layer());
-let _guard = tracing::subscriber::set_default(subscriber);
+tracing_subscriber::registry()
+    .with(session.layer())
+    .init();
+
+// startup-only path: install once, then run service/workload
+
 let span = tracing::info_span!(
     "request",
     tt.kind = "request",
@@ -79,7 +83,7 @@ let span = tracing::info_span!(
     tt.outcome = "ok",
 );
 work().instrument(span).await;
-session.shutdown()?;
+let _imported = session.shutdown()?;
 # Ok(())
 }
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -87,6 +91,10 @@ session.shutdown()?;
 #   Ok(())
 # }
 ```
+
+In reusable/library-style integration docs, compose `session.layer()` beside the application's existing `tracing_subscriber` layers and have the application install the resulting subscriber in its normal global subscriber setup. `tailtriage` augments an existing tracing pipeline; it does not replace it.
+
+`set_default` is scoped to the current thread and guard lifetime; service startup should install the tailtriage layer in the process-wide subscriber setup.
 
 Stage and queue spans use their own `tt.stage` / `tt.queue` fields around the awaited work they measure.
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -36,6 +36,8 @@ cargo add tracing tracing-subscriber
 
 ## Recommended live session setup (`live` feature)
 
+Install the `tailtriage` tracing layer beside your existing subscriber layers, then install the composed subscriber in your application's normal process-wide/global subscriber setup during startup.
+
 ```rust,no_run
 use tailtriage_tracing::TracingIntakeSession;
 use tracing::Instrument as _;
@@ -48,8 +50,12 @@ let session = TracingIntakeSession::builder("checkout-service")
     .completed_span_jsonl_path("target/tailtriage-examples/checkout.spans.jsonl")
     .build()?;
 
-let subscriber = tracing_subscriber::registry().with(session.layer());
-let _guard = tracing::subscriber::set_default(subscriber);
+tracing_subscriber::registry()
+    .with(session.layer())
+    .init();
+
+// run service/workload here
+
 let request = tracing::info_span!(
     "request",
     tt.kind = "request",
@@ -59,7 +65,7 @@ let request = tracing::info_span!(
 );
 work().instrument(request).await;
 
-session.shutdown()?;
+let _imported = session.shutdown()?;
 # Ok(())
 # }
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -67,6 +73,8 @@ session.shutdown()?;
 #   Ok(())
 # }
 ```
+
+Use `.init()` only from startup-only binary code paths where no prior global subscriber is installed. `tailtriage` does not replace your tracing pipeline; it adds a layer beside your existing subscriber layers.
 
 ## Direct Run JSON path
 


### PR DESCRIPTION
### Motivation
- Public live-session docs previously taught `tracing::subscriber::set_default(...)` as the primary setup pattern which is scoped to the current thread/guard lifetime and is fragile for Tokio multi-thread services. 
- The intent is to give service-safe guidance that composes the tailtriage layer into the application’s normal process-global subscriber setup so live intake works reliably in real services.

### Description
- Replaced examples that used `set_default(...)` with composing `session.layer()` into `tracing_subscriber::registry().with(session.layer())` and demonstrating startup installation via `.init()` in `tailtriage-tracing/README.md` and `docs/user-guide.md`.
- Added guidance that `.init()` is only for startup-only binary code paths and that `tailtriage` layers augment existing tracing pipelines rather than replacing them. 
- Preserved `set_default` only as a scoped/local/test-only pattern and added the explicit warning that `set_default` is thread/guard scoped and not the service-startup pattern. 
- Updated shutdown/import handling in examples to show the session finalization (`let _imported = session.shutdown()?;`).

### Testing
- Ran `cargo fmt --check` and it completed successfully with no formatting errors. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it completed successfully with no warnings. 
- Ran `cargo test --workspace --all-targets --all-features --locked` and the workspace test suite completed successfully with all tests passing. 
- Ran `python3 scripts/validate_docs_contracts.py` and it reported `docs contracts validated successfully`.

Commands executed and results:
- `cargo fmt --check` — succeeded (no changes required).
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — succeeded (no warnings/errors).
- `cargo test --workspace --all-targets --all-features --locked` — succeeded (workspace tests passed).
- `python3 scripts/validate_docs_contracts.py` — succeeded with message: `docs contracts validated successfully`.

Files changed:
- `tailtriage-tracing/README.md` (update live-session example and guidance)
- `docs/user-guide.md` (update live-session example and guidance)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a142b6be7e48330b79d618ab1c1a01d)