### PR TITLE
Use close wall time in tracing recorder

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -93,7 +93,8 @@ If your service already builds a subscriber in startup code, compose `session.la
 ## Timing model
 
 - Imported or live tracing evidence is converted to normal tailtriage Run timing fields.
-- Durations are the authoritative elapsed-time evidence when present.
+- Live tracing samples finish wall time when the span closes.
+- Duration remains monotonic elapsed time and is the authoritative elapsed-time evidence when present.
 - Unix-ms timestamps are wall-clock anchors and may be coarser than durations.
 - Ordinary tracing log timestamps are not enough for completed-span import; completed spans need explicit start/end timing and semantic tt.* fields.
 

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -728,10 +728,9 @@ where
                 record_incomplete_candidate_issue(&mut state, &open, kind, reason);
                 return;
             }
+            let finished_at_unix_ms = tailtriage_core::unix_time_ms();
             let duration_us =
                 u64::try_from(open.started_instant.elapsed().as_micros()).unwrap_or(u64::MAX);
-            let finished_at_unix_ms =
-                finish_unix_ms_from_started_and_duration(open.started_at_unix_ms, duration_us);
             let mut record =
                 SpanRecord::new(open.name, open.started_at_unix_ms, finished_at_unix_ms)
                     .duration_us(duration_us);
@@ -753,12 +752,6 @@ where
             );
         }
     }
-}
-
-fn finish_unix_ms_from_started_and_duration(started_at_unix_ms: u64, duration_us: u64) -> u64 {
-    let elapsed_ms =
-        (duration_us / 1_000).saturating_add(u64::from(!duration_us.is_multiple_of(1_000)));
-    started_at_unix_ms.saturating_add(elapsed_ms)
 }
 
 fn completed_span_records(state: &RecorderState) -> Vec<SpanRecord> {
@@ -1271,57 +1264,6 @@ mod tests {
     }
 
     #[test]
-    fn finish_unix_ms_from_started_and_duration_rounds_up_microseconds() {
-        let start = 1_700_000_000_000;
-        assert_eq!(finish_unix_ms_from_started_and_duration(start, 0), start);
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(start, 1),
-            start + 1
-        );
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(start, 999),
-            start + 1
-        );
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(start, 1_000),
-            start + 1
-        );
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(start, 1_001),
-            start + 2
-        );
-    }
-
-    #[test]
-    fn finish_unix_ms_from_started_and_duration_saturates_on_overflow() {
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(u64::MAX - 1, 1_001),
-            u64::MAX
-        );
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(u64::MAX - 1, u64::MAX),
-            u64::MAX
-        );
-    }
-
-    #[test]
-    fn finish_unix_ms_from_started_and_duration_rounds_extreme_duration_up() {
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(0, u64::MAX),
-            (u64::MAX / 1_000) + 1
-        );
-    }
-
-    #[test]
-    fn finish_unix_ms_from_started_and_duration_keeps_extreme_multiple_exact() {
-        let duration_us = u64::MAX - (u64::MAX % 1_000);
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(0, duration_us),
-            duration_us / 1_000
-        );
-    }
-
-    #[test]
     fn request_span_collected() {
         with_recorder(|recorder| {
             let span = tracing::info_span!(
@@ -1358,7 +1300,7 @@ mod tests {
     }
 
     #[test]
-    fn live_completed_request_uses_positive_elapsed_latency_for_finish_time() {
+    fn live_completed_request_samples_close_wall_time_and_monotonic_latency() {
         with_recorder(|recorder| {
             let span = tracing::info_span!(
                 "request",
@@ -1373,13 +1315,44 @@ mod tests {
             let request = &snapshot.run().requests[0];
             assert!(request.finished_at_unix_ms >= request.started_at_unix_ms);
             assert!(request.latency_us > 0);
-            assert_eq!(
-                request.finished_at_unix_ms,
-                finish_unix_ms_from_started_and_duration(
-                    request.started_at_unix_ms,
-                    request.latency_us
-                )
+            // Live tracing samples the close wall-clock timestamp directly; it is not
+            // required to equal started_at_unix_ms plus a rounded monotonic latency.
+        });
+    }
+
+    #[test]
+    fn live_tracing_timing_matches_native_wall_bounds_plus_monotonic_duration_semantics() {
+        let native = Tailtriage::builder("svc")
+            .sink(MemorySink::new())
+            .run_id("native")
+            .build()
+            .unwrap();
+        let started = native.begin_request_with(
+            "/a",
+            tailtriage_core::RequestOptions::new().request_id("native-r1"),
+        );
+        std::thread::sleep(std::time::Duration::from_millis(1));
+        started.completion.finish_ok();
+        let native_run = native.snapshot();
+        let native_request = &native_run.requests[0];
+
+        with_recorder(|recorder| {
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "tracing-r1",
+                tt.route = "/a"
             );
+            std::thread::sleep(std::time::Duration::from_millis(1));
+            drop(span);
+
+            let tracing_run = recorder.snapshot_run().unwrap();
+            let tracing_request = &tracing_run.run().requests[0];
+
+            for request in [native_request, tracing_request] {
+                assert!(request.finished_at_unix_ms >= request.started_at_unix_ms);
+                assert!(request.latency_us > 0);
+            }
         });
     }
 


### PR DESCRIPTION
### Motivation
- Live tracing should record the actual wall-clock finish time when a span closes while keeping the monotonic elapsed duration as the authoritative latency evidence.
- This keeps live `tracing` semantics aligned with native capture semantics (wall-clock anchors + monotonic durations) and avoids constructing finish timestamps by rounding a monotonic duration back into millis.

### Description
- In `tailtriage-tracing/src/recorder.rs` `on_close` now samples `finished_at_unix_ms` with `tailtriage_core::unix_time_ms()` and computes `duration_us` from `open.started_instant.elapsed()` before building the `SpanRecord` with `started_at_unix_ms = open.started_at_unix_ms` and `finished_at_unix_ms = finished_at_unix_ms`.
- The helper `finish_unix_ms_from_started_and_duration` and its direct rounding tests were removed because live recorder no longer derives finish time from duration.
- Tests were updated: removed strict equality assertions tying finish timestamp to rounded monotonic latency, added `live_completed_request_samples_close_wall_time_and_monotonic_latency` and `live_tracing_timing_matches_native_wall_bounds_plus_monotonic_duration_semantics` to assert ordering and positive duration and to document parity between native and tracing timing semantics.
- `tailtriage-tracing/README.md` timing wording was updated to state that live tracing samples finish wall time at span close and that duration remains monotonic elapsed time.

### Testing
- Ran code format and lint checks with `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings`, which passed.
- Ran unit tests with `cargo test --workspace` and the stricter check `cargo test --workspace --all-targets --all-features --locked`, both of which passed.
- Ran docs contract validation with `python3 scripts/validate_docs_contracts.py`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d70fa1f2883309cdf97548a511210)