### PR TITLE
docs: tighten tracing intake guidance

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -162,6 +162,9 @@ Tracing import expects completed tailtriage `tt.*` tracing span JSONL, not ordin
 
 Important limits for production interpretation:
 
+* tracing intake works best when request correlation is already reliable
+* missing or inconsistent `tt.request_id` causes child stage/queue evidence to be skipped or weakened
+* native capture is the recommended first path when correlation is not already available
 * tracing-only runs do not fabricate runtime snapshots
 * without runtime snapshots, executor-pressure and blocking-pool suspects can be weaker or absent
 * runtime-pressure evidence remains Tokio-specific and requires runtime snapshots or Tokio sampler coupling

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -34,7 +34,9 @@ The `controller` and `tokio` namespaces are available with default features; `ax
 
 ### Using existing tracing spans
 
-If you already instrument request/stage/queue work with Rust `tracing`, use `tailtriage-tracing` as an intake path into the same triage workflow.
+Use this path when the service already uses Rust `tracing`. It is best when the service already has stable per-request correlation IDs. New integrations without existing tracing/correlation should start with native `tailtriage` capture first.
+
+Every request, stage, and queue span for one work item must carry the same `tt.request_id`; child stage/queue evidence is correlated to retained request evidence by `tt.request_id`. `tailtriage-tracing` converts tracing-shaped evidence into standard `Run` artifacts; it is not a tracing backend.
 
 Install for typed records plus JSONL import APIs (default feature set):
 
@@ -49,7 +51,33 @@ tailtriage import tracing-spans-jsonl completed-spans.jsonl --service checkout -
 tailtriage analyze tailtriage-run.json
 ```
 
-`tailtriage import tracing-spans-jsonl` imports completed tailtriage tracing span JSONL and writes Run artifact JSON (not Report JSON), and analysis remains a separate step after import. Use the documented stable wrapper JSONL shape from `tailtriage-tracing` (`{"format":"tailtriage.tracing-span.v1","span":{...}}`). `--strict` fails on malformed or incomplete `tt.*` spans; non-strict mode skips malformed `tt.*` spans and prints `warning: ...` messages. Tracing import and native capture use the same `CaptureMode`/`CaptureLimits` semantics for request/stage/queue retention. Offline import exposes `--mode <light|investigation>` plus `--max-requests`, `--max-stages`, and `--max-queues` because those are the imported evidence types. It does not expose runtime/in-flight snapshot limit flags because those evidence types are not imported by this path. Tracing-only runs do not fabricate runtime snapshots, and runtime-pressure evidence remains Tokio-specific. Persisted Run JSON and persisted completed-span JSONL intended for offline CLI workflows must include at least one completed request event; in-process library snapshots may still be zero-request for inspection. Completed-span JSONL replays retained request/stage/queue evidence and does not carry live-session warning/truncation metadata; use Run JSON for the complete persisted artifact.
+#### What this imports
+
+Imports completed tailtriage tracing span JSONL. The stable/default input is the wrapper-only shape: `{"format":"tailtriage.tracing-span.v1","span":{...}}`. Ordinary `tracing_subscriber::fmt().json()` logs remain unsupported.
+
+#### What this writes
+
+Writes Run JSON, not Report JSON. Analysis is a separate `tailtriage analyze` step.
+
+#### Strict vs non-strict
+
+`--strict` fails malformed or incomplete `tt.*` spans. Non-strict mode skips malformed `tt.*` spans and prints `warning: ...` messages.
+
+#### Retention limits
+
+Offline import exposes request/stage/queue retention options (`--mode <light|investigation>`, `--max-requests`, `--max-stages`, and `--max-queues`) because those are the imported evidence types.
+
+#### Runtime evidence
+
+Offline import does not ingest runtime snapshots or in-flight snapshots. Tracing-only runs do not fabricate runtime snapshots, so runtime-pressure evidence remains Tokio-specific and limited unless runtime snapshots are captured separately.
+
+#### Zero-request artifacts
+
+Persisted CLI artifacts require at least one completed request. In-process library snapshots may still be zero-request for inspection.
+
+#### Completed-span JSONL caveat
+
+Completed-span JSONL is retained replay/debug evidence. It omits warning/truncation metadata and does not preserve the full Run warning/truncation context. Use Run JSON for the complete persisted artifact.
 
 B) Direct Run JSON path with async span instrumentation (`live` feature required):
 
@@ -95,6 +123,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 Stage and queue spans use their own `tt.stage` / `tt.queue` fields around the awaited work they measure.
 `tt.outcome` on request spans is optional: missing values default to `ok` with a warning; recommended common labels are `ok`, `error`, `timeout`, `cancelled`, and `rejected`; custom non-empty labels are preserved exactly.
+
+Live tracing intake tracks spans that are tailtriage candidates at span creation time. Declare `tt.*` fields when the span is created. For late values, declare the field with `tracing::field::Empty` and then call `span.record(...)`; adding brand-new `tt.*` fields later is not supported.
 
 In service code, add `session.layer()` beside your existing tracing layers and install the resulting subscriber in the application's normal process-wide/global subscriber setup. `set_default` is scoped to the current thread and guard lifetime; service startup should install the tailtriage layer in the process-wide subscriber setup.
 

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -89,11 +89,21 @@ When paths include spaces, quote them in shell usage:
 tailtriage import tracing-spans-jsonl "fixtures/tracing spans.jsonl" --service checkout --output "runs/imported run.json"
 ```
 
-The command imports completed tailtriage `tt.*` tracing span JSONL records in the documented shape and writes Run JSON through the normal local JSON artifact writer, not Report JSON. Import warnings are printed to stderr as `warning: ...`. Analysis is a separate step: `tailtriage analyze tailtriage-run.json`.
-Tracing import and native capture share the same CaptureMode/CaptureLimits semantics for request/stage/queue evidence retention. Offline CLI tracing import exposes request/stage/queue limit overrides because those are the evidence types it imports. It intentionally does not expose runtime-snapshot or in-flight-snapshot limit flags because this import path does not ingest those evidence types. Tracing-only imports do not fabricate runtime snapshots; executor/blocking-pressure interpretation remains limited unless runtime snapshots are also captured (for example via Tokio runtime sampling).
-Malformed JSON input remains fatal. In non-strict mode, syntactically valid malformed/incomplete `tt.*` records are skipped with `warning: ...` lines.
-`--service` must not be empty or whitespace.
-Import fails when zero request events would be written (for example unrelated-only input or all-skipped malformed `tt.*` input), because `tailtriage analyze` requires at least one request in CLI-loaded run artifacts. The same non-empty-request rule applies before persisting completed-span JSONL artifacts in tracing intake sessions.
+Import behavior checklist:
+
+- Imports completed tailtriage `tt.*` tracing span JSONL records in the documented shape.
+- Writes Run JSON through the normal local JSON artifact writer, not Report JSON.
+- Keeps analysis separate: `tailtriage analyze tailtriage-run.json`.
+- Prints import warnings to stderr as `warning: ...`.
+- Shares `CaptureMode`/`CaptureLimits` semantics with native capture for request/stage/queue evidence retention.
+- Exposes offline CLI request/stage/queue limit overrides because those are the evidence types it imports.
+- Does not expose runtime-snapshot or in-flight-snapshot limit flags because this path does not ingest those evidence types.
+- Does not fabricate runtime snapshots; executor/blocking-pressure interpretation remains limited unless runtime snapshots are also captured, for example via Tokio runtime sampling.
+- Treats malformed JSON input as fatal.
+- In non-strict mode, skips syntactically valid malformed/incomplete `tt.*` records with `warning: ...` lines.
+- Requires non-empty/non-whitespace `--service`.
+- Fails when zero request events would be written because `tailtriage analyze` requires at least one request in CLI-loaded run artifacts.
+- Applies the same non-empty-request rule before persisting completed-span JSONL artifacts in tracing intake sessions.
 
 `tailtriage analyze <run.json> --format json` emits the same pretty Report JSON as `tailtriage_analyzer::render_json_pretty`.
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -12,6 +12,12 @@ It is **not**:
 - an OTel/OTLP pipeline,
 - proof of root cause (output remains triage leads).
 
+## When to use this crate
+
+Use this path when the service already uses Rust `tracing` and already has stable per-request correlation IDs. New integrations without existing tracing/correlation should start with native `tailtriage` capture first.
+
+Every request, stage, and queue span for one work item must carry the same `tt.request_id`; child stage/queue evidence is correlated only to retained request evidence with the same `tt.request_id`. This crate converts tracing-shaped evidence into standard `Run` artifacts; it is not a tracing backend.
+
 ## Feature flags
 
 - Base crate: typed `SpanRecord`, `ImportOptions`, `ImportedRun`, semantic constants, and `run_from_span_records(...)`.
@@ -141,6 +147,19 @@ Import does not guess span timing from line receive time: provide explicit unix-
 Record semantic `tt.*` fields (`tt.kind`, `tt.request_id`, `tt.route`, `tt.stage`, `tt.queue`) as plain scalar strings (string literals or display-formatted scalar strings). Do not use debug formatting for semantic `tt.*` fields.
 
 For example: `tt.kind = "request"` works, `tt.kind = %kind` can work when `kind` displays as `request`, but `tt.kind = ?kind` may record `"request"` (debug quoting) and be rejected as unknown.
+
+Live tracing intake tracks spans that are tailtriage candidates at span creation time. Declare `tt.*` fields when the span is created. If a value is filled later, declare that field with `tracing::field::Empty` at creation time and then call `span.record(...)`; adding a brand-new `tt.*` field later is not supported.
+
+```rust
+let span = tracing::info_span!(
+    "request",
+    tt.kind = "request",
+    tt.request_id = "req-1",
+    tt.route = "/checkout",
+    tt.outcome = tracing::field::Empty,
+);
+span.record("tt.outcome", "timeout");
+```
 
 Missing request `tt.outcome` defaults to `ok` with a warning.
 If present, request `tt.outcome` must be a string and cannot be empty/whitespace-only; accepted custom labels are preserved exactly.


### PR DESCRIPTION
### Motivation

- Clarify fit and operational boundaries for the tracing intake path so users pick the right capture path and understand limitations. 
- Surface the live `tracing` field-recording rules to prevent common misintegration pitfalls that silently drop or weaken evidence. 
- Restructure user-facing tracing import guidance into short, scannable sections so CLI and docs readers find the important facts quickly. 

### Description

- Add a new “When to use this crate” section and correlation guidance to `tailtriage-tracing/README.md` to state that this path is for services already using `tracing` with stable per-request IDs and that it converts tracing-shaped evidence into `Run` artifacts (not a tracing backend). 
- Document the live `tt.*` field-recording rule and include the concise `tracing::field::Empty` + `span.record(...)` example snippet in `tailtriage-tracing/README.md`. 
- Restructure `docs/user-guide.md` “Using existing tracing spans” subsection so fit guidance appears before install commands and replace the long completed-span JSONL paragraph with short subsections using the exact headings: `What this imports`, `What this writes`, `Strict vs non-strict`, `Retention limits`, `Runtime evidence`, `Zero-request artifacts`, and `Completed-span JSONL caveat`. 
- Add an operational caveat block to `docs/operations.md` under “Operating with tracing-based runs” to call out that tracing intake works best with reliable request correlation and that missing/inconsistent `tt.request_id` weakens child evidence and that native capture is recommended when correlation is not already available. 
- Replace the long CLI import paragraph in `tailtriage-cli/README.md` with a short checklist preserving the same import facts (wrapper JSONL shape, Run vs Report JSON, `--strict` behavior, non-strict warnings, retention flags, runtime-snapshot non-ingest behavior, non-empty request requirement, and malformed-input handling). 

### Testing

- Ran code/docs validators and linters: `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, both succeed. 
- Ran the full test suite and targeted tests: `cargo test --workspace --all-targets --all-features --locked`, `cargo test -p tailtriage-tracing --all-features --locked`, and `cargo test -p tailtriage-cli --all-targets --locked`, all tests pass. 
- Ran docs contract validation and unit checks: `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts`, both succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d0c2d490483309146b02f5e78ce62)