### PR TITLE
Record tracing close timing before recorder lock

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -716,9 +716,11 @@ where
     }
 
     fn on_close(&self, id: Id, _ctx: Context<'_, S>) {
+        let closed_at_unix_ms = tailtriage_core::unix_time_ms();
+        let closed_instant = std::time::Instant::now();
+
         let mut state = lock_state(&self.state);
         if let Some(open) = state.open.remove(&id.into_u64()) {
-            let finished_at_unix_ms = tailtriage_core::unix_time_ms();
             let kind = classify_kind(&open.fields);
             if let Err(reason) = kind {
                 record_invalid_kind_issue(&mut state, &open, reason);
@@ -729,11 +731,14 @@ where
                 record_incomplete_candidate_issue(&mut state, &open, kind, reason);
                 return;
             }
-            let duration_us =
-                u64::try_from(open.started_instant.elapsed().as_micros()).unwrap_or(u64::MAX);
-            let mut record =
-                SpanRecord::new(open.name, open.started_at_unix_ms, finished_at_unix_ms)
-                    .duration_us(duration_us);
+            let duration_us = u64::try_from(
+                closed_instant
+                    .duration_since(open.started_instant)
+                    .as_micros(),
+            )
+            .unwrap_or(u64::MAX);
+            let mut record = SpanRecord::new(open.name, open.started_at_unix_ms, closed_at_unix_ms)
+                .duration_us(duration_us);
             if let Some(span_id) = open.id {
                 record = record.id(span_id);
             }
@@ -1325,6 +1330,46 @@ mod tests {
         let request = &snapshot.run().requests[0];
         assert!(request.finished_at_unix_ms >= request.started_at_unix_ms);
         assert!(request.latency_us > 0);
+    }
+
+    #[test]
+    fn live_close_duration_excludes_waiting_for_recorder_mutex() {
+        let recorder = TracingRecorder::builder("svc")
+            .run_id("rid")
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            );
+
+            let state_guard = lock_state(&recorder.state);
+            let (ready_tx, ready_rx) = std::sync::mpsc::channel();
+            let drop_thread = std::thread::spawn(move || {
+                ready_tx.send(()).expect("notify drop readiness");
+                drop(span);
+            });
+
+            ready_rx.recv().expect("drop thread is ready");
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            drop(state_guard);
+            drop_thread.join().expect("span drop thread succeeds");
+
+            let snapshot = recorder.snapshot_run().unwrap();
+            assert_eq!(snapshot.run().requests.len(), 1);
+            let request = &snapshot.run().requests[0];
+            assert!(request.finished_at_unix_ms >= request.started_at_unix_ms);
+            assert!(request.latency_us > 0);
+            assert!(
+                request.latency_us < 50_000,
+                "latency_us should be captured before waiting on the recorder mutex; got {}",
+                request.latency_us
+            );
+        });
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Live tracing should capture the wall-clock close time and the monotonic instant at the callback entry so retained spans carry an accurate finish-time anchor and recorded latency does not include recorder-mutex wait time.
- Preserve monotonic elapsed-time as the authoritative latency evidence and avoid synthesizing finish times from duration to keep timing semantics clear and deterministic.

### Description
- Sample `closed_at_unix_ms = tailtriage_core::unix_time_ms()` and `closed_instant = std::time::Instant::now()` at the top of `TailtriageLayer::on_close` before calling `lock_state(&self.state)`.
- After locking and removing the open span, validate `tt.kind` and required fields as before and compute `duration_us` using `closed_instant.duration_since(open.started_instant)` converted with `u64::try_from(...as_micros()).unwrap_or(u64::MAX)`.
- Construct the `SpanRecord` using `started_at_unix_ms = open.started_at_unix_ms`, `finished_at_unix_ms = closed_at_unix_ms`, and `duration_us = duration_us`, and preserve id/parent/field copying, kind-classification, retention, and ordering behavior.
- Add a regression test `live_close_duration_excludes_waiting_for_recorder_mutex` that holds the recorder mutex while another thread drops a valid `tt.kind = "request"` span and asserts the recorded `latency_us` is much smaller than the mutex-hold delay, while keeping existing live recorder timing tests.

### Testing
- Ran `cargo fmt --check` which succeeded.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which succeeded.
- Ran unit and workspace tests with `cargo test --workspace --all-targets --all-features --locked` and `cargo test --workspace`, and all tests (including the new regression test) passed.
- Ran `python3 scripts/validate_docs_contracts.py` and `cargo check -p tailtriage-tracing --no-default-features` with `--features jsonl`, `--features live`, and `--features tokio`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dcbc00d9c8330bdf1e9ea9f7821f7)