### PR TITLE
Add timing-semantics parity and temporal-segmentation tests

### DIFF
--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -1779,9 +1779,87 @@ fn temporal_runtime_and_inflight_filtering_uses_run_relative_times() {
     let report = analyze_run(&run, AnalyzeOptions::default());
 
     assert_eq!(report.temporal_segments.len(), 2);
+    let early = report
+        .temporal_segments
+        .iter()
+        .find(|segment| segment.name == "early")
+        .expect("early temporal segment should be emitted");
+    let late = report
+        .temporal_segments
+        .iter()
+        .find(|segment| segment.name == "late")
+        .expect("late temporal segment should be emitted");
+
+    assert_eq!(early.evidence_quality.runtime_snapshot_count, 1);
+    assert_eq!(early.evidence_quality.inflight_snapshot_count, 1);
+    assert_eq!(late.evidence_quality.runtime_snapshot_count, 1);
+    assert_eq!(late.evidence_quality.inflight_snapshot_count, 1);
+    for segment in &report.temporal_segments {
+        assert!(!segment.warnings.iter().any(|warning| warning
+            == "Temporal segment used wall-clock timestamp fallback; attribution is approximate for artifacts without complete run-relative timing."));
+    }
+}
+
+#[test]
+fn temporal_runtime_and_inflight_fallback_for_older_artifacts_still_reports_and_warns() {
+    let mut run = test_run();
+    run.requests = (1..=20).map(sample_request).collect();
+
+    for (idx, request) in run.requests.iter_mut().enumerate() {
+        let idx = u64::try_from(idx).expect("test index should fit in u64");
+        request.started_at_unix_ms = 1 + idx;
+        request.finished_at_unix_ms = 2 + idx;
+        request.started_at_run_us = None;
+        request.finished_at_run_us = None;
+        if idx >= 10 {
+            request.latency_us = 6_000;
+        }
+    }
+
+    run.runtime_snapshots = vec![
+        RuntimeSnapshot {
+            at_unix_ms: 5,
+            at_run_us: None,
+            global_queue_depth: Some(50),
+            local_queue_depth: Some(50),
+            alive_tasks: Some(100),
+            blocking_queue_depth: Some(0),
+            remote_schedule_count: None,
+        },
+        RuntimeSnapshot {
+            at_unix_ms: 15,
+            at_run_us: None,
+            global_queue_depth: Some(1),
+            local_queue_depth: Some(1),
+            alive_tasks: Some(100),
+            blocking_queue_depth: Some(0),
+            remote_schedule_count: None,
+        },
+    ];
+    run.inflight = vec![
+        tailtriage_core::InFlightSnapshot {
+            at_unix_ms: 5,
+            at_run_us: None,
+            gauge: "http.server.requests".into(),
+            count: 2,
+        },
+        tailtriage_core::InFlightSnapshot {
+            at_unix_ms: 15,
+            at_run_us: None,
+            gauge: "http.server.requests".into(),
+            count: 9,
+        },
+    ];
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert_eq!(report.request_count, 20);
+    assert_eq!(report.temporal_segments.len(), 2);
     for segment in &report.temporal_segments {
         assert_eq!(segment.evidence_quality.runtime_snapshot_count, 1);
         assert_eq!(segment.evidence_quality.inflight_snapshot_count, 1);
+        assert!(segment.warnings.iter().any(|warning| warning
+            == "Temporal segment used wall-clock timestamp fallback; attribution is approximate for artifacts without complete run-relative timing."));
     }
 }
 

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -639,6 +639,11 @@ mod tests {
             .warnings()
             .iter()
             .any(|warning| warning.message().contains("duration_us was retained")));
+
+        let strict_err =
+            super::import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+                .expect_err("strict import should reject contradictory duration_us");
+        assert!(matches!(strict_err, ImportError::StrictViolation(_)));
     }
 
     #[test]

--- a/tailtriage-tracing/tests/equivalence.rs
+++ b/tailtriage-tracing/tests/equivalence.rs
@@ -2,9 +2,156 @@
 
 mod support;
 
+use std::time::Duration;
+
 use support::equivalence_harness::assert_deterministic_span_import_full_parity;
+use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
+use tailtriage_core::{RequestOptions, Run, Tailtriage};
+use tracing_subscriber::prelude::*;
 
 #[test]
 fn deterministic_span_import_matches_native_run_analysis_and_rendering() {
     assert_deterministic_span_import_full_parity();
+}
+
+#[test]
+fn native_core_and_live_tracing_capture_preserve_authoritative_duration_semantics() {
+    let native = native_request_queue_stage_run();
+    let live = live_tracing_request_queue_stage_run();
+
+    assert_capture_duration_semantics(&native, "native core capture");
+    assert_capture_duration_semantics(&live, "live tracing capture");
+}
+
+fn native_request_queue_stage_run() -> Run {
+    let tailtriage = Tailtriage::builder("svc")
+        .run_id("native-timing-parity")
+        .build()
+        .expect("native Tailtriage build should succeed");
+    let started = tailtriage.begin_request_with(
+        "/checkout",
+        RequestOptions::new().request_id("req-1").kind("http"),
+    );
+    let request = started.handle;
+
+    futures_executor::block_on(request.queue("permits").await_on(async {
+        std::thread::sleep(Duration::from_millis(1));
+    }));
+    futures_executor::block_on(request.stage("db").await_value(async {
+        std::thread::sleep(Duration::from_millis(1));
+    }));
+    std::thread::sleep(Duration::from_millis(1));
+    started.completion.finish_ok();
+
+    tailtriage.snapshot()
+}
+
+fn live_tracing_request_queue_stage_run() -> Run {
+    let recorder = tailtriage_tracing::TracingRecorder::builder("svc")
+        .run_id("live-timing-parity")
+        .build()
+        .expect("live tracing recorder build should succeed");
+    let subscriber = tracing_subscriber::registry().with(recorder.layer());
+
+    tracing::subscriber::with_default(subscriber, || {
+        let request = tracing::info_span!(
+            "request",
+            tt.kind = "request",
+            tt.request_id = "req-1",
+            tt.route = "/checkout"
+        )
+        .entered();
+
+        {
+            let queue = tracing::info_span!(
+                "queue",
+                tt.kind = "queue",
+                tt.request_id = "req-1",
+                tt.queue = "permits"
+            )
+            .entered();
+            std::thread::sleep(Duration::from_millis(1));
+            drop(queue);
+        }
+
+        {
+            let stage = tracing::info_span!(
+                "stage",
+                tt.kind = "stage",
+                tt.request_id = "req-1",
+                tt.stage = "db"
+            )
+            .entered();
+            std::thread::sleep(Duration::from_millis(1));
+            drop(stage);
+        }
+
+        std::thread::sleep(Duration::from_millis(1));
+        drop(request);
+    });
+
+    recorder
+        .snapshot_run()
+        .expect("live tracing recorder snapshot should convert")
+        .run()
+        .clone()
+}
+
+fn assert_capture_duration_semantics(run: &Run, label: &str) {
+    assert_eq!(run.requests.len(), 1, "{label} should retain one request");
+    assert_eq!(run.stages.len(), 1, "{label} should retain one stage");
+    assert_eq!(run.queues.len(), 1, "{label} should retain one queue");
+
+    let request = &run.requests[0];
+    let stage = &run.stages[0];
+    let queue = &run.queues[0];
+
+    assert!(
+        request.latency_us > 0,
+        "{label} request latency_us should be positive"
+    );
+    assert!(
+        stage.latency_us > 0,
+        "{label} stage latency_us should be positive"
+    );
+    assert!(
+        queue.wait_us <= request.latency_us,
+        "{label} queue wait_us should be retained as a duration field"
+    );
+    assert!(
+        request.finished_at_unix_ms >= request.started_at_unix_ms,
+        "{label} request finish wall timestamp should not precede start"
+    );
+    assert!(
+        stage.finished_at_unix_ms >= stage.started_at_unix_ms,
+        "{label} stage finish wall timestamp should not precede start"
+    );
+    assert!(
+        queue.waited_until_unix_ms >= queue.waited_from_unix_ms,
+        "{label} queue finish wall timestamp should not precede start"
+    );
+
+    let value = serde_json::to_value(run).expect("run should serialize to JSON");
+    assert!(
+        value["requests"][0].get("latency_us").is_some(),
+        "{label} request latency_us should serialize as an explicit duration field"
+    );
+    assert!(
+        value["stages"][0].get("latency_us").is_some(),
+        "{label} stage latency_us should serialize as an explicit duration field"
+    );
+    assert!(
+        value["queues"][0].get("wait_us").is_some(),
+        "{label} queue wait_us should serialize as an explicit duration field"
+    );
+
+    let mut contradictory = run.clone();
+    contradictory.requests[0].started_at_unix_ms = 10_000;
+    contradictory.requests[0].finished_at_unix_ms = 10_001;
+    let report = analyze_run(&contradictory, AnalyzeOptions::default());
+    assert_eq!(
+        report.p50_latency_us,
+        Some(request.latency_us),
+        "{label} analyzer should use explicit latency_us rather than wall timestamp deltas"
+    );
 }


### PR DESCRIPTION
### Motivation
- Prevent timing-semantics regressions across native core capture, live tracing intake, JSONL import, and analyzer temporal segmentation. 
- Make duration fields (e.g., `latency_us`, `wait_us`) authoritative and ensure the analyzer uses explicit duration fields rather than recomputing from timestamps. 
- Ensure analyzer temporal segmentation prefers run-relative fields when present and falls back with a clear warning for older artifacts.

### Description
- Added an end-to-end parity test in `tailtriage-tracing/tests/equivalence.rs` that builds equivalent native and live-tracing runs (one request, one queue, one stage) and asserts positive durations, monotonic wall timestamps, explicit duration serialization, and that the analyzer respects `latency_us` as authoritative. 
- Extended JSONL import tests in `tailtriage-tracing/src/jsonl.rs` to assert that a wrapped span with contradictory `duration_us` is retained (and warns) in non-strict mode and is rejected in strict mode. 
- Strengthened analyzer temporal tests in `tailtriage-analyzer/src/tests.rs` to (a) assert runtime/inflight filtering uses run-relative windows when run-relative fields are present and (b) assert the wall-clock fallback path still emits a warning for older artifacts missing run-relative fields. 
- No new crates or dependencies were added and no public API changes were made; changes are confined to test code and minor test-formatting adjustments.

### Testing
- Ran `cargo fmt --check` (passed). 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (passed). 
- Ran full test matrix: `cargo test --workspace --all-targets --all-features --locked` and `cargo test --workspace` (all tests passed). 
- Ran docs contract validation: `python3 scripts/validate_docs_contracts.py` (passed). 
- Ran tracing parity and retention validations: `python3 scripts/demo_tool.py validate-tracing-parity all --profile release` and `python3 scripts/demo_tool.py validate-tracing-retention-parity --profile release` (both passed). 
- Targeted new/modified tests that exercised the changes include the new equivalence/ parity test, the updated JSONL duration mismatch test, and the enhanced analyzer temporal segmentation tests, all of which passed in CI-local runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ee17e64f48330936ed35ae0ea800c)