### PR TITLE
Document repository timing contract

### DIFF
--- a/tailtriage-analyzer/tests/timing_contract.rs
+++ b/tailtriage-analyzer/tests/timing_contract.rs
@@ -1,0 +1,51 @@
+use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
+use tailtriage_core::{
+    CaptureMode, RequestEvent, Run, RunMetadata, TruncationSummary, SCHEMA_VERSION,
+};
+
+#[test]
+fn latency_percentiles_use_duration_fields_not_timestamp_subtraction() {
+    let run = Run {
+        schema_version: SCHEMA_VERSION,
+        metadata: RunMetadata {
+            run_id: "timing-contract-run".to_string(),
+            service_name: "svc".to_string(),
+            service_version: None,
+            started_at_unix_ms: 1_000,
+            finished_at_unix_ms: 1_001,
+            finalized_at_unix_ms: Some(1_001),
+            mode: CaptureMode::Light,
+            effective_core_config: Some(tailtriage_core::EffectiveCoreConfig {
+                mode: CaptureMode::Light,
+                capture_limits: CaptureMode::Light.core_defaults(),
+                strict_lifecycle: false,
+            }),
+            effective_tokio_sampler_config: None,
+            host: None,
+            pid: None,
+            lifecycle_warnings: Vec::new(),
+            unfinished_requests: tailtriage_core::UnfinishedRequests::default(),
+            run_end_reason: None,
+        },
+        requests: vec![RequestEvent {
+            request_id: "req-1".to_string(),
+            route: "/checkout".to_string(),
+            kind: None,
+            started_at_unix_ms: 1_000,
+            finished_at_unix_ms: 1_001,
+            latency_us: 50_000,
+            outcome: "ok".to_string(),
+        }],
+        stages: Vec::new(),
+        queues: Vec::new(),
+        inflight: Vec::new(),
+        runtime_snapshots: Vec::new(),
+        truncation: TruncationSummary::default(),
+    };
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert_eq!(report.p50_latency_us, Some(50_000));
+    assert_eq!(report.p95_latency_us, Some(50_000));
+    assert_eq!(report.p99_latency_us, Some(50_000));
+}

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -17,6 +17,14 @@ Use it when you want explicit request lifecycle instrumentation and bounded JSON
 For in-process analysis/report generation, use `tailtriage-analyzer`.
 For command-line analysis of saved artifacts, use `tailtriage-cli`.
 
+## Timing model
+
+- Duration fields in microseconds (`latency_us`, `wait_us`, stage `latency_us`) are authoritative for elapsed-time analysis.
+- Unix millisecond timestamps are wall-clock anchors for log correlation, artifact readability, and coarse temporal grouping.
+- Wall-clock timestamps can be coarse and can move if the system clock changes.
+- Analyzer scoring uses duration fields for latency, queue wait, and stage duration.
+- Temporal segmentation may use wall-clock timestamps when no monotonic run-relative timing is available, so runtime/in-flight attribution can be approximate.
+
 ## Crate selection
 
 Use `tailtriage-core` when you want the smallest framework-agnostic capture surface.

--- a/tailtriage-core/src/events.rs
+++ b/tailtriage-core/src/events.rs
@@ -223,6 +223,11 @@ pub struct UnfinishedRequestSample {
 }
 
 /// Per-request timing and status.
+///
+/// Timing model: microsecond duration fields are authoritative for elapsed-time
+/// analysis; unix-ms timestamps are wall-clock anchors for correlation,
+/// readability, and coarse grouping, and may be coarse or move with the system
+/// clock.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RequestEvent {
     /// Correlation ID for the request.
@@ -242,6 +247,11 @@ pub struct RequestEvent {
 }
 
 /// Timing record for one named stage.
+///
+/// Timing model: microsecond duration fields are authoritative for elapsed-time
+/// analysis; unix-ms timestamps are wall-clock anchors for correlation,
+/// readability, and coarse grouping, and may be coarse or move with the system
+/// clock.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StageEvent {
     /// Parent request ID.
@@ -260,6 +270,11 @@ pub struct StageEvent {
 }
 
 /// Queue wait measurement for a request waiting on a queue/permit.
+///
+/// Timing model: microsecond duration fields are authoritative for elapsed-time
+/// analysis; unix-ms timestamps are wall-clock anchors for correlation,
+/// readability, and coarse grouping, and may be coarse or move with the system
+/// clock.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct QueueEvent {
     /// Parent request ID.
@@ -277,6 +292,10 @@ pub struct QueueEvent {
 }
 
 /// Point-in-time in-flight gauge reading.
+///
+/// Timing model: unix-ms timestamps are wall-clock anchors for correlation,
+/// readability, and coarse grouping; elapsed-time analysis uses request, stage,
+/// and queue duration fields when present.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InFlightSnapshot {
     /// Gauge name.
@@ -288,6 +307,10 @@ pub struct InFlightSnapshot {
 }
 
 /// Point-in-time runtime metrics sample.
+///
+/// Timing model: unix-ms timestamps are wall-clock anchors for correlation,
+/// readability, and coarse grouping; elapsed-time analysis uses request, stage,
+/// and queue duration fields when present.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RuntimeSnapshot {
     /// Timestamp (milliseconds since epoch UTC).

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -20,6 +20,13 @@ This crate converts tracing-shaped request, stage, and queue evidence into stand
 
 For one work item, every request, stage, and queue span must carry the same `tt.request_id`. Child stage/queue evidence is correlated to retained request evidence by `tt.request_id`; missing or inconsistent IDs cause child evidence to be skipped or weakened.
 
+## Timing model
+
+- Imported or live tracing evidence is converted to normal tailtriage Run timing fields.
+- Durations are the authoritative elapsed-time evidence when present.
+- Unix-ms timestamps are wall-clock anchors and may be coarser than durations.
+- Ordinary tracing log timestamps are not enough for completed-span import; completed spans need explicit start/end timing and semantic tt.* fields.
+
 ## Feature flags
 
 - Base crate: typed `SpanRecord`, `ImportOptions`, `ImportedRun`, semantic constants, and `run_from_span_records(...)`.


### PR DESCRIPTION
### Motivation

- Make the repository-wide timing contract explicit so analyzers, importers, and users share the same expectations about elapsed-time evidence vs wall-clock anchors.  
- Preserve the product distinction that outputs are triage leads (not root-cause proof) and keep wording narrow and operational.  

### Description

- Add a `Timing model` section to `tailtriage-core/README.md` stating that microsecond duration fields (`latency_us`, `wait_us`, stage `latency_us`) are authoritative, Unix-ms timestamps are wall-clock anchors, timestamps can be coarse/move, analyzer scoring uses duration fields, and temporal segmentation may fall back to wall-clock timestamps.  
- Add concise rustdoc timing notes to `tailtriage-core/src/events.rs` for `RequestEvent`, `StageEvent`, `QueueEvent`, `InFlightSnapshot`, and `RuntimeSnapshot` explaining duration-authoritative vs wall-clock-anchor semantics.  
- Add a concise `Timing model` section to `tailtriage-tracing/README.md` stating that imported/live tracing evidence is converted to Run timing fields, durations are authoritative, Unix-ms timestamps are anchors, and completed-span import requires explicit start/end timing and `tt.*` semantics.  
- Add a unit test `tailtriage-analyzer/tests/timing_contract.rs` proving analyzer percentiles use `latency_us` (the duration field) rather than subtracting Unix-ms timestamps; no schema fields were changed and no new dependencies were added.  

### Testing

- Ran `cargo fmt --check` and it passed.  
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it passed.  
- Ran `cargo test --workspace` and the full test suite (including the new `timing_contract` test) passed.  
- Ran `python3 scripts/validate_docs_contracts.py` and it passed.  
- Ran `cargo test --workspace --all-targets --all-features --locked` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d40da7dc48330bf37ce1fd9c9616c)