### PR TITLE
Document tracing tt.* field type requirements

### DIFF
--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -75,6 +75,12 @@ Behavior:
 - Close-event/fmt-like tracing log envelopes are unsupported import input.
 - Ordinary `tracing_subscriber::fmt().json()` logs are unsupported and rejected; timing is not guessed from JSONL line receive time.
 
+Tracing import field types:
+- `tt.success`: optional bool; strings `"true"` and `"false"` are also accepted case-insensitively.
+- `tt.depth_at_start`: optional non-negative integer. Do not record it with debug formatting.
+- `tt.outcome`: optional non-empty string.
+- `tt.kind`, `tt.request_id`, `tt.route`, `tt.stage`, and `tt.queue`: scalar strings.
+
 After import, run analysis separately:
 
 ```bash

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -154,12 +154,22 @@ Import does not guess span timing from line receive time: provide explicit unix-
 | stage | `tt.kind="stage"`, `tt.request_id`, `tt.stage` | `tt.success` |
 | queue | `tt.kind="queue"`, `tt.request_id`, `tt.queue` | `tt.depth_at_start` |
 
+Accepted field types:
+
+- `tt.success`: optional bool; strings `"true"` and `"false"` are also accepted case-insensitively.
+- `tt.depth_at_start`: optional non-negative integer. Do not record it with debug formatting.
+- `tt.outcome`: optional non-empty string.
+- `tt.kind`, `tt.request_id`, `tt.route`, `tt.stage`, and `tt.queue`: scalar strings.
+
 Record semantic `tt.*` fields (`tt.kind`, `tt.request_id`, `tt.route`, `tt.stage`, `tt.queue`) as plain scalar strings (string literals or display-formatted scalar strings). Do not use debug formatting for semantic `tt.*` fields.
 
 For example: `tt.kind = "request"` works, `tt.kind = %kind` can work when `kind` displays as `request`, but `tt.kind = ?kind` may record `"request"` (debug quoting) and be rejected as unknown.
 
+Correct queue depth field: `tt.depth_at_start = depth_u64`.
+
+Warning: `tt.depth_at_start = ?depth` may produce a debug-formatted value and be rejected.
+
 Missing request `tt.outcome` defaults to `ok` with a warning.
-If present, request `tt.outcome` must be a string and cannot be empty/whitespace-only; accepted custom labels are preserved exactly.
 Missing stage `tt.success` defaults to `true` with a warning.
 
 Live tracing intake only tracks spans that are tailtriage candidates at span creation time. Declare `tt.*` fields when the span is created. If a value is filled later, declare the field with `tracing::field::Empty` and then call `span.record(...)`; adding brand-new `tt.*` fields later with `span.record(...)` is not supported.


### PR DESCRIPTION
### Motivation

- Make `tt.*` tracing field type requirements user-visible and explicitly aligned with the existing parser behavior so users avoid common import rejections. 

### Description

- Update `tailtriage-tracing/README.md` to add an "Accepted field types" list covering `tt.success`, `tt.depth_at_start`, `tt.outcome`, and the semantic scalar string fields, plus a short correct example and a brief warning about debug formatting. 
- Update `tailtriage-cli/README.md` to add a concise tracing-import field types summary that matches the tracing README without duplicating larger examples. 
- No parser, behavior, or dependency changes were made; this change is documentation-only. 

### Testing

- Ran `cargo fmt --check` and it succeeded. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it succeeded. 
- Ran `cargo test --workspace --all-targets --all-features --locked` and `cargo test --workspace` and all tests passed. 
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e5a92320c8330831ef5f4db926ef4)