### PR TITLE
Write completed-span JSONL from retained original SpanRecord sources

### DIFF
--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -137,7 +137,9 @@ configured file is written independently through its own temp/rename path. The t
 outputs are not committed as one atomic transaction: if the second write fails, the
 first output may already exist as a finalized artifact. For production workflows that
 need one canonical shutdown artifact, prefer `run_json_path(...)`. Completed-span JSONL
-remains a replay/debug export, not trace archival.
+is written from retained original source spans. It preserves source span identity and
+fields represented by `SpanRecord`, but remains replay/debug evidence rather than a
+complete Run artifact or trace archive.
 
 ## Stable JSONL wrapper format
 
@@ -213,11 +215,11 @@ span.record("tt.outcome", "timeout");
 - Under raw-cap pressure, request roots are preserved preferentially when possible.
 - Child stage/queue evidence may be dropped or evicted under that pressure and is surfaced through warnings plus `truncation.limits_hit`.
 - Request/stage/queue semantic retention uses `CaptureMode`, `CaptureLimits`, and `CaptureLimitsOverride`.
-- `completed_span_jsonl_path(...)` writes retained tailtriage semantic evidence as stable span-shaped JSONL on shutdown only when at least one completed request is retained.
-- Completed-span JSONL is retained-evidence replay/debug export for the same request/stage/queue evidence path through `tailtriage import`; it is not a production trace archive.
-- The current shutdown exporter reconstructs stable span-shaped records from normalized retained Run evidence. It may omit `duration_us` when including it would not replay consistently with the reconstructed timing fields.
-- It does not preserve lifecycle warnings, truncation counters, original span names, original span IDs, parent IDs, or non-`tt.*` source fields.
-- Direct source-span archival and provenance-preserving completed-span export are deferred to Prompt 04; the current export is retained-evidence replay/debug output.
+- `completed_span_jsonl_path(...)` writes retained original source spans as stable span-shaped JSONL on shutdown only when at least one completed request is retained.
+- Completed-span JSONL contains only span-derived evidence retained after tracing limits and core normalization. Excluded or unavailable source records are absent.
+- The writer preserves source span identity and fields represented by `SpanRecord`: original span name, span ID, parent ID, non-`tt.*` fields, `tt.*` fields, Unix-ms bounds, optional run-relative offsets, and optional explicit duration.
+- Completed-span JSONL is retained-evidence replay/debug export for the same request/stage/queue evidence path through `tailtriage import`; it is not a complete Run artifact or production trace archive.
+- It does not encode Run-only metadata, runtime/in-flight snapshots, lifecycle warnings, truncation counters, or omitted-source diagnostics.
 - For production workflows that need the complete persisted triage artifact including warnings/truncation metadata, prefer `run_json_path(...)`.
 - Callers using JSONL-only export should inspect `session.shutdown()?.warnings()` in the same process.
 - This completed-span JSONL is a narrow retained-evidence export, not a generic tracing log stream and not OTel/OTLP.

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -755,21 +755,6 @@ fn required_string(
     }
 }
 
-#[cfg(feature = "live")]
-pub(crate) fn duration_within_derived_tolerance(duration_us: u64, derived_us: u64) -> bool {
-    duration_us.abs_diff(derived_us) <= tailtriage_core::RUN_RELATIVE_DURATION_TOLERANCE_US
-}
-
-#[cfg(feature = "live")]
-pub(crate) fn duration_within_tolerance(
-    duration_us: u64,
-    started_at_unix_ms: u64,
-    finished_at_unix_ms: u64,
-) -> bool {
-    let derived_us = timestamp_derived_duration_us(started_at_unix_ms, finished_at_unix_ms);
-    duration_within_derived_tolerance(duration_us, derived_us)
-}
-
 fn timestamp_derived_duration_us(started_at_unix_ms: u64, finished_at_unix_ms: u64) -> u64 {
     finished_at_unix_ms
         .saturating_sub(started_at_unix_ms)

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -334,13 +334,7 @@ impl TracingIntakeSession {
             ensure_persistable_run_with_warnings(&run, &warnings)?;
         }
         if let Some(path) = &self.completed_span_jsonl_path {
-            if retained_sources.is_empty() && !run.requests.is_empty() {
-                return Err(ImportError::Io {
-                    operation: "prepare completed span jsonl retained sources",
-                    context: path.display().to_string(),
-                    reason: "internal invariant violation: completed-span JSONL output requires retained original source spans".to_string(),
-                });
-            }
+            validate_completed_span_jsonl_retained_sources(&run, &retained_sources, path)?;
             write_completed_span_jsonl_from_retained_sources(&retained_sources, path)?;
         }
         if let Some(path) = self.run_json_path {
@@ -358,6 +352,22 @@ impl TracingIntakeSession {
             retained_sources,
         ))
     }
+}
+
+fn validate_completed_span_jsonl_retained_sources(
+    run: &tailtriage_core::Run,
+    retained_sources: &[SpanRecord],
+    path: &Path,
+) -> Result<(), ImportError> {
+    if retained_sources.is_empty() && !run.requests.is_empty() {
+        return Err(ImportError::Io {
+            operation: "prepare completed span jsonl retained sources",
+            context: path.display().to_string(),
+            reason: "internal invariant violation: completed-span JSONL output requires retained original source spans".to_string(),
+        });
+    }
+
+    Ok(())
 }
 
 fn write_completed_span_jsonl_from_retained_sources(
@@ -1262,6 +1272,31 @@ mod tests {
             .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || f(&recorder))
+    }
+
+    fn decode_completed_span_jsonl(path: &Path) -> Vec<SpanRecord> {
+        std::fs::read_to_string(path)
+            .unwrap()
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .map(|line| {
+                let value: serde_json::Value = serde_json::from_str(line).unwrap();
+                assert_eq!(value["format"], "tailtriage.tracing-span.v1");
+                serde_json::from_value(value["span"].clone()).unwrap()
+            })
+            .collect()
+    }
+
+    fn source_projection(spans: &[SpanRecord]) -> Vec<(String, String)> {
+        spans
+            .iter()
+            .map(|span| {
+                (
+                    span.name().to_owned(),
+                    span.id_ref().unwrap_or_default().to_owned(),
+                )
+            })
+            .collect()
     }
 
     #[test]
@@ -3539,6 +3574,317 @@ mod tests {
                 .message()
                 .contains("open candidate span(s) at snapshot/shutdown")));
         });
+    }
+
+    #[test]
+    fn direct_completed_span_jsonl_writer_preserves_exact_retained_sources() {
+        let dir = tempfile::tempdir().unwrap();
+        let first_path = dir.path().join("first.jsonl");
+        let second_path = dir.path().join("second.jsonl");
+        let sources = vec![
+            SpanRecord::new("request-source", 1_700_000_000_001, 1_700_000_000_051)
+                .id("req-span")
+                .parent_id("root-span")
+                .started_at_run_us(10)
+                .finished_at_run_us(50_010)
+                .duration_us(50_000)
+                .field(TT_KIND, "request")
+                .field("tt.request_id", "r1")
+                .field("tt.route", "/exact")
+                .field("tt.outcome", "ok")
+                .field("custom.string", "value")
+                .field("custom.bool", true)
+                .field("custom.u64", 7_u64),
+            SpanRecord::new("stage-source", 1_700_000_000_010, 1_700_000_000_020)
+                .id("stage-span")
+                .parent_id("req-span")
+                .started_at_run_us(9_000)
+                .finished_at_run_us(19_000)
+                .duration_us(10_000)
+                .field(TT_KIND, "stage")
+                .field("tt.request_id", "r1")
+                .field("tt.stage", "db")
+                .field("custom.i64", -3_i64)
+                .field("custom.f64", 1.25_f64),
+            SpanRecord::new("queue-source", 1_700_000_000_021, 1_700_000_000_025)
+                .id("queue-span")
+                .parent_id("req-span")
+                .duration_us(4_000)
+                .field(TT_KIND, "queue")
+                .field("tt.request_id", "r1")
+                .field("tt.queue", "permits")
+                .field("custom.null", FieldValue::Null),
+        ];
+
+        write_completed_span_jsonl_from_retained_sources(&sources, &first_path).unwrap();
+        write_completed_span_jsonl_from_retained_sources(&sources, &second_path).unwrap();
+
+        let raw = std::fs::read_to_string(&first_path).unwrap();
+        let lines = raw.lines().collect::<Vec<_>>();
+        assert_eq!(lines.len(), sources.len());
+        for line in &lines {
+            let value: serde_json::Value = serde_json::from_str(line).unwrap();
+            assert_eq!(value["format"], "tailtriage.tracing-span.v1");
+        }
+        assert_eq!(decode_completed_span_jsonl(&first_path), sources);
+        assert_eq!(
+            source_projection(&decode_completed_span_jsonl(&first_path)),
+            source_projection(&sources)
+        );
+        assert_eq!(
+            std::fs::read(&first_path).unwrap(),
+            std::fs::read(&second_path).unwrap()
+        );
+    }
+
+    #[test]
+    fn direct_completed_span_jsonl_writer_excludes_core_excluded_sources() {
+        let dir = tempfile::tempdir().unwrap();
+        let spans_path = dir.path().join("spans.jsonl");
+        let sources = vec![
+            SpanRecord::new("duplicate-request-a", 100, 150)
+                .id("dup-a")
+                .field(TT_KIND, "request")
+                .field("tt.request_id", "dup")
+                .field("tt.route", "/dup-a"),
+            SpanRecord::new("duplicate-request-b", 101, 151)
+                .id("dup-b")
+                .field(TT_KIND, "request")
+                .field("tt.request_id", "dup")
+                .field("tt.route", "/dup-b"),
+            SpanRecord::new("ambiguous-child", 110, 120)
+                .id("ambiguous")
+                .parent_id("dup-a")
+                .field(TT_KIND, "stage")
+                .field("tt.request_id", "dup")
+                .field("tt.stage", "ambiguous"),
+            SpanRecord::new("orphan-child", 110, 120)
+                .id("orphan")
+                .field(TT_KIND, "queue")
+                .field("tt.request_id", "missing")
+                .field("tt.queue", "orphan"),
+            SpanRecord::new("child-of-excluded-parent", 111, 121)
+                .id("excluded-child")
+                .parent_id("dup-a")
+                .field(TT_KIND, "queue")
+                .field("tt.request_id", "dup")
+                .field("tt.queue", "excluded-parent"),
+            SpanRecord::new("valid-request", 200, 300)
+                .id("valid-req")
+                .started_at_run_us(0)
+                .finished_at_run_us(100_000)
+                .field(TT_KIND, "request")
+                .field("tt.request_id", "ok")
+                .field("tt.route", "/ok"),
+            SpanRecord::new("outside-child", 301, 310)
+                .id("outside")
+                .parent_id("valid-req")
+                .started_at_run_us(101_000)
+                .finished_at_run_us(110_000)
+                .field(TT_KIND, "stage")
+                .field("tt.request_id", "ok")
+                .field("tt.stage", "outside"),
+            SpanRecord::new("valid-child", 210, 220)
+                .id("valid-child")
+                .parent_id("valid-req")
+                .started_at_run_us(10_000)
+                .finished_at_run_us(20_000)
+                .field(TT_KIND, "stage")
+                .field("tt.request_id", "ok")
+                .field("tt.stage", "inside"),
+        ];
+        let imported = run_from_span_records(sources, ImportOptions::new("svc")).unwrap();
+
+        write_completed_span_jsonl_from_retained_sources(imported.retained_sources(), &spans_path)
+            .unwrap();
+
+        assert_eq!(
+            source_projection(&decode_completed_span_jsonl(&spans_path)),
+            vec![
+                ("valid-request".to_owned(), "valid-req".to_owned()),
+                ("valid-child".to_owned(), "valid-child".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn repaired_optional_precision_writer_emits_original_source_values() {
+        let dir = tempfile::tempdir().unwrap();
+        let spans_path = dir.path().join("spans.jsonl");
+        let source = SpanRecord::new("repairable-request", 1_000, 1_020)
+            .id("repairable")
+            .started_at_run_us(50)
+            .finished_at_run_us(10)
+            .duration_us(20_000)
+            .field(TT_KIND, "request")
+            .field("tt.request_id", "repair")
+            .field("tt.route", "/repair");
+        let direct =
+            run_from_span_records(vec![source.clone()], ImportOptions::new("svc")).unwrap();
+        assert_eq!(direct.run().requests[0].started_at_run_us, None);
+        assert_eq!(direct.run().requests[0].finished_at_run_us, None);
+        assert_eq!(direct.run().requests[0].latency_us, 20_000);
+        assert_eq!(direct.retained_sources(), std::slice::from_ref(&source));
+
+        write_completed_span_jsonl_from_retained_sources(direct.retained_sources(), &spans_path)
+            .unwrap();
+        assert_eq!(decode_completed_span_jsonl(&spans_path), vec![source]);
+        let replay = crate::jsonl::import_jsonl_path_with_mode(
+            &spans_path,
+            ImportOptions::new("svc"),
+            crate::jsonl::JsonlParseMode::TailtriageWrapperOnly,
+        )
+        .unwrap();
+        assert_eq!(replay.run().requests, direct.run().requests);
+        assert_eq!(
+            analyze_run(replay.run(), AnalyzeOptions::default()),
+            analyze_run(direct.run(), AnalyzeOptions::default())
+        );
+    }
+
+    #[test]
+    fn semantic_unavailable_records_are_not_written_to_completed_jsonl() {
+        let semantic_dir = tempfile::tempdir().unwrap();
+        let semantic_path = semantic_dir.path().join("semantic.jsonl");
+        let semantic_session = TracingIntakeSession::builder("svc")
+            .completed_span_jsonl_path(&semantic_path)
+            .capture_limits(CaptureLimits {
+                max_requests: 1,
+                max_stages: 1,
+                max_queues: 1,
+                ..CaptureMode::Light.core_defaults()
+            })
+            .build()
+            .unwrap();
+        {
+            let mut state = semantic_session.recorder.state.lock().unwrap();
+            state.completed_requests.push(
+                SpanRecord::new("sem-request-kept", 100, 200)
+                    .id("sr1")
+                    .field(TT_KIND, "request")
+                    .field("tt.request_id", "sr1")
+                    .field("tt.route", "/one"),
+            );
+            state.completed_requests.push(
+                SpanRecord::new("sem-request-dropped", 101, 201)
+                    .id("sr2")
+                    .field(TT_KIND, "request")
+                    .field("tt.request_id", "sr2")
+                    .field("tt.route", "/two"),
+            );
+            state.completed_stages.push(
+                SpanRecord::new("sem-stage-kept", 110, 120)
+                    .id("ss1")
+                    .field(TT_KIND, "stage")
+                    .field("tt.request_id", "sr1")
+                    .field("tt.stage", "db"),
+            );
+            state.completed_stages.push(
+                SpanRecord::new("sem-stage-dropped", 121, 130)
+                    .id("ss2")
+                    .field(TT_KIND, "stage")
+                    .field("tt.request_id", "sr1")
+                    .field("tt.stage", "cache"),
+            );
+            state.completed_queues.push(
+                SpanRecord::new("sem-queue-kept", 130, 140)
+                    .id("sq1")
+                    .field(TT_KIND, "queue")
+                    .field("tt.request_id", "sr1")
+                    .field("tt.queue", "permits"),
+            );
+            state.completed_queues.push(
+                SpanRecord::new("sem-queue-dropped", 141, 150)
+                    .id("sq2")
+                    .field(TT_KIND, "queue")
+                    .field("tt.request_id", "sr1")
+                    .field("tt.queue", "work"),
+            );
+        }
+        let semantic_snapshot = semantic_session.snapshot_run().unwrap();
+        assert_eq!(semantic_snapshot.run().truncation.dropped_requests, 1);
+        assert_eq!(semantic_snapshot.run().truncation.dropped_stages, 1);
+        assert_eq!(semantic_snapshot.run().truncation.dropped_queues, 1);
+        semantic_session.shutdown().unwrap();
+        assert_eq!(
+            source_projection(&decode_completed_span_jsonl(&semantic_path)),
+            vec![
+                ("sem-request-kept".into(), "sr1".into()),
+                ("sem-stage-kept".into(), "ss1".into()),
+                ("sem-queue-kept".into(), "sq1".into())
+            ]
+        );
+    }
+
+    #[test]
+    fn raw_unavailable_records_are_not_written_to_completed_jsonl() {
+        let raw_dir = tempfile::tempdir().unwrap();
+        let raw_path = raw_dir.path().join("raw.jsonl");
+        let raw_session = TracingIntakeSession::builder("svc")
+            .completed_span_jsonl_path(&raw_path)
+            .max_completed_candidate_spans(1)
+            .build()
+            .unwrap();
+        let subscriber = tracing_subscriber::registry().with(raw_session.layer());
+        tracing::subscriber::with_default(subscriber, || {
+            drop(tracing::info_span!(
+                "raw-kept",
+                tt.kind = "request",
+                tt.request_id = "raw-kept",
+                tt.route = "/kept"
+            ));
+            drop(tracing::info_span!(
+                "raw-dropped",
+                tt.kind = "stage",
+                tt.request_id = "raw-kept",
+                tt.stage = "dropped"
+            ));
+        });
+        let raw_snapshot = raw_session.snapshot_run().unwrap();
+        assert!(raw_snapshot.warnings().iter().any(|w| w
+            .message()
+            .contains("dropped 1 completed child candidate span(s)")
+            && w.message().contains("max_completed_candidate_spans=1")));
+        raw_session.shutdown().unwrap();
+        let raw_names = decode_completed_span_jsonl(&raw_path)
+            .iter()
+            .map(|span| span.name().to_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(raw_names, vec!["raw-kept".to_owned()]);
+    }
+
+    #[test]
+    fn completed_jsonl_missing_retained_sources_error_is_deterministic_without_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let spans_path = dir.path().join("spans.jsonl");
+        let imported = run_from_span_records(
+            vec![SpanRecord::new("request", 100, 200)
+                .field(TT_KIND, "request")
+                .field("tt.request_id", "r1")
+                .field("tt.route", "/a")],
+            ImportOptions::new("svc"),
+        )
+        .unwrap();
+        let err = validate_completed_span_jsonl_retained_sources(imported.run(), &[], &spans_path)
+            .unwrap_err();
+        match err {
+            ImportError::Io {
+                operation,
+                context,
+                reason,
+            } => {
+                assert_eq!(operation, "prepare completed span jsonl retained sources");
+                assert_eq!(context, spans_path.display().to_string());
+                assert_eq!(reason, "internal invariant violation: completed-span JSONL output requires retained original source spans");
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+        assert!(!spans_path.exists());
+        assert!(completed_span_jsonl_temp_path(&spans_path)
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .contains("tailtriage-tmp"));
     }
 
     #[test]

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -12,7 +12,6 @@ use tracing::{Id, Subscriber};
 use tracing_subscriber::layer::{Context, Layer};
 
 use crate::{
-    duration_within_derived_tolerance, duration_within_tolerance,
     ensure_persistable_run_with_warnings, run_from_span_records, FieldValue, ImportError,
     ImportOptions, ImportedRun, SpanRecord, TT_KIND,
 };
@@ -31,8 +30,11 @@ pub struct TracingRecorder {
 /// artifacts through [`Self::snapshot_run`] or [`Self::shutdown`].
 ///
 /// When configured, the session emits stable completed-span JSONL records in the
-/// wrapper form `{"format":"tailtriage.tracing-span.v1","span":{...}}` and can
-/// optionally write a Run JSON file on shutdown.
+/// wrapper form `{"format":"tailtriage.tracing-span.v1","span":{...}}` from
+/// retained original source spans and can optionally write a Run JSON file on shutdown.
+/// The JSONL evidence preserves source span identity and fields represented by
+/// [`SpanRecord`], but does not encode Run-only metadata, runtime/in-flight snapshots,
+/// lifecycle warnings, truncation counters, or omitted-source diagnostics.
 ///
 /// This API is intentionally a tracing intake bridge; it does not implement OTel/OTLP.
 /// Tracing-only evidence does not fabricate runtime-pressure snapshots, and suspects
@@ -332,7 +334,14 @@ impl TracingIntakeSession {
             ensure_persistable_run_with_warnings(&run, &warnings)?;
         }
         if let Some(path) = &self.completed_span_jsonl_path {
-            write_completed_span_jsonl_from_run(&run, path)?;
+            if retained_sources.is_empty() && !run.requests.is_empty() {
+                return Err(ImportError::Io {
+                    operation: "prepare completed span jsonl retained sources",
+                    context: path.display().to_string(),
+                    reason: "internal invariant violation: completed-span JSONL output requires retained original source spans".to_string(),
+                });
+            }
+            write_completed_span_jsonl_from_retained_sources(&retained_sources, path)?;
         }
         if let Some(path) = self.run_json_path {
             create_output_parent_dir(&path, "create run json parent directory")?;
@@ -351,8 +360,8 @@ impl TracingIntakeSession {
     }
 }
 
-fn write_completed_span_jsonl_from_run(
-    run: &tailtriage_core::Run,
+fn write_completed_span_jsonl_from_retained_sources(
+    retained_sources: &[SpanRecord],
     path: &Path,
 ) -> Result<(), ImportError> {
     create_output_parent_dir(path, "create completed span jsonl parent directory")?;
@@ -369,7 +378,7 @@ fn write_completed_span_jsonl_from_run(
         })?;
 
     let write_result = (|| -> Result<(), ImportError> {
-        for span in retained_span_records_from_run(run) {
+        for span in retained_sources {
             let wrapped =
                 serde_json::json!({ "format": "tailtriage.tracing-span.v1", "span": span });
 
@@ -441,113 +450,6 @@ fn completed_span_jsonl_temp_path(path: &Path) -> PathBuf {
         std::process::id(),
     );
     path.with_file_name(temp_name)
-}
-
-fn retained_span_records_from_run(run: &tailtriage_core::Run) -> Vec<SpanRecord> {
-    let mut spans = Vec::new();
-    for req in &run.requests {
-        let mut span = SpanRecord::new(
-            "tt.request",
-            req.started_at_unix_ms,
-            req.finished_at_unix_ms,
-        )
-        .field("tt.kind", "request")
-        .field("tt.request_id", req.request_id.clone())
-        .field("tt.route", req.route.clone())
-        .field("tt.outcome", req.outcome.clone());
-        if let Some(started_at_run_us) = req.started_at_run_us {
-            span = span.started_at_run_us(started_at_run_us);
-        }
-        if let Some(finished_at_run_us) = req.finished_at_run_us {
-            span = span.finished_at_run_us(finished_at_run_us);
-        }
-        span = span_with_replay_safe_duration(
-            span,
-            req.latency_us,
-            req.started_at_unix_ms,
-            req.finished_at_unix_ms,
-        );
-        spans.push(span);
-    }
-    for stage in &run.stages {
-        let mut span = SpanRecord::new(
-            "tt.stage",
-            stage.started_at_unix_ms,
-            stage.finished_at_unix_ms,
-        )
-        .field("tt.kind", "stage")
-        .field("tt.request_id", stage.request_id.clone())
-        .field("tt.stage", stage.stage.clone())
-        .field("tt.success", stage.success);
-        if let Some(started_at_run_us) = stage.started_at_run_us {
-            span = span.started_at_run_us(started_at_run_us);
-        }
-        if let Some(finished_at_run_us) = stage.finished_at_run_us {
-            span = span.finished_at_run_us(finished_at_run_us);
-        }
-        span = span_with_replay_safe_duration(
-            span,
-            stage.latency_us,
-            stage.started_at_unix_ms,
-            stage.finished_at_unix_ms,
-        );
-        spans.push(span);
-    }
-    for queue in &run.queues {
-        let mut span = SpanRecord::new(
-            "tt.queue",
-            queue.waited_from_unix_ms,
-            queue.waited_until_unix_ms,
-        )
-        .field("tt.kind", "queue")
-        .field("tt.request_id", queue.request_id.clone())
-        .field("tt.queue", queue.queue.clone());
-        if let Some(waited_from_run_us) = queue.waited_from_run_us {
-            span = span.started_at_run_us(waited_from_run_us);
-        }
-        if let Some(waited_until_run_us) = queue.waited_until_run_us {
-            span = span.finished_at_run_us(waited_until_run_us);
-        }
-        span = span_with_replay_safe_duration(
-            span,
-            queue.wait_us,
-            queue.waited_from_unix_ms,
-            queue.waited_until_unix_ms,
-        );
-        if let Some(depth) = queue.depth_at_start {
-            span = span.field("tt.depth_at_start", depth);
-        }
-        spans.push(span);
-    }
-    spans
-}
-fn span_with_replay_safe_duration(
-    span: SpanRecord,
-    duration_us: u64,
-    started_at_unix_ms: u64,
-    finished_at_unix_ms: u64,
-) -> SpanRecord {
-    let run_relative_derived_us =
-        match (span.started_at_run_us_ref(), span.finished_at_run_us_ref()) {
-            (Some(started_at_run_us), Some(finished_at_run_us))
-                if finished_at_run_us >= started_at_run_us =>
-            {
-                Some(finished_at_run_us.saturating_sub(started_at_run_us))
-            }
-            _ => None,
-        };
-
-    let replay_safe = if let Some(run_relative_derived_us) = run_relative_derived_us {
-        duration_within_derived_tolerance(duration_us, run_relative_derived_us)
-    } else {
-        duration_within_tolerance(duration_us, started_at_unix_ms, finished_at_unix_ms)
-    };
-
-    if replay_safe {
-        span.duration_us(duration_us)
-    } else {
-        span
-    }
 }
 
 impl TracingIntakeSessionBuilder {
@@ -1351,7 +1253,6 @@ impl Visit for FieldVisitor {
 mod tests {
     use super::*;
     use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
-    use tailtriage_core::{MemorySink, Tailtriage};
     use tracing_subscriber::prelude::*;
 
     fn with_recorder<T>(f: impl FnOnce(&TracingRecorder) -> T) -> T {
@@ -1361,14 +1262,6 @@ mod tests {
             .unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || f(&recorder))
-    }
-
-    fn empty_run() -> tailtriage_core::Run {
-        Tailtriage::builder("svc")
-            .sink(MemorySink::new())
-            .build()
-            .expect("collector")
-            .snapshot()
     }
 
     #[test]
@@ -3706,7 +3599,7 @@ mod tests {
         let value: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
         assert_eq!(value["format"], "tailtriage.tracing-span.v1");
         assert!(value["span"].is_object());
-        assert_eq!(value["span"]["name"], "tt.request");
+        assert_eq!(value["span"]["name"], "request");
         assert!(value["span"]["started_at_unix_ms"].is_number());
         assert!(value["span"]["finished_at_unix_ms"].is_number());
         assert!(value["span"]["duration_us"].is_number());
@@ -3726,7 +3619,7 @@ mod tests {
     }
 
     #[test]
-    fn session_shutdown_keeps_private_sources_while_completed_span_writer_reconstructs_run_shape() {
+    fn session_shutdown_writes_retained_original_sources_without_reconstruction() {
         let dir = tempfile::tempdir().unwrap();
         let spans_path = dir.path().join("spans.jsonl");
         let run_path = dir.path().join("run.json");
@@ -3743,7 +3636,7 @@ mod tests {
                 tt.request_id = "r1",
                 tt.route = "/a",
                 tt.outcome = "ok",
-                custom_source = "not-written"
+                custom_source = "written"
             ));
         });
 
@@ -3752,7 +3645,7 @@ mod tests {
         assert_eq!(snapshot.retained_sources()[0].name(), "request-source-name");
         assert_eq!(
             snapshot.retained_sources()[0].fields().get("custom_source"),
-            Some(&FieldValue::String("not-written".to_owned()))
+            Some(&FieldValue::String("written".to_owned()))
         );
 
         let imported = session.shutdown().unwrap();
@@ -3771,12 +3664,10 @@ mod tests {
         assert_eq!(written.run().queues, imported.run().queues);
         assert_eq!(written.run().truncation, imported.run().truncation);
         assert_eq!(written.retained_sources().len(), 1);
-        assert_eq!(written.retained_sources()[0].name(), "tt.request");
-        assert_eq!(written.retained_sources()[0].id_ref(), None);
-        assert_eq!(written.retained_sources()[0].parent_id_ref(), None);
+        assert_eq!(written.retained_sources()[0].name(), "request-source-name");
         assert_eq!(
             written.retained_sources()[0].fields().get("custom_source"),
-            None
+            Some(&FieldValue::String("written".to_owned()))
         );
         let run_json: tailtriage_core::Run =
             serde_json::from_slice(&std::fs::read(&run_path).unwrap()).unwrap();
@@ -4246,196 +4137,6 @@ mod tests {
         assert_eq!(imported.run().requests.len(), 1);
         assert_eq!(imported.run().stages.len(), 0);
         assert_eq!(imported.run().queues.len(), 0);
-    }
-
-    fn run_with_coherent_replay_timing() -> tailtriage_core::Run {
-        let mut run = empty_run();
-        run.requests.push(tailtriage_core::RequestEvent {
-            request_id: "r1".into(),
-            route: "/a".into(),
-            kind: None,
-            started_at_unix_ms: 100,
-            started_at_run_us: Some(1_000),
-            finished_at_unix_ms: 199,
-            finished_at_run_us: Some(100_000),
-            latency_us: 99_000,
-            outcome: "ok".into(),
-        });
-        run.stages.push(tailtriage_core::StageEvent {
-            request_id: "r1".into(),
-            stage: "db".into(),
-            started_at_unix_ms: 100,
-            started_at_run_us: Some(2_000),
-            finished_at_unix_ms: 101,
-            finished_at_run_us: Some(72_000),
-            latency_us: 70_000,
-            success: true,
-        });
-        run.queues.push(tailtriage_core::QueueEvent {
-            request_id: "r1".into(),
-            queue: "permits".into(),
-            waited_from_unix_ms: 100,
-            waited_from_run_us: Some(3_000),
-            waited_until_unix_ms: 101,
-            waited_until_run_us: Some(33_000),
-            wait_us: 30_000,
-            depth_at_start: None,
-        });
-        run
-    }
-
-    #[test]
-    fn retained_request_stage_queue_emit_only_replay_safe_durations_and_run_offsets() {
-        let run = run_with_coherent_replay_timing();
-        let spans = retained_span_records_from_run(&run);
-        assert_eq!(spans.len(), 3);
-
-        let request = spans
-            .iter()
-            .find(|span| {
-                span.fields().get("tt.kind") == Some(&FieldValue::String("request".into()))
-            })
-            .expect("request span");
-        assert_eq!(request.duration_us_ref(), Some(99_000));
-        assert_eq!(request.started_at_run_us_ref(), Some(1_000));
-        assert_eq!(request.finished_at_run_us_ref(), Some(100_000));
-
-        let stage = spans
-            .iter()
-            .find(|span| span.fields().get("tt.kind") == Some(&FieldValue::String("stage".into())))
-            .expect("stage span");
-        assert_eq!(stage.duration_us_ref(), Some(70_000));
-        assert_eq!(stage.started_at_run_us_ref(), Some(2_000));
-        assert_eq!(stage.finished_at_run_us_ref(), Some(72_000));
-
-        let queue = spans
-            .iter()
-            .find(|span| span.fields().get("tt.kind") == Some(&FieldValue::String("queue".into())))
-            .expect("queue span");
-        assert_eq!(queue.duration_us_ref(), Some(30_000));
-        assert_eq!(queue.started_at_run_us_ref(), Some(3_000));
-        assert_eq!(queue.finished_at_run_us_ref(), Some(33_000));
-
-        let imported = run_from_span_records(spans, ImportOptions::new("svc").strict(true))
-            .expect("coherent replay spans should import strictly");
-        assert_eq!(imported.run().requests.len(), 1);
-        assert_eq!(imported.run().stages.len(), 1);
-        assert_eq!(imported.run().queues.len(), 1);
-        assert_eq!(imported.run().requests[0].latency_us, 99_000);
-        assert_eq!(imported.run().stages[0].latency_us, 70_000);
-        assert_eq!(imported.run().queues[0].wait_us, 30_000);
-        assert_eq!(imported.run().requests[0].started_at_run_us, Some(1_000));
-        assert_eq!(imported.run().requests[0].finished_at_run_us, Some(100_000));
-        assert_eq!(imported.run().stages[0].started_at_run_us, Some(2_000));
-        assert_eq!(imported.run().stages[0].finished_at_run_us, Some(72_000));
-        assert_eq!(imported.run().queues[0].waited_from_run_us, Some(3_000));
-        assert_eq!(imported.run().queues[0].waited_until_run_us, Some(33_000));
-    }
-
-    #[test]
-    fn completed_span_jsonl_export_omits_duration_when_run_relative_offsets_disagree_even_if_unix_matches(
-    ) {
-        let mut run = empty_run();
-        run.requests.push(tailtriage_core::RequestEvent {
-            request_id: "r1".into(),
-            route: "/a".into(),
-            kind: None,
-            started_at_unix_ms: 10,
-            started_at_run_us: Some(1_000),
-            finished_at_unix_ms: 60,
-            finished_at_run_us: Some(11_000),
-            latency_us: 50_000,
-            outcome: "ok".into(),
-        });
-
-        let spans = retained_span_records_from_run(&run);
-
-        assert_eq!(spans.len(), 1);
-        assert_eq!(spans[0].duration_us_ref(), None);
-
-        let imported =
-            run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap();
-
-        assert_eq!(imported.run().requests[0].latency_us, 10_000);
-    }
-
-    #[test]
-    fn completed_span_jsonl_export_preserves_duration_when_run_relative_offsets_match() {
-        let mut run = empty_run();
-        run.requests.push(tailtriage_core::RequestEvent {
-            request_id: "r1".into(),
-            route: "/a".into(),
-            kind: None,
-            started_at_unix_ms: 10,
-            started_at_run_us: Some(1_000),
-            finished_at_unix_ms: 11,
-            finished_at_run_us: Some(51_000),
-            latency_us: 50_000,
-            outcome: "ok".into(),
-        });
-
-        let spans = retained_span_records_from_run(&run);
-
-        assert_eq!(spans.len(), 1);
-        assert_eq!(spans[0].duration_us_ref(), Some(50_000));
-
-        let imported =
-            run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap();
-
-        assert_eq!(imported.run().requests[0].latency_us, 50_000);
-    }
-
-    #[test]
-    fn completed_span_jsonl_preserves_run_relative_safe_durations_for_strict_replay() {
-        let dir = tempfile::tempdir().unwrap();
-        let spans_path = dir.path().join("spans.jsonl");
-        let run = run_with_coherent_replay_timing();
-        write_completed_span_jsonl_from_run(&run, &spans_path).unwrap();
-
-        let raw = std::fs::read_to_string(&spans_path).unwrap();
-        let records: Vec<SpanRecord> = raw
-            .lines()
-            .filter(|line| !line.trim().is_empty())
-            .map(|line| {
-                let value: serde_json::Value = serde_json::from_str(line).unwrap();
-                serde_json::from_value(value.get("span").unwrap().clone()).unwrap()
-            })
-            .collect();
-
-        let request = records
-            .iter()
-            .find(|span| {
-                span.fields().get("tt.kind") == Some(&FieldValue::String("request".into()))
-            })
-            .expect("request span");
-        assert_eq!(request.duration_us_ref(), Some(99_000));
-
-        let stage = records
-            .iter()
-            .find(|span| span.fields().get("tt.kind") == Some(&FieldValue::String("stage".into())))
-            .expect("stage span");
-        assert_eq!(stage.duration_us_ref(), Some(70_000));
-
-        let queue = records
-            .iter()
-            .find(|span| span.fields().get("tt.kind") == Some(&FieldValue::String("queue".into())))
-            .expect("queue span");
-        assert_eq!(queue.duration_us_ref(), Some(30_000));
-
-        let replay = crate::jsonl::import_jsonl_path_with_mode(
-            &spans_path,
-            ImportOptions::new("svc").strict(true),
-            crate::jsonl::JsonlParseMode::TailtriageWrapperOnly,
-        )
-        .unwrap();
-        assert_eq!(replay.run().requests.len(), 1);
-        assert_eq!(replay.run().stages.len(), 1);
-        assert_eq!(replay.run().queues.len(), 1);
-        assert_eq!(replay.run().requests[0].latency_us, 99_000);
-        assert_eq!(replay.run().stages[0].latency_us, 70_000);
-        assert_eq!(replay.run().queues[0].wait_us, 30_000);
-        assert_eq!(replay.run().requests[0].started_at_run_us, Some(1_000));
-        assert_eq!(replay.run().requests[0].finished_at_run_us, Some(100_000));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Ensure completed-span JSONL is a provenance-preserving export of the private retained original source spans rather than a synthetic reconstruction from the normalized `Run` artifact. 
- Fail deterministically when JSONL output is requested but retained-source records are unavailable, avoiding silent reconstruction fallbacks. 
- Keep the existing shutdown semantics, per-file temp/write/flush/rename behavior, and independent-write semantics so callers relying on current ordering and failure modes are not surprised.

### Description
- Replace the Run->span reconstruction writer with a direct writer that consumes the private retained `SpanRecord` list and emits wrapper lines shaped `{"format":"tailtriage.tracing-span.v1","span":{...}}` in retained original source input order. 
- Add an explicit deterministic `ImportError::Io` when `completed_span_jsonl_path(...)` is configured for a non-empty `Run` but `retained_sources` is empty, preventing fallback reconstruction. 
- Remove reconstruction-only helpers and code paths: `write_completed_span_jsonl_from_run`, `retained_span_records_from_run`, `span_with_replay_safe_duration`, and the reconstruction-only duration/tolerance bindings, and update imports/tests that referenced them. 
- Update tracing rustdoc and `tailtriage-tracing/README.md` to document that completed-span JSONL is written from retained original source spans, preserves `SpanRecord` identity/fields (name, id, parent id, non-`tt.*` fields, `tt.*` fields, unix-ms bounds, optional run-relative offsets, optional explicit duration), and does not encode Run-only metadata, runtime snapshots, lifecycle warnings, truncation counters, or omitted-source diagnostics.

### Testing
- Ran formatting and lint checks (`cargo fmt --check`, `cargo clippy -p tailtriage-tracing --all-targets --all-features --locked -- -D warnings`) and they passed. 
- Ran unit and integration tests (`cargo test -p tailtriage-tracing --all-targets --all-features --locked`, `cargo test -p tailtriage --all-targets --all-features --locked`, and `cargo test --workspace --all-targets --all-features --locked`) and all tests passed. 
- Built docs and ran validation/demo parity scripts (`cargo doc --workspace --all-features --no-deps --locked`, `python3 scripts/validate_docs_contracts.py`, `python3 scripts/demo_tool.py validate-tracing-parity all --profile release`, `python3 scripts/demo_tool.py validate-tracing-retention-parity --profile release`) and they completed successfully. 
- Confirmed by searching the codebase that the removed reconstruction symbols are no longer present and that JSONL wrapper shape and Run JSON output behavior remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f4cc44e248330ba82c41499174e00)