### PR TITLE
Make stable tracing JSONL wrapper mandatory

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -113,7 +113,7 @@ Near-term tasks:
 - keep docs aligned to the implemented tracing-intake path:
   - `TracingSession` as the primary live setup
   - stable completed-span JSONL wrapper (`tailtriage.tracing-span.v1`)
-  - CLI `--input-format` guardrails (`compatible`, `tailtriage-span-jsonl`)
+  - CLI stable import guardrails (the command accepts only `tailtriage.tracing-span.v1`)
   - golden wrapper fixture, examples, and contract tests for request/stage/queue + duration preservation
 - keep positioning explicit: tracing intake converts tracing-shaped evidence into standard Runs for the existing analyzer
 - preserve bounded claims: no tracing backend semantics, no OTel/OTLP, no observability-platform expansion

--- a/SPEC.md
+++ b/SPEC.md
@@ -231,7 +231,7 @@ Core Run integrity contract:
 - default Run artifact analysis is compatibility-oriented and warns on some ambiguous request-scoped attribution cases instead of failing
 - strict Run artifact validation is opt-in through the analyzer strict-validation APIs and `tailtriage analyze --strict-artifact`
 - tracing import `--strict` separately controls malformed or incomplete `tt.*` span handling during conversion; it does not replace strict Run artifact validation
-- tracing completed-span JSONL import supports the stable wrapper format and the explicitly selected compatibility parser for supported pre-stable/internal record shapes
+- tracing completed-span JSONL import supports the stable wrapper format as the only accepted tracing JSONL file format; pre-stable/internal JSONL must be regenerated with the current writer or converted externally
 
 Artifact/report contract split:
 

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -37,8 +37,8 @@ Normal CI keeps deterministic diagnostics and docs contracts as gates but does n
 
 Tracing-intake contract coverage is currently validated by unit/package tests and examples that exercise:
 - stable wrapper fixture (`tailtriage.tracing-span.v1`)
-- wrapper-only import mode and compatible-mode behavior
-- CLI `--input-format` guardrails
+- stable wrapper-only import behavior
+- CLI stable import guardrails
 - `TracingSession` request/stage/queue capture and conversion
 - example compile/run coverage under package example tests
 

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -26,7 +26,7 @@ Schema contract:
 - default Run artifact analysis is compatibility-oriented and warns on some ambiguous request-scoped attribution cases instead of failing
 - strict Run artifact validation is opt-in through the analyzer strict-validation APIs and `tailtriage analyze --strict-artifact`
 - tracing import `--strict` separately controls malformed or incomplete `tt.*` span handling during conversion; it does not replace strict Run artifact validation
-- tracing completed-span JSONL import supports the stable wrapper format and the explicitly selected compatibility parser for supported pre-stable/internal record shapes
+- tracing completed-span JSONL import supports the stable wrapper format as the only accepted tracing jsonl file format; pre-stable/internal jsonl must be regenerated
 """
         with tempfile.TemporaryDirectory() as tmp_dir:
             spec_path = Path(tmp_dir) / "SPEC.md"
@@ -41,7 +41,7 @@ Schema contract:
 - default Run artifact analysis is compatibility-oriented and warns on some ambiguous request-scoped attribution cases instead of failing
 - strict Run artifact validation is opt-in through the analyzer strict-validation APIs and `tailtriage analyze --strict-artifact`
 - tracing import `--strict` separately controls malformed or incomplete `tt.*` span handling during conversion; it does not replace strict Run artifact validation
-- tracing completed-span JSONL import supports the stable wrapper format and the explicitly selected compatibility parser for supported pre-stable/internal record shapes
+- tracing completed-span JSONL import supports the stable wrapper format as the only accepted tracing jsonl file format; pre-stable/internal jsonl must be regenerated
 - strict artifact validation is currently opt-in through strict analyzer validation APIs or CLI/import strict flags
 """
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -265,8 +265,8 @@ def validate_governance_strictness_contract() -> None:
         "tracing import `--strict` separately controls",
         "does not replace strict run artifact validation",
         "stable wrapper format",
-        "explicitly selected compatibility parser",
-        "supported pre-stable/internal record shapes",
+        "only accepted tracing jsonl file format",
+        "pre-stable/internal jsonl must be regenerated",
     )
     for token in required_tokens:
         if token not in lower_text:
@@ -1191,6 +1191,31 @@ def validate_tracing_completed_jsonl_public_contract() -> None:
     )
 
 
+
+def validate_tracing_jsonl_no_compat_guidance_contract() -> None:
+    public_paths = (
+        README_PATH,
+        SPEC_PATH,
+        USER_GUIDE_PATH,
+        DOCS_INDEX_PATH,
+        ARCHITECTURE_PATH,
+        REPO_ROOT / "tailtriage-cli" / "README.md",
+        REPO_ROOT / "tailtriage-tracing" / "README.md",
+    )
+    disallowed_patterns = (
+        (r"jsonl" + r"parse" + r"mode", "JSONL parse mode API"),
+        (r"--" + r"\s*" + r"input-format", "CLI input format option"),
+        (r"compatible\s+(?:mode|parser|tracing\s+import)", "compatible tracing import guidance"),
+        (r'(?<!"format":"tailtriage\.tracing-span\.v1",)"span"\s*:\s*\{', "unversioned tracing JSONL example"),
+    )
+    for path in public_paths:
+        text = path.read_text(encoding="utf-8")
+        compact = re.sub(r"\s+", " ", text.lower())
+        for pattern, label in disallowed_patterns:
+            if re.search(pattern, compact):
+                raise ValueError(f"{path.relative_to(REPO_ROOT)} contains unsupported tracing JSONL guidance: {label}")
+
+
 def strip_live_tracing_migration_sections(text: str) -> str:
     pattern = re.compile(
         r"^## Live tracing session migration\s*$.*?(?=^##\s+|\Z)",
@@ -1301,6 +1326,7 @@ def main() -> int:
     validate_controller_example_usage_contract()
     validate_sampler_integration_boundary()
     validate_tracing_completed_jsonl_public_contract()
+    validate_tracing_jsonl_no_compat_guidance_contract()
     validate_live_tracing_session_public_contract()
     print("docs contracts validated successfully")
     return 0

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -1204,6 +1204,7 @@ def validate_tracing_jsonl_no_compat_guidance_contract() -> None:
     )
     disallowed_patterns = (
         (r"jsonl" + r"parse" + r"mode", "JSONL parse mode API"),
+        (r"wrapper" + r"\s*" + r"-?" + r"\s*" + r"only" + r"\s+" + r"mode", "tracing JSONL wrapper-only mode wording"),
         (r"--" + r"\s*" + r"input-format", "CLI input format option"),
         (r"compatible\s+(?:mode|parser|tracing\s+import)", "compatible tracing import guidance"),
         (r'(?<!"format":"tailtriage\.tracing-span\.v1",)"span"\s*:\s*\{', "unversioned tracing JSONL example"),

--- a/tailtriage-cli/README.md
+++ b/tailtriage-cli/README.md
@@ -48,11 +48,10 @@ Import completed tailtriage `tt.*` tracing span JSONL into Run JSON:
 tailtriage import tracing-spans-jsonl spans.jsonl --service checkout --output tailtriage-run.json
 ```
 
-With optional metadata flags, strict validation, and explicit format:
+With optional metadata flags and strict tracing-span validation:
 
 ```bash
-tailtriage import tracing-spans-jsonl spans.jsonl --service checkout --output tailtriage-run.json --service-version v1 --run-id run-42 --strict \
-  --input-format tailtriage-span-jsonl
+tailtriage import tracing-spans-jsonl spans.jsonl --service checkout --output tailtriage-run.json --service-version v1 --run-id run-42 --strict
 ```
 
 
@@ -71,16 +70,7 @@ Recommended stable input format is the tailtriage wrapper JSONL shape:
 {"format":"tailtriage.tracing-span.v1","span":{...}}
 ```
 
-`--input-format` values:
-- `tailtriage-span-jsonl`
-- `compatible`
-
-Behavior:
-- `tailtriage-span-jsonl` enforces wrapper-only parsing.
-- `tailtriage-span-jsonl` is the default library contract: non-wrapper non-empty JSON records are hard errors.
-- `compatible` is only for pre-stable/internal normalized completed-span shapes with explicit start/end timestamps; it is not auto-detection and not generic tracing JSON import.
-- Close-event/fmt-like tracing log envelopes are unsupported import input.
-- Ordinary `tracing_subscriber::fmt().json()` logs are unsupported and rejected; timing is not guessed from JSONL line receive time.
+Only `tailtriage.tracing-span.v1` wrapper records are accepted for tracing JSONL file import. Files produced by current `TracingSession` completed-span JSONL output remain supported. Pre-stable/internal JSONL must be regenerated with the current writer or converted externally into `tailtriage.tracing-span.v1` before import. Ordinary `tracing_subscriber::fmt().json()` output is unsupported.
 
 After import, run analysis separately:
 

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -1,5 +1,4 @@
 use std::fmt::Write as _;
-use std::io::BufRead;
 use std::path::PathBuf;
 
 use clap::{Parser, ValueEnum};
@@ -10,10 +9,7 @@ use tailtriage_core::{
     validate_run_strict, CaptureLimitsOverride, CaptureMode, LocalJsonSink, RunSink,
     RunValidationSeverity,
 };
-use tailtriage_tracing::{
-    ensure_persistable_run_has_requests, import_jsonl_path_with_mode, ImportError, ImportOptions,
-    JsonlParseMode,
-};
+use tailtriage_tracing::{ensure_persistable_run_has_requests, import_jsonl_path, ImportOptions};
 
 #[derive(Debug, Parser)]
 #[command(name = "tailtriage")]
@@ -76,9 +72,6 @@ enum ImportCommand {
         /// Fail on malformed/incomplete tailtriage spans.
         #[arg(long)]
         strict: bool,
-        /// Input format. Defaults to the stable tailtriage wrapper JSONL format.
-        #[arg(long, value_enum, default_value_t = TracingInputFormat::TailtriageSpanJsonl)]
-        input_format: TracingInputFormat,
         /// Import capture mode semantics for request/stage/queue retention.
         #[arg(long, value_enum, default_value_t = ImportCaptureMode::Light)]
         mode: ImportCaptureMode,
@@ -92,13 +85,6 @@ enum ImportCommand {
         #[arg(long)]
         max_queues: Option<usize>,
     },
-}
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
-enum TracingInputFormat {
-    /// Stable wrapper-only format: {"format":"tailtriage.tracing-span.v1","span":{...}}.
-    TailtriageSpanJsonl,
-    /// Compatibility parser for pre-stable/internal normalized completed-span shapes; not arbitrary tracing log JSON.
-    Compatible,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -134,7 +120,6 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 service_version,
                 run_id,
                 strict,
-                input_format,
                 mode,
                 max_requests,
                 max_stages,
@@ -146,7 +131,6 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 service_version,
                 run_id,
                 strict,
-                input_format,
                 mode,
                 max_requests,
                 max_stages,
@@ -286,7 +270,6 @@ fn import_tracing_spans_jsonl(
     service_version: Option<String>,
     run_id: Option<String>,
     strict: bool,
-    input_format: TracingInputFormat,
     mode: ImportCaptureMode,
     max_requests: Option<usize>,
     max_stages: Option<usize>,
@@ -319,112 +302,42 @@ fn import_tracing_spans_jsonl(
     }
     options = options.capture_limits_override(capture_limits_override);
 
-    let looks_like_fmt_json = if matches!(
-        input_format,
-        TracingInputFormat::TailtriageSpanJsonl | TracingInputFormat::Compatible
-    ) {
-        input_looks_like_tracing_fmt_json(&spans_jsonl).map_err(|err| {
-            std::io::Error::new(
-                err.kind(),
-                format!(
-                    "failed to inspect completed tailtriage tracing span JSONL input '{}': {err}",
-                    spans_jsonl.display()
-                ),
-            )
-        })?
-    } else {
-        false
-    };
-
-    if looks_like_fmt_json {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            tracing_spans_jsonl_setup_guidance(),
-        )
-        .into());
-    }
-    let parse_mode = match input_format {
-        TracingInputFormat::TailtriageSpanJsonl => JsonlParseMode::TailtriageWrapperOnly,
-        TracingInputFormat::Compatible => JsonlParseMode::Compatible,
-    };
-    let imported =
-        import_jsonl_path_with_mode(spans_jsonl, options, parse_mode).map_err(|err| {
-            if should_append_wrapper_guidance(input_format, &err) {
-                let message = format!("{err}\n{}", wrapper_only_rejection_guidance());
-                Box::<dyn std::error::Error>::from(std::io::Error::new(
-                    std::io::ErrorKind::InvalidInput,
-                    message,
-                ))
-            } else {
-                Box::<dyn std::error::Error>::from(err)
-            }
-        })?;
+    let imported = import_jsonl_path(spans_jsonl, options).map_err(|err| {
+        if should_append_wrapper_guidance(&err) {
+            let message = format!(
+                "{err}
+{}",
+                wrapper_only_rejection_guidance()
+            );
+            Box::<dyn std::error::Error>::from(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                message,
+            ))
+        } else {
+            Box::<dyn std::error::Error>::from(err)
+        }
+    })?;
     for warning in imported.warnings() {
         eprintln!("warning: {}", warning.message());
     }
     if let Err(err) = ensure_persistable_run_has_requests(imported.run()) {
-        if matches!(input_format, TracingInputFormat::TailtriageSpanJsonl) {
-            let message = format!("{err}\n{}", wrapper_only_rejection_guidance());
-            return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, message).into());
-        }
-        return Err(err.into());
+        let message = format!("{err}\n{}", wrapper_only_rejection_guidance());
+        return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, message).into());
     }
     create_output_parent_dir(output.as_path())?;
     LocalJsonSink::new(output).write(imported.run())?;
     Ok(())
 }
 
-fn tracing_spans_jsonl_setup_guidance() -> &'static str {
-    "the file looks like ordinary tracing log JSON, not completed tailtriage tracing span JSONL. tailtriage requires completed spans with literal dotted tt.* keys and explicit unix-ms start/end timestamps. Stable import expects wrapper JSONL records shaped like {\"format\":\"tailtriage.tracing-span.v1\",\"span\":{...}}. Ordinary tracing_subscriber::fmt().json() logs are unsupported. Recommended setup: TracingSession::builder(...).completed_span_jsonl_path(...). Then run: tailtriage import tracing-spans-jsonl <completed-spans.jsonl> --service <service> --output <run-json>"
-}
-
-fn should_append_wrapper_guidance(input_format: TracingInputFormat, err: &ImportError) -> bool {
-    matches!(input_format, TracingInputFormat::TailtriageSpanJsonl)
-        && matches!(err, ImportError::ExpectedTailtriageWrapper { .. })
+fn should_append_wrapper_guidance(err: &tailtriage_tracing::ImportError) -> bool {
+    matches!(
+        err,
+        tailtriage_tracing::ImportError::ExpectedTailtriageWrapper { .. }
+    )
 }
 
 fn wrapper_only_rejection_guidance() -> &'static str {
-    "stable import expects wrapper JSONL records shaped like {\"format\":\"tailtriage.tracing-span.v1\",\"span\":{...}}. Ordinary tracing_subscriber::fmt().json() logs are unsupported. Use --input-format compatible only for pre-stable/internal normalized completed-span shapes."
-}
-
-fn input_looks_like_tracing_fmt_json(path: &std::path::Path) -> Result<bool, std::io::Error> {
-    let file = std::fs::File::open(path)?;
-    let reader = std::io::BufReader::new(file);
-    for line in reader.lines() {
-        let line = line?;
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        if let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) {
-            let has_start = value.get("started_at_unix_ms").is_some()
-                || value.get("start_unix_ms").is_some()
-                || value
-                    .get("span")
-                    .and_then(|s| s.as_object())
-                    .is_some_and(|span| {
-                        span.contains_key("started_at_unix_ms")
-                            || span.contains_key("start_unix_ms")
-                    });
-            let has_end = value.get("finished_at_unix_ms").is_some()
-                || value.get("end_unix_ms").is_some()
-                || value
-                    .get("span")
-                    .and_then(|s| s.as_object())
-                    .is_some_and(|span| {
-                        span.contains_key("finished_at_unix_ms") || span.contains_key("end_unix_ms")
-                    });
-            let has_completed_span_timing = has_start && has_end;
-            let looks_like_fmt = value.get("timestamp").is_some()
-                && value.get("level").is_some()
-                && value.get("target").is_some();
-            if looks_like_fmt && !has_completed_span_timing {
-                return Ok(true);
-            }
-        }
-        break;
-    }
-    Ok(false)
+    "stable import expects wrapper JSONL records shaped like {\"format\":\"tailtriage.tracing-span.v1\",\"span\":{...}}. Ordinary tracing_subscriber::fmt().json() logs are unsupported. Pre-stable/internal JSONL must be regenerated with the current writer or converted externally before import."
 }
 
 fn main() {

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -1067,7 +1067,7 @@ fn import_tracing_spans_jsonl_help_shows_only_live_input_format_values() {
 }
 
 #[test]
-fn import_tracing_spans_jsonl_auto_is_rejected() {
+fn import_tracing_spans_jsonl_input_format_compatible_is_clap_unknown_argument() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
@@ -1081,10 +1081,21 @@ fn import_tracing_spans_jsonl_auto_is_rejected() {
         .arg("--output")
         .arg(&run_path)
         .arg("--input-format")
-        .arg("auto")
+        .arg("compatible")
         .output()
         .expect("cli should run");
     assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("--input-format"), "{stderr}");
+    assert!(
+        stderr.contains("unexpected argument") || stderr.contains("unknown argument"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("Usage:"), "{stderr}");
+    assert!(!stderr.contains("tailtriage.tracing-span.v1"), "{stderr}");
+    assert!(!stderr.contains("ExpectedTailtriageWrapper"), "{stderr}");
+    assert!(!stderr.contains("MalformedJsonLine"), "{stderr}");
+    assert!(!run_path.exists());
 }
 
 #[test]

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -656,8 +656,6 @@ fn import_tracing_spans_jsonl_capture_limit_overrides_apply() {
         .arg("checkout")
         .arg("--output")
         .arg(&run_path)
-        .arg("--input-format")
-        .arg("compatible")
         .arg("--max-requests")
         .arg("1")
         .arg("--max-stages")
@@ -829,7 +827,7 @@ fn import_tracing_spans_jsonl_input_format_tailtriage_wrapper_only_rejects_unwra
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("spans.jsonl");
     let run_path = dir.path().join("run.json");
-    std::fs::write(&spans_path, one_valid_request_span_fixture()).expect("fixture should write");
+    std::fs::write(&spans_path, r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout"}}}"#).expect("fixture should write");
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
         .arg("import")
         .arg("tracing-spans-jsonl")
@@ -844,7 +842,7 @@ fn import_tracing_spans_jsonl_input_format_tailtriage_wrapper_only_rejects_unwra
     let stderr = String::from_utf8(output.stderr).unwrap();
     assert!(stderr.contains("tailtriage.tracing-span.v1") || stderr.contains("stable wrapper"));
     assert!(stderr.contains("tracing_subscriber::fmt().json() logs are unsupported"));
-    assert!(!stderr.contains("ordinary tracing log JSON"));
+    assert!(!stderr.contains("ordinary tracing formatter JSON"));
     assert!(!run_path.exists());
 }
 
@@ -993,8 +991,8 @@ fn import_tracing_spans_jsonl_default_rejects_fmt_json_with_guidance() {
     let stderr = String::from_utf8(output.stderr).unwrap();
     assert!(stderr.contains("tailtriage.tracing-span.v1"));
     assert!(stderr.contains("tracing_subscriber::fmt().json() logs are unsupported"));
-    assert!(!stderr.contains("line 1: expected stable wrapper shape"));
-    assert!(!stderr.contains("line 2: expected stable wrapper shape"));
+    assert!(!stderr.contains("line 1: stable import expects wrapper JSONL records"));
+    assert!(!stderr.contains("line 2: stable import expects wrapper JSONL records"));
     assert!(!run_path.exists());
 }
 
@@ -1016,8 +1014,6 @@ fn import_tracing_spans_jsonl_compatible_rejects_ordinary_fmt_json_without_compl
         .arg("checkout")
         .arg("--output")
         .arg(&run_path)
-        .arg("--input-format")
-        .arg("compatible")
         .output()
         .expect("cli should run");
     assert!(
@@ -1025,12 +1021,12 @@ fn import_tracing_spans_jsonl_compatible_rejects_ordinary_fmt_json_without_compl
         "cli unexpectedly succeeded: {output:?}"
     );
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
-    assert!(stderr.contains("ordinary tracing log JSON"));
+    assert!(stderr.contains("ordinary tracing formatter JSON"));
     assert!(!run_path.exists(), "run json should not be written");
 }
 
 #[test]
-fn import_tracing_spans_jsonl_compatible_accepts_fmt_metadata_with_completed_span_timing() {
+fn import_tracing_spans_jsonl_rejects_fmt_metadata_with_completed_span_timing() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let spans_path = dir.path().join("compatible.jsonl");
     let run_path = dir.path().join("run.json");
@@ -1047,19 +1043,12 @@ fn import_tracing_spans_jsonl_compatible_accepts_fmt_metadata_with_completed_spa
         .arg("checkout")
         .arg("--output")
         .arg(&run_path)
-        .arg("--input-format")
-        .arg("compatible")
         .output()
         .expect("cli should run");
-    assert!(output.status.success(), "cli failed: {output:?}");
-    assert_precise_interval_warning_only_in_stderr(&output);
-    assert!(run_path.exists(), "run json should be written");
-
-    let loaded = tailtriage_cli::artifact::load_run_artifact(&run_path)
-        .expect("imported run should load in cli loader");
-    assert_eq!(loaded.run.requests.len(), 1);
-    assert_eq!(loaded.run.requests[0].route, "/checkout");
-    assert_no_precise_interval_lifecycle_warning(&loaded.run);
+    assert!(!output.status.success(), "cli unexpectedly succeeded");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("ordinary tracing formatter JSON is unsupported"));
+    assert!(!run_path.exists(), "run json should not be written");
 }
 
 #[test]
@@ -1072,8 +1061,8 @@ fn import_tracing_spans_jsonl_help_shows_only_live_input_format_values() {
         .expect("cli should run");
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("compatible"));
-    assert!(stdout.contains("tailtriage-span-jsonl"));
+    assert!(!stdout.contains("compatible"));
+    assert!(!stdout.contains("tailtriage-span-jsonl"));
     assert!(!stdout.contains("tracing-subscriber-fmt-json"));
 }
 
@@ -1114,8 +1103,6 @@ fn import_tracing_spans_jsonl_strict_fails_on_incomplete_tailtriage_span() {
         .arg("checkout")
         .arg("--output")
         .arg(&run_path)
-        .arg("--input-format")
-        .arg("compatible")
         .arg("--strict")
         .output()
         .expect("cli should run");
@@ -1290,8 +1277,6 @@ fn import_tracing_spans_jsonl_non_strict_writes_output_and_emits_warning_to_stde
         .arg("checkout")
         .arg("--output")
         .arg(&run_path)
-        .arg("--input-format")
-        .arg("compatible")
         .output()
         .expect("cli should run");
 
@@ -1325,8 +1310,6 @@ fn import_tracing_spans_jsonl_writes_metadata_flags_into_run_json() {
         .arg("run-42")
         .arg("--output")
         .arg(&run_path)
-        .arg("--input-format")
-        .arg("compatible")
         .output()
         .expect("cli should run");
 
@@ -1357,8 +1340,6 @@ fn import_tracing_spans_jsonl_accepts_paths_with_spaces() {
         .arg("checkout")
         .arg("--output")
         .arg(&run_path)
-        .arg("--input-format")
-        .arg("compatible")
         .output()
         .expect("cli should run");
 
@@ -1388,7 +1369,7 @@ fn import_tracing_spans_jsonl_rejects_whitespace_service_name() {
         .expect("cli should run");
     assert!(!output.status.success(), "cli unexpectedly succeeded");
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
-    assert!(stderr.contains("expected stable wrapper shape"));
+    assert!(stderr.contains("service name must not be empty"));
     assert!(!run_path.exists(), "run output should not be written");
 }
 
@@ -1433,7 +1414,7 @@ fn import_tracing_spans_jsonl_fails_when_non_strict_skips_all_malformed_tt_spans
         .expect("cli should run");
     assert!(!output.status.success(), "cli unexpectedly succeeded");
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
-    assert!(stderr.contains("expected stable wrapper shape"));
+    assert!(stderr.contains("stable import expects wrapper JSONL records"));
     assert!(!stderr.trim().is_empty());
     assert!(!run_path.exists(), "run output should not be written");
 }
@@ -1453,8 +1434,6 @@ fn import_tracing_spans_jsonl_fails_when_only_tt_spans_are_missing_kind() {
         .arg("checkout")
         .arg("--output")
         .arg(&run_path)
-        .arg("--input-format")
-        .arg("compatible")
         .output()
         .expect("cli should run");
     assert!(!output.status.success(), "cli unexpectedly succeeded");
@@ -1480,8 +1459,6 @@ fn import_tracing_spans_jsonl_warns_for_tt_fields_missing_kind_and_still_writes_
         .arg("checkout")
         .arg("--output")
         .arg(&run_path)
-        .arg("--input-format")
-        .arg("compatible")
         .output()
         .expect("cli should run");
     assert!(
@@ -1519,8 +1496,6 @@ fn import_tracing_spans_jsonl_persists_unknown_kind_warning_in_run_artifact() {
         .arg("checkout")
         .arg("--output")
         .arg(&run_path)
-        .arg("--input-format")
-        .arg("compatible")
         .output()
         .expect("cli should run");
 
@@ -1557,8 +1532,6 @@ fn import_tracing_spans_jsonl_persists_optional_default_assumption_warnings_in_r
         .arg("checkout")
         .arg("--output")
         .arg(&run_path)
-        .arg("--input-format")
-        .arg("compatible")
         .output()
         .expect("cli should run");
 
@@ -1676,8 +1649,8 @@ fn valid_cli_artifact_with_requests() -> &'static str {
 }
 
 fn missing_optional_defaults_fixture() -> &'static str {
-    r#"{"span":{"name":"request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout"}}}
-{"span":{"name":"stage","started_at_unix_ms":1001,"finished_at_unix_ms":1009,"fields":{"tt.kind":"stage","tt.request_id":"req-1","tt.stage":"db"}}}
+    r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout"}}}
+{"format":"tailtriage.tracing-span.v1","span":{"name":"stage","started_at_unix_ms":1001,"finished_at_unix_ms":1009,"fields":{"tt.kind":"stage","tt.request_id":"req-1","tt.stage":"db"}}}
 "#
 }
 
@@ -1742,50 +1715,50 @@ fn complete_span_jsonl_fixture() -> &'static str {
 }
 
 fn incomplete_tailtriage_span_fixture() -> &'static str {
-    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1"}}}
+    r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1"}}}
 "#
 }
 
 fn one_valid_request_span_fixture() -> &'static str {
-    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}
+    r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}
 "#
 }
 
 fn multi_span_jsonl_fixture() -> &'static str {
-    r#"{"span":{"name":"req-1","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout"}}}
-{"span":{"name":"req-2","started_at_unix_ms":1020,"finished_at_unix_ms":1030,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout"}}}
-{"span":{"name":"stage-1","started_at_unix_ms":1001,"finished_at_unix_ms":1009,"fields":{"tt.kind":"stage","tt.request_id":"req-1","tt.stage":"db"}}}
-{"span":{"name":"stage-2","started_at_unix_ms":1021,"finished_at_unix_ms":1029,"fields":{"tt.kind":"stage","tt.request_id":"req-2","tt.stage":"cache"}}}
-{"span":{"name":"queue-1","started_at_unix_ms":1002,"finished_at_unix_ms":1008,"fields":{"tt.kind":"queue","tt.request_id":"req-1","tt.queue":"permits"}}}
-{"span":{"name":"queue-2","started_at_unix_ms":1022,"finished_at_unix_ms":1028,"fields":{"tt.kind":"queue","tt.request_id":"req-2","tt.queue":"permits"}}}
+    r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req-1","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout"}}}
+{"format":"tailtriage.tracing-span.v1","span":{"name":"req-2","started_at_unix_ms":1020,"finished_at_unix_ms":1030,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout"}}}
+{"format":"tailtriage.tracing-span.v1","span":{"name":"stage-1","started_at_unix_ms":1001,"finished_at_unix_ms":1009,"fields":{"tt.kind":"stage","tt.request_id":"req-1","tt.stage":"db"}}}
+{"format":"tailtriage.tracing-span.v1","span":{"name":"stage-2","started_at_unix_ms":1021,"finished_at_unix_ms":1029,"fields":{"tt.kind":"stage","tt.request_id":"req-2","tt.stage":"cache"}}}
+{"format":"tailtriage.tracing-span.v1","span":{"name":"queue-1","started_at_unix_ms":1002,"finished_at_unix_ms":1008,"fields":{"tt.kind":"queue","tt.request_id":"req-1","tt.queue":"permits"}}}
+{"format":"tailtriage.tracing-span.v1","span":{"name":"queue-2","started_at_unix_ms":1022,"finished_at_unix_ms":1028,"fields":{"tt.kind":"queue","tt.request_id":"req-2","tt.queue":"permits"}}}
 "#
 }
 
 fn malformed_tailtriage_span_fixture() -> &'static str {
-    r#"{"span":{"name":"req","started_at_unix_ms":"bad","finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#
+    r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req","started_at_unix_ms":"bad","finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#
 }
 
 fn mixed_valid_and_incomplete_request_span_fixture() -> &'static str {
-    r#"{"span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1"}}}
-{"span":{"name":"http.request","started_at_unix_ms":1020,"finished_at_unix_ms":1032,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout","tt.outcome":"ok"}}}
+    r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"http.request","started_at_unix_ms":1000,"finished_at_unix_ms":1010,"fields":{"tt.kind":"request","tt.request_id":"req-1"}}}
+{"format":"tailtriage.tracing-span.v1","span":{"name":"http.request","started_at_unix_ms":1020,"finished_at_unix_ms":1032,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout","tt.outcome":"ok"}}}
 "#
 }
 
 fn mixed_valid_and_missing_kind_fixture() -> &'static str {
-    r#"{"span":{"name":"oops","started_at_unix_ms":1000,"finished_at_unix_ms":1005,"fields":{"tt.request_id":"req-0","tt.route":"/oops"}}}
-{"span":{"name":"http.request","started_at_unix_ms":1020,"finished_at_unix_ms":1032,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout","tt.outcome":"ok"}}}
+    r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"oops","started_at_unix_ms":1000,"finished_at_unix_ms":1005,"fields":{"tt.request_id":"req-0","tt.route":"/oops"}}}
+{"format":"tailtriage.tracing-span.v1","span":{"name":"http.request","started_at_unix_ms":1020,"finished_at_unix_ms":1032,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout","tt.outcome":"ok"}}}
 "#
 }
 
 fn only_missing_kind_tailtriage_spans_fixture() -> &'static str {
-    r#"{"span":{"name":"oops-1","started_at_unix_ms":1000,"finished_at_unix_ms":1005,"fields":{"tt.request_id":"req-0","tt.route":"/oops"}}}
-{"span":{"name":"oops-2","started_at_unix_ms":1010,"finished_at_unix_ms":1015,"fields":{"tt.request_id":"req-1","tt.route":"/oops2"}}}
+    r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"oops-1","started_at_unix_ms":1000,"finished_at_unix_ms":1005,"fields":{"tt.request_id":"req-0","tt.route":"/oops"}}}
+{"format":"tailtriage.tracing-span.v1","span":{"name":"oops-2","started_at_unix_ms":1010,"finished_at_unix_ms":1015,"fields":{"tt.request_id":"req-1","tt.route":"/oops2"}}}
 "#
 }
 
 fn mixed_valid_and_unknown_kind_fixture() -> &'static str {
-    r#"{"span":{"name":"unknown","started_at_unix_ms":1000,"finished_at_unix_ms":1005,"fields":{"tt.kind":"mystery"}}}
-{"span":{"name":"http.request","started_at_unix_ms":1020,"finished_at_unix_ms":1032,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout","tt.outcome":"ok"}}}
+    r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"unknown","started_at_unix_ms":1000,"finished_at_unix_ms":1005,"fields":{"tt.kind":"mystery"}}}
+{"format":"tailtriage.tracing-span.v1","span":{"name":"http.request","started_at_unix_ms":1020,"finished_at_unix_ms":1032,"fields":{"tt.kind":"request","tt.request_id":"req-2","tt.route":"/checkout","tt.outcome":"ok"}}}
 "#
 }
 

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -150,7 +150,7 @@ Stable completed-span JSONL records use this wrapper:
 
 `format` is a wrapper-level field (not a `SpanRecord` field).
 The simple library import APIs (`import_jsonl_reader` / `import_jsonl_path`) default to this wrapper-only mode and return an error for any non-empty non-wrapper JSON record.
-Use `*_with_mode(..., JsonlParseMode::Compatible)` only for pre-stable/internal normalized completed-span records with explicit unix-ms start/end timestamps.
+Only `tailtriage.tracing-span.v1` wrapper records are accepted for tracing JSONL file import. Pre-stable/internal JSONL must be regenerated with the current writer or converted externally before import.
 
 Close-event/fmt-like tracing log envelopes are not supported import input.
 Ordinary tracing log JSON (for example `tracing_subscriber::fmt().json()` output) is unsupported and rejected by import.

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -149,7 +149,7 @@ Stable completed-span JSONL records use this wrapper:
 ```
 
 `format` is a wrapper-level field (not a `SpanRecord` field).
-The simple library import APIs (`import_jsonl_reader` / `import_jsonl_path`) default to this wrapper-only mode and return an error for any non-empty non-wrapper JSON record.
+The simple library import APIs (`import_jsonl_reader` / `import_jsonl_path`) accept only this wrapper shape and return an error for any non-empty non-wrapper JSON record.
 Only `tailtriage.tracing-span.v1` wrapper records are accepted for tracing JSONL file import. Pre-stable/internal JSONL must be regenerated with the current writer or converted externally before import.
 
 Close-event/fmt-like tracing log envelopes are not supported import input.

--- a/tailtriage-tracing/src/error.rs
+++ b/tailtriage-tracing/src/error.rs
@@ -19,7 +19,7 @@ pub enum ImportError {
         /// Underlying JSON parser error text.
         reason: String,
     },
-    /// JSONL input did not match the stable tailtriage wrapper shape required by wrapper-only mode.
+    /// JSONL input did not match the stable tailtriage wrapper shape required by the stable tracing JSONL wrapper contract.
     ExpectedTailtriageWrapper {
         /// Human-readable reason the wrapper shape was rejected.
         reason: String,

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -128,18 +128,21 @@ fn parse_record(
         ));
     }
 
+    reject_forbidden_wrapper_keys(line_no, obj)?;
+
     let span_value = obj.get("span").ok_or_else(|| {
         wrapper_error(
             line_no,
             "missing field 'span' for tailtriage.tracing-span.v1 wrapper",
         )
     })?;
-    if !span_value.is_object() {
-        return Err(wrapper_error(
+    let span_obj = span_value.as_object().ok_or_else(|| {
+        wrapper_error(
             line_no,
             "invalid field 'span': expected completed span object for tailtriage.tracing-span.v1",
-        ));
-    }
+        )
+    })?;
+    reject_forbidden_span_keys(line_no, span_obj)?;
 
     match serde_json::from_value::<SpanRecord>(span_value.clone()) {
         Ok(span) => Ok(Some(span)),
@@ -153,6 +156,40 @@ fn parse_record(
             }
         }
     }
+}
+
+fn reject_forbidden_wrapper_keys(
+    line_no: usize,
+    obj: &serde_json::Map<String, Value>,
+) -> Result<(), ImportError> {
+    if obj.contains_key("fields") {
+        return Err(wrapper_error(
+            line_no,
+            "forbidden wrapper-level compatibility key 'fields'",
+        ));
+    }
+    if let Some(key) = obj.keys().find(|key| key.starts_with("tt.")) {
+        return Err(wrapper_error(
+            line_no,
+            format!("forbidden wrapper-level compatibility key '{key}'"),
+        ));
+    }
+    Ok(())
+}
+
+fn reject_forbidden_span_keys(
+    line_no: usize,
+    obj: &serde_json::Map<String, Value>,
+) -> Result<(), ImportError> {
+    for key in ["start_unix_ms", "end_unix_ms"] {
+        if obj.contains_key(key) {
+            return Err(wrapper_error(
+                line_no,
+                format!("forbidden span timestamp alias '{key}'"),
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn classify_missing_format(obj: &serde_json::Map<String, Value>) -> &'static str {
@@ -266,6 +303,61 @@ mod tests {
             1,
             "unversioned",
         );
+    }
+
+    #[test]
+    fn stable_wrapper_rejects_wrapper_level_fields() {
+        assert_wrapper_rejected(
+            r#"{"format":"tailtriage.tracing-span.v1","fields":{"tt.request_id":"legacy"},"span":{"name":"request","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/"}}}"#,
+            1,
+            "forbidden wrapper-level compatibility key 'fields'",
+        );
+    }
+
+    #[test]
+    fn stable_wrapper_rejects_wrapper_level_tt_key() {
+        assert_wrapper_rejected(
+            r#"{"format":"tailtriage.tracing-span.v1","tt.route":"/legacy","span":{"name":"request","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/"}}}"#,
+            1,
+            "forbidden wrapper-level compatibility key 'tt.route'",
+        );
+    }
+
+    #[test]
+    fn stable_wrapper_rejects_mixed_compatibility_placement_deterministically() {
+        assert_wrapper_rejected(
+            r#"{"format":"tailtriage.tracing-span.v1","fields":{"tt.request_id":"legacy"},"tt.route":"/legacy","span":{"name":"request","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/"}}}"#,
+            1,
+            "forbidden wrapper-level compatibility key 'fields'",
+        );
+    }
+
+    #[test]
+    fn stable_wrapper_rejects_alias_only_timestamps_in_strict_and_non_strict() {
+        let input = r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"request","start_unix_ms":1,"end_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/"}}}"#;
+        assert_wrapper_rejected(input, 1, "forbidden span timestamp alias 'start_unix_ms'");
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+            .expect_err("strict mode must reject forbidden aliases structurally");
+        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
+        assert!(err.to_string().contains("line 1"));
+        assert!(err.to_string().contains("start_unix_ms"));
+    }
+
+    #[test]
+    fn stable_wrapper_rejects_canonical_timestamps_plus_aliases() {
+        assert_wrapper_rejected(
+            r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"request","started_at_unix_ms":1,"finished_at_unix_ms":2,"start_unix_ms":100,"end_unix_ms":200,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/"}}}"#,
+            1,
+            "forbidden span timestamp alias 'start_unix_ms'",
+        );
+    }
+
+    #[test]
+    fn stable_wrapper_accepts_unrelated_wrapper_extension_key() {
+        let input = r#"{"format":"tailtriage.tracing-span.v1","producer":"example","span":{"name":"request","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/"}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.retained_sources().len(), 1);
+        assert_eq!(imported.retained_sources()[0].name(), "request");
     }
 
     #[test]

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -1,54 +1,28 @@
-use std::collections::BTreeMap;
 use std::io::{BufRead, BufReader, Read};
 use std::path::Path;
 
 use serde_json::Value;
 
-use crate::{
-    run_from_span_records, FieldValue, ImportError, ImportOptions, ImportedRun, SpanRecord,
-};
+use crate::{run_from_span_records, ImportError, ImportOptions, ImportedRun, SpanRecord};
 
-/// Imports newline-delimited JSON records from a reader into a converted run.
+const FORMAT_MARKER: &str = "tailtriage.tracing-span.v1";
+
+/// Imports newline-delimited stable completed-span JSONL records from a reader into a converted run.
 ///
-/// This parser accepts only the stable wrapper shape
-/// `{"format":"tailtriage.tracing-span.v1","span":{...}}`.
-/// Use [`crate::import_jsonl_reader_with_mode`] with [`JsonlParseMode::Compatible`]
-/// for explicit compatibility parsing.
+/// This parser accepts only records shaped as
+/// `{"format":"tailtriage.tracing-span.v1","span":{...}}`. Empty or
+/// whitespace-only lines are ignored.
 ///
 /// # Errors
 ///
 /// Returns [`ImportError::Io`] for reader I/O failures,
 /// [`ImportError::MalformedJsonLine`] for malformed non-empty JSONL lines,
+/// [`ImportError::ExpectedTailtriageWrapper`] for structural JSONL shape errors,
 /// and existing field/conversion errors for malformed tailtriage span records
 /// or strict conversion violations surfaced by [`run_from_span_records`].
 pub fn import_jsonl_reader<R: Read>(
     reader: R,
     options: ImportOptions,
-) -> Result<ImportedRun, ImportError> {
-    import_jsonl_reader_with_mode(reader, options, JsonlParseMode::TailtriageWrapperOnly)
-}
-
-/// Parse mode for completed tailtriage tracing span JSONL import.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum JsonlParseMode {
-    /// Accept stable wrapper records plus compatibility legacy shapes.
-    Compatible,
-    /// Accept only the stable wrapper shape `{"format":"tailtriage.tracing-span.v1","span":{...}}`.
-    TailtriageWrapperOnly,
-}
-
-/// Imports newline-delimited JSON records from a reader with an explicit parse mode.
-///
-/// # Errors
-///
-/// Returns [`ImportError::Io`] for reader I/O failures,
-/// [`ImportError::MalformedJsonLine`] for malformed non-empty JSONL lines,
-/// and existing field/conversion errors for malformed tailtriage span records
-/// or strict conversion violations surfaced by [`run_from_span_records`].
-pub fn import_jsonl_reader_with_mode<R: Read>(
-    reader: R,
-    options: ImportOptions,
-    mode: JsonlParseMode,
 ) -> Result<ImportedRun, ImportError> {
     let mut spans = Vec::new();
     let mut parse_warnings = Vec::new();
@@ -56,9 +30,10 @@ pub fn import_jsonl_reader_with_mode<R: Read>(
     let strict = options.strict_mode();
 
     for (line_no, line_result) in reader.lines().enumerate() {
+        let line_no = line_no + 1;
         let line = line_result.map_err(|err| ImportError::Io {
             operation: "read jsonl line",
-            context: format!("line {}", line_no + 1),
+            context: format!("line {line_no}"),
             reason: err.to_string(),
         })?;
 
@@ -68,11 +43,11 @@ pub fn import_jsonl_reader_with_mode<R: Read>(
 
         let value: Value =
             serde_json::from_str(&line).map_err(|err| ImportError::MalformedJsonLine {
-                line: line_no + 1,
+                line: line_no,
                 reason: err.to_string(),
             })?;
 
-        if let Some(span) = parse_record(line_no + 1, &value, strict, &mut parse_warnings, mode)? {
+        if let Some(span) = parse_record(line_no, &value, strict, &mut parse_warnings)? {
             spans.push(span);
         }
     }
@@ -105,32 +80,18 @@ fn attach_parse_warnings_to_lifecycle(
     }
 }
 
-/// Imports newline-delimited JSON records from a filesystem path.
+/// Imports newline-delimited stable completed-span JSONL records from a filesystem path.
 ///
 /// # Errors
 ///
 /// Returns [`ImportError::Io`] when path open or line reads fail,
 /// [`ImportError::MalformedJsonLine`] for malformed non-empty JSONL lines,
+/// [`ImportError::ExpectedTailtriageWrapper`] for structural JSONL shape errors,
 /// and existing field/conversion errors for malformed tailtriage-tagged records
 /// or strict conversion violations.
 pub fn import_jsonl_path(
     path: impl AsRef<Path>,
     options: ImportOptions,
-) -> Result<ImportedRun, ImportError> {
-    import_jsonl_path_with_mode(path, options, JsonlParseMode::TailtriageWrapperOnly)
-}
-
-/// Imports newline-delimited JSON records from a filesystem path with an explicit parse mode.
-///
-/// # Errors
-///
-/// Returns [`ImportError::Io`] for path open/read failures,
-/// [`ImportError::MalformedJsonLine`] for malformed non-empty JSON lines,
-/// and strict/field errors for invalid span records.
-pub fn import_jsonl_path_with_mode(
-    path: impl AsRef<Path>,
-    options: ImportOptions,
-    mode: JsonlParseMode,
 ) -> Result<ImportedRun, ImportError> {
     let path_ref = path.as_ref();
     let file = std::fs::File::open(path_ref).map_err(|err| ImportError::Io {
@@ -138,1551 +99,331 @@ pub fn import_jsonl_path_with_mode(
         context: path_ref.display().to_string(),
         reason: err.to_string(),
     })?;
-    import_jsonl_reader_with_mode(file, options, mode)
+    import_jsonl_reader(file, options)
 }
 
-#[allow(clippy::too_many_lines)]
 fn parse_record(
     line_no: usize,
     value: &Value,
     strict: bool,
     warnings: &mut Vec<crate::ImportWarning>,
-    mode: JsonlParseMode,
 ) -> Result<Option<SpanRecord>, ImportError> {
-    if let Some(obj) = value.as_object() {
-        if let Some(format) = obj.get("format") {
-            let Some(format_marker) = format.as_str() else {
-                let message = format!(
-                    "line {line_no}: invalid field 'format': expected string format marker"
-                );
-                return if matches!(mode, JsonlParseMode::TailtriageWrapperOnly) {
-                    Err(ImportError::ExpectedTailtriageWrapper { reason: message })
-                } else if strict {
-                    Err(ImportError::StrictViolation(message))
-                } else {
-                    warnings.push(crate::ImportWarning::new(message));
-                    Ok(None)
-                };
-            };
+    let obj = value
+        .as_object()
+        .ok_or_else(|| wrapper_error(line_no, "JSONL record must be an object"))?;
 
-            if format_marker != "tailtriage.tracing-span.v1" {
-                let message =
-                    format!("line {line_no}: unsupported span format marker '{format_marker}'");
-                return if matches!(mode, JsonlParseMode::TailtriageWrapperOnly) {
-                    Err(ImportError::ExpectedTailtriageWrapper { reason: message })
-                } else if strict {
-                    Err(ImportError::StrictViolation(message))
-                } else {
-                    warnings.push(crate::ImportWarning::new(message));
-                    Ok(None)
-                };
-            }
-
-            let Some(span_value) = obj.get("span") else {
-                let message = format!(
-                    "line {line_no}: missing field 'span' for tailtriage.tracing-span.v1 wrapper"
-                );
-                return if matches!(mode, JsonlParseMode::TailtriageWrapperOnly) {
-                    Err(ImportError::ExpectedTailtriageWrapper { reason: message })
-                } else if strict {
-                    Err(ImportError::StrictViolation(message))
-                } else {
-                    warnings.push(crate::ImportWarning::new(message));
-                    Ok(None)
-                };
-            };
-
-            let Some(_) = span_value.as_object() else {
-                let message = format!(
-                    "line {line_no}: invalid field 'span': expected completed span object for tailtriage.tracing-span.v1"
-                );
-                return if matches!(mode, JsonlParseMode::TailtriageWrapperOnly) {
-                    Err(ImportError::ExpectedTailtriageWrapper { reason: message })
-                } else if strict {
-                    Err(ImportError::StrictViolation(message))
-                } else {
-                    warnings.push(crate::ImportWarning::new(message));
-                    Ok(None)
-                };
-            };
-
-            if let Some(span_obj) = span_value.as_object() {
-                validate_optional_run_relative_fields(span_obj)?;
-            }
-
-            return match serde_json::from_value::<SpanRecord>(span_value.clone()) {
-                Ok(span) => Ok(Some(span)),
-                Err(err) => {
-                    let message =
-                        format!("line {line_no}: invalid tailtriage.tracing-span.v1 span: {err}");
-                    if strict {
-                        Err(ImportError::StrictViolation(message))
-                    } else {
-                        warnings.push(crate::ImportWarning::new(message));
-                        Ok(None)
-                    }
-                }
-            };
-        }
-    }
-    if matches!(mode, JsonlParseMode::TailtriageWrapperOnly) {
-        let message = format!(
-            "line {line_no}: expected stable wrapper shape {{\"format\":\"tailtriage.tracing-span.v1\",\"span\":{{...}}}}"
-        );
-        return Err(ImportError::ExpectedTailtriageWrapper { reason: message });
-    }
-    if is_ordinary_fmt_json_without_completed_span_timing(value) {
-        let message = format!(
-            "line {line_no}: unsupported tracing fmt JSON envelope for compatible import (timestamp/level/target without completed-span timing)"
-        );
-        if strict {
-            return Err(ImportError::StrictViolation(message));
-        }
-        warnings.push(crate::ImportWarning::new(message));
-        return Ok(None);
-    }
-    if let Ok(span) = serde_json::from_value::<SpanRecord>(value.clone()) {
-        return Ok(Some(span));
-    }
-    if let Some(field_name) = first_non_scalar_tailtriage_field(value) {
-        let message = format!(
-            "line {line_no}: invalid field '{field_name}': expected scalar tt.* value in JSONL record"
-        );
-        if strict {
-            return Err(ImportError::StrictViolation(message));
-        }
-        warnings.push(crate::ImportWarning::new(message));
-        return Ok(None);
+    let format = obj
+        .get("format")
+        .ok_or_else(|| wrapper_error(line_no, classify_missing_format(obj)))?;
+    let Some(format_marker) = format.as_str() else {
+        return Err(wrapper_error(
+            line_no,
+            "invalid field 'format': expected string format marker",
+        ));
+    };
+    if format_marker != FORMAT_MARKER {
+        return Err(wrapper_error(
+            line_no,
+            format!("unsupported span format marker '{format_marker}'"),
+        ));
     }
 
-    let has_tt = value_has_tailtriage_field(value);
-    if let Some(span_obj) = value.get("span").and_then(Value::as_object) {
-        let is_normalized_shape = span_obj.contains_key("name")
-            && (span_obj.contains_key("started_at_unix_ms")
-                || span_obj.contains_key("start_unix_ms"))
-            && (span_obj.contains_key("finished_at_unix_ms")
-                || span_obj.contains_key("end_unix_ms"));
-        if is_normalized_shape {
-            if !has_tt {
-                return Ok(None);
-            }
-            return match parse_normalized_span(value, span_obj) {
-                Ok(span) => Ok(Some(span)),
-                Err(err) => {
-                    let message = format!("line {line_no}: {err}");
-                    if strict {
-                        Err(ImportError::StrictViolation(message))
-                    } else {
-                        warnings.push(crate::ImportWarning::new(message));
-                        Ok(None)
-                    }
-                }
-            };
-        }
-        if has_tt {
-            let message = format!(
-                "line {line_no}: invalid field `span`: tailtriage span must include name, started_at_unix_ms/start_unix_ms, and finished_at_unix_ms/end_unix_ms"
-            );
+    let span_value = obj.get("span").ok_or_else(|| {
+        wrapper_error(
+            line_no,
+            "missing field 'span' for tailtriage.tracing-span.v1 wrapper",
+        )
+    })?;
+    if !span_value.is_object() {
+        return Err(wrapper_error(
+            line_no,
+            "invalid field 'span': expected completed span object for tailtriage.tracing-span.v1",
+        ));
+    }
+
+    match serde_json::from_value::<SpanRecord>(span_value.clone()) {
+        Ok(span) => Ok(Some(span)),
+        Err(err) => {
+            let message = format!("line {line_no}: invalid tailtriage.tracing-span.v1 span: {err}");
             if strict {
-                return Err(ImportError::StrictViolation(message));
-            }
-            warnings.push(crate::ImportWarning::new(message));
-            return Ok(None);
-        }
-    }
-
-    if has_tt {
-        let message = format!(
-            "line {line_no}: tailtriage JSONL record must use normalized completed-span shape with explicit timestamps"
-        );
-        if strict {
-            Err(ImportError::StrictViolation(message))
-        } else {
-            warnings.push(crate::ImportWarning::new(message));
-            Ok(None)
-        }
-    } else {
-        Ok(None)
-    }
-}
-
-fn is_ordinary_fmt_json_without_completed_span_timing(value: &Value) -> bool {
-    value.as_object().is_some_and(|obj| {
-        let looks_like_fmt = obj.contains_key("timestamp")
-            && obj.contains_key("level")
-            && obj.contains_key("target");
-        looks_like_fmt && !has_completed_span_timing(value)
-    })
-}
-
-fn has_completed_span_timing(value: &Value) -> bool {
-    has_start_and_end_timing(value) || value.get("span").is_some_and(has_start_and_end_timing)
-}
-
-fn has_start_and_end_timing(value: &Value) -> bool {
-    value.as_object().is_some_and(|obj| {
-        (obj.contains_key("started_at_unix_ms") || obj.contains_key("start_unix_ms"))
-            && (obj.contains_key("finished_at_unix_ms") || obj.contains_key("end_unix_ms"))
-    })
-}
-
-fn first_non_scalar_tailtriage_field(value: &Value) -> Option<String> {
-    let is_non_scalar = |v: &Value| matches!(v, Value::Array(_) | Value::Object(_));
-    let mut first: Option<String> = None;
-    let mut consider = |key: &str, raw: &Value| {
-        if key.starts_with("tt.") && is_non_scalar(raw) && first.is_none() {
-            first = Some(key.to_owned());
-        }
-    };
-
-    if let Some(map) = value.get("fields").and_then(Value::as_object) {
-        for (k, v) in map {
-            consider(k, v);
-        }
-    }
-    if let Some(map) = value
-        .get("span")
-        .and_then(Value::as_object)
-        .and_then(|span| span.get("fields"))
-        .and_then(Value::as_object)
-    {
-        for (k, v) in map {
-            consider(k, v);
-        }
-    }
-    if let Some(map) = value.as_object() {
-        for (k, v) in map {
-            consider(k, v);
-        }
-    }
-
-    first
-}
-
-fn value_has_tailtriage_field(value: &Value) -> bool {
-    value
-        .get("fields")
-        .and_then(Value::as_object)
-        .is_some_and(|fields| fields.keys().any(|k| k.starts_with("tt.")))
-        || value
-            .get("span")
-            .and_then(Value::as_object)
-            .and_then(|span| span.get("fields"))
-            .and_then(Value::as_object)
-            .is_some_and(|fields| fields.keys().any(|k| k.starts_with("tt.")))
-        || value
-            .as_object()
-            .is_some_and(|obj| obj.keys().any(|k| k.starts_with("tt.")))
-}
-
-fn validate_optional_run_relative_fields(
-    obj: &serde_json::Map<String, Value>,
-) -> Result<(), ImportError> {
-    let _ = optional_u64(obj, "started_at_run_us")?;
-    let _ = optional_u64(obj, "finished_at_run_us")?;
-    Ok(())
-}
-
-fn parse_normalized_span(
-    value: &Value,
-    span_obj: &serde_json::Map<String, Value>,
-) -> Result<SpanRecord, ImportError> {
-    let name = required_string(span_obj, "name")?;
-    let id = optional_string(span_obj, "id")?;
-    let parent_id = optional_string(span_obj, "parent_id")?;
-    let started_at_unix_ms = required_timestamp(span_obj, "started_at_unix_ms", "start_unix_ms")?;
-    let finished_at_unix_ms = required_timestamp(span_obj, "finished_at_unix_ms", "end_unix_ms")?;
-    let started_at_run_us = optional_u64(span_obj, "started_at_run_us")?;
-    let finished_at_run_us = optional_u64(span_obj, "finished_at_run_us")?;
-    let duration_us = optional_duration_us(span_obj)?;
-
-    let mut span = SpanRecord::new(name, started_at_unix_ms, finished_at_unix_ms);
-    if let Some(id) = id {
-        span = span.id(id);
-    }
-    if let Some(parent_id) = parent_id {
-        span = span.parent_id(parent_id);
-    }
-    if let Some(started_at_run_us) = started_at_run_us {
-        span = span.started_at_run_us(started_at_run_us);
-    }
-    if let Some(finished_at_run_us) = finished_at_run_us {
-        span = span.finished_at_run_us(finished_at_run_us);
-    }
-    if let Some(duration_us) = duration_us {
-        span = span.duration_us(duration_us);
-    }
-
-    let fields = extract_fields_for_span(value);
-    for (k, v) in fields {
-        span = span.field(k, v);
-    }
-
-    Ok(span)
-}
-
-fn extract_fields_for_span(value: &Value) -> BTreeMap<String, FieldValue> {
-    let mut out = BTreeMap::new();
-    // Precedence for duplicate keys is: outer fields < span.fields < top-level tt.*.
-    collect_fields_object(value.get("fields"), &mut out);
-    collect_fields_object(value.get("span").and_then(|s| s.get("fields")), &mut out);
-    collect_tt_top_level(value, &mut out);
-    out
-}
-
-fn collect_fields_object(value: Option<&Value>, out: &mut BTreeMap<String, FieldValue>) {
-    let Some(map) = value.and_then(Value::as_object) else {
-        return;
-    };
-    for (k, v) in map {
-        if let Some(scalar) = to_field_value(v) {
-            out.insert(k.clone(), scalar);
-        }
-    }
-}
-fn collect_tt_top_level(value: &Value, out: &mut BTreeMap<String, FieldValue>) {
-    let Some(map) = value.as_object() else {
-        return;
-    };
-    for (k, v) in map {
-        if k.starts_with("tt.") {
-            if let Some(scalar) = to_field_value(v) {
-                out.insert(k.clone(), scalar);
-            }
-        }
-    }
-}
-
-fn to_field_value(value: &Value) -> Option<FieldValue> {
-    match value {
-        Value::String(s) => Some(FieldValue::String(s.clone())),
-        Value::Bool(b) => Some(FieldValue::Bool(*b)),
-        Value::Number(n) => {
-            if let Some(u) = n.as_u64() {
-                Some(FieldValue::U64(u))
-            } else if let Some(i) = n.as_i64() {
-                Some(FieldValue::I64(i))
+                Err(ImportError::StrictViolation(message))
             } else {
-                n.as_f64().map(FieldValue::F64)
+                warnings.push(crate::ImportWarning::new(message));
+                Ok(None)
             }
         }
-        Value::Null => Some(FieldValue::Null),
-        _ => None,
     }
 }
 
-fn required_string(
-    obj: &serde_json::Map<String, Value>,
-    key: &'static str,
-) -> Result<String, ImportError> {
-    optional_string(obj, key)?.ok_or(ImportError::MissingField(key))
-}
-fn optional_string(
-    obj: &serde_json::Map<String, Value>,
-    key: &'static str,
-) -> Result<Option<String>, ImportError> {
-    match obj.get(key) {
-        Some(Value::String(s)) => Ok(Some(s.clone())),
-        Some(_) => Err(ImportError::InvalidField {
-            field: key,
-            reason: "expected string".to_owned(),
-        }),
-        None => Ok(None),
-    }
-}
-fn required_timestamp(
-    obj: &serde_json::Map<String, Value>,
-    primary: &'static str,
-    alias: &'static str,
-) -> Result<u64, ImportError> {
-    required_timestamp_obj(obj, primary, alias)
-}
-fn required_timestamp_obj(
-    obj: &serde_json::Map<String, Value>,
-    primary: &'static str,
-    alias: &'static str,
-) -> Result<u64, ImportError> {
-    if let Some(v) = obj.get(primary).or_else(|| obj.get(alias)) {
-        return parse_u64(v, primary);
-    }
-    Err(ImportError::MissingField(primary))
-}
-fn optional_duration_us(obj: &serde_json::Map<String, Value>) -> Result<Option<u64>, ImportError> {
-    optional_u64(obj, "duration_us").map_err(|err| match err {
-        ImportError::InvalidField { .. } => ImportError::InvalidField {
-            field: "duration_us",
-            reason: "expected unsigned integer microseconds as u64".to_owned(),
-        },
-        other => other,
-    })
-}
-
-fn optional_u64(
-    obj: &serde_json::Map<String, Value>,
-    key: &'static str,
-) -> Result<Option<u64>, ImportError> {
-    match obj.get(key) {
-        Some(Value::Number(n)) => n
-            .as_u64()
-            .ok_or_else(|| ImportError::InvalidField {
-                field: key,
-                reason: "expected unsigned integer as u64".to_owned(),
-            })
-            .map(Some),
-        Some(_) => Err(ImportError::InvalidField {
-            field: key,
-            reason: "expected unsigned integer as u64".to_owned(),
-        }),
-        None => Ok(None),
+fn classify_missing_format(obj: &serde_json::Map<String, Value>) -> &'static str {
+    if looks_like_ordinary_fmt_json(obj) {
+        "ordinary tracing formatter JSON is unsupported; expected stable wrapper shape {\"format\":\"tailtriage.tracing-span.v1\",\"span\":{...}}"
+    } else if obj.contains_key("span") {
+        "missing field 'format'; unversioned tracing span envelopes are unsupported"
+    } else if obj.contains_key("name")
+        || obj.contains_key("start_unix_ms")
+        || obj.contains_key("end_unix_ms")
+    {
+        "missing field 'format'; raw or pre-stable tracing span records are unsupported"
+    } else if obj.keys().any(|k| k.starts_with("tt.")) || obj.contains_key("fields") {
+        "missing field 'format'; compatibility field placement is unsupported"
+    } else {
+        "missing field 'format' for tailtriage.tracing-span.v1 wrapper"
     }
 }
 
-fn parse_u64(v: &Value, field: &'static str) -> Result<u64, ImportError> {
-    v.as_u64().ok_or_else(|| ImportError::InvalidField {
-        field,
-        reason: "expected unix timestamp in milliseconds as u64".to_owned(),
-    })
+fn looks_like_ordinary_fmt_json(obj: &serde_json::Map<String, Value>) -> bool {
+    obj.contains_key("timestamp") && obj.contains_key("level") && obj.contains_key("target")
+}
+
+fn wrapper_error(line_no: usize, reason: impl Into<String>) -> ImportError {
+    ImportError::ExpectedTailtriageWrapper {
+        reason: format!("line {line_no}: {}", reason.into()),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ImportOptions;
-    use std::io::{Cursor, Read};
+    use crate::{FieldValue, ImportOptions};
+    use std::io::Cursor;
 
-    fn import_jsonl_reader<R: Read>(
-        reader: R,
-        options: ImportOptions,
-    ) -> Result<ImportedRun, ImportError> {
-        super::import_jsonl_reader_with_mode(reader, options, JsonlParseMode::Compatible)
-    }
-
-    #[test]
-    fn normalized_jsonl_request_only() {
-        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests.len(), 1);
-    }
-
-    #[test]
-    fn compatible_jsonl_retained_sources_preserve_decoded_original_and_skip_bad_records() {
-        let input = r#"
-{"message":"completed request","span":{"id":"req-id","parent_id":"root-id","name":"req","started_at_unix_ms":1000,"started_at_run_us":10,"finished_at_unix_ms":1020,"finished_at_run_us":20010,"duration_us":20000,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a","custom":"request-source"}}}
-{"timestamp":"2026-06-01T00:00:00Z","level":"INFO","target":"svc","message":"ordinary log","fields":{"request_id":"noise"}}
-{"message":"completed stage","span":{"id":"stage-id","parent_id":"req-id","name":"stage","started_at_unix_ms":1005,"started_at_run_us":5010,"finished_at_unix_ms":1010,"finished_at_run_us":10010,"duration_us":5000,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db","custom":"stage-source"}}}
-"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-
-        assert!(imported
-            .warnings()
-            .iter()
-            .any(|warning| warning.message().contains("fmt JSON")));
-        let retained = imported.retained_sources();
-        assert_eq!(retained.len(), 2);
-        assert_eq!(
-            retained.iter().map(SpanRecord::name).collect::<Vec<_>>(),
-            vec!["req", "stage"]
-        );
-
-        let request = &retained[0];
-        assert_eq!(request.id_ref(), Some("req-id"));
-        assert_eq!(request.parent_id_ref(), Some("root-id"));
-        assert_eq!(
-            request.fields().get("custom"),
-            Some(&FieldValue::String("request-source".to_owned()))
-        );
-        assert_eq!(request.started_at_unix_ms(), 1000);
-        assert_eq!(request.finished_at_unix_ms(), 1020);
-        assert_eq!(request.started_at_run_us_ref(), Some(10));
-        assert_eq!(request.finished_at_run_us_ref(), Some(20010));
-        assert_eq!(request.duration_us_ref(), Some(20_000));
-
-        let stage = &retained[1];
-        assert_eq!(stage.id_ref(), Some("stage-id"));
-        assert_eq!(stage.parent_id_ref(), Some("req-id"));
-        assert_eq!(
-            stage.fields().get("custom"),
-            Some(&FieldValue::String("stage-source".to_owned()))
-        );
-        assert_eq!(stage.started_at_unix_ms(), 1005);
-        assert_eq!(stage.finished_at_unix_ms(), 1010);
-        assert_eq!(stage.started_at_run_us_ref(), Some(5010));
-        assert_eq!(stage.finished_at_run_us_ref(), Some(10010));
-        assert_eq!(stage.duration_us_ref(), Some(5000));
-    }
-
-    #[test]
-    fn stable_wrapper_jsonl_privately_carries_decoded_original_sources_in_input_order() {
-        let input = r#"
-{"format":"tailtriage.tracing-span.v1","span":{"id":"req-id","parent_id":"root","name":"req","started_at_unix_ms":10,"started_at_run_us":100,"finished_at_unix_ms":20,"finished_at_run_us":200,"duration_us":100,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a","extra":"kept"}}}
-{"format":"tailtriage.tracing-span.v1","span":{"id":"stage-id","parent_id":"req-id","name":"stage","started_at_unix_ms":12,"started_at_run_us":120,"finished_at_unix_ms":15,"finished_at_run_us":150,"duration_us":30,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
-"#;
-        let imported = super::import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc"))
-            .expect("stable import should work");
-
-        assert_eq!(
-            imported
-                .retained_sources()
-                .iter()
-                .map(SpanRecord::name)
-                .collect::<Vec<_>>(),
-            vec!["req", "stage"]
-        );
-        assert_eq!(imported.retained_sources()[0].id_ref(), Some("req-id"));
-        assert_eq!(imported.retained_sources()[0].parent_id_ref(), Some("root"));
-        assert_eq!(
-            imported.retained_sources()[0].fields().get("extra"),
-            Some(&FieldValue::String("kept".to_owned()))
-        );
-        assert_eq!(
-            imported.retained_sources()[1].started_at_run_us_ref(),
-            Some(120)
-        );
-    }
-
-    #[test]
-    fn normalized_jsonl_request_stage_queue() {
-        let input = r#"
-{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
-{"span":{"name":"st","started_at_unix_ms":11,"finished_at_unix_ms":18,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
-{"span":{"name":"q","started_at_unix_ms":10,"finished_at_unix_ms":11,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":3}}}
-"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests.len(), 1);
-        assert_eq!(imported.run().stages.len(), 1);
-        assert_eq!(imported.run().queues.len(), 1);
-        assert_eq!(imported.run().queues[0].queue, "permits");
-    }
-
-    #[test]
-    fn stable_wrapper_jsonl_preserves_run_relative_fields_into_run_events() {
-        let input = r#"
-{"format":"tailtriage.tracing-span.v1","span":{"name":"req","started_at_unix_ms":10,"started_at_run_us":100,"finished_at_unix_ms":20,"finished_at_run_us":10100,"duration_us":10000,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
-{"format":"tailtriage.tracing-span.v1","span":{"name":"st","started_at_unix_ms":11,"started_at_run_us":1100,"finished_at_unix_ms":18,"finished_at_run_us":8100,"duration_us":7000,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
-{"format":"tailtriage.tracing-span.v1","span":{"name":"q","started_at_unix_ms":12,"started_at_run_us":2100,"finished_at_unix_ms":13,"finished_at_run_us":3100,"duration_us":1000,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits"}}}
-"#;
-        let imported =
-            super::import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        let run = imported.run();
-
-        assert_eq!(run.requests[0].started_at_run_us, Some(100));
-        assert_eq!(run.requests[0].finished_at_run_us, Some(10_100));
-        assert_eq!(run.stages[0].started_at_run_us, Some(1_100));
-        assert_eq!(run.stages[0].finished_at_run_us, Some(8_100));
-        assert_eq!(run.queues[0].waited_from_run_us, Some(2_100));
-        assert_eq!(run.queues[0].waited_until_run_us, Some(3_100));
-    }
-
-    #[test]
-    fn stable_wrapper_jsonl_without_run_relative_fields_imports_none() {
-        let input = r#"
-{"format":"tailtriage.tracing-span.v1","span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":10000,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
-{"format":"tailtriage.tracing-span.v1","span":{"name":"st","started_at_unix_ms":11,"finished_at_unix_ms":18,"duration_us":7000,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
-{"format":"tailtriage.tracing-span.v1","span":{"name":"q","started_at_unix_ms":12,"finished_at_unix_ms":13,"duration_us":1000,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits"}}}
-"#;
-        let imported =
-            super::import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        let run = imported.run();
-
-        assert_eq!(run.requests[0].started_at_run_us, None);
-        assert_eq!(run.requests[0].finished_at_run_us, None);
-        assert_eq!(run.stages[0].started_at_run_us, None);
-        assert_eq!(run.stages[0].finished_at_run_us, None);
-        assert_eq!(run.queues[0].waited_from_run_us, None);
-        assert_eq!(run.queues[0].waited_until_run_us, None);
-    }
-
-    #[test]
-    fn stable_wrapper_jsonl_invalid_run_relative_field_fails_invalid_field() {
-        let input = r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req","started_at_unix_ms":10,"started_at_run_us":"bad","finished_at_unix_ms":20,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
-        let err =
-            super::import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap_err();
-
-        assert!(matches!(
-            err,
-            ImportError::InvalidField {
-                field: "started_at_run_us",
-                ..
-            }
-        ));
-    }
-
-    #[test]
-    fn stable_wrapper_non_strict_duration_mismatch_keeps_duration_us_authoritative() {
-        let input = r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req","started_at_unix_ms":100,"started_at_run_us":10,"finished_at_unix_ms":101,"finished_at_run_us":20,"duration_us":50000,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
-        let imported =
-            super::import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-
-        assert_eq!(imported.run().requests[0].latency_us, 50_000);
-        assert_eq!(imported.run().requests[0].started_at_run_us, None);
-        assert_eq!(imported.run().requests[0].finished_at_run_us, None);
-        assert!(imported
-            .warnings()
-            .iter()
-            .any(|warning| warning.message().contains("duration_mismatch")));
-        assert!(imported
-            .warnings()
-            .iter()
-            .any(|warning| warning.message().contains("duration evidence was retained")));
-    }
-
-    #[test]
-    fn unrelated_line_ignored() {
-        let input = r#"{"message":"ordinary log","level":"info"}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().requests.is_empty());
-    }
-
-    #[test]
-    fn empty_lines_ignored() {
-        let input = "\n\n";
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().requests.is_empty());
-    }
-
-    #[test]
-    fn malformed_json_returns_malformed_json_line_error() {
-        let err =
-            import_jsonl_reader(Cursor::new("{not-json}"), ImportOptions::new("svc")).unwrap_err();
-        assert!(matches!(
-            err,
-            ImportError::MalformedJsonLine { line: 1, .. }
-        ));
-    }
-
-    #[test]
-    fn malformed_json_reports_correct_line_number() {
-        let input = "{\"message\":\"ok\"}\n{not-json}";
-        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap_err();
-        assert!(matches!(
-            err,
-            ImportError::MalformedJsonLine { line: 2, .. }
-        ));
-    }
-
-    #[test]
-    fn missing_required_fields_surface_conversion_warnings() {
-        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1"}}}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().requests.is_empty());
-        assert_eq!(imported.warnings().len(), 1);
-    }
-
-    #[test]
-    fn strict_mode_propagates_conversion_errors() {
-        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1"}}}"#;
-        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
-            .unwrap_err();
-        assert!(matches!(err, ImportError::StrictViolation(_)));
-    }
-
-    #[test]
-    fn path_import_works() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("input.jsonl");
-        std::fs::write(&path, r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#).unwrap();
-        let imported = import_jsonl_path_with_mode(
-            &path,
-            ImportOptions::new("svc"),
-            JsonlParseMode::Compatible,
+    fn stable_request(name: &str, request_id: &str) -> String {
+        format!(
+            r#"{{"format":"tailtriage.tracing-span.v1","span":{{"name":"{name}","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{{"tt.kind":"request","tt.request_id":"{request_id}","tt.route":"/a"}}}}}}"#
         )
-        .unwrap();
-        assert_eq!(imported.run().requests.len(), 1);
     }
 
-    #[test]
-    fn path_open_failure_returns_io_error() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("missing.jsonl");
-        let err = import_jsonl_path(&path, ImportOptions::new("svc")).unwrap_err();
+    fn assert_wrapper_rejected(input: &str, line: usize, text: &str) {
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc"))
+            .expect_err("record should be structurally rejected");
         match err {
-            ImportError::Io {
-                operation, context, ..
-            } => {
-                assert_eq!(operation, "open jsonl path");
-                assert!(context.contains("missing.jsonl"));
+            ImportError::ExpectedTailtriageWrapper { reason } => {
+                assert!(reason.contains(&format!("line {line}")), "{reason}");
+                assert!(reason.contains(text), "{reason}");
             }
             other => panic!("unexpected error: {other:?}"),
         }
     }
 
-    struct BoomReader;
+    #[test]
+    fn stable_wrapper_fixture_imports() {
+        let fixture = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/tailtriage-span-v1.jsonl");
+        let imported = import_jsonl_path(fixture, ImportOptions::new("svc")).unwrap();
+        assert!(!imported.run().requests.is_empty());
+    }
 
-    impl Read for BoomReader {
-        fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
-            Err(std::io::Error::other("boom"))
+    #[test]
+    fn rejects_raw_top_level_span_record() {
+        assert_wrapper_rejected(
+            r#"{"name":"request","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/"}}"#,
+            1,
+            "raw or pre-stable",
+        );
+    }
+
+    #[test]
+    fn rejects_unversioned_span_envelope() {
+        assert_wrapper_rejected(
+            r#"{"span":{"name":"request","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/"}}}"#,
+            1,
+            "unversioned",
+        );
+    }
+
+    #[test]
+    fn rejects_start_unix_ms_and_end_unix_ms_aliases() {
+        assert_wrapper_rejected(
+            r#"{"name":"request","start_unix_ms":1,"end_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/"}}"#,
+            1,
+            "raw or pre-stable",
+        );
+    }
+
+    #[test]
+    fn rejects_top_level_tt_fields() {
+        assert_wrapper_rejected(
+            r#"{"span":{"name":"request","started_at_unix_ms":1,"finished_at_unix_ms":2},"tt.kind":"request","tt.request_id":"r1","tt.route":"/"}"#,
+            1,
+            "unversioned",
+        );
+    }
+
+    #[test]
+    fn rejects_outer_fields_compatibility_input() {
+        assert_wrapper_rejected(
+            r#"{"span":{"name":"request","started_at_unix_ms":1,"finished_at_unix_ms":2},"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/"}}"#,
+            1,
+            "unversioned",
+        );
+    }
+
+    #[test]
+    fn rejects_mixed_compatibility_field_locations() {
+        assert_wrapper_rejected(
+            r#"{"span":{"name":"request","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request"}},"fields":{"tt.request_id":"r1"},"tt.route":"/"}"#,
+            1,
+            "unversioned",
+        );
+    }
+
+    #[test]
+    fn rejects_ordinary_tracing_formatter_json() {
+        assert_wrapper_rejected(
+            r#"{"timestamp":"2026-01-01T00:00:00Z","level":"INFO","target":"svc","fields":{"message":"hello"}}"#,
+            1,
+            "ordinary tracing formatter JSON is unsupported",
+        );
+    }
+
+    #[test]
+    fn rejects_missing_format() {
+        assert_wrapper_rejected(r#"{"message":"x"}"#, 1, "missing field 'format'");
+    }
+
+    #[test]
+    fn rejects_non_string_format() {
+        assert_wrapper_rejected(r#"{"format":1,"span":{}}"#, 1, "invalid field 'format'");
+    }
+
+    #[test]
+    fn rejects_unsupported_format_marker() {
+        assert_wrapper_rejected(
+            r#"{"format":"other","span":{}}"#,
+            1,
+            "unsupported span format marker 'other'",
+        );
+    }
+
+    #[test]
+    fn rejects_missing_span() {
+        assert_wrapper_rejected(
+            r#"{"format":"tailtriage.tracing-span.v1"}"#,
+            1,
+            "missing field 'span'",
+        );
+    }
+
+    #[test]
+    fn rejects_non_object_span() {
+        assert_wrapper_rejected(
+            r#"{"format":"tailtriage.tracing-span.v1","span":"bad"}"#,
+            1,
+            "invalid field 'span'",
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_json_with_line_number() {
+        let err =
+            import_jsonl_reader(Cursor::new("\n{bad"), ImportOptions::new("svc")).unwrap_err();
+        match err {
+            ImportError::MalformedJsonLine { line, .. } => assert_eq!(line, 2),
+            other => panic!("unexpected error: {other:?}"),
         }
     }
 
     #[test]
-    fn reader_error_returns_io_error() {
-        let err = import_jsonl_reader(BoomReader, ImportOptions::new("svc")).unwrap_err();
-        assert!(matches!(
-            err,
-            ImportError::Io {
-                operation: "read jsonl line",
-                ..
+    fn rejects_non_object_json_value() {
+        assert_wrapper_rejected("[]", 1, "JSONL record must be an object");
+    }
+
+    #[test]
+    fn structural_errors_are_fatal_even_non_strict() {
+        let input = format!(
+            "{}\n\n{{\"name\":\"legacy\",\"started_at_unix_ms\":1,\"finished_at_unix_ms\":2}}\n{}",
+            stable_request("req", "r1"),
+            stable_request("stage", "r2")
+        );
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(false))
+            .unwrap_err();
+        match err {
+            ImportError::ExpectedTailtriageWrapper { reason } => {
+                assert!(reason.contains("line 3"));
+                assert!(reason.contains("raw or pre-stable"));
             }
-        ));
-    }
-
-    #[test]
-    fn compatible_mode_rejects_close_event_shape_with_explicit_timestamps() {
-        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":10,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
-{"event":"close","span":{"name":"st","fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}},"started_at_unix_ms":5,"finished_at_unix_ms":8}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().stages.is_empty());
-        assert!(!imported.warnings().is_empty());
-    }
-
-    #[test]
-    fn incomplete_normalized_tt_kind_span_warns_non_strict_and_errors_strict() {
-        let input = r#"{"span":{"name":"req","fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests.len(), 0);
-        assert_eq!(imported.warnings().len(), 1);
-        assert!(imported.warnings()[0].message().contains("line 1"));
-
-        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
-            .unwrap_err();
-        assert!(matches!(err, ImportError::StrictViolation(_)));
-    }
-
-    #[test]
-    fn compatible_mode_accepts_normalized_span_with_top_level_event_when_timed() {
-        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":10,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a","tt.outcome":"ok","tt.success":true}}}
-{"event":"close","span":{"name":"st","started_at_unix_ms":5,"finished_at_unix_ms":8,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db","tt.success":true}}}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().stages.len(), 1);
-        assert!(imported.warnings().iter().any(|w| w
-            .message()
-            .contains("precise_interval_validation_unavailable")));
-    }
-
-    #[test]
-    fn non_strict_normalized_tt_span_invalid_timestamp_warns_and_skips() {
-        let input = r#"{"span":{"name":"req","started_at_unix_ms":"bad","finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().requests.is_empty());
-        assert_eq!(imported.warnings().len(), 1);
-        assert!(imported.warnings()[0].message().contains("line 1"));
-    }
-
-    #[test]
-    fn strict_normalized_tt_span_invalid_timestamp_errors() {
-        let input = r#"{"span":{"name":"req","started_at_unix_ms":"bad","finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
-        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
-            .unwrap_err();
-        assert!(matches!(err, ImportError::StrictViolation(_)));
-    }
-
-    #[test]
-    fn malformed_unrelated_normalized_spans_are_ignored() {
-        let input = r#"
-{"span":{"name":"other","id":123,"started_at_unix_ms":1,"finished_at_unix_ms":2}}
-{"span":{"name":"other","parent_id":{},"started_at_unix_ms":1,"finished_at_unix_ms":2}}
-{"span":{"name":123,"started_at_unix_ms":1,"finished_at_unix_ms":2}}
-"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().requests.is_empty());
-        assert!(imported.warnings().is_empty());
-    }
-
-    #[test]
-    fn parse_warnings_are_persisted_to_run_lifecycle_warnings() {
-        let input = r#"
-{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok","tt.outcome":"ok"}}}
-{"span":{"name":"broken","fields":{"tt.kind":"request","tt.request_id":"r2","tt.route":"/broken"}}}
-"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests.len(), 1);
-        assert!(imported
-            .warnings()
-            .iter()
-            .any(|w| w.message().contains("line 3")));
-        let warning_message = imported
-            .warnings()
-            .iter()
-            .find(|w| w.message().contains("line 3"))
-            .unwrap()
-            .message();
-        assert!(imported
-            .run()
-            .metadata
-            .lifecycle_warnings
-            .iter()
-            .any(|warning| warning == warning_message));
-    }
-
-    #[test]
-    fn conversion_warnings_still_follow_existing_lifecycle_policy() {
-        let input = r#"
-{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok","tt.outcome":"ok"}}}
-{"span":{"name":"req2","started_at_unix_ms":3,"finished_at_unix_ms":4,"fields":{"tt.kind":"request","tt.request_id":"r2"}}}
-"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests.len(), 1);
-        assert!(imported
-            .warnings()
-            .iter()
-            .any(|w| w.message().contains("tt.route")));
-        let conversion_warning = imported
-            .warnings()
-            .iter()
-            .find(|w| w.message().contains("tt.route"))
-            .unwrap()
-            .message();
-        assert!(imported
-            .run()
-            .metadata
-            .lifecycle_warnings
-            .iter()
-            .any(|warning| warning == conversion_warning));
-    }
-
-    #[test]
-    fn unknown_kind_warning_is_durable_once_with_valid_request_present() {
-        let input = r#"
-{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok","tt.outcome":"ok"}}}
-{"span":{"name":"unknown","started_at_unix_ms":3,"finished_at_unix_ms":4,"fields":{"tt.kind":"mystery"}}}
-"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests.len(), 1);
-        let warning_message = "unknown tt.kind 'mystery' in span 'unknown'";
-        assert!(imported
-            .warnings()
-            .iter()
-            .any(|w| w.message() == warning_message));
-        let matches = imported
-            .run()
-            .metadata
-            .lifecycle_warnings
-            .iter()
-            .filter(|warning| warning.as_str() == warning_message)
-            .count();
-        assert_eq!(matches, 1);
-    }
-
-    #[test]
-    fn tt_fields_without_kind_warn_non_strict_and_error_strict() {
-        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.request_id":"r1","tt.route":"/ok"}}}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().requests.is_empty());
-        assert!(imported.warnings().iter().any(|w| w
-            .message()
-            .contains("missing required field 'tt.kind' in span 'req'")));
-
-        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
-            .unwrap_err();
-        assert!(matches!(err, ImportError::StrictViolation(_)));
-    }
-
-    #[test]
-    fn non_scalar_span_fields_tt_kind_warns_non_strict_and_errors_strict() {
-        let input = r#"{"span":{"name":"bad","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":{"bad":true}}}}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().requests.is_empty());
-        assert!(imported
-            .warnings()
-            .iter()
-            .any(|w| w.message().contains("line 1") && w.message().contains("tt.kind")));
-        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
-            .unwrap_err();
-        assert!(matches!(err, ImportError::StrictViolation(_)));
-    }
-
-    #[test]
-    fn non_scalar_outer_fields_tt_kind_warns_non_strict_and_errors_strict() {
-        let input = r#"{"span":{"name":"bad","started_at_unix_ms":1,"finished_at_unix_ms":2},"fields":{"tt.kind":{"bad":true}}}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().requests.is_empty());
-        assert!(imported
-            .warnings()
-            .iter()
-            .any(|w| w.message().contains("line 1") && w.message().contains("tt.kind")));
-        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
-            .unwrap_err();
-        assert!(matches!(err, ImportError::StrictViolation(_)));
-    }
-
-    #[test]
-    fn non_scalar_top_level_tt_kind_warns_non_strict_and_errors_strict() {
-        let input = r#"{"span":{"name":"bad","started_at_unix_ms":1,"finished_at_unix_ms":2},"tt.kind":{"bad":true}}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().requests.is_empty());
-        assert!(imported
-            .warnings()
-            .iter()
-            .any(|w| w.message().contains("line 1") && w.message().contains("tt.kind")));
-        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
-            .unwrap_err();
-        assert!(matches!(err, ImportError::StrictViolation(_)));
-    }
-
-    #[test]
-    fn missing_optional_defaults_emit_aggregate_warnings_once() {
-        let input = r#"
-{"span":{"name":"req1","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok"}}}
-{"span":{"name":"req2","started_at_unix_ms":3,"finished_at_unix_ms":4,"fields":{"tt.kind":"request","tt.request_id":"r2","tt.route":"/ok2"}}}
-{"span":{"name":"st1","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
-{"span":{"name":"st2","started_at_unix_ms":3,"finished_at_unix_ms":4,"fields":{"tt.kind":"stage","tt.request_id":"r2","tt.stage":"cache"}}}
-"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        let msgs = imported
-            .warnings()
-            .iter()
-            .map(|w| w.message().to_owned())
-            .collect::<Vec<_>>();
-        assert_eq!(
-            msgs.iter()
-                .filter(|m| m.contains("missing optional 'tt.outcome'"))
-                .count(),
-            1
-        );
-        assert_eq!(
-            msgs.iter()
-                .filter(|m| m.contains("missing optional 'tt.success'"))
-                .count(),
-            1
-        );
-    }
-
-    #[test]
-    fn unrelated_malformed_normalized_span_does_not_create_lifecycle_warning() {
-        let input = r#"
-{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/ok","tt.outcome":"ok"}}}
-{"span":{"name":"other","id":123,"started_at_unix_ms":3,"finished_at_unix_ms":4}}
-"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests.len(), 1);
-        assert!(imported.warnings().iter().any(|w| w
-            .message()
-            .contains("precise_interval_validation_unavailable")));
-        assert!(imported.run().metadata.lifecycle_warnings.is_empty());
-    }
-
-    #[test]
-    fn strict_parse_warning_case_still_errors_without_run() {
-        let input = r#"{"span":{"name":"req","fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
-        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
-            .unwrap_err();
-        assert!(matches!(err, ImportError::StrictViolation(_)));
-    }
-
-    #[test]
-    fn malformed_tt_normalized_spans_warn_non_strict_and_error_strict() {
-        let malformed = [
-            r#"{"span":{"name":"req","id":123,"started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request"}}}"#,
-            r#"{"span":{"name":"req","parent_id":{},"started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request"}}}"#,
-            r#"{"span":{"name":123,"started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request"}}}"#,
-        ];
-        for line in malformed {
-            let imported =
-                import_jsonl_reader(Cursor::new(line), ImportOptions::new("svc")).unwrap();
-            assert!(imported.run().requests.is_empty());
-            assert_eq!(imported.warnings().len(), 1);
-            let err =
-                import_jsonl_reader(Cursor::new(line), ImportOptions::new("svc").strict(true))
-                    .unwrap_err();
-            assert!(matches!(err, ImportError::StrictViolation(_)));
+            other => panic!("unexpected error: {other:?}"),
         }
     }
 
     #[test]
-    fn normalized_contradictory_duration_us_warns_and_retains_duration_us() {
-        let input = r#"
-{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":1234,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
-{"span":{"name":"st","started_at_unix_ms":11,"finished_at_unix_ms":18,"duration_us":1234,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
-{"span":{"name":"q","started_at_unix_ms":10,"finished_at_unix_ms":11,"duration_us":1234,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":3}}}
-"#;
+    fn valid_only_multiline_preserves_source_order() {
+        let input = format!(
+            "{}\n{}",
+            stable_request("req-a", "r1"),
+            stable_request("req-b", "r2")
+        );
         let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests[0].latency_us, 1234);
-        assert_eq!(imported.run().stages[0].latency_us, 1234);
-        assert_eq!(imported.run().queues[0].wait_us, 1234);
+        let retained = imported.retained_sources();
+        assert_eq!(retained.len(), 2);
+        assert_eq!(retained[0].name(), "req-a");
+        assert_eq!(retained[1].name(), "req-b");
+    }
+
+    #[test]
+    fn stable_wrapper_duration_us_is_authoritative_when_wall_timestamps_disagree() {
+        let input = r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"request","started_at_unix_ms":1700000000000,"started_at_run_us":0,"finished_at_unix_ms":1700000000001,"finished_at_run_us":1000,"duration_us":50000,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}"#;
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc"))
+            .expect("non-strict import should retain mismatched duration");
+        assert_eq!(imported.run().requests.len(), 1);
+        assert_eq!(imported.run().requests[0].latency_us, 50_000);
         assert!(imported
             .warnings()
             .iter()
-            .any(|w| w.message().contains("duration evidence was retained")));
-    }
-
-    #[test]
-    fn normalized_zero_duration_us_outside_tolerance_retains_duration_us() {
-        let input = r#"
-{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":0,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}
-{"span":{"name":"st","started_at_unix_ms":11,"finished_at_unix_ms":18,"duration_us":0,"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}
-{"span":{"name":"q","started_at_unix_ms":10,"finished_at_unix_ms":11,"duration_us":0,"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":3}}}
-"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests[0].latency_us, 0);
-        assert_eq!(imported.run().stages[0].latency_us, 0);
-        assert_eq!(imported.run().queues[0].wait_us, 0);
-    }
-
-    #[test]
-    fn normalized_request_fields_import_from_outer_fields() {
-        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2},"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/outer"}}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests.len(), 1);
-        assert_eq!(imported.run().requests[0].route, "/outer");
-    }
-
-    #[test]
-    fn normalized_request_fields_import_from_top_level_tt_keys() {
-        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2},"tt.kind":"request","tt.request_id":"r1","tt.route":"/top"}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests.len(), 1);
-        assert_eq!(imported.run().requests[0].route, "/top");
-    }
-
-    #[test]
-    fn normalized_stage_fields_import_from_outer_fields() {
-        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2},"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}
-{"span":{"name":"st","started_at_unix_ms":1,"finished_at_unix_ms":2},"fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().stages.len(), 1);
-        assert_eq!(imported.run().stages[0].stage, "db");
-    }
-
-    #[test]
-    fn normalized_stage_fields_import_from_top_level_tt_keys() {
-        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2},"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}
-{"span":{"name":"st","started_at_unix_ms":1,"finished_at_unix_ms":2},"tt.kind":"stage","tt.request_id":"r1","tt.stage":"cache"}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().stages.len(), 1);
-        assert_eq!(imported.run().stages[0].stage, "cache");
-    }
-
-    #[test]
-    fn normalized_queue_fields_import_from_outer_fields() {
-        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2},"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}
-{"span":{"name":"q","started_at_unix_ms":1,"finished_at_unix_ms":2},"fields":{"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":3}}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().queues.len(), 1);
-        assert_eq!(imported.run().queues[0].depth_at_start, Some(3));
-    }
-
-    #[test]
-    fn normalized_queue_fields_import_from_top_level_tt_keys() {
-        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2},"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}
-{"span":{"name":"q","started_at_unix_ms":1,"finished_at_unix_ms":2},"tt.kind":"queue","tt.request_id":"r1","tt.queue":"permits","tt.depth_at_start":7}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().queues.len(), 1);
-        assert_eq!(imported.run().queues[0].depth_at_start, Some(7));
-    }
-
-    #[test]
-    fn normalized_span_fields_still_imports() {
-        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/span"}}}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests.len(), 1);
-        assert_eq!(imported.run().requests[0].route, "/span");
-    }
-
-    #[test]
-    fn normalized_field_precedence_is_outer_then_span_then_top_level() {
-        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.route":"/span","tt.kind":"request","tt.request_id":"r1"}},"fields":{"tt.route":"/outer"},"tt.route":"/top"}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests[0].route, "/top");
-    }
-
-    #[test]
-    fn normalized_duration_us_from_outer_fields_retains_duration_us_when_outside_tolerance() {
-        let input = r#"{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":1234},"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/outer"}}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests[0].latency_us, 1234);
-    }
-
-    #[test]
-    fn normalized_duration_us_from_top_level_tt_keys_retains_duration_us_when_outside_tolerance() {
-        let input = r#"{"span":{"name":"req","started_at_unix_ms":10,"finished_at_unix_ms":20,"duration_us":1234},"tt.kind":"request","tt.request_id":"r1","tt.route":"/top"}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests[0].latency_us, 1234);
-    }
-
-    #[test]
-    fn invalid_duration_us_on_tt_span_warns_or_errors() {
-        let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"duration_us":"bad","fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().requests.is_empty());
-        assert_eq!(imported.warnings().len(), 1);
+            .any(|warning| warning.message().contains("duration_mismatch")));
         let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
-            .unwrap_err();
-        assert!(matches!(err, ImportError::StrictViolation(_)));
+            .expect_err("strict import should reject mismatched duration");
+        assert!(err.to_string().contains("duration_mismatch"));
     }
 
     #[test]
-    fn invalid_duration_us_on_unrelated_normalized_span_is_ignored() {
-        let input = r#"{"span":{"name":"other","started_at_unix_ms":1,"finished_at_unix_ms":2,"duration_us":"bad"}}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().requests.is_empty());
-        assert!(imported.warnings().is_empty());
-    }
-
-    #[test]
-    fn compatible_mode_close_event_like_tt_span_missing_timestamps_warns_and_skips() {
-        let input = r#"{"event":"close","span":{"name":"st","fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().stages.is_empty());
-        assert_eq!(imported.warnings().len(), 1);
-        assert!(imported.warnings()[0].message().contains("line 1"));
-    }
-
-    #[test]
-    fn compatible_mode_close_event_like_tt_span_missing_timestamps_errors() {
-        let input = r#"{"event":"close","span":{"name":"st","fields":{"tt.kind":"stage","tt.request_id":"r1","tt.stage":"db"}}}"#;
-        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
-            .unwrap_err();
-        assert!(matches!(err, ImportError::StrictViolation(_)));
-    }
-
-    #[test]
-    fn top_level_tt_record_without_span_shape_warns_non_strict() {
-        let input = r#"{"tt.kind":"request","tt.request_id":"r1","tt.route":"/checkout"}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().requests.is_empty());
-        assert!(imported.run().stages.is_empty());
-        assert!(imported.run().queues.is_empty());
-        assert_eq!(imported.warnings().len(), 1);
-        let msg = imported.warnings()[0].message();
-        assert!(msg.contains("line 1"));
-        assert!(msg.contains("normalized completed-span shape"));
-        assert!(imported
-            .run()
-            .metadata
-            .lifecycle_warnings
-            .iter()
-            .any(|w| w == msg));
-    }
-
-    #[test]
-    fn top_level_tt_record_without_span_shape_errors_strict() {
-        let input = r#"{"tt.kind":"request","tt.request_id":"r1","tt.route":"/checkout"}"#;
-        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
-            .unwrap_err();
-        assert!(matches!(err, ImportError::StrictViolation(_)));
-        assert!(err.to_string().contains("normalized completed-span shape"));
-    }
-
-    #[test]
-    fn unrelated_top_level_json_record_still_ignored() {
-        let input = r#"{"message":"ordinary log","level":"info","request_id":"r1"}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().requests.is_empty());
-        assert!(imported.run().stages.is_empty());
-        assert!(imported.run().queues.is_empty());
-        assert!(imported.warnings().is_empty());
-    }
-
-    #[test]
-    fn compatible_mode_accepts_normalized_span_with_top_level_message_when_timed() {
-        let input = r#"{"message":"completed request","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/message","tt.outcome":"ok","tt.success":true}}}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests.len(), 1);
-        assert_eq!(imported.run().requests[0].route, "/message");
-        assert!(imported.warnings().iter().any(|w| w
-            .message()
-            .contains("precise_interval_validation_unavailable")));
-    }
-
-    #[test]
-    fn compatible_mode_accepts_normalized_span_with_fmt_metadata_when_timed() {
-        let input = r#"{"timestamp":"2026-06-01T00:00:00Z","level":"INFO","target":"svc","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/fmt","tt.outcome":"ok","tt.success":true}}}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests.len(), 1);
-        assert_eq!(imported.run().requests[0].route, "/fmt");
-        assert!(imported.warnings().iter().any(|w| w
-            .message()
-            .contains("precise_interval_validation_unavailable")));
-    }
-
-    #[test]
-    fn compatible_mode_rejects_ordinary_fmt_json_without_completed_span_timing() {
-        let input = r#"{"timestamp":"2026-06-01T00:00:00Z","level":"INFO","target":"svc","message":"ordinary log","fields":{"request_id":"r1"}}"#;
-        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().requests.is_empty());
-        assert!(imported.run().stages.is_empty());
-        assert!(imported.run().queues.is_empty());
-        assert_eq!(imported.warnings().len(), 1);
-        assert!(imported.warnings()[0].message().contains("fmt JSON"));
-
-        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
-            .unwrap_err();
-        assert!(matches!(err, ImportError::StrictViolation(_)));
-        assert!(err.to_string().contains("fmt JSON"));
-    }
-
-    #[test]
-    fn wrapper_only_rejects_non_wrapper_compatible_normalized_record() {
-        let input = r#"{"timestamp":"2026-06-01T00:00:00Z","level":"INFO","target":"svc","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/fmt","tt.outcome":"ok","tt.success":true}}}"#;
-        let err = import_jsonl_reader_with_mode(
-            Cursor::new(input),
-            ImportOptions::new("svc"),
-            JsonlParseMode::TailtriageWrapperOnly,
-        )
-        .unwrap_err();
-        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
-    }
-
-    #[test]
-    fn wrapper_only_mode_accepts_wrapper_and_rejects_unwrapped() {
-        let wrapped = r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
-        let imported = import_jsonl_reader_with_mode(
-            Cursor::new(wrapped),
-            ImportOptions::new("svc"),
-            JsonlParseMode::TailtriageWrapperOnly,
-        )
-        .unwrap();
-        assert_eq!(imported.run().requests.len(), 1);
-
-        let unwrapped = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
-        let err = import_jsonl_reader_with_mode(
-            Cursor::new(unwrapped),
-            ImportOptions::new("svc").strict(true),
-            JsonlParseMode::TailtriageWrapperOnly,
-        )
-        .unwrap_err();
-        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
-    }
-
-    #[test]
-    fn wrapper_only_mode_missing_span_strict_returns_expected_wrapper_error() {
-        let missing_span = r#"{"format":"tailtriage.tracing-span.v1"}"#;
-        let err = import_jsonl_reader_with_mode(
-            Cursor::new(missing_span),
-            ImportOptions::new("svc").strict(true),
-            JsonlParseMode::TailtriageWrapperOnly,
-        )
-        .unwrap_err();
-        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
-    }
-
-    #[test]
-    fn wrapper_only_non_strict_unwrapped_errors() {
-        let unwrapped = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
-        let err = import_jsonl_reader_with_mode(
-            Cursor::new(unwrapped),
-            ImportOptions::new("svc"),
-            JsonlParseMode::TailtriageWrapperOnly,
-        )
-        .unwrap_err();
-        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
-    }
-
-    #[test]
-    fn wrapper_only_unsupported_marker_strict_errors_and_non_strict_warns() {
-        let v2 = r#"{"format":"tailtriage.tracing-span.v2","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
-        let err = import_jsonl_reader_with_mode(
-            Cursor::new(v2),
-            ImportOptions::new("svc").strict(true),
-            JsonlParseMode::TailtriageWrapperOnly,
-        )
-        .unwrap_err();
-        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
-        assert!(err.to_string().contains("v2") || err.to_string().contains("unsupported"));
-
-        let err = import_jsonl_reader_with_mode(
-            Cursor::new(v2),
-            ImportOptions::new("svc"),
-            JsonlParseMode::TailtriageWrapperOnly,
-        )
-        .unwrap_err();
-        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
-    }
-
-    #[test]
-    fn compatible_mode_wrapper_marker_missing_span_warns_non_strict_and_errors_strict() {
-        let missing_span = r#"{"format":"tailtriage.tracing-span.v1"}"#;
-        let imported =
-            import_jsonl_reader(Cursor::new(missing_span), ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().requests.is_empty());
-        assert!(imported.run().stages.is_empty());
-        assert!(imported.run().queues.is_empty());
-        assert_eq!(imported.warnings().len(), 1);
-        assert!(imported.warnings()[0].message().contains("line 1"));
-        assert!(imported.warnings()[0]
-            .message()
-            .contains("missing field 'span'"));
-
-        let err = import_jsonl_reader(
-            Cursor::new(missing_span),
-            ImportOptions::new("svc").strict(true),
-        )
-        .unwrap_err();
-        assert!(matches!(err, ImportError::StrictViolation(_)));
-        assert!(err.to_string().contains("line 1"));
-        assert!(err.to_string().contains("missing field 'span'"));
-    }
-
-    #[test]
-    fn compatible_mode_wrapper_marker_non_object_span_warns_non_strict_and_errors_strict() {
-        let span_not_object = r#"{"format":"tailtriage.tracing-span.v1","span":"not an object"}"#;
-        let imported =
-            import_jsonl_reader(Cursor::new(span_not_object), ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().requests.is_empty());
-        assert!(imported.run().stages.is_empty());
-        assert!(imported.run().queues.is_empty());
-        assert_eq!(imported.warnings().len(), 1);
-        assert!(imported.warnings()[0].message().contains("line 1"));
-        assert!(imported.warnings()[0]
-            .message()
-            .contains("invalid field 'span'"));
-
-        let err = import_jsonl_reader(
-            Cursor::new(span_not_object),
-            ImportOptions::new("svc").strict(true),
-        )
-        .unwrap_err();
-        assert!(matches!(err, ImportError::StrictViolation(_)));
-        assert!(err.to_string().contains("line 1"));
-        assert!(err.to_string().contains("invalid field 'span'"));
-    }
-
-    #[test]
-    fn compatible_mode_wrapper_marker_non_string_format_warns_non_strict_and_errors_strict() {
-        let format_not_string = r#"{"format":1,"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
-        let imported =
-            import_jsonl_reader(Cursor::new(format_not_string), ImportOptions::new("svc")).unwrap();
-        assert!(imported.run().requests.is_empty());
-        assert!(imported.run().stages.is_empty());
-        assert!(imported.run().queues.is_empty());
-        assert_eq!(imported.warnings().len(), 1);
-        assert!(imported.warnings()[0].message().contains("line 1"));
-        assert!(imported.warnings()[0]
-            .message()
-            .contains("expected string format marker"));
-
-        let err = import_jsonl_reader(
-            Cursor::new(format_not_string),
-            ImportOptions::new("svc").strict(true),
-        )
-        .unwrap_err();
-        assert!(matches!(err, ImportError::StrictViolation(_)));
-        assert!(err.to_string().contains("line 1"));
-        assert!(err.to_string().contains("expected string format marker"));
-    }
-
-    #[test]
-    fn compatible_mode_wrapper_marker_unsupported_format_warns_non_strict_and_errors_strict() {
-        let unsupported_format = r#"{"format":"tailtriage.tracing-span.v2","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
-        let imported =
-            import_jsonl_reader(Cursor::new(unsupported_format), ImportOptions::new("svc"))
-                .unwrap();
-        assert!(imported.run().requests.is_empty());
-        assert!(imported.run().stages.is_empty());
-        assert!(imported.run().queues.is_empty());
-        assert_eq!(imported.warnings().len(), 1);
-        assert!(imported.warnings()[0].message().contains("line 1"));
-        assert!(imported.warnings()[0]
-            .message()
-            .contains("unsupported span format marker"));
-        assert!(imported.warnings()[0].message().contains("v2"));
-
-        let err = import_jsonl_reader(
-            Cursor::new(unsupported_format),
-            ImportOptions::new("svc").strict(true),
-        )
-        .unwrap_err();
-        assert!(matches!(err, ImportError::StrictViolation(_)));
-        assert!(err.to_string().contains("line 1"));
-        assert!(err.to_string().contains("unsupported span format marker"));
-        assert!(err.to_string().contains("v2"));
-    }
-
-    #[test]
-    fn wrapper_v1_with_bad_span_timestamp_reports_invalid_span_not_marker() {
+    fn invalid_contained_span_warns_non_strict_and_errors_strict() {
         let input = r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req","started_at_unix_ms":"bad","finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
-        let err = import_jsonl_reader_with_mode(
-            Cursor::new(input),
-            ImportOptions::new("svc").strict(true),
-            JsonlParseMode::TailtriageWrapperOnly,
-        )
-        .unwrap_err();
-        let msg = err.to_string();
-        assert!(matches!(err, ImportError::StrictViolation(_)));
-        assert!(msg.contains("tailtriage.tracing-span.v1"));
-        assert!(msg.contains("started_at_unix_ms") || msg.contains("expected"));
-        assert!(!msg.contains("unsupported span format marker"));
-
-        let err = import_jsonl_reader_with_mode(
-            Cursor::new(input),
-            ImportOptions::new("svc").strict(true),
-            JsonlParseMode::TailtriageWrapperOnly,
-        )
-        .unwrap_err();
-        assert!(matches!(err, ImportError::StrictViolation(_)));
-    }
-
-    #[test]
-    fn wrapper_v1_with_missing_required_span_field_reports_invalid_span() {
-        let input = r#"{"format":"tailtriage.tracing-span.v1","span":{"started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
-        let err = import_jsonl_reader_with_mode(
-            Cursor::new(input),
-            ImportOptions::new("svc").strict(true),
-            JsonlParseMode::TailtriageWrapperOnly,
-        )
-        .unwrap_err();
-        let msg = err.to_string();
-        assert!(matches!(err, ImportError::StrictViolation(_)));
-        assert!(msg.contains("span") || msg.contains("name"));
-        assert!(!msg.contains("unsupported span format marker"));
-    }
-
-    #[test]
-    fn default_library_import_rejects_non_wrapper_records() {
-        let err = super::import_jsonl_reader(
-            Cursor::new(r#"{"message":"ordinary"}"#),
-            ImportOptions::new("svc"),
-        )
-        .unwrap_err();
-        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
-    }
-
-    #[test]
-    fn wrapper_only_tt_like_non_wrapper_returns_expected_wrapper_error() {
-        let err = import_jsonl_reader_with_mode(
-            Cursor::new(r#"{"span":{"name":"x"},"tt.kind":"request"}"#),
-            ImportOptions::new("svc"),
-            JsonlParseMode::TailtriageWrapperOnly,
-        )
-        .unwrap_err();
-        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
-    }
-
-    #[test]
-    fn wrapper_v1_with_non_object_span_reports_invalid_span_field() {
-        let input = r#"{"format":"tailtriage.tracing-span.v1","span":"not an object"}"#;
-        let err = import_jsonl_reader_with_mode(
-            Cursor::new(input),
-            ImportOptions::new("svc").strict(true),
-            JsonlParseMode::TailtriageWrapperOnly,
-        )
-        .unwrap_err();
-        let msg = err.to_string();
-        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
-        assert!(
-            msg.contains("invalid field 'span'") || msg.contains("expected completed span object")
-        );
-        assert!(!msg.contains("unsupported span format marker"));
-
-        let err = import_jsonl_reader_with_mode(
-            Cursor::new(input),
-            ImportOptions::new("svc"),
-            JsonlParseMode::TailtriageWrapperOnly,
-        )
-        .unwrap_err();
-        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
-    }
-
-    #[test]
-    fn wrapper_with_non_string_format_reports_invalid_format_field() {
-        let input = r#"{"format":1,"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
-        let err = import_jsonl_reader_with_mode(
-            Cursor::new(input),
-            ImportOptions::new("svc").strict(true),
-            JsonlParseMode::TailtriageWrapperOnly,
-        )
-        .unwrap_err();
-        let msg = err.to_string();
-        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
-        assert!(msg.contains("format") && msg.contains("expected string"));
-
-        let err = import_jsonl_reader_with_mode(
-            Cursor::new(input),
-            ImportOptions::new("svc"),
-            JsonlParseMode::TailtriageWrapperOnly,
-        )
-        .unwrap_err();
-        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
-    }
-
-    #[test]
-    fn compatible_mode_accepts_old_normalized_shape() {
-        let unwrapped = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
-        let imported = import_jsonl_reader_with_mode(
-            Cursor::new(unwrapped),
-            ImportOptions::new("svc"),
-            JsonlParseMode::Compatible,
-        )
-        .unwrap();
-        assert_eq!(imported.run().requests.len(), 1);
-    }
-
-    #[test]
-    fn import_jsonl_reader_accepts_wrapper_by_default() {
-        let wrapped = r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
-        let imported =
-            super::import_jsonl_reader(Cursor::new(wrapped), ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests.len(), 1);
-    }
-
-    #[test]
-    fn import_jsonl_reader_unwrapped_non_strict_rejects_by_default() {
-        let unwrapped = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
-        let err = super::import_jsonl_reader(Cursor::new(unwrapped), ImportOptions::new("svc"))
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert!(imported.run().requests.is_empty());
+        assert!(imported
+            .warnings()
+            .iter()
+            .any(|w| w.message().contains("line 1")));
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
             .unwrap_err();
-        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
+        assert!(err.to_string().contains("line 1"));
     }
 
     #[test]
-    fn import_jsonl_reader_unwrapped_strict_rejects_with_expected_wrapper_error() {
-        let unwrapped = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
-        let err = super::import_jsonl_reader(
-            Cursor::new(unwrapped),
-            ImportOptions::new("svc").strict(true),
-        )
-        .unwrap_err();
-        assert!(matches!(err, ImportError::ExpectedTailtriageWrapper { .. }));
-    }
-
-    #[test]
-    fn import_jsonl_path_accepts_wrapper_by_default() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("wrapped.jsonl");
-        std::fs::write(
-            &path,
-            r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#,
-        )
-        .unwrap();
-        let imported = super::import_jsonl_path(&path, ImportOptions::new("svc")).unwrap();
-        assert_eq!(imported.run().requests.len(), 1);
-    }
-
-    #[test]
-    fn wrapper_fixture_imports_request_stage_queue() {
-        let imported = import_jsonl_reader_with_mode(
-            Cursor::new(include_str!("../tests/fixtures/tailtriage-span-v1.jsonl")),
-            ImportOptions::new("svc"),
-            JsonlParseMode::TailtriageWrapperOnly,
-        )
-        .unwrap();
-        let run = imported.run();
-        assert_eq!(run.requests.len(), 1);
-        assert_eq!(run.stages.len(), 1);
-        assert_eq!(run.queues.len(), 1);
-        assert_eq!(run.requests[0].request_id, "req-1");
-        assert_eq!(run.requests[0].route, "/checkout");
-        assert_eq!(run.stages[0].stage, "db");
-        assert_eq!(run.queues[0].queue, "admission");
-        assert_eq!(run.queues[0].depth_at_start, Some(7));
-    }
-
-    #[test]
-    fn wrapper_fixture_preserves_duration_us() {
-        let imported = import_jsonl_reader_with_mode(
-            Cursor::new(include_str!("../tests/fixtures/tailtriage-span-v1.jsonl")),
-            ImportOptions::new("svc"),
-            JsonlParseMode::TailtriageWrapperOnly,
-        )
-        .unwrap();
-        let run = imported.run();
-        assert_eq!(run.requests[0].latency_us, 30_000);
-        assert_eq!(run.stages[0].latency_us, 10_000);
-        assert_eq!(run.queues[0].wait_us, 4_000);
-    }
-
-    #[test]
-    fn empty_service_name_is_rejected_for_jsonl_import() {
-        let err = import_jsonl_reader(Cursor::new(""), ImportOptions::new("")).unwrap_err();
-        assert!(matches!(err, ImportError::EmptyServiceName));
+    fn stable_writer_output_reimports_with_explicit_evidence() {
+        let span = SpanRecord::new("http.request", 1000, 1100)
+            .id("span-id")
+            .parent_id("parent-id")
+            .started_at_run_us(10)
+            .finished_at_run_us(100_010)
+            .duration_us(100_000)
+            .field(crate::TT_KIND, "request")
+            .field(crate::TT_REQUEST_ID, "req-1")
+            .field(crate::TT_ROUTE, "/checkout")
+            .field("custom", "kept");
+        let jsonl =
+            serde_json::json!({"format":"tailtriage.tracing-span.v1","span":span}).to_string();
+        let imported = import_jsonl_reader(Cursor::new(jsonl), ImportOptions::new("svc")).unwrap();
+        let retained = imported.retained_sources();
+        assert_eq!(retained.len(), 1);
+        let source = &retained[0];
+        assert_eq!(source.id_ref(), Some("span-id"));
+        assert_eq!(source.parent_id_ref(), Some("parent-id"));
+        assert_eq!(source.name(), "http.request");
+        assert_eq!(source.started_at_unix_ms(), 1000);
+        assert_eq!(source.finished_at_unix_ms(), 1100);
+        assert_eq!(source.started_at_run_us_ref(), Some(10));
+        assert_eq!(source.finished_at_run_us_ref(), Some(100_010));
+        assert_eq!(source.duration_us_ref(), Some(100_000));
+        assert_eq!(
+            source.fields().get(crate::TT_KIND),
+            Some(&FieldValue::String("request".to_owned()))
+        );
+        assert_eq!(
+            source.fields().get("custom"),
+            Some(&FieldValue::String("kept".to_owned()))
+        );
     }
 }

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -53,10 +53,7 @@ pub use convention::{
 };
 pub use error::ImportError;
 #[cfg(feature = "jsonl")]
-pub use jsonl::{
-    import_jsonl_path, import_jsonl_path_with_mode, import_jsonl_reader,
-    import_jsonl_reader_with_mode, JsonlParseMode,
-};
+pub use jsonl::{import_jsonl_path, import_jsonl_reader};
 #[cfg(feature = "live")]
 pub use recorder::{
     RecorderLimits, TailtriageLayer, TracingSession, TracingSessionBuilder,

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -3897,6 +3897,55 @@ mod tests {
     }
 
     #[test]
+    fn production_completed_span_jsonl_writer_output_reimports_expected_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let spans_path = dir.path().join("completed.jsonl");
+        let sources = vec![
+            SpanRecord::new("http.request", 1_700_000_000_000, 1_700_000_000_120)
+                .id("span-id")
+                .parent_id("parent-id")
+                .started_at_run_us(10)
+                .finished_at_run_us(120_010)
+                .duration_us(120_000)
+                .field(TT_KIND, "request")
+                .field("tt.request_id", "req-1")
+                .field("tt.route", "/checkout")
+                .field("custom.source", "kept"),
+        ];
+
+        write_completed_span_jsonl_from_retained_sources(&sources, &spans_path).unwrap();
+        let imported = crate::import_jsonl_path(&spans_path, ImportOptions::new("svc")).unwrap();
+
+        let retained = imported.retained_sources();
+        assert_eq!(retained.len(), 1);
+        let span = &retained[0];
+        assert_eq!(span.id_ref(), Some("span-id"));
+        assert_eq!(span.parent_id_ref(), Some("parent-id"));
+        assert_eq!(span.name(), "http.request");
+        assert_eq!(span.started_at_unix_ms(), 1_700_000_000_000);
+        assert_eq!(span.finished_at_unix_ms(), 1_700_000_000_120);
+        assert_eq!(span.started_at_run_us_ref(), Some(10));
+        assert_eq!(span.finished_at_run_us_ref(), Some(120_010));
+        assert_eq!(span.duration_us_ref(), Some(120_000));
+        assert_eq!(
+            span.fields().get(TT_KIND),
+            Some(&FieldValue::String("request".to_owned()))
+        );
+        assert_eq!(
+            span.fields().get("tt.request_id"),
+            Some(&FieldValue::String("req-1".to_owned()))
+        );
+        assert_eq!(
+            span.fields().get("tt.route"),
+            Some(&FieldValue::String("/checkout".to_owned()))
+        );
+        assert_eq!(
+            span.fields().get("custom.source"),
+            Some(&FieldValue::String("kept".to_owned()))
+        );
+    }
+
+    #[test]
     fn direct_completed_span_jsonl_writer_excludes_core_excluded_sources() {
         let dir = tempfile::tempdir().unwrap();
         let spans_path = dir.path().join("spans.jsonl");

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -4219,12 +4219,8 @@ mod tests {
                 "{} retained source identity write/read mismatch",
                 case.name
             );
-            let replay = crate::jsonl::import_jsonl_path_with_mode(
-                &spans_path,
-                ImportOptions::new("svc"),
-                crate::jsonl::JsonlParseMode::TailtriageWrapperOnly,
-            )
-            .unwrap_or_else(|err| panic!("{} permissive replay failed: {err}", case.name));
+            let replay = crate::jsonl::import_jsonl_path(&spans_path, ImportOptions::new("svc"))
+                .unwrap_or_else(|err| panic!("{} permissive replay failed: {err}", case.name));
             assert_eq!(
                 representable_evidence(replay.run()),
                 direct_projection,
@@ -4238,10 +4234,9 @@ mod tests {
                 case.name
             );
             if case.strict_replay {
-                let strict = crate::jsonl::import_jsonl_path_with_mode(
+                let strict = crate::jsonl::import_jsonl_path(
                     &spans_path,
                     ImportOptions::new("svc").strict(true),
-                    crate::jsonl::JsonlParseMode::TailtriageWrapperOnly,
                 )
                 .unwrap_or_else(|err| panic!("{} strict replay failed: {err}", case.name));
                 assert_eq!(representable_evidence(strict.run()), direct_projection);
@@ -4335,12 +4330,8 @@ mod tests {
             direct_issues
         );
 
-        let replay = crate::jsonl::import_jsonl_path_with_mode(
-            &first_path,
-            ImportOptions::new("svc"),
-            crate::jsonl::JsonlParseMode::TailtriageWrapperOnly,
-        )
-        .unwrap();
+        let replay =
+            crate::jsonl::import_jsonl_path(&first_path, ImportOptions::new("svc")).unwrap();
         assert_eq!(
             representable_evidence(replay.run()),
             representable_evidence(direct.run())
@@ -4484,12 +4475,7 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(raw_names, vec!["raw-kept".to_owned()]);
         assert!(!raw_names.iter().any(|name| name == "raw-dropped"));
-        let replay = crate::jsonl::import_jsonl_path_with_mode(
-            &raw_path,
-            ImportOptions::new("svc"),
-            crate::jsonl::JsonlParseMode::TailtriageWrapperOnly,
-        )
-        .unwrap();
+        let replay = crate::jsonl::import_jsonl_path(&raw_path, ImportOptions::new("svc")).unwrap();
         assert_eq!(
             representable_evidence(replay.run()),
             representable_evidence(raw_shutdown.run())
@@ -4576,12 +4562,8 @@ mod tests {
             source_identity(first.retained_sources())
         );
 
-        let replay = crate::jsonl::import_jsonl_path_with_mode(
-            &first_path,
-            ImportOptions::new("svc"),
-            crate::jsonl::JsonlParseMode::TailtriageWrapperOnly,
-        )
-        .unwrap();
+        let replay =
+            crate::jsonl::import_jsonl_path(&first_path, ImportOptions::new("svc")).unwrap();
         assert_eq!(
             representable_evidence(replay.run()),
             representable_evidence(first.run())
@@ -4595,12 +4577,8 @@ mod tests {
         let direct = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         write_completed_span_jsonl_from_retained_sources(direct.retained_sources(), &first_path)
             .unwrap();
-        let replay = crate::jsonl::import_jsonl_path_with_mode(
-            &first_path,
-            ImportOptions::new("svc"),
-            crate::jsonl::JsonlParseMode::TailtriageWrapperOnly,
-        )
-        .unwrap();
+        let replay =
+            crate::jsonl::import_jsonl_path(&first_path, ImportOptions::new("svc")).unwrap();
         write_completed_span_jsonl_from_retained_sources(replay.retained_sources(), &second_path)
             .unwrap();
         assert_eq!(
@@ -4711,12 +4689,8 @@ mod tests {
         assert_eq!(imported.run().runtime_snapshots.len(), 1);
         write_completed_span_jsonl_from_retained_sources(imported.retained_sources(), &spans_path)
             .unwrap();
-        let replay = crate::jsonl::import_jsonl_path_with_mode(
-            &spans_path,
-            ImportOptions::new("svc"),
-            crate::jsonl::JsonlParseMode::TailtriageWrapperOnly,
-        )
-        .unwrap();
+        let replay =
+            crate::jsonl::import_jsonl_path(&spans_path, ImportOptions::new("svc")).unwrap();
         assert_eq!(
             representable_evidence(replay.run()),
             representable_evidence(imported.run())
@@ -4831,12 +4805,8 @@ mod tests {
         assert_eq!(value["span"]["fields"]["tt.request_id"], "r1");
         assert_eq!(value["span"]["fields"]["tt.route"], "/a");
 
-        let imported = crate::jsonl::import_jsonl_path_with_mode(
-            &spans_path,
-            ImportOptions::new("svc"),
-            crate::jsonl::JsonlParseMode::TailtriageWrapperOnly,
-        )
-        .unwrap();
+        let imported =
+            crate::jsonl::import_jsonl_path(&spans_path, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests.len(), 1);
         assert_eq!(imported.run().requests[0].request_id, "r1");
         assert_eq!(imported.run().requests[0].route, "/a");
@@ -4877,12 +4847,8 @@ mod tests {
         assert_eq!(imported.run(), snapshot.run());
         assert_eq!(imported.warnings(), snapshot.warnings());
 
-        let written = crate::jsonl::import_jsonl_path_with_mode(
-            &spans_path,
-            ImportOptions::new("svc"),
-            crate::jsonl::JsonlParseMode::TailtriageWrapperOnly,
-        )
-        .unwrap();
+        let written =
+            crate::jsonl::import_jsonl_path(&spans_path, ImportOptions::new("svc")).unwrap();
         assert_eq!(written.run().requests, imported.run().requests);
         assert_eq!(written.run().stages, imported.run().stages);
         assert_eq!(written.run().queues, imported.run().queues);
@@ -4931,12 +4897,8 @@ mod tests {
         assert_eq!(snapshot.run().requests.len(), 1);
         assert_eq!(snapshot.run().truncation.dropped_requests, 1);
         futures_executor::block_on(session.shutdown()).unwrap();
-        let imported = crate::jsonl::import_jsonl_path_with_mode(
-            &spans_path,
-            ImportOptions::new("svc"),
-            crate::jsonl::JsonlParseMode::TailtriageWrapperOnly,
-        )
-        .unwrap();
+        let imported =
+            crate::jsonl::import_jsonl_path(&spans_path, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests.len(), 1);
         assert_eq!(imported.run().stages.len(), 0);
         assert_eq!(imported.run().queues.len(), 0);
@@ -5467,12 +5429,8 @@ mod tests {
             ));
         });
         let _ = futures_executor::block_on(session.shutdown()).unwrap();
-        let imported = crate::jsonl::import_jsonl_path_with_mode(
-            &spans_path,
-            ImportOptions::new("svc"),
-            crate::jsonl::JsonlParseMode::TailtriageWrapperOnly,
-        )
-        .unwrap();
+        let imported =
+            crate::jsonl::import_jsonl_path(&spans_path, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests.len(), 1);
         assert_eq!(imported.run().stages.len(), 0);
         assert_eq!(imported.run().queues.len(), 0);

--- a/tailtriage-tracing/tests/tracing_examples.rs
+++ b/tailtriage-tracing/tests/tracing_examples.rs
@@ -5,10 +5,7 @@ use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
 use tailtriage_core::{RequestOptions, Run, Tailtriage};
 #[cfg(feature = "live")]
 use tailtriage_tracing::TracingSession;
-use tailtriage_tracing::{
-    import_jsonl_path, import_jsonl_reader, import_jsonl_reader_with_mode, ImportOptions,
-    JsonlParseMode,
-};
+use tailtriage_tracing::{import_jsonl_path, import_jsonl_reader, ImportOptions};
 #[cfg(feature = "live")]
 use tracing_subscriber::prelude::*;
 
@@ -218,12 +215,8 @@ fn imported_fixture_run_is_analyzable_and_has_no_runtime_snapshots() {
 fn stable_wrapper_duration_us_is_authoritative_when_wall_timestamps_disagree() {
     let input = r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"request","started_at_unix_ms":1700000000000,"started_at_run_us":0,"finished_at_unix_ms":1700000000001,"finished_at_run_us":1000,"duration_us":50000,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}"#;
 
-    let imported = import_jsonl_reader_with_mode(
-        Cursor::new(input),
-        ImportOptions::new("svc"),
-        JsonlParseMode::TailtriageWrapperOnly,
-    )
-    .expect("non-strict import should retain mismatched duration");
+    let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc"))
+        .expect("non-strict import should retain mismatched duration");
 
     assert_eq!(imported.run().requests.len(), 1);
     assert_eq!(imported.run().requests[0].latency_us, 50_000);
@@ -232,25 +225,7 @@ fn stable_wrapper_duration_us_is_authoritative_when_wall_timestamps_disagree() {
         .iter()
         .any(|warning| warning.message().contains("duration_mismatch")));
 
-    let err = import_jsonl_reader_with_mode(
-        Cursor::new(input),
-        ImportOptions::new("svc").strict(true),
-        JsonlParseMode::TailtriageWrapperOnly,
-    )
-    .expect_err("strict import should reject mismatched duration");
+    let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc").strict(true))
+        .expect_err("strict import should reject mismatched duration");
     assert!(err.to_string().contains("duration_mismatch"));
-}
-
-#[test]
-fn compatible_reader_api_is_reachable_from_crate_root() {
-    let input = r#"{"span":{"name":"req","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
-
-    let imported = import_jsonl_reader_with_mode(
-        std::io::Cursor::new(input),
-        ImportOptions::new("svc"),
-        JsonlParseMode::Compatible,
-    )
-    .expect("compatible import should work");
-
-    assert_eq!(imported.run().requests.len(), 1);
 }

--- a/tailtriage/tests/tracing_facade.rs
+++ b/tailtriage/tests/tracing_facade.rs
@@ -58,3 +58,28 @@ async fn tracing_tokio_facade_exposes_runtime_methods_and_async_shutdown() {
         .iter()
         .any(|snapshot| snapshot.at_unix_ms == 88 && snapshot.alive_tasks == Some(12)));
 }
+
+#[cfg(feature = "tracing")]
+#[test]
+fn tracing_facade_exposes_stable_jsonl_reader_and_path_imports() {
+    let input = r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"request","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/"}}}"#;
+    let from_reader = tailtriage::tracing::import_jsonl_reader(
+        std::io::Cursor::new(input),
+        tailtriage::tracing::ImportOptions::new("svc"),
+    )
+    .expect("reader import through facade");
+    assert_eq!(from_reader.run().requests.len(), 1);
+
+    let path = std::env::temp_dir().join(format!(
+        "tailtriage-facade-{}-spans.jsonl",
+        std::process::id()
+    ));
+    std::fs::write(&path, input).expect("write jsonl");
+    let from_path = tailtriage::tracing::import_jsonl_path(
+        &path,
+        tailtriage::tracing::ImportOptions::new("svc"),
+    )
+    .expect("path import through facade");
+    assert_eq!(from_path.run().requests.len(), 1);
+    let _ = std::fs::remove_file(path);
+}


### PR DESCRIPTION
### Motivation

- Simplify and harden tracing JSONL intake by accepting only the stable wrapper shape `{"format":"tailtriage.tracing-span.v1","span":{...}}` and removing compatibility parse modes and CLI format selection.
- Reduce maintenance surface and avoid ambiguous/auto-detected legacy parsing while preserving run-artifact semantics and strict/non-strict behaviors for contained span validation.

### Description

- JSONL parser: Replace multi-mode parser with a single-wrapper-only parser that accepts only `format == "tailtriage.tracing-span.v1"` and a `span` object; structural errors are fatal with 1-based line numbers (`tailtriage-tracing/src/jsonl.rs`).
- Public API: Export only `import_jsonl_reader` and `import_jsonl_path` under the `jsonl` feature and re-export them via the top-level `tailtriage::tracing` façade (`tailtriage-tracing/src/lib.rs`).
- CLI: Remove `TracingInputFormat`, `--input-format`, and all branches that selected parse-modes; `tailtriage import tracing-spans-jsonl` now always means the stable wrapper and uses `import_jsonl_path(...)` (`tailtriage-cli/src/main.rs`).
- Tests: Add and keep explicit tests that accept stable wrapper fixtures and explicitly reject legacy/compatibility shapes (raw top-level span, unversioned `{span:{...}}`, start_unix_ms/end_unix_ms aliases, top-level tt.* keys, outer `fields`, mixed placements, ordinary tracing formatter JSON, missing/non-string/unknown `format`, missing/non-object `span`, malformed JSON, non-object JSON value), plus multi-line mixed acceptance/rejection cases and writer-to-reader round-trip evidence assertions (`tailtriage-tracing/src/jsonl.rs` tests, `tailtriage-cli/tests/cli_boundary.rs`).
- Recorder/tests: Updated recorder tests to call the new single-mode import functions and preserve replay/round-trip checks (`tailtriage-tracing/src/recorder.rs`).
- Docs and validation: Update README, SPEC, VALIDATION, and tracing README to state the stable-wrapper-only contract and add a docs-validator check preventing reintroduction of parse-mode/`--input-format` guidance (`scripts/validate_docs_contracts.py`, `tailtriage-cli/README.md`, `tailtriage-tracing/README.md`, `SPEC.md`, `VALIDATION.md`).
- Facade: Add a top-level test proving `tailtriage::tracing::import_jsonl_reader` and `import_jsonl_path` are available under `--no-default-features --features tracing` (`tailtriage/tests/tracing_facade.rs`).

### Testing

- Ran the full workspace validation and toolchain checks; all steps succeeded.
- Format and lint: `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (dev and release) passed.
- Unit/integration tests: `cargo test --workspace --all-targets --all-features --locked` passed; targeted package tests passed: `tailtriage-tracing` (jsonl feature) tests passed under `--no-default-features --features jsonl` and with all-features; `tailtriage-cli` tests passed after adapting expectations; top-level façade test passed under `--no-default-features --features tracing`.
- Documentation contract: `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked` and `python3 scripts/validate_docs_contracts.py` passed; unit tests for the docs validator `python3 -m unittest scripts.tests.test_validate_docs_contracts` passed.
- Tracing parity/retention demos: `python3 scripts/demo_tool.py validate-tracing-parity all --profile release` and `python3 scripts/demo_tool.py validate-tracing-retention-parity --profile release` ran and reported parity/retention validations passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5fe5e192d48330b31d9023c50e5bb5)