### PR TITLE
Document repository timing contract

### DIFF
--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -103,6 +103,26 @@ fn runtime_snapshot(
 }
 
 #[test]
+fn latency_percentiles_use_duration_fields_not_wall_clock_subtraction() {
+    let mut run = test_run();
+    run.requests = vec![RequestEvent {
+        request_id: "req-1".to_owned(),
+        route: "/test".to_owned(),
+        kind: None,
+        started_at_unix_ms: 1,
+        finished_at_unix_ms: 2,
+        latency_us: 50_000,
+        outcome: "ok".to_owned(),
+    }];
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert_eq!(report.p50_latency_us, Some(50_000));
+    assert_eq!(report.p95_latency_us, Some(50_000));
+    assert_eq!(report.p99_latency_us, Some(50_000));
+}
+
+#[test]
 fn downstream_stage_tie_break_is_deterministic() {
     let mut run = test_run();
     run.stages = vec![

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -138,6 +138,15 @@ req.queue("ingress")
 # }
 ```
 
+
+## Timing model
+
+- Duration fields in microseconds (`latency_us`, `wait_us`, stage `latency_us`) are authoritative for elapsed-time analysis.
+- Unix millisecond timestamps are wall-clock anchors for log correlation, artifact readability, and coarse temporal grouping.
+- Wall-clock timestamps can be coarse and can move if the system clock changes.
+- Analyzer scoring uses duration fields for latency, queue wait, and stage duration.
+- Temporal segmentation may use wall-clock timestamps when no monotonic run-relative timing is available, so runtime/in-flight attribution can be approximate.
+
 ## Lifecycle contract
 
 - `queue(...)`, `stage(...)`, and `inflight(...)` do **not** finish requests.

--- a/tailtriage-core/src/events.rs
+++ b/tailtriage-core/src/events.rs
@@ -223,6 +223,12 @@ pub struct UnfinishedRequestSample {
 }
 
 /// Per-request timing and status.
+///
+/// Duration fields are authoritative for elapsed-time analysis; unix-ms
+/// timestamps are wall-clock anchors for log correlation, artifact readability,
+/// and coarse temporal grouping. Wall-clock anchors may be coarse or move if
+/// the system clock changes, so analyzer scoring uses duration fields where
+/// present.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RequestEvent {
     /// Correlation ID for the request.
@@ -242,6 +248,12 @@ pub struct RequestEvent {
 }
 
 /// Timing record for one named stage.
+///
+/// Duration fields are authoritative for elapsed-time analysis; unix-ms
+/// timestamps are wall-clock anchors for log correlation, artifact readability,
+/// and coarse temporal grouping. Wall-clock anchors may be coarse or move if
+/// the system clock changes, so analyzer scoring uses duration fields where
+/// present.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StageEvent {
     /// Parent request ID.
@@ -260,6 +272,12 @@ pub struct StageEvent {
 }
 
 /// Queue wait measurement for a request waiting on a queue/permit.
+///
+/// Duration fields are authoritative for elapsed-time analysis; unix-ms
+/// timestamps are wall-clock anchors for log correlation, artifact readability,
+/// and coarse temporal grouping. Wall-clock anchors may be coarse or move if
+/// the system clock changes, so analyzer scoring uses duration fields where
+/// present.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct QueueEvent {
     /// Parent request ID.
@@ -277,6 +295,11 @@ pub struct QueueEvent {
 }
 
 /// Point-in-time in-flight gauge reading.
+///
+/// Unix-ms timestamps are wall-clock anchors for log correlation, artifact
+/// readability, and coarse temporal grouping. When no monotonic run-relative
+/// timing is available, temporal segmentation may use these anchors and
+/// in-flight attribution can be approximate.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InFlightSnapshot {
     /// Gauge name.
@@ -288,6 +311,11 @@ pub struct InFlightSnapshot {
 }
 
 /// Point-in-time runtime metrics sample.
+///
+/// Unix-ms timestamps are wall-clock anchors for log correlation, artifact
+/// readability, and coarse temporal grouping. When no monotonic run-relative
+/// timing is available, temporal segmentation may use these anchors and
+/// runtime attribution can be approximate.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RuntimeSnapshot {
     /// Timestamp (milliseconds since epoch UTC).

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -122,6 +122,14 @@ first output may already exist as a finalized artifact. For production workflows
 need one canonical shutdown artifact, prefer `run_json_path(...)`. Completed-span JSONL
 remains a replay/debug export, not trace archival.
 
+
+## Timing model
+
+- Imported or live tracing evidence is converted to normal tailtriage Run timing fields.
+- Durations are the authoritative elapsed-time evidence when present.
+- Unix-ms timestamps are wall-clock anchors and may be coarser than durations.
+- Ordinary tracing log timestamps are not enough for completed-span import; completed spans need explicit start/end timing and semantic tt.* fields.
+
 ## Stable JSONL wrapper format
 
 Stable completed-span JSONL records use this wrapper:


### PR DESCRIPTION
### Motivation

- Define and document a repository-wide timing contract so consumers and integrators understand which fields are authoritative for elapsed-time analysis and how wall-clock timestamps are used for correlation and grouping.  
- Make the analyzer's dependence on duration fields explicit and add a regression test preventing accidental reliance on timestamp subtraction.  

### Description

- Add a "Timing model" section to `tailtriage-core/README.md` describing that duration fields in microseconds are authoritative, unix-ms timestamps are wall-clock anchors, wall-clock timestamps may be coarse or move, analyzer scoring uses duration fields, and temporal segmentation may fall back to wall-clock anchors when monotonic timing is unavailable.  
- Add a matching "Timing model" section to `tailtriage-tracing/README.md` clarifying that imported/live tracing evidence is converted to Run timing fields, durations are authoritative, unix-ms timestamps are wall-clock anchors, and completed-span import requires explicit start/end timing and semantic `tt.*` fields.  
- Add concise rustdoc comments to `tailtriage-core/src/events.rs` for `RequestEvent`, `StageEvent`, `QueueEvent`, `InFlightSnapshot`, and `RuntimeSnapshot` conveying the duration-authoritative vs wall-clock-anchor semantics and noting that attribution based on wall-clock anchors can be approximate.  
- Add an analyzer regression test `latency_percentiles_use_duration_fields_not_wall_clock_subtraction` in `tailtriage-analyzer/src/tests.rs` which assembles a `Run` where unix-ms timestamps imply 1ms but `latency_us == 50_000`, calls `analyze_run`, and asserts p50/p95/p99 equal `Some(50_000)`.  

### Testing

- Ran `cargo fmt --check` and it passed.  
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and it passed.  
- Ran `cargo test --workspace` and all unit and doc tests passed.  
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed.  
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d40da7dc48330bf37ce1fd9c9616c)