### PR TITLE
Add deterministic Tokio sampler mode and Run JSON shutdown write for TracingTokioSession

### DIFF
--- a/demos/demo_support/src/lib.rs
+++ b/demos/demo_support/src/lib.rs
@@ -380,7 +380,9 @@ impl RuntimeDemoInstrumentation {
                 )?),
             }),
             InstrumentationMode::Tracing => {
-                let mut builder = TracingTokioSession::builder(service_name).strict(false);
+                let mut builder = TracingTokioSession::builder(service_name)
+                    .strict(false)
+                    .disable_background_sampler();
                 builder = builder.mode(capture.mode);
                 if capture.max_requests.is_some()
                     || capture.max_stages.is_some()

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -166,7 +166,7 @@ Important limits for production interpretation:
 * without runtime snapshots, executor-pressure and blocking-pool suspects can be weaker or absent
 * runtime-pressure evidence remains Tokio-specific and requires runtime snapshots or Tokio sampler coupling
 
-`TracingTokioSession` uses the same core capture-limit model as native Tokio sampling for runtime snapshot retention. For `TracingTokioSession`, run metadata time bounds cover both retained tracing evidence and retained runtime snapshots. There is no tracing-specific `max_runtime_snapshots(...)` builder method; configure explicit caps with `capture_limits_override(CaptureLimitsOverride { max_runtime_snapshots: Some(...), ..Default::default() })`. Tracing-only runs still do not fabricate runtime snapshots, so runtime-pressure evidence requires Tokio session/runtime sampler coupling.
+`TracingTokioSession` uses the same core capture-limit model as native Tokio sampling for runtime snapshot retention. For `TracingTokioSession`, run metadata time bounds cover both retained tracing evidence and retained runtime snapshots. There is no tracing-specific `max_runtime_snapshots(...)` builder method; configure explicit caps with `capture_limits_override(CaptureLimitsOverride { max_runtime_snapshots: Some(...), ..Default::default() })`. Tracing-only runs still do not fabricate runtime snapshots, so runtime-pressure evidence requires Tokio session/runtime sampler coupling. `TracingTokioSession` defaults to background sampler enabled; deterministic demos/validation can call `.disable_background_sampler()` and inject snapshots via `record_runtime_snapshot(...)`.
 
 Treat tracing-based reports the same way as other reports: evidence-ranked suspects and next checks are triage leads, not proof.
 

--- a/scripts/demo_tool.py
+++ b/scripts/demo_tool.py
@@ -1012,8 +1012,17 @@ def validate_tracing_parity(root_dir: Path, scenario: str, *, profile: str = "de
         if scenario in RUNTIME_SENSITIVE_TRACING_SCENARIOS:
             if not run.get("runtime_snapshots"):
                 raise SystemExit(f"expected runtime snapshots in tracing run {run_name}")
-            if run.get("metadata", {}).get("effective_tokio_sampler_config") is None:
-                raise SystemExit(f"expected effective_tokio_sampler_config in tracing run {run_name}")
+            metadata = run.get("metadata", {})
+            sampler_config = metadata.get("effective_tokio_sampler_config")
+            warnings = metadata.get("lifecycle_warnings", []) or []
+            disabled_manual_warning = any(
+                "background Tokio runtime sampling disabled" in warning for warning in warnings
+            )
+            if sampler_config is None and not disabled_manual_warning:
+                raise SystemExit(
+                    "expected effective_tokio_sampler_config or explicit disabled-sampler lifecycle warning "
+                    f"in tracing run {run_name}"
+                )
         if scenario in NON_RUNTIME_TRACING_SCENARIOS:
             _require_equal(
                 scenario=scenario,

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -54,3 +54,7 @@ required-features = ["live"]
 [[example]]
 name = "live_session_to_run"
 required-features = ["live"]
+
+[[example]]
+name = "tokio_session_to_run"
+required-features = ["tokio"]

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -17,7 +17,7 @@ It is **not**:
 - Base crate: typed `SpanRecord`, `ImportOptions`, `ImportedRun`, semantic constants, and `run_from_span_records(...)`.
 - Default (`jsonl`): JSONL import APIs and stable wrapper parsing.
 - `live`: enables `TracingRecorder`, `TailtriageLayer`, and `TracingIntakeSession`.
-- `tokio`: enables `TracingTokioSession` runtime-sampler coupling and includes `live`.
+- `tokio`: enables `TracingTokioSession` runtime-sampler coupling (enabled by default, disable-able for deterministic/manual snapshots) and includes `live`.
 
 CLI offline import workflows only need JSONL import support and do not require the live `tracing_subscriber` layer dependency.
 
@@ -82,7 +82,7 @@ If your service already builds a subscriber in startup code, compose `session.la
 
 ## Direct Run JSON path
 
-Use `run_json_path(...)` when you want to skip a separate import step and write Run JSON through the same robust writer path used by native capture sinks:
+Use `run_json_path(...)` when you want to skip a separate import step and write Run JSON during `TracingTokioSession::shutdown()` through the same robust writer path used by native capture sinks:
 
 ```bash
 tailtriage analyze target/tailtriage-examples/checkout.run.json
@@ -157,8 +157,11 @@ For `TracingTokioSession`, runtime snapshot retention also uses the same core ca
 - configure retention with `mode(...)`, `capture_limits(...)`, or `capture_limits_override(...)`
 - there is no tracing-specific `.max_runtime_snapshots(...)` session builder method
 - tracing-only runs still do not fabricate runtime snapshots
+- deterministic demos/validation can call `.disable_background_sampler()` and inject snapshots with `record_runtime_snapshot(...)`
+- if background sampling is disabled, lifecycle warnings explicitly mark runtime evidence as manual
 
 ## Examples
 
 - `tailtriage-tracing/examples/live_session_to_run.rs`
 - `tailtriage-tracing/examples/completed_span_jsonl_import.rs`
+- `tailtriage-tracing/examples/tokio_session_to_run.rs`

--- a/tailtriage-tracing/examples/tokio_session_to_run.rs
+++ b/tailtriage-tracing/examples/tokio_session_to_run.rs
@@ -1,0 +1,61 @@
+use std::error::Error;
+
+use tailtriage_core::RuntimeSnapshot;
+use tailtriage_tracing::tokio::TracingTokioSession;
+use tracing_subscriber::prelude::*;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let run_path = std::path::PathBuf::from("target/tailtriage-examples/tokio-run.json");
+
+    let session = TracingTokioSession::builder("checkout-service")
+        .run_json_path(&run_path)
+        .start()?;
+
+    let subscriber = tracing_subscriber::registry().with(session.layer());
+    tracing::subscriber::with_default(subscriber, || {
+        let _request = tracing::info_span!(
+            "http.request",
+            tt.kind = "request",
+            tt.request_id = "req-1",
+            tt.route = "/checkout",
+            tt.outcome = "ok"
+        )
+        .entered();
+
+        {
+            let _queue_guard = tracing::info_span!(
+                "admission.queue",
+                tt.kind = "queue",
+                tt.request_id = "req-1",
+                tt.queue = "admission",
+                tt.depth_at_start = 2_u64
+            )
+            .entered();
+        }
+        {
+            let _stage_guard = tracing::info_span!(
+                "db.stage",
+                tt.kind = "stage",
+                tt.request_id = "req-1",
+                tt.stage = "db",
+                tt.success = true
+            )
+            .entered();
+        }
+    });
+
+    session.record_runtime_snapshot(RuntimeSnapshot {
+        at_unix_ms: 1_000,
+        alive_tasks: Some(4),
+        global_queue_depth: Some(3),
+        local_queue_depth: Some(1),
+        blocking_queue_depth: Some(0),
+        remote_schedule_count: Some(7),
+    });
+
+    session.shutdown().await?;
+    println!("wrote run JSON to: {}", run_path.display());
+    println!("analyze with: tailtriage analyze {}", run_path.display());
+    Ok(())
+}

--- a/tailtriage-tracing/src/tokio.rs
+++ b/tailtriage-tracing/src/tokio.rs
@@ -1,3 +1,4 @@
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -5,10 +6,12 @@ use tailtriage_core::{
     BuildError, CaptureLimits, CaptureLimitsOverride, CaptureMode, MemorySink, Run,
     RuntimeSnapshot, Tailtriage,
 };
+use tailtriage_core::{LocalJsonSink, RunSink};
 use tailtriage_tokio::{RuntimeSampler, SamplerStartError};
 
 use crate::{
-    ImportError, ImportWarning, ImportedRun, RecorderLimits, TailtriageLayer, TracingRecorder,
+    ensure_persistable_run_has_requests, ImportError, ImportWarning, ImportedRun, RecorderLimits,
+    TailtriageLayer, TracingRecorder,
 };
 
 /// Error returned when starting [`TracingTokioSession`].
@@ -41,12 +44,22 @@ impl std::error::Error for TracingTokioSessionStartError {}
 pub enum TracingTokioSessionShutdownError {
     /// Snapshot import failed.
     Import(ImportError),
+    /// Failed to write Run JSON artifact during shutdown.
+    RunJsonWrite {
+        /// Destination path that failed.
+        path: String,
+        /// Human-readable write or parent-directory error reason.
+        reason: String,
+    },
 }
 
 impl core::fmt::Display for TracingTokioSessionShutdownError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Import(err) => write!(f, "failed to import tracing spans during shutdown: {err}"),
+            Self::RunJsonWrite { path, reason } => {
+                write!(f, "failed to write run JSON artifact at {path}: {reason}")
+            }
         }
     }
 }
@@ -58,6 +71,8 @@ impl std::error::Error for TracingTokioSessionShutdownError {}
 pub struct TracingTokioSessionBuilder {
     recorder_builder: crate::TracingRecorderBuilder,
     sampler_interval: Option<Duration>,
+    disable_background_sampler: bool,
+    run_json_path: Option<PathBuf>,
 }
 
 /// Combined tracing and Tokio runtime sampler session.
@@ -65,7 +80,9 @@ pub struct TracingTokioSessionBuilder {
 pub struct TracingTokioSession {
     recorder: TracingRecorder,
     runtime_collector: Arc<Tailtriage>,
-    sampler: RuntimeSampler,
+    sampler: Option<RuntimeSampler>,
+    run_json_path: Option<PathBuf>,
+    disable_background_sampler: bool,
 }
 
 impl TracingTokioSession {
@@ -74,6 +91,8 @@ impl TracingTokioSession {
         TracingTokioSessionBuilder {
             recorder_builder: TracingRecorder::builder(service_name),
             sampler_interval: None,
+            disable_background_sampler: false,
+            run_json_path: None,
         }
     }
 
@@ -107,13 +126,20 @@ impl TracingTokioSession {
     ///
     /// Returns [`TracingTokioSessionShutdownError::Import`] when strict span import fails.
     pub async fn shutdown(self) -> Result<ImportedRun, TracingTokioSessionShutdownError> {
-        self.sampler.shutdown().await;
+        if let Some(sampler) = self.sampler {
+            sampler.shutdown().await;
+        }
         let imported = self
             .recorder
             .snapshot_run()
             .map_err(TracingTokioSessionShutdownError::Import)?;
         let runtime = self.runtime_collector.snapshot();
-        Ok(merge_runtime_data(imported, &runtime))
+        let merged = merge_runtime_data(imported, &runtime);
+        let merged = add_runtime_sampler_mode_warnings(merged, self.disable_background_sampler);
+        if let Some(path) = self.run_json_path {
+            persist_run_json(merged.run(), &path)?;
+        }
+        Ok(merged)
     }
 }
 
@@ -188,6 +214,18 @@ impl TracingTokioSessionBuilder {
         self.sampler_interval = Some(sampler_interval);
         self
     }
+    /// Disables the background Tokio runtime sampler.
+    #[must_use]
+    pub fn disable_background_sampler(mut self) -> Self {
+        self.disable_background_sampler = true;
+        self
+    }
+    /// Writes merged Run JSON directly during shutdown.
+    #[must_use]
+    pub fn run_json_path(mut self, path: impl AsRef<Path>) -> Self {
+        self.run_json_path = Some(path.as_ref().to_path_buf());
+        self
+    }
     /// Builds the session and starts Tokio runtime sampling.
     ///
     /// # Errors
@@ -223,23 +261,71 @@ impl TracingTokioSessionBuilder {
                 .build()
                 .map_err(TracingTokioSessionStartError::Build)?,
         );
-        let sampler_builder = RuntimeSampler::builder(Arc::clone(&runtime_collector));
-        let sampler_builder = if let Some(interval) = self.sampler_interval {
-            sampler_builder.interval(interval)
+        let sampler = if self.disable_background_sampler {
+            None
         } else {
-            sampler_builder
+            let sampler_builder = RuntimeSampler::builder(Arc::clone(&runtime_collector));
+            let sampler_builder = if let Some(interval) = self.sampler_interval {
+                sampler_builder.interval(interval)
+            } else {
+                sampler_builder
+            };
+            let sampler_builder =
+                sampler_builder.max_runtime_snapshots(resolved_limits.max_runtime_snapshots);
+            Some(
+                sampler_builder
+                    .start()
+                    .map_err(TracingTokioSessionStartError::SamplerStart)?,
+            )
         };
-        let sampler_builder =
-            sampler_builder.max_runtime_snapshots(resolved_limits.max_runtime_snapshots);
-        let sampler = sampler_builder
-            .start()
-            .map_err(TracingTokioSessionStartError::SamplerStart)?;
         Ok(TracingTokioSession {
             recorder,
             runtime_collector,
             sampler,
+            run_json_path: self.run_json_path,
+            disable_background_sampler: self.disable_background_sampler,
         })
     }
+}
+
+fn persist_run_json(run: &Run, path: &Path) -> Result<(), TracingTokioSessionShutdownError> {
+    ensure_persistable_run_has_requests(run).map_err(TracingTokioSessionShutdownError::Import)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|err| {
+            TracingTokioSessionShutdownError::RunJsonWrite {
+                path: path.display().to_string(),
+                reason: format!("failed to create parent directory: {err}"),
+            }
+        })?;
+    }
+    LocalJsonSink::new(path).write(run).map_err(|err| {
+        TracingTokioSessionShutdownError::RunJsonWrite {
+            path: path.display().to_string(),
+            reason: err.to_string(),
+        }
+    })
+}
+
+fn add_runtime_sampler_mode_warnings(
+    imported: ImportedRun,
+    disable_background_sampler: bool,
+) -> ImportedRun {
+    if !disable_background_sampler {
+        return imported;
+    }
+    let (mut run, mut warnings) = imported.into_parts();
+    let warning = if run.runtime_snapshots.is_empty() {
+        "background Tokio runtime sampling disabled; runtime evidence depends on manual snapshots, but no runtime snapshots were recorded"
+    } else {
+        "background Tokio runtime sampling disabled; runtime evidence depends on manually recorded runtime snapshots"
+    };
+    if !run.metadata.lifecycle_warnings.iter().any(|w| w == warning) {
+        run.metadata.lifecycle_warnings.push(warning.to_string());
+    }
+    if !warnings.iter().any(|w| w.message() == warning) {
+        warnings.push(ImportWarning::new(warning.to_string()));
+    }
+    ImportedRun::new(run, warnings)
 }
 
 fn merge_runtime_data(imported: ImportedRun, runtime_run: &Run) -> ImportedRun {
@@ -298,10 +384,13 @@ fn merge_runtime_data(imported: ImportedRun, runtime_run: &Run) -> ImportedRun {
 
 #[cfg(test)]
 mod tests {
-    use super::merge_runtime_data;
+    use super::{merge_runtime_data, TracingTokioSession, TracingTokioSessionShutdownError};
     use crate::{ImportWarning, ImportedRun};
+    use std::fs;
     use std::time::Duration;
     use tailtriage_core::{CaptureMode, MemorySink, RuntimeSnapshot, Tailtriage};
+    use tempfile::tempdir;
+    use tracing_subscriber::prelude::*;
 
     fn empty_run(service_name: &str) -> tailtriage_core::Run {
         Tailtriage::builder(service_name)
@@ -620,5 +709,124 @@ mod tests {
             sampler_config.resolved_runtime_snapshot_retention
                 <= effective_core.capture_limits.max_runtime_snapshots
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn disabled_sampler_with_manual_snapshot_records_runtime_and_warning() {
+        let session = TracingTokioSession::builder("svc")
+            .disable_background_sampler()
+            .start()
+            .expect("start session");
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let _request = tracing::info_span!(
+                "req",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/",
+                tt.outcome = "ok"
+            )
+            .entered();
+        });
+        session.record_runtime_snapshot(RuntimeSnapshot {
+            at_unix_ms: 1_000,
+            alive_tasks: Some(1),
+            global_queue_depth: Some(2),
+            local_queue_depth: Some(3),
+            blocking_queue_depth: Some(4),
+            remote_schedule_count: Some(5),
+        });
+        let run = session.shutdown().await.expect("shutdown").run().clone();
+        assert_eq!(run.runtime_snapshots.len(), 1);
+        assert!(run
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|w| w.contains("disabled")));
+        assert!(run
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|w| w.contains("manually")));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn disabled_sampler_without_manual_snapshot_has_clear_warning_and_no_snapshots() {
+        let session = TracingTokioSession::builder("svc")
+            .disable_background_sampler()
+            .start()
+            .expect("start session");
+        let run = session.shutdown().await.expect("shutdown").run().clone();
+        assert!(run.runtime_snapshots.is_empty());
+        assert!(run
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|w| w.contains("no runtime snapshots were recorded")));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn default_sampler_behavior_keeps_effective_sampler_metadata() {
+        let session = TracingTokioSession::builder("svc")
+            .sampler_interval(Duration::from_millis(5))
+            .start()
+            .expect("start session");
+        tokio::time::sleep(Duration::from_millis(12)).await;
+        let run = session.shutdown().await.expect("shutdown").run().clone();
+        assert!(run.metadata.effective_tokio_sampler_config.is_some());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn run_json_path_writes_run_and_creates_parent_directories() {
+        let dir = tempdir().expect("tempdir");
+        let run_path = dir.path().join("nested/path/run.json");
+        let session = TracingTokioSession::builder("svc")
+            .disable_background_sampler()
+            .run_json_path(&run_path)
+            .start()
+            .expect("start session");
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let _request = tracing::info_span!(
+                "req",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/",
+                tt.outcome = "ok"
+            )
+            .entered();
+        });
+        let imported = session.shutdown().await.expect("shutdown");
+        assert_eq!(imported.run().requests.len(), 1);
+        let raw = fs::read_to_string(&run_path).expect("read run");
+        let parsed: tailtriage_core::Run = serde_json::from_str(&raw).expect("parse run");
+        assert_eq!(parsed.requests.len(), 1);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn run_json_path_rejects_zero_requests_without_creating_file() {
+        let dir = tempdir().expect("tempdir");
+        let run_path = dir.path().join("empty/run.json");
+        let session = TracingTokioSession::builder("svc")
+            .disable_background_sampler()
+            .run_json_path(&run_path)
+            .start()
+            .expect("start session");
+        let err = session.shutdown().await.expect_err("should fail");
+        assert!(matches!(err, TracingTokioSessionShutdownError::Import(_)));
+        assert!(!run_path.exists());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn snapshot_run_does_not_write_run_json_path() {
+        let dir = tempdir().expect("tempdir");
+        let run_path = dir.path().join("snapshot/run.json");
+        let session = TracingTokioSession::builder("svc")
+            .disable_background_sampler()
+            .run_json_path(&run_path)
+            .start()
+            .expect("start session");
+        let _ = session.snapshot_run().expect("snapshot");
+        assert!(!run_path.exists());
     }
 }


### PR DESCRIPTION
### Motivation
- Enable deterministic, noise-free runtime evidence for demos and validation by allowing manual injection of runtime snapshots without a background sampler. 
- Provide a direct, robust library path to persist merged `Run` JSON on shutdown so tracing-based live sessions can produce analyzable artifacts without a separate import step. 
- Keep default production behavior unchanged while making demo/validation behavior explicit and discoverable. 

### Description
- Added builder APIs `TracingTokioSessionBuilder::disable_background_sampler()` and `TracingTokioSessionBuilder::run_json_path(path)` to control sampler startup and optional shutdown persistence. 
- Switched `TracingTokioSession` to store `sampler: Option<RuntimeSampler>` and `run_json_path: Option<PathBuf>`, start the sampler only when not disabled, and only await shutdown when present. 
- On shutdown, the merged run is validated with `ensure_persistable_run_has_requests`, parent directories are created, and `LocalJsonSink` writes the `Run` artifact; write failures surface as `TracingTokioSessionShutdownError::RunJsonWrite { path, reason }`. 
- Added lifecycle warnings for the disabled-sampler mode that clearly state either that runtime snapshots were manually recorded or that no runtime snapshots were recorded, and preserved existing sampler metadata behavior for default sessions. 
- Added example `tailtriage-tracing/examples/tokio_session_to_run.rs` and demo changes to use `disable_background_sampler()` plus `record_runtime_snapshot(...)`. 
- Files changed: `tailtriage-tracing/src/tokio.rs`, `tailtriage-tracing/README.md`, `tailtriage-tracing/Cargo.toml`, `tailtriage-tracing/examples/tokio_session_to_run.rs` (new), `demos/demo_support/src/lib.rs`, `docs/operations.md`, `scripts/demo_tool.py`. 

### Testing
- Ran formatting and linting: `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings`, both succeeded. 
- Ran the full test suite: `cargo test --workspace` and `cargo test -p tailtriage-tracing --all-features`, all tests passed. 
- Built and ran the new example: `cargo run -p tailtriage-tracing --example tokio_session_to_run --features tokio`, which wrote `target/tailtriage-examples/tokio-run.json` successfully. 
- Validated runtime-sensitive tracing parity with `python3 scripts/demo_tool.py validate-tracing-parity blocking --profile release` and `... executor --profile release`, both validations passed (script updated to accept explicit disabled-sampler lifecycle warnings). 
- Docs contract validation `python3 scripts/validate_docs_contracts.py` passed. 

Notes and remaining limitations:
- Disabled background sampler intentionally omits `effective_tokio_sampler_config` metadata; runtime-pressure evidence then depends on manually injected `RuntimeSnapshot`s and is indicated explicitly via lifecycle warnings. 
- `snapshot_run()` remains non-persisting and does not write to `run_json_path`; only `shutdown()` triggers persistence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15dc85107083309286797875aac847)