### PR TITLE
Sample live span start time before recorder lock

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -713,22 +713,24 @@ where
         if !(metadata_candidate || initial_candidate) {
             return;
         }
+        let started_at_unix_ms = tailtriage_core::unix_time_ms();
         let started_instant = Instant::now();
+
         let mut state = lock_state(&self.state);
         if state.open.len() >= self.limits.max_open_spans {
             state.dropped_open_spans = state.dropped_open_spans.saturating_add(1);
             return;
         }
-        let open_span = OpenSpan {
-            id: Some(id.into_u64().to_string()),
+        let open_span = open_span_from_start_sample(
+            Some(id.into_u64().to_string()),
             parent_id,
-            name: attrs.metadata().name().to_owned(),
-            fields: visitor.fields,
-            started_at_unix_ms: tailtriage_core::unix_time_ms(),
-            started_at_run_us: duration_us_between(state.start_instant, started_instant),
+            attrs.metadata().name().to_owned(),
+            visitor.fields,
+            started_at_unix_ms,
             started_instant,
-            is_tt_candidate: metadata_candidate || initial_candidate,
-        };
+            state.start_instant,
+            metadata_candidate || initial_candidate,
+        );
         state.open.insert(id.into_u64(), open_span);
     }
 
@@ -788,6 +790,29 @@ fn duration_us_between(
     closed_instant: std::time::Instant,
 ) -> u64 {
     u64::try_from(closed_instant.duration_since(started_instant).as_micros()).unwrap_or(u64::MAX)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn open_span_from_start_sample(
+    id: Option<String>,
+    parent_id: Option<String>,
+    name: String,
+    fields: BTreeMap<String, FieldValue>,
+    started_at_unix_ms: u64,
+    started_instant: Instant,
+    recorder_start_instant: Instant,
+    is_tt_candidate: bool,
+) -> OpenSpan {
+    OpenSpan {
+        id,
+        parent_id,
+        name,
+        fields,
+        started_at_unix_ms,
+        started_at_run_us: duration_us_between(recorder_start_instant, started_instant),
+        started_instant,
+        is_tt_candidate,
+    }
 }
 
 fn completed_span_records(state: &RecorderState) -> Vec<SpanRecord> {
@@ -1297,6 +1322,28 @@ mod tests {
             .build()
             .expect("collector")
             .snapshot()
+    }
+
+    #[test]
+    fn open_span_from_start_sample_uses_supplied_start_times() {
+        let started_at_unix_ms = 123_456_789;
+        let recorder_start = Instant::now();
+        let started_instant = recorder_start + std::time::Duration::from_micros(42);
+
+        let open_span = open_span_from_start_sample(
+            Some("span-1".to_owned()),
+            Some("parent-1".to_owned()),
+            "request".to_owned(),
+            BTreeMap::new(),
+            started_at_unix_ms,
+            started_instant,
+            recorder_start,
+            true,
+        );
+
+        assert_eq!(open_span.started_at_unix_ms, started_at_unix_ms);
+        assert_eq!(open_span.started_at_run_us, 42);
+        assert_eq!(open_span.started_instant, started_instant);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Ensure live tracing span start timing (wall-clock and monotonic) is sampled before acquiring the recorder mutex so start and close semantics match and syscall/clock sampling isn't done while holding the recorder lock.
- Reduce potential skew and make start-time behavior deterministic for tests that assert run-relative offsets.
- Preserve existing open-span bookkeeping and retention semantics while changing only when the start timestamps are sampled.

### Description

- In `tailtriage-tracing/src/recorder.rs`, `TailtriageLayer::on_new_span` now samples both `started_at_unix_ms` and `started_instant` immediately after detecting a tailtriage candidate and before calling `lock_state(&self.state)`.
- Added a private helper `open_span_from_start_sample(...) -> OpenSpan` that builds an `OpenSpan` from supplied `started_at_unix_ms`, `started_instant`, and the recorder `start_instant` without calling `unix_time_ms()` or `Instant::now()` inside the helper, and it computes `started_at_run_us` via `duration_us_between(recorder_start_instant, started_instant)`.
- `on_new_span` uses the helper after acquiring the mutex and after enforcing `max_open_spans`, and inserts the resulting `OpenSpan` into `state.open`; all previous behaviors (field collection, parent_id extraction, candidate checks, max-open-spans enforcement, retention, and warnings) remain unchanged.
- Added `#[allow(clippy::too_many_arguments)]` on the helper to satisfy linting without altering public APIs.
- Added a focused unit test `open_span_from_start_sample_uses_supplied_start_times` that supplies a fixed unix-ms sentinel and a deterministic 42µs monotonic offset and asserts the helper uses the supplied samples (no threads or wall-clock-dependent assertions).

### Testing

- Ran formatting, linting, and full test suite and static checks: `cargo fmt --check` (passed), `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (passed), `cargo test --workspace --all-targets --all-features --locked` (passed), and `cargo test --workspace` (passed).
- Ran docs contract validation: `python3 scripts/validate_docs_contracts.py` (passed).
- Ran feature-specific checks for the tracing crate: `cargo check -p tailtriage-tracing --no-default-features --locked`, `--features jsonl`, `--features live`, and `--features tokio` (all passed).
- All automated checks and unit tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f35326d1c83308b09291a1b9a4e4e)