### PR TITLE
Clarify tt.* scalar formatting and add live-recorder tests for Debug vs Display

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -118,6 +118,8 @@ Import does not guess span timing from line receive time: provide explicit unix-
 
 ## `tt.*` field convention
 
+Record semantic `tt.*` fields (`tt.kind`, `tt.request_id`, `tt.route`, `tt.stage`, `tt.queue`) as plain scalar strings (string literals or `%`/Display output that renders as an unquoted scalar value). Do not use `?`/Debug formatting for semantic `tt.*` fields: `tt.kind = "request"` works, `%kind` can work when `kind` displays as `request`, but `?kind` may record `"request"` with debug quoting and be rejected as unknown.
+
 | Span kind | Required fields | Optional fields |
 | --- | --- | --- |
 | request | `tt.kind="request"`, `tt.request_id`, `tt.route` | `tt.outcome` (optional non-empty string; recommended common labels: `ok`, `error`, `timeout`, `cancelled`, `rejected`) |

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -1462,6 +1462,56 @@ mod tests {
     }
 
     #[test]
+    fn display_formatted_tt_kind_string_imports_as_request() {
+        with_recorder(|recorder| {
+            let kind = "request".to_string();
+            let span = tracing::info_span!(
+                "display-kind",
+                tt.kind = %kind,
+                tt.request_id = "r-display",
+                tt.route = "/display",
+                tt.outcome = "ok"
+            );
+            drop(span);
+
+            let run = recorder.snapshot_run().unwrap();
+            assert_eq!(run.run().requests.len(), 1);
+            assert_eq!(run.run().requests[0].request_id, "r-display");
+            assert_eq!(run.run().requests[0].route, "/display");
+            assert!(run.warnings().is_empty());
+        });
+    }
+
+    #[test]
+    fn debug_formatted_tt_kind_string_is_rejected_as_unknown() {
+        with_recorder(|recorder| {
+            let kind = "request".to_string();
+            let span = tracing::info_span!(
+                "debug-kind-string",
+                tt.kind = ?kind,
+                tt.request_id = "r-debug-string",
+                tt.route = "/debug-string"
+            );
+            drop(span);
+
+            let imported = recorder.snapshot_run().unwrap();
+            assert!(imported.run().requests.is_empty());
+            assert_eq!(imported.warnings().len(), 1);
+            let msg = imported.warnings()[0].message();
+            assert!(msg.contains("invalid tt.kind"));
+            assert!(msg.contains("unknown=1"));
+            assert!(msg.contains("reason=unknown"));
+            assert!(msg.contains("r-debug-string"));
+            assert!(imported
+                .run()
+                .metadata
+                .lifecycle_warnings
+                .iter()
+                .any(|w| w == msg));
+        });
+    }
+
+    #[test]
     fn debug_or_invalid_tt_kind_does_not_become_valid_kind() {
         with_recorder(|recorder| {
             let debug_kind = tracing::info_span!(


### PR DESCRIPTION
### Motivation

- Make it explicit that semantic `tt.*` fields must be recorded as plain scalar strings because `Debug` formatting can produce quoted values the semantic parser will reject. 
- Add test coverage that exercises the live `tracing` recorder path where `record_debug` can produce this footgun so the behavior is documented and protected by tests. 

### Description

- Update `tailtriage-tracing/README.md` near the `tt.* field convention` section to instruct users to record `tt.kind`, `tt.request_id`, `tt.route`, `tt.stage`, and `tt.queue` as plain scalar strings (string literals or `Display`/`%` output) and to avoid `Debug`/`?` formatting for semantic `tt.*` fields. 
- Add a live-recorder test `display_formatted_tt_kind_string_imports_as_request` to `tailtriage-tracing/src/recorder.rs` that verifies `tt.kind = %kind` (Display-formatted) imports correctly when it displays as `request`. 
- Add a live-recorder test `debug_formatted_tt_kind_string_is_rejected_as_unknown` to `tailtriage-tracing/src/recorder.rs` that verifies `tt.kind = ?kind` (Debug-formatted) is rejected as unknown and surfaces an invalid-kind warning and lifecycle warning. 
- Intentionally do not change parser behavior or add any normalization; this PR is documentation and test coverage only. 

### Testing

- Ran `cargo fmt --all --check` and it passed. 
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests (including the new recorder tests) passed. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed. 
- Ran `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts` and both validations passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16d5aed1988330826732c9da6d7f8d)