### PR TITLE
Rename CLI import subcommand to `tracing-spans-jsonl`

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ Add `tailtriage-analyzer` when you want to analyze a completed Run inside Rust c
 
 If your service already emits `tracing` spans, use `tailtriage-tracing` as a narrow tracing intake bridge. Native capture remains the default path for new integrations.
 
-Offline import expects completed `tt.*` span JSONL (not arbitrary tracing log JSON), requires explicit unix-ms timing, and writes Run JSON before a separate `tailtriage analyze` step.
+Offline import expects completed tailtriage tracing span JSONL with `tt.*` fields (not arbitrary tracing log JSON), requires explicit unix-ms timing, and writes Run JSON before a separate `tailtriage analyze` step.
 
 - Offline JSONL import:
   ```bash
-  tailtriage import tracing-json completed-spans.jsonl --service checkout --output tailtriage-run.json
+  tailtriage import tracing-spans-jsonl completed-spans.jsonl --service checkout --output tailtriage-run.json
   tailtriage analyze tailtriage-run.json
   ```
 - Live session path: first install `tailtriage-tracing` with `live` (`cargo add tailtriage-tracing --features live`), then add `tailtriage_tracing::TracingIntakeSession` and `session.layer()` beside your existing subscriber setup.
@@ -238,13 +238,13 @@ if let Some(finalized_run) = sink.take_run() {
 tailtriage analyze tailtriage-run.json --format json
 ```
 
-Import completed tracing span records (JSONL) into a Run artifact first when needed:
+Import completed tailtriage tracing span JSONL records into a Run artifact first when needed:
 
 ```bash
-tailtriage import tracing-json completed-spans.jsonl --service checkout --output tailtriage-run.json
+tailtriage import tracing-spans-jsonl completed-spans.jsonl --service checkout --output tailtriage-run.json
 ```
 
-`tailtriage import tracing-json` writes **Run JSON** (capture artifact and CLI input), not Report JSON. Use `--strict` to fail on malformed/incomplete `tt.*` spans; without `--strict`, malformed `tt.*` spans are skipped and surfaced as `warning: ...` lines on stderr. Arbitrary `tracing_subscriber::fmt().json()` log JSON is not imported, and timing is not guessed from line receive time: completed spans must include explicit unix-ms start/end timestamps. Persisted Run JSON intended for `tailtriage analyze` must include at least one completed request event; in-process library snapshots may still be zero-request for inspection.
+`tailtriage import tracing-spans-jsonl` imports completed tailtriage tracing span JSONL and writes **Run JSON** (capture artifact and CLI input), not Report JSON. Use `--strict` to fail on malformed/incomplete `tt.*` spans; without `--strict`, malformed `tt.*` spans are skipped and surfaced as `warning: ...` lines on stderr. Arbitrary `tracing_subscriber::fmt().json()` log JSON is not imported, and timing is not guessed from line receive time: completed spans must include explicit unix-ms start/end timestamps. Persisted Run JSON intended for `tailtriage analyze` must include at least one completed request event; in-process library snapshots may still be zero-request for inspection.
 Tracing-only imports can provide request/stage/queue evidence outside Tokio runtimes, but they do not fabricate runtime-pressure snapshots.
 
 Analyzer thresholds can be tuned through Rust (`AnalyzeOptions`), TOML (`[analyzer]` with `schema_version = 1`), and CLI (`--analyzer-config` / `--analyzer-set`). Start with defaults first, then tune after representative runs. See [docs/diagnostics.md](docs/diagnostics.md), [docs/operations.md](docs/operations.md), and [`examples/analyzer-config.toml`](examples/analyzer-config.toml).

--- a/SPEC.md
+++ b/SPEC.md
@@ -162,11 +162,11 @@ Analyzer configuration contract:
 
 - primary live path is `TracingIntakeSession` / `TracingIntakeSessionBuilder`; users add `session.layer()` beside their existing `tracing_subscriber` setup
 - live session output can write standard Run JSON on shutdown via `run_json_path(...)`
-- live session output can write stable completed-span JSONL on shutdown via `completed_span_jsonl_path(...)`, using retained semantically valid request/stage/queue evidence
-- stable completed-span JSONL wrapper format is:
+- live session output can write stable completed tailtriage tracing span JSONL on shutdown via `completed_span_jsonl_path(...)`, using retained semantically valid request/stage/queue evidence
+- stable completed tailtriage tracing span JSONL wrapper format is:
   `{"format":"tailtriage.tracing-span.v1","span":{...}}`
 - CLI imports that wrapper shape with:
-  `tailtriage import tracing-json <completed-spans.jsonl> --service <service> --output <run.json>`
+  `tailtriage import tracing-spans-jsonl <completed-spans.jsonl> --service <service> --output <run.json>`
 - tracing intake converts request/stage/queue evidence into the same standard `Run` schema; analyzer semantics remain unchanged
 - request `tt.outcome` is optional; missing defaults to `ok` with a warning, recommended common labels are `ok`/`error`/`timeout`/`cancelled`/`rejected`, and custom non-empty string labels are preserved exactly
 - `tracing_subscriber::fmt().json()` arbitrary log scraping is intentionally unsupported

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -158,7 +158,7 @@ Prefer moderate intervals and bounded runs before increasing density.
 
 ## Operating with tracing-based runs
 
-Tracing import expects completed `tt.*` span JSONL, not ordinary tracing log JSON (`fmt().json` output is a common non-supported example). Import writes Run JSON (not Report JSON), and analysis is a separate step after import (`tailtriage analyze`). Completed-span JSONL is not a production trace archive and does not preserve warning/truncation context; prefer Run JSON when the artifact itself must carry that context. Persisted Run JSON intended for `tailtriage analyze` must include at least one completed request event; in-process library snapshots may still be zero-request for inspection. Timing is not guessed from line receive time, so completed spans must include explicit unix-ms start/end timestamps. OTel/OTLP intake remains out of scope on this path.
+`tailtriage import tracing-spans-jsonl` expects completed tailtriage tracing span JSONL with `tt.*` fields, not ordinary tracing log JSON (`fmt().json` output is a common non-supported example). Import writes Run JSON (not Report JSON), and analysis is a separate step after import (`tailtriage analyze`). Completed tailtriage tracing span JSONL is not a production trace archive and does not preserve warning/truncation context; prefer Run JSON when the artifact itself must carry that context. Persisted Run JSON intended for `tailtriage analyze` must include at least one completed request event; in-process library snapshots may still be zero-request for inspection. Timing is not guessed from line receive time, so completed spans must include explicit unix-ms start/end timestamps. OTel/OTLP intake remains out of scope on this path.
 
 Important limits for production interpretation:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -42,14 +42,14 @@ Install for typed records plus JSONL import APIs (default feature set):
 cargo add tailtriage-tracing
 ```
 
-A) Completed-span JSONL intake path:
+A) Completed tailtriage tracing span JSONL intake path:
 
 ```bash
-tailtriage import tracing-json completed-spans.jsonl --service checkout --output tailtriage-run.json
+tailtriage import tracing-spans-jsonl completed-spans.jsonl --service checkout --output tailtriage-run.json
 tailtriage analyze tailtriage-run.json
 ```
 
-`tailtriage import tracing-json` writes Run artifact JSON (not Report JSON), and analysis remains a separate step after import. Use the documented stable wrapper JSONL shape from `tailtriage-tracing` (`{"format":"tailtriage.tracing-span.v1","span":{...}}`). `--strict` fails on malformed or incomplete `tt.*` spans; non-strict mode skips malformed `tt.*` spans and prints `warning: ...` messages. Tracing import and native capture use the same `CaptureMode`/`CaptureLimits` semantics for request/stage/queue retention. Offline import exposes `--mode <light|investigation>` plus `--max-requests`, `--max-stages`, and `--max-queues` because those are the imported evidence types. It does not expose runtime/in-flight snapshot limit flags because those evidence types are not imported by this path. Tracing-only runs do not fabricate runtime snapshots, and runtime-pressure evidence remains Tokio-specific. Persisted Run JSON and persisted completed-span JSONL intended for offline CLI workflows must include at least one completed request event; in-process library snapshots may still be zero-request for inspection. Completed-span JSONL replays retained request/stage/queue evidence and does not carry live-session warning/truncation metadata; use Run JSON for the complete persisted artifact.
+`tailtriage import tracing-spans-jsonl` imports completed tailtriage tracing span JSONL and writes Run artifact JSON (not Report JSON); analysis remains a separate step after import. Use the documented stable wrapper JSONL shape from `tailtriage-tracing` (`{"format":"tailtriage.tracing-span.v1","span":{...}}`). `--strict` fails on malformed or incomplete `tt.*` spans; non-strict mode skips malformed `tt.*` spans and prints `warning: ...` messages. Completed tracing span JSONL import and native capture use the same `CaptureMode`/`CaptureLimits` semantics for request/stage/queue retention. Offline import exposes `--mode <light|investigation>` plus `--max-requests`, `--max-stages`, and `--max-queues` because those are the imported evidence types. It does not expose runtime/in-flight snapshot limit flags because those evidence types are not imported by this path. Tracing-only runs do not fabricate runtime snapshots, and runtime-pressure evidence remains Tokio-specific. Persisted Run JSON and persisted completed-span JSONL intended for offline CLI workflows must include at least one completed request event; in-process library snapshots may still be zero-request for inspection. Completed-span JSONL replays retained request/stage/queue evidence and does not carry live-session warning/truncation metadata; use Run JSON for the complete persisted artifact.
 
 B) Direct Run JSON path with async span instrumentation (`live` feature required):
 

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -42,21 +42,21 @@ Machine-readable JSON output:
 tailtriage analyze tailtriage-run.json --format json
 ```
 
-Import completed `tt.*` tracing span JSONL into Run JSON:
+Import completed tailtriage tracing span JSONL with `tt.*` fields into Run JSON:
 
 ```bash
-tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json
+tailtriage import tracing-spans-jsonl spans.jsonl --service checkout --output tailtriage-run.json
 ```
 
 With optional metadata flags, strict validation, and explicit format:
 
 ```bash
-tailtriage import tracing-json spans.jsonl --service checkout --output tailtriage-run.json --service-version v1 --run-id run-42 --strict \
+tailtriage import tracing-spans-jsonl spans.jsonl --service checkout --output tailtriage-run.json --service-version v1 --run-id run-42 --strict \
   --input-format tailtriage-span-jsonl
 ```
 
 
-`tailtriage import tracing-json` imports **completed `tt.*` tracing span JSONL** into **Run JSON** (not Report JSON).
+`tailtriage import tracing-spans-jsonl` imports **completed tailtriage tracing span JSONL** with `tt.*` fields into **Run JSON** (not Report JSON).
 
 Recommended stable input format is the tailtriage wrapper JSONL shape:
 
@@ -86,11 +86,11 @@ Zero-request imports fail by design (the CLI loader requires at least one reques
 When paths include spaces, quote them in shell usage:
 
 ```bash
-tailtriage import tracing-json "fixtures/tracing spans.jsonl" --service checkout --output "runs/imported run.json"
+tailtriage import tracing-spans-jsonl "fixtures/tracing spans.jsonl" --service checkout --output "runs/imported run.json"
 ```
 
 The command imports completed `tt.*` tracing span records in the documented JSONL shape and writes Run JSON through the normal local JSON artifact writer, not Report JSON. Import warnings are printed to stderr as `warning: ...`. Analysis is a separate step: `tailtriage analyze tailtriage-run.json`.
-Tracing import and native capture share the same CaptureMode/CaptureLimits semantics for request/stage/queue evidence retention. Offline CLI tracing import exposes request/stage/queue limit overrides because those are the evidence types it imports. It intentionally does not expose runtime-snapshot or in-flight-snapshot limit flags because this import path does not ingest those evidence types. Tracing-only imports do not fabricate runtime snapshots; executor/blocking-pressure interpretation remains limited unless runtime snapshots are also captured (for example via Tokio runtime sampling).
+Completed tracing span JSONL import and native capture share the same CaptureMode/CaptureLimits semantics for request/stage/queue evidence retention. Offline CLI completed span JSONL import exposes request/stage/queue limit overrides because those are the evidence types it imports. It intentionally does not expose runtime-snapshot or in-flight-snapshot limit flags because this import path does not ingest those evidence types. Tracing-only imports do not fabricate runtime snapshots; executor/blocking-pressure interpretation remains limited unless runtime snapshots are also captured (for example via Tokio runtime sampling).
 Malformed JSON input remains fatal. In non-strict mode, syntactically valid malformed/incomplete `tt.*` records are skipped with `warning: ...` lines.
 `--service` must not be empty or whitespace.
 Import fails when zero request events would be written (for example unrelated-only input or all-skipped malformed `tt.*` input), because `tailtriage analyze` requires at least one request in CLI-loaded run artifacts. The same non-empty-request rule applies before persisting completed-span JSONL artifacts in tracing intake sessions.

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -21,7 +21,7 @@ struct Cli {
 
 #[derive(Debug, clap::Subcommand)]
 enum Command {
-    /// Import tracing JSONL spans into a tailtriage run JSON artifact.
+    /// Import completed tailtriage tracing span JSONL into a tailtriage run JSON artifact.
     Import {
         #[command(subcommand)]
         command: ImportCommand,
@@ -49,7 +49,8 @@ enum Command {
 #[derive(Debug, clap::Subcommand)]
 enum ImportCommand {
     /// Import completed `tt.*` tracing span JSONL into Run JSON.
-    TracingJson {
+    #[command(name = "tracing-spans-jsonl")]
+    TracingSpansJsonl {
         /// Path to newline-delimited JSON span records.
         #[arg(value_name = "SPANS_JSONL")]
         spans_jsonl: PathBuf,
@@ -119,7 +120,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     match cli.command {
         Command::Import { command } => match command {
-            ImportCommand::TracingJson {
+            ImportCommand::TracingSpansJsonl {
                 spans_jsonl,
                 service,
                 output,
@@ -131,7 +132,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 max_requests,
                 max_stages,
                 max_queues,
-            } => import_tracing_json(
+            } => import_tracing_spans_jsonl(
                 spans_jsonl,
                 service,
                 &output,
@@ -203,7 +204,7 @@ fn create_output_parent_dir(path: &std::path::Path) -> Result<(), std::io::Error
 }
 
 #[allow(clippy::too_many_arguments)]
-fn import_tracing_json(
+fn import_tracing_spans_jsonl(
     spans_jsonl: PathBuf,
     service: String,
     output: &PathBuf,
@@ -243,7 +244,7 @@ fn import_tracing_json(
             std::io::Error::new(
                 err.kind(),
                 format!(
-                    "failed to inspect tracing JSON input '{}': {err}",
+                    "failed to inspect completed tailtriage tracing span JSONL input '{}': {err}",
                     spans_jsonl.display()
                 ),
             )
@@ -255,7 +256,7 @@ fn import_tracing_json(
     if looks_like_fmt_json {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
-            tracing_json_setup_guidance(),
+            tracing_spans_jsonl_setup_guidance(),
         )
         .into());
     }
@@ -290,8 +291,8 @@ fn import_tracing_json(
     Ok(())
 }
 
-fn tracing_json_setup_guidance() -> &'static str {
-    "the file looks like ordinary tracing log JSON, not completed tailtriage span JSONL. tailtriage requires completed spans with literal dotted tt.* keys and explicit unix-ms start/end timestamps. Stable import expects wrapper JSONL records shaped like {\"format\":\"tailtriage.tracing-span.v1\",\"span\":{...}}. Ordinary tracing_subscriber::fmt().json() logs are unsupported. Recommended setup: TracingIntakeSession::builder(...).completed_span_jsonl_path(...). Then run: tailtriage import tracing-json <completed-spans.jsonl> --service <service> --output <run-json>"
+fn tracing_spans_jsonl_setup_guidance() -> &'static str {
+    "the file looks like ordinary tracing log JSON, not completed tailtriage tracing span JSONL. tailtriage requires completed spans with literal dotted tt.* keys and explicit unix-ms start/end timestamps. Stable import expects wrapper JSONL records shaped like {\"format\":\"tailtriage.tracing-span.v1\",\"span\":{...}}. Ordinary tracing_subscriber::fmt().json() logs are unsupported. Recommended setup: TracingIntakeSession::builder(...).completed_span_jsonl_path(...). Then run: tailtriage import tracing-spans-jsonl <completed-spans.jsonl> --service <service> --output <run-json>"
 }
 
 fn should_append_wrapper_guidance(input_format: TracingInputFormat, err: &ImportError) -> bool {

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -223,7 +223,7 @@ fn missing_run_json_without_help_flag_fails_clearly() {
 }
 
 #[test]
-fn import_tracing_json_creates_missing_output_parent_directories() {
+fn import_tracing_spans_jsonl_creates_missing_output_parent_directories() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("missing-parent/run.json");
@@ -231,7 +231,7 @@ fn import_tracing_json_creates_missing_output_parent_directories() {
 
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -251,7 +251,7 @@ fn import_tracing_json_creates_missing_output_parent_directories() {
 }
 
 #[test]
-fn import_tracing_json_fails_when_output_parent_path_is_not_directory() {
+fn import_tracing_spans_jsonl_fails_when_output_parent_path_is_not_directory() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let invalid_parent = dir.path().join("not-a-dir");
@@ -261,7 +261,7 @@ fn import_tracing_json_fails_when_output_parent_path_is_not_directory() {
 
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -281,7 +281,7 @@ fn import_tracing_json_fails_when_output_parent_path_is_not_directory() {
 }
 
 #[test]
-fn import_tracing_json_writes_run_json_analyzable_by_existing_apis() {
+fn import_tracing_spans_jsonl_writes_run_json_analyzable_by_existing_apis() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
@@ -289,7 +289,7 @@ fn import_tracing_json_writes_run_json_analyzable_by_existing_apis() {
 
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -309,7 +309,7 @@ fn import_tracing_json_writes_run_json_analyzable_by_existing_apis() {
 }
 
 #[test]
-fn import_tracing_json_writes_run_json_when_output_path_contains_spaces() {
+fn import_tracing_spans_jsonl_writes_run_json_when_output_path_contains_spaces() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run artifact with spaces.json");
@@ -317,7 +317,7 @@ fn import_tracing_json_writes_run_json_when_output_path_contains_spaces() {
 
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -335,14 +335,14 @@ fn import_tracing_json_writes_run_json_when_output_path_contains_spaces() {
 }
 
 #[test]
-fn import_tracing_json_mode_investigation_sets_run_metadata_mode() {
+fn import_tracing_spans_jsonl_mode_investigation_sets_run_metadata_mode() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
     std::fs::write(&spans_path, complete_span_jsonl_fixture()).expect("fixture should write");
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--mode")
         .arg("investigation")
@@ -358,14 +358,14 @@ fn import_tracing_json_mode_investigation_sets_run_metadata_mode() {
 }
 
 #[test]
-fn import_tracing_json_capture_limit_overrides_apply() {
+fn import_tracing_spans_jsonl_capture_limit_overrides_apply() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
     std::fs::write(&spans_path, multi_span_jsonl_fixture()).expect("fixture should write");
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -389,14 +389,14 @@ fn import_tracing_json_capture_limit_overrides_apply() {
 }
 
 #[test]
-fn import_tracing_json_rejects_inert_runtime_snapshot_flags() {
+fn import_tracing_spans_jsonl_rejects_inert_runtime_snapshot_flags() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
     std::fs::write(&spans_path, complete_span_jsonl_fixture()).expect("fixture should write");
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -412,14 +412,14 @@ fn import_tracing_json_rejects_inert_runtime_snapshot_flags() {
 }
 
 #[test]
-fn import_tracing_json_rejects_inert_inflight_snapshot_flags() {
+fn import_tracing_spans_jsonl_rejects_inert_inflight_snapshot_flags() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
     std::fs::write(&spans_path, complete_span_jsonl_fixture()).expect("fixture should write");
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -446,7 +446,7 @@ fn tailtriage_help_mentions_import_and_analyze_artifacts() {
 }
 
 #[test]
-fn import_tracing_json_input_format_tailtriage_wrapper_only_accepts_fixture() {
+fn import_tracing_spans_jsonl_input_format_tailtriage_wrapper_only_accepts_fixture() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
@@ -454,7 +454,7 @@ fn import_tracing_json_input_format_tailtriage_wrapper_only_accepts_fixture() {
 
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -476,14 +476,14 @@ fn import_tracing_json_input_format_tailtriage_wrapper_only_accepts_fixture() {
 }
 
 #[test]
-fn import_tracing_json_input_format_tailtriage_wrapper_only_rejects_unwrapped() {
+fn import_tracing_spans_jsonl_input_format_tailtriage_wrapper_only_rejects_unwrapped() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
     std::fs::write(&spans_path, one_valid_request_span_fixture()).expect("fixture should write");
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -500,14 +500,14 @@ fn import_tracing_json_input_format_tailtriage_wrapper_only_rejects_unwrapped() 
 }
 
 #[test]
-fn import_tracing_json_default_wrapper_mode_rejects_wrong_wrapper_format_with_guidance() {
+fn import_tracing_spans_jsonl_default_wrapper_mode_rejects_wrong_wrapper_format_with_guidance() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
     std::fs::write(&spans_path, r#"{"format":"tailtriage.tracing-span.v2","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#).unwrap();
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -521,14 +521,14 @@ fn import_tracing_json_default_wrapper_mode_rejects_wrong_wrapper_format_with_gu
 }
 
 #[test]
-fn import_tracing_json_default_wrapper_mode_semantic_missing_route_no_wrapper_guidance() {
+fn import_tracing_spans_jsonl_default_wrapper_mode_semantic_missing_route_no_wrapper_guidance() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
     std::fs::write(&spans_path, r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1"}}}"#).unwrap();
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -544,14 +544,15 @@ fn import_tracing_json_default_wrapper_mode_semantic_missing_route_no_wrapper_gu
 }
 
 #[test]
-fn import_tracing_json_default_wrapper_mode_semantic_invalid_kind_type_no_wrapper_guidance() {
+fn import_tracing_spans_jsonl_default_wrapper_mode_semantic_invalid_kind_type_no_wrapper_guidance()
+{
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
     std::fs::write(&spans_path, r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":1,"tt.request_id":"r1","tt.route":"/a"}}}"#).unwrap();
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -567,13 +568,14 @@ fn import_tracing_json_default_wrapper_mode_semantic_invalid_kind_type_no_wrappe
 }
 
 #[test]
-fn import_tracing_json_default_wrapper_mode_missing_input_does_not_append_wrapper_guidance() {
+fn import_tracing_spans_jsonl_default_wrapper_mode_missing_input_does_not_append_wrapper_guidance()
+{
     let dir = tempfile::tempdir().expect("tempdir should build");
     let missing_spans_path = dir.path().join("missing-spans.jsonl");
     let run_path = dir.path().join("run.json");
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&missing_spans_path)
         .arg("--service")
         .arg("checkout")
@@ -589,14 +591,15 @@ fn import_tracing_json_default_wrapper_mode_missing_input_does_not_append_wrappe
 }
 
 #[test]
-fn import_tracing_json_default_wrapper_mode_malformed_json_does_not_append_wrapper_guidance() {
+fn import_tracing_spans_jsonl_default_wrapper_mode_malformed_json_does_not_append_wrapper_guidance()
+{
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("bad.jsonl");
     let run_path = dir.path().join("run.json");
     std::fs::write(&spans_path, "{\"format\":").expect("fixture should write");
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -612,7 +615,7 @@ fn import_tracing_json_default_wrapper_mode_malformed_json_does_not_append_wrapp
 }
 
 #[test]
-fn import_tracing_json_default_rejects_fmt_json_with_guidance() {
+fn import_tracing_spans_jsonl_default_rejects_fmt_json_with_guidance() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("fmt.jsonl");
     let run_path = dir.path().join("run.json");
@@ -629,7 +632,7 @@ fn import_tracing_json_default_rejects_fmt_json_with_guidance() {
     .unwrap();
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -647,7 +650,8 @@ fn import_tracing_json_default_rejects_fmt_json_with_guidance() {
 }
 
 #[test]
-fn import_tracing_json_compatible_rejects_fmt_like_record_with_top_level_explicit_timestamps() {
+fn import_tracing_spans_jsonl_compatible_rejects_fmt_like_record_with_top_level_explicit_timestamps(
+) {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("compatible.jsonl");
     let run_path = dir.path().join("run.json");
@@ -658,7 +662,7 @@ fn import_tracing_json_compatible_rejects_fmt_like_record_with_top_level_explici
     .unwrap();
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -678,7 +682,7 @@ fn import_tracing_json_compatible_rejects_fmt_like_record_with_top_level_explici
 }
 
 #[test]
-fn import_tracing_json_compatible_rejects_fmt_like_record_with_nested_explicit_timestamps() {
+fn import_tracing_spans_jsonl_compatible_rejects_fmt_like_record_with_nested_explicit_timestamps() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("compatible.jsonl");
     let run_path = dir.path().join("run.json");
@@ -689,7 +693,7 @@ fn import_tracing_json_compatible_rejects_fmt_like_record_with_nested_explicit_t
     .unwrap();
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -709,10 +713,10 @@ fn import_tracing_json_compatible_rejects_fmt_like_record_with_nested_explicit_t
 }
 
 #[test]
-fn import_tracing_json_help_shows_only_live_input_format_values() {
+fn import_tracing_spans_jsonl_help_shows_only_live_input_format_values() {
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg("--help")
         .output()
         .expect("cli should run");
@@ -724,14 +728,14 @@ fn import_tracing_json_help_shows_only_live_input_format_values() {
 }
 
 #[test]
-fn import_tracing_json_auto_is_rejected() {
+fn import_tracing_spans_jsonl_auto_is_rejected() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
     std::fs::write(&spans_path, complete_span_jsonl_fixture()).expect("fixture should write");
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -745,7 +749,7 @@ fn import_tracing_json_auto_is_rejected() {
 }
 
 #[test]
-fn import_tracing_json_strict_fails_on_incomplete_tailtriage_span() {
+fn import_tracing_spans_jsonl_strict_fails_on_incomplete_tailtriage_span() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
@@ -754,7 +758,7 @@ fn import_tracing_json_strict_fails_on_incomplete_tailtriage_span() {
 
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -776,8 +780,8 @@ fn import_tracing_json_strict_fails_on_incomplete_tailtriage_span() {
 }
 
 #[test]
-fn import_tracing_json_strict_with_max_requests_keeps_retained_request_and_skips_overflow_children()
-{
+fn import_tracing_spans_jsonl_strict_with_max_requests_keeps_retained_request_and_skips_overflow_children(
+) {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
@@ -798,7 +802,7 @@ fn import_tracing_json_strict_with_max_requests_keeps_retained_request_and_skips
 
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -830,7 +834,7 @@ fn import_tracing_json_strict_with_max_requests_keeps_retained_request_and_skips
 }
 
 #[test]
-fn import_tracing_json_strict_with_max_requests_fails_on_invalid_overflow_stage() {
+fn import_tracing_spans_jsonl_strict_with_max_requests_fails_on_invalid_overflow_stage() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
@@ -847,7 +851,7 @@ fn import_tracing_json_strict_with_max_requests_fails_on_invalid_overflow_stage(
 
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -870,7 +874,7 @@ fn import_tracing_json_strict_with_max_requests_fails_on_invalid_overflow_stage(
 }
 
 #[test]
-fn import_tracing_json_non_strict_writes_output_and_emits_warning_to_stderr() {
+fn import_tracing_spans_jsonl_non_strict_writes_output_and_emits_warning_to_stderr() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
@@ -882,7 +886,7 @@ fn import_tracing_json_non_strict_writes_output_and_emits_warning_to_stderr() {
 
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -905,7 +909,7 @@ fn import_tracing_json_non_strict_writes_output_and_emits_warning_to_stderr() {
 }
 
 #[test]
-fn import_tracing_json_writes_metadata_flags_into_run_json() {
+fn import_tracing_spans_jsonl_writes_metadata_flags_into_run_json() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
@@ -913,7 +917,7 @@ fn import_tracing_json_writes_metadata_flags_into_run_json() {
 
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -940,7 +944,7 @@ fn import_tracing_json_writes_metadata_flags_into_run_json() {
 }
 
 #[test]
-fn import_tracing_json_accepts_paths_with_spaces() {
+fn import_tracing_spans_jsonl_accepts_paths_with_spaces() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("tracing spans.jsonl");
     let run_path = dir.path().join("imported run.json");
@@ -948,7 +952,7 @@ fn import_tracing_json_accepts_paths_with_spaces() {
 
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -968,14 +972,14 @@ fn import_tracing_json_accepts_paths_with_spaces() {
 }
 
 #[test]
-fn import_tracing_json_rejects_whitespace_service_name() {
+fn import_tracing_spans_jsonl_rejects_whitespace_service_name() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
     std::fs::write(&spans_path, one_valid_request_span_fixture()).expect("fixture should write");
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg(" ")
@@ -990,14 +994,14 @@ fn import_tracing_json_rejects_whitespace_service_name() {
 }
 
 #[test]
-fn import_tracing_json_fails_when_only_unrelated_lines_are_present() {
+fn import_tracing_spans_jsonl_fails_when_only_unrelated_lines_are_present() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
     std::fs::write(&spans_path, r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"plain","started_at_unix_ms":1,"finished_at_unix_ms":2}}"#).expect("fixture should write");
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -1013,14 +1017,14 @@ fn import_tracing_json_fails_when_only_unrelated_lines_are_present() {
 }
 
 #[test]
-fn import_tracing_json_fails_when_non_strict_skips_all_malformed_tt_spans() {
+fn import_tracing_spans_jsonl_fails_when_non_strict_skips_all_malformed_tt_spans() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
     std::fs::write(&spans_path, malformed_tailtriage_span_fixture()).expect("fixture should write");
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -1036,7 +1040,7 @@ fn import_tracing_json_fails_when_non_strict_skips_all_malformed_tt_spans() {
 }
 
 #[test]
-fn import_tracing_json_fails_when_only_tt_spans_are_missing_kind() {
+fn import_tracing_spans_jsonl_fails_when_only_tt_spans_are_missing_kind() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
@@ -1044,7 +1048,7 @@ fn import_tracing_json_fails_when_only_tt_spans_are_missing_kind() {
         .expect("fixture should write");
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -1063,7 +1067,7 @@ fn import_tracing_json_fails_when_only_tt_spans_are_missing_kind() {
 }
 
 #[test]
-fn import_tracing_json_warns_for_tt_fields_missing_kind_and_still_writes_run() {
+fn import_tracing_spans_jsonl_warns_for_tt_fields_missing_kind_and_still_writes_run() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
@@ -1071,7 +1075,7 @@ fn import_tracing_json_warns_for_tt_fields_missing_kind_and_still_writes_run() {
         .expect("fixture should write");
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -1102,7 +1106,7 @@ fn import_tracing_json_warns_for_tt_fields_missing_kind_and_still_writes_run() {
 }
 
 #[test]
-fn import_tracing_json_persists_unknown_kind_warning_in_run_artifact() {
+fn import_tracing_spans_jsonl_persists_unknown_kind_warning_in_run_artifact() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
@@ -1110,7 +1114,7 @@ fn import_tracing_json_persists_unknown_kind_warning_in_run_artifact() {
         .expect("fixture should write");
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -1141,14 +1145,14 @@ fn import_tracing_json_persists_unknown_kind_warning_in_run_artifact() {
 }
 
 #[test]
-fn import_tracing_json_persists_optional_default_assumption_warnings_in_run_artifact() {
+fn import_tracing_spans_jsonl_persists_optional_default_assumption_warnings_in_run_artifact() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
     std::fs::write(&spans_path, missing_optional_defaults_fixture()).expect("fixture should write");
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -1188,7 +1192,7 @@ fn import_tracing_json_persists_optional_default_assumption_warnings_in_run_arti
 }
 
 #[test]
-fn import_tracing_json_whitespace_outcome_non_strict_warns_and_fails_zero_request() {
+fn import_tracing_spans_jsonl_whitespace_outcome_non_strict_warns_and_fails_zero_request() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
@@ -1196,7 +1200,7 @@ fn import_tracing_json_whitespace_outcome_non_strict_warns_and_fails_zero_reques
         .expect("fixture should write");
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -1213,7 +1217,7 @@ fn import_tracing_json_whitespace_outcome_non_strict_warns_and_fails_zero_reques
 }
 
 #[test]
-fn import_tracing_json_whitespace_outcome_strict_fails_with_message() {
+fn import_tracing_spans_jsonl_whitespace_outcome_strict_fails_with_message() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
@@ -1221,7 +1225,7 @@ fn import_tracing_json_whitespace_outcome_strict_fails_with_message() {
         .expect("fixture should write");
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")
@@ -1237,14 +1241,14 @@ fn import_tracing_json_whitespace_outcome_strict_fails_with_message() {
 }
 
 #[test]
-fn import_tracing_json_valid_outcomes_import_successfully() {
+fn import_tracing_spans_jsonl_valid_outcomes_import_successfully() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
     std::fs::write(&spans_path, valid_outcomes_fixture()).expect("fixture should write");
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
-        .arg("tracing-json")
+        .arg("tracing-spans-jsonl")
         .arg(&spans_path)
         .arg("--service")
         .arg("checkout")

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -4,7 +4,7 @@
 
 It helps existing `tracing` users produce standard `tailtriage_core::Run` artifacts by:
 - writing Run JSON on shutdown, and/or
-- writing retained, semantically valid completed-span JSONL on shutdown.
+- writing retained, semantically valid completed tailtriage tracing span JSONL on shutdown.
 
 It is **not**:
 - an observability backend,
@@ -94,12 +94,12 @@ returns a zero-request error when no request is retained. When tracing intake wa
 exist (for example malformed `tt.*` fields), shutdown includes those warning messages in
 the same error to guide setup corrections before rerunning capture.
 
-## Completed-span JSONL path
+## Completed tailtriage tracing span JSONL path
 
 Use `completed_span_jsonl_path(...)` when you want an offline import workflow:
 
 ```bash
-tailtriage import tracing-json target/tailtriage-examples/checkout.spans.jsonl \
+tailtriage import tracing-spans-jsonl target/tailtriage-examples/checkout.spans.jsonl \
   --service checkout-service \
   --output target/tailtriage-examples/checkout.run.json
 
@@ -115,7 +115,7 @@ remains a replay/debug export, not trace archival.
 
 ## Stable JSONL wrapper format
 
-Stable completed-span JSONL records use this wrapper:
+Stable completed tailtriage tracing span JSONL records use this wrapper:
 
 ```json
 {"format":"tailtriage.tracing-span.v1","span":{...}}
@@ -162,15 +162,15 @@ Missing stage `tt.success` defaults to `true` with a warning.
 - Child stage/queue evidence may be dropped or evicted under that pressure and is surfaced through warnings plus `truncation.limits_hit`.
 - Request/stage/queue semantic retention uses `CaptureMode`, `CaptureLimits`, and `CaptureLimitsOverride`.
 - `completed_span_jsonl_path(...)` writes retained tailtriage semantic evidence as stable span-shaped JSONL on shutdown only when at least one completed request is retained.
-- Completed-span JSONL is retained-evidence replay/debug export for the same request/stage/queue evidence path through `tailtriage import`; it is not a production trace archive.
+- Completed tailtriage tracing span JSONL is retained-evidence replay/debug export for the same request/stage/queue evidence path through `tailtriage import`; it is not a production trace archive.
 - It does not preserve lifecycle warnings, truncation counters, original span IDs, parent IDs, original span names, or non-`tt.*` fields.
 - For production workflows that need the complete persisted triage artifact including warnings/truncation metadata, prefer `run_json_path(...)`.
 - Callers using JSONL-only export should inspect `session.shutdown()?.warnings()` in the same process.
-- This completed-span JSONL is a narrow retained-evidence export, not a generic tracing log stream and not OTel/OTLP.
+- This completed tailtriage tracing span JSONL is a narrow retained-evidence export, not a generic tracing log stream and not OTel/OTLP.
 
 ## Runtime-pressure limitation
 
-Tracing intake import and native capture share the same CaptureMode/CaptureLimits semantics for request/stage/queue evidence retention. Offline tracing JSONL import does not fabricate runtime snapshots. Runtime-pressure evidence still requires runtime snapshots/Tokio sampler coupling. Runtime-sensitive tracing contract parity uses deterministic/manual runtime snapshots and requires non-empty runtime snapshots, scenario-specific runtime field evidence, and the explicit disabled-background-sampler lifecycle warning (via `disable_background_sampler()` + `record_runtime_snapshot(...)`). It does not rely on ambient sampler metadata/noise.
+Completed tracing span JSONL import and native capture share the same CaptureMode/CaptureLimits semantics for request/stage/queue evidence retention. Offline completed tailtriage tracing span JSONL import does not fabricate runtime snapshots. Runtime-pressure evidence still requires runtime snapshots/Tokio sampler coupling. Runtime-sensitive tracing contract parity uses deterministic/manual runtime snapshots and requires non-empty runtime snapshots, scenario-specific runtime field evidence, and the explicit disabled-background-sampler lifecycle warning (via `disable_background_sampler()` + `record_runtime_snapshot(...)`). It does not rely on ambient sampler metadata/noise.
 Persisted Run JSON intended for `tailtriage analyze` must include at least one completed request event; shutdown fails for persisted-output sessions when zero completed requests are retained. When intake/lifecycle warnings are available, that shutdown error includes warning summaries to help tracing-intake setup triage. In-process library snapshots may still be zero-request for inspection.
 
 For `TracingTokioSession`, runtime snapshot retention also uses the same core capture-limit model. Run metadata time bounds cover merged retained tracing evidence plus retained runtime snapshots, which supports triage interpretation but is not root-cause proof:

--- a/tailtriage-tracing/examples/completed_span_jsonl_export.rs
+++ b/tailtriage-tracing/examples/completed_span_jsonl_export.rs
@@ -48,7 +48,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
     println!("wrote completed spans to: {}", spans_path.display());
     // Import + analyze with:
-    // tailtriage import tracing-json target/tailtriage-examples/completed-spans.jsonl --service checkout-service --output target/tailtriage-examples/run.json
+    // tailtriage import tracing-spans-jsonl target/tailtriage-examples/completed-spans.jsonl --service checkout-service --output target/tailtriage-examples/run.json
     // tailtriage analyze target/tailtriage-examples/run.json
     Ok(())
 }

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -28,7 +28,7 @@ pub fn import_jsonl_reader<R: Read>(
     import_jsonl_reader_with_mode(reader, options, JsonlParseMode::TailtriageWrapperOnly)
 }
 
-/// Parse mode for tracing JSONL import.
+/// Parse mode for completed tailtriage tracing span JSONL import.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum JsonlParseMode {
     /// Accept stable wrapper records plus compatibility legacy shapes.


### PR DESCRIPTION
### Motivation

- Make the CLI command name precise so it does not imply support for arbitrary tracing JSON and to communicate the actual accepted input shape (completed tailtriage tracing span JSONL).

### Description

- Renamed the import subcommand variant from `TracingJson` to `TracingSpansJsonl` and set the explicit clap command name to `tracing-spans-jsonl` in `tailtriage-cli/src/main.rs`.
- Renamed the import helper call-site to `import_tracing_spans_jsonl` and updated guidance/error text to reference completed tailtriage tracing span JSONL without changing parser behavior or adding auto-detection or aliases.
- Updated user-facing docs and examples to use `tailtriage import tracing-spans-jsonl` and to describe input as completed tailtriage tracing span JSONL, including `README.md`, `docs/user-guide.md`, `docs/operations.md`, `tailtriage-cli/README.md`, `tailtriage-tracing/README.md`, `tailtriage-tracing/examples/completed_span_jsonl_export.rs`, and `SPEC.md`.
- Updated CLI boundary tests and related references to the new command string and adjusted a small jsonl comment in `tailtriage-tracing/src/jsonl.rs` to reflect the narrower naming.

### Testing

- Ran formatting check: `cargo fmt --check` — passed.
- Ran lints: `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- Ran full workspace tests: `cargo test --workspace` — passed.
- Ran docs contract validator: `python3 scripts/validate_docs_contracts.py` — passed (`docs contracts validated successfully`).
- Ran targeted crate tests: `cargo test -p tailtriage-cli --all-targets --locked` and `cargo test -p tailtriage-tracing --all-targets --all-features --locked` — both passed.

Files changed include: `tailtriage-cli/src/main.rs`, `tailtriage-cli/tests/cli_boundary.rs`, `tailtriage-cli/README.md`, `README.md`, `docs/user-guide.md`, `docs/operations.md`, `SPEC.md`, `tailtriage-tracing/README.md`, `tailtriage-tracing/examples/completed_span_jsonl_export.rs`, and `tailtriage-tracing/src/jsonl.rs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b540dc2c88330a612ae0e8b1d5d8d)