### PR TITLE
Document non-atomic dual-output shutdown semantics for TracingIntakeSession

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -100,6 +100,11 @@ tailtriage import tracing-json target/tailtriage-examples/checkout.spans.jsonl \
 tailtriage analyze target/tailtriage-examples/checkout.run.json
 ```
 
+Each configured shutdown output is written independently through its own temp/rename path.
+If both `completed_span_jsonl_path(...)` and `run_json_path(...)` are configured and the second write fails, the first artifact may already be finalized.
+For production workflows that need one canonical shutdown artifact, prefer `run_json_path(...)`.
+Completed-span JSONL remains a replay/debug export for retained triage evidence, not trace archival.
+
 ## Stable JSONL wrapper format
 
 Stable completed-span JSONL records use this wrapper:

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -288,7 +288,12 @@ impl TracingIntakeSession {
     pub fn snapshot_run(&self) -> Result<ImportedRun, ImportError> {
         self.recorder.snapshot_run()
     }
-    /// Finalizes intake and optionally writes run JSON when configured.
+    /// Finalizes intake and optionally writes configured output artifacts.
+    ///
+    /// Each configured output path is written independently through its own temp/rename flow.
+    /// If both completed-span JSONL and Run JSON outputs are configured, they are not committed
+    /// as one atomic multi-file transaction: a failure writing the second output can occur after
+    /// the first output has already been finalized.
     ///
     /// # Errors
     ///
@@ -548,7 +553,7 @@ impl TracingIntakeSessionBuilder {
     ///
     /// Writes retained tailtriage semantic evidence as stable span-shaped JSONL on shutdown.
     ///
-    /// Intended for replay through `tailtriage import`, not trace archival; this output
+    /// Intended for replay/debug through `tailtriage import`, not trace archival; this output
     /// does not preserve original tracing span names, span IDs, parent IDs, or non-`tt.*` fields.
     #[must_use]
     pub fn completed_span_jsonl_path(mut self, path: impl AsRef<Path>) -> Self {
@@ -556,6 +561,8 @@ impl TracingIntakeSessionBuilder {
         self
     }
     /// Enables Run JSON output on shutdown at the given path.
+    ///
+    /// Prefer this when you need one canonical persisted shutdown artifact.
     #[must_use]
     pub fn run_json_path(mut self, path: impl AsRef<Path>) -> Self {
         self.run_json_path = Some(path.as_ref().to_path_buf());


### PR DESCRIPTION
### Motivation

- Clarify user-facing shutdown semantics when a session is configured to emit both completed-span JSONL and Run JSON so users understand they are separate outputs and not an atomic multi-file commit. 
- Prevent surprising production workflows that expect a single canonical shutdown artifact by directing them to the more appropriate API and setting accurate expectations for `completed_span_jsonl_path(...)` usage.

### Description

- Add a concise note to `tailtriage-tracing/README.md` near the Completed-span JSONL / Run JSON sections that states each configured shutdown output is written independently, a second-write failure can leave the first artifact finalized, recommends `run_json_path(...)` for a single canonical artifact, and reiterates that completed-span JSONL is a replay/debug export. 
- Update the `TracingIntakeSession::shutdown()` rustdoc in `tailtriage-tracing/src/recorder.rs` to explicitly document non-atomic multi-file output behavior and the independent temp/rename flow for each configured output. 
- Tighten builder doc comments for `completed_span_jsonl_path(...)` and `run_json_path(...)` to emphasize replay/debug intent for JSONL and to recommend `run_json_path(...)` when a canonical persisted shutdown artifact is required. 
- No runtime or behavior changes were made to the output paths or writers; this is documentation-only (no new transactional semantics implemented). 

### Testing

- Ran `cargo fmt --all --check` and formatting passed. 
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests passed. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` with no warnings. 
- Ran `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts` and both validation checks passed. 
- No new unit test was added because there is no reliable, non-flaky existing harness to deterministically simulate a “second write fails after the first succeeds” scenario without introducing brittle filesystem behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16fb3ee7bc8330a19812260d7f91f0)