### PR TITLE
Preserve request roots when tracing recorder completed-candidate cap is saturated

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -47,7 +47,7 @@ async fn work() {
     // Your request work goes here.
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let session = TracingIntakeSession::builder("checkout-service")
         .run_json_path("target/tailtriage-examples/checkout.run.json")
@@ -136,7 +136,9 @@ Missing stage `tt.success` defaults to `true` with a warning.
 
 - `DEFAULT_MAX_OPEN_SPANS` and `DEFAULT_MAX_COMPLETED_CANDIDATE_SPANS` are live-recorder memory caps for in-memory span tracking.
 - `max_open_spans` bounds in-flight span tracking.
-- `max_completed_candidate_spans` bounds retained raw completed candidate spans before semantic conversion.
+- `max_completed_candidate_spans` bounds retained raw completed candidate spans before semantic conversion and serves as the raw live-recorder memory safety cap.
+- Under `max_completed_candidate_spans` pressure, request-root candidates are preserved preferentially whenever a child candidate (queue first, then stage) can be evicted.
+- Child stage/queue evidence may be dropped or evicted under this raw cap; warnings and `truncation.limits_hit` surface this retained-evidence truncation explicitly.
 - Request/stage/queue semantic retention uses `CaptureMode`, `CaptureLimits`, and `CaptureLimitsOverride`.
 - `completed_span_jsonl_path(...)` writes retained tailtriage semantic evidence as stable span-shaped JSONL on shutdown only when at least one completed request is retained.
 - It is intended for replaying the same retained request/stage/queue evidence through `tailtriage import`, not for trace archival.

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -92,9 +92,13 @@ impl Default for RecorderLimits {
 #[derive(Debug, Default)]
 struct RecorderState {
     open: BTreeMap<u64, OpenSpan>,
-    completed: Vec<SpanRecord>,
+    completed_requests: Vec<SpanRecord>,
+    completed_stages: Vec<SpanRecord>,
+    completed_queues: Vec<SpanRecord>,
     dropped_open_spans: u64,
-    dropped_completed_candidate_spans: u64,
+    dropped_completed_request_candidates: u64,
+    dropped_completed_child_candidates: u64,
+    evicted_child_candidates_for_request: u64,
     closed_missing_kind_spans: u64,
     closed_unknown_kind_spans: u64,
     closed_malformed_kind_spans: u64,
@@ -133,7 +137,9 @@ struct ClosedKindIssueSample {
 
 struct SnapshotStats {
     dropped_open_spans: u64,
-    dropped_completed_candidate_spans: u64,
+    dropped_completed_request_candidates: u64,
+    dropped_completed_child_candidates: u64,
+    evicted_child_candidates_for_request: u64,
     open_candidate_count: u64,
     open_samples: Vec<OpenSpanSample>,
     closed_missing_kind_spans: u64,
@@ -142,6 +148,11 @@ struct SnapshotStats {
     closed_kind_samples: Vec<ClosedKindIssueSample>,
     closed_incomplete_candidate_spans: u64,
     closed_incomplete_candidate_samples: Vec<ClosedKindIssueSample>,
+}
+impl RecorderState {
+    fn completed_len(&self) -> usize {
+        self.completed_requests.len() + self.completed_stages.len() + self.completed_queues.len()
+    }
 }
 fn lock_state(state: &Arc<Mutex<RecorderState>>) -> std::sync::MutexGuard<'_, RecorderState> {
     match state.lock() {
@@ -194,10 +205,20 @@ impl TracingRecorder {
                 }
             }
             (
-                state.completed.clone(),
+                {
+                    let mut spans = Vec::with_capacity(state.completed_len());
+                    spans.extend(state.completed_requests.iter().cloned());
+                    spans.extend(state.completed_stages.iter().cloned());
+                    spans.extend(state.completed_queues.iter().cloned());
+                    spans
+                },
                 SnapshotStats {
                     dropped_open_spans: state.dropped_open_spans,
-                    dropped_completed_candidate_spans: state.dropped_completed_candidate_spans,
+                    dropped_completed_request_candidates: state
+                        .dropped_completed_request_candidates,
+                    dropped_completed_child_candidates: state.dropped_completed_child_candidates,
+                    evicted_child_candidates_for_request: state
+                        .evicted_child_candidates_for_request,
                     open_candidate_count: count,
                     open_samples: samples,
                     closed_missing_kind_spans: state.closed_missing_kind_spans,
@@ -720,11 +741,37 @@ where
             for (k, v) in open.fields {
                 record = record.field(k, v);
             }
-            if state.completed.len() >= self.limits.max_completed_candidate_spans {
-                state.dropped_completed_candidate_spans =
-                    state.dropped_completed_candidate_spans.saturating_add(1);
+            if state.completed_len() < self.limits.max_completed_candidate_spans {
+                match kind {
+                    "request" => state.completed_requests.push(record),
+                    "stage" => state.completed_stages.push(record),
+                    "queue" => state.completed_queues.push(record),
+                    _ => unreachable!("validated kind"),
+                }
             } else {
-                state.completed.push(record);
+                match kind {
+                    "request" => {
+                        if !state.completed_queues.is_empty() {
+                            state.completed_queues.remove(0);
+                            state.evicted_child_candidates_for_request =
+                                state.evicted_child_candidates_for_request.saturating_add(1);
+                            state.completed_requests.push(record);
+                        } else if !state.completed_stages.is_empty() {
+                            state.completed_stages.remove(0);
+                            state.evicted_child_candidates_for_request =
+                                state.evicted_child_candidates_for_request.saturating_add(1);
+                            state.completed_requests.push(record);
+                        } else {
+                            state.dropped_completed_request_candidates =
+                                state.dropped_completed_request_candidates.saturating_add(1);
+                        }
+                    }
+                    "stage" | "queue" => {
+                        state.dropped_completed_child_candidates =
+                            state.dropped_completed_child_candidates.saturating_add(1);
+                    }
+                    _ => unreachable!("validated kind"),
+                }
             }
         }
     }
@@ -899,10 +946,22 @@ fn push_strict_recorder_messages(
             stats.dropped_open_spans, limits.max_open_spans
         ));
     }
-    if stats.dropped_completed_candidate_spans > 0 {
+    if stats.dropped_completed_request_candidates > 0 {
         messages.push(format!(
-            "live recorder dropped {} completed candidate span(s) because max_completed_candidate_spans={} was reached; this is a raw closed-span memory cap before semantic conversion, not request/stage/queue CaptureLimits; raise max_completed_candidate_spans, snapshot/shutdown sooner, or reduce capture scope",
-            stats.dropped_completed_candidate_spans, limits.max_completed_candidate_spans
+            "live recorder dropped {} completed request candidate span(s) because max_completed_candidate_spans={} was reached and no child candidate was available to evict",
+            stats.dropped_completed_request_candidates, limits.max_completed_candidate_spans
+        ));
+    }
+    if stats.dropped_completed_child_candidates > 0 {
+        messages.push(format!(
+            "live recorder dropped {} completed child candidate span(s) because max_completed_candidate_spans={} was reached; request candidates are preserved preferentially under raw memory-cap pressure",
+            stats.dropped_completed_child_candidates, limits.max_completed_candidate_spans
+        ));
+    }
+    if stats.evicted_child_candidates_for_request > 0 {
+        messages.push(format!(
+            "live recorder evicted {} completed child candidate span(s) to preserve completed request candidates because max_completed_candidate_spans={} was reached",
+            stats.evicted_child_candidates_for_request, limits.max_completed_candidate_spans
         ));
     }
 }
@@ -983,15 +1042,35 @@ fn append_non_strict_drop_warnings(
         run.metadata.lifecycle_warnings.push(msg.clone());
         warnings.push(crate::ImportWarning::new(msg));
     }
-    if stats.dropped_completed_candidate_spans > 0 {
+    if stats.dropped_completed_request_candidates > 0 {
         let msg = format!(
-            "live recorder dropped {} completed candidate span(s) because max_completed_candidate_spans={} was reached; this is a raw closed-span memory cap before semantic conversion, not request/stage/queue CaptureLimits; raise max_completed_candidate_spans, snapshot/shutdown sooner, or reduce capture scope",
-            stats.dropped_completed_candidate_spans, limits.max_completed_candidate_spans
+            "live recorder dropped {} completed request candidate span(s) because max_completed_candidate_spans={} was reached and no child candidate was available to evict",
+            stats.dropped_completed_request_candidates, limits.max_completed_candidate_spans
         );
         run.metadata.lifecycle_warnings.push(msg.clone());
         warnings.push(crate::ImportWarning::new(msg));
     }
-    if stats.dropped_open_spans > 0 || stats.dropped_completed_candidate_spans > 0 {
+    if stats.dropped_completed_child_candidates > 0 {
+        let msg = format!(
+            "live recorder dropped {} completed child candidate span(s) because max_completed_candidate_spans={} was reached; request candidates are preserved preferentially under raw memory-cap pressure",
+            stats.dropped_completed_child_candidates, limits.max_completed_candidate_spans
+        );
+        run.metadata.lifecycle_warnings.push(msg.clone());
+        warnings.push(crate::ImportWarning::new(msg));
+    }
+    if stats.evicted_child_candidates_for_request > 0 {
+        let msg = format!(
+            "live recorder evicted {} completed child candidate span(s) to preserve completed request candidates because max_completed_candidate_spans={} was reached",
+            stats.evicted_child_candidates_for_request, limits.max_completed_candidate_spans
+        );
+        run.metadata.lifecycle_warnings.push(msg.clone());
+        warnings.push(crate::ImportWarning::new(msg));
+    }
+    if stats.dropped_open_spans > 0
+        || stats.dropped_completed_request_candidates > 0
+        || stats.dropped_completed_child_candidates > 0
+        || stats.evicted_child_candidates_for_request > 0
+    {
         run.truncation.limits_hit = true;
     }
 }
@@ -1047,7 +1126,9 @@ fn imported_with_drop_warnings(
     }
 
     if stats.dropped_open_spans == 0
-        && stats.dropped_completed_candidate_spans == 0
+        && stats.dropped_completed_request_candidates == 0
+        && stats.dropped_completed_child_candidates == 0
+        && stats.evicted_child_candidates_for_request == 0
         && stats.open_candidate_count == 0
         && stats.closed_missing_kind_spans == 0
         && stats.closed_unknown_kind_spans == 0
@@ -1477,6 +1558,126 @@ mod tests {
             }
             other => panic!("unexpected error: {other:?}"),
         }
+    }
+
+    #[test]
+    fn completed_candidate_cap_preserves_request_over_children_non_strict() {
+        let recorder = TracingRecorder::builder("svc")
+            .max_completed_candidate_spans(2)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let request = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/checkout"
+            )
+            .entered();
+            let queue = tracing::info_span!(
+                "queue",
+                tt.kind = "queue",
+                tt.request_id = "r1",
+                tt.queue = "db.pool"
+            );
+            let stage = tracing::info_span!(
+                "stage",
+                tt.kind = "stage",
+                tt.request_id = "r1",
+                tt.stage = "db.query"
+            );
+            drop(queue);
+            drop(stage);
+            drop(request);
+        });
+        let imported = recorder.snapshot_run().unwrap();
+        let run = imported.run();
+        assert_eq!(run.requests.len(), 1);
+        assert!(run.queues.len() + run.stages.len() <= 1);
+        assert!(run.truncation.limits_hit);
+        let warnings = imported
+            .warnings()
+            .iter()
+            .map(crate::ImportWarning::message)
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(warnings.contains("child candidate"));
+        assert!(!warnings.contains("silently"));
+    }
+
+    #[test]
+    fn strict_mode_errors_when_request_preservation_evicts_child_evidence() {
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .max_completed_candidate_spans(2)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let request = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/checkout"
+            )
+            .entered();
+            drop(tracing::info_span!(
+                "queue",
+                tt.kind = "queue",
+                tt.request_id = "r1",
+                tt.queue = "db.pool"
+            ));
+            drop(tracing::info_span!(
+                "stage",
+                tt.kind = "stage",
+                tt.request_id = "r1",
+                tt.stage = "db.query"
+            ));
+            drop(request);
+        });
+        let err = recorder.snapshot_run().unwrap_err();
+        match err {
+            ImportError::StrictViolation(message) => {
+                assert!(message.contains("max_completed_candidate_spans"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn snapshot_conversion_orders_request_then_stage_then_queue() {
+        let recorder = TracingRecorder::builder("svc")
+            .max_completed_candidate_spans(16)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let request = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/checkout"
+            )
+            .entered();
+            drop(tracing::info_span!(
+                "queue",
+                tt.kind = "queue",
+                tt.request_id = "r1",
+                tt.queue = "db.pool"
+            ));
+            drop(tracing::info_span!(
+                "stage",
+                tt.kind = "stage",
+                tt.request_id = "r1",
+                tt.stage = "db.query"
+            ));
+            drop(request);
+        });
+        let run = recorder.snapshot_run().unwrap().run().clone();
+        assert_eq!(run.requests[0].request_id, "r1");
+        assert_eq!(run.stages[0].request_id, "r1");
+        assert_eq!(run.queues[0].request_id, "r1");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Fix a retention bug where a parent request span could be dropped because `max_completed_candidate_spans` filled with child stage/queue spans before the parent closed.  
- Maintain the raw live-recorder memory-cap semantics while preferentially preserving valid request roots under pressure, without adding dependencies or changing public APIs.  
- Make non-strict warnings and strict-mode behavior explicit when raw completed-candidate slots are dropped or evicted so triage evidence is not silently lost.  

### Description
- Replaced the single raw `completed: Vec<SpanRecord>` with private kind-aware buffers `completed_requests`, `completed_stages`, and `completed_queues`, and added counters `dropped_completed_request_candidates`, `dropped_completed_child_candidates`, and `evicted_child_candidates_for_request`.  
- Implemented a single total admission cap based on `RecorderLimits::max_completed_candidate_spans` with the admission policy: if below cap append to the matching kind buffer; if at cap and a request closes, evict a child (queue first, then stage) to preserve the request, otherwise drop the request; if at cap and a child closes, drop that child candidate.  
- Snapshot conversion now concatenates spans in request-first, stage-second, queue-third order before calling `run_from_span_records`, preserved the existing incomplete/malformed precheck behavior so invalid/incomplete closes do not consume completed-candidate slots, and added distinct warning/lifecycle messages for dropped requests, dropped child candidates, and evicted child candidates.  
- Changed files: `tailtriage-tracing/src/recorder.rs` and `tailtriage-tracing/README.md` (the README update also documents the new `max_completed_candidate_spans` behavior and adjusts a Tokio doc-example runtime flavor to keep doctests deterministic).  

### Testing
- Added tests `completed_candidate_cap_preserves_request_over_children_non_strict`, `strict_mode_errors_when_request_preservation_evicts_child_evidence`, and `snapshot_conversion_orders_request_then_stage_then_queue`, and kept/adapted existing recorder cap tests to validate request-only behavior.  
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo test -p tailtriage-tracing --all-features`, and `python3 scripts/validate_docs_contracts.py`, and all commands completed successfully.  
- All unit tests (including the new recorder regression tests) passed and docs contract validation succeeded, and the doctest runtime-flavor adjustment resolved the earlier doc-test failure.  
- Remaining limitation: under very small `max_completed_candidate_spans`, child stage/queue evidence may still be dropped or evicted by design to preserve request roots, which reduces available child evidence for diagnostics but is surfaced via explicit warnings and `run.truncation.limits_hit`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15b39c14e88330b016414536feeea3)