### PR TITLE
Fix tracing docs span shutdown examples and live recorder raw-cap semantics

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -77,14 +77,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::registry()
         .with(session.layer())
         .init(); // startup-only: global subscriber installation for this process
-    let span = tracing::info_span!(
-        "request",
-        tt.kind = "request",
-        tt.request_id = "req-1",
-        tt.route = "/checkout",
-        tt.outcome = "ok",
-    );
-    work().instrument(span).await;
+    {
+        let span = tracing::info_span!(
+            "request",
+            tt.kind = "request",
+            tt.request_id = "req-1",
+            tt.route = "/checkout",
+            tt.outcome = "ok",
+        );
+        work().instrument(span).await;
+    } // the request span is closed before shutdown
     let imported = session.shutdown()?;
     let _ = imported;
     Ok(())

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -59,15 +59,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with(session.layer())
         .init(); // startup-only: global subscriber installation for this process
 
-    let request = tracing::info_span!(
-        "request",
-        tt.kind = "request",
-        tt.request_id = "req-1",
-        tt.route = "/checkout",
-        tt.outcome = "ok"
-    );
+    {
+        let request = tracing::info_span!(
+            "request",
+            tt.kind = "request",
+            tt.request_id = "req-1",
+            tt.route = "/checkout",
+            tt.outcome = "ok"
+        );
 
-    work().instrument(request).await;
+        work().instrument(request).await;
+    } // the request span is closed before shutdown
 
     let imported = session.shutdown()?;
     let _ = imported;


### PR DESCRIPTION
### Motivation

- Prevent docs and examples from encouraging span handles to be kept alive across `shutdown()` and ensure the live recorder raw-cap logic preserves child evidence for semantically retained requests under `max_requests`, while keeping tracing intake scope and export wording unchanged.

### Description

- Add `semantic_max_requests` to the live recorder/layer and change `push_completed_candidate_with_kind_aware_retention` to enforce semantic request limits before evicting retained child candidates, with retention-aware behavior implemented in `tailtriage-tracing/src/recorder.rs` and tests added covering raw-cap and shutdown scenarios.
- Update live tracing examples and documentation so request spans are scoped and dropped before calling `shutdown()`, changing `tailtriage-tracing/README.md`, `docs/user-guide.md`, and example files under `tailtriage-tracing/examples/` to use scoped `.entered()` guards instead of retaining span handles.
- Preserve and clarify existing wording that `tailtriage-tracing` is a narrow tracing intake bridge (not an OTel/OTLP or general tracing backend), that completed-span JSONL is a retained replay/debug export (not trace archival), and that tracing-only runs do not fabricate runtime-pressure snapshots.
- Files changed include `tailtriage-tracing/src/recorder.rs`, `tailtriage-tracing/README.md`, `docs/user-guide.md`, and edits to example files under `tailtriage-tracing/examples/`.

### Testing

- Ran `cargo fmt --check` which passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which passed.
- Ran `cargo test --workspace --all-targets --all-features --locked` where an intermittent analyzer end-to-end test failed once during the first full run but a targeted rerun and a subsequent full run both passed, leaving the final test run green.
- Ran `cargo check -p tailtriage-tracing --no-default-features --locked` and the same with `--features jsonl`, `--features live`, and `--features tokio`, all of which succeeded (the builds show existing non-fatal `dead_code` warnings but no failures).
- Ran `python3 scripts/validate_docs_contracts.py` and demo validations `python3 scripts/demo_tool.py validate-tracing-parity all --profile release` and `python3 scripts/demo_tool.py validate-tracing-retention-parity --profile release`, all of which passed.
- Remaining known risks: a timing-sensitive analyzer E2E test exhibited a single transient failure but passed on reruns, and a couple of harmless `dead_code` warnings remain in `tailtriage-tracing` build outputs; otherwise the branch is merge-ready.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c69de8304833090d0fd6aad02f558)