### PR TITLE
Clarify tt.* semantic field formatting and add live-recorder tests for debug/display tt.kind

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -128,6 +128,8 @@ Missing request `tt.outcome` defaults to `ok` with a warning.
 If present, request `tt.outcome` must be a string and cannot be empty/whitespace-only; accepted custom labels are preserved exactly.
 Missing stage `tt.success` defaults to `true` with a warning.
 
+Setup guidance for semantic fields: record `tt.kind`, `tt.request_id`, `tt.route`, `tt.stage`, and `tt.queue` as plain scalar strings (literal values or Display-formatted values). Do not use Debug formatting for semantic `tt.*` fields. For example, `tt.kind = "request"` works, and `%kind` can work when `kind` displays as `request`, but `?kind` may record `"request"` with debug quoting and be rejected as unknown.
+
 ## Strict vs non-strict
 
 - Strict mode: malformed/incomplete `tt.*` span records fail import/session conversion.

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -1443,6 +1443,25 @@ mod tests {
     }
 
     #[test]
+    fn display_formatted_tt_kind_is_accepted_when_it_displays_as_request() {
+        with_recorder(|recorder| {
+            let kind = "request";
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = %kind,
+                tt.request_id = "r-display",
+                tt.route = "/display-kind"
+            );
+            drop(span);
+
+            let run = recorder.snapshot_run().unwrap();
+            assert_eq!(run.run().requests.len(), 1);
+            assert_eq!(run.run().requests[0].request_id, "r-display");
+            assert_eq!(run.run().requests[0].route, "/display-kind");
+        });
+    }
+
+    #[test]
     fn non_tailtriage_fields_do_not_make_span_candidate() {
         with_recorder(|recorder| {
             let span = tracing::info_span!(
@@ -1484,6 +1503,34 @@ mod tests {
             assert!(run.run().requests.is_empty());
             assert!(run.run().stages.is_empty());
             assert!(run.run().queues.is_empty());
+        });
+    }
+
+    #[test]
+    fn debug_formatted_tt_kind_is_rejected_with_invalid_kind_warning() {
+        with_recorder(|recorder| {
+            let kind = "request";
+            let span = tracing::info_span!(
+                "debug-kind",
+                tt.kind = ?kind,
+                tt.request_id = "r-debug-kind",
+                tt.route = "/debug-kind"
+            );
+            drop(span);
+
+            let run = recorder.snapshot_run().unwrap();
+            assert!(run.run().requests.is_empty());
+
+            let message = run
+                .warnings()
+                .iter()
+                .find_map(|warning| {
+                    let msg = warning.message();
+                    msg.contains("invalid tt.kind").then_some(msg)
+                })
+                .unwrap_or("");
+            assert!(message.contains("reason=unknown"));
+            assert!(message.contains("r-debug-kind"));
         });
     }
 


### PR DESCRIPTION
### Motivation
- Prevent a common footgun where `tracing` Debug formatting (`?`) records quoted/Debug-escaped values that the semantic `tt.*` parser rejects. 
- Make the intended recording style explicit in tracing setup guidance so integrators record semantic `tt.*` fields in a form the importer expects. 
- Add live-recorder tests that exercise the real recording path to lock regression coverage on the footgun (the issue is in `record_debug`).

### Description
- Added a short setup guidance note to `tailtriage-tracing/README.md` under the `tt.*` field convention that instructs users to record `tt.kind`, `tt.request_id`, `tt.route`, `tt.stage`, and `tt.queue` as plain scalar strings (literal or Display-formatted) and to avoid Debug formatting for semantic `tt.*` fields, with a concrete example. 
- Added a live-recorder test `display_formatted_tt_kind_is_accepted_when_it_displays_as_request` to `tailtriage-tracing/src/recorder.rs` that shows a Display-formatted `tt.kind` (`%kind`) imports correctly when it renders as `request`. 
- Added a live-recorder test `debug_formatted_tt_kind_is_rejected_with_invalid_kind_warning` to `tailtriage-tracing/src/recorder.rs` that shows Debug-formatted `tt.kind` (`?kind`) is not accepted as a semantic kind and surfaces an invalid-kind lifecycle warning. 
- Did not change parser behavior or add any normalization; this is documentation and test coverage only.

### Testing
- Ran formatting check with `cargo fmt --all --check` and it passed (format applied where necessary before checking). 
- Ran full test and build validation with `cargo test --workspace --all-targets --all-features --locked` and all tests passed. 
- Ran lints with `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed with no warnings. 
- Ran docs contract validation `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts` and both validations passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16d5aed1988330826732c9da6d7f8d)