### PR TITLE
Fix tracing request candidate retention

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -852,7 +852,13 @@ fn push_completed_candidate_with_kind_aware_retention(
         return;
     }
 
-    if retained_request_id_is_represented(state, &record)
+    let Some(incoming_request_id) = valid_request_id_from_span(&record) else {
+        state.dropped_completed_request_candidates =
+            state.dropped_completed_request_candidates.saturating_add(1);
+        return;
+    };
+
+    if retained_request_id_is_represented(state, incoming_request_id)
         || unique_retained_request_id_count(&state.completed_requests) >= semantic_max_requests
     {
         state.dropped_completed_request_candidates =
@@ -896,11 +902,7 @@ fn unique_retained_request_id_count(records: &[SpanRecord]) -> usize {
         .len()
 }
 
-fn retained_request_id_is_represented(state: &RecorderState, record: &SpanRecord) -> bool {
-    let Some(incoming_request_id) = valid_request_id_from_span(record) else {
-        return false;
-    };
-
+fn retained_request_id_is_represented(state: &RecorderState, incoming_request_id: &str) -> bool {
     state
         .completed_requests
         .iter()
@@ -2236,6 +2238,115 @@ mod tests {
             .warnings()
             .iter()
             .any(|w| w.message().contains("max_completed_candidate_spans")));
+    }
+
+    #[test]
+    fn raw_completed_candidate_cap_evicts_retained_duplicate_for_later_unique_request() {
+        let recorder = TracingRecorder::builder("svc")
+            .max_completed_candidate_spans(3)
+            .capture_limits(CaptureLimits {
+                max_requests: 3,
+                ..CaptureMode::Light.core_defaults()
+            })
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request-1",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            ));
+            drop(tracing::info_span!(
+                "request-1-duplicate",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a-duplicate"
+            ));
+            drop(tracing::info_span!(
+                "request-2",
+                tt.kind = "request",
+                tt.request_id = "r2",
+                tt.route = "/b"
+            ));
+            drop(tracing::info_span!(
+                "request-3",
+                tt.kind = "request",
+                tt.request_id = "r3",
+                tt.route = "/c"
+            ));
+        });
+
+        let imported = recorder.snapshot_run().unwrap();
+        let request_ids = imported
+            .run()
+            .requests
+            .iter()
+            .map(|request| request.request_id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(request_ids, vec!["r1", "r2", "r3"]);
+        assert_eq!(imported.run().requests.len(), 3);
+        assert!(imported
+            .run()
+            .requests
+            .iter()
+            .any(|request| request.request_id == "r3"));
+        assert!(imported.warnings().iter().any(|w| {
+            w.message()
+                .contains("dropped 1 completed request candidate span(s)")
+                && w.message().contains("max_completed_candidate_spans=3")
+        }));
+    }
+
+    #[test]
+    fn strict_mode_errors_when_raw_cap_evicts_retained_duplicate_request() {
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .max_completed_candidate_spans(3)
+            .capture_limits(CaptureLimits {
+                max_requests: 3,
+                ..CaptureMode::Light.core_defaults()
+            })
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request-1",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            ));
+            drop(tracing::info_span!(
+                "request-1-duplicate",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a-duplicate"
+            ));
+            drop(tracing::info_span!(
+                "request-2",
+                tt.kind = "request",
+                tt.request_id = "r2",
+                tt.route = "/b"
+            ));
+            drop(tracing::info_span!(
+                "request-3",
+                tt.kind = "request",
+                tt.request_id = "r3",
+                tt.route = "/c"
+            ));
+        });
+
+        let err = recorder
+            .snapshot_run()
+            .expect_err("strict should reject retained duplicate request eviction");
+        match err {
+            ImportError::StrictViolation(message) => {
+                assert!(message.contains("max_completed_candidate_spans"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
     }
 
     #[test]

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -871,7 +871,11 @@ fn push_completed_candidate_with_kind_aware_retention(
         return;
     }
 
-    if !state.completed_queues.is_empty() {
+    if let Some(index) = retained_duplicate_request_candidate_position(state) {
+        state.completed_requests.remove(index);
+        state.dropped_completed_request_candidates =
+            state.dropped_completed_request_candidates.saturating_add(1);
+    } else if !state.completed_queues.is_empty() {
         state.completed_queues.pop();
         state.evicted_child_candidates_to_preserve_request = state
             .evicted_child_candidates_to_preserve_request
@@ -881,10 +885,6 @@ fn push_completed_candidate_with_kind_aware_retention(
         state.evicted_child_candidates_to_preserve_request = state
             .evicted_child_candidates_to_preserve_request
             .saturating_add(1);
-    } else if let Some(index) = retained_duplicate_request_candidate_position(state) {
-        state.completed_requests.remove(index);
-        state.dropped_completed_request_candidates =
-            state.dropped_completed_request_candidates.saturating_add(1);
     } else {
         state.dropped_completed_request_candidates =
             state.dropped_completed_request_candidates.saturating_add(1);
@@ -2300,12 +2300,12 @@ mod tests {
     }
 
     #[test]
-    fn strict_mode_errors_when_raw_cap_evicts_retained_duplicate_request() {
+    fn raw_completed_candidate_cap_evicts_retained_duplicate_before_useful_child_evidence() {
         let recorder = TracingRecorder::builder("svc")
-            .strict(true)
             .max_completed_candidate_spans(3)
             .capture_limits(CaptureLimits {
                 max_requests: 3,
+                max_stages: 10,
                 ..CaptureMode::Light.core_defaults()
             })
             .build()
@@ -2325,16 +2325,75 @@ mod tests {
                 tt.route = "/a-duplicate"
             ));
             drop(tracing::info_span!(
+                "stage-r1",
+                tt.kind = "stage",
+                tt.request_id = "r1",
+                tt.stage = "db"
+            ));
+            drop(tracing::info_span!(
                 "request-2",
                 tt.kind = "request",
                 tt.request_id = "r2",
                 tt.route = "/b"
             ));
+        });
+
+        let imported = recorder.snapshot_run().unwrap();
+        let run = imported.run();
+        let request_ids = run
+            .requests
+            .iter()
+            .map(|request| request.request_id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(request_ids, vec!["r1", "r2"]);
+        assert_eq!(run.requests.len(), 2);
+        assert_eq!(run.stages.len(), 1);
+        assert_eq!(run.stages[0].request_id, "r1");
+        assert_eq!(run.stages[0].stage, "db");
+        assert!(imported.warnings().iter().any(|w| {
+            w.message()
+                .contains("dropped 1 completed request candidate span(s)")
+                && w.message().contains("max_completed_candidate_spans=3")
+        }));
+    }
+
+    #[test]
+    fn strict_mode_errors_when_raw_cap_evicts_retained_duplicate_request() {
+        let recorder = TracingRecorder::builder("svc")
+            .strict(true)
+            .max_completed_candidate_spans(3)
+            .capture_limits(CaptureLimits {
+                max_requests: 3,
+                max_stages: 10,
+                ..CaptureMode::Light.core_defaults()
+            })
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
             drop(tracing::info_span!(
-                "request-3",
+                "request-1",
                 tt.kind = "request",
-                tt.request_id = "r3",
-                tt.route = "/c"
+                tt.request_id = "r1",
+                tt.route = "/a"
+            ));
+            drop(tracing::info_span!(
+                "request-1-duplicate",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a-duplicate"
+            ));
+            drop(tracing::info_span!(
+                "stage-r1",
+                tt.kind = "stage",
+                tt.request_id = "r1",
+                tt.stage = "db"
+            ));
+            drop(tracing::info_span!(
+                "request-2",
+                tt.kind = "request",
+                tt.request_id = "r2",
+                tt.route = "/b"
             ));
         });
 

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::fmt::Write as _;
 use std::io::Write;
@@ -837,39 +837,100 @@ fn push_completed_candidate_with_kind_aware_retention(
     let total = state.completed_requests.len()
         + state.completed_stages.len()
         + state.completed_queues.len();
-    if total < limits.max_completed_candidate_spans {
-        push_record_by_kind(state, record, kind);
-        return;
-    }
-
-    match kind {
-        "request" => {
-            if state.completed_requests.len() >= semantic_max_requests {
-                state.dropped_completed_request_candidates =
-                    state.dropped_completed_request_candidates.saturating_add(1);
-                return;
-            }
-
-            if !state.completed_queues.is_empty() {
-                state.completed_queues.pop();
-            } else if !state.completed_stages.is_empty() {
-                state.completed_stages.pop();
-            } else {
-                state.dropped_completed_request_candidates =
-                    state.dropped_completed_request_candidates.saturating_add(1);
-                return;
-            }
-
-            state.evicted_child_candidates_to_preserve_request = state
-                .evicted_child_candidates_to_preserve_request
-                .saturating_add(1);
-            state.completed_requests.push(record);
-        }
-        "stage" | "queue" => {
+    if kind != "request" {
+        if total < limits.max_completed_candidate_spans {
+            push_record_by_kind(state, record, kind);
+        } else if matches!(kind, "stage" | "queue") {
             state.dropped_completed_child_candidates =
                 state.dropped_completed_child_candidates.saturating_add(1);
         }
-        _ => {}
+        return;
+    }
+
+    if total + 1 < limits.max_completed_candidate_spans {
+        state.completed_requests.push(record);
+        return;
+    }
+
+    if retained_request_id_is_represented(state, &record)
+        || unique_retained_request_id_count(&state.completed_requests) >= semantic_max_requests
+    {
+        state.dropped_completed_request_candidates =
+            state.dropped_completed_request_candidates.saturating_add(1);
+        return;
+    }
+
+    if total < limits.max_completed_candidate_spans {
+        state.completed_requests.push(record);
+        return;
+    }
+
+    if !state.completed_queues.is_empty() {
+        state.completed_queues.pop();
+        state.evicted_child_candidates_to_preserve_request = state
+            .evicted_child_candidates_to_preserve_request
+            .saturating_add(1);
+    } else if !state.completed_stages.is_empty() {
+        state.completed_stages.pop();
+        state.evicted_child_candidates_to_preserve_request = state
+            .evicted_child_candidates_to_preserve_request
+            .saturating_add(1);
+    } else if let Some(index) = retained_duplicate_request_candidate_position(state) {
+        state.completed_requests.remove(index);
+        state.dropped_completed_request_candidates =
+            state.dropped_completed_request_candidates.saturating_add(1);
+    } else {
+        state.dropped_completed_request_candidates =
+            state.dropped_completed_request_candidates.saturating_add(1);
+        return;
+    }
+
+    state.completed_requests.push(record);
+}
+
+fn unique_retained_request_id_count(records: &[SpanRecord]) -> usize {
+    records
+        .iter()
+        .filter_map(valid_request_id_from_span)
+        .collect::<BTreeSet<_>>()
+        .len()
+}
+
+fn retained_request_id_is_represented(state: &RecorderState, record: &SpanRecord) -> bool {
+    let Some(incoming_request_id) = valid_request_id_from_span(record) else {
+        return false;
+    };
+
+    state
+        .completed_requests
+        .iter()
+        .filter_map(valid_request_id_from_span)
+        .any(|retained_request_id| retained_request_id == incoming_request_id)
+}
+
+fn retained_duplicate_request_candidate_position(state: &RecorderState) -> Option<usize> {
+    for index in (0..state.completed_requests.len()).rev() {
+        let Some(request_id) = valid_request_id_from_span(&state.completed_requests[index]) else {
+            continue;
+        };
+        if state.completed_requests[..index]
+            .iter()
+            .filter_map(valid_request_id_from_span)
+            .any(|retained_request_id| retained_request_id == request_id)
+        {
+            return Some(index);
+        }
+    }
+
+    None
+}
+
+fn valid_request_id_from_span(record: &SpanRecord) -> Option<&str> {
+    match record.fields().get("tt.request_id") {
+        Some(FieldValue::String(request_id)) if !request_id.trim().is_empty() => {
+            Some(request_id.as_str())
+        }
+        _ => None,
     }
 }
 
@@ -2175,6 +2236,90 @@ mod tests {
             .warnings()
             .iter()
             .any(|w| w.message().contains("max_completed_candidate_spans")));
+    }
+
+    #[test]
+    fn raw_completed_candidate_cap_drops_duplicate_request_before_later_unique_request() {
+        let recorder = TracingRecorder::builder("svc")
+            .max_completed_candidate_spans(2)
+            .capture_limits(CaptureLimits {
+                max_requests: 2,
+                ..CaptureMode::Light.core_defaults()
+            })
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request-1",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            ));
+            drop(tracing::info_span!(
+                "request-1-duplicate",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a-duplicate"
+            ));
+            drop(tracing::info_span!(
+                "request-2",
+                tt.kind = "request",
+                tt.request_id = "r2",
+                tt.route = "/b"
+            ));
+        });
+
+        let imported = recorder.snapshot_run().unwrap();
+        let request_ids = imported
+            .run()
+            .requests
+            .iter()
+            .map(|request| request.request_id.as_str())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(request_ids, BTreeSet::from(["r1", "r2"]));
+        assert_eq!(imported.run().requests.len(), 2);
+        assert!(imported.warnings().iter().any(|w| {
+            w.message()
+                .contains("dropped 1 completed request candidate span(s)")
+                && w.message().contains("max_completed_candidate_spans=2")
+        }));
+    }
+
+    #[test]
+    fn raw_completed_candidate_cap_drops_unique_request_when_semantic_request_retention_is_exhausted(
+    ) {
+        let recorder = TracingRecorder::builder("svc")
+            .max_completed_candidate_spans(2)
+            .capture_limits(CaptureLimits {
+                max_requests: 1,
+                ..CaptureMode::Light.core_defaults()
+            })
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request-1",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a"
+            ));
+            drop(tracing::info_span!(
+                "request-2",
+                tt.kind = "request",
+                tt.request_id = "r2",
+                tt.route = "/b"
+            ));
+        });
+
+        let imported = recorder.snapshot_run().unwrap();
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].request_id, "r1");
+        assert!(imported.warnings().iter().any(|w| {
+            w.message()
+                .contains("would not fit semantic max_requests retention")
+        }));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent duplicate request-span candidates from crowding out later unique request roots under the live raw completed-candidate cap before semantic conversion dedupe runs.

### Description
- Change `push_completed_candidate_with_kind_aware_retention(...)` in `tailtriage-tracing/src/recorder.rs` to make semantic request capacity decisions based on the number of unique valid `tt.request_id` values represented in the retained `state.completed_requests` rather than `state.completed_requests.len()`.
- Add helpers `valid_request_id_from_span`, `unique_retained_request_id_count`, `retained_request_id_is_represented`, and `retained_duplicate_request_candidate_position` to extract valid request IDs, count unique retained IDs, detect representation of an incoming ID, and locate duplicated retained request candidates respectively.
- Under raw-cap pressure for `tt.kind == "request"`, drop the incoming candidate when it is a duplicate of an already retained request ID or when the unique retained request count is already `>= semantic_max_requests`; otherwise preserve a new unique request root by evicting a child candidate (queue then stage) or, if no child exists and a duplicate retained request candidate can be removed, drop that duplicate and account for the drop counters; maintain existing child-eviction order and existing warning/stat counters.
- Import `BTreeSet` for unique counting and keep all other retention/warning logic and strict-mode behavior unchanged.
- Add two focused unit tests in `tailtriage-tracing/src/recorder.rs` to cover the duplicate-request vs later-unique-request case and the semantic `max_requests` exhaustion case.

### Testing
- Files changed: `tailtriage-tracing/src/recorder.rs`.
- Commands executed:
  - `cargo test -p tailtriage-tracing raw_completed_candidate_cap --all-targets --all-features --locked`
  - `cargo fmt --check`
  - `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
  - `cargo test --workspace --all-targets --all-features --locked`
  - `python3 scripts/validate_docs_contracts.py`
- Results: the focused `raw_completed_candidate_cap` tests passed and the full workspace test suite passed; `cargo fmt --check`, `cargo clippy` (with `-D warnings`), and `python3 scripts/validate_docs_contracts.py` all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a252f105950833098e8c503b3de2b4c)