### PR TITLE
Make live tracing raw completed-candidate retention semantic-request-limit-aware

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -62,6 +62,7 @@ pub struct TracingRecorderBuilder {
 pub struct TailtriageLayer {
     state: Arc<Mutex<RecorderState>>,
     limits: RecorderLimits,
+    semantic_max_requests: usize,
 }
 /// Default maximum number of concurrently tracked open candidate spans.
 pub const DEFAULT_MAX_OPEN_SPANS: usize = 8_192;
@@ -171,6 +172,7 @@ impl TracingRecorder {
         TailtriageLayer {
             state: Arc::clone(&self.state),
             limits: self.limits,
+            semantic_max_requests: self.options.resolved_capture_limits().max_requests,
         }
     }
 
@@ -748,6 +750,7 @@ where
                 record,
                 kind,
                 self.limits,
+                self.semantic_max_requests,
             );
         }
     }
@@ -770,6 +773,7 @@ fn push_completed_candidate_with_kind_aware_retention(
     record: SpanRecord,
     kind: &str,
     limits: RecorderLimits,
+    semantic_max_requests: usize,
 ) {
     let total = state.completed_requests.len()
         + state.completed_stages.len()
@@ -781,7 +785,10 @@ fn push_completed_candidate_with_kind_aware_retention(
 
     match kind {
         "request" => {
-            if !state.completed_queues.is_empty() {
+            if state.completed_requests.len() >= semantic_max_requests {
+                state.dropped_completed_request_candidates =
+                    state.dropped_completed_request_candidates.saturating_add(1);
+            } else if !state.completed_queues.is_empty() {
                 state.completed_queues.pop();
                 state.evicted_child_candidates_to_preserve_request = state
                     .evicted_child_candidates_to_preserve_request
@@ -986,7 +993,7 @@ fn push_strict_recorder_messages(
     }
     if stats.dropped_completed_request_candidates > 0 {
         messages.push(format!(
-            "live recorder dropped {} completed request candidate span(s) because max_completed_candidate_spans={} was reached and no child candidate was available to evict",
+            "live recorder dropped {} completed request candidate span(s) because max_completed_candidate_spans={} was reached and the request could not be preserved within semantic request retention",
             stats.dropped_completed_request_candidates, limits.max_completed_candidate_spans
         ));
     }
@@ -998,7 +1005,7 @@ fn push_strict_recorder_messages(
     }
     if stats.evicted_child_candidates_to_preserve_request > 0 {
         messages.push(format!(
-            "live recorder evicted {} completed child candidate span(s) to preserve completed request candidate span(s) under max_completed_candidate_spans={}",
+            "live recorder evicted {} completed child candidate span(s) to preserve completed request candidate span(s) that can still survive semantic request retention under max_completed_candidate_spans={}",
             stats.evicted_child_candidates_to_preserve_request, limits.max_completed_candidate_spans
         ));
     }
@@ -1082,7 +1089,7 @@ fn append_non_strict_drop_warnings(
     }
     if stats.dropped_completed_request_candidates > 0 {
         let msg = format!(
-            "live recorder dropped {} completed request candidate span(s) because max_completed_candidate_spans={} was reached and no child candidate was available to evict",
+            "live recorder dropped {} completed request candidate span(s) because max_completed_candidate_spans={} was reached and the request could not be preserved within semantic request retention",
             stats.dropped_completed_request_candidates, limits.max_completed_candidate_spans
         );
         run.metadata.lifecycle_warnings.push(msg.clone());
@@ -1098,7 +1105,7 @@ fn append_non_strict_drop_warnings(
     }
     if stats.evicted_child_candidates_to_preserve_request > 0 {
         let msg = format!(
-            "live recorder evicted {} completed child candidate span(s) to preserve completed request candidate span(s) under max_completed_candidate_spans={}",
+            "live recorder evicted {} completed child candidate span(s) to preserve completed request candidate span(s) that can still survive semantic request retention under max_completed_candidate_spans={}",
             stats.evicted_child_candidates_to_preserve_request, limits.max_completed_candidate_spans
         );
         run.metadata.lifecycle_warnings.push(msg.clone());
@@ -1755,6 +1762,119 @@ mod tests {
         assert_eq!(ordered[0].name(), "request");
         assert_eq!(ordered[1].name(), "stage");
         assert_eq!(ordered[2].name(), "queue");
+    }
+
+    #[test]
+    fn raw_cap_does_not_evict_retained_request_child_for_later_unretained_request() {
+        let recorder = TracingRecorder::builder("svc")
+            .capture_limits_override(CaptureLimitsOverride {
+                max_requests: Some(1),
+                max_stages: Some(10),
+                max_queues: Some(10),
+                ..Default::default()
+            })
+            .max_completed_candidate_spans(2)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let request = tracing::info_span!(
+                "request-r1",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/r1"
+            );
+            let request_guard = request.enter();
+            drop(tracing::info_span!(
+                "stage-r1",
+                tt.kind = "stage",
+                tt.request_id = "r1",
+                tt.stage = "db.query"
+            ));
+            drop(request_guard);
+            drop(request);
+            drop(tracing::info_span!(
+                "request-r2",
+                tt.kind = "request",
+                tt.request_id = "r2",
+                tt.route = "/r2"
+            ));
+        });
+
+        let imported = recorder.snapshot_run().unwrap();
+        let run = imported.run();
+        assert_eq!(run.requests.len(), 1);
+        assert_eq!(run.requests[0].request_id, "r1");
+        assert_eq!(run.stages.len(), 1);
+        assert_eq!(run.stages[0].request_id, "r1");
+        assert!(run
+            .requests
+            .iter()
+            .all(|request| request.request_id != "r2"));
+        assert!(run.truncation.limits_hit);
+        assert_eq!(run.truncation.dropped_requests, 0);
+        assert!(imported.warnings().iter().any(|warning| {
+            warning
+                .message()
+                .contains("dropped 1 completed request candidate span")
+        }));
+        assert!(!imported.warnings().iter().any(|warning| {
+            warning
+                .message()
+                .contains("evicted 1 completed child candidate span")
+        }));
+    }
+
+    #[test]
+    fn raw_cap_still_preserves_request_root_when_within_semantic_request_limit() {
+        let recorder = TracingRecorder::builder("svc")
+            .capture_limits_override(CaptureLimitsOverride {
+                max_requests: Some(2),
+                max_stages: Some(10),
+                max_queues: Some(10),
+                ..Default::default()
+            })
+            .max_completed_candidate_spans(2)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let request = tracing::info_span!(
+                "request-r1",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/r1"
+            );
+            let request_guard = request.enter();
+            drop(tracing::info_span!(
+                "stage-r1",
+                tt.kind = "stage",
+                tt.request_id = "r1",
+                tt.stage = "db.query"
+            ));
+            drop(request_guard);
+            drop(request);
+            drop(tracing::info_span!(
+                "request-r2",
+                tt.kind = "request",
+                tt.request_id = "r2",
+                tt.route = "/r2"
+            ));
+        });
+
+        let imported = recorder.snapshot_run().unwrap();
+        let run = imported.run();
+        assert_eq!(run.requests.len(), 2);
+        assert_eq!(run.requests[0].request_id, "r1");
+        assert_eq!(run.requests[1].request_id, "r2");
+        assert!(run.stages.is_empty());
+        assert!(run.truncation.limits_hit);
+        assert_eq!(run.truncation.dropped_requests, 0);
+        assert!(imported.warnings().iter().any(|warning| {
+            warning
+                .message()
+                .contains("evicted 1 completed child candidate span")
+        }));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Fix a correctness bug where the raw completed-candidate cap could evict child evidence for an earlier retained request in order to preserve a later request root that would ultimately be dropped by semantic `max_requests`.
- Ensure request-root preference in the raw retention policy respects the effective semantic request limit so earlier retained requests keep their child evidence when a later request cannot survive semantic retention.

### Description
- Update `tailtriage-tracing/src/recorder.rs` to pass the resolved semantic `max_requests` into the raw retention routine by adding `semantic_max_requests` to the layer and calling `push_completed_candidate_with_kind_aware_retention(..., semantic_max_requests)`. 
- Change raw retention logic so that when the raw cap is full and a new completed `request` candidate arrives it is dropped if `completed_requests.len() >= semantic_max_requests`, otherwise a child candidate is evicted (if present) to preserve the request; child arrivals keep existing behavior. 
- Preserve the public API, existing counters (`dropped_completed_request_candidates`, `dropped_completed_child_candidates`, `evicted_child_candidates_to_preserve_request`), and default caps; adjust recorder warning text to explicitly mention semantic-aware request-root preservation. 
- Add two focused regression tests in `tailtriage-tracing/src/recorder.rs`: `raw_cap_does_not_evict_retained_request_child_for_later_unretained_request` and `raw_cap_still_preserves_request_root_when_within_semantic_request_limit` to protect the intended behavior.

### Testing
- Ran `cargo fmt --check` and it passed successfully. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed (no new lints introduced). 
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests passed, including the two new regression tests which reported as passing. 
- Ran `cargo check -p tailtriage-tracing` with the combinations `--no-default-features`, `--no-default-features --features jsonl`, `--no-default-features --features live`, and `--no-default-features --features tokio` and all checks completed successfully (some preexisting dead_code warnings remained but no failures). 
- Ran `python3 scripts/validate_docs_contracts.py` and docs contracts validated successfully.

Changed files:
- tailtriage-tracing/src/recorder.rs

Command summary (high-level): `cargo fmt --check` ✓, `cargo clippy ...` ✓, `cargo test ...` ✓, `cargo check` (multiple feature combos) ✓, `python3 scripts/validate_docs_contracts.py` ✓.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c5dcf3c4c83309e707c53619f4c87)