### PR TITLE
Polish tracing import output directory handling and make live tracing snippets copy-pasteable

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -56,6 +56,7 @@ B) Direct Run JSON path with async span instrumentation (`live` feature required
 ```bash
 cargo add tailtriage-tracing --features live
 cargo add tracing tracing-subscriber
+cargo add tokio --features macros,rt-multi-thread
 ```
 
 
@@ -64,8 +65,12 @@ use tailtriage_tracing::TracingIntakeSession;
 use tracing::Instrument as _;
 use tracing_subscriber::prelude::*;
 
-# async fn work() {}
-# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+async fn work() {
+    // Your request work goes here.
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
 let session = TracingIntakeSession::builder("checkout-service")
     .run_json_path("target/tailtriage-examples/checkout.run.json")
     .build()?;
@@ -81,13 +86,9 @@ let span = tracing::info_span!(
 );
 work().instrument(span).await;
 let imported = session.shutdown()?;
-# let _ = imported;
-# Ok(())
+let _ = imported;
+Ok(())
 }
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-#   let _ = run();
-#   Ok(())
-# }
 ```
 
 Stage and queue spans use their own `tt.stage` / `tt.queue` fields around the awaited work they measure.

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -252,8 +252,27 @@ fn import_tracing_json(
         }
         return Err(err.into());
     }
+    create_output_parent_dir(output)?;
     LocalJsonSink::new(output).write(imported.run())?;
     Ok(())
+}
+
+fn create_output_parent_dir(path: &std::path::Path) -> Result<(), std::io::Error> {
+    let Some(parent) = path.parent() else {
+        return Ok(());
+    };
+    if parent.as_os_str().is_empty() {
+        return Ok(());
+    }
+    std::fs::create_dir_all(parent).map_err(|err| {
+        std::io::Error::new(
+            err.kind(),
+            format!(
+                "failed to create output parent directory '{}': {err}",
+                parent.display()
+            ),
+        )
+    })
 }
 
 fn tracing_json_setup_guidance() -> &'static str {

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -277,6 +277,70 @@ fn import_tracing_json_writes_run_json_when_output_path_contains_spaces() {
 }
 
 #[test]
+fn import_tracing_json_creates_missing_output_parent_directories() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("missing-parent/run.json");
+    std::fs::write(&spans_path, complete_span_jsonl_fixture()).expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+
+    assert!(output.status.success(), "cli failed: {output:?}");
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+    assert!(
+        run_path.exists(),
+        "expected output to exist at {run_path:?}"
+    );
+
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
+        .expect("imported run should load from nested output path");
+    assert_eq!(loaded.run.requests.len(), 1);
+}
+
+#[test]
+fn import_tracing_json_fails_when_output_parent_is_file() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let not_a_dir = dir.path().join("not-a-dir");
+    let run_path = not_a_dir.join("run.json");
+    std::fs::write(&spans_path, complete_span_jsonl_fixture()).expect("fixture should write");
+    std::fs::write(&not_a_dir, "x").expect("marker file should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .output()
+        .expect("cli should run");
+
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(
+        stderr.contains("failed to create output parent directory")
+            || stderr.contains(not_a_dir.to_string_lossy().as_ref())
+    );
+    assert!(
+        !run_path.exists(),
+        "output unexpectedly exists at {run_path:?}"
+    );
+}
+
+#[test]
 fn import_tracing_json_mode_investigation_sets_run_metadata_mode() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -25,6 +25,7 @@ For live tracing intake sessions, `tailtriage-tracing` enables optional dependen
 ```bash
 cargo add tailtriage-tracing --features live
 cargo add tracing tracing-subscriber
+cargo add tokio --features macros,rt-multi-thread
 ```
 
 If you use Tokio runtime sampler coupling via `TracingTokioSession`, use:
@@ -41,8 +42,12 @@ use tailtriage_tracing::TracingIntakeSession;
 use tracing::Instrument as _;
 use tracing_subscriber::prelude::*;
 
-# async fn work() {}
-# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+async fn work() {
+    // Your request work goes here.
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
 let session = TracingIntakeSession::builder("checkout-service")
     .run_json_path("target/tailtriage-examples/checkout.run.json")
     .completed_span_jsonl_path("target/tailtriage-examples/checkout.spans.jsonl")
@@ -61,13 +66,9 @@ let request = tracing::info_span!(
 );
 work().instrument(request).await;
 let imported = session.shutdown()?;
-# let _ = imported;
-# Ok(())
-# }
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-#   let _ = run();
-#   Ok(())
-# }
+let _ = imported;
+Ok(())
+}
 ```
 
 Install the tailtriage layer beside your existing tracing layers in the application's normal process-wide subscriber setup; tailtriage augments your tracing pipeline rather than replacing it.


### PR DESCRIPTION
### Motivation

- Ensure CLI import parity with live tracing writer by creating missing output parent directories for `tailtriage import tracing-json --output <path>` so users don't get surprising write failures for nested paths.
- Make the primary live tracing documentation examples fully copy-pasteable standalone Tokio programs so first-time users can run the snippets without hidden rustdoc harness lines.
- Keep the change narrowly scoped to CLI-level behavior and docs polish without altering tracing semantics, Run schema, analyzer behavior, or adding new outcome labels.

### Description

- Added a small CLI-local helper `create_output_parent_dir(path: &std::path::Path) -> Result<(), std::io::Error>` in `tailtriage-cli/src/main.rs` that creates the parent directory when present and returns a contextual `std::io::Error` on failure including the problematic parent path. 
- Called the helper from `import_tracing_json` after `ensure_persistable_run_has_requests(imported.run())` and before `LocalJsonSink::new(output).write(...)`, keeping the behavior local to the CLI import path.
- Added two CLI boundary tests in `tailtriage-cli/tests/cli_boundary.rs`: one success case that verifies nested missing parents are created and the resulting Run JSON contains one request, and one failure case where the intended parent is a regular file that asserts a clear error and that no output file is created.
- Replaced rustdoc-hidden harness lines in the primary live tracing snippets in `tailtriage-tracing/README.md` and `docs/user-guide.md` with standalone `#[tokio::main]` examples and updated the snippet dependency blocks to include `cargo add tokio --features macros,rt-multi-thread` so the examples are copy-pasteable and runnable.

Files changed: `tailtriage-cli/src/main.rs`, `tailtriage-cli/tests/cli_boundary.rs`, `tailtriage-tracing/README.md`, `docs/user-guide.md`.

### Testing

- Ran `cargo fmt --check` and it passed after formatting adjustments. (passed)
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed. (passed)
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests passed. (passed)
- Built docs with `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked` and documentation generation succeeded. (passed)
- Ran `python3 scripts/validate_docs_contracts.py` and it completed successfully. (passed)
- Ran `cargo check -p tailtriage-tracing --no-default-features --locked` and `cargo check -p tailtriage-tracing --no-default-features --features jsonl --locked` and both checks passed. (passed)
- Ran `cargo check -p tailtriage-tracing --no-default-features --features live --locked` which completed successfully but emitted an existing `dead_code` warning in `tailtriage-tracing::selected_mode` (warning only; no failures). (passed with warning)
- Ran `cargo check -p tailtriage-tracing --no-default-features --features tokio --locked` and it passed. (passed)

All automated checks listed in the validation instructions were executed and completed successfully (one non-fatal compiler warning noted above).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a148c0ed47083308a2c6131570384cd)