### PR TITLE
Make raw completed-candidate retention semantic-request-aware

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -62,6 +62,7 @@ pub struct TracingRecorderBuilder {
 pub struct TailtriageLayer {
     state: Arc<Mutex<RecorderState>>,
     limits: RecorderLimits,
+    semantic_max_requests: usize,
 }
 /// Default maximum number of concurrently tracked open candidate spans.
 pub const DEFAULT_MAX_OPEN_SPANS: usize = 8_192;
@@ -171,6 +172,7 @@ impl TracingRecorder {
         TailtriageLayer {
             state: Arc::clone(&self.state),
             limits: self.limits,
+            semantic_max_requests: self.options.resolved_capture_limits().max_requests,
         }
     }
 
@@ -748,6 +750,7 @@ where
                 record,
                 kind,
                 self.limits,
+                self.semantic_max_requests,
             );
         }
     }
@@ -770,6 +773,7 @@ fn push_completed_candidate_with_kind_aware_retention(
     record: SpanRecord,
     kind: &str,
     limits: RecorderLimits,
+    semantic_max_requests: usize,
 ) {
     let total = state.completed_requests.len()
         + state.completed_stages.len()
@@ -781,7 +785,10 @@ fn push_completed_candidate_with_kind_aware_retention(
 
     match kind {
         "request" => {
-            if !state.completed_queues.is_empty() {
+            if state.completed_requests.len() >= semantic_max_requests {
+                state.dropped_completed_request_candidates =
+                    state.dropped_completed_request_candidates.saturating_add(1);
+            } else if !state.completed_queues.is_empty() {
                 state.completed_queues.pop();
                 state.evicted_child_candidates_to_preserve_request = state
                     .evicted_child_candidates_to_preserve_request
@@ -986,7 +993,7 @@ fn push_strict_recorder_messages(
     }
     if stats.dropped_completed_request_candidates > 0 {
         messages.push(format!(
-            "live recorder dropped {} completed request candidate span(s) because max_completed_candidate_spans={} was reached and no child candidate was available to evict",
+            "live recorder dropped {} completed request candidate span(s) because max_completed_candidate_spans={} was reached and the request could not survive semantic request retention or no child candidate was available to evict",
             stats.dropped_completed_request_candidates, limits.max_completed_candidate_spans
         ));
     }
@@ -1082,7 +1089,7 @@ fn append_non_strict_drop_warnings(
     }
     if stats.dropped_completed_request_candidates > 0 {
         let msg = format!(
-            "live recorder dropped {} completed request candidate span(s) because max_completed_candidate_spans={} was reached and no child candidate was available to evict",
+            "live recorder dropped {} completed request candidate span(s) because max_completed_candidate_spans={} was reached and the request could not survive semantic request retention or no child candidate was available to evict",
             stats.dropped_completed_request_candidates, limits.max_completed_candidate_spans
         );
         run.metadata.lifecycle_warnings.push(msg.clone());
@@ -1789,6 +1796,125 @@ mod tests {
             .warnings()
             .iter()
             .any(|w| w.message().contains("max_completed_candidate_spans")));
+    }
+
+    #[test]
+    fn raw_cap_does_not_evict_retained_request_child_for_later_unretained_request() {
+        let recorder = TracingRecorder::builder("svc")
+            .capture_limits_override(CaptureLimitsOverride {
+                max_requests: Some(1),
+                max_stages: Some(10),
+                max_queues: Some(10),
+                ..Default::default()
+            })
+            .max_completed_candidate_spans(2)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let request = tracing::info_span!(
+                "request-r1",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/r1"
+            );
+            let request_guard = request.enter();
+            drop(tracing::info_span!(
+                "stage-r1",
+                tt.kind = "stage",
+                tt.request_id = "r1",
+                tt.stage = "db"
+            ));
+            drop(request_guard);
+            drop(request);
+            drop(tracing::info_span!(
+                "request-r2",
+                tt.kind = "request",
+                tt.request_id = "r2",
+                tt.route = "/r2"
+            ));
+        });
+
+        let imported = recorder.snapshot_run().unwrap();
+        let run = imported.run();
+        assert_eq!(run.requests.len(), 1);
+        assert_eq!(run.requests[0].request_id, "r1");
+        assert_eq!(run.stages.len(), 1);
+        assert_eq!(run.stages[0].request_id, "r1");
+        assert_eq!(run.stages[0].stage, "db");
+        assert!(!run
+            .requests
+            .iter()
+            .any(|request| request.request_id == "r2"));
+        assert!(run.truncation.limits_hit);
+        assert_eq!(run.truncation.dropped_requests, 0);
+        assert!(imported.warnings().iter().any(|warning| {
+            warning
+                .message()
+                .contains("dropped 1 completed request candidate span")
+        }));
+        assert!(imported.warnings().iter().any(|warning| {
+            warning
+                .message()
+                .contains("could not survive semantic request retention")
+        }));
+    }
+
+    #[test]
+    fn raw_cap_still_preserves_request_root_when_within_semantic_request_limit() {
+        let recorder = TracingRecorder::builder("svc")
+            .capture_limits_override(CaptureLimitsOverride {
+                max_requests: Some(2),
+                max_stages: Some(10),
+                max_queues: Some(10),
+                ..Default::default()
+            })
+            .max_completed_candidate_spans(2)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let request = tracing::info_span!(
+                "request-r1",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/r1"
+            );
+            let request_guard = request.enter();
+            drop(tracing::info_span!(
+                "stage-r1",
+                tt.kind = "stage",
+                tt.request_id = "r1",
+                tt.stage = "db"
+            ));
+            drop(request_guard);
+            drop(request);
+            drop(tracing::info_span!(
+                "request-r2",
+                tt.kind = "request",
+                tt.request_id = "r2",
+                tt.route = "/r2"
+            ));
+        });
+
+        let imported = recorder.snapshot_run().unwrap();
+        let run = imported.run();
+        assert_eq!(run.requests.len(), 2);
+        assert!(run
+            .requests
+            .iter()
+            .any(|request| request.request_id == "r1"));
+        assert!(run
+            .requests
+            .iter()
+            .any(|request| request.request_id == "r2"));
+        assert!(run.stages.is_empty());
+        assert!(run.truncation.limits_hit);
+        assert!(imported.warnings().iter().any(|warning| {
+            warning
+                .message()
+                .contains("evicted 1 completed child candidate span")
+        }));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Prevent the raw completed-candidate cap from evicting child evidence for an earlier request in order to preserve a later request root that will be dropped by the semantic `max_requests` retention during import conversion.

### Description

- Modified `tailtriage-tracing/src/recorder.rs` to make raw completed-candidate retention aware of the resolved semantic `max_requests` limit while keeping the existing public API surface and counters.
- Added a `semantic_max_requests` field to the live `TailtriageLayer` and pass `options.resolved_capture_limits().max_requests` into the raw retention function `push_completed_candidate_with_kind_aware_retention`.
- Updated `push_completed_candidate_with_kind_aware_retention` to: drop a newly-arriving request candidate when the number of already-retained completed request candidates is >= semantic `max_requests`, otherwise prefer evicting a child candidate to preserve a request root (if a child exists); child candidates still follow the existing drop behavior when the raw cap is full.
- Kept existing counters (`dropped_completed_request_candidates`, `dropped_completed_child_candidates`, `evicted_child_candidates_to_preserve_request`), default caps, and public API unchanged, and updated warning messages to reflect the semantic-aware decision.
- Added two focused regression tests in `tailtriage-tracing/src/recorder.rs`: `raw_cap_does_not_evict_retained_request_child_for_later_unretained_request` and `raw_cap_still_preserves_request_root_when_within_semantic_request_limit` to cover the corrected behavior and the intended preservation/eviction behavior.

### Testing

- `cargo test -p tailtriage-tracing raw_cap_ --all-features --locked` — passed (targeted tests: 2 passed; 0 failed).
- `cargo fmt --check` — passed.
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — passed.
- `cargo test --workspace --all-targets --all-features --locked` — passed (workspace tests completed with all tests passing).
- `cargo check -p tailtriage-tracing --no-default-features --locked` — passed (completed; emitted an existing `dead_code` warning for `ensure_persistable_run_with_warnings`).
- `cargo check -p tailtriage-tracing --no-default-features --features jsonl --locked` — passed (completed; emitted the same existing `dead_code` warning).
- `cargo check -p tailtriage-tracing --no-default-features --features live --locked` — passed (completed; emitted an existing `dead_code` warning for `selected_mode`).
- `cargo check -p tailtriage-tracing --no-default-features --features tokio --locked` — passed.
- `python3 scripts/validate_docs_contracts.py` — passed (`docs contracts validated successfully`).

Changed file:
- tailtriage-tracing/src/recorder.rs

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c5dcf3c4c83309e707c53619f4c87)