### PR TITLE
Prefer run-relative temporal segmentation

### DIFF
--- a/tailtriage-analyzer/src/temporal.rs
+++ b/tailtriage-analyzer/src/temporal.rs
@@ -10,26 +10,78 @@ pub(super) const TEMPORAL_SUSPECT_SHIFT_WARNING: &str = "Temporal segments show 
 pub(super) const TEMPORAL_P95_SHIFT_WARNING: &str =
     "Temporal segments show a large p95 latency shift between early and late requests.";
 pub(super) const TEMPORAL_OVERLAP_ATTRIBUTION_WARNING: &str = "Segment windows overlap under concurrent requests; timestamp-filtered runtime/in-flight attribution is approximate.";
+pub(super) const TEMPORAL_WALL_CLOCK_FALLBACK_WARNING: &str = "Temporal segment used wall-clock timestamp fallback; attribution is approximate for artifacts without complete run-relative timing.";
 
-fn filtered_run_for_temporal_segment(
+#[derive(Clone, Copy)]
+enum SegmentWindow {
+    RunRelative { start: u64, finish: u64 },
+    Unix { start: u64, finish: u64 },
+}
+
+fn request_temporal_sort_key(request: &RequestEvent) -> (u64, &str) {
+    (
+        request
+            .started_at_run_us
+            .unwrap_or(request.started_at_unix_ms),
+        request.request_id.as_str(),
+    )
+}
+
+fn segment_run_relative_window(seg: &[RequestEvent]) -> Option<(u64, u64)> {
+    if !seg
+        .iter()
+        .all(|r| r.started_at_run_us.is_some() && r.finished_at_run_us.is_some())
+    {
+        return None;
+    }
+
+    let start = seg.iter().filter_map(|r| r.started_at_run_us).min()?;
+    let finish = seg.iter().filter_map(|r| r.finished_at_run_us).max()?;
+    Some((start, finish))
+}
+
+fn segment_unix_window(seg: &[RequestEvent]) -> Option<(u64, u64)> {
+    let start = seg.iter().map(|r| r.started_at_unix_ms).min()?;
+    let finish = seg.iter().map(|r| r.finished_at_unix_ms).max()?;
+    Some((start, finish))
+}
+
+fn filter_segment_runtime_and_inflight(
     run: &Run,
     request_ids: &[String],
-    start: u64,
-    end: u64,
+    window: SegmentWindow,
 ) -> Run {
     let mut filtered = route::filtered_run_for_route(run, request_ids);
-    filtered.runtime_snapshots = run
-        .runtime_snapshots
-        .iter()
-        .filter(|s| s.at_unix_ms >= start && s.at_unix_ms <= end)
-        .cloned()
-        .collect();
-    filtered.inflight = run
-        .inflight
-        .iter()
-        .filter(|s| s.at_unix_ms >= start && s.at_unix_ms <= end)
-        .cloned()
-        .collect();
+    match window {
+        SegmentWindow::RunRelative { start, finish } => {
+            filtered.runtime_snapshots = run
+                .runtime_snapshots
+                .iter()
+                .filter(|s| matches!(s.at_run_us, Some(at) if at >= start && at <= finish))
+                .cloned()
+                .collect();
+            filtered.inflight = run
+                .inflight
+                .iter()
+                .filter(|s| matches!(s.at_run_us, Some(at) if at >= start && at <= finish))
+                .cloned()
+                .collect();
+        }
+        SegmentWindow::Unix { start, finish } => {
+            filtered.runtime_snapshots = run
+                .runtime_snapshots
+                .iter()
+                .filter(|s| s.at_unix_ms >= start && s.at_unix_ms <= finish)
+                .cloned()
+                .collect();
+            filtered.inflight = run
+                .inflight
+                .iter()
+                .filter(|s| s.at_unix_ms >= start && s.at_unix_ms <= finish)
+                .cloned()
+                .collect();
+        }
+    }
     filtered
 }
 
@@ -42,11 +94,7 @@ pub(super) fn temporal_segments(
         return vec![];
     }
     let mut requests = run.requests.clone();
-    requests.sort_by(|a, b| {
-        a.started_at_unix_ms
-            .cmp(&b.started_at_unix_ms)
-            .then_with(|| a.request_id.cmp(&b.request_id))
-    });
+    requests.sort_by(|a, b| request_temporal_sort_key(a).cmp(&request_temporal_sort_key(b)));
     let split = requests.len() / 2;
     let (early, late) = requests.split_at(split);
     if early.len() < options.temporal.min_segment_request_count
@@ -56,13 +104,17 @@ pub(super) fn temporal_segments(
     }
     let build = |name: &str, seg: &[RequestEvent]| {
         let ids: Vec<String> = seg.iter().map(|r| r.request_id.clone()).collect();
-        let start = seg.iter().map(|r| r.started_at_unix_ms).min();
-        let finish = seg.iter().map(|r| r.finished_at_unix_ms).max();
-        let mut analyzed = match (start, finish) {
-            (Some(s), Some(f)) => {
-                analyze_run_internal(&filtered_run_for_temporal_segment(run, &ids, s, f), options)
-            }
-            _ => analyze_run_internal(&route::filtered_run_for_route(run, &ids), options),
+        let unix_window = segment_unix_window(seg);
+        let run_relative_window = segment_run_relative_window(seg);
+        let window = run_relative_window
+            .map(|(start, finish)| SegmentWindow::RunRelative { start, finish })
+            .or_else(|| unix_window.map(|(start, finish)| SegmentWindow::Unix { start, finish }));
+        let mut analyzed = match window {
+            Some(window) => analyze_run_internal(
+                &filter_segment_runtime_and_inflight(run, &ids, window),
+                options,
+            ),
+            None => analyze_run_internal(&route::filtered_run_for_route(run, &ids), options),
         };
         let sparse_runtime =
             analyzed.evidence_quality.runtime_snapshots != SignalCoverageStatus::Present;
@@ -77,11 +129,16 @@ pub(super) fn temporal_segments(
                 .warnings
                 .push(TEMPORAL_RUNTIME_ATTRIBUTION_WARNING.to_string());
         }
+        if run_relative_window.is_none() {
+            analyzed
+                .warnings
+                .push(TEMPORAL_WALL_CLOCK_FALLBACK_WARNING.to_string());
+        }
         TemporalSegment {
             name: name.to_string(),
             request_count: analyzed.request_count,
-            started_at_unix_ms: start,
-            finished_at_unix_ms: finish,
+            started_at_unix_ms: unix_window.map(|(start, _)| start),
+            finished_at_unix_ms: unix_window.map(|(_, finish)| finish),
             p50_latency_us: analyzed.p50_latency_us,
             p95_latency_us: analyzed.p95_latency_us,
             p99_latency_us: analyzed.p99_latency_us,

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -6,7 +6,7 @@ use tailtriage_core::{
 use super::temporal::{
     apply_temporal_overlap_attribution_warning, has_material_p95_shift,
     TEMPORAL_OVERLAP_ATTRIBUTION_WARNING, TEMPORAL_P95_SHIFT_WARNING,
-    TEMPORAL_SUSPECT_SHIFT_WARNING,
+    TEMPORAL_SUSPECT_SHIFT_WARNING, TEMPORAL_WALL_CLOCK_FALLBACK_WARNING,
 };
 use crate::{
     analyze_run, analyze_run_internal, analyze_run_json_pretty, evidence, render_json,
@@ -1654,6 +1654,210 @@ fn temporal_segment_window_uses_max_finish_timestamp() {
         .find(|s| s.name == "early")
         .expect("early temporal segment should be emitted");
     assert_eq!(early.finished_at_unix_ms, Some(1000));
+}
+
+#[test]
+fn temporal_sort_prefers_run_relative_start_when_unix_timestamps_tie() {
+    let mut run = test_run();
+    run.requests = (1..=20)
+        .map(|i| {
+            let mut req = sample_request(i);
+            req.started_at_unix_ms = 1;
+            req.finished_at_unix_ms = 2;
+            req.started_at_run_us = Some((21 - i) * 1_000);
+            req.finished_at_run_us = Some((21 - i) * 1_000 + 500);
+            req
+        })
+        .collect();
+
+    for i in 11..=20 {
+        run.queues.push(QueueEvent {
+            request_id: format!("req-{i}"),
+            queue: "q".into(),
+            wait_us: 900,
+            waited_from_unix_ms: 1,
+            waited_from_run_us: None,
+            waited_until_unix_ms: 2,
+            waited_until_run_us: None,
+            depth_at_start: Some(9),
+        });
+    }
+    for i in 1..=10 {
+        run.stages.push(StageEvent {
+            request_id: format!("req-{i}"),
+            stage: "db".into(),
+            started_at_unix_ms: 1,
+            started_at_run_us: None,
+            finished_at_unix_ms: 2,
+            finished_at_run_us: None,
+            latency_us: 5_000,
+            success: true,
+        });
+    }
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert_eq!(report.temporal_segments.len(), 2);
+    let early = report
+        .temporal_segments
+        .iter()
+        .find(|segment| segment.name == "early")
+        .expect("early temporal segment should be emitted");
+    assert_eq!(
+        early.primary_suspect.kind,
+        DiagnosisKind::ApplicationQueueSaturation
+    );
+}
+
+#[test]
+fn temporal_runtime_and_inflight_filtering_uses_run_relative_snapshot_times() {
+    let mut run = test_run();
+    run.requests = (1..=20)
+        .map(|i| {
+            let mut req = sample_request(i);
+            req.started_at_unix_ms = 1;
+            req.finished_at_unix_ms = 1;
+            req.started_at_run_us = Some(i * 10_000);
+            req.finished_at_run_us = Some(i * 10_000 + 1_000);
+            if i > 10 {
+                req.latency_us = 5_000;
+            }
+            req
+        })
+        .collect();
+    run.runtime_snapshots = vec![
+        RuntimeSnapshot {
+            at_unix_ms: 1,
+            at_run_us: Some(55_000),
+            global_queue_depth: Some(1),
+            local_queue_depth: Some(1),
+            alive_tasks: Some(10),
+            blocking_queue_depth: Some(0),
+            remote_schedule_count: None,
+        },
+        RuntimeSnapshot {
+            at_unix_ms: 1,
+            at_run_us: Some(155_000),
+            global_queue_depth: Some(2),
+            local_queue_depth: Some(2),
+            alive_tasks: Some(20),
+            blocking_queue_depth: Some(0),
+            remote_schedule_count: None,
+        },
+    ];
+    run.inflight = vec![
+        tailtriage_core::InFlightSnapshot {
+            at_unix_ms: 1,
+            at_run_us: Some(55_000),
+            gauge: "http.server.requests".into(),
+            count: 1,
+        },
+        tailtriage_core::InFlightSnapshot {
+            at_unix_ms: 1,
+            at_run_us: Some(155_000),
+            gauge: "http.server.requests".into(),
+            count: 2,
+        },
+    ];
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert_eq!(report.temporal_segments.len(), 2);
+    for segment in &report.temporal_segments {
+        assert_eq!(segment.evidence_quality.runtime_snapshot_count, 1);
+        assert_eq!(segment.evidence_quality.inflight_snapshot_count, 1);
+        assert!(!segment
+            .warnings
+            .iter()
+            .any(|w| w == TEMPORAL_WALL_CLOCK_FALLBACK_WARNING));
+    }
+}
+
+#[test]
+fn older_temporal_artifacts_use_unix_fallback_and_warn() {
+    let mut run = test_run();
+    run.requests = (0..20).map(|i| sample_request(i + 1)).collect();
+    for i in 1..=10 {
+        run.queues.push(QueueEvent {
+            request_id: format!("req-{i}"),
+            queue: "q".into(),
+            wait_us: 900,
+            waited_from_unix_ms: i,
+            waited_from_run_us: None,
+            waited_until_unix_ms: i + 1,
+            waited_until_run_us: None,
+            depth_at_start: Some(9),
+        });
+    }
+    for i in 11..=20 {
+        run.stages.push(StageEvent {
+            request_id: format!("req-{i}"),
+            stage: "db".into(),
+            started_at_unix_ms: i,
+            started_at_run_us: None,
+            finished_at_unix_ms: i + 1,
+            finished_at_run_us: None,
+            latency_us: 5_000,
+            success: true,
+        });
+    }
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert_eq!(report.temporal_segments.len(), 2);
+    for segment in &report.temporal_segments {
+        assert!(segment
+            .warnings
+            .iter()
+            .any(|w| w == TEMPORAL_WALL_CLOCK_FALLBACK_WARNING));
+    }
+}
+
+#[test]
+fn complete_run_relative_temporal_artifacts_do_not_emit_fallback_warning() {
+    let mut run = test_run();
+    run.requests = (1..=20)
+        .map(|i| {
+            let mut req = sample_request(i);
+            req.started_at_run_us = Some(i * 1_000);
+            req.finished_at_run_us = Some(i * 1_000 + 500);
+            req
+        })
+        .collect();
+    for i in 1..=10 {
+        run.queues.push(QueueEvent {
+            request_id: format!("req-{i}"),
+            queue: "q".into(),
+            wait_us: 900,
+            waited_from_unix_ms: i,
+            waited_from_run_us: None,
+            waited_until_unix_ms: i + 1,
+            waited_until_run_us: None,
+            depth_at_start: Some(9),
+        });
+    }
+    for i in 11..=20 {
+        run.stages.push(StageEvent {
+            request_id: format!("req-{i}"),
+            stage: "db".into(),
+            started_at_unix_ms: i,
+            started_at_run_us: None,
+            finished_at_unix_ms: i + 1,
+            finished_at_run_us: None,
+            latency_us: 5_000,
+            success: true,
+        });
+    }
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert_eq!(report.temporal_segments.len(), 2);
+    for segment in &report.temporal_segments {
+        assert!(!segment
+            .warnings
+            .iter()
+            .any(|w| w == TEMPORAL_WALL_CLOCK_FALLBACK_WARNING));
+    }
 }
 
 #[test]


### PR DESCRIPTION
### Motivation

- Use monotonic, run-relative timing when present to produce more accurate early/late segmentation and precise runtime/in-flight attribution.  
- Preserve existing behavior for older artifacts that lack run-relative fields by falling back to wall-clock (Unix-ms) timestamps.  
- Surface a clear warning when the analyzer had to fall back to wall-clock timestamps so users know attribution is approximate.

### Description

- Change request sorting for temporal segmentation to prefer `RequestEvent.started_at_run_us`, fall back to `started_at_unix_ms`, and use `request_id` as a deterministic tie-breaker via `request_temporal_sort_key`.  
- Choose segment windows with two helpers: `segment_run_relative_window(...)` (used when every request in the segment has both `started_at_run_us` and `finished_at_run_us`) and `segment_unix_window(...)` (Unix-ms fallback).  
- Filter runtime and in-flight snapshots with `filter_segment_runtime_and_inflight(...)` so that when a run-relative window is used only snapshots with `snapshot.at_run_us` inside the run-relative window are retained, and when the Unix window is used the existing `at_unix_ms` filtering is preserved.  
- Add the exact fallback warning `"Temporal segment used wall-clock timestamp fallback; attribution is approximate for artifacts without complete run-relative timing."` and only push it for segments that used the Unix-ms fallback; existing sparse runtime/in-flight warnings and overlap attribution warnings are preserved.  
- Add small private helpers in `temporal.rs`: `request_temporal_sort_key`, `segment_run_relative_window`, `segment_unix_window`, and `filter_segment_runtime_and_inflight`.  
- Add unit tests covering run-relative ordering, run-relative runtime/in-flight filtering, older-artifact Unix fallback warning emission, and ensuring no fallback warning when run-relative fields are complete.

### Testing

- Ran `cargo fmt --check` and it succeeded.  
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it succeeded (no warnings).  
- Ran full test suites with `cargo test --workspace --all-targets --all-features --locked` and `cargo test --workspace`, and all tests passed (including the new temporal tests).  
- Ran `python3 scripts/validate_docs_contracts.py` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e84c03ec08330985a9ecdc9f0b3ad)