### PR TITLE
Refine compatible JSONL fmt envelope rejection

### DIFF
--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -713,14 +713,13 @@ fn import_tracing_spans_jsonl_default_rejects_fmt_json_with_guidance() {
 }
 
 #[test]
-fn import_tracing_spans_jsonl_compatible_rejects_fmt_like_record_with_top_level_explicit_timestamps(
-) {
+fn import_tracing_spans_jsonl_compatible_accepts_fmt_metadata_with_top_level_completed_timing() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("compatible.jsonl");
     let run_path = dir.path().join("run.json");
     std::fs::write(
         &spans_path,
-        r#"{"timestamp":"2026-01-01T00:00:00Z","level":"INFO","target":"svc","event":"close","name":"request","started_at_unix_ms":1000,"finished_at_unix_ms":2000,"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}"#,
+        r#"{"timestamp":"2026-01-01T00:00:00Z","level":"INFO","target":"svc","event":"close","name":"request","started_at_unix_ms":1000,"finished_at_unix_ms":2000,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}"#,
     )
     .unwrap();
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
@@ -736,16 +735,19 @@ fn import_tracing_spans_jsonl_compatible_rejects_fmt_like_record_with_top_level_
         .output()
         .expect("cli should run");
     assert!(
-        !output.status.success(),
-        "cli unexpectedly succeeded: {output:?}"
+        output.status.success(),
+        "cli unexpectedly failed: {output:?}"
     );
-    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
-    assert!(stderr.contains("unsupported tracing log envelope fields for compatible import (timestamp/level/target/event/message)"));
-    assert!(!run_path.exists(), "run json should not be written");
+    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+    let run: Run = serde_json::from_str(
+        &std::fs::read_to_string(&run_path).expect("run json should be written"),
+    )
+    .expect("run json should decode");
+    assert_eq!(run.requests.len(), 1);
 }
 
 #[test]
-fn import_tracing_spans_jsonl_compatible_rejects_fmt_like_record_with_nested_explicit_timestamps() {
+fn import_tracing_spans_jsonl_compatible_accepts_fmt_metadata_with_nested_completed_timing() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("compatible.jsonl");
     let run_path = dir.path().join("run.json");
@@ -767,12 +769,15 @@ fn import_tracing_spans_jsonl_compatible_rejects_fmt_like_record_with_nested_exp
         .output()
         .expect("cli should run");
     assert!(
-        !output.status.success(),
-        "cli unexpectedly succeeded: {output:?}"
+        output.status.success(),
+        "cli unexpectedly failed: {output:?}"
     );
-    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
-    assert!(stderr.contains("unsupported tracing log envelope fields for compatible import (timestamp/level/target/event/message)"));
-    assert!(!run_path.exists(), "run json should not be written");
+    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+    let run: Run = serde_json::from_str(
+        &std::fs::read_to_string(&run_path).expect("run json should be written"),
+    )
+    .expect("run json should decode");
+    assert_eq!(run.requests.len(), 1);
 }
 
 #[test]

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -223,9 +223,9 @@ fn parse_record(
         );
         return Err(ImportError::ExpectedTailtriageWrapper { reason: message });
     }
-    if has_fmt_log_envelope_fields(value) {
+    if is_ordinary_fmt_json_without_completed_span_timing(value) {
         let message = format!(
-            "line {line_no}: unsupported tracing log envelope fields for compatible import (timestamp/level/target/event/message)"
+            "line {line_no}: unsupported ordinary tracing fmt JSON envelope for compatible import (timestamp/level/target without completed-span timing)"
         );
         if strict {
             return Err(ImportError::StrictViolation(message));
@@ -298,13 +298,27 @@ fn parse_record(
     }
 }
 
-fn has_fmt_log_envelope_fields(value: &Value) -> bool {
-    value.as_object().is_some_and(|obj| {
-        obj.contains_key("timestamp")
-            || obj.contains_key("level")
-            || obj.contains_key("target")
-            || obj.contains_key("event")
-            || obj.contains_key("message")
+fn is_ordinary_fmt_json_without_completed_span_timing(value: &Value) -> bool {
+    let Some(obj) = value.as_object() else {
+        return false;
+    };
+    let looks_like_fmt =
+        obj.contains_key("timestamp") && obj.contains_key("level") && obj.contains_key("target");
+    looks_like_fmt && !has_completed_span_timing(value)
+}
+
+fn has_completed_span_timing(value: &Value) -> bool {
+    has_explicit_start_and_end(value.as_object())
+        || value
+            .get("span")
+            .and_then(Value::as_object)
+            .is_some_and(|span| has_explicit_start_and_end(Some(span)))
+}
+
+fn has_explicit_start_and_end(obj: Option<&serde_json::Map<String, Value>>) -> bool {
+    obj.is_some_and(|obj| {
+        (obj.contains_key("started_at_unix_ms") || obj.contains_key("start_unix_ms"))
+            && (obj.contains_key("finished_at_unix_ms") || obj.contains_key("end_unix_ms"))
     })
 }
 
@@ -633,7 +647,7 @@ mod tests {
 
     #[test]
     fn compatible_mode_rejects_close_event_shape_with_explicit_timestamps() {
-        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":10,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":10,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a","tt.outcome":"ok"}}}
 {"event":"close","span":{"name":"st","fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}},"started_at_unix_ms":5,"finished_at_unix_ms":8}"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
         assert!(imported.run().stages.is_empty());
@@ -654,15 +668,48 @@ mod tests {
     }
 
     #[test]
-    fn compatible_mode_rejects_close_event_shape_with_nested_span_timestamps() {
-        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":10,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
+    fn compatible_mode_accepts_normalized_span_with_top_level_event_and_timestamps() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":10,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a","tt.outcome":"ok"}}}
 {"event":"close","span":{"name":"st","started_at_unix_ms":5,"finished_at_unix_ms":8,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().stages.len(), 0);
-        assert!(!imported.warnings().is_empty());
-        assert!(imported.warnings().iter().any(|w| w
+        assert_eq!(imported.run().stages.len(), 1);
+        assert!(!imported.warnings().iter().any(|w| w
             .message()
-            .contains("unsupported tracing log envelope fields")));
+            .contains("unsupported ordinary tracing fmt JSON envelope")));
+    }
+
+    #[test]
+    fn compatible_mode_accepts_normalized_span_with_top_level_message_and_timing() {
+        let input = r#"{"message":"completed request","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a","tt.outcome":"ok"}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert!(imported.warnings().is_empty());
+    }
+
+    #[test]
+    fn compatible_mode_accepts_normalized_span_with_fmt_metadata_and_timing() {
+        let input = r#"{"timestamp":"2026-06-01T00:00:00Z","level":"INFO","target":"svc","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a","tt.outcome":"ok"}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert!(imported.warnings().is_empty());
+    }
+
+    #[test]
+    fn compatible_mode_ordinary_fmt_json_without_completed_timing_warns_or_errors() {
+        let input = r#"{"timestamp":"2026-06-01T00:00:00Z","level":"INFO","target":"svc","message":"ordinary log"}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert_eq!(imported.warnings().len(), 1);
+        assert!(imported.warnings()[0]
+            .message()
+            .contains("unsupported ordinary tracing fmt JSON envelope"));
+
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+            .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(err
+            .to_string()
+            .contains("unsupported ordinary tracing fmt JSON envelope"));
     }
 
     #[test]
@@ -1058,7 +1105,7 @@ mod tests {
         assert!(imported.run().requests.is_empty());
         assert!(imported.run().stages.is_empty());
         assert!(imported.run().queues.is_empty());
-        assert_eq!(imported.warnings().len(), 1);
+        assert!(imported.warnings().is_empty());
     }
 
     #[test]
@@ -1076,6 +1123,26 @@ mod tests {
         let err = import_jsonl_reader_with_mode(
             Cursor::new(unwrapped),
             ImportOptions::new("svc").strict(true),
+            JsonlParseMode::TailtriageWrapperOnly,
+        )
+        .unwrap_err();
+        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
+    }
+
+    #[test]
+    fn wrapper_only_mode_rejects_non_wrapper_compatible_record_with_fmt_metadata() {
+        let compatible = r#"{"timestamp":"2026-06-01T00:00:00Z","level":"INFO","target":"svc","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
+        let imported = import_jsonl_reader_with_mode(
+            Cursor::new(compatible),
+            ImportOptions::new("svc"),
+            JsonlParseMode::Compatible,
+        )
+        .unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+
+        let err = import_jsonl_reader_with_mode(
+            Cursor::new(compatible),
+            ImportOptions::new("svc"),
             JsonlParseMode::TailtriageWrapperOnly,
         )
         .unwrap_err();


### PR DESCRIPTION
### Motivation
- Prevent rejecting valid normalized completed-span JSON just because it carries harmless top-level fmt-like fields emitted by `tracing_subscriber::fmt().json()` while still rejecting ordinary fmt log JSON that lacks completed-span timing.
- Preserve existing wrapper-only semantics and the strict vs non-strict handling policy for incompatible records.

### Description
- Replace the broad `has_fmt_log_envelope_fields` check with a narrower `is_ordinary_fmt_json_without_completed_span_timing` predicate that only flags records that look like ordinary tracing fmt JSON (`timestamp` AND `level` AND `target`) and do not contain explicit completed-span timing.
- Add helper functions `has_completed_span_timing` and `has_explicit_start_and_end` to detect completed-span timing at the top level or inside a nested `span` object (supports `started_at_unix_ms`/`start_unix_ms` and `finished_at_unix_ms`/`end_unix_ms`).
- Update the rejection/warning message to clarify the narrower ordinary-fmt envelope rejection, and keep non-strict mode as warning+skip and strict mode as strict violation.
- Add and adjust tests in `tailtriage-tracing/src/jsonl.rs` and `tailtriage-cli/tests/cli_boundary.rs` to verify that: normalized completed spans with top-level `message` or fmt-like metadata plus explicit timing import successfully in compatible mode; ordinary fmt JSON (timestamp+level+target without completed-span timing) still warns/skips in non-strict and errors in strict; and wrapper-only mode continues to reject non-wrapper compatible records.

### Testing
- Ran formatting and linting: `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and both passed.
- Ran the full test matrix: `cargo test --workspace --all-targets --all-features --locked` and `cargo test --workspace`, and all tests passed.
- Ran docs contract validation: `python3 scripts/validate_docs_contracts.py` and it passed.
- Ran focused crate tests `cargo test -p tailtriage-tracing jsonl --all-features --locked` and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dd3e7b498833092bca428e8276395)