### PR TITLE
Fix temporal request split ordering

### DIFF
--- a/tailtriage-analyzer/src/temporal.rs
+++ b/tailtriage-analyzer/src/temporal.rs
@@ -18,14 +18,31 @@ enum SegmentWindow {
     Unix { start: u64, finish: u64 },
 }
 
-fn request_temporal_sort_key(request: &RequestEvent) -> (bool, u64, &str) {
-    (
-        request.started_at_run_us.is_none(),
-        request
-            .started_at_run_us
-            .unwrap_or(request.started_at_unix_ms),
-        request.request_id.as_str(),
-    )
+fn all_requests_have_run_relative_start(requests: &[RequestEvent]) -> bool {
+    requests
+        .iter()
+        .all(|request| request.started_at_run_us.is_some())
+}
+
+fn sort_requests_for_temporal_segments(requests: &mut [RequestEvent]) {
+    if all_requests_have_run_relative_start(requests) {
+        requests.sort_by(|a, b| {
+            a.started_at_run_us
+                .expect("all requests should have run-relative starts")
+                .cmp(
+                    &b.started_at_run_us
+                        .expect("all requests should have run-relative starts"),
+                )
+                .then_with(|| a.started_at_unix_ms.cmp(&b.started_at_unix_ms))
+                .then_with(|| a.request_id.cmp(&b.request_id))
+        });
+    } else {
+        requests.sort_by(|a, b| {
+            a.started_at_unix_ms
+                .cmp(&b.started_at_unix_ms)
+                .then_with(|| a.request_id.cmp(&b.request_id))
+        });
+    }
 }
 
 fn segment_run_relative_window(requests: &[RequestEvent]) -> Option<(u64, u64)> {
@@ -119,7 +136,7 @@ pub(super) fn temporal_segments(
         return vec![];
     }
     let mut requests = run.requests.clone();
-    requests.sort_by(|a, b| request_temporal_sort_key(a).cmp(&request_temporal_sort_key(b)));
+    sort_requests_for_temporal_segments(&mut requests);
     let split = requests.len() / 2;
     let (early, late) = requests.split_at(split);
     if early.len() < options.temporal.min_segment_request_count

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -1723,6 +1723,74 @@ fn temporal_sort_prefers_run_relative_start_when_unix_starts_match() {
 }
 
 #[test]
+fn temporal_sort_uses_unix_start_when_only_some_requests_have_run_relative_start() {
+    let mut run = test_run();
+    run.requests = (1..=20).map(sample_request).collect();
+
+    for request in &mut run.requests {
+        let id = request
+            .request_id
+            .strip_prefix("req-")
+            .expect("test request id should use req- prefix")
+            .parse::<u64>()
+            .expect("test request id should end with an integer");
+        request.started_at_unix_ms = id;
+        request.finished_at_unix_ms = id + 1;
+        if id > 10 {
+            request.started_at_run_us = Some(id - 10);
+            request.finished_at_run_us = Some(id - 10 + 100);
+        }
+    }
+
+    for id in 1..=10 {
+        run.queues.push(QueueEvent {
+            request_id: format!("req-{id}"),
+            queue: "ingress".into(),
+            wait_us: 900,
+            waited_from_unix_ms: id,
+            waited_from_run_us: None,
+            waited_until_unix_ms: id + 1,
+            waited_until_run_us: None,
+            depth_at_start: Some(9),
+        });
+    }
+    for id in 11..=20 {
+        run.stages.push(StageEvent {
+            request_id: format!("req-{id}"),
+            stage: "db".into(),
+            started_at_unix_ms: id,
+            started_at_run_us: None,
+            finished_at_unix_ms: id + 1,
+            finished_at_run_us: None,
+            latency_us: 5_000,
+            success: true,
+        });
+    }
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert_eq!(report.temporal_segments.len(), 2);
+    let early = report
+        .temporal_segments
+        .iter()
+        .find(|segment| segment.name == "early")
+        .expect("early temporal segment should be emitted");
+    let late = report
+        .temporal_segments
+        .iter()
+        .find(|segment| segment.name == "late")
+        .expect("late temporal segment should be emitted");
+    assert_eq!(
+        early.primary_suspect.kind,
+        DiagnosisKind::ApplicationQueueSaturation
+    );
+    assert_eq!(
+        late.primary_suspect.kind,
+        DiagnosisKind::DownstreamStageDominates
+    );
+}
+
+#[test]
 fn temporal_runtime_and_inflight_filtering_uses_run_relative_times() {
     let mut run = test_run();
     run.requests = (1..=20).map(sample_request).collect();


### PR DESCRIPTION
### Motivation
- Prevent mixing run-relative microseconds and Unix milliseconds when sorting requests for temporal segmentation to avoid inconsistent early/late splits.
- Make the sort decision all-or-nothing so segments either use run-relative ordering consistently or fall back to Unix timestamps.

### Description
- Replaced the previous mixed-clock comparator with two helpers in `tailtriage-analyzer/src/temporal.rs`: `all_requests_have_run_relative_start(requests: &[RequestEvent]) -> bool` and `sort_requests_for_temporal_segments(requests: &mut [RequestEvent])`.
- `sort_requests_for_temporal_segments` sorts by run-relative start, then Unix start, then `request_id` when every request has `started_at_run_us`, and otherwise sorts by Unix start then `request_id` for all requests.
- Removed the mixed-key approach (no function returns a key that mixes `started_at_run_us` and `started_at_unix_ms` across requests) and replaced the inline `requests.sort_by(...)` in `temporal_segments(...)` with `sort_requests_for_temporal_segments(&mut requests)`.
- Added a test `temporal_sort_uses_unix_start_when_only_some_requests_have_run_relative_start` in `tailtriage-analyzer/src/tests.rs` to assert Unix-based ordering when only some requests have run-relative timestamps, and kept/validated the existing test that prefers run-relative ordering when all run-relative starts are present.
- Did not change segment window selection rules, scoring formulas, public schema, or tracing imports.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed with no warnings.
- Ran focused analyzer tests and full workspace tests via `cargo test -p tailtriage-analyzer temporal_sort --all-features --locked`, `cargo test --workspace --all-targets --all-features --locked`, and `cargo test --workspace`, and all tests passed (including the new temporal tests).
- Ran `python3 scripts/validate_docs_contracts.py` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fbad6801c83308267e531c511327d)