### PR TITLE
Validate and sanitize run-relative timing offsets

### DIFF
--- a/tailtriage-core/src/run_builder.rs
+++ b/tailtriage-core/src/run_builder.rs
@@ -380,6 +380,17 @@ fn validate_request_event(event: &RequestEvent) -> Result<(), RunBuilderEventErr
             "must be >= started_at_unix_ms",
         ));
     }
+    if let (Some(started_at_run_us), Some(finished_at_run_us)) =
+        (event.started_at_run_us, event.finished_at_run_us)
+    {
+        if finished_at_run_us < started_at_run_us {
+            return Err(invalid_event(
+                "RequestEvent",
+                "finished_at_run_us",
+                "must be >= started_at_run_us",
+            ));
+        }
+    }
     if event.outcome.trim().is_empty() {
         return Err(invalid_event(
             "RequestEvent",
@@ -407,6 +418,17 @@ fn validate_stage_event(event: &StageEvent) -> Result<(), RunBuilderEventError> 
             "must be >= started_at_unix_ms",
         ));
     }
+    if let (Some(started_at_run_us), Some(finished_at_run_us)) =
+        (event.started_at_run_us, event.finished_at_run_us)
+    {
+        if finished_at_run_us < started_at_run_us {
+            return Err(invalid_event(
+                "StageEvent",
+                "finished_at_run_us",
+                "must be >= started_at_run_us",
+            ));
+        }
+    }
     Ok(())
 }
 fn validate_queue_event(event: &QueueEvent) -> Result<(), RunBuilderEventError> {
@@ -426,6 +448,17 @@ fn validate_queue_event(event: &QueueEvent) -> Result<(), RunBuilderEventError> 
             "waited_until_unix_ms",
             "must be >= waited_from_unix_ms",
         ));
+    }
+    if let (Some(waited_from_run_us), Some(waited_until_run_us)) =
+        (event.waited_from_run_us, event.waited_until_run_us)
+    {
+        if waited_until_run_us < waited_from_run_us {
+            return Err(invalid_event(
+                "QueueEvent",
+                "waited_until_run_us",
+                "must be >= waited_from_run_us",
+            ));
+        }
     }
     Ok(())
 }

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -1716,6 +1716,94 @@ fn run_builder_event_validation_rejects_invalid_shapes() {
 }
 
 #[test]
+fn run_builder_rejects_inverted_request_run_relative_offsets() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+    let mut request = test_request_event("req");
+    request.started_at_run_us = Some(20);
+    request.finished_at_run_us = Some(19);
+
+    let err = builder
+        .push_request(request)
+        .expect_err("inverted request run-relative offsets should fail");
+    assert_eq!(
+        err,
+        crate::RunBuilderEventError::InvalidEvent {
+            event: "RequestEvent",
+            field: "finished_at_run_us",
+            reason: "must be >= started_at_run_us".to_string(),
+        }
+    );
+}
+
+#[test]
+fn run_builder_rejects_inverted_stage_run_relative_offsets() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+    let mut stage = test_stage_event("req", "stage");
+    stage.started_at_run_us = Some(20);
+    stage.finished_at_run_us = Some(19);
+
+    let err = builder
+        .push_stage(stage)
+        .expect_err("inverted stage run-relative offsets should fail");
+    assert_eq!(
+        err,
+        crate::RunBuilderEventError::InvalidEvent {
+            event: "StageEvent",
+            field: "finished_at_run_us",
+            reason: "must be >= started_at_run_us".to_string(),
+        }
+    );
+}
+
+#[test]
+fn run_builder_rejects_inverted_queue_run_relative_offsets() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+    let mut queue = test_queue_event("req", "queue");
+    queue.waited_from_run_us = Some(20);
+    queue.waited_until_run_us = Some(19);
+
+    let err = builder
+        .push_queue(queue)
+        .expect_err("inverted queue run-relative offsets should fail");
+    assert_eq!(
+        err,
+        crate::RunBuilderEventError::InvalidEvent {
+            event: "QueueEvent",
+            field: "waited_until_run_us",
+            reason: "must be >= waited_from_run_us".to_string(),
+        }
+    );
+}
+
+#[test]
+fn run_builder_accepts_incomplete_run_relative_offsets() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+
+    let mut request = test_request_event("req");
+    request.started_at_run_us = Some(10);
+    request.finished_at_run_us = None;
+    builder.push_request(request).expect("request accepted");
+
+    let mut stage = test_stage_event("req", "stage");
+    stage.started_at_run_us = None;
+    stage.finished_at_run_us = Some(20);
+    builder.push_stage(stage).expect("stage accepted");
+
+    let mut queue = test_queue_event("req", "queue");
+    queue.waited_from_run_us = Some(30);
+    queue.waited_until_run_us = None;
+    builder.push_queue(queue).expect("queue accepted");
+
+    let run = builder.finish();
+    assert_eq!(run.requests[0].started_at_run_us, Some(10));
+    assert_eq!(run.requests[0].finished_at_run_us, None);
+    assert_eq!(run.stages[0].started_at_run_us, None);
+    assert_eq!(run.stages[0].finished_at_run_us, Some(20));
+    assert_eq!(run.queues[0].waited_from_run_us, Some(30));
+    assert_eq!(run.queues[0].waited_until_run_us, None);
+}
+
+#[test]
 fn run_builder_accepts_authoritative_request_latency_when_timestamps_disagree() {
     let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
 

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -185,15 +185,20 @@ where
                     else {
                         continue;
                     };
+                    let (started_at_run_us, finished_at_run_us) = sanitized_run_relative_offsets(
+                        &span,
+                        options.strict_mode(),
+                        &mut warnings,
+                    )?;
                     parsed_requests.push(ParsedRequestEvent {
                         event: RequestEvent {
                             request_id,
                             route,
                             kind: None,
                             started_at_unix_ms: span.started_at_unix_ms(),
-                            started_at_run_us: span.started_at_run_us_ref(),
+                            started_at_run_us,
                             finished_at_unix_ms: span.finished_at_unix_ms(),
-                            finished_at_run_us: span.finished_at_run_us_ref(),
+                            finished_at_run_us,
                             latency_us: elapsed_duration_us(
                                 &span,
                                 options.strict_mode(),
@@ -216,14 +221,19 @@ where
                         OptionalField::Value(success) => success,
                         OptionalField::Invalid => continue,
                     };
+                    let (started_at_run_us, finished_at_run_us) = sanitized_run_relative_offsets(
+                        &span,
+                        options.strict_mode(),
+                        &mut warnings,
+                    )?;
                     parsed_stages.push(ParsedStageEvent {
                         event: StageEvent {
                             request_id,
                             stage,
                             started_at_unix_ms: span.started_at_unix_ms(),
-                            started_at_run_us: span.started_at_run_us_ref(),
+                            started_at_run_us,
                             finished_at_unix_ms: span.finished_at_unix_ms(),
-                            finished_at_run_us: span.finished_at_run_us_ref(),
+                            finished_at_run_us,
                             latency_us: elapsed_duration_us(
                                 &span,
                                 options.strict_mode(),
@@ -246,13 +256,18 @@ where
                             OptionalField::Value(depth) => Some(depth),
                             OptionalField::Invalid => continue,
                         };
+                    let (waited_from_run_us, waited_until_run_us) = sanitized_run_relative_offsets(
+                        &span,
+                        options.strict_mode(),
+                        &mut warnings,
+                    )?;
                     queues.push(QueueEvent {
                         request_id,
                         queue,
                         waited_from_unix_ms: span.started_at_unix_ms(),
-                        waited_from_run_us: span.started_at_run_us_ref(),
+                        waited_from_run_us,
                         waited_until_unix_ms: span.finished_at_unix_ms(),
-                        waited_until_run_us: span.finished_at_run_us_ref(),
+                        waited_until_run_us,
                         wait_us: elapsed_duration_us(&span, options.strict_mode(), &mut warnings)?,
                         depth_at_start,
                     });
@@ -724,6 +739,58 @@ fn timestamp_derived_duration_us(started_at_unix_ms: u64, finished_at_unix_ms: u
         .saturating_mul(1000)
 }
 
+fn sanitized_run_relative_offsets(
+    span: &SpanRecord,
+    strict: bool,
+    warnings: &mut Vec<ImportWarning>,
+) -> Result<(Option<u64>, Option<u64>), ImportError> {
+    match (span.started_at_run_us_ref(), span.finished_at_run_us_ref()) {
+        (Some(started_at_run_us), Some(finished_at_run_us))
+            if finished_at_run_us >= started_at_run_us =>
+        {
+            Ok((Some(started_at_run_us), Some(finished_at_run_us)))
+        }
+        (Some(started_at_run_us), Some(finished_at_run_us)) => {
+            let message = format!(
+                "span '{}' run-relative timing is inverted: start={} finish={}; dropped run-relative offsets",
+                span.name(),
+                started_at_run_us,
+                finished_at_run_us
+            );
+            if strict {
+                return Err(ImportError::StrictViolation(message));
+            }
+            warnings.push(ImportWarning::new(message));
+            Ok((None, None))
+        }
+        (Some(offset), None) => {
+            let message = format!(
+                "span '{}' incomplete run-relative timing: started_at_run_us={} finished_at_run_us missing; dropped run-relative offsets",
+                span.name(),
+                offset
+            );
+            if strict {
+                return Err(ImportError::StrictViolation(message));
+            }
+            warnings.push(ImportWarning::new(message));
+            Ok((None, None))
+        }
+        (None, Some(offset)) => {
+            let message = format!(
+                "span '{}' incomplete run-relative timing: started_at_run_us missing finished_at_run_us={}; dropped run-relative offsets",
+                span.name(),
+                offset
+            );
+            if strict {
+                return Err(ImportError::StrictViolation(message));
+            }
+            warnings.push(ImportWarning::new(message));
+            Ok((None, None))
+        }
+        (None, None) => Ok((None, None)),
+    }
+}
+
 fn elapsed_duration_us(
     span: &SpanRecord,
     strict: bool,
@@ -765,6 +832,8 @@ fn is_durable_conversion_warning(message: &str) -> bool {
         || message.starts_with("invalid field")
         || message.starts_with("unknown tt.kind")
         || message.contains("duration_us differs from timestamp-derived duration")
+        || message.contains("run-relative timing is inverted")
+        || message.contains("incomplete run-relative timing")
         || message.contains("missing optional 'tt.outcome'; assumed 'ok'")
         || message.contains("missing optional 'tt.success'; assumed true")
 }
@@ -1024,6 +1093,167 @@ mod tests {
         assert_eq!(run.stages[0].finished_at_run_us, Some(15_010));
         assert_eq!(run.queues[0].waited_from_run_us, Some(2_010));
         assert_eq!(run.queues[0].waited_until_run_us, Some(3_010));
+    }
+
+    #[test]
+    fn non_strict_inverted_request_run_relative_offsets_are_dropped_with_warning() {
+        let spans = vec![SpanRecord::new("req", 100, 120)
+            .started_at_run_us(20_000)
+            .finished_at_run_us(10_000)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].started_at_run_us, None);
+        assert_eq!(imported.run().requests[0].finished_at_run_us, None);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("run-relative timing is inverted")));
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("dropped run-relative offsets")));
+    }
+
+    #[test]
+    fn strict_inverted_request_run_relative_offsets_fail() {
+        let spans = vec![SpanRecord::new("req", 100, 120)
+            .started_at_run_us(20_000)
+            .finished_at_run_us(10_000)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+
+        let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true))
+            .expect_err("strict import should reject inverted run-relative offsets");
+
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(err.to_string().contains("run-relative timing is inverted"));
+    }
+
+    #[test]
+    fn non_strict_incomplete_request_run_relative_offsets_are_dropped_with_warning() {
+        let spans = vec![SpanRecord::new("req", 100, 120)
+            .started_at_run_us(10_000)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].started_at_run_us, None);
+        assert_eq!(imported.run().requests[0].finished_at_run_us, None);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("incomplete run-relative timing")));
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("dropped run-relative offsets")));
+    }
+
+    #[test]
+    fn non_strict_inverted_queue_run_relative_offsets_are_dropped_with_warning() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("q", 102, 103)
+                .started_at_run_us(3_000)
+                .finished_at_run_us(2_000)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+
+        assert_eq!(imported.run().queues.len(), 1);
+        assert_eq!(imported.run().queues[0].waited_from_run_us, None);
+        assert_eq!(imported.run().queues[0].waited_until_run_us, None);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("run-relative timing is inverted")));
+    }
+
+    #[test]
+    fn strict_inverted_queue_run_relative_offsets_fail() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("q", 102, 103)
+                .started_at_run_us(3_000)
+                .finished_at_run_us(2_000)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+
+        let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true))
+            .expect_err("strict import should reject inverted queue run-relative offsets");
+
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(err.to_string().contains("run-relative timing is inverted"));
+    }
+
+    #[test]
+    fn non_strict_incomplete_queue_run_relative_offsets_are_dropped_with_warning() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("q", 102, 103)
+                .finished_at_run_us(3_000)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+
+        assert_eq!(imported.run().queues.len(), 1);
+        assert_eq!(imported.run().queues[0].waited_from_run_us, None);
+        assert_eq!(imported.run().queues[0].waited_until_run_us, None);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("incomplete run-relative timing")));
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("dropped run-relative offsets")));
+    }
+
+    #[test]
+    fn strict_incomplete_queue_run_relative_offsets_fail() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("q", 102, 103)
+                .finished_at_run_us(3_000)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+
+        let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true))
+            .expect_err("strict import should reject incomplete run-relative offsets");
+
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(err.to_string().contains("incomplete run-relative timing"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent invalid run-relative timing offsets from being stored in Run artifacts or causing misleading temporal filtering during analysis.
- Preserve backward compatibility for incomplete offsets while surfacing clear errors or warnings for inverted or partial run-relative timings.

### Description
- Extend `RunBuilder` event validation to reject inverted run-relative offsets by requiring `finished_at_run_us >= started_at_run_us` for `RequestEvent` and `StageEvent` and `waited_until_run_us >= waited_from_run_us` for `QueueEvent`, returning `RunBuilderEventError::InvalidEvent` with the specified field and reason when violated.
- Add `sanitized_run_relative_offsets(span, strict, warnings)` in the tracing intake to normalize run-relative offsets before conversion, returning the original offsets when valid, returning `ImportError::StrictViolation` in strict mode on inverted or incomplete offsets, and in non-strict mode dropping offsets (returning `(None, None)`) while pushing `ImportWarning`s containing `run-relative timing is inverted` or `incomplete run-relative timing` and `dropped run-relative offsets`.
- Wire sanitized offsets into conversion for `RequestEvent` (`started_at_run_us`/`finished_at_run_us`), `StageEvent` (`started_at_run_us`/`finished_at_run_us`), and `QueueEvent` (`waited_from_run_us`/`waited_until_run_us`) without changing existing duration-authority or Unix-timestamp validation behavior.
- Mark the new run-relative warnings as durable conversion warnings so relevant messages are persisted in run lifecycle warnings.
- Add unit tests in `tailtriage-core` covering inverted run-relative offsets for request, stage, and queue events and acceptance of one-sided/incomplete offsets, and add `tailtriage-tracing` tests for non-strict and strict import behaviors for inverted and incomplete run-relative offsets (including queue child-span coverage), keeping existing JSONL/ duration-authority tests intact.
- No new dependencies were added.

### Testing
- Ran `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` with no failures.
- Ran full test suite (`cargo test --workspace --all-targets --all-features --locked` and `cargo test --workspace`) and all tests passed, including the new core and tracing tests.
- Validated docs contract with `python3 scripts/validate_docs_contracts.py` and performed feature matrix checks for `tailtriage-tracing` via `cargo check` with `--no-default-features` and the `jsonl`, `live`, and `tokio` features, all succeeding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fbf413ee0833083ea699622dc6863)