### PR TITLE
Align controller generation start metadata and document runtime sampler cadence semantics

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -148,6 +148,8 @@ Runtime sampling is usually unnecessary when:
 Important operational constraints:
 
 * runtime sampling must start inside an active Tokio runtime
+* sampler startup records an initial sample promptly, then follows the configured target cadence
+* sampler cadence is a target periodic cadence, not a hard real-time guarantee
 * runtime snapshots are bounded by capture limits
 * some runtime fields require `tokio_unstable`
 * runtime sampling increases event volume and artifact growth

--- a/tailtriage-controller/src/lib.rs
+++ b/tailtriage-controller/src/lib.rs
@@ -454,10 +454,11 @@ impl TailtriageController {
         builder = builder.strict_lifecycle(template.strict_lifecycle);
 
         let run = Arc::new(builder.build().map_err(EnableError::Build)?);
+        let generation_started_at_unix_ms = run.snapshot().metadata.started_at_unix_ms;
         let runtime = Arc::new(ActiveGenerationRuntime {
             state: ActiveGenerationState {
                 generation_id: next_generation,
-                started_at_unix_ms: tailtriage_core::unix_time_ms(),
+                started_at_unix_ms: generation_started_at_unix_ms,
                 artifact_path: artifact_path.clone(),
                 accepting_new_admissions: true,
                 closing: false,
@@ -1643,9 +1644,9 @@ mod tests {
     use std::time::Duration;
 
     use super::{
-        ControllerBuildError, ControllerSinkTemplate, DisableOutcome, EnableError, GenerationState,
-        ReloadConfigError, ReloadTemplateError, RunEndPolicy, RuntimeSamplerTemplate,
-        TailtriageController, TailtriageControllerTemplate,
+        ControllerBuildError, ControllerLifecycle, ControllerSinkTemplate, DisableOutcome,
+        EnableError, GenerationState, ReloadConfigError, ReloadTemplateError, RunEndPolicy,
+        RuntimeSamplerTemplate, TailtriageController, TailtriageControllerTemplate,
     };
     use serde::Serialize;
     use tailtriage_core::{
@@ -1894,6 +1895,36 @@ mod tests {
         assert!(expected.exists());
 
         fs::remove_file(expected).expect("cleanup should succeed");
+    }
+
+    #[test]
+    fn enable_generation_start_matches_underlying_run_metadata() {
+        let output = test_output("enable-start-metadata");
+        let controller = TailtriageController::builder("checkout-service")
+            .output(&output)
+            .build()
+            .expect("build should succeed");
+
+        let active = controller.enable().expect("enable should succeed");
+
+        let run_started_at_unix_ms = {
+            let lifecycle = controller
+                .inner
+                .lifecycle
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            match *lifecycle {
+                ControllerLifecycle::Active { ref active, .. } => {
+                    active.run.snapshot().metadata.started_at_unix_ms
+                }
+                ControllerLifecycle::Disabled { .. } => panic!("controller should be active"),
+            }
+        };
+
+        assert_eq!(active.started_at_unix_ms, run_started_at_unix_ms);
+
+        controller.shutdown().expect("shutdown should succeed");
+        fs::remove_file(active.artifact_path).expect("cleanup should succeed");
     }
 
     #[test]

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -157,6 +157,8 @@ async fn demo() -> Result<(), Box<dyn std::error::Error>> {
 
 On successful sampler start, tailtriage records effective sampler configuration metadata into the run artifact metadata before runtime snapshots are captured.
 
+After start, the sampler records an initial sample promptly, then follows the configured cadence. The cadence is a target periodic sampling cadence, not a hard real-time guarantee.
+
 When the sampler is running, the run artifact can include runtime snapshots such as:
 
 - `alive_tasks`
@@ -190,6 +192,8 @@ run.shutdown()?;
 ```
 
 ### Override cadence and runtime snapshot retention
+
+The cadence setting controls the target periodic sampling cadence after the prompt initial sample. It does not provide a hard real-time timing guarantee.
 
 ```rust,no_run
 use std::sync::Arc;

--- a/tailtriage-tokio/src/lib.rs
+++ b/tailtriage-tokio/src/lib.rs
@@ -443,6 +443,10 @@ impl std::fmt::Display for SamplerStartError {
 impl std::error::Error for SamplerStartError {}
 
 /// Periodically samples Tokio runtime metrics and records them into a [`Tailtriage`] run.
+///
+/// After startup, the sampler records an initial sample promptly, then follows
+/// the configured cadence. That cadence is a target periodic sampling cadence,
+/// not a hard real-time guarantee.
 #[derive(Debug)]
 pub struct RuntimeSampler {
     stop_tx: Option<oneshot::Sender<()>>,
@@ -515,6 +519,10 @@ impl RuntimeSampler {
 
     /// Starts periodic runtime metrics sampling on the current Tokio runtime.
     ///
+    /// The sampler records an initial sample promptly after start, then follows
+    /// the configured cadence. The cadence is a target periodic sampling
+    /// cadence, not a hard real-time guarantee.
+    ///
     /// Use this during incident triage when runtime pressure evidence is needed
     /// to rank suspects (for example: global queue growth or alive-task spikes).
     /// For lower runtime-cost core-only capture categories, skip sampler startup.
@@ -569,6 +577,10 @@ impl RuntimeSamplerBuilder {
     }
 
     /// Resolves configuration and starts periodic runtime metrics sampling.
+    ///
+    /// The sampler records an initial sample promptly after start, then follows
+    /// the configured cadence. The cadence is a target periodic sampling
+    /// cadence, not a hard real-time guarantee.
     ///
     /// Resolution precedence:
     ///


### PR DESCRIPTION
### Motivation
- Prevent a start-time drift between the controller-visible generation status and the core `Run` metadata by reusing the authoritative run start timestamp when enabling a generation.
- Clarify runtime sampler semantics so users understand sampling records an initial prompt sample and that cadence is a target, not a hard real-time guarantee.
- Keep runtime sampler and analyzer behavior unchanged while improving internal correctness and documentation.

### Description
- In `tailtriage-controller/src/lib.rs` `TailtriageController::enable` now reads `let generation_started_at_unix_ms = run.snapshot().metadata.started_at_unix_ms;` and uses that value for `ActiveGenerationState.started_at_unix_ms` instead of calling `tailtriage_core::unix_time_ms()`.
- Added an internal controller unit test `enable_generation_start_matches_underlying_run_metadata` inside the same module that enables a controller, inspects the active generation and the underlying run snapshot, and asserts their `started_at_unix_ms` values match.
- Updated rustdoc in `tailtriage-tokio/src/lib.rs`, `tailtriage-tokio/README.md`, and `docs/operations.md` to state that the sampler records an initial sample promptly after start and then follows the configured cadence, and that cadence is a target periodic cadence not a hard real-time guarantee.
- No runtime sampler behavior, analyzer scoring, public API, or dependencies were changed.

### Testing
- Ran `cargo fmt --check` and formatting passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and the lint run passed with no warnings.
- Ran `cargo test --workspace --all-targets --all-features --locked` and `cargo test --workspace`, and all unit and integration tests passed successfully.
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ed34ca8348330918ccedc711219a7)