### PR TITLE
Fail fast for fmt JSON import and block zero-request completed-span JSONL persistence

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -42,7 +42,7 @@ Install for typed records plus JSONL import APIs (default feature set):
 cargo add tailtriage-tracing
 ```
 
-A) Completed-span JSONL intake path:
+A) Completed-span JSONL intake path (persisted JSONL requires at least one completed request):
 
 ```bash
 tailtriage import tracing-json completed-spans.jsonl --service checkout --output tailtriage-run.json

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -42,7 +42,7 @@ Machine-readable JSON output:
 tailtriage analyze tailtriage-run.json --format json
 ```
 
-Import completed `tt.*` tracing span JSONL into Run JSON:
+Import completed `tt.*` tracing span JSONL into Run JSON (importable persisted artifacts require at least one completed request):
 
 ```bash
 tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -235,8 +235,10 @@ fn import_tracing_json(
     }
     options = options.capture_limits_override(capture_limits_override);
 
-    if matches!(input_format, TracingInputFormat::Compatible)
-        && input_looks_like_tracing_fmt_json(&spans_jsonl)?
+    if matches!(
+        input_format,
+        TracingInputFormat::TailtriageSpanJsonl | TracingInputFormat::Compatible
+    ) && input_looks_like_tracing_fmt_json(&spans_jsonl)?
     {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -619,7 +619,17 @@ fn import_tracing_json_default_rejects_fmt_json_with_guidance() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("fmt.jsonl");
     let run_path = dir.path().join("run.json");
-    std::fs::write(&spans_path, r#"{"timestamp":"2026-01-01T00:00:00Z","level":"INFO","target":"svc","fields":{"message":"close"}}"#).unwrap();
+    std::fs::write(
+        &spans_path,
+        [
+            r#"{"timestamp":"2026-01-01T00:00:00Z","level":"INFO","target":"svc","fields":{"message":"close-1"}}"#,
+            r#"{"timestamp":"2026-01-01T00:00:01Z","level":"INFO","target":"svc","fields":{"message":"close-2"}}"#,
+            r#"{"timestamp":"2026-01-01T00:00:02Z","level":"INFO","target":"svc","fields":{"message":"close-3"}}"#,
+        ]
+        .join("
+"),
+    )
+    .unwrap();
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
         .arg("tracing-json")
@@ -632,9 +642,9 @@ fn import_tracing_json_default_rejects_fmt_json_with_guidance() {
         .expect("cli should run");
     assert!(!output.status.success());
     let stderr = String::from_utf8(output.stderr).unwrap();
-    assert!(stderr.contains("stable wrapper shape"));
-    assert!(stderr.contains("tailtriage.tracing-span.v1"));
     assert!(stderr.contains("tracing_subscriber::fmt().json() logs are unsupported"));
+    assert!(!stderr.contains("line 1: expected stable wrapper shape"));
+    assert!(!stderr.contains("line 2: expected stable wrapper shape"));
     assert!(!run_path.exists());
 }
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -89,7 +89,7 @@ tailtriage analyze target/tailtriage-examples/checkout.run.json
 
 ## Completed-span JSONL path
 
-Use `completed_span_jsonl_path(...)` when you want an offline import workflow:
+Use `completed_span_jsonl_path(...)` when you want an offline import workflow (persisted JSONL requires at least one completed request):
 
 ```bash
 tailtriage import tracing-json target/tailtriage-examples/checkout.spans.jsonl \
@@ -137,7 +137,7 @@ Missing stage `tt.success` defaults to `true` with a warning.
 - `max_open_spans` bounds in-flight span tracking.
 - `max_completed_candidate_spans` bounds retained raw completed candidate spans before semantic conversion.
 - Request/stage/queue semantic retention uses `CaptureMode`, `CaptureLimits`, and `CaptureLimitsOverride`.
-- `completed_span_jsonl_path(...)` writes retained valid completed-span JSONL on shutdown.
+- `completed_span_jsonl_path(...)` writes retained valid completed-span JSONL on shutdown when at least one completed request is retained.
 - The completed-span JSONL is replayable into the same retained request/stage/queue evidence when imported with matching service metadata.
 - This completed-span JSONL is a narrow retained-evidence export, not a generic tracing log stream and not OTel/OTLP.
 - Warnings and lifecycle warnings indicate evidence may be incomplete when limits are hit or writer issues occur.

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -283,7 +283,7 @@ impl TracingIntakeSession {
         let strict_mode = self.recorder.options.strict_mode();
         let imported = self.recorder.shutdown()?;
         let (mut run, mut warnings) = imported.into_parts();
-        if self.run_json_path.is_some() {
+        if self.run_json_path.is_some() || self.completed_span_jsonl_path.is_some() {
             ensure_persistable_run_has_requests(&run)?;
         }
         if let Some(path) = &self.completed_span_jsonl_path {
@@ -2712,6 +2712,15 @@ mod tests {
             .strict(true)
             .build()
             .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/ok"
+            ));
+        });
         let err = session.shutdown().unwrap_err();
         assert!(matches!(err, ImportError::Io { .. }));
         assert!(err
@@ -2834,6 +2843,26 @@ mod tests {
         let err = session.shutdown().unwrap_err();
         assert!(matches!(err, ImportError::ZeroRequestArtifact { .. }));
         assert_eq!(std::fs::read_to_string(&run_path).unwrap(), "keep-me");
+    }
+
+    #[test]
+    fn shutdown_with_completed_span_jsonl_only_and_zero_requests_writes_no_artifacts() {
+        let dir = tempfile::tempdir().unwrap();
+        let spans_path = dir.path().join("spans.jsonl");
+        let session = TracingIntakeSession::builder("svc")
+            .completed_span_jsonl_path(&spans_path)
+            .build()
+            .unwrap();
+        let err = session.shutdown().unwrap_err();
+        assert!(matches!(err, ImportError::ZeroRequestArtifact { .. }));
+        assert!(!spans_path.exists());
+    }
+
+    #[test]
+    fn shutdown_without_persisted_paths_and_zero_requests_still_succeeds() {
+        let session = TracingIntakeSession::builder("svc").build().unwrap();
+        let imported = session.shutdown().unwrap();
+        assert!(imported.run().requests.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent long scans and per-line wrapper warnings when users accidentally pass ordinary `tracing_subscriber::fmt().json()` logs to `tailtriage import tracing-json` by failing fast with actionable guidance.
- Avoid persisting completed-span JSONL artifacts that contain no completed requests, which later break the offline import/analyze workflow and have no durable warning channel.

### Description
- Run the existing `input_looks_like_tracing_fmt_json(&spans_jsonl)?` detector before calling `import_jsonl_path_with_mode(...)` for both `TracingInputFormat::TailtriageSpanJsonl` (default) and `TracingInputFormat::Compatible`, and return the existing `tracing_json_setup_guidance()` error immediately when fmt-like JSON is detected. (`tailtriage-cli/src/main.rs`) 
- Keep the current compatibility detector semantics so `compatible` mode can still accept fmt-like records that include explicit completed-span timestamps. (`tailtriage-cli/src/main.rs`) 
- Update `TracingIntakeSession::shutdown` to run `ensure_persistable_run_has_requests(&run)?` when either `run_json_path.is_some()` or `completed_span_jsonl_path.is_some()`, and run the guard before writing either persisted output. (`tailtriage-tracing/src/recorder.rs`) 
- Add CLI boundary test verifying default import fails fast on multiple ordinary fmt-json lines without emitting per-line wrapper warnings and that no run JSON file is created, and add recorder tests covering zero-request shutdown behavior for: completed-span-only persisted path, no persisted paths, and both persisted paths. (`tailtriage-cli/tests/cli_boundary.rs`, `tailtriage-tracing/src/recorder.rs`) 
- Tweak concise wording in `tailtriage-tracing/README.md`, `docs/user-guide.md`, and `tailtriage-cli/README.md` to make clear persisted completed-span JSONL implies at least one completed request is retained.

### Testing
- Executed the repository validation and tracing-focused checks below, all of which completed successfully (tests passed and docs contract validated). A non-fatal `dead_code` lint warning was observed in a `--no-default-features --features live` doc/build slice but did not fail the checks.
  - `cargo fmt --check` — success
  - `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — success
  - `cargo test --workspace --all-targets --all-features --locked` — success (workspace tests passed)
  - `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked` — success
  - `python3 scripts/validate_docs_contracts.py` — success
  - `cargo check -p tailtriage-tracing --no-default-features --locked` — success
  - `cargo check -p tailtriage-tracing --no-default-features --features jsonl --locked` — success
  - `cargo check -p tailtriage-tracing --no-default-features --features live --locked` — success (non-fatal `dead_code` warning observed)
  - `cargo check -p tailtriage-tracing --no-default-features --features tokio --locked` — success
- Unit tests added and updated passed as part of the workspace test run (CLI boundary tests and tracing recorder tests included and green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14a2fdcdd88330a7ecb0810f04ef9d)