### PR TITLE
Fix live tracing finish timestamps

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -728,13 +728,12 @@ where
                 record_incomplete_candidate_issue(&mut state, &open, kind, reason);
                 return;
             }
-            let mut record = SpanRecord::new(
-                open.name,
-                open.started_at_unix_ms,
-                tailtriage_core::unix_time_ms(),
-            );
             let duration_us =
                 u64::try_from(open.started_instant.elapsed().as_micros()).unwrap_or(u64::MAX);
+            let finished_at_unix_ms =
+                finish_unix_ms_from_started_and_duration(open.started_at_unix_ms, duration_us);
+            let mut record =
+                SpanRecord::new(open.name, open.started_at_unix_ms, finished_at_unix_ms);
             record = record.duration_us(duration_us);
             if let Some(span_id) = open.id {
                 record = record.id(span_id);
@@ -754,6 +753,11 @@ where
             );
         }
     }
+}
+
+fn finish_unix_ms_from_started_and_duration(started_at_unix_ms: u64, duration_us: u64) -> u64 {
+    let elapsed_ms = duration_us.saturating_add(999) / 1000;
+    started_at_unix_ms.saturating_add(elapsed_ms)
 }
 
 fn completed_span_records(state: &RecorderState) -> Vec<SpanRecord> {
@@ -1263,6 +1267,77 @@ mod tests {
             .build()
             .expect("collector")
             .snapshot()
+    }
+
+    #[test]
+    fn finish_unix_ms_from_started_and_duration_rounds_up_and_saturates() {
+        assert_eq!(finish_unix_ms_from_started_and_duration(42, 0), 42);
+        assert_eq!(finish_unix_ms_from_started_and_duration(42, 1), 43);
+        assert_eq!(finish_unix_ms_from_started_and_duration(42, 999), 43);
+        assert_eq!(finish_unix_ms_from_started_and_duration(42, 1000), 43);
+        assert_eq!(finish_unix_ms_from_started_and_duration(42, 1001), 44);
+        assert_eq!(
+            finish_unix_ms_from_started_and_duration(u64::MAX - 1, 1001),
+            u64::MAX
+        );
+        assert_eq!(
+            finish_unix_ms_from_started_and_duration(0, u64::MAX),
+            u64::MAX / 1000
+        );
+    }
+
+    #[test]
+    fn strict_snapshot_run_succeeds_for_completed_live_request_span() {
+        let recorder = TracingRecorder::builder("svc")
+            .run_id("rid")
+            .strict(true)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            );
+            drop(span);
+        });
+
+        let run = recorder.snapshot_run().unwrap();
+        assert_eq!(run.run().requests.len(), 1);
+    }
+
+    #[test]
+    fn completed_live_request_uses_positive_elapsed_latency_for_finish_time() {
+        let recorder = TracingRecorder::builder("svc")
+            .run_id("rid")
+            .strict(true)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(1));
+            drop(span);
+        });
+
+        let run = recorder.snapshot_run().unwrap();
+        let request = &run.run().requests[0];
+        assert!(request.finished_at_unix_ms >= request.started_at_unix_ms);
+        assert!(request.latency_us > 0);
+        assert_eq!(
+            request.finished_at_unix_ms,
+            finish_unix_ms_from_started_and_duration(
+                request.started_at_unix_ms,
+                request.latency_us
+            )
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Live-recorded spans previously used `tailtriage_core::unix_time_ms()` at close while `duration_us` came from `open.started_instant.elapsed()`, causing inconsistent duration vs wall-clock validation when the wall clock moved during a live span. 
- The intent is to preserve monotonic elapsed timing for live spans while keeping external/offline JSONL import validation unchanged. 
- Live span finish timestamps must be derived deterministically from the recorded start timestamp plus the duration to avoid wall-clock skew issues.

### Description
- In `TailtriageLayer::on_close` compute `duration_us` from `open.started_instant.elapsed()` and derive `finished_at_unix_ms` by calling the new helper instead of calling `tailtriage_core::unix_time_ms()` at close. 
- Add `fn finish_unix_ms_from_started_and_duration(started_at_unix_ms: u64, duration_us: u64) -> u64` which rounds up microsecond durations to milliseconds and uses saturating arithmetic as `duration_us.saturating_add(999) / 1000` then `started_at_unix_ms.saturating_add(...)`. 
- Add unit tests covering the helper rounding/saturation and two live-recorder tests: a strict `snapshot_run()` success for a completed request span and a positive-latency test that asserts `finished_at_unix_ms >= started_at_unix_ms`, `latency_us > 0`, and `finished_at_unix_ms == finish_unix_ms_from_started_and_duration(start, latency_us)`; JSONL/import validation and `TRACE_TIME_TOLERANCE_US` behavior remain unchanged.

### Testing
- Ran formatting and static checks with `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and both succeeded. 
- Ran the full test matrix `cargo test --workspace --all-targets --all-features --locked` (and `cargo test -p tailtriage-tracing --all-features --locked`) and all tests passed including the newly added tests. 
- Ran docs contract validation and feature checks `python3 scripts/validate_docs_contracts.py` and multiple `cargo check` permutations (`--no-default-features`, `--features jsonl|live|tokio`) and they all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c9057cb248330bccf8dc7e8890c65)