### PR TITLE
Fix live tracing span finish timestamps

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -728,13 +728,12 @@ where
                 record_incomplete_candidate_issue(&mut state, &open, kind, reason);
                 return;
             }
-            let mut record = SpanRecord::new(
-                open.name,
-                open.started_at_unix_ms,
-                tailtriage_core::unix_time_ms(),
-            );
             let duration_us =
                 u64::try_from(open.started_instant.elapsed().as_micros()).unwrap_or(u64::MAX);
+            let finished_at_unix_ms =
+                finish_unix_ms_from_started_and_duration(open.started_at_unix_ms, duration_us);
+            let mut record =
+                SpanRecord::new(open.name, open.started_at_unix_ms, finished_at_unix_ms);
             record = record.duration_us(duration_us);
             if let Some(span_id) = open.id {
                 record = record.id(span_id);
@@ -754,6 +753,11 @@ where
             );
         }
     }
+}
+
+fn finish_unix_ms_from_started_and_duration(started_at_unix_ms: u64, duration_us: u64) -> u64 {
+    let rounded_elapsed_ms = duration_us.saturating_add(999) / 1_000;
+    started_at_unix_ms.saturating_add(rounded_elapsed_ms)
 }
 
 fn completed_span_records(state: &RecorderState) -> Vec<SpanRecord> {
@@ -1266,6 +1270,41 @@ mod tests {
     }
 
     #[test]
+    fn finish_unix_ms_from_started_and_duration_rounds_up_positive_microseconds() {
+        let start = 1_700_000_000_000;
+
+        assert_eq!(finish_unix_ms_from_started_and_duration(start, 0), start);
+        assert_eq!(
+            finish_unix_ms_from_started_and_duration(start, 1),
+            start + 1
+        );
+        assert_eq!(
+            finish_unix_ms_from_started_and_duration(start, 999),
+            start + 1
+        );
+        assert_eq!(
+            finish_unix_ms_from_started_and_duration(start, 1_000),
+            start + 1
+        );
+        assert_eq!(
+            finish_unix_ms_from_started_and_duration(start, 1_001),
+            start + 2
+        );
+    }
+
+    #[test]
+    fn finish_unix_ms_from_started_and_duration_saturates_overflow() {
+        assert_eq!(
+            finish_unix_ms_from_started_and_duration(u64::MAX - 1, 1_001),
+            u64::MAX
+        );
+        assert_eq!(
+            finish_unix_ms_from_started_and_duration(0, u64::MAX),
+            u64::MAX / 1_000
+        );
+    }
+
+    #[test]
     fn request_span_collected() {
         with_recorder(|recorder| {
             let span = tracing::info_span!(
@@ -1278,6 +1317,60 @@ mod tests {
             let run = recorder.snapshot_run().unwrap();
             assert_eq!(run.run().requests.len(), 1);
         });
+    }
+
+    #[test]
+    fn strict_snapshot_run_succeeds_for_completed_request_span() {
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/strict"
+            );
+            drop(span);
+        });
+
+        let run = recorder.snapshot_run().unwrap();
+        assert_eq!(run.run().requests.len(), 1);
+        assert_eq!(run.run().requests[0].request_id, "r1");
+        assert_eq!(run.run().requests[0].route, "/strict");
+    }
+
+    #[test]
+    fn completed_request_span_records_positive_latency_from_monotonic_duration() {
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/latency"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(2));
+            drop(span);
+        });
+
+        let run = recorder.snapshot_run().unwrap();
+        let request = &run.run().requests[0];
+        assert!(request.finished_at_unix_ms >= request.started_at_unix_ms);
+        assert!(request.latency_us > 0);
+        assert_eq!(
+            request.finished_at_unix_ms,
+            finish_unix_ms_from_started_and_duration(
+                request.started_at_unix_ms,
+                request.latency_us
+            )
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Live recorder previously used wall-clock time for the span finish timestamp while using a monotonic `Instant` for duration, which made `duration_us` and `finished_at_unix_ms` inconsistent when the system clock shifted during a live span. 
- The change confines semantics to live-generated SpanRecords: keep the monotonic elapsed duration authoritative for live spans and derive the finish timestamp from the start timestamp plus the rounded duration. 

### Description
- Update `TailtriageLayer::on_close` to compute `duration_us` from `open.started_instant.elapsed()` and derive `finished_at_unix_ms` via a new helper instead of calling `tailtriage_core::unix_time_ms()` at close, while preserving `duration_us` on the SpanRecord. 
- Add `fn finish_unix_ms_from_started_and_duration(started_at_unix_ms: u64, duration_us: u64) -> u64` which rounds up microseconds to milliseconds and uses saturating arithmetic to avoid overflow. 
- Add unit tests for the helper (zero, 1us, 999us, 1000us, 1001us, and overflow saturation) and live-recorder tests that assert strict `snapshot_run()` succeeds for a simple completed request span and that a short-sleeped completed request produces a positive `latency_us` and a `finished_at_unix_ms` equal to the helper result. 

### Testing
- Ran formatting, linting, and full test suite: `cargo fmt --check` (OK), `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (OK), and `cargo test --workspace --all-targets --all-features --locked` (OK). 
- Validated docs contract with `python3 scripts/validate_docs_contracts.py` (OK) and ran targeted package checks/tests for `tailtriage-tracing` with combinations of features (`--no-default-features`, `jsonl`, `live`, `tokio`) and `cargo test -p tailtriage-tracing --all-features --locked`, all of which passed. 
- Added tests (helper + two live recorder tests) executed as part of the suite and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c9057cb248330bccf8dc7e8890c65)