### PR TITLE
Document non-atomic dual-output shutdown semantics for TracingIntakeSession

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -100,6 +100,8 @@ tailtriage import tracing-json target/tailtriage-examples/checkout.spans.jsonl \
 tailtriage analyze target/tailtriage-examples/checkout.run.json
 ```
 
+When you configure output files, each file is finalized independently through its own temp-file rename path. If both `completed_span_jsonl_path(...)` and `run_json_path(...)` are set and the second write fails, the first output may already exist as a finalized artifact. For production workflows that need one canonical shutdown artifact, prefer `run_json_path(...)`; completed-span JSONL remains a replay/debug export, not trace archival.
+
 ## Stable JSONL wrapper format
 
 Stable completed-span JSONL records use this wrapper:

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -288,7 +288,12 @@ impl TracingIntakeSession {
     pub fn snapshot_run(&self) -> Result<ImportedRun, ImportError> {
         self.recorder.snapshot_run()
     }
-    /// Finalizes intake and optionally writes run JSON when configured.
+    /// Finalizes intake and writes configured outputs on shutdown.
+    ///
+    /// Each configured output path is finalized independently using its own write-temp-and-rename flow.
+    /// When both `completed_span_jsonl_path(...)` and `run_json_path(...)` are configured, writes are
+    /// not committed as one atomic multi-file transaction: if the later write fails, an earlier output
+    /// file may already exist as a finalized artifact.
     ///
     /// # Errors
     ///
@@ -547,8 +552,9 @@ impl TracingIntakeSessionBuilder {
     /// Enables completed-span JSONL output at the given path.
     ///
     /// Writes retained tailtriage semantic evidence as stable span-shaped JSONL on shutdown.
+    /// This output is finalized independently from other configured outputs.
     ///
-    /// Intended for replay through `tailtriage import`, not trace archival; this output
+    /// Intended for replay/debug through `tailtriage import`, not trace archival; this output
     /// does not preserve original tracing span names, span IDs, parent IDs, or non-`tt.*` fields.
     #[must_use]
     pub fn completed_span_jsonl_path(mut self, path: impl AsRef<Path>) -> Self {
@@ -556,6 +562,8 @@ impl TracingIntakeSessionBuilder {
         self
     }
     /// Enables Run JSON output on shutdown at the given path.
+    ///
+    /// This output is finalized independently from other configured outputs.
     #[must_use]
     pub fn run_json_path(mut self, path: impl AsRef<Path>) -> Self {
         self.run_json_path = Some(path.as_ref().to_path_buf());


### PR DESCRIPTION
### Motivation
- Make the shutdown semantics explicit so users understand that when both `completed_span_jsonl_path(...)` and `run_json_path(...)` are configured each output is finalized independently and the two files are not committed atomically, and to recommend `run_json_path(...)` for production workflows that need one canonical shutdown artifact.

### Description
- Add a concise user-facing note to `tailtriage-tracing/README.md` describing independent temp-file/rename finalization and the non-atomic behavior when both outputs are set, update the `TracingIntakeSession::shutdown()` rustdoc to document non-atomic multi-file output semantics, and annotate the `completed_span_jsonl_path(...)` and `run_json_path(...)` builder docs to note independent finalization and that completed-span JSONL is a replay/debug export.

### Testing
- Ran formatting, tests, lints, and docs validation: `cargo fmt --all --check`, `cargo test --workspace --all-targets --all-features --locked`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `python3 scripts/validate_docs_contracts.py`, and `python3 -m unittest scripts.tests.test_validate_docs_contracts`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16fb3ee7bc8330a19812260d7f91f0)