### PR TITLE
Align controller generation start timestamp with core Run metadata and document sampler cadence

### DIFF
--- a/tailtriage-controller/src/lib.rs
+++ b/tailtriage-controller/src/lib.rs
@@ -454,10 +454,11 @@ impl TailtriageController {
         builder = builder.strict_lifecycle(template.strict_lifecycle);
 
         let run = Arc::new(builder.build().map_err(EnableError::Build)?);
+        let generation_started_at_unix_ms = run.snapshot().metadata.started_at_unix_ms;
         let runtime = Arc::new(ActiveGenerationRuntime {
             state: ActiveGenerationState {
                 generation_id: next_generation,
-                started_at_unix_ms: tailtriage_core::unix_time_ms(),
+                started_at_unix_ms: generation_started_at_unix_ms,
                 artifact_path: artifact_path.clone(),
                 accepting_new_admissions: true,
                 closing: false,
@@ -1894,6 +1895,28 @@ mod tests {
         assert!(expected.exists());
 
         fs::remove_file(expected).expect("cleanup should succeed");
+    }
+
+    #[test]
+    fn active_generation_started_at_matches_underlying_run_metadata() {
+        let output = test_output("active-start-matches-run");
+        let controller = TailtriageController::builder("checkout-service")
+            .output(&output)
+            .build()
+            .expect("build should succeed");
+
+        let active_state = controller.enable().expect("enable should succeed");
+        let active_runtime = active_runtime(&controller);
+        let run_started_at = active_runtime.run.snapshot().metadata.started_at_unix_ms;
+
+        assert_eq!(active_state.started_at_unix_ms, run_started_at);
+        assert_eq!(active_runtime.snapshot().started_at_unix_ms, run_started_at);
+
+        assert!(matches!(
+            controller.disable(),
+            Ok(DisableOutcome::Finalized { generation_id: 1 })
+        ));
+        fs::remove_file(active_state.artifact_path).expect("cleanup should succeed");
     }
 
     #[test]

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -157,6 +157,8 @@ async fn demo() -> Result<(), Box<dyn std::error::Error>> {
 
 On successful sampler start, tailtriage records effective sampler configuration metadata into the run artifact metadata before runtime snapshots are captured.
 
+The sampler records an initial runtime sample promptly after start, then follows the configured cadence. The cadence is a target periodic sampling cadence, not a hard real-time guarantee.
+
 When the sampler is running, the run artifact can include runtime snapshots such as:
 
 - `alive_tasks`
@@ -190,6 +192,8 @@ run.shutdown()?;
 ```
 
 ### Override cadence and runtime snapshot retention
+
+Cadence controls the target periodic sampling cadence after the prompt initial sample; it is not a hard real-time guarantee.
 
 ```rust,no_run
 use std::sync::Arc;

--- a/tailtriage-tokio/src/lib.rs
+++ b/tailtriage-tokio/src/lib.rs
@@ -443,6 +443,10 @@ impl std::fmt::Display for SamplerStartError {
 impl std::error::Error for SamplerStartError {}
 
 /// Periodically samples Tokio runtime metrics and records them into a [`Tailtriage`] run.
+///
+/// The sampler records an initial runtime snapshot promptly after start, then
+/// follows the configured cadence. That cadence is a target periodic sampling
+/// cadence, not a hard real-time guarantee.
 #[derive(Debug)]
 pub struct RuntimeSampler {
     stop_tx: Option<oneshot::Sender<()>>,
@@ -515,6 +519,10 @@ impl RuntimeSampler {
 
     /// Starts periodic runtime metrics sampling on the current Tokio runtime.
     ///
+    /// The sampler records an initial sample promptly after start, then follows
+    /// the configured cadence. Cadence is a target periodic sampling cadence,
+    /// not a hard real-time guarantee.
+    ///
     /// Use this during incident triage when runtime pressure evidence is needed
     /// to rank suspects (for example: global queue growth or alive-task spikes).
     /// For lower runtime-cost core-only capture categories, skip sampler startup.
@@ -555,6 +563,9 @@ impl RuntimeSamplerBuilder {
     }
 
     /// Overrides resolved sampler cadence.
+    ///
+    /// The cadence is a target periodic sampling cadence after the prompt
+    /// initial sample, not a hard real-time guarantee.
     #[must_use]
     pub fn interval(mut self, interval: Duration) -> Self {
         self.interval_override = Some(interval);
@@ -569,6 +580,10 @@ impl RuntimeSamplerBuilder {
     }
 
     /// Resolves configuration and starts periodic runtime metrics sampling.
+    ///
+    /// The sampler records an initial sample promptly after start, then follows
+    /// the configured cadence. Cadence is a target periodic sampling cadence,
+    /// not a hard real-time guarantee.
     ///
     /// Resolution precedence:
     ///


### PR DESCRIPTION
### Motivation

- Prevent start-time drift between the controller-visible generation status and the authoritative `Tailtriage` run metadata so timestamps reported by the controller match the underlying run artifact.  
- Make runtime sampler semantics explicit in docs and rustdoc: record an initial sample promptly, then follow the configured cadence as a target (not a hard real-time guarantee), without changing sampler behavior or claiming universal production overhead guarantees.

### Description

- Use the core run metadata start time for the controller active generation state by reading `run.snapshot().metadata.started_at_unix_ms` immediately after `builder.build()` and assigning it to `ActiveGenerationState.started_at_unix_ms` in `tailtriage-controller/src/lib.rs`.  
- Remove the separate `tailtriage_core::unix_time_ms()` sampling for the generation `started_at_unix_ms` and keep lifecycle behavior unchanged.  
- Add an internal (module-private) controller unit test `active_generation_started_at_matches_underlying_run_metadata` that enables a controller, inspects the active generation runtime and underlying run snapshot, and asserts the timestamps match without exposing new public APIs.  
- Document sampler cadence semantics in `tailtriage-tokio/src/lib.rs` rustdoc and `tailtriage-tokio/README.md` by stating the sampler records an initial sample promptly after start and that cadence is a target periodic sampling cadence, not a hard real-time guarantee; do not change sampler behavior.  
- No new dependencies were added and analyzer scoring was not modified.

### Testing

- Ran `cargo fmt --check` and it succeeded.  
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it succeeded.  
- Ran `cargo test --workspace --all-targets --all-features --locked` and full test-suite succeeded; an initial `cargo test --workspace` run showed one transient failure in `tailtriage-analyzer::end_to_end_capture_analysis::queue_and_stage_data_drives_ranked_suspects` which was retested specifically and passed, and the final `cargo test --workspace` completed successfully.  
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ed34ca8348330918ccedc711219a7)