### PR TITLE
Add timing-semantics parity and JSONL duration tests

### DIFF
--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -1779,9 +1779,25 @@ fn temporal_runtime_and_inflight_filtering_uses_run_relative_times() {
     let report = analyze_run(&run, AnalyzeOptions::default());
 
     assert_eq!(report.temporal_segments.len(), 2);
+    let early = report
+        .temporal_segments
+        .iter()
+        .find(|segment| segment.name == "early")
+        .expect("early temporal segment should be emitted");
+    let late = report
+        .temporal_segments
+        .iter()
+        .find(|segment| segment.name == "late")
+        .expect("late temporal segment should be emitted");
+
+    assert_eq!(early.evidence_quality.runtime_snapshot_count, 1);
+    assert_eq!(early.evidence_quality.inflight_snapshot_count, 1);
+    assert_eq!(late.evidence_quality.runtime_snapshot_count, 1);
+    assert_eq!(late.evidence_quality.inflight_snapshot_count, 1);
+    assert!(early.p95_latency_us < late.p95_latency_us);
     for segment in &report.temporal_segments {
-        assert_eq!(segment.evidence_quality.runtime_snapshot_count, 1);
-        assert_eq!(segment.evidence_quality.inflight_snapshot_count, 1);
+        assert!(!segment.warnings.iter().any(|warning| warning
+            == "Temporal segment used wall-clock timestamp fallback; attribution is approximate for artifacts without complete run-relative timing."));
     }
 }
 
@@ -1792,9 +1808,44 @@ fn temporal_segments_fallback_for_older_artifacts_warns() {
     for request in run.requests.iter_mut().skip(10) {
         request.latency_us = 6_000;
     }
+    run.runtime_snapshots = vec![
+        RuntimeSnapshot {
+            at_unix_ms: 2,
+            at_run_us: None,
+            global_queue_depth: Some(50),
+            local_queue_depth: Some(50),
+            alive_tasks: Some(100),
+            blocking_queue_depth: Some(0),
+            remote_schedule_count: None,
+        },
+        RuntimeSnapshot {
+            at_unix_ms: 12,
+            at_run_us: None,
+            global_queue_depth: Some(1),
+            local_queue_depth: Some(1),
+            alive_tasks: Some(100),
+            blocking_queue_depth: Some(0),
+            remote_schedule_count: None,
+        },
+    ];
+    run.inflight = vec![
+        tailtriage_core::InFlightSnapshot {
+            at_unix_ms: 2,
+            at_run_us: None,
+            gauge: "http.server.requests".into(),
+            count: 2,
+        },
+        tailtriage_core::InFlightSnapshot {
+            at_unix_ms: 12,
+            at_run_us: None,
+            gauge: "http.server.requests".into(),
+            count: 9,
+        },
+    ];
 
     let report = analyze_run(&run, AnalyzeOptions::default());
 
+    assert_eq!(report.request_count, 20);
     assert_eq!(report.temporal_segments.len(), 2);
     for segment in &report.temporal_segments {
         assert!(segment.warnings.iter().any(|warning| warning

--- a/tailtriage-tracing/tests/tracing_examples.rs
+++ b/tailtriage-tracing/tests/tracing_examples.rs
@@ -1,10 +1,143 @@
-use std::{fs::File, path::PathBuf};
+use std::{fs::File, io::Cursor, path::PathBuf};
 
 use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
+#[cfg(feature = "live")]
+use tailtriage_core::{RequestOptions, Run, Tailtriage};
+#[cfg(feature = "live")]
+use tailtriage_tracing::TracingRecorder;
 use tailtriage_tracing::{
     import_jsonl_path, import_jsonl_reader, import_jsonl_reader_with_mode, ImportOptions,
     JsonlParseMode,
 };
+#[cfg(feature = "live")]
+use tracing_subscriber::prelude::*;
+
+#[cfg(feature = "live")]
+fn native_single_request_run() -> Run {
+    let tailtriage = Tailtriage::builder("svc")
+        .build()
+        .expect("native recorder should build");
+    let started = tailtriage.begin_request_with(
+        "/checkout",
+        RequestOptions::new().request_id("req-1").kind("http"),
+    );
+    let request = started.handle;
+
+    futures_executor::block_on(request.queue("admission").await_on(async {
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }));
+    futures_executor::block_on(request.stage("db").await_value(async {
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }));
+    std::thread::sleep(std::time::Duration::from_millis(1));
+    started.completion.finish_ok();
+
+    tailtriage.snapshot()
+}
+
+#[cfg(feature = "live")]
+fn live_tracing_single_request_run() -> Run {
+    let recorder = TracingRecorder::builder("svc")
+        .build()
+        .expect("live recorder should build");
+    let subscriber = tracing_subscriber::registry().with(recorder.layer());
+    tracing::subscriber::with_default(subscriber, || {
+        let request = tracing::info_span!(
+            "request",
+            tt.kind = "request",
+            tt.request_id = "req-1",
+            tt.route = "/checkout",
+            tt.outcome = "ok"
+        );
+        let request_guard = request.enter();
+
+        let queue = tracing::info_span!(
+            "queue",
+            tt.kind = "queue",
+            tt.request_id = "req-1",
+            tt.queue = "admission",
+            tt.depth_at_start = 1_u64
+        );
+        {
+            let _queue_guard = queue.enter();
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+        drop(queue);
+
+        let stage = tracing::info_span!(
+            "stage",
+            tt.kind = "stage",
+            tt.request_id = "req-1",
+            tt.stage = "db",
+            tt.success = true
+        );
+        {
+            let _stage_guard = stage.enter();
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+        drop(stage);
+        std::thread::sleep(std::time::Duration::from_millis(1));
+
+        drop(request_guard);
+        drop(request);
+    });
+
+    recorder
+        .snapshot_run()
+        .expect("live recorder snapshot should convert")
+        .run()
+        .clone()
+}
+
+#[cfg(feature = "live")]
+fn assert_single_request_timing_semantics(run: &Run) {
+    assert_eq!(run.requests.len(), 1);
+    assert_eq!(run.queues.len(), 1);
+    assert_eq!(run.stages.len(), 1);
+
+    let request = &run.requests[0];
+    assert!(request.latency_us > 0);
+    assert!(request.finished_at_unix_ms >= request.started_at_unix_ms);
+
+    let stage = &run.stages[0];
+    assert!(stage.latency_us > 0);
+    assert!(stage.finished_at_unix_ms >= stage.started_at_unix_ms);
+
+    let queue = &run.queues[0];
+    assert!(queue.waited_until_unix_ms >= queue.waited_from_unix_ms);
+
+    let json = serde_json::to_value(run).expect("run should serialize");
+    assert!(json["requests"][0].get("latency_us").is_some());
+    assert!(json["stages"][0].get("latency_us").is_some());
+    assert!(json["queues"][0].get("wait_us").is_some());
+
+    let mut duration_authority = run.clone();
+    duration_authority.requests[0].started_at_unix_ms = 10;
+    duration_authority.requests[0].finished_at_unix_ms = 11;
+    duration_authority.requests[0].latency_us = 50_000;
+    duration_authority.stages[0].started_at_unix_ms = 10;
+    duration_authority.stages[0].finished_at_unix_ms = 11;
+    duration_authority.stages[0].latency_us = 40_000;
+    duration_authority.queues[0].waited_from_unix_ms = 10;
+    duration_authority.queues[0].waited_until_unix_ms = 11;
+    duration_authority.queues[0].wait_us = 30_000;
+
+    let report = analyze_run(&duration_authority, AnalyzeOptions::default());
+    assert_eq!(report.p50_latency_us, Some(50_000));
+    assert_eq!(report.p95_latency_us, Some(50_000));
+    assert_eq!(report.p99_latency_us, Some(50_000));
+    assert_eq!(report.p95_queue_share_permille, Some(600));
+}
+
+#[cfg(feature = "live")]
+#[test]
+fn native_core_and_live_tracing_capture_preserve_timing_semantics() {
+    let native = native_single_request_run();
+    let tracing = live_tracing_single_request_run();
+
+    assert_single_request_timing_semantics(&native);
+    assert_single_request_timing_semantics(&tracing);
+}
 
 #[test]
 fn jsonl_fixture_imports_completed_span_shape() {
@@ -77,6 +210,34 @@ fn imported_fixture_run_is_analyzable_and_has_no_runtime_snapshots() {
     );
     let report = analyze_run(run, AnalyzeOptions::default());
     assert_eq!(report.request_count, 1);
+}
+
+#[test]
+fn stable_wrapper_duration_us_is_authoritative_when_wall_timestamps_disagree() {
+    let input = r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"request","started_at_unix_ms":1700000000000,"finished_at_unix_ms":1700000000001,"duration_us":50000,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}"#;
+
+    let imported = import_jsonl_reader_with_mode(
+        Cursor::new(input),
+        ImportOptions::new("svc"),
+        JsonlParseMode::TailtriageWrapperOnly,
+    )
+    .expect("non-strict import should retain mismatched duration");
+
+    assert_eq!(imported.run().requests.len(), 1);
+    assert_eq!(imported.run().requests[0].latency_us, 50_000);
+    assert!(imported.warnings().iter().any(|warning| warning
+        .message()
+        .contains("duration_us differs from timestamp-derived duration")));
+
+    let err = import_jsonl_reader_with_mode(
+        Cursor::new(input),
+        ImportOptions::new("svc").strict(true),
+        JsonlParseMode::TailtriageWrapperOnly,
+    )
+    .expect_err("strict import should reject mismatched duration");
+    assert!(err
+        .to_string()
+        .contains("duration_us differs from timestamp-derived duration"));
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Prevent accidental drift in timing semantics across native core capture, live tracing intake, JSONL import, and analyzer temporal segmentation. 
- Ensure explicit duration fields remain authoritative and not silently recomputed from Unix timestamps during import or analysis. 
- Make temporal segmentation prefer run-relative monotonic offsets when present and emit a clear fallback warning for older artifacts.

### Description
- Added a live vs native parity end-to-end test in `tailtriage-tracing/tests/tracing_examples.rs` that builds a native `Tailtriage` run and an equivalent live `TracingRecorder` run with one request, one queue, and one stage, and asserts positive `latency_us`/`wait_us`, monotonic finish >= start wall timestamps, presence of explicit `duration_us` fields in serialized Run JSON, and that analyzer honors explicit duration fields (no recomputation). 
- Added a stable-wrapper JSONL import test in `tailtriage-tracing/tests/tracing_examples.rs` that imports a wrapper record whose wall timestamps imply 1ms but `duration_us` is 50ms, and asserts the imported Run uses the 50ms duration, a non-strict warning is emitted, and strict mode fails. 
- Hardened analyzer temporal tests in `tailtriage-analyzer/src/tests.rs` to assert run-relative ordering/filtering (early/late selection and runtime/inflight snapshot filtering), ensure no wall-clock-fallback warning when run-relative fields are complete, and assert the wall-clock fallback warning appears for older artifacts lacking run-relative fields. 
- No new dependencies were added and no public docs were changed.

### Testing
- Ran formatting and lints: `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (passed). 
- Ran the full test matrix: `cargo test --workspace --all-targets --all-features --locked` and `cargo test --workspace` (all tests passed). 
- Ran docs contract validation and tracing parity checks: `python3 scripts/validate_docs_contracts.py`, `python3 scripts/demo_tool.py validate-tracing-parity all --profile release`, and `python3 scripts/demo_tool.py validate-tracing-retention-parity --profile release` (all passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ee17e64f48330936ed35ae0ea800c)