### PR TITLE
Select latest in-flight activity episode deterministically

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -206,6 +206,15 @@ Direct capture lifecycle output options:
 
 Analyzer output includes:
 
+- `inflight_trend` summarizes the selected label's latest retained activity episode. Positive
+  samples start or continue an episode; the first retained zero closes it, and later positive
+  activity starts a new episode. Active episodes outrank closed historical episodes. Sample
+  count, peak, p95, and delta are episode-local. A one-sample episode has unknown direction
+  while retaining `growth_delta = 0` for compatibility. Precise rates use only valid
+  run-relative microsecond timing; `null` means unavailable, and Unix milliseconds are only a
+  coarse ordering fallback. Truncation never causes analysis to invent a missing closure.
+  Growth supports a triage lead and is not root-cause proof.
+
 - request count
 - p50/p95/p99 request latency
 - p95 queue/service share summaries

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -57,7 +57,15 @@ Each suspect includes:
 - `evidence_quality`: structured signal coverage status, truncation counters, and overall evidence quality (`strong`/`partial`/`weak`).
 - `primary_suspect`: highest-ranked suspect with evidence and next checks.
 - `secondary_suspects[]`: additional ranked suspects.
-- `inflight_trend` (optional): dominant in-flight gauge trend summary when snapshots exist.
+- `inflight_trend` (optional): the selected gauge's latest retained activity-episode summary.
+  Positive samples open or continue an episode, the first retained zero closes it, and a later
+  positive sample starts a new episode. Active latest episodes outrank closed historical ones.
+  `sample_count` (including a terminal zero), peak, p95, and `growth_delta` are episode-local.
+  One sample has unknown direction even though `growth_delta` is represented as `0` for
+  compatibility. `growth_per_sec_milli` uses only valid run-relative microsecond timing;
+  `null` means a precise rate was unavailable. Unix milliseconds are only a coarse ordering
+  fallback and never produce a rate. Truncation can hide a zero transition, so analysis does
+  not fabricate closure. Growth remains supporting triage evidence, not root-cause proof.
 - `route_breakdowns`: always present and usually empty. It is populated only when at least two captured routes have enough completed requests and route-level context adds signal (for example, different route-level primary suspects or a large route p95 latency spread). Route breakdowns are supporting context only; global `primary_suspect` remains the primary full-run triage lead. Route breakdowns use route-attributed request, queue, and stage events. Runtime snapshots and in-flight gauges are global signals and are intentionally not attributed to individual routes. Route-level summaries do not prove per-route root cause.
 - `temporal_segments`: always present and usually empty. It is populated only when conservative within-run early/late checks detect material signal movement (for example suspect-kind shifts or large p95 movement). Temporal segments are supporting within-run hints only; global `primary_suspect` remains the full-run triage lead. A temporal p95 warning means early/late request latency changed materially within the run. Temporal segments do not prove phase-specific root cause. Runtime and in-flight phase attribution is timestamp-filtered to each segment window and is limited when segment-filtered samples are sparse; when early/late windows overlap under concurrent requests, timestamp-filtered runtime/in-flight attribution is approximate.
 

--- a/tailtriage-analyzer/README.md
+++ b/tailtriage-analyzer/README.md
@@ -14,6 +14,20 @@ Use this crate when you already have a completed `tailtriage_core::Run` in memor
 
 Suspects are investigation leads, not proof of root cause.
 
+### In-flight activity episodes
+
+`inflight_trend` summarizes the selected gauge's latest retained activity episode, not its
+full history. A positive sample starts an episode, the first retained zero closes it, and a
+later positive sample starts a new episode. Active latest episodes outrank closed historical
+episodes; sample count, peak, p95, and delta are episode-local.
+
+Complete run-relative microsecond timestamps are the only basis for
+`growth_per_sec_milli`. If any timestamp is missing, Unix milliseconds provide only a coarse
+ordering fallback and the rate is `null`. A `null` rate otherwise means a precise rate was
+unavailable. With one sample, direction is unknown even though `growth_delta` is represented
+as `0` for compatibility. Truncation can hide a zero; the analyzer does not invent closure.
+Growth is supporting triage evidence, not root-cause proof.
+
 `tailtriage-analyzer` accepts any `tailtriage_core::Run` value. It is intended for completed/finalized captures or stable snapshots; callers that require finalized artifacts should validate that separately.
 
 ## Installation

--- a/tailtriage-analyzer/src/lib.rs
+++ b/tailtriage-analyzer/src/lib.rs
@@ -333,20 +333,21 @@ impl Suspect {
     }
 }
 
-/// Summary of one dominant in-flight gauge trend over the run window.
+/// Summary of the selected gauge's latest retained in-flight activity episode.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct InflightTrend {
     /// Gauge name chosen as the dominant trend candidate.
     pub gauge: String,
-    /// Number of snapshots seen for this gauge.
+    /// Number of retained snapshots in the episode, including a terminal zero.
     pub sample_count: usize,
-    /// Peak in-flight count observed for this gauge.
+    /// Peak in-flight count observed in the episode.
     pub peak_count: u64,
-    /// p95 in-flight count for this gauge.
+    /// p95 in-flight count for the episode.
     pub p95_count: u64,
-    /// Net growth (`last - first`) across the sampled run window.
+    /// Episode-local net growth (`last - first`). With fewer than two samples,
+    /// zero represents unknown direction rather than observed flatness.
     pub growth_delta: i64,
-    /// Growth rate in milli-counts/sec, if timestamps permit calculation.
+    /// Growth rate in milli-counts/sec when valid run-relative microsecond timing permits it.
     pub growth_per_sec_milli: Option<i64>,
 }
 
@@ -717,7 +718,10 @@ fn analyze_run_internal(run: &Run, options: &AnalyzeOptions) -> Report {
     let request_time_shares = request_time_shares(run);
     let p95_queue_share_permille = percentile(&request_time_shares.completed_queue, 95, 100);
     let p95_service_share_permille = percentile(&request_time_shares.completed_service, 95, 100);
-    let inflight_trend = dominant_inflight_trend(&run.inflight);
+    let inflight_candidate = dominant_inflight_candidate(&run.inflight);
+    let inflight_trend = inflight_candidate
+        .as_ref()
+        .map(|candidate| candidate.trend.clone());
 
     let mut suspects = Vec::new();
 
@@ -725,7 +729,7 @@ fn analyze_run_internal(run: &Run, options: &AnalyzeOptions) -> Report {
         run,
         &request_time_shares.completed_queue,
         &request_time_shares.observed_queue,
-        inflight_trend.as_ref(),
+        inflight_candidate.as_ref(),
         options,
     ) {
         suspects.push(queue_suspect);
@@ -739,7 +743,7 @@ fn analyze_run_internal(run: &Run, options: &AnalyzeOptions) -> Report {
     }
 
     if let Some(executor_suspect) =
-        scoring::executor_pressure_suspect(run, inflight_trend.as_ref(), options)
+        scoring::executor_pressure_suspect(run, inflight_candidate.as_ref(), options)
     {
         suspects.push(ScoredSuspect {
             suspect: executor_suspect,
@@ -1006,64 +1010,150 @@ fn runtime_metric_series(
     snapshots.iter().filter_map(selector).collect::<Vec<_>>()
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum InflightOrdering {
+    RunRelative,
+    UnixFallback,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct InflightCandidate {
+    pub(crate) trend: InflightTrend,
+    active: bool,
+    pub(crate) ordering: InflightOrdering,
+}
+
+impl InflightCandidate {
+    pub(crate) fn known_positive_growth(&self) -> bool {
+        self.trend.sample_count >= 2 && self.trend.growth_delta > 0
+    }
+}
+
+#[cfg(test)]
 fn dominant_inflight_trend(snapshots: &[InFlightSnapshot]) -> Option<InflightTrend> {
-    let mut by_gauge: BTreeMap<&str, Vec<&InFlightSnapshot>> = BTreeMap::new();
-    for snapshot in snapshots {
+    dominant_inflight_candidate(snapshots).map(|candidate| candidate.trend)
+}
+
+fn dominant_inflight_candidate(snapshots: &[InFlightSnapshot]) -> Option<InflightCandidate> {
+    let mut by_gauge: BTreeMap<&str, Vec<(usize, &InFlightSnapshot)>> = BTreeMap::new();
+    for (index, snapshot) in snapshots.iter().enumerate() {
         by_gauge
             .entry(snapshot.gauge.as_str())
             .or_default()
-            .push(snapshot);
+            .push((index, snapshot));
     }
 
     by_gauge
         .into_iter()
         .filter_map(|(gauge, samples)| inflight_trend_for_gauge(gauge, samples))
-        .max_by(|left, right| {
-            left.peak_count
-                .cmp(&right.peak_count)
-                .then_with(|| left.p95_count.cmp(&right.p95_count))
-                .then_with(|| left.gauge.cmp(&right.gauge).reverse())
-        })
+        .max_by(compare_inflight_candidates)
 }
 
 fn inflight_trend_for_gauge(
     gauge: &str,
-    mut samples: Vec<&InFlightSnapshot>,
-) -> Option<InflightTrend> {
+    mut samples: Vec<(usize, &InFlightSnapshot)>,
+) -> Option<InflightCandidate> {
     if samples.is_empty() {
         return None;
     }
 
-    samples.sort_unstable_by(|left, right| {
-        left.at_unix_ms
-            .cmp(&right.at_unix_ms)
-            .then_with(|| left.count.cmp(&right.count))
-    });
-
-    let counts = samples
-        .iter()
-        .map(|sample| sample.count)
-        .collect::<Vec<_>>();
-    let first = samples.first()?;
-    let last = samples.last()?;
-    let growth_delta = signed_u64_delta(first.count, last.count);
-    let window_ms = last.at_unix_ms.saturating_sub(first.at_unix_ms);
-    let growth_per_sec_milli = if window_ms == 0 {
-        None
+    let ordering = if samples.iter().all(|(_, sample)| sample.at_run_us.is_some()) {
+        samples.sort_by_key(|(index, sample)| (sample.at_run_us.unwrap_or(0), *index));
+        InflightOrdering::RunRelative
     } else {
-        i64::try_from(window_ms)
-            .ok()
-            .map(|window_ms_i64| growth_delta.saturating_mul(1_000_000) / window_ms_i64)
+        samples.sort_by_key(|(index, sample)| (sample.at_unix_ms, *index));
+        InflightOrdering::UnixFallback
     };
 
-    Some(InflightTrend {
-        gauge: gauge.to_owned(),
-        sample_count: counts.len(),
-        peak_count: counts.iter().copied().max().unwrap_or(0),
-        p95_count: percentile(&counts, 95, 100).unwrap_or(0),
-        growth_delta,
-        growth_per_sec_milli,
+    let mut latest = Vec::new();
+    let mut open = false;
+    for sample in samples {
+        if sample.1.count > 0 {
+            if !open {
+                latest.clear();
+                open = true;
+            }
+            latest.push(sample);
+        } else if open {
+            latest.push(sample);
+            open = false;
+        }
+    }
+    if latest.is_empty() {
+        return None;
+    }
+
+    let counts = latest
+        .iter()
+        .map(|(_, sample)| sample.count)
+        .collect::<Vec<_>>();
+    let first = latest.first()?.1;
+    let last = latest.last()?.1;
+    let growth_delta = signed_u64_delta(first.count, last.count);
+    let growth_per_sec_milli = (latest.len() >= 2 && ordering == InflightOrdering::RunRelative)
+        .then(|| {
+            let times = latest
+                .iter()
+                .map(|(_, sample)| sample.at_run_us.unwrap_or(0))
+                .collect::<Vec<_>>();
+            let elapsed = times.last()?.checked_sub(*times.first()?)?;
+            if elapsed == 0 || !times.windows(2).all(|pair| pair[0] <= pair[1]) {
+                return None;
+            }
+            let rate = i128::from(growth_delta) * 1_000_000_000i128 / i128::from(elapsed);
+            Some(
+                i64::try_from(rate.clamp(i128::from(i64::MIN), i128::from(i64::MAX)))
+                    .expect("clamped growth rate fits i64"),
+            )
+        })
+        .flatten();
+
+    Some(InflightCandidate {
+        active: last.count > 0,
+        ordering,
+        trend: InflightTrend {
+            gauge: gauge.to_owned(),
+            sample_count: counts.len(),
+            peak_count: counts.iter().copied().max().unwrap_or(0),
+            p95_count: percentile(&counts, 95, 100).unwrap_or(0),
+            growth_delta,
+            growth_per_sec_milli,
+        },
     })
+}
+
+fn compare_inflight_candidates(
+    left: &InflightCandidate,
+    right: &InflightCandidate,
+) -> std::cmp::Ordering {
+    let left_positive = left.known_positive_growth();
+    let right_positive = right.known_positive_growth();
+    left.active
+        .cmp(&right.active)
+        .then_with(|| left_positive.cmp(&right_positive))
+        .then_with(|| {
+            if left_positive && right_positive {
+                left.trend.growth_delta.cmp(&right.trend.growth_delta)
+            } else {
+                std::cmp::Ordering::Equal
+            }
+        })
+        .then_with(|| {
+            if left_positive
+                && right_positive
+                && left.trend.growth_delta == right.trend.growth_delta
+            {
+                left.trend
+                    .growth_per_sec_milli
+                    .filter(|rate| *rate > 0)
+                    .cmp(&right.trend.growth_per_sec_milli.filter(|rate| *rate > 0))
+            } else {
+                std::cmp::Ordering::Equal
+            }
+        })
+        .then_with(|| left.trend.p95_count.cmp(&right.trend.p95_count))
+        .then_with(|| left.trend.peak_count.cmp(&right.trend.peak_count))
+        .then_with(|| left.trend.gauge.cmp(&right.trend.gauge).reverse())
 }
 
 fn signed_u64_delta(start: u64, end: u64) -> i64 {

--- a/tailtriage-analyzer/src/render.rs
+++ b/tailtriage-analyzer/src/render.rs
@@ -44,16 +44,7 @@ pub fn render_text(report: &Report) -> String {
     ];
 
     match &report.inflight_trend {
-        Some(trend) => {
-            lines.push(format!(
-                "Inflight trend: gauge '{}', samples {}, peak {}, p95 {}, net growth {:+}",
-                trend.gauge,
-                trend.sample_count,
-                trend.peak_count,
-                trend.p95_count,
-                trend.growth_delta,
-            ));
-        }
+        Some(trend) => lines.push(render_inflight_trend(trend)),
         None => lines.push("Inflight trend: none".to_string()),
     }
 
@@ -128,6 +119,22 @@ pub fn render_text(report: &Report) -> String {
     }
     append_temporal_segment_text(&mut lines, &report.temporal_segments);
     lines.join("\n")
+}
+
+fn render_inflight_trend(trend: &crate::InflightTrend) -> String {
+    let direction = if trend.sample_count < 2 {
+        "direction unknown".to_string()
+    } else {
+        format!("net growth {:+}", trend.growth_delta)
+    };
+    let rate = trend.growth_per_sec_milli.map_or_else(
+        || "precise rate unavailable".to_string(),
+        |rate| format!("run-relative rate {rate} milli-counts/sec"),
+    );
+    format!(
+        "Inflight latest activity episode: gauge '{}', samples {}, peak {}, p95 {}, {}, {}",
+        trend.gauge, trend.sample_count, trend.peak_count, trend.p95_count, direction, rate,
+    )
 }
 
 fn append_temporal_segment_text(lines: &mut Vec<String>, segments: &[TemporalSegment]) {

--- a/tailtriage-analyzer/src/scoring.rs
+++ b/tailtriage-analyzer/src/scoring.rs
@@ -3,7 +3,7 @@ use tailtriage_core::Run;
 use crate::{
     partial_evidence::{EvidenceBasis, PartialEvidenceProfile, ScoredSuspect},
     percentile, runtime_metric_series, stage_attribution, AnalyzeOptions, DiagnosisKind,
-    InflightTrend, Suspect,
+    InflightCandidate, InflightOrdering, Suspect,
 };
 
 const SAMPLE_QUALITY_HIGH_SAMPLE_COUNT: usize = 100;
@@ -32,7 +32,7 @@ pub(super) fn queue_saturation_suspect(
     run: &Run,
     completed_queue_shares: &[u64],
     observed_queue_shares: &[u64],
-    inflight_trend: Option<&InflightTrend>,
+    inflight_trend: Option<&InflightCandidate>,
     options: &AnalyzeOptions,
 ) -> Option<ScoredSuspect> {
     let completed_p95 = percentile(completed_queue_shares, 95, 100);
@@ -65,7 +65,7 @@ fn queue_candidate(
     queue_shares: &[u64],
     completed_only: bool,
     completed_queue_p95_permille: Option<u64>,
-    inflight_trend: Option<&InflightTrend>,
+    inflight_trend: Option<&InflightCandidate>,
     options: &AnalyzeOptions,
 ) -> Option<ScoredSuspect> {
     let p95_queue_share_permille = percentile(queue_shares, 95, 100)?;
@@ -80,14 +80,14 @@ fn queue_candidate(
         .collect::<Vec<_>>();
     let max_depth = max_or_zero(&queue_depths);
     let growth_bonus = inflight_trend
-        .filter(|t| t.growth_delta > 0)
+        .filter(|t| t.known_positive_growth())
         .map_or(0, |_| 5);
     let depth_bonus = (max_depth.min(40) * 2) / 3;
     let base = score_from_permille(22, p95_queue_share_permille, 14);
     let clean_extreme = p95_queue_share_permille >= 985
         && max_depth >= 12
         && queue_shares.len() >= 20
-        && inflight_trend.is_some_and(|t| t.growth_delta > 0);
+        && inflight_trend.is_some_and(InflightCandidate::known_positive_growth);
     let score = cap_unless_clean_evidence(
         base + depth_bonus + growth_bonus + u64::from(score_sample_quality(queue_shares.len())),
         clean_extreme,
@@ -120,11 +120,8 @@ fn queue_candidate(
     if max_depth > 0 {
         evidence.push(format!("Observed queue depth sample up to {max_depth}."));
     }
-    if let Some(trend) = inflight_trend.filter(|trend| trend.growth_delta > 0) {
-        evidence.push(format!(
-            "In-flight gauge '{}' grew by {} over the run window (p95={}, peak={}).",
-            trend.gauge, trend.growth_delta, trend.p95_count, trend.peak_count
-        ));
+    if let Some(trend) = inflight_trend.filter(|trend| trend.known_positive_growth()) {
+        evidence.push(inflight_growth_evidence(trend));
     }
     Some(ScoredSuspect {
         suspect: suspect(
@@ -240,7 +237,7 @@ pub(super) fn blocking_pressure_suspect(run: &Run, options: &AnalyzeOptions) -> 
 
 pub(super) fn executor_pressure_suspect(
     run: &Run,
-    inflight_trend: Option<&InflightTrend>,
+    inflight_trend: Option<&InflightCandidate>,
     options: &AnalyzeOptions,
 ) -> Option<Suspect> {
     let global = runtime_metric_series(&run.runtime_snapshots, |s| s.global_queue_depth);
@@ -251,7 +248,7 @@ pub(super) fn executor_pressure_suspect(
     let local = runtime_metric_series(&run.runtime_snapshots, |s| s.local_queue_depth);
     let alive = runtime_metric_series(&run.runtime_snapshots, |s| s.alive_tasks);
     let growth_bonus = inflight_trend
-        .filter(|t| t.growth_delta > 0)
+        .filter(|t| t.known_positive_growth())
         .map_or(0, |_| 4);
     let clean_extreme = p95_global >= 140 && global.len() >= 30;
     let score = cap_unless_clean_evidence(
@@ -272,6 +269,9 @@ pub(super) fn executor_pressure_suspect(
     if let Some(ap95) = percentile(&alive, 95, 100) {
         evidence.push(format!("Runtime alive_tasks p95 is {ap95}."));
     }
+    if let Some(trend) = inflight_trend.filter(|trend| trend.known_positive_growth()) {
+        evidence.push(inflight_growth_evidence(trend));
+    }
     Some(suspect(
         DiagnosisKind::ExecutorPressureSuspected,
         score,
@@ -282,6 +282,24 @@ pub(super) fn executor_pressure_suspect(
         ],
         options,
     ))
+}
+
+fn inflight_growth_evidence(candidate: &InflightCandidate) -> String {
+    let trend = &candidate.trend;
+    match (candidate.ordering, trend.growth_per_sec_milli) {
+        (_, Some(rate)) => format!(
+            "In-flight gauge '{}' latest active episode grew by {} across {} samples (p95={}, peak={}, run-relative rate={} milli-counts/sec).",
+            trend.gauge, trend.growth_delta, trend.sample_count, trend.p95_count, trend.peak_count, rate
+        ),
+        (InflightOrdering::UnixFallback, None) => format!(
+            "In-flight gauge '{}' latest active episode grew by {} across {} samples (p95={}, peak={}); ordering used Unix-ms fallback and no precise growth rate was derived.",
+            trend.gauge, trend.growth_delta, trend.sample_count, trend.p95_count, trend.peak_count
+        ),
+        (InflightOrdering::RunRelative, None) => format!(
+            "In-flight gauge '{}' latest active episode grew by {} across {} samples (p95={}, peak={}); precise run-relative growth rate is unavailable.",
+            trend.gauge, trend.growth_delta, trend.sample_count, trend.p95_count, trend.peak_count
+        ),
+    }
 }
 
 #[derive(Clone)]

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -1819,17 +1819,18 @@ fn inflight_candidate_order_prefers_larger_positive_rate() {
 
 #[test]
 fn inflight_candidate_order_prefers_larger_p95() {
-    let samples = [
-        inflight("high-p95", 1, Some(1), 8),
-        inflight("high-p95", 2, Some(2), 8),
-        inflight("low-p95", 1, Some(1), 7),
-        inflight("low-p95", 2, Some(2), 7),
-    ];
+    let mut samples = (1..=21)
+        .map(|time| inflight("high-p95", time, Some(time), 8))
+        .collect::<Vec<_>>();
+
+    samples.push(inflight("low-p95-high-peak", 1, Some(1), 100));
+    samples.extend((2..=21).map(|time| inflight("low-p95-high-peak", time, Some(time), 1)));
+
     assert_dominant_inflight(
         &samples,
         InflightTrend {
             gauge: "high-p95".into(),
-            sample_count: 2,
+            sample_count: 21,
             peak_count: 8,
             p95_count: 8,
             growth_delta: 0,

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -1529,7 +1529,324 @@ fn inflight_trend_handles_monotonic_increase() {
     assert_eq!(trend.peak_count, 6);
     assert_eq!(trend.p95_count, 6);
     assert_eq!(trend.growth_delta, 5);
-    assert_eq!(trend.growth_per_sec_milli, Some(250_000));
+    assert_eq!(trend.growth_per_sec_milli, None);
+}
+
+fn inflight(
+    gauge: &str,
+    unix: u64,
+    run_us: Option<u64>,
+    count: u64,
+) -> tailtriage_core::InFlightSnapshot {
+    tailtriage_core::InFlightSnapshot {
+        gauge: gauge.to_owned(),
+        at_unix_ms: unix,
+        at_run_us: run_us,
+        count,
+    }
+}
+
+#[test]
+fn latest_active_inflight_episode_outranks_closed_historical_spike() {
+    let trend = super::dominant_inflight_trend(&[
+        inflight("old", 1, Some(1_000_000), 1),
+        inflight("old", 2, Some(2_000_000), 20),
+        inflight("old", 3, Some(3_000_000), 0),
+        inflight("current", 4, Some(4_000_000), 1),
+        inflight("current", 5, Some(5_000_000), 2),
+        inflight("current", 6, Some(6_000_000), 4),
+    ])
+    .unwrap();
+    assert_eq!(
+        trend,
+        InflightTrend {
+            gauge: "current".into(),
+            sample_count: 3,
+            peak_count: 4,
+            p95_count: 4,
+            growth_delta: 3,
+            growth_per_sec_milli: Some(1500)
+        }
+    );
+}
+
+#[test]
+fn reused_inflight_label_uses_only_latest_episode() {
+    let counts = [1, 9, 0, 2, 3, 5];
+    let samples = counts
+        .into_iter()
+        .enumerate()
+        .map(|(i, count)| inflight("reuse", i as u64, Some(i as u64 * 1_000_000), count))
+        .collect::<Vec<_>>();
+    let trend = super::dominant_inflight_trend(&samples).unwrap();
+    assert_eq!(
+        (
+            trend.sample_count,
+            trend.peak_count,
+            trend.p95_count,
+            trend.growth_delta,
+            trend.growth_per_sec_milli
+        ),
+        (3, 5, 5, 3, Some(1500))
+    );
+}
+
+#[test]
+fn leading_and_consecutive_zero_snapshots_do_not_create_episodes() {
+    let samples = [0, 0, 2, 4, 0, 0, 3, 0]
+        .into_iter()
+        .enumerate()
+        .map(|(i, count)| inflight("g", i as u64, Some(i as u64), count))
+        .collect::<Vec<_>>();
+    let trend = super::dominant_inflight_trend(&samples).unwrap();
+    assert_eq!(
+        (trend.sample_count, trend.peak_count, trend.growth_delta),
+        (2, 3, -3)
+    );
+}
+
+#[test]
+fn all_zero_inflight_label_has_no_candidate() {
+    assert!(super::dominant_inflight_trend(&[
+        inflight("zero", 1, Some(1), 0),
+        inflight("zero", 2, Some(2), 0)
+    ])
+    .is_none());
+}
+
+#[test]
+fn run_relative_time_orders_inflight_samples_before_wall_clock() {
+    let trend = super::dominant_inflight_trend(&[
+        inflight("g", 30, Some(1), 2),
+        inflight("g", 10, Some(3), 7),
+        inflight("g", 20, Some(2), 4),
+    ])
+    .unwrap();
+    assert_eq!(
+        (trend.growth_delta, trend.growth_per_sec_milli),
+        (5, Some(2_500_000_000))
+    );
+}
+
+#[test]
+fn inflight_wall_clock_fallback_is_deterministic_without_rate() {
+    let trend = super::dominant_inflight_trend(&[
+        inflight("g", 30, Some(1), 5),
+        inflight("g", 10, None, 2),
+    ])
+    .unwrap();
+    assert_eq!((trend.growth_delta, trend.growth_per_sec_milli), (3, None));
+}
+
+#[test]
+fn distinct_timestamp_reordering_preserves_inflight_selection() {
+    let a = vec![
+        inflight("g", 3, Some(3), 5),
+        inflight("g", 1, Some(1), 1),
+        inflight("g", 2, Some(2), 3),
+    ];
+    let b = vec![a[1].clone(), a[0].clone(), a[2].clone()];
+    assert_eq!(
+        super::dominant_inflight_trend(&a),
+        super::dominant_inflight_trend(&b)
+    );
+}
+
+#[test]
+fn equal_timestamp_inflight_order_uses_original_input_index() {
+    let forward = super::dominant_inflight_trend(&[
+        inflight("g", 1, Some(1), 2),
+        inflight("g", 1, Some(1), 5),
+    ])
+    .unwrap();
+    let reverse = super::dominant_inflight_trend(&[
+        inflight("g", 1, Some(1), 5),
+        inflight("g", 1, Some(1), 2),
+    ])
+    .unwrap();
+    assert_eq!((forward.growth_delta, reverse.growth_delta), (3, -3));
+    assert_eq!(forward.growth_per_sec_milli, None);
+}
+
+#[test]
+fn one_sample_inflight_episode_is_unknown_and_adds_no_bonus() {
+    let trend = super::dominant_inflight_trend(&[inflight("single", 1, Some(1), 7)]).unwrap();
+    assert_eq!(
+        trend,
+        InflightTrend {
+            gauge: "single".into(),
+            sample_count: 1,
+            peak_count: 7,
+            p95_count: 7,
+            growth_delta: 0,
+            growth_per_sec_milli: None
+        }
+    );
+}
+
+#[test]
+fn inflight_candidate_order_prefers_rate_then_p95_peak_and_label() {
+    let samples = [
+        inflight("no-rate", 1, None, 1),
+        inflight("no-rate", 2, None, 4),
+        inflight("rate", 1, Some(1), 1),
+        inflight("rate", 2, Some(2_000_001), 4),
+    ];
+    assert_eq!(
+        super::dominant_inflight_trend(&samples).unwrap().gauge,
+        "rate"
+    );
+    let tied = [
+        inflight("z", 1, Some(1), 2),
+        inflight("z", 2, Some(2), 2),
+        inflight("a", 1, Some(1), 2),
+        inflight("a", 2, Some(2), 2),
+    ];
+    assert_eq!(super::dominant_inflight_trend(&tied).unwrap().gauge, "a");
+}
+
+#[test]
+fn truncated_inflight_history_does_not_infer_missing_zero() {
+    let mut run = test_run();
+    run.inflight = vec![
+        inflight("truncated", 1, Some(1), 2),
+        inflight("truncated", 2, Some(2), 3),
+    ];
+    run.truncation.dropped_inflight_snapshots = 1;
+    let trend = analyze_run(&run, AnalyzeOptions::default())
+        .inflight_trend
+        .unwrap();
+    assert_eq!((trend.sample_count, trend.growth_delta), (2, 1));
+}
+
+#[test]
+fn inflight_trend_json_shape_remains_unchanged() {
+    let value = serde_json::to_value(InflightTrend {
+        gauge: "g".into(),
+        sample_count: 3,
+        peak_count: 4,
+        p95_count: 4,
+        growth_delta: 3,
+        growth_per_sec_milli: Some(1500),
+    })
+    .unwrap();
+    let object = value.as_object().unwrap();
+    assert_eq!(
+        object.keys().cloned().collect::<Vec<_>>(),
+        [
+            "gauge",
+            "growth_delta",
+            "growth_per_sec_milli",
+            "p95_count",
+            "peak_count",
+            "sample_count"
+        ]
+    );
+    assert!(
+        object["gauge"].is_string()
+            && object["sample_count"].is_u64()
+            && object["growth_per_sec_milli"].is_i64()
+    );
+}
+
+fn suspect_score(report: &Report, kind: &DiagnosisKind) -> u8 {
+    std::iter::once(&report.primary_suspect)
+        .chain(&report.secondary_suspects)
+        .find(|s| &s.kind == kind)
+        .unwrap()
+        .score
+}
+
+fn queue_bonus_run(inflight_samples: Vec<tailtriage_core::InFlightSnapshot>) -> Run {
+    let mut run = option_run_twenty_requests();
+    run.queues = (1..=20)
+        .map(|i| QueueEvent {
+            request_id: format!("req-{i}"),
+            queue: "q".into(),
+            waited_from_unix_ms: i,
+            waited_from_run_us: None,
+            waited_until_unix_ms: i + 1,
+            waited_until_run_us: None,
+            wait_us: 700,
+            depth_at_start: Some(1),
+            completed: true,
+        })
+        .collect();
+    run.inflight = inflight_samples;
+    run
+}
+
+#[test]
+fn queue_inflight_growth_bonus_remains_exactly_five() {
+    let baseline = analyze_run(&queue_bonus_run(vec![]), AnalyzeOptions::default());
+    let growing = analyze_run(
+        &queue_bonus_run(vec![
+            inflight("g", 1, Some(1), 1),
+            inflight("g", 2, Some(1_000_001), 3),
+        ]),
+        AnalyzeOptions::default(),
+    );
+    assert_eq!(
+        suspect_score(&growing, &DiagnosisKind::ApplicationQueueSaturation)
+            - suspect_score(&baseline, &DiagnosisKind::ApplicationQueueSaturation),
+        5
+    );
+}
+
+#[test]
+fn executor_inflight_growth_bonus_remains_exactly_four() {
+    let mut baseline = option_run_twenty_requests();
+    baseline.runtime_snapshots = vec![runtime_snapshot(Some(20), Some(0), Some(20)); 20];
+    let mut growing = baseline.clone();
+    growing.inflight = vec![
+        inflight("g", 1, Some(1), 1),
+        inflight("g", 2, Some(1_000_001), 3),
+    ];
+    let without = analyze_run(&baseline, AnalyzeOptions::default());
+    let with = analyze_run(&growing, AnalyzeOptions::default());
+    assert_eq!(
+        suspect_score(&with, &DiagnosisKind::ExecutorPressureSuspected)
+            - suspect_score(&without, &DiagnosisKind::ExecutorPressureSuspected),
+        4
+    );
+    assert!(with
+        .primary_suspect
+        .evidence
+        .iter()
+        .chain(with.secondary_suspects.iter().flat_map(|s| &s.evidence))
+        .any(|e| e.contains("latest active episode") && e.contains("run-relative rate=2000")));
+}
+
+#[test]
+fn declining_inflight_episode_adds_no_growth_bonus() {
+    let baseline = analyze_run(&queue_bonus_run(vec![]), AnalyzeOptions::default());
+    for samples in [
+        vec![inflight("g", 1, Some(1), 7)],
+        vec![inflight("g", 1, Some(1), 3), inflight("g", 2, Some(2), 3)],
+        vec![inflight("g", 1, Some(1), 3), inflight("g", 2, Some(2), 1)],
+    ] {
+        let report = analyze_run(&queue_bonus_run(samples), AnalyzeOptions::default());
+        assert_eq!(
+            suspect_score(&report, &DiagnosisKind::ApplicationQueueSaturation),
+            suspect_score(&baseline, &DiagnosisKind::ApplicationQueueSaturation)
+        );
+        assert!(!report
+            .primary_suspect
+            .evidence
+            .iter()
+            .any(|e| e.contains(" grew by ")));
+    }
+}
+
+#[test]
+fn render_text_marks_one_sample_inflight_trend_unknown() {
+    let report = analyze_run(
+        &queue_bonus_run(vec![inflight("single", 1, Some(1), 7)]),
+        AnalyzeOptions::default(),
+    );
+    let text = render_text(&report);
+    assert!(text.contains("direction unknown") && text.contains("precise rate unavailable"));
+    assert!(!text.contains("net growth +0"));
 }
 
 #[test]
@@ -1585,11 +1902,12 @@ fn render_text_formats_inflight_trend_fields() {
     };
 
     let text = render_text(&report);
-    assert!(text.contains("Inflight trend: gauge 'queue_inflight'"));
+    assert!(text.contains("Inflight latest activity episode: gauge 'queue_inflight'"));
     assert!(text.contains("samples 4"));
     assert!(text.contains("peak 8"));
     assert!(text.contains("p95 7"));
     assert!(text.contains("net growth +5"));
+    assert!(text.contains("run-relative rate 2500 milli-counts/sec"));
     assert!(text.contains("Request time at p95: queue 10.0%, non-queue service 90.0%"));
 }
 

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -1684,25 +1684,196 @@ fn one_sample_inflight_episode_is_unknown_and_adds_no_bonus() {
     );
 }
 
+fn assert_dominant_inflight(
+    samples: &[tailtriage_core::InFlightSnapshot],
+    expected: InflightTrend,
+) {
+    assert_eq!(super::dominant_inflight_trend(samples), Some(expected));
+}
+
 #[test]
-fn inflight_candidate_order_prefers_rate_then_p95_peak_and_label() {
-    let samples = [
-        inflight("no-rate", 1, None, 1),
-        inflight("no-rate", 2, None, 4),
-        inflight("rate", 1, Some(1), 1),
-        inflight("rate", 2, Some(2_000_001), 4),
-    ];
-    assert_eq!(
-        super::dominant_inflight_trend(&samples).unwrap().gauge,
-        "rate"
+fn inflight_candidate_order_prefers_active_over_closed() {
+    assert_dominant_inflight(
+        &[
+            inflight("closed", 1, Some(1), 1),
+            inflight("closed", 2, Some(2), 20),
+            inflight("closed", 3, Some(3), 0),
+            inflight("active", 4, Some(4), 5),
+            inflight("active", 5, Some(5), 5),
+        ],
+        InflightTrend {
+            gauge: "active".into(),
+            sample_count: 2,
+            peak_count: 5,
+            p95_count: 5,
+            growth_delta: 0,
+            growth_per_sec_milli: Some(0),
+        },
     );
-    let tied = [
-        inflight("z", 1, Some(1), 2),
-        inflight("z", 2, Some(2), 2),
-        inflight("a", 1, Some(1), 2),
-        inflight("a", 2, Some(2), 2),
+}
+
+#[test]
+fn inflight_candidate_order_prefers_positive_over_unknown() {
+    let samples = [
+        inflight("positive", 1, Some(1), 1),
+        inflight("positive", 2, Some(1_000_001), 2),
+        inflight("unknown", 3, Some(3), 50),
     ];
-    assert_eq!(super::dominant_inflight_trend(&tied).unwrap().gauge, "a");
+    assert_dominant_inflight(
+        &samples,
+        InflightTrend {
+            gauge: "positive".into(),
+            sample_count: 2,
+            peak_count: 2,
+            p95_count: 2,
+            growth_delta: 1,
+            growth_per_sec_milli: Some(1000),
+        },
+    );
+}
+
+#[test]
+fn inflight_candidate_order_prefers_positive_over_non_growing() {
+    for (label, counts) in [("flat", [20, 20]), ("declining", [20, 10])] {
+        let samples = [
+            inflight("positive", 1, Some(1), 1),
+            inflight("positive", 2, Some(1_000_001), 2),
+            inflight(label, 1, Some(1), counts[0]),
+            inflight(label, 2, Some(1_000_001), counts[1]),
+        ];
+        assert_dominant_inflight(
+            &samples,
+            InflightTrend {
+                gauge: "positive".into(),
+                sample_count: 2,
+                peak_count: 2,
+                p95_count: 2,
+                growth_delta: 1,
+                growth_per_sec_milli: Some(1000),
+            },
+        );
+    }
+}
+
+#[test]
+fn inflight_candidate_order_prefers_larger_positive_delta() {
+    let samples = [
+        inflight("larger-delta", 1, Some(1), 1),
+        inflight("larger-delta", 2, Some(1_000_001), 6),
+        inflight("larger-peak", 1, Some(1), 100),
+        inflight("larger-peak", 2, Some(1_000_001), 103),
+    ];
+    assert_dominant_inflight(
+        &samples,
+        InflightTrend {
+            gauge: "larger-delta".into(),
+            sample_count: 2,
+            peak_count: 6,
+            p95_count: 6,
+            growth_delta: 5,
+            growth_per_sec_milli: Some(5000),
+        },
+    );
+}
+
+#[test]
+fn inflight_candidate_order_prefers_available_positive_rate() {
+    assert_dominant_inflight(
+        &[
+            inflight("no-rate", 1, None, 1),
+            inflight("no-rate", 2, None, 4),
+            inflight("rate", 1, Some(1), 1),
+            inflight("rate", 2, Some(2_000_001), 4),
+        ],
+        InflightTrend {
+            gauge: "rate".into(),
+            sample_count: 2,
+            peak_count: 4,
+            p95_count: 4,
+            growth_delta: 3,
+            growth_per_sec_milli: Some(1500),
+        },
+    );
+}
+
+#[test]
+fn inflight_candidate_order_prefers_larger_positive_rate() {
+    let samples = [
+        inflight("fast", 1, Some(1), 1),
+        inflight("fast", 2, Some(1_000_001), 4),
+        inflight("slow-large-peak", 1, Some(1), 100),
+        inflight("slow-large-peak", 2, Some(2_000_001), 103),
+    ];
+    assert_dominant_inflight(
+        &samples,
+        InflightTrend {
+            gauge: "fast".into(),
+            sample_count: 2,
+            peak_count: 4,
+            p95_count: 4,
+            growth_delta: 3,
+            growth_per_sec_milli: Some(3000),
+        },
+    );
+}
+
+#[test]
+fn inflight_candidate_order_prefers_larger_p95() {
+    let samples = [
+        inflight("high-p95", 1, Some(1), 8),
+        inflight("high-p95", 2, Some(2), 8),
+        inflight("low-p95", 1, Some(1), 7),
+        inflight("low-p95", 2, Some(2), 7),
+    ];
+    assert_dominant_inflight(
+        &samples,
+        InflightTrend {
+            gauge: "high-p95".into(),
+            sample_count: 2,
+            peak_count: 8,
+            p95_count: 8,
+            growth_delta: 0,
+            growth_per_sec_milli: Some(0),
+        },
+    );
+}
+
+#[test]
+fn inflight_candidate_order_prefers_larger_peak() {
+    let mut samples = vec![inflight("larger-peak", 1, Some(1), 10)];
+    samples.extend((2..=21).map(|time| inflight("larger-peak", time, Some(time), 1)));
+    samples.extend((1..=21).map(|time| inflight("smaller-peak", time, Some(time), 1)));
+    assert_dominant_inflight(
+        &samples,
+        InflightTrend {
+            gauge: "larger-peak".into(),
+            sample_count: 21,
+            peak_count: 10,
+            p95_count: 1,
+            growth_delta: -9,
+            growth_per_sec_milli: Some(-450_000_000),
+        },
+    );
+}
+
+#[test]
+fn inflight_candidate_order_uses_lexical_label_last() {
+    assert_dominant_inflight(
+        &[
+            inflight("z", 1, Some(1), 2),
+            inflight("z", 2, Some(2), 2),
+            inflight("a", 1, Some(1), 2),
+            inflight("a", 2, Some(2), 2),
+        ],
+        InflightTrend {
+            gauge: "a".into(),
+            sample_count: 2,
+            peak_count: 2,
+            p95_count: 2,
+            growth_delta: 0,
+            growth_per_sec_milli: Some(0),
+        },
+    );
 }
 
 #[test]
@@ -1720,7 +1891,7 @@ fn truncated_inflight_history_does_not_infer_missing_zero() {
 }
 
 #[test]
-fn inflight_trend_json_shape_remains_unchanged() {
+fn inflight_trend_json_shape_and_values_remain_unchanged() {
     let value = serde_json::to_value(InflightTrend {
         gauge: "g".into(),
         sample_count: 3,
@@ -1730,22 +1901,35 @@ fn inflight_trend_json_shape_remains_unchanged() {
         growth_per_sec_milli: Some(1500),
     })
     .unwrap();
-    let object = value.as_object().unwrap();
     assert_eq!(
-        object.keys().cloned().collect::<Vec<_>>(),
-        [
-            "gauge",
-            "growth_delta",
-            "growth_per_sec_milli",
-            "p95_count",
-            "peak_count",
-            "sample_count"
-        ]
+        value,
+        serde_json::json!({
+            "gauge": "g",
+            "sample_count": 3,
+            "peak_count": 4,
+            "p95_count": 4,
+            "growth_delta": 3,
+            "growth_per_sec_milli": 1500
+        })
     );
-    assert!(
-        object["gauge"].is_string()
-            && object["sample_count"].is_u64()
-            && object["growth_per_sec_milli"].is_i64()
+    assert_eq!(
+        serde_json::to_value(InflightTrend {
+            gauge: "g".into(),
+            sample_count: 1,
+            peak_count: 4,
+            p95_count: 4,
+            growth_delta: 0,
+            growth_per_sec_milli: None,
+        })
+        .unwrap(),
+        serde_json::json!({
+            "gauge": "g",
+            "sample_count": 1,
+            "peak_count": 4,
+            "p95_count": 4,
+            "growth_delta": 0,
+            "growth_per_sec_milli": null
+        })
     );
 }
 
@@ -1774,6 +1958,100 @@ fn queue_bonus_run(inflight_samples: Vec<tailtriage_core::InFlightSnapshot>) -> 
         .collect();
     run.inflight = inflight_samples;
     run
+}
+
+fn suspect_evidence<'a>(report: &'a Report, kind: &DiagnosisKind) -> &'a [String] {
+    &std::iter::once(&report.primary_suspect)
+        .chain(&report.secondary_suspects)
+        .find(|suspect| &suspect.kind == kind)
+        .expect("expected suspect")
+        .evidence
+}
+
+#[test]
+fn closed_historical_inflight_spike_adds_no_bonus_when_active_flat_episode_wins() {
+    let baseline = analyze_run(&queue_bonus_run(vec![]), AnalyzeOptions::default());
+    let report = analyze_run(
+        &queue_bonus_run(vec![
+            inflight("closed", 1, Some(1), 1),
+            inflight("closed", 2, Some(2), 20),
+            inflight("closed", 3, Some(3), 0),
+            inflight("active", 4, Some(4), 5),
+            inflight("active", 5, Some(5), 5),
+        ]),
+        AnalyzeOptions::default(),
+    );
+    assert_eq!(
+        report.inflight_trend,
+        Some(InflightTrend {
+            gauge: "active".into(),
+            sample_count: 2,
+            peak_count: 5,
+            p95_count: 5,
+            growth_delta: 0,
+            growth_per_sec_milli: Some(0),
+        })
+    );
+    assert_eq!(
+        suspect_score(&report, &DiagnosisKind::ApplicationQueueSaturation),
+        suspect_score(&baseline, &DiagnosisKind::ApplicationQueueSaturation)
+    );
+    assert!(
+        !suspect_evidence(&report, &DiagnosisKind::ApplicationQueueSaturation)
+            .iter()
+            .any(|evidence| evidence.contains("grew by"))
+    );
+}
+
+#[test]
+fn inflight_growth_evidence_states_unix_fallback_without_rate() {
+    let baseline = analyze_run(&queue_bonus_run(vec![]), AnalyzeOptions::default());
+    let report = analyze_run(
+        &queue_bonus_run(vec![
+            inflight("fallback", 1, Some(1), 1),
+            inflight("fallback", 2, None, 3),
+        ]),
+        AnalyzeOptions::default(),
+    );
+    assert_eq!(
+        report.inflight_trend.as_ref().unwrap().growth_per_sec_milli,
+        None
+    );
+    assert_eq!(
+        suspect_score(&report, &DiagnosisKind::ApplicationQueueSaturation)
+            - suspect_score(&baseline, &DiagnosisKind::ApplicationQueueSaturation),
+        5
+    );
+    let evidence = suspect_evidence(&report, &DiagnosisKind::ApplicationQueueSaturation).join(" ");
+    assert!(evidence.contains("latest active episode grew by 2"));
+    assert!(evidence.contains("ordering used Unix-ms fallback"));
+    assert!(evidence.contains("no precise growth rate was derived"));
+    assert!(!evidence.contains("rate="));
+}
+
+#[test]
+fn inflight_growth_evidence_states_unavailable_run_relative_rate() {
+    let baseline = analyze_run(&queue_bonus_run(vec![]), AnalyzeOptions::default());
+    let report = analyze_run(
+        &queue_bonus_run(vec![
+            inflight("zero-elapsed", 1, Some(10), 1),
+            inflight("zero-elapsed", 2, Some(10), 3),
+        ]),
+        AnalyzeOptions::default(),
+    );
+    assert_eq!(
+        report.inflight_trend.as_ref().unwrap().growth_per_sec_milli,
+        None
+    );
+    assert_eq!(
+        suspect_score(&report, &DiagnosisKind::ApplicationQueueSaturation)
+            - suspect_score(&baseline, &DiagnosisKind::ApplicationQueueSaturation),
+        5
+    );
+    let evidence = suspect_evidence(&report, &DiagnosisKind::ApplicationQueueSaturation).join(" ");
+    assert!(evidence.contains("latest active episode grew by 2"));
+    assert!(evidence.contains("precise run-relative growth rate is unavailable"));
+    assert!(!evidence.contains("Unix-ms fallback"));
 }
 
 #[test]


### PR DESCRIPTION
### Motivation

* Stop the analyzer from combining disconnected in-flight activity across retained zero transitions and reused labels.
* Prevent closed historical spikes from outranking more relevant current activity.
* Make episode ordering, trend calculation, and candidate selection deterministic when timestamps are mixed, missing, or tied.
* Preserve the public `InflightTrend` API, Report JSON shape, and existing scoring constants.

### What changed

* Group in-flight snapshots by gauge while preserving each snapshot’s original input index.
* Order each gauge using:
  * run-relative `at_run_us` when every snapshot for that gauge has one;
  * otherwise, `at_unix_ms` with original input index as the tie-breaker.
* Extract activity episodes using retained zero transitions:
  * a positive count starts or continues an episode;
  * the first zero closes it and remains part of that episode;
  * leading and consecutive zeros are ignored;
  * later positive activity starts a new episode.
* Summarize only each gauge’s latest retained episode.
* Select the dominant candidate using the following deterministic priority:
  1. active episode over closed episode;
  2. known positive growth over unknown, flat, or declining activity;
  3. larger positive growth delta;
  4. available positive rate, then larger positive rate;
  5. larger p95;
  6. larger peak;
  7. lexically smaller gauge label.
* Keep activity status and ordering mode internal while preserving the existing public `InflightTrend` fields.

### Trend semantics

`inflight_trend` now describes the selected gauge’s latest retained activity episode rather than its complete retained history.

Its existing fields remain unchanged:

* `sample_count`: retained snapshots in the selected episode, including a terminal zero;
* `peak_count`: episode-local peak;
* `p95_count`: episode-local p95;
* `growth_delta`: episode-local final count minus initial count;
* `growth_per_sec_milli`: precise rate derived only from valid run-relative microsecond timing.

A one-sample episode retains `growth_delta = 0` for compatibility but is treated as having unknown direction.

Unix timestamps are used only as a deterministic ordering fallback and never produce a growth rate. Truncation does not cause the analyzer to invent a missing zero or synthetic closure.

### Scoring and evidence

* Queue growth support remains exactly `+5`.
* Executor growth support remains exactly `+4`.
* Only known-positive, multi-sample episodes receive those bonuses.
* One-sample, flat, declining, and selected active-flat episodes add no growth bonus.
* Queue and executor evidence now describes the selected latest active episode.
* Evidence distinguishes:

  * a valid run-relative rate;
  * Unix-ms fallback with no precise rate;
  * run-relative ordering where a precise rate is unavailable.
* Blocking, downstream, confidence, route, and temporal scoring behavior is unchanged.

### Rendering and documentation

* Text output now labels the value as the latest in-flight activity episode.
* One-sample episodes render as `direction unknown`.
* Text output shows a run-relative rate when available and explicitly states when a precise rate is unavailable.
* Updated:

  * `SPEC.md`
  * `docs/diagnostics.md`
  * `tailtriage-analyzer/README.md`
  * analyzer rustdoc

### Test coverage

Added focused coverage for:

* active episodes outranking closed historical spikes;
* reused labels selecting only their latest episode;
* leading and consecutive zero handling;
* all-zero labels producing no candidate;
* run-relative ordering taking precedence over wall-clock ordering;
* deterministic Unix fallback without a derived rate;
* input reordering across distinct timestamps;
* original-index ordering for equal timestamps;
* one-sample unknown direction;
* truncation without fabricated closure;
* every dominant-candidate priority stage independently:

  * active over closed;
  * positive growth over unknown;
  * positive growth over flat and declining;
  * larger positive delta;
  * available positive rate;
  * larger positive rate;
  * p95 over a competing larger peak;
  * peak with equal p95;
  * lexical label as the final tie-breaker;
* a closed historical spike adding no bonus when an active flat episode wins;
* exact queue `+5` and executor `+4` score deltas;
* Unix-fallback and unavailable run-relative evidence wording;
* exact `InflightTrend` JSON values with both numeric and `null` rates;
* text rendering for unknown direction and rate availability.

### Validation

```text
cargo fmt --check
cargo test -p tailtriage-analyzer --all-targets --all-features --locked
cargo test -p tailtriage-cli --all-targets --all-features --locked
python3 scripts/validate_docs_contracts.py
cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
cargo test --workspace --all-targets --all-features --locked
```

All local validation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6641d3d73c83308950cca062ffdad6)