### PR TITLE
Fix Tokio-session docs/example feature mismatch in tailtriage-tracing

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -109,6 +109,7 @@ Tokio runtime sampler coupling via `TracingTokioSession` requires the `tokio` fe
 ```bash
 cargo add tailtriage-tracing --features tokio
 cargo add tracing tracing-subscriber
+cargo add tokio --features macros,rt-multi-thread
 ```
 
 For the full tracing setup details and both flows, see `tailtriage-tracing/README.md`.

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -42,6 +42,7 @@ workspace = true
 tailtriage-analyzer.workspace = true
 futures-executor = "0.3"
 tempfile = "3"
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
 
 [[example]]
 name = "completed_span_jsonl_import"

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -34,6 +34,7 @@ If you use Tokio runtime sampler coupling via `TracingTokioSession`, use:
 ```bash
 cargo add tailtriage-tracing --features tokio
 cargo add tracing tracing-subscriber
+cargo add tokio --features macros,rt-multi-thread
 ```
 
 ## Recommended live session setup (`live` feature)


### PR DESCRIPTION
### Motivation

- Examples and package tests that use `#[tokio::main]` require the `tokio` `macros` feature to compile in isolation, but the crate's public optional `tokio` dependency should remain lightweight and not expose `macros` unless the library itself needs it. 
- The install snippets in the docs omitted an explicit app dependency line for Tokio with the `macros` feature, which can confuse users and prevent examples from compiling when added to a project.

### Description

- Added a `dev-dependency` entry in `tailtriage-tracing/Cargo.toml` for `tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }` so examples and tests using `#[tokio::main]` compile during isolated package builds. 
- Kept the public optional `tokio` dependency used by the crate feature as `tokio = { version = "1", features = ["rt", "sync", "time"], optional = true }` without adding `macros` to the public feature surface. 
- Updated `tailtriage-tracing/README.md` to add the explicit install line `cargo add tokio --features macros,rt-multi-thread` to the `TracingTokioSession` usage snippet. 
- Updated `docs/user-guide.md` to add the same explicit `cargo add tokio --features macros,rt-multi-thread` install line in the short `TracingTokioSession` setup snippet.

### Testing

- Changed files: `tailtriage-tracing/Cargo.toml`, `tailtriage-tracing/README.md`, and `docs/user-guide.md`.
- Ran `cargo fmt --check` which passed. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` which passed. 
- Ran `cargo test --workspace` which passed. 
- Ran `python3 scripts/validate_docs_contracts.py` which passed (`docs contracts validated successfully`). 
- Verified isolated package checks `cargo test -p tailtriage-tracing --no-default-features --features tokio --all-targets --locked` and `cargo check -p tailtriage-tracing --no-default-features --features tokio --examples --locked`, both of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a181b37690083309f6902ccc94615d3)