### PR TITLE
Add timing-semantics parity and JSONL duration authority tests

### DIFF
--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -136,6 +136,152 @@ fn runtime_snapshot(
     }
 }
 
+fn temporal_options_for_four_request_tests() -> AnalyzeOptions {
+    AnalyzeOptions::default().with_temporal(|temporal| {
+        temporal.min_request_count = 4;
+        temporal.min_segment_request_count = 2;
+        temporal.p95_shift_ratio_numerator = 2;
+        temporal.p95_shift_ratio_denominator = 1;
+    })
+}
+
+fn run_relative_temporal_test_run() -> Run {
+    let mut run = test_run();
+    run.metadata.started_at_unix_ms = 1_000;
+    run.metadata.finished_at_unix_ms = 1_001;
+    run.metadata.finalized_at_unix_ms = Some(1_001);
+    run.requests = vec![
+        temporal_request("r1", Some(0), Some(1_000), 1_000),
+        temporal_request("r2", Some(20_000), Some(21_000), 1_000),
+        temporal_request("r3", Some(40_000), Some(50_000), 10_000),
+        temporal_request("r4", Some(60_000), Some(70_000), 10_000),
+    ];
+    run.runtime_snapshots = vec![
+        temporal_runtime_snapshot(9_000, Some(500)),
+        temporal_runtime_snapshot(1_000, Some(45_000)),
+        temporal_runtime_snapshot(1_000, Some(99_000)),
+    ];
+    run.inflight = vec![
+        temporal_inflight_snapshot(9_000, Some(500)),
+        temporal_inflight_snapshot(1_000, Some(45_000)),
+        temporal_inflight_snapshot(1_000, Some(99_000)),
+    ];
+    run
+}
+
+fn wall_clock_temporal_fallback_test_run() -> Run {
+    let mut run = run_relative_temporal_test_run();
+    for request in &mut run.requests {
+        request.started_at_run_us = None;
+        request.finished_at_run_us = None;
+    }
+    for snapshot in &mut run.runtime_snapshots {
+        snapshot.at_run_us = None;
+    }
+    for snapshot in &mut run.inflight {
+        snapshot.at_run_us = None;
+    }
+    run
+}
+
+fn temporal_request(
+    request_id: &str,
+    started_at_run_us: Option<u64>,
+    finished_at_run_us: Option<u64>,
+    latency_us: u64,
+) -> RequestEvent {
+    RequestEvent {
+        request_id: request_id.to_owned(),
+        route: "/temporal".to_owned(),
+        kind: None,
+        started_at_unix_ms: 1_000,
+        started_at_run_us,
+        finished_at_unix_ms: 1_000 + latency_us.div_ceil(1_000),
+        finished_at_run_us,
+        latency_us,
+        outcome: "ok".to_owned(),
+    }
+}
+
+fn temporal_runtime_snapshot(at_unix_ms: u64, at_run_us: Option<u64>) -> RuntimeSnapshot {
+    RuntimeSnapshot {
+        at_unix_ms,
+        at_run_us,
+        alive_tasks: Some(10),
+        global_queue_depth: Some(1),
+        local_queue_depth: Some(1),
+        blocking_queue_depth: Some(0),
+        remote_schedule_count: None,
+    }
+}
+
+fn temporal_inflight_snapshot(
+    at_unix_ms: u64,
+    at_run_us: Option<u64>,
+) -> tailtriage_core::InFlightSnapshot {
+    tailtriage_core::InFlightSnapshot {
+        gauge: "requests".to_owned(),
+        at_unix_ms,
+        at_run_us,
+        count: 1,
+    }
+}
+
+#[test]
+fn temporal_segmentation_prefers_complete_run_relative_timing() {
+    let run = run_relative_temporal_test_run();
+    let report = analyze_run(&run, temporal_options_for_four_request_tests());
+
+    assert_eq!(report.temporal_segments.len(), 2);
+    assert_eq!(report.temporal_segments[0].name, "early");
+    assert_eq!(report.temporal_segments[0].request_count, 2);
+    assert_eq!(report.temporal_segments[0].p95_latency_us, Some(1_000));
+    assert_eq!(
+        report.temporal_segments[0]
+            .evidence_quality
+            .runtime_snapshot_count,
+        1
+    );
+    assert_eq!(
+        report.temporal_segments[0]
+            .evidence_quality
+            .inflight_snapshot_count,
+        1
+    );
+    assert_eq!(report.temporal_segments[1].name, "late");
+    assert_eq!(report.temporal_segments[1].request_count, 2);
+    assert_eq!(report.temporal_segments[1].p95_latency_us, Some(10_000));
+    assert_eq!(
+        report.temporal_segments[1]
+            .evidence_quality
+            .runtime_snapshot_count,
+        1
+    );
+    assert_eq!(
+        report.temporal_segments[1]
+            .evidence_quality
+            .inflight_snapshot_count,
+        1
+    );
+    assert!(report.temporal_segments.iter().all(|segment| segment
+        .warnings
+        .iter()
+        .all(|warning| !warning.contains("wall-clock timestamp fallback"))));
+}
+
+#[test]
+fn temporal_segmentation_falls_back_for_older_artifacts_without_run_relative_timing() {
+    let run = wall_clock_temporal_fallback_test_run();
+    let report = analyze_run(&run, temporal_options_for_four_request_tests());
+
+    assert_eq!(report.request_count, 4);
+    assert_eq!(report.temporal_segments.len(), 2);
+    assert!(report.temporal_segments.iter().any(|segment| segment
+        .warnings
+        .iter()
+        .any(|warning| warning.contains("wall-clock timestamp fallback"))));
+}
+
 #[test]
 fn downstream_stage_tie_break_is_deterministic() {
     let mut run = test_run();

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -2721,6 +2721,44 @@ mod tests {
         assert_eq!(run.queues[0].depth_at_start, Some(9));
     }
 
+    #[cfg(feature = "jsonl")]
+    #[test]
+    fn stable_wrapper_jsonl_retains_explicit_duration_over_timestamp_delta() {
+        let span = SpanRecord::new("req", 100, 101)
+            .duration_us(50_000)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")
+            .field(TT_OUTCOME, "ok");
+        let jsonl = serde_json::json!({
+            "format": "tailtriage.tracing-span.v1",
+            "span": span,
+        })
+        .to_string()
+            + "\n";
+
+        let imported = import_jsonl_reader(
+            std::io::Cursor::new(jsonl.as_bytes()),
+            ImportOptions::new("svc"),
+        )
+        .expect("non-strict wrapper JSONL import should retain mismatched duration");
+        assert_eq!(imported.run().requests[0].latency_us, 50_000);
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("duration_us differs from timestamp-derived duration")));
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("duration_us was retained")));
+
+        let strict_err = import_jsonl_reader(
+            std::io::Cursor::new(jsonl.as_bytes()),
+            ImportOptions::new("svc").strict(true),
+        )
+        .expect_err("strict wrapper JSONL import should reject mismatched duration");
+        assert!(matches!(strict_err, ImportError::StrictViolation(_)));
+    }
+
     #[test]
     fn mismatched_request_duration_warns_and_retains_duration_us_in_non_strict_mode() {
         let spans = vec![SpanRecord::new("req", 100, 101)

--- a/tailtriage-tracing/tests/equivalence.rs
+++ b/tailtriage-tracing/tests/equivalence.rs
@@ -2,9 +2,17 @@
 
 mod support;
 
-use support::equivalence_harness::assert_deterministic_span_import_full_parity;
+use support::equivalence_harness::{
+    assert_deterministic_span_import_full_parity,
+    assert_single_request_native_and_live_tracing_timing_semantics,
+};
 
 #[test]
 fn deterministic_span_import_matches_native_run_analysis_and_rendering() {
     assert_deterministic_span_import_full_parity();
+}
+
+#[test]
+fn native_core_and_live_tracing_single_request_timing_semantics_match() {
+    assert_single_request_native_and_live_tracing_timing_semantics();
 }

--- a/tailtriage-tracing/tests/support/equivalence_harness.rs
+++ b/tailtriage-tracing/tests/support/equivalence_harness.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 use futures_executor::block_on;
 use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions, DiagnosisKind, Report};
 use tailtriage_core::{
-    CaptureMode, EffectiveCoreConfig, QueueEvent, RequestEvent, Run, RunMetadata, StageEvent,
-    TruncationSummary, UnfinishedRequests, SCHEMA_VERSION,
+    CaptureMode, EffectiveCoreConfig, Outcome, QueueEvent, RequestEvent, RequestOptions, Run,
+    RunMetadata, StageEvent, Tailtriage, TruncationSummary, UnfinishedRequests, SCHEMA_VERSION,
 };
 use tailtriage_tracing::{
     run_from_span_records, ImportOptions, SpanRecord, TracingRecorder, TT_DEPTH_AT_START, TT_KIND,
@@ -242,6 +242,108 @@ fn format_mismatches(mismatches: &[String]) -> String {
             .collect::<Vec<_>>()
             .join("\n")
     }
+}
+
+fn single_request_native_run() -> Run {
+    let tailtriage = Tailtriage::builder("svc")
+        .build()
+        .expect("native tailtriage build should succeed");
+    let started = tailtriage.begin_request_with(
+        "/checkout",
+        RequestOptions::new().request_id("r1").kind("http"),
+    );
+
+    block_on(started.handle.queue("permits").await_on(async {
+        thread::sleep(Duration::from_millis(1));
+    }));
+    block_on(started.handle.stage("db").await_value(async {
+        thread::sleep(Duration::from_millis(1));
+    }));
+    thread::sleep(Duration::from_millis(1));
+    started.completion.finish(Outcome::Ok);
+
+    tailtriage.snapshot()
+}
+
+fn single_request_live_tracing_run() -> Run {
+    let recorder = TracingRecorder::builder("svc")
+        .build()
+        .expect("live recorder build should succeed");
+    let subscriber = tracing_subscriber::registry().with(recorder.layer());
+    tracing::subscriber::with_default(subscriber, || {
+        let request = tracing::info_span!(
+            "request",
+            tt.kind = "request",
+            tt.request_id = "r1",
+            tt.route = "/checkout",
+            tt.outcome = "ok"
+        );
+        {
+            let _request_guard = request.enter();
+            let queue = tracing::info_span!(
+                "queue",
+                tt.kind = "queue",
+                tt.request_id = "r1",
+                tt.queue = "permits",
+                tt.depth_at_start = 1_u64
+            );
+            {
+                let _queue_guard = queue.enter();
+                thread::sleep(Duration::from_millis(1));
+            }
+            drop(queue);
+
+            let stage = tracing::info_span!(
+                "stage",
+                tt.kind = "stage",
+                tt.request_id = "r1",
+                tt.stage = "db",
+                tt.success = true
+            );
+            {
+                let _stage_guard = stage.enter();
+                thread::sleep(Duration::from_millis(1));
+            }
+            drop(stage);
+        }
+        drop(request);
+    });
+
+    recorder
+        .snapshot_run()
+        .expect("live tracing run should import")
+        .run()
+        .clone()
+}
+
+fn assert_single_request_timing_semantics(run: &Run) {
+    assert_eq!(run.requests.len(), 1);
+    assert_eq!(run.stages.len(), 1);
+    assert_eq!(run.queues.len(), 1);
+
+    let request = &run.requests[0];
+    let stage = &run.stages[0];
+    let queue = &run.queues[0];
+
+    assert!(request.latency_us > 0);
+    assert!(stage.latency_us > 0);
+    assert!(queue.wait_us > 0);
+    assert!(request.finished_at_unix_ms >= request.started_at_unix_ms);
+    assert!(stage.finished_at_unix_ms >= stage.started_at_unix_ms);
+    assert!(queue.waited_until_unix_ms >= queue.waited_from_unix_ms);
+
+    let report = analyze_run(run, AnalyzeOptions::default());
+    assert_eq!(report.p50_latency_us, Some(request.latency_us));
+    assert_eq!(report.p95_latency_us, Some(request.latency_us));
+    assert_eq!(report.p99_latency_us, Some(request.latency_us));
+}
+
+pub fn assert_single_request_native_and_live_tracing_timing_semantics() {
+    let native = single_request_native_run();
+    let live_tracing = single_request_live_tracing_run();
+
+    assert_single_request_timing_semantics(&native);
+    assert_single_request_timing_semantics(&live_tracing);
 }
 
 pub fn assert_deterministic_span_import_full_parity() {


### PR DESCRIPTION
### Motivation

- Prevent regressions where timing semantics drift between native core capture, live tracing recorder, JSONL import, and analyzer temporal segmentation.
- Verify authoritative handling of explicit `duration_us` on imported spans and ensure analyzer uses retained duration fields (not recomputed from timestamps).

### Description

- Added temporal segmentation tests to `tailtriage-analyzer/src/tests.rs` that validate run-relative ordering/filtering, runtime/in-flight snapshot filtering, and the wall-clock fallback warning for older artifacts. (new helpers and two tests)
- Added a stable-wrapper JSONL import test in `tailtriage-tracing/src/lib.rs` asserting that an explicit `duration_us` is retained in non-strict mode with a non-strict warning and is rejected in strict mode. (stable wrapper JSONL coverage)
- Added a single-request parity test across native core capture and live tracing recorder by extending the equivalence harness in `tailtriage-tracing/tests/support/equivalence_harness.rs` and wiring a test entry in `tailtriage-tracing/tests/equivalence.rs` to assert positive durations, monotonic wall timestamps, and analyzer percentiles derived from retained duration fields. (live vs native parity coverage)
- Tests added inline to existing test modules; no new crates or dependencies introduced.

### Testing

- Ran `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and both passed.
- Ran `cargo test --workspace --all-targets --all-features --locked` and `cargo test --workspace` and all unit/integration/doc tests passed across the workspace (including new analyzer and tracing tests).
- Ran `python3 scripts/validate_docs_contracts.py` and the docs contract validated successfully.
- Ran tracing parity validations `python3 scripts/demo_tool.py validate-tracing-parity all --profile release` and `python3 scripts/demo_tool.py validate-tracing-retention-parity --profile release` and both validation suites passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ee17e64f48330936ed35ae0ea800c)