### PR TITLE
docs(tracing): update TracingIntakeSession rustdoc to process-wide subscriber setup

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -239,31 +239,30 @@ impl TracingRecorder {
 impl TracingIntakeSession {
     /// Creates a tracing intake session builder with required service metadata.
     ///
+    /// Service startup should install `session.layer()` in process-wide subscriber setup;
+    /// scoped defaults are only for local/test-style usage.
     /// ```no_run
     /// use tailtriage_tracing::TracingIntakeSession;
     /// use tracing_subscriber::prelude::*;
     ///
-    /// // Record completed work from span close/drop; keep the span active around the work you want measured.
-    ///
     /// let session = TracingIntakeSession::builder("checkout")
     ///     .completed_span_jsonl_path("completed-spans.jsonl")
-    ///     .build()
-    ///     .expect("session should build");
+    ///     .build()?;
     ///
-    /// let subscriber = tracing_subscriber::registry().with(session.layer());
-    /// tracing::subscriber::with_default(subscriber, || {
-    ///     let span = tracing::info_span!(
-    ///         "request",
-    ///         tt.kind = "request",
-    ///         tt.request_id = "r1",
-    ///         tt.route = "/checkout"
-    ///     );
+    /// tracing_subscriber::registry().with(session.layer()).init();
     ///
-    ///     let _guard = span.enter();
-    ///     // measured work goes here
-    /// });
+    /// let span = tracing::info_span!(
+    ///     "request",
+    ///     tt.kind = "request",
+    ///     tt.request_id = "r1",
+    ///     tt.route = "/checkout"
+    /// );
+    /// let _guard = span.enter();
+    /// // measured work goes here
+    /// drop(_guard);
     ///
-    /// let _ = session.shutdown().expect("shutdown should succeed");
+    /// session.shutdown()?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn builder(service_name: impl Into<String>) -> TracingIntakeSessionBuilder {
         TracingIntakeSessionBuilder {


### PR DESCRIPTION
### Motivation
- Fix the `TracingIntakeSession::builder(...)` rustdoc example so it does not present scoped `with_default(...)` subscriber setup as the normal service startup path and instead shows the recommended process-wide installation of `session.layer()`.

### Description
- Replaced the rustdoc example in `tailtriage-tracing/src/recorder.rs` for `TracingIntakeSession::builder(...)` with a `no_run` example that uses `use tracing_subscriber::prelude::*;`, builds the session via `let session = TracingIntakeSession::builder("checkout").completed_span_jsonl_path("completed-spans.jsonl").build()?;`, installs the layer with `tracing_subscriber::registry().with(session.layer()).init();`, demonstrates creating a request span with `tt.kind`, `tt.request_id`, and `tt.route`, enters/drops the span so a completed span is shown, calls `session.shutdown()?`, and adds a short sentence clarifying that service startup should install `session.layer()` process-wide while scoped defaults are for local/test use.

### Testing
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `python3 scripts/validate_docs_contracts.py`, and `cargo test -p tailtriage-tracing --all-targets --all-features --locked`, and all checks passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17d2041b5c83309eb346cde1b49dcb)