### PR TITLE
Validate and sanitize run-relative timing offsets

### DIFF
--- a/tailtriage-core/src/run_builder.rs
+++ b/tailtriage-core/src/run_builder.rs
@@ -380,6 +380,17 @@ fn validate_request_event(event: &RequestEvent) -> Result<(), RunBuilderEventErr
             "must be >= started_at_unix_ms",
         ));
     }
+    if let (Some(started_at_run_us), Some(finished_at_run_us)) =
+        (event.started_at_run_us, event.finished_at_run_us)
+    {
+        if finished_at_run_us < started_at_run_us {
+            return Err(invalid_event(
+                "RequestEvent",
+                "finished_at_run_us",
+                "must be >= started_at_run_us",
+            ));
+        }
+    }
     if event.outcome.trim().is_empty() {
         return Err(invalid_event(
             "RequestEvent",
@@ -407,6 +418,17 @@ fn validate_stage_event(event: &StageEvent) -> Result<(), RunBuilderEventError> 
             "must be >= started_at_unix_ms",
         ));
     }
+    if let (Some(started_at_run_us), Some(finished_at_run_us)) =
+        (event.started_at_run_us, event.finished_at_run_us)
+    {
+        if finished_at_run_us < started_at_run_us {
+            return Err(invalid_event(
+                "StageEvent",
+                "finished_at_run_us",
+                "must be >= started_at_run_us",
+            ));
+        }
+    }
     Ok(())
 }
 fn validate_queue_event(event: &QueueEvent) -> Result<(), RunBuilderEventError> {
@@ -426,6 +448,17 @@ fn validate_queue_event(event: &QueueEvent) -> Result<(), RunBuilderEventError> 
             "waited_until_unix_ms",
             "must be >= waited_from_unix_ms",
         ));
+    }
+    if let (Some(waited_from_run_us), Some(waited_until_run_us)) =
+        (event.waited_from_run_us, event.waited_until_run_us)
+    {
+        if waited_until_run_us < waited_from_run_us {
+            return Err(invalid_event(
+                "QueueEvent",
+                "waited_until_run_us",
+                "must be >= waited_from_run_us",
+            ));
+        }
     }
     Ok(())
 }

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -1716,6 +1716,94 @@ fn run_builder_event_validation_rejects_invalid_shapes() {
 }
 
 #[test]
+fn run_builder_rejects_inverted_request_run_relative_fields() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+    let mut request = test_request_event("req");
+    request.started_at_run_us = Some(20);
+    request.finished_at_run_us = Some(10);
+
+    let err = builder.push_request(request).expect_err("should fail");
+    assert!(matches!(
+        err,
+        crate::RunBuilderEventError::InvalidEvent {
+            event: "RequestEvent",
+            field: "finished_at_run_us",
+            ref reason,
+        } if reason == "must be >= started_at_run_us"
+    ));
+}
+
+#[test]
+fn run_builder_rejects_inverted_stage_run_relative_fields() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+    let mut stage = test_stage_event("req", "stage");
+    stage.started_at_run_us = Some(20);
+    stage.finished_at_run_us = Some(10);
+
+    let err = builder.push_stage(stage).expect_err("should fail");
+    assert!(matches!(
+        err,
+        crate::RunBuilderEventError::InvalidEvent {
+            event: "StageEvent",
+            field: "finished_at_run_us",
+            ref reason,
+        } if reason == "must be >= started_at_run_us"
+    ));
+}
+
+#[test]
+fn run_builder_rejects_inverted_queue_run_relative_fields() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+    let mut queue = test_queue_event("req", "queue");
+    queue.waited_from_run_us = Some(20);
+    queue.waited_until_run_us = Some(10);
+
+    let err = builder.push_queue(queue).expect_err("should fail");
+    assert!(matches!(
+        err,
+        crate::RunBuilderEventError::InvalidEvent {
+            event: "QueueEvent",
+            field: "waited_until_run_us",
+            ref reason,
+        } if reason == "must be >= waited_from_run_us"
+    ));
+}
+
+#[test]
+fn run_builder_accepts_incomplete_run_relative_fields() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+
+    let mut request_start_only = test_request_event("req-start-only");
+    request_start_only.started_at_run_us = Some(10);
+    builder.push_request(request_start_only).expect("ok");
+
+    let mut request_finish_only = test_request_event("req-finish-only");
+    request_finish_only.finished_at_run_us = Some(20);
+    builder.push_request(request_finish_only).expect("ok");
+
+    let mut stage_start_only = test_stage_event("req", "stage-start-only");
+    stage_start_only.started_at_run_us = Some(10);
+    builder.push_stage(stage_start_only).expect("ok");
+
+    let mut stage_finish_only = test_stage_event("req", "stage-finish-only");
+    stage_finish_only.finished_at_run_us = Some(20);
+    builder.push_stage(stage_finish_only).expect("ok");
+
+    let mut queue_start_only = test_queue_event("req", "queue-start-only");
+    queue_start_only.waited_from_run_us = Some(10);
+    builder.push_queue(queue_start_only).expect("ok");
+
+    let mut queue_finish_only = test_queue_event("req", "queue-finish-only");
+    queue_finish_only.waited_until_run_us = Some(20);
+    builder.push_queue(queue_finish_only).expect("ok");
+
+    let run = builder.finish();
+    assert_eq!(run.requests.len(), 2);
+    assert_eq!(run.stages.len(), 2);
+    assert_eq!(run.queues.len(), 2);
+}
+
+#[test]
 fn run_builder_accepts_authoritative_request_latency_when_timestamps_disagree() {
     let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
 

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -185,15 +185,20 @@ where
                     else {
                         continue;
                     };
+                    let (started_at_run_us, finished_at_run_us) = sanitized_run_relative_offsets(
+                        &span,
+                        options.strict_mode(),
+                        &mut warnings,
+                    )?;
                     parsed_requests.push(ParsedRequestEvent {
                         event: RequestEvent {
                             request_id,
                             route,
                             kind: None,
                             started_at_unix_ms: span.started_at_unix_ms(),
-                            started_at_run_us: span.started_at_run_us_ref(),
+                            started_at_run_us,
                             finished_at_unix_ms: span.finished_at_unix_ms(),
-                            finished_at_run_us: span.finished_at_run_us_ref(),
+                            finished_at_run_us,
                             latency_us: elapsed_duration_us(
                                 &span,
                                 options.strict_mode(),
@@ -216,14 +221,19 @@ where
                         OptionalField::Value(success) => success,
                         OptionalField::Invalid => continue,
                     };
+                    let (started_at_run_us, finished_at_run_us) = sanitized_run_relative_offsets(
+                        &span,
+                        options.strict_mode(),
+                        &mut warnings,
+                    )?;
                     parsed_stages.push(ParsedStageEvent {
                         event: StageEvent {
                             request_id,
                             stage,
                             started_at_unix_ms: span.started_at_unix_ms(),
-                            started_at_run_us: span.started_at_run_us_ref(),
+                            started_at_run_us,
                             finished_at_unix_ms: span.finished_at_unix_ms(),
-                            finished_at_run_us: span.finished_at_run_us_ref(),
+                            finished_at_run_us,
                             latency_us: elapsed_duration_us(
                                 &span,
                                 options.strict_mode(),
@@ -246,13 +256,18 @@ where
                             OptionalField::Value(depth) => Some(depth),
                             OptionalField::Invalid => continue,
                         };
+                    let (waited_from_run_us, waited_until_run_us) = sanitized_run_relative_offsets(
+                        &span,
+                        options.strict_mode(),
+                        &mut warnings,
+                    )?;
                     queues.push(QueueEvent {
                         request_id,
                         queue,
                         waited_from_unix_ms: span.started_at_unix_ms(),
-                        waited_from_run_us: span.started_at_run_us_ref(),
+                        waited_from_run_us,
                         waited_until_unix_ms: span.finished_at_unix_ms(),
-                        waited_until_run_us: span.finished_at_run_us_ref(),
+                        waited_until_run_us,
                         wait_us: elapsed_duration_us(&span, options.strict_mode(), &mut warnings)?,
                         depth_at_start,
                     });
@@ -835,6 +850,54 @@ fn strict_or_warn(
     Ok(())
 }
 
+fn sanitized_run_relative_offsets(
+    span: &SpanRecord,
+    strict: bool,
+    warnings: &mut Vec<ImportWarning>,
+) -> Result<(Option<u64>, Option<u64>), ImportError> {
+    match (span.started_at_run_us_ref(), span.finished_at_run_us_ref()) {
+        (Some(start), Some(finish)) if finish >= start => Ok((Some(start), Some(finish))),
+        (Some(start), Some(finish)) => {
+            let message = format!(
+                "span '{}' run-relative timing is inverted: start={} finish={}; dropped run-relative offsets",
+                span.name(),
+                start,
+                finish
+            );
+            if strict {
+                return Err(ImportError::StrictViolation(message));
+            }
+            warnings.push(ImportWarning::new(message));
+            Ok((None, None))
+        }
+        (Some(offset), None) => {
+            let message = format!(
+                "span '{}' incomplete run-relative timing: started_at_run_us={} but finished_at_run_us is missing; dropped run-relative offsets",
+                span.name(),
+                offset
+            );
+            if strict {
+                return Err(ImportError::StrictViolation(message));
+            }
+            warnings.push(ImportWarning::new(message));
+            Ok((None, None))
+        }
+        (None, Some(offset)) => {
+            let message = format!(
+                "span '{}' incomplete run-relative timing: finished_at_run_us={} but started_at_run_us is missing; dropped run-relative offsets",
+                span.name(),
+                offset
+            );
+            if strict {
+                return Err(ImportError::StrictViolation(message));
+            }
+            warnings.push(ImportWarning::new(message));
+            Ok((None, None))
+        }
+        (None, None) => Ok((None, None)),
+    }
+}
+
 #[cfg(test)]
 const RECOMMENDED_OUTCOME_LABELS: [&str; 5] = ["ok", "error", "timeout", "cancelled", "rejected"];
 
@@ -1024,6 +1087,121 @@ mod tests {
         assert_eq!(run.stages[0].finished_at_run_us, Some(15_010));
         assert_eq!(run.queues[0].waited_from_run_us, Some(2_010));
         assert_eq!(run.queues[0].waited_until_run_us, Some(3_010));
+    }
+
+    #[test]
+    fn non_strict_inverted_request_run_relative_offsets_are_dropped_with_warning() {
+        let spans = vec![SpanRecord::new("req", 100, 120)
+            .started_at_run_us(30_000)
+            .finished_at_run_us(20_000)
+            .duration_us(20_000)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).expect("ok");
+
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].started_at_run_us, None);
+        assert_eq!(imported.run().requests[0].finished_at_run_us, None);
+        assert!(imported.warnings().iter().any(|warning| {
+            warning
+                .message()
+                .contains("run-relative timing is inverted")
+                && warning.message().contains("dropped run-relative offsets")
+        }));
+    }
+
+    #[test]
+    fn strict_inverted_request_run_relative_offsets_fail() {
+        let spans = vec![SpanRecord::new("req", 100, 120)
+            .started_at_run_us(30_000)
+            .finished_at_run_us(20_000)
+            .duration_us(20_000)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+
+        let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
+
+        assert!(
+            matches!(err, ImportError::StrictViolation(message) if message.contains("run-relative timing is inverted"))
+        );
+    }
+
+    #[test]
+    fn non_strict_incomplete_request_run_relative_offsets_are_dropped_with_warning() {
+        let spans = vec![SpanRecord::new("req", 100, 120)
+            .started_at_run_us(10_000)
+            .duration_us(20_000)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).expect("ok");
+
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].started_at_run_us, None);
+        assert_eq!(imported.run().requests[0].finished_at_run_us, None);
+        assert!(imported.warnings().iter().any(|warning| {
+            warning.message().contains("incomplete run-relative timing")
+                && warning.message().contains("dropped run-relative offsets")
+        }));
+    }
+
+    #[test]
+    fn non_strict_inverted_queue_run_relative_offsets_are_dropped_with_warning() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("q", 102, 103)
+                .started_at_run_us(3_000)
+                .finished_at_run_us(2_000)
+                .duration_us(1_000)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).expect("ok");
+
+        assert_eq!(imported.run().queues.len(), 1);
+        assert_eq!(imported.run().queues[0].waited_from_run_us, None);
+        assert_eq!(imported.run().queues[0].waited_until_run_us, None);
+        assert!(imported.warnings().iter().any(|warning| {
+            warning
+                .message()
+                .contains("run-relative timing is inverted")
+                && warning.message().contains("dropped run-relative offsets")
+        }));
+    }
+
+    #[test]
+    fn non_strict_incomplete_queue_run_relative_offsets_are_dropped_with_warning() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("q", 102, 103)
+                .finished_at_run_us(3_000)
+                .duration_us(1_000)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).expect("ok");
+
+        assert_eq!(imported.run().queues.len(), 1);
+        assert_eq!(imported.run().queues[0].waited_from_run_us, None);
+        assert_eq!(imported.run().queues[0].waited_until_run_us, None);
+        assert!(imported.warnings().iter().any(|warning| {
+            warning.message().contains("incomplete run-relative timing")
+                && warning.message().contains("dropped run-relative offsets")
+        }));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent invalid run-relative offsets from entering `Run` artifacts or misleading temporal filters by validating and sanitizing run-relative microsecond offsets.
- Preserve backward compatibility for incomplete offsets (one side present) while rejecting or sanitizing inverted offsets.

### Description
- Extend `RunBuilder` validation in `tailtriage-core/src/run_builder.rs` to reject inverted run-relative offsets by adding checks that require `finished_at_run_us >= started_at_run_us` for `RequestEvent` and `StageEvent`, and `waited_until_run_us >= waited_from_run_us` for `QueueEvent`, returning `RunBuilderEventError::InvalidEvent` with the specified event/field/reason when violated.
- Add `sanitized_run_relative_offsets(...)` helper in `tailtriage-tracing/src/lib.rs` that enforces the import semantics: when both offsets exist and are ordered, return them; when inverted or incomplete, either return `ImportError::StrictViolation` in strict mode or push an `ImportWarning` and return `(None, None)` in non-strict mode; when both absent, return `(None, None)`.
- Use the sanitized offsets when constructing `RequestEvent`, `StageEvent`, and `QueueEvent` during tracing import so bad run-relative offsets are dropped (non-strict) or fail import (strict) while keeping Unix timestamps and duration evidence unchanged.
- Add unit tests: core tests to reject inverted run-relative offsets and accept one-sided offsets; tracing tests to cover non-strict dropping with warnings, strict failure, and queue-span coverage; preserve existing duration-authority behavior and JSONL import tests.

### Testing
- Ran formatting: `cargo fmt --check` (passed).
- Ran lints: `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (passed).
- Ran unit/integration test suites: `cargo test --workspace --all-targets --all-features --locked` and `cargo test --workspace` (all tests passed across crates; newly added tests passed).
- Ran docs contract validation: `python3 scripts/validate_docs_contracts.py` (passed).
- Performed feature checks for `tailtriage-tracing`: `cargo check -p tailtriage-tracing --no-default-features --locked`, `--features jsonl`, `--features live`, and `--features tokio` (all checks passed; only benign unused warnings observed in non-default feature builds).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fbf413ee0833083ea699622dc6863)