### PR TITLE
Fix live tracing duplicate request retention

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::fmt::Write as _;
 use std::io::Write;
@@ -837,6 +837,19 @@ fn push_completed_candidate_with_kind_aware_retention(
     let total = state.completed_requests.len()
         + state.completed_stages.len()
         + state.completed_queues.len();
+    let incoming_would_exhaust_raw_cap =
+        total.saturating_add(1) >= limits.max_completed_candidate_spans;
+
+    if kind == "request"
+        && incoming_would_exhaust_raw_cap
+        && (incoming_request_id_is_already_retained(&state.completed_requests, &record)
+            || unique_retained_request_id_count(&state.completed_requests) >= semantic_max_requests)
+    {
+        state.dropped_completed_request_candidates =
+            state.dropped_completed_request_candidates.saturating_add(1);
+        return;
+    }
+
     if total < limits.max_completed_candidate_spans {
         push_record_by_kind(state, record, kind);
         return;
@@ -844,7 +857,8 @@ fn push_completed_candidate_with_kind_aware_retention(
 
     match kind {
         "request" => {
-            if state.completed_requests.len() >= semantic_max_requests {
+            if unique_retained_request_id_count(&state.completed_requests) >= semantic_max_requests
+            {
                 state.dropped_completed_request_candidates =
                     state.dropped_completed_request_candidates.saturating_add(1);
                 return;
@@ -870,6 +884,36 @@ fn push_completed_candidate_with_kind_aware_retention(
                 state.dropped_completed_child_candidates.saturating_add(1);
         }
         _ => {}
+    }
+}
+
+fn unique_retained_request_id_count(completed_requests: &[SpanRecord]) -> usize {
+    completed_requests
+        .iter()
+        .filter_map(valid_request_id_from_record)
+        .collect::<BTreeSet<_>>()
+        .len()
+}
+
+fn incoming_request_id_is_already_retained(
+    completed_requests: &[SpanRecord],
+    incoming: &SpanRecord,
+) -> bool {
+    let Some(incoming_request_id) = valid_request_id_from_record(incoming) else {
+        return false;
+    };
+    completed_requests
+        .iter()
+        .filter_map(valid_request_id_from_record)
+        .any(|retained_request_id| retained_request_id == incoming_request_id)
+}
+
+fn valid_request_id_from_record(record: &SpanRecord) -> Option<&str> {
+    match record.fields().get("tt.request_id") {
+        Some(FieldValue::String(request_id)) if !request_id.trim().is_empty() => {
+            Some(request_id.as_str())
+        }
+        Some(_) | None => None,
     }
 }
 
@@ -1935,6 +1979,114 @@ mod tests {
             warning_text.contains("dropped 1 completed child candidate span")
                 || warning_text.contains("evicted 1 completed child candidate span")
         );
+    }
+
+    #[test]
+    fn raw_cap_duplicate_request_candidate_does_not_crowd_out_later_unique_request_root() {
+        let recorder = TracingRecorder::builder("svc")
+            .capture_limits_override(CaptureLimitsOverride {
+                max_requests: Some(2),
+                max_stages: Some(10),
+                max_queues: Some(10),
+                ..Default::default()
+            })
+            .max_completed_candidate_spans(2)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request-r1-first",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/r1"
+            ));
+            drop(tracing::info_span!(
+                "request-r1-duplicate",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/r1-duplicate"
+            ));
+            drop(tracing::info_span!(
+                "request-r2",
+                tt.kind = "request",
+                tt.request_id = "r2",
+                tt.route = "/r2"
+            ));
+        });
+
+        let imported = recorder.snapshot_run().unwrap();
+        let run = imported.run();
+        let request_ids = run
+            .requests
+            .iter()
+            .map(|request| request.request_id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(request_ids, vec!["r1", "r2"]);
+        assert!(run
+            .requests
+            .iter()
+            .all(|request| request.route != "/r1-duplicate"));
+        assert!(run.truncation.limits_hit);
+        assert_eq!(run.truncation.dropped_requests, 0);
+
+        let warning_text = imported
+            .warnings()
+            .iter()
+            .map(|warning| warning.message().to_string())
+            .collect::<Vec<_>>()
+            .join(" | ");
+        assert!(warning_text.contains("dropped 1 completed request candidate span"));
+        assert!(warning_text.contains("max_completed_candidate_spans=2"));
+    }
+
+    #[test]
+    fn raw_cap_drops_later_unique_request_when_semantic_request_retention_is_exhausted() {
+        let recorder = TracingRecorder::builder("svc")
+            .capture_limits_override(CaptureLimitsOverride {
+                max_requests: Some(1),
+                max_stages: Some(10),
+                max_queues: Some(10),
+                ..Default::default()
+            })
+            .max_completed_candidate_spans(2)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request-r1",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/r1"
+            ));
+            drop(tracing::info_span!(
+                "request-r2",
+                tt.kind = "request",
+                tt.request_id = "r2",
+                tt.route = "/r2"
+            ));
+        });
+
+        let imported = recorder.snapshot_run().unwrap();
+        let run = imported.run();
+        assert_eq!(run.requests.len(), 1);
+        assert_eq!(run.requests[0].request_id, "r1");
+        assert!(run
+            .requests
+            .iter()
+            .all(|request| request.request_id != "r2"));
+        assert!(run.truncation.limits_hit);
+        assert_eq!(run.truncation.dropped_requests, 0);
+
+        let warning_text = imported
+            .warnings()
+            .iter()
+            .map(|warning| warning.message().to_string())
+            .collect::<Vec<_>>()
+            .join(" | ");
+        assert!(warning_text.contains("dropped 1 completed request candidate span"));
+        assert!(warning_text.contains("semantic max_requests retention"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent duplicate completed request candidates with the same `tt.request_id` from crowding out later unique request roots when the live raw completed-candidate buffer is under pressure.

### Description
- Change implemented in `tailtriage-tracing/src/recorder.rs` to make raw-cap request retention semantics aware of unique request IDs instead of using `state.completed_requests.len()` for the semantic request capacity decision.
- Added helpers `valid_request_id_from_record`, `unique_retained_request_id_count`, and `incoming_request_id_is_already_retained` to compute and check unique retained `tt.request_id` values while ignoring malformed/empty IDs.
- Under raw-cap pressure the recorder now: drops duplicate incoming request candidates if their `tt.request_id` is already represented; drops incoming unique requests when the unique retained request count >= `semantic_max_requests`; otherwise preserves a new unique request root by evicting one child candidate if available, matching existing eviction order and counters.
- Added two focused tests in the recorder test module: `raw_cap_duplicate_request_candidate_does_not_crowd_out_later_unique_request_root` and `raw_cap_drops_later_unique_request_when_semantic_request_retention_is_exhausted` to validate the new behavior and warning emission.

### Testing
- Files changed: `tailtriage-tracing/src/recorder.rs`.
- Commands run (all completed locally): `cargo fmt --check`; `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`; `cargo test --workspace --all-targets --all-features --locked`; `python3 scripts/validate_docs_contracts.py`; `cargo test -p tailtriage-tracing raw_cap_ --all-features --locked`.
- Results: all lints and the full test suite passed (no failures); docs contract validation passed; the added recorder tests passed. The new behavior preserves existing warning counters and strict-mode behavior and does not change conversion-time dedupe in `run_from_span_records`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a252f105950833098e8c503b3de2b4c)