### PR TITLE
Fix strict import semantics for valid requests dropped by max_requests

### DIFF
--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -778,6 +778,56 @@ fn import_tracing_json_strict_fails_on_incomplete_tailtriage_span() {
 }
 
 #[test]
+fn import_tracing_json_strict_with_max_requests_keeps_retained_request_and_skips_overflow_children()
+{
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(
+        &spans_path,
+        [
+            r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req-1","started_at_unix_ms":100,"finished_at_unix_ms":200,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/checkout"}}}"#,
+            r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"st-1","started_at_unix_ms":120,"finished_at_unix_ms":150,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}"#,
+            r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"q-1","started_at_unix_ms":121,"finished_at_unix_ms":130,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits"}}}"#,
+            r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req-2","started_at_unix_ms":300,"finished_at_unix_ms":400,"fields":{"tt.kind":"request","tt.request_id":"r2","tt.route":"/checkout"}}}"#,
+            r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"st-2","started_at_unix_ms":320,"finished_at_unix_ms":350,"fields":{"tt.kind":"stage","tt.request_id":"r2","tt.stage":"db"}}}"#,
+            r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"q-2","started_at_unix_ms":321,"finished_at_unix_ms":330,"fields":{"tt.kind":"queue","tt.request_id":"r2","tt.queue":"permits"}}}"#,
+        ]
+        .join("
+"),
+    )
+    .expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--strict")
+        .arg("--max-requests")
+        .arg("1")
+        .output()
+        .expect("cli should run");
+
+    assert!(output.status.success(), "cli failed: {output:?}");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(!stderr.contains("no retained request event was imported"));
+    assert!(run_path.exists(), "run output should exist");
+
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
+        .expect("imported run should load in cli loader");
+    assert_eq!(loaded.run.requests.len(), 1);
+    assert_eq!(loaded.run.requests[0].request_id, "r1");
+    assert_eq!(loaded.run.stages.len(), 1);
+    assert_eq!(loaded.run.stages[0].request_id, "r1");
+    assert_eq!(loaded.run.queues.len(), 1);
+    assert_eq!(loaded.run.queues[0].request_id, "r1");
+}
+
+#[test]
 fn import_tracing_json_non_strict_writes_output_and_emits_warning_to_stderr() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -825,6 +825,50 @@ fn import_tracing_json_strict_with_max_requests_keeps_retained_request_and_skips
     assert_eq!(loaded.run.stages[0].request_id, "r1");
     assert_eq!(loaded.run.queues.len(), 1);
     assert_eq!(loaded.run.queues[0].request_id, "r1");
+    assert_eq!(loaded.run.truncation.dropped_requests, 1);
+    assert_eq!(loaded.run.truncation.dropped_stages, 1);
+    assert_eq!(loaded.run.truncation.dropped_queues, 1);
+    assert!(loaded.run.truncation.limits_hit);
+}
+
+#[test]
+fn import_tracing_json_strict_with_max_requests_fails_on_invalid_overflow_stage() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(
+        &spans_path,
+        [
+            r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req-1","started_at_unix_ms":100,"finished_at_unix_ms":200,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/checkout"}}}"#,
+            r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req-2","started_at_unix_ms":300,"finished_at_unix_ms":400,"fields":{"tt.kind":"request","tt.request_id":"r2","tt.route":"/checkout"}}}"#,
+            r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"st-2","started_at_unix_ms":320,"finished_at_unix_ms":450,"fields":{"tt.kind":"stage","tt.request_id":"r2","tt.stage":"db"}}}"#,
+        ]
+        .join("\n"),
+    )
+    .expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--strict")
+        .arg("--max-requests")
+        .arg("1")
+        .output()
+        .expect("cli should run");
+
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("falls outside request interval"));
+    assert!(!stderr.contains("valid but not retained due to max_requests"));
+    assert!(
+        !run_path.exists(),
+        "run output should not exist on strict failure"
+    );
 }
 
 #[test]

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -258,17 +258,12 @@ where
     let all_valid_request_intervals = all_valid_request_intervals(&requests);
     let retained_request_intervals =
         retained_request_intervals(&requests, capture_limits.max_requests);
-    let retained_request_ids: BTreeSet<&str> = retained_request_intervals
-        .keys()
-        .map(String::as_str)
-        .collect();
     let mut dropped_children_due_to_request_retention =
         DroppedChildrenDueToRequestRetention::default();
     filter_correlated_parsed_stages(
         &mut parsed_stages,
         &all_valid_request_intervals,
         &retained_request_intervals,
-        &retained_request_ids,
         options.strict_mode(),
         &mut warnings,
         &mut dropped_children_due_to_request_retention,
@@ -277,7 +272,6 @@ where
         &mut queues,
         &all_valid_request_intervals,
         &retained_request_intervals,
-        &retained_request_ids,
         options.strict_mode(),
         &mut warnings,
         &mut dropped_children_due_to_request_retention,
@@ -474,7 +468,6 @@ fn filter_correlated_parsed_stages(
     stages: &mut Vec<ParsedStageEvent>,
     all_valid_request_intervals: &BTreeMap<String, RequestInterval>,
     retained_request_intervals: &BTreeMap<String, RequestInterval>,
-    retained_request_ids: &BTreeSet<&str>,
     strict: bool,
     warnings: &mut Vec<ImportWarning>,
     dropped_due_to_request_retention: &mut DroppedChildrenDueToRequestRetention,
@@ -482,18 +475,7 @@ fn filter_correlated_parsed_stages(
     let mut filtered = Vec::with_capacity(stages.len());
     for stage in stages.drain(..) {
         let request_id = stage.event.request_id.as_str();
-        let Some(interval) = retained_request_intervals.get(request_id) else {
-            if all_valid_request_intervals.contains_key(request_id)
-                && !retained_request_ids.contains(request_id)
-            {
-                dropped_due_to_request_retention.stages =
-                    dropped_due_to_request_retention.stages.saturating_add(1);
-                warnings.push(ImportWarning::new(format!(
-                    "skipped stage span for request_id '{}' because the matching request was valid but not retained due to max_requests",
-                    stage.event.request_id
-                )));
-                continue;
-            }
+        let Some(valid_interval) = all_valid_request_intervals.get(request_id) else {
             strict_or_warn(
                 strict,
                 warnings,
@@ -507,8 +489,8 @@ fn filter_correlated_parsed_stages(
         if !interval_within_request_with_tolerance(
             stage.event.started_at_unix_ms,
             stage.event.finished_at_unix_ms,
-            interval.started_at_unix_ms,
-            interval.finished_at_unix_ms,
+            valid_interval.started_at_unix_ms,
+            valid_interval.finished_at_unix_ms,
         ) {
             strict_or_warn(
                 strict,
@@ -519,10 +501,19 @@ fn filter_correlated_parsed_stages(
                     stage.event.request_id,
                     stage.event.started_at_unix_ms,
                     stage.event.finished_at_unix_ms,
-                    interval.started_at_unix_ms,
-                    interval.finished_at_unix_ms
+                    valid_interval.started_at_unix_ms,
+                    valid_interval.finished_at_unix_ms
                 ),
             )?;
+            continue;
+        }
+        if !retained_request_intervals.contains_key(request_id) {
+            dropped_due_to_request_retention.stages =
+                dropped_due_to_request_retention.stages.saturating_add(1);
+            warnings.push(ImportWarning::new(format!(
+                "skipped stage span for request_id '{}' because the matching request was valid but not retained due to max_requests",
+                stage.event.request_id
+            )));
             continue;
         }
         filtered.push(stage);
@@ -535,7 +526,6 @@ fn filter_correlated_queues(
     queues: &mut Vec<QueueEvent>,
     all_valid_request_intervals: &BTreeMap<String, RequestInterval>,
     retained_request_intervals: &BTreeMap<String, RequestInterval>,
-    retained_request_ids: &BTreeSet<&str>,
     strict: bool,
     warnings: &mut Vec<ImportWarning>,
     dropped_due_to_request_retention: &mut DroppedChildrenDueToRequestRetention,
@@ -543,18 +533,7 @@ fn filter_correlated_queues(
     let mut filtered = Vec::with_capacity(queues.len());
     for queue in queues.drain(..) {
         let request_id = queue.request_id.as_str();
-        let Some(interval) = retained_request_intervals.get(request_id) else {
-            if all_valid_request_intervals.contains_key(request_id)
-                && !retained_request_ids.contains(request_id)
-            {
-                dropped_due_to_request_retention.queues =
-                    dropped_due_to_request_retention.queues.saturating_add(1);
-                warnings.push(ImportWarning::new(format!(
-                    "skipped queue span for request_id '{}' because the matching request was valid but not retained due to max_requests",
-                    queue.request_id
-                )));
-                continue;
-            }
+        let Some(valid_interval) = all_valid_request_intervals.get(request_id) else {
             strict_or_warn(
                 strict,
                 warnings,
@@ -568,8 +547,8 @@ fn filter_correlated_queues(
         if !interval_within_request_with_tolerance(
             queue.waited_from_unix_ms,
             queue.waited_until_unix_ms,
-            interval.started_at_unix_ms,
-            interval.finished_at_unix_ms,
+            valid_interval.started_at_unix_ms,
+            valid_interval.finished_at_unix_ms,
         ) {
             strict_or_warn(
                 strict,
@@ -580,10 +559,19 @@ fn filter_correlated_queues(
                     queue.request_id,
                     queue.waited_from_unix_ms,
                     queue.waited_until_unix_ms,
-                    interval.started_at_unix_ms,
-                    interval.finished_at_unix_ms
+                    valid_interval.started_at_unix_ms,
+                    valid_interval.finished_at_unix_ms
                 ),
             )?;
+            continue;
+        }
+        if !retained_request_intervals.contains_key(request_id) {
+            dropped_due_to_request_retention.queues =
+                dropped_due_to_request_retention.queues.saturating_add(1);
+            warnings.push(ImportWarning::new(format!(
+                "skipped queue span for request_id '{}' because the matching request was valid but not retained due to max_requests",
+                queue.request_id
+            )));
             continue;
         }
         filtered.push(queue);
@@ -2248,6 +2236,125 @@ mod tests {
         assert!(imported.warnings().iter().all(|w| !w
             .message()
             .contains("no retained request event was imported")));
+    }
+
+    #[test]
+    fn strict_mode_max_requests_overflow_invalid_stage_still_fails() {
+        let spans = vec![
+            SpanRecord::new("req-1", 100, 200)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("req-2", 300, 400)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r2")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("st-2", 320, 450)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r2")
+                .field(TT_STAGE, "db"),
+        ];
+        let err = run_from_span_records(
+            spans,
+            ImportOptions::new("checkout")
+                .strict(true)
+                .capture_limits_override(tailtriage_core::CaptureLimitsOverride {
+                    max_requests: Some(1),
+                    max_stages: None,
+                    max_queues: None,
+                    ..tailtriage_core::CaptureLimitsOverride::default()
+                }),
+        )
+        .expect_err("strict import should fail for out-of-window overflow stage");
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        let msg = err.to_string();
+        assert!(msg.contains("falls outside request interval"));
+        assert!(!msg.contains("valid but not retained due to max_requests"));
+    }
+
+    #[test]
+    fn strict_mode_max_requests_overflow_invalid_queue_still_fails() {
+        let spans = vec![
+            SpanRecord::new("req-1", 100, 200)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("req-2", 300, 400)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r2")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("q-2", 320, 450)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r2")
+                .field(TT_QUEUE, "permits"),
+        ];
+        let err = run_from_span_records(
+            spans,
+            ImportOptions::new("checkout")
+                .strict(true)
+                .capture_limits_override(tailtriage_core::CaptureLimitsOverride {
+                    max_requests: Some(1),
+                    max_stages: None,
+                    max_queues: None,
+                    ..tailtriage_core::CaptureLimitsOverride::default()
+                }),
+        )
+        .expect_err("strict import should fail for out-of-window overflow queue");
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        let msg = err.to_string();
+        assert!(msg.contains("falls outside request interval"));
+        assert!(!msg.contains("valid but not retained due to max_requests"));
+    }
+
+    #[test]
+    fn strict_mode_max_requests_overflow_non_lexical_request_ids_follow_input_order() {
+        let spans = vec![
+            SpanRecord::new("req-1", 100, 200)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "z-retained")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("st-1", 120, 150)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "z-retained")
+                .field(TT_STAGE, "db"),
+            SpanRecord::new("q-1", 121, 130)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "z-retained")
+                .field(TT_QUEUE, "permits"),
+            SpanRecord::new("req-2", 300, 400)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "a-overflow")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("st-2", 320, 350)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "a-overflow")
+                .field(TT_STAGE, "db"),
+            SpanRecord::new("q-2", 321, 330)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "a-overflow")
+                .field(TT_QUEUE, "permits"),
+        ];
+        let imported = run_from_span_records(
+            spans,
+            ImportOptions::new("checkout")
+                .strict(true)
+                .capture_limits_override(tailtriage_core::CaptureLimitsOverride {
+                    max_requests: Some(1),
+                    max_stages: None,
+                    max_queues: None,
+                    ..tailtriage_core::CaptureLimitsOverride::default()
+                }),
+        )
+        .expect("strict import should succeed and retain first input request");
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].request_id, "z-retained");
+        assert_eq!(imported.run().stages.len(), 1);
+        assert_eq!(imported.run().stages[0].request_id, "z-retained");
+        assert_eq!(imported.run().queues.len(), 1);
+        assert_eq!(imported.run().queues[0].request_id, "z-retained");
+        assert_eq!(imported.run().truncation.dropped_requests, 1);
+        assert_eq!(imported.run().truncation.dropped_stages, 1);
+        assert_eq!(imported.run().truncation.dropped_queues, 1);
     }
 
     #[test]

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -255,18 +255,32 @@ where
         .into_iter()
         .map(|request| request.event)
         .collect();
-    let request_intervals = retained_request_intervals(&requests, capture_limits.max_requests);
+    let all_valid_request_intervals = all_valid_request_intervals(&requests);
+    let retained_request_intervals =
+        retained_request_intervals(&requests, capture_limits.max_requests);
+    let retained_request_ids: BTreeSet<&str> = retained_request_intervals
+        .keys()
+        .map(String::as_str)
+        .collect();
+    let mut dropped_children_due_to_request_retention =
+        DroppedChildrenDueToRequestRetention::default();
     filter_correlated_parsed_stages(
         &mut parsed_stages,
-        &request_intervals,
+        &all_valid_request_intervals,
+        &retained_request_intervals,
+        &retained_request_ids,
         options.strict_mode(),
         &mut warnings,
+        &mut dropped_children_due_to_request_retention,
     )?;
     filter_correlated_queues(
         &mut queues,
-        &request_intervals,
+        &all_valid_request_intervals,
+        &retained_request_intervals,
+        &retained_request_ids,
         options.strict_mode(),
         &mut warnings,
+        &mut dropped_children_due_to_request_retention,
     )?;
     let stage_success_default_count = parsed_stages
         .iter()
@@ -345,6 +359,19 @@ where
             .map_err(|err| ImportError::InvalidRunEvent(err.to_string()))?;
     }
     let mut run = run_builder.finish();
+    run.truncation.dropped_stages = run
+        .truncation
+        .dropped_stages
+        .saturating_add(dropped_children_due_to_request_retention.stages);
+    run.truncation.dropped_queues = run
+        .truncation
+        .dropped_queues
+        .saturating_add(dropped_children_due_to_request_retention.queues);
+    if dropped_children_due_to_request_retention.stages > 0
+        || dropped_children_due_to_request_retention.queues > 0
+    {
+        run.truncation.limits_hit = true;
+    }
     attach_durable_conversion_warnings(&mut run, &warnings);
 
     Ok(ImportedRun::new(run, warnings))
@@ -386,6 +413,20 @@ fn dedupe_retained_requests(
     Ok(())
 }
 
+fn all_valid_request_intervals(requests: &[RequestEvent]) -> BTreeMap<String, RequestInterval> {
+    let mut intervals = BTreeMap::new();
+    for request in requests {
+        intervals.insert(
+            request.request_id.clone(),
+            RequestInterval {
+                started_at_unix_ms: request.started_at_unix_ms,
+                finished_at_unix_ms: request.finished_at_unix_ms,
+            },
+        );
+    }
+    intervals
+}
+
 fn retained_request_intervals(
     requests: &[RequestEvent],
     max_requests: usize,
@@ -413,6 +454,12 @@ struct ParsedRequestEvent {
     outcome_defaulted: bool,
 }
 
+#[derive(Default)]
+struct DroppedChildrenDueToRequestRetention {
+    stages: u64,
+    queues: u64,
+}
+
 fn interval_within_request_with_tolerance(
     child_start_ms: u64,
     child_finish_ms: u64,
@@ -425,18 +472,33 @@ fn interval_within_request_with_tolerance(
 
 fn filter_correlated_parsed_stages(
     stages: &mut Vec<ParsedStageEvent>,
-    request_intervals: &BTreeMap<String, RequestInterval>,
+    all_valid_request_intervals: &BTreeMap<String, RequestInterval>,
+    retained_request_intervals: &BTreeMap<String, RequestInterval>,
+    retained_request_ids: &BTreeSet<&str>,
     strict: bool,
     warnings: &mut Vec<ImportWarning>,
+    dropped_due_to_request_retention: &mut DroppedChildrenDueToRequestRetention,
 ) -> Result<(), ImportError> {
     let mut filtered = Vec::with_capacity(stages.len());
     for stage in stages.drain(..) {
-        let Some(interval) = request_intervals.get(stage.event.request_id.as_str()) else {
+        let request_id = stage.event.request_id.as_str();
+        let Some(interval) = retained_request_intervals.get(request_id) else {
+            if all_valid_request_intervals.contains_key(request_id)
+                && !retained_request_ids.contains(request_id)
+            {
+                dropped_due_to_request_retention.stages =
+                    dropped_due_to_request_retention.stages.saturating_add(1);
+                warnings.push(ImportWarning::new(format!(
+                    "skipped stage span for request_id '{}' because the matching request was valid but not retained due to max_requests",
+                    stage.event.request_id
+                )));
+                continue;
+            }
             strict_or_warn(
                 strict,
                 warnings,
                 format!(
-                    "skipped stage span for request_id '{}' because no retained request event was imported",
+                    "skipped stage span for request_id '{}' because no valid matching request event was imported",
                     stage.event.request_id
                 ),
             )?;
@@ -471,18 +533,33 @@ fn filter_correlated_parsed_stages(
 
 fn filter_correlated_queues(
     queues: &mut Vec<QueueEvent>,
-    request_intervals: &BTreeMap<String, RequestInterval>,
+    all_valid_request_intervals: &BTreeMap<String, RequestInterval>,
+    retained_request_intervals: &BTreeMap<String, RequestInterval>,
+    retained_request_ids: &BTreeSet<&str>,
     strict: bool,
     warnings: &mut Vec<ImportWarning>,
+    dropped_due_to_request_retention: &mut DroppedChildrenDueToRequestRetention,
 ) -> Result<(), ImportError> {
     let mut filtered = Vec::with_capacity(queues.len());
     for queue in queues.drain(..) {
-        let Some(interval) = request_intervals.get(queue.request_id.as_str()) else {
+        let request_id = queue.request_id.as_str();
+        let Some(interval) = retained_request_intervals.get(request_id) else {
+            if all_valid_request_intervals.contains_key(request_id)
+                && !retained_request_ids.contains(request_id)
+            {
+                dropped_due_to_request_retention.queues =
+                    dropped_due_to_request_retention.queues.saturating_add(1);
+                warnings.push(ImportWarning::new(format!(
+                    "skipped queue span for request_id '{}' because the matching request was valid but not retained due to max_requests",
+                    queue.request_id
+                )));
+                continue;
+            }
             strict_or_warn(
                 strict,
                 warnings,
                 format!(
-                    "skipped queue span for request_id '{}' because no retained request event was imported",
+                    "skipped queue span for request_id '{}' because no valid matching request event was imported",
                     queue.request_id
                 ),
             )?;
@@ -901,7 +978,7 @@ mod tests {
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests.len(), 1);
         assert_eq!(imported.run().stages.len(), 0);
-        let warning = "skipped stage span for request_id 'r-orphan' because no retained request event was imported";
+        let warning = "skipped stage span for request_id 'r-orphan' because no valid matching request event was imported";
         assert!(imported
             .warnings()
             .iter()
@@ -961,7 +1038,7 @@ mod tests {
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
         match err {
             ImportError::StrictViolation(message) => {
-                assert!(message.contains("no retained request event"));
+                assert!(message.contains("no valid matching request event"));
             }
             _ => panic!("expected StrictViolation"),
         }
@@ -982,7 +1059,7 @@ mod tests {
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests.len(), 1);
         assert_eq!(imported.run().queues.len(), 0);
-        let warning = "skipped queue span for request_id 'r-orphan' because no retained request event was imported";
+        let warning = "skipped queue span for request_id 'r-orphan' because no valid matching request event was imported";
         assert!(imported
             .warnings()
             .iter()
@@ -1010,7 +1087,7 @@ mod tests {
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
         match err {
             ImportError::StrictViolation(message) => {
-                assert!(message.contains("no retained request event"));
+                assert!(message.contains("no valid matching request event"));
             }
             _ => panic!("expected StrictViolation"),
         }
@@ -2104,11 +2181,73 @@ mod tests {
         assert!(imported.run().stages.is_empty());
         assert!(imported.run().queues.is_empty());
         assert!(imported.warnings().iter().any(|w| w.message().contains(
-            "skipped stage span for request_id 'r1' because no retained request event was imported"
+            "skipped stage span for request_id 'r1' because no valid matching request event was imported"
         )));
         assert!(imported.warnings().iter().any(|w| w.message().contains(
-            "skipped queue span for request_id 'r1' because no retained request event was imported"
+            "skipped queue span for request_id 'r1' because no valid matching request event was imported"
         )));
+    }
+
+    #[test]
+    fn strict_mode_max_requests_overflow_children_are_retention_fallout() {
+        let spans = vec![
+            SpanRecord::new("req-1", 100, 200)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("st-1", 120, 150)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+            SpanRecord::new("q-1", 121, 130)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+            SpanRecord::new("req-2", 300, 400)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r2")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("st-2", 320, 350)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r2")
+                .field(TT_STAGE, "db"),
+            SpanRecord::new("q-2", 321, 330)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r2")
+                .field(TT_QUEUE, "permits"),
+        ];
+        let imported = run_from_span_records(
+            spans,
+            ImportOptions::new("checkout")
+                .strict(true)
+                .capture_limits_override(tailtriage_core::CaptureLimitsOverride {
+                    max_requests: Some(1),
+                    max_stages: None,
+                    max_queues: None,
+                    ..tailtriage_core::CaptureLimitsOverride::default()
+                }),
+        )
+        .expect("strict import should succeed for valid overflow request children");
+
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].request_id, "r1");
+        assert_eq!(imported.run().stages.len(), 1);
+        assert_eq!(imported.run().stages[0].request_id, "r1");
+        assert_eq!(imported.run().queues.len(), 1);
+        assert_eq!(imported.run().queues[0].request_id, "r1");
+        assert_eq!(imported.run().truncation.dropped_requests, 1);
+        assert_eq!(imported.run().truncation.dropped_stages, 1);
+        assert_eq!(imported.run().truncation.dropped_queues, 1);
+        assert!(imported.run().truncation.limits_hit);
+        assert!(imported.warnings().iter().any(|w| w.message().contains(
+            "skipped stage span for request_id 'r2' because the matching request was valid but not retained due to max_requests"
+        )));
+        assert!(imported.warnings().iter().any(|w| w.message().contains(
+            "skipped queue span for request_id 'r2' because the matching request was valid but not retained due to max_requests"
+        )));
+        assert!(imported.warnings().iter().all(|w| !w
+            .message()
+            .contains("no retained request event was imported")));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Child stage/queue spans were being validated only against retained requests, causing valid-but-unretained requests (due to `max_requests`) to trigger strict-mode violations instead of being treated as retention fallout.
- The change scopes to distinguishing parsed-but-dropped requests from missing/invalid requests so strict mode only rejects real input-quality problems and not retention-induced drops.

### Description
- Keep two request-interval views: `all_valid_request_intervals` (all parsed valid requests) and `retained_request_intervals` (first N retained by `max_requests`), plus `retained_request_ids` for fast checks.
- Update `filter_correlated_parsed_stages` and `filter_correlated_queues` to: treat children whose parent is valid-but-not-retained as retention fallout (emit a retention-specific warning, increment a `DroppedChildrenDueToRequestRetention` counter, and skip the child), treat missing/invalid parents as before, and continue to enforce interval/tolerance checks against retained parents.
- After `RunBuilder::finish()` add the dropped child counts into `run.truncation.dropped_stages`/`dropped_queues` and set `run.truncation.limits_hit = true` when applicable.
- Adjust warning text for the new retention-fallout case to: `skipped stage/span/queue span for request_id '<id>' because the matching request was valid but not retained due to max_requests` and update existing orphan wording to `no valid matching request event was imported` for clarity.
- Add tests: library unit test `strict_mode_max_requests_overflow_children_are_retention_fallout` (valid r1/r2 with `max_requests = 1`) and CLI boundary test `import_tracing_json_strict_with_max_requests_keeps_retained_request_and_skips_overflow_children` validating import success, retained evidence, truncation counters, and absence of the old orphan wording.

### Testing
- Ran the repository validation and targeted checks; all commands completed successfully (tests passed and docs/contracts validated):
  - `cargo fmt --check` (succeeded)
  - `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (succeeded)
  - `cargo test --workspace --all-targets --all-features --locked` (succeeded)
  - `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked` (succeeded)
  - `python3 scripts/validate_docs_contracts.py` (succeeded)
  - `cargo test -p tailtriage-tracing --all-features --lib --locked` (succeeded)
  - `cargo test -p tailtriage-cli --test cli_boundary --locked` (succeeded)
  - `cargo check -p tailtriage-tracing --no-default-features --locked` (succeeded)
  - `cargo check -p tailtriage-tracing --no-default-features --features jsonl --locked` (succeeded)
  - `cargo check -p tailtriage-tracing --no-default-features --features live --locked` (succeeded; emits existing `selected_mode` dead_code warning in `recorder.rs`)
  - `cargo check -p tailtriage-tracing --no-default-features --features tokio --locked` (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1561228b00833096d3730a6a2f2558)