### PR TITLE
Improve tracing shutdown zero-request persisted error with intake warning summaries

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -153,7 +153,7 @@ Missing stage `tt.success` defaults to `true` with a warning.
 ## Runtime-pressure limitation
 
 Tracing intake import and native capture share the same CaptureMode/CaptureLimits semantics for request/stage/queue evidence retention. Offline tracing JSONL import does not fabricate runtime snapshots. Runtime-pressure evidence still requires runtime snapshots/Tokio sampler coupling. Runtime-sensitive parity uses deterministic/manual runtime snapshots and requires non-empty runtime snapshots, scenario-specific runtime field evidence, and the explicit disabled-background-sampler lifecycle warning (via `disable_background_sampler()` + `record_runtime_snapshot(...)`). It does not rely on ambient sampler metadata/noise.
-Persisted Run JSON intended for `tailtriage analyze` must include at least one completed request event; in-process library snapshots may still be zero-request for inspection.
+Persisted Run JSON intended for `tailtriage analyze` must include at least one completed request event; shutdown fails for persisted-output sessions when zero completed requests are retained. When intake/lifecycle warnings are available, that shutdown error includes warning summaries to help tracing-intake setup triage. In-process library snapshots may still be zero-request for inspection.
 
 For `TracingTokioSession`, runtime snapshot retention also uses the same core capture-limit model. Run metadata time bounds cover merged retained tracing evidence plus retained runtime snapshots, which supports triage interpretation but is not root-cause proof:
 

--- a/tailtriage-tracing/src/error.rs
+++ b/tailtriage-tracing/src/error.rs
@@ -44,6 +44,13 @@ pub enum ImportError {
         /// Actionable setup guidance for creating a persistable run artifact.
         guidance: String,
     },
+    /// Persistable run artifact is missing completed request spans and warnings were observed.
+    ZeroRequestArtifactWithWarnings {
+        /// Actionable setup guidance for creating a persistable run artifact.
+        guidance: String,
+        /// Intake and lifecycle warning summaries observed before shutdown.
+        warnings: Vec<String>,
+    },
     /// Failed to write run JSON output via core sink.
     RunJsonWrite {
         /// Target output path.
@@ -75,6 +82,18 @@ impl fmt::Display for ImportError {
             Self::EmptyServiceName => write!(f, "service name must not be empty"),
             Self::InvalidRunEvent(message) => write!(f, "invalid run event: {message}"),
             Self::ZeroRequestArtifact { guidance } => write!(f, "{guidance}"),
+            Self::ZeroRequestArtifactWithWarnings { guidance, warnings } => {
+                writeln!(f, "{guidance}")?;
+                writeln!(f, "warnings observed during tracing intake:")?;
+                for warning in warnings.iter().take(8) {
+                    writeln!(f, "- {warning}")?;
+                }
+                let omitted = warnings.len().saturating_sub(8);
+                if omitted > 0 {
+                    writeln!(f, "- ... and {omitted} additional warnings omitted")?;
+                }
+                Ok(())
+            }
             Self::RunJsonWrite { path, reason } => {
                 write!(f, "failed to write run JSON at {path}: {reason}")
             }

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -68,10 +68,14 @@ pub use types::{FieldValue, ImportOptions, ImportWarning, ImportedRun, SpanKind,
 pub fn ensure_persistable_run_has_requests(run: &tailtriage_core::Run) -> Result<(), ImportError> {
     if run.requests.is_empty() {
         return Err(ImportError::ZeroRequestArtifact {
-            guidance: "tracing import produced zero request events; persisted Run JSON artifacts intended for tailtriage analyze require at least one completed tt.kind=\"request\" span with tt.request_id, tt.route, and explicit unix-ms timing fields (started_at_unix_ms/finished_at_unix_ms).".to_owned(),
+            guidance: persistable_zero_request_guidance(),
         });
     }
     Ok(())
+}
+
+pub(crate) fn persistable_zero_request_guidance() -> String {
+    "tracing import produced zero request events; persisted Run JSON artifacts intended for tailtriage analyze require at least one completed tt.kind=\"request\" span with tt.request_id, tt.route, and explicit unix-ms timing fields (started_at_unix_ms/finished_at_unix_ms).".to_owned()
 }
 
 /// Converts in-memory tracing span records into a `tailtriage_core::Run`.

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -297,6 +297,20 @@ impl TracingIntakeSession {
         let imported = self.recorder.shutdown()?;
         let (run, warnings) = imported.into_parts();
         if self.run_json_path.is_some() || self.completed_span_jsonl_path.is_some() {
+            if run.requests.is_empty() {
+                let guidance = crate::persistable_zero_request_guidance();
+                let warning_messages = warnings
+                    .iter()
+                    .map(|w| w.message().to_owned())
+                    .collect::<Vec<_>>();
+                if warning_messages.is_empty() {
+                    return Err(ImportError::ZeroRequestArtifact { guidance });
+                }
+                return Err(ImportError::ZeroRequestArtifactWithWarnings {
+                    guidance,
+                    warnings: warning_messages,
+                });
+            }
             ensure_persistable_run_has_requests(&run)?;
         }
         if let Some(path) = &self.completed_span_jsonl_path {
@@ -3020,6 +3034,36 @@ mod tests {
     }
 
     #[test]
+    fn intake_session_zero_request_persisted_error_includes_intake_warnings() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_path = dir.path().join("run.json");
+        let session = TracingIntakeSession::builder("svc")
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "bad-kind",
+                tt.kind = "wat",
+                tt.request_id = "r1",
+                tt.route = "/ignored"
+            ));
+        });
+
+        let err = session.shutdown().unwrap_err();
+        assert!(matches!(
+            err,
+            ImportError::ZeroRequestArtifactWithWarnings { .. }
+        ));
+        let message = err.to_string();
+        assert!(message.contains("tracing import produced zero request events"));
+        assert!(message.contains("warnings observed during tracing intake:"));
+        assert!(message.contains("invalid tt.kind"));
+        assert!(!run_path.exists());
+    }
+
+    #[test]
     fn shutdown_with_completed_span_jsonl_only_and_zero_requests_writes_no_artifact() {
         let dir = tempfile::tempdir().unwrap();
         let spans_path = dir.path().join("spans.jsonl");
@@ -3067,6 +3111,42 @@ mod tests {
         assert!(matches!(err, ImportError::ZeroRequestArtifact { .. }));
         assert!(!spans_path.exists());
         assert!(!run_path.exists());
+    }
+
+    #[test]
+    fn intake_session_persisted_success_keeps_warnings_and_writes_outputs() {
+        let dir = tempfile::tempdir().unwrap();
+        let spans_path = dir.path().join("spans.jsonl");
+        let run_path = dir.path().join("run.json");
+        let session = TracingIntakeSession::builder("svc")
+            .completed_span_jsonl_path(&spans_path)
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "req",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/ok"
+            ));
+            drop(tracing::info_span!(
+                "bad-kind",
+                tt.kind = "wat",
+                tt.request_id = "r1",
+                tt.route = "/ignored"
+            ));
+        });
+
+        let imported = session.shutdown().unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("invalid tt.kind")));
+        assert!(spans_path.exists());
+        assert!(run_path.exists());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Persisted-output `TracingIntakeSession::shutdown()` returned a generic zero-request error when no completed requests were retained, leaving users without the intake/lifecycle warnings that explain why no requests survived conversion. 
- Make the shutdown error actionable when warnings exist by surfacing the accumulated intake warnings alongside the existing zero-request guidance.

### Description
- Add `ImportError::ZeroRequestArtifactWithWarnings { guidance: String, warnings: Vec<String> }` and `Display` logic that prints the standard zero-request guidance followed by a concise `warnings observed during tracing intake:` section, showing up to 8 warnings and an omitted-count line when applicable. 
- Update `TracingIntakeSession::shutdown()` to, when persisted outputs are configured and the converted `Run` has zero requests, return `ZeroRequestArtifactWithWarnings` when conversion produced warnings (using `warnings.iter().map(|w| w.message().to_owned())`) and otherwise return the existing `ZeroRequestArtifact`. 
- Factor the zero-request guidance text into `persistable_zero_request_guidance()` so the same guidance can be reused without changing `ensure_persistable_run_has_requests` behavior. 
- Add tests `intake_session_zero_request_persisted_error_includes_intake_warnings` and `intake_session_persisted_success_keeps_warnings_and_writes_outputs` to cover the new error variant and that successful persisted shutdowns still preserve warnings and write outputs. 
- Update `tailtriage-tracing/README.md` to document that persisted-output shutdown fails on zero retained completed requests and now includes intake warning summaries when available, with bounded setup/intake wording.

### Testing
- Ran formatting and validation with `cargo fmt --all --check` which passed. 
- Ran the full test and lint suite with `cargo test --workspace --all-targets --all-features --locked` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, and all tests and lints passed (added tracing tests executed). 
- Ran documentation contract checks with `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts`, which both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16b23e53148330900725edcf7c65d5)