### PR TITLE
Prefer run-relative temporal segmentation

### DIFF
--- a/tailtriage-analyzer/src/temporal.rs
+++ b/tailtriage-analyzer/src/temporal.rs
@@ -6,31 +6,156 @@ use super::{
 use crate::route;
 
 const TEMPORAL_RUNTIME_ATTRIBUTION_WARNING: &str = "Runtime and in-flight evidence is sparse in this segment after timestamp filtering; executor/blocking attribution is limited.";
+const TEMPORAL_WALL_CLOCK_FALLBACK_WARNING: &str = "Temporal segment used wall-clock timestamp fallback; attribution is approximate for artifacts without complete run-relative timing.";
 pub(super) const TEMPORAL_SUSPECT_SHIFT_WARNING: &str = "Temporal segments show different primary suspects; inspect temporal_segments before acting on the global suspect.";
 pub(super) const TEMPORAL_P95_SHIFT_WARNING: &str =
     "Temporal segments show a large p95 latency shift between early and late requests.";
 pub(super) const TEMPORAL_OVERLAP_ATTRIBUTION_WARNING: &str = "Segment windows overlap under concurrent requests; timestamp-filtered runtime/in-flight attribution is approximate.";
 
-fn filtered_run_for_temporal_segment(
+#[derive(Clone, Copy)]
+enum SegmentWindow {
+    RunRelative { start: u64, finish: u64 },
+    Unix { start: u64, finish: u64 },
+}
+
+fn request_temporal_sort_key(request: &RequestEvent) -> (u8, u64, String) {
+    match request.started_at_run_us {
+        Some(started_at_run_us) => (0, started_at_run_us, request.request_id.clone()),
+        None => (1, request.started_at_unix_ms, request.request_id.clone()),
+    }
+}
+
+fn segment_run_relative_window(requests: &[RequestEvent]) -> Option<(u64, u64)> {
+    if !requests
+        .iter()
+        .all(|r| r.started_at_run_us.is_some() && r.finished_at_run_us.is_some())
+    {
+        return None;
+    }
+    let start = requests.iter().filter_map(|r| r.started_at_run_us).min()?;
+    let finish = requests.iter().filter_map(|r| r.finished_at_run_us).max()?;
+    Some((start, finish))
+}
+
+fn segment_unix_window(requests: &[RequestEvent]) -> Option<(u64, u64)> {
+    let start = requests.iter().map(|r| r.started_at_unix_ms).min()?;
+    let finish = requests.iter().map(|r| r.finished_at_unix_ms).max()?;
+    Some((start, finish))
+}
+
+fn filter_segment_runtime_and_inflight(
     run: &Run,
     request_ids: &[String],
-    start: u64,
-    end: u64,
+    window: SegmentWindow,
 ) -> Run {
     let mut filtered = route::filtered_run_for_route(run, request_ids);
-    filtered.runtime_snapshots = run
-        .runtime_snapshots
-        .iter()
-        .filter(|s| s.at_unix_ms >= start && s.at_unix_ms <= end)
-        .cloned()
-        .collect();
-    filtered.inflight = run
-        .inflight
-        .iter()
-        .filter(|s| s.at_unix_ms >= start && s.at_unix_ms <= end)
-        .cloned()
-        .collect();
+    match window {
+        SegmentWindow::RunRelative { start, finish } => {
+            filtered.runtime_snapshots = run
+                .runtime_snapshots
+                .iter()
+                .filter(|s| matches!(s.at_run_us, Some(at) if at >= start && at <= finish))
+                .cloned()
+                .collect();
+            filtered.inflight = run
+                .inflight
+                .iter()
+                .filter(|s| matches!(s.at_run_us, Some(at) if at >= start && at <= finish))
+                .cloned()
+                .collect();
+        }
+        SegmentWindow::Unix { start, finish } => {
+            filtered.runtime_snapshots = run
+                .runtime_snapshots
+                .iter()
+                .filter(|s| s.at_unix_ms >= start && s.at_unix_ms <= finish)
+                .cloned()
+                .collect();
+            filtered.inflight = run
+                .inflight
+                .iter()
+                .filter(|s| s.at_unix_ms >= start && s.at_unix_ms <= finish)
+                .cloned()
+                .collect();
+        }
+    }
     filtered
+}
+
+fn build_temporal_segment(
+    name: &str,
+    run: &Run,
+    seg: &[RequestEvent],
+    options: &AnalyzeOptions,
+) -> TemporalSegment {
+    let ids: Vec<String> = seg.iter().map(|r| r.request_id.clone()).collect();
+    let (start, finish) = segment_unix_window(seg)
+        .map_or((None, None), |(start, finish)| (Some(start), Some(finish)));
+    let run_relative_window = segment_run_relative_window(seg);
+    let mut used_unix_fallback = false;
+    let mut analyzed = match run_relative_window {
+        Some((s, f)) => analyze_run_internal(
+            &filter_segment_runtime_and_inflight(
+                run,
+                &ids,
+                SegmentWindow::RunRelative {
+                    start: s,
+                    finish: f,
+                },
+            ),
+            options,
+        ),
+        None => match (start, finish) {
+            (Some(s), Some(f)) => {
+                used_unix_fallback = true;
+                analyze_run_internal(
+                    &filter_segment_runtime_and_inflight(
+                        run,
+                        &ids,
+                        SegmentWindow::Unix {
+                            start: s,
+                            finish: f,
+                        },
+                    ),
+                    options,
+                )
+            }
+            _ => analyze_run_internal(&route::filtered_run_for_route(run, &ids), options),
+        },
+    };
+    let sparse_runtime =
+        analyzed.evidence_quality.runtime_snapshots != SignalCoverageStatus::Present;
+    let sparse_inflight =
+        analyzed.evidence_quality.inflight_snapshots != SignalCoverageStatus::Present;
+    if matches!(
+        analyzed.primary_suspect.kind,
+        DiagnosisKind::ExecutorPressureSuspected | DiagnosisKind::BlockingPoolPressure
+    ) && (sparse_runtime || sparse_inflight)
+    {
+        analyzed
+            .warnings
+            .push(TEMPORAL_RUNTIME_ATTRIBUTION_WARNING.to_string());
+    }
+    if used_unix_fallback {
+        analyzed
+            .warnings
+            .push(TEMPORAL_WALL_CLOCK_FALLBACK_WARNING.to_string());
+    }
+    TemporalSegment {
+        name: name.to_string(),
+        request_count: analyzed.request_count,
+        started_at_unix_ms: start,
+        finished_at_unix_ms: finish,
+        p50_latency_us: analyzed.p50_latency_us,
+        p95_latency_us: analyzed.p95_latency_us,
+        p99_latency_us: analyzed.p99_latency_us,
+        p95_queue_share_permille: analyzed.p95_queue_share_permille,
+        p95_service_share_permille: analyzed.p95_service_share_permille,
+        evidence_quality: analyzed.evidence_quality,
+        primary_suspect: analyzed.primary_suspect,
+        secondary_suspects: analyzed.secondary_suspects,
+        warnings: analyzed.warnings,
+    }
 }
 
 pub(super) fn temporal_segments(
@@ -42,11 +167,7 @@ pub(super) fn temporal_segments(
         return vec![];
     }
     let mut requests = run.requests.clone();
-    requests.sort_by(|a, b| {
-        a.started_at_unix_ms
-            .cmp(&b.started_at_unix_ms)
-            .then_with(|| a.request_id.cmp(&b.request_id))
-    });
+    requests.sort_by_key(request_temporal_sort_key);
     let split = requests.len() / 2;
     let (early, late) = requests.split_at(split);
     if early.len() < options.temporal.min_segment_request_count
@@ -54,47 +175,8 @@ pub(super) fn temporal_segments(
     {
         return vec![];
     }
-    let build = |name: &str, seg: &[RequestEvent]| {
-        let ids: Vec<String> = seg.iter().map(|r| r.request_id.clone()).collect();
-        let start = seg.iter().map(|r| r.started_at_unix_ms).min();
-        let finish = seg.iter().map(|r| r.finished_at_unix_ms).max();
-        let mut analyzed = match (start, finish) {
-            (Some(s), Some(f)) => {
-                analyze_run_internal(&filtered_run_for_temporal_segment(run, &ids, s, f), options)
-            }
-            _ => analyze_run_internal(&route::filtered_run_for_route(run, &ids), options),
-        };
-        let sparse_runtime =
-            analyzed.evidence_quality.runtime_snapshots != SignalCoverageStatus::Present;
-        let sparse_inflight =
-            analyzed.evidence_quality.inflight_snapshots != SignalCoverageStatus::Present;
-        if matches!(
-            analyzed.primary_suspect.kind,
-            DiagnosisKind::ExecutorPressureSuspected | DiagnosisKind::BlockingPoolPressure
-        ) && (sparse_runtime || sparse_inflight)
-        {
-            analyzed
-                .warnings
-                .push(TEMPORAL_RUNTIME_ATTRIBUTION_WARNING.to_string());
-        }
-        TemporalSegment {
-            name: name.to_string(),
-            request_count: analyzed.request_count,
-            started_at_unix_ms: start,
-            finished_at_unix_ms: finish,
-            p50_latency_us: analyzed.p50_latency_us,
-            p95_latency_us: analyzed.p95_latency_us,
-            p99_latency_us: analyzed.p99_latency_us,
-            p95_queue_share_permille: analyzed.p95_queue_share_permille,
-            p95_service_share_permille: analyzed.p95_service_share_permille,
-            evidence_quality: analyzed.evidence_quality,
-            primary_suspect: analyzed.primary_suspect,
-            secondary_suspects: analyzed.secondary_suspects,
-            warnings: analyzed.warnings,
-        }
-    };
-    let mut early_seg = build("early", early);
-    let mut late_seg = build("late", late);
+    let mut early_seg = build_temporal_segment("early", run, early, options);
+    let mut late_seg = build_temporal_segment("late", run, late, options);
     let p95_shift =
         has_material_p95_shift(early_seg.p95_latency_us, late_seg.p95_latency_us, options);
     let queue_move = has_material_share_shift(

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -81,6 +81,22 @@ fn test_run() -> Run {
     }
 }
 
+const TEMPORAL_WALL_CLOCK_FALLBACK_WARNING: &str = "Temporal segment used wall-clock timestamp fallback; attribution is approximate for artifacts without complete run-relative timing.";
+
+fn request_with_run_timing(id: u64, started_at_run_us: u64, latency_us: u64) -> RequestEvent {
+    RequestEvent {
+        request_id: format!("req-{id}"),
+        route: "/t".into(),
+        kind: None,
+        started_at_unix_ms: 1,
+        started_at_run_us: Some(started_at_run_us),
+        finished_at_unix_ms: 1,
+        finished_at_run_us: Some(started_at_run_us + latency_us),
+        latency_us,
+        outcome: "ok".into(),
+    }
+}
+
 fn sample_request(id: u64) -> RequestEvent {
     RequestEvent {
         request_id: format!("req-{id}"),
@@ -1654,6 +1670,132 @@ fn temporal_segment_window_uses_max_finish_timestamp() {
         .find(|s| s.name == "early")
         .expect("early temporal segment should be emitted");
     assert_eq!(early.finished_at_unix_ms, Some(1000));
+}
+
+#[test]
+fn temporal_segments_order_requests_by_run_relative_start_before_coarse_unix_tie() {
+    let mut run = test_run();
+    run.requests = (1..=20)
+        .map(|id| request_with_run_timing(id, (21 - id) * 1_000, 1_000))
+        .collect();
+
+    for id in 11..=20 {
+        run.queues.push(QueueEvent {
+            request_id: format!("req-{id}"),
+            queue: "q".into(),
+            wait_us: 900,
+            waited_from_unix_ms: 1,
+            waited_from_run_us: Some((21 - id) * 1_000),
+            waited_until_unix_ms: 1,
+            waited_until_run_us: Some((21 - id) * 1_000 + 900),
+            depth_at_start: Some(9),
+        });
+    }
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert_eq!(report.temporal_segments.len(), 2);
+    let early = report
+        .temporal_segments
+        .iter()
+        .find(|s| s.name == "early")
+        .expect("early temporal segment should be emitted");
+    assert_eq!(
+        early.primary_suspect.kind,
+        DiagnosisKind::ApplicationQueueSaturation
+    );
+}
+
+#[test]
+fn temporal_segments_filter_runtime_and_inflight_by_run_relative_window_when_available() {
+    let mut run = test_run();
+    run.requests = (1..=10)
+        .map(|id| request_with_run_timing(id, id * 1_000, 1_000))
+        .chain((11..=20).map(|id| request_with_run_timing(id, id * 10_000, 5_000)))
+        .collect();
+    run.runtime_snapshots = vec![
+        RuntimeSnapshot {
+            at_unix_ms: 1,
+            at_run_us: Some(5_000),
+            global_queue_depth: Some(1),
+            local_queue_depth: Some(1),
+            alive_tasks: Some(20),
+            blocking_queue_depth: Some(1),
+            remote_schedule_count: None,
+        },
+        RuntimeSnapshot {
+            at_unix_ms: 1,
+            at_run_us: Some(150_000),
+            global_queue_depth: Some(2),
+            local_queue_depth: Some(2),
+            alive_tasks: Some(20),
+            blocking_queue_depth: Some(2),
+            remote_schedule_count: None,
+        },
+    ];
+    run.inflight = vec![
+        tailtriage_core::InFlightSnapshot {
+            at_unix_ms: 1,
+            at_run_us: Some(5_000),
+            gauge: "http.server.requests".into(),
+            count: 1,
+        },
+        tailtriage_core::InFlightSnapshot {
+            at_unix_ms: 1,
+            at_run_us: Some(150_000),
+            gauge: "http.server.requests".into(),
+            count: 2,
+        },
+    ];
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert_eq!(report.temporal_segments.len(), 2);
+    for segment in &report.temporal_segments {
+        assert_eq!(segment.evidence_quality.runtime_snapshot_count, 1);
+        assert_eq!(segment.evidence_quality.inflight_snapshot_count, 1);
+    }
+}
+
+#[test]
+fn temporal_segments_fallback_for_older_artifacts_emits_wall_clock_warning() {
+    let mut run = test_run();
+    run.requests = (0..20).map(|i| sample_request(i + 1)).collect();
+    for i in 10usize..20 {
+        if let Some(req) = run.requests.get_mut(i) {
+            req.latency_us = 5_000;
+        }
+    }
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert_eq!(report.temporal_segments.len(), 2);
+    for segment in &report.temporal_segments {
+        assert!(segment
+            .warnings
+            .iter()
+            .any(|w| w == TEMPORAL_WALL_CLOCK_FALLBACK_WARNING));
+    }
+}
+
+#[test]
+fn temporal_segments_do_not_emit_wall_clock_fallback_warning_when_run_relative_fields_are_complete()
+{
+    let mut run = test_run();
+    run.requests = (1..=10)
+        .map(|id| request_with_run_timing(id, id * 1_000, 1_000))
+        .chain((11..=20).map(|id| request_with_run_timing(id, id * 10_000, 5_000)))
+        .collect();
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert_eq!(report.temporal_segments.len(), 2);
+    for segment in &report.temporal_segments {
+        assert!(!segment
+            .warnings
+            .iter()
+            .any(|w| w == TEMPORAL_WALL_CLOCK_FALLBACK_WARNING));
+    }
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Improve within-run temporal segmentation and runtime/in-flight attribution by preferring monotonic run-relative timestamps when present while preserving correct behavior for older artifacts that lack those fields.

### Description
- Sort temporal requests by run-relative start using `RequestEvent.started_at_run_us`, falling back to `started_at_unix_ms`, and finally `request_id` for a deterministic tie-breaker via `request_temporal_sort_key`.
- Choose the segment window using `segment_run_relative_window` when every request in the segment has both `started_at_run_us` and `finished_at_run_us`, otherwise fall back to the Unix-ms window from `segment_unix_window`.
- Filter runtime and in-flight snapshots with `filter_segment_runtime_and_inflight` to require `at_run_us` when using a run-relative window and preserve the existing `at_unix_ms` filtering when using the Unix-ms window.
- Preserve existing runtime/in-flight sparse attribution and overlap attribution warnings and add the exact fallback warning `Temporal segment used wall-clock timestamp fallback; attribution is approximate for artifacts without complete run-relative timing.` to segments that used the Unix-ms fallback only.
- Added private helper functions in `tailtriage-analyzer/src/temporal.rs`: `request_temporal_sort_key`, `segment_run_relative_window`, `segment_unix_window`, and `filter_segment_runtime_and_inflight`, and refactored segment construction into `build_temporal_segment` to keep logic local and readable.
- Added tests in `tailtriage-analyzer/src/tests.rs` to validate run-relative ordering, run-relative runtime/in-flight filtering, fallback warning emission, and suppression of the fallback warning when run-relative fields are complete.

### Testing
- Ran `cargo fmt --check` and formatting passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and linting passed with no warnings.
- Ran full test suites with `cargo test --workspace --all-targets --all-features --locked` and `cargo test --workspace` and all tests passed.
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed.
- New tests added and executed include `temporal_segments_order_requests_by_run_relative_start_before_coarse_unix_tie`, `temporal_segments_filter_runtime_and_inflight_by_run_relative_window_when_available`, `temporal_segments_fallback_for_older_artifacts_emits_wall_clock_warning`, and `temporal_segments_do_not_emit_wall_clock_fallback_warning_when_run_relative_fields_are_complete`, and they passed as part of the test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e84c03ec08330985a9ecdc9f0b3ad)