### PR TITLE
Make completed-span JSONL persistence failures fatal and clarify tracing docs

### DIFF
--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -51,7 +51,9 @@ tailtriage import tracing-json spans.jsonl --service checkout --output tailtriag
 With optional metadata flags, strict validation, and explicit format:
 
 ```bash
-tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json --service-version v1 --run-id run-42 --strict
+tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json \
+  --service-version v1 --run-id run-42 --strict \
+  --input-format tailtriage-span-jsonl
 ```
 
 
@@ -70,6 +72,7 @@ Recommended stable input format is the tailtriage wrapper JSONL shape:
 Behavior:
 - `tailtriage-span-jsonl` enforces wrapper-only parsing.
 - `compatible` keeps compatibility parsing for pre-stable/internal normalized shapes and rejects ordinary tracing log JSON (including `fmt().json` output) early with setup guidance; timing is not guessed from JSONL line receive time.
+- `compatible` is for pre-stable/internal normalized completed-span shapes with explicit start/end timestamps; it is not auto-detection and not generic tracing JSON import.
 
 After import, run analysis separately:
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -14,9 +14,10 @@ It is **not**:
 
 ## Feature flags
 
-- Default (`jsonl`): typed records plus JSONL import APIs.
+- Base crate: typed `SpanRecord`, `ImportOptions`, `ImportedRun`, semantic constants, and `run_from_span_records(...)`.
+- Default (`jsonl`): JSONL import APIs and stable wrapper parsing.
 - `live`: enables `TracingRecorder`, `TailtriageLayer`, and `TracingIntakeSession`.
-- `tokio`: enables `TracingTokioSession` (and includes `live`).
+- `tokio`: enables `TracingTokioSession` runtime-sampler coupling and includes `live`.
 
 CLI offline import workflows only need JSONL import support and do not require the live `tracing_subscriber` layer dependency.
 
@@ -137,10 +138,11 @@ Missing stage `tt.success` defaults to `true` with a warning.
 - `max_open_spans` bounds in-flight span tracking.
 - `max_completed_candidate_spans` bounds retained raw completed candidate spans before semantic conversion.
 - Request/stage/queue semantic retention uses `CaptureMode`, `CaptureLimits`, and `CaptureLimitsOverride`.
-- `completed_span_jsonl_path(...)` writes retained valid completed-span JSONL on shutdown only when at least one completed request is retained.
-- The completed-span JSONL is replayable into the same retained request/stage/queue evidence when imported with matching service metadata.
+- `completed_span_jsonl_path(...)` writes retained tailtriage semantic evidence as stable span-shaped JSONL on shutdown only when at least one completed request is retained.
+- It is intended for replaying the same retained request/stage/queue evidence through `tailtriage import`, not for trace archival.
+- It does not preserve original tracing span names, span IDs, parent IDs, or non-`tt.*` fields.
 - This completed-span JSONL is a narrow retained-evidence export, not a generic tracing log stream and not OTel/OTLP.
-- Warnings and lifecycle warnings indicate evidence may be incomplete when limits are hit or writer issues occur.
+- Warnings indicate evidence may be incomplete when limits are hit.
 
 ## Runtime-pressure limitation
 

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -246,8 +246,12 @@ impl TracingIntakeSession {
     ///         tt.request_id = "r1",
     ///         tt.route = "/checkout"
     ///     );
-    ///     drop(span);
+    ///
+    ///     let _guard = span.enter();
+    ///     // measured work goes here
     /// });
+    ///
+    /// Record completed work from span close/drop; keep the span active around the work you want measured.
     ///
     /// let _ = session.shutdown().expect("shutdown should succeed");
     /// ```
@@ -280,21 +284,13 @@ impl TracingIntakeSession {
     ///
     /// Returns an error when conversion fails or when configured run-json output cannot be written.
     pub fn shutdown(self) -> Result<ImportedRun, ImportError> {
-        let strict_mode = self.recorder.options.strict_mode();
         let imported = self.recorder.shutdown()?;
-        let (mut run, mut warnings) = imported.into_parts();
+        let (run, warnings) = imported.into_parts();
         if self.run_json_path.is_some() || self.completed_span_jsonl_path.is_some() {
             ensure_persistable_run_has_requests(&run)?;
         }
         if let Some(path) = &self.completed_span_jsonl_path {
-            if let Err(err) = write_completed_span_jsonl_from_run(&run, path) {
-                if strict_mode {
-                    return Err(err);
-                }
-                let msg = err.to_string();
-                run.metadata.lifecycle_warnings.push(msg.clone());
-                warnings.push(crate::ImportWarning::new(msg));
-            }
+            write_completed_span_jsonl_from_run(&run, path)?;
         }
         if let Some(path) = self.run_json_path {
             create_output_parent_dir(&path, "create run json parent directory")?;
@@ -526,7 +522,9 @@ impl TracingIntakeSessionBuilder {
     }
     /// Enables completed-span JSONL output at the given path.
     ///
-    /// Writes retained valid completed spans on shutdown using the stable wrapper shape.
+    /// Writes retained tailtriage semantic evidence as stable span-shaped JSONL on shutdown for
+    /// replay through `tailtriage import`; this is not trace archival and does not preserve
+    /// original tracing span names, span IDs, parent IDs, or non-`tt.*` fields.
     #[must_use]
     pub fn completed_span_jsonl_path(mut self, path: impl AsRef<Path>) -> Self {
         self.completed_span_jsonl_path = Some(path.as_ref().to_path_buf());
@@ -2729,7 +2727,7 @@ mod tests {
     }
 
     #[test]
-    fn intake_session_non_strict_write_failure_adds_warning_and_keeps_run() {
+    fn intake_session_non_strict_write_failure_returns_io_on_shutdown() {
         let dir = tempfile::tempdir().unwrap();
         let parent_file = dir.path().join("missing");
         std::fs::write(&parent_file, "not-a-directory").unwrap();
@@ -2748,29 +2746,11 @@ mod tests {
             ));
         });
 
-        let imported = session.shutdown().unwrap();
-        assert_eq!(imported.run().requests.len(), 1);
-        assert_eq!(imported.run().requests[0].request_id, "r1");
-
-        let warning = imported
-            .warnings()
-            .iter()
-            .map(crate::ImportWarning::message)
-            .find(|m| m.contains("completed span jsonl") || m.contains("spans.jsonl"))
-            .expect("non-strict shutdown should include completed-span JSONL write warning");
-        assert!(
-            warning.contains("completed span jsonl") || warning.contains("spans.jsonl"),
-            "warning should contain completed-span JSONL context: {warning}"
-        );
-        assert!(
-            imported
-                .run()
-                .metadata
-                .lifecycle_warnings
-                .iter()
-                .any(|m| m == warning),
-            "lifecycle warnings should contain the same completed-span JSONL write warning"
-        );
+        let err = session.shutdown().unwrap_err();
+        assert!(matches!(err, ImportError::Io { .. }));
+        assert!(err
+            .to_string()
+            .contains("create completed span jsonl parent directory"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Ensure explicitly configured completed-span JSONL artifacts are reliably persisted: a configured `completed_span_jsonl_path(...)` must cause shutdown to return an error if the artifact cannot be written. 
- Prevent user-facing doc misunderstandings by tightening rustdoc and README wording about retained-span JSONL semantics, feature flags, and an example that correctly demonstrates bracketing measured work.

### Description
- `TracingIntakeSession::shutdown()` now always returns `Err(...)` on `completed_span_jsonl_path(...)` write failures by replacing the non-strict write-warning path with `write_completed_span_jsonl_from_run(&run, path)?;` and removing the now-unused `strict_mode` local. 
- Kept non-strict conversion semantics unchanged so malformed/incomplete `tt.*` spans still warn-and-skip during conversion while writer errors for explicitly configured artifacts are treated as fatal. 
- Updated unit tests in `tailtriage-tracing/src/recorder.rs` so both strict and non-strict sessions assert `Err` for unwritable `completed_span_jsonl_path(...)` and preserved tests covering malformed/incomplete span behavior and Run JSON write behavior. 
- Tightened rustdoc example for `TracingIntakeSession::builder(...)` to use a scoped entered span and added the short sentence: "Record completed work from span close/drop; keep the span active around the work you want measured." 
- Clarified `completed_span_jsonl_path(...)` wording in the tracing crate README and rustdoc to state the JSONL is retained tailtriage evidence for replay via `tailtriage import` and does not preserve original span IDs/names/parents or non-`tt.*` fields. 
- Updated `tailtriage-tracing/README.md` feature-flag bullets to distinguish base crate APIs from the default (`jsonl`) feature, and updated the CLI README import example to include `--input-format tailtriage-span-jsonl` plus a guardrail sentence about `compatible`.

### Testing
- Ran `cargo fmt --check` and it succeeded. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, which initially failed due to an `unused_mut` warning that was fixed, and then passed after the fix. 
- Ran `cargo test -p tailtriage-tracing --all-features recorder::tests --locked` and the recorder tests passed (73 passed; 0 failed). 
- Ran `cargo test -p tailtriage-cli --test cli_boundary --locked` and CLI boundary tests passed (45 passed; 0 failed). 
- Ran the workspace validation/verification sequence `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings && cargo test --workspace --all-targets --all-features --locked && RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked && python3 scripts/validate_docs_contracts.py && cargo check -p tailtriage-tracing --no-default-features --locked && cargo check -p tailtriage-tracing --no-default-features --features jsonl --locked && cargo check -p tailtriage-tracing --no-default-features --features live --locked && cargo check -p tailtriage-tracing --no-default-features --features tokio --locked` and all steps completed successfully after the small fix noted above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a153d9f720883308f84152df0af89bb)