### PR TITLE
Clarify semantic tt.* formatting guidance and add recorder tests

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -124,6 +124,10 @@ Import does not guess span timing from line receive time: provide explicit unix-
 | stage | `tt.kind="stage"`, `tt.request_id`, `tt.stage` | `tt.success` |
 | queue | `tt.kind="queue"`, `tt.request_id`, `tt.queue` | `tt.depth_at_start` |
 
+Record semantic `tt.*` fields (`tt.kind`, `tt.request_id`, `tt.route`, `tt.stage`, `tt.queue`) as plain scalar strings (string literals or display-formatted scalar strings). Do not use debug formatting for semantic `tt.*` fields.
+
+For example: `tt.kind = "request"` works, `tt.kind = %kind` can work when `kind` displays as `request`, but `tt.kind = ?kind` may record `"request"` (debug quoting) and be rejected as unknown.
+
 Missing request `tt.outcome` defaults to `ok` with a warning.
 If present, request `tt.outcome` must be a string and cannot be empty/whitespace-only; accepted custom labels are preserved exactly.
 Missing stage `tt.success` defaults to `true` with a warning.

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -1488,6 +1488,64 @@ mod tests {
     }
 
     #[test]
+    fn display_formatted_tt_kind_request_is_imported() {
+        with_recorder(|recorder| {
+            struct RequestKind;
+            impl fmt::Display for RequestKind {
+                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    f.write_str("request")
+                }
+            }
+
+            let kind = RequestKind;
+            let request = tracing::info_span!(
+                "request",
+                tt.kind = %kind,
+                tt.request_id = "r-display",
+                tt.route = "/display-kind"
+            );
+            drop(request);
+
+            let imported = recorder.snapshot_run().unwrap();
+            let run = imported.run();
+            assert_eq!(run.requests.len(), 1);
+            assert_eq!(run.requests[0].request_id, "r-display");
+            assert_eq!(run.requests[0].route, "/display-kind");
+            assert!(!imported
+                .warnings()
+                .iter()
+                .any(|w| w.message().contains("invalid tt.kind")));
+        });
+    }
+
+    #[test]
+    fn debug_formatted_string_tt_kind_is_rejected_with_invalid_kind_warning() {
+        with_recorder(|recorder| {
+            let kind = "request";
+            let request = tracing::info_span!(
+                "request",
+                tt.kind = ?kind,
+                tt.request_id = "r-debug-string",
+                tt.route = "/debug-string-kind"
+            );
+            drop(request);
+
+            let imported = recorder.snapshot_run().unwrap();
+            let run = imported.run();
+            assert!(run.requests.is_empty());
+            assert!(imported
+                .warnings()
+                .iter()
+                .any(|w| w.message().contains("invalid tt.kind")));
+            assert!(run
+                .metadata
+                .lifecycle_warnings
+                .iter()
+                .any(|msg| msg.contains("invalid tt.kind")));
+        });
+    }
+
+    #[test]
     fn shutdown_output_is_analyzable_and_has_no_runtime_snapshots() {
         with_recorder(|recorder| {
             let request = tracing::info_span!(


### PR DESCRIPTION
### Motivation

- Reduce a common footgun by telling users that semantic `tt.*` fields must be recorded as plain scalar strings because debug formatting can produce values the semantic parser rejects.
- Make the behavior visible in tests using the live recorder/layer path so instrumentation authors can see the real-world effect of `Display` vs `Debug` formatting on `tt.kind`.

### Description

- Add a short setup note to the `tt.* field convention` section in `tailtriage-tracing/README.md` stating that `tt.kind`, `tt.request_id`, `tt.route`, `tt.stage`, and `tt.queue` should be recorded as string literals or `Display`-formatted scalar strings and that `Debug` formatting should not be used, with inline examples (`tt.kind = "request"`, `%kind`, `?kind`).
- Add two recorder-layer tests in `tailtriage-tracing/src/recorder.rs`: one verifying a `Display`-formatted `tt.kind` that displays as `request` is imported as a request span, and one verifying a `Debug`-formatted string `tt.kind` is rejected and produces an `invalid tt.kind` warning; both use the live recorder/layer path to exercise the real footgun.
- Do not change the parser or normalization behavior; this PR is documentation and test coverage only.

### Testing

- Ran `cargo fmt --all --check` and formatting check passed.
- Ran `cargo test --workspace --all-targets --all-features --locked` and the full test suite passed (including the new recorder tests).
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` with no warnings.
- Ran `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts` and both validators passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16d5aed1988330826732c9da6d7f8d)