### PR TITLE
Make live tracing raw completed-candidate retention semantic-request-aware

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -62,6 +62,7 @@ pub struct TracingRecorderBuilder {
 pub struct TailtriageLayer {
     state: Arc<Mutex<RecorderState>>,
     limits: RecorderLimits,
+    semantic_max_requests: usize,
 }
 /// Default maximum number of concurrently tracked open candidate spans.
 pub const DEFAULT_MAX_OPEN_SPANS: usize = 8_192;
@@ -171,6 +172,7 @@ impl TracingRecorder {
         TailtriageLayer {
             state: Arc::clone(&self.state),
             limits: self.limits,
+            semantic_max_requests: self.options.resolved_capture_limits().max_requests,
         }
     }
 
@@ -748,6 +750,7 @@ where
                 record,
                 kind,
                 self.limits,
+                self.semantic_max_requests,
             );
         }
     }
@@ -770,6 +773,7 @@ fn push_completed_candidate_with_kind_aware_retention(
     record: SpanRecord,
     kind: &str,
     limits: RecorderLimits,
+    semantic_max_requests: usize,
 ) {
     let total = state.completed_requests.len()
         + state.completed_stages.len()
@@ -781,22 +785,26 @@ fn push_completed_candidate_with_kind_aware_retention(
 
     match kind {
         "request" => {
+            if state.completed_requests.len() >= semantic_max_requests {
+                state.dropped_completed_request_candidates =
+                    state.dropped_completed_request_candidates.saturating_add(1);
+                return;
+            }
+
             if !state.completed_queues.is_empty() {
                 state.completed_queues.pop();
-                state.evicted_child_candidates_to_preserve_request = state
-                    .evicted_child_candidates_to_preserve_request
-                    .saturating_add(1);
-                state.completed_requests.push(record);
             } else if !state.completed_stages.is_empty() {
                 state.completed_stages.pop();
-                state.evicted_child_candidates_to_preserve_request = state
-                    .evicted_child_candidates_to_preserve_request
-                    .saturating_add(1);
-                state.completed_requests.push(record);
             } else {
                 state.dropped_completed_request_candidates =
                     state.dropped_completed_request_candidates.saturating_add(1);
+                return;
             }
+
+            state.evicted_child_candidates_to_preserve_request = state
+                .evicted_child_candidates_to_preserve_request
+                .saturating_add(1);
+            state.completed_requests.push(record);
         }
         "stage" | "queue" => {
             state.dropped_completed_child_candidates =
@@ -986,7 +994,7 @@ fn push_strict_recorder_messages(
     }
     if stats.dropped_completed_request_candidates > 0 {
         messages.push(format!(
-            "live recorder dropped {} completed request candidate span(s) because max_completed_candidate_spans={} was reached and no child candidate was available to evict",
+            "live recorder dropped {} completed request candidate span(s) because max_completed_candidate_spans={} was reached and preserving the request would not fit semantic max_requests retention or no child candidate was available to evict",
             stats.dropped_completed_request_candidates, limits.max_completed_candidate_spans
         ));
     }
@@ -998,7 +1006,7 @@ fn push_strict_recorder_messages(
     }
     if stats.evicted_child_candidates_to_preserve_request > 0 {
         messages.push(format!(
-            "live recorder evicted {} completed child candidate span(s) to preserve completed request candidate span(s) under max_completed_candidate_spans={}",
+            "live recorder evicted {} completed child candidate span(s) to preserve completed request candidate span(s) still within semantic request retention under max_completed_candidate_spans={}",
             stats.evicted_child_candidates_to_preserve_request, limits.max_completed_candidate_spans
         ));
     }
@@ -1082,7 +1090,7 @@ fn append_non_strict_drop_warnings(
     }
     if stats.dropped_completed_request_candidates > 0 {
         let msg = format!(
-            "live recorder dropped {} completed request candidate span(s) because max_completed_candidate_spans={} was reached and no child candidate was available to evict",
+            "live recorder dropped {} completed request candidate span(s) because max_completed_candidate_spans={} was reached and preserving the request would not fit semantic max_requests retention or no child candidate was available to evict",
             stats.dropped_completed_request_candidates, limits.max_completed_candidate_spans
         );
         run.metadata.lifecycle_warnings.push(msg.clone());
@@ -1098,7 +1106,7 @@ fn append_non_strict_drop_warnings(
     }
     if stats.evicted_child_candidates_to_preserve_request > 0 {
         let msg = format!(
-            "live recorder evicted {} completed child candidate span(s) to preserve completed request candidate span(s) under max_completed_candidate_spans={}",
+            "live recorder evicted {} completed child candidate span(s) to preserve completed request candidate span(s) still within semantic request retention under max_completed_candidate_spans={}",
             stats.evicted_child_candidates_to_preserve_request, limits.max_completed_candidate_spans
         );
         run.metadata.lifecycle_warnings.push(msg.clone());
@@ -1668,6 +1676,125 @@ mod tests {
             warning_text.contains("dropped 1 completed child candidate span")
                 || warning_text.contains("evicted 1 completed child candidate span")
         );
+    }
+
+    #[test]
+    fn raw_cap_does_not_evict_retained_request_child_for_later_unretained_request() {
+        let recorder = TracingRecorder::builder("svc")
+            .capture_limits_override(CaptureLimitsOverride {
+                max_requests: Some(1),
+                max_stages: Some(10),
+                max_queues: Some(10),
+                ..Default::default()
+            })
+            .max_completed_candidate_spans(2)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let request = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/r1"
+            );
+            let request_guard = request.enter();
+            drop(tracing::info_span!(
+                "stage",
+                tt.kind = "stage",
+                tt.request_id = "r1",
+                tt.stage = "db.query"
+            ));
+            drop(request_guard);
+            drop(request);
+
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r2",
+                tt.route = "/r2"
+            ));
+        });
+
+        let imported = recorder.snapshot_run().unwrap();
+        let run = imported.run();
+        assert_eq!(run.requests.len(), 1);
+        assert_eq!(run.requests[0].request_id, "r1");
+        assert_eq!(run.requests[0].route, "/r1");
+        assert_eq!(run.stages.len(), 1);
+        assert_eq!(run.stages[0].request_id, "r1");
+        assert!(run
+            .requests
+            .iter()
+            .all(|request| request.request_id != "r2"));
+        assert!(run.truncation.limits_hit);
+        assert_eq!(run.truncation.dropped_requests, 0);
+
+        let warning_text = imported
+            .warnings()
+            .iter()
+            .map(|w| w.message().to_string())
+            .collect::<Vec<_>>()
+            .join(" | ");
+        assert!(warning_text.contains("dropped 1 completed request candidate span"));
+        assert!(warning_text.contains("semantic max_requests retention"));
+    }
+
+    #[test]
+    fn raw_cap_still_preserves_request_root_when_within_semantic_request_limit() {
+        let recorder = TracingRecorder::builder("svc")
+            .capture_limits_override(CaptureLimitsOverride {
+                max_requests: Some(2),
+                max_stages: Some(10),
+                max_queues: Some(10),
+                ..Default::default()
+            })
+            .max_completed_candidate_spans(2)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let request = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/r1"
+            );
+            let request_guard = request.enter();
+            drop(tracing::info_span!(
+                "stage",
+                tt.kind = "stage",
+                tt.request_id = "r1",
+                tt.stage = "db.query"
+            ));
+            drop(request_guard);
+            drop(request);
+
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r2",
+                tt.route = "/r2"
+            ));
+        });
+
+        let imported = recorder.snapshot_run().unwrap();
+        let run = imported.run();
+        assert_eq!(run.requests.len(), 2);
+        assert_eq!(run.requests[0].request_id, "r1");
+        assert_eq!(run.requests[1].request_id, "r2");
+        assert_eq!(run.stages.len() + run.queues.len(), 0);
+        assert!(run.truncation.limits_hit);
+
+        let warning_text = imported
+            .warnings()
+            .iter()
+            .map(|w| w.message().to_string())
+            .collect::<Vec<_>>()
+            .join(" | ");
+        assert!(warning_text.contains("evicted 1 completed child candidate span"));
+        assert!(warning_text.contains("semantic request retention"));
+        assert!(!warning_text.contains("dropped 1 completed request candidate span"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The raw live recorder could evict child evidence for an earlier retained request in order to preserve a later request candidate that is then dropped by semantic `max_requests`, causing loss of evidence for retained requests.
- The goal is to keep the existing public API and counters while making raw retention aware of the effective semantic `max_requests` so request-root preference only applies when the request can still survive semantic retention.

### Description
- Pass the resolved semantic `max_requests` (from `ImportOptions`/resolved capture limits) into the live `TailtriageLayer` and into `push_completed_candidate_with_kind_aware_retention` without changing any public surface.
- Change the raw retention policy so that when the raw completed-candidate cap is reached and a new completed `request` candidate arrives, the function first checks if retained request roots already meet or exceed the semantic `max_requests` and, if so, drops the new request candidate and increments `dropped_completed_request_candidates`; otherwise it evicts a child candidate if available and preserves the request root.
- Keep existing behavior for child candidates (they are dropped and increment `dropped_completed_child_candidates` when the raw cap is full) and preserve the existing counters `dropped_completed_request_candidates`, `dropped_completed_child_candidates`, and `evicted_child_candidates_to_preserve_request` and default caps.
- Update retention/warning wording to reflect the semantic-aware behavior and add two focused regression tests `raw_cap_does_not_evict_retained_request_child_for_later_unretained_request` and `raw_cap_still_preserves_request_root_when_within_semantic_request_limit` in `tailtriage-tracing/src/recorder.rs` that reproduce the described cases.
- Changed file: `tailtriage-tracing/src/recorder.rs` (adds `semantic_max_requests` to `TailtriageLayer`, updates `push_completed_candidate_with_kind_aware_retention` signature and logic, updates messages, and adds tests).

### Testing
- Ran `cargo fmt --check` which passed with no formatting changes required.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which passed (build-time warnings shown earlier are existing dead-code/unused warnings and did not fail CI).
- Ran `cargo test --workspace --all-targets --all-features --locked` which completed successfully and all tests passed (including the two new regression tests which passed: both tests reported `ok`).
- Ran `cargo check -p tailtriage-tracing --no-default-features --locked` which completed successfully (emitted an existing unused-function warning but returned success).
- Ran `cargo check -p tailtriage-tracing --no-default-features --features jsonl --locked` which completed successfully (same existing warning) and `--features live` and `--features tokio` checks also completed successfully.
- Ran `python3 scripts/validate_docs_contracts.py` which reported `docs contracts validated successfully`.

Command summary (successful):
- `cargo fmt --check` — passed
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — passed
- `cargo test --workspace --all-targets --all-features --locked` — passed (all tests OK; new tests passed)
- `cargo check -p tailtriage-tracing --no-default-features --locked` — passed (existing warnings only)
- `cargo check -p tailtriage-tracing --no-default-features --features jsonl --locked` — passed (existing warnings only)
- `cargo check -p tailtriage-tracing --no-default-features --features live --locked` — passed (existing warnings only)
- `cargo check -p tailtriage-tracing --no-default-features --features tokio --locked` — passed
- `python3 scripts/validate_docs_contracts.py` — passed

Files changed: `tailtriage-tracing/src/recorder.rs` (logic + messages + tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c5dcf3c4c83309e707c53619f4c87)