### PR TITLE
Preserve tracing run-relative span timing

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -94,6 +94,8 @@ If your service already builds a subscriber in startup code, compose `session.la
 
 - Imported or live tracing evidence is converted to normal tailtriage Run timing fields.
 - Live tracing samples finish wall time when the span closes.
+- Newer live tracing output includes run-relative monotonic offsets for request, stage, and queue spans when those offsets are available; these offsets improve temporal grouping inside a captured run.
+- Imported JSONL may omit run-relative offsets. When they are absent, the analyzer falls back to Unix-ms wall-clock timestamps for temporal grouping.
 - `duration_us` remains the authoritative elapsed-time evidence when supplied or recorded by live tracing.
 - Unix-ms timestamps are wall-clock anchors and may be coarser than durations.
 - Ordinary tracing log timestamps are not enough for completed-span import; completed spans need explicit start/end timing and semantic tt.* fields.

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -376,6 +376,8 @@ fn parse_normalized_span(
     let parent_id = optional_string(span_obj, "parent_id")?;
     let started_at_unix_ms = required_timestamp(span_obj, "started_at_unix_ms", "start_unix_ms")?;
     let finished_at_unix_ms = required_timestamp(span_obj, "finished_at_unix_ms", "end_unix_ms")?;
+    let started_at_run_us = optional_u64(span_obj, "started_at_run_us")?;
+    let finished_at_run_us = optional_u64(span_obj, "finished_at_run_us")?;
     let duration_us = optional_duration_us(span_obj)?;
 
     let mut span = SpanRecord::new(name, started_at_unix_ms, finished_at_unix_ms);
@@ -384,6 +386,12 @@ fn parse_normalized_span(
     }
     if let Some(parent_id) = parent_id {
         span = span.parent_id(parent_id);
+    }
+    if let Some(started_at_run_us) = started_at_run_us {
+        span = span.started_at_run_us(started_at_run_us);
+    }
+    if let Some(finished_at_run_us) = finished_at_run_us {
+        span = span.finished_at_run_us(finished_at_run_us);
     }
     if let Some(duration_us) = duration_us {
         span = span.duration_us(duration_us);
@@ -484,17 +492,30 @@ fn required_timestamp_obj(
     Err(ImportError::MissingField(primary))
 }
 fn optional_duration_us(obj: &serde_json::Map<String, Value>) -> Result<Option<u64>, ImportError> {
-    match obj.get("duration_us") {
+    optional_u64(obj, "duration_us").map_err(|err| match err {
+        ImportError::InvalidField { .. } => ImportError::InvalidField {
+            field: "duration_us",
+            reason: "expected unsigned integer microseconds as u64".to_owned(),
+        },
+        other => other,
+    })
+}
+
+fn optional_u64(
+    obj: &serde_json::Map<String, Value>,
+    key: &'static str,
+) -> Result<Option<u64>, ImportError> {
+    match obj.get(key) {
         Some(Value::Number(n)) => n
             .as_u64()
             .ok_or_else(|| ImportError::InvalidField {
-                field: "duration_us",
-                reason: "expected unsigned integer microseconds as u64".to_owned(),
+                field: key,
+                reason: "expected unsigned integer as u64".to_owned(),
             })
             .map(Some),
         Some(_) => Err(ImportError::InvalidField {
-            field: "duration_us",
-            reason: "expected unsigned integer microseconds as u64".to_owned(),
+            field: key,
+            reason: "expected unsigned integer as u64".to_owned(),
         }),
         None => Ok(None),
     }
@@ -539,6 +560,50 @@ mod tests {
         assert_eq!(imported.run().stages.len(), 1);
         assert_eq!(imported.run().queues.len(), 1);
         assert_eq!(imported.run().queues[0].queue, "permits");
+    }
+
+    #[test]
+    fn stable_wrapper_jsonl_preserves_run_relative_fields_into_run_events() {
+        let input = r#"
+{"format":"tailtriage.tracing-span.v1","span":{"name":"req","started_at_unix_ms":10,"started_at_run_us":100,"finished_at_unix_ms":20,"finished_at_run_us":10100,"duration_us":10000,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
+{"format":"tailtriage.tracing-span.v1","span":{"name":"st","started_at_unix_ms":11,"started_at_run_us":1100,"finished_at_unix_ms":18,"finished_at_run_us":8100,"duration_us":7000,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
+{"format":"tailtriage.tracing-span.v1","span":{"name":"q","started_at_unix_ms":12,"started_at_run_us":2100,"finished_at_unix_ms":13,"finished_at_run_us":3100,"duration_us":1000,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits"}}}
+"#;
+        let imported =
+            super::import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        let run = imported.run();
+
+        assert_eq!(run.requests[0].started_at_run_us, Some(100));
+        assert_eq!(run.requests[0].finished_at_run_us, Some(10_100));
+        assert_eq!(run.stages[0].started_at_run_us, Some(1_100));
+        assert_eq!(run.stages[0].finished_at_run_us, Some(8_100));
+        assert_eq!(run.queues[0].waited_from_run_us, Some(2_100));
+        assert_eq!(run.queues[0].waited_until_run_us, Some(3_100));
+    }
+
+    #[test]
+    fn stable_wrapper_jsonl_without_run_relative_fields_imports_none() {
+        let input = r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":10000,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
+        let imported =
+            super::import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        let request = &imported.run().requests[0];
+
+        assert_eq!(request.started_at_run_us, None);
+        assert_eq!(request.finished_at_run_us, None);
+    }
+
+    #[test]
+    fn stable_wrapper_non_strict_duration_mismatch_keeps_duration_us_authoritative() {
+        let input = r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req","started_at_unix_ms":100,"started_at_run_us":10,"finished_at_unix_ms":101,"finished_at_run_us":20,"duration_us":50000,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
+        let imported =
+            super::import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+
+        assert_eq!(imported.run().requests[0].latency_us, 50_000);
+        assert_eq!(imported.run().requests[0].started_at_run_us, Some(10));
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|warning| warning.message().contains("duration_us was retained")));
     }
 
     #[test]

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -191,9 +191,9 @@ where
                             route,
                             kind: None,
                             started_at_unix_ms: span.started_at_unix_ms(),
-                            started_at_run_us: None,
+                            started_at_run_us: span.started_at_run_us_ref(),
                             finished_at_unix_ms: span.finished_at_unix_ms(),
-                            finished_at_run_us: None,
+                            finished_at_run_us: span.finished_at_run_us_ref(),
                             latency_us: elapsed_duration_us(
                                 &span,
                                 options.strict_mode(),
@@ -221,9 +221,9 @@ where
                             request_id,
                             stage,
                             started_at_unix_ms: span.started_at_unix_ms(),
-                            started_at_run_us: None,
+                            started_at_run_us: span.started_at_run_us_ref(),
                             finished_at_unix_ms: span.finished_at_unix_ms(),
-                            finished_at_run_us: None,
+                            finished_at_run_us: span.finished_at_run_us_ref(),
                             latency_us: elapsed_duration_us(
                                 &span,
                                 options.strict_mode(),
@@ -250,9 +250,9 @@ where
                         request_id,
                         queue,
                         waited_from_unix_ms: span.started_at_unix_ms(),
-                        waited_from_run_us: None,
+                        waited_from_run_us: span.started_at_run_us_ref(),
                         waited_until_unix_ms: span.finished_at_unix_ms(),
-                        waited_until_run_us: None,
+                        waited_until_run_us: span.finished_at_run_us_ref(),
                         wait_us: elapsed_duration_us(&span, options.strict_mode(), &mut warnings)?,
                         depth_at_start,
                     });
@@ -986,6 +986,44 @@ mod tests {
             .run()
             .clone();
         assert_eq!(run.queues.len(), 1);
+    }
+
+    #[test]
+    fn span_record_run_relative_fields_convert_to_core_events() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 120)
+                .started_at_run_us(10)
+                .finished_at_run_us(20_010)
+                .duration_us(20_000)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("st", 105, 115)
+                .started_at_run_us(5_010)
+                .finished_at_run_us(15_010)
+                .duration_us(10_000)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+            SpanRecord::new("q", 102, 103)
+                .started_at_run_us(2_010)
+                .finished_at_run_us(3_010)
+                .duration_us(1_000)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+        let run = run_from_span_records(spans, ImportOptions::new("svc"))
+            .unwrap()
+            .run()
+            .clone();
+
+        assert_eq!(run.requests[0].started_at_run_us, Some(10));
+        assert_eq!(run.requests[0].finished_at_run_us, Some(20_010));
+        assert_eq!(run.stages[0].started_at_run_us, Some(5_010));
+        assert_eq!(run.stages[0].finished_at_run_us, Some(15_010));
+        assert_eq!(run.queues[0].waited_from_run_us, Some(2_010));
+        assert_eq!(run.queues[0].waited_until_run_us, Some(3_010));
     }
 
     #[test]

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -90,8 +90,9 @@ impl Default for RecorderLimits {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct RecorderState {
+    start_instant: Instant,
     open: BTreeMap<u64, OpenSpan>,
     completed_requests: Vec<SpanRecord>,
     completed_stages: Vec<SpanRecord>,
@@ -115,8 +116,31 @@ struct OpenSpan {
     name: String,
     fields: BTreeMap<String, FieldValue>,
     started_at_unix_ms: u64,
+    started_at_run_us: u64,
     started_instant: Instant,
     is_tt_candidate: bool,
+}
+
+impl Default for RecorderState {
+    fn default() -> Self {
+        Self {
+            start_instant: Instant::now(),
+            open: BTreeMap::new(),
+            completed_requests: Vec::new(),
+            completed_stages: Vec::new(),
+            completed_queues: Vec::new(),
+            dropped_open_spans: 0,
+            dropped_completed_request_candidates: 0,
+            dropped_completed_child_candidates: 0,
+            evicted_child_candidates_to_preserve_request: 0,
+            closed_missing_kind_spans: 0,
+            closed_unknown_kind_spans: 0,
+            closed_malformed_kind_spans: 0,
+            closed_kind_samples: Vec::new(),
+            closed_incomplete_candidate_spans: 0,
+            closed_incomplete_candidate_samples: Vec::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -428,6 +452,12 @@ fn retained_span_records_from_run(run: &tailtriage_core::Run) -> Vec<SpanRecord>
         .field("tt.request_id", req.request_id.clone())
         .field("tt.route", req.route.clone())
         .field("tt.outcome", req.outcome.clone());
+        if let Some(started_at_run_us) = req.started_at_run_us {
+            span = span.started_at_run_us(started_at_run_us);
+        }
+        if let Some(finished_at_run_us) = req.finished_at_run_us {
+            span = span.finished_at_run_us(finished_at_run_us);
+        }
         if duration_within_tolerance(
             req.latency_us,
             req.started_at_unix_ms,
@@ -447,6 +477,12 @@ fn retained_span_records_from_run(run: &tailtriage_core::Run) -> Vec<SpanRecord>
         .field("tt.request_id", stage.request_id.clone())
         .field("tt.stage", stage.stage.clone())
         .field("tt.success", stage.success);
+        if let Some(started_at_run_us) = stage.started_at_run_us {
+            span = span.started_at_run_us(started_at_run_us);
+        }
+        if let Some(finished_at_run_us) = stage.finished_at_run_us {
+            span = span.finished_at_run_us(finished_at_run_us);
+        }
         if duration_within_tolerance(
             stage.latency_us,
             stage.started_at_unix_ms,
@@ -465,6 +501,12 @@ fn retained_span_records_from_run(run: &tailtriage_core::Run) -> Vec<SpanRecord>
         .field("tt.kind", "queue")
         .field("tt.request_id", queue.request_id.clone())
         .field("tt.queue", queue.queue.clone());
+        if let Some(waited_from_run_us) = queue.waited_from_run_us {
+            span = span.started_at_run_us(waited_from_run_us);
+        }
+        if let Some(waited_until_run_us) = queue.waited_until_run_us {
+            span = span.finished_at_run_us(waited_until_run_us);
+        }
         if duration_within_tolerance(
             queue.wait_us,
             queue.waited_from_unix_ms,
@@ -689,6 +731,7 @@ where
         if !(metadata_candidate || initial_candidate) {
             return;
         }
+        let started_instant = Instant::now();
         let mut state = lock_state(&self.state);
         if state.open.len() >= self.limits.max_open_spans {
             state.dropped_open_spans = state.dropped_open_spans.saturating_add(1);
@@ -700,7 +743,8 @@ where
             name: attrs.metadata().name().to_owned(),
             fields: visitor.fields,
             started_at_unix_ms: tailtriage_core::unix_time_ms(),
-            started_instant: Instant::now(),
+            started_at_run_us: duration_us_between(state.start_instant, started_instant),
+            started_instant,
             is_tt_candidate: metadata_candidate || initial_candidate,
         };
         state.open.insert(id.into_u64(), open_span);
@@ -720,6 +764,7 @@ where
         let closed_instant = std::time::Instant::now();
 
         let mut state = lock_state(&self.state);
+        let finished_at_run_us = duration_us_between(state.start_instant, closed_instant);
         if let Some(open) = state.open.remove(&id.into_u64()) {
             let kind = classify_kind(&open.fields);
             if let Err(reason) = kind {
@@ -733,6 +778,8 @@ where
             }
             let duration_us = duration_us_between(open.started_instant, closed_instant);
             let mut record = SpanRecord::new(open.name, open.started_at_unix_ms, closed_at_unix_ms)
+                .started_at_run_us(open.started_at_run_us)
+                .finished_at_run_us(finished_at_run_us)
                 .duration_us(duration_us);
             if let Some(span_id) = open.id {
                 record = record.id(span_id);
@@ -1268,6 +1315,76 @@ mod tests {
             .build()
             .expect("collector")
             .snapshot()
+    }
+
+    #[test]
+    fn live_recorder_request_conversion_populates_run_relative_fields() {
+        with_recorder(|recorder| {
+            let span = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            );
+            drop(span);
+
+            let imported = recorder.snapshot_run().unwrap();
+            let request = &imported.run().requests[0];
+            assert!(request.started_at_run_us.is_some());
+            assert!(request.finished_at_run_us.is_some());
+        });
+    }
+
+    #[test]
+    fn live_recorder_stage_conversion_populates_run_relative_fields() {
+        with_recorder(|recorder| {
+            let request = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            );
+            let live_request_guard = request.enter();
+            drop(tracing::info_span!(
+                "stage",
+                tt.kind = "stage",
+                tt.request_id = "r1",
+                tt.stage = "db"
+            ));
+            drop(live_request_guard);
+            drop(request);
+
+            let imported = recorder.snapshot_run().unwrap();
+            let stage = &imported.run().stages[0];
+            assert!(stage.started_at_run_us.is_some());
+            assert!(stage.finished_at_run_us.is_some());
+        });
+    }
+
+    #[test]
+    fn live_recorder_queue_conversion_populates_run_relative_fields() {
+        with_recorder(|recorder| {
+            let request = tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            );
+            let live_request_guard = request.enter();
+            drop(tracing::info_span!(
+                "queue",
+                tt.kind = "queue",
+                tt.request_id = "r1",
+                tt.queue = "permits"
+            ));
+            drop(live_request_guard);
+            drop(request);
+
+            let imported = recorder.snapshot_run().unwrap();
+            let queue = &imported.run().queues[0];
+            assert!(queue.waited_from_run_us.is_some());
+            assert!(queue.waited_until_run_us.is_some());
+        });
     }
 
     #[test]

--- a/tailtriage-tracing/src/types.rs
+++ b/tailtriage-tracing/src/types.rs
@@ -91,7 +91,11 @@ pub struct SpanRecord {
     name: String,
     fields: BTreeMap<String, FieldValue>,
     started_at_unix_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    started_at_run_us: Option<u64>,
     finished_at_unix_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    finished_at_run_us: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     duration_us: Option<u64>,
 }
@@ -105,7 +109,9 @@ impl SpanRecord {
             name: name.into(),
             fields: BTreeMap::new(),
             started_at_unix_ms,
+            started_at_run_us: None,
             finished_at_unix_ms,
+            finished_at_run_us: None,
             duration_us: None,
         }
     }
@@ -130,6 +136,20 @@ impl SpanRecord {
         self.fields.insert(key.into(), value.into());
         self
     }
+    /// Sets span start offset from run start in microseconds.
+    #[must_use]
+    pub fn started_at_run_us(mut self, started_at_run_us: u64) -> Self {
+        self.started_at_run_us = Some(started_at_run_us);
+        self
+    }
+
+    /// Sets span finish offset from run start in microseconds.
+    #[must_use]
+    pub fn finished_at_run_us(mut self, finished_at_run_us: u64) -> Self {
+        self.finished_at_run_us = Some(finished_at_run_us);
+        self
+    }
+
     /// Sets explicit span duration in microseconds.
     #[must_use]
     pub fn duration_us(mut self, duration_us: u64) -> Self {
@@ -162,10 +182,20 @@ impl SpanRecord {
     pub fn started_at_unix_ms(&self) -> u64 {
         self.started_at_unix_ms
     }
+    /// Returns span start offset from run start in microseconds when present.
+    #[must_use]
+    pub fn started_at_run_us_ref(&self) -> Option<u64> {
+        self.started_at_run_us
+    }
     /// Returns finish timestamp in unix milliseconds.
     #[must_use]
     pub fn finished_at_unix_ms(&self) -> u64 {
         self.finished_at_unix_ms
+    }
+    /// Returns span finish offset from run start in microseconds when present.
+    #[must_use]
+    pub fn finished_at_run_us_ref(&self) -> Option<u64> {
+        self.finished_at_run_us
     }
     /// Returns explicit span duration in microseconds when present.
     #[must_use]
@@ -355,6 +385,8 @@ mod tests {
         let record = SpanRecord::new("request", 10, 20)
             .id("span-1")
             .parent_id("parent-1")
+            .started_at_run_us(100)
+            .finished_at_run_us(200)
             .field("tt.request_id", "req-1")
             .field(TT_KIND, "request")
             .field(TT_SUCCESS, true)
@@ -364,7 +396,9 @@ mod tests {
         assert_eq!(record.parent_id_ref(), Some("parent-1"));
         assert_eq!(record.name(), "request");
         assert_eq!(record.started_at_unix_ms(), 10);
+        assert_eq!(record.started_at_run_us_ref(), Some(100));
         assert_eq!(record.finished_at_unix_ms(), 20);
+        assert_eq!(record.finished_at_run_us_ref(), Some(200));
         assert_eq!(record.fields().len(), 4);
     }
 


### PR DESCRIPTION
### Motivation

- Capture and preserve run-relative monotonic offsets alongside wall-clock timestamps so analyzer can group events reliably within a captured run without changing duration-authoritative semantics.

### Description

- Added optional run-relative fields to `SpanRecord`: `started_at_run_us: Option<u64>` and `finished_at_run_us: Option<u64>` with `#[serde(default, skip_serializing_if = "Option::is_none")]`, plus builder-style setters and accessors mirroring existing `SpanRecord` methods (file: `tailtriage-tracing/src/types.rs`).
- Added a recorder start `Instant` stored in `RecorderState` and a run-relative start offset on `OpenSpan`; populated `started_at_run_us` at span creation and `finished_at_run_us` at span close using monotonic elapsed from recorder start, while keeping `finished_at_unix_ms` sampled at close and `duration_us` computed from monotonic span elapsed (file: `tailtriage-tracing/src/recorder.rs`).
- When building `SpanRecord` for closed spans, set the new run-relative fields so they flow through live-recording conversion and into retained completed-span JSONL export (files: `tailtriage-tracing/src/recorder.rs`, `tailtriage-tracing/src/lib.rs`).
- Propagated optional run-relative offsets into core events: `RequestEvent.started_at_run_us` / `finished_at_run_us`, `StageEvent.started_at_run_us` / `finished_at_run_us`, and `QueueEvent.waited_from_run_us` / `waited_until_run_us`, mapping to `None` when absent (file: `tailtriage-tracing/src/lib.rs`).
- JSONL import now accepts optional `started_at_run_us` and `finished_at_run_us` in the stable wrapper and preserves them into `SpanRecord` via an `optional_u64` helper; import does not fabricate run-relative offsets when absent (file: `tailtriage-tracing/src/jsonl.rs`).
- JSONL export of retained completed spans includes run-relative fields when present and omits them when `None` (file: `tailtriage-tracing/src/recorder.rs`).
- Updated `tailtriage-tracing/README.md` to document that newer live tracing output may include run-relative monotonic offsets and that imported JSONL may omit them, in which case the analyzer falls back to wall-clock timestamps.
- Added tests covering live recorder conversion populating run-relative fields for requests, stages, and queues, stable-wrapper JSONL import preserving run-relative fields when present, import behavior when absent, and non-strict duration mismatch keeping `duration_us` authoritative (files: `tailtriage-tracing/src/recorder.rs`, `tailtriage-tracing/src/jsonl.rs`, `tailtriage-tracing/src/lib.rs`).

### Testing

- Ran formatting and linting: `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and addressed issues; both passed.
- Ran full test matrix and checks: `cargo test --workspace --all-targets --all-features --locked`, `cargo test --workspace`, and feature/check permutations: `cargo check -p tailtriage-tracing --no-default-features --locked`, `--features jsonl`, `--features live`, `--features tokio`; all succeeded.
- Ran docs contract validator: `python3 scripts/validate_docs_contracts.py` which passed.
- All new and existing unit tests passed (package `tailtriage-tracing` and workspace): 275 tests in the crate / full workspace test suite passed with zero failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e96cf06e083309c0b543d73aa21f0)