### PR TITLE
Fix strict import semantics for valid children dropped by max_requests retention

### DIFF
--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -389,6 +389,40 @@ fn import_tracing_json_capture_limit_overrides_apply() {
 }
 
 #[test]
+fn import_tracing_json_strict_with_max_requests_skips_valid_overflow_children_without_orphan_warning(
+) {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, multi_span_jsonl_fixture()).expect("fixture should write");
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--input-format")
+        .arg("compatible")
+        .arg("--strict")
+        .arg("--max-requests")
+        .arg("1")
+        .output()
+        .expect("cli should run");
+    assert!(output.status.success(), "cli failed: {output:?}");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!stderr.contains("no retained request event was imported"));
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path).unwrap();
+    assert_eq!(loaded.run.requests.len(), 1);
+    assert_eq!(loaded.run.requests[0].request_id, "req-1");
+    assert_eq!(loaded.run.stages.len(), 1);
+    assert_eq!(loaded.run.stages[0].request_id, "req-1");
+    assert_eq!(loaded.run.queues.len(), 1);
+    assert_eq!(loaded.run.queues[0].request_id, "req-1");
+}
+
+#[test]
 fn import_tracing_json_rejects_inert_runtime_snapshot_flags() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -255,18 +255,28 @@ where
         .into_iter()
         .map(|request| request.event)
         .collect();
+    let all_valid_request_intervals = all_valid_request_intervals(&requests);
+    let retained_request_ids = retained_request_ids(&requests, capture_limits.max_requests);
     let request_intervals = retained_request_intervals(&requests, capture_limits.max_requests);
+    let mut dropped_stage_due_to_unretained_request = 0_usize;
+    let mut dropped_queue_due_to_unretained_request = 0_usize;
     filter_correlated_parsed_stages(
         &mut parsed_stages,
+        &all_valid_request_intervals,
+        &retained_request_ids,
         &request_intervals,
         options.strict_mode(),
         &mut warnings,
+        &mut dropped_stage_due_to_unretained_request,
     )?;
     filter_correlated_queues(
         &mut queues,
+        &all_valid_request_intervals,
+        &retained_request_ids,
         &request_intervals,
         options.strict_mode(),
         &mut warnings,
+        &mut dropped_queue_due_to_unretained_request,
     )?;
     let stage_success_default_count = parsed_stages
         .iter()
@@ -345,6 +355,11 @@ where
             .map_err(|err| ImportError::InvalidRunEvent(err.to_string()))?;
     }
     let mut run = run_builder.finish();
+    if dropped_stage_due_to_unretained_request > 0 || dropped_queue_due_to_unretained_request > 0 {
+        run.truncation.limits_hit = true;
+    }
+    run.truncation.dropped_stages += dropped_stage_due_to_unretained_request as u64;
+    run.truncation.dropped_queues += dropped_queue_due_to_unretained_request as u64;
     attach_durable_conversion_warnings(&mut run, &warnings);
 
     Ok(ImportedRun::new(run, warnings))
@@ -403,6 +418,28 @@ fn retained_request_intervals(
     intervals
 }
 
+fn all_valid_request_intervals(requests: &[RequestEvent]) -> BTreeMap<String, RequestInterval> {
+    let mut intervals = BTreeMap::new();
+    for request in requests {
+        intervals.insert(
+            request.request_id.clone(),
+            RequestInterval {
+                started_at_unix_ms: request.started_at_unix_ms,
+                finished_at_unix_ms: request.finished_at_unix_ms,
+            },
+        );
+    }
+    intervals
+}
+
+fn retained_request_ids(requests: &[RequestEvent], max_requests: usize) -> BTreeSet<String> {
+    requests
+        .iter()
+        .take(max_requests)
+        .map(|request| request.request_id.clone())
+        .collect()
+}
+
 struct ParsedStageEvent {
     event: StageEvent,
     success_defaulted: bool,
@@ -425,13 +462,26 @@ fn interval_within_request_with_tolerance(
 
 fn filter_correlated_parsed_stages(
     stages: &mut Vec<ParsedStageEvent>,
+    all_valid_request_intervals: &BTreeMap<String, RequestInterval>,
+    retained_request_ids: &BTreeSet<String>,
     request_intervals: &BTreeMap<String, RequestInterval>,
     strict: bool,
     warnings: &mut Vec<ImportWarning>,
+    dropped_due_to_unretained_request: &mut usize,
 ) -> Result<(), ImportError> {
     let mut filtered = Vec::with_capacity(stages.len());
     for stage in stages.drain(..) {
         let Some(interval) = request_intervals.get(stage.event.request_id.as_str()) else {
+            if all_valid_request_intervals.contains_key(stage.event.request_id.as_str())
+                && !retained_request_ids.contains(stage.event.request_id.as_str())
+            {
+                warnings.push(ImportWarning::new(format!(
+                    "skipped stage span for request_id '{}' because the matching request was valid but not retained due to max_requests",
+                    stage.event.request_id
+                )));
+                *dropped_due_to_unretained_request += 1;
+                continue;
+            }
             strict_or_warn(
                 strict,
                 warnings,
@@ -471,13 +521,26 @@ fn filter_correlated_parsed_stages(
 
 fn filter_correlated_queues(
     queues: &mut Vec<QueueEvent>,
+    all_valid_request_intervals: &BTreeMap<String, RequestInterval>,
+    retained_request_ids: &BTreeSet<String>,
     request_intervals: &BTreeMap<String, RequestInterval>,
     strict: bool,
     warnings: &mut Vec<ImportWarning>,
+    dropped_due_to_unretained_request: &mut usize,
 ) -> Result<(), ImportError> {
     let mut filtered = Vec::with_capacity(queues.len());
     for queue in queues.drain(..) {
         let Some(interval) = request_intervals.get(queue.request_id.as_str()) else {
+            if all_valid_request_intervals.contains_key(queue.request_id.as_str())
+                && !retained_request_ids.contains(queue.request_id.as_str())
+            {
+                warnings.push(ImportWarning::new(format!(
+                    "skipped queue span for request_id '{}' because the matching request was valid but not retained due to max_requests",
+                    queue.request_id
+                )));
+                *dropped_due_to_unretained_request += 1;
+                continue;
+            }
             strict_or_warn(
                 strict,
                 warnings,
@@ -1556,6 +1619,66 @@ mod tests {
         assert_eq!(run.truncation.dropped_requests, 1);
         assert_eq!(run.truncation.dropped_stages, 1);
         assert_eq!(run.truncation.dropped_queues, 1);
+    }
+
+    #[test]
+    fn strict_mode_allows_children_of_valid_but_unretained_requests() {
+        let spans = vec![
+            SpanRecord::new("req-1", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("stage-1", 102, 110)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "s1"),
+            SpanRecord::new("queue-1", 104, 112)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "q1"),
+            SpanRecord::new("req-2", 200, 220)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r2")
+                .field(TT_ROUTE, "/b"),
+            SpanRecord::new("stage-2", 202, 210)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r2")
+                .field(TT_STAGE, "s2"),
+            SpanRecord::new("queue-2", 204, 212)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r2")
+                .field(TT_QUEUE, "q2"),
+        ];
+        let limits = tailtriage_core::CaptureLimitsOverride {
+            max_requests: Some(1),
+            ..tailtriage_core::CaptureLimitsOverride::default()
+        };
+        let imported = run_from_span_records(
+            spans,
+            ImportOptions::new("checkout")
+                .strict(true)
+                .capture_limits_override(limits),
+        )
+        .unwrap();
+        let run = imported.run();
+        assert_eq!(run.requests.len(), 1);
+        assert_eq!(run.requests[0].request_id, "r1");
+        assert_eq!(run.stages.len(), 1);
+        assert_eq!(run.stages[0].request_id, "r1");
+        assert_eq!(run.queues.len(), 1);
+        assert_eq!(run.queues[0].request_id, "r1");
+        assert_eq!(run.truncation.dropped_requests, 1);
+        assert_eq!(run.truncation.dropped_stages, 1);
+        assert_eq!(run.truncation.dropped_queues, 1);
+        assert!(imported.warnings().iter().any(|warning| warning.message().contains(
+            "skipped stage span for request_id 'r2' because the matching request was valid but not retained due to max_requests"
+        )));
+        assert!(imported.warnings().iter().any(|warning| warning.message().contains(
+            "skipped queue span for request_id 'r2' because the matching request was valid but not retained due to max_requests"
+        )));
+        assert!(!imported.warnings().iter().any(|warning| warning
+            .message()
+            .contains("no retained request event was imported")));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Strict import was treating child stage/queue spans as orphaned when their parent request was valid but later dropped by `max_requests`, causing valid input to fail under `--strict`.
- The change narrows strict failures to true input-quality issues (missing/invalid parent or child interval outside parent bounds) while treating overflow children as retention fallout.

### Description
- Build and use two request maps: `all_valid_request_intervals` for every parsed valid request and `retained_request_ids` for the ones kept by `max_requests`, and keep `request_intervals` for retained intervals.
- Update `filter_correlated_parsed_stages` and `filter_correlated_queues` to distinguish: missing/invalid parent => strict failure; valid-but-unretained parent => treat as retention fallout (skip child, issue distinct warning, increment retention-drop counters); retained parent => perform interval validation as before.
- Record retention fallout in truncation state by incrementing `run.truncation.dropped_stages` / `run.truncation.dropped_queues` and set `run.truncation.limits_hit = true` when manual increments occur.
- Adjust warning messages for valid-but-unretained children to explicitly state: "skipped ... because the matching request was valid but not retained due to max_requests".
- Add tests: a tracing-unit test enforcing strict import succeeds with `max_requests=1` and verifies retained evidence, truncation counters, and warning wording; a CLI boundary test for `import tracing-json --strict --max-requests 1` with compatible input validating success, retained-only evidence, and absence of the orphan-message phrasing.

### Testing
- Ran workspace format/lint/test/docs checks: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`, and `python3 scripts/validate_docs_contracts.py`; all commands completed successfully.
- Ran targeted tests: `cargo test -p tailtriage-tracing --all-features --lib --locked` and `cargo test -p tailtriage-cli --test cli_boundary --locked`; both passed and the new tests exercised the retention-vs-validity cases.
- Ran tracing feature checks: `cargo check -p tailtriage-tracing --no-default-features --locked`, `cargo check -p tailtriage-tracing --no-default-features --features jsonl --locked`, `cargo check -p tailtriage-tracing --no-default-features --features live --locked`, and `cargo check -p tailtriage-tracing --no-default-features --features tokio --locked`; all finished successfully (the `--features live` check emitted an unrelated `dead_code` warning in `recorder.rs` but did not fail).
- All tests and checks mentioned above completed with success status.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1561228b00833096d3730a6a2f2558)