### PR TITLE
Reject zero max requests for persisted tracing import

### DIFF
--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -217,6 +217,14 @@ fn import_tracing_spans_jsonl(
     max_stages: Option<usize>,
     max_queues: Option<usize>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    if max_requests == Some(0) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "--max-requests must be at least 1 for persisted tracing import; tailtriage analyze requires at least one request event",
+        )
+        .into());
+    }
+
     let mut options = ImportOptions::new(service).strict(strict).mode(mode.into());
     if let Some(service_version) = service_version {
         options = options.service_version(service_version);

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -389,6 +389,72 @@ fn import_tracing_spans_jsonl_capture_limit_overrides_apply() {
 }
 
 #[test]
+fn import_tracing_spans_jsonl_rejects_zero_max_requests() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, complete_span_jsonl_fixture()).expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-spans-jsonl")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--max-requests")
+        .arg("0")
+        .output()
+        .expect("cli should run");
+
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("--max-requests"));
+    assert!(stderr.contains("at least 1"));
+    assert!(stderr.contains("persisted tracing import"));
+    assert!(stderr.contains("tailtriage analyze requires at least one request event"));
+    assert!(!run_path.exists(), "run artifact should not be written");
+}
+
+#[test]
+fn import_tracing_spans_jsonl_allows_zero_stage_and_queue_limits() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(&spans_path, complete_span_jsonl_fixture()).expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-spans-jsonl")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--max-stages")
+        .arg("0")
+        .arg("--max-queues")
+        .arg("0")
+        .output()
+        .expect("cli should run");
+
+    assert!(output.status.success(), "cli failed: {output:?}");
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
+        .expect("imported run should load in cli loader");
+    assert!(
+        !loaded.run.requests.is_empty(),
+        "at least one request should be retained"
+    );
+    assert_eq!(loaded.run.stages.len(), 0);
+    assert_eq!(loaded.run.queues.len(), 0);
+}
+
+#[test]
 fn import_tracing_spans_jsonl_rejects_inert_runtime_snapshot_flags() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");


### PR DESCRIPTION
### Motivation
- Prevent a confusing footgun where `--max-requests 0` produced a persisted Run JSON with zero requests and later caused failures during analysis by failing fast and clearly during import. 
- Preserve valid use cases where `--max-stages 0` and `--max-queues 0` are useful to create request-only artifacts.

### Description
- Add an early guard in `import_tracing_spans_jsonl` that returns an error when `max_requests == Some(0)` and emits an actionable message containing the required substrings: `--max-requests`, `at least 1`, `persisted tracing import`, and `tailtriage analyze requires at least one request event` (change in `tailtriage-cli/src/main.rs`).
- Add CLI boundary regression tests `import_tracing_spans_jsonl_rejects_zero_max_requests` and `import_tracing_spans_jsonl_allows_zero_stage_and_queue_limits` to `tailtriage-cli/tests/cli_boundary.rs` that verify the rejection behavior for `--max-requests 0` and that `--max-stages 0 --max-queues 0` still succeeds and produces a request-only Run JSON artifact. 
- Limit the scope of the change to the CLI import path; do not alter live recorder/session behavior, analyzer logic, Run schema, or broaden tracing import support.

### Testing
- Ran `cargo fmt --check` and it passed. 
- Ran `cargo test -p tailtriage-cli --test cli_boundary --locked` and the test suite passed including the two new tests. 
- Ran full workspace validation with `cargo test --workspace --all-targets --all-features --locked`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, and `python3 scripts/validate_docs_contracts.py`, and all checks passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c3657d828833099fbefa501289cfe)