### PR TITLE
docs(tracing): use process-wide subscriber setup in TracingIntakeSession rustdoc

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -239,31 +239,33 @@ impl TracingRecorder {
 impl TracingIntakeSession {
     /// Creates a tracing intake session builder with required service metadata.
     ///
+    /// Service startup should install `session.layer()` in the process-wide subscriber setup; use scoped defaults only for local/test-style usage.
+    ///
     /// ```no_run
     /// use tailtriage_tracing::TracingIntakeSession;
     /// use tracing_subscriber::prelude::*;
     ///
-    /// // Record completed work from span close/drop; keep the span active around the work you want measured.
-    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let session = TracingIntakeSession::builder("checkout")
     ///     .completed_span_jsonl_path("completed-spans.jsonl")
-    ///     .build()
-    ///     .expect("session should build");
+    ///     .build()?;
     ///
-    /// let subscriber = tracing_subscriber::registry().with(session.layer());
-    /// tracing::subscriber::with_default(subscriber, || {
-    ///     let span = tracing::info_span!(
-    ///         "request",
-    ///         tt.kind = "request",
-    ///         tt.request_id = "r1",
-    ///         tt.route = "/checkout"
-    ///     );
+    /// tracing_subscriber::registry().with(session.layer()).init();
     ///
+    /// let span = tracing::info_span!(
+    ///     "request",
+    ///     tt.kind = "request",
+    ///     tt.request_id = "r1",
+    ///     tt.route = "/checkout"
+    /// );
+    /// {
     ///     let _guard = span.enter();
     ///     // measured work goes here
-    /// });
+    /// }
     ///
-    /// let _ = session.shutdown().expect("shutdown should succeed");
+    /// session.shutdown()?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn builder(service_name: impl Into<String>) -> TracingIntakeSessionBuilder {
         TracingIntakeSessionBuilder {


### PR DESCRIPTION
### Motivation
- Correct the `TracingIntakeSession::builder(...)` rustdoc example so it demonstrates process-wide subscriber installation (the recommended service startup pattern) rather than teaching `tracing::subscriber::with_default(...)` scoped usage.

### Description
- Updated the rustdoc example in `tailtriage-tracing/src/recorder.rs` for `TracingIntakeSession::builder(...)` to use a `no_run` `main() -> Result` example that calls `TracingIntakeSession::builder(...)`, installs the layer with `tracing_subscriber::registry().with(session.layer()).init()`, creates a single request span with `tt.kind`, `tt.request_id`, and `tt.route`, enters/drops it, and calls `session.shutdown()?`, and added a one-line guidance sentence that service startup should install `session.layer()` process-wide and scoped defaults are only for local/test usage; no runtime behavior or API changes were made.

### Testing
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `python3 scripts/validate_docs_contracts.py`, and `cargo test -p tailtriage-tracing --all-targets --all-features --locked`, and all checks/tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17d2041b5c83309eb346cde1b49dcb)