### PR TITLE
docs: tighten tracing intake guidance

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -158,7 +158,11 @@ Prefer moderate intervals and bounded runs before increasing density.
 
 ## Operating with tracing-based runs
 
+Tracing intake works best when request correlation is already reliable. Every request, stage, and queue span for one work item must carry the same `tt.request_id`; missing or inconsistent `tt.request_id` causes child stage/queue evidence to be skipped or weakened. Native capture is the recommended first path when correlation is not already available.
+
 Tracing import expects completed tailtriage `tt.*` tracing span JSONL, not ordinary tracing log JSON (`fmt().json` output is a common non-supported example). Import writes Run JSON (not Report JSON), and analysis is a separate step after import (`tailtriage analyze`). Completed-span JSONL is not a production trace archive and does not preserve warning/truncation context; prefer Run JSON when the artifact itself must carry that context. Persisted Run JSON intended for `tailtriage analyze` must include at least one completed request event; in-process library snapshots may still be zero-request for inspection. Timing is not guessed from line receive time, so completed spans must include explicit unix-ms start/end timestamps. OTel/OTLP intake remains out of scope on this path.
+
+Live tracing intake only tracks spans that are tailtriage candidates at span creation time. Declare `tt.*` fields when the span is created. If a value is filled later, declare it with `tracing::field::Empty` and then call `span.record(...)`; adding brand-new `tt.*` fields later with `span.record(...)` is not supported.
 
 Important limits for production interpretation:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -34,7 +34,9 @@ The `controller` and `tokio` namespaces are available with default features; `ax
 
 ### Using existing tracing spans
 
-If you already instrument request/stage/queue work with Rust `tracing`, use `tailtriage-tracing` as an intake path into the same triage workflow.
+Use `tailtriage-tracing` when your service already uses Rust `tracing` and already has stable per-request correlation IDs. New integrations without existing tracing/correlation should start with native `tailtriage` capture first.
+
+This path converts tracing-shaped request, stage, and queue evidence into standard Run artifacts for the normal `tailtriage analyze` workflow. It is not a tracing backend. For one work item, every request, stage, and queue span must carry the same `tt.request_id`; child stage/queue evidence is correlated to retained request evidence by `tt.request_id`.
 
 Install for typed records plus JSONL import APIs (default feature set):
 
@@ -49,7 +51,41 @@ tailtriage import tracing-spans-jsonl completed-spans.jsonl --service checkout -
 tailtriage analyze tailtriage-run.json
 ```
 
-`tailtriage import tracing-spans-jsonl` imports completed tailtriage tracing span JSONL and writes Run artifact JSON (not Report JSON), and analysis remains a separate step after import. Use the documented stable wrapper JSONL shape from `tailtriage-tracing` (`{"format":"tailtriage.tracing-span.v1","span":{...}}`). `--strict` fails on malformed or incomplete `tt.*` spans; non-strict mode skips malformed `tt.*` spans and prints `warning: ...` messages. Tracing import and native capture use the same `CaptureMode`/`CaptureLimits` semantics for request/stage/queue retention. Offline import exposes `--mode <light|investigation>` plus `--max-requests`, `--max-stages`, and `--max-queues` because those are the imported evidence types. It does not expose runtime/in-flight snapshot limit flags because those evidence types are not imported by this path. Tracing-only runs do not fabricate runtime snapshots, and runtime-pressure evidence remains Tokio-specific. Persisted Run JSON and persisted completed-span JSONL intended for offline CLI workflows must include at least one completed request event; in-process library snapshots may still be zero-request for inspection. Completed-span JSONL replays retained request/stage/queue evidence and does not carry live-session warning/truncation metadata; use Run JSON for the complete persisted artifact.
+#### What this imports
+
+- Completed tailtriage tracing span JSONL.
+- The stable wrapper shape is `{"format":"tailtriage.tracing-span.v1","span":{...}}`.
+- Ordinary `tracing_subscriber::fmt().json()` logs are unsupported and rejected.
+
+#### What this writes
+
+- `tailtriage import tracing-spans-jsonl` writes Run JSON, not Report JSON.
+- Analysis is a separate `tailtriage analyze tailtriage-run.json` step.
+
+#### Strict vs non-strict
+
+- `--strict` fails malformed or incomplete `tt.*` spans.
+- Non-strict mode skips malformed `tt.*` spans and prints `warning: ...` messages.
+
+#### Retention limits
+
+- Offline import exposes request/stage/queue retention options because those are the imported evidence types.
+- It does not expose runtime-snapshot or in-flight-snapshot limit flags.
+
+#### Runtime evidence
+
+- Offline import does not ingest runtime snapshots or in-flight snapshots.
+- Tracing-only runs do not fabricate runtime snapshots, so executor/blocking-pressure evidence can be weaker or absent.
+
+#### Zero-request artifacts
+
+- Persisted CLI artifacts require at least one completed request.
+- In-process library snapshots may still be zero-request for inspection.
+
+#### Completed-span JSONL caveat
+
+- Completed-span JSONL is retained replay/debug evidence and omits warning/truncation metadata from the full Run artifact.
+- Run JSON is preferred for the complete persisted artifact.
 
 B) Direct Run JSON path with async span instrumentation (`live` feature required):
 
@@ -93,8 +129,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-Stage and queue spans use their own `tt.stage` / `tt.queue` fields around the awaited work they measure.
+Stage and queue spans use their own `tt.stage` / `tt.queue` fields around the awaited work they measure. Every request, stage, and queue span for one work item must carry the same `tt.request_id`; missing or inconsistent IDs cause child stage/queue evidence to be skipped or weakened.
+
 `tt.outcome` on request spans is optional: missing values default to `ok` with a warning; recommended common labels are `ok`, `error`, `timeout`, `cancelled`, and `rejected`; custom non-empty labels are preserved exactly.
+
+Live tracing intake only tracks spans that are tailtriage candidates at span creation time. Declare `tt.*` fields when the span is created. If a value is filled later, declare it with `tracing::field::Empty` and then call `span.record(...)`. Do not add brand-new `tt.*` fields later with `span.record(...)` and expect the span to be tracked.
 
 In service code, add `session.layer()` beside your existing tracing layers and install the resulting subscriber in the application's normal process-wide/global subscriber setup. `set_default` is scoped to the current thread and guard lifetime; service startup should install the tailtriage layer in the process-wide subscriber setup.
 

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -89,11 +89,21 @@ When paths include spaces, quote them in shell usage:
 tailtriage import tracing-spans-jsonl "fixtures/tracing spans.jsonl" --service checkout --output "runs/imported run.json"
 ```
 
-The command imports completed tailtriage `tt.*` tracing span JSONL records in the documented shape and writes Run JSON through the normal local JSON artifact writer, not Report JSON. Import warnings are printed to stderr as `warning: ...`. Analysis is a separate step: `tailtriage analyze tailtriage-run.json`.
-Tracing import and native capture share the same CaptureMode/CaptureLimits semantics for request/stage/queue evidence retention. Offline CLI tracing import exposes request/stage/queue limit overrides because those are the evidence types it imports. It intentionally does not expose runtime-snapshot or in-flight-snapshot limit flags because this import path does not ingest those evidence types. Tracing-only imports do not fabricate runtime snapshots; executor/blocking-pressure interpretation remains limited unless runtime snapshots are also captured (for example via Tokio runtime sampling).
-Malformed JSON input remains fatal. In non-strict mode, syntactically valid malformed/incomplete `tt.*` records are skipped with `warning: ...` lines.
-`--service` must not be empty or whitespace.
-Import fails when zero request events would be written (for example unrelated-only input or all-skipped malformed `tt.*` input), because `tailtriage analyze` requires at least one request in CLI-loaded run artifacts. The same non-empty-request rule applies before persisting completed-span JSONL artifacts in tracing intake sessions.
+Import behavior checklist:
+
+- Imports completed tailtriage `tt.*` tracing span JSONL records in the documented shape.
+- Writes Run JSON through the normal local JSON artifact writer, not Report JSON.
+- Keeps analysis as a separate step: `tailtriage analyze tailtriage-run.json`.
+- Prints import warnings to stderr as `warning: ...`.
+- Uses the same `CaptureMode`/`CaptureLimits` semantics as native capture for request/stage/queue evidence retention.
+- Exposes request/stage/queue limit overrides because those are the evidence types offline CLI tracing import ingests.
+- Does not expose runtime-snapshot or in-flight-snapshot limit flags because this import path does not ingest those evidence types.
+- Does not fabricate runtime snapshots; executor/blocking-pressure interpretation remains limited unless runtime snapshots are also captured, for example via Tokio runtime sampling.
+- Treats malformed JSON input as fatal.
+- In non-strict mode, skips syntactically valid malformed/incomplete `tt.*` records with `warning: ...` lines.
+- Requires `--service` to be non-empty and not whitespace-only.
+- Fails when zero request events would be written, such as unrelated-only input or all-skipped malformed `tt.*` input, because `tailtriage analyze` requires at least one request in CLI-loaded run artifacts.
+- Applies the same non-empty-request rule before persisting completed-span JSONL artifacts in tracing intake sessions.
 
 `tailtriage analyze <run.json> --format json` emits the same pretty Report JSON as `tailtriage_analyzer::render_json_pretty`.
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -12,6 +12,14 @@ It is **not**:
 - an OTel/OTLP pipeline,
 - proof of root cause (output remains triage leads).
 
+## When to use this crate
+
+Use this path when your service already uses Rust `tracing` and already has stable per-request correlation IDs. New integrations without existing tracing/correlation should start with native `tailtriage` capture first.
+
+This crate converts tracing-shaped request, stage, and queue evidence into standard `tailtriage_core::Run` artifacts for the normal `tailtriage analyze` workflow. It is not a tracing backend.
+
+For one work item, every request, stage, and queue span must carry the same `tt.request_id`. Child stage/queue evidence is correlated to retained request evidence by `tt.request_id`; missing or inconsistent IDs cause child evidence to be skipped or weakened.
+
 ## Feature flags
 
 - Base crate: typed `SpanRecord`, `ImportOptions`, `ImportedRun`, semantic constants, and `run_from_span_records(...)`.
@@ -145,6 +153,19 @@ For example: `tt.kind = "request"` works, `tt.kind = %kind` can work when `kind`
 Missing request `tt.outcome` defaults to `ok` with a warning.
 If present, request `tt.outcome` must be a string and cannot be empty/whitespace-only; accepted custom labels are preserved exactly.
 Missing stage `tt.success` defaults to `true` with a warning.
+
+Live tracing intake only tracks spans that are tailtriage candidates at span creation time. Declare `tt.*` fields when the span is created. If a value is filled later, declare the field with `tracing::field::Empty` and then call `span.record(...)`; adding brand-new `tt.*` fields later with `span.record(...)` is not supported.
+
+```rust
+let span = tracing::info_span!(
+    "request",
+    tt.kind = "request",
+    tt.request_id = "req-1",
+    tt.route = "/checkout",
+    tt.outcome = tracing::field::Empty,
+);
+span.record("tt.outcome", "timeout");
+```
 
 ## Strict vs non-strict
 


### PR DESCRIPTION
### Motivation

- Clarify and tighten the user-facing tracing intake guidance so teams can choose the correct path without changing product scope or implementation behavior. 
- Reduce adoption friction by making correlation requirements, live-intake rules, and offline import semantics explicit and easy to find. 
- Keep messaging narrow and present-tense: tracing intake converts tracing-shaped evidence into standard `Run` artifacts and remains a triage intake path, not a tracing backend. 

### Description

- Add a short “When to use this crate” section to `tailtriage-tracing/README.md` that states fit guidance and that every request/stage/queue span for one work item must carry the same `tt.request_id`. 
- Document the live `tracing` field-recording rule and the supported late-value pattern with `tracing::field::Empty` plus a concise code snippet in `tailtriage-tracing/README.md`. 
- Restructure `docs/user-guide.md` “Using existing tracing spans” so fit guidance appears before install commands and replace the long import paragraph with short subsections using the exact headings `What this imports`, `What this writes`, `Strict vs non-strict`, `Retention limits`, `Runtime evidence`, `Zero-request artifacts`, and `Completed-span JSONL caveat`. 
- Add the operational caveat in `docs/operations.md` under “Operating with tracing-based runs” that emphasizes reliable request correlation, the effect of missing/inconsistent `tt.request_id`, recommends native capture when correlation is not available, and documents the live field-declaration rule. 
- Split and rephrase the CLI tracing import paragraph in `tailtriage-cli/README.md` into a short checklist that preserves the same facts about wrapper format, `--strict` behavior, Run vs Report output, runtime-snapshot limits, and the zero-request requirement. 
- Preserve all implemented runtime/CLI/import semantics (no CLI/flag renames, no JSONL parser changes, no claims about root-cause proof, and continued rejection of `tracing_subscriber::fmt().json()` logs). 

### Testing

- Ran docs validation with `python3 scripts/validate_docs_contracts.py` and the dedicated unit suite `python3 -m unittest scripts.tests.test_validate_docs_contracts` which both succeed. 
- Ran formatting and static checks with `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which pass. 
- Ran the full workspace test matrix with `cargo test --workspace --all-targets --all-features --locked` plus targeted tests `cargo test -p tailtriage-tracing --all-features --locked` and `cargo test -p tailtriage-cli --all-targets --locked`, all of which pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d0c2d490483309146b02f5e78ce62)