### PR TITLE
Sample tracing span start before recorder lock

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -713,22 +713,24 @@ where
         if !(metadata_candidate || initial_candidate) {
             return;
         }
+        let started_at_unix_ms = tailtriage_core::unix_time_ms();
         let started_instant = Instant::now();
+
         let mut state = lock_state(&self.state);
         if state.open.len() >= self.limits.max_open_spans {
             state.dropped_open_spans = state.dropped_open_spans.saturating_add(1);
             return;
         }
-        let open_span = OpenSpan {
-            id: Some(id.into_u64().to_string()),
+        let open_span = open_span_from_start_sample(
+            Some(id.into_u64().to_string()),
             parent_id,
-            name: attrs.metadata().name().to_owned(),
-            fields: visitor.fields,
-            started_at_unix_ms: tailtriage_core::unix_time_ms(),
-            started_at_run_us: duration_us_between(state.start_instant, started_instant),
+            attrs.metadata().name().to_owned(),
+            visitor.fields,
+            started_at_unix_ms,
             started_instant,
-            is_tt_candidate: metadata_candidate || initial_candidate,
-        };
+            state.start_instant,
+            metadata_candidate || initial_candidate,
+        );
         state.open.insert(id.into_u64(), open_span);
     }
 
@@ -780,6 +782,29 @@ where
                 self.semantic_max_requests,
             );
         }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn open_span_from_start_sample(
+    id: Option<String>,
+    parent_id: Option<String>,
+    name: String,
+    fields: BTreeMap<String, FieldValue>,
+    started_at_unix_ms: u64,
+    started_instant: Instant,
+    recorder_start_instant: Instant,
+    is_tt_candidate: bool,
+) -> OpenSpan {
+    OpenSpan {
+        id,
+        parent_id,
+        name,
+        fields,
+        started_at_unix_ms,
+        started_at_run_us: duration_us_between(recorder_start_instant, started_instant),
+        started_instant,
+        is_tt_candidate,
     }
 }
 
@@ -1452,6 +1477,28 @@ mod tests {
 
         assert!((1_000..=2_000).contains(&duration_us));
         assert!(duration_us < 10_000);
+    }
+
+    #[test]
+    fn open_span_from_start_sample_uses_supplied_wall_clock_and_monotonic_start() {
+        let started_at_unix_ms = 123_456_789;
+        let recorder_start = Instant::now();
+        let started_instant = recorder_start + std::time::Duration::from_micros(42);
+
+        let open = open_span_from_start_sample(
+            Some("span-1".to_owned()),
+            Some("parent-1".to_owned()),
+            "request".to_owned(),
+            BTreeMap::new(),
+            started_at_unix_ms,
+            started_instant,
+            recorder_start,
+            true,
+        );
+
+        assert_eq!(open.started_at_unix_ms, started_at_unix_ms);
+        assert_eq!(open.started_at_run_us, 42);
+        assert_eq!(open.started_instant, started_instant);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Align live span start semantics with `on_close` by sampling both wall-clock and monotonic start times before acquiring the recorder mutex so start timestamps are not biased by lock acquisition.

### Description
- In `TailtriageLayer::on_new_span` sample `started_at_unix_ms = tailtriage_core::unix_time_ms()` and `started_instant = Instant::now()` before calling `lock_state(&self.state)` and preserve existing candidate checks and limits enforcement.
- Add a private helper `open_span_from_start_sample(...) -> OpenSpan` that builds an `OpenSpan` from supplied `started_at_unix_ms`, `started_instant`, and `recorder_start_instant` and computes `started_at_run_us` using `duration_us_between(recorder_start_instant, started_instant)` without calling `unix_time_ms()` or `Instant::now()` itself.
- Replace inline `OpenSpan` construction in `on_new_span` with a call to `open_span_from_start_sample(...)` and use the pre-sampled `started_at_unix_ms` instead of invoking `tailtriage_core::unix_time_ms()` while holding the mutex.
- Add a deterministic unit test `open_span_from_start_sample_uses_supplied_wall_clock_and_monotonic_start` that uses a sentinel `started_at_unix_ms` (e.g. `123456789`) and a `started_instant` offset of 42µs from a `recorder_start` to assert `OpenSpan.started_at_unix_ms`, `OpenSpan.started_at_run_us`, and `OpenSpan.started_instant` without threads or relying on wall-clock ticks.
- Add `#[allow(clippy::too_many_arguments)]` to the helper to satisfy linting while keeping the helper private and focused.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed after adding the helper and the `#[allow(clippy::too_many_arguments)]` annotation.
- Ran `cargo test --workspace --all-targets --all-features --locked` and `cargo test --workspace` and all tests passed (including new unit test in `tailtriage-tracing`).
- Ran `python3 scripts/validate_docs_contracts.py` and validation passed.
- Ran `cargo check -p tailtriage-tracing` with feature combinations (`--no-default-features`, `--features jsonl`, `--features live`, `--features tokio`) and all succeeded (notes: existing non-failing dead-code warnings remained but did not block checks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f35326d1c83308b09291a1b9a4e4e)