### PR TITLE
tracing: create session output dirs and de-overlap example spans

### DIFF
--- a/tailtriage-tracing/examples/completed_span_jsonl_import.rs
+++ b/tailtriage-tracing/examples/completed_span_jsonl_import.rs
@@ -5,7 +5,6 @@ use tracing_subscriber::prelude::*;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let spans_path = std::path::PathBuf::from("target/tailtriage-examples/completed-spans.jsonl");
-    std::fs::create_dir_all(spans_path.parent().expect("parent path exists"))?;
 
     let session = TracingIntakeSession::builder("checkout-service")
         .completed_span_jsonl_path(&spans_path)
@@ -21,22 +20,26 @@ fn main() -> Result<(), Box<dyn Error>> {
             tt.outcome = "ok"
         );
         let _request_guard = request.enter();
-        let _queue_guard = tracing::info_span!(
-            "admission.queue",
-            tt.kind = "queue",
-            tt.request_id = "req-1",
-            tt.queue = "admission",
-            tt.depth_at_start = 5_u64
-        )
-        .entered();
-        let _stage_guard = tracing::info_span!(
-            "db.stage",
-            tt.kind = "stage",
-            tt.request_id = "req-1",
-            tt.stage = "db",
-            tt.success = true
-        )
-        .entered();
+        {
+            let _queue_guard = tracing::info_span!(
+                "admission.queue",
+                tt.kind = "queue",
+                tt.request_id = "req-1",
+                tt.queue = "admission",
+                tt.depth_at_start = 5_u64
+            )
+            .entered();
+        }
+        {
+            let _stage_guard = tracing::info_span!(
+                "db.stage",
+                tt.kind = "stage",
+                tt.request_id = "req-1",
+                tt.stage = "db",
+                tt.success = true
+            )
+            .entered();
+        }
     });
 
     session.shutdown()?;

--- a/tailtriage-tracing/examples/live_session_to_run.rs
+++ b/tailtriage-tracing/examples/live_session_to_run.rs
@@ -5,7 +5,6 @@ use tracing_subscriber::prelude::*;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let run_path = std::path::PathBuf::from("target/tailtriage-examples/live-session-run.json");
-    std::fs::create_dir_all(run_path.parent().expect("parent path exists"))?;
 
     let session = TracingIntakeSession::builder("checkout-service")
         .run_json_path(&run_path)
@@ -22,23 +21,26 @@ fn main() -> Result<(), Box<dyn Error>> {
         );
         let _request_guard = request.enter();
 
-        let queue = tracing::info_span!(
-            "admission.queue",
-            tt.kind = "queue",
-            tt.request_id = "req-1",
-            tt.queue = "admission",
-            tt.depth_at_start = 3_u64
-        );
-        let _queue_guard = queue.enter();
-
-        let stage = tracing::info_span!(
-            "db.stage",
-            tt.kind = "stage",
-            tt.request_id = "req-1",
-            tt.stage = "db",
-            tt.success = true
-        );
-        let _stage_guard = stage.enter();
+        {
+            let queue = tracing::info_span!(
+                "admission.queue",
+                tt.kind = "queue",
+                tt.request_id = "req-1",
+                tt.queue = "admission",
+                tt.depth_at_start = 3_u64
+            );
+            let _queue_guard = queue.enter();
+        }
+        {
+            let stage = tracing::info_span!(
+                "db.stage",
+                tt.kind = "stage",
+                tt.request_id = "req-1",
+                tt.stage = "db",
+                tt.success = true
+            );
+            let _stage_guard = stage.enter();
+        }
     });
 
     session.shutdown()?;

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -297,6 +297,7 @@ impl TracingIntakeSession {
             }
         }
         if let Some(path) = self.run_json_path {
+            create_output_parent_dir(&path, "create run json parent directory")?;
             LocalJsonSink::new(&path)
                 .write(&run)
                 .map_err(|err| ImportError::RunJsonWrite {
@@ -312,6 +313,7 @@ fn write_completed_span_jsonl_from_run(
     run: &tailtriage_core::Run,
     path: &Path,
 ) -> Result<(), ImportError> {
+    create_output_parent_dir(path, "create completed span jsonl parent directory")?;
     let temp_path = completed_span_jsonl_temp_path(path);
     let mut file = std::fs::OpenOptions::new()
         .create(true)
@@ -368,6 +370,20 @@ fn write_completed_span_jsonl_from_run(
     })?;
 
     Ok(())
+}
+
+fn create_output_parent_dir(path: &Path, operation: &'static str) -> Result<(), ImportError> {
+    let Some(parent) = path.parent() else {
+        return Ok(());
+    };
+    if parent.as_os_str().is_empty() {
+        return Ok(());
+    }
+    std::fs::create_dir_all(parent).map_err(|err| ImportError::Io {
+        operation,
+        context: parent.display().to_string(),
+        reason: err.to_string(),
+    })
 }
 
 fn completed_span_jsonl_temp_path(path: &Path) -> PathBuf {
@@ -2688,7 +2704,9 @@ mod tests {
     #[test]
     fn intake_session_write_failure_returns_io_on_shutdown() {
         let dir = tempfile::tempdir().unwrap();
-        let bad_path = dir.path().join("missing").join("spans.jsonl");
+        let non_dir_parent = dir.path().join("not-a-dir");
+        std::fs::write(&non_dir_parent, "file").unwrap();
+        let bad_path = non_dir_parent.join("spans.jsonl");
         let session = TracingIntakeSession::builder("svc")
             .completed_span_jsonl_path(&bad_path)
             .strict(true)
@@ -2696,13 +2714,15 @@ mod tests {
             .unwrap();
         let err = session.shutdown().unwrap_err();
         assert!(matches!(err, ImportError::Io { .. }));
-        assert!(err.to_string().contains("spans.jsonl"));
+        assert!(err.to_string().contains("not-a-dir"));
     }
 
     #[test]
     fn intake_session_non_strict_write_failure_adds_warning_and_keeps_run() {
         let dir = tempfile::tempdir().unwrap();
-        let bad_path = dir.path().join("missing").join("spans.jsonl");
+        let non_dir_parent = dir.path().join("not-a-dir");
+        std::fs::write(&non_dir_parent, "file").unwrap();
+        let bad_path = non_dir_parent.join("spans.jsonl");
         let session = TracingIntakeSession::builder("svc")
             .completed_span_jsonl_path(&bad_path)
             .build()
@@ -2764,6 +2784,27 @@ mod tests {
         let run: tailtriage_core::Run =
             serde_json::from_slice(&std::fs::read(&run_path).unwrap()).unwrap();
         assert_eq!(run.requests.len(), 1);
+    }
+
+    #[test]
+    fn intake_session_run_json_path_creates_nested_parent_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_path = dir.path().join("nested").join("out").join("run.json");
+        let session = TracingIntakeSession::builder("svc")
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            ));
+        });
+        session.shutdown().unwrap();
+        assert!(run_path.exists());
     }
 
     #[test]
@@ -2835,6 +2876,52 @@ mod tests {
         let value: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
         assert_eq!(value["format"], "tailtriage.tracing-span.v1");
         assert!(value["span"].is_object());
+    }
+
+    #[test]
+    fn completed_span_jsonl_path_creates_nested_parent_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let spans_path = dir.path().join("nested").join("out").join("spans.jsonl");
+        let session = TracingIntakeSession::builder("svc")
+            .completed_span_jsonl_path(&spans_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            ));
+        });
+        session.shutdown().unwrap();
+        assert!(spans_path.exists());
+    }
+
+    #[test]
+    fn run_json_simple_filename_writes_without_parent_dir_creation() {
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+
+        let session = TracingIntakeSession::builder("svc")
+            .run_json_path("run.json")
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            ));
+        });
+        session.shutdown().unwrap();
+        assert!(dir.path().join("run.json").exists());
+
+        std::env::set_current_dir(cwd).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Examples used workspace-local output paths (e.g. `target/tailtriage-examples/...`) that required users to pre-create parent directories, which breaks simple copy-paste usage.  
- Live examples created queue and stage spans with guards that overlapped in time, causing queue spans to incorrectly encompass stage work instead of bracketing queue wait only.

### Description

- Add a small private helper `create_output_parent_dir(path: &Path, operation: &'static str) -> Result<(), ImportError>` and call it before writing completed-span JSONL (`write_completed_span_jsonl_from_run`) and before writing Run JSON in `TracingIntakeSession::shutdown`, preserving existing atomic temp-file + rename behavior.  
- Keep directory-creation local to the tracing session writer and do not change `LocalJsonSink` globally.  
- Update the two live examples `completed_span_jsonl_import.rs` and `live_session_to_run.rs` to remove manual `std::fs::create_dir_all(...)` and to use separate lexical scopes so queue and stage guards are not alive at the same time.  
- Add tests in `tailtriage-tracing/src/recorder.rs` that verify nested parent directories are created for both `run_json_path` and `completed_span_jsonl_path`, and that a simple filename such as `run.json` (no meaningful parent) still writes successfully; adjust write-failure tests to deterministically exercise IO failure by creating a file where the parent directory would be.

### Testing

- Ran formatting check with `cargo fmt --check`, which succeeded.  
- Ran lints with `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, which succeeded.  
- Ran the full test suite with `cargo test --workspace --all-targets --all-features --locked`, which succeeded (tests passed).  
- Ran docs contract validation with `python3 scripts/validate_docs_contracts.py`, which succeeded.  
- Ran feature-specific checks for the tracing crate with: `cargo check -p tailtriage-tracing --no-default-features --locked`, `cargo check -p tailtriage-tracing --no-default-features --features jsonl --locked`, `cargo check -p tailtriage-tracing --no-default-features --features live --locked`, and `cargo check -p tailtriage-tracing --no-default-features --features tokio --locked`, all of which succeeded (note: a non-fatal `dead_code` warning for `selected_mode` was observed during checks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14702a4f808330b557e4061841c07b)