### PR TITLE
Create missing output parent dirs for tracing import and make live tracing docs copy-pasteable

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -56,6 +56,7 @@ B) Direct Run JSON path with async span instrumentation (`live` feature required
 ```bash
 cargo add tailtriage-tracing --features live
 cargo add tracing tracing-subscriber
+cargo add tokio --features macros,rt-multi-thread
 ```
 
 
@@ -64,30 +65,30 @@ use tailtriage_tracing::TracingIntakeSession;
 use tracing::Instrument as _;
 use tracing_subscriber::prelude::*;
 
-# async fn work() {}
-# async fn run() -> Result<(), Box<dyn std::error::Error>> {
-let session = TracingIntakeSession::builder("checkout-service")
-    .run_json_path("target/tailtriage-examples/checkout.run.json")
-    .build()?;
-tracing_subscriber::registry()
-    .with(session.layer())
-    .init(); // startup-only: global subscriber installation for this process
-let span = tracing::info_span!(
-    "request",
-    tt.kind = "request",
-    tt.request_id = "req-1",
-    tt.route = "/checkout",
-    tt.outcome = "ok",
-);
-work().instrument(span).await;
-let imported = session.shutdown()?;
-# let _ = imported;
-# Ok(())
+async fn work() {
+    // Your request work goes here.
 }
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-#   let _ = run();
-#   Ok(())
-# }
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let session = TracingIntakeSession::builder("checkout-service")
+        .run_json_path("target/tailtriage-examples/checkout.run.json")
+        .build()?;
+    tracing_subscriber::registry()
+        .with(session.layer())
+        .init(); // startup-only: global subscriber installation for this process
+    let span = tracing::info_span!(
+        "request",
+        tt.kind = "request",
+        tt.request_id = "req-1",
+        tt.route = "/checkout",
+        tt.outcome = "ok",
+    );
+    work().instrument(span).await;
+    let imported = session.shutdown()?;
+    let _ = imported;
+    Ok(())
+}
 ```
 
 Stage and queue spans use their own `tt.stage` / `tt.queue` fields around the awaited work they measure.

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -184,6 +184,24 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+fn create_output_parent_dir(path: &std::path::Path) -> Result<(), std::io::Error> {
+    let Some(parent) = path.parent() else {
+        return Ok(());
+    };
+    if parent.as_os_str().is_empty() {
+        return Ok(());
+    }
+    std::fs::create_dir_all(parent).map_err(|err| {
+        std::io::Error::new(
+            err.kind(),
+            format!(
+                "failed to create output parent directory '{}': {err}",
+                parent.display()
+            ),
+        )
+    })
+}
+
 #[allow(clippy::too_many_arguments)]
 fn import_tracing_json(
     spans_jsonl: PathBuf,
@@ -252,6 +270,7 @@ fn import_tracing_json(
         }
         return Err(err.into());
     }
+    create_output_parent_dir(output.as_path())?;
     LocalJsonSink::new(output).write(imported.run())?;
     Ok(())
 }

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -223,6 +223,64 @@ fn missing_run_json_without_help_flag_fails_clearly() {
 }
 
 #[test]
+fn import_tracing_json_creates_missing_output_parent_directories() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("missing-parent/run.json");
+    std::fs::write(&spans_path, complete_span_jsonl_fixture()).expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+
+    assert!(output.status.success(), "cli failed: {output:?}");
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+    assert!(run_path.exists(), "run artifact should be written");
+
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
+        .expect("imported run should load in cli loader");
+    assert_eq!(loaded.run.requests.len(), 1);
+}
+
+#[test]
+fn import_tracing_json_fails_when_output_parent_path_is_not_directory() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let invalid_parent = dir.path().join("not-a-dir");
+    let run_path = invalid_parent.join("run.json");
+    std::fs::write(&spans_path, complete_span_jsonl_fixture()).expect("fixture should write");
+    std::fs::write(&invalid_parent, b"not-a-directory").expect("sentinel file should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(
+        stderr.contains("failed to create output parent directory")
+            || stderr.contains(&invalid_parent.display().to_string())
+    );
+    assert!(!run_path.exists(), "run artifact should not be written");
+}
+
+#[test]
 fn import_tracing_json_writes_run_json_analyzable_by_existing_apis() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -25,6 +25,7 @@ For live tracing intake sessions, `tailtriage-tracing` enables optional dependen
 ```bash
 cargo add tailtriage-tracing --features live
 cargo add tracing tracing-subscriber
+cargo add tokio --features macros,rt-multi-thread
 ```
 
 If you use Tokio runtime sampler coupling via `TracingTokioSession`, use:
@@ -41,33 +42,35 @@ use tailtriage_tracing::TracingIntakeSession;
 use tracing::Instrument as _;
 use tracing_subscriber::prelude::*;
 
-# async fn work() {}
-# async fn run() -> Result<(), Box<dyn std::error::Error>> {
-let session = TracingIntakeSession::builder("checkout-service")
-    .run_json_path("target/tailtriage-examples/checkout.run.json")
-    .completed_span_jsonl_path("target/tailtriage-examples/checkout.spans.jsonl")
-    .build()?;
+async fn work() {
+    // Your request work goes here.
+}
 
-tracing_subscriber::registry()
-    .with(session.layer())
-    .init(); // startup-only: global subscriber installation for this process
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let session = TracingIntakeSession::builder("checkout-service")
+        .run_json_path("target/tailtriage-examples/checkout.run.json")
+        .completed_span_jsonl_path("target/tailtriage-examples/checkout.spans.jsonl")
+        .build()?;
 
-let request = tracing::info_span!(
-    "request",
-    tt.kind = "request",
-    tt.request_id = "req-1",
-    tt.route = "/checkout",
-    tt.outcome = "ok"
-);
-work().instrument(request).await;
-let imported = session.shutdown()?;
-# let _ = imported;
-# Ok(())
-# }
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-#   let _ = run();
-#   Ok(())
-# }
+    tracing_subscriber::registry()
+        .with(session.layer())
+        .init(); // startup-only: global subscriber installation for this process
+
+    let request = tracing::info_span!(
+        "request",
+        tt.kind = "request",
+        tt.request_id = "req-1",
+        tt.route = "/checkout",
+        tt.outcome = "ok"
+    );
+
+    work().instrument(request).await;
+
+    let imported = session.shutdown()?;
+    let _ = imported;
+    Ok(())
+}
 ```
 
 Install the tailtriage layer beside your existing tracing layers in the application's normal process-wide subscriber setup; tailtriage augments your tracing pipeline rather than replacing it.


### PR DESCRIPTION
### Motivation
- Align the CLI tracing-import writer behavior with the live-session path by creating missing parent directories for `--output` so offline imports don't fail when nested directories are absent. 
- Make the primary live tracing snippets in the tracing README and user guide copy-pasteable standalone Tokio examples so first-time users can run them without unseen rustdoc harness lines.

### Description
- Add a CLI-local helper `fn create_output_parent_dir(path: &std::path::Path) -> Result<(), std::io::Error>` in `tailtriage-cli/src/main.rs` that no-ops for filename-only paths or empty parents and otherwise calls `std::fs::create_dir_all(parent)` and returns an `io::Error` with a message mentioning the problematic parent on failure. 
- Call `create_output_parent_dir(output.as_path())?` inside `import_tracing_json` immediately after `ensure_persistable_run_has_requests(imported.run())?` and before `LocalJsonSink::new(output).write(imported.run())?`, keeping the behavior local to the CLI import flow. 
- Add two CLI boundary tests in `tailtriage-cli/tests/cli_boundary.rs`: a success case that writes into a previously-missing nested parent and asserts the produced Run artifact has one request, and a failure case where the intended parent is a regular file and the CLI fails with stderr mentioning the parent creation failure and does not create the output file. 
- Replace the live-session snippets in `tailtriage-tracing/README.md` and the `docs/user-guide.md` Run-JSON live snippet with standalone `#[tokio::main]` examples (no rustdoc-hidden `# ...` harness lines) and make the associated dependency examples explicit by including `cargo add tokio --features macros,rt-multi-thread` for copy-pasteable usage. 
- Preserve existing tracing outcome semantics and do not change `LocalJsonSink` globally or analyzer/Run schema behavior.

### Testing
- Ran `cargo fmt --check` (after applying `cargo fmt`) and the check passed. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed with no warnings. 
- Ran `cargo test --workspace --all-targets --all-features --locked`, which executed the full test suite including the new CLI boundary tests and all tests passed. 
- Ran `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked` and it succeeded with documentation warnings elevated to errors. 
- Ran `python3 scripts/validate_docs_contracts.py` and it reported successful validation. 
- Ran feature checks `cargo check -p tailtriage-tracing --no-default-features --locked`, `cargo check -p tailtriage-tracing --no-default-features --features jsonl --locked`, `cargo check -p tailtriage-tracing --no-default-features --features live --locked`, and `cargo check -p tailtriage-tracing --no-default-features --features tokio --locked`, and all completed successfully. 

Files changed: `tailtriage-cli/src/main.rs`, `tailtriage-cli/tests/cli_boundary.rs`, `tailtriage-tracing/README.md`, and `docs/user-guide.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a148c0ed47083308a2c6131570384cd)