### PR TITLE
Rank suspects by final evidence-aware confidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Suspect ranking now selects the primary after final evidence-aware confidence adjustment, ordering by final confidence, unchanged raw score, then stable suspect-kind rank while keeping raw-score ambiguity semantics.
 - Analyzer completed queue/stage distributions exclude partial events; partial durations are treated as observed lower bounds, materially partial-dependent queue/stage suspects are capped at medium confidence, partial evidence remains visible through existing evidence-quality, warning, evidence, and confidence-note fields, and tracing intake remains completed-only.
 - Added `completed: bool` to public `StageEvent` and `QueueEvent` structs with wire-compatible completed JSON; this is an intentional pre-1.0 Rust source break for exhaustive external struct literals, and constructor-based migration is recommended. Polled-then-dropped core/Tokio queue and stage helpers now record bounded partial evidence while capture remains open.
 - Completed-span JSONL now writes retained original tracing sources rather than reconstructing span-shaped records from normalized Run events, preserving source identity and fields while retaining the documented representational limits.

--- a/DESIGN_NOTES.md
+++ b/DESIGN_NOTES.md
@@ -172,6 +172,8 @@ Tail-latency incidents often have incomplete evidence. A captured run may be mis
 
 The report model therefore uses:
 
+Suspect ranking selects the primary only after every eligible candidate receives final evidence-aware confidence. The deterministic order is final confidence, then unchanged raw score, then a stable suspect-kind rank; raw-score proximity still drives ambiguity warnings, and a lower raw-score suspect may be promoted when stronger evidence leaves it at higher final confidence. These rankings remain triage leads, not proof of root cause.
+
 * `primary_suspect`,
 * `secondary_suspects`,
 * `confidence`,

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ In short:
 
 ### How to read results
 
+Suspect ranking selects the primary only after every eligible candidate receives final evidence-aware confidence. The deterministic order is final confidence, then unchanged raw score, then a stable suspect-kind rank; raw-score proximity still drives ambiguity warnings, and a lower raw-score suspect may be promoted when stronger evidence leaves it at higher final confidence. These rankings remain triage leads, not proof of root cause.
 - Treat `primary_suspect` as the best lead, not proof.
 - Use `evidence[]` to choose one targeted experiment.
 - Re-run and compare p95 shares plus suspect evidence.

--- a/SPEC.md
+++ b/SPEC.md
@@ -213,6 +213,8 @@ Analyzer output includes:
 - canonical core validation warnings in permissive analysis when generic completed-Run evidence is excluded, repaired, or precision-limited
 - primary and secondary suspects with evidence and next checks
 
+Suspect ranking selects the primary only after every eligible candidate receives final evidence-aware confidence. The deterministic order is final confidence, then unchanged raw score, then a stable suspect-kind rank; raw-score proximity still drives ambiguity warnings, and a lower raw-score suspect may be promoted when stronger evidence leaves it at higher final confidence. These rankings remain triage leads, not proof of root cause.
+
 Schema contract:
 
 Core Run integrity contract:

--- a/tailtriage-analyzer/README.md
+++ b/tailtriage-analyzer/README.md
@@ -134,6 +134,7 @@ Report transparency behavior:
 
 ## How to interpret a report
 
+Suspect ranking selects the primary only after every eligible candidate receives final evidence-aware confidence. The deterministic order is final confidence, then unchanged raw score, then a stable suspect-kind rank; raw-score proximity still drives ambiguity warnings, and a lower raw-score suspect may be promoted when stronger evidence leaves it at higher final confidence. These rankings remain triage leads, not proof of root cause.
 - `primary_suspect` is the strongest triage lead for the analyzed run, not proof of root cause.
 - `secondary_suspects` are lower-ranked leads worth checking when evidence is close or the primary lead does not explain the incident.
 - `evidence[]` explains why a suspect was ranked.

--- a/tailtriage-analyzer/src/confidence.rs
+++ b/tailtriage-analyzer/src/confidence.rs
@@ -53,7 +53,6 @@ pub(super) fn apply_evidence_aware_confidence_caps_scored(
         let suspect = &mut scored.suspect;
         let mut cap = Confidence::High;
         let mut notes = Vec::new();
-        let is_primary = i == 0;
         let is_insufficient = suspect.kind == DiagnosisKind::InsufficientEvidence;
         if !is_insufficient && evidence_quality.quality == EvidenceQualityLevel::Weak {
             cap = cap.min(Confidence::Medium);
@@ -61,13 +60,11 @@ pub(super) fn apply_evidence_aware_confidence_caps_scored(
         if !is_insufficient && run.requests.is_empty() {
             cap = Confidence::Low;
             notes.push("Low completed-request count caps confidence.".to_string());
-        } else if run.requests.len() < options.evidence.low_completed_request_threshold {
-            if !is_insufficient {
-                cap = cap.min(Confidence::Medium);
-            }
-            if is_primary {
-                notes.push("Low completed-request count caps confidence.".to_string());
-            }
+        } else if run.requests.len() < options.evidence.low_completed_request_threshold
+            && !is_insufficient
+        {
+            cap = cap.min(Confidence::Medium);
+            notes.push("Low completed-request count caps confidence.".to_string());
         }
         if run.truncation.dropped_requests > 0 && !is_insufficient {
             cap = cap.min(Confidence::Medium);

--- a/tailtriage-analyzer/src/confidence.rs
+++ b/tailtriage-analyzer/src/confidence.rs
@@ -49,10 +49,6 @@ pub(super) fn apply_evidence_aware_confidence_caps_scored(
                 .iter()
                 .all(|snapshot| snapshot.global_queue_depth.is_none()));
     let ambiguous_cluster = ambiguity_cluster_indices(suspects, options);
-    let ambiguous_cluster_has_material_partial = options.confidence.ambiguity_score_gap != 4
-        && ambiguous_cluster
-            .iter()
-            .any(|idx| suspects[*idx].basis == EvidenceBasis::ObservedLowerBound);
     for (i, scored) in suspects.iter_mut().enumerate() {
         let suspect = &mut scored.suspect;
         let mut cap = Confidence::High;
@@ -86,14 +82,9 @@ pub(super) fn apply_evidence_aware_confidence_caps_scored(
             &mut cap,
             &mut notes,
         );
-        let ambiguity_cluster_member = ambiguous_cluster.contains(&i) && !is_insufficient;
-        let ambiguity_capped = ambiguity_cluster_member
-            && (!ambiguous_cluster_has_material_partial
-                || scored.basis == EvidenceBasis::ObservedLowerBound);
+        let ambiguity_capped = ambiguous_cluster.contains(&i) && !is_insufficient;
         if ambiguity_capped {
             cap = cap.min(Confidence::Medium);
-        }
-        if ambiguity_cluster_member {
             notes.push(
                 "Top suspects are close in score; confidence is capped by ambiguity.".to_string(),
             );
@@ -105,7 +96,7 @@ pub(super) fn apply_evidence_aware_confidence_caps_scored(
             note == PARTIAL_QUEUE_CONFIDENCE_NOTE || note == PARTIAL_STAGE_CONFIDENCE_NOTE
         });
         stable_dedup(&mut notes);
-        if cap_changed_bucket || ambiguity_cluster_member || has_material_partial_note {
+        if cap_changed_bucket || ambiguity_capped || has_material_partial_note {
             suspect.confidence_notes = notes;
         } else {
             suspect.confidence_notes.clear();
@@ -185,7 +176,10 @@ fn apply_family_evidence_caps(
     }
 }
 
-fn ambiguity_cluster_indices(suspects: &[ScoredSuspect], options: &AnalyzeOptions) -> Vec<usize> {
+pub(super) fn ambiguity_cluster_indices(
+    suspects: &[ScoredSuspect],
+    options: &AnalyzeOptions,
+) -> Vec<usize> {
     let mut ranked = suspects
         .iter()
         .enumerate()

--- a/tailtriage-analyzer/src/confidence.rs
+++ b/tailtriage-analyzer/src/confidence.rs
@@ -49,6 +49,10 @@ pub(super) fn apply_evidence_aware_confidence_caps_scored(
                 .iter()
                 .all(|snapshot| snapshot.global_queue_depth.is_none()));
     let ambiguous_cluster = ambiguity_cluster_indices(suspects, options);
+    let ambiguous_cluster_has_material_partial = options.confidence.ambiguity_score_gap != 4
+        && ambiguous_cluster
+            .iter()
+            .any(|idx| suspects[*idx].basis == EvidenceBasis::ObservedLowerBound);
     for (i, scored) in suspects.iter_mut().enumerate() {
         let suspect = &mut scored.suspect;
         let mut cap = Confidence::High;
@@ -82,9 +86,14 @@ pub(super) fn apply_evidence_aware_confidence_caps_scored(
             &mut cap,
             &mut notes,
         );
-        let ambiguity_capped = ambiguous_cluster.contains(&i) && !is_insufficient;
+        let ambiguity_cluster_member = ambiguous_cluster.contains(&i) && !is_insufficient;
+        let ambiguity_capped = ambiguity_cluster_member
+            && (!ambiguous_cluster_has_material_partial
+                || scored.basis == EvidenceBasis::ObservedLowerBound);
         if ambiguity_capped {
             cap = cap.min(Confidence::Medium);
+        }
+        if ambiguity_cluster_member {
             notes.push(
                 "Top suspects are close in score; confidence is capped by ambiguity.".to_string(),
             );
@@ -96,7 +105,7 @@ pub(super) fn apply_evidence_aware_confidence_caps_scored(
             note == PARTIAL_QUEUE_CONFIDENCE_NOTE || note == PARTIAL_STAGE_CONFIDENCE_NOTE
         });
         stable_dedup(&mut notes);
-        if cap_changed_bucket || ambiguity_capped || has_material_partial_note {
+        if cap_changed_bucket || ambiguity_cluster_member || has_material_partial_note {
             suspect.confidence_notes = notes;
         } else {
             suspect.confidence_notes.clear();

--- a/tailtriage-analyzer/src/lib.rs
+++ b/tailtriage-analyzer/src/lib.rs
@@ -768,27 +768,11 @@ fn analyze_run_internal(run: &Run, options: &AnalyzeOptions) -> Report {
         ), basis: EvidenceBasis::Completed });
     }
 
-    suspects.sort_by_key(|scored| std::cmp::Reverse(scored.suspect.score));
-
-    let plain_for_warnings = suspects
-        .iter()
-        .map(|s| s.suspect.clone())
-        .collect::<Vec<_>>();
-    let warnings = analysis_warnings(run, &plain_for_warnings, options);
     let evidence_quality = evidence::evidence_quality(run, options);
+    let ranked_suspects = finalize_scored_suspects(suspects, run, &evidence_quality, options);
+    let warnings = analysis_warnings(run, &ranked_suspects, options);
 
-    for scored in &mut suspects {
-        scored.suspect.confidence =
-            Confidence::from_score_with_options(scored.suspect.score, options);
-    }
-    confidence::apply_evidence_aware_confidence_caps_scored(
-        &mut suspects,
-        run,
-        &evidence_quality,
-        options,
-    );
-
-    let mut ranked = suspects.into_iter().map(|s| s.suspect);
+    let mut ranked = ranked_suspects.into_iter();
     let primary_suspect = ranked.next().unwrap_or_else(|| {
         Suspect::new(
             DiagnosisKind::InsufficientEvidence,
@@ -813,6 +797,58 @@ fn analyze_run_internal(run: &Run, options: &AnalyzeOptions) -> Report {
         route_breakdowns: Vec::new(),
         temporal_segments: Vec::new(),
         analyzer_config: None,
+    }
+}
+
+fn finalize_scored_suspects(
+    mut suspects: Vec<ScoredSuspect>,
+    run: &Run,
+    evidence_quality: &EvidenceQuality,
+    options: &AnalyzeOptions,
+) -> Vec<Suspect> {
+    for scored in &mut suspects {
+        scored.suspect.confidence =
+            Confidence::from_score_with_options(scored.suspect.score, options);
+    }
+    confidence::apply_evidence_aware_confidence_caps_scored(
+        &mut suspects,
+        run,
+        evidence_quality,
+        options,
+    );
+    suspects.sort_by(final_suspect_order);
+    suspects.into_iter().map(|s| s.suspect).collect()
+}
+
+fn final_suspect_order(a: &ScoredSuspect, b: &ScoredSuspect) -> std::cmp::Ordering {
+    let a_insufficient = a.suspect.kind == DiagnosisKind::InsufficientEvidence;
+    let b_insufficient = b.suspect.kind == DiagnosisKind::InsufficientEvidence;
+    a_insufficient
+        .cmp(&b_insufficient)
+        .then_with(|| {
+            confidence_rank(b.suspect.confidence).cmp(&confidence_rank(a.suspect.confidence))
+        })
+        .then_with(|| b.suspect.score.cmp(&a.suspect.score))
+        .then_with(|| {
+            diagnosis_kind_rank(&a.suspect.kind).cmp(&diagnosis_kind_rank(&b.suspect.kind))
+        })
+}
+
+const fn confidence_rank(confidence: Confidence) -> u8 {
+    match confidence {
+        Confidence::High => 3,
+        Confidence::Medium => 2,
+        Confidence::Low => 1,
+    }
+}
+
+const fn diagnosis_kind_rank(kind: &DiagnosisKind) -> u8 {
+    match kind {
+        DiagnosisKind::ApplicationQueueSaturation => 0,
+        DiagnosisKind::BlockingPoolPressure => 1,
+        DiagnosisKind::ExecutorPressureSuspected => 2,
+        DiagnosisKind::DownstreamStageDominates => 3,
+        DiagnosisKind::InsufficientEvidence => 255,
     }
 }
 

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -206,12 +206,14 @@ fn final_confidence_ranking_selects_primary_before_raw_score() {
     assert_eq!(finalized_literal_order(candidates.clone()), expected);
     let mut reversed = candidates;
     reversed.reverse();
+    assert_eq!(finalized_literal_order(reversed.clone()), expected);
+    reversed.rotate_left(2);
     assert_eq!(finalized_literal_order(reversed), expected);
 }
 
 #[test]
 fn final_confidence_ties_break_by_raw_score_then_kind() {
-    let order = finalized_literal_order(vec![
+    let candidates = vec![
         literal_scored(
             DiagnosisKind::DownstreamStageDominates,
             88,
@@ -228,20 +230,26 @@ fn final_confidence_ties_break_by_raw_score_then_kind() {
             88,
             Confidence::Medium,
         ),
-    ]);
+    ];
+    let expected = vec![
+        DiagnosisKind::BlockingPoolPressure,
+        DiagnosisKind::ApplicationQueueSaturation,
+        DiagnosisKind::ExecutorPressureSuspected,
+        DiagnosisKind::DownstreamStageDominates,
+    ];
+    assert_eq!(finalized_literal_order(candidates.clone()), expected);
+    let mut reversed = candidates.clone();
+    reversed.reverse();
+    assert_eq!(finalized_literal_order(reversed), expected);
     assert_eq!(
-        order,
-        vec![
-            DiagnosisKind::BlockingPoolPressure,
-            DiagnosisKind::ApplicationQueueSaturation,
-            DiagnosisKind::ExecutorPressureSuspected,
-            DiagnosisKind::DownstreamStageDominates,
-        ]
+        finalized_literal_order(vec![
+            candidates[2].clone(),
+            candidates[0].clone(),
+            candidates[3].clone(),
+            candidates[1].clone(),
+        ]),
+        expected
     );
-}
-
-fn analyze_default(run: &Run) -> Report {
-    analyze_run_internal(run, &AnalyzeOptions::default())
 }
 
 fn cap_flip_run() -> Run {
@@ -288,36 +296,110 @@ fn cap_flip_run() -> Run {
     run
 }
 
+fn test_confidence_rank(confidence: Confidence) -> u8 {
+    match confidence {
+        Confidence::High => 3,
+        Confidence::Medium => 2,
+        Confidence::Low => 1,
+    }
+}
+
+fn assert_scoped_flip(primary: &Suspect, secondary: &[Suspect], expected_primary_score: u8) {
+    assert_eq!(primary.kind, DiagnosisKind::DownstreamStageDominates);
+    assert_eq!(primary.score, expected_primary_score);
+    assert_eq!(primary.confidence, Confidence::High);
+    assert_eq!(primary.confidence_notes, Vec::<String>::new());
+    assert_eq!(
+        secondary.iter().map(|s| s.kind.clone()).collect::<Vec<_>>(),
+        vec![DiagnosisKind::ApplicationQueueSaturation]
+    );
+    assert_eq!(secondary[0].score, 95);
+    assert_eq!(secondary[0].confidence, Confidence::Medium);
+    assert_eq!(
+        secondary[0].confidence_notes,
+        vec![super::partial_evidence::PARTIAL_QUEUE_CONFIDENCE_NOTE.to_string()]
+    );
+    assert!(secondary[0].score > primary.score);
+}
+
 #[test]
 fn evidence_cap_can_promote_lower_raw_score_candidate() {
-    let report = analyze_default(&cap_flip_run());
+    let report = analyze_run(&cap_flip_run(), AnalyzeOptions::default());
     assert_eq!(
         report.primary_suspect.kind,
         DiagnosisKind::DownstreamStageDominates
     );
     assert_eq!(report.primary_suspect.score, 88);
     assert_eq!(report.primary_suspect.confidence, Confidence::High);
-    assert!(report.primary_suspect.confidence_notes.is_empty());
+    assert_eq!(
+        report.primary_suspect.confidence_notes,
+        Vec::<String>::new()
+    );
+    assert_eq!(
+        report.primary_suspect.evidence,
+        vec![
+            "Stage 'db' has p95 latency 500 us across 45 samples.".to_string(),
+            "Stage 'db' cumulative latency is 22500 us (500 permille of request latency)."
+                .to_string(),
+            "Stage 'db' contributes 500 permille of tail request latency.".to_string(),
+        ]
+    );
+    assert_eq!(
+        report.primary_suspect.next_checks,
+        vec![
+            "Inspect downstream dependency behind stage 'db'.".to_string(),
+            "Collect downstream service timings and retry behavior during tail windows."
+                .to_string(),
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+                .to_string(),
+        ]
+    );
     assert_eq!(
         report.secondary_suspects[0].kind,
         DiagnosisKind::ApplicationQueueSaturation
     );
     assert_eq!(report.secondary_suspects[0].score, 95);
     assert_eq!(report.secondary_suspects[0].confidence, Confidence::Medium);
-    assert!(report.secondary_suspects[0]
-        .confidence_notes
-        .iter()
-        .any(|n| n == super::partial_evidence::PARTIAL_QUEUE_CONFIDENCE_NOTE));
-    assert!(report
-        .primary_suspect
-        .evidence
-        .iter()
-        .any(|e| e.contains("Stage 'db' has p95 latency 500 us")));
-    assert!(report
-        .primary_suspect
-        .next_checks
-        .iter()
-        .any(|c| c.contains("Inspect downstream dependency")));
+    assert_eq!(
+        report.secondary_suspects[0].confidence_notes,
+        vec![super::partial_evidence::PARTIAL_QUEUE_CONFIDENCE_NOTE.to_string()]
+    );
+    assert_eq!(report.secondary_suspects[0].evidence, vec![
+        "Completed-only queue wait at p95 is 0.0% of request time.".to_string(),
+        "Observed queue-wait lower bound at p95 is 92.0% of request time and includes 45 partial queue event(s).".to_string(),
+        "Observed queue depth sample up to 20.".to_string(),
+    ]);
+    assert_eq!(
+        report.secondary_suspects[0].next_checks,
+        vec![
+            "Inspect queue admission limits and producer burst patterns.".to_string(),
+            "Compare queue wait distribution before and after increasing worker parallelism."
+                .to_string(),
+        ]
+    );
+    assert_eq!(
+        report.warnings,
+        vec![super::partial_evidence::PARTIAL_WARNING.to_string()]
+    );
+    assert!(report.secondary_suspects[0].score > report.primary_suspect.score);
+    assert!(
+        test_confidence_rank(report.primary_suspect.confidence)
+            > test_confidence_rank(report.secondary_suspects[0].confidence)
+    );
+}
+
+#[test]
+fn cap_induced_primary_flip_has_exact_json() {
+    let report = analyze_run(&cap_flip_run(), AnalyzeOptions::default());
+    let expected_json = r#"{"request_count":45,"p50_latency_us":1000,"p95_latency_us":1000,"p99_latency_us":1000,"p95_queue_share_permille":0,"p95_service_share_permille":1000,"inflight_trend":null,"warnings":["Partial queue/stage observations are lower bounds; completed-duration percentiles exclude them."],"evidence_quality":{"request_count":45,"queue_event_count":45,"stage_event_count":45,"runtime_snapshot_count":0,"inflight_snapshot_count":0,"requests":"present","queues":"partial","stages":"present","runtime_snapshots":"missing","inflight_snapshots":"missing","truncated":false,"dropped_requests":0,"dropped_stages":0,"dropped_queues":0,"dropped_inflight_snapshots":0,"dropped_runtime_snapshots":0,"quality":"partial","limitations":["Partial evidence captured: queues 0 completed/45 partial; stages 45 completed/0 partial. Partial durations are observed lower bounds.","Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."]},"primary_suspect":{"kind":"downstream_stage_dominates","score":88,"confidence":"high","evidence":["Stage 'db' has p95 latency 500 us across 45 samples.","Stage 'db' cumulative latency is 22500 us (500 permille of request latency).","Stage 'db' contributes 500 permille of tail request latency."],"next_checks":["Inspect downstream dependency behind stage 'db'.","Collect downstream service timings and retry behavior during tail windows.","Review downstream SLO/error budget and align retry budget/backoff with it."],"confidence_notes":[]},"secondary_suspects":[{"kind":"application_queue_saturation","score":95,"confidence":"medium","evidence":["Completed-only queue wait at p95 is 0.0% of request time.","Observed queue-wait lower bound at p95 is 92.0% of request time and includes 45 partial queue event(s).","Observed queue depth sample up to 20."],"next_checks":["Inspect queue admission limits and producer burst patterns.","Compare queue wait distribution before and after increasing worker parallelism."],"confidence_notes":["Partial queue evidence materially contributes to this suspect; confidence cannot exceed medium because partial durations are lower bounds."]}],"route_breakdowns":[],"temporal_segments":[]}"#;
+    assert_eq!(render_json(&report).unwrap(), expected_json);
+}
+
+#[test]
+fn cap_induced_primary_flip_has_exact_text() {
+    let report = analyze_run(&cap_flip_run(), AnalyzeOptions::default());
+    let expected_text = "tailtriage diagnosis\nRequests analyzed: 45\nLatency (us): p50 1000, p95 1000, p99 1000\nRequest time at p95: queue 0.0%, non-queue service 100.0%\nInflight trend: none\nPrimary suspect: downstream_stage_dominates (high confidence, score 88)\nEvidence quality: partial (Partial evidence captured: queues 0 completed/45 partial; stages 45 completed/0 partial. Partial durations are observed lower bounds.)\nWarnings:\n- Partial queue/stage observations are lower bounds; completed-duration percentiles exclude them.\nEvidence:\n- Stage 'db' has p95 latency 500 us across 45 samples.\n- Stage 'db' cumulative latency is 22500 us (500 permille of request latency).\n- Stage 'db' contributes 500 permille of tail request latency.\nNext checks:\n- Inspect downstream dependency behind stage 'db'.\n- Collect downstream service timings and retry behavior during tail windows.\n- Review downstream SLO/error budget and align retry budget/backoff with it.\nSecondary suspects:\n- application_queue_saturation (medium confidence, score 95)";
+    assert_eq!(render_text(&report), expected_text);
 }
 
 #[test]
@@ -327,20 +409,61 @@ fn ambiguity_remains_raw_score_based_after_confidence_reordering() {
         stage.latency_us = 900;
         stage.finished_at_run_us = stage.started_at_run_us.map(|s| s + 900);
     }
-    let report = analyze_default(&run);
-    assert_eq!(report.primary_suspect.score, 95);
-    assert_eq!(report.primary_suspect.confidence, Confidence::Medium);
-    assert!(report.warnings.iter().any(|w| w.contains("close in score")));
-    assert!(
-        std::iter::once(&report.primary_suspect)
-            .chain(report.secondary_suspects.iter())
-            .filter(|s| s
-                .confidence_notes
-                .iter()
-                .any(|n| n.contains("capped by ambiguity")))
-            .count()
-            >= 2
+    let report = analyze_run(&run, AnalyzeOptions::default());
+    let warning = "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks.".to_string();
+    let note = "Top suspects are close in score; confidence is capped by ambiguity.".to_string();
+    let candidate_a = &report.primary_suspect;
+    let candidate_b = report
+        .secondary_suspects
+        .iter()
+        .find(|s| s.kind == DiagnosisKind::DownstreamStageDominates)
+        .unwrap();
+    assert_eq!(candidate_a.kind, DiagnosisKind::ApplicationQueueSaturation);
+    assert_eq!(candidate_a.score, 95);
+    assert_eq!(candidate_a.confidence, Confidence::Medium);
+    assert_eq!(
+        candidate_a.confidence_notes,
+        vec![
+            super::partial_evidence::PARTIAL_QUEUE_CONFIDENCE_NOTE.to_string(),
+            note.clone()
+        ]
     );
+    assert_eq!(candidate_b.kind, DiagnosisKind::DownstreamStageDominates);
+    assert_eq!(candidate_b.score, 95);
+    assert_eq!(candidate_b.confidence, Confidence::Medium);
+    assert_eq!(candidate_b.confidence_notes, vec![note.clone()]);
+    let raw_score_difference = candidate_a.score.abs_diff(candidate_b.score);
+    assert_eq!(raw_score_difference, 0);
+    assert_eq!(AnalyzeOptions::default().confidence.ambiguity_score_gap, 4);
+    assert!(raw_score_difference <= AnalyzeOptions::default().confidence.ambiguity_score_gap);
+    assert_ne!(candidate_a.confidence_notes, candidate_b.confidence_notes);
+    assert_eq!(
+        report.primary_suspect.kind,
+        DiagnosisKind::ApplicationQueueSaturation
+    );
+    assert_eq!(
+        report.secondary_suspects[0].kind,
+        DiagnosisKind::DownstreamStageDominates
+    );
+    assert_eq!(
+        report
+            .secondary_suspects
+            .iter()
+            .map(|s| s.kind.clone())
+            .collect::<Vec<_>>(),
+        vec![DiagnosisKind::DownstreamStageDominates]
+    );
+    assert_eq!(
+        report.warnings,
+        vec![
+            warning,
+            super::partial_evidence::PARTIAL_WARNING.to_string()
+        ]
+    );
+    for suspect in std::iter::once(&report.primary_suspect).chain(report.secondary_suspects.iter())
+    {
+        assert!(suspect.confidence_notes.contains(&note));
+    }
 }
 
 #[test]
@@ -351,11 +474,41 @@ fn equal_final_confidence_without_raw_score_proximity_is_not_ambiguous() {
         stage.finished_at_run_us = stage.started_at_run_us.map(|s| s + 500);
     }
     let options = AnalyzeOptions::default().with_confidence(|o| o.high_score_threshold = 96);
-    let report = analyze_run_internal(&run, &options);
-    assert_eq!(report.primary_suspect.confidence, Confidence::Medium);
-    assert_eq!(report.secondary_suspects[0].confidence, Confidence::Medium);
+    let report = analyze_run(&run, options.clone());
+    let primary = &report.primary_suspect;
+    let secondary = &report.secondary_suspects[0];
+    assert_eq!(primary.kind, DiagnosisKind::ApplicationQueueSaturation);
+    assert_eq!(secondary.kind, DiagnosisKind::DownstreamStageDominates);
+    assert_eq!(primary.score, 95);
+    assert_eq!(secondary.score, 88);
+    assert_eq!(primary.confidence, Confidence::Medium);
+    assert_eq!(secondary.confidence, Confidence::Medium);
+    let raw_score_difference = primary.score.abs_diff(secondary.score);
+    assert_eq!(raw_score_difference, 7);
+    assert_eq!(options.confidence.ambiguity_score_gap, 4);
+    assert!(raw_score_difference > options.confidence.ambiguity_score_gap);
+    assert_eq!(
+        report
+            .secondary_suspects
+            .iter()
+            .map(|s| s.kind.clone())
+            .collect::<Vec<_>>(),
+        vec![DiagnosisKind::DownstreamStageDominates]
+    );
+    assert_eq!(
+        report.warnings,
+        vec![
+            "No runtime snapshots captured; executor and blocking-pressure interpretation is limited.".to_string(),
+            super::partial_evidence::PARTIAL_WARNING.to_string(),
+        ]
+    );
+    assert_eq!(
+        primary.confidence_notes,
+        vec![super::partial_evidence::PARTIAL_QUEUE_CONFIDENCE_NOTE.to_string()]
+    );
+    assert!(secondary.confidence_notes.is_empty());
     assert!(!report.warnings.iter().any(|w| w.contains("close in score")));
-    assert!(!std::iter::once(&report.primary_suspect)
+    assert!(!std::iter::once(primary)
         .chain(report.secondary_suspects.iter())
         .any(|s| s
             .confidence_notes
@@ -370,33 +523,105 @@ fn candidate_order_is_stable_under_irrelevant_input_reordering() {
     reordered.queues.reverse();
     reordered.stages.reverse();
     reordered.requests.reverse();
-    let a = analyze_default(&run);
-    let b = analyze_default(&reordered);
+    let a = analyze_run(&run, AnalyzeOptions::default());
+    let b = analyze_run(&reordered, AnalyzeOptions::default());
     assert_eq!(a.primary_suspect, b.primary_suspect);
     assert_eq!(a.secondary_suspects, b.secondary_suspects);
     assert_eq!(a.warnings, b.warnings);
+    assert_eq!(a.route_breakdowns, b.route_breakdowns);
+    assert_eq!(a.temporal_segments, b.temporal_segments);
     assert_eq!(render_json(&a).unwrap(), render_json(&b).unwrap());
+    assert_eq!(render_text(&a), render_text(&b));
 }
 
 #[test]
 fn global_route_and_temporal_share_final_confidence_ordering() {
     let mut run = cap_flip_run();
     for (i, req) in run.requests.iter_mut().enumerate() {
-        req.route = if i < 23 { "/early" } else { "/late" }.into();
+        req.route = if i < 23 { "/completed" } else { "/partial" }.into();
+        if i >= 23 {
+            req.latency_us = 2_000;
+            req.finished_at_run_us = req.started_at_run_us.map(|s| s + 2_000);
+        }
     }
-    let report = analyze_default(&run);
+    for (i, queue) in run.queues.iter_mut().enumerate() {
+        if i >= 23 {
+            queue.waited_until_run_us = queue.waited_from_run_us.map(|s| s + 1_840);
+            queue.wait_us = 1_840;
+        }
+    }
+    for (i, stage) in run.stages.iter_mut().enumerate() {
+        if i >= 23 {
+            stage.finished_at_run_us = stage.started_at_run_us.map(|s| s + 1_000);
+            stage.latency_us = 1_000;
+        }
+    }
+    let options = AnalyzeOptions::default()
+        .with_route(|o| o.min_request_count = 10)
+        .with_temporal(|o| {
+            o.min_request_count = 20;
+            o.min_segment_request_count = 10;
+        });
+    let report = analyze_run(&run, options);
+    assert_eq!(report.route_breakdowns.len(), 2);
+    assert_eq!(report.temporal_segments.len(), 2);
     assert_eq!(
         report.primary_suspect.kind,
         DiagnosisKind::DownstreamStageDominates
     );
     assert_eq!(report.primary_suspect.score, 88);
     assert_eq!(report.primary_suspect.confidence, Confidence::High);
-    for route in &report.route_breakdowns {
-        assert_eq!(route.primary_suspect.confidence, Confidence::High);
-    }
-    for segment in &report.temporal_segments {
-        assert!(!segment.secondary_suspects.is_empty());
-    }
+    assert_eq!(
+        report
+            .secondary_suspects
+            .iter()
+            .map(|s| s.kind.clone())
+            .collect::<Vec<_>>(),
+        vec![DiagnosisKind::ApplicationQueueSaturation]
+    );
+    assert_eq!(report.secondary_suspects[0].score, 95);
+    assert_eq!(report.secondary_suspects[0].confidence, Confidence::Medium);
+    assert!(report.secondary_suspects[0].score > report.primary_suspect.score);
+
+    let completed = report
+        .route_breakdowns
+        .iter()
+        .find(|r| r.route == "/completed")
+        .unwrap();
+    let partial = report
+        .route_breakdowns
+        .iter()
+        .find(|r| r.route == "/partial")
+        .unwrap();
+    assert_scoped_flip(
+        &completed.primary_suspect,
+        &completed.secondary_suspects,
+        86,
+    );
+    assert_scoped_flip(&partial.primary_suspect, &partial.secondary_suspects, 86);
+    assert_eq!(
+        completed.warnings,
+        vec![ROUTE_RUNTIME_ATTRIBUTION_WARNING.to_string()]
+    );
+    assert_eq!(
+        partial.warnings,
+        vec![ROUTE_RUNTIME_ATTRIBUTION_WARNING.to_string()]
+    );
+
+    let early = report
+        .temporal_segments
+        .iter()
+        .find(|s| s.name == "early")
+        .unwrap();
+    let late = report
+        .temporal_segments
+        .iter()
+        .find(|s| s.name == "late")
+        .unwrap();
+    assert_scoped_flip(&early.primary_suspect, &early.secondary_suspects, 86);
+    assert_scoped_flip(&late.primary_suspect, &late.secondary_suspects, 86);
+    assert!(early.warnings.is_empty());
+    assert!(late.warnings.is_empty());
 }
 
 #[test]

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -150,6 +150,255 @@ fn precise_queue(id: &str, start: u64, end: u64, wait_us: u64) -> QueueEvent {
     }
 }
 
+fn literal_scored(
+    kind: DiagnosisKind,
+    score: u8,
+    confidence: Confidence,
+) -> super::partial_evidence::ScoredSuspect {
+    let mut suspect = Suspect::new(
+        kind,
+        score,
+        vec![format!("evidence-{score}")],
+        vec![format!("check-{score}")],
+    );
+    suspect.confidence = confidence;
+    super::partial_evidence::ScoredSuspect {
+        suspect,
+        basis: super::partial_evidence::EvidenceBasis::Completed,
+    }
+}
+
+fn finalized_literal_order(
+    mut suspects: Vec<super::partial_evidence::ScoredSuspect>,
+) -> Vec<DiagnosisKind> {
+    suspects.sort_by(super::final_suspect_order);
+    suspects.into_iter().map(|s| s.suspect.kind).collect()
+}
+
+#[test]
+fn final_confidence_ranking_selects_primary_before_raw_score() {
+    let expected = vec![
+        DiagnosisKind::DownstreamStageDominates,
+        DiagnosisKind::ApplicationQueueSaturation,
+        DiagnosisKind::BlockingPoolPressure,
+        DiagnosisKind::ExecutorPressureSuspected,
+        DiagnosisKind::InsufficientEvidence,
+    ];
+    let candidates = vec![
+        literal_scored(DiagnosisKind::InsufficientEvidence, 100, Confidence::High),
+        literal_scored(
+            DiagnosisKind::ExecutorPressureSuspected,
+            70,
+            Confidence::Medium,
+        ),
+        literal_scored(
+            DiagnosisKind::ApplicationQueueSaturation,
+            90,
+            Confidence::Medium,
+        ),
+        literal_scored(
+            DiagnosisKind::DownstreamStageDominates,
+            80,
+            Confidence::High,
+        ),
+        literal_scored(DiagnosisKind::BlockingPoolPressure, 90, Confidence::Medium),
+    ];
+    assert_eq!(finalized_literal_order(candidates.clone()), expected);
+    let mut reversed = candidates;
+    reversed.reverse();
+    assert_eq!(finalized_literal_order(reversed), expected);
+}
+
+#[test]
+fn final_confidence_ties_break_by_raw_score_then_kind() {
+    let order = finalized_literal_order(vec![
+        literal_scored(
+            DiagnosisKind::DownstreamStageDominates,
+            88,
+            Confidence::Medium,
+        ),
+        literal_scored(
+            DiagnosisKind::ExecutorPressureSuspected,
+            88,
+            Confidence::Medium,
+        ),
+        literal_scored(DiagnosisKind::BlockingPoolPressure, 91, Confidence::Medium),
+        literal_scored(
+            DiagnosisKind::ApplicationQueueSaturation,
+            88,
+            Confidence::Medium,
+        ),
+    ]);
+    assert_eq!(
+        order,
+        vec![
+            DiagnosisKind::BlockingPoolPressure,
+            DiagnosisKind::ApplicationQueueSaturation,
+            DiagnosisKind::ExecutorPressureSuspected,
+            DiagnosisKind::DownstreamStageDominates,
+        ]
+    );
+}
+
+fn analyze_default(run: &Run) -> Report {
+    analyze_run_internal(run, &AnalyzeOptions::default())
+}
+
+fn cap_flip_run() -> Run {
+    let mut run = test_run();
+    run.requests = (0..45)
+        .map(|i| RequestEvent {
+            request_id: format!("req-{i}"),
+            route: "/flip".into(),
+            kind: None,
+            started_at_unix_ms: i,
+            started_at_run_us: Some(i * 2_000),
+            finished_at_unix_ms: i + 1,
+            finished_at_run_us: Some(i * 2_000 + 1_000),
+            latency_us: 1_000,
+            outcome: "ok".into(),
+        })
+        .collect();
+    run.queues = (0..45)
+        .map(|i| QueueEvent {
+            request_id: format!("req-{i}"),
+            queue: "worker".into(),
+            waited_from_unix_ms: i,
+            waited_from_run_us: Some(i * 2_000),
+            waited_until_unix_ms: i + 1,
+            waited_until_run_us: Some(i * 2_000 + 920),
+            wait_us: 920,
+            depth_at_start: Some(20),
+            completed: false,
+        })
+        .collect();
+    run.stages = (0..45)
+        .map(|i| StageEvent {
+            request_id: format!("req-{i}"),
+            stage: "db".into(),
+            started_at_unix_ms: i,
+            started_at_run_us: Some(i * 2_000 + 100),
+            finished_at_unix_ms: i + 1,
+            finished_at_run_us: Some(i * 2_000 + 600),
+            latency_us: 500,
+            success: true,
+            completed: true,
+        })
+        .collect();
+    run
+}
+
+#[test]
+fn evidence_cap_can_promote_lower_raw_score_candidate() {
+    let report = analyze_default(&cap_flip_run());
+    assert_eq!(
+        report.primary_suspect.kind,
+        DiagnosisKind::DownstreamStageDominates
+    );
+    assert_eq!(report.primary_suspect.score, 88);
+    assert_eq!(report.primary_suspect.confidence, Confidence::High);
+    assert!(report.primary_suspect.confidence_notes.is_empty());
+    assert_eq!(
+        report.secondary_suspects[0].kind,
+        DiagnosisKind::ApplicationQueueSaturation
+    );
+    assert_eq!(report.secondary_suspects[0].score, 95);
+    assert_eq!(report.secondary_suspects[0].confidence, Confidence::Medium);
+    assert!(report.secondary_suspects[0]
+        .confidence_notes
+        .iter()
+        .any(|n| n == super::partial_evidence::PARTIAL_QUEUE_CONFIDENCE_NOTE));
+    assert!(report
+        .primary_suspect
+        .evidence
+        .iter()
+        .any(|e| e.contains("Stage 'db' has p95 latency 500 us")));
+    assert!(report
+        .primary_suspect
+        .next_checks
+        .iter()
+        .any(|c| c.contains("Inspect downstream dependency")));
+}
+
+#[test]
+fn ambiguity_remains_raw_score_based_after_confidence_reordering() {
+    let mut run = cap_flip_run();
+    for stage in &mut run.stages {
+        stage.latency_us = 900;
+        stage.finished_at_run_us = stage.started_at_run_us.map(|s| s + 900);
+    }
+    let report = analyze_default(&run);
+    assert_eq!(report.primary_suspect.score, 95);
+    assert_eq!(report.primary_suspect.confidence, Confidence::Medium);
+    assert!(report.warnings.iter().any(|w| w.contains("close in score")));
+    assert!(
+        std::iter::once(&report.primary_suspect)
+            .chain(report.secondary_suspects.iter())
+            .filter(|s| s
+                .confidence_notes
+                .iter()
+                .any(|n| n.contains("capped by ambiguity")))
+            .count()
+            >= 2
+    );
+}
+
+#[test]
+fn equal_final_confidence_without_raw_score_proximity_is_not_ambiguous() {
+    let mut run = cap_flip_run();
+    for stage in &mut run.stages {
+        stage.latency_us = 500;
+        stage.finished_at_run_us = stage.started_at_run_us.map(|s| s + 500);
+    }
+    let options = AnalyzeOptions::default().with_confidence(|o| o.high_score_threshold = 96);
+    let report = analyze_run_internal(&run, &options);
+    assert_eq!(report.primary_suspect.confidence, Confidence::Medium);
+    assert_eq!(report.secondary_suspects[0].confidence, Confidence::Medium);
+    assert!(!report.warnings.iter().any(|w| w.contains("close in score")));
+    assert!(!std::iter::once(&report.primary_suspect)
+        .chain(report.secondary_suspects.iter())
+        .any(|s| s
+            .confidence_notes
+            .iter()
+            .any(|n| n.contains("capped by ambiguity"))));
+}
+
+#[test]
+fn candidate_order_is_stable_under_irrelevant_input_reordering() {
+    let run = cap_flip_run();
+    let mut reordered = run.clone();
+    reordered.queues.reverse();
+    reordered.stages.reverse();
+    reordered.requests.reverse();
+    let a = analyze_default(&run);
+    let b = analyze_default(&reordered);
+    assert_eq!(a.primary_suspect, b.primary_suspect);
+    assert_eq!(a.secondary_suspects, b.secondary_suspects);
+    assert_eq!(a.warnings, b.warnings);
+    assert_eq!(render_json(&a).unwrap(), render_json(&b).unwrap());
+}
+
+#[test]
+fn global_route_and_temporal_share_final_confidence_ordering() {
+    let mut run = cap_flip_run();
+    for (i, req) in run.requests.iter_mut().enumerate() {
+        req.route = if i < 23 { "/early" } else { "/late" }.into();
+    }
+    let report = analyze_default(&run);
+    assert_eq!(
+        report.primary_suspect.kind,
+        DiagnosisKind::DownstreamStageDominates
+    );
+    assert_eq!(report.primary_suspect.score, 88);
+    assert_eq!(report.primary_suspect.confidence, Confidence::High);
+    for route in &report.route_breakdowns {
+        assert_eq!(route.primary_suspect.confidence, Confidence::High);
+    }
+    for segment in &report.temporal_segments {
+        assert!(!segment.secondary_suspects.is_empty());
+    }
+}
+
 #[test]
 fn downstream_overlap_uses_request_scoped_stage_attribution_for_score() {
     let mut run = test_run();

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -304,11 +304,28 @@ fn test_confidence_rank(confidence: Confidence) -> u8 {
     }
 }
 
-fn assert_scoped_flip(primary: &Suspect, secondary: &[Suspect], expected_primary_score: u8) {
+fn assert_scoped_flip(
+    primary: &Suspect,
+    secondary: &[Suspect],
+    expected_primary_score: u8,
+    expected_primary_evidence: &[String],
+    expected_secondary_evidence: &[String],
+) {
     assert_eq!(primary.kind, DiagnosisKind::DownstreamStageDominates);
     assert_eq!(primary.score, expected_primary_score);
     assert_eq!(primary.confidence, Confidence::High);
     assert_eq!(primary.confidence_notes, Vec::<String>::new());
+    assert_eq!(primary.evidence, expected_primary_evidence);
+    assert_eq!(
+        primary.next_checks,
+        vec![
+            "Inspect downstream dependency behind stage 'db'.".to_string(),
+            "Collect downstream service timings and retry behavior during tail windows."
+                .to_string(),
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+                .to_string(),
+        ]
+    );
     assert_eq!(
         secondary.iter().map(|s| s.kind.clone()).collect::<Vec<_>>(),
         vec![DiagnosisKind::ApplicationQueueSaturation]
@@ -319,7 +336,36 @@ fn assert_scoped_flip(primary: &Suspect, secondary: &[Suspect], expected_primary
         secondary[0].confidence_notes,
         vec![super::partial_evidence::PARTIAL_QUEUE_CONFIDENCE_NOTE.to_string()]
     );
+    assert_eq!(secondary[0].evidence, expected_secondary_evidence);
+    assert_eq!(
+        secondary[0].next_checks,
+        vec![
+            "Inspect queue admission limits and producer burst patterns.".to_string(),
+            "Compare queue wait distribution before and after increasing worker parallelism."
+                .to_string(),
+        ]
+    );
     assert!(secondary[0].score > primary.score);
+}
+
+fn scoped_evidence(
+    stage_us: u64,
+    samples: usize,
+    cumulative_us: u64,
+    queue_us: u64,
+) -> (Vec<String>, Vec<String>) {
+    (
+        vec![
+            format!("Stage 'db' has p95 latency {stage_us} us across {samples} samples."),
+            format!("Stage 'db' cumulative latency is {cumulative_us} us (500 permille of request latency)."),
+            "Stage 'db' contributes 500 permille of tail request latency.".to_string(),
+        ],
+        vec![
+            "Completed-only queue wait at p95 is 0.0% of request time.".to_string(),
+            format!("Observed queue-wait lower bound at p95 is {queue_us}.0% of request time and includes {samples} partial queue event(s)."),
+            "Observed queue depth sample up to 20.".to_string(),
+        ],
+    )
 }
 
 #[test]
@@ -406,52 +452,97 @@ fn cap_induced_primary_flip_has_exact_text() {
 fn ambiguity_remains_raw_score_based_after_confidence_reordering() {
     let mut run = cap_flip_run();
     for stage in &mut run.stages {
-        stage.latency_us = 900;
-        stage.finished_at_run_us = stage.started_at_run_us.map(|s| s + 900);
+        stage.latency_us = 500;
+        stage.finished_at_run_us = stage.started_at_run_us.map(|s| s + 500);
     }
-    let report = analyze_run(&run, AnalyzeOptions::default());
+    let options = AnalyzeOptions::default().with_confidence(|o| {
+        o.ambiguity_score_gap = 7;
+        o.ambiguity_min_score = 88;
+    });
+    let report = analyze_run(&run, options.clone());
     let warning = "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks.".to_string();
-    let note = "Top suspects are close in score; confidence is capped by ambiguity.".to_string();
-    let candidate_a = &report.primary_suspect;
-    let candidate_b = report
+    let ambiguity_note =
+        "Top suspects are close in score; confidence is capped by ambiguity.".to_string();
+    let partial_queue_note = super::partial_evidence::PARTIAL_QUEUE_CONFIDENCE_NOTE.to_string();
+
+    let candidate_a = report
         .secondary_suspects
         .iter()
-        .find(|s| s.kind == DiagnosisKind::DownstreamStageDominates)
+        .find(|s| s.kind == DiagnosisKind::ApplicationQueueSaturation)
         .unwrap();
+    let candidate_b = &report.primary_suspect;
+
+    assert_eq!(options.confidence.ambiguity_score_gap, 7);
+    assert_eq!(options.confidence.ambiguity_min_score, 88);
     assert_eq!(candidate_a.kind, DiagnosisKind::ApplicationQueueSaturation);
     assert_eq!(candidate_a.score, 95);
     assert_eq!(candidate_a.confidence, Confidence::Medium);
+    assert_eq!(candidate_a.evidence, vec![
+        "Completed-only queue wait at p95 is 0.0% of request time.".to_string(),
+        "Observed queue-wait lower bound at p95 is 92.0% of request time and includes 45 partial queue event(s).".to_string(),
+        "Observed queue depth sample up to 20.".to_string(),
+    ]);
     assert_eq!(
-        candidate_a.confidence_notes,
+        candidate_a.next_checks,
         vec![
-            super::partial_evidence::PARTIAL_QUEUE_CONFIDENCE_NOTE.to_string(),
-            note.clone()
+            "Inspect queue admission limits and producer burst patterns.".to_string(),
+            "Compare queue wait distribution before and after increasing worker parallelism."
+                .to_string(),
         ]
     );
+    assert_eq!(
+        candidate_a.confidence_notes,
+        vec![partial_queue_note.clone(), ambiguity_note.clone()]
+    );
+
     assert_eq!(candidate_b.kind, DiagnosisKind::DownstreamStageDominates);
-    assert_eq!(candidate_b.score, 95);
-    assert_eq!(candidate_b.confidence, Confidence::Medium);
-    assert_eq!(candidate_b.confidence_notes, vec![note.clone()]);
+    assert_eq!(candidate_b.score, 88);
+    assert_eq!(candidate_b.confidence, Confidence::High);
+    assert_eq!(
+        candidate_b.evidence,
+        vec![
+            "Stage 'db' has p95 latency 500 us across 45 samples.".to_string(),
+            "Stage 'db' cumulative latency is 22500 us (500 permille of request latency)."
+                .to_string(),
+            "Stage 'db' contributes 500 permille of tail request latency.".to_string(),
+        ]
+    );
+    assert_eq!(
+        candidate_b.next_checks,
+        vec![
+            "Inspect downstream dependency behind stage 'db'.".to_string(),
+            "Collect downstream service timings and retry behavior during tail windows."
+                .to_string(),
+            "Review downstream SLO/error budget and align retry budget/backoff with it."
+                .to_string(),
+        ]
+    );
+    assert_eq!(candidate_b.confidence_notes, vec![ambiguity_note.clone()]);
+
     let raw_score_difference = candidate_a.score.abs_diff(candidate_b.score);
-    assert_eq!(raw_score_difference, 0);
-    assert_eq!(AnalyzeOptions::default().confidence.ambiguity_score_gap, 4);
-    assert!(raw_score_difference <= AnalyzeOptions::default().confidence.ambiguity_score_gap);
-    assert_ne!(candidate_a.confidence_notes, candidate_b.confidence_notes);
+    assert_eq!(raw_score_difference, 7);
+    assert!(candidate_a.score > candidate_b.score);
+    assert!(candidate_a.score.abs_diff(candidate_b.score) > 0);
+    assert!(
+        candidate_a.score.abs_diff(candidate_b.score) <= options.confidence.ambiguity_score_gap
+    );
+    assert!(
+        test_confidence_rank(candidate_b.confidence)
+            >= test_confidence_rank(candidate_a.confidence)
+    );
     assert_eq!(
         report.primary_suspect.kind,
-        DiagnosisKind::ApplicationQueueSaturation
-    );
-    assert_eq!(
-        report.secondary_suspects[0].kind,
         DiagnosisKind::DownstreamStageDominates
     );
+    assert_eq!(report.primary_suspect.score, 88);
+    assert_eq!(report.primary_suspect.confidence, Confidence::High);
     assert_eq!(
         report
             .secondary_suspects
             .iter()
             .map(|s| s.kind.clone())
             .collect::<Vec<_>>(),
-        vec![DiagnosisKind::DownstreamStageDominates]
+        vec![DiagnosisKind::ApplicationQueueSaturation]
     );
     assert_eq!(
         report.warnings,
@@ -460,10 +551,6 @@ fn ambiguity_remains_raw_score_based_after_confidence_reordering() {
             super::partial_evidence::PARTIAL_WARNING.to_string()
         ]
     );
-    for suspect in std::iter::once(&report.primary_suspect).chain(report.secondary_suspects.iter())
-    {
-        assert!(suspect.confidence_notes.contains(&note));
-    }
 }
 
 #[test]
@@ -534,8 +621,7 @@ fn candidate_order_is_stable_under_irrelevant_input_reordering() {
     assert_eq!(render_text(&a), render_text(&b));
 }
 
-#[test]
-fn global_route_and_temporal_share_final_confidence_ordering() {
+fn scoped_flip_report() -> Report {
     let mut run = cap_flip_run();
     for (i, req) in run.requests.iter_mut().enumerate() {
         req.route = if i < 23 { "/completed" } else { "/partial" }.into();
@@ -562,7 +648,12 @@ fn global_route_and_temporal_share_final_confidence_ordering() {
             o.min_request_count = 20;
             o.min_segment_request_count = 10;
         });
-    let report = analyze_run(&run, options);
+    analyze_run(&run, options)
+}
+
+#[test]
+fn global_route_and_temporal_share_final_confidence_ordering() {
+    let report = scoped_flip_report();
     assert_eq!(report.route_breakdowns.len(), 2);
     assert_eq!(report.temporal_segments.len(), 2);
     assert_eq!(
@@ -593,12 +684,22 @@ fn global_route_and_temporal_share_final_confidence_ordering() {
         .iter()
         .find(|r| r.route == "/partial")
         .unwrap();
+    let completed_evidence = scoped_evidence(500, 23, 11500, 92);
     assert_scoped_flip(
         &completed.primary_suspect,
         &completed.secondary_suspects,
         86,
+        &completed_evidence.0,
+        &completed_evidence.1,
     );
-    assert_scoped_flip(&partial.primary_suspect, &partial.secondary_suspects, 86);
+    let partial_evidence = scoped_evidence(1000, 22, 22000, 92);
+    assert_scoped_flip(
+        &partial.primary_suspect,
+        &partial.secondary_suspects,
+        86,
+        &partial_evidence.0,
+        &partial_evidence.1,
+    );
     assert_eq!(
         completed.warnings,
         vec![ROUTE_RUNTIME_ATTRIBUTION_WARNING.to_string()]
@@ -618,8 +719,22 @@ fn global_route_and_temporal_share_final_confidence_ordering() {
         .iter()
         .find(|s| s.name == "late")
         .unwrap();
-    assert_scoped_flip(&early.primary_suspect, &early.secondary_suspects, 86);
-    assert_scoped_flip(&late.primary_suspect, &late.secondary_suspects, 86);
+    let early_evidence = scoped_evidence(500, 22, 11000, 92);
+    assert_scoped_flip(
+        &early.primary_suspect,
+        &early.secondary_suspects,
+        86,
+        &early_evidence.0,
+        &early_evidence.1,
+    );
+    let late_evidence = scoped_evidence(1000, 23, 22500, 92);
+    assert_scoped_flip(
+        &late.primary_suspect,
+        &late.secondary_suspects,
+        86,
+        &late_evidence.0,
+        &late_evidence.1,
+    );
     assert!(early.warnings.is_empty());
     assert!(late.warnings.is_empty());
 }

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -369,6 +369,50 @@ fn scoped_evidence(
 }
 
 #[test]
+fn ambiguity_cluster_membership_uses_raw_scores_only() {
+    let options = AnalyzeOptions::default().with_confidence(|o| {
+        o.ambiguity_min_score = 90;
+        o.ambiguity_score_gap = 4;
+    });
+    let candidates = vec![
+        literal_scored(
+            DiagnosisKind::ApplicationQueueSaturation,
+            95,
+            Confidence::Low,
+        ),
+        literal_scored(
+            DiagnosisKind::DownstreamStageDominates,
+            92,
+            Confidence::High,
+        ),
+        literal_scored(DiagnosisKind::BlockingPoolPressure, 70, Confidence::High),
+        literal_scored(DiagnosisKind::InsufficientEvidence, 100, Confidence::High),
+    ];
+    let expected = vec![
+        DiagnosisKind::ApplicationQueueSaturation,
+        DiagnosisKind::DownstreamStageDominates,
+    ];
+    let permutations = vec![
+        candidates.clone(),
+        candidates.iter().cloned().rev().collect::<Vec<_>>(),
+        vec![
+            candidates[2].clone(),
+            candidates[0].clone(),
+            candidates[3].clone(),
+            candidates[1].clone(),
+        ],
+    ];
+
+    for permutation in permutations {
+        let cluster = super::confidence::ambiguity_cluster_indices(&permutation, &options)
+            .into_iter()
+            .map(|idx| permutation[idx].suspect.kind.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(cluster, expected);
+    }
+}
+
+#[test]
 fn evidence_cap_can_promote_lower_raw_score_candidate() {
     let report = analyze_run(&cap_flip_run(), AnalyzeOptions::default());
     assert_eq!(
@@ -449,41 +493,31 @@ fn cap_induced_primary_flip_has_exact_text() {
 }
 
 #[test]
-fn ambiguity_remains_raw_score_based_after_confidence_reordering() {
+fn raw_score_ambiguity_caps_all_cluster_members_uniformly() {
     let mut run = cap_flip_run();
     for stage in &mut run.stages {
-        stage.latency_us = 500;
-        stage.finished_at_run_us = stage.started_at_run_us.map(|s| s + 500);
+        stage.latency_us = 900;
+        stage.finished_at_run_us = stage.started_at_run_us.map(|s| s + 900);
     }
-    let options = AnalyzeOptions::default().with_confidence(|o| {
-        o.ambiguity_score_gap = 7;
-        o.ambiguity_min_score = 88;
-    });
-    let report = analyze_run(&run, options.clone());
+    let report = analyze_run(&run, AnalyzeOptions::default());
     let warning = "Top suspects are close in score; treat ranking as ambiguous and validate both with next checks.".to_string();
     let ambiguity_note =
         "Top suspects are close in score; confidence is capped by ambiguity.".to_string();
     let partial_queue_note = super::partial_evidence::PARTIAL_QUEUE_CONFIDENCE_NOTE.to_string();
 
-    let candidate_a = report
-        .secondary_suspects
-        .iter()
-        .find(|s| s.kind == DiagnosisKind::ApplicationQueueSaturation)
-        .unwrap();
-    let candidate_b = &report.primary_suspect;
-
-    assert_eq!(options.confidence.ambiguity_score_gap, 7);
-    assert_eq!(options.confidence.ambiguity_min_score, 88);
-    assert_eq!(candidate_a.kind, DiagnosisKind::ApplicationQueueSaturation);
-    assert_eq!(candidate_a.score, 95);
-    assert_eq!(candidate_a.confidence, Confidence::Medium);
-    assert_eq!(candidate_a.evidence, vec![
+    assert_eq!(
+        report.primary_suspect.kind,
+        DiagnosisKind::ApplicationQueueSaturation
+    );
+    assert_eq!(report.primary_suspect.score, 95);
+    assert_eq!(report.primary_suspect.confidence, Confidence::Medium);
+    assert_eq!(report.primary_suspect.evidence, vec![
         "Completed-only queue wait at p95 is 0.0% of request time.".to_string(),
         "Observed queue-wait lower bound at p95 is 92.0% of request time and includes 45 partial queue event(s).".to_string(),
         "Observed queue depth sample up to 20.".to_string(),
     ]);
     assert_eq!(
-        candidate_a.next_checks,
+        report.primary_suspect.next_checks,
         vec![
             "Inspect queue admission limits and producer burst patterns.".to_string(),
             "Compare queue wait distribution before and after increasing worker parallelism."
@@ -491,24 +525,25 @@ fn ambiguity_remains_raw_score_based_after_confidence_reordering() {
         ]
     );
     assert_eq!(
-        candidate_a.confidence_notes,
+        report.primary_suspect.confidence_notes,
         vec![partial_queue_note.clone(), ambiguity_note.clone()]
     );
 
-    assert_eq!(candidate_b.kind, DiagnosisKind::DownstreamStageDominates);
-    assert_eq!(candidate_b.score, 88);
-    assert_eq!(candidate_b.confidence, Confidence::High);
+    let secondary = &report.secondary_suspects[0];
+    assert_eq!(secondary.kind, DiagnosisKind::DownstreamStageDominates);
+    assert_eq!(secondary.score, 95);
+    assert_eq!(secondary.confidence, Confidence::Medium);
     assert_eq!(
-        candidate_b.evidence,
+        secondary.evidence,
         vec![
-            "Stage 'db' has p95 latency 500 us across 45 samples.".to_string(),
-            "Stage 'db' cumulative latency is 22500 us (500 permille of request latency)."
+            "Stage 'db' has p95 latency 900 us across 45 samples.".to_string(),
+            "Stage 'db' cumulative latency is 40500 us (900 permille of request latency)."
                 .to_string(),
-            "Stage 'db' contributes 500 permille of tail request latency.".to_string(),
+            "Stage 'db' contributes 900 permille of tail request latency.".to_string(),
         ]
     );
     assert_eq!(
-        candidate_b.next_checks,
+        secondary.next_checks,
         vec![
             "Inspect downstream dependency behind stage 'db'.".to_string(),
             "Collect downstream service timings and retry behavior during tail windows."
@@ -517,32 +552,14 @@ fn ambiguity_remains_raw_score_based_after_confidence_reordering() {
                 .to_string(),
         ]
     );
-    assert_eq!(candidate_b.confidence_notes, vec![ambiguity_note.clone()]);
-
-    let raw_score_difference = candidate_a.score.abs_diff(candidate_b.score);
-    assert_eq!(raw_score_difference, 7);
-    assert!(candidate_a.score > candidate_b.score);
-    assert!(candidate_a.score.abs_diff(candidate_b.score) > 0);
-    assert!(
-        candidate_a.score.abs_diff(candidate_b.score) <= options.confidence.ambiguity_score_gap
-    );
-    assert!(
-        test_confidence_rank(candidate_b.confidence)
-            >= test_confidence_rank(candidate_a.confidence)
-    );
-    assert_eq!(
-        report.primary_suspect.kind,
-        DiagnosisKind::DownstreamStageDominates
-    );
-    assert_eq!(report.primary_suspect.score, 88);
-    assert_eq!(report.primary_suspect.confidence, Confidence::High);
+    assert_eq!(secondary.confidence_notes, vec![ambiguity_note.clone()]);
     assert_eq!(
         report
             .secondary_suspects
             .iter()
             .map(|s| s.kind.clone())
             .collect::<Vec<_>>(),
-        vec![DiagnosisKind::ApplicationQueueSaturation]
+        vec![DiagnosisKind::DownstreamStageDominates]
     );
     assert_eq!(
         report.warnings,
@@ -551,6 +568,16 @@ fn ambiguity_remains_raw_score_based_after_confidence_reordering() {
             super::partial_evidence::PARTIAL_WARNING.to_string()
         ]
     );
+
+    for suspect in std::iter::once(&report.primary_suspect).chain(report.secondary_suspects.iter())
+    {
+        assert_eq!(suspect.confidence, Confidence::Medium);
+        assert!(suspect.confidence_notes.contains(&ambiguity_note));
+        assert!(
+            !(suspect.confidence == Confidence::High
+                && suspect.confidence_notes.contains(&ambiguity_note))
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
### Motivation

* Primary selection must occur only after every candidate has received its final evidence-adjusted confidence so ranking reflects evidence quality rather than pre-sort position.
* Remove position-sensitive confidence logic, including `i == 0`, that could make confidence depend on provisional ordering.
* Preserve raw-score-based ambiguity semantics while allowing evidence caps to promote a lower-raw-score candidate when it retains stronger final confidence.
* Keep the public `Report` shape, raw `Suspect.score`, and Prompt 10 partial-evidence behavior unchanged.

### Description

* Add a shared finalization pipeline in `finalize_scored_suspects`:

  * compute base confidence for every candidate;
  * apply candidate-local evidence-aware confidence caps;
  * apply uniform raw-score ambiguity caps;
  * sort the finalized candidates;
  * return the final `Vec<Suspect>` used by global, route, and temporal reports.
* Add deterministic suspect ordering through:

  1. final confidence descending;
  2. unchanged raw score descending;
  3. stable diagnosis-kind rank ascending.
* Keep `InsufficientEvidence` after all eligible diagnosis candidates.
* Remove ranking-sensitive primary-position checks from confidence adjustment.
* Apply low-request, truncation, missing-instrumentation, and partial-evidence caps independently to every applicable candidate.
* Keep ambiguity membership based only on raw scores:

  * exclude `InsufficientEvidence`;
  * require the configured minimum score;
  * include candidates within the configured raw-score gap of the raw-score leader.
* Apply the ambiguity confidence cap uniformly to every non-insufficient candidate in the ambiguity cluster.
* Generate warnings after final candidate confidence and ordering are resolved.
* Use the same finalized ordering for global results, route breakdowns, and temporal segments.
* Update the specification, design notes, changelog, root README, and analyzer README to document the confidence-first deterministic ordering contract.

### Testing

Added and strengthened regression coverage for:

* `final_confidence_ranking_selects_primary_before_raw_score`

  * verifies final confidence outranks raw score;
  * verifies `InsufficientEvidence` remains last;
  * verifies deterministic results across multiple input permutations.
* `final_confidence_ties_break_by_raw_score_then_kind`

  * verifies raw score resolves equal-confidence candidates;
  * verifies stable diagnosis-kind rank resolves exact confidence-and-score ties.
* `evidence_cap_can_promote_lower_raw_score_candidate`

  * verifies a completed downstream-stage candidate at score `88` and `High` confidence becomes primary over a partial queue candidate at score `95` and `Medium` confidence;
  * verifies exact evidence, next checks, confidence notes, warnings, and final order.
* `cap_induced_primary_flip_has_exact_json`

  * verifies the complete compact JSON output against a hard-coded expected result.
* `cap_induced_primary_flip_has_exact_text`

  * verifies the complete text output against a hard-coded expected result.
* `ambiguity_cluster_membership_uses_raw_scores_only`

  * verifies ambiguity membership ignores candidate confidence values;
  * verifies `InsufficientEvidence` and candidates outside the raw-score gap are excluded;
  * verifies identical membership across multiple candidate permutations.
* `raw_score_ambiguity_caps_all_cluster_members_uniformly`

  * verifies all raw-score ambiguity-cluster members receive the same ambiguity cap;
  * verifies all capped members receive the ambiguity note;
  * verifies partial-evidence notes remain attached only to the applicable candidate.
* `equal_final_confidence_without_raw_score_proximity_is_not_ambiguous`

  * verifies equal final-confidence buckets do not create ambiguity when raw scores are outside the configured gap.
* `global_route_and_temporal_share_final_confidence_ordering`

  * verifies the public analysis path produces exactly two route breakdowns and two temporal segments;
  * verifies exact scoped candidate order, scores, confidence, evidence, next checks, confidence notes, and warnings.
* `candidate_order_is_stable_under_irrelevant_input_reordering`

  * verifies identical primary suspects, secondary suspects, warnings, route breakdowns, temporal segments, compact JSON, and text after irrelevant event reordering.

Local validation on the final branch:

* `cargo fmt --check`: **[PASS/FAIL — insert exact result]**
* `cargo clippy -p tailtriage-analyzer --all-targets --all-features --locked -- -D warnings`: **[PASS/FAIL — insert exact result]**
* `cargo test -p tailtriage-analyzer --all-targets --all-features --locked`: **[PASS/FAIL — insert exact result and test count]**
* Focused confidence-ordering and ambiguity tests: **[PASS/FAIL — insert exact result]**
* `python3 scripts/validate_docs_contracts.py`: **[PASS/FAIL — insert exact result]**
* `python3 -m unittest scripts.tests.test_validate_docs_contracts`: **[PASS/FAIL — insert exact result]**
* `python3 -m unittest scripts.tests.test_diagnostic_benchmark`: **[PASS/FAIL — insert exact result]**
* `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0`: **[PASS/FAIL — insert exact result]**
* `python3 scripts/check_demo_fixture_drift.py --profile dev`: **[PASS/FAIL — insert exact result]**

No CI or GitHub Actions results are asserted in this description.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6247340370833090a5254f7d5a351a)