### PR TITLE
Use close wall time for live tracing spans

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -93,7 +93,8 @@ If your service already builds a subscriber in startup code, compose `session.la
 ## Timing model
 
 - Imported or live tracing evidence is converted to normal tailtriage Run timing fields.
-- Durations are the authoritative elapsed-time evidence when present.
+- Live tracing samples the finish wall-clock timestamp when the span closes.
+- Duration remains monotonic elapsed time and is the authoritative elapsed-time evidence when present.
 - Unix-ms timestamps are wall-clock anchors and may be coarser than durations.
 - Ordinary tracing log timestamps are not enough for completed-span import; completed spans need explicit start/end timing and semantic tt.* fields.
 

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -728,10 +728,9 @@ where
                 record_incomplete_candidate_issue(&mut state, &open, kind, reason);
                 return;
             }
+            let finished_at_unix_ms = tailtriage_core::unix_time_ms();
             let duration_us =
                 u64::try_from(open.started_instant.elapsed().as_micros()).unwrap_or(u64::MAX);
-            let finished_at_unix_ms =
-                finish_unix_ms_from_started_and_duration(open.started_at_unix_ms, duration_us);
             let mut record =
                 SpanRecord::new(open.name, open.started_at_unix_ms, finished_at_unix_ms)
                     .duration_us(duration_us);
@@ -753,12 +752,6 @@ where
             );
         }
     }
-}
-
-fn finish_unix_ms_from_started_and_duration(started_at_unix_ms: u64, duration_us: u64) -> u64 {
-    let elapsed_ms =
-        (duration_us / 1_000).saturating_add(u64::from(!duration_us.is_multiple_of(1_000)));
-    started_at_unix_ms.saturating_add(elapsed_ms)
 }
 
 fn completed_span_records(state: &RecorderState) -> Vec<SpanRecord> {
@@ -1271,57 +1264,6 @@ mod tests {
     }
 
     #[test]
-    fn finish_unix_ms_from_started_and_duration_rounds_up_microseconds() {
-        let start = 1_700_000_000_000;
-        assert_eq!(finish_unix_ms_from_started_and_duration(start, 0), start);
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(start, 1),
-            start + 1
-        );
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(start, 999),
-            start + 1
-        );
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(start, 1_000),
-            start + 1
-        );
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(start, 1_001),
-            start + 2
-        );
-    }
-
-    #[test]
-    fn finish_unix_ms_from_started_and_duration_saturates_on_overflow() {
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(u64::MAX - 1, 1_001),
-            u64::MAX
-        );
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(u64::MAX - 1, u64::MAX),
-            u64::MAX
-        );
-    }
-
-    #[test]
-    fn finish_unix_ms_from_started_and_duration_rounds_extreme_duration_up() {
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(0, u64::MAX),
-            (u64::MAX / 1_000) + 1
-        );
-    }
-
-    #[test]
-    fn finish_unix_ms_from_started_and_duration_keeps_extreme_multiple_exact() {
-        let duration_us = u64::MAX - (u64::MAX % 1_000);
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(0, duration_us),
-            duration_us / 1_000
-        );
-    }
-
-    #[test]
     fn request_span_collected() {
         with_recorder(|recorder| {
             let span = tracing::info_span!(
@@ -1358,7 +1300,7 @@ mod tests {
     }
 
     #[test]
-    fn live_completed_request_uses_positive_elapsed_latency_for_finish_time() {
+    fn live_completed_request_samples_close_wall_time_and_monotonic_duration() {
         with_recorder(|recorder| {
             let span = tracing::info_span!(
                 "request",
@@ -1373,13 +1315,43 @@ mod tests {
             let request = &snapshot.run().requests[0];
             assert!(request.finished_at_unix_ms >= request.started_at_unix_ms);
             assert!(request.latency_us > 0);
-            assert_eq!(
-                request.finished_at_unix_ms,
-                finish_unix_ms_from_started_and_duration(
-                    request.started_at_unix_ms,
-                    request.latency_us
-                )
+            // The finish wall timestamp is sampled independently at span close; it is
+            // not required to equal start + rounded monotonic latency.
+        });
+    }
+
+    #[test]
+    fn live_tracing_timing_matches_native_wall_bounds_and_monotonic_duration_semantics() {
+        let tailtriage = Tailtriage::builder("svc")
+            .sink(MemorySink::new())
+            .build()
+            .expect("collector");
+        let started = tailtriage.begin_request_with(
+            "/native",
+            tailtriage_core::RequestOptions::new().request_id("native-r1"),
+        );
+        std::thread::sleep(std::time::Duration::from_millis(1));
+        started.completion.finish_ok();
+        let native_snapshot = tailtriage.snapshot();
+        let native_request = &native_snapshot.requests[0];
+
+        with_recorder(|recorder| {
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "tracing-r1",
+                tt.route = "/tracing"
             );
+            std::thread::sleep(std::time::Duration::from_millis(1));
+            drop(span);
+
+            let tracing_snapshot = recorder.snapshot_run().unwrap();
+            let tracing_request = &tracing_snapshot.run().requests[0];
+
+            assert!(native_request.finished_at_unix_ms >= native_request.started_at_unix_ms);
+            assert!(native_request.latency_us > 0);
+            assert!(tracing_request.finished_at_unix_ms >= tracing_request.started_at_unix_ms);
+            assert!(tracing_request.latency_us > 0);
         });
     }
 


### PR DESCRIPTION
### Motivation
- Live tracing should record actual wall-clock finish time at span close while keeping monotonic elapsed duration as the authoritative latency evidence.
- This ensures recorded `finished_at_unix_ms` reflects the real close instant while preserving monotonic duration accuracy for analysis.

### Description
- In `tailtriage-tracing/src/recorder.rs` changed `on_close` to sample `finished_at_unix_ms` with `tailtriage_core::unix_time_ms()` and compute `duration_us` from `open.started_instant.elapsed()`; the `SpanRecord` is built with `started_at_unix_ms = open.started_at_unix_ms` and `finished_at_unix_ms = finished_at_unix_ms`.
- Removed the derived-finish helper `finish_unix_ms_from_started_and_duration` and its tests since live conversion no longer synthesizes finish time from duration.
- Updated recorder tests to remove the assertion that finish time equals start + rounded latency, added a test that samples a request span with at least `1ms` sleep asserting `finished_at_unix_ms >= started_at_unix_ms` and `latency_us > 0`, and added a parity test that asserts both native and tracing paths expose wall-clock bounds plus positive monotonic duration semantics.
- Updated `tailtriage-tracing/README.md` timing wording to state that live tracing samples finish wall time at span close and that duration remains monotonic elapsed time.

### Testing
- Ran `cargo fmt --check` and formatting passed.
- Ran `cargo clippy --workspace --all-targets -- -D warnings` and linting passed.
- Ran `cargo test --workspace` and all tests passed.
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed.
- Ran `cargo test --workspace --all-targets --all-features --locked` and the full test matrix passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d70fa1f2883309cdf97548a511210)