### PR TITLE
Fix tracing JSONL replay duration semantics

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -99,8 +99,7 @@ If your service already builds a subscriber in startup code, compose `session.la
 - Newer live tracing output includes run-relative monotonic offsets for request, stage, and queue spans when those offsets are available; these offsets improve temporal grouping inside a captured run.
 - Imported JSONL may omit run-relative offsets. When they are absent, the analyzer falls back to Unix-ms wall-clock timestamps for temporal grouping.
 - `duration_us` remains the authoritative elapsed-time evidence when supplied or recorded by live tracing.
-- Completed-span JSONL export preserves `duration_us` when it is replay-safe: the duration matches either complete run-relative monotonic offsets or exported Unix-ms bounds within import tolerance.
-- When neither timing source matches, export omits `duration_us`; replay then derives elapsed time from the best available timing evidence.
+- Completed-span JSONL export preserves `duration_us` when it is replay-safe under import precedence: complete run-relative monotonic offsets are used when present; otherwise exported Unix-ms bounds are used. When the selected timing source does not match the retained duration, export omits `duration_us`; replay then derives elapsed time from the best available timing evidence.
 - Unix-ms timestamps are wall-clock anchors and may be coarser than durations.
 - Ordinary tracing log timestamps are not enough for completed-span import; completed spans need explicit start/end timing and semantic tt.* fields.
 
@@ -196,7 +195,7 @@ span.record("tt.outcome", "timeout");
 
 - Strict mode: malformed/incomplete `tt.*` span records fail import/session conversion.
 - Non-strict mode: malformed/incomplete records are warned and skipped where implemented.
-- Duration consistency rule: `duration_us` remains authoritative elapsed-time evidence when supplied. If complete run-relative monotonic offsets are present, strict conversion requires `duration_us` to match `finished_at_run_us - started_at_run_us` within `2_000` microseconds. If complete run-relative offsets are absent, strict conversion checks `duration_us` against `(finished_at_unix_ms - started_at_unix_ms) * 1000`. Non-strict conversion warns on mismatches but keeps `duration_us`. When `duration_us` is absent, conversion derives elapsed time from complete run-relative offsets first, then falls back to Unix-ms wall-clock bounds.
+- Duration consistency rule: complete run-relative offsets are preferred when present; Unix-ms bounds are the fallback when complete run-relative offsets are absent. `duration_us` remains authoritative elapsed-time evidence when supplied and consistent with the selected timing source. If complete run-relative monotonic offsets are present, strict conversion requires `duration_us` to match `finished_at_run_us - started_at_run_us` within `2_000` microseconds. If complete run-relative offsets are absent, strict conversion checks `duration_us` against `(finished_at_unix_ms - started_at_unix_ms) * 1000`. Non-strict conversion warns on mismatches but keeps the supplied `duration_us`. When `duration_us` is absent, conversion derives elapsed time from complete run-relative offsets first, then falls back to Unix-ms wall-clock bounds.
 - Child stage/queue containment uses a fixed `2` ms tolerance when checking whether child intervals fall inside retained request intervals.
 - That `2` ms containment tolerance is not configurable in this release (no CLI/API knob).
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -99,7 +99,8 @@ If your service already builds a subscriber in startup code, compose `session.la
 - Newer live tracing output includes run-relative monotonic offsets for request, stage, and queue spans when those offsets are available; these offsets improve temporal grouping inside a captured run.
 - Imported JSONL may omit run-relative offsets. When they are absent, the analyzer falls back to Unix-ms wall-clock timestamps for temporal grouping.
 - `duration_us` remains the authoritative elapsed-time evidence when supplied or recorded by live tracing.
-- Completed-span JSONL export includes `duration_us` only when the retained duration is within the import tolerance for the exported Unix-ms bounds; contradictory durations are omitted so strict replay can derive elapsed time from the wall-clock bounds instead of failing.
+- Completed-span JSONL export preserves `duration_us` when it is replay-safe: the duration matches either complete run-relative monotonic offsets or exported Unix-ms bounds within import tolerance.
+- When neither timing source matches, export omits `duration_us`; replay then derives elapsed time from the best available timing evidence.
 - Unix-ms timestamps are wall-clock anchors and may be coarser than durations.
 - Ordinary tracing log timestamps are not enough for completed-span import; completed spans need explicit start/end timing and semantic tt.* fields.
 
@@ -195,7 +196,7 @@ span.record("tt.outcome", "timeout");
 
 - Strict mode: malformed/incomplete `tt.*` span records fail import/session conversion.
 - Non-strict mode: malformed/incomplete records are warned and skipped where implemented.
-- Duration consistency rule: conversion derives duration from wall-clock bounds as `(finished_at_unix_ms - started_at_unix_ms) * 1000` only when `duration_us` is absent. If supplied `duration_us` differs from the timestamp-derived duration by more than `2_000` microseconds, strict conversion fails; non-strict conversion warns, keeps `duration_us` as authoritative elapsed-time evidence, and treats Unix timestamps as wall-clock anchors.
+- Duration consistency rule: `duration_us` remains authoritative elapsed-time evidence when supplied. If complete run-relative monotonic offsets are present, strict conversion requires `duration_us` to match `finished_at_run_us - started_at_run_us` within `2_000` microseconds. If complete run-relative offsets are absent, strict conversion checks `duration_us` against `(finished_at_unix_ms - started_at_unix_ms) * 1000`. Non-strict conversion warns on mismatches but keeps `duration_us`. When `duration_us` is absent, conversion derives elapsed time from complete run-relative offsets first, then falls back to Unix-ms wall-clock bounds.
 - Child stage/queue containment uses a fixed `2` ms tolerance when checking whether child intervals fall inside retained request intervals.
 - That `2` ms containment tolerance is not configurable in this release (no CLI/API knob).
 

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -205,6 +205,8 @@ where
                             finished_at_run_us,
                             latency_us: elapsed_duration_us(
                                 &span,
+                                started_at_run_us,
+                                finished_at_run_us,
                                 options.strict_mode(),
                                 &mut warnings,
                             )?,
@@ -240,6 +242,8 @@ where
                             finished_at_run_us,
                             latency_us: elapsed_duration_us(
                                 &span,
+                                started_at_run_us,
+                                finished_at_run_us,
                                 options.strict_mode(),
                                 &mut warnings,
                             )?,
@@ -272,7 +276,13 @@ where
                         waited_from_run_us,
                         waited_until_unix_ms: span.finished_at_unix_ms(),
                         waited_until_run_us,
-                        wait_us: elapsed_duration_us(&span, options.strict_mode(), &mut warnings)?,
+                        wait_us: elapsed_duration_us(
+                            &span,
+                            waited_from_run_us,
+                            waited_until_run_us,
+                            options.strict_mode(),
+                            &mut warnings,
+                        )?,
                         depth_at_start,
                     });
                 }
@@ -728,13 +738,17 @@ fn required_string(
 pub(crate) const TRACE_TIME_TOLERANCE_US: u64 = 2_000;
 pub(crate) const TRACE_TIME_TOLERANCE_MS: u64 = TRACE_TIME_TOLERANCE_US / 1_000;
 
+pub(crate) fn duration_within_derived_tolerance(duration_us: u64, derived_us: u64) -> bool {
+    duration_us.abs_diff(derived_us) <= TRACE_TIME_TOLERANCE_US
+}
+
 pub(crate) fn duration_within_tolerance(
     duration_us: u64,
     started_at_unix_ms: u64,
     finished_at_unix_ms: u64,
 ) -> bool {
     let derived_us = timestamp_derived_duration_us(started_at_unix_ms, finished_at_unix_ms);
-    duration_us.abs_diff(derived_us) <= TRACE_TIME_TOLERANCE_US
+    duration_within_derived_tolerance(duration_us, derived_us)
 }
 
 fn timestamp_derived_duration_us(started_at_unix_ms: u64, finished_at_unix_ms: u64) -> u64 {
@@ -795,36 +809,67 @@ fn sanitized_run_relative_offsets(
     }
 }
 
+fn run_relative_derived_duration_us(
+    started_at_run_us: Option<u64>,
+    finished_at_run_us: Option<u64>,
+) -> Option<u64> {
+    Some(finished_at_run_us?.saturating_sub(started_at_run_us?))
+}
+
 fn elapsed_duration_us(
     span: &SpanRecord,
+    started_at_run_us: Option<u64>,
+    finished_at_run_us: Option<u64>,
     strict: bool,
     warnings: &mut Vec<ImportWarning>,
 ) -> Result<u64, ImportError> {
-    let derived_us =
+    let unix_derived_us =
         timestamp_derived_duration_us(span.started_at_unix_ms(), span.finished_at_unix_ms());
+    let run_relative_derived_us =
+        run_relative_derived_duration_us(started_at_run_us, finished_at_run_us);
+
     let Some(duration_us) = span.duration_us_ref() else {
-        return Ok(derived_us);
+        return Ok(run_relative_derived_us.unwrap_or(unix_derived_us));
     };
-    if duration_within_tolerance(
-        duration_us,
-        span.started_at_unix_ms(),
-        span.finished_at_unix_ms(),
-    ) {
+
+    if let Some(run_relative_derived_us) = run_relative_derived_us {
+        if duration_within_derived_tolerance(duration_us, run_relative_derived_us) {
+            return Ok(duration_us);
+        }
+
+        let message = format!(
+            "span '{}' duration_us differs from run-relative duration beyond tolerance: duration_us={} run_relative_duration_us={} tolerance_us={TRACE_TIME_TOLERANCE_US}; duration_us was retained as authoritative elapsed-time evidence; Unix timestamps remain wall-clock anchors",
+            span.name(),
+            duration_us,
+            run_relative_derived_us,
+        );
+
+        if strict {
+            return Err(ImportError::StrictViolation(message));
+        }
+
+        warnings.push(ImportWarning::new(message));
         return Ok(duration_us);
     }
+
+    if duration_within_derived_tolerance(duration_us, unix_derived_us) {
+        return Ok(duration_us);
+    }
+
     if strict {
         return Err(ImportError::StrictViolation(format!(
             "span '{}' duration_us differs from timestamp-derived duration beyond tolerance: duration_us={} timestamp_derived_duration_us={} tolerance_us={TRACE_TIME_TOLERANCE_US}; strict import rejected the mismatch; Unix timestamps remain wall-clock anchors",
             span.name(),
             duration_us,
-            derived_us
+            unix_derived_us
         )));
     }
+
     warnings.push(ImportWarning::new(format!(
         "span '{}' duration_us differs from timestamp-derived duration beyond tolerance: duration_us={} timestamp_derived_duration_us={} tolerance_us={TRACE_TIME_TOLERANCE_US}; duration_us was retained as authoritative elapsed-time evidence; Unix timestamps remain wall-clock anchors",
         span.name(),
         duration_us,
-        derived_us
+        unix_derived_us
     )));
     Ok(duration_us)
 }
@@ -836,6 +881,7 @@ fn is_durable_conversion_warning(message: &str) -> bool {
         || message.starts_with("invalid field")
         || message.starts_with("unknown tt.kind")
         || message.contains("duration_us differs from timestamp-derived duration")
+        || message.contains("duration_us differs from run-relative duration")
         || message.contains("run-relative timing is inverted")
         || message.contains("incomplete run-relative timing")
         || message.contains("missing optional 'tt.outcome'; assumed 'ok'")
@@ -1097,6 +1143,78 @@ mod tests {
         assert_eq!(run.stages[0].finished_at_run_us, Some(15_010));
         assert_eq!(run.queues[0].waited_from_run_us, Some(2_010));
         assert_eq!(run.queues[0].waited_until_run_us, Some(3_010));
+    }
+
+    #[test]
+    fn missing_duration_uses_run_relative_delta_before_unix_bounds() {
+        let spans = vec![SpanRecord::new("req", 10, 11)
+            .started_at_run_us(1_000)
+            .finished_at_run_us(51_000)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+
+        assert_eq!(imported.run().requests[0].latency_us, 50_000);
+    }
+
+    #[test]
+    fn strict_duration_matching_run_relative_allows_wall_clock_mismatch() {
+        let spans = vec![SpanRecord::new("req", 10, 11)
+            .started_at_run_us(1_000)
+            .finished_at_run_us(51_000)
+            .duration_us(50_000)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+
+        let imported =
+            run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap();
+
+        assert_eq!(imported.run().requests[0].latency_us, 50_000);
+    }
+
+    #[test]
+    fn strict_duration_mismatching_run_relative_fails_even_if_unix_matches() {
+        let spans = vec![SpanRecord::new("req", 10, 60)
+            .started_at_run_us(1_000)
+            .finished_at_run_us(11_000)
+            .duration_us(50_000)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+
+        let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true))
+            .expect_err("strict import should reject duration/run-relative mismatch");
+
+        assert!(err
+            .to_string()
+            .contains("duration_us differs from run-relative duration"));
+    }
+
+    #[test]
+    fn non_strict_duration_mismatching_run_relative_warns_and_retains_duration() {
+        let spans = vec![SpanRecord::new("req", 10, 60)
+            .started_at_run_us(1_000)
+            .finished_at_run_us(11_000)
+            .duration_us(50_000)
+            .field(TT_KIND, "request")
+            .field(TT_REQUEST_ID, "r1")
+            .field(TT_ROUTE, "/a")];
+
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+
+        assert_eq!(imported.run().requests[0].latency_us, 50_000);
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("duration_us differs from run-relative duration")));
+        assert!(imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|w| w.contains("duration_us differs from run-relative duration")));
     }
 
     #[test]

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -837,18 +837,21 @@ fn elapsed_duration_us(
             return Ok(duration_us);
         }
 
-        let message = format!(
+        if strict {
+            return Err(ImportError::StrictViolation(format!(
+                "span '{}' duration_us differs from run-relative duration beyond tolerance: duration_us={} run_relative_duration_us={} tolerance_us={TRACE_TIME_TOLERANCE_US}; strict import rejected the mismatch; Unix timestamps remain wall-clock anchors",
+                span.name(),
+                duration_us,
+                run_relative_derived_us,
+            )));
+        }
+
+        warnings.push(ImportWarning::new(format!(
             "span '{}' duration_us differs from run-relative duration beyond tolerance: duration_us={} run_relative_duration_us={} tolerance_us={TRACE_TIME_TOLERANCE_US}; duration_us was retained as authoritative elapsed-time evidence; Unix timestamps remain wall-clock anchors",
             span.name(),
             duration_us,
             run_relative_derived_us,
-        );
-
-        if strict {
-            return Err(ImportError::StrictViolation(message));
-        }
-
-        warnings.push(ImportWarning::new(message));
+        )));
         return Ok(duration_us);
     }
 
@@ -1188,9 +1191,10 @@ mod tests {
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true))
             .expect_err("strict import should reject duration/run-relative mismatch");
 
-        assert!(err
-            .to_string()
-            .contains("duration_us differs from run-relative duration"));
+        let message = err.to_string();
+        assert!(message.contains("duration_us differs from run-relative duration"));
+        assert!(message.contains("strict import rejected the mismatch"));
+        assert!(!message.contains("duration_us was retained"));
     }
 
     #[test]

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -12,8 +12,9 @@ use tracing::{Id, Subscriber};
 use tracing_subscriber::layer::{Context, Layer};
 
 use crate::{
-    duration_within_tolerance, ensure_persistable_run_with_warnings, run_from_span_records,
-    FieldValue, ImportError, ImportOptions, ImportedRun, SpanRecord, TT_KIND,
+    duration_within_derived_tolerance, duration_within_tolerance,
+    ensure_persistable_run_with_warnings, run_from_span_records, FieldValue, ImportError,
+    ImportOptions, ImportedRun, SpanRecord, TT_KIND,
 };
 
 /// In-memory recorder for completed tracing spans with `tt.*` fields.
@@ -524,7 +525,21 @@ fn span_with_replay_safe_duration(
     started_at_unix_ms: u64,
     finished_at_unix_ms: u64,
 ) -> SpanRecord {
-    if duration_within_tolerance(duration_us, started_at_unix_ms, finished_at_unix_ms) {
+    let unix_safe = duration_within_tolerance(duration_us, started_at_unix_ms, finished_at_unix_ms);
+
+    let run_relative_safe = match (span.started_at_run_us_ref(), span.finished_at_run_us_ref()) {
+        (Some(started_at_run_us), Some(finished_at_run_us))
+            if finished_at_run_us >= started_at_run_us =>
+        {
+            duration_within_derived_tolerance(
+                duration_us,
+                finished_at_run_us.saturating_sub(started_at_run_us),
+            )
+        }
+        _ => false,
+    };
+
+    if unix_safe || run_relative_safe {
         span.duration_us(duration_us)
     } else {
         span
@@ -4184,7 +4199,7 @@ mod tests {
             .iter()
             .find(|span| span.fields().get("tt.kind") == Some(&FieldValue::String("stage".into())))
             .expect("stage span");
-        assert_eq!(stage.duration_us_ref(), None);
+        assert_eq!(stage.duration_us_ref(), Some(70_000));
         assert_eq!(stage.started_at_run_us_ref(), Some(2_000));
         assert_eq!(stage.finished_at_run_us_ref(), Some(72_000));
 
@@ -4192,13 +4207,39 @@ mod tests {
             .iter()
             .find(|span| span.fields().get("tt.kind") == Some(&FieldValue::String("queue".into())))
             .expect("queue span");
-        assert_eq!(queue.duration_us_ref(), None);
+        assert_eq!(queue.duration_us_ref(), Some(30_000));
         assert_eq!(queue.started_at_run_us_ref(), Some(3_000));
         assert_eq!(queue.finished_at_run_us_ref(), Some(33_000));
     }
 
     #[test]
-    fn completed_span_jsonl_omits_contradictory_durations_for_strict_replay() {
+    fn completed_span_jsonl_export_preserves_duration_when_run_relative_offsets_match() {
+        let mut run = empty_run();
+        run.requests.push(tailtriage_core::RequestEvent {
+            request_id: "r1".into(),
+            route: "/a".into(),
+            kind: None,
+            started_at_unix_ms: 10,
+            started_at_run_us: Some(1_000),
+            finished_at_unix_ms: 11,
+            finished_at_run_us: Some(51_000),
+            latency_us: 50_000,
+            outcome: "ok".into(),
+        });
+
+        let spans = retained_span_records_from_run(&run);
+
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].duration_us_ref(), Some(50_000));
+
+        let imported =
+            run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap();
+
+        assert_eq!(imported.run().requests[0].latency_us, 50_000);
+    }
+
+    #[test]
+    fn completed_span_jsonl_preserves_run_relative_safe_durations_for_strict_replay() {
         let dir = tempfile::tempdir().unwrap();
         let spans_path = dir.path().join("spans.jsonl");
         let run = run_with_replay_safe_and_contradictory_durations();
@@ -4226,13 +4267,13 @@ mod tests {
             .iter()
             .find(|span| span.fields().get("tt.kind") == Some(&FieldValue::String("stage".into())))
             .expect("stage span");
-        assert_eq!(stage.duration_us_ref(), None);
+        assert_eq!(stage.duration_us_ref(), Some(70_000));
 
         let queue = records
             .iter()
             .find(|span| span.fields().get("tt.kind") == Some(&FieldValue::String("queue".into())))
             .expect("queue span");
-        assert_eq!(queue.duration_us_ref(), None);
+        assert_eq!(queue.duration_us_ref(), Some(30_000));
 
         let replay = crate::jsonl::import_jsonl_path_with_mode(
             &spans_path,
@@ -4243,10 +4284,10 @@ mod tests {
         assert_eq!(replay.run().requests[0].latency_us, 2_500);
         assert_eq!(replay.run().requests[0].started_at_run_us, Some(1_000));
         assert_eq!(replay.run().requests[0].finished_at_run_us, Some(3_500));
-        assert_eq!(replay.run().stages[0].latency_us, 1_000);
+        assert_eq!(replay.run().stages[0].latency_us, 70_000);
         assert_eq!(replay.run().stages[0].started_at_run_us, Some(2_000));
         assert_eq!(replay.run().stages[0].finished_at_run_us, Some(72_000));
-        assert_eq!(replay.run().queues[0].wait_us, 1_000);
+        assert_eq!(replay.run().queues[0].wait_us, 30_000);
         assert_eq!(replay.run().queues[0].waited_from_run_us, Some(3_000));
         assert_eq!(replay.run().queues[0].waited_until_run_us, Some(33_000));
     }

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -525,21 +525,23 @@ fn span_with_replay_safe_duration(
     started_at_unix_ms: u64,
     finished_at_unix_ms: u64,
 ) -> SpanRecord {
-    let unix_safe = duration_within_tolerance(duration_us, started_at_unix_ms, finished_at_unix_ms);
+    let run_relative_derived_us =
+        match (span.started_at_run_us_ref(), span.finished_at_run_us_ref()) {
+            (Some(started_at_run_us), Some(finished_at_run_us))
+                if finished_at_run_us >= started_at_run_us =>
+            {
+                Some(finished_at_run_us.saturating_sub(started_at_run_us))
+            }
+            _ => None,
+        };
 
-    let run_relative_safe = match (span.started_at_run_us_ref(), span.finished_at_run_us_ref()) {
-        (Some(started_at_run_us), Some(finished_at_run_us))
-            if finished_at_run_us >= started_at_run_us =>
-        {
-            duration_within_derived_tolerance(
-                duration_us,
-                finished_at_run_us.saturating_sub(started_at_run_us),
-            )
-        }
-        _ => false,
+    let replay_safe = if let Some(run_relative_derived_us) = run_relative_derived_us {
+        duration_within_derived_tolerance(duration_us, run_relative_derived_us)
+    } else {
+        duration_within_tolerance(duration_us, started_at_unix_ms, finished_at_unix_ms)
     };
 
-    if unix_safe || run_relative_safe {
+    if replay_safe {
         span.duration_us(duration_us)
     } else {
         span
@@ -4210,6 +4212,33 @@ mod tests {
         assert_eq!(queue.duration_us_ref(), Some(30_000));
         assert_eq!(queue.started_at_run_us_ref(), Some(3_000));
         assert_eq!(queue.finished_at_run_us_ref(), Some(33_000));
+    }
+
+    #[test]
+    fn completed_span_jsonl_export_omits_duration_when_run_relative_offsets_disagree_even_if_unix_matches(
+    ) {
+        let mut run = empty_run();
+        run.requests.push(tailtriage_core::RequestEvent {
+            request_id: "r1".into(),
+            route: "/a".into(),
+            kind: None,
+            started_at_unix_ms: 10,
+            started_at_run_us: Some(1_000),
+            finished_at_unix_ms: 60,
+            finished_at_run_us: Some(11_000),
+            latency_us: 50_000,
+            outcome: "ok".into(),
+        });
+
+        let spans = retained_span_records_from_run(&run);
+
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].duration_us_ref(), None);
+
+        let imported =
+            run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap();
+
+        assert_eq!(imported.run().requests[0].latency_us, 10_000);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Prevent loss or corruption of authoritative elapsed-time evidence when exporting/importing completed-span JSONL so replay does not change observed latencies.
- Treat `duration_us` as the authoritative elapsed-time value and prefer complete run-relative monotonic offsets (`started_at_run_us`/`finished_at_run_us`) over coarse Unix-ms bounds when deriving or validating elapsed time.
- Make strict imports reject true contradictions with run-relative offsets and make non-strict imports warn while retaining supplied `duration_us`, and persist run-relative mismatch warnings to the run lifecycle warnings.

### Description

- Changed request, stage, and queue conversion to pass sanitized run-relative offsets into `elapsed_duration_us` call sites so monotonic offsets are considered first during import. (`tailtriage-tracing/src/lib.rs`) 
- Added `duration_within_derived_tolerance` and `run_relative_derived_duration_us`, and refactored `duration_within_tolerance` to delegate to the derived-duration helper. (`tailtriage-tracing/src/lib.rs`) 
- Rewrote `elapsed_duration_us` to prefer run-relative derived duration when `duration_us` is absent, validate `duration_us` against run-relative derived duration when present (strict rejects mismatches, non-strict warns and retains), and fall back to Unix-ms-derived duration only if run-relative offsets are absent. (`tailtriage-tracing/src/lib.rs`) 
- Updated durable-warning detection to treat run-relative mismatch messages as durable lifecycle warnings so they are persisted into `run.metadata.lifecycle_warnings`. (`tailtriage-tracing/src/lib.rs`) 
- Modified JSONL export safety in the recorder to mirror import precedence: preserve `duration_us` when it matches complete run-relative offsets if they are present, and fall back to Unix-ms replay safety only when complete run-relative offsets are absent. (`tailtriage-tracing/src/recorder.rs`)
- Added and adjusted unit tests covering: missing `duration_us` using run-relative delta first; strict acceptance and rejection semantics against run-relative offsets; non-strict warnings and retention of `duration_us`; recording of durable lifecycle warnings; recorder JSONL export preserving replay-safe durations; and recorder export omitting `duration_us` when complete run-relative offsets contradict it even if Unix-ms bounds match. (`tailtriage-tracing/src/lib.rs`, `tailtriage-tracing/src/recorder.rs`)
- Updated `tailtriage-tracing/README.md` timing model text to document run-relative precedence, replay-safety rules for completed-span JSONL export, and strict/non-strict duration semantics.

### Testing

- Ran `cargo fmt --check` and it succeeded.  
- Ran `cargo test -p tailtriage-tracing --all-features` and all tracing crate tests passed (unit and integration tests exercised by the crate); new tests passed.  
- Ran `cargo clippy -p tailtriage-tracing --all-features --all-targets -- -D warnings` and it completed without warnings.  
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32603e8ebc83308c6eec2d453517aa)