### PR TITLE
Clarify scoped tracing example subscribers

### DIFF
--- a/tailtriage-tracing/examples/completed_span_jsonl_export.rs
+++ b/tailtriage-tracing/examples/completed_span_jsonl_export.rs
@@ -10,6 +10,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .completed_span_jsonl_path(&spans_path)
         .build()?;
 
+    // This standalone example uses a scoped local subscriber; service startup
+    // should install the tailtriage layer in the process-wide subscriber setup.
     let subscriber = tracing_subscriber::registry().with(session.layer());
     tracing::subscriber::with_default(subscriber, || {
         let request = tracing::info_span!(

--- a/tailtriage-tracing/examples/live_recorder.rs
+++ b/tailtriage-tracing/examples/live_recorder.rs
@@ -11,6 +11,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .strict(false)
         .build()?;
 
+    // This standalone example uses a scoped local subscriber; service startup
+    // should install the tailtriage layer in the process-wide subscriber setup.
     let subscriber = tracing_subscriber::registry().with(recorder.layer());
 
     tracing::subscriber::with_default(subscriber, || {

--- a/tailtriage-tracing/examples/live_session_to_run.rs
+++ b/tailtriage-tracing/examples/live_session_to_run.rs
@@ -10,6 +10,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .run_json_path(&run_path)
         .build()?;
 
+    // This standalone example uses a scoped local subscriber; service startup
+    // should install the tailtriage layer in the process-wide subscriber setup.
     let subscriber = tracing_subscriber::registry().with(session.layer());
     tracing::subscriber::with_default(subscriber, || {
         let request = tracing::info_span!(

--- a/tailtriage-tracing/examples/tokio_session_to_run.rs
+++ b/tailtriage-tracing/examples/tokio_session_to_run.rs
@@ -12,6 +12,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .disable_background_sampler()
         .start()?;
 
+    // This standalone example uses a scoped local subscriber; service startup
+    // should install the tailtriage layer in the process-wide subscriber setup.
     let subscriber = tracing_subscriber::registry().with(session.layer());
     tracing::subscriber::with_default(subscriber, || {
         let _request_guard = tracing::info_span!(


### PR DESCRIPTION
### Motivation
- Final consistency pass after tracing-intake fixes to ensure docs/examples consistently warn about unsupported generic tracing scraping and scoped subscriber usage without changing APIs or behavior.

### Description
- Add scoped/local subscriber guidance comments to four tracing examples to label `tracing::subscriber::with_default` use as example-only and recommend process-wide subscriber installation in real services (`tailtriage-tracing/examples/{completed_span_jsonl_export.rs,live_recorder.rs,live_session_to_run.rs,tokio_session_to_run.rs}`).
- Ran a repository-wide search for `tracing-json`, `completed_span_jsonl_import`, `with_default`, `set_default`, `fmt().json`, `OTel`, and `OTLP` and preserved occurrences that are test/helper/example-scoped or explicitly state unsupported/non-goal behavior; no API renames or behavior changes were made.
- No user-facing docs were altered in substance; only minimal wording added to examples to avoid recommending `with_default` as a service startup path.

### Testing
- Ran formatting, linting, unit tests, and docs validation: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, and `python3 scripts/validate_docs_contracts.py`, all succeeded.
- Ran additional package tests: `cargo test -p tailtriage-cli --all-targets --locked`, `cargo test -p tailtriage-tracing --all-targets --all-features --locked`, and `cargo test -p tailtriage-tracing --no-default-features --features tokio --all-targets --locked`, all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1be221d5788330b22ca6bdb35071c9)