### PR TITLE
Document tracing field type requirements

### DIFF
--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -68,6 +68,15 @@ Recommended stable input format is the tailtriage wrapper JSONL shape:
 - `tailtriage-span-jsonl`
 - `compatible`
 
+Tracing import `tt.*` field types:
+
+- `tt.success`: optional bool; strings `"true"` and `"false"` are also accepted case-insensitively.
+- `tt.depth_at_start`: optional non-negative integer. Do not record it with debug formatting.
+- `tt.outcome`: optional non-empty string.
+- `tt.kind`, `tt.request_id`, `tt.route`, `tt.stage`, and `tt.queue`: scalar strings.
+
+Use `tt.depth_at_start = depth_u64` for queue depth. `tt.depth_at_start = ?depth` may produce a debug-formatted value and be rejected.
+
 Behavior:
 - `tailtriage-span-jsonl` enforces wrapper-only parsing.
 - `tailtriage-span-jsonl` is the default library contract: non-wrapper non-empty JSON records are hard errors.

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -154,12 +154,22 @@ Import does not guess span timing from line receive time: provide explicit unix-
 | stage | `tt.kind="stage"`, `tt.request_id`, `tt.stage` | `tt.success` |
 | queue | `tt.kind="queue"`, `tt.request_id`, `tt.queue` | `tt.depth_at_start` |
 
+Accepted field types:
+
+- `tt.success`: optional bool; strings `"true"` and `"false"` are also accepted case-insensitively.
+- `tt.depth_at_start`: optional non-negative integer. Do not record it with debug formatting.
+- `tt.outcome`: optional non-empty string.
+- `tt.kind`, `tt.request_id`, `tt.route`, `tt.stage`, and `tt.queue`: scalar strings.
+
 Record semantic `tt.*` fields (`tt.kind`, `tt.request_id`, `tt.route`, `tt.stage`, `tt.queue`) as plain scalar strings (string literals or display-formatted scalar strings). Do not use debug formatting for semantic `tt.*` fields.
 
 For example: `tt.kind = "request"` works, `tt.kind = %kind` can work when `kind` displays as `request`, but `tt.kind = ?kind` may record `"request"` (debug quoting) and be rejected as unknown.
 
+For queue depth, record the integer value directly: `tt.depth_at_start = depth_u64`.
+`tt.depth_at_start = ?depth` may produce a debug-formatted value and be rejected.
+
 Missing request `tt.outcome` defaults to `ok` with a warning.
-If present, request `tt.outcome` must be a string and cannot be empty/whitespace-only; accepted custom labels are preserved exactly.
+Accepted custom `tt.outcome` labels are preserved exactly.
 Missing stage `tt.success` defaults to `true` with a warning.
 
 Live tracing intake only tracks spans that are tailtriage candidates at span creation time. Declare `tt.*` fields when the span is created. If a value is filled later, declare the field with `tracing::field::Empty` and then call `span.record(...)`; adding brand-new `tt.*` fields later with `span.record(...)` is not supported.


### PR DESCRIPTION
### Motivation
- Make `tt.*` tracing field type requirements explicit and beginner-friendly in the docs so users know what the parser expects and avoid debug-formatted rejections.

### Description
- Add an "Accepted field types" list to `tailtriage-tracing/README.md` (keeps the existing required/optional table) documenting `tt.success`, `tt.depth_at_start`, `tt.outcome`, and scalar string rules, plus the short queue-depth example `tt.depth_at_start = depth_u64` and the warning about `tt.depth_at_start = ?depth`.
- Add a concise aligned guidance block to `tailtriage-cli/README.md` for the tracing import path without duplicating large examples.
- Do not change parser behavior, tests, or dependencies; documentation-only change.

### Testing
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, `cargo test --workspace`, and `python3 scripts/validate_docs_contracts.py`, and all checks/tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e5a92320c8330831ef5f4db926ef4)