### PR TITLE
Preserve run-relative timings and authoritative durations for tracing intake and JSONL export

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -97,6 +97,7 @@ If your service already builds a subscriber in startup code, compose `session.la
 - Newer live tracing output includes run-relative monotonic offsets for request, stage, and queue spans when those offsets are available; these offsets improve temporal grouping inside a captured run.
 - Imported JSONL may omit run-relative offsets. When they are absent, the analyzer falls back to Unix-ms wall-clock timestamps for temporal grouping.
 - `duration_us` remains the authoritative elapsed-time evidence when supplied or recorded by live tracing.
+- Completed-span JSONL export preserves `duration_us` because duration fields are authoritative elapsed-time evidence.
 - Unix-ms timestamps are wall-clock anchors and may be coarser than durations.
 - Ordinary tracing log timestamps are not enough for completed-span import; completed spans need explicit start/end timing and semantic tt.* fields.
 

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -202,6 +202,10 @@ fn parse_record(
                 };
             };
 
+            if let Some(span_obj) = span_value.as_object() {
+                validate_optional_run_relative_fields(span_obj)?;
+            }
+
             return match serde_json::from_value::<SpanRecord>(span_value.clone()) {
                 Ok(span) => Ok(Some(span)),
                 Err(err) => {
@@ -365,6 +369,14 @@ fn value_has_tailtriage_field(value: &Value) -> bool {
         || value
             .as_object()
             .is_some_and(|obj| obj.keys().any(|k| k.starts_with("tt.")))
+}
+
+fn validate_optional_run_relative_fields(
+    obj: &serde_json::Map<String, Value>,
+) -> Result<(), ImportError> {
+    let _ = optional_u64(obj, "started_at_run_us")?;
+    let _ = optional_u64(obj, "finished_at_run_us")?;
+    Ok(())
 }
 
 fn parse_normalized_span(
@@ -583,13 +595,36 @@ mod tests {
 
     #[test]
     fn stable_wrapper_jsonl_without_run_relative_fields_imports_none() {
-        let input = r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":10000,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
+        let input = r#"
+{"format":"tailtriage.tracing-span.v1","span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":10000,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
+{"format":"tailtriage.tracing-span.v1","span":{"name":"st","started_at_unix_ms":11,"finished_at_unix_ms":18,"duration_us":7000,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
+{"format":"tailtriage.tracing-span.v1","span":{"name":"q","started_at_unix_ms":12,"finished_at_unix_ms":13,"duration_us":1000,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits"}}}
+"#;
         let imported =
             super::import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        let request = &imported.run().requests[0];
+        let run = imported.run();
 
-        assert_eq!(request.started_at_run_us, None);
-        assert_eq!(request.finished_at_run_us, None);
+        assert_eq!(run.requests[0].started_at_run_us, None);
+        assert_eq!(run.requests[0].finished_at_run_us, None);
+        assert_eq!(run.stages[0].started_at_run_us, None);
+        assert_eq!(run.stages[0].finished_at_run_us, None);
+        assert_eq!(run.queues[0].waited_from_run_us, None);
+        assert_eq!(run.queues[0].waited_until_run_us, None);
+    }
+
+    #[test]
+    fn stable_wrapper_jsonl_invalid_run_relative_field_fails_invalid_field() {
+        let input = r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req","started_at_unix_ms":10,"started_at_run_us":"bad","finished_at_unix_ms":20,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
+        let err =
+            super::import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap_err();
+
+        assert!(matches!(
+            err,
+            ImportError::InvalidField {
+                field: "started_at_run_us",
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -12,8 +12,8 @@ use tracing::{Id, Subscriber};
 use tracing_subscriber::layer::{Context, Layer};
 
 use crate::{
-    duration_within_tolerance, ensure_persistable_run_with_warnings, run_from_span_records,
-    FieldValue, ImportError, ImportOptions, ImportedRun, SpanRecord, TT_KIND,
+    ensure_persistable_run_with_warnings, run_from_span_records, FieldValue, ImportError,
+    ImportOptions, ImportedRun, SpanRecord, TT_KIND,
 };
 
 /// In-memory recorder for completed tracing spans with `tt.*` fields.
@@ -458,13 +458,7 @@ fn retained_span_records_from_run(run: &tailtriage_core::Run) -> Vec<SpanRecord>
         if let Some(finished_at_run_us) = req.finished_at_run_us {
             span = span.finished_at_run_us(finished_at_run_us);
         }
-        if duration_within_tolerance(
-            req.latency_us,
-            req.started_at_unix_ms,
-            req.finished_at_unix_ms,
-        ) {
-            span = span.duration_us(req.latency_us);
-        }
+        span = span.duration_us(req.latency_us);
         spans.push(span);
     }
     for stage in &run.stages {
@@ -483,13 +477,7 @@ fn retained_span_records_from_run(run: &tailtriage_core::Run) -> Vec<SpanRecord>
         if let Some(finished_at_run_us) = stage.finished_at_run_us {
             span = span.finished_at_run_us(finished_at_run_us);
         }
-        if duration_within_tolerance(
-            stage.latency_us,
-            stage.started_at_unix_ms,
-            stage.finished_at_unix_ms,
-        ) {
-            span = span.duration_us(stage.latency_us);
-        }
+        span = span.duration_us(stage.latency_us);
         spans.push(span);
     }
     for queue in &run.queues {
@@ -507,13 +495,7 @@ fn retained_span_records_from_run(run: &tailtriage_core::Run) -> Vec<SpanRecord>
         if let Some(waited_until_run_us) = queue.waited_until_run_us {
             span = span.finished_at_run_us(waited_until_run_us);
         }
-        if duration_within_tolerance(
-            queue.wait_us,
-            queue.waited_from_unix_ms,
-            queue.waited_until_unix_ms,
-        ) {
-            span = span.duration_us(queue.wait_us);
-        }
+        span = span.duration_us(queue.wait_us);
         if let Some(depth) = queue.depth_at_start {
             span = span.field("tt.depth_at_start", depth);
         }
@@ -1330,8 +1312,13 @@ mod tests {
 
             let imported = recorder.snapshot_run().unwrap();
             let request = &imported.run().requests[0];
-            assert!(request.started_at_run_us.is_some());
-            assert!(request.finished_at_run_us.is_some());
+            let start = request
+                .started_at_run_us
+                .expect("request run-relative start");
+            let finish = request
+                .finished_at_run_us
+                .expect("request run-relative finish");
+            assert!(finish >= start);
         });
     }
 
@@ -1356,8 +1343,9 @@ mod tests {
 
             let imported = recorder.snapshot_run().unwrap();
             let stage = &imported.run().stages[0];
-            assert!(stage.started_at_run_us.is_some());
-            assert!(stage.finished_at_run_us.is_some());
+            let start = stage.started_at_run_us.expect("stage run-relative start");
+            let finish = stage.finished_at_run_us.expect("stage run-relative finish");
+            assert!(finish >= start);
         });
     }
 
@@ -1382,8 +1370,11 @@ mod tests {
 
             let imported = recorder.snapshot_run().unwrap();
             let queue = &imported.run().queues[0];
-            assert!(queue.waited_from_run_us.is_some());
-            assert!(queue.waited_until_run_us.is_some());
+            let start = queue.waited_from_run_us.expect("queue run-relative start");
+            let finish = queue
+                .waited_until_run_us
+                .expect("queue run-relative finish");
+            assert!(finish >= start);
         });
     }
 
@@ -3745,17 +3736,16 @@ mod tests {
         assert_eq!(imported.run().queues.len(), 0);
     }
 
-    #[test]
-    fn retained_request_stage_queue_omit_contradictory_duration_us() {
+    fn run_with_authoritative_durations_and_run_offsets() -> tailtriage_core::Run {
         let mut run = empty_run();
         run.requests.push(tailtriage_core::RequestEvent {
             request_id: "r1".into(),
             route: "/a".into(),
             kind: None,
             started_at_unix_ms: 100,
-            started_at_run_us: None,
-            finished_at_unix_ms: 100,
-            finished_at_run_us: None,
+            started_at_run_us: Some(1_000),
+            finished_at_unix_ms: 101,
+            finished_at_run_us: Some(51_000),
             latency_us: 50_000,
             outcome: "ok".into(),
         });
@@ -3763,93 +3753,80 @@ mod tests {
             request_id: "r1".into(),
             stage: "db".into(),
             started_at_unix_ms: 100,
-            started_at_run_us: None,
-            finished_at_unix_ms: 100,
-            finished_at_run_us: None,
-            latency_us: 50_000,
+            started_at_run_us: Some(2_000),
+            finished_at_unix_ms: 101,
+            finished_at_run_us: Some(72_000),
+            latency_us: 70_000,
             success: true,
         });
         run.queues.push(tailtriage_core::QueueEvent {
             request_id: "r1".into(),
             queue: "permits".into(),
             waited_from_unix_ms: 100,
-            waited_from_run_us: None,
-            waited_until_unix_ms: 100,
-            waited_until_run_us: None,
-            wait_us: 50_000,
+            waited_from_run_us: Some(3_000),
+            waited_until_unix_ms: 101,
+            waited_until_run_us: Some(33_000),
+            wait_us: 30_000,
             depth_at_start: None,
         });
-        let spans = retained_span_records_from_run(&run);
-        assert_eq!(spans.len(), 3);
-        assert!(spans.iter().all(|span| span.duration_us_ref().is_none()));
+        run
     }
 
     #[test]
-    fn retained_jsonl_replays_in_strict_mode_when_contradictory_durations_omitted() {
+    fn retained_request_stage_queue_preserve_authoritative_durations_and_run_offsets() {
+        let run = run_with_authoritative_durations_and_run_offsets();
+        let spans = retained_span_records_from_run(&run);
+        assert_eq!(spans.len(), 3);
+
+        let request = spans
+            .iter()
+            .find(|span| {
+                span.fields().get("tt.kind") == Some(&FieldValue::String("request".into()))
+            })
+            .expect("request span");
+        assert_eq!(request.duration_us_ref(), Some(50_000));
+        assert_eq!(request.started_at_run_us_ref(), Some(1_000));
+        assert_eq!(request.finished_at_run_us_ref(), Some(51_000));
+
+        let stage = spans
+            .iter()
+            .find(|span| span.fields().get("tt.kind") == Some(&FieldValue::String("stage".into())))
+            .expect("stage span");
+        assert_eq!(stage.duration_us_ref(), Some(70_000));
+        assert_eq!(stage.started_at_run_us_ref(), Some(2_000));
+        assert_eq!(stage.finished_at_run_us_ref(), Some(72_000));
+
+        let queue = spans
+            .iter()
+            .find(|span| span.fields().get("tt.kind") == Some(&FieldValue::String("queue".into())))
+            .expect("queue span");
+        assert_eq!(queue.duration_us_ref(), Some(30_000));
+        assert_eq!(queue.started_at_run_us_ref(), Some(3_000));
+        assert_eq!(queue.finished_at_run_us_ref(), Some(33_000));
+    }
+
+    #[test]
+    fn completed_span_jsonl_round_trip_preserves_authoritative_durations_and_run_offsets() {
         let dir = tempfile::tempdir().unwrap();
         let spans_path = dir.path().join("spans.jsonl");
-        let mut run = empty_run();
-        run.requests.push(tailtriage_core::RequestEvent {
-            request_id: "r1".into(),
-            route: "/a".into(),
-            kind: None,
-            started_at_unix_ms: 100,
-            started_at_run_us: None,
-            finished_at_unix_ms: 100,
-            finished_at_run_us: None,
-            latency_us: 50_000,
-            outcome: "ok".into(),
-        });
-        run.stages.push(tailtriage_core::StageEvent {
-            request_id: "r1".into(),
-            stage: "db".into(),
-            started_at_unix_ms: 100,
-            started_at_run_us: None,
-            finished_at_unix_ms: 100,
-            finished_at_run_us: None,
-            latency_us: 50_000,
-            success: true,
-        });
-        run.queues.push(tailtriage_core::QueueEvent {
-            request_id: "r1".into(),
-            queue: "permits".into(),
-            waited_from_unix_ms: 100,
-            waited_from_run_us: None,
-            waited_until_unix_ms: 100,
-            waited_until_run_us: None,
-            wait_us: 50_000,
-            depth_at_start: None,
-        });
+        let run = run_with_authoritative_durations_and_run_offsets();
         write_completed_span_jsonl_from_run(&run, &spans_path).unwrap();
 
         let replay = crate::jsonl::import_jsonl_path_with_mode(
             &spans_path,
-            ImportOptions::new("svc").strict(true),
+            ImportOptions::new("svc"),
             crate::jsonl::JsonlParseMode::TailtriageWrapperOnly,
         )
         .unwrap();
-        assert_eq!(replay.run().requests.len(), 1);
-        assert_eq!(replay.run().stages.len(), 1);
-        assert_eq!(replay.run().queues.len(), 1);
-    }
-
-    #[test]
-    fn retained_duration_us_preserved_when_within_tolerance() {
-        let mut run = empty_run();
-        run.requests.push(tailtriage_core::RequestEvent {
-            request_id: "r1".into(),
-            route: "/a".into(),
-            kind: None,
-            started_at_unix_ms: 100,
-            started_at_run_us: None,
-            finished_at_unix_ms: 101,
-            finished_at_run_us: None,
-            latency_us: 1_500,
-            outcome: "ok".into(),
-        });
-        let spans = retained_span_records_from_run(&run);
-        assert_eq!(spans.len(), 1);
-        assert_eq!(spans[0].duration_us_ref(), Some(1_500));
+        assert_eq!(replay.run().requests[0].latency_us, 50_000);
+        assert_eq!(replay.run().requests[0].started_at_run_us, Some(1_000));
+        assert_eq!(replay.run().requests[0].finished_at_run_us, Some(51_000));
+        assert_eq!(replay.run().stages[0].latency_us, 70_000);
+        assert_eq!(replay.run().stages[0].started_at_run_us, Some(2_000));
+        assert_eq!(replay.run().stages[0].finished_at_run_us, Some(72_000));
+        assert_eq!(replay.run().queues[0].wait_us, 30_000);
+        assert_eq!(replay.run().queues[0].waited_from_run_us, Some(3_000));
+        assert_eq!(replay.run().queues[0].waited_until_run_us, Some(33_000));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Provide run-relative monotonic offsets from live tracing intake and preserve them when importing/exporting completed-span JSONL to improve temporal grouping without fabricating missing offsets.
- Treat `duration_us` as the authoritative elapsed-time evidence and ensure completed-span JSONL export always preserves those authoritative duration fields. 

### Description

- Added optional run-relative fields to `SpanRecord` (`started_at_run_us` and `finished_at_run_us`) with `#[serde(default, skip_serializing_if = "Option::is_none")]` and initialized them to `None`, plus builder setters `started_at_run_us(...)`/`finished_at_run_us(...)` and accessors `started_at_run_us_ref()`/`finished_at_run_us_ref()` in `tailtriage-tracing/src/types.rs`.
- Introduced a recorder/session monotonic anchor `start_instant: Instant` in `RecorderState`, capture `started_instant = Instant::now()` before locking on span creation to compute and store `started_at_run_us`, and sample `closed_at_unix_ms` and `closed_instant = Instant::now()` before locking on close to compute `finished_at_run_us` and `duration_us` from captured instants; the live path continues to set Unix-ms timestamps as before (in `tailtriage-tracing/src/recorder.rs`).
- JSONL import now validates optional `started_at_run_us`/`finished_at_run_us` as `u64` (rejecting invalid non-u64 values with `ImportError::InvalidField`), accepts and preserves present run-relative fields, and does not fabricate them when absent (`tailtriage-tracing/src/jsonl.rs`).
- Completed-span JSONL export via `retained_span_records_from_run(...)` now preserves run-relative fields when present and always emits authoritative duration fields (`duration_us`) from `RequestEvent`/`StageEvent`/`QueueEvent` without gating on `duration_within_tolerance`.
- Updated documentation (`tailtriage-tracing/README.md`) to state that newer live tracing output includes run-relative monotonic offsets and that completed-span JSONL export preserves `duration_us` as authoritative elapsed-time evidence.
- Added and adjusted tests: live recorder tests assert run-relative start/finish are populated and finish >= start; JSONL import tests cover presence/absence/invalid run-relative fields and non-strict duration-mismatch behavior; completed-span export tests assert exported `SpanRecord` preserves authoritative `duration_us`, run-relative offsets, and `tt.kind` and a wrapper round-trip preserves those fields.

### Testing

- Ran formatting and linting: `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and fixed issues; both passed.
- Ran full test matrix and checks: `cargo test --workspace --all-targets --all-features --locked`, `cargo test --workspace`, `cargo check -p tailtriage-tracing --no-default-features --locked`, `cargo check -p tailtriage-tracing --no-default-features --features jsonl --locked`, `cargo check -p tailtriage-tracing --no-default-features --features live --locked`, and `cargo check -p tailtriage-tracing --no-default-features --features tokio --locked`; all completed successfully with unit tests passing.
- Validated docs contract with `python3 scripts/validate_docs_contracts.py`; validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eb65ffb8483308299668436d01f68)