### PR TITLE
Fix tracing intake shutdown span examples

### DIFF
--- a/tailtriage-tracing/examples/completed_span_jsonl_export.rs
+++ b/tailtriage-tracing/examples/completed_span_jsonl_export.rs
@@ -14,14 +14,14 @@ fn main() -> Result<(), Box<dyn Error>> {
     // should install the tailtriage layer in the process-wide subscriber setup.
     let subscriber = tracing_subscriber::registry().with(session.layer());
     tracing::subscriber::with_default(subscriber, || {
-        let request = tracing::info_span!(
+        let _request_guard = tracing::info_span!(
             "http.request",
             tt.kind = "request",
             tt.request_id = "req-1",
             tt.route = "/checkout",
             tt.outcome = "ok"
-        );
-        let _request_guard = request.enter();
+        )
+        .entered();
         {
             let _queue_guard = tracing::info_span!(
                 "admission.queue",

--- a/tailtriage-tracing/examples/live_recorder.rs
+++ b/tailtriage-tracing/examples/live_recorder.rs
@@ -16,35 +16,35 @@ fn main() -> Result<(), Box<dyn Error>> {
     let subscriber = tracing_subscriber::registry().with(recorder.layer());
 
     tracing::subscriber::with_default(subscriber, || {
-        let request = tracing::info_span!(
+        let _request_entered = tracing::info_span!(
             "http.request",
             tt.kind = "request",
             tt.request_id = "req-1",
             tt.route = "/checkout",
             tt.outcome = "ok"
-        );
-        let _request_entered = request.enter();
+        )
+        .entered();
 
         {
-            let queue = tracing::info_span!(
+            let _queue_entered = tracing::info_span!(
                 "checkout.queue",
                 tt.kind = "queue",
                 tt.request_id = "req-1",
                 tt.queue = "db-pool",
                 tt.depth_at_start = 4_u64
-            );
-            let _queue_entered = queue.enter();
+            )
+            .entered();
         }
 
         {
-            let stage = tracing::info_span!(
+            let _stage_entered = tracing::info_span!(
                 "checkout.stage",
                 tt.kind = "stage",
                 tt.request_id = "req-1",
                 tt.stage = "db.query",
                 tt.success = true
-            );
-            let _stage_entered = stage.enter();
+            )
+            .entered();
         }
     });
 

--- a/tailtriage-tracing/examples/live_session_to_run.rs
+++ b/tailtriage-tracing/examples/live_session_to_run.rs
@@ -14,14 +14,14 @@ fn main() -> Result<(), Box<dyn Error>> {
     // should install the tailtriage layer in the process-wide subscriber setup.
     let subscriber = tracing_subscriber::registry().with(session.layer());
     tracing::subscriber::with_default(subscriber, || {
-        let request = tracing::info_span!(
+        let _request_guard = tracing::info_span!(
             "http.request",
             tt.kind = "request",
             tt.request_id = "req-1",
             tt.route = "/checkout",
             tt.outcome = "ok"
-        );
-        let _request_guard = request.enter();
+        )
+        .entered();
 
         {
             let _queue_guard = tracing::info_span!(

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -252,16 +252,16 @@ impl TracingIntakeSession {
     ///
     /// tracing_subscriber::registry().with(session.layer()).init();
     ///
-    /// let span = tracing::info_span!(
-    ///     "request",
-    ///     tt.kind = "request",
-    ///     tt.request_id = "r1",
-    ///     tt.route = "/checkout"
-    /// );
     /// {
-    ///     let _guard = span.enter();
+    ///     let _guard = tracing::info_span!(
+    ///         "request",
+    ///         tt.kind = "request",
+    ///         tt.request_id = "r1",
+    ///         tt.route = "/checkout"
+    ///     )
+    ///     .entered();
     ///     // measured work goes here
-    /// }
+    /// } // the request span is closed before shutdown
     ///
     /// session.shutdown()?;
     /// # Ok(())
@@ -3054,6 +3054,68 @@ mod tests {
         let run: tailtriage_core::Run =
             serde_json::from_slice(&std::fs::read(&run_path).unwrap()).unwrap();
         assert_eq!(run.requests.len(), 1);
+    }
+
+    #[test]
+    fn session_shutdown_succeeds_when_request_span_handle_is_dropped_before_shutdown() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_path = dir.path().join("run.json");
+        let session = TracingIntakeSession::builder("svc")
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let _request_guard = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            )
+            .entered();
+        });
+
+        session.shutdown().unwrap();
+        assert!(run_path.exists());
+    }
+
+    #[test]
+    fn session_shutdown_rejects_open_request_span_for_persisted_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_path = dir.path().join("run.json");
+        let session = TracingIntakeSession::builder("svc")
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        let mut open_span = None;
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            );
+            {
+                let _request_guard = span.enter();
+            }
+            open_span = Some(span);
+        });
+
+        let span = open_span.expect("span handle retained across shutdown");
+        let err = session.shutdown().unwrap_err();
+        assert!(matches!(
+            err,
+            ImportError::ZeroRequestArtifactWithWarnings { .. }
+                | ImportError::ZeroRequestArtifact { .. }
+        ));
+        let message = err.to_string();
+        assert!(
+            message.contains("tracing import produced zero request events")
+                || message.contains("open candidate span(s)")
+        );
+        assert!(!run_path.exists());
+        drop(span);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Examples and rustdoc in the tracing intake crate retained a `tracing::Span` handle across `shutdown()`, which prevents request spans from being observed as completed and can produce zero-request persisted artifacts. This change fixes teaching examples and adds regression tests to prevent regressions.

### Description

- Updated `TracingIntakeSession::builder` rustdoc so the example uses a scoped `.entered()` call (no retained span handle) and explicitly notes the request span is closed before `shutdown()`; behavior and product scope remain unchanged (this is a narrow tracing intake bridge, not an observability backend).  
- Rewrote examples to use the safe scoped `.entered()` pattern rather than creating and keeping a separate span handle: `tailtriage-tracing/examples/live_recorder.rs`, `tailtriage-tracing/examples/live_session_to_run.rs`, and `tailtriage-tracing/examples/completed_span_jsonl_export.rs`.  
- Added two focused regression tests in `tailtriage-tracing/src/recorder.rs` under the existing tests module: `session_shutdown_succeeds_when_request_span_handle_is_dropped_before_shutdown` and `session_shutdown_rejects_open_request_span_for_persisted_output`, exercising the safe pattern and the old pitfall respectively, using a temporary `run_json_path` and installing `session.layer()` as the subscriber.  
- Did not change product scope, public API, or unrelated docs wording; messaging remains consistent with the repository docs contract (tracing intake bridge; analysis remains a separate `tailtriage analyze` step).

### Testing

- `cargo fmt --check` — passed.
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — passed (no lints raised).
- `cargo test --workspace --all-targets --all-features --locked` — passed (all tests completed successfully; `tailtriage-tracing` tests included the new regression tests). 
- `cargo check -p tailtriage-tracing --no-default-features --locked` — passed with a non-critical `dead_code` warning for `ensure_persistable_run_with_warnings` (existing warning).
- `cargo check -p tailtriage-tracing --no-default-features --features jsonl --locked` — passed with the same `dead_code` warning.
- `cargo check -p tailtriage-tracing --no-default-features --features live --locked` — passed with an existing `dead_code` warning for `selected_mode`.
- `cargo check -p tailtriage-tracing --no-default-features --features tokio --locked` — passed.
- `python3 scripts/validate_docs_contracts.py` — passed (`docs contracts validated successfully`).

Changed files:
- tailtriage-tracing/src/recorder.rs (rustdoc edit + two tests added)
- tailtriage-tracing/examples/live_recorder.rs (example updated)
- tailtriage-tracing/examples/live_session_to_run.rs (example updated)
- tailtriage-tracing/examples/completed_span_jsonl_export.rs (example updated)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c4b62fc8483309ead337a6f829dab)