### PR TITLE
Narrow compatible JSONL fmt rejection

### DIFF
--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -713,14 +713,13 @@ fn import_tracing_spans_jsonl_default_rejects_fmt_json_with_guidance() {
 }
 
 #[test]
-fn import_tracing_spans_jsonl_compatible_rejects_fmt_like_record_with_top_level_explicit_timestamps(
-) {
+fn import_tracing_spans_jsonl_compatible_rejects_ordinary_fmt_json_without_completed_span_timing() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("compatible.jsonl");
     let run_path = dir.path().join("run.json");
     std::fs::write(
         &spans_path,
-        r#"{"timestamp":"2026-01-01T00:00:00Z","level":"INFO","target":"svc","event":"close","name":"request","started_at_unix_ms":1000,"finished_at_unix_ms":2000,"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}"#,
+        r#"{"timestamp":"2026-01-01T00:00:00Z","level":"INFO","target":"svc","fields":{"message":"ordinary log"}}"#,
     )
     .unwrap();
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
@@ -740,12 +739,12 @@ fn import_tracing_spans_jsonl_compatible_rejects_fmt_like_record_with_top_level_
         "cli unexpectedly succeeded: {output:?}"
     );
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
-    assert!(stderr.contains("unsupported tracing log envelope fields for compatible import (timestamp/level/target/event/message)"));
+    assert!(stderr.contains("ordinary tracing log JSON"));
     assert!(!run_path.exists(), "run json should not be written");
 }
 
 #[test]
-fn import_tracing_spans_jsonl_compatible_rejects_fmt_like_record_with_nested_explicit_timestamps() {
+fn import_tracing_spans_jsonl_compatible_accepts_normalized_record_with_fmt_metadata() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("compatible.jsonl");
     let run_path = dir.path().join("run.json");
@@ -767,12 +766,12 @@ fn import_tracing_spans_jsonl_compatible_rejects_fmt_like_record_with_nested_exp
         .output()
         .expect("cli should run");
     assert!(
-        !output.status.success(),
-        "cli unexpectedly succeeded: {output:?}"
+        output.status.success(),
+        "cli unexpectedly failed: {output:?}"
     );
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
-    assert!(stderr.contains("unsupported tracing log envelope fields for compatible import (timestamp/level/target/event/message)"));
-    assert!(!run_path.exists(), "run json should not be written");
+    assert!(!stderr.contains("unsupported tracing fmt JSON for compatible import"));
+    assert!(run_path.exists(), "run json should be written");
 }
 
 #[test]

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -223,9 +223,9 @@ fn parse_record(
         );
         return Err(ImportError::ExpectedTailtriageWrapper { reason: message });
     }
-    if has_fmt_log_envelope_fields(value) {
+    if is_ordinary_fmt_json_without_completed_span_timing(value) {
         let message = format!(
-            "line {line_no}: unsupported tracing log envelope fields for compatible import (timestamp/level/target/event/message)"
+            "line {line_no}: unsupported tracing fmt JSON for compatible import (timestamp/level/target without completed-span timing)"
         );
         if strict {
             return Err(ImportError::StrictViolation(message));
@@ -298,14 +298,30 @@ fn parse_record(
     }
 }
 
-fn has_fmt_log_envelope_fields(value: &Value) -> bool {
-    value.as_object().is_some_and(|obj| {
-        obj.contains_key("timestamp")
-            || obj.contains_key("level")
-            || obj.contains_key("target")
-            || obj.contains_key("event")
-            || obj.contains_key("message")
-    })
+fn is_ordinary_fmt_json_without_completed_span_timing(value: &Value) -> bool {
+    let Some(obj) = value.as_object() else {
+        return false;
+    };
+
+    let looks_like_fmt =
+        obj.contains_key("timestamp") && obj.contains_key("level") && obj.contains_key("target");
+    looks_like_fmt && !has_completed_span_timing(value)
+}
+
+fn has_completed_span_timing(value: &Value) -> bool {
+    has_explicit_start_and_end_timing(value)
+        || value
+            .get("span")
+            .is_some_and(has_explicit_start_and_end_timing)
+}
+
+fn has_explicit_start_and_end_timing(value: &Value) -> bool {
+    let Some(obj) = value.as_object() else {
+        return false;
+    };
+
+    (obj.contains_key("started_at_unix_ms") || obj.contains_key("start_unix_ms"))
+        && (obj.contains_key("finished_at_unix_ms") || obj.contains_key("end_unix_ms"))
 }
 
 fn first_non_scalar_tailtriage_field(value: &Value) -> Option<String> {
@@ -539,6 +555,49 @@ mod tests {
     }
 
     #[test]
+    fn compatible_mode_accepts_normalized_span_with_top_level_message() {
+        let input = r#"{"message":"harmless metadata","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/message"}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].route, "/message");
+        assert!(!imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("unsupported tracing fmt JSON")));
+    }
+
+    #[test]
+    fn compatible_mode_accepts_normalized_span_with_top_level_fmt_metadata() {
+        let input = r#"{"timestamp":"2026-06-01T00:00:00Z","level":"INFO","target":"svc","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/fmt-meta"}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].route, "/fmt-meta");
+        assert!(!imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("unsupported tracing fmt JSON")));
+    }
+
+    #[test]
+    fn compatible_mode_ordinary_fmt_json_warns_and_strict_errors() {
+        let input = r#"{"timestamp":"2026-06-01T00:00:00Z","level":"INFO","target":"svc","fields":{"message":"ordinary log"}}"#;
+
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported.run().stages.is_empty());
+        assert!(imported.run().queues.is_empty());
+        assert_eq!(imported.warnings().len(), 1);
+        assert!(imported.warnings()[0]
+            .message()
+            .contains("unsupported tracing fmt JSON"));
+
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+            .unwrap_err();
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(err.to_string().contains("unsupported tracing fmt JSON"));
+    }
+
+    #[test]
     fn empty_lines_ignored() {
         let input = "\n\n";
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
@@ -654,15 +713,16 @@ mod tests {
     }
 
     #[test]
-    fn compatible_mode_rejects_close_event_shape_with_nested_span_timestamps() {
+    fn compatible_mode_accepts_normalized_span_with_top_level_event_metadata() {
         let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":10,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
 {"event":"close","span":{"name":"st","started_at_unix_ms":5,"finished_at_unix_ms":8,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().stages.len(), 0);
-        assert!(!imported.warnings().is_empty());
-        assert!(imported.warnings().iter().any(|w| w
-            .message()
-            .contains("unsupported tracing log envelope fields")));
+        assert_eq!(imported.run().stages.len(), 1);
+        assert_eq!(imported.run().stages[0].stage, "db");
+        assert!(!imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("unsupported tracing fmt JSON")));
     }
 
     #[test]
@@ -1058,7 +1118,19 @@ mod tests {
         assert!(imported.run().requests.is_empty());
         assert!(imported.run().stages.is_empty());
         assert!(imported.run().queues.is_empty());
-        assert_eq!(imported.warnings().len(), 1);
+        assert!(imported.warnings().is_empty());
+    }
+
+    #[test]
+    fn wrapper_only_mode_rejects_non_wrapper_compatible_record_with_fmt_metadata() {
+        let input = r#"{"timestamp":"2026-06-01T00:00:00Z","level":"INFO","target":"svc","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
+        let err = import_jsonl_reader_with_mode(
+            Cursor::new(input),
+            ImportOptions::new("svc"),
+            JsonlParseMode::TailtriageWrapperOnly,
+        )
+        .unwrap_err();
+        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The existing compatibility check treated any JSON with top-level fmt-like fields (timestamp/level/target/event/message) as an ordinary tracing fmt record and rejected it, which also blocked valid normalized completed-span records that merely include harmless top-level fmt metadata.
- The parser should continue to reject ordinary `tracing_subscriber::fmt().json()` output, but it must accept normalized completed-span records when they include explicit start/end timing even if they have top-level fmt-like fields.

### Description
- Replace the coarse `has_fmt_log_envelope_fields` predicate with `is_ordinary_fmt_json_without_completed_span_timing` and helper functions `has_completed_span_timing` and `has_explicit_start_and_end_timing` so fmt-like rejection only triggers for records that both look like fmt JSON and lack explicit completed-span timing.
- Keep the stable wrapper-only (`JsonlParseMode::TailtriageWrapperOnly`) behavior unchanged while allowing `JsonlParseMode::Compatible` to accept normalized completed spans that include harmless top-level `message`/`timestamp`/`level`/`target`/`event` metadata when explicit start/end timestamps are present.
- Add unit tests in `tailtriage-tracing/src/jsonl.rs` covering: normalized completed span with top-level `message`; normalized completed span with top-level `timestamp`/`level`/`target`; ordinary fmt JSON (timestamp+level+target) without completed-span timing should warn/skip in non-strict and error in strict mode; and a wrapper-only test ensuring wrapper-only mode still rejects non-wrapper compatible records.
- Update CLI boundary tests in `tailtriage-cli/tests/cli_boundary.rs` to assert the compatible import rejects ordinary fmt JSON without completed-span timing but accepts normalized completed spans carrying fmt-like metadata.

### Testing
- Ran `cargo fmt --check` which succeeded.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which succeeded with no warnings.
- Ran focused and full test suites including `cargo test -p tailtriage-tracing jsonl --all-features --locked`, `cargo test -p tailtriage-cli --test cli_boundary import_tracing_spans_jsonl_compatible --all-features --locked`, and `cargo test --workspace --all-targets --all-features --locked`, and all tests passed.
- Ran `python3 scripts/validate_docs_contracts.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dd3e7b498833092bca428e8276395)