### PR TITLE
docs(tracing): use process-wide subscriber in intake session rustdoc

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -239,31 +239,32 @@ impl TracingRecorder {
 impl TracingIntakeSession {
     /// Creates a tracing intake session builder with required service metadata.
     ///
+    /// Service startup should install `session.layer()` in the process-wide subscriber setup;
+    /// scoped defaults are only for local/test-style usage.
     /// ```no_run
     /// use tailtriage_tracing::TracingIntakeSession;
     /// use tracing_subscriber::prelude::*;
     ///
-    /// // Record completed work from span close/drop; keep the span active around the work you want measured.
-    ///
     /// let session = TracingIntakeSession::builder("checkout")
     ///     .completed_span_jsonl_path("completed-spans.jsonl")
-    ///     .build()
-    ///     .expect("session should build");
+    ///     .build()?;
     ///
-    /// let subscriber = tracing_subscriber::registry().with(session.layer());
-    /// tracing::subscriber::with_default(subscriber, || {
-    ///     let span = tracing::info_span!(
-    ///         "request",
-    ///         tt.kind = "request",
-    ///         tt.request_id = "r1",
-    ///         tt.route = "/checkout"
-    ///     );
+    /// tracing_subscriber::registry().with(session.layer()).init();
     ///
+    /// let span = tracing::info_span!(
+    ///     "request",
+    ///     tt.kind = "request",
+    ///     tt.request_id = "r1",
+    ///     tt.route = "/checkout"
+    /// );
+    ///
+    /// {
     ///     let _guard = span.enter();
     ///     // measured work goes here
-    /// });
+    /// }
     ///
-    /// let _ = session.shutdown().expect("shutdown should succeed");
+    /// session.shutdown()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn builder(service_name: impl Into<String>) -> TracingIntakeSessionBuilder {
         TracingIntakeSessionBuilder {


### PR DESCRIPTION
### Motivation
- The rustdoc example for `TracingIntakeSession::builder` previously showed a scoped `tracing::subscriber::with_default(...)` usage that could be misread as the recommended service startup path.
- The project README and usage guidance advocate installing `session.layer()` into a process-wide subscriber for real services, so the example should mirror that pattern.

### Description
- Edited `tailtriage-tracing/src/recorder.rs` to replace the `TracingIntakeSession::builder(...)` rustdoc example to use a process-wide subscriber install via `tracing_subscriber::registry().with(session.layer()).init()` and made the block `no_run`.
- The example now builds the session with `completed_span_jsonl_path`, installs the layer process-wide, creates a single request span with `tt.kind`, `tt.request_id`, and `tt.route`, enters/drops the span to demonstrate a completed span, and calls `session.shutdown()?`.
- Added a one-sentence rustdoc guidance immediately adjacent to the example stating that service startup should install `session.layer()` process-wide while scoped defaults are only for local/test usage.
- No runtime behavior, public APIs, or logic were changed.

### Testing
- Ran `cargo fmt --check` and it succeeded with no changes required.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it completed with no warnings.
- Ran `cargo test --workspace` and the full test suite passed successfully.
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation succeeded.
- Ran `cargo test -p tailtriage-tracing --all-targets --all-features --locked` and the tracing crate tests (including doctests) passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17d2041b5c83309eb346cde1b49dcb)