### PR TITLE
Use close wall time for tracing spans

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -93,6 +93,7 @@ If your service already builds a subscriber in startup code, compose `session.la
 ## Timing model
 
 - Imported or live tracing evidence is converted to normal tailtriage Run timing fields.
+- Live tracing samples finish wall time when a span closes.
 - `duration_us` is the preferred authoritative elapsed-time evidence when supplied.
 - Unix-ms timestamps are wall-clock anchors and may be coarser than durations.
 - Ordinary tracing log timestamps are not enough for completed-span import; completed spans need explicit start/end timing and semantic tt.* fields.

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -728,10 +728,9 @@ where
                 record_incomplete_candidate_issue(&mut state, &open, kind, reason);
                 return;
             }
+            let finished_at_unix_ms = tailtriage_core::unix_time_ms();
             let duration_us =
                 u64::try_from(open.started_instant.elapsed().as_micros()).unwrap_or(u64::MAX);
-            let finished_at_unix_ms =
-                finish_unix_ms_from_started_and_duration(open.started_at_unix_ms, duration_us);
             let mut record =
                 SpanRecord::new(open.name, open.started_at_unix_ms, finished_at_unix_ms)
                     .duration_us(duration_us);
@@ -753,12 +752,6 @@ where
             );
         }
     }
-}
-
-fn finish_unix_ms_from_started_and_duration(started_at_unix_ms: u64, duration_us: u64) -> u64 {
-    let elapsed_ms =
-        (duration_us / 1_000).saturating_add(u64::from(!duration_us.is_multiple_of(1_000)));
-    started_at_unix_ms.saturating_add(elapsed_ms)
 }
 
 fn completed_span_records(state: &RecorderState) -> Vec<SpanRecord> {
@@ -1251,6 +1244,7 @@ mod tests {
     use super::*;
     use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
     use tailtriage_core::{MemorySink, Tailtriage};
+    use tracing::Instrument;
     use tracing_subscriber::prelude::*;
 
     fn with_recorder<T>(f: impl FnOnce(&TracingRecorder) -> T) -> T {
@@ -1268,57 +1262,6 @@ mod tests {
             .build()
             .expect("collector")
             .snapshot()
-    }
-
-    #[test]
-    fn finish_unix_ms_from_started_and_duration_rounds_up_microseconds() {
-        let start = 1_700_000_000_000;
-        assert_eq!(finish_unix_ms_from_started_and_duration(start, 0), start);
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(start, 1),
-            start + 1
-        );
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(start, 999),
-            start + 1
-        );
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(start, 1_000),
-            start + 1
-        );
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(start, 1_001),
-            start + 2
-        );
-    }
-
-    #[test]
-    fn finish_unix_ms_from_started_and_duration_saturates_on_overflow() {
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(u64::MAX - 1, 1_001),
-            u64::MAX
-        );
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(u64::MAX - 1, u64::MAX),
-            u64::MAX
-        );
-    }
-
-    #[test]
-    fn finish_unix_ms_from_started_and_duration_rounds_extreme_duration_up() {
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(0, u64::MAX),
-            (u64::MAX / 1_000) + 1
-        );
-    }
-
-    #[test]
-    fn finish_unix_ms_from_started_and_duration_keeps_extreme_multiple_exact() {
-        let duration_us = u64::MAX - (u64::MAX % 1_000);
-        assert_eq!(
-            finish_unix_ms_from_started_and_duration(0, duration_us),
-            duration_us / 1_000
-        );
     }
 
     #[test]
@@ -1357,8 +1300,35 @@ mod tests {
         assert_eq!(snapshot.run().requests.len(), 1);
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn live_completed_request_samples_close_wall_time_and_keeps_elapsed_latency() {
+        let recorder = TracingRecorder::builder("svc")
+            .run_id("rid")
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        async {
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
+        .instrument(tracing::info_span!(
+            "request",
+            tt.kind = "request",
+            tt.request_id = "r1",
+            tt.route = "/a"
+        ))
+        .await;
+
+        let snapshot = recorder.snapshot_run().unwrap();
+        assert_eq!(snapshot.run().requests.len(), 1);
+        let request = &snapshot.run().requests[0];
+        assert!(request.finished_at_unix_ms >= request.started_at_unix_ms);
+        assert!(request.latency_us > 0);
+    }
+
     #[test]
-    fn live_completed_request_uses_positive_elapsed_latency_for_finish_time() {
+    fn live_completed_request_does_not_require_synthetic_finish_from_duration() {
         with_recorder(|recorder| {
             let span = tracing::info_span!(
                 "request",
@@ -1366,20 +1336,26 @@ mod tests {
                 tt.request_id = "r1",
                 tt.route = "/a"
             );
+
+            {
+                let mut state = lock_state(&recorder.state);
+                let open = state.open.values_mut().next().expect("open request span");
+                open.started_at_unix_ms = 1;
+                open.started_instant = Instant::now();
+            }
+
             std::thread::sleep(std::time::Duration::from_millis(1));
             drop(span);
 
             let snapshot = recorder.snapshot_run().unwrap();
+            assert_eq!(snapshot.run().requests.len(), 1);
             let request = &snapshot.run().requests[0];
-            assert!(request.finished_at_unix_ms >= request.started_at_unix_ms);
-            assert!(request.latency_us > 0);
-            assert_eq!(
-                request.finished_at_unix_ms,
-                finish_unix_ms_from_started_and_duration(
-                    request.started_at_unix_ms,
-                    request.latency_us
-                )
+            let synthetic_finished_at_unix_ms = request.started_at_unix_ms.saturating_add(
+                (request.latency_us / 1_000)
+                    .saturating_add(u64::from(!request.latency_us.is_multiple_of(1_000))),
             );
+            assert!(request.finished_at_unix_ms > synthetic_finished_at_unix_ms);
+            assert!(request.latency_us > 0);
         });
     }
 


### PR DESCRIPTION
### Motivation

- Live tracing should record an actual wall-clock finish time when a span closes while continuing to treat monotonic elapsed measurement as the authoritative duration evidence. 
- Synthesizing finish wall time from `started_at_unix_ms + ceil(duration_us / 1000)` for live spans is brittle and hides real close-time anchors. 
- The change preserves existing import semantics where `duration_us` remains authoritative for elapsed-time evidence and avoids changing JSONL import behavior or schema. 

### Description

- In `TailtriageLayer::on_close` the code now samples finish wall time with `tailtriage_core::unix_time_ms()` and computes `duration_us` from `open.started_instant.elapsed()` before building the `SpanRecord`. 
- The `SpanRecord` is created with `started_at_unix_ms = open.started_at_unix_ms`, `finished_at_unix_ms = sampled close-time unix ms`, and `duration_us = monotonic elapsed micros`. 
- Removed the previous `finish_unix_ms_from_started_and_duration(...)` usage and deleted the helper when unused so live tracing no longer synthesizes finish wall time from duration. 
- Updated `tailtriage-tracing/README.md` Timing model to state that live tracing samples finish wall time at span close while keeping `duration_us` authoritative. 
- Tests in `tailtriage-tracing` were added/updated: a `tokio` async live recorder test that instruments ~1ms of async work and asserts retained request count is 1, `finished_at_unix_ms >= started_at_unix_ms`, and `latency_us > 0`, and a test that verifies live tracing no longer requires the synthetic equality between timestamps and duration; tests that expected synthetic finish timestamps were rewritten accordingly. 

### Testing

- Ran formatting and linters via `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, both succeeded. 
- Ran full test suite with `cargo test --workspace --all-targets --all-features --locked` and `cargo test --workspace`, and all tests passed. 
- Validated docs contract with `python3 scripts/validate_docs_contracts.py`, which succeeded. 
- Performed feature checks for the tracing crate with `cargo check -p tailtriage-tracing --no-default-features` and with `--features jsonl`, `--features live`, and `--features tokio`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dbf7a8fa48330ae6a615ba0a62cc6)