### PR TITLE
Validate and sanitize run-relative timing offsets

### DIFF
--- a/tailtriage-core/src/run_builder.rs
+++ b/tailtriage-core/src/run_builder.rs
@@ -380,6 +380,17 @@ fn validate_request_event(event: &RequestEvent) -> Result<(), RunBuilderEventErr
             "must be >= started_at_unix_ms",
         ));
     }
+    if let (Some(started_at_run_us), Some(finished_at_run_us)) =
+        (event.started_at_run_us, event.finished_at_run_us)
+    {
+        if finished_at_run_us < started_at_run_us {
+            return Err(invalid_event(
+                "RequestEvent",
+                "finished_at_run_us",
+                "must be >= started_at_run_us",
+            ));
+        }
+    }
     if event.outcome.trim().is_empty() {
         return Err(invalid_event(
             "RequestEvent",
@@ -407,6 +418,17 @@ fn validate_stage_event(event: &StageEvent) -> Result<(), RunBuilderEventError> 
             "must be >= started_at_unix_ms",
         ));
     }
+    if let (Some(started_at_run_us), Some(finished_at_run_us)) =
+        (event.started_at_run_us, event.finished_at_run_us)
+    {
+        if finished_at_run_us < started_at_run_us {
+            return Err(invalid_event(
+                "StageEvent",
+                "finished_at_run_us",
+                "must be >= started_at_run_us",
+            ));
+        }
+    }
     Ok(())
 }
 fn validate_queue_event(event: &QueueEvent) -> Result<(), RunBuilderEventError> {
@@ -426,6 +448,17 @@ fn validate_queue_event(event: &QueueEvent) -> Result<(), RunBuilderEventError> 
             "waited_until_unix_ms",
             "must be >= waited_from_unix_ms",
         ));
+    }
+    if let (Some(waited_from_run_us), Some(waited_until_run_us)) =
+        (event.waited_from_run_us, event.waited_until_run_us)
+    {
+        if waited_until_run_us < waited_from_run_us {
+            return Err(invalid_event(
+                "QueueEvent",
+                "waited_until_run_us",
+                "must be >= waited_from_run_us",
+            ));
+        }
     }
     Ok(())
 }

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -1716,6 +1716,92 @@ fn run_builder_event_validation_rejects_invalid_shapes() {
 }
 
 #[test]
+fn run_builder_rejects_inverted_request_run_relative_fields() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+    let mut request = test_request_event("req");
+    request.started_at_run_us = Some(200);
+    request.finished_at_run_us = Some(199);
+
+    let err = builder
+        .push_request(request)
+        .expect_err("inverted run-relative request offsets should be rejected");
+    assert_eq!(
+        err,
+        crate::RunBuilderEventError::InvalidEvent {
+            event: "RequestEvent",
+            field: "finished_at_run_us",
+            reason: "must be >= started_at_run_us".to_string(),
+        }
+    );
+}
+
+#[test]
+fn run_builder_rejects_inverted_stage_run_relative_fields() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+    let mut stage = test_stage_event("req", "stage");
+    stage.started_at_run_us = Some(200);
+    stage.finished_at_run_us = Some(199);
+
+    let err = builder
+        .push_stage(stage)
+        .expect_err("inverted run-relative stage offsets should be rejected");
+    assert_eq!(
+        err,
+        crate::RunBuilderEventError::InvalidEvent {
+            event: "StageEvent",
+            field: "finished_at_run_us",
+            reason: "must be >= started_at_run_us".to_string(),
+        }
+    );
+}
+
+#[test]
+fn run_builder_rejects_inverted_queue_run_relative_fields() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+    let mut queue = test_queue_event("req", "queue");
+    queue.waited_from_run_us = Some(200);
+    queue.waited_until_run_us = Some(199);
+
+    let err = builder
+        .push_queue(queue)
+        .expect_err("inverted run-relative queue offsets should be rejected");
+    assert_eq!(
+        err,
+        crate::RunBuilderEventError::InvalidEvent {
+            event: "QueueEvent",
+            field: "waited_until_run_us",
+            reason: "must be >= waited_from_run_us".to_string(),
+        }
+    );
+}
+
+#[test]
+fn run_builder_accepts_incomplete_run_relative_fields() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+
+    let mut request = test_request_event("req");
+    request.started_at_run_us = Some(100);
+    request.finished_at_run_us = None;
+    builder
+        .push_request(request)
+        .expect("one-sided request run-relative offset should be accepted");
+
+    let mut stage = test_stage_event("req", "stage");
+    stage.started_at_run_us = None;
+    stage.finished_at_run_us = Some(200);
+    builder
+        .push_stage(stage)
+        .expect("one-sided stage run-relative offset should be accepted");
+
+    let mut queue = test_queue_event("req", "queue");
+    queue.waited_from_run_us = Some(300);
+    queue.waited_until_run_us = None;
+    builder
+        .push_queue(queue)
+        .expect("one-sided queue run-relative offset should be accepted");
+}
+
+#[test]
 fn run_builder_accepts_authoritative_request_latency_when_timestamps_disagree() {
     let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
 

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -74,6 +74,7 @@ pub fn ensure_persistable_run_has_requests(run: &tailtriage_core::Run) -> Result
     Ok(())
 }
 
+#[cfg(any(feature = "live", feature = "tokio"))]
 pub(crate) fn ensure_persistable_run_with_warnings(
     run: &tailtriage_core::Run,
     warnings: &[ImportWarning],
@@ -185,15 +186,20 @@ where
                     else {
                         continue;
                     };
+                    let (started_at_run_us, finished_at_run_us) = sanitized_run_relative_offsets(
+                        &span,
+                        options.strict_mode(),
+                        &mut warnings,
+                    )?;
                     parsed_requests.push(ParsedRequestEvent {
                         event: RequestEvent {
                             request_id,
                             route,
                             kind: None,
                             started_at_unix_ms: span.started_at_unix_ms(),
-                            started_at_run_us: span.started_at_run_us_ref(),
+                            started_at_run_us,
                             finished_at_unix_ms: span.finished_at_unix_ms(),
-                            finished_at_run_us: span.finished_at_run_us_ref(),
+                            finished_at_run_us,
                             latency_us: elapsed_duration_us(
                                 &span,
                                 options.strict_mode(),
@@ -216,14 +222,19 @@ where
                         OptionalField::Value(success) => success,
                         OptionalField::Invalid => continue,
                     };
+                    let (started_at_run_us, finished_at_run_us) = sanitized_run_relative_offsets(
+                        &span,
+                        options.strict_mode(),
+                        &mut warnings,
+                    )?;
                     parsed_stages.push(ParsedStageEvent {
                         event: StageEvent {
                             request_id,
                             stage,
                             started_at_unix_ms: span.started_at_unix_ms(),
-                            started_at_run_us: span.started_at_run_us_ref(),
+                            started_at_run_us,
                             finished_at_unix_ms: span.finished_at_unix_ms(),
-                            finished_at_run_us: span.finished_at_run_us_ref(),
+                            finished_at_run_us,
                             latency_us: elapsed_duration_us(
                                 &span,
                                 options.strict_mode(),
@@ -246,13 +257,18 @@ where
                             OptionalField::Value(depth) => Some(depth),
                             OptionalField::Invalid => continue,
                         };
+                    let (waited_from_run_us, waited_until_run_us) = sanitized_run_relative_offsets(
+                        &span,
+                        options.strict_mode(),
+                        &mut warnings,
+                    )?;
                     queues.push(QueueEvent {
                         request_id,
                         queue,
                         waited_from_unix_ms: span.started_at_unix_ms(),
-                        waited_from_run_us: span.started_at_run_us_ref(),
+                        waited_from_run_us,
                         waited_until_unix_ms: span.finished_at_unix_ms(),
-                        waited_until_run_us: span.finished_at_run_us_ref(),
+                        waited_until_run_us,
                         wait_us: elapsed_duration_us(&span, options.strict_mode(), &mut warnings)?,
                         depth_at_start,
                     });
@@ -724,6 +740,54 @@ fn timestamp_derived_duration_us(started_at_unix_ms: u64, finished_at_unix_ms: u
         .saturating_mul(1000)
 }
 
+fn sanitized_run_relative_offsets(
+    span: &SpanRecord,
+    strict: bool,
+    warnings: &mut Vec<ImportWarning>,
+) -> Result<(Option<u64>, Option<u64>), ImportError> {
+    match (span.started_at_run_us_ref(), span.finished_at_run_us_ref()) {
+        (Some(start), Some(finish)) if finish >= start => Ok((Some(start), Some(finish))),
+        (Some(start), Some(finish)) => {
+            let message = format!(
+                "span '{}' run-relative timing is inverted: start={} finish={}; dropped run-relative offsets",
+                span.name(),
+                start,
+                finish
+            );
+            if strict {
+                return Err(ImportError::StrictViolation(message));
+            }
+            warnings.push(ImportWarning::new(message));
+            Ok((None, None))
+        }
+        (Some(offset), None) => {
+            let message = format!(
+                "span '{}' incomplete run-relative timing: started_at_run_us={} but finished_at_run_us is missing; dropped run-relative offsets",
+                span.name(),
+                offset
+            );
+            if strict {
+                return Err(ImportError::StrictViolation(message));
+            }
+            warnings.push(ImportWarning::new(message));
+            Ok((None, None))
+        }
+        (None, Some(offset)) => {
+            let message = format!(
+                "span '{}' incomplete run-relative timing: finished_at_run_us={} but started_at_run_us is missing; dropped run-relative offsets",
+                span.name(),
+                offset
+            );
+            if strict {
+                return Err(ImportError::StrictViolation(message));
+            }
+            warnings.push(ImportWarning::new(message));
+            Ok((None, None))
+        }
+        (None, None) => Ok((None, None)),
+    }
+}
+
 fn elapsed_duration_us(
     span: &SpanRecord,
     strict: bool,
@@ -765,6 +829,7 @@ fn is_durable_conversion_warning(message: &str) -> bool {
         || message.starts_with("invalid field")
         || message.starts_with("unknown tt.kind")
         || message.contains("duration_us differs from timestamp-derived duration")
+        || message.contains("run-relative timing")
         || message.contains("missing optional 'tt.outcome'; assumed 'ok'")
         || message.contains("missing optional 'tt.success'; assumed true")
 }
@@ -1024,6 +1089,125 @@ mod tests {
         assert_eq!(run.stages[0].finished_at_run_us, Some(15_010));
         assert_eq!(run.queues[0].waited_from_run_us, Some(2_010));
         assert_eq!(run.queues[0].waited_until_run_us, Some(3_010));
+    }
+
+    #[test]
+    fn non_strict_inverted_request_run_relative_offsets_are_dropped_with_warning() {
+        let spans = vec![SpanRecord::new("req", 100, 120)
+            .started_at_run_us(20_000)
+            .finished_at_run_us(10_000)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].started_at_run_us, None);
+        assert_eq!(imported.run().requests[0].finished_at_run_us, None);
+        assert_eq!(imported.run().requests[0].latency_us, 20_000);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("run-relative timing is inverted")));
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("dropped run-relative offsets")));
+    }
+
+    #[test]
+    fn strict_inverted_request_run_relative_offsets_fail() {
+        let spans = vec![SpanRecord::new("req", 100, 120)
+            .started_at_run_us(20_000)
+            .finished_at_run_us(10_000)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+
+        let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true))
+            .expect_err("strict import should reject inverted run-relative timing");
+        assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(err.to_string().contains("run-relative timing is inverted"));
+    }
+
+    #[test]
+    fn non_strict_incomplete_request_run_relative_offsets_are_dropped_with_warning() {
+        let spans = vec![SpanRecord::new("req", 100, 120)
+            .started_at_run_us(10_000)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].started_at_run_us, None);
+        assert_eq!(imported.run().requests[0].finished_at_run_us, None);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("incomplete run-relative timing")));
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("dropped run-relative offsets")));
+    }
+
+    #[test]
+    fn non_strict_inverted_queue_run_relative_offsets_are_dropped_with_warning() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("q", 102, 103)
+                .started_at_run_us(3_000)
+                .finished_at_run_us(2_000)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+
+        assert_eq!(imported.run().queues.len(), 1);
+        assert_eq!(imported.run().queues[0].waited_from_run_us, None);
+        assert_eq!(imported.run().queues[0].waited_until_run_us, None);
+        assert_eq!(imported.run().queues[0].wait_us, 1_000);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("run-relative timing is inverted")));
+    }
+
+    #[test]
+    fn non_strict_incomplete_queue_run_relative_offsets_are_dropped_with_warning() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("q", 102, 103)
+                .finished_at_run_us(3_000)
+                .field(TT_KIND, "queue")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_QUEUE, "permits"),
+        ];
+
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+
+        assert_eq!(imported.run().queues.len(), 1);
+        assert_eq!(imported.run().queues[0].waited_from_run_us, None);
+        assert_eq!(imported.run().queues[0].waited_until_run_us, None);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("incomplete run-relative timing")));
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("dropped run-relative offsets")));
     }
 
     #[test]

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -604,6 +604,7 @@ impl TracingIntakeSessionBuilder {
 
 impl TracingRecorderBuilder {
     /// Returns selected capture mode for import conversion semantics.
+    #[cfg(feature = "tokio")]
     #[must_use]
     pub(crate) fn selected_mode(&self) -> CaptureMode {
         self.options.mode_value()


### PR DESCRIPTION
### Motivation
- Prevent inverted or incomplete run-relative offsets from entering Run artifacts or misleading analyzer temporal logic while preserving backward compatibility for one-sided offsets.
- Ensure tracing import does not drop whole spans for bad run-relative offsets in non-strict mode but does surface clear warnings and fails in strict mode.

### Description
- Add run-relative validation to `RunBuilder` by requiring `finished_at_run_us >= started_at_run_us` on `RequestEvent` and `StageEvent`, and `waited_until_run_us >= waited_from_run_us` on `QueueEvent`, returning `RunBuilderEventError::InvalidEvent` with the specified event/field/reason when violated.
- Introduce `sanitized_run_relative_offsets(span, strict, warnings)` in `tailtriage-tracing` that returns validated `(Option<u64>, Option<u64>)`, errors with `ImportError::StrictViolation` in strict mode for inverted or incomplete pairs, and in non-strict mode drops run-relative offsets `(None, None)` while pushing `ImportWarning`s with messages containing the required substrings.
- Wire sanitized offsets into conversion points so `RequestEvent`, `StageEvent`, and `QueueEvent` use the sanitized run-relative offsets instead of raw `SpanRecord` refs, while keeping Unix timestamps and duration-authority behavior unchanged.
- Add unit tests in `tailtriage-core` that assert inverted run-relative fields are rejected and that one-sided (incomplete) offsets are accepted for backward compatibility.
- Add unit tests in `tailtriage-tracing` covering non-strict inverted/incomplete offsets (import succeeds, offsets dropped, warnings emitted), strict-mode failures for inverted offsets, and equivalent queue-span coverage; add the helper and mark durable conversion warnings accordingly.
- Minor feature gating to silence dead-code warnings: gate `ensure_persistable_run_with_warnings` and the `selected_mode` helper behind the features that use them.

### Testing
- Ran formatting, lint, build, and full test matrix and all succeeded: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, and `cargo test --workspace` all passed.
- Ran docs contract validation `python3 scripts/validate_docs_contracts.py` which succeeded.
- Performed feature-specific checks for the tracing crate: `cargo check -p tailtriage-tracing --no-default-features --locked`, `--features jsonl`, `--features live`, and `--features tokio` all succeeded.
- New unit tests added in `tailtriage-core` and `tailtriage-tracing` passed as part of the above test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fbf413ee0833083ea699622dc6863)