### PR TITLE
Align controller generation start timestamp with core run metadata

### DIFF
--- a/tailtriage-controller/src/lib.rs
+++ b/tailtriage-controller/src/lib.rs
@@ -454,10 +454,11 @@ impl TailtriageController {
         builder = builder.strict_lifecycle(template.strict_lifecycle);
 
         let run = Arc::new(builder.build().map_err(EnableError::Build)?);
+        let generation_started_at_unix_ms = run.snapshot().metadata.started_at_unix_ms;
         let runtime = Arc::new(ActiveGenerationRuntime {
             state: ActiveGenerationState {
                 generation_id: next_generation,
-                started_at_unix_ms: tailtriage_core::unix_time_ms(),
+                started_at_unix_ms: generation_started_at_unix_ms,
                 artifact_path: artifact_path.clone(),
                 accepting_new_admissions: true,
                 closing: false,
@@ -1894,6 +1895,28 @@ mod tests {
         assert!(expected.exists());
 
         fs::remove_file(expected).expect("cleanup should succeed");
+    }
+
+    #[test]
+    fn active_generation_started_at_matches_run_metadata() {
+        let output = test_output("started-at-run-metadata");
+        let controller = TailtriageController::builder("checkout-service")
+            .output(&output)
+            .build()
+            .expect("build should succeed");
+
+        let active_state = controller.enable().expect("enable should succeed");
+        let active = active_runtime(&controller);
+        let run_started_at_unix_ms = active.run.snapshot().metadata.started_at_unix_ms;
+
+        assert_eq!(active.state.started_at_unix_ms, run_started_at_unix_ms);
+        assert_eq!(active_state.started_at_unix_ms, run_started_at_unix_ms);
+
+        assert!(matches!(
+            controller.disable(),
+            Ok(DisableOutcome::Finalized { generation_id: 1 })
+        ));
+        fs::remove_file(active_state.artifact_path).expect("cleanup should succeed");
     }
 
     #[test]

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -157,6 +157,8 @@ async fn demo() -> Result<(), Box<dyn std::error::Error>> {
 
 On successful sampler start, tailtriage records effective sampler configuration metadata into the run artifact metadata before runtime snapshots are captured.
 
+The sampler records an initial sample promptly after start, then follows the configured cadence. The cadence is a target periodic sampling cadence, not a hard real-time guarantee.
+
 When the sampler is running, the run artifact can include runtime snapshots such as:
 
 - `alive_tasks`

--- a/tailtriage-tokio/src/lib.rs
+++ b/tailtriage-tokio/src/lib.rs
@@ -515,6 +515,10 @@ impl RuntimeSampler {
 
     /// Starts periodic runtime metrics sampling on the current Tokio runtime.
     ///
+    /// The sampler records an initial sample promptly after start, then follows
+    /// the configured cadence. The cadence is a target periodic sampling cadence,
+    /// not a hard real-time guarantee.
+    ///
     /// Use this during incident triage when runtime pressure evidence is needed
     /// to rank suspects (for example: global queue growth or alive-task spikes).
     /// For lower runtime-cost core-only capture categories, skip sampler startup.
@@ -555,6 +559,9 @@ impl RuntimeSamplerBuilder {
     }
 
     /// Overrides resolved sampler cadence.
+    ///
+    /// This is the target periodic sampling cadence after the prompt initial
+    /// sample, not a hard real-time guarantee.
     #[must_use]
     pub fn interval(mut self, interval: Duration) -> Self {
         self.interval_override = Some(interval);
@@ -569,6 +576,10 @@ impl RuntimeSamplerBuilder {
     }
 
     /// Resolves configuration and starts periodic runtime metrics sampling.
+    ///
+    /// The sampler records an initial sample promptly after start, then follows
+    /// the configured cadence. The cadence is a target periodic sampling cadence,
+    /// not a hard real-time guarantee.
     ///
     /// Resolution precedence:
     ///


### PR DESCRIPTION
### Motivation
- Prevent a small start-time drift between the controller-visible generation `started_at_unix_ms` and the authoritative core `Run` metadata by using the core run timestamp instead of taking a separate sampling time.
- Clarify runtime sampler semantics so users understand sampling behavior and cadence guarantees when the sampler is started.

### Description
- In `tailtriage-controller/src/lib.rs` use the core run metadata timestamp by reading `let generation_started_at_unix_ms = run.snapshot().metadata.started_at_unix_ms;` and assign that value to `ActiveGenerationState.started_at_unix_ms` instead of calling `tailtriage_core::unix_time_ms()`.
- Add an internal controller unit test `active_generation_started_at_matches_run_metadata` (in the same controller test module) that enables a controller, inspects the active generation and underlying `run.snapshot()`, and asserts the two `started_at_unix_ms` values are equal without adding any public API.
- Update rustdoc in `tailtriage-tokio/src/lib.rs` and the crate `README.md` to state that the `RuntimeSampler` records an initial sample promptly after start and then follows the configured cadence, and that cadence is a target periodic cadence rather than a hard real-time guarantee.
- No changes to runtime sampler behavior, analyzer scoring, public API surface, or dependencies were made.

### Testing
- Ran `cargo fmt --check` and it succeeded.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it succeeded without warnings.
- Ran the full test matrix (`cargo test --workspace --all-targets --all-features --locked` and `cargo test --workspace`) and all unit and integration tests passed, including the new controller test (`active_generation_started_at_matches_run_metadata`).
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ed34ca8348330918ccedc711219a7)