### PR TITLE
Ensure tracing import creates missing output parent dirs and make live docs snippets standalone

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -56,6 +56,7 @@ B) Direct Run JSON path with async span instrumentation (`live` feature required
 ```bash
 cargo add tailtriage-tracing --features live
 cargo add tracing tracing-subscriber
+cargo add tokio --features macros,rt-multi-thread
 ```
 
 
@@ -64,30 +65,30 @@ use tailtriage_tracing::TracingIntakeSession;
 use tracing::Instrument as _;
 use tracing_subscriber::prelude::*;
 
-# async fn work() {}
-# async fn run() -> Result<(), Box<dyn std::error::Error>> {
-let session = TracingIntakeSession::builder("checkout-service")
-    .run_json_path("target/tailtriage-examples/checkout.run.json")
-    .build()?;
-tracing_subscriber::registry()
-    .with(session.layer())
-    .init(); // startup-only: global subscriber installation for this process
-let span = tracing::info_span!(
-    "request",
-    tt.kind = "request",
-    tt.request_id = "req-1",
-    tt.route = "/checkout",
-    tt.outcome = "ok",
-);
-work().instrument(span).await;
-let imported = session.shutdown()?;
-# let _ = imported;
-# Ok(())
+async fn work() {
+    // Your request work goes here.
 }
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-#   let _ = run();
-#   Ok(())
-# }
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let session = TracingIntakeSession::builder("checkout-service")
+        .run_json_path("target/tailtriage-examples/checkout.run.json")
+        .build()?;
+    tracing_subscriber::registry()
+        .with(session.layer())
+        .init(); // startup-only: global subscriber installation for this process
+    let span = tracing::info_span!(
+        "request",
+        tt.kind = "request",
+        tt.request_id = "req-1",
+        tt.route = "/checkout",
+        tt.outcome = "ok",
+    );
+    work().instrument(span).await;
+    let imported = session.shutdown()?;
+    let _ = imported;
+    Ok(())
+}
 ```
 
 Stage and queue spans use their own `tt.stage` / `tt.queue` fields around the awaited work they measure.

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -252,8 +252,27 @@ fn import_tracing_json(
         }
         return Err(err.into());
     }
+    create_output_parent_dir(output)?;
     LocalJsonSink::new(output).write(imported.run())?;
     Ok(())
+}
+
+fn create_output_parent_dir(path: &std::path::Path) -> Result<(), std::io::Error> {
+    let Some(parent) = path.parent() else {
+        return Ok(());
+    };
+    if parent.as_os_str().is_empty() {
+        return Ok(());
+    }
+    std::fs::create_dir_all(parent).map_err(|err| {
+        std::io::Error::new(
+            err.kind(),
+            format!(
+                "failed to create output parent directory '{}': {err}",
+                parent.display()
+            ),
+        )
+    })
 }
 
 fn tracing_json_setup_guidance() -> &'static str {

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -223,6 +223,64 @@ fn missing_run_json_without_help_flag_fails_clearly() {
 }
 
 #[test]
+fn import_tracing_json_creates_missing_output_parent_directories() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("missing-parent/run.json");
+    std::fs::write(&spans_path, complete_span_jsonl_fixture()).expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+
+    assert!(output.status.success(), "cli failed: {output:?}");
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+    assert!(run_path.exists(), "run json should be written");
+
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
+        .expect("imported run should load in cli loader");
+    assert_eq!(loaded.run.requests.len(), 1);
+}
+
+#[test]
+fn import_tracing_json_fails_when_output_parent_is_a_file() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let parent_file = dir.path().join("not-a-dir");
+    let run_path = parent_file.join("run.json");
+    std::fs::write(&spans_path, complete_span_jsonl_fixture()).expect("fixture should write");
+    std::fs::write(&parent_file, "file").expect("parent placeholder file should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(
+        stderr.contains("failed to create output parent directory")
+            || stderr.contains(&parent_file.display().to_string())
+    );
+    assert!(!run_path.exists(), "run json should not be written");
+}
+
+#[test]
 fn import_tracing_json_writes_run_json_analyzable_by_existing_apis() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -25,6 +25,7 @@ For live tracing intake sessions, `tailtriage-tracing` enables optional dependen
 ```bash
 cargo add tailtriage-tracing --features live
 cargo add tracing tracing-subscriber
+cargo add tokio --features macros,rt-multi-thread
 ```
 
 If you use Tokio runtime sampler coupling via `TracingTokioSession`, use:
@@ -41,33 +42,35 @@ use tailtriage_tracing::TracingIntakeSession;
 use tracing::Instrument as _;
 use tracing_subscriber::prelude::*;
 
-# async fn work() {}
-# async fn run() -> Result<(), Box<dyn std::error::Error>> {
-let session = TracingIntakeSession::builder("checkout-service")
-    .run_json_path("target/tailtriage-examples/checkout.run.json")
-    .completed_span_jsonl_path("target/tailtriage-examples/checkout.spans.jsonl")
-    .build()?;
+async fn work() {
+    // Your request work goes here.
+}
 
-tracing_subscriber::registry()
-    .with(session.layer())
-    .init(); // startup-only: global subscriber installation for this process
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let session = TracingIntakeSession::builder("checkout-service")
+        .run_json_path("target/tailtriage-examples/checkout.run.json")
+        .completed_span_jsonl_path("target/tailtriage-examples/checkout.spans.jsonl")
+        .build()?;
 
-let request = tracing::info_span!(
-    "request",
-    tt.kind = "request",
-    tt.request_id = "req-1",
-    tt.route = "/checkout",
-    tt.outcome = "ok"
-);
-work().instrument(request).await;
-let imported = session.shutdown()?;
-# let _ = imported;
-# Ok(())
-# }
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-#   let _ = run();
-#   Ok(())
-# }
+    tracing_subscriber::registry()
+        .with(session.layer())
+        .init(); // startup-only: global subscriber installation for this process
+
+    let request = tracing::info_span!(
+        "request",
+        tt.kind = "request",
+        tt.request_id = "req-1",
+        tt.route = "/checkout",
+        tt.outcome = "ok"
+    );
+
+    work().instrument(request).await;
+
+    let imported = session.shutdown()?;
+    let _ = imported;
+    Ok(())
+}
 ```
 
 Install the tailtriage layer beside your existing tracing layers in the application's normal process-wide subscriber setup; tailtriage augments your tracing pipeline rather than replacing it.


### PR DESCRIPTION
### Motivation
- Align the CLI `tracing-json` import path with the live tracing writer by creating missing output parent directories so `--output <path>` behaves predictably for users. 
- Make the primary live tracing snippets copy-pasteable and runnable as standalone Tokio examples so first-time integrators can use them without rustdoc harness lines. 

### Description
- Add a small CLI-local helper `create_output_parent_dir(path: &Path) -> Result<(), std::io::Error>` and call it in `import_tracing_json` after `ensure_persistable_run_has_requests(...)` and before writing via `LocalJsonSink`, returning a clear error on failure that includes the problematic parent path. 
- Keep the change scoped to the CLI import path and do not modify `LocalJsonSink` or tracing import semantics. 
- Add two CLI boundary tests in `tailtriage-cli/tests/cli_boundary.rs` that cover success when parents are missing and a clear failure when the intended parent is a regular file. 
- Replace rustdoc-hidden harness lines in the primary live tracing snippets and make the dependency install blocks explicit (including `tokio --features macros,rt-multi-thread`) in `tailtriage-tracing/README.md` and `docs/user-guide.md`. 

### Testing
- Ran `cargo fmt --check` (initially reported formatting diffs) and then `cargo fmt` followed by `cargo fmt --check`, and the final `--check` passed. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed with no warnings. 
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests passed (including the new CLI boundary tests). 
- Generated docs with `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked` and it completed successfully. 
- Ran the tracing feature checks: `cargo check -p tailtriage-tracing --no-default-features --locked`, `cargo check -p tailtriage-tracing --no-default-features --features jsonl --locked`, `cargo check -p tailtriage-tracing --no-default-features --features live --locked`, and `cargo check -p tailtriage-tracing --no-default-features --features tokio --locked`, and all completed successfully. 
- Ran `python3 scripts/validate_docs_contracts.py` and it reported successful validation. 

Commands executed (high level): `cargo fmt --check`, `cargo fmt`, `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`, `python3 scripts/validate_docs_contracts.py`, and the `tailtriage-tracing` feature `cargo check` permutations; all ultimately passed. 

Files changed: `tailtriage-cli/src/main.rs`, `tailtriage-cli/tests/cli_boundary.rs`, `tailtriage-tracing/README.md`, and `docs/user-guide.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a148c0ed47083308a2c6131570384cd)