### PR TITLE
Make request_id validation explicit; add warnings and strict artifact validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Offline import expects completed tailtriage `tt.*` tracing span JSONL (not arbit
 
 Both paths convert tracing-shaped evidence into standard `tailtriage_core::Run` data and feed the same analyzer/report workflow (evidence-ranked suspects and next checks). Runtime-pressure evidence still requires runtime snapshots (for example via the Tokio sampler).
 
+`request_id` is the per-run identity of one completed logical request or work item. It must be unique among completed requests in one Run, and stage/queue evidence must reuse that ID only for the same logical request. If an external trace or correlation ID can repeat across retries, fanout branches, batch items, or attempts, convert it into a unique tailtriage request ID first, for example by adding attempt/span/branch information. `tailtriage` warns about duplicate completed IDs because request-scoped attribution can become ambiguous, but users remain responsible for meaningful request boundaries and propagation semantics.
+
 ## Why not just tokio-console or tokio-metrics?
 
 Those tools are complementary building blocks. `tailtriage` fills a different gap: it turns request lifecycle timing plus optional runtime signals into a focused triage loop:
@@ -236,6 +238,7 @@ if let Some(finalized_run) = sink.take_run() {
 
 ```bash
 tailtriage analyze tailtriage-run.json --format json
+tailtriage analyze tailtriage-run.json --strict-artifact
 ```
 
 Import completed tailtriage tracing span JSONL into a Run artifact first when needed:

--- a/SPEC.md
+++ b/SPEC.md
@@ -187,6 +187,8 @@ tailtriage analyze <run.json>
 
 Run artifacts include request, stage, queue, in-flight, and optional runtime snapshot data plus metadata/truncation context.
 
+`request_id` is the per-run identity of one completed logical request/work item. Completed request events in one `Run` must have unique `request_id` values, and stage/queue events must use a completed request's ID only for evidence from that same logical request. External trace/correlation IDs that can repeat across retries, fanout branches, batch items, or attempts must be converted into unique tailtriage request IDs, such as by appending attempt/span/branch information. `tailtriage` can warn or strictly reject mechanically ambiguous IDs, but users remain responsible for meaningful instrumentation boundaries and propagation semantics.
+
 Direct capture lifecycle output options:
 
 - default direct capture writes a local run artifact JSON through `LocalJsonSink`

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -158,7 +158,7 @@ Prefer moderate intervals and bounded runs before increasing density.
 
 ## Operating with tracing-based runs
 
-Tracing intake works best when request correlation is already reliable. Every request, stage, and queue span for one work item must carry the same `tt.request_id`; missing or inconsistent `tt.request_id` causes child stage/queue evidence to be skipped or weakened. Native capture is the recommended first path when correlation is not already available.
+Tracing intake works best when request correlation is already reliable. `tt.request_id` must be the unique tailtriage per-run ID for one completed logical request/work item, not necessarily a raw distributed trace ID. Every request, stage, and queue span for one work item must carry that same `tt.request_id`; missing, inconsistent, or duplicate completed IDs can make request-scoped attribution ambiguous. Convert external trace/correlation IDs that can repeat across retries, fanout branches, batch items, or attempts into unique tailtriage IDs, for example by adding attempt/span/branch information. Native capture is the recommended first path when correlation is not already available.
 
 Tracing import expects completed tailtriage `tt.*` tracing span JSONL, not ordinary tracing log JSON (`fmt().json` output is a common non-supported example). Import writes Run JSON (not Report JSON), and analysis is a separate step after import (`tailtriage analyze`). Completed-span JSONL is not a production trace archive and does not preserve warning/truncation context; prefer Run JSON when the artifact itself must carry that context. Persisted Run JSON intended for `tailtriage analyze` must include at least one completed request event; in-process library snapshots may still be zero-request for inspection. Timing is not guessed from line receive time, so completed spans must include explicit unix-ms start/end timestamps. OTel/OTLP intake remains out of scope on this path.
 
@@ -172,7 +172,7 @@ Important limits for production interpretation:
 
 `TracingTokioSession` uses the same core capture-limit model as native Tokio sampling for runtime snapshot retention. For `TracingTokioSession`, run metadata time bounds cover both retained tracing evidence and retained runtime snapshots. There is no tracing-specific `max_runtime_snapshots(...)` builder method; configure explicit caps with `capture_limits_override(CaptureLimitsOverride { max_runtime_snapshots: Some(...), ..Default::default() })`. Tracing-only runs still do not fabricate runtime snapshots. `TracingTokioSession` starts background sampling by default, but deterministic/manual runtime-sensitive workflows can call `disable_background_sampler()` and inject snapshots via `record_runtime_snapshot(...)`; runtime-sensitive tracing contract parity requires non-empty runtime snapshots, scenario-specific runtime field evidence, and the explicit disabled-background-sampler lifecycle warning (not ambient sampler metadata/noise). These are repeatable triage leads, not root-cause proof.
 
-Treat tracing-based reports the same way as other reports: evidence-ranked suspects and next checks are triage leads, not proof.
+Treat tracing-based reports the same way as other reports: evidence-ranked suspects and next checks are triage leads, not proof. Use `tailtriage analyze --strict-artifact` in operational validation when duplicate completed request IDs or orphan stage/queue IDs should fail the run instead of only appearing as warnings.
 
 ## Artifact sizing and retention expectations
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -36,7 +36,7 @@ The `controller` and `tokio` namespaces are available with default features; `ax
 
 Use `tailtriage-tracing` when your service already uses Rust `tracing` and already has stable per-request correlation IDs. New integrations without existing tracing/correlation should start with native `tailtriage` capture first.
 
-This path converts tracing-shaped request, stage, and queue evidence into standard Run artifacts for the normal `tailtriage analyze` workflow. It is not a tracing backend. For one work item, every request, stage, and queue span must carry the same `tt.request_id`; child stage/queue evidence is correlated to retained request evidence by `tt.request_id`.
+This path converts tracing-shaped request, stage, and queue evidence into standard Run artifacts for the normal `tailtriage analyze` workflow. It is not a tracing backend. `tt.request_id` is the tailtriage per-run request ID: it identifies one completed logical request/work item and must be unique among completed requests in that Run. For one work item, every request, stage, and queue span must carry the same `tt.request_id`; child stage/queue evidence is correlated to retained request evidence by `tt.request_id`. If a trace/correlation ID can repeat across retries, fanout branches, batch items, or attempts, derive a unique tailtriage ID first, such as `trace_id:span_id` or `trace_id:attempt`.
 
 Install for typed records plus JSONL import APIs (default feature set):
 
@@ -66,6 +66,7 @@ tailtriage analyze tailtriage-run.json
 
 - `--strict` fails malformed or incomplete `tt.*` spans.
 - Non-strict mode skips malformed `tt.*` spans and prints `warning: ...` messages.
+- `tailtriage analyze --strict-artifact` fails duplicate completed request IDs and orphan stage/queue IDs; default analysis remains permissive and reports warnings.
 
 #### Retention limits
 
@@ -130,7 +131,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-Stage and queue spans use their own `tt.stage` / `tt.queue` fields around the awaited work they measure. Every request, stage, and queue span for one work item must carry the same `tt.request_id`; missing or inconsistent IDs cause child stage/queue evidence to be skipped or weakened.
+Stage and queue spans use their own `tt.stage` / `tt.queue` fields around the awaited work they measure. Every request, stage, and queue span for one work item must carry the same unique tailtriage `tt.request_id`; missing, inconsistent, or duplicate completed IDs cause child stage/queue evidence to be skipped, weakened, or warned as ambiguous. Users still own the semantic request boundary, retry model, fanout model, and propagation correctness.
 
 `tt.outcome` on request spans is optional: missing values default to `ok` with a warning; recommended common labels are `ok`, `error`, `timeout`, `cancelled`, and `rejected`; custom non-empty labels are preserved exactly.
 

--- a/tailtriage-analyzer/README.md
+++ b/tailtriage-analyzer/README.md
@@ -4,6 +4,12 @@
 
 Use this crate when you already have a completed `tailtriage_core::Run` in memory (or an equivalent stable snapshot) and want a typed triage report, text rendering, and canonical Report JSON rendering in your Rust process.
 
+## Request ID validation
+
+The analyzer assumes each completed logical request/work item in one `Run` has one unique `request_id`, and all queue/stage evidence for that request reuses the same ID. Duplicate completed IDs or orphan stage/queue IDs make request-scoped attribution ambiguous for evidence-ranked suspects and next checks.
+
+Default analysis is permissive and emits report warnings plus evidence-quality limitations. Use `AnalyzeOptions::default().strict_artifact(true)` when those mechanical artifact problems should fail analysis. This checks ID consistency only; users still own meaningful request-boundary, retry, fanout, and propagation semantics.
+
 ## What this crate does
 
 - analyzes one completed run/snapshot in batch

--- a/tailtriage-analyzer/src/lib.rs
+++ b/tailtriage-analyzer/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use serde::{Serialize, Serializer};
 
@@ -15,8 +15,8 @@ mod temporal;
 pub use evidence::{EvidenceQuality, EvidenceQualityLevel, SignalCoverageStatus};
 pub use options::{
     analyze_option_descriptors, AnalyzeConfigError, AnalyzeOptionDescriptor, AnalyzeOptions,
-    BlockingOptions, ConfidenceOptions, DownstreamOptions, EvidenceOptions, ExecutorOptions,
-    QueueingOptions, RouteOptions, TemporalOptions,
+    ArtifactOptions, BlockingOptions, ConfidenceOptions, DownstreamOptions, EvidenceOptions,
+    ExecutorOptions, QueueingOptions, RouteOptions, TemporalOptions,
 };
 use tailtriage_core::{InFlightSnapshot, Run, RuntimeSnapshot};
 
@@ -323,9 +323,12 @@ pub fn analyze_run(run: &Run, options: AnalyzeOptions) -> Report {
 ///
 /// # Errors
 ///
-/// Returns an error when options fail semantic validation.
+/// Returns an error when options fail semantic validation or strict artifact validation rejects the run.
 pub fn try_analyze_run(run: &Run, options: AnalyzeOptions) -> Result<Report, AnalyzeConfigError> {
     options.validate()?;
+    if options.artifact.strict {
+        validate_artifact_strict(run)?;
+    }
     Ok(Analyzer::new(options).analyze_run(run))
 }
 
@@ -434,8 +437,23 @@ impl Analyzer {
     }
 
     /// Analyzes one completed [`Run`] (or stable snapshot equivalent) and returns a triage report.
+    ///
+    /// # Panics
+    ///
+    /// Panics when configured options fail semantic validation, or when strict
+    /// artifact validation is enabled and the run contains duplicate completed
+    /// request IDs or orphan stage/queue IDs. Use [`try_analyze_run`] to handle
+    /// those failures as errors.
     #[must_use]
     pub fn analyze_run(&self, run: &Run) -> Report {
+        if let Err(err) = self.options.validate() {
+            panic!("invalid AnalyzeOptions passed to Analyzer::analyze_run: {err}");
+        }
+        if self.options.artifact.strict {
+            if let Err(err) = validate_artifact_strict(run) {
+                panic!("invalid artifact passed to Analyzer::analyze_run: {err}");
+            }
+        }
         analyze_run_with_options(run, &self.options)
     }
 }
@@ -516,7 +534,12 @@ fn analyze_run_internal(run: &Run, options: &AnalyzeOptions) -> Report {
     suspects.sort_by_key(|suspect| std::cmp::Reverse(suspect.score));
 
     let warnings = analysis_warnings(run, &suspects, options);
-    let evidence_quality = evidence::evidence_quality(run, options);
+    let mut evidence_quality = evidence::evidence_quality(run, options);
+    for warning in artifact_validation_warnings(run) {
+        if !evidence_quality.limitations.contains(&warning) {
+            evidence_quality.limitations.push(warning);
+        }
+    }
 
     for suspect in &mut suspects {
         suspect.confidence = Confidence::from_score_with_options(suspect.score, options);
@@ -556,6 +579,88 @@ fn analyze_run_internal(run: &Run, options: &AnalyzeOptions) -> Report {
     }
 }
 
+fn validate_artifact_strict(run: &Run) -> Result<(), AnalyzeConfigError> {
+    let warnings = artifact_validation_warnings(run);
+    if warnings.is_empty() {
+        Ok(())
+    } else {
+        Err(AnalyzeConfigError::ArtifactValidation {
+            message: warnings.join("; "),
+        })
+    }
+}
+
+fn artifact_validation_warnings(run: &Run) -> Vec<String> {
+    let mut warnings = Vec::new();
+    if let Some(warning) = duplicate_completed_request_id_warning(run) {
+        warnings.push(warning);
+    }
+    warnings.extend(orphan_request_id_warnings(run));
+    warnings
+}
+
+fn duplicate_completed_request_id_warning(run: &Run) -> Option<String> {
+    let mut seen = BTreeSet::<&str>::new();
+    let mut duplicates = BTreeSet::<&str>::new();
+    for request in &run.requests {
+        if !seen.insert(request.request_id.as_str()) {
+            duplicates.insert(request.request_id.as_str());
+        }
+    }
+    if duplicates.is_empty() {
+        return None;
+    }
+
+    let sample = duplicates
+        .iter()
+        .take(5)
+        .copied()
+        .collect::<Vec<_>>()
+        .join(", ");
+    Some(format!(
+        "Duplicate completed request_id value(s) in this Run ({sample}); request-scoped attribution may be ambiguous for queue attribution, route breakdowns, temporal segmentation, and downstream-stage matching. tailtriage request_id must be unique per completed logical request/work item within one Run."
+    ))
+}
+
+fn orphan_request_id_warnings(run: &Run) -> Vec<String> {
+    let completed = run
+        .requests
+        .iter()
+        .map(|request| request.request_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut orphan_stage_ids = BTreeSet::<&str>::new();
+    for stage in &run.stages {
+        if !completed.contains(stage.request_id.as_str()) {
+            orphan_stage_ids.insert(stage.request_id.as_str());
+        }
+    }
+    let mut orphan_queue_ids = BTreeSet::<&str>::new();
+    for queue in &run.queues {
+        if !completed.contains(queue.request_id.as_str()) {
+            orphan_queue_ids.insert(queue.request_id.as_str());
+        }
+    }
+
+    let mut warnings = Vec::new();
+    if !orphan_stage_ids.is_empty() {
+        warnings.push(format!(
+            "Stage events reference request_id value(s) with no matching completed request in this Run ({}); downstream-stage attribution may be incomplete.",
+            sample_request_ids(&orphan_stage_ids)
+        ));
+    }
+    if !orphan_queue_ids.is_empty() {
+        warnings.push(format!(
+            "Queue events reference request_id value(s) with no matching completed request in this Run ({}); queue attribution may be incomplete.",
+            sample_request_ids(&orphan_queue_ids)
+        ));
+    }
+    warnings
+}
+
+fn sample_request_ids(ids: &BTreeSet<&str>) -> String {
+    ids.iter().take(5).copied().collect::<Vec<_>>().join(", ")
+}
+
 fn ambiguity_warning(suspects: &[Suspect], options: &AnalyzeOptions) -> Option<String> {
     let mut ranked = suspects
         .iter()
@@ -575,6 +680,7 @@ fn ambiguity_warning(suspects: &[Suspect], options: &AnalyzeOptions) -> Option<S
 
 fn analysis_warnings(run: &Run, suspects: &[Suspect], options: &AnalyzeOptions) -> Vec<String> {
     let mut warnings = evidence::truncation_warnings(run);
+    warnings.extend(artifact_validation_warnings(run));
     if run.requests.len() < options.evidence.low_completed_request_threshold {
         warnings.push(
             "Low completed-request count; diagnosis ranking may be unstable for this run window."

--- a/tailtriage-analyzer/src/options/descriptors.rs
+++ b/tailtriage-analyzer/src/options/descriptors.rs
@@ -6,7 +6,8 @@ pub fn analyze_option_descriptors() -> &'static [AnalyzeOptionDescriptor] {
     &DESCRIPTORS
 }
 
-const DESCRIPTORS: [AnalyzeOptionDescriptor; 29] = [
+const DESCRIPTORS: [AnalyzeOptionDescriptor; 30] = [
+    AnalyzeOptionDescriptor::new("artifact.strict", "false", "bool", "artifact validation", "Fail analysis when request-scoped artifact evidence is ambiguous or orphaned instead of emitting warnings.", None, None),
     AnalyzeOptionDescriptor::new("queueing.trigger_permille", "300", "u64", "queue suspect trigger", "Minimum p95 queue share (permille) required before queue saturation becomes a ranked suspect.", Some("makes queue-saturation suspects harder to trigger"), Some("makes queue-saturation suspects easier to trigger")),
     AnalyzeOptionDescriptor::new("blocking.min_nonzero_samples_for_signal", "2", "usize", "blocking signal eligibility", "Minimum non-zero blocking queue samples required before considering blocking pressure evidence.", Some("requires more samples before blocking signal can appear"), Some("requires fewer samples before blocking signal can appear")),
     AnalyzeOptionDescriptor::new("blocking.strong_p95_threshold", "12", "u64", "blocking suspect strength", "Blocking queue-depth p95 threshold used for strong blocking-pressure evidence.", Some("requires stronger p95 pressure"), Some("accepts weaker p95 pressure")),

--- a/tailtriage-analyzer/src/options/mod.rs
+++ b/tailtriage-analyzer/src/options/mod.rs
@@ -41,6 +41,16 @@ pub struct AnalyzeOptions {
     pub route: RouteOptions,
     /// Temporal-shift thresholds for optional early/late triage segment summaries.
     pub temporal: TemporalOptions,
+    /// Artifact-shape validation controls for analyzer inputs.
+    pub artifact: ArtifactOptions,
+}
+
+/// Artifact-shape validation options.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Default)]
+pub struct ArtifactOptions {
+    /// Fail analysis on ambiguous request-scoped artifact evidence instead of emitting warnings.
+    pub strict: bool,
 }
 
 /// Queue-saturation suspect thresholds.
@@ -247,6 +257,16 @@ fn push_non_default_override(
         path: path.to_string(),
         value,
     });
+}
+
+fn artifact_non_default_overrides(
+    out: &mut Vec<AnalyzeConfigOverrideSummary>,
+    options: &AnalyzeOptions,
+    defaults: &AnalyzeOptions,
+) {
+    if options.artifact.strict != defaults.artifact.strict {
+        push_non_default_override(out, "artifact.strict", options.artifact.strict.to_string());
+    }
 }
 
 fn queueing_non_default_overrides(
@@ -561,6 +581,7 @@ impl AnalyzeOptions {
     pub fn non_default_overrides(&self) -> Vec<AnalyzeConfigOverrideSummary> {
         let defaults = Self::default();
         let mut out = Vec::new();
+        artifact_non_default_overrides(&mut out, self, &defaults);
         queueing_non_default_overrides(&mut out, self, &defaults);
         blocking_non_default_overrides(&mut out, self, &defaults);
         executor_non_default_overrides(&mut out, self, &defaults);
@@ -571,6 +592,16 @@ impl AnalyzeOptions {
         temporal_non_default_overrides(&mut out, self, &defaults);
         out.sort_by(|a, b| a.path.cmp(&b.path));
         out
+    }
+    /// Enables or disables strict artifact validation.
+    ///
+    /// Strict validation fails analysis for duplicate completed request IDs and
+    /// stage/queue events whose `request_id` does not match a completed request.
+    /// Default analysis is permissive and emits warnings instead.
+    #[must_use]
+    pub const fn strict_artifact(mut self, strict: bool) -> Self {
+        self.artifact.strict = strict;
+        self
     }
     /// Applies queueing-option edits and returns updated options for fluent setup.
     #[must_use]
@@ -784,6 +815,11 @@ pub enum AnalyzeConfigError {
         /// TOML parsing or decoding error details.
         message: String,
     },
+    /// Strict artifact validation rejected request-scoped evidence.
+    ArtifactValidation {
+        /// Validation failure detail.
+        message: String,
+    },
 }
 impl Display for AnalyzeConfigError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -814,6 +850,9 @@ impl Display for AnalyzeConfigError {
                 "unsupported schema_version {found}; supported {supported}"
             ),
             Self::InvalidToml { message } => write!(f, "invalid toml: {message}"),
+            Self::ArtifactValidation { message } => {
+                write!(f, "strict artifact validation failed: {message}")
+            }
         }
     }
 }

--- a/tailtriage-analyzer/src/options/overrides.rs
+++ b/tailtriage-analyzer/src/options/overrides.rs
@@ -2,7 +2,8 @@
 use super::analyze_option_descriptors;
 use super::{AnalyzeConfigError, AnalyzeOptions};
 
-const VALID_OVERRIDE_PATHS: [&str; 29] = [
+const VALID_OVERRIDE_PATHS: [&str; 30] = [
+    "artifact.strict",
     "queueing.trigger_permille",
     "blocking.min_nonzero_samples_for_signal",
     "blocking.strong_p95_threshold",
@@ -88,6 +89,7 @@ fn apply_override_path(
     value: &str,
 ) -> Result<(), AnalyzeConfigError> {
     match path {
+        "artifact.strict" => options.artifact.strict = parse_bool(path, value)?,
         "queueing.trigger_permille" => options.queueing.trigger_permille = parse_u64(path, value)?,
         "blocking.min_nonzero_samples_for_signal" => {
             options.blocking.min_nonzero_samples_for_signal = parse_usize(path, value)?;
@@ -287,6 +289,7 @@ mod tests {
     fn every_valid_path_can_be_applied() {
         let mut opts = AnalyzeOptions::default();
         for (path, value) in [
+            ("artifact.strict", "true"),
             ("queueing.trigger_permille", "250"),
             ("blocking.min_nonzero_samples_for_signal", "3"),
             ("blocking.strong_p95_threshold", "15"),

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -10,9 +10,9 @@ use super::temporal::{
 };
 use crate::{
     analyze_run, analyze_run_internal, analyze_run_json_pretty, evidence, render_json,
-    render_json_pretty, render_text, AnalyzeConfigError, AnalyzeOptions, Confidence, DiagnosisKind,
-    EvidenceQuality, EvidenceQualityLevel, InflightTrend, Report, SignalCoverageStatus, Suspect,
-    ROUTE_DIVERGENCE_WARNING, ROUTE_RUNTIME_ATTRIBUTION_WARNING,
+    render_json_pretty, render_text, try_analyze_run, AnalyzeConfigError, AnalyzeOptions,
+    Confidence, DiagnosisKind, EvidenceQuality, EvidenceQualityLevel, InflightTrend, Report,
+    SignalCoverageStatus, Suspect, ROUTE_DIVERGENCE_WARNING, ROUTE_RUNTIME_ATTRIBUTION_WARNING,
 };
 
 fn test_run() -> Run {
@@ -93,6 +93,102 @@ fn sample_request(id: u64) -> RequestEvent {
         latency_us: 1_000,
         outcome: "ok".into(),
     }
+}
+
+fn duplicate_request_id_warning_present(report: &Report) -> bool {
+    report
+        .warnings
+        .iter()
+        .any(|warning| warning.contains("Duplicate completed request_id"))
+}
+
+#[test]
+fn duplicate_completed_request_ids_emit_warning_and_do_not_panic() {
+    let mut run = test_run();
+    run.requests[1].request_id = "req-1".to_owned();
+    run.stages = vec![StageEvent {
+        request_id: "req-1".to_owned(),
+        stage: "db".to_owned(),
+        started_at_unix_ms: 1,
+        started_at_run_us: None,
+        finished_at_unix_ms: 2,
+        finished_at_run_us: None,
+        latency_us: 900,
+        success: true,
+    }];
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert!(duplicate_request_id_warning_present(&report));
+    assert!(report
+        .evidence_quality
+        .limitations
+        .iter()
+        .any(|limitation| limitation.contains("Duplicate completed request_id")));
+    assert_eq!(
+        report.primary_suspect.kind,
+        DiagnosisKind::InsufficientEvidence
+    );
+}
+
+#[test]
+fn unique_completed_request_ids_emit_no_duplicate_id_warning() {
+    let report = analyze_run(&test_run(), AnalyzeOptions::default());
+
+    assert!(!duplicate_request_id_warning_present(&report));
+}
+
+#[test]
+fn strict_artifact_validation_fails_duplicate_completed_request_ids() {
+    let mut run = test_run();
+    run.requests[2].request_id = "req-1".to_owned();
+
+    let err = try_analyze_run(&run, AnalyzeOptions::default().strict_artifact(true))
+        .expect_err("strict artifact validation should fail duplicates");
+
+    assert!(matches!(err, AnalyzeConfigError::ArtifactValidation { .. }));
+    assert!(err.to_string().contains("Duplicate completed request_id"));
+}
+
+#[test]
+fn strict_artifact_validation_fails_orphan_stage_and_queue_ids() {
+    let mut run = test_run();
+    run.stages = vec![StageEvent {
+        request_id: "missing-stage-parent".to_owned(),
+        stage: "db".to_owned(),
+        started_at_unix_ms: 1,
+        started_at_run_us: None,
+        finished_at_unix_ms: 2,
+        finished_at_run_us: None,
+        latency_us: 900,
+        success: true,
+    }];
+    run.queues = vec![QueueEvent {
+        request_id: "missing-queue-parent".to_owned(),
+        queue: "permits".to_owned(),
+        waited_from_unix_ms: 1,
+        waited_from_run_us: None,
+        waited_until_unix_ms: 2,
+        waited_until_run_us: None,
+        wait_us: 800,
+        depth_at_start: Some(2),
+    }];
+
+    let permissive = analyze_run(&run, AnalyzeOptions::default());
+    assert!(permissive
+        .warnings
+        .iter()
+        .any(|warning| warning.contains("Stage events reference request_id")));
+    assert!(permissive
+        .warnings
+        .iter()
+        .any(|warning| warning.contains("Queue events reference request_id")));
+
+    let err = try_analyze_run(&run, AnalyzeOptions::default().strict_artifact(true))
+        .expect_err("strict artifact validation should fail orphan evidence");
+    let message = err.to_string();
+    assert!(message.contains("Stage events reference request_id"));
+    assert!(message.contains("Queue events reference request_id"));
 }
 
 #[test]
@@ -2489,6 +2585,7 @@ fn compact_and_pretty_report_json_are_value_equivalent() {
 #[test]
 fn analyze_options_defaults_match_v1_surface() {
     let options = AnalyzeOptions::default();
+    assert!(!options.artifact.strict);
     assert_eq!(options.queueing.trigger_permille, 300);
     assert_eq!(options.blocking.min_nonzero_samples_for_signal, 2);
     assert_eq!(options.blocking.strong_p95_threshold, 12);
@@ -2689,6 +2786,7 @@ fn descriptors_have_unique_and_exact_v1_paths() {
         .collect::<std::collections::BTreeSet<_>>();
     assert_eq!(paths.len(), descriptors.len());
     let expected = [
+        "artifact.strict",
         "queueing.trigger_permille",
         "blocking.min_nonzero_samples_for_signal",
         "blocking.strong_p95_threshold",
@@ -2729,6 +2827,7 @@ fn descriptors_have_unique_and_exact_v1_paths() {
 fn descriptor_defaults_match_analyze_options_defaults() {
     let opts = AnalyzeOptions::default();
     let expected = std::collections::BTreeMap::from([
+        ("artifact.strict", opts.artifact.strict.to_string()),
         (
             "queueing.trigger_permille",
             opts.queueing.trigger_permille.to_string(),

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -42,6 +42,14 @@ Machine-readable JSON output:
 tailtriage analyze tailtriage-run.json --format json
 ```
 
+Strict artifact validation for request-scoped ID consistency:
+
+```bash
+tailtriage analyze tailtriage-run.json --strict-artifact
+```
+
+Default analysis is permissive: duplicate completed request IDs or stage/queue IDs without a matching completed request produce report warnings. `--strict-artifact` fails those mechanical artifact problems. A tailtriage `request_id` identifies one completed logical request/work item inside one Run and must be unique among completed requests; broad trace/correlation IDs that can repeat across retries, fanout branches, batch items, or attempts should be converted into unique tailtriage IDs first.
+
 Import completed tailtriage `tt.*` tracing span JSONL into Run JSON:
 
 ```bash

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -40,6 +40,9 @@ enum Command {
         /// Analyzer override in `path=value` form; may be repeated.
         #[arg(long = "analyzer-set", value_name = "PATH=VALUE")]
         analyzer_set: Vec<String>,
+        /// Fail if request-scoped artifact evidence is ambiguous or orphaned.
+        #[arg(long)]
+        strict_artifact: bool,
         /// Print analyzer option help and exit successfully.
         #[arg(long)]
         help_analyzer_options: bool,
@@ -151,6 +154,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             format,
             analyzer_config,
             analyzer_set,
+            strict_artifact,
             help_analyzer_options,
         } => {
             if help_analyzer_options {
@@ -168,7 +172,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             for warning in &loaded.warnings {
                 eprintln!("warning: {warning}");
             }
-            let options = build_analyze_options(analyzer_config.as_deref(), &analyzer_set)?;
+            let options = build_analyze_options(analyzer_config.as_deref(), &analyzer_set)?
+                .strict_artifact(strict_artifact);
             let report = try_analyze_run(&loaded.run, options)?;
 
             match format {

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -31,6 +31,41 @@ fn cli_json_output_is_valid_report_json() {
 }
 
 #[test]
+fn cli_strict_artifact_rejects_duplicate_completed_request_ids() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let artifact_path = dir.path().join("duplicate-ids.json");
+    std::fs::write(&artifact_path, duplicate_request_id_artifact()).expect("fixture should write");
+
+    let permissive = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("analyze")
+        .arg(&artifact_path)
+        .arg("--format")
+        .arg("json")
+        .output()
+        .expect("cli should run");
+    let report = parse_report_json(permissive);
+    assert!(report["warnings"]
+        .as_array()
+        .expect("warnings should be array")
+        .iter()
+        .any(|warning| warning
+            .as_str()
+            .is_some_and(|warning| warning.contains("Duplicate completed request_id"))));
+
+    let strict = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("analyze")
+        .arg(&artifact_path)
+        .arg("--strict-artifact")
+        .output()
+        .expect("cli should run");
+
+    assert!(!strict.status.success(), "strict cli should fail");
+    let stderr = String::from_utf8_lossy(&strict.stderr);
+    assert!(stderr.contains("strict artifact validation failed"));
+    assert!(stderr.contains("Duplicate completed request_id"));
+}
+
+#[test]
 fn cli_loader_rejects_empty_requests_but_analyzer_accepts_zero_request_run() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let artifact_path = dir.path().join("empty-requests.json");
@@ -1336,6 +1371,10 @@ fn import_tracing_spans_jsonl_valid_outcomes_import_successfully() {
         outcomes,
         vec!["ok", "error", "timeout", "cancelled", "rejected"]
     );
+}
+
+fn duplicate_request_id_artifact() -> &'static str {
+    r#"{"schema_version":1,"metadata":{"run_id":"r1","service_name":"svc","service_version":null,"started_at_unix_ms":1,"finished_at_unix_ms":3,"mode":"light","host":null,"pid":null,"lifecycle_warnings":[],"unfinished_requests":{"count":0,"sample":[]}},"requests":[{"request_id":"req1","route":"/","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":10,"outcome":"ok"},{"request_id":"req1","route":"/","kind":null,"started_at_unix_ms":2,"finished_at_unix_ms":3,"latency_us":11,"outcome":"ok"}],"stages":[],"queues":[],"inflight":[],"runtime_snapshots":[]}"#
 }
 
 fn valid_cli_artifact_with_requests() -> &'static str {

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -138,6 +138,12 @@ req.queue("ingress")
 # }
 ```
 
+## Request ID contract
+
+A tailtriage `request_id` is the per-run identity of one completed logical request/work item. It must be unique among completed requests in one `Run`. Queue and stage events must reuse that ID only for evidence from that same logical request.
+
+If an external trace/correlation ID can repeat across retries, fanout branches, batch items, or attempts, convert it into a unique tailtriage request ID first, for example by adding attempt/span/branch information. Native core still completes duplicate explicit IDs independently by using an internal pending key, but it records a best-effort metadata warning because request-scoped attribution can become ambiguous. Auto-generated IDs are unique for normal capture. Users remain responsible for meaningful instrumentation boundaries and propagation semantics.
+
 ## Lifecycle contract
 
 - `queue(...)`, `stage(...)`, and `inflight(...)` do **not** finish requests.

--- a/tailtriage-core/src/collector.rs
+++ b/tailtriage-core/src/collector.rs
@@ -98,6 +98,7 @@ struct PendingRequest {
     request_id: String,
     route: String,
     kind: Option<String>,
+    explicit_request_id: bool,
     interval_start: IntervalStart,
 }
 
@@ -573,7 +574,7 @@ impl Tailtriage {
         }
     }
 
-    fn record_request_event(&self, event: RequestEvent) {
+    fn record_request_event(&self, event: RequestEvent, explicit_request_id: bool) {
         if self.truncation_state.requests.is_saturated() {
             self.truncation_state.requests.increment_drop();
             self.notify_limits_hit_transition();
@@ -583,6 +584,9 @@ impl Tailtriage {
         let mut notify_limits_hit = false;
         {
             let mut run = lock_run(&self.run);
+            if explicit_request_id {
+                warn_on_duplicate_explicit_request_id(&mut run, &event.request_id);
+            }
             if crate::retention::push_request_bounded(&mut run, self.limits, event) {
                 self.truncation_state.requests.mark_saturated();
                 notify_limits_hit = true;
@@ -612,6 +616,7 @@ impl Tailtriage {
         route: String,
         options: RequestOptions,
     ) -> (String, String, Option<String>, u64, IntervalStart) {
+        let explicit_request_id = options.request_id.is_some();
         let request_id = options
             .request_id
             .unwrap_or_else(|| generate_request_id(&route));
@@ -622,6 +627,7 @@ impl Tailtriage {
             request_id: request_id.clone(),
             route: route.clone(),
             kind: kind.clone(),
+            explicit_request_id,
             interval_start,
         };
         lock_pending(&self.pending_requests).insert(pending_key, pending);
@@ -736,10 +742,11 @@ impl RequestCompletion<'_> {
         };
         self.finished = true;
 
-        self.tailtriage
-            .record_request_event(request_event_from_finished_interval(
-                pending, finished, outcome,
-            ));
+        let explicit_request_id = pending.explicit_request_id;
+        self.tailtriage.record_request_event(
+            request_event_from_finished_interval(pending, finished, outcome),
+            explicit_request_id,
+        );
     }
 }
 
@@ -845,10 +852,33 @@ impl OwnedRequestCompletion {
         };
         self.finished = true;
 
-        self.tailtriage
-            .record_request_event(request_event_from_finished_interval(
-                pending, finished, outcome,
-            ));
+        let explicit_request_id = pending.explicit_request_id;
+        self.tailtriage.record_request_event(
+            request_event_from_finished_interval(pending, finished, outcome),
+            explicit_request_id,
+        );
+    }
+}
+
+fn warn_on_duplicate_explicit_request_id(run: &mut Run, request_id: &str) {
+    if !run
+        .requests
+        .iter()
+        .any(|request| request.request_id == request_id)
+    {
+        return;
+    }
+
+    let warning = format!(
+        "duplicate explicit request_id '{request_id}' completed in this run; request-scoped attribution may be ambiguous. tailtriage request_id values must be unique per completed logical request/work item within one Run"
+    );
+    if !run
+        .metadata
+        .lifecycle_warnings
+        .iter()
+        .any(|existing| existing == &warning)
+    {
+        run.metadata.lifecycle_warnings.push(warning);
     }
 }
 

--- a/tailtriage-core/src/config.rs
+++ b/tailtriage-core/src/config.rs
@@ -374,7 +374,12 @@ impl TailtriageBuilder {
 /// completion semantics: each request must still be finished exactly once.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct RequestOptions {
-    /// Optional caller-provided request ID used for request correlation.
+    /// Optional caller-provided tailtriage request ID.
+    ///
+    /// This identifies one completed logical request/work item within one Run
+    /// and must be unique among completed requests. If an external trace or
+    /// correlation ID can repeat across retries, fanout branches, batch items,
+    /// or attempts, include attempt/span/branch information before using it here.
     pub request_id: Option<String>,
     /// Optional semantic request kind (for example `http` or `job`).
     pub kind: Option<String>,
@@ -387,7 +392,11 @@ impl RequestOptions {
         Self::default()
     }
 
-    /// Sets an explicit request ID for the next request context.
+    /// Sets an explicit tailtriage request ID for the next request context.
+    ///
+    /// The value must identify one completed logical request/work item within
+    /// one Run. Duplicate explicit IDs are completed independently but surfaced
+    /// as metadata warnings because attribution may be ambiguous.
     #[must_use]
     pub fn request_id(mut self, request_id: impl Into<String>) -> Self {
         self.request_id = Some(request_id.into());

--- a/tailtriage-core/src/events.rs
+++ b/tailtriage-core/src/events.rs
@@ -224,12 +224,20 @@ pub struct UnfinishedRequestSample {
 
 /// Per-request timing and status.
 ///
+/// `request_id` is the per-run identity of one completed logical request/work
+/// item and must be unique among completed requests in one [`Run`]. Stage and
+/// queue events must reuse that ID only for evidence from the same logical
+/// request. External trace/correlation IDs that can repeat across retries,
+/// fanout branches, batch items, or attempts should be converted into a unique
+/// tailtriage request ID before capture. Users remain responsible for meaningful
+/// request-boundary and propagation semantics.
+///
 /// Duration fields are authoritative for elapsed-time analysis; Unix-ms
 /// timestamps are wall-clock anchors for correlation, readability, and coarse
 /// grouping, and may be coarse or move with system clock changes.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RequestEvent {
-    /// Correlation ID for the request.
+    /// Tailtriage per-run request ID for one completed logical request/work item.
     pub request_id: String,
     /// Route name, operation, or endpoint.
     pub route: String,
@@ -258,7 +266,7 @@ pub struct RequestEvent {
 /// grouping, and may be coarse or move with system clock changes.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StageEvent {
-    /// Parent request ID.
+    /// Tailtriage request ID of the completed logical request/work item this stage belongs to.
     pub request_id: String,
     /// Stage identifier.
     pub stage: String,
@@ -286,7 +294,7 @@ pub struct StageEvent {
 /// grouping, and may be coarse or move with system clock changes.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct QueueEvent {
-    /// Parent request ID.
+    /// Tailtriage request ID of the completed logical request/work item this queue wait belongs to.
     pub request_id: String,
     /// Queue identifier.
     pub queue: String,

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -999,6 +999,54 @@ fn request_handle_supports_fractured_code_usage() {
 }
 
 #[test]
+fn duplicate_explicit_request_ids_complete_independently_and_warn() {
+    let tailtriage = build_for_test("payments", "tailtriage-core-duplicate-explicit.json");
+
+    let first = tailtriage.begin_request_with(
+        "/retry",
+        RequestOptions::new().request_id("external-trace-attempt"),
+    );
+    let second = tailtriage.begin_request_with(
+        "/retry",
+        RequestOptions::new().request_id("external-trace-attempt"),
+    );
+    first.completion.finish_ok();
+    second.completion.finish(Outcome::Error);
+
+    let snapshot = tailtriage.snapshot();
+    assert_eq!(snapshot.requests.len(), 2);
+    assert_eq!(snapshot.requests[0].request_id, "external-trace-attempt");
+    assert_eq!(snapshot.requests[1].request_id, "external-trace-attempt");
+    assert_eq!(snapshot.requests[0].outcome, "ok");
+    assert_eq!(snapshot.requests[1].outcome, "error");
+    assert!(snapshot
+        .metadata
+        .lifecycle_warnings
+        .iter()
+        .any(|warning| warning.contains("duplicate explicit request_id")));
+}
+
+#[test]
+fn auto_generated_request_ids_remain_unique_and_warning_free() {
+    let tailtriage = build_for_test("payments", "tailtriage-core-auto-ids.json");
+
+    tailtriage.begin_request("/auto").completion.finish_ok();
+    tailtriage.begin_request("/auto").completion.finish_ok();
+
+    let snapshot = tailtriage.snapshot();
+    assert_eq!(snapshot.requests.len(), 2);
+    assert_ne!(
+        snapshot.requests[0].request_id,
+        snapshot.requests[1].request_id
+    );
+    assert!(!snapshot
+        .metadata
+        .lifecycle_warnings
+        .iter()
+        .any(|warning| warning.contains("duplicate explicit request_id")));
+}
+
+#[test]
 fn shutdown_warns_with_unfinished_requests() {
     let tailtriage = build_for_test("payments", "tailtriage-core-unfinished.json");
     let started = tailtriage.begin_request("/unfinished");

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -20,6 +20,12 @@ This crate converts tracing-shaped request, stage, and queue evidence into stand
 
 For one work item, every request, stage, and queue span must carry the same `tt.request_id`. Child stage/queue evidence is correlated to retained request evidence by `tt.request_id`; missing or inconsistent IDs cause child evidence to be skipped or weakened.
 
+## Request ID contract for `tt.request_id`
+
+`tt.request_id` must be the tailtriage per-run ID for one completed logical request/work item. It must be unique among completed request spans in the imported or live Run, and stage/queue spans must reuse that ID only for the same logical request.
+
+Do not pass a broad distributed trace/correlation ID directly if it can repeat across retries, fanout branches, batch items, or attempts. Derive a unique tailtriage ID first, for example `trace_id:span_id`, `trace_id:attempt`, or `trace_id:branch`. Tracing import treats duplicate completed `tt.request_id` as bad input: strict mode fails, while non-strict mode warns and skips according to the import policy. `tailtriage` cannot infer whether your chosen boundary is semantically correct; it can only triage evidence you correlate consistently.
+
 ## Feature flags
 
 - Base crate: typed `SpanRecord`, `ImportOptions`, `ImportedRun`, semantic constants, and `run_from_span_records(...)`.


### PR DESCRIPTION
### Motivation

- Make the analyzer/core/tracing contracts and public docs explicit that a tailtriage `request_id` is the per-run identity of one completed logical request/work item and must be unique among completed requests in a Run.  This addresses ambiguous attribution caused by duplicate completed IDs.\
- Surface mechanical problems (duplicate completed IDs, orphan stage/queue IDs) consistently as analyzer warnings and evidence-quality limitations by default, and provide an opt-in strict validation path for operational validation.\
- Preserve backward-compatible core behavior: native core continues to allow duplicate explicit IDs to complete independently (internal pending key prevents corruption) while emitting best-effort metadata warnings.\

### Description

- Docs and rustdoc: clarified the `request_id` contract and guidance across user-facing docs and crate READMEs (updated `README.md`, `docs/user-guide.md`, `docs/operations.md`, `SPEC.md`, `tailtriage-core/README.md`, `tailtriage-analyzer/README.md`, `tailtriage-tracing/README.md`, and in-code rustdoc in `tailtriage-core` event/config types).\
- Analyzer changes: added artifact-shape validation and warnings in `tailtriage-analyzer` that detect duplicate completed `RequestEvent.request_id` and orphan `StageEvent`/`QueueEvent` request IDs; those warnings are appended to `Report.warnings` and `EvidenceQuality.limitations`. Implemented `AnalyzeOptions::artifact.strict` (exposed as `AnalyzeOptions::strict_artifact(...)` convenience) and `AnalyzeConfigError::ArtifactValidation` to make strict validation fail the analysis. The `try_analyze_run` path performs strict validation; `analyze_run`/`Analyzer::analyze_run` will panic when strict validation fails (documented via rustdoc).\
- CLI wiring: added `--strict-artifact` to `tailtriage analyze` and wired it into analyzer options so `tailtriage analyze --strict-artifact` fails on duplicate completed IDs or orphaned stage/queue IDs while default CLI behavior remains permissive and emits warnings.\
- Core collector behavior: preserved existing lifecycle/pending-key semantics while adding best-effort metadata warnings when duplicate explicit request IDs complete; implemented `explicit_request_id` tracking in `PendingRequest`, `warn_on_duplicate_explicit_request_id` at request record time, and tests verifying duplicate explicit IDs still complete independently but produce lifecycle warnings and auto-generated IDs remain unique and warning-free.\
- Tracing intake: clarified `tt.request_id` guidance in tracing docs and examples and kept existing strict/non-strict import semantics (strict import already failed duplicates; docs aligned to preserve that distinction).\
- Tests: added focused unit tests across crates: analyzer tests for permissive duplicate warnings and strict failures (`duplicate_completed_request_ids_emit_warning_and_do_not_panic`, `strict_artifact_validation_fails_duplicate_completed_request_ids`, `strict_artifact_validation_fails_orphan_stage_and_queue_ids`), core tests for duplicate explicit-ID completion and auto-generated ID uniqueness, and CLI test to assert `--strict-artifact` rejects artifacts with duplicate completed request IDs. Also updated analyzer options descriptors/tests to include the new `artifact.strict` option.\
- Key modified files (high level): `tailtriage-analyzer/src/lib.rs`, `tailtriage-analyzer/src/options/*`, `tailtriage-analyzer/src/tests.rs`, `tailtriage-core/src/collector.rs`, `tailtriage-core/src/config.rs`, `tailtriage-core/src/events.rs`, `tailtriage-core/src/tests.rs`, `tailtriage-cli/src/main.rs`, CLI tests and multiple README/docs files noted above. No new external dependencies were added.

### Testing

- Ran formatting check with `cargo fmt --check` and it passed.\
- Ran lints with `cargo clippy --workspace --all-targets -- -D warnings` and fixed issues; the workspace now passes clippy with `-D warnings`.\
- Ran the full test suite with `cargo test --workspace` and all tests passed (including the newly added analyzer/core/CLI tests).\
- Ran documentation contract validation `python3 scripts/validate_docs_contracts.py` and it passed.\

Notes and limitations: tailtriage now surfaces mechanical `request_id` ambiguity more consistently and offers strict validation when operators want the artifact to fail on such problems, but it still cannot and will not infer whether a user-chosen request boundary, retry model, fanout model, or propagation scheme is semantically correct; users remain responsible for meaningful instrumentation and request-boundary semantics. The analyzer outputs evidence-ranked suspects and next checks as triage leads, not root-cause proof.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25e3090ae883309adfc25cc23320bc)