### PR TITLE
Accept custom tracing `tt.outcome` labels

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -168,6 +168,8 @@ Analyzer configuration contract:
 - CLI imports that wrapper shape with:
   `tailtriage import tracing-json <completed-spans.jsonl> --service <service> --output <run.json>`
 - tracing intake converts request/stage/queue evidence into the same standard `Run` schema; analyzer semantics remain unchanged
+- request `tt.outcome` is optional; when missing, import defaults to `ok` with a warning
+- recommended outcome labels for common cases are `ok`, `error`, `timeout`, `cancelled`, and `rejected`; custom non-empty labels are accepted and preserved exactly
 - `tracing_subscriber::fmt().json()` arbitrary log scraping is intentionally unsupported
 - tracing-only intake does not fabricate runtime-pressure evidence without runtime snapshots / Tokio sampler coupling
 - OTel/OTLP and tracing backend behavior are out of scope

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -93,6 +93,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 Stage and queue spans use their own `tt.stage` / `tt.queue` fields around the awaited work they measure.
 
+`tt.outcome` is optional on request spans. Missing `tt.outcome` defaults to `ok` with a warning; recommended common labels are `ok`, `error`, `timeout`, `cancelled`, and `rejected`, and custom non-empty labels are preserved exactly as provided.
+
 In service code, add `session.layer()` beside your existing tracing layers and install the resulting subscriber in the application's normal process-wide/global subscriber setup. `set_default` is scoped to the current thread and guard lifetime; service startup should install the tailtriage layer in the process-wide subscriber setup.
 
 Then analyze directly:

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -1191,11 +1191,12 @@ fn import_tracing_json_persists_optional_default_assumption_warnings_in_run_arti
 }
 
 #[test]
-fn import_tracing_json_invalid_outcome_non_strict_warns_and_fails_zero_request() {
+fn import_tracing_json_whitespace_outcome_non_strict_warns_and_fails_zero_request() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
-    std::fs::write(&spans_path, invalid_outcome_only_fixture()).expect("fixture should write");
+    std::fs::write(&spans_path, invalid_whitespace_outcome_only_fixture())
+        .expect("fixture should write");
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
         .arg("tracing-json")
@@ -1211,17 +1212,18 @@ fn import_tracing_json_invalid_outcome_non_strict_warns_and_fails_zero_request()
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
     assert!(stderr.contains("warning:"));
     assert!(stderr.contains(
-        "invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'sucess'"
+        "invalid field 'tt.outcome' in span 'http.request': cannot be empty or whitespace"
     ));
     assert!(stderr.contains("zero request events"));
 }
 
 #[test]
-fn import_tracing_json_invalid_outcome_strict_fails_with_message() {
+fn import_tracing_json_whitespace_outcome_strict_fails_with_message() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
-    std::fs::write(&spans_path, invalid_outcome_only_fixture()).expect("fixture should write");
+    std::fs::write(&spans_path, invalid_whitespace_outcome_only_fixture())
+        .expect("fixture should write");
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
         .arg("tracing-json")
@@ -1237,7 +1239,7 @@ fn import_tracing_json_invalid_outcome_strict_fails_with_message() {
     assert!(!output.status.success(), "cli unexpectedly succeeded");
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
     assert!(stderr.contains(
-        "invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'sucess'"
+        "invalid field 'tt.outcome' in span 'http.request': cannot be empty or whitespace"
     ));
 }
 
@@ -1269,12 +1271,20 @@ fn import_tracing_json_valid_outcomes_import_successfully() {
         .collect::<Vec<_>>();
     assert_eq!(
         outcomes,
-        vec!["ok", "error", "timeout", "cancelled", "rejected"]
+        vec![
+            "ok",
+            "error",
+            "timeout",
+            "cancelled",
+            "rejected",
+            "cache_miss_fallback"
+        ]
     );
 }
 
 fn valid_cli_artifact_with_requests() -> &'static str {
-    r#"{"schema_version":1,"metadata":{"run_id":"r1","service_name":"svc","service_version":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"mode":"light","host":null,"pid":null,"lifecycle_warnings":[],"unfinished_requests":{"count":0,"sample":[]}},"requests":[{"request_id":"req1","route":"/","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":10,"outcome":"ok"}],"stages":[],"queues":[],"inflight":[],"runtime_snapshots":[]}"#
+    r#"{"schema_version":1,"metadata":{"run_id":"r1","service_name":"svc","service_version":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"mode":"light","host":null,"pid":null,"lifecycle_warnings":[],"unfinished_requests":{"count":0,"sample":[]}},"requests":[{"request_id":"req1","route":"/","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":10,"outcome":"ok"}],"stages":[],"queues":[],"inflight":[],"runtime_snapshots":[]}
+"#
 }
 
 fn missing_optional_defaults_fixture() -> &'static str {
@@ -1354,8 +1364,8 @@ fn mixed_valid_and_unknown_kind_fixture() -> &'static str {
 "#
 }
 
-fn invalid_outcome_only_fixture() -> &'static str {
-    r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"sucess"}}}
+fn invalid_whitespace_outcome_only_fixture() -> &'static str {
+    r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"   "}}}
 "#
 }
 
@@ -1365,5 +1375,6 @@ fn valid_outcomes_fixture() -> &'static str {
 {"format":"tailtriage.tracing-span.v1","span":{"name":"http.request-3","started_at_unix_ms":1020,"finished_at_unix_ms":1030,"fields":{"tt.kind":"request","tt.request_id":"req-3","tt.route":"/checkout","tt.outcome":"timeout"}}}
 {"format":"tailtriage.tracing-span.v1","span":{"name":"http.request-4","started_at_unix_ms":1030,"finished_at_unix_ms":1040,"fields":{"tt.kind":"request","tt.request_id":"req-4","tt.route":"/checkout","tt.outcome":"cancelled"}}}
 {"format":"tailtriage.tracing-span.v1","span":{"name":"http.request-5","started_at_unix_ms":1040,"finished_at_unix_ms":1050,"fields":{"tt.kind":"request","tt.request_id":"req-5","tt.route":"/checkout","tt.outcome":"rejected"}}}
+{"format":"tailtriage.tracing-span.v1","span":{"name":"http.request-6","started_at_unix_ms":1050,"finished_at_unix_ms":1060,"fields":{"tt.kind":"request","tt.request_id":"req-6","tt.route":"/checkout","tt.outcome":"cache_miss_fallback"}}}
 "#
 }

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -117,11 +117,11 @@ Ordinary tracing log JSON (for example `fmt().json` output) is rejected by impor
 
 | Span kind | Required fields | Optional fields |
 | --- | --- | --- |
-| request | `tt.kind="request"`, `tt.request_id`, `tt.route` | `tt.outcome` (`ok`, `error`, `timeout`, `cancelled`, or `rejected`) |
+| request | `tt.kind="request"`, `tt.request_id`, `tt.route` | optional `tt.outcome` (recommended: `ok`, `error`, `timeout`, `cancelled`, `rejected`; custom non-empty labels allowed) |
 | stage | `tt.kind="stage"`, `tt.request_id`, `tt.stage` | `tt.success` |
 | queue | `tt.kind="queue"`, `tt.request_id`, `tt.queue` | `tt.depth_at_start` |
 
-Missing request `tt.outcome` defaults to `ok` with a warning.
+`tt.outcome` is optional. Missing request `tt.outcome` defaults to `ok` with a warning. Custom non-empty labels are preserved exactly as provided.
 Missing stage `tt.success` defaults to `true` with a warning.
 
 ## Strict vs non-strict

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -797,8 +797,8 @@ fn strict_or_warn(
     Ok(())
 }
 
+#[cfg(test)]
 const ACCEPTED_OUTCOME_LABELS: [&str; 5] = ["ok", "error", "timeout", "cancelled", "rejected"];
-const ACCEPTED_OUTCOME_LABELS_CSV: &str = "ok,error,timeout,cancelled,rejected";
 
 fn parse_outcome(
     span: &SpanRecord,
@@ -808,18 +808,18 @@ fn parse_outcome(
     match get_string_field_state(span, TT_OUTCOME) {
         StringFieldState::Missing => Ok(Some(("ok".to_owned(), true))),
         StringFieldState::Value(value) => {
-            if ACCEPTED_OUTCOME_LABELS.contains(&value) {
-                Ok(Some((value.to_owned(), false)))
-            } else {
+            if value.trim().is_empty() {
                 strict_or_warn(
                     strict,
                     warnings,
                     format!(
-                        "invalid field '{TT_OUTCOME}' in span '{}': expected one of {ACCEPTED_OUTCOME_LABELS_CSV}, got '{value}'",
+                        "invalid field '{TT_OUTCOME}' in span '{}': cannot be empty or whitespace",
                         span.name()
                     ),
                 )?;
                 Ok(None)
+            } else {
+                Ok(Some((value.to_owned(), false)))
             }
         }
         StringFieldState::InvalidType => {
@@ -2104,45 +2104,85 @@ mod tests {
     }
 
     #[test]
-    fn invalid_outcome_non_strict_skips_request_and_warns() {
+    fn custom_outcome_non_strict_is_accepted_and_preserved() {
         let spans = vec![SpanRecord::new("http.request", 1, 2)
             .field(TT_KIND, "request")
             .field(TT_REQUEST_ID, "r1")
             .field(TT_ROUTE, "/")
-            .field(TT_OUTCOME, "sucess")];
+            .field(TT_OUTCOME, "cache_miss_fallback")];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].outcome, "cache_miss_fallback");
+    }
+
+    #[test]
+    fn whitespace_only_outcome_non_strict_skips_request_and_warns() {
+        let spans = vec![SpanRecord::new("http.request", 1, 2)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")
+            .field(TT_OUTCOME, "   ")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(imported.run().requests.is_empty());
         assert!(imported.warnings().iter().any(|w| w.message().contains(
-            "invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'sucess'"
+            "invalid field 'tt.outcome' in span 'http.request': cannot be empty or whitespace"
         )));
     }
 
     #[test]
-    fn invalid_outcome_strict_fails() {
+    fn whitespace_only_outcome_strict_fails() {
         let spans = vec![SpanRecord::new("http.request", 1, 2)
             .field(TT_KIND, "request")
             .field(TT_REQUEST_ID, "r1")
             .field(TT_ROUTE, "/")
-            .field(TT_OUTCOME, "sucess")];
+            .field(TT_OUTCOME, "\t")];
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
         assert!(matches!(err, ImportError::StrictViolation(_)));
         assert!(err.to_string().contains(
-            "invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'sucess'"
+            "invalid field 'tt.outcome' in span 'http.request': cannot be empty or whitespace"
         ));
     }
 
     #[test]
-    fn invalid_outcome_with_whitespace_is_rejected() {
+    fn invalid_outcome_non_string_non_strict_skips_request_and_warns() {
         let spans = vec![SpanRecord::new("http.request", 1, 2)
             .field(TT_KIND, "request")
             .field(TT_REQUEST_ID, "r1")
             .field(TT_ROUTE, "/")
-            .field(TT_OUTCOME, "ok ")];
+            .field(TT_OUTCOME, 7_u64)];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(imported.run().requests.is_empty());
-        assert!(imported.warnings().iter().any(|w| w.message().contains(
-            "invalid field 'tt.outcome' in span 'http.request': expected one of ok,error,timeout,cancelled,rejected, got 'ok '"
-        )));
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("invalid field 'tt.outcome' in span 'http.request': expected string")));
+    }
+
+    #[test]
+    fn invalid_outcome_non_string_strict_fails() {
+        let spans = vec![SpanRecord::new("http.request", 1, 2)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")
+            .field(TT_OUTCOME, false)];
+        let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(err
+            .to_string()
+            .contains("invalid field 'tt.outcome' in span 'http.request': expected string"));
+    }
+
+    #[test]
+    fn custom_outcome_round_trips_through_tracing_import() {
+        let spans = vec![SpanRecord::new("req", 1, 2)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/")
+            .field(
+                TT_OUTCOME,
+                tailtriage_core::Outcome::Other("custom".into()).as_str(),
+            )];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests[0].outcome, "custom");
     }
 
     #[test]
@@ -2152,7 +2192,7 @@ mod tests {
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/")
-                .field(TT_OUTCOME, "sucess"),
+                .field(TT_OUTCOME, "   "),
             SpanRecord::new("db.stage", 1_100, 1_200)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, "r1")


### PR DESCRIPTION
### Motivation

- Tracing intake rejected non-built-in outcome labels, causing a semantic mismatch with native capture which preserves `Outcome::Other(String)`, so imports lost custom outcome labels or failed in strict mode. 
- The intent is to allow tracing import to accept any non-empty outcome string while preserving existing strict/non-strict validation behavior and defaulting missing outcomes to `ok`.

### Description

- Update `parse_outcome` in `tailtriage-tracing/src/lib.rs` to accept any string where `value.trim().is_empty()` is false and to reject empty/whitespace-only strings, preserving non-string invalid-type behavior. 
- Remove the closed allowlist semantics and related CSV constant, keep built-in labels (`ok`, `error`, `timeout`, `cancelled`, `rejected`) as recommended examples rather than an exclusive enum, and mark the previous allowlist constant `ACCEPTED_OUTCOME_LABELS` as `#[cfg(test)]`. 
- Updated docs and guidance in `tailtriage-tracing/README.md`, `docs/user-guide.md`, and `SPEC.md` to state that `tt.outcome` is optional, missing defaults to `ok` with a warning, built-ins are recommended, and custom non-empty labels are preserved exactly. 
- Added and adjusted focused tests in `tailtriage-tracing/src/lib.rs` and `tailtriage-cli/tests/cli_boundary.rs` to cover built-ins, a custom outcome (`cache_miss_fallback`), whitespace-only rejection (strict and non-strict), non-string rejection (strict and non-strict), missing-outcome defaulting, and a round-trip test showing `Outcome::Other("custom")` survives tracing-style intake. 

### Testing

- Ran `cargo fmt --check` which passed, and `cargo clippy --workspace --all-targets -- -D warnings` which passed with warnings addressed. 
- Ran the full test suite with `cargo test --workspace` and the tracing crate with `cargo test -p tailtriage-tracing --all-features`, both of which completed successfully (all unit tests passed). 
- Ran the docs contract validator `python3 scripts/validate_docs_contracts.py` which returned `docs contracts validated successfully`. 
- Remaining limitations: analyzer ranking and interpretation logic were intentionally not changed so only import semantics were adjusted and the analyzer continues to operate on preserved custom labels without any change to scoring or diagnosis logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15c01c59308330b53e7809dfa0dea8)