### PR TITLE
Sample live tracing span start times before recorder lock

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -713,22 +713,24 @@ where
         if !(metadata_candidate || initial_candidate) {
             return;
         }
+        let started_at_unix_ms = tailtriage_core::unix_time_ms();
         let started_instant = Instant::now();
+
         let mut state = lock_state(&self.state);
         if state.open.len() >= self.limits.max_open_spans {
             state.dropped_open_spans = state.dropped_open_spans.saturating_add(1);
             return;
         }
-        let open_span = OpenSpan {
-            id: Some(id.into_u64().to_string()),
+        let open_span = open_span_from_start_sample(
+            Some(id.into_u64().to_string()),
             parent_id,
-            name: attrs.metadata().name().to_owned(),
-            fields: visitor.fields,
-            started_at_unix_ms: tailtriage_core::unix_time_ms(),
-            started_at_run_us: duration_us_between(state.start_instant, started_instant),
+            attrs.metadata().name().to_owned(),
+            visitor.fields,
+            started_at_unix_ms,
             started_instant,
-            is_tt_candidate: metadata_candidate || initial_candidate,
-        };
+            state.start_instant,
+            metadata_candidate || initial_candidate,
+        );
         state.open.insert(id.into_u64(), open_span);
     }
 
@@ -780,6 +782,29 @@ where
                 self.semantic_max_requests,
             );
         }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn open_span_from_start_sample(
+    id: Option<String>,
+    parent_id: Option<String>,
+    name: String,
+    fields: BTreeMap<String, FieldValue>,
+    started_at_unix_ms: u64,
+    started_instant: Instant,
+    recorder_start_instant: Instant,
+    is_tt_candidate: bool,
+) -> OpenSpan {
+    OpenSpan {
+        id,
+        parent_id,
+        name,
+        fields,
+        started_at_unix_ms,
+        started_at_run_us: duration_us_between(recorder_start_instant, started_instant),
+        started_instant,
+        is_tt_candidate,
     }
 }
 
@@ -1297,6 +1322,30 @@ mod tests {
             .build()
             .expect("collector")
             .snapshot()
+    }
+
+    #[test]
+    fn open_span_from_start_sample_uses_supplied_start_times() {
+        let started_at_unix_ms = 123_456_789;
+        let recorder_start = Instant::now();
+        let started_instant = recorder_start
+            .checked_add(std::time::Duration::from_micros(42))
+            .expect("started instant within range");
+
+        let open = open_span_from_start_sample(
+            Some("span-1".to_owned()),
+            Some("parent-1".to_owned()),
+            "request".to_owned(),
+            BTreeMap::new(),
+            started_at_unix_ms,
+            started_instant,
+            recorder_start,
+            true,
+        );
+
+        assert_eq!(open.started_at_unix_ms, started_at_unix_ms);
+        assert_eq!(open.started_at_run_us, 42);
+        assert_eq!(open.started_instant, started_instant);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Ensure the live tracing span start timestamp semantics match close-time semantics by sampling both wall-clock and monotonic time before acquiring the recorder mutex to avoid measuring while holding the lock.
- Make start-time sampling deterministic/testable so unit tests can assert run-relative offsets without flaky thread scheduling.

### Description
- Sampled `started_at_unix_ms = tailtriage_core::unix_time_ms()` and `started_instant = Instant::now()` in `TailtriageLayer::on_new_span` before acquiring `lock_state(&self.state)` and performing max-open-span enforcement.
- Added a private helper `open_span_from_start_sample(...) -> OpenSpan` that constructs an `OpenSpan` from provided wall-clock and monotonic samples and computes `started_at_run_us` using `duration_us_between(recorder_start_instant, started_instant)` without performing any new clock calls.
- Replaced the inline `OpenSpan` construction in `on_new_span` with a call to the helper and passed the previously sampled `started_at_unix_ms` into the `OpenSpan` instead of calling `unix_time_ms()` while holding the mutex.
- Added a focused unit test `open_span_from_start_sample_uses_supplied_start_times` that asserts the helper uses the supplied `started_at_unix_ms` sentinel, records the 42µs run-relative offset deterministically, and preserves the supplied `started_instant` without using threads or wall-clock ticks.

### Testing
- Ran `cargo fmt --check` and it succeeded.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it succeeded (added an `#[allow(clippy::too_many_arguments)]` on the new helper to satisfy lints).
- Ran `cargo test --workspace --all-targets --all-features --locked` and `cargo test --workspace` and all tests passed (including the new unit test in `tailtriage-tracing`).
- Ran `python3 scripts/validate_docs_contracts.py` and it succeeded.
- Ran feature checks `cargo check -p tailtriage-tracing --no-default-features --locked`, `--features jsonl`, `--features live`, and `--features tokio` and they all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f35326d1c83308b09291a1b9a4e4e)