### PR TITLE
Create parent dirs for tracing outputs and fix live example span scopes

### DIFF
--- a/tailtriage-tracing/examples/completed_span_jsonl_import.rs
+++ b/tailtriage-tracing/examples/completed_span_jsonl_import.rs
@@ -5,8 +5,6 @@ use tracing_subscriber::prelude::*;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let spans_path = std::path::PathBuf::from("target/tailtriage-examples/completed-spans.jsonl");
-    std::fs::create_dir_all(spans_path.parent().expect("parent path exists"))?;
-
     let session = TracingIntakeSession::builder("checkout-service")
         .completed_span_jsonl_path(&spans_path)
         .build()?;
@@ -21,22 +19,26 @@ fn main() -> Result<(), Box<dyn Error>> {
             tt.outcome = "ok"
         );
         let _request_guard = request.enter();
-        let _queue_guard = tracing::info_span!(
-            "admission.queue",
-            tt.kind = "queue",
-            tt.request_id = "req-1",
-            tt.queue = "admission",
-            tt.depth_at_start = 5_u64
-        )
-        .entered();
-        let _stage_guard = tracing::info_span!(
-            "db.stage",
-            tt.kind = "stage",
-            tt.request_id = "req-1",
-            tt.stage = "db",
-            tt.success = true
-        )
-        .entered();
+        {
+            let _queue_guard = tracing::info_span!(
+                "admission.queue",
+                tt.kind = "queue",
+                tt.request_id = "req-1",
+                tt.queue = "admission",
+                tt.depth_at_start = 5_u64
+            )
+            .entered();
+        }
+        {
+            let _stage_guard = tracing::info_span!(
+                "db.stage",
+                tt.kind = "stage",
+                tt.request_id = "req-1",
+                tt.stage = "db",
+                tt.success = true
+            )
+            .entered();
+        }
     });
 
     session.shutdown()?;

--- a/tailtriage-tracing/examples/live_session_to_run.rs
+++ b/tailtriage-tracing/examples/live_session_to_run.rs
@@ -5,8 +5,6 @@ use tracing_subscriber::prelude::*;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let run_path = std::path::PathBuf::from("target/tailtriage-examples/live-session-run.json");
-    std::fs::create_dir_all(run_path.parent().expect("parent path exists"))?;
-
     let session = TracingIntakeSession::builder("checkout-service")
         .run_json_path(&run_path)
         .build()?;
@@ -22,23 +20,27 @@ fn main() -> Result<(), Box<dyn Error>> {
         );
         let _request_guard = request.enter();
 
-        let queue = tracing::info_span!(
-            "admission.queue",
-            tt.kind = "queue",
-            tt.request_id = "req-1",
-            tt.queue = "admission",
-            tt.depth_at_start = 3_u64
-        );
-        let _queue_guard = queue.enter();
+        {
+            let queue = tracing::info_span!(
+                "admission.queue",
+                tt.kind = "queue",
+                tt.request_id = "req-1",
+                tt.queue = "admission",
+                tt.depth_at_start = 3_u64
+            );
+            let _queue_guard = queue.enter();
+        }
 
-        let stage = tracing::info_span!(
-            "db.stage",
-            tt.kind = "stage",
-            tt.request_id = "req-1",
-            tt.stage = "db",
-            tt.success = true
-        );
-        let _stage_guard = stage.enter();
+        {
+            let stage = tracing::info_span!(
+                "db.stage",
+                tt.kind = "stage",
+                tt.request_id = "req-1",
+                tt.stage = "db",
+                tt.success = true
+            );
+            let _stage_guard = stage.enter();
+        }
     });
 
     session.shutdown()?;

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -297,6 +297,7 @@ impl TracingIntakeSession {
             }
         }
         if let Some(path) = self.run_json_path {
+            create_output_parent_dir(&path, "create run json parent directory")?;
             LocalJsonSink::new(&path)
                 .write(&run)
                 .map_err(|err| ImportError::RunJsonWrite {
@@ -308,10 +309,25 @@ impl TracingIntakeSession {
     }
 }
 
+fn create_output_parent_dir(path: &Path, operation: &'static str) -> Result<(), ImportError> {
+    let Some(parent) = path.parent() else {
+        return Ok(());
+    };
+    if parent.as_os_str().is_empty() {
+        return Ok(());
+    }
+    std::fs::create_dir_all(parent).map_err(|err| ImportError::Io {
+        operation,
+        context: parent.display().to_string(),
+        reason: err.to_string(),
+    })
+}
+
 fn write_completed_span_jsonl_from_run(
     run: &tailtriage_core::Run,
     path: &Path,
 ) -> Result<(), ImportError> {
+    create_output_parent_dir(path, "create completed span jsonl parent directory")?;
     let temp_path = completed_span_jsonl_temp_path(path);
     let mut file = std::fs::OpenOptions::new()
         .create(true)
@@ -2687,8 +2703,7 @@ mod tests {
 
     #[test]
     fn intake_session_write_failure_returns_io_on_shutdown() {
-        let dir = tempfile::tempdir().unwrap();
-        let bad_path = dir.path().join("missing").join("spans.jsonl");
+        let bad_path = PathBuf::from(".");
         let session = TracingIntakeSession::builder("svc")
             .completed_span_jsonl_path(&bad_path)
             .strict(true)
@@ -2696,13 +2711,11 @@ mod tests {
             .unwrap();
         let err = session.shutdown().unwrap_err();
         assert!(matches!(err, ImportError::Io { .. }));
-        assert!(err.to_string().contains("spans.jsonl"));
     }
 
     #[test]
     fn intake_session_non_strict_write_failure_adds_warning_and_keeps_run() {
-        let dir = tempfile::tempdir().unwrap();
-        let bad_path = dir.path().join("missing").join("spans.jsonl");
+        let bad_path = PathBuf::from(".");
         let session = TracingIntakeSession::builder("svc")
             .completed_span_jsonl_path(&bad_path)
             .build()
@@ -2911,6 +2924,77 @@ mod tests {
         assert_eq!(imported.run().requests.len(), 1);
         assert_eq!(imported.run().stages.len(), 0);
         assert_eq!(imported.run().queues.len(), 0);
+    }
+
+    #[test]
+    fn intake_session_run_json_path_creates_nested_parent_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_path = dir.path().join("nested").join("output").join("run.json");
+        let session = TracingIntakeSession::builder("svc")
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            ));
+        });
+
+        session.shutdown().unwrap();
+        assert!(run_path.exists());
+    }
+
+    #[test]
+    fn intake_session_completed_span_jsonl_path_creates_nested_parent_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let spans_path = dir.path().join("nested").join("output").join("spans.jsonl");
+        let session = TracingIntakeSession::builder("svc")
+            .completed_span_jsonl_path(&spans_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            ));
+        });
+
+        session.shutdown().unwrap();
+        assert!(spans_path.exists());
+    }
+
+    #[test]
+    fn intake_session_run_json_path_without_meaningful_parent_writes_successfully() {
+        let dir = tempfile::tempdir().unwrap();
+        let old = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+
+        let run_path = PathBuf::from("run.json");
+        let session = TracingIntakeSession::builder("svc")
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            ));
+        });
+
+        session.shutdown().unwrap();
+        assert!(run_path.exists());
+
+        std::env::set_current_dir(old).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Ensure public examples that write tracing-session artifacts work out-of-the-box without requiring callers to create parent directories manually. 
- Make live examples teach non-overlapping queue vs stage spans so queue spans only cover queue wait and stage spans only cover downstream work.

### Description
- Add a small private helper `create_output_parent_dir(path: &Path, operation: &'static str) -> Result<(), ImportError>` in `tailtriage-tracing/src/recorder.rs` that checks `path.parent()`, skips when there is no parent or when parent is empty, and otherwise calls `std::fs::create_dir_all(parent)` mapping failures to `ImportError::Io`.
- Call the helper before creating the completed-span JSONL temp file in `write_completed_span_jsonl_from_run(...)` with operation text `create completed span jsonl parent directory` to preserve the existing atomic temp-file/rename behavior.
- Call the helper in `TracingIntakeSession::shutdown` before writing the run JSON via `LocalJsonSink` with operation text `create run json parent directory`.
- Add tests in `tailtriage-tracing/src/recorder.rs` that assert nested parent directories are created and that a filename-only `run.json` (no meaningful parent) still writes successfully, and adjust failure tests to remain meaningful.
- Update examples `tailtriage-tracing/examples/completed_span_jsonl_import.rs` and `tailtriage-tracing/examples/live_session_to_run.rs` to remove manual `create_dir_all(...)` setup and to use separate lexical scopes so queue and stage guards are not alive at the same time (queue bracketed and stage bracketed inside the request span).

### Testing
- Ran formatting, linting, unit tests, docs contract validation, and feature checks:
  - `cargo fmt --check` — succeeded.
  - `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — succeeded.
  - `cargo test --workspace --all-targets --all-features --locked` — succeeded (all workspace tests passed).
  - `python3 scripts/validate_docs_contracts.py` — output: `docs contracts validated successfully`.
  - `cargo check -p tailtriage-tracing --no-default-features --locked` — succeeded.
  - `cargo check -p tailtriage-tracing --no-default-features --features jsonl --locked` — succeeded.
  - `cargo check -p tailtriage-tracing --no-default-features --features live --locked` — succeeded (note: emitted an existing dead-code warning about `selected_mode`, test/command still passed).
  - `cargo check -p tailtriage-tracing --no-default-features --features tokio --locked` — succeeded.
- Added and executed unit tests in `tailtriage-tracing` that validate nested directory creation for both run JSON and completed-span JSONL outputs, and a filename-only `run.json` case; these tests passed as part of the workspace test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14702a4f808330b557e4061841c07b)