### PR TITLE
Centralize native core interval timing

### DIFF
--- a/tailtriage-core/src/collector.rs
+++ b/tailtriage-core/src/collector.rs
@@ -3,9 +3,9 @@ use std::ffi::OsString;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
-use std::time::{Duration, Instant};
 
 use crate::config::Config;
+use crate::time::{finish_interval, start_interval, FinishedInterval, IntervalStart};
 use crate::InflightGuard;
 use crate::RunSink;
 use crate::{
@@ -97,8 +97,7 @@ struct PendingRequest {
     request_id: String,
     route: String,
     kind: Option<String>,
-    started_at_unix_ms: u64,
-    started: Instant,
+    interval_start: IntervalStart,
 }
 
 impl std::fmt::Debug for Tailtriage {
@@ -196,6 +195,7 @@ pub struct OwnedRequestHandle {
 pub struct RequestCompletion<'a> {
     tailtriage: &'a Tailtriage,
     pending_key: u64,
+    interval_start: IntervalStart,
     finished: bool,
 }
 
@@ -208,6 +208,7 @@ pub struct RequestCompletion<'a> {
 pub struct OwnedRequestCompletion {
     tailtriage: Arc<Tailtriage>,
     pending_key: u64,
+    interval_start: IntervalStart,
     finished: bool,
 }
 
@@ -292,7 +293,8 @@ impl Tailtriage {
         route: impl Into<String>,
         options: RequestOptions,
     ) -> StartedRequest<'_> {
-        let (request_id, route, kind, pending_key) = self.start_request(route.into(), options);
+        let (request_id, route, kind, pending_key, interval_start) =
+            self.start_request(route.into(), options);
 
         StartedRequest {
             handle: RequestHandle {
@@ -304,6 +306,7 @@ impl Tailtriage {
             completion: RequestCompletion {
                 tailtriage: self,
                 pending_key,
+                interval_start,
                 finished: false,
             },
         }
@@ -325,7 +328,8 @@ impl Tailtriage {
         route: impl Into<String>,
         options: RequestOptions,
     ) -> OwnedStartedRequest {
-        let (request_id, route, kind, pending_key) = self.start_request(route.into(), options);
+        let (request_id, route, kind, pending_key, interval_start) =
+            self.start_request(route.into(), options);
 
         OwnedStartedRequest {
             handle: OwnedRequestHandle {
@@ -337,6 +341,7 @@ impl Tailtriage {
             completion: OwnedRequestCompletion {
                 tailtriage: Arc::clone(self),
                 pending_key,
+                interval_start,
                 finished: false,
             },
         }
@@ -593,22 +598,22 @@ impl Tailtriage {
         &self,
         route: String,
         options: RequestOptions,
-    ) -> (String, String, Option<String>, u64) {
+    ) -> (String, String, Option<String>, u64, IntervalStart) {
         let request_id = options
             .request_id
             .unwrap_or_else(|| generate_request_id(&route));
         let pending_key = PENDING_SEQUENCE.fetch_add(1, Ordering::Relaxed);
         let kind = options.kind;
+        let interval_start = start_interval();
         let pending = PendingRequest {
             request_id: request_id.clone(),
             route: route.clone(),
             kind: kind.clone(),
-            started_at_unix_ms: unix_time_ms(),
-            started: Instant::now(),
+            interval_start,
         };
         lock_pending(&self.pending_requests).insert(pending_key, pending);
 
-        (request_id, route, kind, pending_key)
+        (request_id, route, kind, pending_key, interval_start)
     }
 }
 
@@ -703,6 +708,7 @@ impl RequestCompletion<'_> {
             return;
         }
 
+        let finished = finish_interval(self.interval_start);
         let pending = lock_pending(&self.tailtriage.pending_requests).remove(&self.pending_key);
         let Some(pending) = pending else {
             debug_assert!(
@@ -714,15 +720,8 @@ impl RequestCompletion<'_> {
         };
         self.finished = true;
 
-        self.tailtriage.record_request_event(RequestEvent {
-            request_id: pending.request_id,
-            route: pending.route,
-            kind: pending.kind,
-            started_at_unix_ms: pending.started_at_unix_ms,
-            finished_at_unix_ms: unix_time_ms(),
-            latency_us: duration_to_us(pending.started.elapsed()),
-            outcome: outcome.into_string(),
-        });
+        self.tailtriage
+            .record_request_event(request_event_from_finished(pending, finished, outcome));
     }
 }
 
@@ -817,6 +816,7 @@ impl OwnedRequestCompletion {
             return;
         }
 
+        let finished = finish_interval(self.interval_start);
         let pending = lock_pending(&self.tailtriage.pending_requests).remove(&self.pending_key);
         let Some(pending) = pending else {
             self.finished = true;
@@ -824,15 +824,8 @@ impl OwnedRequestCompletion {
         };
         self.finished = true;
 
-        self.tailtriage.record_request_event(RequestEvent {
-            request_id: pending.request_id,
-            route: pending.route,
-            kind: pending.kind,
-            started_at_unix_ms: pending.started_at_unix_ms,
-            finished_at_unix_ms: unix_time_ms(),
-            latency_us: duration_to_us(pending.started.elapsed()),
-            outcome: outcome.into_string(),
-        });
+        self.tailtriage
+            .record_request_event(request_event_from_finished(pending, finished, outcome));
     }
 }
 
@@ -851,6 +844,26 @@ impl Drop for OwnedRequestCompletion {
             self.finished || std::thread::panicking(),
             "tailtriage request completion dropped without finish(...), finish_ok(), or finish_result(...)"
         );
+    }
+}
+
+fn request_event_from_finished(
+    pending: PendingRequest,
+    finished: FinishedInterval,
+    outcome: Outcome,
+) -> RequestEvent {
+    debug_assert_eq!(
+        pending.interval_start.started_at_unix_ms,
+        finished.started_at_unix_ms
+    );
+    RequestEvent {
+        request_id: pending.request_id,
+        route: pending.route,
+        kind: pending.kind,
+        started_at_unix_ms: pending.interval_start.started_at_unix_ms,
+        finished_at_unix_ms: finished.finished_at_unix_ms,
+        latency_us: finished.duration_us,
+        outcome: outcome.into_string(),
     }
 }
 
@@ -877,10 +890,6 @@ fn lock_pending(
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     }
-}
-
-pub(crate) fn duration_to_us(duration: Duration) -> u64 {
-    duration.as_micros().try_into().unwrap_or(u64::MAX)
 }
 
 pub(crate) fn generate_run_id() -> String {

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -2,6 +2,7 @@ use std::future::ready;
 #[cfg(debug_assertions)]
 use std::panic::AssertUnwindSafe;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use crate::{
     BuildError, CaptureLimits, CaptureLimitsOverride, CaptureMode, EffectiveTokioSamplerConfig,
@@ -142,6 +143,39 @@ fn queue_stage_and_inflight_are_recorded() {
     assert_eq!(snapshot.inflight.len(), 2);
     assert_eq!(snapshot.queues.len(), 1);
     assert_eq!(snapshot.stages.len(), 1);
+}
+
+#[test]
+fn slept_request_stage_and_queue_record_ordered_positive_durations() {
+    let tailtriage = build_for_test("payments", "tailtriage-core-slept-timers.json");
+    let started =
+        tailtriage.begin_request_with("/invoice", RequestOptions::new().request_id("req-sleep"));
+    let request = started.handle;
+
+    futures_executor::block_on(request.queue("permit").await_on(async {
+        std::thread::sleep(Duration::from_millis(1));
+    }));
+    futures_executor::block_on(request.stage("persist").await_value(async {
+        std::thread::sleep(Duration::from_millis(1));
+    }));
+    std::thread::sleep(Duration::from_millis(1));
+    started.completion.finish_ok();
+
+    let snapshot = tailtriage.snapshot();
+    let request = snapshot
+        .requests
+        .first()
+        .expect("request should be recorded");
+    assert!(request.finished_at_unix_ms >= request.started_at_unix_ms);
+    assert!(request.latency_us > 0);
+
+    let stage = snapshot.stages.first().expect("stage should be recorded");
+    assert!(stage.finished_at_unix_ms >= stage.started_at_unix_ms);
+    assert!(stage.latency_us > 0);
+
+    let queue = snapshot.queues.first().expect("queue should be recorded");
+    assert!(queue.waited_until_unix_ms >= queue.waited_from_unix_ms);
+    assert!(queue.wait_us > 0);
 }
 
 #[test]

--- a/tailtriage-core/src/time.rs
+++ b/tailtriage-core/src/time.rs
@@ -1,4 +1,44 @@
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+/// Monotonic and wall-clock start samples for an interval.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct IntervalStart {
+    pub(crate) started_at_unix_ms: u64,
+    pub(crate) started: Instant,
+}
+
+/// Completed interval timing derived from a shared start sample.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FinishedInterval {
+    pub(crate) started_at_unix_ms: u64,
+    pub(crate) finished_at_unix_ms: u64,
+    pub(crate) duration_us: u64,
+}
+
+/// Starts an interval by sampling wall-clock and monotonic time.
+#[must_use]
+pub(crate) fn start_interval() -> IntervalStart {
+    IntervalStart {
+        started_at_unix_ms: unix_time_ms(),
+        started: Instant::now(),
+    }
+}
+
+/// Finishes an interval by sampling wall-clock time and using monotonic elapsed duration.
+#[must_use]
+pub(crate) fn finish_interval(start: IntervalStart) -> FinishedInterval {
+    FinishedInterval {
+        started_at_unix_ms: start.started_at_unix_ms,
+        finished_at_unix_ms: unix_time_ms(),
+        duration_us: duration_to_us(start.started.elapsed()),
+    }
+}
+
+/// Converts a [`Duration`] to microseconds, saturating at [`u64::MAX`].
+#[must_use]
+pub(crate) fn duration_to_us(duration: Duration) -> u64 {
+    duration.as_micros().try_into().unwrap_or(u64::MAX)
+}
 
 /// Converts a [`Duration`] since [`UNIX_EPOCH`] to unix epoch milliseconds,
 /// saturating at [`u64::MAX`].
@@ -27,7 +67,10 @@ pub fn unix_time_ms() -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{duration_to_unix_ms, system_time_to_unix_ms};
+    use super::{
+        duration_to_unix_ms, duration_to_us, finish_interval, start_interval,
+        system_time_to_unix_ms,
+    };
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     #[test]
@@ -51,5 +94,24 @@ mod tests {
             system_time_to_unix_ms(SystemTime::UNIX_EPOCH + Duration::from_secs(1)),
             1_000
         );
+    }
+
+    #[test]
+    fn duration_to_us_saturates_on_overflow() {
+        let overflow_duration = Duration::from_micros(u64::MAX)
+            .checked_add(Duration::from_micros(1))
+            .expect("overflow test duration should be representable");
+
+        assert_eq!(duration_to_us(overflow_duration), u64::MAX);
+        assert_eq!(duration_to_us(Duration::from_micros(123)), 123);
+    }
+
+    #[test]
+    fn finish_interval_preserves_timestamp_ordering() {
+        let start = start_interval();
+        let finished = finish_interval(start);
+
+        assert!(finished.finished_at_unix_ms >= finished.started_at_unix_ms);
+        assert!(i128::from(finished.duration_us) >= 0);
     }
 }

--- a/tailtriage-core/src/timers.rs
+++ b/tailtriage-core/src/timers.rs
@@ -1,6 +1,5 @@
-use std::time::Instant;
-
-use crate::collector::{duration_to_us, lock_map};
+use crate::collector::lock_map;
+use crate::time::{finish_interval, start_interval};
 use crate::{unix_time_ms, InFlightSnapshot, QueueEvent, StageEvent, Tailtriage};
 
 /// RAII guard tracking one in-flight unit for a named gauge.
@@ -64,18 +63,17 @@ impl StageTimer<'_> {
             return fut.await;
         }
 
-        let started_at_unix_ms = unix_time_ms();
-        let started = Instant::now();
+        let started = start_interval();
         let value = fut.await;
-        let finished_at_unix_ms = unix_time_ms();
+        let finished = finish_interval(started);
         let success = value.is_ok();
 
         self.tailtriage.record_stage_event(StageEvent {
             request_id: self.request_id,
             stage: self.stage,
-            started_at_unix_ms,
-            finished_at_unix_ms,
-            latency_us: duration_to_us(started.elapsed()),
+            started_at_unix_ms: finished.started_at_unix_ms,
+            finished_at_unix_ms: finished.finished_at_unix_ms,
+            latency_us: finished.duration_us,
             success,
         });
 
@@ -94,17 +92,16 @@ impl StageTimer<'_> {
             return fut.await;
         }
 
-        let started_at_unix_ms = unix_time_ms();
-        let started = Instant::now();
+        let started = start_interval();
         let value = fut.await;
-        let finished_at_unix_ms = unix_time_ms();
+        let finished = finish_interval(started);
 
         self.tailtriage.record_stage_event(StageEvent {
             request_id: self.request_id,
             stage: self.stage,
-            started_at_unix_ms,
-            finished_at_unix_ms,
-            latency_us: duration_to_us(started.elapsed()),
+            started_at_unix_ms: finished.started_at_unix_ms,
+            finished_at_unix_ms: finished.finished_at_unix_ms,
+            latency_us: finished.duration_us,
             success: true,
         });
 
@@ -143,17 +140,16 @@ impl QueueTimer<'_> {
             return fut.await;
         }
 
-        let waited_from_unix_ms = unix_time_ms();
-        let started = Instant::now();
+        let started = start_interval();
         let value = fut.await;
-        let waited_until_unix_ms = unix_time_ms();
+        let finished = finish_interval(started);
 
         self.tailtriage.record_queue_event(QueueEvent {
             request_id: self.request_id,
             queue: self.queue,
-            waited_from_unix_ms,
-            waited_until_unix_ms,
-            wait_us: duration_to_us(started.elapsed()),
+            waited_from_unix_ms: finished.started_at_unix_ms,
+            waited_until_unix_ms: finished.finished_at_unix_ms,
+            wait_us: finished.duration_us,
             depth_at_start: self.depth_at_start,
         });
 


### PR DESCRIPTION
### Motivation
- Reduce instrumentation overhead noise by centralizing monotonic + wall-clock interval sampling so request finish `latency_us` is measured before pending-map lock/removal overhead can be included.
- Provide a single shared implementation for stage/queue/request timing to avoid duplicated `unix_time_ms()` + `Instant::now()` pairs.
- Keep public schema and tracing crate untouched while improving timing fidelity.

### Description
- Added interval timing helpers in `tailtriage-core/src/time.rs`: crate-visible structs `IntervalStart` and `FinishedInterval`, and functions `start_interval()`, `finish_interval(start: IntervalStart)`, and `duration_to_us(Duration)`; moved the previous `duration_to_us` into `time.rs`.
- Updated request lifecycle in `tailtriage-core/src/collector.rs` so `PendingRequest` stores an `IntervalStart`; `start_request()` uses `start_interval()`; `RequestCompletion::finish_internal` and `OwnedRequestCompletion::finish_internal` call `finish_interval(...)` and then lock/remove the pending entry, ensuring the monotonic duration and finish wall time are sampled before pending-map lock/removal overhead is incurred; a helper `request_event_from_finished` constructs the `RequestEvent`.
- Updated timers in `tailtriage-core/src/timers.rs` so `StageTimer::await_on`, `StageTimer::await_value`, and `QueueTimer::await_on` use `start_interval()` / `finish_interval()` and the shared `duration_to_us` rather than ad-hoc `unix_time_ms()` + `Instant::now()` pairs while preserving recorded fields.
- Kept `InFlightSnapshot` timing as a point-in-time `unix_time_ms()` sample and did not add any schema fields or modify `tailtriage-tracing`.
- Added tests: unit test for `duration_to_us` saturation and `finish_interval` ordering in `time.rs`, and a test that sleeps at least 1ms for request/stage/queue timing asserting non-negative ordering and positive durations in `tests.rs`.

### Testing
- Ran `cargo fmt --check` (passed).
- Ran `cargo clippy --workspace --all-targets -- -D warnings` (passed with no warnings turned into errors).
- Ran `cargo test --workspace` (all tests passed).
- Ran `python3 scripts/validate_docs_contracts.py` (validated successfully).
- Ran `cargo test --workspace --all-targets --all-features --locked` (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d5758e0548330b31e7d2be26a65c3)