### PR TITLE
docs: clarify tracing intake consistency

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -158,7 +158,7 @@ Prefer moderate intervals and bounded runs before increasing density.
 
 ## Operating with tracing-based runs
 
-Tracing import expects completed tailtriage `tt.*` tracing span JSONL, not ordinary tracing log JSON (`fmt().json` output is a common non-supported example). Import writes Run JSON (not Report JSON), and analysis is a separate step after import (`tailtriage analyze`). Completed-span JSONL is not a production trace archive and does not preserve warning/truncation context; prefer Run JSON when the artifact itself must carry that context. Persisted Run JSON intended for `tailtriage analyze` must include at least one completed request event; in-process library snapshots may still be zero-request for inspection. Timing is not guessed from line receive time, so completed spans must include explicit unix-ms start/end timestamps. OTel/OTLP intake remains out of scope on this path.
+Tracing import expects completed tailtriage `tt.*` tracing span JSONL, not ordinary tracing log JSON (`fmt().json` output is a common non-supported example). Import writes Run JSON (not Report JSON), and analysis is a separate step after import (`tailtriage analyze`). Completed-span JSONL is a retained-evidence replay/debug export, not a production trace archive, and does not preserve warning/truncation context; prefer Run JSON when the artifact itself must carry that context. Persisted Run JSON intended for `tailtriage analyze` must include at least one completed request event; in-process library snapshots may still be zero-request for inspection. Timing is not guessed from line receive time, so completed spans must include explicit unix-ms start/end timestamps. OTel/OTLP intake remains out of scope on this path.
 
 Important limits for production interpretation:
 

--- a/tailtriage-tracing/examples/completed_span_jsonl_export.rs
+++ b/tailtriage-tracing/examples/completed_span_jsonl_export.rs
@@ -10,6 +10,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .completed_span_jsonl_path(&spans_path)
         .build()?;
 
+    // Example-local scoped subscriber; service startup should install the layer globally.
     let subscriber = tracing_subscriber::registry().with(session.layer());
     tracing::subscriber::with_default(subscriber, || {
         let request = tracing::info_span!(

--- a/tailtriage-tracing/examples/live_recorder.rs
+++ b/tailtriage-tracing/examples/live_recorder.rs
@@ -11,6 +11,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .strict(false)
         .build()?;
 
+    // Example-local scoped subscriber; service startup should install the layer globally.
     let subscriber = tracing_subscriber::registry().with(recorder.layer());
 
     tracing::subscriber::with_default(subscriber, || {

--- a/tailtriage-tracing/examples/live_session_to_run.rs
+++ b/tailtriage-tracing/examples/live_session_to_run.rs
@@ -10,6 +10,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .run_json_path(&run_path)
         .build()?;
 
+    // Example-local scoped subscriber; service startup should install the layer globally.
     let subscriber = tracing_subscriber::registry().with(session.layer());
     tracing::subscriber::with_default(subscriber, || {
         let request = tracing::info_span!(

--- a/tailtriage-tracing/examples/tokio_session_to_run.rs
+++ b/tailtriage-tracing/examples/tokio_session_to_run.rs
@@ -12,6 +12,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .disable_background_sampler()
         .start()?;
 
+    // Example-local scoped subscriber; service startup should install the layer globally.
     let subscriber = tracing_subscriber::registry().with(session.layer());
     tracing::subscriber::with_default(subscriber, || {
         let _request_guard = tracing::info_span!(


### PR DESCRIPTION
### Motivation
- Make small consistency fixes after tracing intake work so docs and examples unambiguously reflect the narrow tracing-intake scope and recommended usage.

### Description
- Clarified operations/docs guidance to state that completed-span JSONL is a retained-evidence replay/debug export (not a production trace archive) and that Run JSON should be preferred when warning/truncation context must persist, and added brief example-local notes to tracing examples to avoid implying `with_default` is the recommended service startup path; changes applied to `docs/operations.md` and four tracing examples under `tailtriage-tracing/examples/*.rs`.
- Verified and left supported/intentional occurrences of unsupported terms (`fmt().json`, `OTel`, `OTLP`) and kept `with_default`/`set_default` only where they are explicitly scoped/example/test-style usage.

### Testing
- Ran formatting, lint, tests and docs contract checks: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `python3 scripts/validate_docs_contracts.py`, `cargo test -p tailtriage-cli --all-targets --locked`, `cargo test -p tailtriage-tracing --all-targets --all-features --locked`, and `cargo test -p tailtriage-tracing --no-default-features --features tokio --all-targets --locked`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1be221d5788330b22ca6bdb35071c9)