### PR TITLE
Prefer run-relative temporal segmentation

### DIFF
--- a/tailtriage-analyzer/src/temporal.rs
+++ b/tailtriage-analyzer/src/temporal.rs
@@ -10,26 +10,98 @@ pub(super) const TEMPORAL_SUSPECT_SHIFT_WARNING: &str = "Temporal segments show 
 pub(super) const TEMPORAL_P95_SHIFT_WARNING: &str =
     "Temporal segments show a large p95 latency shift between early and late requests.";
 pub(super) const TEMPORAL_OVERLAP_ATTRIBUTION_WARNING: &str = "Segment windows overlap under concurrent requests; timestamp-filtered runtime/in-flight attribution is approximate.";
+pub(super) const TEMPORAL_WALL_CLOCK_FALLBACK_WARNING: &str = "Temporal segment used wall-clock timestamp fallback; attribution is approximate for artifacts without complete run-relative timing.";
 
-fn filtered_run_for_temporal_segment(
+#[derive(Debug, Clone, Copy)]
+enum SegmentWindow {
+    RunRelative { start: u64, finish: u64 },
+    Unix { start: u64, finish: u64 },
+}
+
+fn request_temporal_sort_key(request: &RequestEvent) -> (u64, &str) {
+    (
+        request
+            .started_at_run_us
+            .unwrap_or(request.started_at_unix_ms),
+        request.request_id.as_str(),
+    )
+}
+
+fn segment_run_relative_window(segment: &[RequestEvent]) -> Option<SegmentWindow> {
+    if !segment
+        .iter()
+        .all(|request| request.started_at_run_us.is_some() && request.finished_at_run_us.is_some())
+    {
+        return None;
+    }
+
+    let start = segment
+        .iter()
+        .filter_map(|request| request.started_at_run_us)
+        .min()?;
+    let finish = segment
+        .iter()
+        .filter_map(|request| request.finished_at_run_us)
+        .max()?;
+    Some(SegmentWindow::RunRelative { start, finish })
+}
+
+fn segment_unix_window(segment: &[RequestEvent]) -> Option<SegmentWindow> {
+    let start = segment
+        .iter()
+        .map(|request| request.started_at_unix_ms)
+        .min()?;
+    let finish = segment
+        .iter()
+        .map(|request| request.finished_at_unix_ms)
+        .max()?;
+    Some(SegmentWindow::Unix { start, finish })
+}
+
+fn filter_segment_runtime_and_inflight(
     run: &Run,
     request_ids: &[String],
-    start: u64,
-    end: u64,
+    window: SegmentWindow,
 ) -> Run {
     let mut filtered = route::filtered_run_for_route(run, request_ids);
-    filtered.runtime_snapshots = run
-        .runtime_snapshots
-        .iter()
-        .filter(|s| s.at_unix_ms >= start && s.at_unix_ms <= end)
-        .cloned()
-        .collect();
-    filtered.inflight = run
-        .inflight
-        .iter()
-        .filter(|s| s.at_unix_ms >= start && s.at_unix_ms <= end)
-        .cloned()
-        .collect();
+    match window {
+        SegmentWindow::RunRelative { start, finish } => {
+            filtered.runtime_snapshots = run
+                .runtime_snapshots
+                .iter()
+                .filter(|snapshot| {
+                    snapshot
+                        .at_run_us
+                        .is_some_and(|at_run_us| at_run_us >= start && at_run_us <= finish)
+                })
+                .cloned()
+                .collect();
+            filtered.inflight = run
+                .inflight
+                .iter()
+                .filter(|snapshot| {
+                    snapshot
+                        .at_run_us
+                        .is_some_and(|at_run_us| at_run_us >= start && at_run_us <= finish)
+                })
+                .cloned()
+                .collect();
+        }
+        SegmentWindow::Unix { start, finish } => {
+            filtered.runtime_snapshots = run
+                .runtime_snapshots
+                .iter()
+                .filter(|snapshot| snapshot.at_unix_ms >= start && snapshot.at_unix_ms <= finish)
+                .cloned()
+                .collect();
+            filtered.inflight = run
+                .inflight
+                .iter()
+                .filter(|snapshot| snapshot.at_unix_ms >= start && snapshot.at_unix_ms <= finish)
+                .cloned()
+                .collect();
+        }
+    }
     filtered
 }
 
@@ -42,11 +114,7 @@ pub(super) fn temporal_segments(
         return vec![];
     }
     let mut requests = run.requests.clone();
-    requests.sort_by(|a, b| {
-        a.started_at_unix_ms
-            .cmp(&b.started_at_unix_ms)
-            .then_with(|| a.request_id.cmp(&b.request_id))
-    });
+    requests.sort_by(|a, b| request_temporal_sort_key(a).cmp(&request_temporal_sort_key(b)));
     let split = requests.len() / 2;
     let (early, late) = requests.split_at(split);
     if early.len() < options.temporal.min_segment_request_count
@@ -54,47 +122,9 @@ pub(super) fn temporal_segments(
     {
         return vec![];
     }
-    let build = |name: &str, seg: &[RequestEvent]| {
-        let ids: Vec<String> = seg.iter().map(|r| r.request_id.clone()).collect();
-        let start = seg.iter().map(|r| r.started_at_unix_ms).min();
-        let finish = seg.iter().map(|r| r.finished_at_unix_ms).max();
-        let mut analyzed = match (start, finish) {
-            (Some(s), Some(f)) => {
-                analyze_run_internal(&filtered_run_for_temporal_segment(run, &ids, s, f), options)
-            }
-            _ => analyze_run_internal(&route::filtered_run_for_route(run, &ids), options),
-        };
-        let sparse_runtime =
-            analyzed.evidence_quality.runtime_snapshots != SignalCoverageStatus::Present;
-        let sparse_inflight =
-            analyzed.evidence_quality.inflight_snapshots != SignalCoverageStatus::Present;
-        if matches!(
-            analyzed.primary_suspect.kind,
-            DiagnosisKind::ExecutorPressureSuspected | DiagnosisKind::BlockingPoolPressure
-        ) && (sparse_runtime || sparse_inflight)
-        {
-            analyzed
-                .warnings
-                .push(TEMPORAL_RUNTIME_ATTRIBUTION_WARNING.to_string());
-        }
-        TemporalSegment {
-            name: name.to_string(),
-            request_count: analyzed.request_count,
-            started_at_unix_ms: start,
-            finished_at_unix_ms: finish,
-            p50_latency_us: analyzed.p50_latency_us,
-            p95_latency_us: analyzed.p95_latency_us,
-            p99_latency_us: analyzed.p99_latency_us,
-            p95_queue_share_permille: analyzed.p95_queue_share_permille,
-            p95_service_share_permille: analyzed.p95_service_share_permille,
-            evidence_quality: analyzed.evidence_quality,
-            primary_suspect: analyzed.primary_suspect,
-            secondary_suspects: analyzed.secondary_suspects,
-            warnings: analyzed.warnings,
-        }
-    };
-    let mut early_seg = build("early", early);
-    let mut late_seg = build("late", late);
+
+    let mut early_seg = build_temporal_segment("early", early, run, options);
+    let mut late_seg = build_temporal_segment("late", late, run, options);
     let p95_shift =
         has_material_p95_shift(early_seg.p95_latency_us, late_seg.p95_latency_us, options);
     let queue_move = has_material_share_shift(
@@ -125,6 +155,66 @@ pub(super) fn temporal_segments(
     }
     apply_temporal_overlap_attribution_warning(&mut early_seg, &mut late_seg);
     vec![early_seg, late_seg]
+}
+
+fn build_temporal_segment(
+    name: &str,
+    segment: &[RequestEvent],
+    run: &Run,
+    options: &AnalyzeOptions,
+) -> TemporalSegment {
+    let ids: Vec<String> = segment
+        .iter()
+        .map(|request| request.request_id.clone())
+        .collect();
+    let report_window = segment_unix_window(segment);
+    let filter_window = segment_run_relative_window(segment).or(report_window);
+    let used_wall_clock_fallback =
+        !matches!(filter_window, Some(SegmentWindow::RunRelative { .. }));
+    let mut analyzed = match filter_window {
+        Some(window) => analyze_run_internal(
+            &filter_segment_runtime_and_inflight(run, &ids, window),
+            options,
+        ),
+        None => analyze_run_internal(&route::filtered_run_for_route(run, &ids), options),
+    };
+    let sparse_runtime =
+        analyzed.evidence_quality.runtime_snapshots != SignalCoverageStatus::Present;
+    let sparse_inflight =
+        analyzed.evidence_quality.inflight_snapshots != SignalCoverageStatus::Present;
+    if matches!(
+        analyzed.primary_suspect.kind,
+        DiagnosisKind::ExecutorPressureSuspected | DiagnosisKind::BlockingPoolPressure
+    ) && (sparse_runtime || sparse_inflight)
+    {
+        analyzed
+            .warnings
+            .push(TEMPORAL_RUNTIME_ATTRIBUTION_WARNING.to_string());
+    }
+    if used_wall_clock_fallback {
+        analyzed
+            .warnings
+            .push(TEMPORAL_WALL_CLOCK_FALLBACK_WARNING.to_string());
+    }
+    let (start, finish) = match report_window {
+        Some(SegmentWindow::Unix { start, finish }) => (Some(start), Some(finish)),
+        Some(SegmentWindow::RunRelative { .. }) | None => (None, None),
+    };
+    TemporalSegment {
+        name: name.to_string(),
+        request_count: analyzed.request_count,
+        started_at_unix_ms: start,
+        finished_at_unix_ms: finish,
+        p50_latency_us: analyzed.p50_latency_us,
+        p95_latency_us: analyzed.p95_latency_us,
+        p99_latency_us: analyzed.p99_latency_us,
+        p95_queue_share_permille: analyzed.p95_queue_share_permille,
+        p95_service_share_permille: analyzed.p95_service_share_permille,
+        evidence_quality: analyzed.evidence_quality,
+        primary_suspect: analyzed.primary_suspect,
+        secondary_suspects: analyzed.secondary_suspects,
+        warnings: analyzed.warnings,
+    }
 }
 
 fn has_material_share_shift(

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -6,7 +6,7 @@ use tailtriage_core::{
 use super::temporal::{
     apply_temporal_overlap_attribution_warning, has_material_p95_shift,
     TEMPORAL_OVERLAP_ATTRIBUTION_WARNING, TEMPORAL_P95_SHIFT_WARNING,
-    TEMPORAL_SUSPECT_SHIFT_WARNING,
+    TEMPORAL_SUSPECT_SHIFT_WARNING, TEMPORAL_WALL_CLOCK_FALLBACK_WARNING,
 };
 use crate::{
     analyze_run, analyze_run_internal, analyze_run_json_pretty, evidence, render_json,
@@ -1710,6 +1710,204 @@ fn temporal_segments_emitted_when_primary_suspects_differ() {
         .warnings
         .iter()
         .any(|w| w == TEMPORAL_P95_SHIFT_WARNING));
+}
+
+#[test]
+fn temporal_segments_order_by_run_relative_start_when_unix_starts_match() {
+    let mut run = test_run();
+    run.requests = (0..20).map(|i| sample_request(i + 1)).collect();
+    for request in &mut run.requests {
+        request.started_at_unix_ms = 1;
+        request.finished_at_unix_ms = 2;
+        let id = request
+            .request_id
+            .strip_prefix("req-")
+            .and_then(|value| value.parse::<u64>().ok())
+            .expect("request id should contain numeric suffix");
+        let run_start = if id <= 10 { id + 10 } else { id - 10 };
+        request.started_at_run_us = Some(run_start);
+        request.finished_at_run_us = Some(run_start + 1);
+    }
+    for i in 11..=20 {
+        run.queues.push(QueueEvent {
+            request_id: format!("req-{i}"),
+            queue: "q".into(),
+            wait_us: 2_000,
+            waited_from_unix_ms: 1,
+            waited_from_run_us: None,
+            waited_until_unix_ms: 2,
+            waited_until_run_us: None,
+            depth_at_start: Some(12),
+        });
+    }
+    for i in 1..=10 {
+        run.stages.push(StageEvent {
+            request_id: format!("req-{i}"),
+            stage: "db".into(),
+            started_at_unix_ms: 1,
+            started_at_run_us: None,
+            finished_at_unix_ms: 2,
+            finished_at_run_us: None,
+            latency_us: 9_000,
+            success: true,
+        });
+    }
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert_eq!(report.temporal_segments.len(), 2);
+    assert_eq!(
+        report.temporal_segments[0].primary_suspect.kind,
+        DiagnosisKind::ApplicationQueueSaturation
+    );
+    assert_eq!(
+        report.temporal_segments[1].primary_suspect.kind,
+        DiagnosisKind::DownstreamStageDominates
+    );
+}
+
+#[test]
+fn temporal_segment_runtime_and_inflight_filtering_uses_run_relative_snapshot_times() {
+    let mut run = test_run();
+    run.requests = (0..20).map(|i| sample_request(i + 1)).collect();
+    for (idx, request) in run.requests.iter_mut().enumerate() {
+        request.started_at_unix_ms = 1;
+        request.finished_at_unix_ms = 1;
+        let idx = u64::try_from(idx).expect("test index should fit in u64");
+        let run_start = if idx < 10 { 1_000 + idx } else { 20_000 + idx };
+        request.started_at_run_us = Some(run_start);
+        request.finished_at_run_us = Some(run_start + 10);
+        if idx >= 10 {
+            request.latency_us = 5_000;
+        }
+    }
+    run.runtime_snapshots = vec![
+        RuntimeSnapshot {
+            at_unix_ms: 1,
+            at_run_us: Some(1_005),
+            global_queue_depth: Some(8),
+            local_queue_depth: Some(4),
+            alive_tasks: Some(20),
+            blocking_queue_depth: Some(0),
+            remote_schedule_count: None,
+        },
+        RuntimeSnapshot {
+            at_unix_ms: 1,
+            at_run_us: Some(20_015),
+            global_queue_depth: Some(1),
+            local_queue_depth: Some(1),
+            alive_tasks: Some(20),
+            blocking_queue_depth: Some(0),
+            remote_schedule_count: None,
+        },
+    ];
+    run.inflight = vec![
+        tailtriage_core::InFlightSnapshot {
+            at_unix_ms: 1,
+            at_run_us: Some(1_005),
+            gauge: "http.server.requests".into(),
+            count: 3,
+        },
+        tailtriage_core::InFlightSnapshot {
+            at_unix_ms: 1,
+            at_run_us: Some(20_015),
+            gauge: "http.server.requests".into(),
+            count: 9,
+        },
+    ];
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert_eq!(report.temporal_segments.len(), 2);
+    for segment in &report.temporal_segments {
+        assert_eq!(segment.evidence_quality.runtime_snapshot_count, 1);
+        assert_eq!(segment.evidence_quality.inflight_snapshot_count, 1);
+    }
+}
+
+#[test]
+fn temporal_segments_for_older_artifacts_use_unix_fallback_and_warn() {
+    let mut run = test_run();
+    run.requests = (0..20).map(|i| sample_request(i + 1)).collect();
+    for i in 1..=10 {
+        run.queues.push(QueueEvent {
+            request_id: format!("req-{i}"),
+            queue: "q".into(),
+            wait_us: 2_000,
+            waited_from_unix_ms: i,
+            waited_from_run_us: None,
+            waited_until_unix_ms: i + 1,
+            waited_until_run_us: None,
+            depth_at_start: Some(12),
+        });
+    }
+    for i in 11..=20 {
+        run.stages.push(StageEvent {
+            request_id: format!("req-{i}"),
+            stage: "db".into(),
+            started_at_unix_ms: i,
+            started_at_run_us: None,
+            finished_at_unix_ms: i + 1,
+            finished_at_run_us: None,
+            latency_us: 9_000,
+            success: true,
+        });
+    }
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert_eq!(report.temporal_segments.len(), 2);
+    for segment in &report.temporal_segments {
+        assert!(segment
+            .warnings
+            .iter()
+            .any(|warning| warning == TEMPORAL_WALL_CLOCK_FALLBACK_WARNING));
+    }
+}
+
+#[test]
+fn temporal_segments_with_complete_run_relative_request_times_do_not_warn_for_unix_fallback() {
+    let mut run = test_run();
+    run.requests = (0..20).map(|i| sample_request(i + 1)).collect();
+    for request in &mut run.requests {
+        let run_start = request.started_at_unix_ms * 1_000;
+        request.started_at_run_us = Some(run_start);
+        request.finished_at_run_us = Some(run_start + 10);
+    }
+    for i in 1..=10 {
+        run.queues.push(QueueEvent {
+            request_id: format!("req-{i}"),
+            queue: "q".into(),
+            wait_us: 2_000,
+            waited_from_unix_ms: i,
+            waited_from_run_us: None,
+            waited_until_unix_ms: i + 1,
+            waited_until_run_us: None,
+            depth_at_start: Some(12),
+        });
+    }
+    for i in 11..=20 {
+        run.stages.push(StageEvent {
+            request_id: format!("req-{i}"),
+            stage: "db".into(),
+            started_at_unix_ms: i,
+            started_at_run_us: None,
+            finished_at_unix_ms: i + 1,
+            finished_at_run_us: None,
+            latency_us: 9_000,
+            success: true,
+        });
+    }
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert_eq!(report.temporal_segments.len(), 2);
+    for segment in &report.temporal_segments {
+        assert!(!segment
+            .warnings
+            .iter()
+            .any(|warning| warning == TEMPORAL_WALL_CLOCK_FALLBACK_WARNING));
+    }
 }
 
 #[test]


### PR DESCRIPTION
### Motivation

- Improve temporal early/late segmentation precision by preferring run-relative monotonic timing when available while preserving compatibility with older artifacts that only have wall-clock timestamps.

### Description

- Sort requests for temporal segmentation using `started_at_run_us` when present, falling back to `started_at_unix_ms`, and using `request_id` as the final deterministic tie-breaker via a new `request_temporal_sort_key` helper.
- Select a segment window using run-relative fields when every request in the segment has both `started_at_run_us` and `finished_at_run_us` (`start = min started_at_run_us`, `finish = max finished_at_run_us`), otherwise use the Unix-ms window (`start = min started_at_unix_ms`, `finish = max finished_at_unix_ms`).
- Filter runtime and in-flight snapshots by run-relative `at_run_us` when using a run-relative window and preserve the existing Unix-ms filtering behavior when the Unix fallback is used; implemented in `filter_segment_runtime_and_inflight` and supported by `segment_run_relative_window` and `segment_unix_window` helpers.
- Preserve existing sparse runtime/in-flight and overlap attribution warnings and add the exact segment-scoped fallback warning `Temporal segment used wall-clock timestamp fallback; attribution is approximate for artifacts without complete run-relative timing.` only when the Unix-ms fallback is used; added a small `build_temporal_segment` helper to keep logic compact.

### Testing

- Ran `cargo fmt --check` and it succeeded.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it succeeded with no warnings.
- Ran full test suites with `cargo test --workspace --all-targets --all-features --locked` and `cargo test --workspace` and all tests passed (including new unit tests for run-relative ordering, run-relative runtime/in-flight filtering, Unix fallback warning emission, and absence of fallback warning when run-relative fields are complete).
- Ran `python3 scripts/validate_docs_contracts.py` and documentation contracts validated successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e84c03ec08330985a9ecdc9f0b3ad)