### PR TITLE
Preflight tracing output dirs and fix example span scoping

### DIFF
--- a/tailtriage-tracing/examples/completed_span_jsonl_import.rs
+++ b/tailtriage-tracing/examples/completed_span_jsonl_import.rs
@@ -5,7 +5,6 @@ use tracing_subscriber::prelude::*;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let spans_path = std::path::PathBuf::from("target/tailtriage-examples/completed-spans.jsonl");
-    std::fs::create_dir_all(spans_path.parent().expect("parent path exists"))?;
 
     let session = TracingIntakeSession::builder("checkout-service")
         .completed_span_jsonl_path(&spans_path)
@@ -21,22 +20,26 @@ fn main() -> Result<(), Box<dyn Error>> {
             tt.outcome = "ok"
         );
         let _request_guard = request.enter();
-        let _queue_guard = tracing::info_span!(
-            "admission.queue",
-            tt.kind = "queue",
-            tt.request_id = "req-1",
-            tt.queue = "admission",
-            tt.depth_at_start = 5_u64
-        )
-        .entered();
-        let _stage_guard = tracing::info_span!(
-            "db.stage",
-            tt.kind = "stage",
-            tt.request_id = "req-1",
-            tt.stage = "db",
-            tt.success = true
-        )
-        .entered();
+        {
+            let _queue_guard = tracing::info_span!(
+                "admission.queue",
+                tt.kind = "queue",
+                tt.request_id = "req-1",
+                tt.queue = "admission",
+                tt.depth_at_start = 5_u64
+            )
+            .entered();
+        }
+        {
+            let _stage_guard = tracing::info_span!(
+                "db.stage",
+                tt.kind = "stage",
+                tt.request_id = "req-1",
+                tt.stage = "db",
+                tt.success = true
+            )
+            .entered();
+        }
     });
 
     session.shutdown()?;

--- a/tailtriage-tracing/examples/live_session_to_run.rs
+++ b/tailtriage-tracing/examples/live_session_to_run.rs
@@ -5,7 +5,6 @@ use tracing_subscriber::prelude::*;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let run_path = std::path::PathBuf::from("target/tailtriage-examples/live-session-run.json");
-    std::fs::create_dir_all(run_path.parent().expect("parent path exists"))?;
 
     let session = TracingIntakeSession::builder("checkout-service")
         .run_json_path(&run_path)
@@ -22,23 +21,26 @@ fn main() -> Result<(), Box<dyn Error>> {
         );
         let _request_guard = request.enter();
 
-        let queue = tracing::info_span!(
-            "admission.queue",
-            tt.kind = "queue",
-            tt.request_id = "req-1",
-            tt.queue = "admission",
-            tt.depth_at_start = 3_u64
-        );
-        let _queue_guard = queue.enter();
-
-        let stage = tracing::info_span!(
-            "db.stage",
-            tt.kind = "stage",
-            tt.request_id = "req-1",
-            tt.stage = "db",
-            tt.success = true
-        );
-        let _stage_guard = stage.enter();
+        {
+            let queue = tracing::info_span!(
+                "admission.queue",
+                tt.kind = "queue",
+                tt.request_id = "req-1",
+                tt.queue = "admission",
+                tt.depth_at_start = 3_u64
+            );
+            let _queue_guard = queue.enter();
+        }
+        {
+            let stage = tracing::info_span!(
+                "db.stage",
+                tt.kind = "stage",
+                tt.request_id = "req-1",
+                tt.stage = "db",
+                tt.success = true
+            );
+            let _stage_guard = stage.enter();
+        }
     });
 
     session.shutdown()?;

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -297,6 +297,7 @@ impl TracingIntakeSession {
             }
         }
         if let Some(path) = self.run_json_path {
+            create_output_parent_dir(&path, "create run json parent directory")?;
             LocalJsonSink::new(&path)
                 .write(&run)
                 .map_err(|err| ImportError::RunJsonWrite {
@@ -312,6 +313,7 @@ fn write_completed_span_jsonl_from_run(
     run: &tailtriage_core::Run,
     path: &Path,
 ) -> Result<(), ImportError> {
+    create_output_parent_dir(path, "create completed span jsonl parent directory")?;
     let temp_path = completed_span_jsonl_temp_path(path);
     let mut file = std::fs::OpenOptions::new()
         .create(true)
@@ -367,6 +369,21 @@ fn write_completed_span_jsonl_from_run(
         }
     })?;
 
+    Ok(())
+}
+
+fn create_output_parent_dir(path: &Path, operation: &'static str) -> Result<(), ImportError> {
+    let Some(parent) = path.parent() else {
+        return Ok(());
+    };
+    if parent.as_os_str().is_empty() {
+        return Ok(());
+    }
+    std::fs::create_dir_all(parent).map_err(|err| ImportError::Io {
+        operation,
+        context: parent.display().to_string(),
+        reason: err.to_string(),
+    })?;
     Ok(())
 }
 
@@ -2688,7 +2705,11 @@ mod tests {
     #[test]
     fn intake_session_write_failure_returns_io_on_shutdown() {
         let dir = tempfile::tempdir().unwrap();
-        let bad_path = dir.path().join("missing").join("spans.jsonl");
+        let bad_path = dir
+            .path()
+            .join("missing-parent-is-file")
+            .join("spans.jsonl");
+        std::fs::write(dir.path().join("missing-parent-is-file"), "not-a-directory").unwrap();
         let session = TracingIntakeSession::builder("svc")
             .completed_span_jsonl_path(&bad_path)
             .strict(true)
@@ -2696,13 +2717,17 @@ mod tests {
             .unwrap();
         let err = session.shutdown().unwrap_err();
         assert!(matches!(err, ImportError::Io { .. }));
-        assert!(err.to_string().contains("spans.jsonl"));
+        assert!(err.to_string().contains("missing-parent-is-file"));
     }
 
     #[test]
     fn intake_session_non_strict_write_failure_adds_warning_and_keeps_run() {
         let dir = tempfile::tempdir().unwrap();
-        let bad_path = dir.path().join("missing").join("spans.jsonl");
+        let bad_path = dir
+            .path()
+            .join("missing-parent-is-file")
+            .join("spans.jsonl");
+        std::fs::write(dir.path().join("missing-parent-is-file"), "not-a-directory").unwrap();
         let session = TracingIntakeSession::builder("svc")
             .completed_span_jsonl_path(&bad_path)
             .build()
@@ -2764,6 +2789,72 @@ mod tests {
         let run: tailtriage_core::Run =
             serde_json::from_slice(&std::fs::read(&run_path).unwrap()).unwrap();
         assert_eq!(run.requests.len(), 1);
+    }
+
+    #[test]
+    fn intake_session_run_json_path_creates_nested_parent_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_path = dir.path().join("nested").join("deep").join("run.json");
+        let session = TracingIntakeSession::builder("svc")
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            ));
+        });
+        session.shutdown().unwrap();
+        assert!(run_path.exists());
+    }
+
+    #[test]
+    fn intake_session_completed_jsonl_path_creates_nested_parent_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let spans_path = dir.path().join("nested").join("deep").join("spans.jsonl");
+        let session = TracingIntakeSession::builder("svc")
+            .completed_span_jsonl_path(&spans_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            ));
+        });
+        session.shutdown().unwrap();
+        assert!(spans_path.exists());
+    }
+
+    #[test]
+    fn intake_session_run_json_simple_filename_writes_without_parent_creation() {
+        let dir = tempfile::tempdir().unwrap();
+        let current = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+        let run_path = PathBuf::from("run.json");
+        let session = TracingIntakeSession::builder("svc")
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            ));
+        });
+        session.shutdown().unwrap();
+        assert!(run_path.exists());
+        std::env::set_current_dir(current).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Public examples used workspace-local paths under `target/tailtriage-examples/...` but required users to create parent directories manually, which breaks copy-paste usage.
- Live examples currently left queue spans open while stage spans were active, causing queue spans to overlap stage work and misteach queue/stage boundaries.

### Description
- Added a private helper `create_output_parent_dir(path: &Path, operation: &'static str) -> Result<(), ImportError>` in `tailtriage-tracing/src/recorder.rs` to preflight and create parent directories when needed and to return `ImportError::Io` on failure.
- Call the helper before creating the completed-span JSONL temp file in `write_completed_span_jsonl_from_run(...)` and before writing the final run JSON via `LocalJsonSink` in `TracingIntakeSession::shutdown`, preserving the existing atomic temp-file + rename behavior.
- Added deterministic tests in `tailtriage-tracing/src/recorder.rs` that verify nested parent directories are created for both run JSON and completed-span JSONL outputs and that a simple filename (e.g., `run.json`) does not try to `create_dir_all("")` and still writes successfully, and adapted failure tests to use a deterministic "parent-is-file" scenario.
- Updated examples `tailtriage-tracing/examples/completed_span_jsonl_import.rs` and `tailtriage-tracing/examples/live_session_to_run.rs` to remove manual `create_dir_all` setup and to use separate lexical scopes so queue and stage guards do not overlap inside the request span.

### Testing
- Ran `cargo fmt --check` and verified formatting passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and verified there are no clippy warnings/errors.
- Ran `cargo test --workspace --all-targets --all-features --locked` and verified the full test suite passed (all tests green).
- Ran `python3 scripts/validate_docs_contracts.py` and verified docs contract validation passed.
- Ran feature-specific checks `cargo check -p tailtriage-tracing --no-default-features --locked`, `cargo check -p tailtriage-tracing --no-default-features --features jsonl --locked`, `cargo check -p tailtriage-tracing --no-default-features --features live --locked`, and `cargo check -p tailtriage-tracing --no-default-features --features tokio --locked` and verified all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14702a4f808330b557e4061841c07b)