### PR TITLE
Prefer run-relative temporal segmentation

### DIFF
--- a/tailtriage-analyzer/src/temporal.rs
+++ b/tailtriage-analyzer/src/temporal.rs
@@ -10,26 +10,103 @@ pub(super) const TEMPORAL_SUSPECT_SHIFT_WARNING: &str = "Temporal segments show 
 pub(super) const TEMPORAL_P95_SHIFT_WARNING: &str =
     "Temporal segments show a large p95 latency shift between early and late requests.";
 pub(super) const TEMPORAL_OVERLAP_ATTRIBUTION_WARNING: &str = "Segment windows overlap under concurrent requests; timestamp-filtered runtime/in-flight attribution is approximate.";
+const TEMPORAL_WALL_CLOCK_FALLBACK_WARNING: &str = "Temporal segment used wall-clock timestamp fallback; attribution is approximate for artifacts without complete run-relative timing.";
+
+#[derive(Clone, Copy)]
+enum SegmentWindow {
+    RunRelative { start: u64, finish: u64 },
+    Unix { start: u64, finish: u64 },
+}
+
+fn request_temporal_sort_key(request: &RequestEvent) -> (bool, u64, &str) {
+    (
+        request.started_at_run_us.is_none(),
+        request
+            .started_at_run_us
+            .unwrap_or(request.started_at_unix_ms),
+        request.request_id.as_str(),
+    )
+}
+
+fn segment_run_relative_window(requests: &[RequestEvent]) -> Option<(u64, u64)> {
+    if !requests
+        .iter()
+        .all(|request| request.started_at_run_us.is_some() && request.finished_at_run_us.is_some())
+    {
+        return None;
+    }
+
+    let start = requests
+        .iter()
+        .filter_map(|request| request.started_at_run_us)
+        .min()?;
+    let finish = requests
+        .iter()
+        .filter_map(|request| request.finished_at_run_us)
+        .max()?;
+    Some((start, finish))
+}
+
+fn segment_unix_window(requests: &[RequestEvent]) -> Option<(u64, u64)> {
+    let start = requests
+        .iter()
+        .map(|request| request.started_at_unix_ms)
+        .min()?;
+    let finish = requests
+        .iter()
+        .map(|request| request.finished_at_unix_ms)
+        .max()?;
+    Some((start, finish))
+}
+
+fn filter_segment_runtime_and_inflight(run: &mut Run, source: &Run, window: SegmentWindow) {
+    match window {
+        SegmentWindow::RunRelative { start, finish } => {
+            run.runtime_snapshots = source
+                .runtime_snapshots
+                .iter()
+                .filter(|snapshot| {
+                    snapshot
+                        .at_run_us
+                        .is_some_and(|at| at >= start && at <= finish)
+                })
+                .cloned()
+                .collect();
+            run.inflight = source
+                .inflight
+                .iter()
+                .filter(|snapshot| {
+                    snapshot
+                        .at_run_us
+                        .is_some_and(|at| at >= start && at <= finish)
+                })
+                .cloned()
+                .collect();
+        }
+        SegmentWindow::Unix { start, finish } => {
+            run.runtime_snapshots = source
+                .runtime_snapshots
+                .iter()
+                .filter(|snapshot| snapshot.at_unix_ms >= start && snapshot.at_unix_ms <= finish)
+                .cloned()
+                .collect();
+            run.inflight = source
+                .inflight
+                .iter()
+                .filter(|snapshot| snapshot.at_unix_ms >= start && snapshot.at_unix_ms <= finish)
+                .cloned()
+                .collect();
+        }
+    }
+}
 
 fn filtered_run_for_temporal_segment(
     run: &Run,
     request_ids: &[String],
-    start: u64,
-    end: u64,
+    window: SegmentWindow,
 ) -> Run {
     let mut filtered = route::filtered_run_for_route(run, request_ids);
-    filtered.runtime_snapshots = run
-        .runtime_snapshots
-        .iter()
-        .filter(|s| s.at_unix_ms >= start && s.at_unix_ms <= end)
-        .cloned()
-        .collect();
-    filtered.inflight = run
-        .inflight
-        .iter()
-        .filter(|s| s.at_unix_ms >= start && s.at_unix_ms <= end)
-        .cloned()
-        .collect();
+    filter_segment_runtime_and_inflight(&mut filtered, run, window);
     filtered
 }
 
@@ -42,11 +119,7 @@ pub(super) fn temporal_segments(
         return vec![];
     }
     let mut requests = run.requests.clone();
-    requests.sort_by(|a, b| {
-        a.started_at_unix_ms
-            .cmp(&b.started_at_unix_ms)
-            .then_with(|| a.request_id.cmp(&b.request_id))
-    });
+    requests.sort_by(|a, b| request_temporal_sort_key(a).cmp(&request_temporal_sort_key(b)));
     let split = requests.len() / 2;
     let (early, late) = requests.split_at(split);
     if early.len() < options.temporal.min_segment_request_count
@@ -56,14 +129,28 @@ pub(super) fn temporal_segments(
     }
     let build = |name: &str, seg: &[RequestEvent]| {
         let ids: Vec<String> = seg.iter().map(|r| r.request_id.clone()).collect();
-        let start = seg.iter().map(|r| r.started_at_unix_ms).min();
-        let finish = seg.iter().map(|r| r.finished_at_unix_ms).max();
-        let mut analyzed = match (start, finish) {
-            (Some(s), Some(f)) => {
-                analyze_run_internal(&filtered_run_for_temporal_segment(run, &ids, s, f), options)
-            }
-            _ => analyze_run_internal(&route::filtered_run_for_route(run, &ids), options),
+        let (start, finish) = segment_unix_window(seg)
+            .map_or((None, None), |(start, finish)| (Some(start), Some(finish)));
+        let run_relative_window = segment_run_relative_window(seg);
+        let used_unix_fallback = run_relative_window.is_none();
+        let window = run_relative_window
+            .map(|(start, finish)| SegmentWindow::RunRelative { start, finish })
+            .or_else(|| {
+                segment_unix_window(seg)
+                    .map(|(start, finish)| SegmentWindow::Unix { start, finish })
+            });
+        let mut analyzed = match window {
+            Some(window) => analyze_run_internal(
+                &filtered_run_for_temporal_segment(run, &ids, window),
+                options,
+            ),
+            None => analyze_run_internal(&route::filtered_run_for_route(run, &ids), options),
         };
+        if used_unix_fallback {
+            analyzed
+                .warnings
+                .push(TEMPORAL_WALL_CLOCK_FALLBACK_WARNING.to_string());
+        }
         let sparse_runtime =
             analyzed.evidence_quality.runtime_snapshots != SignalCoverageStatus::Present;
         let sparse_inflight =

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -1657,6 +1657,174 @@ fn temporal_segment_window_uses_max_finish_timestamp() {
 }
 
 #[test]
+fn temporal_sort_prefers_run_relative_start_when_unix_starts_match() {
+    let mut run = test_run();
+    run.requests = (1..=20).map(sample_request).collect();
+
+    for request in &mut run.requests {
+        let id = request
+            .request_id
+            .strip_prefix("req-")
+            .expect("test request id should use req- prefix")
+            .parse::<u64>()
+            .expect("test request id should end with an integer");
+        request.started_at_unix_ms = 100;
+        request.finished_at_unix_ms = 101;
+        request.started_at_run_us = Some((21 - id) * 1_000);
+        request.finished_at_run_us = Some((21 - id) * 1_000 + 100);
+    }
+
+    for id in 11..=20 {
+        run.queues.push(QueueEvent {
+            request_id: format!("req-{id}"),
+            queue: "ingress".into(),
+            wait_us: 900,
+            waited_from_unix_ms: 100,
+            waited_from_run_us: None,
+            waited_until_unix_ms: 101,
+            waited_until_run_us: None,
+            depth_at_start: Some(9),
+        });
+    }
+    for id in 1..=10 {
+        run.stages.push(StageEvent {
+            request_id: format!("req-{id}"),
+            stage: "db".into(),
+            started_at_unix_ms: 100,
+            started_at_run_us: None,
+            finished_at_unix_ms: 101,
+            finished_at_run_us: None,
+            latency_us: 5_000,
+            success: true,
+        });
+    }
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert_eq!(report.temporal_segments.len(), 2);
+    let early = report
+        .temporal_segments
+        .iter()
+        .find(|segment| segment.name == "early")
+        .expect("early temporal segment should be emitted");
+    let late = report
+        .temporal_segments
+        .iter()
+        .find(|segment| segment.name == "late")
+        .expect("late temporal segment should be emitted");
+    assert_eq!(
+        early.primary_suspect.kind,
+        DiagnosisKind::ApplicationQueueSaturation
+    );
+    assert_eq!(
+        late.primary_suspect.kind,
+        DiagnosisKind::DownstreamStageDominates
+    );
+}
+
+#[test]
+fn temporal_runtime_and_inflight_filtering_uses_run_relative_times() {
+    let mut run = test_run();
+    run.requests = (1..=20).map(sample_request).collect();
+
+    for (idx, request) in run.requests.iter_mut().enumerate() {
+        let idx = u64::try_from(idx).expect("test index should fit in u64");
+        request.started_at_unix_ms = 1;
+        request.finished_at_unix_ms = 1;
+        if idx < 10 {
+            request.started_at_run_us = Some(1_000 + idx * 100);
+            request.finished_at_run_us = Some(1_050 + idx * 100);
+        } else {
+            request.started_at_run_us = Some(10_000 + idx * 100);
+            request.finished_at_run_us = Some(10_050 + idx * 100);
+            request.latency_us = 6_000;
+        }
+    }
+
+    run.runtime_snapshots = vec![
+        RuntimeSnapshot {
+            at_unix_ms: 1,
+            at_run_us: Some(1_200),
+            global_queue_depth: Some(50),
+            local_queue_depth: Some(50),
+            alive_tasks: Some(100),
+            blocking_queue_depth: Some(0),
+            remote_schedule_count: None,
+        },
+        RuntimeSnapshot {
+            at_unix_ms: 1,
+            at_run_us: Some(11_200),
+            global_queue_depth: Some(1),
+            local_queue_depth: Some(1),
+            alive_tasks: Some(100),
+            blocking_queue_depth: Some(0),
+            remote_schedule_count: None,
+        },
+    ];
+    run.inflight = vec![
+        tailtriage_core::InFlightSnapshot {
+            at_unix_ms: 1,
+            at_run_us: Some(1_200),
+            gauge: "http.server.requests".into(),
+            count: 2,
+        },
+        tailtriage_core::InFlightSnapshot {
+            at_unix_ms: 1,
+            at_run_us: Some(11_200),
+            gauge: "http.server.requests".into(),
+            count: 9,
+        },
+    ];
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert_eq!(report.temporal_segments.len(), 2);
+    for segment in &report.temporal_segments {
+        assert_eq!(segment.evidence_quality.runtime_snapshot_count, 1);
+        assert_eq!(segment.evidence_quality.inflight_snapshot_count, 1);
+    }
+}
+
+#[test]
+fn temporal_segments_fallback_for_older_artifacts_warns() {
+    let mut run = test_run();
+    run.requests = (1..=20).map(sample_request).collect();
+    for request in run.requests.iter_mut().skip(10) {
+        request.latency_us = 6_000;
+    }
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert_eq!(report.temporal_segments.len(), 2);
+    for segment in &report.temporal_segments {
+        assert!(segment.warnings.iter().any(|warning| warning
+            == "Temporal segment used wall-clock timestamp fallback; attribution is approximate for artifacts without complete run-relative timing."));
+    }
+}
+
+#[test]
+fn temporal_segments_with_complete_run_relative_fields_do_not_warn_about_fallback() {
+    let mut run = test_run();
+    run.requests = (1..=20).map(sample_request).collect();
+    for (idx, request) in run.requests.iter_mut().enumerate() {
+        let idx = u64::try_from(idx).expect("test index should fit in u64");
+        request.started_at_run_us = Some(idx * 1_000);
+        request.finished_at_run_us = Some(idx * 1_000 + 100);
+        if idx >= 10 {
+            request.latency_us = 6_000;
+        }
+    }
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert_eq!(report.temporal_segments.len(), 2);
+    for segment in &report.temporal_segments {
+        assert!(!segment.warnings.iter().any(|warning| warning
+            == "Temporal segment used wall-clock timestamp fallback; attribution is approximate for artifacts without complete run-relative timing."));
+    }
+}
+
+#[test]
 fn temporal_segments_not_emitted_when_no_meaningful_difference() {
     let mut run = test_run();
     run.requests = (0..20).map(|i| sample_request(i + 1)).collect();


### PR DESCRIPTION
### Motivation

- Improve temporal segmentation accuracy by using run-relative monotonic timestamps when available so early/late ordering and runtime/in-flight attribution align with captured monotonic timing. 
- Preserve backward compatibility for older artifacts that lack run-relative fields by falling back to Unix-ms windows and keeping existing warning semantics.

### Description

- Prefer run-relative fields when ordering requests by introducing `request_temporal_sort_key(...)` that sorts by `started_at_run_us` when present, then `started_at_unix_ms`, and finally `request_id` as a deterministic tie-breaker.  
- Add private helpers `segment_run_relative_window(...)`, `segment_unix_window(...)`, and `filter_segment_runtime_and_inflight(...)` and a `SegmentWindow` enum, and update `filtered_run_for_temporal_segment(...)` to accept a `SegmentWindow` and filter runtime/in-flight snapshots by `at_run_us` when using a run-relative window. 
- Choose run-relative segment windows when every request in the segment has both `started_at_run_us` and `finished_at_run_us`, otherwise use the Unix-ms window; emit the exact fallback warning `Temporal segment used wall-clock timestamp fallback; attribution is approximate for artifacts without complete run-relative timing.` only when the Unix-ms fallback is used, and preserve existing sparse-runtime and overlap warnings. 
- No changes to scoring formulas, public `Run` schema, or external dependencies.

### Testing

- Added unit tests covering: run-relative early/late ordering (`temporal_sort_prefers_run_relative_start_when_unix_starts_match`), run-relative runtime/in-flight filtering (`temporal_runtime_and_inflight_filtering_uses_run_relative_times`), fallback warning for legacy artifacts (`temporal_segments_fallback_for_older_artifacts_warns`), and absence of fallback warning when run-relative fields are complete (`temporal_segments_with_complete_run_relative_fields_do_not_warn_about_fallback`).
- Ran the full workspace validation and lint/test commands with success: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, `cargo test --workspace`, and `python3 scripts/validate_docs_contracts.py`, all of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e84c03ec08330985a9ecdc9f0b3ad)