### PR TITLE
Remove obsolete core timing interval helpers

### DIFF
--- a/tailtriage-core/src/time.rs
+++ b/tailtriage-core/src/time.rs
@@ -92,36 +92,6 @@ impl RunClock {
     }
 }
 
-/// Starts a measured interval using a wall-clock sample and monotonic instant.
-#[allow(dead_code)]
-#[must_use]
-pub(crate) fn start_interval() -> IntervalStart {
-    let started_at_unix_ms = unix_time_ms();
-    let started = Instant::now();
-
-    IntervalStart {
-        started_at_unix_ms,
-        started_at_run_us: None,
-        started,
-    }
-}
-
-/// Finishes a measured interval using wall-clock finish time and monotonic duration.
-#[allow(dead_code)]
-#[must_use]
-pub(crate) fn finish_interval(start: IntervalStart) -> FinishedInterval {
-    let finished = Instant::now();
-    let finished_at_unix_ms = unix_time_ms();
-
-    FinishedInterval {
-        started_at_unix_ms: start.started_at_unix_ms,
-        started_at_run_us: start.started_at_run_us,
-        finished_at_unix_ms,
-        finished_at_run_us: None,
-        duration_us: duration_to_us(finished.duration_since(start.started)),
-    }
-}
-
 /// Converts a [`Duration`] to microseconds, saturating at [`u64::MAX`].
 #[must_use]
 pub(crate) fn duration_to_us(duration: Duration) -> u64 {
@@ -148,10 +118,7 @@ pub fn unix_time_ms() -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        duration_to_unix_ms, duration_to_us, finish_interval, start_interval,
-        system_time_to_unix_ms, RunClock,
-    };
+    use super::{duration_to_unix_ms, duration_to_us, system_time_to_unix_ms, RunClock};
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     #[test]
@@ -165,20 +132,6 @@ mod tests {
     }
 
     #[test]
-    fn finish_interval_preserves_timestamp_ordering() {
-        let start = start_interval();
-        std::thread::sleep(Duration::from_millis(1));
-
-        let finished = finish_interval(start);
-
-        assert_eq!(finished.started_at_unix_ms, start.started_at_unix_ms);
-        assert!(finished.finished_at_unix_ms >= finished.started_at_unix_ms);
-        assert_eq!(finished.started_at_run_us, None);
-        assert_eq!(finished.finished_at_run_us, None);
-        assert!(finished.duration_us > 0);
-    }
-
-    #[test]
     fn run_clock_intervals_include_run_relative_offsets() {
         let clock = RunClock::new();
         let start = clock.start_interval();
@@ -187,8 +140,10 @@ mod tests {
         let finished = clock.finish_interval(start);
 
         assert_eq!(finished.started_at_run_us, start.started_at_run_us);
-        assert!(finished.finished_at_unix_ms >= finished.started_at_unix_ms);
+        assert!(finished.started_at_run_us.is_some());
+        assert!(finished.finished_at_run_us.is_some());
         assert!(finished.finished_at_run_us >= finished.started_at_run_us);
+        assert!(finished.finished_at_unix_ms >= finished.started_at_unix_ms);
         assert!(finished.duration_us > 0);
         assert!(clock.run_started_at_unix_ms() <= finished.finished_at_unix_ms);
     }


### PR DESCRIPTION
### Motivation
- Remove obsolete standalone timing helpers now that native capture uses `RunClock` so the module has a single canonical timing path. 
- Eliminate dead-code allowances and reduce maintenance surface while keeping runtime-relative timing semantics intact.

### Description
- Deleted the standalone `pub(crate) fn start_interval()` and `pub(crate) fn finish_interval(...)` helpers from `tailtriage-core/src/time.rs` and removed the `#[allow(dead_code)]` attributes that only applied to them. 
- Kept the `RunClock` APIs and shared timing types (`RunClock`, `RunClockSample`, `IntervalStart`, `FinishedInterval`) unchanged and available with their existing visibility. 
- Left `duration_to_us(...)` and other time-conversion helpers unchanged, and preserved saturation behavior tests. 
- Updated unit tests in `tailtriage-core/src/time.rs` to stop calling the deleted standalone helpers and to assert interval properties via `RunClock::start_interval()` / `RunClock::finish_interval(...)` (including run-relative fields being `Some`, timestamp ordering, and positive duration after a 1ms sleep).

### Testing
- Ran formatting and linters with `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, which passed. 
- Ran the full test suite with `cargo test --workspace --all-targets --all-features --locked` and `cargo test --workspace`, and all tests passed. 
- Ran docs validation and doc generation with `python3 scripts/validate_docs_contracts.py` and `cargo doc --workspace --all-features --locked --no-deps`, both of which passed. 
- Searched the workspace for remaining calls to the deleted standalone helpers and verified there are no remaining usages outside the retained `RunClock` methods.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fb7c7b31c83309663a028e9163959)