### PR TITLE
Thread retained tracing sources through import results

### DIFF
--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -565,6 +565,53 @@ mod tests {
     }
 
     #[test]
+    fn compatible_jsonl_retained_sources_preserve_decoded_original_and_skip_bad_records() {
+        let input = r#"
+{"message":"completed request","span":{"id":"req-id","parent_id":"root-id","name":"req","started_at_unix_ms":1000,"started_at_run_us":10,"finished_at_unix_ms":1020,"finished_at_run_us":20010,"duration_us":20000,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a","custom":"request-source"}}}
+{"timestamp":"2026-06-01T00:00:00Z","level":"INFO","target":"svc","message":"ordinary log","fields":{"request_id":"noise"}}
+{"message":"completed stage","span":{"id":"stage-id","parent_id":"req-id","name":"stage","started_at_unix_ms":1005,"started_at_run_us":5010,"finished_at_unix_ms":1010,"finished_at_run_us":10010,"duration_us":5000,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db","custom":"stage-source"}}}
+"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|warning| warning.message().contains("fmt JSON")));
+        let retained = imported.retained_sources();
+        assert_eq!(retained.len(), 2);
+        assert_eq!(
+            retained.iter().map(SpanRecord::name).collect::<Vec<_>>(),
+            vec!["req", "stage"]
+        );
+
+        let request = &retained[0];
+        assert_eq!(request.id_ref(), Some("req-id"));
+        assert_eq!(request.parent_id_ref(), Some("root-id"));
+        assert_eq!(
+            request.fields().get("custom"),
+            Some(&FieldValue::String("request-source".to_owned()))
+        );
+        assert_eq!(request.started_at_unix_ms(), 1000);
+        assert_eq!(request.finished_at_unix_ms(), 1020);
+        assert_eq!(request.started_at_run_us_ref(), Some(10));
+        assert_eq!(request.finished_at_run_us_ref(), Some(20010));
+        assert_eq!(request.duration_us_ref(), Some(20_000));
+
+        let stage = &retained[1];
+        assert_eq!(stage.id_ref(), Some("stage-id"));
+        assert_eq!(stage.parent_id_ref(), Some("req-id"));
+        assert_eq!(
+            stage.fields().get("custom"),
+            Some(&FieldValue::String("stage-source".to_owned()))
+        );
+        assert_eq!(stage.started_at_unix_ms(), 1005);
+        assert_eq!(stage.finished_at_unix_ms(), 1010);
+        assert_eq!(stage.started_at_run_us_ref(), Some(5010));
+        assert_eq!(stage.finished_at_run_us_ref(), Some(10010));
+        assert_eq!(stage.duration_us_ref(), Some(5000));
+    }
+
+    #[test]
     fn stable_wrapper_jsonl_privately_carries_decoded_original_sources_in_input_order() {
         let input = r#"
 {"format":"tailtriage.tracing-span.v1","span":{"id":"req-id","parent_id":"root","name":"req","started_at_unix_ms":10,"started_at_run_us":100,"finished_at_unix_ms":20,"finished_at_run_us":200,"duration_us":100,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a","extra":"kept"}}}

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -78,10 +78,14 @@ pub fn import_jsonl_reader_with_mode<R: Read>(
     }
 
     let imported = run_from_span_records(spans, options)?;
-    let (mut run, mut conversion_warnings) = imported.into_parts();
+    let (mut run, mut conversion_warnings, retained_sources) = imported.into_internal_parts();
     attach_parse_warnings_to_lifecycle(&mut run, &parse_warnings);
     parse_warnings.append(&mut conversion_warnings);
-    Ok(ImportedRun::new(run, parse_warnings))
+    Ok(ImportedRun::with_retained_sources(
+        run,
+        parse_warnings,
+        retained_sources,
+    ))
 }
 
 fn attach_parse_warnings_to_lifecycle(
@@ -558,6 +562,35 @@ mod tests {
         let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests.len(), 1);
+    }
+
+    #[test]
+    fn stable_wrapper_jsonl_privately_carries_decoded_original_sources_in_input_order() {
+        let input = r#"
+{"format":"tailtriage.tracing-span.v1","span":{"id":"req-id","parent_id":"root","name":"req","started_at_unix_ms":10,"started_at_run_us":100,"finished_at_unix_ms":20,"finished_at_run_us":200,"duration_us":100,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a","extra":"kept"}}}
+{"format":"tailtriage.tracing-span.v1","span":{"id":"stage-id","parent_id":"req-id","name":"stage","started_at_unix_ms":12,"started_at_run_us":120,"finished_at_unix_ms":15,"finished_at_run_us":150,"duration_us":30,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
+"#;
+        let imported = super::import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc"))
+            .expect("stable import should work");
+
+        assert_eq!(
+            imported
+                .retained_sources()
+                .iter()
+                .map(SpanRecord::name)
+                .collect::<Vec<_>>(),
+            vec!["req", "stage"]
+        );
+        assert_eq!(imported.retained_sources()[0].id_ref(), Some("req-id"));
+        assert_eq!(imported.retained_sources()[0].parent_id_ref(), Some("root"));
+        assert_eq!(
+            imported.retained_sources()[0].fields().get("extra"),
+            Some(&FieldValue::String("kept".to_owned()))
+        );
+        assert_eq!(
+            imported.retained_sources()[1].started_at_run_us_ref(),
+            Some(120)
+        );
     }
 
     #[test]

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -414,7 +414,7 @@ where
     }
 
     Ok(ProvenanceImportedRun {
-        imported: ImportedRun::new(run, warnings),
+        imported: ImportedRun::with_retained_sources(run, warnings, retained_sources.clone()),
         normalized,
         candidate_provenance: provenance,
         source_outcomes,
@@ -434,6 +434,7 @@ struct ProvenanceImportedRun {
     normalized: NormalizedRun,
     candidate_provenance: CandidateProvenance,
     source_outcomes: SourceOutcomes,
+    #[allow(dead_code)]
     retained_sources: Vec<SpanRecord>,
 }
 
@@ -443,7 +444,6 @@ impl ProvenanceImportedRun {
             &self.normalized,
             &self.candidate_provenance,
             &self.source_outcomes,
-            &self.retained_sources,
         );
         self.imported
     }
@@ -1125,6 +1125,39 @@ mod tests {
         );
         assert_eq!(retained_indices(&result), vec![0, 1, 2]);
         assert_eq!(result.retained_sources, spans);
+    }
+
+    #[test]
+    fn imported_run_privately_carries_exact_retained_original_sources() {
+        let request = req("a", 100, 120)
+            .id("req-span")
+            .parent_id("root")
+            .started_at_run_us(10)
+            .finished_at_run_us(30)
+            .duration_us(20_000)
+            .field("custom", 7_u64);
+        let child = stage("a", "db", 105, 110)
+            .id("stage-span")
+            .parent_id("req-span")
+            .started_at_run_us(15)
+            .finished_at_run_us(20)
+            .duration_us(5_000);
+        let imported = run_from_span_records(vec![request.clone(), child.clone()], opts()).unwrap();
+
+        assert_eq!(
+            imported.retained_sources(),
+            &[request.clone(), child.clone()]
+        );
+        assert_eq!(imported.clone().retained_sources(), &[request, child]);
+
+        let (_run, _warnings) = imported.into_parts();
+    }
+
+    #[test]
+    fn imported_run_new_has_no_private_retained_sources() {
+        let imported = ImportedRun::new(empty_candidate_run(), Vec::new());
+
+        assert!(imported.retained_sources().is_empty());
     }
 
     #[test]

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -1551,6 +1551,18 @@ mod tests {
             && codes.contains(&RunValidationIssueCode::OrphanRequestScopedEvent)));
         assert!(excluded.iter().any(|(idx, codes)| *idx == 5
             && codes.contains(&RunValidationIssueCode::ChildIntervalOutsideRequest)));
+        assert_eq!(
+            result
+                .imported
+                .retained_sources()
+                .iter()
+                .map(SpanRecord::name)
+                .collect::<Vec<_>>(),
+            vec!["req-bad"]
+        );
+        assert_eq!(result.imported.run().truncation.dropped_requests, 0);
+        assert_eq!(result.imported.run().truncation.dropped_stages, 0);
+        assert_eq!(result.imported.run().truncation.dropped_queues, 0);
     }
 
     #[test]
@@ -1580,9 +1592,26 @@ mod tests {
             vec![0, 2, 4]
         );
         assert_eq!(retained_indices(&result), vec![0, 2, 4]);
+        assert_eq!(
+            result
+                .imported
+                .retained_sources()
+                .iter()
+                .map(SpanRecord::name)
+                .collect::<Vec<_>>(),
+            vec!["req-r1", "stage-s1", "queue-q1"]
+        );
         assert_eq!(result.imported.run().truncation.dropped_requests, 1);
         assert_eq!(result.imported.run().truncation.dropped_stages, 1);
         assert_eq!(result.imported.run().truncation.dropped_queues, 1);
+        assert_eq!(
+            result.imported.run().truncation.dropped_inflight_snapshots,
+            0
+        );
+        assert_eq!(
+            result.imported.run().truncation.dropped_runtime_snapshots,
+            0
+        );
     }
 
     #[test]

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -327,7 +327,7 @@ impl TracingIntakeSession {
     /// Returns an error when conversion fails or when configured output artifacts cannot be written.
     pub fn shutdown(self) -> Result<ImportedRun, ImportError> {
         let imported = self.recorder.shutdown()?;
-        let (run, warnings) = imported.into_parts();
+        let (run, warnings, retained_sources) = imported.into_internal_parts();
         if self.run_json_path.is_some() || self.completed_span_jsonl_path.is_some() {
             ensure_persistable_run_with_warnings(&run, &warnings)?;
         }
@@ -343,7 +343,11 @@ impl TracingIntakeSession {
                     reason: err.to_string(),
                 })?;
         }
-        Ok(ImportedRun::new(run, warnings))
+        Ok(ImportedRun::with_retained_sources(
+            run,
+            warnings,
+            retained_sources,
+        ))
     }
 }
 
@@ -1282,9 +1286,13 @@ fn imported_with_drop_warnings(
         return Ok(imported);
     }
 
-    let (mut run, mut warnings) = imported.into_parts();
+    let (mut run, mut warnings, retained_sources) = imported.into_internal_parts();
     append_non_strict_drop_warnings(&mut run, &mut warnings, stats, limits);
-    Ok(ImportedRun::new(run, warnings))
+    Ok(ImportedRun::with_retained_sources(
+        run,
+        warnings,
+        retained_sources,
+    ))
 }
 
 fn scalar_field_string(value: Option<&FieldValue>) -> Option<String> {

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -2425,11 +2425,117 @@ mod tests {
             .collect::<std::collections::BTreeSet<_>>();
         assert!(request_ids.is_empty());
         assert_eq!(imported.run().requests.len(), 0);
+        assert!(imported.retained_sources().is_empty());
+        assert_eq!(imported.run().truncation.dropped_requests, 0);
         assert!(imported.warnings().iter().any(|w| {
             w.message()
                 .contains("dropped 1 completed request candidate span(s)")
                 && w.message().contains("max_completed_candidate_spans=2")
         }));
+    }
+
+    #[test]
+    fn retained_sources_follow_live_recorder_section_order_with_exact_identity() {
+        let recorder = TracingRecorder::builder("svc").build().unwrap();
+        {
+            let mut state = recorder.state.lock().unwrap();
+            state.completed_stages.push(
+                SpanRecord::new("stage-a", 110, 120)
+                    .id("stage-id")
+                    .parent_id("req-id")
+                    .field(TT_KIND, "stage")
+                    .field("tt.request_id", "r1")
+                    .field("tt.stage", "db")
+                    .field("custom", "stage-custom"),
+            );
+            state.completed_queues.push(
+                SpanRecord::new("queue-a", 105, 109)
+                    .id("queue-id")
+                    .parent_id("req-id")
+                    .field(TT_KIND, "queue")
+                    .field("tt.request_id", "r1")
+                    .field("tt.queue", "permits")
+                    .field("custom", "queue-custom"),
+            );
+            state.completed_requests.push(
+                SpanRecord::new("request-a", 100, 130)
+                    .id("req-id")
+                    .parent_id("root-id")
+                    .field(TT_KIND, "request")
+                    .field("tt.request_id", "r1")
+                    .field("tt.route", "/a")
+                    .field("custom", "request-custom"),
+            );
+        }
+
+        let imported = recorder.snapshot_run().unwrap();
+        let retained = imported.retained_sources();
+        assert_eq!(
+            retained.iter().map(SpanRecord::name).collect::<Vec<_>>(),
+            vec!["request-a", "stage-a", "queue-a"]
+        );
+        assert_eq!(retained[0].id_ref(), Some("req-id"));
+        assert_eq!(retained[0].parent_id_ref(), Some("root-id"));
+        assert_eq!(
+            retained[0].fields().get("custom"),
+            Some(&FieldValue::String("request-custom".to_owned()))
+        );
+        assert_eq!(
+            retained[0].fields().get(TT_KIND),
+            Some(&FieldValue::String("request".to_owned()))
+        );
+        assert_eq!(retained[1].id_ref(), Some("stage-id"));
+        assert_eq!(retained[1].parent_id_ref(), Some("req-id"));
+        assert_eq!(
+            retained[1].fields().get("custom"),
+            Some(&FieldValue::String("stage-custom".to_owned()))
+        );
+        assert_eq!(
+            retained[1].fields().get("tt.stage"),
+            Some(&FieldValue::String("db".to_owned()))
+        );
+        assert_eq!(retained[2].id_ref(), Some("queue-id"));
+        assert_eq!(retained[2].parent_id_ref(), Some("req-id"));
+        assert_eq!(
+            retained[2].fields().get("custom"),
+            Some(&FieldValue::String("queue-custom".to_owned()))
+        );
+        assert_eq!(
+            retained[2].fields().get("tt.queue"),
+            Some(&FieldValue::String("permits".to_owned()))
+        );
+    }
+
+    #[test]
+    fn snapshots_are_non_consuming_and_shutdown_retained_sources_are_deterministic() {
+        let build = || {
+            let recorder = TracingRecorder::builder("svc")
+                .run_id("rid")
+                .build()
+                .unwrap();
+            recorder.state.lock().unwrap().completed_requests.push(
+                SpanRecord::new("request", 100, 120)
+                    .id("req-id")
+                    .field(TT_KIND, "request")
+                    .field("tt.request_id", "r1")
+                    .field("tt.route", "/a")
+                    .field("tt.outcome", "ok")
+                    .field("custom", "kept"),
+            );
+            recorder
+        };
+
+        let recorder = build();
+        let first = recorder.snapshot_run().unwrap();
+        let second = recorder.snapshot_run().unwrap();
+        assert_eq!(first.run(), second.run());
+        assert_eq!(first.warnings(), second.warnings());
+        assert_eq!(first.retained_sources(), second.retained_sources());
+
+        let shutdown = build().shutdown().unwrap();
+        assert_eq!(first.run(), shutdown.run());
+        assert_eq!(first.warnings(), shutdown.warnings());
+        assert_eq!(first.retained_sources(), shutdown.retained_sources());
     }
 
     #[test]
@@ -2461,7 +2567,17 @@ mod tests {
         let imported = recorder.snapshot_run().unwrap();
         assert_eq!(imported.run().requests.len(), 1);
         assert_eq!(imported.run().requests[0].request_id, "r1");
+        assert_eq!(
+            imported
+                .retained_sources()
+                .iter()
+                .map(SpanRecord::name)
+                .collect::<Vec<_>>(),
+            vec!["request-1"]
+        );
         assert_eq!(imported.run().truncation.dropped_requests, 1);
+        assert_eq!(imported.run().truncation.dropped_stages, 0);
+        assert_eq!(imported.run().truncation.dropped_queues, 0);
         assert!(!imported
             .warnings()
             .iter()
@@ -3607,6 +3723,64 @@ mod tests {
         assert_eq!(imported.run().requests.len(), 1);
         assert_eq!(imported.run().requests[0].request_id, "r1");
         assert_eq!(imported.run().requests[0].route, "/a");
+    }
+
+    #[test]
+    fn session_shutdown_keeps_private_sources_while_completed_span_writer_reconstructs_run_shape() {
+        let dir = tempfile::tempdir().unwrap();
+        let spans_path = dir.path().join("spans.jsonl");
+        let run_path = dir.path().join("run.json");
+        let session = TracingIntakeSession::builder("svc")
+            .completed_span_jsonl_path(&spans_path)
+            .run_json_path(&run_path)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "request-source-name",
+                tt.kind = "request",
+                tt.request_id = "r1",
+                tt.route = "/a",
+                tt.outcome = "ok",
+                custom_source = "not-written"
+            ));
+        });
+
+        let snapshot = session.snapshot_run().unwrap();
+        assert_eq!(snapshot.retained_sources().len(), 1);
+        assert_eq!(snapshot.retained_sources()[0].name(), "request-source-name");
+        assert_eq!(
+            snapshot.retained_sources()[0].fields().get("custom_source"),
+            Some(&FieldValue::String("not-written".to_owned()))
+        );
+
+        let imported = session.shutdown().unwrap();
+        assert_eq!(imported.retained_sources(), snapshot.retained_sources());
+        assert_eq!(imported.run(), snapshot.run());
+        assert_eq!(imported.warnings(), snapshot.warnings());
+
+        let written = crate::jsonl::import_jsonl_path_with_mode(
+            &spans_path,
+            ImportOptions::new("svc"),
+            crate::jsonl::JsonlParseMode::TailtriageWrapperOnly,
+        )
+        .unwrap();
+        assert_eq!(written.run().requests, imported.run().requests);
+        assert_eq!(written.run().stages, imported.run().stages);
+        assert_eq!(written.run().queues, imported.run().queues);
+        assert_eq!(written.run().truncation, imported.run().truncation);
+        assert_eq!(written.retained_sources().len(), 1);
+        assert_eq!(written.retained_sources()[0].name(), "tt.request");
+        assert_eq!(written.retained_sources()[0].id_ref(), None);
+        assert_eq!(written.retained_sources()[0].parent_id_ref(), None);
+        assert_eq!(
+            written.retained_sources()[0].fields().get("custom_source"),
+            None
+        );
+        let run_json: tailtriage_core::Run =
+            serde_json::from_slice(&std::fs::read(&run_path).unwrap()).unwrap();
+        assert_eq!(&run_json, imported.run());
     }
 
     #[test]

--- a/tailtriage-tracing/src/tokio.rs
+++ b/tailtriage-tracing/src/tokio.rs
@@ -426,6 +426,49 @@ mod tests {
     }
 
     #[test]
+    fn tokio_merge_and_manual_sampler_warning_preserve_private_retained_sources() {
+        let mut tracing_run = empty_run("tracing");
+        tracing_run.requests.push(tailtriage_core::RequestEvent {
+            request_id: "r1".into(),
+            route: "/r1".into(),
+            kind: None,
+            started_at_unix_ms: 1,
+            started_at_run_us: None,
+            finished_at_unix_ms: 2,
+            finished_at_run_us: None,
+            latency_us: 1_000,
+            outcome: "ok".into(),
+        });
+        let source = crate::SpanRecord::new("source-request", 1, 2)
+            .id("source-id")
+            .parent_id("root-id")
+            .field("tt.kind", "request")
+            .field("tt.request_id", "r1")
+            .field("tt.route", "/r1")
+            .field("custom", "kept");
+        let imported = ImportedRun::with_retained_sources(
+            tracing_run,
+            vec![ImportWarning::new("existing warning")],
+            vec![source.clone()],
+        );
+        let mut runtime_run = empty_run("runtime");
+        runtime_run.runtime_snapshots = vec![RuntimeSnapshot {
+            at_unix_ms: 2,
+            at_run_us: Some(1_000),
+            alive_tasks: Some(1),
+            global_queue_depth: Some(0),
+            local_queue_depth: Some(0),
+            blocking_queue_depth: Some(0),
+            remote_schedule_count: Some(0),
+        }];
+
+        let merged = merge_runtime_data(imported, &runtime_run);
+        assert_eq!(merged.retained_sources(), std::slice::from_ref(&source));
+        let warned = super::with_manual_sampler_warning(merged, true);
+        assert_eq!(warned.retained_sources(), &[source]);
+    }
+
+    #[test]
     fn merge_runtime_data_preserves_tracing_events_and_merges_runtime_fields() {
         let mut tracing_run = empty_run("tracing");
         tracing_run.requests.push(tailtriage_core::RequestEvent {

--- a/tailtriage-tracing/src/tokio.rs
+++ b/tailtriage-tracing/src/tokio.rs
@@ -170,14 +170,14 @@ fn with_manual_sampler_warning(mut merged: ImportedRun, sampler_disabled: bool) 
     } else {
         "tailtriage-tracing session ran with background runtime sampling disabled; runtime snapshots were manually recorded"
     };
-    let (mut run, mut warnings) = merged.into_parts();
+    let (mut run, mut warnings, retained_sources) = merged.into_internal_parts();
     if !run.metadata.lifecycle_warnings.iter().any(|w| w == warning) {
         run.metadata.lifecycle_warnings.push(warning.to_string());
     }
     if !warnings.iter().any(|w| w.message() == warning) {
         warnings.push(ImportWarning::new(warning.to_string()));
     }
-    merged = ImportedRun::new(run, warnings);
+    merged = ImportedRun::with_retained_sources(run, warnings, retained_sources);
     merged
 }
 
@@ -331,7 +331,7 @@ impl TracingTokioSessionBuilder {
 const MERGED_RUNTIME_SNAPSHOT_RUN_OFFSET_WARNING: &str = "TracingTokioSession merged runtime snapshots from a separate runtime collector; runtime snapshot at_run_us offsets were cleared so temporal runtime attribution uses Unix-ms windows.";
 
 fn merge_runtime_data(imported: ImportedRun, runtime_run: &Run) -> ImportedRun {
-    let (mut tracing_run, mut warnings) = imported.into_parts();
+    let (mut tracing_run, mut warnings, retained_sources) = imported.into_internal_parts();
     let runtime_snapshot_offsets_cleared = runtime_run
         .runtime_snapshots
         .iter()
@@ -407,7 +407,7 @@ fn merge_runtime_data(imported: ImportedRun, runtime_run: &Run) -> ImportedRun {
             warnings.push(ImportWarning::new(warning.to_string()));
         }
     }
-    ImportedRun::new(tracing_run, warnings)
+    ImportedRun::with_retained_sources(tracing_run, warnings, retained_sources)
 }
 
 #[cfg(test)]

--- a/tailtriage-tracing/src/types.rs
+++ b/tailtriage-tracing/src/types.rs
@@ -347,13 +347,41 @@ impl core::fmt::Display for ImportWarning {
 pub struct ImportedRun {
     run: tailtriage_core::Run,
     warnings: Vec<ImportWarning>,
+    retained_sources: Vec<SpanRecord>,
 }
 
 impl ImportedRun {
     /// Creates imported output from a converted run and non-fatal warnings.
     #[must_use]
     pub fn new(run: tailtriage_core::Run, warnings: Vec<ImportWarning>) -> Self {
-        Self { run, warnings }
+        Self {
+            run,
+            warnings,
+            retained_sources: Vec::new(),
+        }
+    }
+
+    pub(crate) fn with_retained_sources(
+        run: tailtriage_core::Run,
+        warnings: Vec<ImportWarning>,
+        retained_sources: Vec<SpanRecord>,
+    ) -> Self {
+        Self {
+            run,
+            warnings,
+            retained_sources,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn retained_sources(&self) -> &[SpanRecord] {
+        &self.retained_sources
+    }
+
+    pub(crate) fn into_internal_parts(
+        self,
+    ) -> (tailtriage_core::Run, Vec<ImportWarning>, Vec<SpanRecord>) {
+        (self.run, self.warnings, self.retained_sources)
     }
 
     /// Returns converted run artifact.


### PR DESCRIPTION
### Motivation
- Carry the deterministic list of retained original `SpanRecord` sources selected by the existing conversion+core normalization flow through import, JSONL parsing, live recorder snapshots, and session internals so future writer/switch work can use precise private provenance without changing public APIs. 
- Preserve existing public behavior (`ImportedRun::new`, `run()`, `warnings()`, `into_parts()`) and writer semantics while adding a minimal private retention path. 
- Starting HEAD (no local `main` ref available) was 4d1d1af (the branch used as the change base). 

### Description
- Add a private `retained_sources: Vec<SpanRecord>` field to `ImportedRun` and crate-private helpers: `with_retained_sources(...)`, `retained_sources()`, and `into_internal_parts()` so conversion/session code can pass and read private provenance while the public API remains unchanged (`into_parts()` still returns only `(Run, Vec<ImportWarning>)`).
- Thread the retained original `SpanRecord` list through the conversion path (`convert_span_records_with_provenance` → `ProvenanceImportedRun` → `ImportedRun::with_retained_sources`) and through JSONL import, live recorder snapshot/shutdown, drop-warning augmentation, and Tokio-assisted merge/manually-added warnings; the completed-span JSONL writer still reconstructs records from the `Run` as before.
- Preserve ordering and selection semantics: retained sources are selected after semantic normalization and core dispositions (so core exclusions, duplicate/orphan handling, semantic truncation, and raw-cap drops remain separate accounting) and the kept sequence preserves the original input ordering policy (requests, stages, queues with original order preserved within each section).
- Files changed: `tailtriage-tracing/src/types.rs`, `tailtriage-tracing/src/lib.rs`, `tailtriage-tracing/src/jsonl.rs`, `tailtriage-tracing/src/recorder.rs`, `tailtriage-tracing/src/tokio.rs`; tests added/updated in `jsonl.rs` and `lib.rs` to validate private retention behavior.

### Testing
- Ran formatting and lints: `cargo fmt --check` and `cargo clippy -p tailtriage-tracing --all-targets --all-features --locked -- -D warnings`, both passed.
- Ran unit and workspace tests: `cargo test -p tailtriage-tracing --all-targets --all-features --locked`, `cargo test -p tailtriage --all-targets --all-features --locked`, and `cargo test --workspace --all-targets --all-features --locked`, all passed (no failures).
- Ran validation/demo scripts: `python3 scripts/validate_docs_contracts.py`, `python3 scripts/demo_tool.py validate-tracing-parity all --profile release`, and `python3 scripts/demo_tool.py validate-tracing-retention-parity --profile release`, all completed successfully.
- Added focused tests that passed covering: direct conversion private retention (IDs/parent IDs/fields/run-relative timing), stable wrapper JSONL decoded-source retention in input order, cloning preserves private retained sources, `ImportedRun::new` has no private sources, snapshot vs shutdown retention behavior (non-consuming snapshot), that core-excluded/duplicate/orphan sources remain absent, optional-offset repaired events keep original private values, and that semantic-limit/raw-cap behavior does not revive unavailable records.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f3d7c10888330b3399a9f37e34df0)