### PR TITLE
Treat children of valid-but-unretained requests as retention fallout in strict tracing import

### DIFF
--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -778,6 +778,59 @@ fn import_tracing_json_strict_fails_on_incomplete_tailtriage_span() {
 }
 
 #[test]
+fn import_tracing_json_strict_with_max_requests_treats_overflow_children_as_retention_fallout() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    let spans = [
+        r#"{"tailtriage.tracing-span.v1":true,"name":"req1","started_at_unix_ms":1000,"finished_at_unix_ms":2000,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/checkout"}}"#,
+        r#"{"tailtriage.tracing-span.v1":true,"name":"st1","started_at_unix_ms":1100,"finished_at_unix_ms":1200,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}"#,
+        r#"{"tailtriage.tracing-span.v1":true,"name":"q1","started_at_unix_ms":1210,"finished_at_unix_ms":1250,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits"}}"#,
+        r#"{"tailtriage.tracing-span.v1":true,"name":"req2","started_at_unix_ms":3000,"finished_at_unix_ms":4000,"fields":{"tt.kind":"request","tt.request_id":"r2","tt.route":"/checkout"}}"#,
+        r#"{"tailtriage.tracing-span.v1":true,"name":"st2","started_at_unix_ms":3100,"finished_at_unix_ms":3200,"fields":{"tt.kind":"stage","tt.request_id":"r2","tt.stage":"db"}}"#,
+        r#"{"tailtriage.tracing-span.v1":true,"name":"q2","started_at_unix_ms":3210,"finished_at_unix_ms":3250,"fields":{"tt.kind":"queue","tt.request_id":"r2","tt.queue":"permits"}}"#,
+    ].join("
+");
+    std::fs::write(&spans_path, spans).expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-json")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--input-format")
+        .arg("compatible")
+        .arg("--strict")
+        .arg("--max-requests")
+        .arg("1")
+        .output()
+        .expect("cli should run");
+
+    assert!(output.status.success(), "cli failed: {output:?}");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(!stderr.contains("no retained request event was imported"));
+    assert!(run_path.exists(), "run output should be written");
+
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
+        .expect("imported run should load in cli loader");
+    assert_eq!(loaded.run.requests.len(), 1);
+    assert_eq!(loaded.run.requests[0].request_id, "r1");
+    assert!(loaded
+        .run
+        .stages
+        .iter()
+        .all(|stage| stage.request_id == "r1"));
+    assert!(loaded
+        .run
+        .queues
+        .iter()
+        .all(|queue| queue.request_id == "r1"));
+}
+
+#[test]
 fn import_tracing_json_non_strict_writes_output_and_emits_warning_to_stderr() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -255,16 +255,20 @@ where
         .into_iter()
         .map(|request| request.event)
         .collect();
-    let request_intervals = retained_request_intervals(&requests, capture_limits.max_requests);
-    filter_correlated_parsed_stages(
+    let valid_request_intervals = request_intervals(&requests);
+    let retained_request_intervals =
+        retained_request_intervals(&valid_request_intervals, capture_limits.max_requests);
+    let dropped_stages_due_to_request_retention = filter_correlated_parsed_stages(
         &mut parsed_stages,
-        &request_intervals,
+        &valid_request_intervals,
+        &retained_request_intervals,
         options.strict_mode(),
         &mut warnings,
     )?;
-    filter_correlated_queues(
+    let dropped_queues_due_to_request_retention = filter_correlated_queues(
         &mut queues,
-        &request_intervals,
+        &valid_request_intervals,
+        &retained_request_intervals,
         options.strict_mode(),
         &mut warnings,
     )?;
@@ -345,6 +349,20 @@ where
             .map_err(|err| ImportError::InvalidRunEvent(err.to_string()))?;
     }
     let mut run = run_builder.finish();
+    if dropped_stages_due_to_request_retention > 0 {
+        run.truncation.dropped_stages = run
+            .truncation
+            .dropped_stages
+            .saturating_add(dropped_stages_due_to_request_retention);
+        run.truncation.limits_hit = true;
+    }
+    if dropped_queues_due_to_request_retention > 0 {
+        run.truncation.dropped_queues = run
+            .truncation
+            .dropped_queues
+            .saturating_add(dropped_queues_due_to_request_retention);
+        run.truncation.limits_hit = true;
+    }
     attach_durable_conversion_warnings(&mut run, &warnings);
 
     Ok(ImportedRun::new(run, warnings))
@@ -386,12 +404,9 @@ fn dedupe_retained_requests(
     Ok(())
 }
 
-fn retained_request_intervals(
-    requests: &[RequestEvent],
-    max_requests: usize,
-) -> BTreeMap<String, RequestInterval> {
+fn request_intervals(requests: &[RequestEvent]) -> BTreeMap<String, RequestInterval> {
     let mut intervals = BTreeMap::new();
-    for request in requests.iter().take(max_requests) {
+    for request in requests {
         intervals.insert(
             request.request_id.clone(),
             RequestInterval {
@@ -401,6 +416,17 @@ fn retained_request_intervals(
         );
     }
     intervals
+}
+
+fn retained_request_intervals(
+    valid_request_intervals: &BTreeMap<String, RequestInterval>,
+    max_requests: usize,
+) -> BTreeMap<String, RequestInterval> {
+    valid_request_intervals
+        .iter()
+        .take(max_requests)
+        .map(|(request_id, interval)| (request_id.clone(), *interval))
+        .collect()
 }
 
 struct ParsedStageEvent {
@@ -425,23 +451,35 @@ fn interval_within_request_with_tolerance(
 
 fn filter_correlated_parsed_stages(
     stages: &mut Vec<ParsedStageEvent>,
-    request_intervals: &BTreeMap<String, RequestInterval>,
+    valid_request_intervals: &BTreeMap<String, RequestInterval>,
+    retained_request_intervals: &BTreeMap<String, RequestInterval>,
     strict: bool,
     warnings: &mut Vec<ImportWarning>,
-) -> Result<(), ImportError> {
+) -> Result<u64, ImportError> {
     let mut filtered = Vec::with_capacity(stages.len());
+    let mut dropped_due_to_request_retention = 0_u64;
     for stage in stages.drain(..) {
-        let Some(interval) = request_intervals.get(stage.event.request_id.as_str()) else {
+        let Some(valid_interval) = valid_request_intervals.get(stage.event.request_id.as_str())
+        else {
             strict_or_warn(
                 strict,
                 warnings,
                 format!(
-                    "skipped stage span for request_id '{}' because no retained request event was imported",
+                    "skipped stage span for request_id '{}' because no valid matching request event was imported",
                     stage.event.request_id
                 ),
             )?;
             continue;
         };
+        if !retained_request_intervals.contains_key(stage.event.request_id.as_str()) {
+            dropped_due_to_request_retention = dropped_due_to_request_retention.saturating_add(1);
+            warnings.push(ImportWarning::new(format!(
+                "skipped stage span for request_id '{}' because the matching request was valid but not retained due to max_requests",
+                stage.event.request_id
+            )));
+            continue;
+        }
+        let interval = valid_interval;
         if !interval_within_request_with_tolerance(
             stage.event.started_at_unix_ms,
             stage.event.finished_at_unix_ms,
@@ -466,28 +504,39 @@ fn filter_correlated_parsed_stages(
         filtered.push(stage);
     }
     *stages = filtered;
-    Ok(())
+    Ok(dropped_due_to_request_retention)
 }
 
 fn filter_correlated_queues(
     queues: &mut Vec<QueueEvent>,
-    request_intervals: &BTreeMap<String, RequestInterval>,
+    valid_request_intervals: &BTreeMap<String, RequestInterval>,
+    retained_request_intervals: &BTreeMap<String, RequestInterval>,
     strict: bool,
     warnings: &mut Vec<ImportWarning>,
-) -> Result<(), ImportError> {
+) -> Result<u64, ImportError> {
     let mut filtered = Vec::with_capacity(queues.len());
+    let mut dropped_due_to_request_retention = 0_u64;
     for queue in queues.drain(..) {
-        let Some(interval) = request_intervals.get(queue.request_id.as_str()) else {
+        let Some(valid_interval) = valid_request_intervals.get(queue.request_id.as_str()) else {
             strict_or_warn(
                 strict,
                 warnings,
                 format!(
-                    "skipped queue span for request_id '{}' because no retained request event was imported",
+                    "skipped queue span for request_id '{}' because no valid matching request event was imported",
                     queue.request_id
                 ),
             )?;
             continue;
         };
+        if !retained_request_intervals.contains_key(queue.request_id.as_str()) {
+            dropped_due_to_request_retention = dropped_due_to_request_retention.saturating_add(1);
+            warnings.push(ImportWarning::new(format!(
+                "skipped queue span for request_id '{}' because the matching request was valid but not retained due to max_requests",
+                queue.request_id
+            )));
+            continue;
+        }
+        let interval = valid_interval;
         if !interval_within_request_with_tolerance(
             queue.waited_from_unix_ms,
             queue.waited_until_unix_ms,
@@ -512,7 +561,7 @@ fn filter_correlated_queues(
         filtered.push(queue);
     }
     *queues = filtered;
-    Ok(())
+    Ok(dropped_due_to_request_retention)
 }
 
 fn validate_service_name(service_name: &str) -> Result<(), ImportError> {
@@ -901,7 +950,7 @@ mod tests {
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests.len(), 1);
         assert_eq!(imported.run().stages.len(), 0);
-        let warning = "skipped stage span for request_id 'r-orphan' because no retained request event was imported";
+        let warning = "skipped stage span for request_id 'r-orphan' because no valid matching request event was imported";
         assert!(imported
             .warnings()
             .iter()
@@ -961,7 +1010,7 @@ mod tests {
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
         match err {
             ImportError::StrictViolation(message) => {
-                assert!(message.contains("no retained request event"));
+                assert!(message.contains("no valid matching request event"));
             }
             _ => panic!("expected StrictViolation"),
         }
@@ -982,7 +1031,7 @@ mod tests {
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests.len(), 1);
         assert_eq!(imported.run().queues.len(), 0);
-        let warning = "skipped queue span for request_id 'r-orphan' because no retained request event was imported";
+        let warning = "skipped queue span for request_id 'r-orphan' because no valid matching request event was imported";
         assert!(imported
             .warnings()
             .iter()
@@ -1010,7 +1059,7 @@ mod tests {
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
         match err {
             ImportError::StrictViolation(message) => {
-                assert!(message.contains("no retained request event"));
+                assert!(message.contains("no valid matching request event"));
             }
             _ => panic!("expected StrictViolation"),
         }
@@ -1325,6 +1374,65 @@ mod tests {
         assert!(matches!(err, ImportError::StrictViolation(_)));
     }
 
+    #[test]
+    fn strict_mode_max_requests_overflow_children_are_retention_fallout_not_violations() {
+        let spans = vec![
+            SpanRecord::new("req1", 1_000, 2_000)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/checkout"),
+            SpanRecord::new("st1", 1_100, 1_200)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+            SpanRecord::new("q1", 1_210, 1_250)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+            SpanRecord::new("req2", 3_000, 4_000)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r2")
+                .field(TT_ROUTE, "/checkout"),
+            SpanRecord::new("st2", 3_100, 3_200)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r2")
+                .field(TT_STAGE, "db"),
+            SpanRecord::new("q2", 3_210, 3_250)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r2")
+                .field(TT_QUEUE, "permits"),
+        ];
+        let imported = run_from_span_records(
+            spans,
+            ImportOptions::new("checkout")
+                .strict(true)
+                .capture_limits_override(tailtriage_core::CaptureLimitsOverride {
+                    max_requests: Some(1),
+                    ..tailtriage_core::CaptureLimitsOverride::default()
+                }),
+        )
+        .unwrap();
+        let run = imported.run();
+        assert_eq!(run.requests.len(), 1);
+        assert_eq!(run.requests[0].request_id, "r1");
+        assert_eq!(run.stages.len(), 1);
+        assert_eq!(run.stages[0].request_id, "r1");
+        assert_eq!(run.queues.len(), 1);
+        assert_eq!(run.queues[0].request_id, "r1");
+        assert_eq!(run.truncation.dropped_requests, 1);
+        assert_eq!(run.truncation.dropped_stages, 1);
+        assert_eq!(run.truncation.dropped_queues, 1);
+        assert!(run.truncation.limits_hit);
+        assert!(imported.warnings().iter().any(|w| w.message().contains(
+            "skipped stage span for request_id 'r2' because the matching request was valid but not retained due to max_requests"
+        )));
+        assert!(imported.warnings().iter().any(|w| w.message().contains(
+            "skipped queue span for request_id 'r2' because the matching request was valid but not retained due to max_requests"
+        )));
+        assert!(!imported.warnings().iter().any(|w| w
+            .message()
+            .contains("no retained request event was imported")));
+    }
     #[test]
     fn overflow_duplicate_request_ids_beyond_max_requests_do_not_warn() {
         let spans = vec![
@@ -2104,10 +2212,10 @@ mod tests {
         assert!(imported.run().stages.is_empty());
         assert!(imported.run().queues.is_empty());
         assert!(imported.warnings().iter().any(|w| w.message().contains(
-            "skipped stage span for request_id 'r1' because no retained request event was imported"
+            "skipped stage span for request_id 'r1' because no valid matching request event was imported"
         )));
         assert!(imported.warnings().iter().any(|w| w.message().contains(
-            "skipped queue span for request_id 'r1' because no retained request event was imported"
+            "skipped queue span for request_id 'r1' because no valid matching request event was imported"
         )));
     }
 


### PR DESCRIPTION
### Motivation

- Fix a strict-mode import bug where child stage/queue spans for requests that were valid but dropped by `max_requests` were treated as orphan/malformed input and caused strict violations.
- Preserve existing strict failure semantics for true input-quality problems while ensuring retention fallout is reflected as truncation/warnings instead of strict errors.

### Description

- Build and keep two request-interval maps: one for all valid parsed requests (`request_intervals`) and one for the retained-first-N requests (`retained_request_intervals`).
- Update stage/queue correlation logic to branch on three distinct cases: no valid parsed request, valid-but-not-retained (retention fallout), and retained request (interval validation), emitting appropriate warnings or strict violations only when input-quality errors occur.
- Count children skipped solely due to request retention overflow and add those counts to `run.truncation.dropped_stages` / `run.truncation.dropped_queues` and set `run.truncation.limits_hit = true` when applicable.
- Add unit test coverage in `tailtriage-tracing/src/lib.rs` and a CLI boundary test in `tailtriage-cli/tests/cli_boundary.rs` that verify strict import succeeds with `--strict --max-requests 1`, retained evidence belongs only to the retained request, truncation counters reflect dropped request and dependent children, and warning text distinguishes retention fallout from orphan/malformed input.

### Testing

- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed with no new warnings or errors.
- Ran full test suite with `cargo test --workspace --all-targets --all-features --locked` and it passed.
- Built docs with `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked` and it completed successfully.
- Validated docs contract with `python3 scripts/validate_docs_contracts.py` and it passed.
- Ran targeted tracing tests `cargo test -p tailtriage-tracing --all-features --lib --locked` and they passed.
- Ran targeted CLI boundary tests `cargo test -p tailtriage-cli --test cli_boundary --locked` and they passed.
- Performed feature checks: `cargo check -p tailtriage-tracing --no-default-features --locked`, `cargo check -p tailtriage-tracing --no-default-features --features jsonl --locked`, `cargo check -p tailtriage-tracing --no-default-features --features live --locked`, and `cargo check -p tailtriage-tracing --no-default-features --features tokio --locked`; all completed successfully (note: a pre-existing non-blocking `dead_code`/unused-method warning in `recorder.rs` was observed but not introduced by this change).

Commands run (exact):
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-targets --all-features --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `python3 scripts/validate_docs_contracts.py`
- `cargo test -p tailtriage-tracing --all-features --lib --locked`
- `cargo test -p tailtriage-cli --test cli_boundary --locked`
- `cargo check -p tailtriage-tracing --no-default-features --locked`
- `cargo check -p tailtriage-tracing --no-default-features --features jsonl --locked`
- `cargo check -p tailtriage-tracing --no-default-features --features live --locked`
- `cargo check -p tailtriage-tracing --no-default-features --features tokio --locked`

All of the above completed successfully for this change; tests exercising the strict + `max_requests` overflow case now pass and warning/truncation behavior matches the required semantics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1561228b00833096d3730a6a2f2558)