### PR TITLE
Delegate CLI Run artifact integrity to core

### DIFF
--- a/tailtriage-cli/src/artifact.rs
+++ b/tailtriage-cli/src/artifact.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use serde_json::Value;
-use tailtriage_core::{Run, SCHEMA_VERSION};
+use tailtriage_core::{normalize_run_permissive, Run, SCHEMA_VERSION};
 
 const SUPPORTED_SCHEMA_VERSION: u64 = SCHEMA_VERSION;
 
@@ -10,6 +10,8 @@ const SUPPORTED_SCHEMA_VERSION: u64 = SCHEMA_VERSION;
 pub struct LoadedArtifact {
     /// Parsed run artifact data used by analyzer and renderer flows.
     pub run: Run,
+    /// Original decoded run before permissive normalization.
+    pub original_run: Run,
     /// Non-fatal loader findings that did not block loading.
     pub warnings: Vec<String>,
 }
@@ -106,11 +108,11 @@ impl std::error::Error for ArtifactLoadError {
     }
 }
 
-/// Loads and validates a tailtriage run artifact from disk.
+/// Loads and decodes a tailtriage run artifact from disk, then applies
+/// permissive core normalization for analyzer use.
 ///
-/// Validation is strict:
-/// - top-level `schema_version` must exist and match this binary exactly
-/// - the decoded artifact must include at least one request event
+/// The CLI owns file/JSON/schema-envelope decoding and the analyze command
+/// requirement that at least one request remains after core normalization.
 ///
 /// Loader warnings are non-fatal findings and are returned in
 /// [`LoadedArtifact::warnings`].
@@ -119,6 +121,18 @@ impl std::error::Error for ArtifactLoadError {
 /// Returns [`ArtifactLoadError`] when the file cannot be read, the JSON is malformed,
 /// the schema is unsupported, or required sections are missing.
 pub fn load_run_artifact(path: &Path) -> Result<LoadedArtifact, ArtifactLoadError> {
+    let loaded = decode_run_artifact(path)?;
+    validate_required_sections(&loaded.run, path)?;
+    Ok(loaded)
+}
+
+/// Decodes a run artifact and applies permissive core normalization without
+/// enforcing command-specific minimum-request policy.
+///
+/// # Errors
+/// Returns [`ArtifactLoadError`] when the file cannot be read, the JSON is malformed,
+/// the schema envelope is unsupported, or the decoded shape is incompatible.
+pub fn decode_run_artifact(path: &Path) -> Result<LoadedArtifact, ArtifactLoadError> {
     let input = std::fs::read_to_string(path).map_err(|source| ArtifactLoadError::Read {
         path: path.to_path_buf(),
         source,
@@ -131,24 +145,29 @@ pub fn load_run_artifact(path: &Path) -> Result<LoadedArtifact, ArtifactLoadErro
 
     validate_schema_version(&raw, path)?;
 
-    let run: Run = serde_json::from_value(raw).map_err(|err| ArtifactLoadError::Parse {
+    let original_run: Run = serde_json::from_value(raw).map_err(|err| ArtifactLoadError::Parse {
         path: path.to_path_buf(),
         message: format!(
             "JSON shape does not match the tailtriage run schema ({err}). Check for missing required fields such as metadata.run_id and requests[]."
         ),
     })?;
 
-    validate_required_sections(&run, path)?;
+    let normalized = normalize_run_permissive(&original_run);
+    let run = normalized.run;
 
-    let mut warnings = run.metadata.lifecycle_warnings.clone();
-    if run.metadata.unfinished_requests.count > 0 {
+    let mut warnings = original_run.metadata.lifecycle_warnings.clone();
+    if original_run.metadata.unfinished_requests.count > 0 {
         warnings.push(format!(
             "artifact recorded {} unfinished request(s) at shutdown",
-            run.metadata.unfinished_requests.count
+            original_run.metadata.unfinished_requests.count
         ));
     }
 
-    Ok(LoadedArtifact { run, warnings })
+    Ok(LoadedArtifact {
+        run,
+        original_run,
+        warnings,
+    })
 }
 
 fn validate_schema_version(raw: &Value, path: &Path) -> Result<(), ArtifactLoadError> {

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -2,12 +2,13 @@ use std::io::BufRead;
 use std::path::PathBuf;
 
 use clap::{Parser, ValueEnum};
-use tailtriage_analyzer::{
-    render_json_pretty, render_text, try_analyze_run, validate_artifact_strict,
-};
-use tailtriage_cli::artifact::load_run_artifact;
+use tailtriage_analyzer::{render_json_pretty, render_text, try_analyze_run};
+use tailtriage_cli::artifact::{decode_run_artifact, ArtifactLoadError};
 use tailtriage_cli::{analyzer_options_help_text, build_analyze_options};
-use tailtriage_core::{CaptureLimitsOverride, CaptureMode, LocalJsonSink, RunSink};
+use tailtriage_core::{
+    validate_run_strict, CaptureLimitsOverride, CaptureMode, LocalJsonSink, RunSink,
+    RunValidationSeverity,
+};
 use tailtriage_tracing::{
     ensure_persistable_run_has_requests, import_jsonl_path_with_mode, ImportError, ImportOptions,
     JsonlParseMode,
@@ -170,9 +171,16 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                     "missing required RUN_JSON argument (or use --help-analyzer-options)",
                 )
             })?;
-            let loaded = load_run_artifact(&run_json)?;
+            let loaded = decode_run_artifact(&run_json)?;
             if strict_artifact {
-                validate_artifact_strict(&loaded.run)?;
+                validate_cli_strict_artifact(&loaded.original_run)?;
+            }
+            if loaded.run.requests.is_empty() {
+                return Err(ArtifactLoadError::Validation {
+                    path: run_json.clone(),
+                    message: "requests section is empty. Capture at least one request event before running triage.".to_string(),
+                }
+                .into());
             }
             for warning in &loaded.warnings {
                 eprintln!("warning: {warning}");
@@ -192,6 +200,49 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+fn validate_cli_strict_artifact(run: &tailtriage_core::Run) -> Result<(), std::io::Error> {
+    validate_run_strict(run).map_err(|err| {
+        let mut codes = err
+            .report()
+            .issues
+            .iter()
+            .filter(|issue| issue.severity == RunValidationSeverity::Error)
+            .map(|issue| issue.code.as_str())
+            .collect::<Vec<_>>();
+        codes.sort_unstable();
+        codes.dedup();
+
+        let mut details = err
+            .report()
+            .issues
+            .iter()
+            .filter(|issue| issue.severity == RunValidationSeverity::Error)
+            .take(8)
+            .map(|issue| {
+                let location = if let Some(index) = issue.location.index {
+                    format!("{}[{index}]", issue.location.section.as_str())
+                } else if let Some(field) = issue.location.field {
+                    format!("{}.{}", issue.location.section.as_str(), field)
+                } else {
+                    issue.location.section.as_str().to_string()
+                };
+                format!("{} at {location}: {}", issue.code.as_str(), issue.message)
+            })
+            .collect::<Vec<_>>();
+        if details.is_empty() {
+            details.push(err.to_string());
+        }
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "strict artifact validation failed; core issue code(s): {}; {}",
+                codes.join(", "),
+                details.join("; ")
+            ),
+        )
+    })
 }
 
 fn create_output_parent_dir(path: &std::path::Path) -> Result<(), std::io::Error> {

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write as _;
 use std::io::BufRead;
 use std::path::PathBuf;
 
@@ -186,7 +187,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 eprintln!("warning: {warning}");
             }
             let options = build_analyze_options(analyzer_config.as_deref(), &analyzer_set)?;
-            let report = try_analyze_run(&loaded.run, options)?;
+            let report = try_analyze_run(&loaded.original_run, options)?;
 
             match format {
                 OutputFormat::Text => {
@@ -214,23 +215,37 @@ fn validate_cli_strict_artifact(run: &tailtriage_core::Run) -> Result<(), std::i
         codes.sort_unstable();
         codes.dedup();
 
+        let error_count = err
+            .report()
+            .issues
+            .iter()
+            .filter(|issue| issue.severity == RunValidationSeverity::Error)
+            .count();
+        let detail_limit = 8;
         let mut details = err
             .report()
             .issues
             .iter()
             .filter(|issue| issue.severity == RunValidationSeverity::Error)
-            .take(8)
+            .take(detail_limit)
             .map(|issue| {
-                let location = if let Some(index) = issue.location.index {
-                    format!("{}[{index}]", issue.location.section.as_str())
-                } else if let Some(field) = issue.location.field {
-                    format!("{}.{}", issue.location.section.as_str(), field)
-                } else {
-                    issue.location.section.as_str().to_string()
-                };
+                let mut location = issue.location.section.as_str().to_string();
+                if let Some(index) = issue.location.index {
+                    write!(location, "[{index}]").expect("writing to String should not fail");
+                }
+                if let Some(field) = issue.location.field {
+                    location.push('.');
+                    location.push_str(field);
+                }
                 format!("{} at {location}: {}", issue.code.as_str(), issue.message)
             })
             .collect::<Vec<_>>();
+        if error_count > detail_limit {
+            details.push(format!(
+                "{} additional error finding(s) omitted",
+                error_count - detail_limit
+            ));
+        }
         if details.is_empty() {
             details.push(err.to_string());
         }

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -221,6 +221,214 @@ fn analyze_strict_artifact_rejects_orphan_stage_request_ids() {
 }
 
 #[test]
+fn analyze_strict_artifact_allows_missing_optional_precision_only() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let artifact_path = write_valid_artifact(&dir);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("analyze")
+        .arg(&artifact_path)
+        .arg("--strict-artifact")
+        .arg("--format")
+        .arg("json")
+        .output()
+        .expect("cli should run");
+
+    assert!(output.status.success(), "cli failed: {output:?}");
+}
+
+#[test]
+fn analyze_strict_artifact_required_field_location_includes_index_and_field() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let artifact_path = dir.path().join("missing-route.json");
+    let artifact = valid_cli_artifact_with_requests().replace(r#""route":"/""#, r#""route":" ""#);
+    std::fs::write(&artifact_path, artifact).expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("analyze")
+        .arg(&artifact_path)
+        .arg("--strict-artifact")
+        .output()
+        .expect("cli should run");
+
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("empty_required_field"));
+    assert!(stderr.contains("request[0].route"));
+}
+
+#[test]
+fn analyze_strict_artifact_duplicate_plus_orphan_displays_unique_error_codes_only() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let artifact_path = dir.path().join("duplicate-plus-orphan.json");
+    let artifact = valid_cli_artifact_with_requests()
+        .replace(
+            r#""requests":[{"request_id":"req1","route":"/","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":10,"outcome":"ok"}]"#,
+            r#""requests":[{"request_id":"req1","route":"/","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":10,"outcome":"ok"},{"request_id":"req1","route":"/retry","kind":null,"started_at_unix_ms":3,"finished_at_unix_ms":4,"latency_us":20,"outcome":"ok"}]"#,
+        )
+        .replace(
+            r#""stages":[]"#,
+            r#""stages":[{"request_id":"missing","stage":"db","started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":10,"success":true}]"#,
+        );
+    std::fs::write(&artifact_path, artifact).expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("analyze")
+        .arg(&artifact_path)
+        .arg("--strict-artifact")
+        .output()
+        .expect("cli should run");
+
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("duplicate_completed_request_id"));
+    assert!(stderr.contains("orphan_request_scoped_event"));
+    assert!(!stderr.contains("precise_interval_validation_unavailable"));
+}
+
+#[test]
+fn analyze_malformed_json_fails_before_core_validation() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let artifact_path = dir.path().join("malformed.json");
+    std::fs::write(&artifact_path, "{\"schema_version\":1,").expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("analyze")
+        .arg(&artifact_path)
+        .arg("--strict-artifact")
+        .output()
+        .expect("cli should run");
+
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("failed to parse run artifact"));
+    assert!(!stderr.contains("strict artifact validation failed"));
+}
+
+#[test]
+fn analyze_strict_artifact_discloses_truncated_error_details() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let artifact_path = dir.path().join("many-errors.json");
+    let requests = (0..10)
+        .map(|idx| {
+            format!(
+                r#"{{"request_id":"req{idx}","route":" ","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":10,"outcome":"ok"}}"#
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    let artifact = valid_cli_artifact_with_requests().replace(
+        r#""requests":[{"request_id":"req1","route":"/","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":10,"outcome":"ok"}]"#,
+        &format!(r#""requests":[{requests}]"#),
+    );
+    std::fs::write(&artifact_path, artifact).expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("analyze")
+        .arg(&artifact_path)
+        .arg("--strict-artifact")
+        .output()
+        .expect("cli should run");
+
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("empty_required_field"));
+    assert!(stderr.contains("2 additional error finding(s) omitted"));
+}
+
+#[test]
+fn analyze_permissive_artifact_preserves_orphan_stage_core_warning_without_lifecycle_mutation() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let artifact_path = dir.path().join("orphan-stage.json");
+    let artifact = valid_cli_artifact_with_requests().replace(
+        r#""stages":[]"#,
+        r#""stages":[{"request_id":"missing","stage":"db","started_at_unix_ms":1,"started_at_run_us":1,"finished_at_unix_ms":2,"finished_at_run_us":2,"latency_us":1,"success":true}]"#,
+    );
+    std::fs::write(&artifact_path, artifact).expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("analyze")
+        .arg(&artifact_path)
+        .arg("--format")
+        .arg("json")
+        .output()
+        .expect("cli should run");
+
+    let report = parse_report_json(output);
+    assert_eq!(report["request_count"].as_u64(), Some(1));
+    assert!(warnings(&report)
+        .iter()
+        .any(|warning| warning.contains("orphan_request_scoped_event")));
+
+    let original: Run =
+        serde_json::from_str(&std::fs::read_to_string(&artifact_path).unwrap()).unwrap();
+    assert!(original.metadata.lifecycle_warnings.is_empty());
+}
+
+#[test]
+fn analyze_permissive_artifact_preserves_invalid_optional_precision_warning_and_duration() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let artifact_path = dir.path().join("partial-precision.json");
+    let artifact = valid_cli_artifact_with_requests().replace(
+        r#""request_id":"req1","route":"/","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":10,"outcome":"ok""#,
+        r#""request_id":"req1","route":"/","kind":null,"started_at_unix_ms":1,"started_at_run_us":1,"finished_at_unix_ms":2,"latency_us":10,"outcome":"ok""#,
+    );
+    std::fs::write(&artifact_path, artifact).expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("analyze")
+        .arg(&artifact_path)
+        .arg("--format")
+        .arg("json")
+        .output()
+        .expect("cli should run");
+
+    let report = parse_report_json(output);
+    assert_eq!(report["request_count"].as_u64(), Some(1));
+    assert!(warnings(&report)
+        .iter()
+        .any(|warning| warning.contains("partial_run_relative_interval")));
+    assert!(evidence_quality_limitations(&report)
+        .iter()
+        .any(|limitation| limitation.contains("duration evidence was retained")));
+}
+
+#[test]
+fn analyze_permissive_artifact_excludes_precise_child_outside_parent_but_retains_request() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let artifact_path = dir.path().join("outside-child.json");
+    let artifact = valid_cli_artifact_with_requests()
+        .replace(
+            r#""request_id":"req1","route":"/","kind":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":10,"outcome":"ok""#,
+            r#""request_id":"req1","route":"/","kind":null,"started_at_unix_ms":1,"started_at_run_us":10,"finished_at_unix_ms":2,"finished_at_run_us":20,"latency_us":10,"outcome":"ok""#,
+        )
+        .replace(
+            r#""stages":[]"#,
+            r#""stages":[{"request_id":"req1","stage":"db","started_at_unix_ms":1,"started_at_run_us":0,"finished_at_unix_ms":2,"finished_at_run_us":5,"latency_us":5,"success":true}]"#,
+        );
+    std::fs::write(&artifact_path, artifact).expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("analyze")
+        .arg(&artifact_path)
+        .arg("--format")
+        .arg("json")
+        .output()
+        .expect("cli should run");
+
+    let report = parse_report_json(output);
+    assert_eq!(report["request_count"].as_u64(), Some(1));
+    assert!(warnings(&report)
+        .iter()
+        .any(|warning| warning.contains("child_interval_outside_request")));
+    assert!(!report.to_string().contains(r#""db""#));
+}
+
+#[test]
 fn cli_misspelled_analyzer_set_reports_suggestion() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let artifact_path = write_valid_artifact(&dir);
@@ -1486,6 +1694,24 @@ fn parse_report_json(output: std::process::Output) -> serde_json::Value {
 
     let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
     serde_json::from_str(&stdout).expect("stdout should be valid json")
+}
+
+fn warnings(report: &serde_json::Value) -> Vec<&str> {
+    report["warnings"]
+        .as_array()
+        .expect("warnings should be array")
+        .iter()
+        .map(|value| value.as_str().expect("warning should be string"))
+        .collect()
+}
+
+fn evidence_quality_limitations(report: &serde_json::Value) -> Vec<&str> {
+    report["evidence_quality"]["limitations"]
+        .as_array()
+        .expect("limitations should be array")
+        .iter()
+        .map(|value| value.as_str().expect("limitation should be string"))
+        .collect()
 }
 
 fn assert_precise_interval_warning_only_in_stderr(output: &std::process::Output) {

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -166,12 +166,13 @@ fn analyze_strict_artifact_rejects_duplicate_completed_request_ids() {
     assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
     assert!(stderr.contains("strict artifact validation failed"));
-    assert!(stderr.contains("duplicate completed request_id"));
-    assert!(stderr.contains("req1"));
+    assert!(stderr.contains("duplicate_completed_request_id"));
+    assert!(stderr.contains("request[0]"));
+    assert!(stderr.contains("request[1]"));
 }
 
 #[test]
-fn analyze_permissive_artifact_warns_on_duplicate_completed_request_ids() {
+fn analyze_permissive_artifact_reports_empty_after_duplicate_exclusion_as_command_policy() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let artifact_path = dir.path().join("duplicate-ids.json");
     let artifact = valid_cli_artifact_with_requests().replace(
@@ -188,15 +189,12 @@ fn analyze_permissive_artifact_warns_on_duplicate_completed_request_ids() {
         .output()
         .expect("cli should run");
 
-    assert!(output.status.success(), "cli failed: {output:?}");
-    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
-    let report: serde_json::Value = serde_json::from_str(&stdout).expect("stdout should be json");
-    let warnings = report["warnings"]
-        .as_array()
-        .expect("warnings should be array");
-    assert!(warnings.iter().any(|warning| warning
-        .as_str()
-        .is_some_and(|text| text.contains("duplicate_completed_request_id"))));
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("requests section is empty"));
+    assert!(!stderr.contains("failed to parse"));
+    assert!(!stderr.contains("strict run validation"));
 }
 
 #[test]
@@ -218,8 +216,8 @@ fn analyze_strict_artifact_rejects_orphan_stage_request_ids() {
 
     assert!(!output.status.success(), "cli unexpectedly succeeded");
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
-    assert!(stderr.contains("orphan stage request_id"));
-    assert!(stderr.contains("missing"));
+    assert!(stderr.contains("orphan_request_scoped_event"));
+    assert!(stderr.contains("stage[0]"));
 }
 
 #[test]

--- a/tailtriage-cli/tests/json_parity.rs
+++ b/tailtriage-cli/tests/json_parity.rs
@@ -1,6 +1,8 @@
 use std::process::Command;
 
-use tailtriage_core::{RequestOptions, Tailtriage};
+use std::collections::BTreeSet;
+
+use tailtriage_core::{normalize_run_permissive, RequestOptions, Run, Tailtriage};
 
 #[test]
 fn cli_json_matches_analyzer_renderer_output() {
@@ -46,4 +48,155 @@ fn cli_json_matches_analyzer_renderer_output() {
 
     assert_eq!(stderr, "");
     assert_eq!(stdout, format!("{expected_json}\n"));
+}
+
+#[test]
+fn permissive_cli_reports_preserve_core_warning_equivalence_for_boundary_artifacts() {
+    for candidate in [
+        Candidate {
+            name: "orphan-stage",
+            artifact: valid_request_plus_orphan_stage(),
+            expected_code: "orphan_request_scoped_event",
+            expected_stages_after_normalization: Some(0),
+        },
+        Candidate {
+            name: "partial-precision",
+            artifact: request_with_partial_optional_precision(),
+            expected_code: "partial_run_relative_interval",
+            expected_stages_after_normalization: None,
+        },
+        Candidate {
+            name: "outside-child",
+            artifact: precise_child_outside_parent(),
+            expected_code: "child_interval_outside_request",
+            expected_stages_after_normalization: Some(0),
+        },
+    ] {
+        let original: Run =
+            serde_json::from_str(candidate.artifact).expect("candidate should decode");
+        let normalized = normalize_run_permissive(&original);
+        let analyzer_report = tailtriage_analyzer::analyze_run(
+            &original,
+            tailtriage_analyzer::AnalyzeOptions::default(),
+        );
+
+        let tempdir = tempfile::tempdir().expect("tempdir should build");
+        let artifact_path = tempdir.path().join(format!("{}.json", candidate.name));
+        std::fs::write(&artifact_path, candidate.artifact).expect("artifact should write");
+        let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+            .arg("analyze")
+            .arg(&artifact_path)
+            .arg("--format")
+            .arg("json")
+            .output()
+            .expect("cli should run");
+        assert!(output.status.success(), "cli failed: {output:?}");
+        let cli_report: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("cli stdout should be report JSON");
+
+        assert_eq!(
+            cli_report["request_count"].as_u64(),
+            Some(normalized.run.requests.len() as u64),
+            "{} retained request count should match",
+            candidate.name
+        );
+        assert_eq!(
+            analyzer_report.request_count,
+            normalized.run.requests.len(),
+            "{} analyzer retained request count should match",
+            candidate.name
+        );
+        if let Some(expected_stages) = candidate.expected_stages_after_normalization {
+            assert_eq!(
+                normalized.run.stages.len(),
+                expected_stages,
+                "{} normalized stage retention should match expected exclusion",
+                candidate.name
+            );
+        }
+
+        let core_codes = normalized
+            .report
+            .issues
+            .iter()
+            .map(|issue| issue.code.as_str())
+            .collect::<BTreeSet<_>>();
+        let analyzer_codes = warning_codes(&analyzer_report.warnings);
+        let cli_codes = warning_codes_from_json(&cli_report);
+        assert!(
+            core_codes.contains(candidate.expected_code),
+            "{} core should report expected code",
+            candidate.name
+        );
+        assert!(
+            analyzer_codes.contains(candidate.expected_code),
+            "{} analyzer should report expected code",
+            candidate.name
+        );
+        assert!(
+            cli_codes.contains(candidate.expected_code),
+            "{} CLI should not lose expected core warning",
+            candidate.name
+        );
+        assert!(
+            core_codes.iter().all(|code| cli_codes.contains(code)),
+            "{} CLI warning codes should include all core issue codes: core={core_codes:?}, cli={cli_codes:?}",
+            candidate.name
+        );
+    }
+}
+
+struct Candidate {
+    name: &'static str,
+    artifact: &'static str,
+    expected_code: &'static str,
+    expected_stages_after_normalization: Option<usize>,
+}
+
+fn warning_codes(warnings: &[String]) -> BTreeSet<&'static str> {
+    stable_issue_codes()
+        .into_iter()
+        .filter(|code| warnings.iter().any(|warning| warning.contains(code)))
+        .collect()
+}
+
+fn warning_codes_from_json(report: &serde_json::Value) -> BTreeSet<&'static str> {
+    let warnings = report["warnings"]
+        .as_array()
+        .expect("warnings should be array")
+        .iter()
+        .map(|value| value.as_str().expect("warning should be string"))
+        .collect::<Vec<_>>();
+    stable_issue_codes()
+        .into_iter()
+        .filter(|code| warnings.iter().any(|warning| warning.contains(code)))
+        .collect()
+}
+
+fn stable_issue_codes() -> [&'static str; 11] {
+    [
+        "unsupported_schema_version",
+        "empty_required_field",
+        "inverted_interval",
+        "partial_run_relative_interval",
+        "duration_mismatch",
+        "duplicate_completed_request_id",
+        "ambiguous_parent_request_id",
+        "orphan_request_scoped_event",
+        "parent_request_excluded",
+        "child_interval_outside_request",
+        "precise_interval_validation_unavailable",
+    ]
+}
+
+fn valid_request_plus_orphan_stage() -> &'static str {
+    r#"{"schema_version":1,"metadata":{"run_id":"r1","service_name":"svc","service_version":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"mode":"light","host":null,"pid":null,"lifecycle_warnings":[],"unfinished_requests":{"count":0,"sample":[]}},"requests":[{"request_id":"req1","route":"/","kind":null,"started_at_unix_ms":1,"started_at_run_us":1,"finished_at_unix_ms":2,"finished_at_run_us":11,"latency_us":10,"outcome":"ok"}],"stages":[{"request_id":"missing","stage":"db","started_at_unix_ms":1,"started_at_run_us":1,"finished_at_unix_ms":2,"finished_at_run_us":2,"latency_us":1,"success":true}],"queues":[],"inflight":[],"runtime_snapshots":[]}"#
+}
+
+fn request_with_partial_optional_precision() -> &'static str {
+    r#"{"schema_version":1,"metadata":{"run_id":"r1","service_name":"svc","service_version":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"mode":"light","host":null,"pid":null,"lifecycle_warnings":[],"unfinished_requests":{"count":0,"sample":[]}},"requests":[{"request_id":"req1","route":"/","kind":null,"started_at_unix_ms":1,"started_at_run_us":1,"finished_at_unix_ms":2,"latency_us":10,"outcome":"ok"}],"stages":[],"queues":[],"inflight":[],"runtime_snapshots":[]}"#
+}
+
+fn precise_child_outside_parent() -> &'static str {
+    r#"{"schema_version":1,"metadata":{"run_id":"r1","service_name":"svc","service_version":null,"started_at_unix_ms":1,"finished_at_unix_ms":2,"mode":"light","host":null,"pid":null,"lifecycle_warnings":[],"unfinished_requests":{"count":0,"sample":[]}},"requests":[{"request_id":"req1","route":"/","kind":null,"started_at_unix_ms":1,"started_at_run_us":10,"finished_at_unix_ms":2,"finished_at_run_us":20,"latency_us":10,"outcome":"ok"}],"stages":[{"request_id":"req1","stage":"db","started_at_unix_ms":1,"started_at_run_us":0,"finished_at_unix_ms":2,"finished_at_run_us":5,"latency_us":5,"success":true}],"queues":[],"inflight":[],"runtime_snapshots":[]}"#
 }


### PR DESCRIPTION
### Motivation

- Ensure `tailtriage-core` is the single owner of generic `Run` integrity decisions (duplicates, orphans, parent/child containment, and optional-precision normalization) instead of the CLI re-implementing that policy. 
- Separate decoding (file read, JSON parsing, schema envelope) from core validation/normalization so permissive analysis and `--strict-artifact` semantics are deterministic and consistent with core. 
- Preserve existing CLI responsibilities (decoding, I/O errors, command-level empty-request policy, stderr/exit handling) while delegating relationship/integrity policy to core.

### Description

- Split CLI artifact load into two phases by adding `decode_run_artifact` which decodes the original `Run`, calls `normalize_run_permissive`, and returns a `LoadedArtifact` containing both the normalized `run` and the `original_run`. (changed `tailtriage-cli/src/artifact.rs`).
- The analyze command uses the normalized Run for the CLI-owned minimum-request check, while passing the original decoded Run to the analyzer so canonical normalization findings remain visible in report warnings. --strict-artifact validates the same original unnormalized Run before analysis.
- Keep the CLI-owned minimum-request requirement as a command-level check after core normalization so permissive normalization can exclude events while the CLI still returns a user-friendly empty-request error where applicable. (changed `tailtriage-cli/src/main.rs`).
- Replace earlier CLI-specific duplicate/orphan wording with deterministic core issue-code reporting in strict failures and present bounded detail (stable issue codes and deterministic section/index locations) in stderr via a `validate_cli_strict_artifact` helper. (changed `tailtriage-cli/src/main.rs`).
- Update CLI boundary tests to assert core codes and deterministic locations and to reflect permissive duplicate exclusion flowing into the existing CLI empty-request behavior. (changed `tailtriage-cli/tests/cli_boundary.rs`).

### Testing

- Ran formatting and lints: `cargo fmt --check` and `cargo clippy -p tailtriage-cli --all-targets --all-features --locked -- -D warnings`, both passed. 
- Ran unit and integration tests: `cargo test -p tailtriage-cli --all-targets --all-features --locked`, `cargo test -p tailtriage-analyzer --all-targets --all-features --locked`, and `cargo test --workspace --all-targets --all-features --locked`, and all executed tests passed in this environment. 
- Ran the tracing parity and docs checks: `python3 scripts/demo_tool.py validate-tracing-parity all --profile release` and `python3 scripts/validate_docs_contracts.py`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e574256408330b78c1a356a35c075)