### PR TITLE
Fix live tracing request candidate retention

### DIFF
--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::fmt::Write as _;
 use std::io::Write;
@@ -837,6 +837,17 @@ fn push_completed_candidate_with_kind_aware_retention(
     let total = state.completed_requests.len()
         + state.completed_stages.len()
         + state.completed_queues.len();
+    let request_raw_cap_pressure = total.saturating_add(1) >= limits.max_completed_candidate_spans;
+    if kind == "request"
+        && request_raw_cap_pressure
+        && (completed_requests_contains_request_id(state, &record)
+            || unique_completed_request_id_count(state) >= semantic_max_requests)
+    {
+        state.dropped_completed_request_candidates =
+            state.dropped_completed_request_candidates.saturating_add(1);
+        return;
+    }
+
     if total < limits.max_completed_candidate_spans {
         push_record_by_kind(state, record, kind);
         return;
@@ -844,12 +855,6 @@ fn push_completed_candidate_with_kind_aware_retention(
 
     match kind {
         "request" => {
-            if state.completed_requests.len() >= semantic_max_requests {
-                state.dropped_completed_request_candidates =
-                    state.dropped_completed_request_candidates.saturating_add(1);
-                return;
-            }
-
             if !state.completed_queues.is_empty() {
                 state.completed_queues.pop();
             } else if !state.completed_stages.is_empty() {
@@ -870,6 +875,34 @@ fn push_completed_candidate_with_kind_aware_retention(
                 state.dropped_completed_child_candidates.saturating_add(1);
         }
         _ => {}
+    }
+}
+
+fn unique_completed_request_id_count(state: &RecorderState) -> usize {
+    state
+        .completed_requests
+        .iter()
+        .filter_map(valid_request_id)
+        .collect::<BTreeSet<_>>()
+        .len()
+}
+
+fn completed_requests_contains_request_id(state: &RecorderState, record: &SpanRecord) -> bool {
+    let Some(request_id) = valid_request_id(record) else {
+        return false;
+    };
+
+    state
+        .completed_requests
+        .iter()
+        .filter_map(valid_request_id)
+        .any(|retained_request_id| retained_request_id == request_id)
+}
+
+fn valid_request_id(record: &SpanRecord) -> Option<&str> {
+    match record.fields().get("tt.request_id") {
+        Some(FieldValue::String(value)) if !value.trim().is_empty() => Some(value),
+        _ => None,
     }
 }
 
@@ -1935,6 +1968,112 @@ mod tests {
             warning_text.contains("dropped 1 completed child candidate span")
                 || warning_text.contains("evicted 1 completed child candidate span")
         );
+    }
+
+    #[test]
+    fn raw_completed_candidate_retention_drops_duplicate_request_before_later_unique_root() {
+        let recorder = TracingRecorder::builder("svc")
+            .capture_limits_override(CaptureLimitsOverride {
+                max_requests: Some(2),
+                max_stages: Some(10),
+                max_queues: Some(10),
+                ..Default::default()
+            })
+            .max_completed_candidate_spans(2)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/r1"
+            ));
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/r1-duplicate"
+            ));
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r2",
+                tt.route = "/r2"
+            ));
+        });
+
+        let imported = recorder.snapshot_run().unwrap();
+        let run = imported.run();
+        assert_eq!(run.requests.len(), 2);
+        assert_eq!(run.requests[0].request_id, "r1");
+        assert_eq!(run.requests[0].route, "/r1");
+        assert_eq!(run.requests[1].request_id, "r2");
+        assert_eq!(run.requests[1].route, "/r2");
+        assert!(run
+            .requests
+            .iter()
+            .all(|request| request.route != "/r1-duplicate"));
+        assert!(run.truncation.limits_hit);
+
+        let warning_text = imported
+            .warnings()
+            .iter()
+            .map(|w| w.message().to_string())
+            .collect::<Vec<_>>()
+            .join(" | ");
+        assert!(warning_text.contains("dropped 1 completed request candidate span"));
+        assert!(warning_text.contains("max_completed_candidate_spans"));
+    }
+
+    #[test]
+    fn raw_completed_candidate_retention_drops_unique_request_after_semantic_max_requests() {
+        let recorder = TracingRecorder::builder("svc")
+            .capture_limits_override(CaptureLimitsOverride {
+                max_requests: Some(1),
+                max_stages: Some(10),
+                max_queues: Some(10),
+                ..Default::default()
+            })
+            .max_completed_candidate_spans(2)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(recorder.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/r1"
+            ));
+            drop(tracing::info_span!(
+                "request",
+                tt.kind = "request",
+                tt.request_id = "r2",
+                tt.route = "/r2"
+            ));
+        });
+
+        let imported = recorder.snapshot_run().unwrap();
+        let run = imported.run();
+        assert_eq!(run.requests.len(), 1);
+        assert_eq!(run.requests[0].request_id, "r1");
+        assert_eq!(run.requests[0].route, "/r1");
+        assert!(run
+            .requests
+            .iter()
+            .all(|request| request.request_id != "r2"));
+        assert!(run.truncation.limits_hit);
+
+        let warning_text = imported
+            .warnings()
+            .iter()
+            .map(|w| w.message().to_string())
+            .collect::<Vec<_>>()
+            .join(" | ");
+        assert!(warning_text.contains("dropped 1 completed request candidate span"));
+        assert!(warning_text.contains("semantic max_requests retention"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Prevent duplicate request IDs in the live raw completed-candidate buffer from crowding out later unique request roots before semantic conversion dedupe runs.
- Ensure raw-cap enforcement for `tt.kind == "request"` reasons about unique request IDs (valid non-empty `tt.request_id` strings) rather than simply using the vector length of retained request records.

### Description

- Update `push_completed_candidate_with_kind_aware_retention(...)` to detect raw-cap pressure and, for `kind == "request"`, drop incoming candidates early when the incoming `tt.request_id` is already represented or when the unique retained request count >= `semantic_max_requests`.
- Add three helpers: `valid_request_id(...)`, `completed_requests_contains_request_id(...)`, and `unique_completed_request_id_count(...)`, import `BTreeSet`, and keep existing child-eviction order (queues before stages) and counters; do not change conversion-time dedupe in `run_from_span_records`.
- Add two focused unit tests validating (1) duplicate `r1` candidates do not prevent retaining later unique `r2` under a small raw cap, and (2) semantic `max_requests` exhaustion still drops a later unique request and emits the existing warning semantics.

### Testing

- Files changed: `tailtriage-tracing/src/recorder.rs`.
- Exact commands run: `cargo fmt --check`; `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`; `cargo test --workspace --all-targets --all-features --locked`; `python3 scripts/validate_docs_contracts.py`; and targeted runs `cargo test -p tailtriage-tracing raw_completed_candidate_retention --all-features --locked` and full workspace test runs shown in the rollout transcript.
- Results: `cargo fmt --check` passed, `cargo clippy ... -D warnings` passed, `cargo test ...` passed (all tests passed across the workspace including the new focused tests), and `python3 scripts/validate_docs_contracts.py` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a252f105950833098e8c503b3de2b4c)