### PR TITLE
Fix tailtriage-tracing Tokio session docs/example feature mismatch

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -109,6 +109,7 @@ Tokio runtime sampler coupling via `TracingTokioSession` requires the `tokio` fe
 ```bash
 cargo add tailtriage-tracing --features tokio
 cargo add tracing tracing-subscriber
+cargo add tokio --features macros,rt-multi-thread
 ```
 
 For the full tracing setup details and both flows, see `tailtriage-tracing/README.md`.

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -42,6 +42,7 @@ workspace = true
 tailtriage-analyzer.workspace = true
 futures-executor = "0.3"
 tempfile = "3"
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
 
 [[example]]
 name = "completed_span_jsonl_import"

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -34,6 +34,7 @@ If you use Tokio runtime sampler coupling via `TracingTokioSession`, use:
 ```bash
 cargo add tailtriage-tracing --features tokio
 cargo add tracing tracing-subscriber
+cargo add tokio --features macros,rt-multi-thread
 ```
 
 ## Recommended live session setup (`live` feature)


### PR DESCRIPTION
### Motivation
- Package-local examples and tests that use `#[tokio::main]` need the `tokio::macros` feature to compile in isolated package checks, but the public optional `tokio` dependency was intentionally lightweight (no `macros`).
- Provide a minimal, non-public fix so examples/tests compile in isolation while preserving the public feature surface and not adding `macros` to the public `tokio` feature.

### Description
- Add a `dev-dependency` on `tokio = { version = "1", features = ["macros","rt","rt-multi-thread","sync","time"] }` to `tailtriage-tracing/Cargo.toml` so examples/tests using `#[tokio::main]` build in package-local checks.
- Leave the public optional `tokio` dependency unchanged and lightweight (`features = ["rt","sync","time"]`) to avoid exposing `macros` on the public feature surface.
- Update `tailtriage-tracing/README.md` and `docs/user-guide.md` `TracingTokioSession` snippets to add the explicit application install guidance `cargo add tokio --features macros,rt-multi-thread`.

### Testing
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, and `python3 scripts/validate_docs_contracts.py`, all of which completed successfully.
- Ran isolated package checks `cargo test -p tailtriage-tracing --no-default-features --features tokio --all-targets --locked` and `cargo check -p tailtriage-tracing --no-default-features --features tokio --examples --locked`, both of which succeeded.
- Files changed: `tailtriage-tracing/Cargo.toml`, `tailtriage-tracing/README.md`, and `docs/user-guide.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a181b37690083309f6902ccc94615d3)