### PR TITLE
Document non-atomic dual-output shutdown semantics for TracingIntakeSession

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -100,6 +100,13 @@ tailtriage import tracing-json target/tailtriage-examples/checkout.spans.jsonl \
 tailtriage analyze target/tailtriage-examples/checkout.run.json
 ```
 
+If you configure both `completed_span_jsonl_path(...)` and `run_json_path(...)`, each
+configured file is written independently through its own temp/rename path. The two
+outputs are not committed as one atomic transaction: if the second write fails, the
+first output may already exist as a finalized artifact. For production workflows that
+need one canonical shutdown artifact, prefer `run_json_path(...)`. Completed-span JSONL
+remains a replay/debug export, not trace archival.
+
 ## Stable JSONL wrapper format
 
 Stable completed-span JSONL records use this wrapper:

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -288,7 +288,12 @@ impl TracingIntakeSession {
     pub fn snapshot_run(&self) -> Result<ImportedRun, ImportError> {
         self.recorder.snapshot_run()
     }
-    /// Finalizes intake and optionally writes run JSON when configured.
+    /// Finalizes intake and optionally writes configured output artifacts.
+    ///
+    /// Each configured file (`completed_span_jsonl_path` and `run_json_path`) is written
+    /// independently through its own temp/rename path. When both are configured, shutdown
+    /// is not an atomic multi-file transaction: if the later write fails, an earlier output
+    /// may already exist as a finalized artifact.
     ///
     /// # Errors
     ///
@@ -550,12 +555,18 @@ impl TracingIntakeSessionBuilder {
     ///
     /// Intended for replay through `tailtriage import`, not trace archival; this output
     /// does not preserve original tracing span names, span IDs, parent IDs, or non-`tt.*` fields.
+    ///
+    /// When both output paths are configured, this file is finalized independently and may
+    /// exist even if the later run-json write fails.
     #[must_use]
     pub fn completed_span_jsonl_path(mut self, path: impl AsRef<Path>) -> Self {
         self.completed_span_jsonl_path = Some(path.as_ref().to_path_buf());
         self
     }
     /// Enables Run JSON output on shutdown at the given path.
+    ///
+    /// When both output paths are configured, this file is written independently from
+    /// completed-span JSONL; shutdown does not commit both files as one atomic transaction.
     #[must_use]
     pub fn run_json_path(mut self, path: impl AsRef<Path>) -> Self {
         self.run_json_path = Some(path.as_ref().to_path_buf());


### PR DESCRIPTION
### Motivation

- Clarify shutdown semantics when both `completed_span_jsonl_path(...)` and `run_json_path(...)` are configured so users do not assume both files are committed atomically on shutdown and can choose the appropriate single canonical artifact for production workflows.

### Description

- Add a concise user-facing note to `tailtriage-tracing/README.md` (Completed-span JSONL section) explaining that each configured output is written via its own temp/rename path and that the two outputs are not committed as one atomic transaction, recommending `run_json_path(...)` as the canonical shutdown artifact for production and framing completed-span JSONL as a replay/debug export.
- Update the `TracingIntakeSession::shutdown()` rustdoc to document non-atomic multi-file output behavior when both output paths are configured.
- Update builder method docs for `completed_span_jsonl_path(...)` and `run_json_path(...)` to mention independent finalization and non-atomic semantics.
- No new unit tests were added because this change is a documentation clarification and existing tests cover shutdown/write failure behavior.

### Testing

- Ran formatting check with `cargo fmt --all --check` and it passed (formatting applied as needed prior to check).
- Ran the full test suite with `cargo test --workspace --all-targets --all-features --locked` and all tests passed.
- Ran lints with `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed.
- Ran documentation contract validation with `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts` and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16fb3ee7bc8330a19812260d7f91f0)