### PR TITLE
Fix tracing raw retention semantics and scope example request spans before shutdown

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -77,14 +77,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::registry()
         .with(session.layer())
         .init(); // startup-only: global subscriber installation for this process
-    let span = tracing::info_span!(
-        "request",
-        tt.kind = "request",
-        tt.request_id = "req-1",
-        tt.route = "/checkout",
-        tt.outcome = "ok",
-    );
-    work().instrument(span).await;
+    {
+        let span = tracing::info_span!(
+            "request",
+            tt.kind = "request",
+            tt.request_id = "req-1",
+            tt.route = "/checkout",
+            tt.outcome = "ok",
+        );
+        work().instrument(span).await;
+    } // the request span is closed before shutdown
     let imported = session.shutdown()?;
     let _ = imported;
     Ok(())

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -59,15 +59,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with(session.layer())
         .init(); // startup-only: global subscriber installation for this process
 
-    let request = tracing::info_span!(
-        "request",
-        tt.kind = "request",
-        tt.request_id = "req-1",
-        tt.route = "/checkout",
-        tt.outcome = "ok"
-    );
-
-    work().instrument(request).await;
+    {
+        let request = tracing::info_span!(
+            "request",
+            tt.kind = "request",
+            tt.request_id = "req-1",
+            tt.route = "/checkout",
+            tt.outcome = "ok"
+        );
+        work().instrument(request).await;
+    } // the request span is closed before shutdown
 
     let imported = session.shutdown()?;
     let _ = imported;


### PR DESCRIPTION
### Motivation
- Prevent doc examples from demonstrating retained span handles across `shutdown()` and ensure live recorder raw-cap behavior preserves child evidence for semantically retained requests (so later requests that exceed `max_requests` do not evict needed child evidence for already-retained requests).

### Description
- Scoped example request spans in `docs/user-guide.md` and `tailtriage-tracing/README.md` so the request span is dropped before calling `session.shutdown()` in the documented live-session examples. 
- Added `semantic_max_requests` plumbing to `tailtriage-tracing/src/recorder.rs` and updated `push_completed_candidate_with_kind_aware_retention` to honor semantic `max_requests` when raw completed-candidate caps are reached, preferentially preserving request roots and avoiding evicting retained request child evidence incorrectly. 
- Updated live-recorder lifecycle warning text to reference semantic retention behavior. 
- Added unit tests in `tailtriage-tracing/src/recorder.rs` covering raw-cap retention behavior and session shutdown semantics when span handles are retained/dropped.

### Testing
- Ran `cargo fmt --check` and it passed (exit code 0).  
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed.  
- Ran `cargo test --workspace --all-targets --all-features --locked` and the full test suite passed (workspace tests, including `tailtriage-tracing` tests).  
- Ran `cargo check -p tailtriage-tracing --no-default-features --locked`, `--features jsonl`, `--features live`, and `--features tokio`; all checks completed successfully (some feature checks emitted non-fatal `dead_code` warnings).  
- Ran `python3 scripts/validate_docs_contracts.py` and it reported `docs contracts validated successfully`.  
- Ran `python3 scripts/demo_tool.py validate-tracing-parity all --profile release` and `python3 scripts/demo_tool.py validate-tracing-retention-parity --profile release`; both demo validations completed successfully and reported parity/retention validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c69de8304833090d0fd6aad02f558)