### PR TITLE
Clarify semantic tt.* field formatting and add live recorder tests

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -128,6 +128,8 @@ Missing request `tt.outcome` defaults to `ok` with a warning.
 If present, request `tt.outcome` must be a string and cannot be empty/whitespace-only; accepted custom labels are preserved exactly.
 Missing stage `tt.success` defaults to `true` with a warning.
 
+Record semantic `tt.*` fields as plain scalar values (string literals or Display-formatted scalar strings). For semantic keys like `tt.kind`, `tt.request_id`, `tt.route`, `tt.stage`, and `tt.queue`, do not use Debug formatting. For example, `tt.kind = "request"` works; `%kind` can work when `kind` displays as `request`; `?kind` may record debug-quoted output like `"request"`, which semantic parsing treats as unknown.
+
 ## Strict vs non-strict
 
 - Strict mode: malformed/incomplete `tt.*` span records fail import/session conversion.

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -1488,6 +1488,60 @@ mod tests {
     }
 
     #[test]
+    fn display_formatted_tt_kind_string_is_imported() {
+        #[derive(Clone, Copy)]
+        struct KindDisplay;
+
+        impl fmt::Display for KindDisplay {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "request")
+            }
+        }
+
+        with_recorder(|recorder| {
+            let kind = KindDisplay;
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = %kind,
+                tt.request_id = "r-display",
+                tt.route = "/display-kind"
+            );
+            drop(span);
+
+            let imported = recorder.snapshot_run().unwrap();
+            assert_eq!(imported.run().requests.len(), 1);
+            assert_eq!(imported.run().requests[0].request_id, "r-display");
+        });
+    }
+
+    #[test]
+    fn debug_formatted_tt_kind_string_warns_and_is_not_imported() {
+        with_recorder(|recorder| {
+            let kind = "request";
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = ?kind,
+                tt.request_id = "r-debug-string",
+                tt.route = "/debug-kind"
+            );
+            drop(span);
+
+            let imported = recorder.snapshot_run().unwrap();
+            assert!(imported.run().requests.is_empty());
+            assert!(imported
+                .run()
+                .metadata
+                .lifecycle_warnings
+                .iter()
+                .any(|warning| {
+                    warning.contains("invalid tt.kind")
+                        && warning.contains("reason=unknown")
+                        && warning.contains("r-debug-string")
+                }));
+        });
+    }
+
+    #[test]
     fn shutdown_output_is_analyzable_and_has_no_runtime_snapshots() {
         with_recorder(|recorder| {
             let request = tracing::info_span!(


### PR DESCRIPTION
### Motivation
- Make the `tt.*` semantic-field expectations explicit so users record semantic keys as plain scalar strings and avoid the common footgun where Debug formatting produces quoted values that the parser rejects.
- Provide automated live-recorder coverage that demonstrates the difference between `Display`-formatted and `Debug`-formatted `tt.kind` values so the guidance is backed by tests.

### Description
- Add a short setup guidance paragraph to `tailtriage-tracing/README.md` (near the `tt.* field convention`) instructing users to record `tt.kind`, `tt.request_id`, `tt.route`, `tt.stage`, and `tt.queue` as string literals or Display-formatted scalar strings and warning against Debug formatting, with a concrete `tt.kind = "request"` / `%kind` / `?kind` example.
- Add two live-recorder tests in `tailtriage-tracing/src/recorder.rs`: `display_formatted_tt_kind_string_is_imported` that shows `%kind` (Display) importing correctly when it renders as `request`, and `debug_formatted_tt_kind_string_warns_and_is_not_imported` that shows `?kind` (Debug) is treated as unknown and produces an invalid-`tt.kind` lifecycle warning.
- No changes were made to parser logic or conversion/normalization behavior; this PR is documentation and test coverage only.

### Testing
- Ran formatting, unit tests, clippy, and docs validation with `cargo fmt --all --check`, `cargo test --workspace --all-targets --all-features --locked`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `python3 scripts/validate_docs_contracts.py`, and `python3 -m unittest scripts.tests.test_validate_docs_contracts`; all commands completed successfully.
- The new recorder tests passed as part of the full test suite and lifecycle warnings for the debug-formatted case are asserted by the tests.
- No test failures or linter warnings were introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16d5aed1988330826732c9da6d7f8d)