### PR TITLE
Centralize core interval timing and sample finish before pending-map lock

### DIFF
--- a/tailtriage-core/src/collector.rs
+++ b/tailtriage-core/src/collector.rs
@@ -3,9 +3,9 @@ use std::ffi::OsString;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
-use std::time::{Duration, Instant};
 
 use crate::config::Config;
+use crate::time::{finish_interval, start_interval, FinishedInterval, IntervalStart};
 use crate::InflightGuard;
 use crate::RunSink;
 use crate::{
@@ -97,8 +97,7 @@ struct PendingRequest {
     request_id: String,
     route: String,
     kind: Option<String>,
-    started_at_unix_ms: u64,
-    started: Instant,
+    interval_start: IntervalStart,
 }
 
 impl std::fmt::Debug for Tailtriage {
@@ -196,6 +195,7 @@ pub struct OwnedRequestHandle {
 pub struct RequestCompletion<'a> {
     tailtriage: &'a Tailtriage,
     pending_key: u64,
+    interval_start: IntervalStart,
     finished: bool,
 }
 
@@ -208,6 +208,7 @@ pub struct RequestCompletion<'a> {
 pub struct OwnedRequestCompletion {
     tailtriage: Arc<Tailtriage>,
     pending_key: u64,
+    interval_start: IntervalStart,
     finished: bool,
 }
 
@@ -292,7 +293,8 @@ impl Tailtriage {
         route: impl Into<String>,
         options: RequestOptions,
     ) -> StartedRequest<'_> {
-        let (request_id, route, kind, pending_key) = self.start_request(route.into(), options);
+        let (request_id, route, kind, pending_key, interval_start) =
+            self.start_request(route.into(), options);
 
         StartedRequest {
             handle: RequestHandle {
@@ -304,6 +306,7 @@ impl Tailtriage {
             completion: RequestCompletion {
                 tailtriage: self,
                 pending_key,
+                interval_start,
                 finished: false,
             },
         }
@@ -325,7 +328,8 @@ impl Tailtriage {
         route: impl Into<String>,
         options: RequestOptions,
     ) -> OwnedStartedRequest {
-        let (request_id, route, kind, pending_key) = self.start_request(route.into(), options);
+        let (request_id, route, kind, pending_key, interval_start) =
+            self.start_request(route.into(), options);
 
         OwnedStartedRequest {
             handle: OwnedRequestHandle {
@@ -337,6 +341,7 @@ impl Tailtriage {
             completion: OwnedRequestCompletion {
                 tailtriage: Arc::clone(self),
                 pending_key,
+                interval_start,
                 finished: false,
             },
         }
@@ -593,22 +598,22 @@ impl Tailtriage {
         &self,
         route: String,
         options: RequestOptions,
-    ) -> (String, String, Option<String>, u64) {
+    ) -> (String, String, Option<String>, u64, IntervalStart) {
         let request_id = options
             .request_id
             .unwrap_or_else(|| generate_request_id(&route));
         let pending_key = PENDING_SEQUENCE.fetch_add(1, Ordering::Relaxed);
         let kind = options.kind;
+        let interval_start = start_interval();
         let pending = PendingRequest {
             request_id: request_id.clone(),
             route: route.clone(),
             kind: kind.clone(),
-            started_at_unix_ms: unix_time_ms(),
-            started: Instant::now(),
+            interval_start,
         };
         lock_pending(&self.pending_requests).insert(pending_key, pending);
 
-        (request_id, route, kind, pending_key)
+        (request_id, route, kind, pending_key, interval_start)
     }
 }
 
@@ -703,6 +708,7 @@ impl RequestCompletion<'_> {
             return;
         }
 
+        let finished = finish_interval(self.interval_start);
         let pending = lock_pending(&self.tailtriage.pending_requests).remove(&self.pending_key);
         let Some(pending) = pending else {
             debug_assert!(
@@ -714,15 +720,10 @@ impl RequestCompletion<'_> {
         };
         self.finished = true;
 
-        self.tailtriage.record_request_event(RequestEvent {
-            request_id: pending.request_id,
-            route: pending.route,
-            kind: pending.kind,
-            started_at_unix_ms: pending.started_at_unix_ms,
-            finished_at_unix_ms: unix_time_ms(),
-            latency_us: duration_to_us(pending.started.elapsed()),
-            outcome: outcome.into_string(),
-        });
+        self.tailtriage
+            .record_request_event(request_event_from_finished_interval(
+                pending, finished, outcome,
+            ));
     }
 }
 
@@ -817,6 +818,7 @@ impl OwnedRequestCompletion {
             return;
         }
 
+        let finished = finish_interval(self.interval_start);
         let pending = lock_pending(&self.tailtriage.pending_requests).remove(&self.pending_key);
         let Some(pending) = pending else {
             self.finished = true;
@@ -824,15 +826,30 @@ impl OwnedRequestCompletion {
         };
         self.finished = true;
 
-        self.tailtriage.record_request_event(RequestEvent {
-            request_id: pending.request_id,
-            route: pending.route,
-            kind: pending.kind,
-            started_at_unix_ms: pending.started_at_unix_ms,
-            finished_at_unix_ms: unix_time_ms(),
-            latency_us: duration_to_us(pending.started.elapsed()),
-            outcome: outcome.into_string(),
-        });
+        self.tailtriage
+            .record_request_event(request_event_from_finished_interval(
+                pending, finished, outcome,
+            ));
+    }
+}
+
+fn request_event_from_finished_interval(
+    pending: PendingRequest,
+    finished: FinishedInterval,
+    outcome: Outcome,
+) -> RequestEvent {
+    debug_assert_eq!(
+        pending.interval_start.started_at_unix_ms,
+        finished.started_at_unix_ms
+    );
+    RequestEvent {
+        request_id: pending.request_id,
+        route: pending.route,
+        kind: pending.kind,
+        started_at_unix_ms: finished.started_at_unix_ms,
+        finished_at_unix_ms: finished.finished_at_unix_ms,
+        latency_us: finished.duration_us,
+        outcome: outcome.into_string(),
     }
 }
 
@@ -877,10 +894,6 @@ fn lock_pending(
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     }
-}
-
-pub(crate) fn duration_to_us(duration: Duration) -> u64 {
-    duration.as_micros().try_into().unwrap_or(u64::MAX)
 }
 
 pub(crate) fn generate_run_id() -> String {

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -145,6 +145,42 @@ fn queue_stage_and_inflight_are_recorded() {
 }
 
 #[test]
+fn request_stage_and_queue_timing_preserves_order_after_sleep() {
+    let tailtriage = build_for_test("payments", "tailtriage-core-sleep-timing.json");
+    let started = tailtriage.begin_request_with(
+        "/sleep",
+        RequestOptions::new().request_id("req-sleep").kind("http"),
+    );
+    let request = started.handle;
+
+    futures_executor::block_on(request.queue("permit").await_on(async {
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }));
+    futures_executor::block_on(request.stage("db").await_value(async {
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }));
+    std::thread::sleep(std::time::Duration::from_millis(1));
+    started.completion.finish_ok();
+
+    let snapshot = tailtriage.snapshot();
+    assert_eq!(snapshot.requests.len(), 1);
+    assert_eq!(snapshot.stages.len(), 1);
+    assert_eq!(snapshot.queues.len(), 1);
+
+    let request = &snapshot.requests[0];
+    assert!(request.finished_at_unix_ms >= request.started_at_unix_ms);
+    assert!(request.latency_us > 0);
+
+    let stage = &snapshot.stages[0];
+    assert!(stage.finished_at_unix_ms >= stage.started_at_unix_ms);
+    assert!(stage.latency_us > 0);
+
+    let queue = &snapshot.queues[0];
+    assert!(queue.waited_until_unix_ms >= queue.waited_from_unix_ms);
+    assert!(queue.wait_us > 0);
+}
+
+#[test]
 fn unfinished_requests_still_trigger_strict_lifecycle_errors() {
     let sink = Arc::new(RecordingSink::default());
     let tailtriage = Tailtriage::builder("payments")

--- a/tailtriage-core/src/time.rs
+++ b/tailtriage-core/src/time.rs
@@ -25,8 +25,8 @@ pub(crate) struct FinishedInterval {
 /// Starts a measured interval using a wall-clock sample and monotonic instant.
 #[must_use]
 pub(crate) fn start_interval() -> IntervalStart {
-    let started = Instant::now();
     let started_at_unix_ms = unix_time_ms();
+    let started = Instant::now();
 
     IntervalStart {
         started_at_unix_ms,

--- a/tailtriage-core/src/time.rs
+++ b/tailtriage-core/src/time.rs
@@ -25,19 +25,25 @@ pub(crate) struct FinishedInterval {
 /// Starts a measured interval using a wall-clock sample and monotonic instant.
 #[must_use]
 pub(crate) fn start_interval() -> IntervalStart {
+    let started = Instant::now();
+    let started_at_unix_ms = unix_time_ms();
+
     IntervalStart {
-        started_at_unix_ms: unix_time_ms(),
-        started: Instant::now(),
+        started_at_unix_ms,
+        started,
     }
 }
 
 /// Finishes a measured interval using wall-clock finish time and monotonic duration.
 #[must_use]
 pub(crate) fn finish_interval(start: IntervalStart) -> FinishedInterval {
+    let finished = Instant::now();
+    let finished_at_unix_ms = unix_time_ms();
+
     FinishedInterval {
         started_at_unix_ms: start.started_at_unix_ms,
-        finished_at_unix_ms: unix_time_ms(),
-        duration_us: duration_to_us(start.started.elapsed()),
+        finished_at_unix_ms,
+        duration_us: duration_to_us(finished.duration_since(start.started)),
     }
 }
 

--- a/tailtriage-core/src/time.rs
+++ b/tailtriage-core/src/time.rs
@@ -1,10 +1,50 @@
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 /// Converts a [`Duration`] since [`UNIX_EPOCH`] to unix epoch milliseconds,
 /// saturating at [`u64::MAX`].
 #[must_use]
 fn duration_to_unix_ms(duration: Duration) -> u64 {
     duration.as_millis().try_into().unwrap_or(u64::MAX)
+}
+
+/// Monotonic and wall-clock start sample for one measured interval.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct IntervalStart {
+    pub(crate) started_at_unix_ms: u64,
+    pub(crate) started: Instant,
+}
+
+/// Completed interval timing derived from a start sample.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct FinishedInterval {
+    pub(crate) started_at_unix_ms: u64,
+    pub(crate) finished_at_unix_ms: u64,
+    pub(crate) duration_us: u64,
+}
+
+/// Starts a measured interval using a wall-clock sample and monotonic instant.
+#[must_use]
+pub(crate) fn start_interval() -> IntervalStart {
+    IntervalStart {
+        started_at_unix_ms: unix_time_ms(),
+        started: Instant::now(),
+    }
+}
+
+/// Finishes a measured interval using wall-clock finish time and monotonic duration.
+#[must_use]
+pub(crate) fn finish_interval(start: IntervalStart) -> FinishedInterval {
+    FinishedInterval {
+        started_at_unix_ms: start.started_at_unix_ms,
+        finished_at_unix_ms: unix_time_ms(),
+        duration_us: duration_to_us(start.started.elapsed()),
+    }
+}
+
+/// Converts a [`Duration`] to microseconds, saturating at [`u64::MAX`].
+#[must_use]
+pub(crate) fn duration_to_us(duration: Duration) -> u64 {
+    duration.as_micros().try_into().unwrap_or(u64::MAX)
 }
 
 /// Converts a [`SystemTime`] to unix epoch milliseconds.
@@ -27,8 +67,33 @@ pub fn unix_time_ms() -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{duration_to_unix_ms, system_time_to_unix_ms};
+    use super::{
+        duration_to_unix_ms, duration_to_us, finish_interval, start_interval,
+        system_time_to_unix_ms,
+    };
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn duration_to_us_saturates_at_u64_max() {
+        assert_eq!(duration_to_us(Duration::from_micros(123)), 123);
+
+        let overflow_duration = Duration::from_micros(u64::MAX)
+            .checked_add(Duration::from_micros(1))
+            .expect("overflow test duration should be representable");
+        assert_eq!(duration_to_us(overflow_duration), u64::MAX);
+    }
+
+    #[test]
+    fn finish_interval_preserves_timestamp_ordering() {
+        let start = start_interval();
+        std::thread::sleep(Duration::from_millis(1));
+
+        let finished = finish_interval(start);
+
+        assert_eq!(finished.started_at_unix_ms, start.started_at_unix_ms);
+        assert!(finished.finished_at_unix_ms >= finished.started_at_unix_ms);
+        assert!(finished.duration_us > 0);
+    }
 
     #[test]
     fn system_time_to_unix_ms_clamps_epoch_and_overflow() {

--- a/tailtriage-core/src/timers.rs
+++ b/tailtriage-core/src/timers.rs
@@ -1,6 +1,5 @@
-use std::time::Instant;
-
-use crate::collector::{duration_to_us, lock_map};
+use crate::collector::lock_map;
+use crate::time::{finish_interval, start_interval};
 use crate::{unix_time_ms, InFlightSnapshot, QueueEvent, StageEvent, Tailtriage};
 
 /// RAII guard tracking one in-flight unit for a named gauge.
@@ -64,18 +63,17 @@ impl StageTimer<'_> {
             return fut.await;
         }
 
-        let started_at_unix_ms = unix_time_ms();
-        let started = Instant::now();
+        let interval_start = start_interval();
         let value = fut.await;
-        let finished_at_unix_ms = unix_time_ms();
+        let finished = finish_interval(interval_start);
         let success = value.is_ok();
 
         self.tailtriage.record_stage_event(StageEvent {
             request_id: self.request_id,
             stage: self.stage,
-            started_at_unix_ms,
-            finished_at_unix_ms,
-            latency_us: duration_to_us(started.elapsed()),
+            started_at_unix_ms: finished.started_at_unix_ms,
+            finished_at_unix_ms: finished.finished_at_unix_ms,
+            latency_us: finished.duration_us,
             success,
         });
 
@@ -94,17 +92,16 @@ impl StageTimer<'_> {
             return fut.await;
         }
 
-        let started_at_unix_ms = unix_time_ms();
-        let started = Instant::now();
+        let interval_start = start_interval();
         let value = fut.await;
-        let finished_at_unix_ms = unix_time_ms();
+        let finished = finish_interval(interval_start);
 
         self.tailtriage.record_stage_event(StageEvent {
             request_id: self.request_id,
             stage: self.stage,
-            started_at_unix_ms,
-            finished_at_unix_ms,
-            latency_us: duration_to_us(started.elapsed()),
+            started_at_unix_ms: finished.started_at_unix_ms,
+            finished_at_unix_ms: finished.finished_at_unix_ms,
+            latency_us: finished.duration_us,
             success: true,
         });
 
@@ -143,17 +140,16 @@ impl QueueTimer<'_> {
             return fut.await;
         }
 
-        let waited_from_unix_ms = unix_time_ms();
-        let started = Instant::now();
+        let interval_start = start_interval();
         let value = fut.await;
-        let waited_until_unix_ms = unix_time_ms();
+        let finished = finish_interval(interval_start);
 
         self.tailtriage.record_queue_event(QueueEvent {
             request_id: self.request_id,
             queue: self.queue,
-            waited_from_unix_ms,
-            waited_until_unix_ms,
-            wait_us: duration_to_us(started.elapsed()),
+            waited_from_unix_ms: finished.started_at_unix_ms,
+            waited_until_unix_ms: finished.finished_at_unix_ms,
+            wait_us: finished.duration_us,
             depth_at_start: self.depth_at_start,
         });
 


### PR DESCRIPTION
### Motivation
- Centralize monotonic + wall-clock interval sampling so all core timing uses a consistent helper and duration conversion logic.
- Ensure recorded request latency excludes pending-map lock/removal overhead by sampling finish timing before acquiring the pending-request lock.
- Keep public behavior and event fields unchanged while reducing instrumentation-induced noise in durations.

### Description
- Add crate-visible interval helpers in `tailtriage-core/src/time.rs`: `IntervalStart`, `FinishedInterval`, `start_interval()`, `finish_interval()`, and `duration_to_us()` (moved from `collector.rs`).
- Store an `IntervalStart` on `PendingRequest` and on completion tokens so the finish time and monotonic duration can be sampled prior to pending-map locking in `collector.rs`.
- In `RequestCompletion::finish_internal` and `OwnedRequestCompletion::finish_internal` sample finish timing with `finish_interval(...)` before removing the pending entry, and produce `RequestEvent` using the finished sample (start wall ms, finish wall ms, monotonic `duration_us`).
- Update `tailtriage-core/src/timers.rs` (`StageTimer::await_on`, `StageTimer::await_value`, `QueueTimer::await_on`) to use `start_interval()` / `finish_interval()` instead of ad-hoc `unix_time_ms()` + `Instant::now()` sampling while preserving event fields.
- Add helper `request_event_from_finished_interval` to translate a pending request + finished sample into a `RequestEvent`.
- Add unit tests: `duration_to_us` saturation, `finish_interval` ordering/duration, and a request/stage/queue timing test that sleeps to assert non-negative timestamp ordering and positive durations.

### Testing
- Run formatting: `cargo fmt --check` — passed.
- Run lints: `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- Run unit and integration tests: `cargo test --workspace` — all tests passed (including new time and sleep-ordering tests).
- Validate docs contract: `python3 scripts/validate_docs_contracts.py` — passed.
- Run strict matrix: `cargo test --workspace --all-targets --all-features --locked` — passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d5758e0548330b31e7d2be26a65c3)