### PR TITLE
Fix temporal request ordering clocks

### DIFF
--- a/tailtriage-analyzer/src/temporal.rs
+++ b/tailtriage-analyzer/src/temporal.rs
@@ -18,14 +18,34 @@ enum SegmentWindow {
     Unix { start: u64, finish: u64 },
 }
 
-fn request_temporal_sort_key(request: &RequestEvent) -> (bool, u64, &str) {
-    (
-        request.started_at_run_us.is_none(),
-        request
-            .started_at_run_us
-            .unwrap_or(request.started_at_unix_ms),
-        request.request_id.as_str(),
-    )
+fn all_requests_have_run_relative_start(requests: &[RequestEvent]) -> bool {
+    requests
+        .iter()
+        .all(|request| request.started_at_run_us.is_some())
+}
+
+fn sort_requests_for_temporal_segments(requests: &mut [RequestEvent]) {
+    if all_requests_have_run_relative_start(requests) {
+        requests.sort_by(|a, b| {
+            (
+                a.started_at_run_us
+                    .expect("checked by all_requests_have_run_relative_start"),
+                a.started_at_unix_ms,
+                a.request_id.as_str(),
+            )
+                .cmp(&(
+                    b.started_at_run_us
+                        .expect("checked by all_requests_have_run_relative_start"),
+                    b.started_at_unix_ms,
+                    b.request_id.as_str(),
+                ))
+        });
+    } else {
+        requests.sort_by(|a, b| {
+            (a.started_at_unix_ms, a.request_id.as_str())
+                .cmp(&(b.started_at_unix_ms, b.request_id.as_str()))
+        });
+    }
 }
 
 fn segment_run_relative_window(requests: &[RequestEvent]) -> Option<(u64, u64)> {
@@ -119,7 +139,7 @@ pub(super) fn temporal_segments(
         return vec![];
     }
     let mut requests = run.requests.clone();
-    requests.sort_by(|a, b| request_temporal_sort_key(a).cmp(&request_temporal_sort_key(b)));
+    sort_requests_for_temporal_segments(&mut requests);
     let split = requests.len() / 2;
     let (early, late) = requests.split_at(split);
     if early.len() < options.temporal.min_segment_request_count

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -1723,6 +1723,79 @@ fn temporal_sort_prefers_run_relative_start_when_unix_starts_match() {
 }
 
 #[test]
+fn temporal_sort_uses_unix_start_when_any_request_lacks_run_relative_start() {
+    let mut run = test_run();
+    run.requests = (1..=20).map(sample_request).collect();
+
+    for request in &mut run.requests {
+        let id = request
+            .request_id
+            .strip_prefix("req-")
+            .expect("test request id should use req- prefix")
+            .parse::<u64>()
+            .expect("test request id should end with an integer");
+        if id <= 10 {
+            request.started_at_unix_ms = id;
+            request.finished_at_unix_ms = id + 1;
+            request.started_at_run_us = None;
+            request.finished_at_run_us = None;
+        } else {
+            request.started_at_unix_ms = 100 + id;
+            request.finished_at_unix_ms = 101 + id;
+            request.started_at_run_us = Some((21 - id) * 1_000);
+            request.finished_at_run_us = Some((21 - id) * 1_000 + 100);
+        }
+    }
+
+    for id in 1..=10 {
+        run.queues.push(QueueEvent {
+            request_id: format!("req-{id}"),
+            queue: "ingress".into(),
+            wait_us: 900,
+            waited_from_unix_ms: id,
+            waited_from_run_us: None,
+            waited_until_unix_ms: id + 1,
+            waited_until_run_us: None,
+            depth_at_start: Some(9),
+        });
+    }
+    for id in 11..=20 {
+        run.stages.push(StageEvent {
+            request_id: format!("req-{id}"),
+            stage: "db".into(),
+            started_at_unix_ms: 100 + id,
+            started_at_run_us: None,
+            finished_at_unix_ms: 101 + id,
+            finished_at_run_us: None,
+            latency_us: 5_000,
+            success: true,
+        });
+    }
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert_eq!(report.temporal_segments.len(), 2);
+    let early = report
+        .temporal_segments
+        .iter()
+        .find(|segment| segment.name == "early")
+        .expect("early temporal segment should be emitted");
+    let late = report
+        .temporal_segments
+        .iter()
+        .find(|segment| segment.name == "late")
+        .expect("late temporal segment should be emitted");
+    assert_eq!(
+        early.primary_suspect.kind,
+        DiagnosisKind::ApplicationQueueSaturation
+    );
+    assert_eq!(
+        late.primary_suspect.kind,
+        DiagnosisKind::DownstreamStageDominates
+    );
+}
+
+#[test]
 fn temporal_runtime_and_inflight_filtering_uses_run_relative_times() {
     let mut run = test_run();
     run.requests = (1..=20).map(sample_request).collect();


### PR DESCRIPTION
### Motivation

- Prevent mixing run-relative microsecond (`started_at_run_us`) and Unix-millisecond (`started_at_unix_ms`) clocks when ordering requests for early/late temporal splits.  Mixing produced inconsistent segment boundaries and inaccurate temporal attribution.  
- Ensure the whole temporal split uses a single clock for ordering: prefer run-relative ordering only when every request has a run-relative start, otherwise fall back to Unix timestamps for the entire split.

### Description

- Added `fn all_requests_have_run_relative_start(requests: &[RequestEvent]) -> bool` which returns true only when every request has `started_at_run_us` present.  
- Added `fn sort_requests_for_temporal_segments(requests: &mut [RequestEvent])` which sorts by run-relative start, then Unix start, then `request_id` when all requests have run-relative starts, and otherwise sorts all requests by Unix start then `request_id`.  
- Replaced the previous mixed-key `request_temporal_sort_key` usage and call sites with `sort_requests_for_temporal_segments(&mut requests)` in `temporal_segments`, keeping existing segment window selection and scoring logic unchanged.  
- Added analyzer tests: `temporal_sort_prefers_run_relative_start_when_unix_starts_match` (existing coverage reaffirmed) and a new `temporal_sort_uses_unix_start_when_any_request_lacks_run_relative_start` that verifies fallback to Unix ordering when run-relative timing is partially missing.

### Testing

- Ran `cargo fmt --check` and formatting is clean.  
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and the workspace is lint-clean.  
- Ran focused analyzer tests and full test suite with `cargo test -p tailtriage-analyzer temporal_sort --all-targets --all-features --locked` and `cargo test --workspace --all-targets --all-features --locked` and all tests passed.  
- Ran `python3 scripts/validate_docs_contracts.py` and validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fbad6801c83308267e531c511327d)