### PR TITLE
Allow custom tt.outcome labels in tracing import

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -168,6 +168,7 @@ Analyzer configuration contract:
 - CLI imports that wrapper shape with:
   `tailtriage import tracing-json <completed-spans.jsonl> --service <service> --output <run.json>`
 - tracing intake converts request/stage/queue evidence into the same standard `Run` schema; analyzer semantics remain unchanged
+- request `tt.outcome` is optional; missing defaults to `ok` with a warning, recommended common labels are `ok`/`error`/`timeout`/`cancelled`/`rejected`, and custom non-empty string labels are preserved exactly
 - `tracing_subscriber::fmt().json()` arbitrary log scraping is intentionally unsupported
 - tracing-only intake does not fabricate runtime-pressure evidence without runtime snapshots / Tokio sampler coupling
 - OTel/OTLP and tracing backend behavior are out of scope

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -92,6 +92,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```
 
 Stage and queue spans use their own `tt.stage` / `tt.queue` fields around the awaited work they measure.
+`tt.outcome` on request spans is optional: missing values default to `ok` with a warning; recommended common labels are `ok`, `error`, `timeout`, `cancelled`, and `rejected`; custom non-empty labels are preserved exactly.
 
 In service code, add `session.layer()` beside your existing tracing layers and install the resulting subscriber in the application's normal process-wide/global subscriber setup. `set_default` is scoped to the current thread and guard lifetime; service startup should install the tailtriage layer in the process-wide subscriber setup.
 

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -1191,11 +1191,12 @@ fn import_tracing_json_persists_optional_default_assumption_warnings_in_run_arti
 }
 
 #[test]
-fn import_tracing_json_invalid_outcome_non_strict_warns_and_fails_zero_request() {
+fn import_tracing_json_whitespace_outcome_non_strict_warns_and_fails_zero_request() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
-    std::fs::write(&spans_path, invalid_outcome_only_fixture()).expect("fixture should write");
+    std::fs::write(&spans_path, invalid_whitespace_outcome_only_fixture())
+        .expect("fixture should write");
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
         .arg("tracing-json")
@@ -1210,18 +1211,17 @@ fn import_tracing_json_invalid_outcome_non_strict_warns_and_fails_zero_request()
     assert!(!output.status.success(), "cli unexpectedly succeeded");
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
     assert!(stderr.contains("warning:"));
-    assert!(stderr.contains(
-        "invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'sucess'"
-    ));
+    assert!(stderr.contains("expected non-empty, non-whitespace string"));
     assert!(stderr.contains("zero request events"));
 }
 
 #[test]
-fn import_tracing_json_invalid_outcome_strict_fails_with_message() {
+fn import_tracing_json_whitespace_outcome_strict_fails_with_message() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
-    std::fs::write(&spans_path, invalid_outcome_only_fixture()).expect("fixture should write");
+    std::fs::write(&spans_path, invalid_whitespace_outcome_only_fixture())
+        .expect("fixture should write");
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
         .arg("tracing-json")
@@ -1236,9 +1236,7 @@ fn import_tracing_json_invalid_outcome_strict_fails_with_message() {
 
     assert!(!output.status.success(), "cli unexpectedly succeeded");
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
-    assert!(stderr.contains(
-        "invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'sucess'"
-    ));
+    assert!(stderr.contains("expected non-empty, non-whitespace string"));
 }
 
 #[test]
@@ -1354,8 +1352,8 @@ fn mixed_valid_and_unknown_kind_fixture() -> &'static str {
 "#
 }
 
-fn invalid_outcome_only_fixture() -> &'static str {
-    r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"sucess"}}}
+fn invalid_whitespace_outcome_only_fixture() -> &'static str {
+    r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":" "}}}
 "#
 }
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -117,11 +117,12 @@ Ordinary tracing log JSON (for example `fmt().json` output) is rejected by impor
 
 | Span kind | Required fields | Optional fields |
 | --- | --- | --- |
-| request | `tt.kind="request"`, `tt.request_id`, `tt.route` | `tt.outcome` (`ok`, `error`, `timeout`, `cancelled`, or `rejected`) |
+| request | `tt.kind="request"`, `tt.request_id`, `tt.route` | `tt.outcome` (optional non-empty string; recommended common labels: `ok`, `error`, `timeout`, `cancelled`, `rejected`) |
 | stage | `tt.kind="stage"`, `tt.request_id`, `tt.stage` | `tt.success` |
 | queue | `tt.kind="queue"`, `tt.request_id`, `tt.queue` | `tt.depth_at_start` |
 
 Missing request `tt.outcome` defaults to `ok` with a warning.
+If present, request `tt.outcome` must be a string and cannot be empty/whitespace-only; accepted custom labels are preserved exactly.
 Missing stage `tt.success` defaults to `true` with a warning.
 
 ## Strict vs non-strict

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -797,8 +797,8 @@ fn strict_or_warn(
     Ok(())
 }
 
-const ACCEPTED_OUTCOME_LABELS: [&str; 5] = ["ok", "error", "timeout", "cancelled", "rejected"];
-const ACCEPTED_OUTCOME_LABELS_CSV: &str = "ok,error,timeout,cancelled,rejected";
+#[cfg(test)]
+const RECOMMENDED_OUTCOME_LABELS: [&str; 5] = ["ok", "error", "timeout", "cancelled", "rejected"];
 
 fn parse_outcome(
     span: &SpanRecord,
@@ -808,18 +808,18 @@ fn parse_outcome(
     match get_string_field_state(span, TT_OUTCOME) {
         StringFieldState::Missing => Ok(Some(("ok".to_owned(), true))),
         StringFieldState::Value(value) => {
-            if ACCEPTED_OUTCOME_LABELS.contains(&value) {
-                Ok(Some((value.to_owned(), false)))
-            } else {
+            if value.trim().is_empty() {
                 strict_or_warn(
                     strict,
                     warnings,
                     format!(
-                        "invalid field '{TT_OUTCOME}' in span '{}': expected one of {ACCEPTED_OUTCOME_LABELS_CSV}, got '{value}'",
+                        "invalid field '{TT_OUTCOME}' in span '{}': expected non-empty, non-whitespace string",
                         span.name()
                     ),
                 )?;
                 Ok(None)
+            } else {
+                Ok(Some((value.to_owned(), false)))
             }
         }
         StringFieldState::InvalidType => {
@@ -2067,8 +2067,8 @@ mod tests {
     }
 
     #[test]
-    fn accepted_request_outcomes_are_retained_exactly() {
-        let spans = ACCEPTED_OUTCOME_LABELS
+    fn builtin_request_outcomes_are_retained_exactly() {
+        let spans = RECOMMENDED_OUTCOME_LABELS
             .iter()
             .enumerate()
             .map(|(idx, outcome)| {
@@ -2086,7 +2086,7 @@ mod tests {
             .iter()
             .map(|request| request.outcome.as_str())
             .collect::<Vec<_>>();
-        assert_eq!(retained, ACCEPTED_OUTCOME_LABELS);
+        assert_eq!(retained, RECOMMENDED_OUTCOME_LABELS);
     }
 
     #[test]
@@ -2104,55 +2104,94 @@ mod tests {
     }
 
     #[test]
-    fn invalid_outcome_non_strict_skips_request_and_warns() {
+    fn custom_outcome_is_accepted_and_preserved_exactly() {
         let spans = vec![SpanRecord::new("http.request", 1, 2)
             .field(TT_KIND, "request")
             .field(TT_REQUEST_ID, "r1")
             .field(TT_ROUTE, "/")
-            .field(TT_OUTCOME, "sucess")];
+            .field(TT_OUTCOME, "cache_miss_fallback")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().requests.is_empty());
-        assert!(imported.warnings().iter().any(|w| w.message().contains(
-            "invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'sucess'"
-        )));
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].outcome, "cache_miss_fallback");
     }
 
     #[test]
-    fn invalid_outcome_strict_fails() {
+    fn whitespace_only_outcome_non_strict_skips_request_and_warns() {
         let spans = vec![SpanRecord::new("http.request", 1, 2)
             .field(TT_KIND, "request")
             .field(TT_REQUEST_ID, "r1")
             .field(TT_ROUTE, "/")
-            .field(TT_OUTCOME, "sucess")];
+            .field(TT_OUTCOME, "   ")];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("invalid field 'tt.outcome' in span 'http.request': expected non-empty, non-whitespace string")));
+    }
+
+    #[test]
+    fn whitespace_only_outcome_strict_fails() {
+        let spans = vec![SpanRecord::new("http.request", 1, 2)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")
+            .field(TT_OUTCOME, " \t")];
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
         assert!(matches!(err, ImportError::StrictViolation(_)));
-        assert!(err.to_string().contains(
-            "invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'sucess'"
-        ));
+        assert!(err
+            .to_string()
+            .contains("invalid field 'tt.outcome' in span 'http.request': expected non-empty, non-whitespace string"));
     }
 
     #[test]
-    fn invalid_outcome_with_whitespace_is_rejected() {
+    fn non_string_outcome_non_strict_skips_request_and_warns() {
         let spans = vec![SpanRecord::new("http.request", 1, 2)
             .field(TT_KIND, "request")
             .field(TT_REQUEST_ID, "r1")
             .field(TT_ROUTE, "/")
-            .field(TT_OUTCOME, "ok ")];
+            .field(TT_OUTCOME, 42_u64)];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(imported.run().requests.is_empty());
-        assert!(imported.warnings().iter().any(|w| w.message().contains(
-            "invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'ok '"
-        )));
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("invalid field 'tt.outcome' in span 'http.request': expected string")));
     }
 
     #[test]
-    fn invalid_outcome_skips_child_spans_via_existing_correlation_logic() {
+    fn non_string_outcome_strict_fails() {
+        let spans = vec![SpanRecord::new("http.request", 1, 2)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")
+            .field(TT_OUTCOME, false)];
+        let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(err
+            .to_string()
+            .contains("invalid field 'tt.outcome' in span 'http.request': expected string"));
+    }
+
+    #[test]
+    fn native_other_outcome_round_trips_through_tracing_style_outcome_field() {
+        let native = tailtriage_core::Outcome::Other("custom".to_owned());
+        let spans = vec![SpanRecord::new("http.request", 1, 2)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")
+            .field(TT_OUTCOME, native.as_str())];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].outcome, native.as_str());
+    }
+
+    #[test]
+    fn invalid_whitespace_outcome_skips_child_spans_via_existing_correlation_logic() {
         let spans = vec![
             SpanRecord::new("http.request", 1_000, 2_000)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/")
-                .field(TT_OUTCOME, "sucess"),
+                .field(TT_OUTCOME, "   "),
             SpanRecord::new("db.stage", 1_100, 1_200)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, "r1")


### PR DESCRIPTION
### Motivation
- Tracing intake previously enforced a closed allowlist for `tt.outcome`, which dropped or rejected custom non-empty labels that native capture preserved as `Outcome::Other(String)`.
- The intent is to make tracing import preserve any developer-provided non-empty outcome label while keeping built-in labels as recommended defaults.

### Description
- Relaxed `parse_outcome` in `tailtriage-tracing/src/lib.rs` to accept any non-empty, non-whitespace string and preserve it exactly, while maintaining existing behavior for missing and non-string values.
- Replaced the closed allowlist constant with a test-only `RECOMMENDED_OUTCOME_LABELS` name to avoid implying `tt.outcome` is a closed enum.
- Updated and added focused tests in `tailtriage-tracing/src/lib.rs` to cover built-in labels, custom labels (e.g. `cache_miss_fallback`), whitespace-only rejection (strict and non-strict), non-string rejection (strict and non-strict), and a native `Outcome::Other` round-trip through tracing intake.
- Adjusted CLI boundary tests in `tailtriage-cli/tests/cli_boundary.rs` to reflect the new whitespace-only invalidation semantics and updated error expectations.
- Updated user-facing docs in `tailtriage-tracing/README.md`, `docs/user-guide.md`, and `SPEC.md` to document that `tt.outcome` is optional, missing defaults to `ok` with a warning, built-in labels are recommended, and custom non-empty labels are preserved.

### Testing
- Ran formatting and linting: `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings` and both passed.
- Ran the full test suite: `cargo test --workspace` completed successfully with all tests passing.
- Ran tracing crate feature tests: `cargo test -p tailtriage-tracing --all-features` completed successfully with all tests passing.
- Validated docs contract: `python3 scripts/validate_docs_contracts.py` succeeded.

Changed files
- `tailtriage-tracing/src/lib.rs`
- `tailtriage-tracing/README.md`
- `tailtriage-cli/tests/cli_boundary.rs`
- `docs/user-guide.md`
- `SPEC.md`

Exact outcome semantics
- Missing `tt.outcome` → defaults to `"ok"` and emits the existing warning.
- `tt.outcome` must be a string; non-string values are invalid and are warned-and-skipped in non-strict mode or fail in strict mode.
- Any string where `value.trim().is_empty()` is false is accepted and stored exactly as provided (no trimming or normalization), including custom labels.
- Empty or whitespace-only strings remain invalid and are treated as described above.

Tests added/updated
- New/updated tests in `tailtriage-tracing/src/lib.rs` for built-in labels, custom label preservation, whitespace-only rejection (non-strict & strict), non-string rejection (non-strict & strict), native `Outcome::Other` round-trip, and child-span skipping behavior when the request outcome is invalid.
- Updated CLI boundary tests in `tailtriage-cli/tests/cli_boundary.rs` to use a whitespace-only invalid outcome fixture and assert the updated error message.

Command results
- `cargo fmt --check` — passed.
- `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- `cargo test --workspace` — passed (all tests).
- `cargo test -p tailtriage-tracing --all-features` — passed (all tests).
- `python3 scripts/validate_docs_contracts.py` — passed.

Remaining limitations
- `tt.outcome` still must be a typed string in tracing intake; numeric/bool outcomes remain invalid by design.
- The change preserves custom labels verbatim but does not otherwise normalize or recommend a custom labeling scheme beyond documenting recommended common labels.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15c01c59308330b53e7809dfa0dea8)