### PR TITLE
Accept custom tracing outcomes and validate non-empty outcome strings

### DIFF
--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -1191,11 +1191,11 @@ fn import_tracing_json_persists_optional_default_assumption_warnings_in_run_arti
 }
 
 #[test]
-fn import_tracing_json_invalid_outcome_non_strict_warns_and_fails_zero_request() {
+fn import_tracing_json_whitespace_outcome_non_strict_warns_and_fails_zero_request() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
-    std::fs::write(&spans_path, invalid_outcome_only_fixture()).expect("fixture should write");
+    std::fs::write(&spans_path, whitespace_outcome_only_fixture()).expect("fixture should write");
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
         .arg("tracing-json")
@@ -1211,17 +1211,17 @@ fn import_tracing_json_invalid_outcome_non_strict_warns_and_fails_zero_request()
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
     assert!(stderr.contains("warning:"));
     assert!(stderr.contains(
-        "invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'sucess'"
+        "invalid field 'tt.outcome' in span 'http.request': expected non-empty, non-whitespace string"
     ));
     assert!(stderr.contains("zero request events"));
 }
 
 #[test]
-fn import_tracing_json_invalid_outcome_strict_fails_with_message() {
+fn import_tracing_json_whitespace_outcome_strict_fails_with_message() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
-    std::fs::write(&spans_path, invalid_outcome_only_fixture()).expect("fixture should write");
+    std::fs::write(&spans_path, whitespace_outcome_only_fixture()).expect("fixture should write");
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
         .arg("tracing-json")
@@ -1237,7 +1237,7 @@ fn import_tracing_json_invalid_outcome_strict_fails_with_message() {
     assert!(!output.status.success(), "cli unexpectedly succeeded");
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
     assert!(stderr.contains(
-        "invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'sucess'"
+        "invalid field 'tt.outcome' in span 'http.request': expected non-empty, non-whitespace string"
     ));
 }
 
@@ -1354,8 +1354,8 @@ fn mixed_valid_and_unknown_kind_fixture() -> &'static str {
 "#
 }
 
-fn invalid_outcome_only_fixture() -> &'static str {
-    r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"sucess"}}}
+fn whitespace_outcome_only_fixture() -> &'static str {
+    r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":" "}}}
 "#
 }
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -117,11 +117,11 @@ Ordinary tracing log JSON (for example `fmt().json` output) is rejected by impor
 
 | Span kind | Required fields | Optional fields |
 | --- | --- | --- |
-| request | `tt.kind="request"`, `tt.request_id`, `tt.route` | `tt.outcome` (`ok`, `error`, `timeout`, `cancelled`, or `rejected`) |
+| request | `tt.kind="request"`, `tt.request_id`, `tt.route` | `tt.outcome` (recommended: `ok`, `error`, `timeout`, `cancelled`, `rejected`; custom non-empty labels are allowed and preserved) |
 | stage | `tt.kind="stage"`, `tt.request_id`, `tt.stage` | `tt.success` |
 | queue | `tt.kind="queue"`, `tt.request_id`, `tt.queue` | `tt.depth_at_start` |
 
-Missing request `tt.outcome` defaults to `ok` with a warning.
+`tt.outcome` is optional. Missing request `tt.outcome` defaults to `ok` with a warning. Empty/whitespace-only values are invalid, and custom non-empty labels are preserved exactly.
 Missing stage `tt.success` defaults to `true` with a warning.
 
 ## Strict vs non-strict

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -797,8 +797,8 @@ fn strict_or_warn(
     Ok(())
 }
 
-const ACCEPTED_OUTCOME_LABELS: [&str; 5] = ["ok", "error", "timeout", "cancelled", "rejected"];
-const ACCEPTED_OUTCOME_LABELS_CSV: &str = "ok,error,timeout,cancelled,rejected";
+#[cfg(test)]
+const RECOMMENDED_OUTCOME_LABELS: [&str; 5] = ["ok", "error", "timeout", "cancelled", "rejected"];
 
 fn parse_outcome(
     span: &SpanRecord,
@@ -808,19 +808,18 @@ fn parse_outcome(
     match get_string_field_state(span, TT_OUTCOME) {
         StringFieldState::Missing => Ok(Some(("ok".to_owned(), true))),
         StringFieldState::Value(value) => {
-            if ACCEPTED_OUTCOME_LABELS.contains(&value) {
-                Ok(Some((value.to_owned(), false)))
-            } else {
+            if value.trim().is_empty() {
                 strict_or_warn(
                     strict,
                     warnings,
                     format!(
-                        "invalid field '{TT_OUTCOME}' in span '{}': expected one of {ACCEPTED_OUTCOME_LABELS_CSV}, got '{value}'",
+                        "invalid field '{TT_OUTCOME}' in span '{}': expected non-empty, non-whitespace string",
                         span.name()
                     ),
                 )?;
-                Ok(None)
+                return Ok(None);
             }
+            Ok(Some((value.to_owned(), false)))
         }
         StringFieldState::InvalidType => {
             strict_or_warn(
@@ -2068,7 +2067,7 @@ mod tests {
 
     #[test]
     fn accepted_request_outcomes_are_retained_exactly() {
-        let spans = ACCEPTED_OUTCOME_LABELS
+        let spans = RECOMMENDED_OUTCOME_LABELS
             .iter()
             .enumerate()
             .map(|(idx, outcome)| {
@@ -2086,7 +2085,18 @@ mod tests {
             .iter()
             .map(|request| request.outcome.as_str())
             .collect::<Vec<_>>();
-        assert_eq!(retained, ACCEPTED_OUTCOME_LABELS);
+        assert_eq!(retained, RECOMMENDED_OUTCOME_LABELS);
+    }
+
+    #[test]
+    fn custom_outcome_is_retained_exactly() {
+        let spans = vec![SpanRecord::new("http.request", 1, 2)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")
+            .field(TT_OUTCOME, "cache_miss_fallback")];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests[0].outcome, "cache_miss_fallback");
     }
 
     #[test]
@@ -2096,7 +2106,6 @@ mod tests {
             .field(TT_REQUEST_ID, "r1")
             .field(TT_ROUTE, "/")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests.len(), 1);
         assert_eq!(imported.run().requests[0].outcome, "ok");
         assert!(imported.warnings().iter().any(|w| w
             .message()
@@ -2104,55 +2113,80 @@ mod tests {
     }
 
     #[test]
-    fn invalid_outcome_non_strict_skips_request_and_warns() {
+    fn whitespace_only_outcome_non_strict_skips_request_and_warns() {
         let spans = vec![SpanRecord::new("http.request", 1, 2)
             .field(TT_KIND, "request")
             .field(TT_REQUEST_ID, "r1")
             .field(TT_ROUTE, "/")
-            .field(TT_OUTCOME, "sucess")];
+            .field(TT_OUTCOME, "   ")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(imported.run().requests.is_empty());
         assert!(imported.warnings().iter().any(|w| w.message().contains(
-            "invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'sucess'"
+            "invalid field 'tt.outcome' in span 'http.request': expected non-empty, non-whitespace string"
         )));
     }
 
     #[test]
-    fn invalid_outcome_strict_fails() {
+    fn whitespace_only_outcome_strict_fails() {
         let spans = vec![SpanRecord::new("http.request", 1, 2)
             .field(TT_KIND, "request")
             .field(TT_REQUEST_ID, "r1")
             .field(TT_ROUTE, "/")
-            .field(TT_OUTCOME, "sucess")];
+            .field(TT_OUTCOME, "	")];
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
         assert!(matches!(err, ImportError::StrictViolation(_)));
         assert!(err.to_string().contains(
-            "invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'sucess'"
+            "invalid field 'tt.outcome' in span 'http.request': expected non-empty, non-whitespace string"
         ));
     }
 
     #[test]
-    fn invalid_outcome_with_whitespace_is_rejected() {
+    fn non_string_outcome_non_strict_skips_request_and_warns() {
         let spans = vec![SpanRecord::new("http.request", 1, 2)
             .field(TT_KIND, "request")
             .field(TT_REQUEST_ID, "r1")
             .field(TT_ROUTE, "/")
-            .field(TT_OUTCOME, "ok ")];
+            .field(TT_OUTCOME, 7_u64)];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(imported.run().requests.is_empty());
-        assert!(imported.warnings().iter().any(|w| w.message().contains(
-            "invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'ok '"
-        )));
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("invalid field 'tt.outcome' in span 'http.request': expected string")));
     }
 
     #[test]
-    fn invalid_outcome_skips_child_spans_via_existing_correlation_logic() {
+    fn non_string_outcome_strict_fails() {
+        let spans = vec![SpanRecord::new("http.request", 1, 2)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")
+            .field(TT_OUTCOME, false)];
+        let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(err
+            .to_string()
+            .contains("invalid field 'tt.outcome' in span 'http.request': expected string"));
+    }
+
+    #[test]
+    fn core_other_outcome_round_trips_through_tracing_import() {
+        let custom = tailtriage_core::Outcome::Other("custom".to_owned());
+        let spans = vec![SpanRecord::new("http.request", 1, 2)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")
+            .field(TT_OUTCOME, custom.as_str())];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests[0].outcome, custom.as_str());
+    }
+    #[test]
+    fn invalid_whitespace_outcome_skips_child_spans_via_existing_correlation_logic() {
         let spans = vec![
             SpanRecord::new("http.request", 1_000, 2_000)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/")
-                .field(TT_OUTCOME, "sucess"),
+                .field(TT_OUTCOME, " "),
             SpanRecord::new("db.stage", 1_100, 1_200)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, "r1")


### PR DESCRIPTION
### Motivation
- Native capture preserves custom outcome labels via `tailtriage_core::Outcome::Other(String)` but the tracing import enforced a closed allowlist, causing custom labels to be dropped or rejected. 
- The change aligns tracing intake semantics with native capture so custom non-empty outcome labels survive import and analysis. 

### Description
- Relaxed `parse_outcome` in `tailtriage-tracing/src/lib.rs` to accept any string value whose `trim()` is non-empty and preserve the exact provided string; empty/whitespace-only and non-string values remain invalid and retain existing strict/non-strict behavior. 
- Renamed the prior allowlist constant to `RECOMMENDED_OUTCOME_LABELS` and marked it test-only to clarify those labels are recommended, not enforced. 
- Updated docs to state `tt.outcome` is optional, missing defaults to `ok` with a warning, built-ins are recommended, and custom non-empty labels are preserved. 
- Added focused tests in `tailtriage-tracing` and adjusted CLI boundary tests to match the new semantics. 
- Changed files: `tailtriage-tracing/src/lib.rs`, `tailtriage-tracing/README.md`, and `tailtriage-cli/tests/cli_boundary.rs`. 
- Exact outcome semantics after this change: any accepted `tt.outcome` must be a string and must not be empty or whitespace-only; missing outcome defaults to `"ok"` with the existing warning; accepted custom strings are preserved exactly (no trimming/normalization); built-ins `ok,error,timeout,cancelled,rejected` remain recommended labels. 

### Testing
- Tests added/updated: new/adjusted unit tests in `tailtriage-tracing/src/lib.rs` covering built-in labels, a custom label (`cache_miss_fallback`) retained exactly, missing outcome default/warning, whitespace-only outcome rejected (non-strict warn/skip and strict fail), non-string outcome rejected (non-strict warn/skip and strict fail), and a round-trip test for `tailtriage_core::Outcome::Other("custom")`; `tailtriage-cli/tests/cli_boundary.rs` updated to reflect whitespace-only outcome fixture. 
- Commands run and results: `cargo fmt --check` (passed), `cargo clippy --workspace --all-targets -- -D warnings` (passed), `cargo test --workspace` (passed; full workspace), `cargo test -p tailtriage-tracing --all-features` (passed), and `python3 scripts/validate_docs_contracts.py` (docs validated successfully). 
- All unit and integration tests in the workspace passed after changes. 
- Remaining limitations: outcome values are intentionally free-form non-empty strings so downstream tooling/analysis must interpret uncommon custom labels by name (the analyzer logic was not changed beyond preserving the label).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15c01c59308330b53e7809dfa0dea8)