### PR TITLE
Create parent dirs for tracing outputs and fix live examples (non-overlapping spans)

### DIFF
--- a/tailtriage-tracing/examples/completed_span_jsonl_import.rs
+++ b/tailtriage-tracing/examples/completed_span_jsonl_import.rs
@@ -5,7 +5,6 @@ use tracing_subscriber::prelude::*;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let spans_path = std::path::PathBuf::from("target/tailtriage-examples/completed-spans.jsonl");
-    std::fs::create_dir_all(spans_path.parent().expect("parent path exists"))?;
 
     let session = TracingIntakeSession::builder("checkout-service")
         .completed_span_jsonl_path(&spans_path)
@@ -21,22 +20,26 @@ fn main() -> Result<(), Box<dyn Error>> {
             tt.outcome = "ok"
         );
         let _request_guard = request.enter();
-        let _queue_guard = tracing::info_span!(
-            "admission.queue",
-            tt.kind = "queue",
-            tt.request_id = "req-1",
-            tt.queue = "admission",
-            tt.depth_at_start = 5_u64
-        )
-        .entered();
-        let _stage_guard = tracing::info_span!(
-            "db.stage",
-            tt.kind = "stage",
-            tt.request_id = "req-1",
-            tt.stage = "db",
-            tt.success = true
-        )
-        .entered();
+        {
+            let _queue_guard = tracing::info_span!(
+                "admission.queue",
+                tt.kind = "queue",
+                tt.request_id = "req-1",
+                tt.queue = "admission",
+                tt.depth_at_start = 5_u64
+            )
+            .entered();
+        }
+        {
+            let _stage_guard = tracing::info_span!(
+                "db.stage",
+                tt.kind = "stage",
+                tt.request_id = "req-1",
+                tt.stage = "db",
+                tt.success = true
+            )
+            .entered();
+        }
     });
 
     session.shutdown()?;

--- a/tailtriage-tracing/examples/live_session_to_run.rs
+++ b/tailtriage-tracing/examples/live_session_to_run.rs
@@ -5,7 +5,6 @@ use tracing_subscriber::prelude::*;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let run_path = std::path::PathBuf::from("target/tailtriage-examples/live-session-run.json");
-    std::fs::create_dir_all(run_path.parent().expect("parent path exists"))?;
 
     let session = TracingIntakeSession::builder("checkout-service")
         .run_json_path(&run_path)
@@ -22,23 +21,27 @@ fn main() -> Result<(), Box<dyn Error>> {
         );
         let _request_guard = request.enter();
 
-        let queue = tracing::info_span!(
-            "admission.queue",
-            tt.kind = "queue",
-            tt.request_id = "req-1",
-            tt.queue = "admission",
-            tt.depth_at_start = 3_u64
-        );
-        let _queue_guard = queue.enter();
+        {
+            let _queue_guard = tracing::info_span!(
+                "admission.queue",
+                tt.kind = "queue",
+                tt.request_id = "req-1",
+                tt.queue = "admission",
+                tt.depth_at_start = 3_u64
+            )
+            .entered();
+        }
 
-        let stage = tracing::info_span!(
-            "db.stage",
-            tt.kind = "stage",
-            tt.request_id = "req-1",
-            tt.stage = "db",
-            tt.success = true
-        );
-        let _stage_guard = stage.enter();
+        {
+            let _stage_guard = tracing::info_span!(
+                "db.stage",
+                tt.kind = "stage",
+                tt.request_id = "req-1",
+                tt.stage = "db",
+                tt.success = true
+            )
+            .entered();
+        }
     });
 
     session.shutdown()?;

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -2714,7 +2714,9 @@ mod tests {
             .unwrap();
         let err = session.shutdown().unwrap_err();
         assert!(matches!(err, ImportError::Io { .. }));
-        assert!(err.to_string().contains("create completed span jsonl parent directory"));
+        assert!(err
+            .to_string()
+            .contains("create completed span jsonl parent directory"));
     }
 
     #[test]
@@ -2900,28 +2902,9 @@ mod tests {
     }
 
     #[test]
-    fn run_json_simple_filename_without_parent_writes_successfully() {
-        let dir = tempfile::tempdir().unwrap();
-        let cwd = std::env::current_dir().unwrap();
-        std::env::set_current_dir(dir.path()).unwrap();
-
-        let session = TracingIntakeSession::builder("svc")
-            .run_json_path("run.json")
-            .build()
+    fn create_output_parent_dir_skips_filename_only_path() {
+        create_output_parent_dir(Path::new("run.json"), "create run json parent directory")
             .unwrap();
-        let subscriber = tracing_subscriber::registry().with(session.layer());
-        tracing::subscriber::with_default(subscriber, || {
-            drop(tracing::info_span!(
-                "request",
-                tt.kind = "request",
-                tt.request_id = "r1",
-                tt.route = "/a"
-            ));
-        });
-        session.shutdown().unwrap();
-        assert!(dir.path().join("run.json").exists());
-
-        std::env::set_current_dir(cwd).unwrap();
     }
 
     #[test]

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -297,6 +297,7 @@ impl TracingIntakeSession {
             }
         }
         if let Some(path) = self.run_json_path {
+            create_output_parent_dir(&path, "create run json parent directory")?;
             LocalJsonSink::new(&path)
                 .write(&run)
                 .map_err(|err| ImportError::RunJsonWrite {
@@ -312,6 +313,7 @@ fn write_completed_span_jsonl_from_run(
     run: &tailtriage_core::Run,
     path: &Path,
 ) -> Result<(), ImportError> {
+    create_output_parent_dir(path, "create completed span jsonl parent directory")?;
     let temp_path = completed_span_jsonl_temp_path(path);
     let mut file = std::fs::OpenOptions::new()
         .create(true)
@@ -368,6 +370,20 @@ fn write_completed_span_jsonl_from_run(
     })?;
 
     Ok(())
+}
+
+fn create_output_parent_dir(path: &Path, operation: &'static str) -> Result<(), ImportError> {
+    let Some(parent) = path.parent() else {
+        return Ok(());
+    };
+    if parent.as_os_str().is_empty() {
+        return Ok(());
+    }
+    std::fs::create_dir_all(parent).map_err(|err| ImportError::Io {
+        operation,
+        context: parent.display().to_string(),
+        reason: err.to_string(),
+    })
 }
 
 fn completed_span_jsonl_temp_path(path: &Path) -> PathBuf {
@@ -2688,7 +2704,9 @@ mod tests {
     #[test]
     fn intake_session_write_failure_returns_io_on_shutdown() {
         let dir = tempfile::tempdir().unwrap();
-        let bad_path = dir.path().join("missing").join("spans.jsonl");
+        let parent_file = dir.path().join("missing");
+        std::fs::write(&parent_file, "not-a-directory").unwrap();
+        let bad_path = parent_file.join("spans.jsonl");
         let session = TracingIntakeSession::builder("svc")
             .completed_span_jsonl_path(&bad_path)
             .strict(true)
@@ -2696,13 +2714,15 @@ mod tests {
             .unwrap();
         let err = session.shutdown().unwrap_err();
         assert!(matches!(err, ImportError::Io { .. }));
-        assert!(err.to_string().contains("spans.jsonl"));
+        assert!(err.to_string().contains("create completed span jsonl parent directory"));
     }
 
     #[test]
     fn intake_session_non_strict_write_failure_adds_warning_and_keeps_run() {
         let dir = tempfile::tempdir().unwrap();
-        let bad_path = dir.path().join("missing").join("spans.jsonl");
+        let parent_file = dir.path().join("missing");
+        std::fs::write(&parent_file, "not-a-directory").unwrap();
+        let bad_path = parent_file.join("spans.jsonl");
         let session = TracingIntakeSession::builder("svc")
             .completed_span_jsonl_path(&bad_path)
             .build()
@@ -2764,6 +2784,27 @@ mod tests {
         let run: tailtriage_core::Run =
             serde_json::from_slice(&std::fs::read(&run_path).unwrap()).unwrap();
         assert_eq!(run.requests.len(), 1);
+    }
+
+    #[test]
+    fn intake_session_run_json_path_creates_nested_parent_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_path = dir.path().join("nested/out/run.json");
+        let session = TracingIntakeSession::builder("svc")
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            ));
+        });
+        session.shutdown().unwrap();
+        assert!(run_path.exists());
     }
 
     #[test]
@@ -2835,6 +2876,52 @@ mod tests {
         let value: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
         assert_eq!(value["format"], "tailtriage.tracing-span.v1");
         assert!(value["span"].is_object());
+    }
+
+    #[test]
+    fn completed_span_jsonl_path_creates_nested_parent_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let spans_path = dir.path().join("nested/out/spans.jsonl");
+        let session = TracingIntakeSession::builder("svc")
+            .completed_span_jsonl_path(&spans_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            ));
+        });
+        session.shutdown().unwrap();
+        assert!(spans_path.exists());
+    }
+
+    #[test]
+    fn run_json_simple_filename_without_parent_writes_successfully() {
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+
+        let session = TracingIntakeSession::builder("svc")
+            .run_json_path("run.json")
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            ));
+        });
+        session.shutdown().unwrap();
+        assert!(dir.path().join("run.json").exists());
+
+        std::env::set_current_dir(cwd).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Ensure example copy-paste works without users manually creating parent directories for tracing session outputs. 
- Make live tracing examples show non-overlapping queue and stage spans so queue/bracket only the queue wait and stage brackets only downstream work. 
- Make tests deterministic and cover nested-parent creation and simple filename cases for tracing outputs.

### Description
- Add a private helper `create_output_parent_dir(path: &Path, operation: &'static str) -> Result<(), ImportError>` in `tailtriage-tracing/src/recorder.rs` that skips empty/no parent cases and calls `std::fs::create_dir_all(parent)` otherwise, returning `ImportError::Io` on failure. 
- Invoke the helper before creating the completed-span JSONL temp file in `write_completed_span_jsonl_from_run(...)` and before calling `LocalJsonSink` in `TracingIntakeSession::shutdown(...)`, preserving the existing atomic temp-file + rename behavior for JSONL writes. 
- Add tests in `tailtriage-tracing/src/recorder.rs` that assert nested `run_json_path(...)` parent directories are created, nested `completed_span_jsonl_path(...)` parent directories are created, and a simple filename like `run.json` (no meaningful parent) still writes successfully. 
- Update strict/non-strict write-failure tests to use a deterministic non-directory parent (create a file where a parent directory is expected) so failures exercise the new directory-preflight logic. 
- Update examples `examples/completed_span_jsonl_import.rs` and `examples/live_session_to_run.rs` to drop manual `create_dir_all(...)` and place queue and stage spans into separate lexical scopes so their guards do not overlap with each other (queue and stage are not alive at the same time).

### Testing
- Ran `cargo fmt --check` which succeeded. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which completed successfully. 
- Ran `cargo test --workspace --all-targets --all-features --locked` which passed (final run reported all tests passing). 
- Ran `python3 scripts/validate_docs_contracts.py` which reported `docs contracts validated successfully`. 
- Ran feature/package checks for the tracing crate which all completed successfully: `cargo check -p tailtriage-tracing --no-default-features --locked`, `cargo check -p tailtriage-tracing --no-default-features --features jsonl --locked`, `cargo check -p tailtriage-tracing --no-default-features --features live --locked`, and `cargo check -p tailtriage-tracing --no-default-features --features tokio --locked`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14702a4f808330b557e4061841c07b)