### PR TITLE
Document timing model and add analyzer regression test

### DIFF
--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -87,6 +87,29 @@ fn sample_request(id: u64) -> RequestEvent {
     }
 }
 
+#[test]
+fn latency_percentiles_use_duration_fields_not_timestamp_subtraction() {
+    let mut run = test_run();
+    run.metadata.started_at_unix_ms = 10;
+    run.metadata.finished_at_unix_ms = 11;
+    run.metadata.finalized_at_unix_ms = Some(11);
+    run.requests = vec![RequestEvent {
+        request_id: "req-duration".to_owned(),
+        route: "/timing".to_owned(),
+        kind: None,
+        started_at_unix_ms: 10,
+        finished_at_unix_ms: 11,
+        latency_us: 50_000,
+        outcome: "ok".to_owned(),
+    }];
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert_eq!(report.p50_latency_us, Some(50_000));
+    assert_eq!(report.p95_latency_us, Some(50_000));
+    assert_eq!(report.p99_latency_us, Some(50_000));
+}
+
 fn runtime_snapshot(
     global: Option<u64>,
     local: Option<u64>,

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -155,6 +155,14 @@ Finalization timestamps:
 - Older artifacts may deserialize with `metadata.finalized_at_unix_ms == None`.
 - When `finalized_at_unix_ms` is present, prefer that field as the finalization signal; `finished_at_unix_ms` remains for backward compatibility.
 
+## Timing model
+
+- Duration fields in microseconds (`latency_us`, `wait_us`, stage `latency_us`) are authoritative for elapsed-time analysis.
+- Unix millisecond timestamps are wall-clock anchors for log correlation, artifact readability, and coarse temporal grouping.
+- Wall-clock timestamps can be coarse and can move if the system clock changes.
+- Analyzer scoring uses duration fields for latency, queue wait, and stage duration.
+- Temporal segmentation may use wall-clock timestamps when no monotonic run-relative timing is available, so runtime/in-flight attribution can be approximate.
+
 ## Capture modes
 
 Modes change retention defaults only. They do not change lifecycle semantics and do **not** auto-start runtime sampling.

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -161,7 +161,7 @@ Finalization timestamps:
 - Unix millisecond timestamps are wall-clock anchors for log correlation, artifact readability, and coarse temporal grouping.
 - Wall-clock timestamps can be coarse and can move if the system clock changes.
 - Analyzer scoring uses duration fields for latency, queue wait, and stage duration.
-- Temporal segmentation may use wall-clock timestamps when no monotonic run-relative timing is available, so runtime/in-flight attribution can be approximate.
+- Temporal segmentation currently uses Unix-ms wall-clock timestamp anchors, so runtime/in-flight attribution can be approximate.
 
 ## Capture modes
 

--- a/tailtriage-core/src/events.rs
+++ b/tailtriage-core/src/events.rs
@@ -223,6 +223,10 @@ pub struct UnfinishedRequestSample {
 }
 
 /// Per-request timing and status.
+///
+/// Duration fields are authoritative for elapsed-time analysis; Unix-ms
+/// timestamps are wall-clock anchors for correlation, readability, and coarse
+/// grouping, and may be coarse or move with system clock changes.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RequestEvent {
     /// Correlation ID for the request.
@@ -242,6 +246,10 @@ pub struct RequestEvent {
 }
 
 /// Timing record for one named stage.
+///
+/// Duration fields are authoritative for elapsed-time analysis; Unix-ms
+/// timestamps are wall-clock anchors for correlation, readability, and coarse
+/// grouping, and may be coarse or move with system clock changes.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StageEvent {
     /// Parent request ID.
@@ -260,6 +268,10 @@ pub struct StageEvent {
 }
 
 /// Queue wait measurement for a request waiting on a queue/permit.
+///
+/// Duration fields are authoritative for elapsed-time analysis; Unix-ms
+/// timestamps are wall-clock anchors for correlation, readability, and coarse
+/// grouping, and may be coarse or move with system clock changes.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct QueueEvent {
     /// Parent request ID.
@@ -277,6 +289,11 @@ pub struct QueueEvent {
 }
 
 /// Point-in-time in-flight gauge reading.
+///
+/// Snapshot timestamps are Unix-ms wall-clock anchors for correlation,
+/// readability, and coarse temporal grouping; they may be coarse or move with
+/// system clock changes, so attribution can be approximate when no monotonic
+/// run-relative timing is available.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InFlightSnapshot {
     /// Gauge name.
@@ -288,6 +305,11 @@ pub struct InFlightSnapshot {
 }
 
 /// Point-in-time runtime metrics sample.
+///
+/// Snapshot timestamps are Unix-ms wall-clock anchors for correlation,
+/// readability, and coarse temporal grouping; they may be coarse or move with
+/// system clock changes, so attribution can be approximate when no monotonic
+/// run-relative timing is available.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RuntimeSnapshot {
     /// Timestamp (milliseconds since epoch UTC).

--- a/tailtriage-core/src/events.rs
+++ b/tailtriage-core/src/events.rs
@@ -291,9 +291,8 @@ pub struct QueueEvent {
 /// Point-in-time in-flight gauge reading.
 ///
 /// Snapshot timestamps are Unix-ms wall-clock anchors for correlation,
-/// readability, and coarse temporal grouping; they may be coarse or move with
-/// system clock changes, so attribution can be approximate when no monotonic
-/// run-relative timing is available.
+/// readability, and coarse temporal grouping; runtime/in-flight attribution
+/// based on those anchors can be approximate.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InFlightSnapshot {
     /// Gauge name.
@@ -307,9 +306,8 @@ pub struct InFlightSnapshot {
 /// Point-in-time runtime metrics sample.
 ///
 /// Snapshot timestamps are Unix-ms wall-clock anchors for correlation,
-/// readability, and coarse temporal grouping; they may be coarse or move with
-/// system clock changes, so attribution can be approximate when no monotonic
-/// run-relative timing is available.
+/// readability, and coarse temporal grouping; runtime/in-flight attribution
+/// based on those anchors can be approximate.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RuntimeSnapshot {
     /// Timestamp (milliseconds since epoch UTC).

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -90,6 +90,13 @@ If your service already builds a subscriber in startup code, compose `session.la
 
 `set_default` is scoped to the current thread and guard lifetime; service startup should install the tailtriage layer in the process-wide subscriber setup.
 
+## Timing model
+
+- Imported or live tracing evidence is converted to normal tailtriage Run timing fields.
+- Durations are the authoritative elapsed-time evidence when present.
+- Unix-ms timestamps are wall-clock anchors and may be coarser than durations.
+- Ordinary tracing log timestamps are not enough for completed-span import; completed spans need explicit start/end timing and semantic tt.* fields.
+
 ## Direct Run JSON path
 
 Use `run_json_path(...)` when you want to skip a separate import step and write Run JSON through the same robust writer path used by native capture sinks:


### PR DESCRIPTION
### Motivation

- Provide a clear, repository-wide timing contract so captures, tracing imports, and the analyzer share the same expectations about which fields are authoritative for elapsed-time analysis. 
- Avoid accidental use of wall-clock timestamp subtraction for latency scoring and make temporal attribution rules explicit for readers and integrators.

### Description

- Add a "Timing model" section to `tailtriage-core/README.md` that states duration fields in microseconds are authoritative for elapsed-time analysis, unix-ms timestamps are wall-clock anchors (which can be coarse or move with system clock changes), analyzer scoring uses duration fields, and temporal segmentation may fall back to wall-clock timestamps when no run-relative timing is available. (`tailtriage-core/README.md`).
- Add concise rustdoc comments to `tailtriage-core/src/events.rs` on `RequestEvent`, `StageEvent`, `QueueEvent`, `InFlightSnapshot`, and `RuntimeSnapshot` that explain duration-authoritative vs wall-clock-anchor semantics without altering any schema fields. (`tailtriage-core/src/events.rs`).
- Add a matching "Timing model" section to `tailtriage-tracing/README.md` clarifying that imported/live tracing evidence is converted to Run timing fields, durations are authoritative when present, unix-ms timestamps are wall-clock anchors, and completed-span import requires explicit start/end timing and semantic `tt.*` fields. (`tailtriage-tracing/README.md`).
- Add an analyzer regression test proving analyzer percentile computation uses `latency_us` rather than subtracting `started_at_unix_ms`/`finished_at_unix_ms`; the test constructs a `Run` where timestamps imply 1ms but `latency_us` is 50_000 and asserts `p50/p95/p99 == Some(50_000)`. (`tailtriage-analyzer/src/tests.rs`).
- No schema fields were changed, no dependencies were added, and tracing import behavior was not modified.

### Testing

- Ran `cargo fmt --check` (passed). 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` (passed). 
- Ran `cargo test --workspace` (all unit and integration tests passed). 
- Ran `python3 scripts/validate_docs_contracts.py` (docs contract validation passed). 
- Ran `cargo test --workspace --all-targets --all-features --locked` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d40da7dc48330bf37ce1fd9c9616c)