### PR TITLE
Fix tracing intake span shutdown examples

### DIFF
--- a/tailtriage-tracing/examples/completed_span_jsonl_export.rs
+++ b/tailtriage-tracing/examples/completed_span_jsonl_export.rs
@@ -14,14 +14,14 @@ fn main() -> Result<(), Box<dyn Error>> {
     // should install the tailtriage layer in the process-wide subscriber setup.
     let subscriber = tracing_subscriber::registry().with(session.layer());
     tracing::subscriber::with_default(subscriber, || {
-        let request = tracing::info_span!(
+        let _request_guard = tracing::info_span!(
             "http.request",
             tt.kind = "request",
             tt.request_id = "req-1",
             tt.route = "/checkout",
             tt.outcome = "ok"
-        );
-        let _request_guard = request.enter();
+        )
+        .entered();
         {
             let _queue_guard = tracing::info_span!(
                 "admission.queue",

--- a/tailtriage-tracing/examples/live_recorder.rs
+++ b/tailtriage-tracing/examples/live_recorder.rs
@@ -16,35 +16,35 @@ fn main() -> Result<(), Box<dyn Error>> {
     let subscriber = tracing_subscriber::registry().with(recorder.layer());
 
     tracing::subscriber::with_default(subscriber, || {
-        let request = tracing::info_span!(
+        let _request_entered = tracing::info_span!(
             "http.request",
             tt.kind = "request",
             tt.request_id = "req-1",
             tt.route = "/checkout",
             tt.outcome = "ok"
-        );
-        let _request_entered = request.enter();
+        )
+        .entered();
 
         {
-            let queue = tracing::info_span!(
+            let _queue_entered = tracing::info_span!(
                 "checkout.queue",
                 tt.kind = "queue",
                 tt.request_id = "req-1",
                 tt.queue = "db-pool",
                 tt.depth_at_start = 4_u64
-            );
-            let _queue_entered = queue.enter();
+            )
+            .entered();
         }
 
         {
-            let stage = tracing::info_span!(
+            let _stage_entered = tracing::info_span!(
                 "checkout.stage",
                 tt.kind = "stage",
                 tt.request_id = "req-1",
                 tt.stage = "db.query",
                 tt.success = true
-            );
-            let _stage_entered = stage.enter();
+            )
+            .entered();
         }
     });
 

--- a/tailtriage-tracing/examples/live_session_to_run.rs
+++ b/tailtriage-tracing/examples/live_session_to_run.rs
@@ -14,14 +14,14 @@ fn main() -> Result<(), Box<dyn Error>> {
     // should install the tailtriage layer in the process-wide subscriber setup.
     let subscriber = tracing_subscriber::registry().with(session.layer());
     tracing::subscriber::with_default(subscriber, || {
-        let request = tracing::info_span!(
+        let _request_guard = tracing::info_span!(
             "http.request",
             tt.kind = "request",
             tt.request_id = "req-1",
             tt.route = "/checkout",
             tt.outcome = "ok"
-        );
-        let _request_guard = request.enter();
+        )
+        .entered();
 
         {
             let _queue_guard = tracing::info_span!(

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -252,14 +252,14 @@ impl TracingIntakeSession {
     ///
     /// tracing_subscriber::registry().with(session.layer()).init();
     ///
-    /// let span = tracing::info_span!(
-    ///     "request",
-    ///     tt.kind = "request",
-    ///     tt.request_id = "r1",
-    ///     tt.route = "/checkout"
-    /// );
     /// {
-    ///     let _guard = span.enter();
+    ///     let _guard = tracing::info_span!(
+    ///         "request",
+    ///         tt.kind = "request",
+    ///         tt.request_id = "r1",
+    ///         tt.route = "/checkout"
+    ///     )
+    ///     .entered();
     ///     // measured work goes here
     /// }
     ///
@@ -2855,6 +2855,70 @@ mod tests {
                 .message()
                 .contains("open candidate span(s) at snapshot/shutdown")));
         });
+    }
+
+    #[test]
+    fn session_shutdown_succeeds_when_request_span_handle_is_dropped_before_shutdown() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_path = dir.path().join("run.json");
+        let session = TracingIntakeSession::builder("svc")
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+
+        tracing::subscriber::with_default(subscriber, || {
+            let _request_guard = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a",
+                tt.outcome = "ok"
+            )
+            .entered();
+        });
+
+        session.shutdown().unwrap();
+        assert!(run_path.exists());
+    }
+
+    #[test]
+    fn session_shutdown_rejects_open_request_span_for_persisted_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_path = dir.path().join("run.json");
+        let session = TracingIntakeSession::builder("svc")
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a",
+                tt.outcome = "ok"
+            );
+            {
+                let _request_guard = span.enter();
+            }
+
+            let err = session.shutdown().unwrap_err();
+            assert!(matches!(
+                err,
+                ImportError::ZeroRequestArtifact { .. }
+                    | ImportError::ZeroRequestArtifactWithWarnings { .. }
+            ));
+            let message = err.to_string();
+            assert!(
+                message.contains("tracing import produced zero request events")
+                    || message.contains("open candidate spans")
+                    || message.contains("open candidate span(s)")
+            );
+            drop(span);
+        });
+        assert!(!run_path.exists());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Examples and rustdoc retained a `tracing::Span` handle across `shutdown()`, which leaves request candidate spans open and causes persisted Run JSON to contain zero completed request spans. 
- Update documentation and examples to demonstrate the safe pattern so users don't accidentally keep spans alive across shutdown and to reduce confusing zero-request failures.

### Description
- Replace the unsafe rustdoc example in `TracingIntakeSession::builder` to use a nested block with `.entered()` on `tracing::info_span!(...)` so the request span is closed before `session.shutdown()` (pattern (a)).
- Update live/example sources to the same safe pattern in `tailtriage-tracing/examples/live_recorder.rs`, `tailtriage-tracing/examples/live_session_to_run.rs`, and `tailtriage-tracing/examples/completed_span_jsonl_export.rs`.
- Add two focused regression tests to `tailtriage-tracing/src/recorder.rs`: `session_shutdown_succeeds_when_request_span_handle_is_dropped_before_shutdown` (successful case) and `session_shutdown_rejects_open_request_span_for_persisted_output` (old-pitfall failure case).
- Audited `tailtriage-tracing/README.md`, `docs/user-guide.md`, and `tailtriage-tracing/examples/tokio_session_to_run.rs` for the same unsafe pattern and left them unchanged where the pattern was already safe or not applicable, preserving the narrow "tracing intake bridge" wording and triage guidance.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it completed successfully with no new warnings or errors.
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests passed (`...  finished in 2m 16s` and many test suites reported `ok`).
- Ran `cargo check -p tailtriage-tracing --no-default-features --locked` which finished successfully and emitted an existing `dead_code` warning for `ensure_persistable_run_with_warnings`.
- Ran `cargo check -p tailtriage-tracing --no-default-features --features jsonl --locked` which finished successfully and emitted the same existing warning.
- Ran `cargo check -p tailtriage-tracing --no-default-features --features live --locked` which finished successfully and emitted an existing `dead_code` warning for `selected_mode`.
- Ran `cargo check -p tailtriage-tracing --no-default-features --features tokio --locked` and it finished successfully.
- Ran `python3 scripts/validate_docs_contracts.py` and it reported `docs contracts validated successfully`.

Changed files: `tailtriage-tracing/src/recorder.rs`, `tailtriage-tracing/examples/live_recorder.rs`, `tailtriage-tracing/examples/live_session_to_run.rs`, `tailtriage-tracing/examples/completed_span_jsonl_export.rs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c4b62fc8483309ead337a6f829dab)