### PR TITLE
Use close wall time in tracing recorder

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -93,7 +93,8 @@ If your service already builds a subscriber in startup code, compose `session.la
 ## Timing model
 
 - Imported or live tracing evidence is converted to normal tailtriage Run timing fields.
-- Durations are the authoritative elapsed-time evidence when present.
+- Live tracing samples finish wall time when the span closes.
+- Duration remains monotonic elapsed time and is the authoritative elapsed-time evidence when present.
 - Unix-ms timestamps are wall-clock anchors and may be coarser than durations.
 - Ordinary tracing log timestamps are not enough for completed-span import; completed spans need explicit start/end timing and semantic tt.* fields.
 

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -728,10 +728,9 @@ where
                 record_incomplete_candidate_issue(&mut state, &open, kind, reason);
                 return;
             }
+            let finished_at_unix_ms = tailtriage_core::unix_time_ms();
             let duration_us =
                 u64::try_from(open.started_instant.elapsed().as_micros()).unwrap_or(u64::MAX);
-            let finished_at_unix_ms =
-                finish_unix_ms_from_started_and_duration(open.started_at_unix_ms, duration_us);
             let mut record =
                 SpanRecord::new(open.name, open.started_at_unix_ms, finished_at_unix_ms)
                     .duration_us(duration_us);
@@ -753,12 +752,6 @@ where
             );
         }
     }
-}
-
-fn finish_unix_ms_from_started_and_duration(started_at_unix_ms: u64, duration_us: u64) -> u64 {
-    let elapsed_ms =
-        (duration_us / 1_000).saturating_add(u64::from(!duration_us.is_multiple_of(1_000)));
-    started_at_unix_ms.saturating_add(elapsed_ms)
 }
 
 fn completed_span_records(state: &RecorderState) -> Vec<SpanRecord> {
@@ -1250,7 +1243,7 @@ impl Visit for FieldVisitor {
 mod tests {
     use super::*;
     use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
-    use tailtriage_core::{MemorySink, Tailtriage};
+    use tailtriage_core::{MemorySink, RequestOptions, Tailtriage};
     use tracing_subscriber::prelude::*;
 
     fn with_recorder<T>(f: impl FnOnce(&TracingRecorder) -> T) -> T {
@@ -1268,57 +1261,6 @@ mod tests {
             .build()
             .expect("collector")
             .snapshot()
-    }
-
-    #[test]
-    fn finish_unix_ms_from_started_and_duration_rounds_up_microseconds() {
-        let start = 1_700_000_000_000;
-        assert_eq!(finish_unix_ms_from_started_and_duration(start, 0), start);
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(start, 1),
-            start + 1
-        );
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(start, 999),
-            start + 1
-        );
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(start, 1_000),
-            start + 1
-        );
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(start, 1_001),
-            start + 2
-        );
-    }
-
-    #[test]
-    fn finish_unix_ms_from_started_and_duration_saturates_on_overflow() {
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(u64::MAX - 1, 1_001),
-            u64::MAX
-        );
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(u64::MAX - 1, u64::MAX),
-            u64::MAX
-        );
-    }
-
-    #[test]
-    fn finish_unix_ms_from_started_and_duration_rounds_extreme_duration_up() {
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(0, u64::MAX),
-            (u64::MAX / 1_000) + 1
-        );
-    }
-
-    #[test]
-    fn finish_unix_ms_from_started_and_duration_keeps_extreme_multiple_exact() {
-        let duration_us = u64::MAX - (u64::MAX % 1_000);
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(0, duration_us),
-            duration_us / 1_000
-        );
     }
 
     #[test]
@@ -1358,7 +1300,7 @@ mod tests {
     }
 
     #[test]
-    fn live_completed_request_uses_positive_elapsed_latency_for_finish_time() {
+    fn live_completed_request_samples_finish_wall_time_and_monotonic_duration() {
         with_recorder(|recorder| {
             let span = tracing::info_span!(
                 "request",
@@ -1373,13 +1315,46 @@ mod tests {
             let request = &snapshot.run().requests[0];
             assert!(request.finished_at_unix_ms >= request.started_at_unix_ms);
             assert!(request.latency_us > 0);
-            assert_eq!(
-                request.finished_at_unix_ms,
-                finish_unix_ms_from_started_and_duration(
-                    request.started_at_unix_ms,
-                    request.latency_us
-                )
+
+            let rounded_latency_ms = request.latency_us.div_ceil(1_000);
+            let _derived_finish = request
+                .started_at_unix_ms
+                .saturating_add(rounded_latency_ms);
+            // Live tracing samples the close wall-clock timestamp directly. It is not
+            // required to equal start + rounded monotonic latency.
+        });
+    }
+
+    #[test]
+    fn live_tracing_matches_native_timing_semantics_without_exact_timestamp_parity() {
+        let native = Tailtriage::builder("svc")
+            .sink(MemorySink::new())
+            .build()
+            .unwrap();
+        let started =
+            native.begin_request_with("/native", RequestOptions::new().request_id("native-r1"));
+        std::thread::sleep(std::time::Duration::from_millis(1));
+        started.completion.finish_ok();
+        let native_run = native.snapshot();
+        let native_request = &native_run.requests[0];
+
+        with_recorder(|recorder| {
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "tracing-r1",
+                tt.route = "/tracing"
             );
+            std::thread::sleep(std::time::Duration::from_millis(1));
+            drop(span);
+
+            let tracing_run = recorder.snapshot_run().unwrap();
+            let tracing_request = &tracing_run.run().requests[0];
+
+            assert!(native_request.finished_at_unix_ms >= native_request.started_at_unix_ms);
+            assert!(native_request.latency_us > 0);
+            assert!(tracing_request.finished_at_unix_ms >= tracing_request.started_at_unix_ms);
+            assert!(tracing_request.latency_us > 0);
         });
     }
 


### PR DESCRIPTION
### Motivation
- Live tracing should record the actual wall-clock finish timestamp sampled at span close while preserving monotonic duration as the authoritative elapsed-time evidence.
- Current live recorder derived finish timestamps from start + rounded duration which can diverge from the real close wall time and is confusing for parity with native capture.

### Description
- In `tailtriage-tracing/src/recorder.rs` sample `finished_at_unix_ms` at span close using `tailtriage_core::unix_time_ms()` and compute `duration_us` from `open.started_instant.elapsed()` so wall time is the close anchor and duration remains monotonic.
- Build `SpanRecord` with `started_at_unix_ms = open.started_at_unix_ms` and `finished_at_unix_ms = finished_at_unix_ms` and keep `.duration_us(duration_us)` on the record.
- Remove use of the helper that derived finish from start+duration and delete `finish_unix_ms_from_started_and_duration` (and its rounding/overflow tests) since it is no longer used in the live recorder path.
- Update tests in `tailtriage-tracing/src/recorder.rs` to remove assertions that required finish == start + rounded latency, add a test that sleeps >=1ms then asserts `finished_at_unix_ms >= started_at_unix_ms` and `latency_us > 0`, and add a parity test that asserts both native and tracing paths use ordered wall-clock bounds plus positive monotonic duration without requiring exact timestamp equality.
- Update `tailtriage-tracing/README.md` timing wording to state that live tracing samples finish wall time at span close and duration remains monotonic elapsed time.
- No JSONL import behavior changes, no new dependencies added, and no OpenTelemetry/generic observability wording introduced.

### Testing
- Ran `cargo fmt --check` and formatting checks passed.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and static lints passed.
- Ran `cargo test --workspace` and all workspace unit tests passed.
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed.
- Ran the stricter `cargo test --workspace --all-targets --all-features --locked` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d70fa1f2883309cdf97548a511210)