### PR TITLE
Make tracing raw retention respect semantic max_requests to avoid evicting retained child evidence

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -62,6 +62,7 @@ pub struct TracingRecorderBuilder {
 pub struct TailtriageLayer {
     state: Arc<Mutex<RecorderState>>,
     limits: RecorderLimits,
+    semantic_max_requests: usize,
 }
 /// Default maximum number of concurrently tracked open candidate spans.
 pub const DEFAULT_MAX_OPEN_SPANS: usize = 8_192;
@@ -171,6 +172,7 @@ impl TracingRecorder {
         TailtriageLayer {
             state: Arc::clone(&self.state),
             limits: self.limits,
+            semantic_max_requests: self.options.resolved_capture_limits().max_requests,
         }
     }
 
@@ -748,6 +750,7 @@ where
                 record,
                 kind,
                 self.limits,
+                self.semantic_max_requests,
             );
         }
     }
@@ -770,6 +773,7 @@ fn push_completed_candidate_with_kind_aware_retention(
     record: SpanRecord,
     kind: &str,
     limits: RecorderLimits,
+    semantic_max_requests: usize,
 ) {
     let total = state.completed_requests.len()
         + state.completed_stages.len()
@@ -781,7 +785,10 @@ fn push_completed_candidate_with_kind_aware_retention(
 
     match kind {
         "request" => {
-            if !state.completed_queues.is_empty() {
+            if state.completed_requests.len() >= semantic_max_requests {
+                state.dropped_completed_request_candidates =
+                    state.dropped_completed_request_candidates.saturating_add(1);
+            } else if !state.completed_queues.is_empty() {
                 state.completed_queues.pop();
                 state.evicted_child_candidates_to_preserve_request = state
                     .evicted_child_candidates_to_preserve_request
@@ -986,19 +993,19 @@ fn push_strict_recorder_messages(
     }
     if stats.dropped_completed_request_candidates > 0 {
         messages.push(format!(
-            "live recorder dropped {} completed request candidate span(s) because max_completed_candidate_spans={} was reached and no child candidate was available to evict",
+            "live recorder dropped {} completed request candidate span(s) because max_completed_candidate_spans={} was reached and the request root could not still survive semantic max_requests retention or no child candidate was available to evict",
             stats.dropped_completed_request_candidates, limits.max_completed_candidate_spans
         ));
     }
     if stats.dropped_completed_child_candidates > 0 {
         messages.push(format!(
-            "live recorder dropped {} completed child candidate span(s) because max_completed_candidate_spans={} was reached while preserving request roots",
+            "live recorder dropped {} completed child candidate span(s) because max_completed_candidate_spans={} was reached while preserving request roots that can still survive semantic request retention",
             stats.dropped_completed_child_candidates, limits.max_completed_candidate_spans
         ));
     }
     if stats.evicted_child_candidates_to_preserve_request > 0 {
         messages.push(format!(
-            "live recorder evicted {} completed child candidate span(s) to preserve completed request candidate span(s) under max_completed_candidate_spans={}",
+            "live recorder evicted {} completed child candidate span(s) to preserve completed request candidate span(s) that can still survive semantic request retention under max_completed_candidate_spans={}",
             stats.evicted_child_candidates_to_preserve_request, limits.max_completed_candidate_spans
         ));
     }
@@ -1082,7 +1089,7 @@ fn append_non_strict_drop_warnings(
     }
     if stats.dropped_completed_request_candidates > 0 {
         let msg = format!(
-            "live recorder dropped {} completed request candidate span(s) because max_completed_candidate_spans={} was reached and no child candidate was available to evict",
+            "live recorder dropped {} completed request candidate span(s) because max_completed_candidate_spans={} was reached and the request root could not still survive semantic max_requests retention or no child candidate was available to evict",
             stats.dropped_completed_request_candidates, limits.max_completed_candidate_spans
         );
         run.metadata.lifecycle_warnings.push(msg.clone());
@@ -1090,7 +1097,7 @@ fn append_non_strict_drop_warnings(
     }
     if stats.dropped_completed_child_candidates > 0 {
         let msg = format!(
-            "live recorder dropped {} completed child candidate span(s) because max_completed_candidate_spans={} was reached while preserving request roots",
+            "live recorder dropped {} completed child candidate span(s) because max_completed_candidate_spans={} was reached while preserving request roots that can still survive semantic request retention",
             stats.dropped_completed_child_candidates, limits.max_completed_candidate_spans
         );
         run.metadata.lifecycle_warnings.push(msg.clone());
@@ -1098,7 +1105,7 @@ fn append_non_strict_drop_warnings(
     }
     if stats.evicted_child_candidates_to_preserve_request > 0 {
         let msg = format!(
-            "live recorder evicted {} completed child candidate span(s) to preserve completed request candidate span(s) under max_completed_candidate_spans={}",
+            "live recorder evicted {} completed child candidate span(s) to preserve completed request candidate span(s) that can still survive semantic request retention under max_completed_candidate_spans={}",
             stats.evicted_child_candidates_to_preserve_request, limits.max_completed_candidate_spans
         );
         run.metadata.lifecycle_warnings.push(msg.clone());
@@ -1668,6 +1675,125 @@ mod tests {
             warning_text.contains("dropped 1 completed child candidate span")
                 || warning_text.contains("evicted 1 completed child candidate span")
         );
+    }
+
+    #[test]
+    fn raw_cap_does_not_evict_retained_request_child_for_later_unretained_request() {
+        let recorder = TracingRecorder::builder("svc")
+            .capture_limits_override(CaptureLimitsOverride {
+                max_requests: Some(1),
+                max_stages: Some(10),
+                max_queues: Some(10),
+                ..Default::default()
+            })
+            .max_completed_candidate_spans(2)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request-r1",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/r1"
+            ));
+            drop(tracing::info_span!(
+                "stage-r1",
+                tt.kind = "stage",
+                tt.request_id = "r1",
+                tt.stage = "db.query"
+            ));
+            drop(tracing::info_span!(
+                "request-r2",
+                tt.kind = "request",
+                tt.request_id = "r2",
+                tt.route = "/r2"
+            ));
+        });
+
+        let imported = recorder.snapshot_run().unwrap();
+        let run = imported.run();
+        assert_eq!(run.requests.len(), 1);
+        assert_eq!(run.requests[0].request_id, "r1");
+        assert_eq!(run.requests[0].route, "/r1");
+        assert_eq!(run.stages.len(), 1);
+        assert_eq!(run.stages[0].request_id, "r1");
+        assert_eq!(run.stages[0].stage, "db.query");
+        assert!(run
+            .requests
+            .iter()
+            .all(|request| request.request_id != "r2"));
+        assert!(run.truncation.limits_hit);
+        assert_eq!(run.truncation.dropped_requests, 0);
+
+        let warning_text = imported
+            .warnings()
+            .iter()
+            .map(|w| w.message().to_string())
+            .collect::<Vec<_>>()
+            .join(" | ");
+        assert!(warning_text.contains("dropped 1 completed request candidate span"));
+        assert!(warning_text.contains("max_completed_candidate_spans=2"));
+    }
+
+    #[test]
+    fn raw_cap_still_preserves_request_root_when_within_semantic_request_limit() {
+        let recorder = TracingRecorder::builder("svc")
+            .capture_limits_override(CaptureLimitsOverride {
+                max_requests: Some(2),
+                max_stages: Some(10),
+                max_queues: Some(10),
+                ..Default::default()
+            })
+            .max_completed_candidate_spans(2)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request-r1",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/r1"
+            ));
+            drop(tracing::info_span!(
+                "stage-r1",
+                tt.kind = "stage",
+                tt.request_id = "r1",
+                tt.stage = "db.query"
+            ));
+            drop(tracing::info_span!(
+                "request-r2",
+                tt.kind = "request",
+                tt.request_id = "r2",
+                tt.route = "/r2"
+            ));
+        });
+
+        let imported = recorder.snapshot_run().unwrap();
+        let run = imported.run();
+        assert_eq!(run.requests.len(), 2);
+        assert!(run
+            .requests
+            .iter()
+            .any(|request| request.request_id == "r1"));
+        assert!(run
+            .requests
+            .iter()
+            .any(|request| request.request_id == "r2"));
+        assert!(run.stages.is_empty());
+        assert!(run.truncation.limits_hit);
+        assert_eq!(run.truncation.dropped_requests, 0);
+        assert_eq!(run.truncation.dropped_stages, 0);
+
+        let warning_text = imported
+            .warnings()
+            .iter()
+            .map(|w| w.message().to_string())
+            .collect::<Vec<_>>()
+            .join(" | ");
+        assert!(warning_text.contains("evicted 1 completed child candidate span"));
+        assert!(warning_text.contains("max_completed_candidate_spans=2"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent a later completed request candidate from evicting child evidence of an earlier request that will survive semantic `max_requests` retention. 
- Keep the existing public API and counters while making raw completed-candidate retention aware of the resolved semantic request limit so preserved roots are meaningful after conversion.

### Description
- Pass the resolved semantic `max_requests` from `ImportOptions` into the live recorder layer and into `push_completed_candidate_with_kind_aware_retention` so raw retention can consult it at insertion time. 
- Change the raw retention policy so that when the raw cap is full and a new request arrives we drop the new request if `completed_requests.len() >= semantic_max_requests`, otherwise evict a child candidate if available to preserve the request, preserving existing child evidence for earlier semantically retained requests. 
- Preserve the existing counters (`dropped_completed_request_candidates`, `dropped_completed_child_candidates`, `evicted_child_candidates_to_preserve_request`), default caps, and public API surface, and keep child-arrival behavior unchanged (child candidates still drop when raw cap is full). 
- Update recorder warning text to clarify that request-root preference applies only when the request root can still survive semantic `max_requests`, and add two focused regression tests (`raw_cap_does_not_evict_retained_request_child_for_later_unretained_request` and `raw_cap_still_preserves_request_root_when_within_semantic_request_limit`) in `tailtriage-tracing/src/recorder.rs` and a single modified file `tailtriage-tracing/src/recorder.rs`.

### Testing
- Ran `cargo fmt --check` and it passed. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed. 
- Ran `cargo test --workspace --all-targets --all-features --locked` and the test suite completed successfully with all tests passing. 
- Ran `cargo check -p tailtriage-tracing --no-default-features --locked` and it completed successfully (one existing dead_code warning noted). 
- Ran `cargo check -p tailtriage-tracing --no-default-features --features jsonl --locked` and it completed successfully (one existing dead_code warning noted). 
- Ran `cargo check -p tailtriage-tracing --no-default-features --features live --locked` and it completed successfully (one existing dead_code/unused-method warning noted). 
- Ran `cargo check -p tailtriage-tracing --no-default-features --features tokio --locked` and it completed successfully. 
- Ran `python3 scripts/validate_docs_contracts.py` and it passed. 

Changed files: `tailtriage-tracing/src/recorder.rs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c5dcf3c4c83309e707c53619f4c87)