### PR TITLE
Fix duplicate tt.request_id aliasing after max_requests in tracing import

### DIFF
--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -410,13 +410,12 @@ fn dedupe_retained_requests(
 fn all_valid_request_intervals(requests: &[RequestEvent]) -> BTreeMap<String, RequestInterval> {
     let mut intervals = BTreeMap::new();
     for request in requests {
-        intervals.insert(
-            request.request_id.clone(),
-            RequestInterval {
+        intervals
+            .entry(request.request_id.clone())
+            .or_insert(RequestInterval {
                 started_at_unix_ms: request.started_at_unix_ms,
                 finished_at_unix_ms: request.finished_at_unix_ms,
-            },
-        );
+            });
     }
     intervals
 }
@@ -2355,6 +2354,153 @@ mod tests {
         assert_eq!(imported.run().truncation.dropped_requests, 1);
         assert_eq!(imported.run().truncation.dropped_stages, 1);
         assert_eq!(imported.run().truncation.dropped_queues, 1);
+    }
+
+    #[test]
+    fn strict_mode_duplicate_request_id_overflow_keeps_retained_child_valid() {
+        let spans = vec![
+            SpanRecord::new("req-1", 100, 200)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("st-1", 120, 150)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+            SpanRecord::new("q-1", 130, 140)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+            SpanRecord::new("req-2", 300, 400)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+        ];
+        let imported = run_from_span_records(
+            spans,
+            ImportOptions::new("checkout")
+                .strict(true)
+                .capture_limits_override(tailtriage_core::CaptureLimitsOverride {
+                    max_requests: Some(1),
+                    max_stages: None,
+                    max_queues: None,
+                    ..tailtriage_core::CaptureLimitsOverride::default()
+                }),
+        )
+        .expect("strict import should keep retained child valid despite overflow duplicate");
+
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].request_id, "r1");
+        assert_eq!(imported.run().requests[0].started_at_unix_ms, 100);
+        assert_eq!(imported.run().requests[0].finished_at_unix_ms, 200);
+        assert_eq!(imported.run().stages.len(), 1);
+        assert_eq!(imported.run().stages[0].request_id, "r1");
+        assert_eq!(imported.run().stages[0].started_at_unix_ms, 120);
+        assert_eq!(imported.run().stages[0].finished_at_unix_ms, 150);
+        assert_eq!(imported.run().queues.len(), 1);
+        assert_eq!(imported.run().queues[0].request_id, "r1");
+        assert_eq!(imported.run().queues[0].waited_from_unix_ms, 130);
+        assert_eq!(imported.run().queues[0].waited_until_unix_ms, 140);
+        assert_eq!(imported.run().truncation.dropped_requests, 1);
+    }
+
+    #[test]
+    fn strict_mode_duplicate_request_id_overflow_only_child_fails_outside_interval() {
+        let spans = vec![
+            SpanRecord::new("req-1", 100, 200)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("req-2", 300, 400)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("st-2", 320, 350)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+            SpanRecord::new("q-2", 330, 340)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+        let err = run_from_span_records(
+            spans,
+            ImportOptions::new("checkout")
+                .strict(true)
+                .capture_limits_override(tailtriage_core::CaptureLimitsOverride {
+                    max_requests: Some(1),
+                    max_stages: None,
+                    max_queues: None,
+                    ..tailtriage_core::CaptureLimitsOverride::default()
+                }),
+        )
+        .expect_err("strict import should fail for overflow-only child on duplicate request_id");
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        let msg = err.to_string();
+        assert!(msg.contains("falls outside request interval"));
+        assert!(!msg.contains("valid but not retained due to max_requests"));
+    }
+
+    #[test]
+    fn non_strict_duplicate_request_id_overflow_only_children_warn_and_do_not_count_as_retention_fallout(
+    ) {
+        let spans = vec![
+            SpanRecord::new("req-1", 100, 200)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("req-2", 300, 400)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("st-2", 320, 350)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+            SpanRecord::new("q-2", 330, 340)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+        let imported = run_from_span_records(
+            spans,
+            ImportOptions::new("checkout").capture_limits_override(
+                tailtriage_core::CaptureLimitsOverride {
+                    max_requests: Some(1),
+                    max_stages: None,
+                    max_queues: None,
+                    ..tailtriage_core::CaptureLimitsOverride::default()
+                },
+            ),
+        )
+        .expect("non-strict import should succeed with warnings");
+
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().stages.len(), 0);
+        assert_eq!(imported.run().queues.len(), 0);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("falls outside request interval")));
+        assert!(imported.warnings().iter().all(|w| !w
+            .message()
+            .contains("valid but not retained due to max_requests")));
+        assert!(imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|warning| warning.contains("falls outside request interval")));
+        assert!(imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .all(|warning| !warning.contains("valid but not retained due to max_requests")));
+        assert_eq!(imported.run().truncation.dropped_requests, 1);
+        assert_eq!(imported.run().truncation.dropped_stages, 0);
+        assert_eq!(imported.run().truncation.dropped_queues, 0);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Prevent later overflow request events that reuse the same `tt.request_id` from overwriting the retained request interval used to validate child spans, which caused strictly-mode retained children to be incorrectly classified as outside the retained interval.

### Description

- Change `all_valid_request_intervals` in `tailtriage-tracing/src/lib.rs` to be first-wins by `request_id` by replacing `insert(...)` with `entry(...).or_insert(...)`, so the first valid request instance is used for child interval validation.
- Keep `retained_request_intervals(...)` unchanged and still built from `requests.iter().take(max_requests)` to preserve input-order retention semantics and PR #880 behavior.
- Add focused regression tests in `tailtriage-tracing/src/lib.rs` that cover strict and non-strict handling of duplicate request IDs beyond `max_requests`, verifying retained-child acceptance, overflow-only child rejection, and non-strict warning semantics without misclassifying retention fallout.

### Testing

- Ran the full validation sequence `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`, and `python3 scripts/validate_docs_contracts.py`, and all commands completed successfully (docs contract validation passed). 
- Ran targeted tracing/CLI checks `cargo test -p tailtriage-tracing --all-features --lib --locked` and `cargo test -p tailtriage-cli --test cli_boundary --locked`, both succeeded. 
- Ran feature matrix `cargo check -p tailtriage-tracing --no-default-features --locked` and with `jsonl`, `live`, and `tokio` feature variants, all `cargo check` invocations succeeded (one non-fatal `dead_code` warning emitted from `recorder.rs` but did not fail the build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a158c4c519883309320e71597230717)