### PR TITLE
Tighten tracing intake documentation

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -160,6 +160,8 @@ Prefer moderate intervals and bounded runs before increasing density.
 
 Tracing import expects completed tailtriage `tt.*` tracing span JSONL, not ordinary tracing log JSON (`fmt().json` output is a common non-supported example). Import writes Run JSON (not Report JSON), and analysis is a separate step after import (`tailtriage analyze`). Completed-span JSONL is not a production trace archive and does not preserve warning/truncation context; prefer Run JSON when the artifact itself must carry that context. Persisted Run JSON intended for `tailtriage analyze` must include at least one completed request event; in-process library snapshots may still be zero-request for inspection. Timing is not guessed from line receive time, so completed spans must include explicit unix-ms start/end timestamps. OTel/OTLP intake remains out of scope on this path.
 
+Tracing intake works best when request correlation is already reliable. Every request, stage, and queue span for one work item must carry the same `tt.request_id`; missing or inconsistent IDs cause child stage/queue evidence to be skipped or weakened. Native capture is the recommended first path when correlation is not already available.
+
 Important limits for production interpretation:
 
 * tracing-only runs do not fabricate runtime snapshots

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -34,7 +34,11 @@ The `controller` and `tokio` namespaces are available with default features; `ax
 
 ### Using existing tracing spans
 
-If you already instrument request/stage/queue work with Rust `tracing`, use `tailtriage-tracing` as an intake path into the same triage workflow.
+Use `tailtriage-tracing` when your service already uses Rust `tracing` and already has stable per-request correlation IDs. New integrations without existing tracing/correlation should start with native `tailtriage` capture first.
+
+Every request, stage, and queue span for one work item must carry the same `tt.request_id`. Child stage/queue evidence is correlated to retained request evidence by that value; missing or inconsistent IDs weaken or skip child evidence.
+
+This path converts tracing-shaped evidence into standard Run artifacts. It is not a tracing backend.
 
 Install for typed records plus JSONL import APIs (default feature set):
 
@@ -49,7 +53,33 @@ tailtriage import tracing-spans-jsonl completed-spans.jsonl --service checkout -
 tailtriage analyze tailtriage-run.json
 ```
 
-`tailtriage import tracing-spans-jsonl` imports completed tailtriage tracing span JSONL and writes Run artifact JSON (not Report JSON), and analysis remains a separate step after import. Use the documented stable wrapper JSONL shape from `tailtriage-tracing` (`{"format":"tailtriage.tracing-span.v1","span":{...}}`). `--strict` fails on malformed or incomplete `tt.*` spans; non-strict mode skips malformed `tt.*` spans and prints `warning: ...` messages. Tracing import and native capture use the same `CaptureMode`/`CaptureLimits` semantics for request/stage/queue retention. Offline import exposes `--mode <light|investigation>` plus `--max-requests`, `--max-stages`, and `--max-queues` because those are the imported evidence types. It does not expose runtime/in-flight snapshot limit flags because those evidence types are not imported by this path. Tracing-only runs do not fabricate runtime snapshots, and runtime-pressure evidence remains Tokio-specific. Persisted Run JSON and persisted completed-span JSONL intended for offline CLI workflows must include at least one completed request event; in-process library snapshots may still be zero-request for inspection. Completed-span JSONL replays retained request/stage/queue evidence and does not carry live-session warning/truncation metadata; use Run JSON for the complete persisted artifact.
+#### What this imports
+
+Imports completed tailtriage tracing span JSONL. The stable wrapper shape is `{"format":"tailtriage.tracing-span.v1","span":{...}}`.
+
+#### What this writes
+
+Writes Run JSON, not Report JSON. Analysis is a separate `tailtriage analyze` step.
+
+#### Strict vs non-strict
+
+`--strict` fails malformed or incomplete `tt.*` spans. Non-strict mode skips malformed `tt.*` spans and prints `warning: ...` messages.
+
+#### Retention limits
+
+Tracing import and native capture use the same `CaptureMode`/`CaptureLimits` semantics for request/stage/queue retention. Offline import exposes only request/stage/queue retention options: `--mode <light|investigation>`, `--max-requests`, `--max-stages`, and `--max-queues`.
+
+#### Runtime evidence
+
+Offline import does not ingest runtime snapshots or in-flight snapshots. Tracing-only runs do not fabricate runtime snapshots, and runtime-pressure evidence remains Tokio-specific.
+
+#### Zero-request artifacts
+
+Persisted Run JSON and persisted completed-span JSONL intended for offline CLI workflows require at least one completed request. In-process library snapshots may still be zero-request for inspection.
+
+#### Completed-span JSONL caveat
+
+Completed-span JSONL replays retained request/stage/queue evidence and omits warning/truncation metadata. Use Run JSON for the complete persisted artifact.
 
 B) Direct Run JSON path with async span instrumentation (`live` feature required):
 
@@ -93,7 +123,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-Stage and queue spans use their own `tt.stage` / `tt.queue` fields around the awaited work they measure.
+Stage and queue spans use their own `tt.stage` / `tt.queue` fields around the awaited work they measure, and every request/stage/queue span for one work item carries the same `tt.request_id`.
+
+Live tracing tracks spans that are tailtriage candidates when the span is created. Declare `tt.*` fields on the span at creation time. For late values, declare the field with `tracing::field::Empty` and then call `span.record(...)`; do not add brand-new `tt.*` fields later with `span.record(...)`.
+
 `tt.outcome` on request spans is optional: missing values default to `ok` with a warning; recommended common labels are `ok`, `error`, `timeout`, `cancelled`, and `rejected`; custom non-empty labels are preserved exactly.
 
 In service code, add `session.layer()` beside your existing tracing layers and install the resulting subscriber in the application's normal process-wide/global subscriber setup. `set_default` is scoped to the current thread and guard lifetime; service startup should install the tailtriage layer in the process-wide subscriber setup.

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -89,11 +89,20 @@ When paths include spaces, quote them in shell usage:
 tailtriage import tracing-spans-jsonl "fixtures/tracing spans.jsonl" --service checkout --output "runs/imported run.json"
 ```
 
-The command imports completed tailtriage `tt.*` tracing span JSONL records in the documented shape and writes Run JSON through the normal local JSON artifact writer, not Report JSON. Import warnings are printed to stderr as `warning: ...`. Analysis is a separate step: `tailtriage analyze tailtriage-run.json`.
-Tracing import and native capture share the same CaptureMode/CaptureLimits semantics for request/stage/queue evidence retention. Offline CLI tracing import exposes request/stage/queue limit overrides because those are the evidence types it imports. It intentionally does not expose runtime-snapshot or in-flight-snapshot limit flags because this import path does not ingest those evidence types. Tracing-only imports do not fabricate runtime snapshots; executor/blocking-pressure interpretation remains limited unless runtime snapshots are also captured (for example via Tokio runtime sampling).
-Malformed JSON input remains fatal. In non-strict mode, syntactically valid malformed/incomplete `tt.*` records are skipped with `warning: ...` lines.
-`--service` must not be empty or whitespace.
-Import fails when zero request events would be written (for example unrelated-only input or all-skipped malformed `tt.*` input), because `tailtriage analyze` requires at least one request in CLI-loaded run artifacts. The same non-empty-request rule applies before persisting completed-span JSONL artifacts in tracing intake sessions.
+Import behavior checklist:
+
+- Imports completed tailtriage `tt.*` tracing span JSONL records in the documented shape.
+- Writes Run JSON through the normal local JSON artifact writer, not Report JSON.
+- Prints import warnings to stderr as `warning: ...`.
+- Keeps analysis as a separate step: `tailtriage analyze tailtriage-run.json`.
+- Uses the same `CaptureMode`/`CaptureLimits` semantics as native capture for request/stage/queue evidence retention.
+- Exposes request/stage/queue limit overrides because those are the evidence types offline CLI tracing import ingests.
+- Does not expose runtime-snapshot or in-flight-snapshot limit flags because this import path does not ingest those evidence types.
+- Does not fabricate runtime snapshots; executor/blocking-pressure interpretation remains limited unless runtime snapshots are also captured, for example via Tokio runtime sampling.
+- Treats malformed JSON input as fatal.
+- In non-strict mode, skips syntactically valid malformed/incomplete `tt.*` records with `warning: ...` lines.
+- Requires `--service` to be non-empty and non-whitespace.
+- Fails when zero request events would be written, because `tailtriage analyze` requires at least one request in CLI-loaded run artifacts. The same non-empty-request rule applies before persisting completed-span JSONL artifacts in tracing intake sessions.
 
 `tailtriage analyze <run.json> --format json` emits the same pretty Report JSON as `tailtriage_analyzer::render_json_pretty`.
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -12,6 +12,14 @@ It is **not**:
 - an OTel/OTLP pipeline,
 - proof of root cause (output remains triage leads).
 
+## When to use this crate
+
+Use this path when your service already uses Rust `tracing` and already has stable per-request correlation IDs. New integrations without existing tracing/correlation should start with native `tailtriage` capture first.
+
+Every request, stage, and queue span for one work item must carry the same `tt.request_id`. Child stage/queue evidence is correlated to retained request evidence by that value, so missing or inconsistent IDs weaken or skip child evidence.
+
+This crate converts tracing-shaped evidence into standard `tailtriage_core::Run` artifacts. It is not a tracing backend.
+
 ## Feature flags
 
 - Base crate: typed `SpanRecord`, `ImportOptions`, `ImportedRun`, semantic constants, and `run_from_span_records(...)`.
@@ -141,6 +149,19 @@ Import does not guess span timing from line receive time: provide explicit unix-
 Record semantic `tt.*` fields (`tt.kind`, `tt.request_id`, `tt.route`, `tt.stage`, `tt.queue`) as plain scalar strings (string literals or display-formatted scalar strings). Do not use debug formatting for semantic `tt.*` fields.
 
 For example: `tt.kind = "request"` works, `tt.kind = %kind` can work when `kind` displays as `request`, but `tt.kind = ?kind` may record `"request"` (debug quoting) and be rejected as unknown.
+
+Live tracing tracks spans that are tailtriage candidates when the span is created. Declare `tt.*` fields on the span at creation time. If a value is filled later, declare that field with `tracing::field::Empty` and then call `span.record(...)`; adding brand-new `tt.*` fields later with `span.record(...)` is not supported.
+
+```rust
+let span = tracing::info_span!(
+    "request",
+    tt.kind = "request",
+    tt.request_id = "req-1",
+    tt.route = "/checkout",
+    tt.outcome = tracing::field::Empty,
+);
+span.record("tt.outcome", "timeout");
+```
 
 Missing request `tt.outcome` defaults to `ok` with a warning.
 If present, request `tt.outcome` must be a string and cannot be empty/whitespace-only; accepted custom labels are preserved exactly.


### PR DESCRIPTION
### Motivation

- Clarify and tighten user-facing guidance for the tracing intake path so adopters understand fit boundaries, correlation requirements, and live-tracing field-recording rules without changing product scope or runtime behavior. 
- Reduce long paragraphs and surface the exact import/retention caveats and JSONL shape up-front so users pick the correct capture path and avoid common misconfigurations.

### Description

- Add a top-level “When to use this crate” section to `tailtriage-tracing/README.md` that states tracing intake is for services already using Rust `tracing` with stable per-request correlation IDs and that the crate converts tracing-shaped evidence into `tailtriage_core::Run` artifacts rather than acting as a tracing backend. 
- Document the live `tracing` field-recording rule and include the requested concise example in `tailtriage-tracing/README.md`, stating that `tt.*` fields must be declared at span creation and late values must use `tracing::field::Empty` plus `span.record(...)`, and that adding brand-new `tt.*` fields later is not supported. 
- Restructure `docs/user-guide.md` “Using existing tracing spans” so fit guidance appears before install steps and replace the long completed-span JSONL paragraph with short subsections using the exact headings `What this imports`, `What this writes`, `Strict vs non-strict`, `Retention limits`, `Runtime evidence`, `Zero-request artifacts`, and `Completed-span JSONL caveat`, preserving the documented facts about wrapper shape, Run vs Report JSON, `--strict` semantics, retention limits, runtime snapshot limitations, zero-request requirements, and the completed-span caveat. 
- Add the operational caveat to `docs/operations.md` under “Operating with tracing-based runs” explaining that tracing intake works best when request correlation is reliable, that missing/inconsistent `tt.request_id` weakens or skips child evidence, and that native capture is recommended when correlation is not available. 
- Replace the long import-behavior paragraph in `tailtriage-cli/README.md` with a concise checklist that preserves the same behavioral facts and constraints (input wrapper shape, output Run JSON, separate `tailtriage analyze` step, capture-limit scope, runtime-snapshot omission, strict/non-strict behavior, malformed input handling, `--service` validation, and zero-request rule). 
- Do not change runtime code, JSONL parser behavior, CLI command names, or feature behavior; the edits are documentation only and preserve all existing facts and semantics. 

### Testing

- Ran `cargo fmt --check` which succeeds. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which succeeds. 
- Ran the full test matrix: `cargo test --workspace --all-targets --all-features --locked`, `cargo test -p tailtriage-tracing --all-features --locked`, and `cargo test -p tailtriage-cli --all-targets --locked`, all of which passed (one non-failing compiler warning `dead_code` was emitted under the tracing feature set). 
- Ran docs validation and unit checks `python3 scripts/validate_docs_contracts.py` and `python3 -m unittest scripts.tests.test_validate_docs_contracts`, both of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d0c2d490483309146b02f5e78ce62)