### PR TITLE
Stabilize analyzer queue fixture

### DIFF
--- a/tailtriage-analyzer/tests/end_to_end_capture_analysis.rs
+++ b/tailtriage-analyzer/tests/end_to_end_capture_analysis.rs
@@ -32,7 +32,7 @@ async fn queue_and_stage_data_drives_ranked_suspects() {
         request
             .queue("ingress")
             .with_depth_at_start(12)
-            .await_on(tokio::time::sleep(std::time::Duration::from_millis(4)))
+            .await_on(tokio::time::sleep(std::time::Duration::from_millis(40)))
             .await;
         request
             .stage("local_work")
@@ -47,7 +47,8 @@ async fn queue_and_stage_data_drives_ranked_suspects() {
     let report = analyze_run(&run, AnalyzeOptions::default());
     assert_eq!(
         report.primary_suspect.kind.as_str(),
-        "application_queue_saturation"
+        "application_queue_saturation",
+        "unexpected report: {report:#?}"
     );
 }
 


### PR DESCRIPTION
### Motivation

- Fix a flaky Windows failure where 4ms vs 1ms real Tokio sleeps could tie due to timer rounding and scheduler jitter, causing the analyzer to sometimes rank `downstream_stage_dominates` instead of the intended queue saturation.

### Description

- Increase the end-to-end analyzer capture fixture queue wait from `4ms` to `40ms` so queue time clearly dominates the `1ms` stage sleep (file: `tailtriage-analyzer/tests/end_to_end_capture_analysis.rs`).
- Improve the final assertion to include the full `report` on failure for easier diagnosis without changing analyzer scoring semantics or version numbers.

### Testing

- Ran `cargo test -p tailtriage-analyzer --test end_to_end_capture_analysis` and the three tests in that file passed.
- Ran `cargo test -p tailtriage-analyzer` and all analyzer unit tests passed.
- Ran `cargo test --workspace`, `cargo fmt --check`, `python3 scripts/validate_docs_contracts.py`, and `cargo clippy --workspace --all-targets -- -D warnings` and they all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32b5bb41208330836f682dbf7d872a)