### PR TITLE
Reject --max-requests 0 for tracing imports and add CLI regression tests

### DIFF
--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -224,6 +224,14 @@ fn import_tracing_spans_jsonl(
     if let Some(run_id) = run_id {
         options = options.run_id(run_id);
     }
+    if max_requests == Some(0) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "--max-requests must be at least 1 for persisted tracing import; tailtriage analyze requires at least one request event",
+        )
+        .into());
+    }
+
     let mut capture_limits_override = CaptureLimitsOverride::default();
     if let Some(max_requests) = max_requests {
         capture_limits_override.max_requests = Some(max_requests);

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -389,6 +389,73 @@ fn import_tracing_spans_jsonl_capture_limit_overrides_apply() {
 }
 
 #[test]
+fn import_tracing_spans_jsonl_rejects_zero_max_requests() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, complete_span_jsonl_fixture()).expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-spans-jsonl")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--max-requests")
+        .arg("0")
+        .output()
+        .expect("cli should run");
+
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("--max-requests"));
+    assert!(stderr.contains("at least 1"));
+    assert!(stderr.contains("persisted tracing import"));
+    assert!(stderr.contains("tailtriage analyze requires at least one request event"));
+    assert!(!run_path.exists(), "run json should not be written");
+}
+
+#[test]
+fn import_tracing_spans_jsonl_allows_zero_stage_and_queue_limits() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(
+        &spans_path,
+        request_stage_queue_wrapper_span_jsonl_fixture(),
+    )
+    .expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-spans-jsonl")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--max-stages")
+        .arg("0")
+        .arg("--max-queues")
+        .arg("0")
+        .output()
+        .expect("cli should run");
+
+    assert!(output.status.success(), "cli failed: {output:?}");
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
+        .expect("imported run should load in cli loader");
+    assert!(!loaded.run.requests.is_empty());
+    assert_eq!(loaded.run.stages.len(), 0);
+    assert_eq!(loaded.run.queues.len(), 0);
+}
+
+#[test]
 fn import_tracing_spans_jsonl_rejects_inert_runtime_snapshot_flags() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
@@ -1322,6 +1389,13 @@ fn multi_span_jsonl_fixture() -> &'static str {
 {"span":{"name":"stage-2","started_at_unix_ms":1021,"finished_at_unix_ms":1029,"fields":{"tt.kind":"stage","tt.request_id":"req-2","tt.stage":"cache"}}}
 {"span":{"name":"queue-1","started_at_unix_ms":1002,"finished_at_unix_ms":1008,"fields":{"tt.kind":"queue","tt.request_id":"req-1","tt.queue":"permits"}}}
 {"span":{"name":"queue-2","started_at_unix_ms":1022,"finished_at_unix_ms":1028,"fields":{"tt.kind":"queue","tt.request_id":"req-2","tt.queue":"permits"}}}
+"#
+}
+
+fn request_stage_queue_wrapper_span_jsonl_fixture() -> &'static str {
+    r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"request","started_at_unix_ms":1000,"finished_at_unix_ms":1100,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}
+{"format":"tailtriage.tracing-span.v1","span":{"name":"stage","started_at_unix_ms":1010,"finished_at_unix_ms":1080,"fields":{"tt.kind":"stage","tt.request_id":"req-1","tt.stage":"db"}}}
+{"format":"tailtriage.tracing-span.v1","span":{"name":"queue","started_at_unix_ms":1020,"finished_at_unix_ms":1030,"fields":{"tt.kind":"queue","tt.request_id":"req-1","tt.queue":"permits"}}}
 "#
 }
 


### PR DESCRIPTION
### Motivation
- Persisted Run JSON used by `tailtriage analyze` must contain at least one completed request, but the CLI previously accepted `--max-requests 0` and produced an unusable artifact later in the pipeline.  
- Improve UX by failing fast with a clear error for the tracing import footgun while keeping valid request-only artifacts possible.  

### Description
- Add an early validation in `import_tracing_spans_jsonl(...)` to reject `--max-requests 0` before constructing or applying `CaptureLimitsOverride` and return an `InvalidInput` error.  
- The error message includes the required substrings: `--max-requests`, `at least 1`, `persisted tracing import`, and `tailtriage analyze requires at least one request event`.  
- Preserve existing behavior so `--max-stages 0` and `--max-queues 0` remain allowed and live recorder/session limits are unchanged.  
- Add two CLI boundary tests in `tailtriage-cli/tests/cli_boundary.rs`: `import_tracing_spans_jsonl_rejects_zero_max_requests` and `import_tracing_spans_jsonl_allows_zero_stage_and_queue_limits`, plus a small local wrapper JSONL fixture returning one request, one contained stage, and one contained queue for the zero-stage/queue test.  

### Testing
- Ran formatting check with `cargo fmt --check` and it passed.  
- Ran the targeted test binary with `cargo test -p tailtriage-cli --test cli_boundary --locked` and the suite passed including the two new tests.  
- Ran full workspace tests with `cargo test --workspace --all-targets --all-features --locked` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and both completed successfully.  
- Ran docs contract validation with `python3 scripts/validate_docs_contracts.py` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c3657d828833099fbefa501289cfe)