### PR TITLE
Capture partial queue and stage evidence (add `completed` + partial-drop timers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Added `completed: bool` to public `StageEvent` and `QueueEvent` structs with wire-compatible completed JSON; this is an intentional pre-1.0 Rust source break for exhaustive external struct literals, and constructor-based migration is recommended. Polled-then-dropped core/Tokio queue and stage helpers now record bounded partial evidence while capture remains open.
 - Completed-span JSONL now writes retained original tracing sources rather than reconstructing span-shaped records from normalized Run events, preserving source identity and fields while retaining the documented representational limits.
 - Core Run validation is now centralized in `tailtriage-core`, with strict validation and deterministic permissive normalization APIs for duplicate request IDs, request-scoped child integrity, required fields, schema version checks, and run-relative timing issues.
 - Aligned documented local validation commands with CI baseline flags in `AGENTS.md` and `scripts/validate_all.py`.

--- a/DESIGN_NOTES.md
+++ b/DESIGN_NOTES.md
@@ -747,3 +747,32 @@ Core Run integrity contract:
 - Strict entry points validate the original unnormalized candidate and reject error-level core findings. Warning-only missing optional precision does not reject.
 - Current tracing provenance keeps retained source spans private through normalization and writes completed-span JSONL directly from retained original sources. Prompt 05 owns public tracing API simplification; Prompt 06 owns compatibility-mode removal and stable-wrapper-only input.
 
+
+
+### Partial queue and stage events
+
+Completed queue and stage JSON remains wire-compatible: schema version stays `2`, older schema-v2 JSON without `completed` reads as completed evidence, and completed events omit `completed` when serialized. The Rust structs now include `completed: bool`, which is an intentional pre-1.0 source break for external exhaustive `StageEvent` and `QueueEvent` struct literals. Prefer `StageEvent::new(...)` and `QueueEvent::new(...)`; constructors default to completed evidence and `into_partial()` should be used only when intentionally constructing partial evidence.
+
+Timing starts on first poll. Dropping a never-polled helper records no event. Dropping a polled pending helper while capture is open records one bounded partial event whose duration ends at observed helper Drop; late Drop after collector finalization is inert. Partial evidence is a lower-bound observation and does not prove that the underlying operation stopped. For partial stages, `success` is forced to `false`; it is not a completed operation result, so completion-aware consumers must inspect `completed`. Tracing spans remain completed-only, and analyzer interpretation is unchanged in this release.
+
+Migration example:
+
+```rust
+# use tailtriage_core::StageEvent;
+// Old exhaustive struct literal (now must include `completed`).
+let _old = StageEvent {
+    request_id: "req".into(),
+    stage: "db".into(),
+    started_at_unix_ms: 1,
+    started_at_run_us: None,
+    finished_at_unix_ms: 2,
+    finished_at_run_us: None,
+    latency_us: 10,
+    success: true,
+    completed: true,
+};
+
+// Recommended: constructors default to completed evidence.
+let completed = StageEvent::new("req", "db", 1, 2, 10, true);
+let partial = completed.clone().into_partial();
+```

--- a/README.md
+++ b/README.md
@@ -393,3 +393,32 @@ The canonical user documentation index lives in [`docs/README.md`](docs/README.m
 
 Start there for the user workflow, crate selection, controller configuration, analyzer and CLI contracts, diagnostics interpretation, demos, validation, runtime-cost measurement, collector limits, and architecture.
 
+
+
+### Partial queue and stage events
+
+Completed queue and stage JSON remains wire-compatible: schema version stays `2`, older schema-v2 JSON without `completed` reads as completed evidence, and completed events omit `completed` when serialized. The Rust structs now include `completed: bool`, which is an intentional pre-1.0 source break for external exhaustive `StageEvent` and `QueueEvent` struct literals. Prefer `StageEvent::new(...)` and `QueueEvent::new(...)`; constructors default to completed evidence and `into_partial()` should be used only when intentionally constructing partial evidence.
+
+Timing starts on first poll. Dropping a never-polled helper records no event. Dropping a polled pending helper while capture is open records one bounded partial event whose duration ends at observed helper Drop; late Drop after collector finalization is inert. Partial evidence is a lower-bound observation and does not prove that the underlying operation stopped. For partial stages, `success` is forced to `false`; it is not a completed operation result, so completion-aware consumers must inspect `completed`. Tracing spans remain completed-only, and analyzer interpretation is unchanged in this release.
+
+Migration example:
+
+```rust
+# use tailtriage_core::StageEvent;
+// Old exhaustive struct literal (now must include `completed`).
+let _old = StageEvent {
+    request_id: "req".into(),
+    stage: "db".into(),
+    started_at_unix_ms: 1,
+    started_at_run_us: None,
+    finished_at_unix_ms: 2,
+    finished_at_run_us: None,
+    latency_us: 10,
+    success: true,
+    completed: true,
+};
+
+// Recommended: constructors default to completed evidence.
+let completed = StageEvent::new("req", "db", 1, 2, 10, true);
+let partial = completed.clone().into_partial();
+```

--- a/SPEC.md
+++ b/SPEC.md
@@ -85,11 +85,11 @@ Single-run shape:
 Contract details:
 
 - completion must happen exactly once through `RequestCompletion`
-- drop does not auto-complete; dropped request completions remain unfinished
+- dropping an admitted completion token while capture is open records one request with outcome `cancelled`
 - `shutdown()` does not fabricate outcomes or timings for unfinished requests
 - unfinished requests are surfaced as warnings/metadata
 - `strict_lifecycle(true)` makes `shutdown()` fail if unfinished requests remain
-- cancellation or early drop of queue/stage timing helpers currently records no partial queue or stage event
+- queue/stage timing begins on first poll; a never-polled helper records no event, while a polled-then-dropped helper records one bounded partial child event if capture remains open
 
 ### 5.4 Controller surface (`tailtriage-controller`)
 
@@ -377,4 +377,33 @@ When behavior or public guidance changes, update relevant public docs together:
 
 Explicit completion remains preferred whenever the application knows the request outcome. Dropping an admitted unfinished completion token while capture is still open records one completed request with outcome `cancelled`; Drop is non-panicking, including during panic unwinding. If shutdown wins before a held token finishes or drops, that request is recorded only as unfinished metadata and a late finish or Drop is inert. A finalized Run is immutable to late request admission, completion, stage, queue, in-flight, runtime-snapshot, sampler-metadata, and end-reason mutations.
 
-Strict lifecycle shutdown with pending requests returns a retryable lifecycle error, performs no sink attempt, leaves pending requests open, and does not add finalization timestamps, unfinished metadata, or lifecycle warnings. Once an eligible shutdown attempts the sink, that finalization is terminal and single-shot on both success and failure; repeated or concurrent shutdown callers observe the same terminal attempt rather than writing again. Controller completion Drop participates in admitted-generation drain accounting exactly once, so a closing generation can finalize after the last admitted token is dropped. Cancellation does not add partial queue or stage evidence.
+Strict lifecycle shutdown with pending requests returns a retryable lifecycle error, performs no sink attempt, leaves pending requests open, and does not add finalization timestamps, unfinished metadata, or lifecycle warnings. Once an eligible shutdown attempts the sink, that finalization is terminal and single-shot on both success and failure; repeated or concurrent shutdown callers observe the same terminal attempt rather than writing again. Controller completion Drop participates in admitted-generation drain accounting exactly once, so a closing generation can finalize after the last admitted token is dropped. Completion-token Drop records the cancelled request and does not itself fabricate child evidence. Independently, any queue or stage helper that was polled and then dropped while capture was open records one partial child event.
+
+
+### Partial queue and stage events
+
+Completed queue and stage JSON remains wire-compatible: schema version stays `2`, older schema-v2 JSON without `completed` reads as completed evidence, and completed events omit `completed` when serialized. The Rust structs now include `completed: bool`, which is an intentional pre-1.0 source break for external exhaustive `StageEvent` and `QueueEvent` struct literals. Prefer `StageEvent::new(...)` and `QueueEvent::new(...)`; constructors default to completed evidence and `into_partial()` should be used only when intentionally constructing partial evidence.
+
+Timing starts on first poll. Dropping a never-polled helper records no event. Dropping a polled pending helper while capture is open records one bounded partial event whose duration ends at observed helper Drop; late Drop after collector finalization is inert. Partial evidence is a lower-bound observation and does not prove that the underlying operation stopped. For partial stages, `success` is forced to `false`; it is not a completed operation result, so completion-aware consumers must inspect `completed`. Tracing spans remain completed-only, and analyzer interpretation is unchanged in this release.
+
+Migration example:
+
+```rust
+# use tailtriage_core::StageEvent;
+// Old exhaustive struct literal (now must include `completed`).
+let _old = StageEvent {
+    request_id: "req".into(),
+    stage: "db".into(),
+    started_at_unix_ms: 1,
+    started_at_run_us: None,
+    finished_at_unix_ms: 2,
+    finished_at_run_us: None,
+    latency_us: 10,
+    success: true,
+    completed: true,
+};
+
+// Recommended: constructors default to completed evidence.
+let completed = StageEvent::new("req", "db", 1, 2, 10, true);
+let partial = completed.clone().into_partial();
+```

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -504,4 +504,33 @@ For tracing import and tracing-session operations guidance, see the canonical se
 
 Explicit completion remains preferred whenever the application knows the request outcome. Dropping an admitted unfinished completion token while capture is still open records one completed request with outcome `cancelled`; Drop is non-panicking, including during panic unwinding. If shutdown wins before a held token finishes or drops, that request is recorded only as unfinished metadata and a late finish or Drop is inert. A finalized Run is immutable to late request admission, completion, stage, queue, in-flight, runtime-snapshot, sampler-metadata, and end-reason mutations.
 
-Strict lifecycle shutdown with pending requests returns a retryable lifecycle error, performs no sink attempt, leaves pending requests open, and does not add finalization timestamps, unfinished metadata, or lifecycle warnings. Once an eligible shutdown attempts the sink, that finalization is terminal and single-shot on both success and failure; repeated or concurrent shutdown callers observe the same terminal attempt rather than writing again. Controller completion Drop participates in admitted-generation drain accounting exactly once, so a closing generation can finalize after the last admitted token is dropped. Cancellation does not add partial queue or stage evidence.
+Strict lifecycle shutdown with pending requests returns a retryable lifecycle error, performs no sink attempt, leaves pending requests open, and does not add finalization timestamps, unfinished metadata, or lifecycle warnings. Once an eligible shutdown attempts the sink, that finalization is terminal and single-shot on both success and failure; repeated or concurrent shutdown callers observe the same terminal attempt rather than writing again. Controller completion Drop participates in admitted-generation drain accounting exactly once, so a closing generation can finalize after the last admitted token is dropped. Completion-token Drop records the cancelled request and does not itself fabricate child evidence. Independently, any queue or stage helper that was polled and then dropped while capture was open records one partial child event.
+
+
+### Partial queue and stage events
+
+Completed queue and stage JSON remains wire-compatible: schema version stays `2`, older schema-v2 JSON without `completed` reads as completed evidence, and completed events omit `completed` when serialized. The Rust structs now include `completed: bool`, which is an intentional pre-1.0 source break for external exhaustive `StageEvent` and `QueueEvent` struct literals. Prefer `StageEvent::new(...)` and `QueueEvent::new(...)`; constructors default to completed evidence and `into_partial()` should be used only when intentionally constructing partial evidence.
+
+Timing starts on first poll. Dropping a never-polled helper records no event. Dropping a polled pending helper while capture is open records one bounded partial event whose duration ends at observed helper Drop; late Drop after collector finalization is inert. Partial evidence is a lower-bound observation and does not prove that the underlying operation stopped. For partial stages, `success` is forced to `false`; it is not a completed operation result, so completion-aware consumers must inspect `completed`. Tracing spans remain completed-only, and analyzer interpretation is unchanged in this release.
+
+Migration example:
+
+```rust
+# use tailtriage_core::StageEvent;
+// Old exhaustive struct literal (now must include `completed`).
+let _old = StageEvent {
+    request_id: "req".into(),
+    stage: "db".into(),
+    started_at_unix_ms: 1,
+    started_at_run_us: None,
+    finished_at_unix_ms: 2,
+    finished_at_run_us: None,
+    latency_us: 10,
+    success: true,
+    completed: true,
+};
+
+// Recommended: constructors default to completed evidence.
+let completed = StageEvent::new("req", "db", 1, 2, 10, true);
+let partial = completed.clone().into_partial();
+```

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -448,7 +448,7 @@ These helpers are shorthand for explicit `queue(...).await_on(...)`, `stage(...)
 
 Semantics notes:
 
-- Queue/stage helper events are completion-based: dropping/canceling a pending helper future records no queue/stage event.
+- Queue/stage helper timing begins on first poll: dropping a never-polled helper records no event, while dropping a polled pending helper records one bounded partial event if capture remains open. Partial duration ends at observed helper Drop and does not prove the underlying operation stopped.
 - The helper API intentionally does not include a generic mpsc receive wait helper. Receiver-side recv wait cannot distinguish idle workers from queued work residence time. For worker intake, start request/work-item capture after receiving the item unless you have explicit enqueue timestamps.
 - `join_task(...)` records await time for the supplied `JoinHandle`, not necessarily the full task runtime.
 - `join_task(...)`, `timeout_stage(...)`, and `blocking_stage(...)` preserve nested `Result`s; recorded stage success/failure comes from the outer Tokio wrapper result, so `Ok(Err(_))` is preserved and records as successful.
@@ -484,4 +484,33 @@ Run JSON is the complete persisted artifact. Completed-span JSONL output contain
 
 Explicit completion remains preferred whenever the application knows the request outcome. Dropping an admitted unfinished completion token while capture is still open records one completed request with outcome `cancelled`; Drop is non-panicking, including during panic unwinding. If shutdown wins before a held token finishes or drops, that request is recorded only as unfinished metadata and a late finish or Drop is inert. A finalized Run is immutable to late request admission, completion, stage, queue, in-flight, runtime-snapshot, sampler-metadata, and end-reason mutations.
 
-Strict lifecycle shutdown with pending requests returns a retryable lifecycle error, performs no sink attempt, leaves pending requests open, and does not add finalization timestamps, unfinished metadata, or lifecycle warnings. Once an eligible shutdown attempts the sink, that finalization is terminal and single-shot on both success and failure; repeated or concurrent shutdown callers observe the same terminal attempt rather than writing again. Controller completion Drop participates in admitted-generation drain accounting exactly once, so a closing generation can finalize after the last admitted token is dropped. Cancellation does not add partial queue or stage evidence.
+Strict lifecycle shutdown with pending requests returns a retryable lifecycle error, performs no sink attempt, leaves pending requests open, and does not add finalization timestamps, unfinished metadata, or lifecycle warnings. Once an eligible shutdown attempts the sink, that finalization is terminal and single-shot on both success and failure; repeated or concurrent shutdown callers observe the same terminal attempt rather than writing again. Controller completion Drop participates in admitted-generation drain accounting exactly once, so a closing generation can finalize after the last admitted token is dropped. Completion-token Drop records the cancelled request and does not itself fabricate child evidence. Independently, any queue or stage helper that was polled and then dropped while capture was open records one partial child event.
+
+
+### Partial queue and stage events
+
+Completed queue and stage JSON remains wire-compatible: schema version stays `2`, older schema-v2 JSON without `completed` reads as completed evidence, and completed events omit `completed` when serialized. The Rust structs now include `completed: bool`, which is an intentional pre-1.0 source break for external exhaustive `StageEvent` and `QueueEvent` struct literals. Prefer `StageEvent::new(...)` and `QueueEvent::new(...)`; constructors default to completed evidence and `into_partial()` should be used only when intentionally constructing partial evidence.
+
+Timing starts on first poll. Dropping a never-polled helper records no event. Dropping a polled pending helper while capture is open records one bounded partial event whose duration ends at observed helper Drop; late Drop after collector finalization is inert. Partial evidence is a lower-bound observation and does not prove that the underlying operation stopped. For partial stages, `success` is forced to `false`; it is not a completed operation result, so completion-aware consumers must inspect `completed`. Tracing spans remain completed-only, and analyzer interpretation is unchanged in this release.
+
+Migration example:
+
+```rust
+# use tailtriage_core::StageEvent;
+// Old exhaustive struct literal (now must include `completed`).
+let _old = StageEvent {
+    request_id: "req".into(),
+    stage: "db".into(),
+    started_at_unix_ms: 1,
+    started_at_run_us: None,
+    finished_at_unix_ms: 2,
+    finished_at_run_us: None,
+    latency_us: 10,
+    success: true,
+    completed: true,
+};
+
+// Recommended: constructors default to completed evidence.
+let completed = StageEvent::new("req", "db", 1, 2, 10, true);
+let partial = completed.clone().into_partial();
+```

--- a/tailtriage-analyzer/src/stage_attribution.rs
+++ b/tailtriage-analyzer/src/stage_attribution.rs
@@ -179,6 +179,7 @@ mod tests {
             finished_at_run_us: end,
             latency_us: dur,
             success: true,
+            completed: true,
         }
     }
 

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -125,6 +125,7 @@ fn precise_stage(
         finished_at_run_us: end,
         latency_us,
         success: true,
+        completed: true,
     }
 }
 
@@ -145,6 +146,7 @@ fn precise_queue(id: &str, start: u64, end: u64, wait_us: u64) -> QueueEvent {
         waited_until_run_us: Some(end),
         wait_us,
         depth_at_start: Some(1),
+        completed: true,
     }
 }
 
@@ -384,6 +386,7 @@ fn missing_run_relative_queue_endpoint_falls_back_to_capped_duration_sum() {
             waited_until_run_us: None,
             wait_us: 90,
             depth_at_start: Some(1),
+            completed: true,
         },
     ];
 
@@ -485,6 +488,7 @@ fn duplicate_completed_request_ids_emit_warning_without_panic() {
         waited_until_run_us: None,
         wait_us: 500,
         depth_at_start: Some(3),
+        completed: true,
     }];
 
     let report = analyze_run(&run, AnalyzeOptions::default());
@@ -534,6 +538,7 @@ fn strict_artifact_validation_fails_orphan_stage_and_queue_request_ids() {
         finished_at_run_us: None,
         latency_us: 100,
         success: true,
+        completed: true,
     }];
     let stage_err = validate_artifact_strict(&stage_run)
         .expect_err("orphan stage id should fail strict validation");
@@ -555,6 +560,7 @@ fn strict_artifact_validation_fails_orphan_stage_and_queue_request_ids() {
         waited_until_run_us: None,
         wait_us: 100,
         depth_at_start: Some(1),
+        completed: true,
     }];
     let queue_err = validate_artifact_strict(&queue_run)
         .expect_err("orphan queue id should fail strict validation");
@@ -579,6 +585,7 @@ fn strict_artifact_validation_simultaneous_stage_and_queue_orphans_return_core_w
         finished_at_run_us: None,
         latency_us: 100,
         success: true,
+        completed: true,
     }];
     run.queues = vec![QueueEvent {
         request_id: "missing-queue-request".to_owned(),
@@ -589,6 +596,7 @@ fn strict_artifact_validation_simultaneous_stage_and_queue_orphans_return_core_w
         waited_until_run_us: None,
         wait_us: 100,
         depth_at_start: Some(1),
+        completed: true,
     }];
 
     let err = validate_artifact_strict(&run)
@@ -622,6 +630,7 @@ fn strict_artifact_validation_orphan_plus_timing_returns_core() {
         finished_at_run_us: None,
         latency_us: 100,
         success: true,
+        completed: true,
     }];
 
     let err = validate_artifact_strict(&run).expect_err("mixed failures should use core");
@@ -646,6 +655,7 @@ fn strict_artifact_validation_compatibility_variants_have_no_source() {
         finished_at_run_us: None,
         latency_us: 100,
         success: true,
+        completed: true,
     }];
     let err = validate_artifact_strict(&orphan_run).expect_err("orphan should fail");
     assert!(std::error::Error::source(&err).is_none());
@@ -663,6 +673,7 @@ fn permissive_analysis_warns_but_accepts_orphan_request_scoped_events() {
         finished_at_run_us: None,
         latency_us: 100,
         success: true,
+        completed: true,
     }];
     run.queues = vec![QueueEvent {
         request_id: "missing-queue-request".to_owned(),
@@ -673,6 +684,7 @@ fn permissive_analysis_warns_but_accepts_orphan_request_scoped_events() {
         waited_until_run_us: None,
         wait_us: 100,
         depth_at_start: Some(1),
+        completed: true,
     }];
 
     let report = analyze_run(&run, AnalyzeOptions::default());
@@ -698,6 +710,7 @@ fn matching_unique_request_scoped_events_do_not_add_request_id_limitations() {
         finished_at_run_us: None,
         latency_us: 100,
         success: true,
+        completed: true,
     }];
     run.queues = vec![QueueEvent {
         request_id: "req-2".to_owned(),
@@ -708,6 +721,7 @@ fn matching_unique_request_scoped_events_do_not_add_request_id_limitations() {
         waited_until_run_us: None,
         wait_us: 100,
         depth_at_start: Some(1),
+        completed: true,
     }];
 
     let report = analyze_run(&run, AnalyzeOptions::default());
@@ -773,6 +787,7 @@ fn downstream_stage_tie_break_is_deterministic() {
             finished_at_run_us: None,
             latency_us: 300,
             success: true,
+            completed: true,
         },
         StageEvent {
             request_id: "req-2".to_owned(),
@@ -783,6 +798,7 @@ fn downstream_stage_tie_break_is_deterministic() {
             finished_at_run_us: None,
             latency_us: 300,
             success: true,
+            completed: true,
         },
         StageEvent {
             request_id: "req-3".to_owned(),
@@ -793,6 +809,7 @@ fn downstream_stage_tie_break_is_deterministic() {
             finished_at_run_us: None,
             latency_us: 300,
             success: true,
+            completed: true,
         },
         StageEvent {
             request_id: "req-1".to_owned(),
@@ -803,6 +820,7 @@ fn downstream_stage_tie_break_is_deterministic() {
             finished_at_run_us: None,
             latency_us: 300,
             success: true,
+            completed: true,
         },
         StageEvent {
             request_id: "req-2".to_owned(),
@@ -813,6 +831,7 @@ fn downstream_stage_tie_break_is_deterministic() {
             finished_at_run_us: None,
             latency_us: 300,
             success: true,
+            completed: true,
         },
         StageEvent {
             request_id: "req-3".to_owned(),
@@ -823,6 +842,7 @@ fn downstream_stage_tie_break_is_deterministic() {
             finished_at_run_us: None,
             latency_us: 300,
             success: true,
+            completed: true,
         },
     ];
 
@@ -1052,6 +1072,7 @@ fn no_runtime_warning_not_emitted_for_clean_queue_primary() {
             waited_until_unix_ms: 1,
             waited_until_run_us: None,
             depth_at_start: Some(9),
+            completed: true,
         },
         QueueEvent {
             request_id: "req-2".into(),
@@ -1062,6 +1083,7 @@ fn no_runtime_warning_not_emitted_for_clean_queue_primary() {
             waited_until_unix_ms: 2,
             waited_until_run_us: None,
             depth_at_start: Some(9),
+            completed: true,
         },
         QueueEvent {
             request_id: "req-3".into(),
@@ -1072,6 +1094,7 @@ fn no_runtime_warning_not_emitted_for_clean_queue_primary() {
             waited_until_unix_ms: 3,
             waited_until_run_us: None,
             depth_at_start: Some(9),
+            completed: true,
         },
     ];
     let report = analyze_run(&run, AnalyzeOptions::default());
@@ -1098,6 +1121,7 @@ fn runtime_missing_warning_uses_configured_high_confidence_threshold() {
             waited_until_unix_ms: 1,
             waited_until_run_us: None,
             depth_at_start: Some(9),
+            completed: true,
         },
         QueueEvent {
             request_id: "req-2".into(),
@@ -1108,6 +1132,7 @@ fn runtime_missing_warning_uses_configured_high_confidence_threshold() {
             waited_until_unix_ms: 2,
             waited_until_run_us: None,
             depth_at_start: Some(9),
+            completed: true,
         },
     ];
 
@@ -1155,6 +1180,7 @@ fn downstream_beats_weak_blocking() {
             finished_at_run_us: None,
             latency_us: 900,
             success: true,
+            completed: true,
         },
         StageEvent {
             request_id: "req-2".into(),
@@ -1165,6 +1191,7 @@ fn downstream_beats_weak_blocking() {
             finished_at_run_us: None,
             latency_us: 900,
             success: true,
+            completed: true,
         },
         StageEvent {
             request_id: "req-3".into(),
@@ -1175,6 +1202,7 @@ fn downstream_beats_weak_blocking() {
             finished_at_run_us: None,
             latency_us: 900,
             success: true,
+            completed: true,
         },
     ];
     run.runtime_snapshots = vec![runtime_snapshot(Some(2), Some(1), Some(1)); 5];
@@ -1213,6 +1241,7 @@ fn score_100_is_reserved_for_overwhelming_queue_evidence() {
             waited_until_run_us: None,
             wait_us: 990,
             depth_at_start: Some(20),
+            completed: true,
         })
         .collect();
     let report = analyze_run(&run, AnalyzeOptions::default());
@@ -1270,6 +1299,7 @@ fn blocking_like_stage_does_not_outrank_strong_blocking_runtime_signal() {
             finished_at_run_us: None,
             latency_us: 3_900_000,
             success: true,
+            completed: true,
         })
         .collect();
     run.runtime_snapshots = vec![runtime_snapshot(Some(1), Some(1), Some(240)); 80];
@@ -1328,6 +1358,7 @@ fn downstream_blocking_correlation_margin_changes_downstream_cap_behavior() {
             finished_at_run_us: None,
             latency_us: 3_900_000,
             success: true,
+            completed: true,
         })
         .collect();
     run.runtime_snapshots = vec![runtime_snapshot(Some(1), Some(1), Some(240)); 80];
@@ -1439,6 +1470,7 @@ fn evidence_quality_partial_for_runtime_partial_fields() {
             waited_until_unix_ms: 2,
             waited_until_run_us: None,
             depth_at_start: Some(2),
+            completed: true,
         })
         .collect();
     run.runtime_snapshots = vec![runtime_snapshot(Some(1), None, Some(1)); 10];
@@ -1481,6 +1513,7 @@ fn evidence_quality_strong_without_runtime_snapshots_when_queue_stage_present() 
             waited_until_unix_ms: 2,
             waited_until_run_us: None,
             depth_at_start: Some(2),
+            completed: true,
         })
         .collect();
     run.stages = run
@@ -1495,6 +1528,7 @@ fn evidence_quality_strong_without_runtime_snapshots_when_queue_stage_present() 
             finished_at_run_us: None,
             latency_us: 400,
             success: true,
+            completed: true,
         })
         .collect();
     let report = analyze_run(&run, AnalyzeOptions::default());
@@ -1532,6 +1566,7 @@ fn evidence_quality_marks_queue_signal_truncated_and_not_strong() {
             waited_until_unix_ms: 2,
             waited_until_run_us: None,
             depth_at_start: Some(2),
+            completed: true,
         })
         .collect();
     run.stages = run
@@ -1546,6 +1581,7 @@ fn evidence_quality_marks_queue_signal_truncated_and_not_strong() {
             finished_at_run_us: None,
             latency_us: 400,
             success: true,
+            completed: true,
         })
         .collect();
     run.truncation.dropped_queues = 2;
@@ -1589,6 +1625,7 @@ fn confidence_caps_do_not_change_score_ordering() {
             waited_until_unix_ms: 2,
             waited_until_run_us: None,
             depth_at_start: Some(8),
+            completed: true,
         })
         .collect();
     run.stages = run
@@ -1603,6 +1640,7 @@ fn confidence_caps_do_not_change_score_ordering() {
             finished_at_run_us: None,
             latency_us: 800,
             success: true,
+            completed: true,
         })
         .collect();
     run.truncation.dropped_requests = 1;
@@ -1640,6 +1678,7 @@ fn low_request_count_caps_primary_confidence_and_adds_note() {
             waited_until_run_us: None,
             wait_us: 990,
             depth_at_start: Some(18),
+            completed: true,
         })
         .collect();
     let report = analyze_run(&run, AnalyzeOptions::default());
@@ -1679,6 +1718,7 @@ fn clean_strong_queue_evidence_keeps_high_confidence_without_notes() {
             waited_until_run_us: None,
             wait_us: 985,
             depth_at_start: Some(15),
+            completed: true,
         })
         .collect();
     run.inflight = vec![
@@ -1732,6 +1772,7 @@ fn queue_truncation_uses_truncation_note_not_missing_queue_note() {
             waited_until_run_us: None,
             wait_us: 990,
             depth_at_start: Some(15),
+            completed: true,
         })
         .collect();
     run.truncation.dropped_queues = 1;
@@ -1801,6 +1842,7 @@ fn stage_truncation_uses_truncation_note_not_missing_stage_note() {
             finished_at_run_us: None,
             latency_us: 4_800,
             success: true,
+            completed: true,
         })
         .collect();
     run.truncation.dropped_stages = 1;
@@ -1998,6 +2040,7 @@ fn non_ambiguous_clean_evidence_keeps_high_confidence() {
             waited_until_run_us: None,
             wait_us: 990,
             depth_at_start: Some(15),
+            completed: true,
         })
         .collect();
     let mut suspects = vec![
@@ -2076,6 +2119,7 @@ fn multi_route_divergence_emits_sorted_breakdowns_and_stable_warning() {
             waited_until_unix_ms: 1,
             waited_until_run_us: None,
             depth_at_start: Some(9),
+            completed: true,
         });
     }
     for req_id in ["req-5", "req-6", "req-7"] {
@@ -2088,6 +2132,7 @@ fn multi_route_divergence_emits_sorted_breakdowns_and_stable_warning() {
             finished_at_run_us: None,
             latency_us: 1_900,
             success: true,
+            completed: true,
         });
     }
     run.runtime_snapshots = vec![runtime_snapshot(Some(200), Some(140), Some(180))];
@@ -2156,6 +2201,7 @@ fn route_divergence_warning_respects_emit_toggle_even_when_breakdowns_emit_from_
             waited_until_unix_ms: 1,
             waited_until_run_us: None,
             depth_at_start: Some(9),
+            completed: true,
         });
     }
     for req_id in ["req-5", "req-6", "req-7"] {
@@ -2168,6 +2214,7 @@ fn route_divergence_warning_respects_emit_toggle_even_when_breakdowns_emit_from_
             finished_at_run_us: None,
             latency_us: 1_900,
             success: true,
+            completed: true,
         });
     }
 
@@ -2216,6 +2263,7 @@ fn multi_route_same_primary_keeps_route_breakdowns_empty() {
             waited_until_unix_ms: 1,
             waited_until_run_us: None,
             depth_at_start: Some(7),
+            completed: true,
         });
     }
     let report = analyze_run(&run, AnalyzeOptions::default());
@@ -2268,6 +2316,7 @@ fn temporal_segment_window_uses_max_finish_timestamp() {
             waited_until_unix_ms: 2,
             waited_until_run_us: None,
             depth_at_start: Some(9),
+            completed: true,
         });
     }
     let report = analyze_run(&run, AnalyzeOptions::default());
@@ -2308,6 +2357,7 @@ fn temporal_sort_prefers_run_relative_start_when_unix_starts_match() {
             waited_until_unix_ms: 101,
             waited_until_run_us: None,
             depth_at_start: Some(9),
+            completed: true,
         });
     }
     for id in 1..=10 {
@@ -2320,6 +2370,7 @@ fn temporal_sort_prefers_run_relative_start_when_unix_starts_match() {
             finished_at_run_us: None,
             latency_us: 5_000,
             success: true,
+            completed: true,
         });
     }
 
@@ -2677,6 +2728,7 @@ fn temporal_segments_emitted_when_primary_suspects_differ() {
             waited_until_unix_ms: i + 1,
             waited_until_run_us: None,
             depth_at_start: Some(9),
+            completed: true,
         });
     }
     for i in 11..=20 {
@@ -2689,6 +2741,7 @@ fn temporal_segments_emitted_when_primary_suspects_differ() {
             finished_at_run_us: None,
             latency_us: 5_000,
             success: true,
+            completed: true,
         });
     }
     let report = analyze_run(&run, AnalyzeOptions::default());
@@ -2754,6 +2807,7 @@ fn temporal_segments_do_not_change_global_primary_suspect_or_score() {
             waited_until_unix_ms: i + 1,
             waited_until_run_us: None,
             depth_at_start: Some(9),
+            completed: true,
         });
     }
     let global = analyze_run_internal(&run, &AnalyzeOptions::default());
@@ -2784,6 +2838,7 @@ fn run_with_temporal_shift_and_run_relative_offsets() -> Run {
             waited_until_unix_ms: i + 1,
             waited_until_run_us: Some(i * 10_000 + 2_000),
             depth_at_start: Some(12),
+            completed: true,
         });
     }
     for i in 11usize..=20usize {
@@ -2801,6 +2856,7 @@ fn run_with_temporal_shift_and_run_relative_offsets() -> Run {
             finished_at_run_us: Some(i_u64 * 10_000 + 7_000),
             latency_us: 7_000,
             success: true,
+            completed: true,
         });
     }
     run.runtime_snapshots = vec![
@@ -2906,6 +2962,7 @@ fn queue_to_downstream_shift_emits_temporal_segments_when_runtime_samples_are_sp
             waited_until_unix_ms: i + 1,
             waited_until_run_us: None,
             depth_at_start: Some(12),
+            completed: true,
         });
     }
     for i in 11..=20 {
@@ -2918,6 +2975,7 @@ fn queue_to_downstream_shift_emits_temporal_segments_when_runtime_samples_are_sp
             finished_at_run_us: None,
             latency_us: 9_000,
             success: true,
+            completed: true,
         });
     }
     run.runtime_snapshots = vec![runtime_snapshot(Some(1), Some(1), Some(1))];
@@ -2958,6 +3016,7 @@ fn temporal_segments_emit_both_global_warnings_when_p95_and_suspect_shift_apply(
             waited_until_unix_ms: i + 1,
             waited_until_run_us: None,
             depth_at_start: Some(12),
+            completed: true,
         });
     }
     for i in 11usize..=20usize {
@@ -2974,6 +3033,7 @@ fn temporal_segments_emit_both_global_warnings_when_p95_and_suspect_shift_apply(
             finished_at_run_us: None,
             latency_us: 9_000,
             success: true,
+            completed: true,
         });
     }
     let report = analyze_run(&run, AnalyzeOptions::default());
@@ -3517,6 +3577,7 @@ fn default_options_compat_queue_saturation_case() {
             waited_until_unix_ms: 2,
             waited_until_run_us: None,
             depth_at_start: Some(9),
+            completed: true,
         })
         .collect();
     let report = analyze_run(&run, AnalyzeOptions::default());
@@ -3543,6 +3604,7 @@ fn default_options_compat_blocking_pool_pressure_case() {
             finished_at_run_us: None,
             latency_us: 3_900_000,
             success: true,
+            completed: true,
         })
         .collect();
     run.runtime_snapshots = vec![runtime_snapshot(Some(1), Some(1), Some(240)); 80];
@@ -3584,6 +3646,7 @@ fn default_options_compat_downstream_stage_dominates_case() {
             finished_at_run_us: None,
             latency_us: 900,
             success: true,
+            completed: true,
         })
         .collect();
     run.runtime_snapshots = vec![runtime_snapshot(Some(2), Some(1), Some(1)); 5];
@@ -3654,6 +3717,7 @@ fn default_options_compat_route_breakdowns_case() {
             waited_until_unix_ms: 1,
             waited_until_run_us: None,
             depth_at_start: Some(9),
+            completed: true,
         });
     }
     for req_id in ["req-5", "req-6", "req-7"] {
@@ -3666,6 +3730,7 @@ fn default_options_compat_route_breakdowns_case() {
             finished_at_run_us: None,
             latency_us: 1_900,
             success: true,
+            completed: true,
         });
     }
     run.runtime_snapshots = vec![runtime_snapshot(Some(200), Some(140), Some(180))];
@@ -3707,6 +3772,7 @@ fn default_options_compat_temporal_segments_case() {
             waited_until_unix_ms: 2,
             waited_until_run_us: None,
             depth_at_start: Some(3),
+            completed: true,
         })
         .collect();
     run.stages = run
@@ -3722,6 +3788,7 @@ fn default_options_compat_temporal_segments_case() {
             finished_at_run_us: None,
             latency_us: if i < 20 { 200 } else { 4_400 },
             success: true,
+            completed: true,
         })
         .collect();
     let report = analyze_run(&run, AnalyzeOptions::default());
@@ -3835,6 +3902,7 @@ fn option_queueing_trigger_permille_changes_queue_suspect() {
             waited_until_unix_ms: i + 1,
             waited_until_run_us: None,
             depth_at_start: Some(3),
+            completed: true,
         });
     }
     let default_report = analyze_run(&run, AnalyzeOptions::default());
@@ -3898,6 +3966,7 @@ fn option_confidence_high_score_threshold_changes_scoring_suspect_bucket() {
             waited_until_unix_ms: i + 1,
             waited_until_run_us: None,
             depth_at_start: Some(12),
+            completed: true,
         });
     }
 
@@ -4071,4 +4140,27 @@ fn analyzer_toml_empty_pattern_fails_validation() {
             ..
         }
     ));
+}
+
+#[test]
+fn prompt09_partial_stage_and_queue_events_do_not_change_analyzer_output() {
+    let mut completed = test_run();
+    completed.stages = vec![StageEvent::new("req-1", "db", 1, 2, 900, true)];
+    completed.queues = vec![QueueEvent::new("req-1", "pool", 1, 2, 800).with_depth_at_start(5)];
+
+    let mut partial = completed.clone();
+    partial.stages[0] = partial.stages[0].clone().into_partial();
+    partial.queues[0] = partial.queues[0].clone().into_partial();
+
+    let completed_report = analyze_run(&completed, AnalyzeOptions::default());
+    let partial_report = analyze_run(&partial, AnalyzeOptions::default());
+
+    assert!(
+        !completed_report.primary_suspect.evidence.is_empty()
+            || !completed_report.secondary_suspects.is_empty()
+    );
+    assert_eq!(
+        serde_json::to_value(&completed_report).unwrap(),
+        serde_json::to_value(&partial_report).unwrap()
+    );
 }

--- a/tailtriage-analyzer/tests/boundary_thresholds.rs
+++ b/tailtriage-analyzer/tests/boundary_thresholds.rs
@@ -89,6 +89,7 @@ fn queue_share_threshold_uses_300_permille_boundary() {
         waited_until_run_us: None,
         wait_us: 299,
         depth_at_start: Some(2),
+        completed: true,
     }];
 
     let below_report = analyze_run(&below, AnalyzeOptions::default());
@@ -109,6 +110,7 @@ fn queue_share_threshold_uses_300_permille_boundary() {
         waited_until_run_us: None,
         wait_us: 300,
         depth_at_start: Some(2),
+        completed: true,
     }];
 
     let above_report = analyze_run(&above, AnalyzeOptions::default());
@@ -205,6 +207,7 @@ fn downstream_stage_requires_at_least_three_samples() {
             finished_at_run_us: None,
             latency_us: 350,
             success: true,
+            completed: true,
         },
         StageEvent {
             request_id: "r2".to_string(),
@@ -215,6 +218,7 @@ fn downstream_stage_requires_at_least_three_samples() {
             finished_at_run_us: None,
             latency_us: 360,
             success: true,
+            completed: true,
         },
     ];
 
@@ -236,6 +240,7 @@ fn downstream_stage_requires_at_least_three_samples() {
             finished_at_run_us: None,
             latency_us: 350,
             success: true,
+            completed: true,
         },
         StageEvent {
             request_id: "r2".to_string(),
@@ -246,6 +251,7 @@ fn downstream_stage_requires_at_least_three_samples() {
             finished_at_run_us: None,
             latency_us: 360,
             success: true,
+            completed: true,
         },
         StageEvent {
             request_id: "r3".to_string(),
@@ -256,6 +262,7 @@ fn downstream_stage_requires_at_least_three_samples() {
             finished_at_run_us: None,
             latency_us: 340,
             success: true,
+            completed: true,
         },
     ];
 

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -143,7 +143,7 @@ req.queue("ingress")
 
 - `queue(...)`, `stage(...)`, and `inflight(...)` do **not** finish requests.
 - Every admitted request must be finished exactly once.
-- Dropping a completion token does **not** auto-finish.
+- Dropping an admitted completion token while capture is open records one request with outcome `cancelled`.
 - Non-strict lifecycle: `shutdown()` writes the artifact and records unfinished-request warnings/metadata.
 - `strict_lifecycle(true)`: unfinished requests cause `shutdown()` to return an error and no artifact is written.
 
@@ -223,4 +223,33 @@ Use sibling crates for those surfaces: `tailtriage-controller`, `tailtriage-toki
 
 Explicit completion remains preferred whenever the application knows the request outcome. Dropping an admitted unfinished completion token while capture is still open records one completed request with outcome `cancelled`; Drop is non-panicking, including during panic unwinding. If shutdown wins before a held token finishes or drops, that request is recorded only as unfinished metadata and a late finish or Drop is inert. A finalized Run is immutable to late request admission, completion, stage, queue, in-flight, runtime-snapshot, sampler-metadata, and end-reason mutations.
 
-Strict lifecycle shutdown with pending requests returns a retryable lifecycle error, performs no sink attempt, leaves pending requests open, and does not add finalization timestamps, unfinished metadata, or lifecycle warnings. Once an eligible shutdown attempts the sink, that finalization is terminal and single-shot on both success and failure; repeated or concurrent shutdown callers observe the same terminal attempt rather than writing again. Controller completion Drop participates in admitted-generation drain accounting exactly once, so a closing generation can finalize after the last admitted token is dropped. Cancellation does not add partial queue or stage evidence.
+Strict lifecycle shutdown with pending requests returns a retryable lifecycle error, performs no sink attempt, leaves pending requests open, and does not add finalization timestamps, unfinished metadata, or lifecycle warnings. Once an eligible shutdown attempts the sink, that finalization is terminal and single-shot on both success and failure; repeated or concurrent shutdown callers observe the same terminal attempt rather than writing again. Controller completion Drop participates in admitted-generation drain accounting exactly once, so a closing generation can finalize after the last admitted token is dropped. Completion-token Drop records the cancelled request and does not itself fabricate child evidence. Independently, any queue or stage helper that was polled and then dropped while capture was open records one partial child event.
+
+
+### Partial queue and stage events
+
+Completed queue and stage JSON remains wire-compatible: schema version stays `2`, older schema-v2 JSON without `completed` reads as completed evidence, and completed events omit `completed` when serialized. The Rust structs now include `completed: bool`, which is an intentional pre-1.0 source break for external exhaustive `StageEvent` and `QueueEvent` struct literals. Prefer `StageEvent::new(...)` and `QueueEvent::new(...)`; constructors default to completed evidence and `into_partial()` should be used only when intentionally constructing partial evidence.
+
+Timing starts on first poll. Dropping a never-polled helper records no event. Dropping a polled pending helper while capture is open records one bounded partial event whose duration ends at observed helper Drop; late Drop after collector finalization is inert. Partial evidence is a lower-bound observation and does not prove that the underlying operation stopped. For partial stages, `success` is forced to `false`; it is not a completed operation result, so completion-aware consumers must inspect `completed`. Tracing spans remain completed-only, and analyzer interpretation is unchanged in this release.
+
+Migration example:
+
+```rust
+# use tailtriage_core::StageEvent;
+// Old exhaustive struct literal (now must include `completed`).
+let _old = StageEvent {
+    request_id: "req".into(),
+    stage: "db".into(),
+    started_at_unix_ms: 1,
+    started_at_run_us: None,
+    finished_at_unix_ms: 2,
+    finished_at_run_us: None,
+    latency_us: 10,
+    success: true,
+    completed: true,
+};
+
+// Recommended: constructors default to completed evidence.
+let completed = StageEvent::new("req", "db", 1, 2, 10, true);
+let partial = completed.clone().into_partial();
+```

--- a/tailtriage-core/src/events.rs
+++ b/tailtriage-core/src/events.rs
@@ -1,5 +1,13 @@
 use serde::{Deserialize, Serialize};
 
+const fn default_completed() -> bool {
+    true
+}
+#[allow(clippy::trivially_copy_pass_by_ref)]
+const fn is_completed(value: &bool) -> bool {
+    *value
+}
+
 use crate::{CaptureMode, EffectiveCoreConfig};
 
 /// Current schema version for `Run` JSON artifacts.
@@ -280,7 +288,65 @@ pub struct StageEvent {
     pub latency_us: u64,
     /// Whether the stage completed successfully (`Result::is_ok()` for
     /// `StageTimer::await_on`, always `true` for `StageTimer::await_value`).
+    ///
+    /// For partial events (`completed == false`), this is forced to `false` and
+    /// is not an operation result. Consumers that need completion-aware
+    /// interpretation must inspect [`StageEvent::completed`].
     pub success: bool,
+    /// Whether the instrumented stage future completed normally.
+    ///
+    /// Older schema-v2 JSON without this field deserializes as completed.
+    /// Completed events omit the field when serialized; partial events serialize
+    /// `completed: false`.
+    #[serde(default = "default_completed", skip_serializing_if = "is_completed")]
+    pub completed: bool,
+}
+
+impl StageEvent {
+    /// Creates a completed stage event with required identity, wall-clock
+    /// interval, duration, and success fields.
+    #[must_use]
+    pub fn new(
+        request_id: impl Into<String>,
+        stage: impl Into<String>,
+        started_at_unix_ms: u64,
+        finished_at_unix_ms: u64,
+        latency_us: u64,
+        success: bool,
+    ) -> Self {
+        Self {
+            request_id: request_id.into(),
+            stage: stage.into(),
+            started_at_unix_ms,
+            started_at_run_us: None,
+            finished_at_unix_ms,
+            finished_at_run_us: None,
+            latency_us,
+            success,
+            completed: true,
+        }
+    }
+
+    /// Adds monotonic run-relative start and finish offsets.
+    #[must_use]
+    pub const fn with_run_interval(
+        mut self,
+        started_at_run_us: Option<u64>,
+        finished_at_run_us: Option<u64>,
+    ) -> Self {
+        self.started_at_run_us = started_at_run_us;
+        self.finished_at_run_us = finished_at_run_us;
+        self
+    }
+
+    /// Marks this stage event as a partial observation and forces `success` to
+    /// `false` because no completed operation result was observed.
+    #[must_use]
+    pub const fn into_partial(mut self) -> Self {
+        self.completed = false;
+        self.success = false;
+        self
+    }
 }
 
 /// Queue wait measurement for a request waiting on a queue/permit.
@@ -311,6 +377,64 @@ pub struct QueueEvent {
     pub wait_us: u64,
     /// Queue depth sample captured at wait start, if known.
     pub depth_at_start: Option<u64>,
+    /// Whether the instrumented queue future completed normally.
+    ///
+    /// Older schema-v2 JSON without this field deserializes as completed.
+    /// Completed events omit the field when serialized; partial events serialize
+    /// `completed: false`.
+    #[serde(default = "default_completed", skip_serializing_if = "is_completed")]
+    pub completed: bool,
+}
+
+impl QueueEvent {
+    /// Creates a completed queue event with required identity, wall-clock
+    /// interval, and duration fields.
+    #[must_use]
+    pub fn new(
+        request_id: impl Into<String>,
+        queue: impl Into<String>,
+        waited_from_unix_ms: u64,
+        waited_until_unix_ms: u64,
+        wait_us: u64,
+    ) -> Self {
+        Self {
+            request_id: request_id.into(),
+            queue: queue.into(),
+            waited_from_unix_ms,
+            waited_from_run_us: None,
+            waited_until_unix_ms,
+            waited_until_run_us: None,
+            wait_us,
+            depth_at_start: None,
+            completed: true,
+        }
+    }
+
+    /// Adds monotonic run-relative wait start and finish offsets.
+    #[must_use]
+    pub const fn with_run_interval(
+        mut self,
+        waited_from_run_us: Option<u64>,
+        waited_until_run_us: Option<u64>,
+    ) -> Self {
+        self.waited_from_run_us = waited_from_run_us;
+        self.waited_until_run_us = waited_until_run_us;
+        self
+    }
+
+    /// Adds the queue depth sample captured at wait start.
+    #[must_use]
+    pub const fn with_depth_at_start(mut self, depth_at_start: u64) -> Self {
+        self.depth_at_start = Some(depth_at_start);
+        self
+    }
+
+    /// Marks this queue event as a partial observation.
+    #[must_use]
+    pub const fn into_partial(mut self) -> Self {
+        self.completed = false;
+        self
+    }
 }
 
 /// Point-in-time in-flight gauge reading.

--- a/tailtriage-core/src/lib.rs
+++ b/tailtriage-core/src/lib.rs
@@ -18,8 +18,9 @@
 // // queue(...), stage(...), and inflight(...) instrumentation can happen here.
 // // They do not finish the request lifecycle.
 // started.completion.finish_ok();
-// // You must finish each request exactly once via finish(...), finish_ok(), or finish_result(...).
-// // Drop only asserts on unfinished completions in debug builds; it does not auto-record completion.
+// // Explicit completion remains preferred when the outcome is known.
+// // Dropping an admitted unfinished completion token while capture remains open records one request with outcome `cancelled`.
+// // If finalization wins first, a late completion-token Drop is inert.
 //
 // tailtriage.shutdown()?;
 // # Ok(())

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -3344,32 +3344,136 @@ mod prompt09_partial_events {
         }
     }
 
+    fn assert_one_partial_stage(run: &Run, expected_request_id: &str, expected_stage: &str) {
+        let events: Vec<_> = run
+            .stages
+            .iter()
+            .filter(|event| {
+                event.request_id == expected_request_id && event.stage == expected_stage
+            })
+            .collect();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].request_id, expected_request_id);
+        assert_eq!(events[0].stage, expected_stage);
+        assert!(!events[0].completed);
+        assert!(!events[0].success);
+    }
+
+    fn assert_one_partial_queue(
+        run: &Run,
+        expected_request_id: &str,
+        expected_queue: &str,
+        expected_depth: u64,
+    ) {
+        let events: Vec<_> = run
+            .queues
+            .iter()
+            .filter(|event| {
+                event.request_id == expected_request_id && event.queue == expected_queue
+            })
+            .collect();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].request_id, expected_request_id);
+        assert_eq!(events[0].queue, expected_queue);
+        assert!(!events[0].completed);
+        assert_eq!(events[0].depth_at_start, Some(expected_depth));
+    }
+
     #[test]
     fn partial_stage_and_queue_are_preserved_through_owned_and_borrowed_handles() {
         let tt = Arc::new(capture());
-        let borrowed = tt.begin_request_with("/r", RequestOptions::new().request_id("borrowed"));
-        let fut = borrowed
+
+        let borrowed_stage = tt.begin_request_with(
+            "/r",
+            RequestOptions::new().request_id("borrowed-stage-request"),
+        );
+        let fut = borrowed_stage
             .handle
-            .stage("stage")
+            .stage("borrowed-stage")
             .await_value(poll_fn(|_| Poll::<()>::Pending));
         let mut fut = Box::pin(fut);
         assert!(poll_once(&mut fut).is_pending());
         drop(fut);
-        let owned = tt.begin_request_with_owned("/r", RequestOptions::new().request_id("owned"));
-        let fut = owned
+
+        let borrowed_queue = tt.begin_request_with(
+            "/r",
+            RequestOptions::new().request_id("borrowed-queue-request"),
+        );
+        let fut = borrowed_queue
             .handle
-            .queue("queue")
+            .queue("borrowed-queue")
             .with_depth_at_start(4)
             .await_on(poll_fn(|_| Poll::<()>::Pending));
         let mut fut = Box::pin(fut);
         assert!(poll_once(&mut fut).is_pending());
         drop(fut);
+
+        let owned_stage = tt.begin_request_with_owned(
+            "/r",
+            RequestOptions::new().request_id("owned-stage-request"),
+        );
+        let fut = owned_stage
+            .handle
+            .stage("owned-stage")
+            .await_value(poll_fn(|_| Poll::<()>::Pending));
+        let mut fut = Box::pin(fut);
+        assert!(poll_once(&mut fut).is_pending());
+        drop(fut);
+
+        let owned_queue = tt.begin_request_with_owned(
+            "/r",
+            RequestOptions::new().request_id("owned-queue-request"),
+        );
+        let fut = owned_queue
+            .handle
+            .queue("owned-queue")
+            .with_depth_at_start(9)
+            .await_on(poll_fn(|_| Poll::<()>::Pending));
+        let mut fut = Box::pin(fut);
+        assert!(poll_once(&mut fut).is_pending());
+        drop(fut);
+
         let run = tt.snapshot();
-        assert_eq!(run.stages[0].request_id, "borrowed");
-        assert!(!run.stages[0].completed);
-        assert_eq!(run.queues[0].request_id, "owned");
-        assert_eq!(run.queues[0].depth_at_start, Some(4));
-        assert!(!run.queues[0].completed);
+        assert_eq!(
+            run.stages
+                .iter()
+                .filter(|event| !event.completed
+                    && matches!(
+                        (event.request_id.as_str(), event.stage.as_str()),
+                        ("borrowed-stage-request", "borrowed-stage")
+                            | ("owned-stage-request", "owned-stage")
+                    ))
+                .count(),
+            2
+        );
+        assert_eq!(
+            run.queues
+                .iter()
+                .filter(|event| !event.completed
+                    && matches!(
+                        (event.request_id.as_str(), event.queue.as_str()),
+                        ("borrowed-queue-request", "borrowed-queue")
+                            | ("owned-queue-request", "owned-queue")
+                    ))
+                .count(),
+            2
+        );
+        assert!(!run.stages.iter().any(|event| event.completed
+            && matches!(
+                (event.request_id.as_str(), event.stage.as_str()),
+                ("borrowed-stage-request", "borrowed-stage")
+                    | ("owned-stage-request", "owned-stage")
+            )));
+        assert!(!run.queues.iter().any(|event| event.completed
+            && matches!(
+                (event.request_id.as_str(), event.queue.as_str()),
+                ("borrowed-queue-request", "borrowed-queue")
+                    | ("owned-queue-request", "owned-queue")
+            )));
+        assert_one_partial_stage(&run, "borrowed-stage-request", "borrowed-stage");
+        assert_one_partial_queue(&run, "borrowed-queue-request", "borrowed-queue", 4);
+        assert_one_partial_stage(&run, "owned-stage-request", "owned-stage");
+        assert_one_partial_queue(&run, "owned-queue-request", "owned-queue", 9);
     }
 
     #[test]
@@ -3393,7 +3497,7 @@ mod prompt09_partial_events {
     }
 
     #[test]
-    fn stage_and_queue_late_drop_after_finalization_does_not_mutate_finalized_run() {
+    fn armed_stage_and_queue_drop_after_finalization_leave_persisted_run_unchanged() {
         let sink = MemorySink::default();
         let tt = Tailtriage::builder("prompt09")
             .sink(sink.clone())
@@ -3404,12 +3508,33 @@ mod prompt09_partial_events {
             .handle
             .stage("db")
             .await_value(poll_fn(|_| Poll::<()>::Pending));
+        let queue = started
+            .handle
+            .queue("permit")
+            .with_depth_at_start(13)
+            .await_on(poll_fn(|_| Poll::<()>::Pending));
         let mut stage = Box::pin(stage);
+        let mut queue = Box::pin(queue);
         assert!(poll_once(&mut stage).is_pending());
+        assert!(poll_once(&mut queue).is_pending());
+
         tt.shutdown().unwrap();
         let before = sink.last_run().unwrap();
+        let before_stages = before.stages.clone();
+        let before_queues = before.queues.clone();
+        let before_truncation = before.truncation.clone();
+        let before_metadata = before.metadata.clone();
+
         drop(stage);
+        drop(queue);
+
         let after = sink.last_run().unwrap();
         assert_eq!(before, after);
+        assert_eq!(before_stages, after.stages);
+        assert_eq!(before_queues, after.queues);
+        assert_eq!(before_truncation, after.truncation);
+        assert_eq!(before_metadata, after.metadata);
+        assert!(after.stages.is_empty());
+        assert!(after.queues.is_empty());
     }
 }

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -1511,6 +1511,7 @@ fn test_stage_event(request_id: &str, stage: &str) -> crate::StageEvent {
         finished_at_run_us: None,
         latency_us: 11,
         success: true,
+        completed: true,
     }
 }
 
@@ -1524,6 +1525,7 @@ fn test_queue_event(request_id: &str, queue: &str) -> crate::QueueEvent {
         waited_until_run_us: None,
         wait_us: 12,
         depth_at_start: Some(1),
+        completed: true,
     }
 }
 
@@ -2097,6 +2099,7 @@ mod run_validation_contract {
             finished_at_run_us: Some(20),
             latency_us: 10,
             success: true,
+            completed: true,
         }
     }
 
@@ -2110,6 +2113,7 @@ mod run_validation_contract {
             waited_until_run_us: Some(20),
             wait_us: 10,
             depth_at_start: Some(1),
+            completed: true,
         }
     }
 
@@ -2198,6 +2202,7 @@ mod run_validation_contract {
             finished_at_run_us: Some(20),
             latency_us: 10,
             success: true,
+            completed: true,
         });
         let normalized = normalize_run_permissive(&run);
         assert!(normalized.run.requests.is_empty());
@@ -2373,6 +2378,7 @@ mod run_validation_contract {
             finished_at_run_us: Some(20),
             latency_us: 10,
             success: true,
+            completed: true,
         });
         run.stages.push(StageEvent {
             request_id: "missing".into(),
@@ -2383,6 +2389,7 @@ mod run_validation_contract {
             finished_at_run_us: Some(20),
             latency_us: 10,
             success: true,
+            completed: true,
         });
         run.queues.push(QueueEvent {
             request_id: "ok".into(),
@@ -2393,6 +2400,7 @@ mod run_validation_contract {
             waited_until_run_us: Some(40),
             wait_us: 10,
             depth_at_start: Some(1),
+            completed: true,
         });
         run.queues.push(QueueEvent {
             request_id: "ok".into(),
@@ -2403,6 +2411,7 @@ mod run_validation_contract {
             waited_until_run_us: Some(40),
             wait_us: 10,
             depth_at_start: Some(1),
+            completed: true,
         });
         run.inflight.push(InFlightSnapshot {
             gauge: " ".into(),
@@ -2751,6 +2760,7 @@ mod run_validation_contract {
             finished_at_run_us: Some(20),
             latency_us: 10,
             success: true,
+            completed: true,
         });
         run.stages.push(StageEvent {
             request_id: "ok".into(),
@@ -2761,6 +2771,7 @@ mod run_validation_contract {
             finished_at_run_us: Some(20),
             latency_us: 20,
             success: true,
+            completed: true,
         });
         run.stages.push(StageEvent {
             request_id: "ok".into(),
@@ -2771,6 +2782,7 @@ mod run_validation_contract {
             finished_at_run_us: None,
             latency_us: 20,
             success: true,
+            completed: true,
         });
         let a = normalize_run_permissive(&run);
         let b = normalize_run_permissive(&run);
@@ -3022,4 +3034,382 @@ fn shutdown_wins_before_drop_keeps_request_unfinished_only() {
         "req-held-unfinished"
     );
     assert_eq!(sink.calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+}
+
+mod prompt09_partial_events {
+    use std::future::{poll_fn, ready, Future};
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+    use std::sync::Arc;
+    use std::task::{Context, Poll, Waker};
+
+    use crate::{
+        MemorySink, Outcome, QueueEvent, RequestOptions, Run, StageEvent, Tailtriage,
+        TruncationSummary, SCHEMA_VERSION,
+    };
+
+    fn poll_once<F: Future>(future: &mut std::pin::Pin<Box<F>>) -> Poll<F::Output> {
+        let waker = Waker::noop();
+        let mut cx = Context::from_waker(waker);
+        future.as_mut().poll(&mut cx)
+    }
+
+    fn capture() -> Tailtriage {
+        Tailtriage::builder("prompt09")
+            .sink(MemorySink::default())
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn legacy_stage_event_missing_completed_deserializes_true() {
+        let event: StageEvent = serde_json::from_str(r#"{"request_id":"r","stage":"db","started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":3,"success":true}"#).unwrap();
+        assert!(event.completed);
+    }
+
+    #[test]
+    fn legacy_queue_event_missing_completed_deserializes_true() {
+        let event: QueueEvent = serde_json::from_str(r#"{"request_id":"r","queue":"q","waited_from_unix_ms":1,"waited_until_unix_ms":2,"wait_us":3,"depth_at_start":7}"#).unwrap();
+        assert!(event.completed);
+    }
+
+    #[test]
+    fn completed_stage_and_queue_json_omit_completed_and_schema_stays_two() {
+        assert_eq!(SCHEMA_VERSION, 2);
+        let stage = StageEvent::new("r", "db", 1, 2, 3, true);
+        let queue = QueueEvent::new("r", "q", 4, 5, 6).with_depth_at_start(7);
+        assert_eq!(
+            serde_json::to_string(&stage).unwrap(),
+            r#"{"request_id":"r","stage":"db","started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":3,"success":true}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&queue).unwrap(),
+            r#"{"request_id":"r","queue":"q","waited_from_unix_ms":4,"waited_until_unix_ms":5,"wait_us":6,"depth_at_start":7}"#
+        );
+    }
+
+    #[test]
+    fn partial_stage_and_queue_json_serialize_completed_false_and_round_trip() {
+        let stage = StageEvent::new("r", "db", 1, 2, 3, true).into_partial();
+        let queue = QueueEvent::new("r", "q", 4, 5, 6)
+            .with_depth_at_start(7)
+            .into_partial();
+        let stage_value = serde_json::to_value(&stage).unwrap();
+        let queue_value = serde_json::to_value(&queue).unwrap();
+        assert_eq!(stage_value["completed"], serde_json::json!(false));
+        assert_eq!(queue_value["completed"], serde_json::json!(false));
+        assert_eq!(
+            stage_value.as_object().unwrap().get("success"),
+            Some(&serde_json::json!(false))
+        );
+        assert_eq!(
+            serde_json::from_value::<StageEvent>(stage_value).unwrap(),
+            stage
+        );
+        assert_eq!(
+            serde_json::from_value::<QueueEvent>(queue_value).unwrap(),
+            queue
+        );
+        let run = Run {
+            schema_version: SCHEMA_VERSION,
+            metadata: capture().snapshot().metadata,
+            requests: vec![],
+            stages: vec![stage],
+            queues: vec![queue],
+            inflight: vec![],
+            runtime_snapshots: vec![],
+            truncation: TruncationSummary::default(),
+        };
+        assert_eq!(
+            serde_json::to_value(&run).unwrap()["schema_version"],
+            serde_json::json!(2)
+        );
+    }
+
+    #[test]
+    fn partial_stage_and_queue_validate_and_normalize_without_rewriting_completed() {
+        let mut run = capture().snapshot();
+        run.requests.push(crate::RequestEvent {
+            request_id: "req".to_string(),
+            route: "/r".to_string(),
+            kind: None,
+            started_at_unix_ms: 1,
+            started_at_run_us: Some(1),
+            finished_at_unix_ms: 3,
+            finished_at_run_us: Some(30),
+            latency_us: 29,
+            outcome: "ok".to_string(),
+        });
+        run.stages.push(
+            StageEvent::new("req", "db", 1, 2, 10, true)
+                .with_run_interval(Some(2), Some(12))
+                .into_partial(),
+        );
+        run.queues.push(
+            QueueEvent::new("req", "pool", 1, 2, 9)
+                .with_run_interval(Some(3), Some(12))
+                .with_depth_at_start(5)
+                .into_partial(),
+        );
+        crate::validate_run_strict(&run).unwrap();
+        let normalized = crate::normalize_run_permissive(&run).run;
+        assert_eq!(normalized.stages[0], run.stages[0]);
+        assert_eq!(normalized.queues[0], run.queues[0]);
+    }
+
+    #[test]
+    fn stage_await_on_immediate_ready_records_one_completed_event() {
+        let tt = capture();
+        let started = tt.begin_request_with("/r", RequestOptions::new().request_id("req"));
+        let result: Result<(), ()> =
+            futures_executor::block_on(started.handle.stage("db").await_on(ready(Ok(()))));
+        assert!(result.is_ok());
+        let run = tt.snapshot();
+        assert_eq!(run.stages.len(), 1);
+        let ev = &run.stages[0];
+        assert_eq!(ev.request_id, "req");
+        assert_eq!(ev.stage, "db");
+        assert!(ev.completed);
+        assert!(ev.success);
+    }
+
+    #[test]
+    fn stage_await_value_immediate_ready_records_successful_completed_event() {
+        let tt = capture();
+        let started = tt.begin_request_with("/r", RequestOptions::new().request_id("req"));
+        futures_executor::block_on(started.handle.stage("cache").await_value(ready(())));
+        let ev = &tt.snapshot().stages[0];
+        assert!(ev.completed);
+        assert!(ev.success);
+    }
+
+    #[test]
+    fn queue_immediate_ready_records_one_completed_event() {
+        let tt = capture();
+        let started = tt.begin_request_with("/r", RequestOptions::new().request_id("req"));
+        futures_executor::block_on(
+            started
+                .handle
+                .queue("permit")
+                .with_depth_at_start(9)
+                .await_on(ready(())),
+        );
+        let ev = &tt.snapshot().queues[0];
+        assert_eq!(ev.queue, "permit");
+        assert_eq!(ev.depth_at_start, Some(9));
+        assert!(ev.completed);
+    }
+
+    #[test]
+    fn stage_pending_then_drop_records_one_partial_event() {
+        let tt = capture();
+        let started = tt.begin_request_with("/r", RequestOptions::new().request_id("req"));
+        let fut = started
+            .handle
+            .stage("db")
+            .await_value(poll_fn(|_| Poll::<()>::Pending));
+        let mut fut = Box::pin(fut);
+        assert!(poll_once(&mut fut).is_pending());
+        drop(fut);
+        let run = tt.snapshot();
+        assert_eq!(run.stages.len(), 1);
+        let ev = &run.stages[0];
+        assert_eq!(ev.request_id, "req");
+        assert_eq!(ev.stage, "db");
+        assert!(!ev.completed);
+        assert!(!ev.success);
+        assert!(ev.latency_us <= ev.finished_at_run_us.unwrap_or(u64::MAX));
+    }
+
+    #[test]
+    fn queue_pending_then_drop_records_one_partial_event_with_depth() {
+        let tt = capture();
+        let started = tt.begin_request_with("/r", RequestOptions::new().request_id("req"));
+        let fut = started
+            .handle
+            .queue("permit")
+            .with_depth_at_start(11)
+            .await_on(poll_fn(|_| Poll::<()>::Pending));
+        let mut fut = Box::pin(fut);
+        assert!(poll_once(&mut fut).is_pending());
+        drop(fut);
+        let run = tt.snapshot();
+        assert_eq!(run.queues.len(), 1);
+        let ev = &run.queues[0];
+        assert_eq!(ev.request_id, "req");
+        assert_eq!(ev.queue, "permit");
+        assert_eq!(ev.depth_at_start, Some(11));
+        assert!(!ev.completed);
+    }
+
+    #[test]
+    fn stage_never_polled_drop_records_no_event() {
+        let tt = capture();
+        let started = tt.begin_request("/r");
+        let fut = started
+            .handle
+            .stage("db")
+            .await_value(poll_fn(|_| Poll::<()>::Pending));
+        drop(fut);
+        assert!(tt.snapshot().stages.is_empty());
+    }
+
+    #[test]
+    fn queue_never_polled_drop_records_no_event() {
+        let tt = capture();
+        let started = tt.begin_request("/r");
+        let fut = started
+            .handle
+            .queue("q")
+            .await_on(poll_fn(|_| Poll::<()>::Pending));
+        drop(fut);
+        assert!(tt.snapshot().queues.is_empty());
+    }
+
+    #[test]
+    fn repeated_pending_polls_then_ready_records_completed_without_partial() {
+        let tt = capture();
+        let started = tt.begin_request("/r");
+        let mut polls = 0;
+        futures_executor::block_on(started.handle.stage("db").await_value(poll_fn(|cx| {
+            polls += 1;
+            if polls < 3 {
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            } else {
+                Poll::Ready(())
+            }
+        })));
+        let run = tt.snapshot();
+        assert_eq!(run.stages.len(), 1);
+        assert!(run.stages[0].completed);
+    }
+
+    #[test]
+    fn queue_repeated_pending_polls_then_ready_records_completed_without_partial() {
+        let tt = capture();
+        let started = tt.begin_request("/r");
+        let mut polls = 0;
+        futures_executor::block_on(started.handle.queue("q").await_on(poll_fn(|cx| {
+            polls += 1;
+            if polls < 3 {
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            } else {
+                Poll::Ready(())
+            }
+        })));
+        let run = tt.snapshot();
+        assert_eq!(run.queues.len(), 1);
+        assert!(run.queues[0].completed);
+    }
+
+    #[test]
+    fn stage_panic_after_arming_does_not_double_panic_and_records_at_most_one_partial() {
+        let tt = capture();
+        let started = tt.begin_request("/r");
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            futures_executor::block_on(
+                started
+                    .handle
+                    .stage("panic")
+                    .await_value(poll_fn(|_| -> Poll<()> { panic!("wrapped panic") })),
+            );
+        }));
+        assert!(result.is_err());
+        let run = tt.snapshot();
+        assert!(run.stages.len() <= 1);
+        if let Some(ev) = run.stages.first() {
+            assert!(!ev.completed);
+            assert!(!ev.success);
+        }
+    }
+
+    #[test]
+    fn queue_panic_after_arming_does_not_double_panic_and_records_at_most_one_partial() {
+        let tt = capture();
+        let started = tt.begin_request("/r");
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            futures_executor::block_on(
+                started
+                    .handle
+                    .queue("panic")
+                    .await_on(poll_fn(|_| -> Poll<()> { panic!("wrapped panic") })),
+            );
+        }));
+        assert!(result.is_err());
+        let run = tt.snapshot();
+        assert!(run.queues.len() <= 1);
+        if let Some(ev) = run.queues.first() {
+            assert!(!ev.completed);
+        }
+    }
+
+    #[test]
+    fn partial_stage_and_queue_are_preserved_through_owned_and_borrowed_handles() {
+        let tt = Arc::new(capture());
+        let borrowed = tt.begin_request_with("/r", RequestOptions::new().request_id("borrowed"));
+        let fut = borrowed
+            .handle
+            .stage("stage")
+            .await_value(poll_fn(|_| Poll::<()>::Pending));
+        let mut fut = Box::pin(fut);
+        assert!(poll_once(&mut fut).is_pending());
+        drop(fut);
+        let owned = tt.begin_request_with_owned("/r", RequestOptions::new().request_id("owned"));
+        let fut = owned
+            .handle
+            .queue("queue")
+            .with_depth_at_start(4)
+            .await_on(poll_fn(|_| Poll::<()>::Pending));
+        let mut fut = Box::pin(fut);
+        assert!(poll_once(&mut fut).is_pending());
+        drop(fut);
+        let run = tt.snapshot();
+        assert_eq!(run.stages[0].request_id, "borrowed");
+        assert!(!run.stages[0].completed);
+        assert_eq!(run.queues[0].request_id, "owned");
+        assert_eq!(run.queues[0].depth_at_start, Some(4));
+        assert!(!run.queues[0].completed);
+    }
+
+    #[test]
+    fn pending_helper_drop_plus_completion_token_drop_records_partial_child_and_cancelled_request()
+    {
+        let tt = capture();
+        let started = tt.begin_request_with("/r", RequestOptions::new().request_id("req"));
+        let fut = started
+            .handle
+            .stage("db")
+            .await_value(poll_fn(|_| Poll::<()>::Pending));
+        let mut fut = Box::pin(fut);
+        assert!(poll_once(&mut fut).is_pending());
+        drop(fut);
+        drop(started.completion);
+        let run = tt.snapshot();
+        assert_eq!(run.stages.len(), 1);
+        assert!(!run.stages[0].completed);
+        assert_eq!(run.requests.len(), 1);
+        assert_eq!(run.requests[0].outcome, Outcome::Cancelled.as_str());
+    }
+
+    #[test]
+    fn stage_and_queue_late_drop_after_finalization_does_not_mutate_finalized_run() {
+        let sink = MemorySink::default();
+        let tt = Tailtriage::builder("prompt09")
+            .sink(sink.clone())
+            .build()
+            .unwrap();
+        let started = tt.begin_request("/r");
+        let stage = started
+            .handle
+            .stage("db")
+            .await_value(poll_fn(|_| Poll::<()>::Pending));
+        let mut stage = Box::pin(stage);
+        assert!(poll_once(&mut stage).is_pending());
+        tt.shutdown().unwrap();
+        let before = sink.last_run().unwrap();
+        drop(stage);
+        let after = sink.last_run().unwrap();
+        assert_eq!(before, after);
+    }
 }

--- a/tailtriage-core/src/timers.rs
+++ b/tailtriage-core/src/timers.rs
@@ -1,4 +1,7 @@
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
 use crate::collector::{lock_state, CollectorPhase};
+use crate::time::IntervalStart;
 use crate::{InFlightSnapshot, QueueEvent, StageEvent, Tailtriage};
 
 /// RAII guard tracking one in-flight unit for a named gauge.
@@ -50,6 +53,84 @@ impl Drop for InflightGuard<'_> {
     }
 }
 
+#[derive(Debug)]
+enum ArmedTimerRecord<'a> {
+    Stage {
+        tailtriage: &'a Tailtriage,
+        request_id: String,
+        stage: String,
+        interval_start: Option<IntervalStart>,
+    },
+    Queue {
+        tailtriage: &'a Tailtriage,
+        request_id: String,
+        queue: String,
+        depth_at_start: Option<u64>,
+        interval_start: Option<IntervalStart>,
+    },
+}
+
+impl ArmedTimerRecord<'_> {
+    fn disarm(&mut self) -> Option<IntervalStart> {
+        match self {
+            Self::Stage { interval_start, .. } | Self::Queue { interval_start, .. } => {
+                interval_start.take()
+            }
+        }
+    }
+}
+
+impl Drop for ArmedTimerRecord<'_> {
+    fn drop(&mut self) {
+        let _ = catch_unwind(AssertUnwindSafe(|| match self {
+            Self::Stage {
+                tailtriage,
+                request_id,
+                stage,
+                interval_start,
+            } => {
+                if let Some(start) = interval_start.take() {
+                    let finished = tailtriage.run_clock.finish_interval(start);
+                    tailtriage.record_stage_event(
+                        StageEvent::new(
+                            request_id.clone(),
+                            stage.clone(),
+                            finished.started_at_unix_ms,
+                            finished.finished_at_unix_ms,
+                            finished.duration_us,
+                            false,
+                        )
+                        .with_run_interval(finished.started_at_run_us, finished.finished_at_run_us)
+                        .into_partial(),
+                    );
+                }
+            }
+            Self::Queue {
+                tailtriage,
+                request_id,
+                queue,
+                depth_at_start,
+                interval_start,
+            } => {
+                if let Some(start) = interval_start.take() {
+                    let finished = tailtriage.run_clock.finish_interval(start);
+                    let mut event = QueueEvent::new(
+                        request_id.clone(),
+                        queue.clone(),
+                        finished.started_at_unix_ms,
+                        finished.finished_at_unix_ms,
+                        finished.duration_us,
+                    )
+                    .with_run_interval(finished.started_at_run_us, finished.finished_at_run_us)
+                    .into_partial();
+                    event.depth_at_start = *depth_at_start;
+                    tailtriage.record_queue_event(event);
+                }
+            }
+        }));
+    }
+}
+
 /// Thin wrapper for recording stage latency around one await point.
 #[derive(Debug)]
 pub struct StageTimer<'a> {
@@ -62,16 +143,16 @@ pub struct StageTimer<'a> {
 impl StageTimer<'_> {
     /// Awaits `fut`, records stage duration, and returns the original output.
     ///
-    /// This helper is intended for fallible stage work where success can be
-    /// derived from `Result::is_ok`.
-    ///
-    /// Prefer this method when your stage naturally returns `Result<T, E>` and
-    /// you want success/failure evidence in the resulting triage report.
+    /// Timing begins on first poll. A future dropped before first poll records
+    /// no evidence. A polled helper future dropped before normal readiness
+    /// records one bounded partial event ending at observed Drop; this does not
+    /// prove the underlying operation stopped. Partial stage events have
+    /// `completed = false` and `success = false`.
     ///
     /// # Errors
     ///
     /// Returns the same error value produced by `fut` after recording the
-    /// stage event with `success = false`.
+    /// stage event with `success = false` for completed errors.
     pub async fn await_on<Fut, T, E>(self, fut: Fut) -> Result<T, E>
     where
         Fut: std::future::Future<Output = Result<T, E>>,
@@ -80,29 +161,36 @@ impl StageTimer<'_> {
             return fut.await;
         }
 
-        let interval_start = self.tailtriage.run_clock.start_interval();
+        let mut guard = ArmedTimerRecord::Stage {
+            tailtriage: self.tailtriage,
+            request_id: self.request_id.clone(),
+            stage: self.stage.clone(),
+            interval_start: Some(self.tailtriage.run_clock.start_interval()),
+        };
         let value = fut.await;
-        let finished = self.tailtriage.run_clock.finish_interval(interval_start);
-        let success = value.is_ok();
-
-        self.tailtriage.record_stage_event(StageEvent {
-            request_id: self.request_id,
-            stage: self.stage,
-            started_at_unix_ms: finished.started_at_unix_ms,
-            started_at_run_us: finished.started_at_run_us,
-            finished_at_unix_ms: finished.finished_at_unix_ms,
-            finished_at_run_us: finished.finished_at_run_us,
-            latency_us: finished.duration_us,
-            success,
-        });
-
+        if let Some(interval_start) = guard.disarm() {
+            let finished = self.tailtriage.run_clock.finish_interval(interval_start);
+            let success = value.is_ok();
+            self.tailtriage.record_stage_event(
+                StageEvent::new(
+                    self.request_id,
+                    self.stage,
+                    finished.started_at_unix_ms,
+                    finished.finished_at_unix_ms,
+                    finished.duration_us,
+                    success,
+                )
+                .with_run_interval(finished.started_at_run_us, finished.finished_at_run_us),
+            );
+        }
         value
     }
 
     /// Awaits an infallible stage future and records a successful stage event.
     ///
-    /// Use this method when there is no meaningful stage-level error signal
-    /// (for example, internal CPU work or a prevalidated transformation).
+    /// Timing begins on first poll. A future dropped before first poll records
+    /// no evidence. A polled helper future dropped before normal readiness
+    /// records one bounded partial event ending at observed Drop.
     pub async fn await_value<Fut, T>(self, fut: Fut) -> T
     where
         Fut: std::future::Future<Output = T>,
@@ -111,21 +199,27 @@ impl StageTimer<'_> {
             return fut.await;
         }
 
-        let interval_start = self.tailtriage.run_clock.start_interval();
+        let mut guard = ArmedTimerRecord::Stage {
+            tailtriage: self.tailtriage,
+            request_id: self.request_id.clone(),
+            stage: self.stage.clone(),
+            interval_start: Some(self.tailtriage.run_clock.start_interval()),
+        };
         let value = fut.await;
-        let finished = self.tailtriage.run_clock.finish_interval(interval_start);
-
-        self.tailtriage.record_stage_event(StageEvent {
-            request_id: self.request_id,
-            stage: self.stage,
-            started_at_unix_ms: finished.started_at_unix_ms,
-            started_at_run_us: finished.started_at_run_us,
-            finished_at_unix_ms: finished.finished_at_unix_ms,
-            finished_at_run_us: finished.finished_at_run_us,
-            latency_us: finished.duration_us,
-            success: true,
-        });
-
+        if let Some(interval_start) = guard.disarm() {
+            let finished = self.tailtriage.run_clock.finish_interval(interval_start);
+            self.tailtriage.record_stage_event(
+                StageEvent::new(
+                    self.request_id,
+                    self.stage,
+                    finished.started_at_unix_ms,
+                    finished.finished_at_unix_ms,
+                    finished.duration_us,
+                    true,
+                )
+                .with_run_interval(finished.started_at_run_us, finished.finished_at_run_us),
+            );
+        }
         value
     }
 }
@@ -150,9 +244,10 @@ impl QueueTimer<'_> {
 
     /// Awaits `fut`, records queue wait duration, and returns the original output.
     ///
-    /// Queue events are interpreted as application-level wait evidence (a lead,
-    /// not proof). Record these around bounded resources to help separate
-    /// queueing pressure from slow downstream stage time.
+    /// Timing begins on first poll. A future dropped before first poll records
+    /// no evidence. A polled helper future dropped before normal readiness
+    /// records one bounded partial wait event ending at observed Drop; this does
+    /// not prove the underlying operation stopped.
     pub async fn await_on<Fut, T>(self, fut: Fut) -> T
     where
         Fut: std::future::Future<Output = T>,
@@ -161,21 +256,27 @@ impl QueueTimer<'_> {
             return fut.await;
         }
 
-        let interval_start = self.tailtriage.run_clock.start_interval();
-        let value = fut.await;
-        let finished = self.tailtriage.run_clock.finish_interval(interval_start);
-
-        self.tailtriage.record_queue_event(QueueEvent {
-            request_id: self.request_id,
-            queue: self.queue,
-            waited_from_unix_ms: finished.started_at_unix_ms,
-            waited_from_run_us: finished.started_at_run_us,
-            waited_until_unix_ms: finished.finished_at_unix_ms,
-            waited_until_run_us: finished.finished_at_run_us,
-            wait_us: finished.duration_us,
+        let mut guard = ArmedTimerRecord::Queue {
+            tailtriage: self.tailtriage,
+            request_id: self.request_id.clone(),
+            queue: self.queue.clone(),
             depth_at_start: self.depth_at_start,
-        });
-
+            interval_start: Some(self.tailtriage.run_clock.start_interval()),
+        };
+        let value = fut.await;
+        if let Some(interval_start) = guard.disarm() {
+            let finished = self.tailtriage.run_clock.finish_interval(interval_start);
+            let mut event = QueueEvent::new(
+                self.request_id,
+                self.queue,
+                finished.started_at_unix_ms,
+                finished.finished_at_unix_ms,
+                finished.duration_us,
+            )
+            .with_run_interval(finished.started_at_run_us, finished.finished_at_run_us);
+            event.depth_at_start = self.depth_at_start;
+            self.tailtriage.record_queue_event(event);
+        }
         value
     }
 }

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -151,7 +151,7 @@ async fn demo() -> Result<(), Box<dyn std::error::Error>> {
 - only one successful sampler start is allowed per `Tailtriage` run
 - `CaptureMode` does **not** auto-start runtime sampling
 - runtime snapshot retention is bounded by the resolved core capture limits
-- queue/stage helper events are completion-based: dropping/canceling a pending helper future records no queue/stage event
+- queue/stage helper timing begins on first poll: dropping a never-polled helper records no event, while dropping a polled pending helper records one bounded partial event if capture remains open
 
 ## Runtime sampler details
 
@@ -286,7 +286,7 @@ Helpers map common Tokio primitives to explicit queue/stage/in-flight signals wh
 
 ### Semantics notes
 
-- Queue/stage helper events are completion-based: dropping/canceling a pending helper future records no queue/stage event.
+- Queue/stage helper timing begins on first poll: dropping a never-polled helper records no event, while dropping a polled pending helper records one bounded partial event if capture remains open. Partial duration ends at observed helper Drop and does not prove the underlying operation stopped.
 - The helper API intentionally does not include a generic mpsc receive wait helper. Receiver-side recv wait cannot distinguish idle workers from queued work residence time. For worker intake, start request/work-item capture after receiving the item unless you have explicit enqueue timestamps.
 - `join_task(...)` records await time for the supplied `JoinHandle`, not necessarily the full task runtime.
 - `join_task(...)`, `timeout_stage(...)`, and `blocking_stage(...)` preserve nested `Result`s; recorded stage success/failure comes from the outer Tokio wrapper result, so `Ok(Err(_))` is preserved and records as successful.
@@ -355,3 +355,32 @@ When used alongside `tailtriage-tracing`, runtime-pressure evidence still depend
 - `tailtriage-tracing`: optional tracing intake bridge that converts tracing-shaped evidence into standard `tailtriage_core::Run` values
 - `tailtriage-analyzer`: in-process analysis/report generation for completed runs
 - `tailtriage-cli`: command-line analysis of saved run artifacts
+
+
+### Partial queue and stage events
+
+Completed queue and stage JSON remains wire-compatible: schema version stays `2`, older schema-v2 JSON without `completed` reads as completed evidence, and completed events omit `completed` when serialized. The Rust structs now include `completed: bool`, which is an intentional pre-1.0 source break for external exhaustive `StageEvent` and `QueueEvent` struct literals. Prefer `StageEvent::new(...)` and `QueueEvent::new(...)`; constructors default to completed evidence and `into_partial()` should be used only when intentionally constructing partial evidence.
+
+Timing starts on first poll. Dropping a never-polled helper records no event. Dropping a polled pending helper while capture is open records one bounded partial event whose duration ends at observed helper Drop; late Drop after collector finalization is inert. Partial evidence is a lower-bound observation and does not prove that the underlying operation stopped. For partial stages, `success` is forced to `false`; it is not a completed operation result, so completion-aware consumers must inspect `completed`. Tracing spans remain completed-only, and analyzer interpretation is unchanged in this release.
+
+Migration example:
+
+```rust
+# use tailtriage_core::StageEvent;
+// Old exhaustive struct literal (now must include `completed`).
+let _old = StageEvent {
+    request_id: "req".into(),
+    stage: "db".into(),
+    started_at_unix_ms: 1,
+    started_at_run_us: None,
+    finished_at_unix_ms: 2,
+    finished_at_run_us: None,
+    latency_us: 10,
+    success: true,
+    completed: true,
+};
+
+// Recommended: constructors default to completed evidence.
+let completed = StageEvent::new("req", "db", 1, 2, 10, true);
+let partial = completed.clone().into_partial();
+```

--- a/tailtriage-tokio/src/lib.rs
+++ b/tailtriage-tokio/src/lib.rs
@@ -1575,7 +1575,6 @@ mod helper_tests {
 
 #[cfg(test)]
 mod prompt09_tokio_partial_tests {
-    const ONE_MINUTE_SECS: u64 = 60;
     use std::future::Future;
     use std::pin::Pin;
     use std::sync::{mpsc as std_mpsc, Arc};
@@ -1705,7 +1704,7 @@ mod prompt09_tokio_partial_tests {
 
         let fut = started.handle.timeout_stage(
             "timeout",
-            std::time::Duration::from_secs(ONE_MINUTE_SECS),
+            std::time::Duration::from_mins(1),
             std::future::pending::<()>(),
         );
         let mut fut = Box::pin(fut);

--- a/tailtriage-tokio/src/lib.rs
+++ b/tailtriage-tokio/src/lib.rs
@@ -34,7 +34,7 @@ pub trait TokioRequestHandleExt: sealed::Sealed {
     /// Equivalent low-level form: `req.queue(label).await_on(semaphore.acquire())` via [`InstrumentedSemaphore::acquire`].
     ///
     /// Records only acquisition wait time, not the protected work after the permit is acquired.
-    /// Queue events are recorded only when `acquire()` completes; dropping before completion records no queue event.
+    /// Timing starts on first poll; dropping before first poll records no event, and dropping after a pending poll records one bounded partial queue event if capture remains open.
     /// Returns Tokio's permit/error types unchanged. Request completion remains explicit.
     fn semaphore<'req, 'sem>(
         &'req self,
@@ -46,7 +46,7 @@ pub trait TokioRequestHandleExt: sealed::Sealed {
     /// Equivalent low-level form: `req.queue(label).await_on(semaphore.acquire_owned())` via [`InstrumentedOwnedSemaphore::acquire_owned`].
     ///
     /// Records only acquisition wait time, not work after permit acquisition.
-    /// Queue events are recorded only when `acquire_owned()` completes; dropping before completion records no queue event.
+    /// Timing starts on first poll; dropping before first poll records no event, and dropping after a pending poll records one bounded partial queue event if capture remains open.
     /// Returns Tokio's permit/error types unchanged. Request completion remains explicit.
     fn owned_semaphore(
         &self,
@@ -58,7 +58,7 @@ pub trait TokioRequestHandleExt: sealed::Sealed {
     /// Equivalent low-level form: `req.queue(label).await_on(sender.send(value))`.
     ///
     /// Measures bounded-channel send/backpressure wait, not receiver-side processing.
-    /// Queue events are recorded only when send completes; dropping before completion records no queue event.
+    /// Timing starts on first poll; dropping before first poll records no event, and dropping after a pending poll records one bounded partial queue event if capture remains open.
     /// Preserves `Result<(), SendError<T>>` unchanged. Request completion remains explicit.
     fn mpsc_send<'a, T>(
         &'a self,
@@ -71,7 +71,7 @@ pub trait TokioRequestHandleExt: sealed::Sealed {
     /// Equivalent low-level form: `req.queue(label).await_on(mutex.lock())`.
     ///
     /// Measures lock acquisition only, not work while holding the guard.
-    /// Queue events are recorded only when lock acquisition completes; dropping before completion records no queue event.
+    /// Timing starts on first poll; dropping before first poll records no event, and dropping after a pending poll records one bounded partial queue event if capture remains open.
     /// Request completion remains explicit.
     fn mutex_lock<'req, 'lock, T>(
         &'req self,
@@ -85,7 +85,7 @@ pub trait TokioRequestHandleExt: sealed::Sealed {
     /// Equivalent low-level form: `req.queue(label).await_on(lock.read())`.
     ///
     /// Measures acquisition only, not work while holding the guard.
-    /// Queue events are recorded only when lock acquisition completes; dropping before completion records no queue event.
+    /// Timing starts on first poll; dropping before first poll records no event, and dropping after a pending poll records one bounded partial queue event if capture remains open.
     /// Request completion remains explicit.
     fn rwlock_read<'req, 'lock, T>(
         &'req self,
@@ -99,7 +99,7 @@ pub trait TokioRequestHandleExt: sealed::Sealed {
     /// Equivalent low-level form: `req.queue(label).await_on(lock.write())`.
     ///
     /// Measures acquisition only, not work while holding the guard.
-    /// Queue events are recorded only when lock acquisition completes; dropping before completion records no queue event.
+    /// Timing starts on first poll; dropping before first poll records no event, and dropping after a pending poll records one bounded partial queue event if capture remains open.
     /// Request completion remains explicit.
     fn rwlock_write<'req, 'lock, T>(
         &'req self,
@@ -116,7 +116,7 @@ pub trait TokioRequestHandleExt: sealed::Sealed {
     /// Stage success/failure is derived from the outer `Result<T, JoinError>`.
     /// If `T` is itself a `Result`, inner `Err` values are preserved and do not mark the recorded stage as failed.
     /// Preserves `Result<T, JoinError>` unchanged, including panic/cancel join errors.
-    /// Dropping before completion records no stage event. Request completion remains explicit.
+    /// Dropping before first poll records no stage event; dropping after a pending poll records one bounded partial stage event if capture remains open. Request completion remains explicit.
     fn join_task<T>(
         &self,
         stage: impl Into<String>,
@@ -130,7 +130,7 @@ pub trait TokioRequestHandleExt: sealed::Sealed {
     /// Timeout elapsed is represented by outer `Err(Elapsed)` and records a failed stage.
     /// Preserves the outer timeout `Result` and any nested inner `Result` exactly (no flattening/remapping).
     /// Because stage success/failure is derived from the outer timeout `Result`, `Ok(Err(_))` is preserved and records a successful stage.
-    /// Dropping before completion records no stage event. Request completion remains explicit.
+    /// Dropping before first poll records no stage event; dropping after a pending poll records one bounded partial stage event if capture remains open. Request completion remains explicit.
     fn timeout_stage<'a, Fut: Future + 'a>(
         &'a self,
         stage: impl Into<String>,
@@ -149,7 +149,7 @@ pub trait TokioRequestHandleExt: sealed::Sealed {
     /// Stage success/failure is derived from the outer `Result<R, tokio::task::JoinError>`.
     /// If `R` is itself a `Result`, inner `Err` values are preserved and do not mark the recorded stage as failed.
     /// Preserves `Result<R, tokio::task::JoinError>` unchanged.
-    /// Dropping before completion records no stage event. Request completion remains explicit.
+    /// Dropping before first poll records no stage event; dropping after a pending poll records one bounded partial stage event if capture remains open. Request completion remains explicit.
     /// If you need eager/overlapped spawning, call `tokio::task::spawn_blocking` directly and instrument
     /// the returned handle with `join_task(...)` (which records await time for an already-started task).
     fn blocking_stage<F, R>(
@@ -1443,7 +1443,7 @@ mod helper_tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn dropping_pending_queue_and_stage_helpers_records_no_events() {
+    async fn dropping_pending_queue_and_stage_helpers_records_partial_events() {
         let run = run();
         let started = run.begin_request("/drop-pending");
         let req = started.handle.clone();
@@ -1474,8 +1474,19 @@ mod helper_tests {
         }
 
         let snap = run.snapshot();
-        assert!(snap.queues.iter().all(|q| q.queue != "drop_send_wait"));
-        assert!(snap.stages.iter().all(|s| s.stage != "drop_stage_wait"));
+        let queue = snap
+            .queues
+            .iter()
+            .find(|q| q.queue == "drop_send_wait")
+            .expect("partial queue event");
+        assert!(!queue.completed);
+        let stage = snap
+            .stages
+            .iter()
+            .find(|s| s.stage == "drop_stage_wait")
+            .expect("partial stage event");
+        assert!(!stage.completed);
+        assert!(!stage.success);
 
         started.completion.finish_ok();
     }
@@ -1559,5 +1570,191 @@ mod helper_tests {
 
         assert_eq!(*mutex.lock().await, 42);
         assert_eq!(*rw.read().await, 9);
+    }
+}
+
+#[cfg(test)]
+mod prompt09_tokio_partial_tests {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::{mpsc as std_mpsc, Arc};
+    use std::task::{Context, Poll, Waker};
+
+    use tailtriage_core::{MemorySink, RequestOptions, Tailtriage};
+
+    use super::TokioRequestHandleExt;
+
+    fn poll_once<F: Future>(future: &mut Pin<Box<F>>) -> Poll<F::Output> {
+        let waker = Waker::noop();
+        let mut cx = Context::from_waker(waker);
+        future.as_mut().poll(&mut cx)
+    }
+
+    fn capture() -> Tailtriage {
+        Tailtriage::builder("tokio-prompt09")
+            .sink(MemorySink::default())
+            .build()
+            .unwrap()
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn borrowed_semaphore_pending_then_drop_records_partial_queue() {
+        let tt = capture();
+        let started = tt.begin_request_with("/r", RequestOptions::new().request_id("req"));
+        let sem = tokio::sync::Semaphore::new(1);
+        let permit = sem.acquire().await.unwrap();
+        let fut = started.handle.semaphore("sem", &sem).acquire();
+        let mut fut = Box::pin(fut);
+        assert!(poll_once(&mut fut).is_pending());
+        drop(fut);
+        drop(permit);
+        let ev = &tt.snapshot().queues[0];
+        assert_eq!(ev.request_id, "req");
+        assert_eq!(ev.queue, "sem");
+        assert!(!ev.completed);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn owned_semaphore_pending_then_drop_records_partial_queue() {
+        let tt = capture();
+        let started = tt.begin_request_with("/r", RequestOptions::new().request_id("req"));
+        let sem = Arc::new(tokio::sync::Semaphore::new(1));
+        let permit = sem.acquire().await.unwrap();
+        let fut = started
+            .handle
+            .owned_semaphore("owned_sem", Arc::clone(&sem))
+            .acquire_owned();
+        let mut fut = Box::pin(fut);
+        assert!(poll_once(&mut fut).is_pending());
+        drop(fut);
+        drop(permit);
+        let ev = &tt.snapshot().queues[0];
+        assert_eq!(ev.queue, "owned_sem");
+        assert!(!ev.completed);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn mpsc_send_pending_then_drop_records_partial_queue() {
+        let tt = capture();
+        let started = tt.begin_request("/r");
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        tx.send(1).await.unwrap();
+        let fut = started.handle.mpsc_send("chan", &tx, 2);
+        let mut fut = Box::pin(fut);
+        assert!(poll_once(&mut fut).is_pending());
+        drop(fut);
+        let _ = rx.recv().await;
+        let ev = &tt.snapshot().queues[0];
+        assert_eq!(ev.queue, "chan");
+        assert!(!ev.completed);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn mutex_and_rwlock_pending_then_drop_record_partial_queues() {
+        let tt = capture();
+        let started = tt.begin_request("/r");
+        let mutex = tokio::sync::Mutex::new(());
+        let guard = mutex.lock().await;
+        let fut = started.handle.mutex_lock("mutex", &mutex);
+        let mut fut = Box::pin(fut);
+        assert!(poll_once(&mut fut).is_pending());
+        drop(fut);
+        drop(guard);
+
+        let rw = tokio::sync::RwLock::new(());
+        let write_guard = rw.write().await;
+        let fut = started.handle.rwlock_read("rw_read", &rw);
+        let mut fut = Box::pin(fut);
+        assert!(poll_once(&mut fut).is_pending());
+        drop(fut);
+        drop(write_guard);
+
+        let read_guard = rw.read().await;
+        let fut = started.handle.rwlock_write("rw_write", &rw);
+        let mut fut = Box::pin(fut);
+        assert!(poll_once(&mut fut).is_pending());
+        drop(fut);
+        drop(read_guard);
+
+        let run = tt.snapshot();
+        let labels: Vec<_> = run
+            .queues
+            .iter()
+            .map(|q| (q.queue.as_str(), q.completed))
+            .collect();
+        assert_eq!(
+            labels,
+            vec![("mutex", false), ("rw_read", false), ("rw_write", false)]
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn join_timeout_and_blocking_pending_then_drop_record_partial_stages() {
+        let tt = capture();
+        let started = tt.begin_request("/r");
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let handle = tokio::spawn(async move {
+            let _ = rx.await;
+        });
+        let fut = started.handle.join_task("join", handle);
+        let mut fut = Box::pin(fut);
+        assert!(poll_once(&mut fut).is_pending());
+        drop(fut);
+        let _ = tx.send(());
+
+        let fut = started.handle.timeout_stage(
+            "timeout",
+            std::time::Duration::from_secs(60),
+            std::future::pending::<()>(),
+        );
+        let mut fut = Box::pin(fut);
+        assert!(poll_once(&mut fut).is_pending());
+        drop(fut);
+
+        let (entered_tx, entered_rx) = std_mpsc::channel();
+        let (release_tx, release_rx) = std_mpsc::channel();
+        let fut = started.handle.blocking_stage("blocking", move || {
+            let _ = entered_tx.send(());
+            let _ = release_rx.recv();
+        });
+        let mut fut = Box::pin(fut);
+        assert!(poll_once(&mut fut).is_pending());
+        entered_rx.recv().unwrap();
+        drop(fut);
+        let _ = release_tx.send(());
+
+        let run = tt.snapshot();
+        let labels: Vec<_> = run
+            .stages
+            .iter()
+            .map(|s| (s.stage.as_str(), s.completed, s.success))
+            .collect();
+        assert_eq!(
+            labels,
+            vec![
+                ("join", false, false),
+                ("timeout", false, false),
+                ("blocking", false, false)
+            ]
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn owned_handle_stage_helper_pending_then_drop_records_partial_stage() {
+        let tt = Arc::new(capture());
+        let started = tt.begin_request_owned("/r");
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let handle = tokio::spawn(async move {
+            let _ = rx.await;
+        });
+        let fut = started.handle.join_task("owned_join", handle);
+        let mut fut = Box::pin(fut);
+        assert!(poll_once(&mut fut).is_pending());
+        drop(fut);
+        let _ = tx.send(());
+        let ev = &tt.snapshot().stages[0];
+        assert_eq!(ev.stage, "owned_join");
+        assert!(!ev.completed);
+        assert!(!ev.success);
     }
 }

--- a/tailtriage-tokio/src/lib.rs
+++ b/tailtriage-tokio/src/lib.rs
@@ -1575,6 +1575,7 @@ mod helper_tests {
 
 #[cfg(test)]
 mod prompt09_tokio_partial_tests {
+    const ONE_MINUTE_SECS: u64 = 60;
     use std::future::Future;
     use std::pin::Pin;
     use std::sync::{mpsc as std_mpsc, Arc};
@@ -1704,7 +1705,7 @@ mod prompt09_tokio_partial_tests {
 
         let fut = started.handle.timeout_stage(
             "timeout",
-            std::time::Duration::from_secs(60),
+            std::time::Duration::from_secs(ONE_MINUTE_SECS),
             std::future::pending::<()>(),
         );
         let mut fut = Box::pin(fut);

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -258,6 +258,7 @@ where
                                 finished_at_run_us,
                             ),
                             success,
+                            completed: true,
                         },
                         success_defaulted: matches!(success_field, OptionalField::Missing),
                     });
@@ -291,6 +292,7 @@ where
                                 waited_until_run_us,
                             ),
                             depth_at_start,
+                            completed: true,
                         },
                     });
                 }
@@ -1184,6 +1186,7 @@ mod tests {
             finished_at_run_us: None,
             latency_us: 5_000,
             success: true,
+            completed: true,
         });
         candidate.queues.push(QueueEvent {
             request_id: "excluded".to_owned(),
@@ -1194,6 +1197,7 @@ mod tests {
             waited_until_run_us: None,
             wait_us: 1_000,
             depth_at_start: None,
+            completed: true,
         });
         candidate.requests.push(RequestEvent {
             request_id: "valid".to_owned(),
@@ -1215,6 +1219,7 @@ mod tests {
             finished_at_run_us: None,
             latency_us: 5_000,
             success: true,
+            completed: true,
         });
         let provenance = CandidateProvenance {
             inputs: vec![

--- a/tailtriage-tracing/tests/support/equivalence_harness.rs
+++ b/tailtriage-tracing/tests/support/equivalence_harness.rs
@@ -145,6 +145,7 @@ fn deterministic_native_run() -> Run {
             waited_until_run_us: None,
             wait_us: queue_us,
             depth_at_start: Some(3),
+            completed: true,
         });
         run.stages.push(StageEvent {
             request_id: id.to_owned(),
@@ -155,6 +156,7 @@ fn deterministic_native_run() -> Run {
             finished_at_run_us: None,
             latency_us: db_us,
             success: true,
+            completed: true,
         });
         run.stages.push(StageEvent {
             request_id: id.to_owned(),
@@ -165,6 +167,7 @@ fn deterministic_native_run() -> Run {
             finished_at_run_us: None,
             latency_us: cache_us,
             success: true,
+            completed: true,
         });
     }
     run


### PR DESCRIPTION
### Motivation

- Record bounded partial queue and stage evidence when an instrumentation future was polled at least once and then dropped while capture remains open, preserving that lower-bound observation without changing completed-event JSON bytes. 
- Keep wire compatibility with schema v2 and make the Rust addition an intentional pre-1.0 source break with a clear migration path. 
- Ensure Tokio helpers inherit the canonical core timer policy and that tracing intake stays completed-only. 
- Preserve analyzer neutrality and existing collector/finalization semantics while adding robust tests and docs.

### Description

- Added `pub completed: bool` to `StageEvent` and `QueueEvent` with Serde helpers so missing field deserializes as `true`, serialization omits `true`, and `false` serializes as `"completed": false`.
- Added `StageEvent::new`, `QueueEvent::new`, chainable `with_*` run-interval/depth helpers, and `into_partial()` to construct partial events and to default constructors to `completed = true`.
- Reworked core timers in `tailtriage-core/src/timers.rs` to create a private `ArmedTimerRecord` guard on first poll; guard `Drop` performs best-effort partial-event recording (caught via `catch_unwind`) and disarm is done on normal readiness to avoid double-recording.
- Kept public `StageTimer::await_on`, `StageTimer::await_value`, and `QueueTimer::await_on` signatures and implemented guard creation inside their async bodies to satisfy first-poll semantics and never-polled/no-event behavior.
- Left `Tailtriage::record_stage_event` / `record_queue_event` as the canonical recording paths; partial recording goes through these methods and respects `CollectorPhase` checks and retention/truncation rules.
- Ensured `tailtriage-tokio` helpers delegate to core timers unchanged; updated helper docs and added runtime parity tests to prove borrowed/owned helper behaviour for semaphores, mpsc send, mutex/rwlock, join/timeout/blocking.
- Tracing conversion continues to construct completed events and explicitly sets `completed = true` for all trace-created `StageEvent` and `QueueEvent` values.
- Updated validation/normalization to preserve `completed` exactly through permissive normalization and added `StageEvent`/`QueueEvent`-aware tests and migration docs; updated READMEs, SPEC, DESIGN_NOTES, and CHANGELOG to document the source break and partial semantics.

### Testing

- Focused new tests added and run: `cargo test -p tailtriage-core prompt09_partial_events`, `cargo test -p tailtriage-tokio prompt09_tokio_partial_tests`, and `cargo test -p tailtriage-analyzer prompt09_partial_stage_and_queue_events_do_not_change_analyzer_output`; these targeted tests passed locally.
- Full validation performed: `cargo fmt --check`, `cargo clippy` (per-crate and workspace, debug and release with `-D warnings`), `cargo test --workspace --all-targets --all-features --locked`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`, and `python3 scripts/validate_docs_contracts.py` (plus its unit test); all checks completed successfully.
- Representative newly-added test names exercised: `prompt09_partial_events::partial_stage_and_queue_json_serialize_completed_false_and_round_trip`, `prompt09_partial_events::stage_pending_then_drop_records_one_partial_event`, `prompt09_partial_events::queue_pending_then_drop_records_one_partial_event_with_depth`, `prompt09_partial_events::stage_never_polled_drop_records_no_event`, `prompt09_partial_events::pending_helper_drop_plus_completion_token_drop_records_partial_child_and_cancelled_request`, `prompt09_tokio_partial_tests::borrowed_semaphore_pending_then_drop_records_partial_queue`, and the analyzer neutrality test `prompt09_partial_stage_and_queue_events_do_not_change_analyzer_output`.

All automated checks and tests listed above passed against the final commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61e139298483309df23a81022c0621)