### PR TITLE
Delegate tracing Run integrity to core; preserve source parsing and retention

### DIFF
--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -319,12 +319,13 @@ fn import_tracing_spans_jsonl_creates_missing_output_parent_directories() {
 
     assert!(output.status.success(), "cli failed: {output:?}");
     assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
-    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+    assert_precise_interval_warning_only_in_stderr(&output);
     assert!(run_path.exists(), "run artifact should be written");
 
     let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
         .expect("imported run should load in cli loader");
     assert_eq!(loaded.run.requests.len(), 1);
+    assert_no_precise_interval_lifecycle_warning(&loaded.run);
 }
 
 #[test]
@@ -377,12 +378,13 @@ fn import_tracing_spans_jsonl_writes_run_json_analyzable_by_existing_apis() {
 
     assert!(output.status.success(), "cli failed: {output:?}");
     assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
-    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+    assert_precise_interval_warning_only_in_stderr(&output);
 
     let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
         .expect("imported run should load in cli loader");
     let report = analyze_run(&loaded.run, AnalyzeOptions::default());
     assert_eq!(report.request_count, 1);
+    assert_no_precise_interval_lifecycle_warning(&loaded.run);
 }
 
 #[test]
@@ -519,13 +521,14 @@ fn import_tracing_spans_jsonl_allows_zero_stage_and_queue_limits() {
 
     assert!(output.status.success(), "cli failed: {output:?}");
     assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
-    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+    assert_precise_interval_warning_only_in_stderr(&output);
 
     let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
         .expect("imported request-only run should load in cli loader");
     assert!(!loaded.run.requests.is_empty());
     assert!(loaded.run.stages.is_empty());
     assert!(loaded.run.queues.is_empty());
+    assert_no_precise_interval_lifecycle_warning(&loaded.run);
 }
 
 #[test]
@@ -605,7 +608,7 @@ fn import_tracing_spans_jsonl_input_format_tailtriage_wrapper_only_accepts_fixtu
 
     assert!(output.status.success(), "cli failed: {output:?}");
     assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
-    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+    assert_precise_interval_warning_only_in_stderr(&output);
     let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
         .expect("imported run should load in cli loader");
     assert_eq!(loaded.run.requests.len(), 1);
@@ -843,16 +846,14 @@ fn import_tracing_spans_jsonl_compatible_accepts_fmt_metadata_with_completed_spa
         .output()
         .expect("cli should run");
     assert!(output.status.success(), "cli failed: {output:?}");
-    assert!(
-        String::from_utf8_lossy(&output.stderr).trim().is_empty(),
-        "stderr should be empty: {output:?}"
-    );
+    assert_precise_interval_warning_only_in_stderr(&output);
     assert!(run_path.exists(), "run json should be written");
 
     let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
         .expect("imported run should load in cli loader");
     assert_eq!(loaded.run.requests.len(), 1);
     assert_eq!(loaded.run.requests[0].route, "/checkout");
+    assert_no_precise_interval_lifecycle_warning(&loaded.run);
 }
 
 #[test]
@@ -923,8 +924,7 @@ fn import_tracing_spans_jsonl_strict_fails_on_incomplete_tailtriage_span() {
 }
 
 #[test]
-fn import_tracing_spans_jsonl_strict_with_max_requests_keeps_retained_request_and_skips_overflow_children(
-) {
+fn import_tracing_spans_jsonl_strict_with_max_requests_rejects_retained_orphan_children() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
@@ -957,9 +957,53 @@ fn import_tracing_spans_jsonl_strict_with_max_requests_keeps_retained_request_an
         .output()
         .expect("cli should run");
 
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("orphan_request_scoped_event"));
+    assert!(!stderr.contains("valid but not retained due to max_requests"));
+    assert!(!stderr.contains("no retained request event was imported"));
+    assert!(
+        !run_path.exists(),
+        "run output should not exist on strict failure"
+    );
+}
+
+#[test]
+fn import_tracing_spans_jsonl_permissive_with_max_requests_excludes_retained_orphan_children() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let spans_path = dir.path().join("spans.jsonl");
+    let run_path = dir.path().join("run.json");
+    std::fs::write(
+        &spans_path,
+        [
+            r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req-1","started_at_unix_ms":100,"finished_at_unix_ms":200,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/checkout"}}}"#,
+            r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"st-1","started_at_unix_ms":120,"finished_at_unix_ms":150,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}"#,
+            r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"q-1","started_at_unix_ms":121,"finished_at_unix_ms":130,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits"}}}"#,
+            r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req-2","started_at_unix_ms":300,"finished_at_unix_ms":400,"fields":{"tt.kind":"request","tt.request_id":"r2","tt.route":"/checkout"}}}"#,
+            r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"st-2","started_at_unix_ms":320,"finished_at_unix_ms":350,"fields":{"tt.kind":"stage","tt.request_id":"r2","tt.stage":"db"}}}"#,
+            r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"q-2","started_at_unix_ms":321,"finished_at_unix_ms":330,"fields":{"tt.kind":"queue","tt.request_id":"r2","tt.queue":"permits"}}}"#,
+        ]
+        .join("\n"),
+    )
+    .expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("import")
+        .arg("tracing-spans-jsonl")
+        .arg(&spans_path)
+        .arg("--service")
+        .arg("checkout")
+        .arg("--output")
+        .arg(&run_path)
+        .arg("--max-requests")
+        .arg("1")
+        .output()
+        .expect("cli should run");
+
     assert!(output.status.success(), "cli failed: {output:?}");
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
-    assert!(!stderr.contains("no retained request event was imported"));
+    assert!(stderr.contains("orphan_request_scoped_event"));
+    assert!(!stderr.contains("valid but not retained due to max_requests"));
     assert!(run_path.exists(), "run output should exist");
 
     let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
@@ -971,9 +1015,14 @@ fn import_tracing_spans_jsonl_strict_with_max_requests_keeps_retained_request_an
     assert_eq!(loaded.run.queues.len(), 1);
     assert_eq!(loaded.run.queues[0].request_id, "r1");
     assert_eq!(loaded.run.truncation.dropped_requests, 1);
-    assert_eq!(loaded.run.truncation.dropped_stages, 1);
-    assert_eq!(loaded.run.truncation.dropped_queues, 1);
-    assert!(loaded.run.truncation.limits_hit);
+    assert_eq!(loaded.run.truncation.dropped_stages, 0);
+    assert_eq!(loaded.run.truncation.dropped_queues, 0);
+    assert!(loaded
+        .run
+        .metadata
+        .lifecycle_warnings
+        .iter()
+        .any(|warning| warning.contains("orphan_request_scoped_event")));
 }
 
 #[test]
@@ -1008,7 +1057,7 @@ fn import_tracing_spans_jsonl_strict_with_max_requests_fails_on_invalid_overflow
 
     assert!(!output.status.success(), "cli unexpectedly succeeded");
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
-    assert!(stderr.contains("falls outside request interval"));
+    assert!(stderr.contains("orphan_request_scoped_event"));
     assert!(!stderr.contains("valid but not retained due to max_requests"));
     assert!(
         !run_path.exists(),
@@ -1077,13 +1126,14 @@ fn import_tracing_spans_jsonl_writes_metadata_flags_into_run_json() {
 
     assert!(output.status.success(), "cli failed: {output:?}");
     assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
-    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+    assert_precise_interval_warning_only_in_stderr(&output);
 
     let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
         .expect("imported run should load in cli loader");
     assert_eq!(loaded.run.metadata.service_name, "checkout");
     assert_eq!(loaded.run.metadata.service_version.as_deref(), Some("v1"));
     assert_eq!(loaded.run.metadata.run_id, "run-42");
+    assert_no_precise_interval_lifecycle_warning(&loaded.run);
 }
 
 #[test]
@@ -1438,6 +1488,25 @@ fn parse_report_json(output: std::process::Output) -> serde_json::Value {
 
     let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
     serde_json::from_str(&stdout).expect("stdout should be valid json")
+}
+
+fn assert_precise_interval_warning_only_in_stderr(output: &std::process::Output) {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("precise_interval_validation_unavailable"),
+        "stderr should contain precise interval warning: {output:?}"
+    );
+}
+
+fn assert_no_precise_interval_lifecycle_warning(run: &tailtriage_core::Run) {
+    assert!(
+        !run.metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|warning| warning.contains("precise_interval_validation_unavailable")),
+        "missing precision warning should not be durable lifecycle noise: {:?}",
+        run.metadata.lifecycle_warnings
+    );
 }
 
 fn valid_cli_artifact_with_empty_requests() -> &'static str {

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -635,10 +635,15 @@ mod tests {
 
         assert_eq!(imported.run().requests[0].latency_us, 50_000);
         assert_eq!(imported.run().requests[0].started_at_run_us, None);
+        assert_eq!(imported.run().requests[0].finished_at_run_us, None);
         assert!(imported
             .warnings()
             .iter()
-            .any(|warning| warning.message().contains("duration_us was retained")));
+            .any(|warning| warning.message().contains("duration_mismatch")));
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|warning| warning.message().contains("duration evidence was retained")));
     }
 
     #[test]
@@ -769,7 +774,9 @@ mod tests {
 {"event":"close","span":{"name":"st","started_at_unix_ms":5,"finished_at_unix_ms":8,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db","tt.success":true}}}"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().stages.len(), 1);
-        assert!(imported.warnings().is_empty());
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("precise_interval_validation_unavailable")));
     }
 
     #[test]
@@ -809,9 +816,16 @@ mod tests {
 "#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests.len(), 1);
-        assert_eq!(imported.warnings().len(), 1);
-        let warning_message = imported.warnings()[0].message();
-        assert!(warning_message.contains("line 3"));
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("line 3")));
+        let warning_message = imported
+            .warnings()
+            .iter()
+            .find(|w| w.message().contains("line 3"))
+            .unwrap()
+            .message();
         assert!(imported
             .run()
             .metadata
@@ -828,9 +842,16 @@ mod tests {
 "#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests.len(), 1);
-        assert_eq!(imported.warnings().len(), 1);
-        let conversion_warning = imported.warnings()[0].message();
-        assert!(conversion_warning.contains("tt.route"));
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("tt.route")));
+        let conversion_warning = imported
+            .warnings()
+            .iter()
+            .find(|w| w.message().contains("tt.route"))
+            .unwrap()
+            .message();
         assert!(imported
             .run()
             .metadata
@@ -847,9 +868,11 @@ mod tests {
 "#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests.len(), 1);
-        assert_eq!(imported.warnings().len(), 1);
         let warning_message = "unknown tt.kind 'mystery' in span 'unknown'";
-        assert_eq!(imported.warnings()[0].message(), warning_message);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message() == warning_message));
         let matches = imported
             .run()
             .metadata
@@ -952,7 +975,9 @@ mod tests {
 "#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests.len(), 1);
-        assert!(imported.warnings().is_empty());
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("precise_interval_validation_unavailable")));
         assert!(imported.run().metadata.lifecycle_warnings.is_empty());
     }
 
@@ -997,7 +1022,7 @@ mod tests {
         assert!(imported
             .warnings()
             .iter()
-            .any(|w| w.message().contains("duration_us was retained")));
+            .any(|w| w.message().contains("duration evidence was retained")));
     }
 
     #[test]
@@ -1174,7 +1199,9 @@ mod tests {
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests.len(), 1);
         assert_eq!(imported.run().requests[0].route, "/message");
-        assert!(imported.warnings().is_empty());
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("precise_interval_validation_unavailable")));
     }
 
     #[test]
@@ -1183,7 +1210,9 @@ mod tests {
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests.len(), 1);
         assert_eq!(imported.run().requests[0].route, "/fmt");
-        assert!(imported.warnings().is_empty());
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("precise_interval_validation_unavailable")));
     }
 
     #[test]

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -1547,6 +1547,12 @@ mod tests {
             .lifecycle_warnings
             .iter()
             .any(|w| w.contains("duplicate_completed_request_id")));
+        assert!(imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|w| w.contains("ambiguous_parent_request_id")));
     }
 
     #[test]
@@ -2535,7 +2541,7 @@ mod tests {
     }
 
     #[test]
-    fn strict_mode_duplicate_request_id_overflow_only_children_fail_outside_interval() {
+    fn strict_mode_duplicate_request_id_overflow_only_children_retains_coarse_timing() {
         let spans = vec![
             SpanRecord::new("req-1", 100, 200)
                 .field(TT_KIND, "request")
@@ -2571,7 +2577,7 @@ mod tests {
     }
 
     #[test]
-    fn non_strict_duplicate_request_id_overflow_only_children_warn_outside_interval() {
+    fn non_strict_duplicate_request_id_overflow_only_children_retains_coarse_timing() {
         let spans = vec![
             SpanRecord::new("req-1", 100, 200)
                 .field(TT_KIND, "request")

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -539,9 +539,9 @@ fn required_string(
     }
 }
 
-pub(crate) const TRACE_TIME_TOLERANCE_US: u64 = 2_000;
+#[cfg(feature = "live")]
 pub(crate) fn duration_within_derived_tolerance(duration_us: u64, derived_us: u64) -> bool {
-    duration_us.abs_diff(derived_us) <= TRACE_TIME_TOLERANCE_US
+    duration_us.abs_diff(derived_us) <= tailtriage_core::RUN_RELATIVE_DURATION_TOLERANCE_US
 }
 
 #[cfg(feature = "live")]
@@ -1655,7 +1655,7 @@ mod tests {
         assert!(!imported
             .warnings()
             .iter()
-            .any(|w| w.message().contains("duplicate tt.request_id")));
+            .any(|w| w.message().contains("duplicate_completed_request_id")));
     }
 
     #[test]

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -44,8 +44,7 @@ mod types;
 use tailtriage_core::{
     normalize_run_permissive, summarize_run_validation, summarize_run_validation_lifecycle,
     validate_run_strict, EffectiveCoreConfig, QueueEvent, RequestEvent, Run, RunMetadata,
-    RunValidationIssueCode, RunValidationSeverity, StageEvent, TruncationSummary,
-    UnfinishedRequests,
+    RunValidationSeverity, StageEvent, TruncationSummary, UnfinishedRequests,
 };
 
 pub use convention::{
@@ -371,9 +370,6 @@ where
     let mut run = normalized.run;
     refresh_normalized_metadata_bounds(&mut run, explicit_run_id);
     for warning in core_warnings {
-        if warning.contains(RunValidationIssueCode::PreciseIntervalValidationUnavailable.as_str()) {
-            continue;
-        }
         if !warnings
             .iter()
             .any(|existing| existing.message() == warning)
@@ -784,6 +780,8 @@ mod tests {
     fn request_and_stage_convert() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
+                .started_at_run_us(100_000)
+                .finished_at_run_us(120_000)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/a"),
@@ -804,6 +802,8 @@ mod tests {
     fn request_and_queue_convert() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
+                .started_at_run_us(100_000)
+                .finished_at_run_us(120_000)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/a"),
@@ -901,9 +901,7 @@ mod tests {
             .expect_err("strict import should reject duration/run-relative mismatch");
 
         let message = err.to_string();
-        assert!(message.contains("duration_us differs from run-relative duration"));
-        assert!(message.contains("strict import rejected the mismatch"));
-        assert!(!message.contains("duration_us was retained"));
+        assert!(message.contains("duration_mismatch"));
     }
 
     #[test]
@@ -919,15 +917,16 @@ mod tests {
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
 
         assert_eq!(imported.run().requests[0].latency_us, 50_000);
-        assert!(imported.warnings().iter().any(|w| w
-            .message()
-            .contains("duration_us differs from run-relative duration")));
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("duration_mismatch")));
         assert!(imported
             .run()
             .metadata
             .lifecycle_warnings
             .iter()
-            .any(|w| w.contains("duration_us differs from run-relative duration")));
+            .any(|w| w.contains("duration_mismatch")));
     }
 
     #[test]
@@ -944,14 +943,15 @@ mod tests {
         assert_eq!(imported.run().requests.len(), 1);
         assert_eq!(imported.run().requests[0].started_at_run_us, None);
         assert_eq!(imported.run().requests[0].finished_at_run_us, None);
+        assert_eq!(imported.run().requests[0].latency_us, 20_000);
         assert!(imported
             .warnings()
             .iter()
-            .any(|w| w.message().contains("run-relative timing is inverted")));
+            .any(|w| w.message().contains("inverted_interval")));
         assert!(imported
             .warnings()
             .iter()
-            .any(|w| w.message().contains("dropped run-relative offsets")));
+            .any(|w| w.message().contains("optional run-relative offsets")));
     }
 
     #[test]
@@ -967,7 +967,7 @@ mod tests {
             .expect_err("strict import should reject inverted run-relative offsets");
 
         assert!(matches!(err, ImportError::StrictViolation(_)));
-        assert!(err.to_string().contains("run-relative timing is inverted"));
+        assert!(err.to_string().contains("inverted_interval"));
     }
 
     #[test]
@@ -986,11 +986,11 @@ mod tests {
         assert!(imported
             .warnings()
             .iter()
-            .any(|w| w.message().contains("incomplete run-relative timing")));
+            .any(|w| w.message().contains("partial_run_relative_interval")));
         assert!(imported
             .warnings()
             .iter()
-            .any(|w| w.message().contains("dropped run-relative offsets")));
+            .any(|w| w.message().contains("optional run-relative offsets")));
     }
 
     #[test]
@@ -1013,10 +1013,42 @@ mod tests {
         assert_eq!(imported.run().queues.len(), 1);
         assert_eq!(imported.run().queues[0].waited_from_run_us, None);
         assert_eq!(imported.run().queues[0].waited_until_run_us, None);
+        assert_eq!(imported.run().queues[0].wait_us, 1_000);
         assert!(imported
             .warnings()
             .iter()
-            .any(|w| w.message().contains("run-relative timing is inverted")));
+            .any(|w| w.message().contains("inverted_interval")));
+    }
+
+    #[test]
+    fn non_strict_inverted_stage_run_relative_without_duration_uses_coarse_delta() {
+        let spans = vec![
+            SpanRecord::new("req", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("stage", 102, 105)
+                .started_at_run_us(5_000)
+                .finished_at_run_us(2_000)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "r1")
+                .field(TT_STAGE, "db"),
+        ];
+
+        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+
+        assert_eq!(imported.run().stages.len(), 1);
+        assert_eq!(imported.run().stages[0].started_at_run_us, None);
+        assert_eq!(imported.run().stages[0].finished_at_run_us, None);
+        assert_eq!(imported.run().stages[0].latency_us, 3_000);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("inverted_interval")));
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("optional run-relative offsets")));
     }
 
     #[test]
@@ -1038,7 +1070,7 @@ mod tests {
             .expect_err("strict import should reject inverted queue run-relative offsets");
 
         assert!(matches!(err, ImportError::StrictViolation(_)));
-        assert!(err.to_string().contains("run-relative timing is inverted"));
+        assert!(err.to_string().contains("inverted_interval"));
     }
 
     #[test]
@@ -1063,11 +1095,11 @@ mod tests {
         assert!(imported
             .warnings()
             .iter()
-            .any(|w| w.message().contains("incomplete run-relative timing")));
+            .any(|w| w.message().contains("partial_run_relative_interval")));
         assert!(imported
             .warnings()
             .iter()
-            .any(|w| w.message().contains("dropped run-relative offsets")));
+            .any(|w| w.message().contains("optional run-relative offsets")));
     }
 
     #[test]
@@ -1088,7 +1120,7 @@ mod tests {
             .expect_err("strict import should reject incomplete run-relative offsets");
 
         assert!(matches!(err, ImportError::StrictViolation(_)));
-        assert!(err.to_string().contains("incomplete run-relative timing"));
+        assert!(err.to_string().contains("partial_run_relative_interval"));
     }
 
     #[test]
@@ -1106,7 +1138,7 @@ mod tests {
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests.len(), 1);
         assert_eq!(imported.run().stages.len(), 0);
-        let warning = "skipped stage span for request_id 'r-orphan' because no valid matching request event was imported";
+        let warning = "orphan_request_scoped_event";
         assert!(imported
             .warnings()
             .iter()
@@ -1138,17 +1170,18 @@ mod tests {
         assert_eq!(run.metadata.started_at_unix_ms, 100);
         assert_eq!(run.metadata.finished_at_unix_ms, 120);
         assert!(run.metadata.run_id.contains("tracing-import-100-120"));
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("orphan_request_scoped_event")));
         assert!(imported.warnings().iter().any(|w| w
-            .message()
-            .contains("skipped stage span for request_id 'r-orphan'")));
-        assert!(imported.warnings().iter().all(|w| !w
             .message()
             .contains("missing optional 'tt.success'; assumed true")));
         assert!(run
             .metadata
             .lifecycle_warnings
             .iter()
-            .all(|w| !w.contains("missing optional 'tt.success'; assumed true")));
+            .any(|w| w.contains("missing optional 'tt.success'; assumed true")));
     }
 
     #[test]
@@ -1166,7 +1199,7 @@ mod tests {
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
         match err {
             ImportError::StrictViolation(message) => {
-                assert!(message.contains("no valid matching request event"));
+                assert!(message.contains("orphan_request_scoped_event"));
             }
             _ => panic!("expected StrictViolation"),
         }
@@ -1187,7 +1220,7 @@ mod tests {
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests.len(), 1);
         assert_eq!(imported.run().queues.len(), 0);
-        let warning = "skipped queue span for request_id 'r-orphan' because no valid matching request event was imported";
+        let warning = "orphan_request_scoped_event";
         assert!(imported
             .warnings()
             .iter()
@@ -1215,14 +1248,14 @@ mod tests {
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
         match err {
             ImportError::StrictViolation(message) => {
-                assert!(message.contains("no valid matching request event"));
+                assert!(message.contains("orphan_request_scoped_event"));
             }
             _ => panic!("expected StrictViolation"),
         }
     }
 
     #[test]
-    fn non_strict_stage_before_request_start_is_skipped_and_warning_is_durable() {
+    fn wall_clock_stage_before_request_start_is_retained_without_precise_containment_warning() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
                 .field(TT_KIND, "request")
@@ -1234,22 +1267,24 @@ mod tests {
                 .field(TT_STAGE, "db"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().stages.is_empty());
-        let warning = "skipped stage span 'db' for request_id 'r1' because interval [97, 110] falls outside request interval [100, 120] beyond tolerance_ms=2";
-        assert!(imported
+        assert_eq!(imported.run().stages.len(), 1);
+        assert!(!imported
             .warnings()
             .iter()
-            .any(|w| w.message().contains(warning)));
-        assert!(imported
+            .any(|w| w.message().contains("child_interval_outside_request")));
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("precise_interval_validation_unavailable")));
+        assert!(!imported
             .run()
             .metadata
             .lifecycle_warnings
             .iter()
-            .any(|w| w.contains(warning)));
+            .any(|w| w.contains("precise_interval_validation_unavailable")));
     }
 
     #[test]
-    fn non_strict_stage_after_request_finish_is_skipped_and_warning_is_durable() {
+    fn wall_clock_stage_after_request_finish_is_retained_without_precise_containment_warning() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
                 .field(TT_KIND, "request")
@@ -1261,22 +1296,24 @@ mod tests {
                 .field(TT_STAGE, "db"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().stages.is_empty());
-        let warning = "skipped stage span 'db' for request_id 'r1' because interval [110, 123] falls outside request interval [100, 120] beyond tolerance_ms=2";
-        assert!(imported
+        assert_eq!(imported.run().stages.len(), 1);
+        assert!(!imported
             .warnings()
             .iter()
-            .any(|w| w.message().contains(warning)));
-        assert!(imported
+            .any(|w| w.message().contains("child_interval_outside_request")));
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("precise_interval_validation_unavailable")));
+        assert!(!imported
             .run()
             .metadata
             .lifecycle_warnings
             .iter()
-            .any(|w| w.contains(warning)));
+            .any(|w| w.contains("precise_interval_validation_unavailable")));
     }
 
     #[test]
-    fn non_strict_queue_before_request_start_is_skipped_and_warning_is_durable() {
+    fn wall_clock_queue_before_request_start_is_retained_without_precise_containment_warning() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
                 .field(TT_KIND, "request")
@@ -1288,22 +1325,24 @@ mod tests {
                 .field(TT_QUEUE, "permits"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().queues.is_empty());
-        let warning = "skipped queue span 'permits' for request_id 'r1' because interval [97, 110] falls outside request interval [100, 120] beyond tolerance_ms=2";
-        assert!(imported
+        assert_eq!(imported.run().queues.len(), 1);
+        assert!(!imported
             .warnings()
             .iter()
-            .any(|w| w.message().contains(warning)));
-        assert!(imported
+            .any(|w| w.message().contains("child_interval_outside_request")));
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("precise_interval_validation_unavailable")));
+        assert!(!imported
             .run()
             .metadata
             .lifecycle_warnings
             .iter()
-            .any(|w| w.contains(warning)));
+            .any(|w| w.contains("precise_interval_validation_unavailable")));
     }
 
     #[test]
-    fn non_strict_queue_after_request_finish_is_skipped_and_warning_is_durable() {
+    fn wall_clock_queue_after_request_finish_is_retained_without_precise_containment_warning() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
                 .field(TT_KIND, "request")
@@ -1315,54 +1354,78 @@ mod tests {
                 .field(TT_QUEUE, "permits"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().queues.is_empty());
-        let warning = "skipped queue span 'permits' for request_id 'r1' because interval [110, 123] falls outside request interval [100, 120] beyond tolerance_ms=2";
-        assert!(imported
+        assert_eq!(imported.run().queues.len(), 1);
+        assert!(!imported
             .warnings()
             .iter()
-            .any(|w| w.message().contains(warning)));
-        assert!(imported
+            .any(|w| w.message().contains("child_interval_outside_request")));
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("precise_interval_validation_unavailable")));
+        assert!(!imported
             .run()
             .metadata
             .lifecycle_warnings
             .iter()
-            .any(|w| w.contains(warning)));
+            .any(|w| w.contains("precise_interval_validation_unavailable")));
     }
 
     #[test]
-    fn strict_mode_fails_for_out_of_window_stage() {
+    fn precise_stage_outside_request_is_excluded_permissively_and_rejected_strictly() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
+                .started_at_run_us(100_000)
+                .finished_at_run_us(120_000)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/a"),
             SpanRecord::new("stage", 97, 110)
+                .started_at_run_us(97_000)
+                .finished_at_run_us(110_000)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_STAGE, "db"),
         ];
+        let imported = run_from_span_records(spans.clone(), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().stages.is_empty());
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("child_interval_outside_request")));
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
         assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(err.to_string().contains("child_interval_outside_request"));
     }
 
     #[test]
-    fn strict_mode_fails_for_out_of_window_queue() {
+    fn precise_queue_outside_request_is_excluded_permissively_and_rejected_strictly() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
+                .started_at_run_us(100_000)
+                .finished_at_run_us(120_000)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/a"),
             SpanRecord::new("queue", 110, 123)
+                .started_at_run_us(110_000)
+                .finished_at_run_us(123_000)
                 .field(TT_KIND, "queue")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_QUEUE, "permits"),
         ];
+        let imported = run_from_span_records(spans.clone(), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().queues.is_empty());
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("child_interval_outside_request")));
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
         assert!(matches!(err, ImportError::StrictViolation(_)));
+        assert!(err.to_string().contains("child_interval_outside_request"));
     }
 
     #[test]
-    fn stage_starting_1ms_before_request_is_retained_with_tolerance() {
+    fn wall_clock_stage_starting_before_request_is_retained_without_containment() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
                 .field(TT_KIND, "request")
@@ -1378,7 +1441,7 @@ mod tests {
     }
 
     #[test]
-    fn queue_ending_1ms_after_request_is_retained_with_tolerance() {
+    fn wall_clock_queue_ending_after_request_is_retained_without_containment() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
                 .field(TT_KIND, "request")
@@ -1444,7 +1507,7 @@ mod tests {
     }
 
     #[test]
-    fn non_strict_duplicate_request_id_skips_later_request() {
+    fn non_strict_duplicate_request_id_excludes_all_duplicate_requests_and_children() {
         let spans = vec![
             SpanRecord::new("req-1", 100, 120)
                 .field(TT_KIND, "request")
@@ -1462,30 +1525,32 @@ mod tests {
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         let run = imported.run();
-        assert_eq!(run.requests.len(), 1);
-        assert_eq!(run.requests[0].route, "/a");
+        assert_eq!(run.requests.len(), 0);
         assert_eq!(run.stages.len(), 0);
         assert_eq!(run.truncation.dropped_requests, 0);
 
-        assert!(imported.warnings().iter().any(|w| w
-            .message()
-            .contains("duplicate tt.request_id 'dup' is an input-quality problem")));
-        assert!(imported.warnings().iter().any(|w| w
-            .message()
-            .contains("skipped later duplicate request event")));
-        assert!(imported.warnings().iter().any(|w| w
-            .message()
-            .contains("child stage/queue evidence outside the retained first request interval may also be skipped")));
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("duplicate_completed_request_id")));
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("were excluded from analysis")));
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("ambiguous_parent_request_id")));
         assert!(imported
             .run()
             .metadata
             .lifecycle_warnings
             .iter()
-            .any(|w| w.contains("duplicate tt.request_id 'dup' is an input-quality problem")));
+            .any(|w| w.contains("duplicate_completed_request_id")));
     }
 
     #[test]
-    fn non_strict_skipped_duplicate_missing_outcome_does_not_warn_outcome_defaulted() {
+    fn non_strict_retained_duplicate_missing_outcome_warns_before_core_exclusion() {
         let spans = vec![
             SpanRecord::new("req-1", 100, 120)
                 .field(TT_KIND, "request")
@@ -1499,15 +1564,15 @@ mod tests {
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         let run = imported.run();
-        assert_eq!(run.requests.len(), 1);
-        assert_eq!(run.requests[0].route, "/a");
+        assert_eq!(run.requests.len(), 0);
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("duplicate_completed_request_id")));
         assert!(imported.warnings().iter().any(|w| w
             .message()
-            .contains("duplicate tt.request_id 'dup' is an input-quality problem")));
-        assert!(!imported.warnings().iter().any(|w| w
-            .message()
             .contains("missing optional 'tt.outcome'; assumed 'ok'")));
-        assert!(!run
+        assert!(run
             .metadata
             .lifecycle_warnings
             .iter()
@@ -1528,6 +1593,37 @@ mod tests {
         ];
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
         assert!(matches!(err, ImportError::StrictViolation(_)));
+    }
+
+    #[test]
+    fn strict_error_lists_unique_core_issue_codes_once_in_order() {
+        let spans = vec![
+            SpanRecord::new("req-1", 100, 120)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "dup")
+                .field(TT_ROUTE, "/a"),
+            SpanRecord::new("req-2", 130, 150)
+                .field(TT_KIND, "request")
+                .field(TT_REQUEST_ID, "dup")
+                .field(TT_ROUTE, "/b"),
+            SpanRecord::new("stage", 135, 140)
+                .field(TT_KIND, "stage")
+                .field(TT_REQUEST_ID, "dup")
+                .field(TT_STAGE, "db"),
+        ];
+
+        let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true))
+            .expect_err("strict import should reject duplicate requests and ambiguous child");
+        let message = err.to_string();
+        let duplicate_index = message
+            .find("duplicate_completed_request_id")
+            .expect("duplicate issue code should be listed");
+        let ambiguous_index = message
+            .find("ambiguous_parent_request_id")
+            .expect("ambiguous parent issue code should be listed");
+        assert!(duplicate_index < ambiguous_index);
+        assert_eq!(message.matches("duplicate_completed_request_id").count(), 1);
+        assert_eq!(message.matches("ambiguous_parent_request_id").count(), 1);
     }
 
     #[test]
@@ -1566,14 +1662,20 @@ mod tests {
     fn invalid_extreme_timestamps_do_not_affect_metadata_bounds_or_default_run_id() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
+                .started_at_run_us(100_000)
+                .finished_at_run_us(120_000)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/a"),
             SpanRecord::new("stage-extreme", 1, 1_000_000)
+                .started_at_run_us(1_000)
+                .finished_at_run_us(1_000_000_000)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_STAGE, "db"),
             SpanRecord::new("queue-extreme", 1, 1_000_000)
+                .started_at_run_us(1_000)
+                .finished_at_run_us(1_000_000_000)
                 .field(TT_KIND, "queue")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_QUEUE, "permits"),
@@ -1591,6 +1693,8 @@ mod tests {
     fn orphan_queue_does_not_affect_retained_bounds_or_default_run_id() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
+                .started_at_run_us(100_000)
+                .finished_at_run_us(120_000)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/a"),
@@ -1610,9 +1714,9 @@ mod tests {
 
     #[test]
     fn overflow_request_does_not_affect_metadata_bounds_or_run_id() {
-        let limits = CaptureMode::Light.core_defaults();
+        let max_requests = 2;
         let mut spans = Vec::new();
-        for index in 0..limits.max_requests {
+        for index in 0..max_requests {
             spans.push(
                 SpanRecord::new(format!("req-{index}"), 100, 120)
                     .field(TT_KIND, "request")
@@ -1627,9 +1731,18 @@ mod tests {
                 .field(TT_REQUEST_ID, "r-overflow")
                 .field(TT_ROUTE, "/overflow"),
         );
-        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        let imported = run_from_span_records(
+            spans,
+            ImportOptions::new("svc").capture_limits_override(
+                tailtriage_core::CaptureLimitsOverride {
+                    max_requests: Some(max_requests),
+                    ..tailtriage_core::CaptureLimitsOverride::default()
+                },
+            ),
+        )
+        .unwrap();
         let run = imported.run();
-        assert_eq!(run.requests.len(), limits.max_requests);
+        assert_eq!(run.requests.len(), max_requests);
         assert_eq!(run.truncation.dropped_requests, 1);
         assert_eq!(run.metadata.started_at_unix_ms, 100);
         assert_eq!(run.metadata.finished_at_unix_ms, 120);
@@ -1641,13 +1754,13 @@ mod tests {
 
     #[test]
     fn overflow_stage_does_not_affect_metadata_bounds_or_success_warning() {
-        let limits = CaptureMode::Light.core_defaults();
+        let max_stages = 2;
         let mut spans = vec![SpanRecord::new("req", 100, 120)
             .field(TT_KIND, "request")
             .field(TT_REQUEST_ID, "r1")
             .field(TT_ROUTE, "/a")
             .field(TT_OUTCOME, "ok")];
-        for index in 0..limits.max_stages {
+        for index in 0..max_stages {
             spans.push(
                 SpanRecord::new(format!("stage-{index}"), 101, 110)
                     .field(TT_KIND, "stage")
@@ -1662,10 +1775,19 @@ mod tests {
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_STAGE, "overflow-stage"),
         );
-        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        let imported = run_from_span_records(
+            spans,
+            ImportOptions::new("svc").capture_limits_override(
+                tailtriage_core::CaptureLimitsOverride {
+                    max_stages: Some(max_stages),
+                    ..tailtriage_core::CaptureLimitsOverride::default()
+                },
+            ),
+        )
+        .unwrap();
         let run = imported.run();
-        assert_eq!(run.stages.len(), limits.max_stages);
-        assert_eq!(run.truncation.dropped_stages, 0);
+        assert_eq!(run.stages.len(), max_stages);
+        assert_eq!(run.truncation.dropped_stages, 1);
         assert_eq!(run.metadata.started_at_unix_ms, 100);
         assert_eq!(run.metadata.finished_at_unix_ms, 120);
         assert!(!imported.warnings().iter().any(|w| w
@@ -1675,13 +1797,13 @@ mod tests {
 
     #[test]
     fn overflow_queue_does_not_affect_metadata_bounds() {
-        let limits = CaptureMode::Light.core_defaults();
+        let max_queues = 2;
         let mut spans = vec![SpanRecord::new("req", 100, 120)
             .field(TT_KIND, "request")
             .field(TT_REQUEST_ID, "r1")
             .field(TT_ROUTE, "/a")
             .field(TT_OUTCOME, "ok")];
-        for index in 0..limits.max_queues {
+        for index in 0..max_queues {
             spans.push(
                 SpanRecord::new(format!("queue-{index}"), 101, 110)
                     .field(TT_KIND, "queue")
@@ -1695,10 +1817,19 @@ mod tests {
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_QUEUE, "overflow-queue"),
         );
-        let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
+        let imported = run_from_span_records(
+            spans,
+            ImportOptions::new("svc").capture_limits_override(
+                tailtriage_core::CaptureLimitsOverride {
+                    max_queues: Some(max_queues),
+                    ..tailtriage_core::CaptureLimitsOverride::default()
+                },
+            ),
+        )
+        .unwrap();
         let run = imported.run();
-        assert_eq!(run.queues.len(), limits.max_queues);
-        assert_eq!(run.truncation.dropped_queues, 0);
+        assert_eq!(run.queues.len(), max_queues);
+        assert_eq!(run.truncation.dropped_queues, 1);
         assert_eq!(run.metadata.started_at_unix_ms, 100);
         assert_eq!(run.metadata.finished_at_unix_ms, 120);
     }
@@ -1851,7 +1982,7 @@ mod tests {
             .field(TT_REQUEST_ID, "r1")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests.len(), 0);
-        assert_eq!(imported.warnings().len(), 1);
+        assert!(!imported.warnings().is_empty());
     }
 
     #[test]
@@ -1867,7 +1998,7 @@ mod tests {
     fn unknown_kind_warns_non_strict() {
         let spans = vec![SpanRecord::new("x", 1, 2).field(TT_KIND, "wat")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.warnings().len(), 1);
+        assert!(!imported.warnings().is_empty());
         assert!(imported
             .run()
             .metadata
@@ -2089,7 +2220,7 @@ mod tests {
     fn non_string_kind_warns_non_strict_and_errors_strict() {
         let bad = SpanRecord::new("bad", 1, 2).field(TT_KIND, true);
         let imported = run_from_span_records(vec![bad.clone()], ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.warnings().len(), 1);
+        assert!(!imported.warnings().is_empty());
         assert!(run_from_span_records(vec![bad], ImportOptions::new("svc").strict(true)).is_err());
     }
 
@@ -2102,7 +2233,7 @@ mod tests {
         let imported =
             run_from_span_records(vec![bad_route.clone()], ImportOptions::new("svc")).unwrap();
         assert!(imported.run().requests.is_empty());
-        assert_eq!(imported.warnings().len(), 1);
+        assert!(!imported.warnings().is_empty());
         assert!(
             run_from_span_records(vec![bad_route], ImportOptions::new("svc").strict(true)).is_err()
         );
@@ -2115,7 +2246,7 @@ mod tests {
         let imported =
             run_from_span_records(vec![bad_outcome.clone()], ImportOptions::new("svc")).unwrap();
         assert!(imported.run().requests.is_empty());
-        assert_eq!(imported.warnings().len(), 1);
+        assert!(!imported.warnings().is_empty());
         assert!(
             run_from_span_records(vec![bad_outcome], ImportOptions::new("svc").strict(true))
                 .is_err()
@@ -2347,12 +2478,10 @@ mod tests {
         assert!(imported.run().requests.is_empty());
         assert!(imported.run().stages.is_empty());
         assert!(imported.run().queues.is_empty());
-        assert!(imported.warnings().iter().any(|w| w.message().contains(
-            "skipped stage span for request_id 'r1' because no valid matching request event was imported"
-        )));
-        assert!(imported.warnings().iter().any(|w| w.message().contains(
-            "skipped queue span for request_id 'r1' because no valid matching request event was imported"
-        )));
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("orphan_request_scoped_event")));
     }
 
     #[test]
@@ -2425,7 +2554,7 @@ mod tests {
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_QUEUE, "permits"),
         ];
-        let err = run_from_span_records(
+        let imported = run_from_span_records(
             spans,
             ImportOptions::new("checkout")
                 .strict(true)
@@ -2436,11 +2565,9 @@ mod tests {
                     ..tailtriage_core::CaptureLimitsOverride::default()
                 }),
         )
-        .expect_err("strict import should fail when child only matches overflow duplicate request");
-        assert!(matches!(err, ImportError::StrictViolation(_)));
-        let msg = err.to_string();
-        assert!(msg.contains("falls outside request interval"));
-        assert!(!msg.contains("valid but not retained due to max_requests"));
+        .expect("strict import should retain coarse-only children for retained overflow request");
+        assert_eq!(imported.run().stages.len(), 1);
+        assert_eq!(imported.run().queues.len(), 1);
     }
 
     #[test]
@@ -2477,8 +2604,8 @@ mod tests {
         .expect("non-strict import should succeed with warnings");
 
         assert_eq!(imported.run().requests.len(), 1);
-        assert_eq!(imported.run().stages.len(), 0);
-        assert_eq!(imported.run().queues.len(), 0);
+        assert_eq!(imported.run().stages.len(), 1);
+        assert_eq!(imported.run().queues.len(), 1);
         assert_eq!(imported.run().truncation.dropped_requests, 1);
         assert_eq!(imported.run().truncation.dropped_stages, 0);
         assert_eq!(imported.run().truncation.dropped_queues, 0);
@@ -2490,7 +2617,7 @@ mod tests {
             .collect();
         assert!(warning_msgs
             .iter()
-            .any(|msg| msg.contains("falls outside request interval")));
+            .all(|msg| !msg.contains("child_interval_outside_request")));
         assert!(warning_msgs
             .iter()
             .all(|msg| !msg.contains("valid but not retained due to max_requests")));
@@ -2498,7 +2625,7 @@ mod tests {
         let lifecycle_warnings = &imported.run().metadata.lifecycle_warnings;
         assert!(lifecycle_warnings
             .iter()
-            .any(|msg| msg.contains("falls outside request interval")));
+            .all(|msg| !msg.contains("child_interval_outside_request")));
         assert!(lifecycle_warnings
             .iter()
             .all(|msg| !msg.contains("valid but not retained due to max_requests")));
@@ -2542,27 +2669,9 @@ mod tests {
                     ..tailtriage_core::CaptureLimitsOverride::default()
                 }),
         )
-        .expect("strict import should succeed for valid overflow request children");
-
-        assert_eq!(imported.run().requests.len(), 1);
-        assert_eq!(imported.run().requests[0].request_id, "r1");
-        assert_eq!(imported.run().stages.len(), 1);
-        assert_eq!(imported.run().stages[0].request_id, "r1");
-        assert_eq!(imported.run().queues.len(), 1);
-        assert_eq!(imported.run().queues[0].request_id, "r1");
-        assert_eq!(imported.run().truncation.dropped_requests, 1);
-        assert_eq!(imported.run().truncation.dropped_stages, 1);
-        assert_eq!(imported.run().truncation.dropped_queues, 1);
-        assert!(imported.run().truncation.limits_hit);
-        assert!(imported.warnings().iter().any(|w| w.message().contains(
-            "skipped stage span for request_id 'r2' because the matching request was valid but not retained due to max_requests"
-        )));
-        assert!(imported.warnings().iter().any(|w| w.message().contains(
-            "skipped queue span for request_id 'r2' because the matching request was valid but not retained due to max_requests"
-        )));
-        assert!(imported.warnings().iter().all(|w| !w
-            .message()
-            .contains("no retained request event was imported")));
+        .expect_err("strict import should reject retained children whose parent was dropped by max_requests");
+        assert!(matches!(imported, ImportError::StrictViolation(_)));
+        assert!(imported.to_string().contains("orphan_request_scoped_event"));
     }
 
     #[test]
@@ -2595,7 +2704,7 @@ mod tests {
         .expect_err("strict import should fail for out-of-window overflow stage");
         assert!(matches!(err, ImportError::StrictViolation(_)));
         let msg = err.to_string();
-        assert!(msg.contains("falls outside request interval"));
+        assert!(msg.contains("orphan_request_scoped_event"));
         assert!(!msg.contains("valid but not retained due to max_requests"));
     }
 
@@ -2629,7 +2738,7 @@ mod tests {
         .expect_err("strict import should fail for out-of-window overflow queue");
         assert!(matches!(err, ImportError::StrictViolation(_)));
         let msg = err.to_string();
-        assert!(msg.contains("falls outside request interval"));
+        assert!(msg.contains("orphan_request_scoped_event"));
         assert!(!msg.contains("valid but not retained due to max_requests"));
     }
 
@@ -2672,16 +2781,9 @@ mod tests {
                     ..tailtriage_core::CaptureLimitsOverride::default()
                 }),
         )
-        .expect("strict import should succeed and retain first input request");
-        assert_eq!(imported.run().requests.len(), 1);
-        assert_eq!(imported.run().requests[0].request_id, "z-retained");
-        assert_eq!(imported.run().stages.len(), 1);
-        assert_eq!(imported.run().stages[0].request_id, "z-retained");
-        assert_eq!(imported.run().queues.len(), 1);
-        assert_eq!(imported.run().queues[0].request_id, "z-retained");
-        assert_eq!(imported.run().truncation.dropped_requests, 1);
-        assert_eq!(imported.run().truncation.dropped_stages, 1);
-        assert_eq!(imported.run().truncation.dropped_queues, 1);
+        .expect_err("strict import should reject overflow children whose parent was dropped by max_requests");
+        assert!(matches!(imported, ImportError::StrictViolation(_)));
+        assert!(imported.to_string().contains("orphan_request_scoped_event"));
     }
 
     #[test]
@@ -2700,7 +2802,7 @@ mod tests {
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().stages.len(), 0);
-        assert_eq!(imported.warnings().len(), 1);
+        assert!(!imported.warnings().is_empty());
         assert_eq!(imported.run().metadata.started_at_unix_ms, 10);
         assert_eq!(imported.run().metadata.finished_at_unix_ms, 20);
     }
@@ -2738,7 +2840,7 @@ mod tests {
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().queues.len(), 0);
-        assert_eq!(imported.warnings().len(), 1);
+        assert!(!imported.warnings().is_empty());
         assert_eq!(imported.run().metadata.started_at_unix_ms, 10);
         assert_eq!(imported.run().metadata.finished_at_unix_ms, 20);
     }
@@ -2789,6 +2891,8 @@ mod tests {
     #[test]
     fn mismatched_request_duration_warns_and_retains_duration_us_in_non_strict_mode() {
         let spans = vec![SpanRecord::new("req", 100, 101)
+            .started_at_run_us(100_000)
+            .finished_at_run_us(101_000)
             .duration_us(50_000)
             .field(TT_KIND, "request")
             .field(TT_REQUEST_ID, "r1")
@@ -2798,19 +2902,17 @@ mod tests {
         assert!(imported
             .warnings()
             .iter()
-            .any(|w| w.message().contains("duration_us was retained")));
-        assert!(imported.warnings().iter().any(|w| w
-            .message()
-            .contains("duration_us differs from timestamp-derived duration")));
-        assert!(imported.warnings().iter().any(|w| w
-            .message()
-            .contains("Unix timestamps remain wall-clock anchors")));
+            .any(|w| w.message().contains("duration evidence was retained")));
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("duration_mismatch")));
         assert!(imported
             .run()
             .metadata
             .lifecycle_warnings
             .iter()
-            .any(|w| w.contains("duration_us was retained")));
+            .any(|w| w.contains("duration evidence was retained")));
     }
 
     #[test]
@@ -2822,7 +2924,15 @@ mod tests {
             .field(TT_OUTCOME, "ok")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests[0].latency_us, 1_000);
-        assert!(imported.warnings().is_empty());
+        assert!(imported.warnings().iter().any(|w| w
+            .message()
+            .contains("precise_interval_validation_unavailable")));
+        assert!(!imported
+            .run()
+            .metadata
+            .lifecycle_warnings
+            .iter()
+            .any(|w| w.contains("precise_interval_validation_unavailable")));
     }
 
     #[test]
@@ -2833,6 +2943,8 @@ mod tests {
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/"),
             SpanRecord::new("stage", 100, 101)
+                .started_at_run_us(100_000)
+                .finished_at_run_us(101_000)
                 .duration_us(50_000)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, "r1")
@@ -2843,7 +2955,7 @@ mod tests {
         assert!(imported
             .warnings()
             .iter()
-            .any(|w| w.message().contains("duration_us was retained")));
+            .any(|w| w.message().contains("duration evidence was retained")));
     }
 
     #[test]
@@ -2854,6 +2966,8 @@ mod tests {
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/a"),
             SpanRecord::new("q", 101, 102)
+                .started_at_run_us(101_000)
+                .finished_at_run_us(102_000)
                 .duration_us(50_000)
                 .field(TT_KIND, "queue")
                 .field(TT_REQUEST_ID, "r1")
@@ -2864,12 +2978,14 @@ mod tests {
         assert!(imported
             .warnings()
             .iter()
-            .any(|w| w.message().contains("duration_us was retained")));
+            .any(|w| w.message().contains("duration evidence was retained")));
     }
 
     #[test]
     fn strict_mode_rejects_mismatched_request_duration() {
         let spans = vec![SpanRecord::new("req", 100, 101)
+            .started_at_run_us(100_000)
+            .finished_at_run_us(101_000)
             .duration_us(50_000)
             .field(TT_KIND, "request")
             .field(TT_REQUEST_ID, "r1")
@@ -2878,9 +2994,7 @@ mod tests {
             .expect_err("strict import should reject mismatched duration_us");
         assert!(matches!(err, ImportError::StrictViolation(_)));
         let message = err.to_string();
-        assert!(message.contains("duration_us differs from timestamp-derived duration"));
-        assert!(message.contains("strict import rejected the mismatch"));
-        assert!(!message.contains("duration_us was retained"));
+        assert!(message.contains("duration_mismatch"));
     }
 
     #[test]
@@ -2891,6 +3005,8 @@ mod tests {
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/"),
             SpanRecord::new("stage", 100, 101)
+                .started_at_run_us(100_000)
+                .finished_at_run_us(101_000)
                 .duration_us(50_000)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, "r1")
@@ -2910,6 +3026,8 @@ mod tests {
                 .field(TT_REQUEST_ID, "r1")
                 .field(TT_ROUTE, "/a"),
             SpanRecord::new("q", 101, 102)
+                .started_at_run_us(101_000)
+                .finished_at_run_us(102_000)
                 .duration_us(50_000)
                 .field(TT_KIND, "queue")
                 .field(TT_REQUEST_ID, "r1")
@@ -2930,9 +3048,10 @@ mod tests {
             .field(TT_ROUTE, "/a")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests[0].latency_us, 2_999);
-        assert!(!imported.warnings().iter().any(|w| w
-            .message()
-            .contains("duration_us differs from timestamp-derived duration")));
+        assert!(!imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("duration_mismatch")));
     }
 
     #[test]

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -44,7 +44,8 @@ mod types;
 use tailtriage_core::{
     normalize_run_permissive, summarize_run_validation, summarize_run_validation_lifecycle,
     validate_run_strict, EffectiveCoreConfig, QueueEvent, RequestEvent, Run, RunMetadata,
-    RunValidationSeverity, StageEvent, TruncationSummary, UnfinishedRequests,
+    RunValidationIssueCode, RunValidationSeverity, StageEvent, TruncationSummary,
+    UnfinishedRequests,
 };
 
 pub use convention::{
@@ -324,6 +325,7 @@ where
             let now = tailtriage_core::unix_time_ms();
             (now, now)
         });
+    let explicit_run_id = options.run_id_ref().is_some();
     let run_id = options.run_id_ref().map_or_else(
         || format!("tracing-import-{started_at_unix_ms}-{finished_at_unix_ms}"),
         ToOwned::to_owned,
@@ -367,7 +369,11 @@ where
     let core_warnings = summarize_run_validation(&normalized);
     let lifecycle_warnings = summarize_run_validation_lifecycle(&normalized);
     let mut run = normalized.run;
+    refresh_normalized_metadata_bounds(&mut run, explicit_run_id);
     for warning in core_warnings {
+        if warning.contains(RunValidationIssueCode::PreciseIntervalValidationUnavailable.as_str()) {
+            continue;
+        }
         if !warnings
             .iter()
             .any(|existing| existing.message() == warning)
@@ -394,15 +400,37 @@ fn apply_retention_limit<T>(items: &mut Vec<T>, max: usize, set_dropped: impl Fn
 }
 
 fn strict_core_error(err: &tailtriage_core::RunValidationError) -> ImportError {
-    let label = err
+    let mut codes = err
         .report()
         .issues
         .iter()
-        .find(|issue| issue.severity == RunValidationSeverity::Error)
-        .map_or("run_validation_failed", |issue| issue.code.as_str());
+        .filter(|issue| issue.severity == RunValidationSeverity::Error)
+        .map(|issue| issue.code)
+        .collect::<Vec<_>>();
+    codes.sort_unstable();
+    codes.dedup();
+    let labels = codes
+        .iter()
+        .map(|code| code.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
     ImportError::StrictViolation(format!(
-        "core run validation failed with issue code '{label}': {err}"
+        "core run validation failed with issue codes [{labels}]: {err}"
     ))
+}
+
+fn refresh_normalized_metadata_bounds(run: &mut Run, explicit_run_id: bool) {
+    if let Some((started_at_unix_ms, finished_at_unix_ms)) =
+        retained_event_time_bounds(&run.requests, &run.stages, &run.queues)
+    {
+        run.metadata.started_at_unix_ms = started_at_unix_ms;
+        run.metadata.finished_at_unix_ms = finished_at_unix_ms;
+        run.metadata.finalized_at_unix_ms = Some(finished_at_unix_ms);
+        if !explicit_run_id {
+            run.metadata.run_id =
+                format!("tracing-import-{started_at_unix_ms}-{finished_at_unix_ms}");
+        }
+    }
 }
 
 struct ParsedStageEvent {
@@ -544,7 +572,9 @@ fn run_relative_derived_duration_us(
     started_at_run_us: Option<u64>,
     finished_at_run_us: Option<u64>,
 ) -> Option<u64> {
-    Some(finished_at_run_us?.saturating_sub(started_at_run_us?))
+    let started_at_run_us = started_at_run_us?;
+    let finished_at_run_us = finished_at_run_us?;
+    finished_at_run_us.checked_sub(started_at_run_us)
 }
 
 fn elapsed_duration_us(

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -41,9 +41,10 @@ mod recorder;
 pub mod tokio;
 mod types;
 
-use std::collections::{BTreeMap, BTreeSet};
 use tailtriage_core::{
-    BuildError, QueueEvent, RequestEvent, RunBuilder, RunBuilderOptions, StageEvent,
+    normalize_run_permissive, summarize_run_validation, summarize_run_validation_lifecycle,
+    validate_run_strict, EffectiveCoreConfig, QueueEvent, RequestEvent, Run, RunMetadata,
+    RunValidationSeverity, StageEvent, TruncationSummary, UnfinishedRequests,
 };
 
 pub use convention::{
@@ -189,11 +190,8 @@ where
                     else {
                         continue;
                     };
-                    let (started_at_run_us, finished_at_run_us) = sanitized_run_relative_offsets(
-                        &span,
-                        options.strict_mode(),
-                        &mut warnings,
-                    )?;
+                    let (started_at_run_us, finished_at_run_us) =
+                        sanitized_run_relative_offsets(&span);
                     parsed_requests.push(ParsedRequestEvent {
                         event: RequestEvent {
                             request_id,
@@ -207,9 +205,7 @@ where
                                 &span,
                                 started_at_run_us,
                                 finished_at_run_us,
-                                options.strict_mode(),
-                                &mut warnings,
-                            )?,
+                            ),
                             outcome,
                         },
                         outcome_defaulted,
@@ -227,11 +223,8 @@ where
                         OptionalField::Value(success) => success,
                         OptionalField::Invalid => continue,
                     };
-                    let (started_at_run_us, finished_at_run_us) = sanitized_run_relative_offsets(
-                        &span,
-                        options.strict_mode(),
-                        &mut warnings,
-                    )?;
+                    let (started_at_run_us, finished_at_run_us) =
+                        sanitized_run_relative_offsets(&span);
                     parsed_stages.push(ParsedStageEvent {
                         event: StageEvent {
                             request_id,
@@ -244,9 +237,7 @@ where
                                 &span,
                                 started_at_run_us,
                                 finished_at_run_us,
-                                options.strict_mode(),
-                                &mut warnings,
-                            )?,
+                            ),
                             success,
                         },
                         success_defaulted: matches!(success_field, OptionalField::Missing),
@@ -264,11 +255,8 @@ where
                             OptionalField::Value(depth) => Some(depth),
                             OptionalField::Invalid => continue,
                         };
-                    let (waited_from_run_us, waited_until_run_us) = sanitized_run_relative_offsets(
-                        &span,
-                        options.strict_mode(),
-                        &mut warnings,
-                    )?;
+                    let (waited_from_run_us, waited_until_run_us) =
+                        sanitized_run_relative_offsets(&span);
                     queues.push(QueueEvent {
                         request_id,
                         queue,
@@ -280,9 +268,7 @@ where
                             &span,
                             waited_from_run_us,
                             waited_until_run_us,
-                            options.strict_mode(),
-                            &mut warnings,
-                        )?,
+                        ),
                         depth_at_start,
                     });
                 }
@@ -291,12 +277,7 @@ where
     }
     let mode = options.mode_value();
     let capture_limits = options.resolved_capture_limits();
-    dedupe_retained_requests(
-        &mut parsed_requests,
-        capture_limits.max_requests,
-        options.strict_mode(),
-        &mut warnings,
-    )?;
+
     let request_outcome_default_count = parsed_requests
         .iter()
         .take(capture_limits.max_requests)
@@ -307,31 +288,6 @@ where
             "{request_outcome_default_count} request span(s) missing optional '{TT_OUTCOME}'; assumed 'ok'"
         )));
     }
-    let requests: Vec<RequestEvent> = parsed_requests
-        .into_iter()
-        .map(|request| request.event)
-        .collect();
-    let all_valid_request_intervals = all_valid_request_intervals(&requests);
-    let retained_request_intervals =
-        retained_request_intervals(&requests, capture_limits.max_requests);
-    let mut dropped_children_due_to_request_retention =
-        DroppedChildrenDueToRequestRetention::default();
-    filter_correlated_parsed_stages(
-        &mut parsed_stages,
-        &all_valid_request_intervals,
-        &retained_request_intervals,
-        options.strict_mode(),
-        &mut warnings,
-        &mut dropped_children_due_to_request_retention,
-    )?;
-    filter_correlated_queues(
-        &mut queues,
-        &all_valid_request_intervals,
-        &retained_request_intervals,
-        options.strict_mode(),
-        &mut warnings,
-        &mut dropped_children_due_to_request_retention,
-    )?;
     let stage_success_default_count = parsed_stages
         .iter()
         .take(capture_limits.max_stages)
@@ -342,155 +298,111 @@ where
             "{stage_success_default_count} stage span(s) missing optional '{TT_SUCCESS}'; assumed true"
         )));
     }
-    let stages: Vec<StageEvent> = parsed_stages.into_iter().map(|stage| stage.event).collect();
-    let retained_requests = &requests[..requests.len().min(capture_limits.max_requests)];
-    let retained_stages = &stages[..stages.len().min(capture_limits.max_stages)];
-    let retained_queues = &queues[..queues.len().min(capture_limits.max_queues)];
+
+    let mut requests: Vec<RequestEvent> = parsed_requests
+        .into_iter()
+        .map(|request| request.event)
+        .collect();
+    let mut stages: Vec<StageEvent> = parsed_stages.into_iter().map(|stage| stage.event).collect();
+
+    let mut truncation = TruncationSummary::default();
+    apply_retention_limit(&mut requests, capture_limits.max_requests, |dropped| {
+        truncation.dropped_requests = dropped;
+    });
+    apply_retention_limit(&mut stages, capture_limits.max_stages, |dropped| {
+        truncation.dropped_stages = dropped;
+    });
+    apply_retention_limit(&mut queues, capture_limits.max_queues, |dropped| {
+        truncation.dropped_queues = dropped;
+    });
+    truncation.limits_hit = truncation.dropped_requests > 0
+        || truncation.dropped_stages > 0
+        || truncation.dropped_queues > 0;
 
     let (started_at_unix_ms, finished_at_unix_ms) =
-        retained_event_time_bounds(retained_requests, retained_stages, retained_queues)
-            .unwrap_or_else(|| {
-                let now = tailtriage_core::unix_time_ms();
-                (now, now)
-            });
+        retained_event_time_bounds(&requests, &stages, &queues).unwrap_or_else(|| {
+            let now = tailtriage_core::unix_time_ms();
+            (now, now)
+        });
     let run_id = options.run_id_ref().map_or_else(
         || format!("tracing-import-{started_at_unix_ms}-{finished_at_unix_ms}"),
         ToOwned::to_owned,
     );
 
-    let mut builder_options = RunBuilderOptions::new(options.service_name())
-        .run_id(run_id)
-        .mode(mode)
-        .capture_limits(capture_limits)
-        .strict_lifecycle(false)
-        .started_at_unix_ms(started_at_unix_ms)
-        .finished_at_unix_ms(finished_at_unix_ms)
-        .finalized_at_unix_ms(finished_at_unix_ms);
-
-    if let Some(service_version) = options.service_version_ref() {
-        builder_options = builder_options.service_version(service_version);
-    }
-
-    let mut run_builder = RunBuilder::new(builder_options).map_err(|err| match err {
-        BuildError::EmptyServiceName => ImportError::EmptyServiceName,
-        BuildError::InvalidRunTimeBounds {
+    let candidate = Run {
+        schema_version: tailtriage_core::SCHEMA_VERSION,
+        metadata: RunMetadata {
+            run_id,
+            service_name: options.service_name().to_owned(),
+            service_version: options.service_version_ref().map(ToOwned::to_owned),
             started_at_unix_ms,
-                    finished_at_unix_ms,
-        } => ImportError::InvalidField {
-            field: "tt.finished_at_unix_ms",
-            reason: format!(
-                "finished_at_unix_ms ({finished_at_unix_ms}) must be >= started_at_unix_ms ({started_at_unix_ms})"
-            ),
-        },
-        BuildError::InvalidFinalizationTime {
             finished_at_unix_ms,
-            finalized_at_unix_ms,
-        } => ImportError::InvalidField {
-            field: "tt.finalized_at_unix_ms",
-            reason: format!(
-                "finalized_at_unix_ms ({finalized_at_unix_ms}) must be >= finished_at_unix_ms ({finished_at_unix_ms})"
-            ),
+            finalized_at_unix_ms: Some(finished_at_unix_ms),
+            mode,
+            effective_core_config: Some(EffectiveCoreConfig {
+                mode,
+                capture_limits,
+                strict_lifecycle: false,
+            }),
+            effective_tokio_sampler_config: None,
+            host: None,
+            pid: None,
+            lifecycle_warnings: Vec::new(),
+            unfinished_requests: UnfinishedRequests::default(),
+            run_end_reason: None,
         },
-    })?;
+        requests,
+        stages,
+        queues,
+        inflight: Vec::new(),
+        runtime_snapshots: Vec::new(),
+        truncation,
+    };
 
-    for request in requests {
-        run_builder
-            .push_request(request)
-            .map_err(|err| ImportError::InvalidRunEvent(err.to_string()))?;
+    if options.strict_mode() {
+        validate_run_strict(&candidate).map_err(|err| strict_core_error(&err))?;
     }
-    for stage in stages {
-        run_builder
-            .push_stage(stage)
-            .map_err(|err| ImportError::InvalidRunEvent(err.to_string()))?;
-    }
-    for queue in queues {
-        run_builder
-            .push_queue(queue)
-            .map_err(|err| ImportError::InvalidRunEvent(err.to_string()))?;
-    }
-    let mut run = run_builder.finish();
-    run.truncation.dropped_stages = run
-        .truncation
-        .dropped_stages
-        .saturating_add(dropped_children_due_to_request_retention.stages);
-    run.truncation.dropped_queues = run
-        .truncation
-        .dropped_queues
-        .saturating_add(dropped_children_due_to_request_retention.queues);
-    if dropped_children_due_to_request_retention.stages > 0
-        || dropped_children_due_to_request_retention.queues > 0
-    {
-        run.truncation.limits_hit = true;
+
+    let normalized = normalize_run_permissive(&candidate);
+    let core_warnings = summarize_run_validation(&normalized);
+    let lifecycle_warnings = summarize_run_validation_lifecycle(&normalized);
+    let mut run = normalized.run;
+    for warning in core_warnings {
+        if !warnings
+            .iter()
+            .any(|existing| existing.message() == warning)
+        {
+            warnings.push(ImportWarning::new(warning));
+        }
     }
     attach_durable_conversion_warnings(&mut run, &warnings);
+    for warning in lifecycle_warnings {
+        if !run.metadata.lifecycle_warnings.contains(&warning) {
+            run.metadata.lifecycle_warnings.push(warning);
+        }
+    }
 
     Ok(ImportedRun::new(run, warnings))
 }
 
-#[derive(Clone, Copy)]
-struct RequestInterval {
-    started_at_unix_ms: u64,
-    finished_at_unix_ms: u64,
+fn apply_retention_limit<T>(items: &mut Vec<T>, max: usize, set_dropped: impl FnOnce(u64)) {
+    let dropped = items.len().saturating_sub(max) as u64;
+    if items.len() > max {
+        items.truncate(max);
+    }
+    set_dropped(dropped);
 }
 
-fn dedupe_retained_requests(
-    requests: &mut Vec<ParsedRequestEvent>,
-    max_requests: usize,
-    strict: bool,
-    warnings: &mut Vec<ImportWarning>,
-) -> Result<(), ImportError> {
-    let mut seen = BTreeSet::new();
-    let mut retained = Vec::with_capacity(requests.len());
-    for request in requests.drain(..) {
-        if retained.len() >= max_requests {
-            retained.push(request);
-            continue;
-        }
-        if !seen.insert(request.event.request_id.clone()) {
-            strict_or_warn(
-                strict,
-                warnings,
-                format!(
-                    "duplicate tt.request_id '{}' is an input-quality problem; skipped later duplicate request event; child stage/queue evidence outside the retained first request interval may also be skipped",
-                    request.event.request_id
-                ),
-            )?;
-            continue;
-        }
-        retained.push(request);
-    }
-    *requests = retained;
-    Ok(())
-}
-
-fn all_valid_request_intervals(requests: &[RequestEvent]) -> BTreeMap<String, RequestInterval> {
-    let mut intervals = BTreeMap::new();
-    for request in requests {
-        intervals
-            .entry(request.request_id.clone())
-            .or_insert(RequestInterval {
-                started_at_unix_ms: request.started_at_unix_ms,
-                finished_at_unix_ms: request.finished_at_unix_ms,
-            });
-    }
-    intervals
-}
-
-fn retained_request_intervals(
-    requests: &[RequestEvent],
-    max_requests: usize,
-) -> BTreeMap<String, RequestInterval> {
-    let mut intervals = BTreeMap::new();
-    for request in requests.iter().take(max_requests) {
-        intervals.insert(
-            request.request_id.clone(),
-            RequestInterval {
-                started_at_unix_ms: request.started_at_unix_ms,
-                finished_at_unix_ms: request.finished_at_unix_ms,
-            },
-        );
-    }
-    intervals
+fn strict_core_error(err: &tailtriage_core::RunValidationError) -> ImportError {
+    let label = err
+        .report()
+        .issues
+        .iter()
+        .find(|issue| issue.severity == RunValidationSeverity::Error)
+        .map_or("run_validation_failed", |issue| issue.code.as_str());
+    ImportError::StrictViolation(format!(
+        "core run validation failed with issue code '{label}': {err}"
+    ))
 }
 
 struct ParsedStageEvent {
@@ -501,138 +413,6 @@ struct ParsedStageEvent {
 struct ParsedRequestEvent {
     event: RequestEvent,
     outcome_defaulted: bool,
-}
-
-#[derive(Default)]
-struct DroppedChildrenDueToRequestRetention {
-    stages: u64,
-    queues: u64,
-}
-
-fn interval_within_request_with_tolerance(
-    child_start_ms: u64,
-    child_finish_ms: u64,
-    request_start_ms: u64,
-    request_finish_ms: u64,
-) -> bool {
-    child_start_ms.saturating_add(TRACE_TIME_TOLERANCE_MS) >= request_start_ms
-        && child_finish_ms <= request_finish_ms.saturating_add(TRACE_TIME_TOLERANCE_MS)
-}
-
-fn filter_correlated_parsed_stages(
-    stages: &mut Vec<ParsedStageEvent>,
-    all_valid_request_intervals: &BTreeMap<String, RequestInterval>,
-    retained_request_intervals: &BTreeMap<String, RequestInterval>,
-    strict: bool,
-    warnings: &mut Vec<ImportWarning>,
-    dropped_due_to_request_retention: &mut DroppedChildrenDueToRequestRetention,
-) -> Result<(), ImportError> {
-    let mut filtered = Vec::with_capacity(stages.len());
-    for stage in stages.drain(..) {
-        let request_id = stage.event.request_id.as_str();
-        let Some(valid_interval) = all_valid_request_intervals.get(request_id) else {
-            strict_or_warn(
-                strict,
-                warnings,
-                format!(
-                    "skipped stage span for request_id '{}' because no valid matching request event was imported",
-                    stage.event.request_id
-                ),
-            )?;
-            continue;
-        };
-        if !interval_within_request_with_tolerance(
-            stage.event.started_at_unix_ms,
-            stage.event.finished_at_unix_ms,
-            valid_interval.started_at_unix_ms,
-            valid_interval.finished_at_unix_ms,
-        ) {
-            strict_or_warn(
-                strict,
-                warnings,
-                format!(
-                    "skipped stage span '{}' for request_id '{}' because interval [{}, {}] falls outside request interval [{}, {}] beyond tolerance_ms={TRACE_TIME_TOLERANCE_MS}",
-                    stage.event.stage,
-                    stage.event.request_id,
-                    stage.event.started_at_unix_ms,
-                    stage.event.finished_at_unix_ms,
-                    valid_interval.started_at_unix_ms,
-                    valid_interval.finished_at_unix_ms
-                ),
-            )?;
-            continue;
-        }
-        if !retained_request_intervals.contains_key(request_id) {
-            dropped_due_to_request_retention.stages =
-                dropped_due_to_request_retention.stages.saturating_add(1);
-            warnings.push(ImportWarning::new(format!(
-                "skipped stage span for request_id '{}' because the matching request was valid but not retained due to max_requests",
-                stage.event.request_id
-            )));
-            continue;
-        }
-        filtered.push(stage);
-    }
-    *stages = filtered;
-    Ok(())
-}
-
-fn filter_correlated_queues(
-    queues: &mut Vec<QueueEvent>,
-    all_valid_request_intervals: &BTreeMap<String, RequestInterval>,
-    retained_request_intervals: &BTreeMap<String, RequestInterval>,
-    strict: bool,
-    warnings: &mut Vec<ImportWarning>,
-    dropped_due_to_request_retention: &mut DroppedChildrenDueToRequestRetention,
-) -> Result<(), ImportError> {
-    let mut filtered = Vec::with_capacity(queues.len());
-    for queue in queues.drain(..) {
-        let request_id = queue.request_id.as_str();
-        let Some(valid_interval) = all_valid_request_intervals.get(request_id) else {
-            strict_or_warn(
-                strict,
-                warnings,
-                format!(
-                    "skipped queue span for request_id '{}' because no valid matching request event was imported",
-                    queue.request_id
-                ),
-            )?;
-            continue;
-        };
-        if !interval_within_request_with_tolerance(
-            queue.waited_from_unix_ms,
-            queue.waited_until_unix_ms,
-            valid_interval.started_at_unix_ms,
-            valid_interval.finished_at_unix_ms,
-        ) {
-            strict_or_warn(
-                strict,
-                warnings,
-                format!(
-                    "skipped queue span '{}' for request_id '{}' because interval [{}, {}] falls outside request interval [{}, {}] beyond tolerance_ms={TRACE_TIME_TOLERANCE_MS}",
-                    queue.queue,
-                    queue.request_id,
-                    queue.waited_from_unix_ms,
-                    queue.waited_until_unix_ms,
-                    valid_interval.started_at_unix_ms,
-                    valid_interval.finished_at_unix_ms
-                ),
-            )?;
-            continue;
-        }
-        if !retained_request_intervals.contains_key(request_id) {
-            dropped_due_to_request_retention.queues =
-                dropped_due_to_request_retention.queues.saturating_add(1);
-            warnings.push(ImportWarning::new(format!(
-                "skipped queue span for request_id '{}' because the matching request was valid but not retained due to max_requests",
-                queue.request_id
-            )));
-            continue;
-        }
-        filtered.push(queue);
-    }
-    *queues = filtered;
-    Ok(())
 }
 
 fn validate_service_name(service_name: &str) -> Result<(), ImportError> {
@@ -736,8 +516,6 @@ fn required_string(
 }
 
 pub(crate) const TRACE_TIME_TOLERANCE_US: u64 = 2_000;
-pub(crate) const TRACE_TIME_TOLERANCE_MS: u64 = TRACE_TIME_TOLERANCE_US / 1_000;
-
 pub(crate) fn duration_within_derived_tolerance(duration_us: u64, derived_us: u64) -> bool {
     duration_us.abs_diff(derived_us) <= TRACE_TIME_TOLERANCE_US
 }
@@ -758,56 +536,8 @@ fn timestamp_derived_duration_us(started_at_unix_ms: u64, finished_at_unix_ms: u
         .saturating_mul(1000)
 }
 
-fn sanitized_run_relative_offsets(
-    span: &SpanRecord,
-    strict: bool,
-    warnings: &mut Vec<ImportWarning>,
-) -> Result<(Option<u64>, Option<u64>), ImportError> {
-    match (span.started_at_run_us_ref(), span.finished_at_run_us_ref()) {
-        (Some(started_at_run_us), Some(finished_at_run_us))
-            if finished_at_run_us >= started_at_run_us =>
-        {
-            Ok((Some(started_at_run_us), Some(finished_at_run_us)))
-        }
-        (Some(started_at_run_us), Some(finished_at_run_us)) => {
-            let message = format!(
-                "span '{}' run-relative timing is inverted: start={} finish={}; dropped run-relative offsets",
-                span.name(),
-                started_at_run_us,
-                finished_at_run_us
-            );
-            if strict {
-                return Err(ImportError::StrictViolation(message));
-            }
-            warnings.push(ImportWarning::new(message));
-            Ok((None, None))
-        }
-        (Some(offset), None) => {
-            let message = format!(
-                "span '{}' incomplete run-relative timing: started_at_run_us={} finished_at_run_us missing; dropped run-relative offsets",
-                span.name(),
-                offset
-            );
-            if strict {
-                return Err(ImportError::StrictViolation(message));
-            }
-            warnings.push(ImportWarning::new(message));
-            Ok((None, None))
-        }
-        (None, Some(offset)) => {
-            let message = format!(
-                "span '{}' incomplete run-relative timing: started_at_run_us missing finished_at_run_us={}; dropped run-relative offsets",
-                span.name(),
-                offset
-            );
-            if strict {
-                return Err(ImportError::StrictViolation(message));
-            }
-            warnings.push(ImportWarning::new(message));
-            Ok((None, None))
-        }
-        (None, None) => Ok((None, None)),
-    }
+fn sanitized_run_relative_offsets(span: &SpanRecord) -> (Option<u64>, Option<u64>) {
+    (span.started_at_run_us_ref(), span.finished_at_run_us_ref())
 }
 
 fn run_relative_derived_duration_us(
@@ -821,73 +551,21 @@ fn elapsed_duration_us(
     span: &SpanRecord,
     started_at_run_us: Option<u64>,
     finished_at_run_us: Option<u64>,
-    strict: bool,
-    warnings: &mut Vec<ImportWarning>,
-) -> Result<u64, ImportError> {
-    let unix_derived_us =
-        timestamp_derived_duration_us(span.started_at_unix_ms(), span.finished_at_unix_ms());
-    let run_relative_derived_us =
-        run_relative_derived_duration_us(started_at_run_us, finished_at_run_us);
-
-    let Some(duration_us) = span.duration_us_ref() else {
-        return Ok(run_relative_derived_us.unwrap_or(unix_derived_us));
-    };
-
-    if let Some(run_relative_derived_us) = run_relative_derived_us {
-        if duration_within_derived_tolerance(duration_us, run_relative_derived_us) {
-            return Ok(duration_us);
-        }
-
-        if strict {
-            return Err(ImportError::StrictViolation(format!(
-                "span '{}' duration_us differs from run-relative duration beyond tolerance: duration_us={} run_relative_duration_us={} tolerance_us={TRACE_TIME_TOLERANCE_US}; strict import rejected the mismatch; Unix timestamps remain wall-clock anchors",
-                span.name(),
-                duration_us,
-                run_relative_derived_us,
-            )));
-        }
-
-        warnings.push(ImportWarning::new(format!(
-            "span '{}' duration_us differs from run-relative duration beyond tolerance: duration_us={} run_relative_duration_us={} tolerance_us={TRACE_TIME_TOLERANCE_US}; duration_us was retained as authoritative elapsed-time evidence; Unix timestamps remain wall-clock anchors",
-            span.name(),
-            duration_us,
-            run_relative_derived_us,
-        )));
-        return Ok(duration_us);
+) -> u64 {
+    if let Some(duration_us) = span.duration_us_ref() {
+        return duration_us;
     }
 
-    if duration_within_derived_tolerance(duration_us, unix_derived_us) {
-        return Ok(duration_us);
-    }
-
-    if strict {
-        return Err(ImportError::StrictViolation(format!(
-            "span '{}' duration_us differs from timestamp-derived duration beyond tolerance: duration_us={} timestamp_derived_duration_us={} tolerance_us={TRACE_TIME_TOLERANCE_US}; strict import rejected the mismatch; Unix timestamps remain wall-clock anchors",
-            span.name(),
-            duration_us,
-            unix_derived_us
-        )));
-    }
-
-    warnings.push(ImportWarning::new(format!(
-        "span '{}' duration_us differs from timestamp-derived duration beyond tolerance: duration_us={} timestamp_derived_duration_us={} tolerance_us={TRACE_TIME_TOLERANCE_US}; duration_us was retained as authoritative elapsed-time evidence; Unix timestamps remain wall-clock anchors",
-        span.name(),
-        duration_us,
-        unix_derived_us
-    )));
-    Ok(duration_us)
+    run_relative_derived_duration_us(started_at_run_us, finished_at_run_us).unwrap_or_else(|| {
+        timestamp_derived_duration_us(span.started_at_unix_ms(), span.finished_at_unix_ms())
+    })
 }
 
 fn is_durable_conversion_warning(message: &str) -> bool {
     message.starts_with("skipped ")
-        || message.starts_with("duplicate tt.request_id")
         || message.starts_with("missing required field")
         || message.starts_with("invalid field")
         || message.starts_with("unknown tt.kind")
-        || message.contains("duration_us differs from timestamp-derived duration")
-        || message.contains("duration_us differs from run-relative duration")
-        || message.contains("run-relative timing is inverted")
-        || message.contains("incomplete run-relative timing")
         || message.contains("missing optional 'tt.outcome'; assumed 'ok'")
         || message.contains("missing optional 'tt.success'; assumed true")
 }

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -2212,7 +2212,7 @@ mod tests {
     }
 
     #[test]
-    fn raw_completed_candidate_cap_evicts_retained_duplicate_for_later_unique_request() {
+    fn raw_completed_candidate_cap_drops_incoming_request_when_full_of_requests() {
         let recorder = TracingRecorder::builder("svc")
             .max_completed_candidate_spans(3)
             .capture_limits(CaptureLimits {
@@ -2270,7 +2270,7 @@ mod tests {
     }
 
     #[test]
-    fn raw_completed_candidate_cap_evicts_retained_duplicate_before_useful_child_evidence() {
+    fn request_arriving_at_full_child_containing_cap_evicts_child_regardless_of_identity() {
         let recorder = TracingRecorder::builder("svc")
             .max_completed_candidate_spans(3)
             .capture_limits(CaptureLimits {
@@ -2326,7 +2326,7 @@ mod tests {
     }
 
     #[test]
-    fn strict_mode_errors_when_raw_cap_evicts_retained_duplicate_request() {
+    fn strict_mode_errors_when_raw_cap_evicts_child_before_core_excludes_ambiguous_requests() {
         let recorder = TracingRecorder::builder("svc")
             .strict(true)
             .max_completed_candidate_spans(3)
@@ -2377,7 +2377,7 @@ mod tests {
     }
 
     #[test]
-    fn raw_completed_candidate_cap_drops_duplicate_request_before_later_unique_request() {
+    fn full_request_only_raw_cap_drops_incoming_request_regardless_of_identity() {
         let recorder = TracingRecorder::builder("svc")
             .max_completed_candidate_spans(2)
             .capture_limits(CaptureLimits {
@@ -2425,8 +2425,7 @@ mod tests {
     }
 
     #[test]
-    fn raw_completed_candidate_cap_drops_unique_request_when_semantic_request_retention_is_exhausted(
-    ) {
+    fn semantic_request_limit_applies_after_raw_recorder_retention() {
         let recorder = TracingRecorder::builder("svc")
             .max_completed_candidate_spans(2)
             .capture_limits(CaptureLimits {
@@ -2811,7 +2810,7 @@ mod tests {
     }
 
     #[test]
-    fn orphan_stage_does_not_consume_stage_retention_in_non_strict_mode() {
+    fn source_valid_orphan_stage_consumes_semantic_stage_retention_before_core_exclusion() {
         let recorder = TracingRecorder::builder("svc")
             .capture_limits(CaptureLimits {
                 max_requests: 1,
@@ -2848,7 +2847,7 @@ mod tests {
     }
 
     #[test]
-    fn orphan_queue_does_not_consume_queue_retention_in_non_strict_mode() {
+    fn source_valid_orphan_queue_consumes_semantic_queue_retention_before_core_exclusion() {
         let recorder = TracingRecorder::builder("svc")
             .capture_limits(CaptureLimits {
                 max_requests: 1,
@@ -4067,7 +4066,7 @@ mod tests {
         assert_eq!(imported.run().queues.len(), 0);
     }
 
-    fn run_with_replay_safe_and_contradictory_durations() -> tailtriage_core::Run {
+    fn run_with_coherent_replay_timing() -> tailtriage_core::Run {
         let mut run = empty_run();
         run.requests.push(tailtriage_core::RequestEvent {
             request_id: "r1".into(),
@@ -4105,7 +4104,7 @@ mod tests {
 
     #[test]
     fn retained_request_stage_queue_emit_only_replay_safe_durations_and_run_offsets() {
-        let run = run_with_replay_safe_and_contradictory_durations();
+        let run = run_with_coherent_replay_timing();
         let spans = retained_span_records_from_run(&run);
         assert_eq!(spans.len(), 3);
 
@@ -4208,7 +4207,7 @@ mod tests {
     fn completed_span_jsonl_preserves_run_relative_safe_durations_for_strict_replay() {
         let dir = tempfile::tempdir().unwrap();
         let spans_path = dir.path().join("spans.jsonl");
-        let run = run_with_replay_safe_and_contradictory_durations();
+        let run = run_with_coherent_replay_timing();
         write_completed_span_jsonl_from_run(&run, &spans_path).unwrap();
 
         let raw = std::fs::read_to_string(&spans_path).unwrap();

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::fmt;
 use std::fmt::Write as _;
 use std::io::Write;
@@ -63,7 +63,6 @@ pub struct TracingRecorderBuilder {
 pub struct TailtriageLayer {
     state: Arc<Mutex<RecorderState>>,
     limits: RecorderLimits,
-    semantic_max_requests: usize,
 }
 /// Default maximum number of concurrently tracked open candidate spans.
 pub const DEFAULT_MAX_OPEN_SPANS: usize = 8_192;
@@ -197,7 +196,6 @@ impl TracingRecorder {
         TailtriageLayer {
             state: Arc::clone(&self.state),
             limits: self.limits,
-            semantic_max_requests: self.options.resolved_capture_limits().max_requests,
         }
     }
 
@@ -824,7 +822,6 @@ where
                 record,
                 kind,
                 self.limits,
-                self.semantic_max_requests,
             );
         }
     }
@@ -877,7 +874,6 @@ fn push_completed_candidate_with_kind_aware_retention(
     record: SpanRecord,
     kind: &str,
     limits: RecorderLimits,
-    semantic_max_requests: usize,
 ) {
     let total = state.completed_requests.len()
         + state.completed_stages.len()
@@ -892,35 +888,12 @@ fn push_completed_candidate_with_kind_aware_retention(
         return;
     }
 
-    if total + 1 < limits.max_completed_candidate_spans {
-        state.completed_requests.push(record);
-        return;
-    }
-
-    let Some(incoming_request_id) = valid_request_id_from_span(&record) else {
-        state.dropped_completed_request_candidates =
-            state.dropped_completed_request_candidates.saturating_add(1);
-        return;
-    };
-
-    if retained_request_id_is_represented(state, incoming_request_id)
-        || unique_retained_request_id_count(&state.completed_requests) >= semantic_max_requests
-    {
-        state.dropped_completed_request_candidates =
-            state.dropped_completed_request_candidates.saturating_add(1);
-        return;
-    }
-
     if total < limits.max_completed_candidate_spans {
         state.completed_requests.push(record);
         return;
     }
 
-    if let Some(index) = retained_duplicate_request_candidate_position(state) {
-        state.completed_requests.remove(index);
-        state.dropped_completed_request_candidates =
-            state.dropped_completed_request_candidates.saturating_add(1);
-    } else if !state.completed_queues.is_empty() {
+    if !state.completed_queues.is_empty() {
         state.completed_queues.pop();
         state.evicted_child_candidates_to_preserve_request = state
             .evicted_child_candidates_to_preserve_request
@@ -937,48 +910,6 @@ fn push_completed_candidate_with_kind_aware_retention(
     }
 
     state.completed_requests.push(record);
-}
-
-fn unique_retained_request_id_count(records: &[SpanRecord]) -> usize {
-    records
-        .iter()
-        .filter_map(valid_request_id_from_span)
-        .collect::<BTreeSet<_>>()
-        .len()
-}
-
-fn retained_request_id_is_represented(state: &RecorderState, incoming_request_id: &str) -> bool {
-    state
-        .completed_requests
-        .iter()
-        .filter_map(valid_request_id_from_span)
-        .any(|retained_request_id| retained_request_id == incoming_request_id)
-}
-
-fn retained_duplicate_request_candidate_position(state: &RecorderState) -> Option<usize> {
-    for index in (0..state.completed_requests.len()).rev() {
-        let Some(request_id) = valid_request_id_from_span(&state.completed_requests[index]) else {
-            continue;
-        };
-        if state.completed_requests[..index]
-            .iter()
-            .filter_map(valid_request_id_from_span)
-            .any(|retained_request_id| retained_request_id == request_id)
-        {
-            return Some(index);
-        }
-    }
-
-    None
-}
-
-fn valid_request_id_from_span(record: &SpanRecord) -> Option<&str> {
-    match record.fields().get("tt.request_id") {
-        Some(FieldValue::String(request_id)) if !request_id.trim().is_empty() => {
-            Some(request_id.as_str())
-        }
-        _ => None,
-    }
 }
 
 fn push_record_by_kind(state: &mut RecorderState, record: SpanRecord, kind: &str) {
@@ -1161,7 +1092,7 @@ fn push_strict_recorder_messages(
     }
     if stats.dropped_completed_request_candidates > 0 {
         messages.push(format!(
-            "live recorder dropped {} completed request candidate span(s) because max_completed_candidate_spans={} was reached and preserving the request would not fit semantic max_requests retention or no child candidate was available to evict",
+            "live recorder dropped {} completed request candidate span(s) because max_completed_candidate_spans={} was reached and no child candidate was available to evict",
             stats.dropped_completed_request_candidates, limits.max_completed_candidate_spans
         ));
     }
@@ -1173,7 +1104,7 @@ fn push_strict_recorder_messages(
     }
     if stats.evicted_child_candidates_to_preserve_request > 0 {
         messages.push(format!(
-            "live recorder evicted {} completed child candidate span(s) to preserve completed request candidate span(s) still within semantic request retention under max_completed_candidate_spans={}",
+            "live recorder evicted {} completed child candidate span(s) to preserve completed request candidate span(s) under max_completed_candidate_spans={}",
             stats.evicted_child_candidates_to_preserve_request, limits.max_completed_candidate_spans
         ));
     }
@@ -1257,7 +1188,7 @@ fn append_non_strict_drop_warnings(
     }
     if stats.dropped_completed_request_candidates > 0 {
         let msg = format!(
-            "live recorder dropped {} completed request candidate span(s) because max_completed_candidate_spans={} was reached and preserving the request would not fit semantic max_requests retention or no child candidate was available to evict",
+            "live recorder dropped {} completed request candidate span(s) because max_completed_candidate_spans={} was reached and no child candidate was available to evict",
             stats.dropped_completed_request_candidates, limits.max_completed_candidate_spans
         );
         run.metadata.lifecycle_warnings.push(msg.clone());
@@ -1273,7 +1204,7 @@ fn append_non_strict_drop_warnings(
     }
     if stats.evicted_child_candidates_to_preserve_request > 0 {
         let msg = format!(
-            "live recorder evicted {} completed child candidate span(s) to preserve completed request candidate span(s) still within semantic request retention under max_completed_candidate_spans={}",
+            "live recorder evicted {} completed child candidate span(s) to preserve completed request candidate span(s) under max_completed_candidate_spans={}",
             stats.evicted_child_candidates_to_preserve_request, limits.max_completed_candidate_spans
         );
         run.metadata.lifecycle_warnings.push(msg.clone());
@@ -2088,14 +2019,9 @@ mod tests {
         assert_eq!(run.requests.len(), 1);
         assert_eq!(run.requests[0].request_id, "r1");
         assert_eq!(run.requests[0].route, "/r1");
-        assert_eq!(run.stages.len(), 1);
-        assert_eq!(run.stages[0].request_id, "r1");
-        assert!(run
-            .requests
-            .iter()
-            .all(|request| request.request_id != "r2"));
+        assert!(run.stages.is_empty());
         assert!(run.truncation.limits_hit);
-        assert_eq!(run.truncation.dropped_requests, 0);
+        assert_eq!(run.truncation.dropped_requests, 1);
 
         let warning_text = imported
             .warnings()
@@ -2103,8 +2029,8 @@ mod tests {
             .map(|w| w.message().to_string())
             .collect::<Vec<_>>()
             .join(" | ");
-        assert!(warning_text.contains("dropped 1 completed request candidate span"));
-        assert!(warning_text.contains("semantic max_requests retention"));
+        assert!(warning_text.contains("evicted 1 completed child candidate span"));
+        assert!(!warning_text.contains("dropped 1 completed request candidate span"));
     }
 
     #[test]
@@ -2160,7 +2086,7 @@ mod tests {
             .collect::<Vec<_>>()
             .join(" | ");
         assert!(warning_text.contains("evicted 1 completed child candidate span"));
-        assert!(warning_text.contains("semantic request retention"));
+        assert!(warning_text.contains("max_completed_candidate_spans=2"));
         assert!(!warning_text.contains("dropped 1 completed request candidate span"));
     }
 
@@ -2330,13 +2256,12 @@ mod tests {
             .iter()
             .map(|request| request.request_id.as_str())
             .collect::<Vec<_>>();
-        assert_eq!(request_ids, vec!["r1", "r2", "r3"]);
-        assert_eq!(imported.run().requests.len(), 3);
+        assert_eq!(request_ids, vec!["r2"]);
+        assert_eq!(imported.run().requests.len(), 1);
         assert!(imported
-            .run()
-            .requests
+            .warnings()
             .iter()
-            .any(|request| request.request_id == "r3"));
+            .any(|w| { w.message().contains("duplicate_completed_request_id") }));
         assert!(imported.warnings().iter().any(|w| {
             w.message()
                 .contains("dropped 1 completed request candidate span(s)")
@@ -2390,12 +2315,12 @@ mod tests {
             .iter()
             .map(|request| request.request_id.as_str())
             .collect::<Vec<_>>();
-        assert_eq!(request_ids, vec!["r1", "r2"]);
-        assert_eq!(run.requests.len(), 2);
+        assert_eq!(request_ids, vec!["r2"]);
+        assert_eq!(run.requests.len(), 1);
         assert!(run.stages.is_empty());
         assert!(imported.warnings().iter().any(|w| {
             w.message()
-                .contains("dropped 1 completed request candidate span(s)")
+                .contains("evicted 1 completed child candidate span(s)")
                 && w.message().contains("max_completed_candidate_spans=3")
         }));
     }
@@ -2489,9 +2414,9 @@ mod tests {
             .requests
             .iter()
             .map(|request| request.request_id.as_str())
-            .collect::<BTreeSet<_>>();
-        assert_eq!(request_ids, BTreeSet::from(["r1", "r2"]));
-        assert_eq!(imported.run().requests.len(), 2);
+            .collect::<std::collections::BTreeSet<_>>();
+        assert!(request_ids.is_empty());
+        assert_eq!(imported.run().requests.len(), 0);
         assert!(imported.warnings().iter().any(|w| {
             w.message()
                 .contains("dropped 1 completed request candidate span(s)")
@@ -2529,10 +2454,11 @@ mod tests {
         let imported = recorder.snapshot_run().unwrap();
         assert_eq!(imported.run().requests.len(), 1);
         assert_eq!(imported.run().requests[0].request_id, "r1");
-        assert!(imported.warnings().iter().any(|w| {
-            w.message()
-                .contains("would not fit semantic max_requests retention")
-        }));
+        assert_eq!(imported.run().truncation.dropped_requests, 1);
+        assert!(!imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("max_completed_candidate_spans")));
     }
 
     #[test]
@@ -2672,7 +2598,6 @@ mod tests {
         let imported = recorder.snapshot_run().unwrap();
         assert_eq!(imported.run().requests.len(), 1);
         assert_eq!(imported.run().stages.len(), 1);
-        assert_eq!(imported.run().stages[0].request_id, "r1");
         assert_eq!(imported.run().stages[0].stage, "db");
         assert!(imported
             .warnings()
@@ -2718,7 +2643,6 @@ mod tests {
         let imported = recorder.snapshot_run().unwrap();
         assert_eq!(imported.run().requests.len(), 1);
         assert_eq!(imported.run().queues.len(), 1);
-        assert_eq!(imported.run().queues[0].request_id, "r1");
         assert_eq!(imported.run().queues[0].queue, "db-pool");
         assert!(imported
             .warnings()
@@ -2919,8 +2843,8 @@ mod tests {
             ));
         });
         let imported = recorder.snapshot_run().unwrap();
-        assert_eq!(imported.run().stages.len(), 1);
-        assert_eq!(imported.run().stages[0].request_id, "r1");
+        assert!(imported.run().stages.is_empty());
+        assert_eq!(imported.run().truncation.dropped_stages, 1);
     }
 
     #[test]
@@ -2956,8 +2880,8 @@ mod tests {
             ));
         });
         let imported = recorder.snapshot_run().unwrap();
-        assert_eq!(imported.run().queues.len(), 1);
-        assert_eq!(imported.run().queues[0].request_id, "r1");
+        assert!(imported.run().queues.is_empty());
+        assert_eq!(imported.run().truncation.dropped_queues, 1);
     }
 
     #[test]
@@ -4151,9 +4075,9 @@ mod tests {
             kind: None,
             started_at_unix_ms: 100,
             started_at_run_us: Some(1_000),
-            finished_at_unix_ms: 101,
-            finished_at_run_us: Some(3_500),
-            latency_us: 2_500,
+            finished_at_unix_ms: 199,
+            finished_at_run_us: Some(100_000),
+            latency_us: 99_000,
             outcome: "ok".into(),
         });
         run.stages.push(tailtriage_core::StageEvent {
@@ -4191,9 +4115,9 @@ mod tests {
                 span.fields().get("tt.kind") == Some(&FieldValue::String("request".into()))
             })
             .expect("request span");
-        assert_eq!(request.duration_us_ref(), Some(2_500));
+        assert_eq!(request.duration_us_ref(), Some(99_000));
         assert_eq!(request.started_at_run_us_ref(), Some(1_000));
-        assert_eq!(request.finished_at_run_us_ref(), Some(3_500));
+        assert_eq!(request.finished_at_run_us_ref(), Some(100_000));
 
         let stage = spans
             .iter()
@@ -4210,6 +4134,21 @@ mod tests {
         assert_eq!(queue.duration_us_ref(), Some(30_000));
         assert_eq!(queue.started_at_run_us_ref(), Some(3_000));
         assert_eq!(queue.finished_at_run_us_ref(), Some(33_000));
+
+        let imported = run_from_span_records(spans, ImportOptions::new("svc").strict(true))
+            .expect("coherent replay spans should import strictly");
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().stages.len(), 1);
+        assert_eq!(imported.run().queues.len(), 1);
+        assert_eq!(imported.run().requests[0].latency_us, 99_000);
+        assert_eq!(imported.run().stages[0].latency_us, 70_000);
+        assert_eq!(imported.run().queues[0].wait_us, 30_000);
+        assert_eq!(imported.run().requests[0].started_at_run_us, Some(1_000));
+        assert_eq!(imported.run().requests[0].finished_at_run_us, Some(100_000));
+        assert_eq!(imported.run().stages[0].started_at_run_us, Some(2_000));
+        assert_eq!(imported.run().stages[0].finished_at_run_us, Some(72_000));
+        assert_eq!(imported.run().queues[0].waited_from_run_us, Some(3_000));
+        assert_eq!(imported.run().queues[0].waited_until_run_us, Some(33_000));
     }
 
     #[test]
@@ -4288,7 +4227,7 @@ mod tests {
                 span.fields().get("tt.kind") == Some(&FieldValue::String("request".into()))
             })
             .expect("request span");
-        assert_eq!(request.duration_us_ref(), Some(2_500));
+        assert_eq!(request.duration_us_ref(), Some(99_000));
 
         let stage = records
             .iter()
@@ -4308,11 +4247,14 @@ mod tests {
             crate::jsonl::JsonlParseMode::TailtriageWrapperOnly,
         )
         .unwrap();
-        assert_eq!(replay.run().requests[0].latency_us, 2_500);
+        assert_eq!(replay.run().requests.len(), 1);
+        assert_eq!(replay.run().stages.len(), 1);
+        assert_eq!(replay.run().queues.len(), 1);
+        assert_eq!(replay.run().requests[0].latency_us, 99_000);
+        assert_eq!(replay.run().stages[0].latency_us, 70_000);
+        assert_eq!(replay.run().queues[0].wait_us, 30_000);
         assert_eq!(replay.run().requests[0].started_at_run_us, Some(1_000));
-        assert_eq!(replay.run().requests[0].finished_at_run_us, Some(3_500));
-        assert!(replay.run().stages.is_empty());
-        assert!(replay.run().queues.is_empty());
+        assert_eq!(replay.run().requests[0].finished_at_run_us, Some(100_000));
     }
 
     #[test]

--- a/tailtriage-tracing/tests/support/equivalence_harness.rs
+++ b/tailtriage-tracing/tests/support/equivalence_harness.rs
@@ -190,8 +190,11 @@ fn deterministic_tracing_run() -> (Run, Vec<String>) {
     let mut spans = Vec::new();
     for (id, offset_ms, request_us, queue_us, db_us, cache_us) in scenario {
         let req_start = start_ms + offset_ms;
+        let req_run_start_us = offset_ms * 1000;
         spans.push(
             SpanRecord::new("request", req_start, req_start + (request_us / 1000))
+                .started_at_run_us(req_run_start_us)
+                .finished_at_run_us(req_run_start_us + request_us)
                 .duration_us(request_us)
                 .field(TT_KIND, "request")
                 .field(TT_REQUEST_ID, id)
@@ -200,6 +203,8 @@ fn deterministic_tracing_run() -> (Run, Vec<String>) {
         );
         spans.push(
             SpanRecord::new("queue", req_start + 1, req_start + 1 + (queue_us / 1000))
+                .started_at_run_us(req_run_start_us + 1_000)
+                .finished_at_run_us(req_run_start_us + 1_000 + queue_us)
                 .duration_us(queue_us)
                 .field(TT_KIND, "queue")
                 .field(TT_REQUEST_ID, id)
@@ -208,6 +213,8 @@ fn deterministic_tracing_run() -> (Run, Vec<String>) {
         );
         spans.push(
             SpanRecord::new("stage", req_start + 85, req_start + 85 + (db_us / 1000))
+                .started_at_run_us(req_run_start_us + 85_000)
+                .finished_at_run_us(req_run_start_us + 85_000 + db_us)
                 .duration_us(db_us)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, id)
@@ -216,6 +223,8 @@ fn deterministic_tracing_run() -> (Run, Vec<String>) {
         );
         spans.push(
             SpanRecord::new("stage", req_start + 93, req_start + 93 + (cache_us / 1000))
+                .started_at_run_us(req_run_start_us + 93_000)
+                .finished_at_run_us(req_run_start_us + 93_000 + cache_us)
                 .duration_us(cache_us)
                 .field(TT_KIND, "stage")
                 .field(TT_REQUEST_ID, id)

--- a/tailtriage-tracing/tests/tracing_examples.rs
+++ b/tailtriage-tracing/tests/tracing_examples.rs
@@ -165,7 +165,9 @@ fn jsonl_fixture_imports_completed_span_shape() {
     assert_eq!(run.queues[0].depth_at_start, Some(7));
     assert_eq!(run.stages[0].stage, "db.query");
     assert!(run.stages[0].success);
-    assert!(imported.warnings().is_empty());
+    assert!(imported.warnings().iter().any(|warning| warning
+        .message()
+        .contains("precise_interval_validation_unavailable")));
 }
 
 #[test]
@@ -214,7 +216,7 @@ fn imported_fixture_run_is_analyzable_and_has_no_runtime_snapshots() {
 
 #[test]
 fn stable_wrapper_duration_us_is_authoritative_when_wall_timestamps_disagree() {
-    let input = r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"request","started_at_unix_ms":1700000000000,"finished_at_unix_ms":1700000000001,"duration_us":50000,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}"#;
+    let input = r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"request","started_at_unix_ms":1700000000000,"started_at_run_us":0,"finished_at_unix_ms":1700000000001,"finished_at_run_us":1000,"duration_us":50000,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}"#;
 
     let imported = import_jsonl_reader_with_mode(
         Cursor::new(input),
@@ -225,9 +227,10 @@ fn stable_wrapper_duration_us_is_authoritative_when_wall_timestamps_disagree() {
 
     assert_eq!(imported.run().requests.len(), 1);
     assert_eq!(imported.run().requests[0].latency_us, 50_000);
-    assert!(imported.warnings().iter().any(|warning| warning
-        .message()
-        .contains("duration_us differs from timestamp-derived duration")));
+    assert!(imported
+        .warnings()
+        .iter()
+        .any(|warning| warning.message().contains("duration_mismatch")));
 
     let err = import_jsonl_reader_with_mode(
         Cursor::new(input),
@@ -235,9 +238,7 @@ fn stable_wrapper_duration_us_is_authoritative_when_wall_timestamps_disagree() {
         JsonlParseMode::TailtriageWrapperOnly,
     )
     .expect_err("strict import should reject mismatched duration");
-    assert!(err
-        .to_string()
-        .contains("duration_us differs from timestamp-derived duration"));
+    assert!(err.to_string().contains("duration_mismatch"));
 }
 
 #[test]


### PR DESCRIPTION
### Motivation

Generic completed-`Run` integrity policy was split between tracing and `tailtriage-core`.

Tracing independently handled duplicate request IDs, orphaned child evidence, parent exclusion, containment, and run-relative timing cleanup. That produced different outcomes depending on whether evidence entered through native collection, tracing conversion, or strict import.

This PR makes core the authoritative owner of generic completed-`Run` validation and normalization for tracing inputs while preserving tracing ownership of source parsing, capture limits, and recorder accounting.

### Description

#### Canonical tracing conversion

`run_from_span_records` now uses one conversion pipeline:

```text
parse tracing source records
→ retain source-valid candidates under tracing capture limits
→ assemble an unnormalized candidate Run
→ apply strict core validation when requested
→ apply permissive core normalization
→ append canonical import and lifecycle summaries
→ return ImportedRun
```

Tracing no longer independently decides:

* which duplicate completed request wins;
* whether a request-scoped child is orphaned;
* whether a child’s parent was excluded;
* whether a child references an ambiguous duplicate request ID;
* whether precise child timing falls outside its parent;
* whether invalid optional run-relative offsets should be retained or cleared.

Every individually source-valid candidate retained under tracing’s semantic limits reaches core validation.

#### Strict and permissive behavior

Strict tracing imports now reject error-level generic integrity findings through stable core issue codes.

Permissive tracing imports now return the normalized core Run and expose canonical analyzer-facing summaries through `ImportedRun::warnings()`.

Outcome-changing normalization findings are also appended to `metadata.lifecycle_warnings`.

Missing optional run-relative precision remains visible as an import warning but is not persisted as lifecycle noise when duration-only evidence was retained unchanged.

#### Metadata and timing behavior

After permissive normalization, metadata bounds are recomputed from the normalized retained evidence.

This ensures that excluded orphan, ambiguous, or out-of-parent evidence does not affect:

* `started_at_unix_ms`;
* `finished_at_unix_ms`;
* `finalized_at_unix_ms`;
* automatically generated tracing-import run IDs.

Explicit caller-supplied run IDs remain unchanged.

When explicit duration is absent, valid complete run-relative intervals may provide the duration. Partial or inverted intervals instead fall back to coarse timestamp-derived duration, and core remains responsible for clearing invalid optional precision.

Tracing now uses the shared core run-relative duration tolerance rather than maintaining a second independent constant.

#### Live recorder retention

The live recorder’s bounded completed-candidate retention is now request-ID agnostic.

The raw recorder cap:

* retains candidates while capacity remains;
* drops incoming child candidates when full;
* allows an incoming request candidate to evict a retained queue, then a retained stage;
* drops the incoming request when no child candidate is available to evict.

It does not inspect request identity, count unique request IDs, prefer one duplicate over another, or apply semantic `max_requests`.

The accounting stages are now distinct:

```text
raw recorder candidate capacity
→ tracing semantic request/stage/queue retention
→ core validation and normalization
```

Raw-cap drops remain recorder warnings and counters.

Semantic capture-limit drops remain `Run.truncation` counts.

Core exclusions remain validation outcomes and do not increment either source-drop category.

#### Replay coverage

The existing completed-span reconstruction architecture remains unchanged.

Positive replay fixtures now use coherent request, stage, and queue timing and verify that strict replay preserves:

* all three event classes;
* authoritative duration fields;
* complete run-relative offsets.

Source-span provenance and direct accepted-source JSONL output remain deferred.

### Preserved behavior

This PR does not change:

* tracing public API shape;
* JSONL envelope formats;
* JSONL parser modes;
* compatibility input support;
* source-field parsing and type validation;
* malformed-source handling and line reporting;
* open-span tracking;
* tracing capture-limit configuration;
* completed-span reconstruction architecture;
* CLI production artifact-loading policy;
* analyzer configuration behavior.

### Testing

The final test suite covers:

* duplicate request exclusion;
* ambiguous-parent child exclusion;
* orphan stage and queue handling;
* excluded-parent classification;
* precise inside-parent retention;
* precise out-of-parent exclusion;
* partial and inverted optional timing cleanup;
* duration mismatch handling;
* duration-only missing-precision warnings;
* deterministic strict issue-code reporting;
* normalized metadata bounds;
* explicit and generated run IDs;
* raw recorder capacity behavior;
* semantic retention behavior;
* raw-drop, semantic-drop, and core-exclusion accounting;
* strict and permissive tracing-import CLI boundaries;
* coherent request/stage/queue replay.

Final head:

```text
d79678e8ce22bd6341b77d9c2a8ebc860c98f33a
```

CI run #1621 completed successfully.

Validated successfully:

```text
cargo fmt --check
cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
cargo test --workspace --all-targets --all-features --locked
python3 scripts/demo_tool.py validate-tracing-parity all --profile release
python3 scripts/demo_tool.py validate-tracing-retention-parity --profile release
python3 scripts/validate_docs_contracts.py
```

### Deferred work

The following remain outside this PR:

* CLI production artifact-loader delegation to core;
* tracing source-span provenance through normalization;
* direct Run JSON and completed-span JSONL generation from the same accepted source records;
* tracing public API simplification;
* JSONL compatibility-format removal.

------
[Initial Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e213ddc5883309c7cc32bca774696)