### PR TITLE
Align controller generation start metadata and document sampler cadence

### DIFF
--- a/tailtriage-controller/src/lib.rs
+++ b/tailtriage-controller/src/lib.rs
@@ -454,10 +454,11 @@ impl TailtriageController {
         builder = builder.strict_lifecycle(template.strict_lifecycle);
 
         let run = Arc::new(builder.build().map_err(EnableError::Build)?);
+        let generation_started_at_unix_ms = run.snapshot().metadata.started_at_unix_ms;
         let runtime = Arc::new(ActiveGenerationRuntime {
             state: ActiveGenerationState {
                 generation_id: next_generation,
-                started_at_unix_ms: tailtriage_core::unix_time_ms(),
+                started_at_unix_ms: generation_started_at_unix_ms,
                 artifact_path: artifact_path.clone(),
                 accepting_new_admissions: true,
                 closing: false,
@@ -1894,6 +1895,28 @@ mod tests {
         assert!(expected.exists());
 
         fs::remove_file(expected).expect("cleanup should succeed");
+    }
+
+    #[test]
+    fn active_generation_started_at_matches_underlying_run_metadata() {
+        let output = test_output("generation-started-at-run-metadata");
+        let controller = TailtriageController::builder("checkout-service")
+            .output(&output)
+            .build()
+            .expect("build should succeed");
+
+        let active = controller.enable().expect("enable should succeed");
+        let runtime = active_runtime(&controller);
+        let run_started_at = runtime.run.snapshot().metadata.started_at_unix_ms;
+
+        assert_eq!(active.started_at_unix_ms, run_started_at);
+        assert_eq!(runtime.state.started_at_unix_ms, run_started_at);
+
+        assert!(matches!(
+            controller.disable(),
+            Ok(DisableOutcome::Finalized { generation_id: 1 })
+        ));
+        fs::remove_file(active.artifact_path).expect("cleanup should succeed");
     }
 
     #[test]

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -20,6 +20,8 @@ The runtime sampler owns Tokio runtime sampler behavior:
 - runtime snapshot retention resolution
 - recording runtime snapshots into the same run artifact as core request data
 
+After startup, the sampler records an initial runtime snapshot promptly, then follows the configured cadence. Cadence is the target periodic sampling cadence, not a hard real-time guarantee; actual timing depends on Tokio scheduling and runtime conditions.
+
 Runtime snapshots help strengthen evidence for bottleneck families such as:
 
 - executor pressure
@@ -230,7 +232,7 @@ When you do not override sampler settings, this crate uses Tokio-owned defaults 
 - cadence: `100ms`
 - `max_runtime_snapshots = 50_000`
 
-These defaults apply only when the sampler is started.
+These defaults apply only when the sampler is started. The sampler records an initial sample promptly after start, then follows the configured target cadence; cadence is not a hard real-time guarantee.
 
 ### Resolution rules
 

--- a/tailtriage-tokio/src/lib.rs
+++ b/tailtriage-tokio/src/lib.rs
@@ -443,6 +443,11 @@ impl std::fmt::Display for SamplerStartError {
 impl std::error::Error for SamplerStartError {}
 
 /// Periodically samples Tokio runtime metrics and records them into a [`Tailtriage`] run.
+///
+/// The sampler records an initial runtime snapshot promptly after start, then
+/// follows the resolved cadence. The cadence is a target periodic sampling
+/// cadence, not a hard real-time guarantee; actual timing depends on Tokio
+/// scheduling and runtime conditions.
 #[derive(Debug)]
 pub struct RuntimeSampler {
     stop_tx: Option<oneshot::Sender<()>>,
@@ -460,7 +465,10 @@ pub struct RuntimeSampler {
 /// Selecting core [`CaptureMode`] never auto-starts runtime sampling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TokioSamplerModeDefaults {
-    /// Default periodic sampler cadence.
+    /// Default target periodic sampler cadence.
+    ///
+    /// Sampling records an initial snapshot promptly after start and then follows
+    /// this target cadence; it is not a hard real-time timing guarantee.
     pub cadence: Duration,
     /// Default maximum number of runtime snapshots this sampler should record.
     pub max_runtime_snapshots: usize,
@@ -555,6 +563,9 @@ impl RuntimeSamplerBuilder {
     }
 
     /// Overrides resolved sampler cadence.
+    ///
+    /// The resolved cadence is a target periodic sampling cadence after the
+    /// initial prompt sample, not a hard real-time timing guarantee.
     #[must_use]
     pub fn interval(mut self, interval: Duration) -> Self {
         self.interval_override = Some(interval);
@@ -579,7 +590,9 @@ impl RuntimeSamplerBuilder {
     ///    [`Self::max_runtime_snapshots`]
     ///
     /// Resolved runtime snapshot retention is clamped by the core run cap
-    /// (`effective_core_config.capture_limits.max_runtime_snapshots`).
+    /// (`effective_core_config.capture_limits.max_runtime_snapshots`). The
+    /// sampler records an initial sample promptly after start, then follows the
+    /// resolved target cadence; cadence is not a hard real-time guarantee.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
### Motivation
- Prevent a start-time drift between controller-visible generation `started_at_unix_ms` and the authoritative core `Run` metadata by reusing the run's metadata timestamp when activating a generation. 
- Clarify runtime sampler semantics so users understand the sampler records an initial snapshot promptly and that cadence is a target, not a hard real-time guarantee.

### Description
- In `tailtriage-controller/src/lib.rs` `TailtriageController::enable` now reads `let generation_started_at_unix_ms = run.snapshot().metadata.started_at_unix_ms;` immediately after building the run and uses it for `ActiveGenerationState.started_at_unix_ms`, removing the separate `tailtriage_core::unix_time_ms()` sampling. 
- Added an internal controller unit test `active_generation_started_at_matches_underlying_run_metadata` that enables a controller, inspects the active generation runtime and underlying run snapshot, and asserts the two `started_at_unix_ms` values match without adding any public API. 
- Updated `tailtriage-tokio/README.md` and `RuntimeSampler` rustdoc to state that the sampler records an initial runtime snapshot promptly after start, then follows the configured cadence, and that cadence is a target periodic sampling cadence rather than a hard real-time guarantee. 
- Did not change `RuntimeSampler` runtime behavior, analyzer scoring, public APIs, or add dependencies.

### Testing
- Ran formatting check with `cargo fmt --check` which passed. 
- Ran linting with `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` which passed. 
- Ran the full test-suite with `cargo test --workspace --all-targets --all-features --locked` and `cargo test --workspace` and all tests passed. 
- Ran documentation contract validation with `python3 scripts/validate_docs_contracts.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ed34ca8348330918ccedc711219a7)