### PR TITLE
docs: clarify tracing field defaults and rename user-guide tracing heading

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -32,7 +32,7 @@ cargo add tailtriage --features axum
 
 The `controller` and `tokio` namespaces are available with default features; `axum` remains opt-in.
 
-### Already using tracing?
+### Using existing tracing spans
 
 If you already instrument request/stage/queue work with Rust `tracing`, use `tailtriage-tracing` as an intake path into the same triage workflow.
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -118,6 +118,7 @@ Ordinary tracing log JSON (for example `fmt().json` output) is rejected by impor
 | queue | `tt.kind="queue"`, `tt.request_id`, `tt.queue` | `tt.depth_at_start` |
 
 Missing request `tt.outcome` defaults to `ok` with a warning.
+Missing stage `tt.success` defaults to `true` with a warning.
 
 ## Strict vs non-strict
 


### PR DESCRIPTION
### Motivation
- Clarify the semantics of optional `tt.*` tracing fields for import consumers and keep the user-guide cross-reference aligned with the heading users will read.

### Description
- In `tailtriage-tracing/README.md` add the explicit note that missing stage `tt.success` defaults to `true` with a warning while preserving the existing note that missing request `tt.outcome` defaults to `ok` with a warning.
- In `docs/user-guide.md` rename the tracing section heading from `### Already using tracing?` to `### Using existing tracing spans` and keep the later cross-reference text exactly aligned with that heading.
- No behavioral code changes, no dependency changes, and `tailtriage-cli/README.md` is left unchanged because it does not require the single-sentence adjustment per the task constraints.

### Testing
- Ran `cargo fmt --check` and it exited successfully with no formatting errors.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it completed successfully with no warnings or errors.
- Ran `cargo test --workspace --all-targets --all-features --locked` and the full workspace test suite completed successfully with all tests passing.
- Ran `python3 scripts/validate_docs_contracts.py` and it returned `docs contracts validated successfully`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1476ba08ac8330ba17dea5fd83ce0b)