### PR TITLE
Narrow compatible JSONL fmt rejection to require absence of completed-span timing

### DIFF
--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -713,14 +713,13 @@ fn import_tracing_spans_jsonl_default_rejects_fmt_json_with_guidance() {
 }
 
 #[test]
-fn import_tracing_spans_jsonl_compatible_rejects_fmt_like_record_with_top_level_explicit_timestamps(
-) {
+fn import_tracing_spans_jsonl_compatible_rejects_fmt_like_record_without_completed_span_timing() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("compatible.jsonl");
     let run_path = dir.path().join("run.json");
     std::fs::write(
         &spans_path,
-        r#"{"timestamp":"2026-01-01T00:00:00Z","level":"INFO","target":"svc","event":"close","name":"request","started_at_unix_ms":1000,"finished_at_unix_ms":2000,"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}"#,
+        r#"{"timestamp":"2026-01-01T00:00:00Z","level":"INFO","target":"svc","message":"ordinary log"}"#,
     )
     .unwrap();
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
@@ -740,18 +739,18 @@ fn import_tracing_spans_jsonl_compatible_rejects_fmt_like_record_with_top_level_
         "cli unexpectedly succeeded: {output:?}"
     );
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
-    assert!(stderr.contains("unsupported tracing log envelope fields for compatible import (timestamp/level/target/event/message)"));
+    assert!(stderr.contains("ordinary tracing log JSON"));
     assert!(!run_path.exists(), "run json should not be written");
 }
 
 #[test]
-fn import_tracing_spans_jsonl_compatible_rejects_fmt_like_record_with_nested_explicit_timestamps() {
+fn import_tracing_spans_jsonl_compatible_accepts_fmt_like_record_with_nested_explicit_timestamps() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("compatible.jsonl");
     let run_path = dir.path().join("run.json");
     std::fs::write(
         &spans_path,
-        r#"{"timestamp":"2026-01-01T00:00:00Z","level":"INFO","target":"svc","span":{"name":"request","started_at_unix_ms":1000,"finished_at_unix_ms":2000,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}"#,
+        r#"{"timestamp":"2026-01-01T00:00:00Z","level":"INFO","target":"svc","span":{"name":"request","started_at_unix_ms":1000,"finished_at_unix_ms":2000,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok","tt.success":true}}}"#,
     )
     .unwrap();
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
@@ -767,12 +766,10 @@ fn import_tracing_spans_jsonl_compatible_rejects_fmt_like_record_with_nested_exp
         .output()
         .expect("cli should run");
     assert!(
-        !output.status.success(),
-        "cli unexpectedly succeeded: {output:?}"
+        output.status.success(),
+        "cli unexpectedly failed: {output:?}"
     );
-    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
-    assert!(stderr.contains("unsupported tracing log envelope fields for compatible import (timestamp/level/target/event/message)"));
-    assert!(!run_path.exists(), "run json should not be written");
+    assert!(run_path.exists(), "run json should be written");
 }
 
 #[test]

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -223,9 +223,9 @@ fn parse_record(
         );
         return Err(ImportError::ExpectedTailtriageWrapper { reason: message });
     }
-    if has_fmt_log_envelope_fields(value) {
+    if is_ordinary_fmt_json_without_completed_span_timing(value) {
         let message = format!(
-            "line {line_no}: unsupported tracing log envelope fields for compatible import (timestamp/level/target/event/message)"
+            "line {line_no}: unsupported ordinary tracing fmt JSON record for compatible import (timestamp/level/target without completed-span timing)"
         );
         if strict {
             return Err(ImportError::StrictViolation(message));
@@ -298,13 +298,24 @@ fn parse_record(
     }
 }
 
-fn has_fmt_log_envelope_fields(value: &Value) -> bool {
+fn is_ordinary_fmt_json_without_completed_span_timing(value: &Value) -> bool {
+    let Some(obj) = value.as_object() else {
+        return false;
+    };
+
+    let looks_like_fmt =
+        obj.contains_key("timestamp") && obj.contains_key("level") && obj.contains_key("target");
+    looks_like_fmt && !has_completed_span_timing(value)
+}
+
+fn has_completed_span_timing(value: &Value) -> bool {
+    has_explicit_start_and_end(value) || value.get("span").is_some_and(has_explicit_start_and_end)
+}
+
+fn has_explicit_start_and_end(value: &Value) -> bool {
     value.as_object().is_some_and(|obj| {
-        obj.contains_key("timestamp")
-            || obj.contains_key("level")
-            || obj.contains_key("target")
-            || obj.contains_key("event")
-            || obj.contains_key("message")
+        (obj.contains_key("started_at_unix_ms") || obj.contains_key("start_unix_ms"))
+            && (obj.contains_key("finished_at_unix_ms") || obj.contains_key("end_unix_ms"))
     })
 }
 
@@ -654,15 +665,44 @@ mod tests {
     }
 
     #[test]
-    fn compatible_mode_rejects_close_event_shape_with_nested_span_timestamps() {
-        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":10,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
-{"event":"close","span":{"name":"st","started_at_unix_ms":5,"finished_at_unix_ms":8,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}"#;
+    fn compatible_mode_accepts_normalized_completed_span_with_top_level_message() {
+        let input = r#"{"message":"completed request","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a","tt.outcome":"ok","tt.success":true}}}"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().stages.len(), 0);
-        assert!(!imported.warnings().is_empty());
-        assert!(imported.warnings().iter().any(|w| w
+        assert_eq!(imported.run().requests.len(), 1);
+        assert!(imported.warnings().is_empty());
+    }
+
+    #[test]
+    fn compatible_mode_accepts_normalized_completed_span_with_fmt_like_metadata() {
+        let input = r#"{"timestamp":"2026-06-01T00:00:00Z","level":"INFO","target":"svc","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a","tt.outcome":"ok","tt.success":true}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert!(imported.warnings().is_empty());
+    }
+
+    #[test]
+    fn compatible_mode_rejects_ordinary_fmt_json_without_completed_span_timing() {
+        let input = r#"{"timestamp":"2026-06-01T00:00:00Z","level":"INFO","target":"svc","message":"ordinary log"}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.run().stages.is_empty());
+        assert_eq!(imported.warnings().len(), 1);
+        assert!(imported.warnings()[0]
             .message()
-            .contains("unsupported tracing log envelope fields")));
+            .contains("ordinary tracing fmt JSON"));
+
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+            .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn compatible_mode_accepts_close_event_shape_with_nested_span_timestamps() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":10,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a","tt.outcome":"ok","tt.success":true}}}
+{"event":"close","span":{"name":"st","started_at_unix_ms":5,"finished_at_unix_ms":8,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db","tt.success":true}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().stages.len(), 1);
+        assert!(imported.warnings().is_empty());
     }
 
     #[test]
@@ -1058,7 +1098,7 @@ mod tests {
         assert!(imported.run().requests.is_empty());
         assert!(imported.run().stages.is_empty());
         assert!(imported.run().queues.is_empty());
-        assert_eq!(imported.warnings().len(), 1);
+        assert!(imported.warnings().is_empty());
     }
 
     #[test]
@@ -1076,6 +1116,18 @@ mod tests {
         let err = import_jsonl_reader_with_mode(
             Cursor::new(unwrapped),
             ImportOptions::new("svc").strict(true),
+            JsonlParseMode::TailtriageWrapperOnly,
+        )
+        .unwrap_err();
+        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
+    }
+
+    #[test]
+    fn wrapper_only_mode_rejects_non_wrapper_compatible_completed_span() {
+        let compatible = r#"{"message":"completed request","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a","tt.outcome":"ok","tt.success":true}}}"#;
+        let err = import_jsonl_reader_with_mode(
+            Cursor::new(compatible),
+            ImportOptions::new("svc"),
             JsonlParseMode::TailtriageWrapperOnly,
         )
         .unwrap_err();


### PR DESCRIPTION
### Motivation
- Prevent rejecting valid normalized completed-span JSONL merely because it contains harmless top-level fmt-like metadata such as `message`, `timestamp`, `level`, or `target`.
- Preserve the existing stable wrapper-only import mode and the prior behavior of rejecting ordinary `tracing_subscriber::fmt().json()` records that are not completed spans.
- Keep non-strict imports as warnings+skip and strict imports as hard failures for unsupported shapes.

### Description
- Replace the coarse `has_fmt_log_envelope_fields` predicate with `is_ordinary_fmt_json_without_completed_span_timing` and supporting helpers `has_completed_span_timing` and `has_explicit_start_and_end` in `tailtriage-tracing/src/jsonl.rs` so the rejection only triggers when the top-level object contains `timestamp` AND `level` AND `target` and it does not include explicit completed-span start/end timing either at top level or under `span`.
- Ensure a record is accepted when explicit completed-span timing is present even if top-level fmt-like keys (`message`, `timestamp`, `level`, `target`) are present.
- Preserve wrapper-only behavior and existing strict/non-strict handling: non-strict produces a warning and skips; strict returns `StrictViolation` for the ordinary fmt case without completed-span timing.
- Add and adjust tests in `tailtriage-tracing/src/jsonl.rs` and `tailtriage-cli/tests/cli_boundary.rs` to cover: acceptance of normalized completed spans with top-level `message`, acceptance when top-level `timestamp`+`level`+`target` exist alongside explicit timing, rejection of ordinary fmt JSON lacking completed-span timing (warn+skip and strict failure), and wrapper-only mode rejecting non-wrapper compatible completed-span records.

### Testing
- Ran formatting, lint, validation, and full test suites: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `python3 scripts/validate_docs_contracts.py`, and `cargo test --workspace --all-targets --all-features --locked`; all commands completed successfully.
- Ran focused tests: `cargo test -p tailtriage-tracing jsonl --all-targets --all-features --locked` and `cargo test -p tailtriage-cli --test cli_boundary import_tracing_spans_jsonl_compatible --all-features --locked`, and they passed.
- The new/updated unit tests exercise the compatible import logic and confirm non-strict warnings and strict violations behave as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dd3e7b498833092bca428e8276395)