### PR TITLE
Fix tracing shutdown span examples

### DIFF
--- a/tailtriage-tracing/examples/completed_span_jsonl_export.rs
+++ b/tailtriage-tracing/examples/completed_span_jsonl_export.rs
@@ -14,14 +14,14 @@ fn main() -> Result<(), Box<dyn Error>> {
     // should install the tailtriage layer in the process-wide subscriber setup.
     let subscriber = tracing_subscriber::registry().with(session.layer());
     tracing::subscriber::with_default(subscriber, || {
-        let request = tracing::info_span!(
+        let _request_guard = tracing::info_span!(
             "http.request",
             tt.kind = "request",
             tt.request_id = "req-1",
             tt.route = "/checkout",
             tt.outcome = "ok"
-        );
-        let _request_guard = request.enter();
+        )
+        .entered();
         {
             let _queue_guard = tracing::info_span!(
                 "admission.queue",

--- a/tailtriage-tracing/examples/live_recorder.rs
+++ b/tailtriage-tracing/examples/live_recorder.rs
@@ -16,35 +16,35 @@ fn main() -> Result<(), Box<dyn Error>> {
     let subscriber = tracing_subscriber::registry().with(recorder.layer());
 
     tracing::subscriber::with_default(subscriber, || {
-        let request = tracing::info_span!(
+        let _request_entered = tracing::info_span!(
             "http.request",
             tt.kind = "request",
             tt.request_id = "req-1",
             tt.route = "/checkout",
             tt.outcome = "ok"
-        );
-        let _request_entered = request.enter();
+        )
+        .entered();
 
         {
-            let queue = tracing::info_span!(
+            let _queue_entered = tracing::info_span!(
                 "checkout.queue",
                 tt.kind = "queue",
                 tt.request_id = "req-1",
                 tt.queue = "db-pool",
                 tt.depth_at_start = 4_u64
-            );
-            let _queue_entered = queue.enter();
+            )
+            .entered();
         }
 
         {
-            let stage = tracing::info_span!(
+            let _stage_entered = tracing::info_span!(
                 "checkout.stage",
                 tt.kind = "stage",
                 tt.request_id = "req-1",
                 tt.stage = "db.query",
                 tt.success = true
-            );
-            let _stage_entered = stage.enter();
+            )
+            .entered();
         }
     });
 

--- a/tailtriage-tracing/examples/live_session_to_run.rs
+++ b/tailtriage-tracing/examples/live_session_to_run.rs
@@ -14,14 +14,14 @@ fn main() -> Result<(), Box<dyn Error>> {
     // should install the tailtriage layer in the process-wide subscriber setup.
     let subscriber = tracing_subscriber::registry().with(session.layer());
     tracing::subscriber::with_default(subscriber, || {
-        let request = tracing::info_span!(
+        let _request_guard = tracing::info_span!(
             "http.request",
             tt.kind = "request",
             tt.request_id = "req-1",
             tt.route = "/checkout",
             tt.outcome = "ok"
-        );
-        let _request_guard = request.enter();
+        )
+        .entered();
 
         {
             let _queue_guard = tracing::info_span!(

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -252,14 +252,14 @@ impl TracingIntakeSession {
     ///
     /// tracing_subscriber::registry().with(session.layer()).init();
     ///
-    /// let span = tracing::info_span!(
-    ///     "request",
-    ///     tt.kind = "request",
-    ///     tt.request_id = "r1",
-    ///     tt.route = "/checkout"
-    /// );
     /// {
-    ///     let _guard = span.enter();
+    ///     let _guard = tracing::info_span!(
+    ///         "request",
+    ///         tt.kind = "request",
+    ///         tt.request_id = "r1",
+    ///         tt.route = "/checkout"
+    ///     )
+    ///     .entered();
     ///     // measured work goes here
     /// }
     ///
@@ -3054,6 +3054,70 @@ mod tests {
         let run: tailtriage_core::Run =
             serde_json::from_slice(&std::fs::read(&run_path).unwrap()).unwrap();
         assert_eq!(run.requests.len(), 1);
+    }
+
+    #[test]
+    fn session_shutdown_succeeds_when_request_span_handle_is_dropped_before_shutdown() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_path = dir.path().join("run.json");
+        let session = TracingIntakeSession::builder("svc")
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+
+        tracing::subscriber::with_default(subscriber, || {
+            let _request_guard = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            )
+            .entered();
+        });
+
+        session.shutdown().unwrap();
+        assert!(run_path.exists());
+    }
+
+    #[test]
+    fn session_shutdown_rejects_open_request_span_for_persisted_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_path = dir.path().join("run.json");
+        let session = TracingIntakeSession::builder("svc")
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+
+        let err = tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            );
+            {
+                let _guard = span.enter();
+            }
+
+            let err = session.shutdown().unwrap_err();
+            assert!(matches!(
+                err,
+                ImportError::ZeroRequestArtifact { .. }
+                    | ImportError::ZeroRequestArtifactWithWarnings { .. }
+            ));
+            let message = err.to_string();
+            assert!(
+                message.contains("tracing import produced zero request events")
+                    || message.contains("open candidate span")
+            );
+            drop(span);
+            err
+        });
+
+        assert!(!run_path.exists());
+        drop(err);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Examples and rustdoc demonstrated an unsafe pattern that retained a `tracing::Span` handle across `shutdown()`, which can cause zero completed request spans to be observed and prevent persisted run artifacts.

### Description
- Replace the unsafe example in `TracingIntakeSession::builder` rustdoc to use the direct `.entered()` pattern so the request span is closed before `shutdown()` (edit: `tailtriage-tracing/src/recorder.rs`).
- Update live/examples to avoid keeping span handles alive across shutdown by switching to the nested `.entered()` guard form (edits: `tailtriage-tracing/examples/live_recorder.rs`, `tailtriage-tracing/examples/live_session_to_run.rs`, `tailtriage-tracing/examples/completed_span_jsonl_export.rs`).
- Add two focused regression tests to `tailtriage-tracing/src/recorder.rs` that validate the safe pattern succeeds (`session_shutdown_succeeds_when_request_span_handle_is_dropped_before_shutdown`) and the old pitfall fails clearly (`session_shutdown_rejects_open_request_span_for_persisted_output`).

### Testing
- Ran `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, both completed without failing checks (clippy passed). 
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests passed (workspace tests completed; tracer crate tests passed with 257 tests in that crate and overall suite succeeded). 
- Ran `cargo check -p tailtriage-tracing` under combinations: `--no-default-features` (completed with a benign dead-code warning), `--no-default-features --features jsonl` (completed with the same benign warning), `--no-default-features --features live` (completed with a benign warning), and `--no-default-features --features tokio` (completed successfully). 
- Ran `python3 scripts/validate_docs_contracts.py` and it returned `docs contracts validated successfully`.

Changed files:
- tailtriage-tracing/src/recorder.rs
- tailtriage-tracing/examples/live_recorder.rs
- tailtriage-tracing/examples/live_session_to_run.rs
- tailtriage-tracing/examples/completed_span_jsonl_export.rs

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c4b62fc8483309ead337a6f829dab)