### PR TITLE
Polish tracing replay safety and validation wording

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ env:
 # - Ubuntu dev/release are the extended legs with split responsibilities.
 # - Ubuntu dev focuses on fast correctness checks, unit/helper tests, docs examples, diagnostics, and one cheap native demo smoke.
 # - Ubuntu release owns runtime/demo validation, tracing parity, collector/runtime-cost smoke, cargo doc, and cargo deny.
-# - Runtime-cost CI is a bounded diagnostic sanity check (not rigorous benchmark gating), and runtime-cost artifacts are validated in-place rather than uploaded.
+# - Runtime-cost CI is a bounded smoke gate with broad tracing/native sanity thresholds. It is not a rigorous benchmark suite and should not be interpreted as stable performance characterization. Runtime-cost artifacts are validated in-place rather than uploaded.
 # - Windows/macOS run Cargo compile/lint/test coverage to catch OS-specific behavior.
 # - The external crates.io consumer smoke step remains intentionally disabled.
 jobs:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -69,7 +69,7 @@ Consumes run artifacts from disk, validates schema/loader rules, invokes `tailtr
 ### `tailtriage-tracing`
 
 A narrow intake bridge for tracing-shaped completed spans and live `tt.*` span recording.
-It converts/imports tracing intake into standard core `Run` artifacts, including stable completed-span JSONL as an intermediate input format (`tailtriage.tracing-span.v1`), does not implement OpenTelemetry/OTLP, and does not change Run schema or analyzer behavior.
+It converts/imports tracing evidence into standard core `Run` artifacts, including stable completed-span JSONL as an intermediate input format (`tailtriage.tracing-span.v1`), does not implement OpenTelemetry/OTLP, and does not introduce a tracing-specific analyzer path.
 
 ## Relationship model
 

--- a/docs/runtime-cost.md
+++ b/docs/runtime-cost.md
@@ -68,7 +68,7 @@ python3 scripts/validate_runtime_cost_summary.py \
   --summary demos/runtime_cost/artifacts/ci-smoke/runtime-cost-summary.json
 ```
 
-This is a bounded diagnostic sanity check only. It enforces tracing/native parity hard checks (p95 <= 1.10x native and throughput >= 0.90x native), a 2% soft warning band (p95 > 1.02x or throughput < 0.98x), and required tracing evidence shape, not rigorous performance benchmarking. CI validates runtime-cost output in-place and does not upload runtime-cost artifacts by default. CI logs print compact runtime-cost tables by default, while full JSON remains in artifacts (`runtime-cost-summary.json`) and can be printed locally with `--print-json`. Full runtime-cost measurement remains a local/developer-run path via the canonical command above. Results remain machine/workload/profile scoped.
+Runtime-cost CI is a bounded smoke gate with broad tracing/native sanity thresholds. It enforces tracing/native parity hard checks (p95 <= 1.10x native and throughput >= 0.90x native), a 2% soft warning band (p95 > 1.02x or throughput < 0.98x), and required tracing evidence shape. It is not a rigorous benchmark suite and should not be interpreted as stable performance characterization. CI validates runtime-cost output in-place and does not upload runtime-cost artifacts by default. CI logs print compact runtime-cost tables by default, while full JSON remains in artifacts (`runtime-cost-summary.json`) and can be printed locally with `--print-json`. Full runtime-cost measurement remains a local/developer-run path via the canonical command above. Results remain machine/workload/profile scoped.
 
 ## Inputs and knobs
 
@@ -99,7 +99,7 @@ Per-mode records now include instrumentation family (`baseline` / `native` / `tr
 
 If `measurement_quality` reports noisy/unstable, CI reports warnings but does not fail solely for that quality classification; rerun on a quieter machine state before drawing stronger conclusions.
 If `measurement_quality` is `insufficient_data` after expected measured rounds, CI fails.
-Numbers are directional and machine/workload/profile scoped; this bounded smoke catches meaningful regressions, not rigorous benchmark conclusions.
+Numbers are directional and machine/workload/profile scoped; this bounded smoke gate catches meaningful regressions, not rigorous benchmark conclusions or stable performance characterization.
 
 ## Semantics reminder
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -97,7 +97,7 @@ If your service already builds a subscriber in startup code, compose `session.la
 - Newer live tracing output includes run-relative monotonic offsets for request, stage, and queue spans when those offsets are available; these offsets improve temporal grouping inside a captured run.
 - Imported JSONL may omit run-relative offsets. When they are absent, the analyzer falls back to Unix-ms wall-clock timestamps for temporal grouping.
 - `duration_us` remains the authoritative elapsed-time evidence when supplied or recorded by live tracing.
-- Completed-span JSONL export preserves `duration_us` because duration fields are authoritative elapsed-time evidence.
+- Completed-span JSONL export includes `duration_us` only when the retained duration is within the import tolerance for the exported Unix-ms bounds; contradictory durations are omitted so strict replay derives elapsed time from the wall-clock bounds instead of failing.
 - Unix-ms timestamps are wall-clock anchors and may be coarser than durations.
 - Ordinary tracing log timestamps are not enough for completed-span import; completed spans need explicit start/end timing and semantic tt.* fields.
 

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -7,7 +7,8 @@
 //! and conversion to [`tailtriage_core::Run`] via [`run_from_span_records`].
 //! The `jsonl` feature adds JSONL import APIs.
 //! The `live` feature adds live in-memory recording APIs.
-//! It does not implement OpenTelemetry/OTLP and does not change analyzer behavior.
+//! It does not implement OpenTelemetry/OTLP. It converts tracing evidence into standard
+//! `tailtriage_core::Run` artifacts and does not introduce a tracing-specific analyzer path.
 //!
 //! # Example
 //!

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -12,8 +12,8 @@ use tracing::{Id, Subscriber};
 use tracing_subscriber::layer::{Context, Layer};
 
 use crate::{
-    ensure_persistable_run_with_warnings, run_from_span_records, FieldValue, ImportError,
-    ImportOptions, ImportedRun, SpanRecord, TT_KIND,
+    duration_within_tolerance, ensure_persistable_run_with_warnings, run_from_span_records,
+    FieldValue, ImportError, ImportOptions, ImportedRun, SpanRecord, TT_KIND,
 };
 
 /// In-memory recorder for completed tracing spans with `tt.*` fields.
@@ -458,7 +458,7 @@ fn retained_span_records_from_run(run: &tailtriage_core::Run) -> Vec<SpanRecord>
         if let Some(finished_at_run_us) = req.finished_at_run_us {
             span = span.finished_at_run_us(finished_at_run_us);
         }
-        span = span.duration_us(req.latency_us);
+        span = span_record_with_replay_safe_duration_us(span, req.latency_us);
         spans.push(span);
     }
     for stage in &run.stages {
@@ -477,7 +477,7 @@ fn retained_span_records_from_run(run: &tailtriage_core::Run) -> Vec<SpanRecord>
         if let Some(finished_at_run_us) = stage.finished_at_run_us {
             span = span.finished_at_run_us(finished_at_run_us);
         }
-        span = span.duration_us(stage.latency_us);
+        span = span_record_with_replay_safe_duration_us(span, stage.latency_us);
         spans.push(span);
     }
     for queue in &run.queues {
@@ -495,7 +495,7 @@ fn retained_span_records_from_run(run: &tailtriage_core::Run) -> Vec<SpanRecord>
         if let Some(waited_until_run_us) = queue.waited_until_run_us {
             span = span.finished_at_run_us(waited_until_run_us);
         }
-        span = span.duration_us(queue.wait_us);
+        span = span_record_with_replay_safe_duration_us(span, queue.wait_us);
         if let Some(depth) = queue.depth_at_start {
             span = span.field("tt.depth_at_start", depth);
         }
@@ -503,6 +503,19 @@ fn retained_span_records_from_run(run: &tailtriage_core::Run) -> Vec<SpanRecord>
     }
     spans
 }
+
+fn span_record_with_replay_safe_duration_us(span: SpanRecord, duration_us: u64) -> SpanRecord {
+    if duration_within_tolerance(
+        duration_us,
+        span.started_at_unix_ms(),
+        span.finished_at_unix_ms(),
+    ) {
+        span.duration_us(duration_us)
+    } else {
+        span
+    }
+}
+
 impl TracingIntakeSessionBuilder {
     /// Enables or disables strict mode for conversion warnings.
     #[must_use]
@@ -4100,7 +4113,7 @@ mod tests {
         assert_eq!(imported.run().queues.len(), 0);
     }
 
-    fn run_with_authoritative_durations_and_run_offsets() -> tailtriage_core::Run {
+    fn run_with_replay_safe_and_contradictory_durations() -> tailtriage_core::Run {
         let mut run = empty_run();
         run.requests.push(tailtriage_core::RequestEvent {
             request_id: "r1".into(),
@@ -4119,8 +4132,8 @@ mod tests {
             started_at_unix_ms: 100,
             started_at_run_us: Some(2_000),
             finished_at_unix_ms: 101,
-            finished_at_run_us: Some(72_000),
-            latency_us: 70_000,
+            finished_at_run_us: Some(4_999),
+            latency_us: 2_999,
             success: true,
         });
         run.queues.push(tailtriage_core::QueueEvent {
@@ -4129,16 +4142,16 @@ mod tests {
             waited_from_unix_ms: 100,
             waited_from_run_us: Some(3_000),
             waited_until_unix_ms: 101,
-            waited_until_run_us: Some(33_000),
-            wait_us: 30_000,
+            waited_until_run_us: Some(4_000),
+            wait_us: 1_000,
             depth_at_start: None,
         });
         run
     }
 
     #[test]
-    fn retained_request_stage_queue_preserve_authoritative_durations_and_run_offsets() {
-        let run = run_with_authoritative_durations_and_run_offsets();
+    fn retained_request_stage_queue_omit_contradictory_duration_us_for_replay_safety() {
+        let run = run_with_replay_safe_and_contradictory_durations();
         let spans = retained_span_records_from_run(&run);
         assert_eq!(spans.len(), 3);
 
@@ -4148,7 +4161,7 @@ mod tests {
                 span.fields().get("tt.kind") == Some(&FieldValue::String("request".into()))
             })
             .expect("request span");
-        assert_eq!(request.duration_us_ref(), Some(50_000));
+        assert_eq!(request.duration_us_ref(), None);
         assert_eq!(request.started_at_run_us_ref(), Some(1_000));
         assert_eq!(request.finished_at_run_us_ref(), Some(51_000));
 
@@ -4156,41 +4169,49 @@ mod tests {
             .iter()
             .find(|span| span.fields().get("tt.kind") == Some(&FieldValue::String("stage".into())))
             .expect("stage span");
-        assert_eq!(stage.duration_us_ref(), Some(70_000));
+        assert_eq!(stage.duration_us_ref(), Some(2_999));
         assert_eq!(stage.started_at_run_us_ref(), Some(2_000));
-        assert_eq!(stage.finished_at_run_us_ref(), Some(72_000));
+        assert_eq!(stage.finished_at_run_us_ref(), Some(4_999));
 
         let queue = spans
             .iter()
             .find(|span| span.fields().get("tt.kind") == Some(&FieldValue::String("queue".into())))
             .expect("queue span");
-        assert_eq!(queue.duration_us_ref(), Some(30_000));
+        assert_eq!(queue.duration_us_ref(), Some(1_000));
         assert_eq!(queue.started_at_run_us_ref(), Some(3_000));
-        assert_eq!(queue.finished_at_run_us_ref(), Some(33_000));
+        assert_eq!(queue.finished_at_run_us_ref(), Some(4_000));
     }
 
     #[test]
-    fn completed_span_jsonl_round_trip_preserves_authoritative_durations_and_run_offsets() {
+    fn completed_span_jsonl_round_trip_succeeds_in_strict_mode_with_safe_durations() {
         let dir = tempfile::tempdir().unwrap();
         let spans_path = dir.path().join("spans.jsonl");
-        let run = run_with_authoritative_durations_and_run_offsets();
+        let run = run_with_replay_safe_and_contradictory_durations();
         write_completed_span_jsonl_from_run(&run, &spans_path).unwrap();
+
+        let lines = std::fs::read_to_string(&spans_path).unwrap();
+        let exported = lines
+            .lines()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+            .collect::<Vec<_>>();
+        assert!(exported[0]["span"].get("duration_us").is_none());
+        assert_eq!(exported[1]["span"]["duration_us"], 2_999);
 
         let replay = crate::jsonl::import_jsonl_path_with_mode(
             &spans_path,
-            ImportOptions::new("svc"),
+            ImportOptions::new("svc").strict(true),
             crate::jsonl::JsonlParseMode::TailtriageWrapperOnly,
         )
         .unwrap();
-        assert_eq!(replay.run().requests[0].latency_us, 50_000);
+        assert_eq!(replay.run().requests[0].latency_us, 1_000);
         assert_eq!(replay.run().requests[0].started_at_run_us, Some(1_000));
         assert_eq!(replay.run().requests[0].finished_at_run_us, Some(51_000));
-        assert_eq!(replay.run().stages[0].latency_us, 70_000);
+        assert_eq!(replay.run().stages[0].latency_us, 2_999);
         assert_eq!(replay.run().stages[0].started_at_run_us, Some(2_000));
-        assert_eq!(replay.run().stages[0].finished_at_run_us, Some(72_000));
-        assert_eq!(replay.run().queues[0].wait_us, 30_000);
+        assert_eq!(replay.run().stages[0].finished_at_run_us, Some(4_999));
+        assert_eq!(replay.run().queues[0].wait_us, 1_000);
         assert_eq!(replay.run().queues[0].waited_from_run_us, Some(3_000));
-        assert_eq!(replay.run().queues[0].waited_until_run_us, Some(33_000));
+        assert_eq!(replay.run().queues[0].waited_until_run_us, Some(4_000));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Make crate-level and public docs wording truthful about how tracing intake fits into the existing `tailtriage` workflow without implying a separate analyzer path. 
- Ensure the completed-span JSONL export is actually replay-safe for strict import by avoiding exported `duration_us` values that contradict the exported Unix-ms start/finish bounds beyond the shared tolerance. 
- Clarify runtime-cost CI wording so it accurately describes the existing behavior as a bounded smoke gate with broad sanity thresholds, not a rigorous benchmark suite.

### Description
- Update crate-level rustdoc in `tailtriage-tracing/src/lib.rs` to: "It converts tracing evidence into standard `tailtriage_core::Run` artifacts and does not introduce a tracing-specific analyzer path." 
- Add `span_record_with_replay_safe_duration_us(...)` in `tailtriage-tracing/src/recorder.rs` and use it when exporting retained span records so `duration_us` is attached only when `duration_within_tolerance(...)` returns true (reusing the existing tolerance logic). 
- Adjust unit tests in `tailtriage-tracing/src/recorder.rs` to cover the replay-safety contract: a contradictory retained duration is omitted from exported JSONL while within-tolerance durations are preserved, and the exported JSONL round-trips in strict import mode. 
- Update public docs and CI wording in `docs/architecture.md`, `tailtriage-tracing/README.md`, `docs/runtime-cost.md`, and `.github/workflows/ci.yml` to reflect the corrected crate claim and to describe runtime-cost CI as a "bounded smoke gate with broad tracing/native sanity thresholds" and not a rigorous benchmark suite.

### Testing
- Ran `cargo fmt --check` which succeeded. 
- Ran `cargo test -p tailtriage-tracing --all-features --locked` and `cargo test --workspace`, and all tests passed (`tailtriage-tracing` unit/integration tests included the new replay-safety assertions). 
- Ran `python3 scripts/validate_docs_contracts.py` which passed. 
- Ran `cargo clippy --workspace --all-targets -- -D warnings` which completed without warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25508718408330a3e6c6c8451a9a1d)