### PR TITLE
Clarify scoped tracing example subscribers

### DIFF
--- a/tailtriage-tracing/examples/completed_span_jsonl_export.rs
+++ b/tailtriage-tracing/examples/completed_span_jsonl_export.rs
@@ -10,6 +10,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .completed_span_jsonl_path(&spans_path)
         .build()?;
 
+    // This runnable example uses `with_default` as a scoped/local harness.
+    // Services should install the layer in process-wide startup subscriber setup.
     let subscriber = tracing_subscriber::registry().with(session.layer());
     tracing::subscriber::with_default(subscriber, || {
         let request = tracing::info_span!(

--- a/tailtriage-tracing/examples/live_recorder.rs
+++ b/tailtriage-tracing/examples/live_recorder.rs
@@ -11,6 +11,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .strict(false)
         .build()?;
 
+    // This runnable example uses `with_default` as a scoped/local harness.
+    // Services should install the layer in process-wide startup subscriber setup.
     let subscriber = tracing_subscriber::registry().with(recorder.layer());
 
     tracing::subscriber::with_default(subscriber, || {

--- a/tailtriage-tracing/examples/live_session_to_run.rs
+++ b/tailtriage-tracing/examples/live_session_to_run.rs
@@ -10,6 +10,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .run_json_path(&run_path)
         .build()?;
 
+    // This runnable example uses `with_default` as a scoped/local harness.
+    // Services should install the layer in process-wide startup subscriber setup.
     let subscriber = tracing_subscriber::registry().with(session.layer());
     tracing::subscriber::with_default(subscriber, || {
         let request = tracing::info_span!(

--- a/tailtriage-tracing/examples/tokio_session_to_run.rs
+++ b/tailtriage-tracing/examples/tokio_session_to_run.rs
@@ -12,6 +12,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .disable_background_sampler()
         .start()?;
 
+    // This runnable example uses `with_default` as a scoped/local harness.
+    // Services should install the layer in process-wide startup subscriber setup.
     let subscriber = tracing_subscriber::registry().with(session.layer());
     tracing::subscriber::with_default(subscriber, || {
         let _request_guard = tracing::info_span!(


### PR DESCRIPTION
### Motivation
- Clarify that runnable tracing examples using `tracing::subscriber::with_default` are a scoped/local harness and not the recommended process-wide service startup installation.

### Description
- Add two-line comments above `tracing_subscriber::registry().with(...)` in four examples (`tailtriage-tracing/examples/live_recorder.rs`, `completed_span_jsonl_export.rs`, `live_session_to_run.rs`, `tokio_session_to_run.rs`) explaining that `with_default` is a scoped/local harness and services should install the layer in process-wide startup subscriber setup.

### Testing
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `python3 scripts/validate_docs_contracts.py`, `cargo test -p tailtriage-cli --all-targets --locked`, `cargo test -p tailtriage-tracing --all-targets --all-features --locked`, and `cargo test -p tailtriage-tracing --no-default-features --features tokio --all-targets --locked`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1be221d5788330b22ca6bdb35071c9)