### PR TITLE
Validate and sanitize run-relative timing offsets

### DIFF
--- a/tailtriage-core/src/run_builder.rs
+++ b/tailtriage-core/src/run_builder.rs
@@ -380,6 +380,17 @@ fn validate_request_event(event: &RequestEvent) -> Result<(), RunBuilderEventErr
             "must be >= started_at_unix_ms",
         ));
     }
+    if let (Some(started_at_run_us), Some(finished_at_run_us)) =
+        (event.started_at_run_us, event.finished_at_run_us)
+    {
+        if finished_at_run_us < started_at_run_us {
+            return Err(invalid_event(
+                "RequestEvent",
+                "finished_at_run_us",
+                "must be >= started_at_run_us",
+            ));
+        }
+    }
     if event.outcome.trim().is_empty() {
         return Err(invalid_event(
             "RequestEvent",
@@ -407,6 +418,17 @@ fn validate_stage_event(event: &StageEvent) -> Result<(), RunBuilderEventError> 
             "must be >= started_at_unix_ms",
         ));
     }
+    if let (Some(started_at_run_us), Some(finished_at_run_us)) =
+        (event.started_at_run_us, event.finished_at_run_us)
+    {
+        if finished_at_run_us < started_at_run_us {
+            return Err(invalid_event(
+                "StageEvent",
+                "finished_at_run_us",
+                "must be >= started_at_run_us",
+            ));
+        }
+    }
     Ok(())
 }
 fn validate_queue_event(event: &QueueEvent) -> Result<(), RunBuilderEventError> {
@@ -426,6 +448,17 @@ fn validate_queue_event(event: &QueueEvent) -> Result<(), RunBuilderEventError> 
             "waited_until_unix_ms",
             "must be >= waited_from_unix_ms",
         ));
+    }
+    if let (Some(waited_from_run_us), Some(waited_until_run_us)) =
+        (event.waited_from_run_us, event.waited_until_run_us)
+    {
+        if waited_until_run_us < waited_from_run_us {
+            return Err(invalid_event(
+                "QueueEvent",
+                "waited_until_run_us",
+                "must be >= waited_from_run_us",
+            ));
+        }
     }
     Ok(())
 }

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -1716,6 +1716,92 @@ fn run_builder_event_validation_rejects_invalid_shapes() {
 }
 
 #[test]
+fn run_builder_rejects_inverted_request_run_relative_offsets() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+    let mut request = test_request_event("req");
+    request.started_at_run_us = Some(20);
+    request.finished_at_run_us = Some(10);
+
+    let err = builder
+        .push_request(request)
+        .expect_err("inverted run-relative request offsets should fail");
+    assert_eq!(
+        err,
+        crate::RunBuilderEventError::InvalidEvent {
+            event: "RequestEvent",
+            field: "finished_at_run_us",
+            reason: "must be >= started_at_run_us".to_string(),
+        }
+    );
+}
+
+#[test]
+fn run_builder_rejects_inverted_stage_run_relative_offsets() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+    let mut stage = test_stage_event("req", "stage");
+    stage.started_at_run_us = Some(30);
+    stage.finished_at_run_us = Some(29);
+
+    let err = builder
+        .push_stage(stage)
+        .expect_err("inverted run-relative stage offsets should fail");
+    assert_eq!(
+        err,
+        crate::RunBuilderEventError::InvalidEvent {
+            event: "StageEvent",
+            field: "finished_at_run_us",
+            reason: "must be >= started_at_run_us".to_string(),
+        }
+    );
+}
+
+#[test]
+fn run_builder_rejects_inverted_queue_run_relative_offsets() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+    let mut queue = test_queue_event("req", "queue");
+    queue.waited_from_run_us = Some(40);
+    queue.waited_until_run_us = Some(39);
+
+    let err = builder
+        .push_queue(queue)
+        .expect_err("inverted run-relative queue offsets should fail");
+    assert_eq!(
+        err,
+        crate::RunBuilderEventError::InvalidEvent {
+            event: "QueueEvent",
+            field: "waited_until_run_us",
+            reason: "must be >= waited_from_run_us".to_string(),
+        }
+    );
+}
+
+#[test]
+fn run_builder_accepts_incomplete_run_relative_offsets() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+
+    let mut request = test_request_event("req-start-only");
+    request.started_at_run_us = Some(10);
+    request.finished_at_run_us = None;
+    builder
+        .push_request(request)
+        .expect("request with one run-relative side should be accepted");
+
+    let mut stage = test_stage_event("req-start-only", "stage");
+    stage.started_at_run_us = None;
+    stage.finished_at_run_us = Some(20);
+    builder
+        .push_stage(stage)
+        .expect("stage with one run-relative side should be accepted");
+
+    let mut queue = test_queue_event("req-start-only", "queue");
+    queue.waited_from_run_us = Some(30);
+    queue.waited_until_run_us = None;
+    builder
+        .push_queue(queue)
+        .expect("queue with one run-relative side should be accepted");
+}
+
+#[test]
 fn run_builder_accepts_authoritative_request_latency_when_timestamps_disagree() {
     let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
 

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -74,6 +74,7 @@ pub fn ensure_persistable_run_has_requests(run: &tailtriage_core::Run) -> Result
     Ok(())
 }
 
+#[cfg(feature = "live")]
 pub(crate) fn ensure_persistable_run_with_warnings(
     run: &tailtriage_core::Run,
     warnings: &[ImportWarning],
@@ -185,15 +186,20 @@ where
                     else {
                         continue;
                     };
+                    let (started_at_run_us, finished_at_run_us) = sanitized_run_relative_offsets(
+                        &span,
+                        options.strict_mode(),
+                        &mut warnings,
+                    )?;
                     parsed_requests.push(ParsedRequestEvent {
                         event: RequestEvent {
                             request_id,
                             route,
                             kind: None,
                             started_at_unix_ms: span.started_at_unix_ms(),
-                            started_at_run_us: span.started_at_run_us_ref(),
+                            started_at_run_us,
                             finished_at_unix_ms: span.finished_at_unix_ms(),
-                            finished_at_run_us: span.finished_at_run_us_ref(),
+                            finished_at_run_us,
                             latency_us: elapsed_duration_us(
                                 &span,
                                 options.strict_mode(),
@@ -216,14 +222,19 @@ where
                         OptionalField::Value(success) => success,
                         OptionalField::Invalid => continue,
                     };
+                    let (started_at_run_us, finished_at_run_us) = sanitized_run_relative_offsets(
+                        &span,
+                        options.strict_mode(),
+                        &mut warnings,
+                    )?;
                     parsed_stages.push(ParsedStageEvent {
                         event: StageEvent {
                             request_id,
                             stage,
                             started_at_unix_ms: span.started_at_unix_ms(),
-                            started_at_run_us: span.started_at_run_us_ref(),
+                            started_at_run_us,
                             finished_at_unix_ms: span.finished_at_unix_ms(),
-                            finished_at_run_us: span.finished_at_run_us_ref(),
+                            finished_at_run_us,
                             latency_us: elapsed_duration_us(
                                 &span,
                                 options.strict_mode(),
@@ -246,13 +257,18 @@ where
                             OptionalField::Value(depth) => Some(depth),
                             OptionalField::Invalid => continue,
                         };
+                    let (waited_from_run_us, waited_until_run_us) = sanitized_run_relative_offsets(
+                        &span,
+                        options.strict_mode(),
+                        &mut warnings,
+                    )?;
                     queues.push(QueueEvent {
                         request_id,
                         queue,
                         waited_from_unix_ms: span.started_at_unix_ms(),
-                        waited_from_run_us: span.started_at_run_us_ref(),
+                        waited_from_run_us,
                         waited_until_unix_ms: span.finished_at_unix_ms(),
-                        waited_until_run_us: span.finished_at_run_us_ref(),
+                        waited_until_run_us,
                         wait_us: elapsed_duration_us(&span, options.strict_mode(), &mut warnings)?,
                         depth_at_start,
                     });
@@ -724,6 +740,58 @@ fn timestamp_derived_duration_us(started_at_unix_ms: u64, finished_at_unix_ms: u
         .saturating_mul(1000)
 }
 
+fn sanitized_run_relative_offsets(
+    span: &SpanRecord,
+    strict: bool,
+    warnings: &mut Vec<ImportWarning>,
+) -> Result<(Option<u64>, Option<u64>), ImportError> {
+    match (span.started_at_run_us_ref(), span.finished_at_run_us_ref()) {
+        (Some(started_at_run_us), Some(finished_at_run_us))
+            if finished_at_run_us >= started_at_run_us =>
+        {
+            Ok((Some(started_at_run_us), Some(finished_at_run_us)))
+        }
+        (Some(started_at_run_us), Some(finished_at_run_us)) => {
+            let message = format!(
+                "span '{}' run-relative timing is inverted: start={} finish={}; dropped run-relative offsets",
+                span.name(),
+                started_at_run_us,
+                finished_at_run_us
+            );
+            if strict {
+                return Err(ImportError::StrictViolation(message));
+            }
+            warnings.push(ImportWarning::new(message));
+            Ok((None, None))
+        }
+        (Some(offset), None) => {
+            let message = format!(
+                "span '{}' incomplete run-relative timing: started_at_run_us={} without finished_at_run_us; dropped run-relative offsets",
+                span.name(),
+                offset
+            );
+            if strict {
+                return Err(ImportError::StrictViolation(message));
+            }
+            warnings.push(ImportWarning::new(message));
+            Ok((None, None))
+        }
+        (None, Some(offset)) => {
+            let message = format!(
+                "span '{}' incomplete run-relative timing: finished_at_run_us={} without started_at_run_us; dropped run-relative offsets",
+                span.name(),
+                offset
+            );
+            if strict {
+                return Err(ImportError::StrictViolation(message));
+            }
+            warnings.push(ImportWarning::new(message));
+            Ok((None, None))
+        }
+        (None, None) => Ok((None, None)),
+    }
+}
+
 fn elapsed_duration_us(
     span: &SpanRecord,
     strict: bool,
@@ -1024,6 +1092,108 @@ mod tests {
         assert_eq!(run.stages[0].finished_at_run_us, Some(15_010));
         assert_eq!(run.queues[0].waited_from_run_us, Some(2_010));
         assert_eq!(run.queues[0].waited_until_run_us, Some(3_010));
+    }
+
+    #[test]
+    fn non_strict_inverted_request_run_relative_offsets_are_dropped_with_warning() {
+        let spans = vec![SpanRecord::new("req", 100, 120)
+            .started_at_run_us(50)
+            .finished_at_run_us(40)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).expect("ok");
+
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].started_at_run_us, None);
+        assert_eq!(imported.run().requests[0].finished_at_run_us, None);
+        assert!(imported.warnings().iter().any(|warning| warning
+            .message()
+            .contains("run-relative timing is inverted")));
+    }
+
+    #[test]
+    fn strict_inverted_request_run_relative_offsets_fail() {
+        let spans = vec![SpanRecord::new("req", 100, 120)
+            .started_at_run_us(50)
+            .finished_at_run_us(40)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+
+        let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true))
+            .expect_err("strict mode should reject inverted run-relative offsets");
+
+        assert!(
+            matches!(err, ImportError::StrictViolation(message) if message.contains("run-relative timing is inverted"))
+        );
+    }
+
+    #[test]
+    fn non_strict_incomplete_request_run_relative_offsets_are_dropped_with_warning() {
+        let spans = vec![SpanRecord::new("req", 100, 120)
+            .started_at_run_us(50)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).expect("ok");
+
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].started_at_run_us, None);
+        assert_eq!(imported.run().requests[0].finished_at_run_us, None);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|warning| warning.message().contains("incomplete run-relative timing")));
+    }
+
+    #[test]
+    fn non_strict_inverted_queue_run_relative_offsets_are_dropped_with_warning() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("q", 105, 110)
+                .started_at_run_us(80)
+                .finished_at_run_us(70)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).expect("ok");
+
+        assert_eq!(imported.run().queues.len(), 1);
+        assert_eq!(imported.run().queues[0].waited_from_run_us, None);
+        assert_eq!(imported.run().queues[0].waited_until_run_us, None);
+        assert!(imported.warnings().iter().any(|warning| warning
+            .message()
+            .contains("run-relative timing is inverted")));
+    }
+
+    #[test]
+    fn strict_incomplete_queue_run_relative_offsets_fail() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("q", 105, 110)
+                .finished_at_run_us(70)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+
+        let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true))
+            .expect_err("strict mode should reject incomplete run-relative offsets");
+
+        assert!(
+            matches!(err, ImportError::StrictViolation(message) if message.contains("incomplete run-relative timing"))
+        );
     }
 
     #[test]

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -604,6 +604,7 @@ impl TracingIntakeSessionBuilder {
 
 impl TracingRecorderBuilder {
     /// Returns selected capture mode for import conversion semantics.
+    #[cfg(feature = "tokio")]
     #[must_use]
     pub(crate) fn selected_mode(&self) -> CaptureMode {
         self.options.mode_value()


### PR DESCRIPTION
### Motivation

- Prevent invalid run-relative offsets (inverted or incomplete) from entering `Run` artifacts and from misleading analyzer temporal filtering while preserving existing timestamp and duration semantics.

### Description

- Added run-relative offset validation in `RunBuilder` so `RequestEvent`, `StageEvent`, and `QueueEvent` reject inverted run-relative pairs when both sides are present, returning `RunBuilderEventError::InvalidEvent` for the specified field and reason, while keeping existing unix-ms ordering checks and not validating duration fields.
- Implemented `sanitized_run_relative_offsets(span: &SpanRecord, strict: bool, warnings: &mut Vec<ImportWarning>) -> Result<(Option<u64>, Option<u64>), ImportError>` in `tailtriage-tracing` and used it to sanitize run-relative offsets before converting spans into `RequestEvent`, `StageEvent`, and `QueueEvent`; in strict mode it returns `ImportError::StrictViolation` for inverted or incomplete offsets and in non-strict mode it drops the bad run-relative offsets, emits `ImportWarning`s, and preserves unix timestamps/duration evidence.
- Kept backward compatibility by accepting cases where one run-relative field is `Some` and the other is `None` at `RunBuilder` (these remain incomplete offsets and are allowed), and explicitly avoided changing duration-mismatch behavior.
- Minor feature-gating to silence dead-code warnings: `ensure_persistable_run_with_warnings` and `TracingRecorderBuilder::selected_mode` were annotated to avoid unused warnings in certain feature builds.

### Testing

- Added core unit tests: `run_builder_rejects_inverted_request_run_relative_offsets`, `run_builder_rejects_inverted_stage_run_relative_offsets`, `run_builder_rejects_inverted_queue_run_relative_offsets`, and `run_builder_accepts_incomplete_run_relative_offsets` in `tailtriage-core` which pass locally.
- Added tracing unit tests in `tailtriage-tracing` covering non-strict dropping-with-warning and strict rejection for inverted/incomplete run-relative offsets, including queue child-span coverage; these tests pass locally.
- Ran repository validation and static checks: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, `cargo test --workspace`, and `python3 scripts/validate_docs_contracts.py`, all of which succeeded.
- Verified tracing crate feature matrix: `cargo check -p tailtriage-tracing --no-default-features --locked`, `--features jsonl`, `--features live`, and `--features tokio` all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fbf413ee0833083ea699622dc6863)