### PR TITLE
Fix temporal request ordering clocks

### DIFF
--- a/tailtriage-analyzer/src/temporal.rs
+++ b/tailtriage-analyzer/src/temporal.rs
@@ -18,14 +18,28 @@ enum SegmentWindow {
     Unix { start: u64, finish: u64 },
 }
 
-fn request_temporal_sort_key(request: &RequestEvent) -> (bool, u64, &str) {
-    (
-        request.started_at_run_us.is_none(),
-        request
-            .started_at_run_us
-            .unwrap_or(request.started_at_unix_ms),
-        request.request_id.as_str(),
-    )
+fn all_requests_have_run_relative_start(requests: &[RequestEvent]) -> bool {
+    requests
+        .iter()
+        .all(|request| request.started_at_run_us.is_some())
+}
+
+fn sort_requests_for_temporal_segments(requests: &mut [RequestEvent]) {
+    if all_requests_have_run_relative_start(requests) {
+        requests.sort_by(|a, b| {
+            a.started_at_run_us
+                .unwrap()
+                .cmp(&b.started_at_run_us.unwrap())
+                .then_with(|| a.started_at_unix_ms.cmp(&b.started_at_unix_ms))
+                .then_with(|| a.request_id.cmp(&b.request_id))
+        });
+    } else {
+        requests.sort_by(|a, b| {
+            a.started_at_unix_ms
+                .cmp(&b.started_at_unix_ms)
+                .then_with(|| a.request_id.cmp(&b.request_id))
+        });
+    }
 }
 
 fn segment_run_relative_window(requests: &[RequestEvent]) -> Option<(u64, u64)> {
@@ -119,7 +133,7 @@ pub(super) fn temporal_segments(
         return vec![];
     }
     let mut requests = run.requests.clone();
-    requests.sort_by(|a, b| request_temporal_sort_key(a).cmp(&request_temporal_sort_key(b)));
+    sort_requests_for_temporal_segments(&mut requests);
     let split = requests.len() / 2;
     let (early, late) = requests.split_at(split);
     if early.len() < options.temporal.min_segment_request_count

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -1876,6 +1876,66 @@ fn temporal_segments_with_complete_run_relative_fields_do_not_warn_about_fallbac
 }
 
 #[test]
+fn temporal_segments_sort_complete_run_relative_starts_by_run_time() {
+    let mut run = test_run();
+    run.requests = (0..20)
+        .map(|idx| RequestEvent {
+            request_id: format!("req-{idx:02}"),
+            route: "/t".into(),
+            kind: None,
+            started_at_unix_ms: 1,
+            started_at_run_us: Some((19 - idx) * 1_000),
+            finished_at_unix_ms: 1,
+            finished_at_run_us: Some((19 - idx) * 1_000 + 100),
+            latency_us: if idx >= 10 { 1_000 } else { 6_000 },
+            outcome: "ok".into(),
+        })
+        .collect();
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert_eq!(report.temporal_segments.len(), 2);
+    assert_eq!(report.temporal_segments[0].name, "early");
+    assert_eq!(report.temporal_segments[1].name, "late");
+    assert_eq!(report.temporal_segments[0].p95_latency_us, Some(1_000));
+    assert_eq!(report.temporal_segments[1].p95_latency_us, Some(6_000));
+}
+
+#[test]
+fn temporal_segments_sort_partial_run_relative_starts_by_unix_time() {
+    let mut run = test_run();
+    run.requests = (0..20)
+        .map(|idx| RequestEvent {
+            request_id: format!("req-{idx:02}"),
+            route: "/t".into(),
+            kind: None,
+            started_at_unix_ms: idx + 1,
+            started_at_run_us: if idx >= 10 {
+                Some((19 - idx) * 1_000)
+            } else {
+                None
+            },
+            finished_at_unix_ms: idx + 2,
+            finished_at_run_us: if idx >= 10 {
+                Some((19 - idx) * 1_000 + 100)
+            } else {
+                None
+            },
+            latency_us: if idx < 10 { 1_000 } else { 6_000 },
+            outcome: "ok".into(),
+        })
+        .collect();
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert_eq!(report.temporal_segments.len(), 2);
+    assert_eq!(report.temporal_segments[0].name, "early");
+    assert_eq!(report.temporal_segments[1].name, "late");
+    assert_eq!(report.temporal_segments[0].p95_latency_us, Some(1_000));
+    assert_eq!(report.temporal_segments[1].p95_latency_us, Some(6_000));
+}
+
+#[test]
 fn temporal_segments_not_emitted_when_no_meaningful_difference() {
     let mut run = test_run();
     run.requests = (0..20).map(|i| sample_request(i + 1)).collect();


### PR DESCRIPTION
### Motivation
- Prevent mixing run-relative microseconds and Unix milliseconds when ordering requests for temporal segmentation to avoid inconsistent early/late splits.
- Ensure sorting uses a single clock across the whole request set: prefer run-relative ordering only when every request has run-relative starts, otherwise use Unix timestamps.

### Description
- Add `fn all_requests_have_run_relative_start(requests: &[RequestEvent]) -> bool` which returns true only when every request has `started_at_run_us`.
- Add `fn sort_requests_for_temporal_segments(requests: &mut [RequestEvent])` which sorts by run-relative start, then Unix start, then `request_id` when all requests have run-relative starts, and otherwise sorts by Unix start then `request_id`.
- Remove the mixed per-request key approach and route sorting in `temporal_segments(...)` through `sort_requests_for_temporal_segments(&mut requests)` without changing segment window selection or scoring formulas.
- Add two regression tests: `temporal_segments_sort_complete_run_relative_starts_by_run_time` and `temporal_segments_sort_partial_run_relative_starts_by_unix_time` to assert correct split behavior in the two clock scenarios.

### Testing
- Ran `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, which succeeded.
- Ran focused analyzer tests and full test suite via `cargo test -p tailtriage-analyzer temporal_segments --all-features --locked`, `cargo test --workspace --all-targets --all-features --locked`, and `cargo test --workspace`, and all tests passed (new tests included).
- Ran `python3 scripts/validate_docs_contracts.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fbad6801c83308267e531c511327d)