### PR TITLE
Fix live recorder completed-candidate retention to preserve request roots

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -47,7 +47,7 @@ async fn work() {
     // Your request work goes here.
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let session = TracingIntakeSession::builder("checkout-service")
         .run_json_path("target/tailtriage-examples/checkout.run.json")
@@ -136,7 +136,9 @@ Missing stage `tt.success` defaults to `true` with a warning.
 
 - `DEFAULT_MAX_OPEN_SPANS` and `DEFAULT_MAX_COMPLETED_CANDIDATE_SPANS` are live-recorder memory caps for in-memory span tracking.
 - `max_open_spans` bounds in-flight span tracking.
-- `max_completed_candidate_spans` bounds retained raw completed candidate spans before semantic conversion.
+- `max_completed_candidate_spans` is a raw live-recorder memory cap for closed candidates before semantic conversion.
+- Under raw-cap pressure, request roots are preserved preferentially when possible.
+- Child stage/queue evidence may be dropped or evicted under that pressure and is surfaced through warnings plus `truncation.limits_hit`.
 - Request/stage/queue semantic retention uses `CaptureMode`, `CaptureLimits`, and `CaptureLimitsOverride`.
 - `completed_span_jsonl_path(...)` writes retained tailtriage semantic evidence as stable span-shaped JSONL on shutdown only when at least one completed request is retained.
 - It is intended for replaying the same retained request/stage/queue evidence through `tailtriage import`, not for trace archival.

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -92,9 +92,13 @@ impl Default for RecorderLimits {
 #[derive(Debug, Default)]
 struct RecorderState {
     open: BTreeMap<u64, OpenSpan>,
-    completed: Vec<SpanRecord>,
+    completed_requests: Vec<SpanRecord>,
+    completed_stages: Vec<SpanRecord>,
+    completed_queues: Vec<SpanRecord>,
     dropped_open_spans: u64,
-    dropped_completed_candidate_spans: u64,
+    dropped_completed_request_candidates: u64,
+    dropped_completed_child_candidates: u64,
+    evicted_child_candidates_to_preserve_request: u64,
     closed_missing_kind_spans: u64,
     closed_unknown_kind_spans: u64,
     closed_malformed_kind_spans: u64,
@@ -133,7 +137,9 @@ struct ClosedKindIssueSample {
 
 struct SnapshotStats {
     dropped_open_spans: u64,
-    dropped_completed_candidate_spans: u64,
+    dropped_completed_request_candidates: u64,
+    dropped_completed_child_candidates: u64,
+    evicted_child_candidates_to_preserve_request: u64,
     open_candidate_count: u64,
     open_samples: Vec<OpenSpanSample>,
     closed_missing_kind_spans: u64,
@@ -194,10 +200,14 @@ impl TracingRecorder {
                 }
             }
             (
-                state.completed.clone(),
+                completed_span_records(&state),
                 SnapshotStats {
                     dropped_open_spans: state.dropped_open_spans,
-                    dropped_completed_candidate_spans: state.dropped_completed_candidate_spans,
+                    dropped_completed_request_candidates: state
+                        .dropped_completed_request_candidates,
+                    dropped_completed_child_candidates: state.dropped_completed_child_candidates,
+                    evicted_child_candidates_to_preserve_request: state
+                        .evicted_child_candidates_to_preserve_request,
                     open_candidate_count: count,
                     open_samples: samples,
                     closed_missing_kind_spans: state.closed_missing_kind_spans,
@@ -720,13 +730,75 @@ where
             for (k, v) in open.fields {
                 record = record.field(k, v);
             }
-            if state.completed.len() >= self.limits.max_completed_candidate_spans {
-                state.dropped_completed_candidate_spans =
-                    state.dropped_completed_candidate_spans.saturating_add(1);
+            push_completed_candidate_with_kind_aware_retention(
+                &mut state,
+                record,
+                kind,
+                self.limits,
+            );
+        }
+    }
+}
+
+fn completed_span_records(state: &RecorderState) -> Vec<SpanRecord> {
+    let mut spans = Vec::with_capacity(
+        state.completed_requests.len()
+            + state.completed_stages.len()
+            + state.completed_queues.len(),
+    );
+    spans.extend(state.completed_requests.iter().cloned());
+    spans.extend(state.completed_stages.iter().cloned());
+    spans.extend(state.completed_queues.iter().cloned());
+    spans
+}
+
+fn push_completed_candidate_with_kind_aware_retention(
+    state: &mut RecorderState,
+    record: SpanRecord,
+    kind: &str,
+    limits: RecorderLimits,
+) {
+    let total = state.completed_requests.len()
+        + state.completed_stages.len()
+        + state.completed_queues.len();
+    if total < limits.max_completed_candidate_spans {
+        push_record_by_kind(state, record, kind);
+        return;
+    }
+
+    match kind {
+        "request" => {
+            if !state.completed_queues.is_empty() {
+                state.completed_queues.pop();
+                state.evicted_child_candidates_to_preserve_request = state
+                    .evicted_child_candidates_to_preserve_request
+                    .saturating_add(1);
+                state.completed_requests.push(record);
+            } else if !state.completed_stages.is_empty() {
+                state.completed_stages.pop();
+                state.evicted_child_candidates_to_preserve_request = state
+                    .evicted_child_candidates_to_preserve_request
+                    .saturating_add(1);
+                state.completed_requests.push(record);
             } else {
-                state.completed.push(record);
+                state.dropped_completed_request_candidates =
+                    state.dropped_completed_request_candidates.saturating_add(1);
             }
         }
+        "stage" | "queue" => {
+            state.dropped_completed_child_candidates =
+                state.dropped_completed_child_candidates.saturating_add(1);
+        }
+        _ => {}
+    }
+}
+
+fn push_record_by_kind(state: &mut RecorderState, record: SpanRecord, kind: &str) {
+    match kind {
+        "request" => state.completed_requests.push(record),
+        "stage" => state.completed_stages.push(record),
+        "queue" => state.completed_queues.push(record),
+        _ => {}
     }
 }
 fn precheck_required_fields(
@@ -899,10 +971,22 @@ fn push_strict_recorder_messages(
             stats.dropped_open_spans, limits.max_open_spans
         ));
     }
-    if stats.dropped_completed_candidate_spans > 0 {
+    if stats.dropped_completed_request_candidates > 0 {
         messages.push(format!(
-            "live recorder dropped {} completed candidate span(s) because max_completed_candidate_spans={} was reached; this is a raw closed-span memory cap before semantic conversion, not request/stage/queue CaptureLimits; raise max_completed_candidate_spans, snapshot/shutdown sooner, or reduce capture scope",
-            stats.dropped_completed_candidate_spans, limits.max_completed_candidate_spans
+            "live recorder dropped {} completed request candidate span(s) because max_completed_candidate_spans={} was reached and no child candidate was available to evict",
+            stats.dropped_completed_request_candidates, limits.max_completed_candidate_spans
+        ));
+    }
+    if stats.dropped_completed_child_candidates > 0 {
+        messages.push(format!(
+            "live recorder dropped {} completed child candidate span(s) because max_completed_candidate_spans={} was reached while preserving request roots",
+            stats.dropped_completed_child_candidates, limits.max_completed_candidate_spans
+        ));
+    }
+    if stats.evicted_child_candidates_to_preserve_request > 0 {
+        messages.push(format!(
+            "live recorder evicted {} completed child candidate span(s) to preserve completed request candidate span(s) under max_completed_candidate_spans={}",
+            stats.evicted_child_candidates_to_preserve_request, limits.max_completed_candidate_spans
         ));
     }
 }
@@ -983,15 +1067,35 @@ fn append_non_strict_drop_warnings(
         run.metadata.lifecycle_warnings.push(msg.clone());
         warnings.push(crate::ImportWarning::new(msg));
     }
-    if stats.dropped_completed_candidate_spans > 0 {
+    if stats.dropped_completed_request_candidates > 0 {
         let msg = format!(
-            "live recorder dropped {} completed candidate span(s) because max_completed_candidate_spans={} was reached; this is a raw closed-span memory cap before semantic conversion, not request/stage/queue CaptureLimits; raise max_completed_candidate_spans, snapshot/shutdown sooner, or reduce capture scope",
-            stats.dropped_completed_candidate_spans, limits.max_completed_candidate_spans
+            "live recorder dropped {} completed request candidate span(s) because max_completed_candidate_spans={} was reached and no child candidate was available to evict",
+            stats.dropped_completed_request_candidates, limits.max_completed_candidate_spans
         );
         run.metadata.lifecycle_warnings.push(msg.clone());
         warnings.push(crate::ImportWarning::new(msg));
     }
-    if stats.dropped_open_spans > 0 || stats.dropped_completed_candidate_spans > 0 {
+    if stats.dropped_completed_child_candidates > 0 {
+        let msg = format!(
+            "live recorder dropped {} completed child candidate span(s) because max_completed_candidate_spans={} was reached while preserving request roots",
+            stats.dropped_completed_child_candidates, limits.max_completed_candidate_spans
+        );
+        run.metadata.lifecycle_warnings.push(msg.clone());
+        warnings.push(crate::ImportWarning::new(msg));
+    }
+    if stats.evicted_child_candidates_to_preserve_request > 0 {
+        let msg = format!(
+            "live recorder evicted {} completed child candidate span(s) to preserve completed request candidate span(s) under max_completed_candidate_spans={}",
+            stats.evicted_child_candidates_to_preserve_request, limits.max_completed_candidate_spans
+        );
+        run.metadata.lifecycle_warnings.push(msg.clone());
+        warnings.push(crate::ImportWarning::new(msg));
+    }
+    if stats.dropped_open_spans > 0
+        || stats.dropped_completed_request_candidates > 0
+        || stats.dropped_completed_child_candidates > 0
+        || stats.evicted_child_candidates_to_preserve_request > 0
+    {
         run.truncation.limits_hit = true;
     }
 }
@@ -1047,7 +1151,9 @@ fn imported_with_drop_warnings(
     }
 
     if stats.dropped_open_spans == 0
-        && stats.dropped_completed_candidate_spans == 0
+        && stats.dropped_completed_request_candidates == 0
+        && stats.dropped_completed_child_candidates == 0
+        && stats.evicted_child_candidates_to_preserve_request == 0
         && stats.open_candidate_count == 0
         && stats.closed_missing_kind_spans == 0
         && stats.closed_unknown_kind_spans == 0
@@ -1447,6 +1553,53 @@ mod tests {
     }
 
     #[test]
+    fn completed_candidate_cap_preserves_request_over_children_non_strict() {
+        let recorder = TracingRecorder::builder("svc")
+            .max_completed_candidate_spans(2)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let request = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/checkout"
+            );
+            let request_guard = request.enter();
+            drop(tracing::info_span!(
+                "queue",
+                tt.kind = "queue",
+                tt.request_id = "r1",
+                tt.queue = "db"
+            ));
+            drop(tracing::info_span!(
+                "stage",
+                tt.kind = "stage",
+                tt.request_id = "r1",
+                tt.stage = "db.query"
+            ));
+            drop(request_guard);
+            drop(request);
+        });
+        let imported = recorder.snapshot_run().unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert!(imported.run().stages.len() + imported.run().queues.len() <= 1);
+        assert!(imported.run().truncation.limits_hit);
+        let warning_text = imported
+            .warnings()
+            .iter()
+            .map(|w| w.message().to_string())
+            .collect::<Vec<_>>()
+            .join(" | ");
+        assert!(warning_text.contains("max_completed_candidate_spans"));
+        assert!(
+            warning_text.contains("dropped 1 completed child candidate span")
+                || warning_text.contains("evicted 1 completed child candidate span")
+        );
+    }
+
+    #[test]
     fn strict_mode_errors_when_completed_candidate_cap_drops_spans() {
         let recorder = TracingRecorder::builder("svc")
             .strict(true)
@@ -1477,6 +1630,60 @@ mod tests {
             }
             other => panic!("unexpected error: {other:?}"),
         }
+    }
+
+    #[test]
+    fn strict_mode_errors_when_completed_candidate_cap_evicts_child_for_request() {
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .max_completed_candidate_spans(2)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let request = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/checkout"
+            );
+            let request_guard = request.enter();
+            drop(tracing::info_span!(
+                "queue",
+                tt.kind = "queue",
+                tt.request_id = "r1",
+                tt.queue = "db"
+            ));
+            drop(tracing::info_span!(
+                "stage",
+                tt.kind = "stage",
+                tt.request_id = "r1",
+                tt.stage = "db.query"
+            ));
+            drop(request_guard);
+            drop(request);
+        });
+        let err = recorder.snapshot_run().unwrap_err();
+        match err {
+            ImportError::StrictViolation(message) => {
+                assert!(message.contains("max_completed_candidate_spans"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn completed_candidate_conversion_order_is_request_stage_queue() {
+        let mut state = RecorderState::default();
+        state.completed_stages.push(SpanRecord::new("stage", 1, 2));
+        state.completed_queues.push(SpanRecord::new("queue", 1, 2));
+        state
+            .completed_requests
+            .push(SpanRecord::new("request", 1, 2));
+        let ordered = completed_span_records(&state);
+        assert_eq!(ordered[0].name(), "request");
+        assert_eq!(ordered[1].name(), "stage");
+        assert_eq!(ordered[2].name(), "queue");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Fix a live-recorder retention bug where the single raw completed buffer could fill with child (stage/queue) spans before a parent request closed, causing the parent request to be dropped and making retained child spans unusable. 
- Ensure request roots are preserved preferentially when the raw `max_completed_candidate_spans` cap is under pressure while keeping that cap as a strict memory safety bound. 
- Surface explicit, distinct warnings and strict-mode failures when raw completed candidates are dropped or evicted so truncation is visible to users and tooling.

### Description
- Replace the single `completed: Vec<SpanRecord>` with private kind-aware in-memory buffers: `completed_requests`, `completed_stages`, and `completed_queues`, while keeping one total raw cap `RecorderLimits::max_completed_candidate_spans` and making the buffers internal only. 
- Implement kind-aware admission policy: below cap append to the matching kind buffer; when at cap a closing request will evict a child candidate (prefer `queue` then `stage`) to preserve the request or else be counted as a dropped completed request candidate; closing `stage`/`queue` candidates are dropped when at cap and counted separately. 
- Add separate accounting counters and warnings for `dropped completed request candidates`, `dropped completed child candidates`, and `evicted child candidates to preserve request`, and set `run.truncation.limits_hit` whenever any raw completed candidate was dropped or evicted. 
- Ensure snapshot conversion feeds `run_from_span_records` in request-first, stage-second, queue-third order so conversion sees preserved requests before child evidence. 
- Update `tailtriage-tracing/README.md` to document that `max_completed_candidate_spans` is a raw live-recorder memory cap, that request roots are preferentially preserved under pressure, and that child evidence may be dropped/evicted and surfaced through warnings and `truncation.limits_hit`. 
- Changed files: `tailtriage-tracing/src/recorder.rs` and `tailtriage-tracing/README.md`.

### Testing
- Tests added and updated: `completed_candidate_cap_preserves_request_over_children_non_strict`, `strict_mode_errors_when_completed_candidate_cap_evicts_child_for_request`, and `completed_candidate_conversion_order_is_request_stage_queue`, while existing cap/strict tests were retained/adapted to ensure sequential request-only cap behavior still works. 
- Commands run and results: `cargo fmt --check` (passed), `cargo clippy --workspace --all-targets -- -D warnings` (passed), `cargo test --workspace` (passed), `cargo test -p tailtriage-tracing --all-features` (passed), and `python3 scripts/validate_docs_contracts.py` (passed). 
- Exact retention behavior now guaranteed: `max_completed_candidate_spans` remains a single raw memory cap; when the cap is reached, the recorder will prefer to preserve valid request roots by evicting retained child evidence (queue first, then stage) if available; child candidates are dropped if no eviction policy applies; requests are dropped only when no child candidate exists to evict; strict mode errors when any completed candidate was dropped or evicted due to the raw cap. 
- Remaining limitations: this change only affects the raw live-recorder admission behavior and does not alter downstream semantic capture limits controlled by `CaptureMode`/`CaptureLimits` which can still truncate during conversion; eviction is local to the recorder and does not attempt to re-order or synthesize evidence beyond these bounded policies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15b39c14e88330b016414536feeea3)