### PR TITLE
Stabilize Tokio helper timeout test

### DIFF
--- a/tailtriage-tokio/src/lib.rs
+++ b/tailtriage-tokio/src/lib.rs
@@ -1288,10 +1288,9 @@ mod helper_tests {
                 .expect("join ok"),
             42
         );
-        assert!(req
-            .join_task("join_panic", tokio::spawn(async { panic!("boom") }))
-            .await
-            .is_err());
+        let handle = tokio::spawn(std::future::pending::<()>());
+        handle.abort();
+        assert!(req.join_task("join_cancelled", handle).await.is_err());
         assert_eq!(
             req.timeout_stage("timeout_ok", Duration::from_millis(50), async { 11usize })
                 .await,
@@ -1304,10 +1303,11 @@ mod helper_tests {
             .await;
         assert_eq!(nested, Ok(Err("inner")));
         assert!(req
-            .timeout_stage("timeout_elapsed", Duration::from_millis(5), async {
-                tokio::time::sleep(Duration::from_millis(30)).await;
-                1usize
-            })
+            .timeout_stage(
+                "timeout_elapsed",
+                Duration::from_millis(20),
+                std::future::pending::<usize>(),
+            )
             .await
             .is_err());
         assert_eq!(
@@ -1341,7 +1341,7 @@ mod helper_tests {
         assert_eq!(snap.stages.len(), 7);
         let stage = |name: &str| snap.stages.iter().find(|s| s.stage == name).unwrap();
         assert!(stage("join_ok").success);
-        assert!(!stage("join_panic").success);
+        assert!(!stage("join_cancelled").success);
         assert!(stage("timeout_ok").success);
         assert!(!stage("timeout_elapsed").success);
         assert!(stage("timeout_nested").success);


### PR DESCRIPTION
### Motivation
- A timing-sensitive assertion in `stage_helpers_and_inflight_behave_and_preserve_results` was flaky because it raced two short Tokio timers and sometimes returned `Ok` instead of `Err` for a supposed timeout. 
- The test should deterministically verify that `timeout_stage` reports elapsed time for a non-completing future while keeping stage success/failure semantics meaningful.

### Description
- In `tailtriage-tokio/src/lib.rs` the test `stage_helpers_and_inflight_behave_and_preserve_results` replaces the deliberately panicking task `tokio::spawn(async { panic!("boom") })` with an aborted pending task created via `tokio::spawn(std::future::pending::<()>())` and `handle.abort()`, and the stage label is updated to `join_cancelled`.
- The timing-sensitive assertion that wrapped `tokio::time::sleep(Duration::from_millis(30)).await` is replaced with a non-completing `std::future::pending::<usize>()` passed to `timeout_stage`, and the timeout is set to `Duration::from_millis(20)` so the helper deterministically returns `Err(Elapsed)`.
- No helper semantics, dependencies, or version numbers were changed.

### Testing
- Ran `cargo fmt --check` and it succeeded.
- Ran `cargo test -p tailtriage-tokio --lib` and all tests passed.
- Ran `cargo test -p tailtriage-tokio` and all tests passed.
- Ran `cargo test --workspace` and the full test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a330030bec8833092f9a22fdacdd355)