### PR TITLE
Make completed-span JSONL write failures fatal and tighten tracing docs/CLI examples

### DIFF
--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -51,7 +51,8 @@ tailtriage import tracing-json spans.jsonl --service checkout --output tailtriag
 With optional metadata flags, strict validation, and explicit format:
 
 ```bash
-tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json --service-version v1 --run-id run-42 --strict
+tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json --service-version v1 --run-id run-42 --strict \
+  --input-format tailtriage-span-jsonl
 ```
 
 
@@ -70,6 +71,7 @@ Recommended stable input format is the tailtriage wrapper JSONL shape:
 Behavior:
 - `tailtriage-span-jsonl` enforces wrapper-only parsing.
 - `compatible` keeps compatibility parsing for pre-stable/internal normalized shapes and rejects ordinary tracing log JSON (including `fmt().json` output) early with setup guidance; timing is not guessed from JSONL line receive time.
+- `compatible` is for pre-stable/internal normalized completed-span shapes with explicit start/end timestamps; it is not auto-detection and not generic tracing JSON import.
 
 After import, run analysis separately:
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -14,9 +14,10 @@ It is **not**:
 
 ## Feature flags
 
-- Default (`jsonl`): typed records plus JSONL import APIs.
+- Base crate: typed `SpanRecord`, `ImportOptions`, `ImportedRun`, semantic constants, and `run_from_span_records(...)`.
+- Default (`jsonl`): JSONL import APIs and stable wrapper parsing.
 - `live`: enables `TracingRecorder`, `TailtriageLayer`, and `TracingIntakeSession`.
-- `tokio`: enables `TracingTokioSession` (and includes `live`).
+- `tokio`: enables `TracingTokioSession` runtime-sampler coupling and includes `live`.
 
 CLI offline import workflows only need JSONL import support and do not require the live `tracing_subscriber` layer dependency.
 
@@ -137,10 +138,11 @@ Missing stage `tt.success` defaults to `true` with a warning.
 - `max_open_spans` bounds in-flight span tracking.
 - `max_completed_candidate_spans` bounds retained raw completed candidate spans before semantic conversion.
 - Request/stage/queue semantic retention uses `CaptureMode`, `CaptureLimits`, and `CaptureLimitsOverride`.
-- `completed_span_jsonl_path(...)` writes retained valid completed-span JSONL on shutdown only when at least one completed request is retained.
-- The completed-span JSONL is replayable into the same retained request/stage/queue evidence when imported with matching service metadata.
+- `completed_span_jsonl_path(...)` writes retained tailtriage semantic evidence as stable span-shaped JSONL on shutdown only when at least one completed request is retained.
+- It is intended for replaying the same retained request/stage/queue evidence through `tailtriage import`, not for trace archival.
+- It does not preserve original tracing span names, span IDs, parent IDs, or non-`tt.*` fields.
 - This completed-span JSONL is a narrow retained-evidence export, not a generic tracing log stream and not OTel/OTLP.
-- Warnings and lifecycle warnings indicate evidence may be incomplete when limits are hit or writer issues occur.
+- Warnings and lifecycle warnings indicate evidence may be incomplete when limits are hit.
 
 ## Runtime-pressure limitation
 

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -233,6 +233,8 @@ impl TracingIntakeSession {
     /// use tailtriage_tracing::TracingIntakeSession;
     /// use tracing_subscriber::prelude::*;
     ///
+    /// Record completed work from span close/drop; keep the span active around the work you want measured.
+    ///
     /// let session = TracingIntakeSession::builder("checkout")
     ///     .completed_span_jsonl_path("completed-spans.jsonl")
     ///     .build()
@@ -246,7 +248,9 @@ impl TracingIntakeSession {
     ///         tt.request_id = "r1",
     ///         tt.route = "/checkout"
     ///     );
-    ///     drop(span);
+    ///
+    ///     let _guard = span.enter();
+    ///     // measured work goes here
     /// });
     ///
     /// let _ = session.shutdown().expect("shutdown should succeed");
@@ -278,23 +282,15 @@ impl TracingIntakeSession {
     ///
     /// # Errors
     ///
-    /// Returns an error when conversion fails or when configured run-json output cannot be written.
+    /// Returns an error when conversion fails or when configured output artifacts cannot be written.
     pub fn shutdown(self) -> Result<ImportedRun, ImportError> {
-        let strict_mode = self.recorder.options.strict_mode();
         let imported = self.recorder.shutdown()?;
-        let (mut run, mut warnings) = imported.into_parts();
+        let (run, warnings) = imported.into_parts();
         if self.run_json_path.is_some() || self.completed_span_jsonl_path.is_some() {
             ensure_persistable_run_has_requests(&run)?;
         }
         if let Some(path) = &self.completed_span_jsonl_path {
-            if let Err(err) = write_completed_span_jsonl_from_run(&run, path) {
-                if strict_mode {
-                    return Err(err);
-                }
-                let msg = err.to_string();
-                run.metadata.lifecycle_warnings.push(msg.clone());
-                warnings.push(crate::ImportWarning::new(msg));
-            }
+            write_completed_span_jsonl_from_run(&run, path)?;
         }
         if let Some(path) = self.run_json_path {
             create_output_parent_dir(&path, "create run json parent directory")?;
@@ -526,7 +522,10 @@ impl TracingIntakeSessionBuilder {
     }
     /// Enables completed-span JSONL output at the given path.
     ///
-    /// Writes retained valid completed spans on shutdown using the stable wrapper shape.
+    /// Writes retained tailtriage semantic evidence as stable span-shaped JSONL on shutdown.
+    ///
+    /// Intended for replay through `tailtriage import`, not trace archival; this output
+    /// does not preserve original tracing span names, span IDs, parent IDs, or non-`tt.*` fields.
     #[must_use]
     pub fn completed_span_jsonl_path(mut self, path: impl AsRef<Path>) -> Self {
         self.completed_span_jsonl_path = Some(path.as_ref().to_path_buf());
@@ -2729,7 +2728,7 @@ mod tests {
     }
 
     #[test]
-    fn intake_session_non_strict_write_failure_adds_warning_and_keeps_run() {
+    fn intake_session_non_strict_write_failure_returns_io_on_shutdown() {
         let dir = tempfile::tempdir().unwrap();
         let parent_file = dir.path().join("missing");
         std::fs::write(&parent_file, "not-a-directory").unwrap();
@@ -2748,29 +2747,11 @@ mod tests {
             ));
         });
 
-        let imported = session.shutdown().unwrap();
-        assert_eq!(imported.run().requests.len(), 1);
-        assert_eq!(imported.run().requests[0].request_id, "r1");
-
-        let warning = imported
-            .warnings()
-            .iter()
-            .map(crate::ImportWarning::message)
-            .find(|m| m.contains("completed span jsonl") || m.contains("spans.jsonl"))
-            .expect("non-strict shutdown should include completed-span JSONL write warning");
-        assert!(
-            warning.contains("completed span jsonl") || warning.contains("spans.jsonl"),
-            "warning should contain completed-span JSONL context: {warning}"
-        );
-        assert!(
-            imported
-                .run()
-                .metadata
-                .lifecycle_warnings
-                .iter()
-                .any(|m| m == warning),
-            "lifecycle warnings should contain the same completed-span JSONL write warning"
-        );
+        let err = session.shutdown().unwrap_err();
+        assert!(matches!(err, ImportError::Io { .. }));
+        assert!(err
+            .to_string()
+            .contains("create completed span jsonl parent directory"));
     }
 
     #[test]

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -233,7 +233,7 @@ impl TracingIntakeSession {
     /// use tailtriage_tracing::TracingIntakeSession;
     /// use tracing_subscriber::prelude::*;
     ///
-    /// Record completed work from span close/drop; keep the span active around the work you want measured.
+    /// // Record completed work from span close/drop; keep the span active around the work you want measured.
     ///
     /// let session = TracingIntakeSession::builder("checkout")
     ///     .completed_span_jsonl_path("completed-spans.jsonl")


### PR DESCRIPTION
### Motivation

- Ensure that explicitly configured output artifacts are reliably persisted by making failures to write completed-span JSONL fatal regardless of strict mode. 
- Preserve existing conversion semantics where non-strict mode still warns-and-skips malformed/incomplete `tt.*` span records. 
- Remove potential user misunderstandings in rustdocs/READMEs about how completed-span JSONL relates to raw tracing span archival and how to measure work with spans. 

### Description

- Updated `TracingIntakeSession::shutdown()` in `tailtriage-tracing/src/recorder.rs` to always propagate errors from `write_completed_span_jsonl_from_run(...)` (replace conditional-warning path with `write_completed_span_jsonl_from_run(&run, path)?;`) and removed the now-unused local `strict_mode`. 
- Kept non-strict conversion behavior unchanged (malformed/incomplete `tt.*` spans still warn and are skipped during conversion) and did not change analyzer behavior or `tt.outcome` semantics. 
- Tightened rustdoc for `TracingIntakeSession::builder(...)` to use a scoped entered span in the sync example and added the sentence: “Record completed work from span close/drop; keep the span active around the work you want measured.” 
- Updated `completed_span_jsonl_path(...)` docs and `tailtriage-tracing/README.md` to state the JSONL is retained tailtriage semantic evidence intended for replay via `tailtriage import` and that it does not preserve original tracing span names/IDs/parent IDs or non-`tt.*` fields. 
- Updated `tailtriage-cli/README.md` example to include `--input-format tailtriage-span-jsonl` and added a short guardrail sentence clarifying what `compatible` means. 
- Adjusted unit tests in `tailtriage-tracing/src/recorder.rs` to assert that both strict and non-strict sessions return an `Err` on unwritable configured `completed_span_jsonl_path(...)`, while preserving existing tests that validate non-strict malformed/incomplete span warnings and Run JSON write behavior. 

### Testing

- Ran `cargo fmt --check` and it succeeded. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it completed with no warnings (fixes applied during changes). 
- Ran full workspace tests with `cargo test --workspace --all-targets --all-features --locked` and they completed successfully (all tests passed). 
- Built documentation with `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked` and it completed successfully with no warnings. 
- Ran docs contract validation `python3 scripts/validate_docs_contracts.py` and it reported success. 
- Ran targeted tests `cargo test -p tailtriage-tracing --all-features recorder::tests --locked` and `cargo test -p tailtriage-cli --test cli_boundary --locked` and both succeeded (their respective test suites passed). 
- Performed feature checks: `cargo check -p tailtriage-tracing --no-default-features --locked`, `cargo check -p tailtriage-tracing --no-default-features --features jsonl --locked`, `cargo check -p tailtriage-tracing --no-default-features --features live --locked`, and `cargo check -p tailtriage-tracing --no-default-features --features tokio --locked`, and all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a153d9f720883308f84152df0af89bb)