### PR TITLE
Fix strict tracing import semantics for max-requests overflow children

### DIFF
--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -389,6 +389,54 @@ fn import_tracing_json_capture_limit_overrides_apply() {
 }
 
 #[test]
+fn import_tracing_json_strict_with_max_requests_skips_valid_overflow_children_without_orphan_warning(
+) {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    let fixture = concat!(
+        "{\"format\":\"tailtriage.tracing-span.v1\",\"span\":{\"name\":\"req-1\",\"started_at_unix_ms\":100,\"finished_at_unix_ms\":150,\"fields\":{\"tt.kind\":\"request\",\"tt.request_id\":\"r1\",\"tt.route\":\"/a\"}}}\n",
+        "{\"format\":\"tailtriage.tracing-span.v1\",\"span\":{\"name\":\"stage-1\",\"started_at_unix_ms\":110,\"finished_at_unix_ms\":120,\"fields\":{\"tt.kind\":\"stage\",\"tt.request_id\":\"r1\",\"tt.stage\":\"db\"}}}\n",
+        "{\"format\":\"tailtriage.tracing-span.v1\",\"span\":{\"name\":\"queue-1\",\"started_at_unix_ms\":121,\"finished_at_unix_ms\":122,\"fields\":{\"tt.kind\":\"queue\",\"tt.request_id\":\"r1\",\"tt.queue\":\"worker\"}}}\n",
+        "{\"format\":\"tailtriage.tracing-span.v1\",\"span\":{\"name\":\"req-2\",\"started_at_unix_ms\":200,\"finished_at_unix_ms\":250,\"fields\":{\"tt.kind\":\"request\",\"tt.request_id\":\"r2\",\"tt.route\":\"/b\"}}}\n",
+        "{\"format\":\"tailtriage.tracing-span.v1\",\"span\":{\"name\":\"stage-2\",\"started_at_unix_ms\":210,\"finished_at_unix_ms\":220,\"fields\":{\"tt.kind\":\"stage\",\"tt.request_id\":\"r2\",\"tt.stage\":\"db\"}}}\n",
+        "{\"format\":\"tailtriage.tracing-span.v1\",\"span\":{\"name\":\"queue-2\",\"started_at_unix_ms\":221,\"finished_at_unix_ms\":222,\"fields\":{\"tt.kind\":\"queue\",\"tt.request_id\":\"r2\",\"tt.queue\":\"worker\"}}}\n"
+    );
+    std::fs::write(&spans_path, fixture).expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--strict")
+        .arg("--max-requests")
+        .arg("1")
+        .output()
+        .expect("cli should run");
+    assert!(output.status.success(), "cli failed: {output:?}");
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path).unwrap();
+    assert_eq!(loaded.run.requests.len(), 1);
+    assert!(loaded
+        .run
+        .stages
+        .iter()
+        .all(|stage| stage.request_id == "r1"));
+    assert!(loaded
+        .run
+        .queues
+        .iter()
+        .all(|queue| queue.request_id == "r1"));
+    assert_eq!(loaded.run.truncation.dropped_requests, 1);
+    assert_eq!(loaded.run.truncation.dropped_stages, 1);
+    assert_eq!(loaded.run.truncation.dropped_queues, 1);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!stderr.contains("no retained request event was imported"));
+}
+
+#[test]
 fn import_tracing_json_rejects_inert_runtime_snapshot_flags() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -98,6 +98,7 @@ where
     let mut parsed_requests = Vec::new();
     let mut parsed_stages = Vec::new();
     let mut queues = Vec::new();
+    let mut request_span_ids = BTreeSet::new();
 
     for span in spans {
         let kind = match get_string_field_state(&span, TT_KIND) {
@@ -153,6 +154,9 @@ where
             SpanKind::Request => {
                 let request_id =
                     required_string(&span, TT_REQUEST_ID, options.strict_mode(), &mut warnings)?;
+                if let Some(request_id) = request_id.as_ref() {
+                    request_span_ids.insert(request_id.clone());
+                }
                 let route = required_string(&span, TT_ROUTE, options.strict_mode(), &mut warnings)?;
                 if let (Some(request_id), Some(route)) = (request_id, route) {
                     let Some((outcome, outcome_defaulted)) =
@@ -255,18 +259,28 @@ where
         .into_iter()
         .map(|request| request.event)
         .collect();
-    let request_intervals = retained_request_intervals(&requests, capture_limits.max_requests);
+    let valid_request_intervals = retained_request_intervals(&requests, requests.len());
+    let retained_request_intervals =
+        retained_request_intervals(&requests, capture_limits.max_requests);
+    let mut dropped_stages_due_to_request_overflow = 0_u64;
+    let mut dropped_queues_due_to_request_overflow = 0_u64;
     filter_correlated_parsed_stages(
         &mut parsed_stages,
-        &request_intervals,
+        &valid_request_intervals,
+        &retained_request_intervals,
+        &request_span_ids,
         options.strict_mode(),
         &mut warnings,
+        &mut dropped_stages_due_to_request_overflow,
     )?;
     filter_correlated_queues(
         &mut queues,
-        &request_intervals,
+        &valid_request_intervals,
+        &retained_request_intervals,
+        &request_span_ids,
         options.strict_mode(),
         &mut warnings,
+        &mut dropped_queues_due_to_request_overflow,
     )?;
     let stage_success_default_count = parsed_stages
         .iter()
@@ -345,6 +359,20 @@ where
             .map_err(|err| ImportError::InvalidRunEvent(err.to_string()))?;
     }
     let mut run = run_builder.finish();
+    if dropped_stages_due_to_request_overflow > 0 {
+        run.truncation.dropped_stages = run
+            .truncation
+            .dropped_stages
+            .saturating_add(dropped_stages_due_to_request_overflow);
+        run.truncation.limits_hit = true;
+    }
+    if dropped_queues_due_to_request_overflow > 0 {
+        run.truncation.dropped_queues = run
+            .truncation
+            .dropped_queues
+            .saturating_add(dropped_queues_due_to_request_overflow);
+        run.truncation.limits_hit = true;
+    }
     attach_durable_conversion_warnings(&mut run, &warnings);
 
     Ok(ImportedRun::new(run, warnings))
@@ -425,28 +453,51 @@ fn interval_within_request_with_tolerance(
 
 fn filter_correlated_parsed_stages(
     stages: &mut Vec<ParsedStageEvent>,
-    request_intervals: &BTreeMap<String, RequestInterval>,
+    valid_request_intervals: &BTreeMap<String, RequestInterval>,
+    retained_request_intervals: &BTreeMap<String, RequestInterval>,
+    request_span_ids: &BTreeSet<String>,
     strict: bool,
     warnings: &mut Vec<ImportWarning>,
+    dropped_due_to_request_overflow: &mut u64,
 ) -> Result<(), ImportError> {
     let mut filtered = Vec::with_capacity(stages.len());
     for stage in stages.drain(..) {
-        let Some(interval) = request_intervals.get(stage.event.request_id.as_str()) else {
-            strict_or_warn(
-                strict,
-                warnings,
-                format!(
-                    "skipped stage span for request_id '{}' because no retained request event was imported",
-                    stage.event.request_id
-                ),
-            )?;
+        let Some(valid_interval) = valid_request_intervals.get(stage.event.request_id.as_str())
+        else {
+            if request_span_ids.contains(stage.event.request_id.as_str()) {
+                strict_or_warn(
+                    strict,
+                    warnings,
+                    format!(
+                        "skipped stage span for request_id '{}' because a matching request span was parsed but invalid/skipped before retention",
+                        stage.event.request_id
+                    ),
+                )?;
+            } else {
+                strict_or_warn(
+                    strict,
+                    warnings,
+                    format!(
+                        "skipped stage span for request_id '{}' because no matching request event was imported",
+                        stage.event.request_id
+                    ),
+                )?;
+            }
             continue;
         };
+        if !retained_request_intervals.contains_key(stage.event.request_id.as_str()) {
+            *dropped_due_to_request_overflow = dropped_due_to_request_overflow.saturating_add(1);
+            warnings.push(ImportWarning::new(format!(
+                "skipped stage span for request_id '{}' because the matching request was valid but not retained due to max_requests",
+                stage.event.request_id
+            )));
+            continue;
+        }
         if !interval_within_request_with_tolerance(
             stage.event.started_at_unix_ms,
             stage.event.finished_at_unix_ms,
-            interval.started_at_unix_ms,
-            interval.finished_at_unix_ms,
+            valid_interval.started_at_unix_ms,
+            valid_interval.finished_at_unix_ms,
         ) {
             strict_or_warn(
                 strict,
@@ -457,8 +508,8 @@ fn filter_correlated_parsed_stages(
                     stage.event.request_id,
                     stage.event.started_at_unix_ms,
                     stage.event.finished_at_unix_ms,
-                    interval.started_at_unix_ms,
-                    interval.finished_at_unix_ms
+                    valid_interval.started_at_unix_ms,
+                    valid_interval.finished_at_unix_ms
                 ),
             )?;
             continue;
@@ -471,28 +522,50 @@ fn filter_correlated_parsed_stages(
 
 fn filter_correlated_queues(
     queues: &mut Vec<QueueEvent>,
-    request_intervals: &BTreeMap<String, RequestInterval>,
+    valid_request_intervals: &BTreeMap<String, RequestInterval>,
+    retained_request_intervals: &BTreeMap<String, RequestInterval>,
+    request_span_ids: &BTreeSet<String>,
     strict: bool,
     warnings: &mut Vec<ImportWarning>,
+    dropped_due_to_request_overflow: &mut u64,
 ) -> Result<(), ImportError> {
     let mut filtered = Vec::with_capacity(queues.len());
     for queue in queues.drain(..) {
-        let Some(interval) = request_intervals.get(queue.request_id.as_str()) else {
-            strict_or_warn(
-                strict,
-                warnings,
-                format!(
-                    "skipped queue span for request_id '{}' because no retained request event was imported",
-                    queue.request_id
-                ),
-            )?;
+        let Some(valid_interval) = valid_request_intervals.get(queue.request_id.as_str()) else {
+            if request_span_ids.contains(queue.request_id.as_str()) {
+                strict_or_warn(
+                    strict,
+                    warnings,
+                    format!(
+                        "skipped queue span for request_id '{}' because a matching request span was parsed but invalid/skipped before retention",
+                        queue.request_id
+                    ),
+                )?;
+            } else {
+                strict_or_warn(
+                    strict,
+                    warnings,
+                    format!(
+                        "skipped queue span for request_id '{}' because no matching request event was imported",
+                        queue.request_id
+                    ),
+                )?;
+            }
             continue;
         };
+        if !retained_request_intervals.contains_key(queue.request_id.as_str()) {
+            *dropped_due_to_request_overflow = dropped_due_to_request_overflow.saturating_add(1);
+            warnings.push(ImportWarning::new(format!(
+                "skipped queue span for request_id '{}' because the matching request was valid but not retained due to max_requests",
+                queue.request_id
+            )));
+            continue;
+        }
         if !interval_within_request_with_tolerance(
             queue.waited_from_unix_ms,
             queue.waited_until_unix_ms,
-            interval.started_at_unix_ms,
-            interval.finished_at_unix_ms,
+            valid_interval.started_at_unix_ms,
+            valid_interval.finished_at_unix_ms,
         ) {
             strict_or_warn(
                 strict,
@@ -503,8 +576,8 @@ fn filter_correlated_queues(
                     queue.request_id,
                     queue.waited_from_unix_ms,
                     queue.waited_until_unix_ms,
-                    interval.started_at_unix_ms,
-                    interval.finished_at_unix_ms
+                    valid_interval.started_at_unix_ms,
+                    valid_interval.finished_at_unix_ms
                 ),
             )?;
             continue;
@@ -826,7 +899,7 @@ fn parse_depth_at_start(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tailtriage_core::CaptureMode;
+    use tailtriage_core::{CaptureLimitsOverride, CaptureMode};
 
     #[test]
     fn span_kind_parser_accepts_supported_values_only() {
@@ -901,7 +974,8 @@ mod tests {
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests.len(), 1);
         assert_eq!(imported.run().stages.len(), 0);
-        let warning = "skipped stage span for request_id 'r-orphan' because no retained request event was imported";
+        let warning =
+            "skipped stage span for request_id 'r-orphan' because no matching request event was imported";
         assert!(imported
             .warnings()
             .iter()
@@ -961,7 +1035,7 @@ mod tests {
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
         match err {
             ImportError::StrictViolation(message) => {
-                assert!(message.contains("no retained request event"));
+                assert!(message.contains("no matching request event"));
             }
             _ => panic!("expected StrictViolation"),
         }
@@ -982,7 +1056,8 @@ mod tests {
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests.len(), 1);
         assert_eq!(imported.run().queues.len(), 0);
-        let warning = "skipped queue span for request_id 'r-orphan' because no retained request event was imported";
+        let warning =
+            "skipped queue span for request_id 'r-orphan' because no matching request event was imported";
         assert!(imported
             .warnings()
             .iter()
@@ -1010,7 +1085,7 @@ mod tests {
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
         match err {
             ImportError::StrictViolation(message) => {
-                assert!(message.contains("no retained request event"));
+                assert!(message.contains("no matching request event"));
             }
             _ => panic!("expected StrictViolation"),
         }
@@ -2104,11 +2179,74 @@ mod tests {
         assert!(imported.run().stages.is_empty());
         assert!(imported.run().queues.is_empty());
         assert!(imported.warnings().iter().any(|w| w.message().contains(
-            "skipped stage span for request_id 'r1' because no retained request event was imported"
+            "skipped stage span for request_id 'r1' because a matching request span was parsed but invalid/skipped before retention"
         )));
         assert!(imported.warnings().iter().any(|w| w.message().contains(
-            "skipped queue span for request_id 'r1' because no retained request event was imported"
+            "skipped queue span for request_id 'r1' because a matching request span was parsed but invalid/skipped before retention"
         )));
+    }
+
+    #[test]
+    fn strict_mode_allows_valid_children_when_parent_request_is_dropped_by_max_requests() {
+        let spans = vec![
+            SpanRecord::new("req-1", 100, 150)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("stage-1", 110, 120)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+            SpanRecord::new("queue-1", 121, 122)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "worker"),
+            SpanRecord::new("req-2", 200, 250)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r2")
+                .field(TT_ROUTE, "/b"),
+            SpanRecord::new("stage-2", 210, 220)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r2")
+                .field(TT_STAGE, "db"),
+            SpanRecord::new("queue-2", 221, 222)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r2")
+                .field(TT_QUEUE, "worker"),
+        ];
+        let imported = run_from_span_records(
+            spans,
+            ImportOptions::new("checkout")
+                .strict(true)
+                .capture_limits_override(CaptureLimitsOverride {
+                    max_requests: Some(1),
+                    ..CaptureLimitsOverride::default()
+                }),
+        )
+        .expect("strict import should succeed");
+        let run = imported.run();
+        assert_eq!(run.requests.len(), 1);
+        assert_eq!(run.requests[0].request_id, "r1");
+        assert!(run.stages.iter().all(|stage| stage.request_id == "r1"));
+        assert!(run.queues.iter().all(|queue| queue.request_id == "r1"));
+        assert_eq!(run.truncation.dropped_requests, 1);
+        assert_eq!(run.truncation.dropped_stages, 1);
+        assert_eq!(run.truncation.dropped_queues, 1);
+        assert!(run.truncation.limits_hit);
+        let warning_messages: Vec<&str> = imported
+            .warnings()
+            .iter()
+            .map(ImportWarning::message)
+            .collect();
+        assert!(
+            warning_messages
+                .iter()
+                .any(|m| m
+                    .contains("matching request was valid but not retained due to max_requests"))
+        );
+        assert!(!warning_messages
+            .iter()
+            .any(|m| m.contains("no retained request event was imported")));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent strict-mode imports from failing when a request is a valid parsed span but is not retained due to `max_requests`, by treating its child stage/queue spans as retention fallout rather than malformed/orphan input.

### Description
- Track all parsed request ids and build two interval maps: `valid_request_intervals` (all valid parsed requests) and `retained_request_intervals` (the retained subset limited by `max_requests`).
- Update stage/queue filtering to validate child timestamps against the parent request's valid interval but only treat children as retained if their parent is in the retained map; children of valid-but-unretained requests are skipped, emit a retention-specific warning, and are counted as truncation fallout.
- Ensure strict-mode only errors on true input-quality failures (missing/invalid parent or out-of-window child) and not on valid-but-unretained parents; preserve existing orphan and out-of-window semantics.
- After `RunBuilder::finish()` increment `run.truncation.dropped_stages` / `dropped_queues` and set `run.truncation.limits_hit = true` for children skipped solely due to parent-request retention overflow.
- Add unit test in `tailtriage-tracing` and a CLI boundary test in `tailtriage-cli/tests/cli_boundary.rs` that exercise `--strict --max-requests 1` with two valid requests and stage/queue children, asserting import success, retained evidence scope, accurate truncation counts, and updated warning wording.

### Testing
- Ran formatting, linting, full test suite, docs, and targeted checks with the following commands and observed successful results (all commands returned success unless noted):
  - `cargo fmt --check` — success
  - `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — success
  - `cargo test --workspace --all-targets --all-features --locked` — success
  - `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked` — success
  - `python3 scripts/validate_docs_contracts.py` — success
  - `cargo test -p tailtriage-tracing --all-features --lib --locked` — success
  - `cargo test -p tailtriage-cli --test cli_boundary --locked` — success
  - `cargo check -p tailtriage-tracing --no-default-features --locked` — success
  - `cargo check -p tailtriage-tracing --no-default-features --features jsonl --locked` — success
  - `cargo check -p tailtriage-tracing --no-default-features --features live --locked` — success (note: emits an existing `dead_code` warning in `recorder.rs`, outside this change)
  - `cargo check -p tailtriage-tracing --no-default-features --features tokio --locked` — success
- All new and existing tests exercised by the runs above passed (unit and CLI tests covering the retention/fallback behavior included and green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1561228b00833096d3730a6a2f2558)