### PR TITLE
Improve zero-request tracing shutdown errors with intake warnings

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -153,7 +153,7 @@ Missing stage `tt.success` defaults to `true` with a warning.
 ## Runtime-pressure limitation
 
 Tracing intake import and native capture share the same CaptureMode/CaptureLimits semantics for request/stage/queue evidence retention. Offline tracing JSONL import does not fabricate runtime snapshots. Runtime-pressure evidence still requires runtime snapshots/Tokio sampler coupling. Runtime-sensitive parity uses deterministic/manual runtime snapshots and requires non-empty runtime snapshots, scenario-specific runtime field evidence, and the explicit disabled-background-sampler lifecycle warning (via `disable_background_sampler()` + `record_runtime_snapshot(...)`). It does not rely on ambient sampler metadata/noise.
-Persisted Run JSON intended for `tailtriage analyze` must include at least one completed request event; in-process library snapshots may still be zero-request for inspection.
+Persisted Run JSON intended for `tailtriage analyze` must include at least one completed request event; in-process library snapshots may still be zero-request for inspection. When persisted-output shutdown retains zero completed requests, shutdown fails with setup guidance and includes accumulated tracing-intake warnings when available.
 
 For `TracingTokioSession`, runtime snapshot retention also uses the same core capture-limit model. Run metadata time bounds cover merged retained tracing evidence plus retained runtime snapshots, which supports triage interpretation but is not root-cause proof:
 

--- a/tailtriage-tracing/src/error.rs
+++ b/tailtriage-tracing/src/error.rs
@@ -44,6 +44,13 @@ pub enum ImportError {
         /// Actionable setup guidance for creating a persistable run artifact.
         guidance: String,
     },
+    /// Persistable run artifact is missing required completed request spans and warnings were observed.
+    ZeroRequestArtifactWithWarnings {
+        /// Actionable setup guidance for creating a persistable run artifact.
+        guidance: String,
+        /// Intake and lifecycle warnings accumulated during conversion.
+        warnings: Vec<String>,
+    },
     /// Failed to write run JSON output via core sink.
     RunJsonWrite {
         /// Target output path.
@@ -75,6 +82,17 @@ impl fmt::Display for ImportError {
             Self::EmptyServiceName => write!(f, "service name must not be empty"),
             Self::InvalidRunEvent(message) => write!(f, "invalid run event: {message}"),
             Self::ZeroRequestArtifact { guidance } => write!(f, "{guidance}"),
+            Self::ZeroRequestArtifactWithWarnings { guidance, warnings } => {
+                writeln!(f, "{guidance}")?;
+                writeln!(f, "warnings observed during tracing intake:")?;
+                for warning in warnings.iter().take(8) {
+                    writeln!(f, "- {warning}")?;
+                }
+                if warnings.len() > 8 {
+                    write!(f, "- {} additional warning(s) omitted", warnings.len() - 8)?;
+                }
+                Ok(())
+            }
             Self::RunJsonWrite { path, reason } => {
                 write!(f, "failed to write run JSON at {path}: {reason}")
             }

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -297,7 +297,17 @@ impl TracingIntakeSession {
         let imported = self.recorder.shutdown()?;
         let (run, warnings) = imported.into_parts();
         if self.run_json_path.is_some() || self.completed_span_jsonl_path.is_some() {
-            ensure_persistable_run_has_requests(&run)?;
+            if let Err(ImportError::ZeroRequestArtifact { guidance }) =
+                ensure_persistable_run_has_requests(&run)
+            {
+                if warnings.is_empty() {
+                    return Err(ImportError::ZeroRequestArtifact { guidance });
+                }
+                return Err(ImportError::ZeroRequestArtifactWithWarnings {
+                    guidance,
+                    warnings: warnings.iter().map(|w| w.message().to_owned()).collect(),
+                });
+            }
         }
         if let Some(path) = &self.completed_span_jsonl_path {
             write_completed_span_jsonl_from_run(&run, path)?;
@@ -3020,6 +3030,31 @@ mod tests {
     }
 
     #[test]
+    fn intake_session_persisted_zero_requests_includes_intake_warnings_in_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_path = dir.path().join("run.json");
+        let session = TracingIntakeSession::builder("svc")
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        let err = tracing::subscriber::with_default(subscriber, || {
+            let leaked = tracing::info_span!(
+                "request-open",
+                tt.kind = "request",
+                tt.request_id = "r-open"
+            );
+            std::mem::forget(leaked);
+            session.shutdown().unwrap_err()
+        });
+        let err_text = err.to_string();
+        assert!(err_text.contains("tracing import produced zero request events"));
+        assert!(err_text.contains("warnings observed during tracing intake:"));
+        assert!(err_text.contains("open candidate span(s) at snapshot/shutdown"));
+        assert!(!run_path.exists());
+    }
+
+    #[test]
     fn shutdown_with_completed_span_jsonl_only_and_zero_requests_writes_no_artifact() {
         let dir = tempfile::tempdir().unwrap();
         let spans_path = dir.path().join("spans.jsonl");
@@ -3067,6 +3102,38 @@ mod tests {
         assert!(matches!(err, ImportError::ZeroRequestArtifact { .. }));
         assert!(!spans_path.exists());
         assert!(!run_path.exists());
+    }
+
+    #[test]
+    fn persisted_shutdown_with_requests_still_returns_warnings_and_writes_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_path = dir.path().join("run.json");
+        let session = TracingIntakeSession::builder("svc")
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/ok"
+            ));
+            drop(tracing::info_span!(
+                "incomplete-stage",
+                tt.kind = "stage",
+                tt.request_id = "r1"
+            ));
+        });
+
+        let imported = session.shutdown().unwrap();
+        assert!(run_path.exists());
+        assert_eq!(imported.run().requests.len(), 1);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|warning| warning.message().contains("incomplete required fields")));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Make shutdown errors for persisted tracing output more actionable when conversion produced zero completed requests by surfacing accumulated intake/lifecycle warnings alongside the existing guidance.

### Description
- Add `ImportError::ZeroRequestArtifactWithWarnings { guidance: String, warnings: Vec<String> }` and implement `Display` to print the zero-request guidance followed by a `warnings observed during tracing intake:` section showing up to 8 warning lines and an omitted-count line when applicable.
- Update `TracingIntakeSession::shutdown()` so when persisted outputs are configured and the converted run has zero requests it returns `ZeroRequestArtifactWithWarnings` if any warnings were accumulated, otherwise it returns the existing `ZeroRequestArtifact`; warnings are mapped with `warnings.iter().map(|w| w.message().to_owned())`.
- Add tests in `tailtriage-tracing` to assert that a persisted zero-request shutdown includes the zero-request guidance and at least one intake warning, and that a persisted shutdown with retained requests still writes output and returns warnings.
- Update `tailtriage-tracing/README.md` to document that persisted-output shutdown fails on zero completed requests and that the error includes tracing-intake warnings when available.

### Testing
- Ran `cargo fmt --all --check` (passed after formatting changes were applied). 
- Ran `cargo test --workspace --all-targets --all-features --locked`: the new/modified tests in `tailtriage-tracing` passed, but the workspace test run failed due to an unrelated pre-existing failure in `tailtriage-analyzer::tests::queue_and_stage_data_drives_ranked_suspects` (external to these changes).
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (passed).
- Ran `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts` (both passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16b23e53148330900725edcf7c65d5)