### PR TITLE
Fix duplicate tt.request_id aliasing after max_requests in tracing import

### DIFF
--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -410,13 +410,12 @@ fn dedupe_retained_requests(
 fn all_valid_request_intervals(requests: &[RequestEvent]) -> BTreeMap<String, RequestInterval> {
     let mut intervals = BTreeMap::new();
     for request in requests {
-        intervals.insert(
-            request.request_id.clone(),
-            RequestInterval {
+        intervals
+            .entry(request.request_id.clone())
+            .or_insert(RequestInterval {
                 started_at_unix_ms: request.started_at_unix_ms,
                 finished_at_unix_ms: request.finished_at_unix_ms,
-            },
-        );
+            });
     }
     intervals
 }
@@ -2355,6 +2354,146 @@ mod tests {
         assert_eq!(imported.run().truncation.dropped_requests, 1);
         assert_eq!(imported.run().truncation.dropped_stages, 1);
         assert_eq!(imported.run().truncation.dropped_queues, 1);
+    }
+
+    #[test]
+    fn strict_mode_duplicate_request_id_overflow_does_not_invalidate_retained_children() {
+        let spans = vec![
+            SpanRecord::new("req-1", 100, 200)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("st-1", 120, 150)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+            SpanRecord::new("q-1", 130, 140)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+            SpanRecord::new("req-2", 300, 400)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+        ];
+        let imported = run_from_span_records(
+            spans,
+            ImportOptions::new("checkout")
+                .strict(true)
+                .capture_limits_override(tailtriage_core::CaptureLimitsOverride {
+                    max_requests: Some(1),
+                    max_stages: None,
+                    max_queues: None,
+                    ..tailtriage_core::CaptureLimitsOverride::default()
+                }),
+        )
+        .expect("strict import should keep retained r1 children valid");
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].request_id, "r1");
+        assert_eq!(imported.run().requests[0].started_at_unix_ms, 100);
+        assert_eq!(imported.run().requests[0].finished_at_unix_ms, 200);
+        assert_eq!(imported.run().stages.len(), 1);
+        assert_eq!(imported.run().stages[0].request_id, "r1");
+        assert_eq!(imported.run().stages[0].started_at_unix_ms, 120);
+        assert_eq!(imported.run().stages[0].finished_at_unix_ms, 150);
+        assert_eq!(imported.run().queues.len(), 1);
+        assert_eq!(imported.run().queues[0].request_id, "r1");
+        assert_eq!(imported.run().queues[0].waited_from_unix_ms, 130);
+        assert_eq!(imported.run().queues[0].waited_until_unix_ms, 140);
+        assert_eq!(imported.run().truncation.dropped_requests, 1);
+    }
+
+    #[test]
+    fn strict_mode_duplicate_request_id_overflow_only_child_fails_outside_interval() {
+        let spans = vec![
+            SpanRecord::new("req-1", 100, 200)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("req-2", 300, 400)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("st-2", 320, 350)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+            SpanRecord::new("q-2", 330, 340)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+        let err = run_from_span_records(
+            spans,
+            ImportOptions::new("checkout")
+                .strict(true)
+                .capture_limits_override(tailtriage_core::CaptureLimitsOverride {
+                    max_requests: Some(1),
+                    max_stages: None,
+                    max_queues: None,
+                    ..tailtriage_core::CaptureLimitsOverride::default()
+                }),
+        )
+        .expect_err("strict import should fail for overflow-only duplicate-id child");
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        let msg = err.to_string();
+        assert!(msg.contains("falls outside request interval"));
+        assert!(!msg.contains("valid but not retained due to max_requests"));
+    }
+
+    #[test]
+    fn non_strict_duplicate_request_id_overflow_only_child_warns_outside_interval() {
+        let spans = vec![
+            SpanRecord::new("req-1", 100, 200)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("req-2", 300, 400)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("st-2", 320, 350)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+            SpanRecord::new("q-2", 330, 340)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+        let imported = run_from_span_records(
+            spans,
+            ImportOptions::new("checkout").capture_limits_override(
+                tailtriage_core::CaptureLimitsOverride {
+                    max_requests: Some(1),
+                    max_stages: None,
+                    max_queues: None,
+                    ..tailtriage_core::CaptureLimitsOverride::default()
+                },
+            ),
+        )
+        .expect("non-strict import should warn and continue");
+        assert_eq!(imported.run().stages.len(), 0);
+        assert_eq!(imported.run().queues.len(), 0);
+        let warnings: Vec<&str> = imported
+            .warnings()
+            .iter()
+            .map(ImportWarning::message)
+            .collect();
+        assert!(warnings
+            .iter()
+            .any(|w| w.contains("falls outside request interval")));
+        assert!(warnings
+            .iter()
+            .all(|w| !w.contains("valid but not retained due to max_requests")));
+        assert!(imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|w| w.contains("falls outside request interval")));
+        assert_eq!(imported.run().truncation.dropped_stages, 0);
+        assert_eq!(imported.run().truncation.dropped_queues, 0);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent later overflow request events that reuse the same `tt.request_id` from overwriting the retained request interval and causing false outside-interval strict-import failures.
- Preserve existing first-N retention semantics and PR #880 child-validation ordering while making the minimal change to avoid aliasing.

### Description
- Make `all_valid_request_intervals(...)` first-wins by `request_id` using `entry(...).or_insert(...)` so the first valid instance for a given `tt.request_id` is retained for child interval validation instead of being overwritten by later overflow duplicates.
- Leave `retained_request_intervals(...)` unchanged and based on input order via `.iter().take(max_requests)` to preserve first-N retention behavior.
- Preserve existing child-filtering order and semantics from PR #880 (look up valid parent interval, validate child interval, then decide retained vs valid-but-unretained fallout).
- Add focused regression tests in `tailtriage-tracing/src/lib.rs` for duplicate-request overflow aliasing covering: strict retained-child validity, strict overflow-only child failure (outside interval and not labeled as retention fallout), and non-strict overflow-only warning behavior.
- Minor test upkeep and lints fixes to make the test suite clean (`ImportWarning::message` mapping and correct queue timestamp field assertions).

### Testing
- Ran `cargo fmt --check` and it succeeded.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it succeeded (fixes applied where needed).
- Ran full test suite with `cargo test --workspace --all-targets --all-features --locked` and it succeeded.
- Generated documentation with `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked` and it succeeded.
- Validated docs contract with `python3 scripts/validate_docs_contracts.py` and it succeeded.
- Ran focused tracing tests with `cargo test -p tailtriage-tracing --all-features --lib --locked` and they succeeded.
- Ran CLI boundary tests with `cargo test -p tailtriage-cli --test cli_boundary --locked` and they succeeded.
- Ran feature checks: `cargo check -p tailtriage-tracing --no-default-features --locked`, `cargo check -p tailtriage-tracing --no-default-features --features jsonl --locked`, `cargo check -p tailtriage-tracing --no-default-features --features live --locked`, and `cargo check -p tailtriage-tracing --no-default-features --features tokio --locked` and all completed successfully (one non-fatal dead_code warning observed in a feature slice but did not block checks).

All automated checks listed above passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a158c4c519883309320e71597230717)