### PR TITLE
Fix tracing shutdown span examples and add regression tests

### DIFF
--- a/tailtriage-tracing/examples/completed_span_jsonl_export.rs
+++ b/tailtriage-tracing/examples/completed_span_jsonl_export.rs
@@ -14,14 +14,14 @@ fn main() -> Result<(), Box<dyn Error>> {
     // should install the tailtriage layer in the process-wide subscriber setup.
     let subscriber = tracing_subscriber::registry().with(session.layer());
     tracing::subscriber::with_default(subscriber, || {
-        let request = tracing::info_span!(
+        let _request_guard = tracing::info_span!(
             "http.request",
             tt.kind = "request",
             tt.request_id = "req-1",
             tt.route = "/checkout",
             tt.outcome = "ok"
-        );
-        let _request_guard = request.enter();
+        )
+        .entered();
         {
             let _queue_guard = tracing::info_span!(
                 "admission.queue",

--- a/tailtriage-tracing/examples/live_recorder.rs
+++ b/tailtriage-tracing/examples/live_recorder.rs
@@ -16,14 +16,14 @@ fn main() -> Result<(), Box<dyn Error>> {
     let subscriber = tracing_subscriber::registry().with(recorder.layer());
 
     tracing::subscriber::with_default(subscriber, || {
-        let request = tracing::info_span!(
+        let _request_entered = tracing::info_span!(
             "http.request",
             tt.kind = "request",
             tt.request_id = "req-1",
             tt.route = "/checkout",
             tt.outcome = "ok"
-        );
-        let _request_entered = request.enter();
+        )
+        .entered();
 
         {
             let queue = tracing::info_span!(

--- a/tailtriage-tracing/examples/live_session_to_run.rs
+++ b/tailtriage-tracing/examples/live_session_to_run.rs
@@ -14,14 +14,14 @@ fn main() -> Result<(), Box<dyn Error>> {
     // should install the tailtriage layer in the process-wide subscriber setup.
     let subscriber = tracing_subscriber::registry().with(session.layer());
     tracing::subscriber::with_default(subscriber, || {
-        let request = tracing::info_span!(
+        let _request_guard = tracing::info_span!(
             "http.request",
             tt.kind = "request",
             tt.request_id = "req-1",
             tt.route = "/checkout",
             tt.outcome = "ok"
-        );
-        let _request_guard = request.enter();
+        )
+        .entered();
 
         {
             let _queue_guard = tracing::info_span!(

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -252,14 +252,14 @@ impl TracingIntakeSession {
     ///
     /// tracing_subscriber::registry().with(session.layer()).init();
     ///
-    /// let span = tracing::info_span!(
-    ///     "request",
-    ///     tt.kind = "request",
-    ///     tt.request_id = "r1",
-    ///     tt.route = "/checkout"
-    /// );
     /// {
-    ///     let _guard = span.enter();
+    ///     let _guard = tracing::info_span!(
+    ///         "request",
+    ///         tt.kind = "request",
+    ///         tt.request_id = "r1",
+    ///         tt.route = "/checkout"
+    ///     )
+    ///     .entered();
     ///     // measured work goes here
     /// }
     ///
@@ -3054,6 +3054,67 @@ mod tests {
         let run: tailtriage_core::Run =
             serde_json::from_slice(&std::fs::read(&run_path).unwrap()).unwrap();
         assert_eq!(run.requests.len(), 1);
+    }
+
+    #[test]
+    fn session_shutdown_succeeds_when_request_span_handle_is_dropped_before_shutdown() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_path = dir.path().join("run.json");
+        let session = TracingIntakeSession::builder("svc")
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+
+        tracing::subscriber::with_default(subscriber, || {
+            let _request_guard = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            )
+            .entered();
+        });
+
+        session.shutdown().unwrap();
+        assert!(run_path.exists());
+    }
+
+    #[test]
+    fn session_shutdown_rejects_open_request_span_for_persisted_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_path = dir.path().join("run.json");
+        let session = TracingIntakeSession::builder("svc")
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+
+        let span = tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            );
+            {
+                let _guard = span.enter();
+            }
+            span
+        });
+
+        let err = session.shutdown().unwrap_err();
+        assert!(matches!(
+            err,
+            ImportError::ZeroRequestArtifact { .. }
+                | ImportError::ZeroRequestArtifactWithWarnings { .. }
+        ));
+        let message = err.to_string();
+        assert!(
+            message.contains("tracing import produced zero request events")
+                || message.contains("open candidate span")
+        );
+        drop(span);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Examples and rustdoc showed an unsafe pattern that kept a `tracing::Span` handle alive across `shutdown()`, which caused persisted-run artifacts to report zero completed request spans. This change fixes the examples to demonstrate the correct safe pattern. 

### Description
- Rewrote the `TracingIntakeSession::builder` rustdoc example to use the synchronous `.entered()` guard form so no span handle remains in scope across `shutdown()` (`tailtriage-tracing/src/recorder.rs`).
- Updated live/example files to use the safe direct `.entered()` pattern instead of creating a separate `span` variable and entering it (`tailtriage-tracing/examples/live_recorder.rs`, `tailtriage-tracing/examples/live_session_to_run.rs`, `tailtriage-tracing/examples/completed_span_jsonl_export.rs`).
- Added two focused regression tests to the existing tests module in `tailtriage-tracing/src/recorder.rs`: `session_shutdown_succeeds_when_request_span_handle_is_dropped_before_shutdown` and `session_shutdown_rejects_open_request_span_for_persisted_output`.
- Kept all product scope and wording consistent with repository guidance; no behavioral changes beyond examples and tests.
- Files changed: `tailtriage-tracing/src/recorder.rs`, `tailtriage-tracing/examples/live_recorder.rs`, `tailtriage-tracing/examples/live_session_to_run.rs`, `tailtriage-tracing/examples/completed_span_jsonl_export.rs`.

### Testing
- `cargo fmt --check` — passed.
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — passed.
- `cargo test --workspace --all-targets --all-features --locked` — passed (all tests succeeded across the workspace).
- `cargo check -p tailtriage-tracing --no-default-features --locked` — passed with an existing `dead_code` warning for `ensure_persistable_run_with_warnings`.
- `cargo check -p tailtriage-tracing --no-default-features --features jsonl --locked` — passed with the same existing `dead_code` warning.
- `cargo check -p tailtriage-tracing --no-default-features --features live --locked` — passed with an existing `dead_code` warning.
- `cargo check -p tailtriage-tracing --no-default-features --features tokio --locked` — passed.
- `python3 scripts/validate_docs_contracts.py` — passed (docs contracts validated successfully).

Command summary (changed files and results):
- Changed files: `tailtriage-tracing/src/recorder.rs`, `tailtriage-tracing/examples/live_recorder.rs`, `tailtriage-tracing/examples/live_session_to_run.rs`, `tailtriage-tracing/examples/completed_span_jsonl_export.rs`.
- All format, lint, test, and checks listed in the task completed successfully; a few pre-existing warnings were emitted during `cargo check` for `tailtriage-tracing` (unused/dead code), but none are new failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c4b62fc8483309ead337a6f829dab)