### PR TITLE
Fix temporal request ordering clocks

### DIFF
--- a/tailtriage-analyzer/src/temporal.rs
+++ b/tailtriage-analyzer/src/temporal.rs
@@ -18,14 +18,34 @@ enum SegmentWindow {
     Unix { start: u64, finish: u64 },
 }
 
-fn request_temporal_sort_key(request: &RequestEvent) -> (bool, u64, &str) {
-    (
-        request.started_at_run_us.is_none(),
-        request
-            .started_at_run_us
-            .unwrap_or(request.started_at_unix_ms),
-        request.request_id.as_str(),
-    )
+fn all_requests_have_run_relative_start(requests: &[RequestEvent]) -> bool {
+    requests
+        .iter()
+        .all(|request| request.started_at_run_us.is_some())
+}
+
+fn sort_requests_for_temporal_segments(requests: &mut [RequestEvent]) {
+    if all_requests_have_run_relative_start(requests) {
+        requests.sort_by(|a, b| {
+            (
+                a.started_at_run_us
+                    .expect("all requests have run-relative start"),
+                a.started_at_unix_ms,
+                a.request_id.as_str(),
+            )
+                .cmp(&(
+                    b.started_at_run_us
+                        .expect("all requests have run-relative start"),
+                    b.started_at_unix_ms,
+                    b.request_id.as_str(),
+                ))
+        });
+    } else {
+        requests.sort_by(|a, b| {
+            (a.started_at_unix_ms, a.request_id.as_str())
+                .cmp(&(b.started_at_unix_ms, b.request_id.as_str()))
+        });
+    }
 }
 
 fn segment_run_relative_window(requests: &[RequestEvent]) -> Option<(u64, u64)> {
@@ -119,7 +139,7 @@ pub(super) fn temporal_segments(
         return vec![];
     }
     let mut requests = run.requests.clone();
-    requests.sort_by(|a, b| request_temporal_sort_key(a).cmp(&request_temporal_sort_key(b)));
+    sort_requests_for_temporal_segments(&mut requests);
     let split = requests.len() / 2;
     let (early, late) = requests.split_at(split);
     if early.len() < options.temporal.min_segment_request_count

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -1723,6 +1723,76 @@ fn temporal_sort_prefers_run_relative_start_when_unix_starts_match() {
 }
 
 #[test]
+fn temporal_sort_uses_unix_order_when_any_request_lacks_run_relative_start() {
+    let mut run = test_run();
+    run.requests = (1..=20).map(sample_request).collect();
+
+    for request in &mut run.requests {
+        let id = request
+            .request_id
+            .strip_prefix("req-")
+            .expect("test request id should use req- prefix")
+            .parse::<u64>()
+            .expect("test request id should end with an integer");
+        request.started_at_unix_ms = id;
+        request.finished_at_unix_ms = id + 1;
+        if id > 10 {
+            request.started_at_run_us = Some((21 - id) * 1_000);
+            request.finished_at_run_us = Some((21 - id) * 1_000 + 100);
+        }
+    }
+
+    for id in 1..=10 {
+        run.queues.push(QueueEvent {
+            request_id: format!("req-{id}"),
+            queue: "ingress".into(),
+            wait_us: 900,
+            waited_from_unix_ms: id,
+            waited_from_run_us: None,
+            waited_until_unix_ms: id + 1,
+            waited_until_run_us: None,
+            depth_at_start: Some(9),
+        });
+    }
+    for id in 11..=20 {
+        run.stages.push(StageEvent {
+            request_id: format!("req-{id}"),
+            stage: "db".into(),
+            started_at_unix_ms: id,
+            started_at_run_us: None,
+            finished_at_unix_ms: id + 1,
+            finished_at_run_us: None,
+            latency_us: 5_000,
+            success: true,
+        });
+    }
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert_eq!(report.temporal_segments.len(), 2);
+    let early = report
+        .temporal_segments
+        .iter()
+        .find(|segment| segment.name == "early")
+        .expect("early temporal segment should be emitted");
+    let late = report
+        .temporal_segments
+        .iter()
+        .find(|segment| segment.name == "late")
+        .expect("late temporal segment should be emitted");
+    assert_eq!(early.started_at_unix_ms, Some(1));
+    assert_eq!(late.started_at_unix_ms, Some(11));
+    assert_eq!(
+        early.primary_suspect.kind,
+        DiagnosisKind::ApplicationQueueSaturation
+    );
+    assert_eq!(
+        late.primary_suspect.kind,
+        DiagnosisKind::DownstreamStageDominates
+    );
+}
+
+#[test]
 fn temporal_runtime_and_inflight_filtering_uses_run_relative_times() {
     let mut run = test_run();
     run.requests = (1..=20).map(sample_request).collect();


### PR DESCRIPTION
### Motivation

- Prevent mixing run-relative microseconds and Unix milliseconds when sorting requests for temporal segmentation, which could produce inconsistent early/late splits.
- Ensure deterministic, all-or-nothing behavior: either use run-relative ordering for the whole split when available, otherwise fall back to Unix timestamps for the whole split.

### Description

- Added `fn all_requests_have_run_relative_start(requests: &[RequestEvent]) -> bool` which returns true only when every request has `started_at_run_us` set.
- Added `fn sort_requests_for_temporal_segments(requests: &mut [RequestEvent])` which sorts by run-relative start, then Unix timestamp, then `request_id` when all requests have run-relative starts, otherwise sorts by Unix timestamp then `request_id` for all requests.
- Removed the mixed per-request key approach and replaced the direct inline sort in `temporal_segments(...)` with a call to `sort_requests_for_temporal_segments(&mut requests)`, avoiding comparisons that mix clocks across requests.
- Kept existing segment window selection logic unchanged, preserving the rule that run-relative segment windows are used only when the segment has complete run-relative start/finish fields and kept scoring formulas intact.

### Testing

- Added a unit test `temporal_sort_uses_unix_order_when_any_request_lacks_run_relative_start` to assert Unix-based ordering when only some requests have `started_at_run_us`, and relied on the existing `temporal_sort_prefers_run_relative_start_when_unix_starts_match` case for the all-run-relative ordering scenario.
- Ran formatting and linting and the full test suite, all green: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, `cargo test --workspace`, and `python3 scripts/validate_docs_contracts.py` all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fbad6801c83308267e531c511327d)