### PR TITLE
Use persisted-run sink path for demo tracing shutdown

### DIFF
--- a/demos/demo_support/src/lib.rs
+++ b/demos/demo_support/src/lib.rs
@@ -4,8 +4,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context;
-use tailtriage_core::{CaptureLimitsOverride, CaptureMode, Tailtriage};
-use tailtriage_tracing::{tokio::TracingTokioSession, TracingRecorder};
+use tailtriage_core::{CaptureLimitsOverride, CaptureMode, LocalJsonSink, RunSink, Tailtriage};
+use tailtriage_tracing::{
+    ensure_persistable_run_has_requests, tokio::TracingTokioSession, TracingRecorder,
+};
 use tokio::sync::Barrier;
 use tracing::Instrument;
 use tracing_subscriber::prelude::*;
@@ -352,8 +354,7 @@ impl DemoInstrumentation {
             }
             DemoInstrumentationBackend::Tracing(state) => {
                 let imported = state.recorder.shutdown()?;
-                let mut file = std::fs::File::create(output_path)?;
-                serde_json::to_writer_pretty(&mut file, imported.run())?;
+                write_persistable_demo_run(imported.run(), output_path)?;
                 Ok(())
             }
         }
@@ -473,12 +474,22 @@ impl RuntimeDemoInstrumentation {
             }
             RuntimeDemoBackend::Tracing(s) => {
                 let imported = s.shutdown().await?;
-                let mut file = std::fs::File::create(output_path)?;
-                serde_json::to_writer_pretty(&mut file, imported.run())?;
+                write_persistable_demo_run(imported.run(), output_path)?;
                 Ok(())
             }
         }
     }
+}
+
+fn write_persistable_demo_run(
+    run: &tailtriage_core::Run,
+    output_path: &Path,
+) -> anyhow::Result<()> {
+    ensure_persistable_run_has_requests(run)?;
+    LocalJsonSink::new(output_path)
+        .write(run)
+        .with_context(|| format!("failed to write demo artifact to {}", output_path.display()))?;
+    Ok(())
 }
 
 impl DemoRequest {
@@ -609,13 +620,79 @@ pub async fn run_warmup_then_measured<Warmup, WarmupFut, Measured, MeasuredFut>(
 #[cfg(test)]
 mod tests {
     use super::{parse_demo_args_from, DemoMode, InstrumentationMode};
-    use tailtriage_core::Outcome;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use tailtriage_core::{
+        CaptureMode, Outcome, RequestEvent, Run, RunMetadata, TruncationSummary, UnfinishedRequests,
+    };
 
     #[test]
     fn demo_args_default_instrumentation_is_native() {
         let args = parse_demo_args_from(&["out.json".to_string()], "ignored").expect("parse args");
         assert_eq!(args.mode, DemoMode::Baseline);
         assert_eq!(args.instrumentation, InstrumentationMode::Native);
+    }
+
+    #[test]
+    fn tracing_artifact_write_rejects_empty_run() {
+        let temp =
+            std::env::temp_dir().join(format!("tailtriage-demo-empty-{}.json", std::process::id()));
+        let _ = std::fs::remove_file(&temp);
+        let run = test_run(Vec::new());
+        let err = super::write_persistable_demo_run(&run, &temp).expect_err("should reject");
+        assert!(!temp.exists(), "artifact should not be written");
+        assert!(err.to_string().contains("zero request events"));
+    }
+
+    #[test]
+    fn tracing_artifact_write_persists_non_empty_run() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let temp = std::env::temp_dir().join(format!("tailtriage-demo-non-empty-{unique}.json"));
+        let _ = std::fs::remove_file(&temp);
+        let run = test_run(vec![RequestEvent {
+            request_id: "req-1".to_string(),
+            route: "/demo".to_string(),
+            kind: None,
+            started_at_unix_ms: 1_000,
+            finished_at_unix_ms: 1_005,
+            latency_us: 5_000,
+            outcome: "ok".to_string(),
+        }]);
+        super::write_persistable_demo_run(&run, &temp).expect("write run");
+        let persisted = std::fs::read_to_string(&temp).expect("read artifact");
+        let parsed: Run = serde_json::from_str(&persisted).expect("valid run JSON");
+        assert_eq!(parsed.requests.len(), 1);
+        let _ = std::fs::remove_file(&temp);
+    }
+
+    fn test_run(requests: Vec<RequestEvent>) -> Run {
+        Run {
+            schema_version: 1,
+            metadata: RunMetadata {
+                run_id: "run-1".to_string(),
+                service_name: "demo".to_string(),
+                service_version: None,
+                started_at_unix_ms: 1_000,
+                finished_at_unix_ms: 2_000,
+                finalized_at_unix_ms: Some(2_000),
+                mode: CaptureMode::Light,
+                effective_core_config: None,
+                effective_tokio_sampler_config: None,
+                host: None,
+                pid: None,
+                lifecycle_warnings: Vec::new(),
+                unfinished_requests: UnfinishedRequests::default(),
+                run_end_reason: None,
+            },
+            requests,
+            stages: Vec::new(),
+            queues: Vec::new(),
+            inflight: Vec::new(),
+            runtime_snapshots: Vec::new(),
+            truncation: TruncationSummary::default(),
+        }
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Make demo tracing shutdown use the same persisted-artifact guard and writer used by the CLI import so tracing shutdown rejects empty runs and writes via the official `LocalJsonSink`/`RunSink` path with consistent error context.

### Description
- Replace direct `File::create` + `serde_json::to_writer_pretty` in `DemoInstrumentation::shutdown` and `RuntimeDemoInstrumentation::shutdown` with a shared private helper `write_persistable_demo_run(...)` that calls `ensure_persistable_run_has_requests(...)` and writes via `tailtriage_core::LocalJsonSink` using the `RunSink` trait and `anyhow::Context` for path-aware errors.
- Keep native demo shutdown behavior unchanged and add the necessary imports from `tailtriage_core` and `tailtriage_tracing` in `demos/demo_support/src/lib.rs`.
- Add helper-level tests that assert zero-request runs are rejected without writing an artifact and that runs with at least one request persist a valid Run JSON artifact.

### Testing
- Ran `cargo fmt --check` which succeeded without changes reported.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which completed with no warnings or errors.
- Ran `cargo test --workspace --all-targets --all-features --locked` which completed successfully (all test suites passed across crates); the demo-support unit tests covering the new helper passed.
- Ran `python3 scripts/validate_docs_contracts.py` which reported "docs contracts validated successfully" and completed.
- Ran `python3 scripts/demo_tool.py validate-tracing-parity all --profile release` and `python3 scripts/demo_tool.py validate-tracing-retention-parity --profile release` which wrote the demo artifacts and reported parity/retention validations passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14387fa0288330834e45579406017c)