### PR TITLE
Document non-atomic dual-output shutdown semantics

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -100,6 +100,8 @@ tailtriage import tracing-json target/tailtriage-examples/checkout.spans.jsonl \
 tailtriage analyze target/tailtriage-examples/checkout.run.json
 ```
 
+Each configured output path is finalized independently. If both `completed_span_jsonl_path(...)` and `run_json_path(...)` are configured and the second write fails, the first output may already exist as a finalized artifact. For production workflows that need one canonical shutdown artifact, prefer `run_json_path(...)`. Completed-span JSONL remains a replay/debug export, not trace archival.
+
 ## Stable JSONL wrapper format
 
 Stable completed-span JSONL records use this wrapper:

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -288,7 +288,12 @@ impl TracingIntakeSession {
     pub fn snapshot_run(&self) -> Result<ImportedRun, ImportError> {
         self.recorder.snapshot_run()
     }
-    /// Finalizes intake and optionally writes run JSON when configured.
+    /// Finalizes intake and optionally writes configured shutdown artifacts.
+    ///
+    /// Each configured output path is written through its own temporary-file/rename flow.
+    /// When both completed-span JSONL and Run JSON outputs are configured, those writes
+    /// are not committed as one atomic multi-file transaction: if a later output write
+    /// fails, an earlier output may already exist as a finalized artifact.
     ///
     /// # Errors
     ///
@@ -550,12 +555,19 @@ impl TracingIntakeSessionBuilder {
     ///
     /// Intended for replay through `tailtriage import`, not trace archival; this output
     /// does not preserve original tracing span names, span IDs, parent IDs, or non-`tt.*` fields.
+    ///
+    /// If both this and [`Self::run_json_path`] are configured, outputs are finalized
+    /// independently rather than as one atomic multi-file commit.
     #[must_use]
     pub fn completed_span_jsonl_path(mut self, path: impl AsRef<Path>) -> Self {
         self.completed_span_jsonl_path = Some(path.as_ref().to_path_buf());
         self
     }
     /// Enables Run JSON output on shutdown at the given path.
+    ///
+    /// For production workflows that need one canonical shutdown artifact, prefer this
+    /// output. If both this and [`Self::completed_span_jsonl_path`] are configured, each
+    /// output is finalized independently rather than as one atomic multi-file commit.
     #[must_use]
     pub fn run_json_path(mut self, path: impl AsRef<Path>) -> Self {
         self.run_json_path = Some(path.as_ref().to_path_buf());


### PR DESCRIPTION
### Motivation
- Clarify shutdown behavior when `TracingIntakeSession` is configured to write both `completed_span_jsonl_path(...)` and `run_json_path(...)`, since each output is finalized independently and they are not committed as a single atomic multi-file transaction.
- Prevent user confusion and unsafe production assumptions by recommending the canonical artifact path and reiterating the intended use of completed-span JSONL as a replay/debug export rather than archival.

### Description
- Added a concise user-facing note to `tailtriage-tracing/README.md` near the Completed-span JSONL / Run JSON sections describing that each configured output is finalized independently and that the first output may already exist if the second write fails.
- Expanded the `TracingIntakeSession::shutdown()` rustdoc in `tailtriage-tracing/src/recorder.rs` to document that configured outputs are written via separate temporary-file/rename flows and are not committed as an atomic multi-file transaction.
- Augmented the builder method docs for `completed_span_jsonl_path(...)` and `run_json_path(...)` to reinforce independent finalization semantics and to recommend `run_json_path(...)` for production workflows that need one canonical shutdown artifact.

### Testing
- Ran `cargo fmt --all --check`, which passed.
- Ran `cargo test --workspace --all-targets --all-features --locked`, which passed (`255` unit tests in core plus workspace tests all succeeded).
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, which passed.
- Ran docs contract validation `python3 scripts/validate_docs_contracts.py`, which passed.
- Ran `python3 -m unittest scripts.tests.test_validate_docs_contracts`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16fb3ee7bc8330a19812260d7f91f0)