### PR TITLE
Remove obsolete standalone timing helpers in tailtriage-core

### DIFF
--- a/tailtriage-core/src/time.rs
+++ b/tailtriage-core/src/time.rs
@@ -92,36 +92,6 @@ impl RunClock {
     }
 }
 
-/// Starts a measured interval using a wall-clock sample and monotonic instant.
-#[allow(dead_code)]
-#[must_use]
-pub(crate) fn start_interval() -> IntervalStart {
-    let started_at_unix_ms = unix_time_ms();
-    let started = Instant::now();
-
-    IntervalStart {
-        started_at_unix_ms,
-        started_at_run_us: None,
-        started,
-    }
-}
-
-/// Finishes a measured interval using wall-clock finish time and monotonic duration.
-#[allow(dead_code)]
-#[must_use]
-pub(crate) fn finish_interval(start: IntervalStart) -> FinishedInterval {
-    let finished = Instant::now();
-    let finished_at_unix_ms = unix_time_ms();
-
-    FinishedInterval {
-        started_at_unix_ms: start.started_at_unix_ms,
-        started_at_run_us: start.started_at_run_us,
-        finished_at_unix_ms,
-        finished_at_run_us: None,
-        duration_us: duration_to_us(finished.duration_since(start.started)),
-    }
-}
-
 /// Converts a [`Duration`] to microseconds, saturating at [`u64::MAX`].
 #[must_use]
 pub(crate) fn duration_to_us(duration: Duration) -> u64 {
@@ -148,10 +118,7 @@ pub fn unix_time_ms() -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        duration_to_unix_ms, duration_to_us, finish_interval, start_interval,
-        system_time_to_unix_ms, RunClock,
-    };
+    use super::{duration_to_unix_ms, duration_to_us, system_time_to_unix_ms, RunClock};
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     #[test]
@@ -165,20 +132,6 @@ mod tests {
     }
 
     #[test]
-    fn finish_interval_preserves_timestamp_ordering() {
-        let start = start_interval();
-        std::thread::sleep(Duration::from_millis(1));
-
-        let finished = finish_interval(start);
-
-        assert_eq!(finished.started_at_unix_ms, start.started_at_unix_ms);
-        assert!(finished.finished_at_unix_ms >= finished.started_at_unix_ms);
-        assert_eq!(finished.started_at_run_us, None);
-        assert_eq!(finished.finished_at_run_us, None);
-        assert!(finished.duration_us > 0);
-    }
-
-    #[test]
     fn run_clock_intervals_include_run_relative_offsets() {
         let clock = RunClock::new();
         let start = clock.start_interval();
@@ -187,8 +140,10 @@ mod tests {
         let finished = clock.finish_interval(start);
 
         assert_eq!(finished.started_at_run_us, start.started_at_run_us);
-        assert!(finished.finished_at_unix_ms >= finished.started_at_unix_ms);
+        assert!(finished.started_at_run_us.is_some());
+        assert!(finished.finished_at_run_us.is_some());
         assert!(finished.finished_at_run_us >= finished.started_at_run_us);
+        assert!(finished.finished_at_unix_ms >= finished.started_at_unix_ms);
         assert!(finished.duration_us > 0);
         assert!(clock.run_started_at_unix_ms() <= finished.finished_at_unix_ms);
     }


### PR DESCRIPTION
### Motivation
- The codebase now uses the `RunClock` path for native capture timing, so the standalone `start_interval()` / `finish_interval(...)` helpers are dead and should be removed to reduce surface area and avoid `#[allow(dead_code)]` cruft.
- Preserve the single coherent run-relative timing API surface (`RunClock` and related types) while keeping existing semantics for duration conversion and epoch helpers.

### Description
- Removed the standalone functions `pub(crate) fn start_interval()` and `pub(crate) fn finish_interval(start: IntervalStart)` from `tailtriage-core/src/time.rs` and removed their `#[allow(dead_code)]` attributes.
- Left the `RunClock` API unchanged, including `RunClock::new()`, `RunClock::sample()`, `RunClock::start_interval()`, `RunClock::finish_interval(...)`, and `RunClock::run_started_at_unix_ms()`.
- Kept shared timing types (`RunClock`, `RunClockSample`, `IntervalStart`, `FinishedInterval`) with existing visibility.
- Left `duration_to_us(...)` and Unix ms helpers unchanged.
- Updated tests in `tailtriage-core/src/time.rs` to remove direct calls to the removed standalone helpers and to assert interval properties using `RunClock::start_interval()` / `RunClock::finish_interval(...)`, including checks that run-relative fields are `Some`, ordering between start/finish unix ms and run us, and positive `duration_us` after a 1ms sleep.

### Testing
- Ran formatting check: `cargo fmt --check` (passed after formatting changes).
- Ran lints: `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (passed).
- Ran tests: `cargo test --workspace --all-targets --all-features --locked` and `cargo test --workspace` (all tests passed across workspace; unit tests and doctests succeeded).
- Validated docs contract: `python3 scripts/validate_docs_contracts.py` (passed).
- Generated docs: `cargo doc --workspace --all-features --locked --no-deps` (succeeded).
- Searched workspace to ensure no remaining calls to the removed standalone `start_interval()` / `finish_interval(...)` helpers and confirmed remaining invocations are `RunClock` method calls only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fb7c7b31c83309663a028e9163959)