### PR TITLE
Fix live tracing finish timestamp semantics

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -728,13 +728,12 @@ where
                 record_incomplete_candidate_issue(&mut state, &open, kind, reason);
                 return;
             }
-            let mut record = SpanRecord::new(
-                open.name,
-                open.started_at_unix_ms,
-                tailtriage_core::unix_time_ms(),
-            );
             let duration_us =
                 u64::try_from(open.started_instant.elapsed().as_micros()).unwrap_or(u64::MAX);
+            let finished_at_unix_ms =
+                finish_unix_ms_from_started_and_duration(open.started_at_unix_ms, duration_us);
+            let mut record =
+                SpanRecord::new(open.name, open.started_at_unix_ms, finished_at_unix_ms);
             record = record.duration_us(duration_us);
             if let Some(span_id) = open.id {
                 record = record.id(span_id);
@@ -754,6 +753,11 @@ where
             );
         }
     }
+}
+
+fn finish_unix_ms_from_started_and_duration(started_at_unix_ms: u64, duration_us: u64) -> u64 {
+    let elapsed_ms = duration_us.saturating_add(999) / 1_000;
+    started_at_unix_ms.saturating_add(elapsed_ms)
 }
 
 fn completed_span_records(state: &RecorderState) -> Vec<SpanRecord> {
@@ -1266,6 +1270,36 @@ mod tests {
     }
 
     #[test]
+    fn finish_unix_ms_from_started_and_duration_rounds_up_and_saturates() {
+        let start = 1_700_000_000_000;
+        assert_eq!(finish_unix_ms_from_started_and_duration(start, 0), start);
+        assert_eq!(
+            finish_unix_ms_from_started_and_duration(start, 1),
+            start + 1
+        );
+        assert_eq!(
+            finish_unix_ms_from_started_and_duration(start, 999),
+            start + 1
+        );
+        assert_eq!(
+            finish_unix_ms_from_started_and_duration(start, 1_000),
+            start + 1
+        );
+        assert_eq!(
+            finish_unix_ms_from_started_and_duration(start, 1_001),
+            start + 2
+        );
+        assert_eq!(
+            finish_unix_ms_from_started_and_duration(u64::MAX - 1, 1_001),
+            u64::MAX
+        );
+        assert_eq!(
+            finish_unix_ms_from_started_and_duration(u64::MAX - 10, u64::MAX),
+            u64::MAX
+        );
+    }
+
+    #[test]
     fn request_span_collected() {
         with_recorder(|recorder| {
             let span = tracing::info_span!(
@@ -1277,6 +1311,54 @@ mod tests {
             drop(span);
             let run = recorder.snapshot_run().unwrap();
             assert_eq!(run.run().requests.len(), 1);
+        });
+    }
+
+    #[test]
+    fn strict_snapshot_succeeds_for_completed_request_span() {
+        let recorder = TracingRecorder::builder("svc")
+            .run_id("rid")
+            .strict(true)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            );
+            drop(span);
+        });
+
+        let run = recorder.snapshot_run().unwrap();
+        assert_eq!(run.run().requests.len(), 1);
+    }
+
+    #[test]
+    fn live_request_latency_is_positive_and_finish_matches_elapsed_duration() {
+        with_recorder(|recorder| {
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(2));
+            drop(span);
+
+            let run = recorder.snapshot_run().unwrap();
+            let request = &run.run().requests[0];
+            assert!(request.finished_at_unix_ms >= request.started_at_unix_ms);
+            assert!(request.latency_us > 0);
+            assert_eq!(
+                request.finished_at_unix_ms,
+                finish_unix_ms_from_started_and_duration(
+                    request.started_at_unix_ms,
+                    request.latency_us
+                )
+            );
         });
     }
 


### PR DESCRIPTION
### Motivation
- Live tracing span finish timestamps were derived by re-reading wall-clock time on `on_close`, which can diverge from the monotonic elapsed duration used to compute `duration_us` and produce inconsistent live-record semantics if the wall clock shifts.
- We must preserve existing offline/JSONL import validation semantics while making live-generated records internally consistent and robust to wall-clock changes.

### Description
- In `TailtriageLayer::on_close` compute `duration_us` from `open.started_instant.elapsed()` and derive `finished_at_unix_ms` via a new helper instead of calling `tailtriage_core::unix_time_ms()` on close.
- Add `fn finish_unix_ms_from_started_and_duration(started_at_unix_ms: u64, duration_us: u64) -> u64` which returns `started_at_unix_ms` for zero duration, rounds positive microsecond durations up to the next millisecond, and saturates safely using `saturating_add` and `saturating_add(999)/1000` style arithmetic.
- Keep `duration_us` present on live `SpanRecord`s and keep offline/external JSONL import duration validation unchanged.
- Add recorder tests: unit tests for the helper rounding/saturation, a strict-mode live snapshot test for a completed request span, and a live recorder test asserting positive latency and finish equality against the helper.

### Testing
- Ran `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and both succeeded.
- Ran full test suite with `cargo test --workspace --all-targets --all-features --locked` and `cargo test -p tailtriage-tracing --all-features --locked`, and all tests passed.
- Ran docs validator `python3 scripts/validate_docs_contracts.py` and various `cargo check` permutations for `tailtriage-tracing` features (`--no-default-features`, `jsonl`, `live`, `tokio`) and they all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c9057cb248330bccf8dc7e8890c65)