### PR TITLE
Tighten tracing intake docs and clarify live `tt.*` rules

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -158,7 +158,11 @@ Prefer moderate intervals and bounded runs before increasing density.
 
 ## Operating with tracing-based runs
 
+Tracing intake works best when request correlation is already reliable. Every request, stage, and queue span for one work item must carry the same `tt.request_id`; missing or inconsistent `tt.request_id` causes child stage/queue evidence to be skipped or weakened. Native capture is the recommended first path when correlation is not already available.
+
 Tracing import expects completed tailtriage `tt.*` tracing span JSONL, not ordinary tracing log JSON (`fmt().json` output is a common non-supported example). Import writes Run JSON (not Report JSON), and analysis is a separate step after import (`tailtriage analyze`). Completed-span JSONL is not a production trace archive and does not preserve warning/truncation context; prefer Run JSON when the artifact itself must carry that context. Persisted Run JSON intended for `tailtriage analyze` must include at least one completed request event; in-process library snapshots may still be zero-request for inspection. Timing is not guessed from line receive time, so completed spans must include explicit unix-ms start/end timestamps. OTel/OTLP intake remains out of scope on this path.
+
+For live tracing sessions, `tt.*` fields must be declared when the span is created. If a value is filled later, declare it with `tracing::field::Empty` and then call `span.record(...)`; adding brand-new `tt.*` fields later is not supported.
 
 Important limits for production interpretation:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -34,7 +34,9 @@ The `controller` and `tokio` namespaces are available with default features; `ax
 
 ### Using existing tracing spans
 
-If you already instrument request/stage/queue work with Rust `tracing`, use `tailtriage-tracing` as an intake path into the same triage workflow.
+Use this path when the service already uses Rust `tracing` and already has stable per-request correlation IDs. Every request, stage, and queue span for one work item must carry the same `tt.request_id`; child stage/queue evidence is correlated to retained request evidence by that value.
+
+New integrations without existing tracing/correlation should start with native `tailtriage` capture first. `tailtriage-tracing` converts tracing-shaped evidence into standard `Run` artifacts; it is not a tracing backend.
 
 Install for typed records plus JSONL import APIs (default feature set):
 
@@ -49,7 +51,44 @@ tailtriage import tracing-spans-jsonl completed-spans.jsonl --service checkout -
 tailtriage analyze tailtriage-run.json
 ```
 
-`tailtriage import tracing-spans-jsonl` imports completed tailtriage tracing span JSONL and writes Run artifact JSON (not Report JSON), and analysis remains a separate step after import. Use the documented stable wrapper JSONL shape from `tailtriage-tracing` (`{"format":"tailtriage.tracing-span.v1","span":{...}}`). `--strict` fails on malformed or incomplete `tt.*` spans; non-strict mode skips malformed `tt.*` spans and prints `warning: ...` messages. Tracing import and native capture use the same `CaptureMode`/`CaptureLimits` semantics for request/stage/queue retention. Offline import exposes `--mode <light|investigation>` plus `--max-requests`, `--max-stages`, and `--max-queues` because those are the imported evidence types. It does not expose runtime/in-flight snapshot limit flags because those evidence types are not imported by this path. Tracing-only runs do not fabricate runtime snapshots, and runtime-pressure evidence remains Tokio-specific. Persisted Run JSON and persisted completed-span JSONL intended for offline CLI workflows must include at least one completed request event; in-process library snapshots may still be zero-request for inspection. Completed-span JSONL replays retained request/stage/queue evidence and does not carry live-session warning/truncation metadata; use Run JSON for the complete persisted artifact.
+#### What this imports
+
+- The command consumes completed tailtriage tracing span JSONL.
+- The stable wrapper shape is `{"format":"tailtriage.tracing-span.v1","span":{...}}`.
+- Ordinary `tracing_subscriber::fmt().json()` logs are unsupported.
+
+#### What this writes
+
+- Import writes Run JSON, not Report JSON.
+- Analysis is a separate `tailtriage analyze tailtriage-run.json` step.
+- Run JSON is preferred for the complete persisted artifact.
+
+#### Strict vs non-strict
+
+- `--strict` fails malformed or incomplete `tt.*` spans.
+- Non-strict mode skips malformed `tt.*` spans and prints `warning: ...` messages.
+
+#### Retention limits
+
+- Tracing import and native capture use the same `CaptureMode`/`CaptureLimits` semantics for request/stage/queue retention.
+- Offline import exposes only request/stage/queue retention options: `--mode <light|investigation>`, `--max-requests`, `--max-stages`, and `--max-queues`.
+
+#### Runtime evidence
+
+- Offline import does not ingest runtime snapshots or in-flight snapshots.
+- Tracing-only runs do not fabricate runtime snapshots.
+- Runtime-pressure evidence remains Tokio-specific.
+
+#### Zero-request artifacts
+
+- Persisted CLI artifacts require at least one completed request.
+- In-process library snapshots may still be zero-request for inspection.
+
+#### Completed-span JSONL caveat
+
+- Completed-span JSONL replays retained request/stage/queue evidence.
+- It omits warning/truncation metadata from the full Run context.
+- Use Run JSON for the complete persisted artifact.
 
 B) Direct Run JSON path with async span instrumentation (`live` feature required):
 
@@ -94,6 +133,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```
 
 Stage and queue spans use their own `tt.stage` / `tt.queue` fields around the awaited work they measure.
+Every request, stage, and queue span for one work item must carry the same `tt.request_id`. Live tracing only tracks spans that are tailtriage candidates at span creation time: declare `tt.*` fields when creating the span, or declare late-filled fields with `tracing::field::Empty` and then call `span.record(...)`. Do not rely on adding brand-new `tt.*` fields later with `span.record(...)`.
 `tt.outcome` on request spans is optional: missing values default to `ok` with a warning; recommended common labels are `ok`, `error`, `timeout`, `cancelled`, and `rejected`; custom non-empty labels are preserved exactly.
 
 In service code, add `session.layer()` beside your existing tracing layers and install the resulting subscriber in the application's normal process-wide/global subscriber setup. `set_default` is scoped to the current thread and guard lifetime; service startup should install the tailtriage layer in the process-wide subscriber setup.

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -89,11 +89,20 @@ When paths include spaces, quote them in shell usage:
 tailtriage import tracing-spans-jsonl "fixtures/tracing spans.jsonl" --service checkout --output "runs/imported run.json"
 ```
 
-The command imports completed tailtriage `tt.*` tracing span JSONL records in the documented shape and writes Run JSON through the normal local JSON artifact writer, not Report JSON. Import warnings are printed to stderr as `warning: ...`. Analysis is a separate step: `tailtriage analyze tailtriage-run.json`.
-Tracing import and native capture share the same CaptureMode/CaptureLimits semantics for request/stage/queue evidence retention. Offline CLI tracing import exposes request/stage/queue limit overrides because those are the evidence types it imports. It intentionally does not expose runtime-snapshot or in-flight-snapshot limit flags because this import path does not ingest those evidence types. Tracing-only imports do not fabricate runtime snapshots; executor/blocking-pressure interpretation remains limited unless runtime snapshots are also captured (for example via Tokio runtime sampling).
-Malformed JSON input remains fatal. In non-strict mode, syntactically valid malformed/incomplete `tt.*` records are skipped with `warning: ...` lines.
-`--service` must not be empty or whitespace.
-Import fails when zero request events would be written (for example unrelated-only input or all-skipped malformed `tt.*` input), because `tailtriage analyze` requires at least one request in CLI-loaded run artifacts. The same non-empty-request rule applies before persisting completed-span JSONL artifacts in tracing intake sessions.
+Import behavior checklist:
+
+- Imports completed tailtriage `tt.*` tracing span JSONL records in the documented shape.
+- Writes Run JSON through the normal local JSON artifact writer, not Report JSON.
+- Keeps analysis separate: run `tailtriage analyze tailtriage-run.json` after import.
+- Prints import warnings to stderr as `warning: ...`.
+- Uses the same `CaptureMode`/`CaptureLimits` semantics as native capture for request/stage/queue evidence retention.
+- Exposes offline CLI limit overrides only for request/stage/queue evidence because those are the evidence types it imports.
+- Does not ingest runtime snapshots or in-flight snapshots and does not expose their limit flags.
+- Does not fabricate runtime snapshots; executor/blocking-pressure interpretation remains limited unless runtime snapshots are also captured, for example via Tokio runtime sampling.
+- Treats malformed JSON input as fatal.
+- In non-strict mode, skips syntactically valid malformed/incomplete `tt.*` records with `warning: ...` lines.
+- Requires `--service` to be non-empty and non-whitespace.
+- Fails when zero request events would be written, because `tailtriage analyze` requires at least one request in CLI-loaded run artifacts. The same non-empty-request rule applies before persisting completed-span JSONL artifacts in tracing intake sessions.
 
 `tailtriage analyze <run.json> --format json` emits the same pretty Report JSON as `tailtriage_analyzer::render_json_pretty`.
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -12,6 +12,12 @@ It is **not**:
 - an OTel/OTLP pipeline,
 - proof of root cause (output remains triage leads).
 
+## When to use this crate
+
+Use this path when your service already uses Rust `tracing` and already has stable per-request correlation IDs. Every request, stage, and queue span for one work item must carry the same `tt.request_id`; child stage/queue evidence is correlated to retained request evidence by that value.
+
+New integrations without existing tracing/correlation should start with native `tailtriage` capture first. This crate converts tracing-shaped evidence into standard `Run` artifacts; it is not a tracing backend.
+
 ## Feature flags
 
 - Base crate: typed `SpanRecord`, `ImportOptions`, `ImportedRun`, semantic constants, and `run_from_span_records(...)`.
@@ -82,6 +88,19 @@ If your service already builds a subscriber in startup code, compose `session.la
 
 `set_default` is scoped to the current thread and guard lifetime; service startup should install the tailtriage layer in the process-wide subscriber setup.
 
+Live tracing only tracks spans that are tailtriage candidates at span creation time. Declare `tt.*` fields on the span when it is created. If a value is filled later, declare the field with `tracing::field::Empty` and then call `span.record(...)`; do not rely on adding brand-new `tt.*` fields later.
+
+```rust
+let span = tracing::info_span!(
+    "request",
+    tt.kind = "request",
+    tt.request_id = "req-1",
+    tt.route = "/checkout",
+    tt.outcome = tracing::field::Empty,
+);
+span.record("tt.outcome", "timeout");
+```
+
 ## Direct Run JSON path
 
 Use `run_json_path(...)` when you want to skip a separate import step and write Run JSON through the same robust writer path used by native capture sinks:
@@ -137,6 +156,8 @@ Import does not guess span timing from line receive time: provide explicit unix-
 | request | `tt.kind="request"`, `tt.request_id`, `tt.route` | `tt.outcome` (optional non-empty string; recommended common labels: `ok`, `error`, `timeout`, `cancelled`, `rejected`) |
 | stage | `tt.kind="stage"`, `tt.request_id`, `tt.stage` | `tt.success` |
 | queue | `tt.kind="queue"`, `tt.request_id`, `tt.queue` | `tt.depth_at_start` |
+
+Every request, stage, and queue span for one work item must carry the same `tt.request_id`; stage/queue evidence without a matching retained request is skipped or weakened during conversion.
 
 Record semantic `tt.*` fields (`tt.kind`, `tt.request_id`, `tt.route`, `tt.stage`, `tt.queue`) as plain scalar strings (string literals or display-formatted scalar strings). Do not use debug formatting for semantic `tt.*` fields.
 


### PR DESCRIPTION
### Motivation

- Clarify fit and operational boundaries for the tracing intake path so users pick the right capture path and avoid instrumentation pitfalls. 
- Make live tracing field-recording semantics explicit to prevent lost evidence when `tt.*` fields are added late. 
- Restructure the user-facing import guidance so import behavior, outputs, and limits are easy to scan and act on.

### Description

- Add a short “When to use this crate” section and fit guidance to `tailtriage-tracing/README.md`, stating this path is for services that already use Rust `tracing` with stable per-request correlation IDs and that new integrations should prefer native capture first. 
- Document the live tracing field-recording rule and include the requested concise code snippet showing `tracing::field::Empty` + `span.record(...)` in `tailtriage-tracing/README.md`. 
- Emphasize that every request, stage, and queue span for a single work item must carry the same `tt.request_id` and note that unmatched child evidence is skipped or weakened in conversion (changes in `tailtriage-tracing/README.md`). 
- Restructure the “Using existing tracing spans” subsection in `docs/user-guide.md` so fit guidance appears before install/usage, and replace the long import paragraph with the exact short subsections: `What this imports`, `What this writes`, `Strict vs non-strict`, `Retention limits`, `Runtime evidence`, `Zero-request artifacts`, and `Completed-span JSONL caveat`. 
- Add an operational caveat block to `docs/operations.md` under “Operating with tracing-based runs” explaining that tracing intake works best when request correlation is reliable, that missing/inconsistent `tt.request_id` weakens/skips child evidence, and that native capture is recommended when correlation isn’t available; also document the live `tt.*` declaration rule. 
- Replace the long CLI import paragraph in `tailtriage-cli/README.md` with a concise checklist that preserves the same facts (wrapper shape, Run vs Report, strictness, retention flags, runtime snapshot limitations, warnings, and zero-request behavior). 

### Testing

- Ran docs contract validation: `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts`, both succeeded. 
- Ran formatting/lint/test suite: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, and `cargo test --workspace --all-targets --all-features --locked`, all completed with no failures. 
- Ran targeted crate tests: `cargo test -p tailtriage-tracing --all-features --locked` and `cargo test -p tailtriage-cli --all-targets --locked`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d0c2d490483309146b02f5e78ce62)