### PR TITLE
Document tracing field type requirements

### DIFF
--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -68,6 +68,13 @@ Recommended stable input format is the tailtriage wrapper JSONL shape:
 - `tailtriage-span-jsonl`
 - `compatible`
 
+Tracing import field types:
+
+- `tt.success`: optional bool; strings `"true"` and `"false"` are also accepted case-insensitively.
+- `tt.depth_at_start`: optional non-negative integer. Do not record it with debug formatting.
+- `tt.outcome`: optional non-empty string.
+- `tt.kind`, `tt.request_id`, `tt.route`, `tt.stage`, and `tt.queue`: scalar strings.
+
 Behavior:
 - `tailtriage-span-jsonl` enforces wrapper-only parsing.
 - `tailtriage-span-jsonl` is the default library contract: non-wrapper non-empty JSON records are hard errors.

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -154,12 +154,24 @@ Import does not guess span timing from line receive time: provide explicit unix-
 | stage | `tt.kind="stage"`, `tt.request_id`, `tt.stage` | `tt.success` |
 | queue | `tt.kind="queue"`, `tt.request_id`, `tt.queue` | `tt.depth_at_start` |
 
-Record semantic `tt.*` fields (`tt.kind`, `tt.request_id`, `tt.route`, `tt.stage`, `tt.queue`) as plain scalar strings (string literals or display-formatted scalar strings). Do not use debug formatting for semantic `tt.*` fields.
+Accepted field types:
+
+- `tt.success`: optional bool; strings `"true"` and `"false"` are also accepted case-insensitively.
+- `tt.depth_at_start`: optional non-negative integer. Do not record it with debug formatting.
+- `tt.outcome`: optional non-empty string.
+- `tt.kind`, `tt.request_id`, `tt.route`, `tt.stage`, and `tt.queue`: scalar strings.
+
+Correct queue depth field:
+
+```text
+tt.depth_at_start = depth_u64
+```
+
+`tt.depth_at_start = ?depth` may produce a debug-formatted value and be rejected.
 
 For example: `tt.kind = "request"` works, `tt.kind = %kind` can work when `kind` displays as `request`, but `tt.kind = ?kind` may record `"request"` (debug quoting) and be rejected as unknown.
 
 Missing request `tt.outcome` defaults to `ok` with a warning.
-If present, request `tt.outcome` must be a string and cannot be empty/whitespace-only; accepted custom labels are preserved exactly.
 Missing stage `tt.success` defaults to `true` with a warning.
 
 Live tracing intake only tracks spans that are tailtriage candidates at span creation time. Declare `tt.*` fields when the span is created. If a value is filled later, declare the field with `tracing::field::Empty` and then call `span.record(...)`; adding brand-new `tt.*` fields later with `span.record(...)` is not supported.


### PR DESCRIPTION
### Motivation

- Make tracing `tt.*` field type requirements explicit and visible to users so documented conventions match the parser behavior.
- Reduce confusion and accidental import failures by showing exact accepted types and a short queue-field example with a formatting warning.

### Description

- Updated `tailtriage-tracing/README.md` to keep the required/optional table and add exact accepted-type bullets for `tt.success`, `tt.depth_at_start`, `tt.outcome`, and scalar string fields, plus a short example `tt.depth_at_start = depth_u64` and a warning about debug formatting being rejected.
- Added a concise "Tracing import field types" section to `tailtriage-cli/README.md` with the same accepted-type rules to keep CLI guidance aligned with the tracing intake docs.
- Switched the queue-depth snippet to a non-doctest code block (`text`) to avoid Rust doctest compilation in crate documentation while preserving the visible example.
- No parser or runtime behavior was changed and no new dependencies were added.

### Testing

- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed with no warnings.
- Ran `cargo test --workspace --all-targets --all-features --locked` and `cargo test --workspace`, and all unit/integration/doc tests passed after fixing the doctest snippet.
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e5a92320c8330831ef5f4db926ef4)