### PR TITLE
Fix duplicate tt.request_id aliasing after max_requests in tracing import

### DIFF
--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -410,13 +410,12 @@ fn dedupe_retained_requests(
 fn all_valid_request_intervals(requests: &[RequestEvent]) -> BTreeMap<String, RequestInterval> {
     let mut intervals = BTreeMap::new();
     for request in requests {
-        intervals.insert(
-            request.request_id.clone(),
-            RequestInterval {
+        intervals
+            .entry(request.request_id.clone())
+            .or_insert(RequestInterval {
                 started_at_unix_ms: request.started_at_unix_ms,
                 finished_at_unix_ms: request.finished_at_unix_ms,
-            },
-        );
+            });
     }
     intervals
 }
@@ -2355,6 +2354,150 @@ mod tests {
         assert_eq!(imported.run().truncation.dropped_requests, 1);
         assert_eq!(imported.run().truncation.dropped_stages, 1);
         assert_eq!(imported.run().truncation.dropped_queues, 1);
+    }
+
+    #[test]
+    fn strict_mode_max_requests_duplicate_overflow_keeps_retained_child_evidence() {
+        let spans = vec![
+            SpanRecord::new("req-retained", 100, 200)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("st-retained", 120, 150)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+            SpanRecord::new("q-retained", 130, 140)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+            SpanRecord::new("req-overflow", 300, 400)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+        ];
+        let imported = run_from_span_records(
+            spans,
+            ImportOptions::new("checkout")
+                .strict(true)
+                .capture_limits_override(tailtriage_core::CaptureLimitsOverride {
+                    max_requests: Some(1),
+                    ..tailtriage_core::CaptureLimitsOverride::default()
+                }),
+        )
+        .expect("strict import should retain children for retained duplicate request id");
+        let run = imported.run();
+        assert_eq!(run.requests.len(), 1);
+        assert_eq!(run.requests[0].request_id, "r1");
+        assert_eq!(run.requests[0].started_at_unix_ms, 100);
+        assert_eq!(run.requests[0].finished_at_unix_ms, 200);
+        assert_eq!(run.stages.len(), 1);
+        assert_eq!(run.stages[0].request_id, "r1");
+        assert_eq!(run.stages[0].started_at_unix_ms, 120);
+        assert_eq!(run.stages[0].finished_at_unix_ms, 150);
+        assert_eq!(run.queues.len(), 1);
+        assert_eq!(run.queues[0].request_id, "r1");
+        assert_eq!(run.queues[0].waited_from_unix_ms, 130);
+        assert_eq!(run.queues[0].waited_until_unix_ms, 140);
+        assert_eq!(run.truncation.dropped_requests, 1);
+    }
+
+    #[test]
+    fn strict_mode_max_requests_duplicate_overflow_only_child_still_fails_outside_interval() {
+        let spans = vec![
+            SpanRecord::new("req-retained", 100, 200)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("req-overflow", 300, 400)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("st-overflow", 320, 350)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+            SpanRecord::new("q-overflow", 330, 340)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+        let err = run_from_span_records(
+            spans,
+            ImportOptions::new("checkout")
+                .strict(true)
+                .capture_limits_override(tailtriage_core::CaptureLimitsOverride {
+                    max_requests: Some(1),
+                    ..tailtriage_core::CaptureLimitsOverride::default()
+                }),
+        )
+        .expect_err("strict import should fail for overflow-only child of duplicate request id");
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        let msg = err.to_string();
+        assert!(msg.contains("falls outside request interval"));
+        assert!(!msg.contains("valid but not retained due to max_requests"));
+    }
+
+    #[test]
+    fn non_strict_max_requests_duplicate_overflow_only_child_warns_outside_interval() {
+        let spans = vec![
+            SpanRecord::new("req-retained", 100, 200)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("req-overflow", 300, 400)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("st-overflow", 320, 350)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+            SpanRecord::new("q-overflow", 330, 340)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+        let imported = run_from_span_records(
+            spans,
+            ImportOptions::new("checkout").capture_limits_override(
+                tailtriage_core::CaptureLimitsOverride {
+                    max_requests: Some(1),
+                    ..tailtriage_core::CaptureLimitsOverride::default()
+                },
+            ),
+        )
+        .expect("non-strict import should warn and skip overflow-only duplicate children");
+        let run = imported.run();
+        assert_eq!(run.requests.len(), 1);
+        assert_eq!(run.stages.len(), 0);
+        assert_eq!(run.queues.len(), 0);
+        let stage_warning = "skipped stage span 'db' for request_id 'r1' because interval [320, 350] falls outside request interval [100, 200] beyond tolerance_ms=2";
+        let queue_warning = "skipped queue span 'permits' for request_id 'r1' because interval [330, 340] falls outside request interval [100, 200] beyond tolerance_ms=2";
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains(stage_warning)));
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains(queue_warning)));
+        assert!(run
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|w| w.contains(stage_warning)));
+        assert!(run
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|w| w.contains(queue_warning)));
+        assert!(imported.warnings().iter().all(|w| !w
+            .message()
+            .contains("valid but not retained due to max_requests")));
+        assert_eq!(run.truncation.dropped_requests, 1);
+        assert_eq!(run.truncation.dropped_stages, 0);
+        assert_eq!(run.truncation.dropped_queues, 0);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Child span validation could be corrupted when an overflow request reused a retained `tt.request_id`, because the global valid-request map used last-wins semantics and could overwrite the retained parent interval. 
- The importer must preserve the retained request identity (first retained instance) for child interval validation while still treating later overflow duplicates as separate valid-but-unretained requests. 
- This change implements the minimal first-wins policy so retained children are validated against the original retained parent interval and overflow-only children are not misattributed.

### Description
- Make `all_valid_request_intervals(...)` first-wins per `tt.request_id` by replacing `insert(...)` with `entry(...).or_insert(...)` so later overflow request events cannot overwrite earlier retained intervals. 
- Keep `retained_request_intervals(...)` unchanged and built from `requests.iter().take(max_requests)` so retained selection still follows input order and `RunBuilder` first-N semantics. 
- Preserve the child-filtering order from the previous fix: look up the valid parent interval, validate the child interval against that interval, then branch into retained vs valid-but-unretained retention fallout and update `DroppedChildrenDueToRequestRetention` and truncation counters. 
- Add focused unit tests in `tailtriage-tracing/src/lib.rs` that assert: retained children remain attached to the retained interval when duplicates overflow, overflow-only children are rejected in strict mode with an outside-interval error (not misclassified as retention fallout), and non-strict behavior emits outside-interval warnings and deterministic truncation counters.

### Testing
- Ran `cargo fmt --check` and it completed successfully. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it completed successfully with no warnings treated as errors. 
- Ran full test suite with `cargo test --workspace --all-targets --all-features --locked` and it completed successfully (workspace tests passed). 
- Built docs with `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked` which completed successfully. 
- Ran `python3 scripts/validate_docs_contracts.py` which reported "docs contracts validated successfully". 
- Ran tracing crate unit tests with `cargo test -p tailtriage-tracing --all-features --lib --locked` which completed successfully (all tracing tests passed, including the new duplicate-overflow tests). 
- Ran the CLI boundary test with `cargo test -p tailtriage-cli --test cli_boundary --locked` which completed successfully. 
- Ran targeted checks for feature permutations with these commands, all of which completed successfully (one benign `dead_code` warning surfaced in a feature set but checks passed): `cargo check -p tailtriage-tracing --no-default-features --locked`, `cargo check -p tailtriage-tracing --no-default-features --features jsonl --locked`, `cargo check -p tailtriage-tracing --no-default-features --features live --locked`, and `cargo check -p tailtriage-tracing --no-default-features --features tokio --locked`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a158c4c519883309320e71597230717)