### PR TITLE
docs: clarify tracing span optional default semantics

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -32,7 +32,7 @@ cargo add tailtriage --features axum
 
 The `controller` and `tokio` namespaces are available with default features; `axum` remains opt-in.
 
-### Already using tracing?
+### Using existing tracing spans
 
 If you already instrument request/stage/queue work with Rust `tracing`, use `tailtriage-tracing` as an intake path into the same triage workflow.
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -118,6 +118,7 @@ Ordinary tracing log JSON (for example `fmt().json` output) is rejected by impor
 | queue | `tt.kind="queue"`, `tt.request_id`, `tt.queue` | `tt.depth_at_start` |
 
 Missing request `tt.outcome` defaults to `ok` with a warning.
+Missing stage `tt.success` defaults to `true` with a warning.
 
 ## Strict vs non-strict
 


### PR DESCRIPTION
### Motivation
- Clarify tracing `tt.*` field semantics and align the user-guide tracing cross-reference to reduce user confusion about optional defaults and where to find the tracing intake documentation.

### Description
- Update `tailtriage-tracing/README.md` `tt.*` field convention to state that missing request `tt.outcome` defaults to `ok` with a warning and missing stage `tt.success` defaults to `true` with a warning.
- Rename the `docs/user-guide.md` heading from `### Already using tracing?` to `### Using existing tracing spans` and keep the later cross-reference text aligned with that heading.
- Do not change code behavior, the CLI README, or docs contract validation logic.

### Testing
- Ran `cargo fmt --check` (exit 0, no formatting changes), `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (exit 0, no warnings), `cargo test --workspace --all-targets --all-features --locked` (exit 0, all tests passed), and `python3 scripts/validate_docs_contracts.py` (printed "docs contracts validated successfully" and exited 0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1476ba08ac8330ba17dea5fd83ce0b)