### PR TITLE
docs: clarify tracing tt.* field type requirements

### DIFF
--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -58,6 +58,13 @@ tailtriage import tracing-spans-jsonl spans.jsonl --service checkout --output ta
 
 `tailtriage import tracing-spans-jsonl` imports **completed tailtriage `tt.*` tracing span JSONL** into **Run JSON** (not Report JSON).
 
+Accepted `tt.*` field types match tracing intake:
+
+- `tt.success`: optional bool; strings `"true"` and `"false"` are also accepted case-insensitively.
+- `tt.depth_at_start`: optional non-negative integer. Do not record it with debug formatting.
+- `tt.outcome`: optional non-empty string.
+- `tt.kind`, `tt.request_id`, `tt.route`, `tt.stage`, and `tt.queue`: scalar strings.
+
 Recommended stable input format is the tailtriage wrapper JSONL shape:
 
 ```json

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -154,13 +154,24 @@ Import does not guess span timing from line receive time: provide explicit unix-
 | stage | `tt.kind="stage"`, `tt.request_id`, `tt.stage` | `tt.success` |
 | queue | `tt.kind="queue"`, `tt.request_id`, `tt.queue` | `tt.depth_at_start` |
 
-Record semantic `tt.*` fields (`tt.kind`, `tt.request_id`, `tt.route`, `tt.stage`, `tt.queue`) as plain scalar strings (string literals or display-formatted scalar strings). Do not use debug formatting for semantic `tt.*` fields.
+Accepted field types:
 
-For example: `tt.kind = "request"` works, `tt.kind = %kind` can work when `kind` displays as `request`, but `tt.kind = ?kind` may record `"request"` (debug quoting) and be rejected as unknown.
+- `tt.success`: optional bool; strings `"true"` and `"false"` are also accepted case-insensitively.
+- `tt.depth_at_start`: optional non-negative integer. Do not record it with debug formatting.
+- `tt.outcome`: optional non-empty string.
+- `tt.kind`, `tt.request_id`, `tt.route`, `tt.stage`, and `tt.queue`: scalar strings.
 
-Missing request `tt.outcome` defaults to `ok` with a warning.
-If present, request `tt.outcome` must be a string and cannot be empty/whitespace-only; accepted custom labels are preserved exactly.
-Missing stage `tt.success` defaults to `true` with a warning.
+Use a plain integer value for queue depth:
+
+```text
+tt.depth_at_start = depth_u64
+```
+
+`tt.depth_at_start = ?depth` may produce a debug-formatted value and be rejected.
+
+For semantic string fields, `tt.kind = "request"` works, and `tt.kind = %kind` can work when `kind` displays as `request`. `tt.kind = ?kind` may record `"request"` with debug quoting and be rejected as unknown.
+
+Missing request `tt.outcome` defaults to `ok` with a warning. Missing stage `tt.success` defaults to `true` with a warning.
 
 Live tracing intake only tracks spans that are tailtriage candidates at span creation time. Declare `tt.*` fields when the span is created. If a value is filled later, declare the field with `tracing::field::Empty` and then call `span.record(...)`; adding brand-new `tt.*` fields later with `span.record(...)` is not supported.
 


### PR DESCRIPTION
### Motivation
- Make `tt.*` field type expectations explicit and beginner-friendly in the documentation so users know what the parser accepts and why some tracing formatting (especially debug formatting) can cause records to be rejected.

### Description
- Update `tailtriage-tracing/README.md` to add an "Accepted field types" list that documents exact accepted types for `tt.success`, `tt.depth_at_start`, `tt.outcome`, and semantic string fields, plus a short integer example and a one-line warning about debug formatting for `tt.depth_at_start`.
- Update `tailtriage-cli/README.md` to include the same concise accepted-type rules for CLI tracing import without duplicating larger examples.

### Testing
- Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, `cargo test --workspace`, and `python3 scripts/validate_docs_contracts.py`, and all automated checks and tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e5a92320c8330831ef5f4db926ef4)