### PR TITLE
Document pre-0.4 governance and align local validation commands with CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,8 +308,8 @@ Do not implement those features unless maintainers explicitly approve them.
 Before considering a task done, run:
 
 - `cargo fmt --check`
-- `cargo clippy --workspace --all-targets -- -D warnings`
-- `cargo test --workspace`
+- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
+- `cargo test --workspace --all-targets --all-features --locked`
 - `python3 scripts/validate_docs_contracts.py`
 
 If a task touches benchmarks or performance-sensitive code, also include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.4.0] - Unreleased
+
+### Changed
+
+- Aligned documented local validation commands with CI baseline flags in `AGENTS.md` and `scripts/validate_all.py`.
+- Updated `SPEC.md` and `DESIGN_NOTES.md` to describe current pre-0.4.0 governance, intake, analyzer, lifecycle, validation, and design-risk baselines without claiming future behavior.
+
 ## [0.3.0] - 2026-06-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "atomic-waker"

--- a/DESIGN_NOTES.md
+++ b/DESIGN_NOTES.md
@@ -28,7 +28,7 @@ The design should be judged by whether it:
 | Capture model      | Artifact-based analysis                      | Reproducible and testable                       | Extra workflow step                  |
 | Workspace          | Multiple crates                              | Dependency and responsibility separation        | More complexity                      |
 | CLI                | First-class analyzer                         | Useful for validation and offline investigation | Extra public interface               |
-| Collector behavior | Bounded retention with truncation summaries  | Avoid unbounded memory risk                     | Partial data under stress            |
+| Collector behavior | Bounded retained event vectors with truncation summaries | Avoid unbounded artifact growth for retained evidence | Pending request bookkeeping is not capture-limited |
 | Overhead claims    | Machine/workload scoped                      | Credible measurement                            | Less marketable                      |
 | Validation         | Controlled demos first                       | Known injected causes                           | Synthetic limits                     |
 | AI usage           | AI-assisted implementation under specs/tests | Productivity without abandoning ownership       | Requires clear ownership and review  |
@@ -241,9 +241,9 @@ This sacrifices plug-and-play compatibility with arbitrary tracing output.
 
 The project values diagnostic precision over broad ingestion.
 
-### Future possibility
+### Current tracing bridge
 
-Tracing import could be added later if there is a clear mapping from span metadata to `tailtriage` concepts.
+A narrow tracing bridge now exists through `tailtriage-tracing`. It is not a generic tracing analyzer: it relies on explicit `tt.*` span conventions, can write standard `Run` JSON or completed-span JSONL, and feeds the same analyzer/report workflow as native capture. Arbitrary `tracing_subscriber::fmt().json()` scraping and OTel/OTLP ingestion remain out of scope.
 
 ---
 
@@ -283,12 +283,14 @@ The project is split into multiple crates rather than one monolithic crate.
 
 The responsibilities are different enough to justify separation:
 
-* core data model and capture logic,
-* Tokio runtime integration,
-* Axum integration,
-* controller/reporting behavior,
-* CLI analysis,
-* top-level facade.
+* `tailtriage-core`: data model, direct capture lifecycle, run building, sinks, retention summaries, and shared lifecycle semantics,
+* `tailtriage-tokio`: optional Tokio runtime sampling and Tokio primitive helper instrumentation,
+* `tailtriage-axum`: Axum middleware/extractor ergonomics over the same request-context model,
+* `tailtriage-controller`: repeated bounded capture windows for long-lived services,
+* `tailtriage-analyzer`: the diagnosis engine, report model, strict artifact validation APIs, and text/JSON report rendering,
+* `tailtriage-cli`: command-line artifact loading, tracing JSONL import, and analyzer/report execution,
+* `tailtriage-tracing`: optional `tracing` intake that converts `tt.*` spans into standard `Run` artifacts,
+* `tailtriage`: top-level onboarding facade with feature-gated integrations.
 
 This separation keeps optional integrations from forcing unnecessary dependencies on users who only need the core model.
 
@@ -386,23 +388,27 @@ Warnings are part of the trust model. A report that explains its limitations is 
 
 ---
 
-## 14. Why bounded collectors and truncation summaries?
+## 14. Why bounded retained evidence and truncation summaries?
 
 ### Decision
 
-Collectors should use bounded retention and expose truncation/drop summaries.
+Retained event vectors and runtime snapshots should use capture limits and expose truncation/drop summaries.
 
 ### Rationale
 
-An investigation tool should not create unbounded memory risk in the service being investigated. Bounded collection reduces operational risk.
+An investigation tool should not create unbounded artifact growth from retained request, queue, stage, in-flight, or runtime evidence. Bounded retained evidence reduces operational risk and keeps artifacts reviewable.
+
+### Current limitation
+
+Not all live bookkeeping is bounded by capture limits today. In particular, pending/unfinished request state can grow with admitted requests until those requests complete or the run shuts down. Documentation and operations guidance should therefore avoid claiming that all live state is capture-limited.
 
 ### Tradeoff
 
-Bounded collection can drop data under heavy load, which weakens diagnosis.
+Bounded retained evidence can drop data under heavy load, which weakens diagnosis. Pending-state tracking preserves lifecycle warnings but still needs operational care during long or high-cardinality capture windows.
 
 ### Why this is acceptable
 
-Dropped data is acceptable only if it is visible. Truncation must appear in the artifact and should reduce confidence where appropriate.
+Dropped retained evidence is acceptable only if it is visible. Truncation must appear in the artifact and should reduce confidence where appropriate. Pending-state limits remain a known design risk rather than a solved invariant.
 
 ---
 
@@ -575,7 +581,7 @@ The following decisions should not be treated as permanent:
 
 5. **Tracing integration**
 
-   * Revisit if a reliable mapping from tracing spans to semantic tailtriage signals emerges.
+   * Keep the current `tt.*` tracing bridge narrow. Revisit only if real usage shows that additional tracing mappings can preserve semantic signal quality without becoming generic log ingestion.
 
 6. **Runtime sampler defaults**
 
@@ -640,6 +646,48 @@ Mitigation:
 * label synthetic results as synthetic,
 * add real-world case studies later,
 * avoid universal production claims.
+
+
+### Risk: Overlapping work can blur attribution
+
+Concurrent requests, retries, fanout, and early/late temporal windows can overlap. Timestamp-filtered runtime and in-flight signals are global rather than truly request-local, and duplicate or reused request identifiers can make queue/stage attribution ambiguous.
+
+Mitigation:
+
+* require per-run unique completed request IDs for strict validation,
+* warn in permissive analysis when IDs are duplicated or attribution is ambiguous,
+* frame route and temporal segments as supporting hints rather than proof.
+
+### Risk: Cancellation and early drop may hide partial work
+
+The current queue and stage helper guards record completed intervals. If a helper is cancelled or dropped before recording a complete interval, no partial queue/stage event is emitted. Dropped request completions remain unfinished instead of being auto-completed.
+
+Mitigation:
+
+* document explicit completion as the current lifecycle contract,
+* surface unfinished requests in run metadata and warnings,
+* use strict lifecycle mode when unfinished requests should fail a capture.
+
+### Risk: Validation artifacts mix execution levels
+
+The validation corpus currently includes artifacts that are executed through the analyzer path and report-only fixtures that validate report contract behavior. Treating all fixtures as equivalent analyzer executions would overstate coverage.
+
+Mitigation:
+
+* label validation paths by execution level,
+* keep scorecards clear about analyzer-executed versus report-only coverage,
+* avoid calling report-only validation root-cause or analyzer accuracy evidence.
+
+### Risk: Duplicated policy can drift
+
+Lifecycle, validation, analyzer, CLI, import, docs-contract, and CI policy is intentionally explicit, but similar rules appear in multiple crates, scripts, and documents. That creates drift risk.
+
+Mitigation:
+
+* keep `SPEC.md` focused on externally meaningful contracts,
+* keep these design notes focused on ownership and invariants,
+* keep `AGENTS.md`, CI, and `scripts/validate_all.py` aligned on local validation commands,
+* update docs-contract tests when public documentation contracts intentionally change.
 
 ---
 

--- a/DESIGN_NOTES.md
+++ b/DESIGN_NOTES.md
@@ -400,15 +400,17 @@ An investigation tool should not create unbounded artifact growth from retained 
 
 ### Current limitation
 
-Not all live bookkeeping is bounded by capture limits today. In particular, pending/unfinished request state can grow with admitted requests until those requests complete or the run shuts down. Documentation and operations guidance should therefore avoid claiming that all live state is capture-limited.
+Not all live bookkeeping is bounded by capture limits today. Pending/unfinished request state can grow with admitted requests and remains until the corresponding request completion token finishes or the collector is dropped.
+
+`shutdown()` currently inspects pending requests and records unfinished-request metadata, but it does not clear pending bookkeeping or seal the collector against later admissions or completion activity. Documentation and operations guidance must therefore avoid claiming that all live state is capture-limited or that shutdown currently establishes a final lifecycle boundary.
 
 ### Tradeoff
 
-Bounded retained evidence can drop data under heavy load, which weakens diagnosis. Pending-state tracking preserves lifecycle warnings but still needs operational care during long or high-cardinality capture windows.
+Bounded retained evidence can drop data under heavy load, which weakens diagnosis. Pending-state tracking preserves lifecycle warnings but remains separate from the retained request, queue, stage, in-flight, and runtime vectors that capture limits bound. Operators should still use bounded capture windows and care during long or high-cardinality captures.
 
 ### Why this is acceptable
 
-Dropped retained evidence is acceptable only if it is visible. Truncation must appear in the artifact and should reduce confidence where appropriate. Pending-state limits remain a known design risk rather than a solved invariant.
+Dropped retained evidence is acceptable only if it is visible. Truncation must appear in the artifact and should reduce confidence where appropriate. Pending-state limits and unsealed shutdown behavior remain known current limitations rather than desired permanent contracts.
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -213,9 +213,10 @@ Schema contract:
 
 - artifacts require top-level `schema_version`
 - current supported schema version is `1`
-- default artifact analysis is compatibility-oriented and warns on some ambiguous request-scoped attribution cases instead of failing
-- strict artifact validation is currently opt-in through strict analyzer validation APIs or CLI/import strict flags
-- tracing completed-span JSONL import supports compatibility parsing for the stable wrapper format and compatible legacy/variant records where current parsing APIs accept them
+- default Run artifact analysis is compatibility-oriented and warns on some ambiguous request-scoped attribution cases instead of failing
+- strict Run artifact validation is opt-in through the analyzer strict-validation APIs and `tailtriage analyze --strict-artifact`
+- tracing import `--strict` separately controls malformed or incomplete `tt.*` span handling during conversion; it does not replace strict Run artifact validation
+- tracing completed-span JSONL import supports the stable wrapper format and the explicitly selected compatibility parser for supported pre-stable/internal record shapes
 
 Artifact/report contract split:
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -73,7 +73,7 @@ Single-run shape:
 
 1. build
 2. capture request lifecycle data
-3. `shutdown()` to finalize artifact
+3. `shutdown()` to finalize a standard `Run` artifact
 
 ### 5.3 Request lifecycle contract
 
@@ -84,11 +84,12 @@ Single-run shape:
 
 Contract details:
 
-- completion must happen exactly once
-- drop does not auto-complete
-- `shutdown()` does not fabricate outcomes or timings
+- completion must happen exactly once through `RequestCompletion`
+- drop does not auto-complete; dropped request completions remain unfinished
+- `shutdown()` does not fabricate outcomes or timings for unfinished requests
 - unfinished requests are surfaced as warnings/metadata
 - `strict_lifecycle(true)` makes `shutdown()` fail if unfinished requests remain
+- cancellation or early drop of queue/stage timing helpers currently records no partial queue or stage event
 
 ### 5.4 Controller surface (`tailtriage-controller`)
 
@@ -136,7 +137,7 @@ Semantics:
 
 ### 5.8 In-process analyzer (`tailtriage-analyzer`)
 
-`tailtriage-analyzer` owns typed report generation from completed runs:
+`tailtriage-analyzer` is the diagnosis engine and owns typed report generation from completed runs:
 
 - `analyze_run(&Run, AnalyzeOptions) -> Report`
 - `render_text(&Report)` for human-readable output
@@ -170,6 +171,7 @@ Users can depend on `tailtriage-tracing` directly for the narrow crate boundary,
   `{"format":"tailtriage.tracing-span.v1","span":{...}}`
 - CLI imports that wrapper shape with:
   `tailtriage import tracing-spans-jsonl <completed-spans.jsonl> --service <service> --output <run.json>`
+- native direct capture and tracing intake both produce standard `Run` artifacts
 - tracing intake converts request/stage/queue evidence into the same standard `Run` schema; analyzer semantics remain unchanged
 - request `tt.outcome` is optional; missing defaults to `ok` with a warning, recommended common labels are `ok`/`error`/`timeout`/`cancelled`/`rejected`, and custom non-empty string labels are preserved exactly
 - `tracing_subscriber::fmt().json()` arbitrary log scraping is intentionally unsupported
@@ -211,6 +213,9 @@ Schema contract:
 
 - artifacts require top-level `schema_version`
 - current supported schema version is `1`
+- default artifact analysis is compatibility-oriented and warns on some ambiguous request-scoped attribution cases instead of failing
+- strict artifact validation is currently opt-in through strict analyzer validation APIs or CLI/import strict flags
+- tracing completed-span JSONL import supports compatibility parsing for the stable wrapper format and compatible legacy/variant records where current parsing APIs accept them
 
 Artifact/report contract split:
 
@@ -247,7 +252,7 @@ The validation surface includes:
 
 ### 8.1 Deterministic diagnostic corpus
 
-The deterministic corpus validates analyzer/report behavior against labeled fixtures.
+The deterministic corpus validates analyzer/report behavior against labeled fixtures. The current corpus mixes analyzer-executed artifacts (`run_artifact` and `tracing_span_jsonl`, which flow through Run JSON analysis) with report-only fixtures that validate report contract handling without re-running the analyzer.
 
 It may check:
 

--- a/scripts/tests/test_validate_all.py
+++ b/scripts/tests/test_validate_all.py
@@ -98,8 +98,38 @@ class ValidateAllTests(unittest.TestCase):
         p = va.derive_publish_dir()
         self.assertIn("validation/artifacts", str(p))
 
-    def test_skip_and_include_cargo(self):
-        a = self.args("ci"); a.include_cargo = True
+    def test_cargo_baseline_matches_ci_flags(self):
+        a = self.args("smoke")
+        cargo = {c.name: c.argv for c in va.build_plan(a) if c.track == "cargo"}
+        self.assertEqual(cargo["cargo fmt"], ["cargo", "fmt", "--check"])
+        self.assertEqual(
+            cargo["cargo clippy"],
+            [
+                "cargo",
+                "clippy",
+                "--workspace",
+                "--all-targets",
+                "--all-features",
+                "--locked",
+                "--",
+                "-D",
+                "warnings",
+            ],
+        )
+        self.assertEqual(
+            cargo["cargo test"],
+            [
+                "cargo",
+                "test",
+                "--workspace",
+                "--all-targets",
+                "--all-features",
+                "--locked",
+            ],
+        )
+
+    def test_skip_cargo(self):
+        a = self.args("ci")
         self.assertTrue(any(c.track == "cargo" for c in va.build_plan(a)))
         a.skip_cargo = True
         self.assertFalse(any(c.track == "cargo" for c in va.build_plan(a)))

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -17,6 +17,76 @@ import validate_docs_contracts  # noqa: E402
 
 
 class ValidateDocsContractsTests(unittest.TestCase):
+
+    def test_governance_strictness_contract_accepts_distinct_policies(self) -> None:
+        spec_text = """# Spec
+
+Schema contract:
+
+- default Run artifact analysis is compatibility-oriented and warns on some ambiguous request-scoped attribution cases instead of failing
+- strict Run artifact validation is opt-in through the analyzer strict-validation APIs and `tailtriage analyze --strict-artifact`
+- tracing import `--strict` separately controls malformed or incomplete `tt.*` span handling during conversion; it does not replace strict Run artifact validation
+- tracing completed-span JSONL import supports the stable wrapper format and the explicitly selected compatibility parser for supported pre-stable/internal record shapes
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            spec_path = Path(tmp_dir) / "SPEC.md"
+            spec_path.write_text(spec_text, encoding="utf-8")
+
+            with mock.patch.object(validate_docs_contracts, "SPEC_PATH", spec_path):
+                validate_docs_contracts.validate_governance_strictness_contract()
+
+    def test_governance_strictness_contract_rejects_cli_import_conflation(self) -> None:
+        spec_text = """# Spec
+
+- default Run artifact analysis is compatibility-oriented and warns on some ambiguous request-scoped attribution cases instead of failing
+- strict Run artifact validation is opt-in through the analyzer strict-validation APIs and `tailtriage analyze --strict-artifact`
+- tracing import `--strict` separately controls malformed or incomplete `tt.*` span handling during conversion; it does not replace strict Run artifact validation
+- tracing completed-span JSONL import supports the stable wrapper format and the explicitly selected compatibility parser for supported pre-stable/internal record shapes
+- strict artifact validation is currently opt-in through strict analyzer validation APIs or CLI/import strict flags
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            spec_path = Path(tmp_dir) / "SPEC.md"
+            spec_path.write_text(spec_text, encoding="utf-8")
+
+            with mock.patch.object(validate_docs_contracts, "SPEC_PATH", spec_path):
+                with self.assertRaisesRegex(ValueError, r"conflates strict Run artifact validation"):
+                    validate_docs_contracts.validate_governance_strictness_contract()
+
+    def test_governance_pending_state_contract_accepts_unsealed_shutdown_wording(self) -> None:
+        design_text = """# Notes
+
+Not all live bookkeeping is bounded by capture limits today. Pending/unfinished request state can grow with admitted requests and remains until the corresponding request completion token finishes or the collector is dropped.
+
+`shutdown()` currently inspects pending requests and records unfinished-request metadata, but it does not clear pending bookkeeping or seal the collector against later admissions or completion activity.
+
+Pending-state tracking preserves lifecycle warnings but remains separate from the retained request, queue, stage, in-flight, and runtime vectors that capture limits bound.
+
+Pending-state limits and unsealed shutdown behavior remain known current limitations rather than desired permanent contracts.
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            design_path = Path(tmp_dir) / "DESIGN_NOTES.md"
+            design_path.write_text(design_text, encoding="utf-8")
+
+            with mock.patch.object(validate_docs_contracts, "DESIGN_NOTES_PATH", design_path):
+                validate_docs_contracts.validate_governance_pending_state_contract()
+
+    def test_governance_pending_state_contract_rejects_shutdown_as_boundary(self) -> None:
+        design_text = """# Notes
+
+Not all live bookkeeping is bounded by capture limits today. Pending/unfinished request state can grow with admitted requests until those requests complete or the run shuts down.
+Pending/unfinished request state can grow with admitted requests and remains until the corresponding request completion token finishes or the collector is dropped.
+`shutdown()` currently inspects pending requests and records unfinished-request metadata, but it does not clear pending bookkeeping or seal the collector against later admissions or completion activity.
+Pending-state tracking preserves lifecycle warnings but remains separate from the retained request, queue, stage, in-flight, and runtime vectors that capture limits bound.
+Pending-state limits and unsealed shutdown behavior remain known current limitations rather than desired permanent contracts.
+"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            design_path = Path(tmp_dir) / "DESIGN_NOTES.md"
+            design_path.write_text(design_text, encoding="utf-8")
+
+            with mock.patch.object(validate_docs_contracts, "DESIGN_NOTES_PATH", design_path):
+                with self.assertRaisesRegex(ValueError, r"shutdown clears pending request state"):
+                    validate_docs_contracts.validate_governance_pending_state_contract()
+
     def test_run_end_policy_variants_include_expected_kinds(self) -> None:
         kinds = validate_docs_contracts.extract_run_end_policy_kinds_from_source()
         self.assertEqual(kinds, {"continue_after_limits_hit", "auto_seal_on_limits_hit"})

--- a/scripts/validate_all.py
+++ b/scripts/validate_all.py
@@ -100,12 +100,12 @@ def build_plan(args: argparse.Namespace) -> list[CommandSpec]:
             CommandSpec("collector-limits full", "collector_limits", _py(args, "scripts/run_operational_validation.py", "--domain", "collector-limits", "--runs", str(args.runs), "--artifact-root", str(operational_artifact_root), "--out", str(out / "operational/collector-limits.jsonl"), "--summary", str(out / "operational/collector-limits-summary.json"), "--scorecard", str(out / "operational/collector-limits-scorecard.md"), *mode, *nfts)),
         ]
 
-    include_cargo = (args.profile in {"full", "publish"} and not args.skip_cargo) or args.include_cargo
-    if include_cargo and not args.skip_cargo:
+    include_cargo = not args.skip_cargo
+    if include_cargo:
         cmds += [
             CommandSpec("cargo fmt", "cargo", ["cargo", "fmt", "--check"]),
-            CommandSpec("cargo clippy", "cargo", ["cargo", "clippy", "--workspace", "--all-targets", "--", "-D", "warnings"]),
-            CommandSpec("cargo test", "cargo", ["cargo", "test", "--workspace"]),
+            CommandSpec("cargo clippy", "cargo", ["cargo", "clippy", "--workspace", "--all-targets", "--all-features", "--locked", "--", "-D", "warnings"]),
+            CommandSpec("cargo test", "cargo", ["cargo", "test", "--workspace", "--all-targets", "--all-features", "--locked"]),
         ]
     return cmds
 
@@ -163,7 +163,7 @@ def main() -> int:
     p.add_argument("--runs", type=int)
     p.add_argument("--profile-mode", choices=["dev", "release"], default="dev")
     p.add_argument("--skip-cargo", action="store_true")
-    p.add_argument("--include-cargo", action="store_true")
+    p.add_argument("--include-cargo", action="store_true", help="Deprecated: cargo baseline checks run by default unless --skip-cargo is set.")
     p.add_argument("--no-fail-fast", action="store_true")
     p.add_argument("--no-fail-thresholds", action="store_true")
     p.add_argument("--dry-run", action="store_true")

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -12,6 +12,8 @@ from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 README_PATH = REPO_ROOT / "README.md"
+SPEC_PATH = REPO_ROOT / "SPEC.md"
+DESIGN_NOTES_PATH = REPO_ROOT / "DESIGN_NOTES.md"
 DOCS_INDEX_PATH = REPO_ROOT / "docs" / "README.md"
 USER_GUIDE_PATH = REPO_ROOT / "docs" / "user-guide.md"
 DIAGNOSTICS_PATH = REPO_ROOT / "docs" / "diagnostics.md"
@@ -251,6 +253,56 @@ def assert_same_object_shape(*, name: str, actual: dict[str, Any], expected: dic
         if actual_kind != expected_kind:
             raise ValueError(f"{name}.{key} type drift: expected {expected_kind}, got {actual_kind}")
 
+
+
+def validate_governance_strictness_contract() -> None:
+    text = SPEC_PATH.read_text(encoding="utf-8")
+    lower_text = text.lower()
+
+    required_tokens = (
+        "default run artifact analysis",
+        "tailtriage analyze --strict-artifact",
+        "tracing import `--strict` separately controls",
+        "does not replace strict run artifact validation",
+        "stable wrapper format",
+        "explicitly selected compatibility parser",
+        "supported pre-stable/internal record shapes",
+    )
+    for token in required_tokens:
+        if token not in lower_text:
+            raise ValueError(f"SPEC.md strictness contract missing token: {token}")
+
+    conflations = (
+        r"strict artifact validation[^\n]*(?:cli/import strict flags|tracing import `--strict`)",
+        r"tracing import `--strict`[^\n]*(?:runs? validate_artifact_strict|(?<!not )replace(?:s)? strict run artifact validation)",
+    )
+    for pattern in conflations:
+        if re.search(pattern, lower_text):
+            raise ValueError("SPEC.md conflates strict Run artifact validation with tracing import --strict")
+
+
+def validate_governance_pending_state_contract() -> None:
+    text = DESIGN_NOTES_PATH.read_text(encoding="utf-8")
+    lower_text = text.lower()
+
+    required_tokens = (
+        "pending/unfinished request state can grow with admitted requests",
+        "completion token finishes or the collector is dropped",
+        "shutdown()` currently inspects pending requests",
+        "does not clear pending bookkeeping",
+        "seal the collector against later admissions",
+        "separate from the retained request, queue, stage, in-flight, and runtime vectors",
+        "known current limitations rather than desired permanent contracts",
+    )
+    for token in required_tokens:
+        if token not in lower_text:
+            raise ValueError(f"DESIGN_NOTES.md pending-state contract missing token: {token}")
+
+    if re.search(r"pending/unfinished request state[^\n]*until[^\n]*run shuts down", lower_text):
+        raise ValueError("DESIGN_NOTES.md must not claim shutdown clears pending request state")
+
+    if re.search(r"(?m)^\s*all live (?:bookkeeping|state) (?:is|are) (?:capture-limited|bounded by capture limits)", lower_text):
+        raise ValueError("DESIGN_NOTES.md must not claim all live bookkeeping is capture-limited")
 
 def validate_readme_analyzer_example() -> None:
     readme_text = README_PATH.read_text(encoding="utf-8")
@@ -1097,6 +1149,8 @@ def validate_sampler_integration_boundary() -> None:
 
 def main() -> int:
     _ = parse_args()
+    validate_governance_strictness_contract()
+    validate_governance_pending_state_contract()
     validate_readme_analyzer_example()
     validate_crate_rustdocs_include_readmes()
     validate_controller_readme_toml()


### PR DESCRIPTION
### Motivation

- Ensure repository guidance and local validation tooling truthfully match CI baseline flags and current pre-0.4.0 behavior. 
- Capture documented facts about intake, analyzer ownership, lifecycle semantics, validation artifact mix, and known limitations instead of describing planned work. 
- Keep the docs/tests/validation runner aligned so contributor commands, CI, and docs-contract checks agree.

### Description

- Align local contributor commands and test runner: update `scripts/validate_all.py` to run cargo baseline checks by default (unless `--skip-cargo`) and use CI-aligned flags (`--all-targets --all-features --locked`) for `clippy` and `test`, and mark `--include-cargo` as deprecated. 
- Update guidance in `AGENTS.md` to list the same cargo command variants used by CI. 
- Update `SPEC.md` to describe current runtime/ingest and analyzer contracts (native and tracing intake both produce standard `Run` artifacts; `tailtriage-analyzer` is the diagnosis engine; explicit `RequestCompletion` semantics; dropped completions remain unfinished; cancellations record no partial queue/stage events; strict artifact validation is opt-in; JSONL tracing import supports compatibility parsing; validation corpus mixes analyzer-executed and report-only artifacts). 
- Revise `DESIGN_NOTES.md` to remove stale "tracing only future work" language, enumerate current crate responsibilities, clarify that retained event vectors are bounded while pending bookkeeping is not fully capture-limited, and add documented risks around overlap, cancellation, validation-level mixing, and duplicated policy drift. 
- Add an `Unreleased / 0.4.0 (Unreleased)` changelog entry limited to these documentation/governance updates. 
- Update `scripts/tests/test_validate_all.py` to assert the concrete cargo baseline commands and preserve existing plan tests.

### Testing

- Ran `cargo fmt --check` and it passed. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it completed cleanly. 
- Ran `cargo test --workspace --all-targets --all-features --locked` and all tests passed. 
- Ran `python3 scripts/validate_docs_contracts.py` and it reported "docs contracts validated successfully." 
- Ran unit tests `python3 -m unittest scripts.tests.test_validate_all scripts.tests.test_validate_docs_contracts` which completed successfully. 
- Executed `python3 scripts/validate_all.py --profile smoke` (dry/full smoke plan run) and the smoke profile plan finished with a passing summary; all validation tracks run in the smoke profile succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d2c3e2e1483309883d007d3b1b215)