### PR TITLE
Fix tailtriage-tracing Tokio session docs/example feature mismatch

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -109,6 +109,7 @@ Tokio runtime sampler coupling via `TracingTokioSession` requires the `tokio` fe
 ```bash
 cargo add tailtriage-tracing --features tokio
 cargo add tracing tracing-subscriber
+cargo add tokio --features macros,rt-multi-thread
 ```
 
 For the full tracing setup details and both flows, see `tailtriage-tracing/README.md`.

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -42,6 +42,7 @@ workspace = true
 tailtriage-analyzer.workspace = true
 futures-executor = "0.3"
 tempfile = "3"
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
 
 [[example]]
 name = "completed_span_jsonl_import"

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -34,6 +34,7 @@ If you use Tokio runtime sampler coupling via `TracingTokioSession`, use:
 ```bash
 cargo add tailtriage-tracing --features tokio
 cargo add tracing tracing-subscriber
+cargo add tokio --features macros,rt-multi-thread
 ```
 
 ## Recommended live session setup (`live` feature)


### PR DESCRIPTION
### Motivation
- Examples and package-level tests that use `#[tokio::main]` were failing to compile in isolated package checks because application code needs the `tokio` `macros` feature while the crate's public optional `tokio` feature remained lightweight.
- The intent is to make examples/tests compile in isolation without adding `macros` to the public `tokio` feature exposed by the crate.

### Description
- Added a `dev-dependency` for `tokio` in `tailtriage-tracing/Cargo.toml` with `macros`, `rt`, `rt-multi-thread`, `sync`, and `time` via `tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }` so examples/tests using `#[tokio::main]` compile in isolation.
- Left the public/optional `tokio` dependency unchanged and lightweight (did not add `macros` to the crate's public `tokio` feature).
- Updated `tailtriage-tracing/README.md` and `docs/user-guide.md` to add an explicit app install line `cargo add tokio --features macros,rt-multi-thread` in the `TracingTokioSession` snippets so users know to add the app dependency with the needed features.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it passed.
- Ran `cargo test --workspace` and it passed.
- Ran `python3 scripts/validate_docs_contracts.py` and it passed with `docs contracts validated successfully`.
- Ran isolated package checks `cargo test -p tailtriage-tracing --no-default-features --features tokio --all-targets --locked` and `cargo check -p tailtriage-tracing --no-default-features --features tokio --examples --locked` and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a181b37690083309f6902ccc94615d3)