### PR TITLE
Clarify scoped tracing example subscribers

### DIFF
--- a/tailtriage-tracing/examples/completed_span_jsonl_export.rs
+++ b/tailtriage-tracing/examples/completed_span_jsonl_export.rs
@@ -11,6 +11,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .build()?;
 
     let subscriber = tracing_subscriber::registry().with(session.layer());
+    // Scoped/local example usage: services should install the layer in their
+    // normal process-wide subscriber setup during startup.
     tracing::subscriber::with_default(subscriber, || {
         let request = tracing::info_span!(
             "http.request",

--- a/tailtriage-tracing/examples/live_recorder.rs
+++ b/tailtriage-tracing/examples/live_recorder.rs
@@ -13,6 +13,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let subscriber = tracing_subscriber::registry().with(recorder.layer());
 
+    // Scoped/local example usage: services should install the layer in their
+    // normal process-wide subscriber setup during startup.
     tracing::subscriber::with_default(subscriber, || {
         let request = tracing::info_span!(
             "http.request",

--- a/tailtriage-tracing/examples/live_session_to_run.rs
+++ b/tailtriage-tracing/examples/live_session_to_run.rs
@@ -11,6 +11,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .build()?;
 
     let subscriber = tracing_subscriber::registry().with(session.layer());
+    // Scoped/local example usage: services should install the layer in their
+    // normal process-wide subscriber setup during startup.
     tracing::subscriber::with_default(subscriber, || {
         let request = tracing::info_span!(
             "http.request",

--- a/tailtriage-tracing/examples/tokio_session_to_run.rs
+++ b/tailtriage-tracing/examples/tokio_session_to_run.rs
@@ -13,6 +13,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .start()?;
 
     let subscriber = tracing_subscriber::registry().with(session.layer());
+    // Scoped/local example usage: services should install the layer in their
+    // normal process-wide subscriber setup during startup.
     tracing::subscriber::with_default(subscriber, || {
         let _request_guard = tracing::info_span!(
             "http.request",


### PR DESCRIPTION
### Motivation
- Make example usage consistent with repository guidance by preventing `tracing::subscriber::with_default(...)` from being shown as the recommended global startup path in user-facing examples after tracing intake fixes.

### Description
- Add a short scoped/local usage comment before `tracing::subscriber::with_default(...)` in four tracing examples so the examples do not present `with_default` as the recommended service startup path.
- Files changed: `tailtriage-tracing/examples/completed_span_jsonl_export.rs`, `tailtriage-tracing/examples/live_recorder.rs`, `tailtriage-tracing/examples/live_session_to_run.rs`, and `tailtriage-tracing/examples/tokio_session_to_run.rs`.
- No API renames, behavior changes, or test helper modifications were made; `with_default` and `set_default` usages in tests and internal helpers were left intact, and existing guidance about unsupported `tracing_subscriber::fmt().json()`, `OTel`/`OTLP`, completed-span JSONL vs Run JSON, `tailtriage analyze`, and runtime-sampler coupling was preserved.

### Testing
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, and `python3 scripts/validate_docs_contracts.py`, all succeeded.
- Ran targeted suites `cargo test -p tailtriage-cli --all-targets --locked`, `cargo test -p tailtriage-tracing --all-targets --all-features --locked`, and `cargo test -p tailtriage-tracing --no-default-features --features tokio --all-targets --locked`, all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1be221d5788330b22ca6bdb35071c9)