### PR TITLE
Fix tailtriage-tracing Tokio session docs/example feature mismatch

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -109,6 +109,7 @@ Tokio runtime sampler coupling via `TracingTokioSession` requires the `tokio` fe
 ```bash
 cargo add tailtriage-tracing --features tokio
 cargo add tracing tracing-subscriber
+cargo add tokio --features macros,rt-multi-thread
 ```
 
 For the full tracing setup details and both flows, see `tailtriage-tracing/README.md`.

--- a/tailtriage-tracing/Cargo.toml
+++ b/tailtriage-tracing/Cargo.toml
@@ -42,6 +42,7 @@ workspace = true
 tailtriage-analyzer.workspace = true
 futures-executor = "0.3"
 tempfile = "3"
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
 
 [[example]]
 name = "completed_span_jsonl_import"

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -34,6 +34,7 @@ If you use Tokio runtime sampler coupling via `TracingTokioSession`, use:
 ```bash
 cargo add tailtriage-tracing --features tokio
 cargo add tracing tracing-subscriber
+cargo add tokio --features macros,rt-multi-thread
 ```
 
 ## Recommended live session setup (`live` feature)


### PR DESCRIPTION
### Motivation
- Examples and package-local tests that use `#[tokio::main]` require the `tokio` `macros` feature during crate-local compilation, while the published `tokio` feature for `tailtriage-tracing` should remain lightweight and not force `macros` on consumers.

### Description
- Add a `tokio` dev-dependency in `tailtriage-tracing/Cargo.toml` with `features = ["macros", "rt", "rt-multi-thread", "sync", "time"]` so examples/tests that use `#[tokio::main]` compile in isolation.
- Keep the crate `tokio` optional dependency used by the public `tokio` feature unchanged (no `macros` added).
- Update `tailtriage-tracing/README.md` and `docs/user-guide.md` to include the explicit app install line `cargo add tokio --features macros,rt-multi-thread` in the `TracingTokioSession` setup snippets.

### Testing
- Ran `cargo fmt --check` and it succeeded.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it succeeded.
- Ran `cargo test --workspace` and the workspace test suite succeeded.
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation succeeded.
- Ran `cargo test -p tailtriage-tracing --no-default-features --features tokio --all-targets --locked` and it succeeded.
- Ran `cargo check -p tailtriage-tracing --no-default-features --features tokio --examples --locked` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a181b37690083309f6902ccc94615d3)