### PR TITLE
Reject --max-requests 0 for tracing import and add CLI regression tests

### DIFF
--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -217,6 +217,14 @@ fn import_tracing_spans_jsonl(
     max_stages: Option<usize>,
     max_queues: Option<usize>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    if max_requests == Some(0) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "--max-requests must be at least 1 for persisted tracing import; tailtriage analyze requires at least one request event",
+        )
+        .into());
+    }
+
     let mut options = ImportOptions::new(service).strict(strict).mode(mode.into());
     if let Some(service_version) = service_version {
         options = options.service_version(service_version);

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -389,6 +389,69 @@ fn import_tracing_spans_jsonl_capture_limit_overrides_apply() {
 }
 
 #[test]
+fn import_tracing_spans_jsonl_rejects_zero_max_requests() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, complete_span_jsonl_fixture()).expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-spans-jsonl")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--max-requests")
+        .arg("0")
+        .output()
+        .expect("cli should run");
+
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--max-requests"));
+    assert!(stderr.contains("at least 1"));
+    assert!(stderr.contains("persisted tracing import"));
+    assert!(stderr.contains("tailtriage analyze requires at least one request event"));
+    assert!(!run_path.exists());
+}
+
+#[test]
+fn import_tracing_spans_jsonl_allows_zero_stage_and_queue_limits() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, complete_span_jsonl_fixture()).expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-spans-jsonl")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--max-stages")
+        .arg("0")
+        .arg("--max-queues")
+        .arg("0")
+        .output()
+        .expect("cli should run");
+
+    assert!(output.status.success(), "cli failed: {output:?}");
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
+        .expect("imported request-only run should load in cli loader");
+    assert!(!loaded.run.requests.is_empty());
+    assert!(loaded.run.stages.is_empty());
+    assert!(loaded.run.queues.is_empty());
+}
+
+#[test]
 fn import_tracing_spans_jsonl_rejects_inert_runtime_snapshot_flags() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");


### PR DESCRIPTION
### Motivation
- Prevent a confusing footgun where `--max-requests 0` is accepted but later causes persisted tracing imports to produce zero-request Run artifacts that `tailtriage analyze` cannot consume.  
- Make the intended behavior explicit: persisted imports must contain at least one completed request, while `--max-stages 0` and `--max-queues 0` remain valid for request-only artifacts. 

### Description
- Added a fast-fail check in `import_tracing_spans_jsonl(...)` in `tailtriage-cli/src/main.rs` that returns an error immediately if `max_requests == Some(0)` with an actionable message containing the required substrings. 
- Left `--max-stages 0` and `--max-queues 0` behavior unchanged and did not alter live recorder/session limits or Run schema. 
- Added two CLI boundary tests in `tailtriage-cli/tests/cli_boundary.rs`: `import_tracing_spans_jsonl_rejects_zero_max_requests` which verifies failing behavior, and `import_tracing_spans_jsonl_allows_zero_stage_and_queue_limits` which verifies that zero stage/queue limits succeed and produce a request-only Run JSON. 

### Testing
- Ran `cargo fmt --check` and it passed. 
- Ran `cargo test -p tailtriage-cli --test cli_boundary --locked` and the test suite passed (including the two new tests). 
- Ran `cargo test --workspace --all-targets --all-features --locked` and it passed. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed without warnings. 
- Ran `python3 scripts/validate_docs_contracts.py` and docs validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c3657d828833099fbefa501289cfe)