### PR TITLE
docs: polish tracing field semantics and user-guide cross-reference

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -32,7 +32,7 @@ cargo add tailtriage --features axum
 
 The `controller` and `tokio` namespaces are available with default features; `axum` remains opt-in.
 
-### Already using tracing?
+### Using existing tracing spans
 
 If you already instrument request/stage/queue work with Rust `tracing`, use `tailtriage-tracing` as an intake path into the same triage workflow.
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -118,6 +118,7 @@ Ordinary tracing log JSON (for example `fmt().json` output) is rejected by impor
 | queue | `tt.kind="queue"`, `tt.request_id`, `tt.queue` | `tt.depth_at_start` |
 
 Missing request `tt.outcome` defaults to `ok` with a warning.
+Missing stage `tt.success` defaults to `true` with a warning.
 
 ## Strict vs non-strict
 


### PR DESCRIPTION
### Motivation

- Clarify user-facing tracing semantics so optional `tt.*` fields have explicit import-time default behavior and visible warnings. 
- Improve discoverability and wording consistency in the user guide so the tracing subsection matches its cross-reference precisely.

### Description

- Update `tailtriage-tracing/README.md` `tt.*` field convention to explicitly state that missing request `tt.outcome` defaults to `ok` with a warning and that missing stage `tt.success` defaults to `true` with a warning. 
- Rename the user-guide heading `### Already using tracing?` to `### Using existing tracing spans` in `docs/user-guide.md` and keep the later cross-reference aligned with that exact phrasing. 
- Do not change runtime behavior, CLI defaults, code, dependencies, or the docs contract validator, and leave `tailtriage-cli/README.md` unchanged because it does not describe tracing optional-field defaults.

### Testing

- Ran `cargo fmt --check` and it exits successfully with no formatting issues. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it completes successfully with no warnings. 
- Ran `cargo test --workspace --all-targets --all-features --locked` and the full workspace test suite completes successfully with all tests passing. 
- Ran `python3 scripts/validate_docs_contracts.py` and it prints `docs contracts validated successfully` indicating the docs contract check passes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1476ba08ac8330ba17dea5fd83ce0b)