### PR TITLE
Reject zero --max-requests for persisted tracing import

### DIFF
--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -224,6 +224,13 @@ fn import_tracing_spans_jsonl(
     if let Some(run_id) = run_id {
         options = options.run_id(run_id);
     }
+    if max_requests == Some(0) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "--max-requests must be at least 1 for persisted tracing import; tailtriage analyze requires at least one request event",
+        )
+        .into());
+    }
     let mut capture_limits_override = CaptureLimitsOverride::default();
     if let Some(max_requests) = max_requests {
         capture_limits_override.max_requests = Some(max_requests);

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -389,6 +389,70 @@ fn import_tracing_spans_jsonl_capture_limit_overrides_apply() {
 }
 
 #[test]
+fn import_tracing_spans_jsonl_rejects_zero_max_requests() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, complete_span_jsonl_fixture()).expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-spans-jsonl")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--max-requests")
+        .arg("0")
+        .output()
+        .expect("cli should run");
+
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("--max-requests"));
+    assert!(stderr.contains("at least 1"));
+    assert!(stderr.contains("persisted tracing import"));
+    assert!(stderr.contains("tailtriage analyze requires at least one request event"));
+    assert!(!run_path.exists(), "run artifact should not be written");
+}
+
+#[test]
+fn import_tracing_spans_jsonl_allows_zero_stage_and_queue_limits() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, request_stage_queue_wrapper_jsonl_fixture())
+        .expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-spans-jsonl")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--max-stages")
+        .arg("0")
+        .arg("--max-queues")
+        .arg("0")
+        .output()
+        .expect("cli should run");
+
+    assert!(output.status.success(), "cli failed: {output:?}");
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
+        .expect("imported run should load in cli loader");
+    assert!(!loaded.run.requests.is_empty());
+    assert_eq!(loaded.run.stages.len(), 0);
+    assert_eq!(loaded.run.queues.len(), 0);
+}
+
+#[test]
 fn import_tracing_spans_jsonl_rejects_inert_runtime_snapshot_flags() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
@@ -1303,6 +1367,13 @@ fn valid_cli_artifact_with_empty_requests() -> &'static str {
 
 fn complete_span_jsonl_fixture() -> &'static str {
     include_str!("../../tailtriage-tracing/tests/fixtures/tailtriage-span-v1.jsonl")
+}
+
+fn request_stage_queue_wrapper_jsonl_fixture() -> &'static str {
+    r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1100,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}
+{"format":"tailtriage.tracing-span.v1","span":{"name":"db","started_at_unix_ms":1020,"finished_at_unix_ms":1080,"fields":{"tt.kind":"stage","tt.request_id":"req-1","tt.stage":"db"}}}
+{"format":"tailtriage.tracing-span.v1","span":{"name":"permits","started_at_unix_ms":1030,"finished_at_unix_ms":1040,"fields":{"tt.kind":"queue","tt.request_id":"req-1","tt.queue":"permits"}}}
+"#
 }
 
 fn incomplete_tailtriage_span_fixture() -> &'static str {


### PR DESCRIPTION
### Motivation
- Prevent a CLI footgun where `tailtriage import tracing-spans-jsonl --max-requests 0` would be accepted, produce a persisted Run JSON with zero requests, and then fail later during analysis. 
- Preserve legitimate use of zero for `--max-stages` and `--max-queues` so request-only persisted artifacts remain useful. 

### Description
- Added a fast-fail check in `tailtriage-cli/src/main.rs` inside `import_tracing_spans_jsonl(...)` that returns an immediate error when `max_requests == Some(0)` before constructing or applying `CaptureLimitsOverride`. 
- The returned error message contains the required substrings: `--max-requests`, `at least 1`, `persisted tracing import`, and `tailtriage analyze requires at least one request event`. 
- Added two regression tests in `tailtriage-cli/tests/cli_boundary.rs`: `import_tracing_spans_jsonl_rejects_zero_max_requests` which asserts the CLI fails with empty stdout, the required stderr substrings, and no output Run file, and `import_tracing_spans_jsonl_allows_zero_stage_and_queue_limits` which verifies `--max-stages 0 --max-queues 0` succeeds and produces a request-only Run JSON (added a small local wrapper JSONL fixture helper `request_stage_queue_wrapper_jsonl_fixture`). 
- No changes were made to live recorder/session limits, analyzer behavior, tracing import scope, or Run schema. 

### Testing
- Ran `cargo fmt --check` and it succeeded. 
- Ran `cargo test -p tailtriage-cli --test cli_boundary --locked` and the CLI boundary test suite passed. 
- Ran `cargo test --workspace --all-targets --all-features --locked` and all workspace tests passed. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and linting passed. 
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c3657d828833099fbefa501289cfe)