### PR TITLE
docs: clarify tracing optional field defaults and user-guide tracing heading

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -32,7 +32,7 @@ cargo add tailtriage --features axum
 
 The `controller` and `tokio` namespaces are available with default features; `axum` remains opt-in.
 
-### Already using tracing?
+### Using existing tracing spans
 
 If you already instrument request/stage/queue work with Rust `tracing`, use `tailtriage-tracing` as an intake path into the same triage workflow.
 

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -87,7 +87,7 @@ tailtriage import tracing-json "fixtures/tracing spans.jsonl" --service checkout
 
 The command imports completed `tt.*` tracing span records in the documented JSONL shape and writes Run JSON through the normal local JSON artifact writer, not Report JSON. Import warnings are printed to stderr as `warning: ...`. Analysis is a separate step: `tailtriage analyze tailtriage-run.json`.
 Tracing import and native capture share the same CaptureMode/CaptureLimits semantics for request/stage/queue evidence retention. Offline CLI tracing import exposes request/stage/queue limit overrides because those are the evidence types it imports. It intentionally does not expose runtime-snapshot or in-flight-snapshot limit flags because this import path does not ingest those evidence types. Tracing-only imports do not fabricate runtime snapshots; executor/blocking-pressure interpretation remains limited unless runtime snapshots are also captured (for example via Tokio runtime sampling).
-Malformed JSON input remains fatal. In non-strict mode, syntactically valid malformed/incomplete `tt.*` records are skipped with `warning: ...` lines.
+Malformed JSON input remains fatal. In non-strict mode, syntactically valid malformed/incomplete `tt.*` records are skipped with `warning: ...` lines. Missing optional tracing fields also default with warnings (`tt.outcome` -> `ok`, `tt.success` -> `true`).
 `--service` must not be empty or whitespace.
 Import fails when zero request events would be written (for example unrelated-only input or all-skipped malformed `tt.*` input), because `tailtriage analyze` requires at least one request in CLI-loaded run artifacts.
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -117,7 +117,7 @@ Ordinary tracing log JSON (for example `fmt().json` output) is rejected by impor
 | stage | `tt.kind="stage"`, `tt.request_id`, `tt.stage` | `tt.success` |
 | queue | `tt.kind="queue"`, `tt.request_id`, `tt.queue` | `tt.depth_at_start` |
 
-Missing request `tt.outcome` defaults to `ok` with a warning.
+Missing request `tt.outcome` defaults to `ok` with a warning. Missing stage `tt.success` defaults to `true` with a warning.
 
 ## Strict vs non-strict
 


### PR DESCRIPTION
### Motivation
- Make tracing field semantics explicit and keep the user-guide cross-reference aligned with the heading so users discover the import/live-recorder guidance reliably.

### Description
- Update `tailtriage-tracing/README.md` `tt.*` field convention to state that missing request `tt.outcome` defaults to `ok` with a warning and that missing stage `tt.success` defaults to `true` with a warning.
- Rename the `### Already using tracing?` heading to `### Using existing tracing spans` in `docs/user-guide.md` and keep the later cross-reference text exactly aligned, and add one short sentence in `tailtriage-cli/README.md` noting the optional tracing field defaults with warnings.

### Testing
- Ran `cargo fmt --check` which exited successfully with no formatting changes.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which completed successfully with no warnings.
- Ran `cargo test --workspace --all-targets --all-features --locked` which completed successfully and ran the full test suite (all tests passed, e.g. the recorded tests include `234 passed; 0 failed` in the main analyzer suite and all additional suites passed).
- Ran `python3 scripts/validate_docs_contracts.py` which printed `docs contracts validated successfully` and exited successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1476ba08ac8330ba17dea5fd83ce0b)