### PR TITLE
Accept custom tt.outcome labels in tracing import

### DIFF
--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -1191,7 +1191,7 @@ fn import_tracing_json_persists_optional_default_assumption_warnings_in_run_arti
 }
 
 #[test]
-fn import_tracing_json_invalid_outcome_non_strict_warns_and_fails_zero_request() {
+fn import_tracing_json_custom_outcome_non_strict_imports_successfully() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
@@ -1207,17 +1207,18 @@ fn import_tracing_json_invalid_outcome_non_strict_warns_and_fails_zero_request()
         .output()
         .expect("cli should run");
 
-    assert!(!output.status.success(), "cli unexpectedly succeeded");
-    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
-    assert!(stderr.contains("warning:"));
-    assert!(stderr.contains(
-        "invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'sucess'"
-    ));
-    assert!(stderr.contains("zero request events"));
+    assert!(
+        output.status.success(),
+        "cli unexpectedly failed: {output:?}"
+    );
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
+        .expect("imported run should load in cli loader");
+    assert_eq!(loaded.run.requests.len(), 1);
+    assert_eq!(loaded.run.requests[0].outcome, "sucess");
 }
 
 #[test]
-fn import_tracing_json_invalid_outcome_strict_fails_with_message() {
+fn import_tracing_json_custom_outcome_strict_imports_successfully() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
@@ -1234,11 +1235,14 @@ fn import_tracing_json_invalid_outcome_strict_fails_with_message() {
         .output()
         .expect("cli should run");
 
-    assert!(!output.status.success(), "cli unexpectedly succeeded");
-    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
-    assert!(stderr.contains(
-        "invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'sucess'"
-    ));
+    assert!(
+        output.status.success(),
+        "cli unexpectedly failed: {output:?}"
+    );
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
+        .expect("imported run should load in cli loader");
+    assert_eq!(loaded.run.requests.len(), 1);
+    assert_eq!(loaded.run.requests[0].outcome, "sucess");
 }
 
 #[test]

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -117,11 +117,12 @@ Ordinary tracing log JSON (for example `fmt().json` output) is rejected by impor
 
 | Span kind | Required fields | Optional fields |
 | --- | --- | --- |
-| request | `tt.kind="request"`, `tt.request_id`, `tt.route` | `tt.outcome` (`ok`, `error`, `timeout`, `cancelled`, or `rejected`) |
+| request | `tt.kind="request"`, `tt.request_id`, `tt.route` | `tt.outcome` (optional; recommended common labels: `ok`, `error`, `timeout`, `cancelled`, `rejected`; custom non-empty labels are accepted and preserved) |
 | stage | `tt.kind="stage"`, `tt.request_id`, `tt.stage` | `tt.success` |
 | queue | `tt.kind="queue"`, `tt.request_id`, `tt.queue` | `tt.depth_at_start` |
 
 Missing request `tt.outcome` defaults to `ok` with a warning.
+Empty/whitespace-only `tt.outcome` values and non-string `tt.outcome` values are invalid.
 Missing stage `tt.success` defaults to `true` with a warning.
 
 ## Strict vs non-strict

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -797,8 +797,8 @@ fn strict_or_warn(
     Ok(())
 }
 
-const ACCEPTED_OUTCOME_LABELS: [&str; 5] = ["ok", "error", "timeout", "cancelled", "rejected"];
-const ACCEPTED_OUTCOME_LABELS_CSV: &str = "ok,error,timeout,cancelled,rejected";
+#[cfg(test)]
+const RECOMMENDED_OUTCOME_LABELS: [&str; 5] = ["ok", "error", "timeout", "cancelled", "rejected"];
 
 fn parse_outcome(
     span: &SpanRecord,
@@ -808,18 +808,18 @@ fn parse_outcome(
     match get_string_field_state(span, TT_OUTCOME) {
         StringFieldState::Missing => Ok(Some(("ok".to_owned(), true))),
         StringFieldState::Value(value) => {
-            if ACCEPTED_OUTCOME_LABELS.contains(&value) {
-                Ok(Some((value.to_owned(), false)))
-            } else {
+            if value.trim().is_empty() {
                 strict_or_warn(
                     strict,
                     warnings,
                     format!(
-                        "invalid field '{TT_OUTCOME}' in span '{}': expected one of {ACCEPTED_OUTCOME_LABELS_CSV}, got '{value}'",
+                        "invalid field '{TT_OUTCOME}' in span '{}': cannot be empty or whitespace",
                         span.name()
                     ),
                 )?;
                 Ok(None)
+            } else {
+                Ok(Some((value.to_owned(), false)))
             }
         }
         StringFieldState::InvalidType => {
@@ -2067,8 +2067,8 @@ mod tests {
     }
 
     #[test]
-    fn accepted_request_outcomes_are_retained_exactly() {
-        let spans = ACCEPTED_OUTCOME_LABELS
+    fn recommended_request_outcomes_are_retained_exactly() {
+        let spans = RECOMMENDED_OUTCOME_LABELS
             .iter()
             .enumerate()
             .map(|(idx, outcome)| {
@@ -2086,7 +2086,20 @@ mod tests {
             .iter()
             .map(|request| request.outcome.as_str())
             .collect::<Vec<_>>();
-        assert_eq!(retained, ACCEPTED_OUTCOME_LABELS);
+        assert_eq!(retained, RECOMMENDED_OUTCOME_LABELS);
+    }
+
+    #[test]
+    fn custom_outcome_is_accepted_and_preserved_exactly() {
+        let custom_outcome = "cache_miss_fallback";
+        let spans = vec![SpanRecord::new("http.request", 1, 2)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")
+            .field(TT_OUTCOME, custom_outcome)];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].outcome, custom_outcome);
     }
 
     #[test]
@@ -2104,55 +2117,81 @@ mod tests {
     }
 
     #[test]
-    fn invalid_outcome_non_strict_skips_request_and_warns() {
+    fn whitespace_only_outcome_non_strict_skips_request_and_warns() {
         let spans = vec![SpanRecord::new("http.request", 1, 2)
             .field(TT_KIND, "request")
             .field(TT_REQUEST_ID, "r1")
             .field(TT_ROUTE, "/")
-            .field(TT_OUTCOME, "sucess")];
+            .field(TT_OUTCOME, "   ")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(imported.run().requests.is_empty());
         assert!(imported.warnings().iter().any(|w| w.message().contains(
-            "invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'sucess'"
+            "invalid field 'tt.outcome' in span 'http.request': cannot be empty or whitespace"
         )));
     }
 
     #[test]
-    fn invalid_outcome_strict_fails() {
+    fn whitespace_only_outcome_strict_fails() {
         let spans = vec![SpanRecord::new("http.request", 1, 2)
             .field(TT_KIND, "request")
             .field(TT_REQUEST_ID, "r1")
             .field(TT_ROUTE, "/")
-            .field(TT_OUTCOME, "sucess")];
+            .field(TT_OUTCOME, "\t")];
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
         assert!(matches!(err, ImportError::StrictViolation(_)));
         assert!(err.to_string().contains(
-            "invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'sucess'"
+            "invalid field 'tt.outcome' in span 'http.request': cannot be empty or whitespace"
         ));
     }
 
     #[test]
-    fn invalid_outcome_with_whitespace_is_rejected() {
+    fn non_string_outcome_non_strict_skips_request_and_warns() {
         let spans = vec![SpanRecord::new("http.request", 1, 2)
             .field(TT_KIND, "request")
             .field(TT_REQUEST_ID, "r1")
             .field(TT_ROUTE, "/")
-            .field(TT_OUTCOME, "ok ")];
+            .field(TT_OUTCOME, 1_u64)];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(imported.run().requests.is_empty());
-        assert!(imported.warnings().iter().any(|w| w.message().contains(
-            "invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'ok '"
-        )));
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("invalid field 'tt.outcome' in span 'http.request': expected string")));
     }
 
     #[test]
-    fn invalid_outcome_skips_child_spans_via_existing_correlation_logic() {
+    fn non_string_outcome_strict_fails() {
+        let spans = vec![SpanRecord::new("http.request", 1, 2)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")
+            .field(TT_OUTCOME, false)];
+        let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(err
+            .to_string()
+            .contains("invalid field 'tt.outcome' in span 'http.request': expected string"));
+    }
+
+    #[test]
+    fn outcome_other_round_trips_through_tracing_import() {
+        let custom = tailtriage_core::Outcome::Other("custom".to_owned());
+        let span = SpanRecord::new("http.request", 1, 2)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")
+            .field(TT_OUTCOME, custom.as_str());
+        let imported = run_from_span_records(vec![span], ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests[0].outcome, custom.as_str());
+    }
+
+    #[test]
+    fn invalid_whitespace_outcome_skips_child_spans_via_existing_correlation_logic() {
         let spans = vec![
             SpanRecord::new("http.request", 1_000, 2_000)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/")
-                .field(TT_OUTCOME, "sucess"),
+                .field(TT_OUTCOME, " "),
             SpanRecord::new("db.stage", 1_100, 1_200)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, "r1")


### PR DESCRIPTION
### Motivation
- Fix a semantic mismatch between native core capture (which preserves `Outcome::Other(String)`) and tracing import (which previously enforced a closed allowlist), so custom outcome labels from tracing instrumentation survive import. 
- Make tracing intake behavior practical for real services by accepting arbitrary non-empty outcome labels while preserving existing strict/non-strict error semantics.

### Description
- Update the tracing importer `parse_outcome` in `tailtriage-tracing/src/lib.rs` to accept any string value where `value.trim().is_empty()` is false, reject empty/whitespace-only strings, and keep non-string values invalid while preserving the provided string exactly without trimming or normalization. 
- Replace the closed allowlist constants/messages wording with a test-only `RECOMMENDED_OUTCOME_LABELS` constant and updated messages that no longer imply a closed enum; leave built-in labels (`ok`, `error`, `timeout`, `cancelled`, `rejected`) as recommended common labels. 
- Add focused tests in `tailtriage-tracing/src/lib.rs` that cover recommended built-ins, a custom outcome (`cache_miss_fallback`), missing defaults (defaults to `ok` and warns), whitespace-only rejection (non-strict warn+skip, strict fail), non-string rejection (non-strict warn+skip, strict fail), and an `Outcome::Other(

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15c01c59308330b53e7809dfa0dea8)