### PR TITLE
Preserve intake warnings for Tokio session zero-request persisted Run JSON

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -88,6 +88,11 @@ Use `run_json_path(...)` when you want to skip a separate import step and write 
 tailtriage analyze target/tailtriage-examples/checkout.run.json
 ```
 
+For both `TracingIntakeSession` and `TracingTokioSession`, persisted-output shutdown
+returns a zero-request error when no request is retained. When tracing intake warnings
+exist (for example malformed `tt.*` fields), shutdown includes those warning messages in
+the same error to guide setup corrections before rerunning capture.
+
 ## Completed-span JSONL path
 
 Use `completed_span_jsonl_path(...)` when you want an offline import workflow:

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -74,6 +74,27 @@ pub fn ensure_persistable_run_has_requests(run: &tailtriage_core::Run) -> Result
     Ok(())
 }
 
+pub(crate) fn ensure_persistable_run_with_warnings(
+    run: &tailtriage_core::Run,
+    warnings: &[ImportWarning],
+) -> Result<(), ImportError> {
+    if run.requests.is_empty() {
+        let guidance = persistable_zero_request_guidance();
+        let warning_messages = warnings
+            .iter()
+            .map(|w| w.message().to_owned())
+            .collect::<Vec<_>>();
+        if warning_messages.is_empty() {
+            return Err(ImportError::ZeroRequestArtifact { guidance });
+        }
+        return Err(ImportError::ZeroRequestArtifactWithWarnings {
+            guidance,
+            warnings: warning_messages,
+        });
+    }
+    ensure_persistable_run_has_requests(run)
+}
+
 pub(crate) fn persistable_zero_request_guidance() -> String {
     "tracing import produced zero request events; persisted Run JSON artifacts intended for tailtriage analyze require at least one completed tt.kind=\"request\" span with tt.request_id, tt.route, and explicit unix-ms timing fields (started_at_unix_ms/finished_at_unix_ms).".to_owned()
 }

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -12,7 +12,7 @@ use tracing::{Id, Subscriber};
 use tracing_subscriber::layer::{Context, Layer};
 
 use crate::{
-    duration_within_tolerance, ensure_persistable_run_has_requests, run_from_span_records,
+    duration_within_tolerance, ensure_persistable_run_with_warnings, run_from_span_records,
     FieldValue, ImportError, ImportOptions, ImportedRun, SpanRecord, TT_KIND,
 };
 
@@ -302,21 +302,7 @@ impl TracingIntakeSession {
         let imported = self.recorder.shutdown()?;
         let (run, warnings) = imported.into_parts();
         if self.run_json_path.is_some() || self.completed_span_jsonl_path.is_some() {
-            if run.requests.is_empty() {
-                let guidance = crate::persistable_zero_request_guidance();
-                let warning_messages = warnings
-                    .iter()
-                    .map(|w| w.message().to_owned())
-                    .collect::<Vec<_>>();
-                if warning_messages.is_empty() {
-                    return Err(ImportError::ZeroRequestArtifact { guidance });
-                }
-                return Err(ImportError::ZeroRequestArtifactWithWarnings {
-                    guidance,
-                    warnings: warning_messages,
-                });
-            }
-            ensure_persistable_run_has_requests(&run)?;
+            ensure_persistable_run_with_warnings(&run, &warnings)?;
         }
         if let Some(path) = &self.completed_span_jsonl_path {
             write_completed_span_jsonl_from_run(&run, path)?;

--- a/tailtriage-tracing/src/tokio.rs
+++ b/tailtriage-tracing/src/tokio.rs
@@ -9,7 +9,7 @@ use tailtriage_core::{
 use tailtriage_tokio::{RuntimeSampler, SamplerStartError};
 
 use crate::{
-    ensure_persistable_run_has_requests, ImportError, ImportWarning, ImportedRun, RecorderLimits,
+    ensure_persistable_run_with_warnings, ImportError, ImportWarning, ImportedRun, RecorderLimits,
     TailtriageLayer, TracingRecorder,
 };
 
@@ -139,7 +139,7 @@ impl TracingTokioSession {
         let merged =
             with_manual_sampler_warning(merge_runtime_data(imported, &runtime), sampler_disabled);
         if let Some(path) = &self.run_json_path {
-            ensure_persistable_run_has_requests(merged.run())
+            ensure_persistable_run_with_warnings(merged.run(), merged.warnings())
                 .map_err(TracingTokioSessionShutdownError::Import)?;
             write_run_json(path, merged.run()).map_err(|reason| {
                 TracingTokioSessionShutdownError::RunJsonWrite {

--- a/tailtriage-tracing/tests/tokio_session.rs
+++ b/tailtriage-tracing/tests/tokio_session.rs
@@ -465,6 +465,41 @@ async fn zero_request_run_json_path_fails_and_does_not_write_file() {
         err,
         TracingTokioSessionShutdownError::Import(ImportError::ZeroRequestArtifact { .. })
     ));
+    let err_text = err.to_string();
+    assert!(err_text.contains("tracing import produced zero request events"));
+    assert!(!err_text.contains("warnings observed during tracing intake:"));
+    assert!(!run_path.exists());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn zero_request_run_json_path_surfaces_intake_warnings_in_shutdown_error() {
+    let run_path = unique_path("tokio-session-empty-with-warnings/run.json");
+    let _ = std::fs::remove_file(&run_path);
+    let session = TracingTokioSession::builder("svc")
+        .run_json_path(&run_path)
+        .start()
+        .expect("start");
+    let subscriber = tracing_subscriber::registry().with(session.layer());
+    tracing::subscriber::with_default(subscriber, || {
+        tracing::info_span!(
+            "bad",
+            tt.kind = "bogus",
+            tt.request_id = "r-bad",
+            tt.route = "/bad"
+        )
+        .in_scope(|| {});
+    });
+    let err = session.shutdown().await.expect_err("must fail");
+    assert!(matches!(
+        err,
+        TracingTokioSessionShutdownError::Import(
+            ImportError::ZeroRequestArtifactWithWarnings { .. }
+        )
+    ));
+    let err_text = err.to_string();
+    assert!(err_text.contains("tracing import produced zero request events"));
+    assert!(err_text.contains("warnings observed during tracing intake:"));
+    assert!(err_text.contains("invalid tt.kind"));
     assert!(!run_path.exists());
 }
 


### PR DESCRIPTION
### Motivation
- Make `TracingTokioSession::shutdown()` surface intake warning context when `run_json_path(...)` is configured and no requests are retained, matching `TracingIntakeSession::shutdown()` behavior.
- Avoid dropping `merged.warnings()` when the zero-request persisted-output error is produced so users get actionable setup guidance.

### Description
- Added a private helper `ensure_persistable_run_with_warnings(run: &Run, warnings: &[ImportWarning]) -> Result<(), ImportError>` in `tailtriage-tracing/src/lib.rs` that returns the warning-carrying `ImportError::ZeroRequestArtifactWithWarnings` when `run.requests.is_empty()` and `warnings` is non-empty, otherwise returns the generic zero-request error or delegates to `ensure_persistable_run_has_requests` for non-empty runs.
- Replaced inline zero-request checks in `TracingIntakeSession::shutdown()` to call `ensure_persistable_run_with_warnings` (no behavior broadening, centralizes logic).
- Updated `TracingTokioSession::shutdown()` to use `ensure_persistable_run_with_warnings(merged.run(), merged.warnings())` before writing Run JSON so zero-request failures preserve intake warnings.
- Added a Tokio-session test `zero_request_run_json_path_surfaces_intake_warnings_in_shutdown_error` that records a malformed `tt.*` span (`tt.kind = "bogus"`) and asserts shutdown returns `TracingTokioSessionShutdownError::Import(ImportError::ZeroRequestArtifactWithWarnings { .. })` and that the error text contains the zero-request guidance and the intake warning text; also tightened the existing zero-request test to assert the no-warning case remains the generic guidance.
- Updated `tailtriage-tracing/README.md` to note that persisted-output zero-request warning-context language applies to both `TracingIntakeSession` and `TracingTokioSession`.

### Testing
- Ran `cargo fmt --all --check` (after an auto-`cargo fmt --all` to address formatting) and it passed.
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests passed, including the new Tokio-session test and updated existing zero-request test.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed with no warnings.
- Ran `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1727aef02083308f0c87c37fd8d1b3)