### PR TITLE
docs: teach service-safe global tracing setup for live intake sessions

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -69,8 +69,9 @@ use tracing_subscriber::prelude::*;
 let session = TracingIntakeSession::builder("checkout-service")
     .run_json_path("target/tailtriage-examples/checkout.run.json")
     .build()?;
-let subscriber = tracing_subscriber::registry().with(session.layer());
-let _guard = tracing::subscriber::set_default(subscriber);
+tracing_subscriber::registry()
+    .with(session.layer())
+    .init(); // startup-only: global subscriber installation for this process
 let span = tracing::info_span!(
     "request",
     tt.kind = "request",
@@ -79,7 +80,8 @@ let span = tracing::info_span!(
     tt.outcome = "ok",
 );
 work().instrument(span).await;
-session.shutdown()?;
+let imported = session.shutdown()?;
+# let _ = imported;
 # Ok(())
 }
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -89,6 +91,8 @@ session.shutdown()?;
 ```
 
 Stage and queue spans use their own `tt.stage` / `tt.queue` fields around the awaited work they measure.
+
+In service code, add `session.layer()` beside your existing tracing layers and install the resulting subscriber in the application's normal process-wide/global subscriber setup. `set_default` is scoped to the current thread and guard lifetime; service startup should install the tailtriage layer in the process-wide subscriber setup.
 
 Then analyze directly:
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -48,8 +48,10 @@ let session = TracingIntakeSession::builder("checkout-service")
     .completed_span_jsonl_path("target/tailtriage-examples/checkout.spans.jsonl")
     .build()?;
 
-let subscriber = tracing_subscriber::registry().with(session.layer());
-let _guard = tracing::subscriber::set_default(subscriber);
+tracing_subscriber::registry()
+    .with(session.layer())
+    .init(); // startup-only: global subscriber installation for this process
+
 let request = tracing::info_span!(
     "request",
     tt.kind = "request",
@@ -58,8 +60,8 @@ let request = tracing::info_span!(
     tt.outcome = "ok"
 );
 work().instrument(request).await;
-
-session.shutdown()?;
+let imported = session.shutdown()?;
+# let _ = imported;
 # Ok(())
 # }
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -67,6 +69,12 @@ session.shutdown()?;
 #   Ok(())
 # }
 ```
+
+Install the tailtriage layer beside your existing tracing layers in the application's normal process-wide subscriber setup; tailtriage augments your tracing pipeline rather than replacing it.
+
+If your service already builds a subscriber in startup code, compose `session.layer()` onto that subscriber and install it once with your normal global install path (for example `.init()` during binary startup, or `tracing::subscriber::set_global_default(...)` with explicit error handling when needed).
+
+`set_default` is scoped to the current thread and guard lifetime; service startup should install the tailtriage layer in the process-wide subscriber setup.
 
 ## Direct Run JSON path
 


### PR DESCRIPTION
### Motivation
- The existing live-session docs taught `tracing::subscriber::set_default(...)` as the primary setup, which is thread/guard-scoped and fragile for Tokio multi-threaded services.
- Docs should show a service-safe, process-wide subscriber installation pattern and avoid implying `.init()` can be called multiple times or that tailtriage replaces the user’s tracing pipeline.

### Description
- Updated live-session examples in `tailtriage-tracing/README.md` and `docs/user-guide.md` to install the tailtriage layer into the application’s process-wide subscriber using `tracing_subscriber::registry().with(session.layer()).init()` as the primary startup pattern.
- Added explicit guidance that the tailtriage layer is composed beside existing tracing layers and does not replace the application’s tracing pipeline.
- Marked `.init()` usage as a startup-only action and kept `set_default` only as a clearly labeled scoped/local/test-only option with the new explanatory text: `set_default is scoped to the current thread and guard lifetime; service startup should install the tailtriage layer in the process-wide subscriber setup.`
- Adjusted snippets to handle `session.shutdown()` return (`let imported = session.shutdown()?;`) and clarified guidance to compose `session.layer()` onto an existing subscriber when appropriate, including mentioning `set_global_default(...)` with explicit error handling as an alternative when required.

### Testing
- Ran `cargo fmt --check` and it succeeded without changes reported.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it completed with no warnings (command completed successfully).
- Ran `cargo test --workspace --all-targets --all-features --locked` and the full test suite completed successfully with all tests passing (numerous unit and integration tests run; final summary: tests passed).
- Ran `python3 scripts/validate_docs_contracts.py` and it printed `docs contracts validated successfully` indicating docs-contract validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a142b6be7e48330b79d618ab1c1a01d)