### PR TITLE
Include intake warnings in zero-request persisted shutdown errors

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -154,6 +154,7 @@ Missing stage `tt.success` defaults to `true` with a warning.
 
 Tracing intake import and native capture share the same CaptureMode/CaptureLimits semantics for request/stage/queue evidence retention. Offline tracing JSONL import does not fabricate runtime snapshots. Runtime-pressure evidence still requires runtime snapshots/Tokio sampler coupling. Runtime-sensitive parity uses deterministic/manual runtime snapshots and requires non-empty runtime snapshots, scenario-specific runtime field evidence, and the explicit disabled-background-sampler lifecycle warning (via `disable_background_sampler()` + `record_runtime_snapshot(...)`). It does not rely on ambient sampler metadata/noise.
 Persisted Run JSON intended for `tailtriage analyze` must include at least one completed request event; in-process library snapshots may still be zero-request for inspection.
+When persisted-output shutdown fails due to zero retained completed requests, the error includes intake warning summaries (when available) to guide tracing setup and field completeness fixes.
 
 For `TracingTokioSession`, runtime snapshot retention also uses the same core capture-limit model. Run metadata time bounds cover merged retained tracing evidence plus retained runtime snapshots, which supports triage interpretation but is not root-cause proof:
 

--- a/tailtriage-tracing/src/error.rs
+++ b/tailtriage-tracing/src/error.rs
@@ -44,6 +44,13 @@ pub enum ImportError {
         /// Actionable setup guidance for creating a persistable run artifact.
         guidance: String,
     },
+    /// Persistable run artifact is missing required completed request spans and warnings were observed.
+    ZeroRequestArtifactWithWarnings {
+        /// Actionable setup guidance for creating a persistable run artifact.
+        guidance: String,
+        /// Non-fatal warnings accumulated during tracing intake/import.
+        warnings: Vec<String>,
+    },
     /// Failed to write run JSON output via core sink.
     RunJsonWrite {
         /// Target output path.
@@ -75,6 +82,22 @@ impl fmt::Display for ImportError {
             Self::EmptyServiceName => write!(f, "service name must not be empty"),
             Self::InvalidRunEvent(message) => write!(f, "invalid run event: {message}"),
             Self::ZeroRequestArtifact { guidance } => write!(f, "{guidance}"),
+            Self::ZeroRequestArtifactWithWarnings { guidance, warnings } => {
+                writeln!(f, "{guidance}")?;
+                writeln!(f, "warnings observed during tracing intake:")?;
+                let shown = warnings.len().min(8);
+                for warning in warnings.iter().take(8) {
+                    writeln!(f, "- {warning}")?;
+                }
+                if warnings.len() > shown {
+                    write!(
+                        f,
+                        "- {} additional warnings omitted",
+                        warnings.len() - shown
+                    )?;
+                }
+                Ok(())
+            }
             Self::RunJsonWrite { path, reason } => {
                 write!(f, "failed to write run JSON at {path}: {reason}")
             }

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -297,7 +297,17 @@ impl TracingIntakeSession {
         let imported = self.recorder.shutdown()?;
         let (run, warnings) = imported.into_parts();
         if self.run_json_path.is_some() || self.completed_span_jsonl_path.is_some() {
-            ensure_persistable_run_has_requests(&run)?;
+            if let Err(ImportError::ZeroRequestArtifact { guidance }) =
+                ensure_persistable_run_has_requests(&run)
+            {
+                if warnings.is_empty() {
+                    return Err(ImportError::ZeroRequestArtifact { guidance });
+                }
+                return Err(ImportError::ZeroRequestArtifactWithWarnings {
+                    guidance,
+                    warnings: warnings.iter().map(|w| w.message().to_owned()).collect(),
+                });
+            }
         }
         if let Some(path) = &self.completed_span_jsonl_path {
             write_completed_span_jsonl_from_run(&run, path)?;
@@ -3033,6 +3043,36 @@ mod tests {
     }
 
     #[test]
+    fn persisted_shutdown_zero_requests_includes_intake_warnings_in_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_path = dir.path().join("run.json");
+        let session = TracingIntakeSession::builder("svc")
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request-missing-route",
+                tt.kind = "request",
+                tt.request_id = "r-missing-route"
+            ));
+        });
+
+        let err = session.shutdown().unwrap_err();
+        let message = err.to_string();
+        assert!(matches!(
+            err,
+            ImportError::ZeroRequestArtifactWithWarnings { .. }
+        ));
+        assert!(message.contains("tracing import produced zero request events"));
+        assert!(message.contains("warnings observed during tracing intake:"));
+        assert!(message.contains("missing required field"));
+        assert!(message.contains("tt.route"));
+        assert!(!run_path.exists());
+    }
+
+    #[test]
     fn shutdown_with_no_persisted_paths_and_zero_requests_still_returns_imported_run() {
         let session = TracingIntakeSession::builder("svc").build().unwrap();
         let imported = session.shutdown().unwrap();
@@ -3067,6 +3107,37 @@ mod tests {
         assert!(matches!(err, ImportError::ZeroRequestArtifact { .. }));
         assert!(!spans_path.exists());
         assert!(!run_path.exists());
+    }
+
+    #[test]
+    fn persisted_shutdown_with_requests_still_returns_warnings_and_writes_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_path = dir.path().join("run.json");
+        let session = TracingIntakeSession::builder("svc")
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request-missing-route",
+                tt.kind = "request",
+                tt.request_id = "r-missing-route"
+            ));
+            drop(tracing::info_span!(
+                "request-valid",
+                tt.kind = "request",
+                tt.request_id = "r-valid",
+                tt.route = "/ok"
+            ));
+        });
+
+        let imported = session.shutdown().unwrap();
+        assert!(run_path.exists());
+        assert_eq!(imported.run().requests.len(), 1);
+        assert!(imported.warnings().iter().any(|w| {
+            w.message().contains("missing required field") && w.message().contains("tt.route")
+        }));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Persisted-output shutdown currently returns a generic zero-request error when no completed requests are retained, leaving users without the intake warnings that explain why no requests were produced.
- Make it easier for users to fix tracing setup by surfacing accumulated import/lifecycle warnings in that error path when available.
- Preserve the existing zero-request error variant for callers without warning context.

### Description
- Add a new error variant `ImportError::ZeroRequestArtifactWithWarnings { guidance, warnings }` to carry guidance and up to many warning messages. 
- Implement `Display` for the new variant to print the existing zero-request guidance then a concise section headed `warnings observed during tracing intake:` showing up to 8 warning lines and, if needed, a single omitted-count line. 
- Update `TracingIntakeSession::shutdown()` to detect the zero-request case when persisted outputs are configured and, if accumulated warnings exist, return `ZeroRequestArtifactWithWarnings` populated via `warnings.iter().map(|w| w.message().to_owned())`; otherwise continue returning the existing `ZeroRequestArtifact`. 
- Add tests in `tailtriage-tracing/src/recorder.rs` to assert that persisted-output zero-request shutdown returns the new, warning-carrying error and that a successful persisted shutdown with retained requests still writes output and preserves warnings. 
- Update `tailtriage-tracing/README.md` to document that persisted-output shutdown failures include intake warning summaries when available.

### Testing
- Ran `cargo fmt --all --check` which succeeded.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which completed without warnings.
- Ran the workspace test suite with `cargo test --workspace --all-targets --all-features --locked`; the added/updated `tailtriage-tracing` tests exercised the new behavior and passed, but the full workspace run failed due to an existing unrelated analyzer test (`tailtriage-analyzer::end_to_end_capture_analysis::queue_and_stage_data_drives_ranked_suspects`).
- Ran `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts`, both of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16b23e53148330900725edcf7c65d5)