### PR TITLE
Document repository-wide timing contract

### DIFF
--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -103,6 +103,26 @@ fn runtime_snapshot(
 }
 
 #[test]
+fn request_latency_percentiles_use_duration_fields_not_wall_clock_subtraction() {
+    let mut run = test_run();
+    run.requests = vec![RequestEvent {
+        request_id: "req-duration".to_owned(),
+        route: "/duration".to_owned(),
+        kind: None,
+        started_at_unix_ms: 1_000,
+        finished_at_unix_ms: 1_001,
+        latency_us: 50_000,
+        outcome: "ok".to_owned(),
+    }];
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert_eq!(report.p50_latency_us, Some(50_000));
+    assert_eq!(report.p95_latency_us, Some(50_000));
+    assert_eq!(report.p99_latency_us, Some(50_000));
+}
+
+#[test]
 fn downstream_stage_tie_break_is_deterministic() {
     let mut run = test_run();
     run.stages = vec![

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -81,6 +81,14 @@ async fn demo() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+## Timing model
+
+- Duration fields in microseconds (`latency_us`, `wait_us`, stage `latency_us`) are authoritative for elapsed-time analysis.
+- Unix millisecond timestamps are wall-clock anchors for log correlation, artifact readability, and coarse temporal grouping.
+- Wall-clock timestamps can be coarse and can move if the system clock changes.
+- Analyzer scoring uses duration fields for latency, queue wait, and stage duration.
+- Temporal segmentation may use wall-clock timestamps when no monotonic run-relative timing is available, so runtime/in-flight attribution can be approximate.
+
 ## Output sinks
 
 `tailtriage-core` captures run data and finalizes through a sink. It does not perform analysis/report generation.

--- a/tailtriage-core/src/events.rs
+++ b/tailtriage-core/src/events.rs
@@ -223,6 +223,10 @@ pub struct UnfinishedRequestSample {
 }
 
 /// Per-request timing and status.
+///
+/// Duration fields are authoritative elapsed-time evidence. Unix-millisecond
+/// timestamps are wall-clock anchors for correlation, readability, and coarse
+/// grouping; they may be coarse or move when the system clock changes.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RequestEvent {
     /// Correlation ID for the request.
@@ -242,6 +246,10 @@ pub struct RequestEvent {
 }
 
 /// Timing record for one named stage.
+///
+/// Duration fields are authoritative elapsed-time evidence. Unix-millisecond
+/// timestamps are wall-clock anchors for correlation, readability, and coarse
+/// grouping; they may be coarse or move when the system clock changes.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StageEvent {
     /// Parent request ID.
@@ -260,6 +268,10 @@ pub struct StageEvent {
 }
 
 /// Queue wait measurement for a request waiting on a queue/permit.
+///
+/// Duration fields are authoritative elapsed-time evidence. Unix-millisecond
+/// timestamps are wall-clock anchors for correlation, readability, and coarse
+/// grouping; they may be coarse or move when the system clock changes.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct QueueEvent {
     /// Parent request ID.
@@ -277,6 +289,10 @@ pub struct QueueEvent {
 }
 
 /// Point-in-time in-flight gauge reading.
+///
+/// Unix-millisecond timestamps are wall-clock anchors for correlation,
+/// readability, and coarse temporal grouping; runtime/in-flight attribution may
+/// be approximate when no monotonic run-relative timing is available.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InFlightSnapshot {
     /// Gauge name.
@@ -288,6 +304,10 @@ pub struct InFlightSnapshot {
 }
 
 /// Point-in-time runtime metrics sample.
+///
+/// Unix-millisecond timestamps are wall-clock anchors for correlation,
+/// readability, and coarse temporal grouping; runtime/in-flight attribution may
+/// be approximate when no monotonic run-relative timing is available.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RuntimeSnapshot {
     /// Timestamp (milliseconds since epoch UTC).

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -20,6 +20,13 @@ This crate converts tracing-shaped request, stage, and queue evidence into stand
 
 For one work item, every request, stage, and queue span must carry the same `tt.request_id`. Child stage/queue evidence is correlated to retained request evidence by `tt.request_id`; missing or inconsistent IDs cause child evidence to be skipped or weakened.
 
+## Timing model
+
+- Imported or live tracing evidence is converted to normal tailtriage Run timing fields.
+- Durations are the authoritative elapsed-time evidence when present.
+- Unix-ms timestamps are wall-clock anchors and may be coarser than durations.
+- Ordinary tracing log timestamps are not enough for completed-span import; completed spans need explicit start/end timing and semantic tt.* fields.
+
 ## Feature flags
 
 - Base crate: typed `SpanRecord`, `ImportOptions`, `ImportedRun`, semantic constants, and `run_from_span_records(...)`.


### PR DESCRIPTION
### Motivation

- Make the repo-wide timing semantics explicit so analyzer behavior and tracing imports are unambiguous about authoritative elapsed-time fields vs wall-clock anchors. 

### Description

- Added a concise "Timing model" section to `tailtriage-core/README.md` that declares duration fields (`latency_us`, `wait_us`, stage `latency_us`) as authoritative and unix-ms timestamps as wall-clock anchors, and notes how temporal segmentation may be approximate when monotonic timing is unavailable. 
- Added matching concise rustdoc comments near the core event/snapshot structs in `tailtriage-core/src/events.rs` for `RequestEvent`, `StageEvent`, `QueueEvent`, `InFlightSnapshot`, and `RuntimeSnapshot` asserting the same duration-authoritative vs wall-clock-anchor semantics. 
- Added a concise "Timing model" section to `tailtriage-tracing/README.md` stating that tracing evidence converts to Run timing fields, durations are authoritative when present, unix-ms timestamps are wall-clock anchors, and completed-span import requires explicit start/end timing plus semantic `tt.*` fields. 
- Added an analyzer regression test `request_latency_percentiles_use_duration_fields_not_wall_clock_subtraction` in `tailtriage-analyzer/src/tests.rs` that constructs a `Run` whose unix-ms start/finish imply 1 ms but whose `latency_us` is 50_000, then asserts analyzer percentiles (`p50/p95/p99`) equal 50_000 to lock down analyzer reliance on duration fields.

### Testing

- Ran `cargo fmt --check` which passed. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` which passed. 
- Ran the full test suite with `cargo test --workspace` and `cargo test --workspace --all-targets --all-features --locked`, and all tests passed. 
- Ran `python3 scripts/validate_docs_contracts.py` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d40da7dc48330bf37ce1fd9c9616c)