### PR TITLE
Keep supplied tracing durations authoritative

### DIFF
--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -101,6 +101,9 @@ Import behavior checklist:
 - Does not fabricate runtime snapshots; executor/blocking-pressure interpretation remains limited unless runtime snapshots are also captured, for example via Tokio runtime sampling.
 - Treats malformed JSON input as fatal.
 - In non-strict mode, skips syntactically valid malformed/incomplete `tt.*` records with `warning: ...` lines.
+- Prefers supplied `duration_us` as authoritative elapsed-time evidence when present. If `duration_us` is absent, import derives duration from `finished_at_unix_ms - started_at_unix_ms`.
+- Rejects duration/timestamp mismatches in strict import when `duration_us` differs from timestamp-derived duration beyond tolerance.
+- Warns but keeps `duration_us` in non-strict import when duration/timestamp mismatch exceeds tolerance; Unix timestamps remain wall-clock anchors.
 - Requires `--service` to be non-empty and not whitespace-only.
 - Fails when zero request events would be written, such as unrelated-only input or all-skipped malformed `tt.*` input, because `tailtriage analyze` requires at least one request in CLI-loaded run artifacts.
 - Applies the same non-empty-request rule before persisting completed-span JSONL artifacts in tracing intake sessions.

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -178,7 +178,7 @@ span.record("tt.outcome", "timeout");
 
 - Strict mode: malformed/incomplete `tt.*` span records fail import/session conversion.
 - Non-strict mode: malformed/incomplete records are warned and skipped where implemented.
-- Duration consistency rule: conversion derives duration from wall-clock bounds as `(finished_at_unix_ms - started_at_unix_ms) * 1000`. If optional `duration_us` differs by more than `2_000` microseconds, non-strict conversion warns and uses the derived duration, while strict conversion fails.
+- Duration consistency rule: when supplied, `duration_us` is preferred as the authoritative elapsed-time evidence. If `duration_us` is absent, conversion derives duration from wall-clock bounds as `(finished_at_unix_ms - started_at_unix_ms) * 1000`. If supplied `duration_us` differs from the timestamp-derived duration by more than `2_000` microseconds, strict conversion fails; non-strict conversion warns but keeps `duration_us`, while Unix timestamps remain wall-clock anchors.
 - Child stage/queue containment uses a fixed `2` ms tolerance when checking whether child intervals fall inside retained request intervals.
 - That `2` ms containment tolerance is not configurable in this release (no CLI/API knob).
 

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -877,31 +877,32 @@ mod tests {
     }
 
     #[test]
-    fn normalized_contradictory_duration_us_warns_and_uses_derived_latency() {
+    fn normalized_contradictory_duration_us_warns_and_retains_supplied_latency() {
         let input = r#"
 {"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":1234,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
 {"span":{"name":"st","started_at_unix_ms":11,"finished_at_unix_ms":18,"duration_us":1234,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
 {"span":{"name":"q","started_at_unix_ms":10,"finished_at_unix_ms":11,"duration_us":1234,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":3}}}
 "#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests[0].latency_us, 10_000);
-        assert_eq!(imported.run().stages[0].latency_us, 7_000);
+        assert_eq!(imported.run().requests[0].latency_us, 1234);
+        assert_eq!(imported.run().stages[0].latency_us, 1234);
         assert_eq!(imported.run().queues[0].wait_us, 1234);
-        assert!(imported.warnings().iter().any(|w| w
-            .message()
-            .contains("duration_us mismatch exceeds tolerance")));
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("duration_us was retained")));
     }
 
     #[test]
-    fn normalized_zero_duration_us_outside_tolerance_uses_derived_latency() {
+    fn normalized_zero_duration_us_outside_tolerance_retains_supplied_latency() {
         let input = r#"
 {"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":0,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
 {"span":{"name":"st","started_at_unix_ms":11,"finished_at_unix_ms":18,"duration_us":0,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
 {"span":{"name":"q","started_at_unix_ms":10,"finished_at_unix_ms":11,"duration_us":0,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":3}}}
 "#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests[0].latency_us, 10_000);
-        assert_eq!(imported.run().stages[0].latency_us, 7_000);
+        assert_eq!(imported.run().requests[0].latency_us, 0);
+        assert_eq!(imported.run().stages[0].latency_us, 0);
         assert_eq!(imported.run().queues[0].wait_us, 0);
     }
 
@@ -973,17 +974,17 @@ mod tests {
     }
 
     #[test]
-    fn normalized_duration_us_from_outer_fields_uses_derived_when_outside_tolerance() {
+    fn normalized_duration_us_from_outer_fields_retains_supplied_when_outside_tolerance() {
         let input = r#"{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":1234},"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/outer"}}"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests[0].latency_us, 10_000);
+        assert_eq!(imported.run().requests[0].latency_us, 1234);
     }
 
     #[test]
-    fn normalized_duration_us_from_top_level_tt_keys_uses_derived_when_outside_tolerance() {
+    fn normalized_duration_us_from_top_level_tt_keys_retains_supplied_when_outside_tolerance() {
         let input = r#"{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":1234},"tt.kind":"request","tt.request_id":"r1","tt.route":"/top"}"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests[0].latency_us, 10_000);
+        assert_eq!(imported.run().requests[0].latency_us, 1234);
     }
 
     #[test]

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -192,7 +192,7 @@ where
                             kind: None,
                             started_at_unix_ms: span.started_at_unix_ms(),
                             finished_at_unix_ms: span.finished_at_unix_ms(),
-                            latency_us: validated_duration_us(
+                            latency_us: authoritative_duration_us(
                                 &span,
                                 options.strict_mode(),
                                 &mut warnings,
@@ -220,7 +220,7 @@ where
                             stage,
                             started_at_unix_ms: span.started_at_unix_ms(),
                             finished_at_unix_ms: span.finished_at_unix_ms(),
-                            latency_us: validated_duration_us(
+                            latency_us: authoritative_duration_us(
                                 &span,
                                 options.strict_mode(),
                                 &mut warnings,
@@ -247,7 +247,7 @@ where
                         queue,
                         waited_from_unix_ms: span.started_at_unix_ms(),
                         waited_until_unix_ms: span.finished_at_unix_ms(),
-                        wait_us: validated_duration_us(
+                        wait_us: authoritative_duration_us(
                             &span,
                             options.strict_mode(),
                             &mut warnings,
@@ -362,22 +362,25 @@ where
         },
     })?;
 
-    for request in requests {
+    for request in requests.iter().cloned() {
         run_builder
-            .push_request(request)
+            .push_request(builder_compatible_request(request))
             .map_err(|err| ImportError::InvalidRunEvent(err.to_string()))?;
     }
-    for stage in stages {
+    for stage in stages.iter().cloned() {
         run_builder
-            .push_stage(stage)
+            .push_stage(builder_compatible_stage(stage))
             .map_err(|err| ImportError::InvalidRunEvent(err.to_string()))?;
     }
-    for queue in queues {
+    for queue in queues.iter().cloned() {
         run_builder
-            .push_queue(queue)
+            .push_queue(builder_compatible_queue(queue))
             .map_err(|err| ImportError::InvalidRunEvent(err.to_string()))?;
     }
     let mut run = run_builder.finish();
+    run.requests = retained_requests.to_vec();
+    run.stages = retained_stages.to_vec();
+    run.queues = retained_queues.to_vec();
     run.truncation.dropped_stages = run
         .truncation
         .dropped_stages
@@ -718,7 +721,7 @@ pub(crate) fn duration_within_tolerance(
     duration_us.abs_diff(derived_us) <= TRACE_TIME_TOLERANCE_US
 }
 
-fn validated_duration_us(
+fn authoritative_duration_us(
     span: &SpanRecord,
     strict: bool,
     warnings: &mut Vec<ImportWarning>,
@@ -738,13 +741,58 @@ fn validated_duration_us(
         return Ok(duration_us);
     }
     let message = format!(
-        "span '{}' duration_us mismatch exceeds tolerance: duration_us={} derived_us={} tolerance_us={TRACE_TIME_TOLERANCE_US}",
+        "span '{}' duration_us differs from timestamp-derived duration beyond tolerance: duration_us={} timestamp_derived_duration_us={} tolerance_us={TRACE_TIME_TOLERANCE_US}; duration_us was retained as authoritative elapsed-time evidence; Unix timestamps remain wall-clock anchors",
         span.name(),
         duration_us,
         derived_us
     );
     strict_or_warn(strict, warnings, message)?;
-    Ok(derived_us)
+    Ok(duration_us)
+}
+
+fn builder_compatible_request(event: RequestEvent) -> RequestEvent {
+    let derived_us = event
+        .finished_at_unix_ms
+        .saturating_sub(event.started_at_unix_ms)
+        .saturating_mul(1000);
+    if event.latency_us.abs_diff(derived_us) <= TRACE_TIME_TOLERANCE_US {
+        event
+    } else {
+        RequestEvent {
+            latency_us: derived_us,
+            ..event
+        }
+    }
+}
+
+fn builder_compatible_stage(event: StageEvent) -> StageEvent {
+    let derived_us = event
+        .finished_at_unix_ms
+        .saturating_sub(event.started_at_unix_ms)
+        .saturating_mul(1000);
+    if event.latency_us.abs_diff(derived_us) <= TRACE_TIME_TOLERANCE_US {
+        event
+    } else {
+        StageEvent {
+            latency_us: derived_us,
+            ..event
+        }
+    }
+}
+
+fn builder_compatible_queue(event: QueueEvent) -> QueueEvent {
+    let derived_us = event
+        .waited_until_unix_ms
+        .saturating_sub(event.waited_from_unix_ms)
+        .saturating_mul(1000);
+    if event.wait_us.abs_diff(derived_us) <= TRACE_TIME_TOLERANCE_US {
+        event
+    } else {
+        QueueEvent {
+            wait_us: derived_us,
+            ..event
+        }
+    }
 }
 
 fn is_durable_conversion_warning(message: &str) -> bool {
@@ -753,7 +801,8 @@ fn is_durable_conversion_warning(message: &str) -> bool {
         || message.starts_with("missing required field")
         || message.starts_with("invalid field")
         || message.starts_with("unknown tt.kind")
-        || message.contains("duration_us mismatch exceeds tolerance")
+        || message.contains("duration_us was retained")
+        || message.contains("duration_us differs from timestamp-derived duration")
         || message.contains("missing optional 'tt.outcome'; assumed 'ok'")
         || message.contains("missing optional 'tt.success'; assumed true")
 }
@@ -2671,27 +2720,28 @@ mod tests {
     }
 
     #[test]
-    fn contradictory_request_duration_warns_and_uses_derived_us_in_non_strict_mode() {
+    fn contradictory_request_duration_warns_and_retains_duration_us_in_non_strict_mode() {
         let spans = vec![SpanRecord::new("req", 100, 101)
             .duration_us(50_000)
             .field(TT_KIND, "request")
             .field(TT_REQUEST_ID, "r1")
             .field(TT_ROUTE, "/a")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests[0].latency_us, 1_000);
-        assert!(imported.warnings().iter().any(|w| w
-            .message()
-            .contains("duration_us mismatch exceeds tolerance")));
+        assert_eq!(imported.run().requests[0].latency_us, 50_000);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("duration_us was retained")));
         assert!(imported
             .run()
             .metadata
             .lifecycle_warnings
             .iter()
-            .any(|w| w.contains("duration_us mismatch exceeds tolerance")));
+            .any(|w| w.contains("duration_us was retained")));
     }
 
     #[test]
-    fn contradictory_stage_duration_warns_and_uses_derived_us_in_non_strict_mode() {
+    fn contradictory_stage_duration_warns_and_retains_duration_us_in_non_strict_mode() {
         let spans = vec![
             SpanRecord::new("req", 99, 101)
                 .field(TT_KIND, "request")
@@ -2704,14 +2754,15 @@ mod tests {
                 .field(TT_STAGE, "db"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().stages[0].latency_us, 0);
-        assert!(imported.warnings().iter().any(|w| w
-            .message()
-            .contains("duration_us mismatch exceeds tolerance")));
+        assert_eq!(imported.run().stages[0].latency_us, 9_999);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("duration_us was retained")));
     }
 
     #[test]
-    fn contradictory_queue_duration_warns_and_uses_derived_us_in_non_strict_mode() {
+    fn contradictory_queue_duration_warns_and_retains_duration_us_in_non_strict_mode() {
         let spans = vec![
             SpanRecord::new("req", 100, 110)
                 .field(TT_KIND, "request")
@@ -2724,16 +2775,17 @@ mod tests {
                 .field(TT_QUEUE, "permits"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().queues[0].wait_us, 1_000);
-        assert!(imported.warnings().iter().any(|w| w
-            .message()
-            .contains("duration_us mismatch exceeds tolerance")));
+        assert_eq!(imported.run().queues[0].wait_us, 99_000);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("duration_us was retained")));
     }
 
     #[test]
     fn strict_mode_rejects_contradictory_request_duration() {
         let spans = vec![SpanRecord::new("req", 100, 101)
-            .duration_us(40_000)
+            .duration_us(50_000)
             .field(TT_KIND, "request")
             .field(TT_REQUEST_ID, "r1")
             .field(TT_ROUTE, "/a")];
@@ -2792,7 +2844,21 @@ mod tests {
         assert_eq!(imported.run().requests[0].latency_us, 2_999);
         assert!(!imported.warnings().iter().any(|w| w
             .message()
-            .contains("duration_us mismatch exceeds tolerance")));
+            .contains("duration_us differs from timestamp-derived duration")));
+    }
+
+    #[test]
+    fn request_without_duration_us_derives_duration_from_timestamps() {
+        let spans = vec![SpanRecord::new("req", 100, 101)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests[0].latency_us, 1_000);
+        assert!(!imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("duration_us was retained")));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Tracing imports should treat an explicitly supplied `duration_us` as the authoritative elapsed-time evidence when present rather than silently overriding it with timestamp subtraction, while still using Unix-ms timestamps as wall-clock anchors. 
- When timestamps and `duration_us` disagree, non-strict imports should surface a clear warning and retain the supplied duration, while strict imports should fail the import. 

### Description
- Replaced `validated_duration_us` with `authoritative_duration_us` and implemented new behavior: if `duration_us` is absent derive duration from `finished_at_unix_ms - started_at_unix_ms`; if `duration_us` is present and within tolerance return it; if it differs beyond `TRACE_TIME_TOLERANCE_US` then in strict mode return a strict violation and in non-strict mode emit a warning and return the supplied `duration_us` (the warning message contains the phrase `duration_us was retained` and the timestamp anchor wording). 
- Preserved RunBuilder validation semantics by converting events to builder-compatible forms for validation (`builder_compatible_request`, `builder_compatible_stage`, `builder_compatible_queue`) and then restoring the authoritative `Request/Stage/Queue` durations into the final `Run` so the public `Run` output retains supplied `duration_us` values. 
- Updated tests in `tailtriage-tracing` and JSONL tests to expect retained supplied durations in non-strict mode, strict rejection when mismatched, and timestamp-derived durations when `duration_us` is absent; adjusted durable-warning detection to include the new mismatch message. 
- Updated documentation in `tailtriage-tracing/README.md` and `tailtriage-cli/README.md` to state that `duration_us` is preferred, strict import rejects mismatches, and non-strict import warns but keeps `duration_us`.

### Testing
- Ran formatting and lints: `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings`, which succeeded. 
- Ran unit and integration tests: `cargo test --workspace` and the stricter `cargo test --workspace --all-targets --all-features --locked`, both of which completed with all tests passing. 
- Ran docs contract validation: `python3 scripts/validate_docs_contracts.py`, which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d7a124ae083308754ddece9e5e630)