### PR TITLE
Refine compatible JSONL fmt rejection

### DIFF
--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -713,14 +713,13 @@ fn import_tracing_spans_jsonl_default_rejects_fmt_json_with_guidance() {
 }
 
 #[test]
-fn import_tracing_spans_jsonl_compatible_rejects_fmt_like_record_with_top_level_explicit_timestamps(
-) {
+fn import_tracing_spans_jsonl_compatible_rejects_ordinary_fmt_json_without_completed_span_timing() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("compatible.jsonl");
     let run_path = dir.path().join("run.json");
     std::fs::write(
         &spans_path,
-        r#"{"timestamp":"2026-01-01T00:00:00Z","level":"INFO","target":"svc","event":"close","name":"request","started_at_unix_ms":1000,"finished_at_unix_ms":2000,"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}"#,
+        r#"{"timestamp":"2026-01-01T00:00:00Z","level":"INFO","target":"svc","message":"ordinary log"}"#,
     )
     .unwrap();
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
@@ -740,18 +739,18 @@ fn import_tracing_spans_jsonl_compatible_rejects_fmt_like_record_with_top_level_
         "cli unexpectedly succeeded: {output:?}"
     );
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
-    assert!(stderr.contains("unsupported tracing log envelope fields for compatible import (timestamp/level/target/event/message)"));
+    assert!(stderr.contains("ordinary tracing log JSON"));
     assert!(!run_path.exists(), "run json should not be written");
 }
 
 #[test]
-fn import_tracing_spans_jsonl_compatible_rejects_fmt_like_record_with_nested_explicit_timestamps() {
+fn import_tracing_spans_jsonl_compatible_accepts_fmt_metadata_with_completed_span_timing() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("compatible.jsonl");
     let run_path = dir.path().join("run.json");
     std::fs::write(
         &spans_path,
-        r#"{"timestamp":"2026-01-01T00:00:00Z","level":"INFO","target":"svc","span":{"name":"request","started_at_unix_ms":1000,"finished_at_unix_ms":2000,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}"#,
+        r#"{"timestamp":"2026-01-01T00:00:00Z","level":"INFO","target":"svc","span":{"name":"request","started_at_unix_ms":1000,"finished_at_unix_ms":2000,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok","tt.success":true}}}"#,
     )
     .unwrap();
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
@@ -766,13 +765,17 @@ fn import_tracing_spans_jsonl_compatible_rejects_fmt_like_record_with_nested_exp
         .arg("compatible")
         .output()
         .expect("cli should run");
+    assert!(output.status.success(), "cli failed: {output:?}");
     assert!(
-        !output.status.success(),
-        "cli unexpectedly succeeded: {output:?}"
+        String::from_utf8_lossy(&output.stderr).trim().is_empty(),
+        "stderr should be empty: {output:?}"
     );
-    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
-    assert!(stderr.contains("unsupported tracing log envelope fields for compatible import (timestamp/level/target/event/message)"));
-    assert!(!run_path.exists(), "run json should not be written");
+    assert!(run_path.exists(), "run json should be written");
+
+    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
+        .expect("imported run should load in cli loader");
+    assert_eq!(loaded.run.requests.len(), 1);
+    assert_eq!(loaded.run.requests[0].route, "/checkout");
 }
 
 #[test]

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -223,9 +223,9 @@ fn parse_record(
         );
         return Err(ImportError::ExpectedTailtriageWrapper { reason: message });
     }
-    if has_fmt_log_envelope_fields(value) {
+    if is_ordinary_fmt_json_without_completed_span_timing(value) {
         let message = format!(
-            "line {line_no}: unsupported tracing log envelope fields for compatible import (timestamp/level/target/event/message)"
+            "line {line_no}: unsupported tracing fmt JSON envelope for compatible import (timestamp/level/target without completed-span timing)"
         );
         if strict {
             return Err(ImportError::StrictViolation(message));
@@ -298,13 +298,23 @@ fn parse_record(
     }
 }
 
-fn has_fmt_log_envelope_fields(value: &Value) -> bool {
+fn is_ordinary_fmt_json_without_completed_span_timing(value: &Value) -> bool {
     value.as_object().is_some_and(|obj| {
-        obj.contains_key("timestamp")
-            || obj.contains_key("level")
-            || obj.contains_key("target")
-            || obj.contains_key("event")
-            || obj.contains_key("message")
+        let looks_like_fmt = obj.contains_key("timestamp")
+            && obj.contains_key("level")
+            && obj.contains_key("target");
+        looks_like_fmt && !has_completed_span_timing(value)
+    })
+}
+
+fn has_completed_span_timing(value: &Value) -> bool {
+    has_start_and_end_timing(value) || value.get("span").is_some_and(has_start_and_end_timing)
+}
+
+fn has_start_and_end_timing(value: &Value) -> bool {
+    value.as_object().is_some_and(|obj| {
+        (obj.contains_key("started_at_unix_ms") || obj.contains_key("start_unix_ms"))
+            && (obj.contains_key("finished_at_unix_ms") || obj.contains_key("end_unix_ms"))
     })
 }
 
@@ -654,15 +664,12 @@ mod tests {
     }
 
     #[test]
-    fn compatible_mode_rejects_close_event_shape_with_nested_span_timestamps() {
-        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":10,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
-{"event":"close","span":{"name":"st","started_at_unix_ms":5,"finished_at_unix_ms":8,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}"#;
+    fn compatible_mode_accepts_normalized_span_with_top_level_event_when_timed() {
+        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":10,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a","tt.outcome":"ok","tt.success":true}}}
+{"event":"close","span":{"name":"st","started_at_unix_ms":5,"finished_at_unix_ms":8,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db","tt.success":true}}}"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().stages.len(), 0);
-        assert!(!imported.warnings().is_empty());
-        assert!(imported.warnings().iter().any(|w| w
-            .message()
-            .contains("unsupported tracing log envelope fields")));
+        assert_eq!(imported.run().stages.len(), 1);
+        assert!(imported.warnings().is_empty());
     }
 
     #[test]
@@ -1058,7 +1065,53 @@ mod tests {
         assert!(imported.run().requests.is_empty());
         assert!(imported.run().stages.is_empty());
         assert!(imported.run().queues.is_empty());
+        assert!(imported.warnings().is_empty());
+    }
+
+    #[test]
+    fn compatible_mode_accepts_normalized_span_with_top_level_message_when_timed() {
+        let input = r#"{"message":"completed request","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/message","tt.outcome":"ok","tt.success":true}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].route, "/message");
+        assert!(imported.warnings().is_empty());
+    }
+
+    #[test]
+    fn compatible_mode_accepts_normalized_span_with_fmt_metadata_when_timed() {
+        let input = r#"{"timestamp":"2026-06-01T00:00:00Z","level":"INFO","target":"svc","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/fmt","tt.outcome":"ok","tt.success":true}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].route, "/fmt");
+        assert!(imported.warnings().is_empty());
+    }
+
+    #[test]
+    fn compatible_mode_rejects_ordinary_fmt_json_without_completed_span_timing() {
+        let input = r#"{"timestamp":"2026-06-01T00:00:00Z","level":"INFO","target":"svc","message":"ordinary log","fields":{"request_id":"r1"}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.run().stages.is_empty());
+        assert!(imported.run().queues.is_empty());
         assert_eq!(imported.warnings().len(), 1);
+        assert!(imported.warnings()[0].message().contains("fmt JSON"));
+
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+            .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(err.to_string().contains("fmt JSON"));
+    }
+
+    #[test]
+    fn wrapper_only_rejects_non_wrapper_compatible_normalized_record() {
+        let input = r#"{"timestamp":"2026-06-01T00:00:00Z","level":"INFO","target":"svc","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/fmt","tt.outcome":"ok","tt.success":true}}}"#;
+        let err = import_jsonl_reader_with_mode(
+            Cursor::new(input),
+            ImportOptions::new("svc"),
+            JsonlParseMode::TailtriageWrapperOnly,
+        )
+        .unwrap_err();
+        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Make compatible JSONL parsing stricter about rejecting ordinary `tracing_subscriber::fmt().json()` logs while not rejecting valid normalized completed spans that merely include harmless top-level fmt-like metadata.
- Allow normalized completed-span records that contain top-level `timestamp`/`level`/`target`/`message`/`event` when explicit completed-span timing is present so real captures are not spuriously skipped.

### Description

- Replace the broad `has_fmt_log_envelope_fields` predicate with `is_ordinary_fmt_json_without_completed_span_timing` that returns true only when the top-level object contains `timestamp` AND `level` AND `target` and the record lacks explicit completed-span timing. The new helpers are `has_start_and_end_timing` and `has_completed_span_timing` and the check lives in `tailtriage-tracing/src/jsonl.rs`.
- Preserve the existing wrapper-only behavior and early rejection path (`JsonlParseMode::TailtriageWrapperOnly`) unchanged so stable wrapper-only semantics remain intact.
- Update compatible-mode warning/error text to reference the new narrower detection (`unsupported tracing fmt JSON envelope for compatible import (timestamp/level/target without completed-span timing)`).
- Add and adjust tests in `tailtriage-tracing/src/jsonl.rs` and `tailtriage-cli/tests/cli_boundary.rs` to cover: accepting normalized completed spans that include top-level `message`, or `timestamp`/`level`/`target` when explicit start/end timing is present; rejecting ordinary fmt JSON with `timestamp`/`level`/`target` and no completed-span timing; and asserting wrapper-only mode still rejects non-wrapper compatible records.

### Testing

- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed without warnings.
- Ran full test suite with `cargo test --workspace --all-targets --all-features --locked` and `cargo test --workspace` and all tests passed.
- Ran focused import tests `cargo test -p tailtriage-tracing jsonl --all-features --locked` and `cargo test -p tailtriage-cli --test cli_boundary import_tracing_spans_jsonl_compatible --all-features --locked` and they passed.
- Ran documentation contract validation `python3 scripts/validate_docs_contracts.py` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dd3e7b498833092bca428e8276395)