### PR TITLE
Sample tracing span start before recorder lock

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -713,22 +713,24 @@ where
         if !(metadata_candidate || initial_candidate) {
             return;
         }
+        let started_at_unix_ms = tailtriage_core::unix_time_ms();
         let started_instant = Instant::now();
+
         let mut state = lock_state(&self.state);
         if state.open.len() >= self.limits.max_open_spans {
             state.dropped_open_spans = state.dropped_open_spans.saturating_add(1);
             return;
         }
-        let open_span = OpenSpan {
-            id: Some(id.into_u64().to_string()),
+        let open_span = open_span_from_start_sample(
+            Some(id.into_u64().to_string()),
             parent_id,
-            name: attrs.metadata().name().to_owned(),
-            fields: visitor.fields,
-            started_at_unix_ms: tailtriage_core::unix_time_ms(),
-            started_at_run_us: duration_us_between(state.start_instant, started_instant),
+            attrs.metadata().name().to_owned(),
+            visitor.fields,
+            started_at_unix_ms,
             started_instant,
-            is_tt_candidate: metadata_candidate || initial_candidate,
-        };
+            state.start_instant,
+            metadata_candidate || initial_candidate,
+        );
         state.open.insert(id.into_u64(), open_span);
     }
 
@@ -788,6 +790,29 @@ fn duration_us_between(
     closed_instant: std::time::Instant,
 ) -> u64 {
     u64::try_from(closed_instant.duration_since(started_instant).as_micros()).unwrap_or(u64::MAX)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn open_span_from_start_sample(
+    id: Option<String>,
+    parent_id: Option<String>,
+    name: String,
+    fields: BTreeMap<String, FieldValue>,
+    started_at_unix_ms: u64,
+    started_instant: Instant,
+    recorder_start_instant: Instant,
+    is_tt_candidate: bool,
+) -> OpenSpan {
+    OpenSpan {
+        id,
+        parent_id,
+        name,
+        fields,
+        started_at_unix_ms,
+        started_at_run_us: duration_us_between(recorder_start_instant, started_instant),
+        started_instant,
+        is_tt_candidate,
+    }
 }
 
 fn completed_span_records(state: &RecorderState) -> Vec<SpanRecord> {
@@ -1440,6 +1465,27 @@ mod tests {
         let request = &snapshot.run().requests[0];
         assert!(request.finished_at_unix_ms >= request.started_at_unix_ms);
         assert!(request.latency_us > 0);
+    }
+
+    #[test]
+    fn open_span_uses_supplied_start_sample() {
+        let recorder_start = Instant::now();
+        let started_instant = recorder_start + std::time::Duration::from_micros(42);
+
+        let open = open_span_from_start_sample(
+            Some("span-1".to_owned()),
+            Some("parent-1".to_owned()),
+            "request".to_owned(),
+            BTreeMap::new(),
+            123_456_789,
+            started_instant,
+            recorder_start,
+            true,
+        );
+
+        assert_eq!(open.started_at_unix_ms, 123_456_789);
+        assert_eq!(open.started_at_run_us, 42);
+        assert_eq!(open.started_instant, started_instant);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Ensure live tracing spans record both wall-clock and monotonic start samples before acquiring the recorder mutex so start-time sampling matches the existing close-time semantics and avoids taking time/syscalls while holding the recorder lock.

### Description
- In `TailtriageLayer::on_new_span` sample `started_at_unix_ms` and `started_instant` before calling `lock_state(&self.state)` and still perform candidate checks, max-open-spans enforcement, and insertion unchanged.
- Add a private helper `open_span_from_start_sample(...) -> OpenSpan` that constructs an `OpenSpan` from the supplied `started_at_unix_ms` and `started_instant` and computes `started_at_run_us` from the provided recorder start instant without calling `unix_time_ms()` or `Instant::now()`.
- Replace the previous in-mutex `OpenSpan` construction with a call to the new helper so the sampled values are used while holding the mutex.
- Add a focused unit test `open_span_uses_supplied_start_sample` that uses a fixed `started_at_unix_ms` sentinel and a deterministic `started_instant` offset to assert the helper stores the supplied values and computes the run-relative offset.

### Testing
- Ran `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, both succeeded.
- Ran full test suites with `cargo test --workspace --all-targets --all-features --locked` and `cargo test --workspace`, and all tests passed.
- Ran `python3 scripts/validate_docs_contracts.py` and it succeeded.
- Ran feature checks `cargo check -p tailtriage-tracing` with `--no-default-features`, `--features jsonl`, `--features live`, and `--features tokio`, and all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f35326d1c83308b09291a1b9a4e4e)