### PR TITLE
Introduce shared Run-slicing for route and temporal analysis

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tailtriage-analyzer/tests/expected/*.json text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Route and temporal analysis now share internal request-scoped Run slicing and scoped-report projection while preserving their distinct runtime/in-flight attribution policies and existing serialized Report output.
 - Simplified controller internals around one pure immutable template resolution path, one generation constructor, and one lifecycle-preserving finalizer. Direct template reload is now the single result-returning `reload_template(template)` API; migrate `try_reload_template(template)?` to `reload_template(template)?`, and handle the `Result` if the former panicking method was used. Direct and TOML reload remain transactional, affect only future generations, and create neither a capture generation nor a runtime sampler.
 - CLI Run-artifact analysis is now strict by default. Error-level core findings stop report generation; warning-only findings remain accepted. The removed `--strict-artifact` option is replaced by the explicit `--allow-ambiguous-artifact` compatibility path, which emits every issue and analyzes only canonical normalized evidence. Tracing import `--strict` and permissive analyzer library defaults are unchanged.
 - Suspect ranking now selects the primary after final evidence-aware confidence adjustment, ordering by final confidence, unchanged raw score, then stable suspect-kind rank while keeping raw-score ambiguity semantics.

--- a/tailtriage-analyzer/src/lib.rs
+++ b/tailtriage-analyzer/src/lib.rs
@@ -12,6 +12,7 @@ mod options;
 mod partial_evidence;
 mod route;
 mod scoring;
+mod slicing;
 mod stage_attribution;
 mod temporal;
 

--- a/tailtriage-analyzer/src/route.rs
+++ b/tailtriage-analyzer/src/route.rs
@@ -51,19 +51,7 @@ pub(super) fn route_breakdowns(
         analyzed
             .warnings
             .push(ROUTE_RUNTIME_ATTRIBUTION_WARNING.to_string());
-        candidates.push(RouteBreakdown {
-            route,
-            request_count: analyzed.request_count,
-            p50_latency_us: analyzed.p50_latency_us,
-            p95_latency_us: analyzed.p95_latency_us,
-            p99_latency_us: analyzed.p99_latency_us,
-            p95_queue_share_permille: analyzed.p95_queue_share_permille,
-            p95_service_share_permille: analyzed.p95_service_share_permille,
-            evidence_quality: analyzed.evidence_quality,
-            primary_suspect: analyzed.primary_suspect,
-            secondary_suspects: analyzed.secondary_suspects,
-            warnings: analyzed.warnings,
-        });
+        candidates.push(analyzed.into_route_breakdown(route));
     }
     if !should_emit_route_breakdowns(global, &candidates, options) {
         return RouteBreakdownContext {

--- a/tailtriage-analyzer/src/route.rs
+++ b/tailtriage-analyzer/src/route.rs
@@ -1,10 +1,9 @@
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 
 use tailtriage_core::Run;
 
-use super::{
-    analyze_run_internal, AnalyzeOptions, Report, RouteBreakdown, ROUTE_RUNTIME_ATTRIBUTION_WARNING,
-};
+use super::{AnalyzeOptions, Report, RouteBreakdown, ROUTE_RUNTIME_ATTRIBUTION_WARNING};
+use crate::slicing::{analyze_slice, GlobalEvidencePolicy};
 
 pub(super) struct RouteBreakdownContext {
     pub(super) breakdowns: Vec<RouteBreakdown>,
@@ -47,8 +46,8 @@ pub(super) fn route_breakdowns(
 
     let mut candidates = Vec::new();
     for (route, request_ids) in eligible {
-        let filtered = filtered_run_for_route(run, &request_ids);
-        let mut analyzed = analyze_run_internal(&filtered, options);
+        let mut analyzed =
+            analyze_slice(run, &request_ids, GlobalEvidencePolicy::Exclude, options).report;
         analyzed
             .warnings
             .push(ROUTE_RUNTIME_ATTRIBUTION_WARNING.to_string());
@@ -133,30 +132,4 @@ fn should_emit_route_breakdowns(
             }
             _ => false,
         }
-}
-
-pub(super) fn filtered_run_for_route(run: &Run, request_ids: &[String]) -> Run {
-    let request_ids: HashSet<&str> = request_ids.iter().map(String::as_str).collect();
-    let mut filtered = run.clone();
-    filtered.requests = run
-        .requests
-        .iter()
-        .filter(|r| request_ids.contains(r.request_id.as_str()))
-        .cloned()
-        .collect();
-    filtered.stages = run
-        .stages
-        .iter()
-        .filter(|s| request_ids.contains(s.request_id.as_str()))
-        .cloned()
-        .collect();
-    filtered.queues = run
-        .queues
-        .iter()
-        .filter(|q| request_ids.contains(q.request_id.as_str()))
-        .cloned()
-        .collect();
-    filtered.runtime_snapshots = Vec::new();
-    filtered.inflight = Vec::new();
-    filtered
 }

--- a/tailtriage-analyzer/src/slicing.rs
+++ b/tailtriage-analyzer/src/slicing.rs
@@ -1,0 +1,261 @@
+use std::collections::HashSet;
+
+use tailtriage_core::Run;
+
+use super::{analyze_run_internal, AnalyzeOptions, EvidenceQuality, Report, Suspect};
+
+#[derive(Clone, Copy)]
+pub(super) enum GlobalEvidencePolicy {
+    Exclude,
+    Window(SampleWindow),
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct SampleWindow {
+    pub(super) unix_start: u64,
+    pub(super) unix_finish: u64,
+    pub(super) run_relative: Option<(u64, u64)>,
+}
+
+pub(super) struct ScopedAnalysis {
+    pub(super) report: ScopedReportProjection,
+    pub(super) used_unix_fallback: bool,
+}
+
+pub(super) struct ScopedReportProjection {
+    pub(super) request_count: usize,
+    pub(super) p50_latency_us: Option<u64>,
+    pub(super) p95_latency_us: Option<u64>,
+    pub(super) p99_latency_us: Option<u64>,
+    pub(super) p95_queue_share_permille: Option<u64>,
+    pub(super) p95_service_share_permille: Option<u64>,
+    pub(super) evidence_quality: EvidenceQuality,
+    pub(super) primary_suspect: Suspect,
+    pub(super) secondary_suspects: Vec<Suspect>,
+    pub(super) warnings: Vec<String>,
+}
+
+impl From<Report> for ScopedReportProjection {
+    fn from(report: Report) -> Self {
+        Self {
+            request_count: report.request_count,
+            p50_latency_us: report.p50_latency_us,
+            p95_latency_us: report.p95_latency_us,
+            p99_latency_us: report.p99_latency_us,
+            p95_queue_share_permille: report.p95_queue_share_permille,
+            p95_service_share_permille: report.p95_service_share_permille,
+            evidence_quality: report.evidence_quality,
+            primary_suspect: report.primary_suspect,
+            secondary_suspects: report.secondary_suspects,
+            warnings: report.warnings,
+        }
+    }
+}
+
+pub(super) fn analyze_slice(
+    source: &Run,
+    request_ids: &[String],
+    global_evidence: GlobalEvidencePolicy,
+    options: &AnalyzeOptions,
+) -> ScopedAnalysis {
+    let sliced = slice_run(source, request_ids, global_evidence);
+    ScopedAnalysis {
+        report: analyze_run_internal(&sliced.run, options).into(),
+        used_unix_fallback: sliced.used_unix_fallback,
+    }
+}
+
+struct SlicedRun {
+    run: Run,
+    used_unix_fallback: bool,
+}
+
+fn slice_run(
+    source: &Run,
+    request_ids: &[String],
+    global_evidence: GlobalEvidencePolicy,
+) -> SlicedRun {
+    let request_ids: HashSet<&str> = request_ids.iter().map(String::as_str).collect();
+    let mut run = source.clone();
+    run.requests
+        .retain(|request| request_ids.contains(request.request_id.as_str()));
+    run.stages
+        .retain(|stage| request_ids.contains(stage.request_id.as_str()));
+    run.queues
+        .retain(|queue| request_ids.contains(queue.request_id.as_str()));
+
+    let used_unix_fallback = match global_evidence {
+        GlobalEvidencePolicy::Exclude => {
+            run.runtime_snapshots.clear();
+            run.inflight.clear();
+            false
+        }
+        GlobalEvidencePolicy::Window(window) => {
+            let mut used_unix_fallback = false;
+            run.runtime_snapshots.retain(|sample| {
+                let (retained, used_fallback) =
+                    retain_sample(sample.at_unix_ms, sample.at_run_us, window);
+                used_unix_fallback |= used_fallback;
+                retained
+            });
+            run.inflight.retain(|sample| {
+                let (retained, used_fallback) =
+                    retain_sample(sample.at_unix_ms, sample.at_run_us, window);
+                used_unix_fallback |= used_fallback;
+                retained
+            });
+            used_unix_fallback
+        }
+    };
+
+    SlicedRun {
+        run,
+        used_unix_fallback,
+    }
+}
+
+fn retain_sample(at_unix_ms: u64, at_run_us: Option<u64>, window: SampleWindow) -> (bool, bool) {
+    if let (Some((start, finish)), Some(at)) = (window.run_relative, at_run_us) {
+        return (at >= start && at <= finish, false);
+    }
+
+    let retained = at_unix_ms >= window.unix_start && at_unix_ms <= window.unix_finish;
+    let used_unix_fallback = retained && window.run_relative.is_some() && at_run_us.is_none();
+    (retained, used_unix_fallback)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{slice_run, GlobalEvidencePolicy, SampleWindow};
+    use tailtriage_core::Run;
+
+    fn fixture(contents: &str) -> Run {
+        serde_json::from_str(contents).expect("fixture should deserialize")
+    }
+
+    #[test]
+    fn shared_slicer_preserves_request_scoped_source_order() {
+        let downstream = fixture(include_str!("../tests/fixtures/downstream_stage.json"));
+        let queue = fixture(include_str!("../tests/fixtures/queue_saturation.json"));
+        let mut source = downstream.clone();
+
+        source.requests = (0..4)
+            .map(|index| {
+                let mut event = downstream.requests[index % downstream.requests.len()].clone();
+                event.request_id = ["selected-b", "other-a", "selected-a", "other-b"][index].into();
+                event
+            })
+            .collect();
+        source.stages = (0..4)
+            .map(|index| {
+                let mut event = downstream.stages[index % downstream.stages.len()].clone();
+                event.request_id = ["other-b", "selected-a", "other-a", "selected-b"][index].into();
+                event
+            })
+            .collect();
+        source.queues = (0..4)
+            .map(|index| {
+                let mut event = queue.queues[index % queue.queues.len()].clone();
+                event.request_id = ["selected-a", "other-a", "selected-b", "other-b"][index].into();
+                event
+            })
+            .collect();
+        source.runtime_snapshots = queue.runtime_snapshots;
+        source.inflight = queue.inflight;
+        source.metadata.run_id = "non-default-slicing-run".into();
+        source.metadata.lifecycle_warnings = vec!["preserve lifecycle warning".into()];
+        source.truncation.dropped_requests = 7;
+
+        let expected_metadata = source.metadata.clone();
+        let expected_truncation = source.truncation.clone();
+        let selected = vec!["selected-a".to_string(), "selected-b".to_string()];
+        let sliced = slice_run(&source, &selected, GlobalEvidencePolicy::Exclude);
+
+        assert_eq!(
+            sliced
+                .run
+                .requests
+                .iter()
+                .map(|e| e.request_id.as_str())
+                .collect::<Vec<_>>(),
+            ["selected-b", "selected-a"]
+        );
+        assert_eq!(
+            sliced
+                .run
+                .stages
+                .iter()
+                .map(|e| e.request_id.as_str())
+                .collect::<Vec<_>>(),
+            ["selected-a", "selected-b"]
+        );
+        assert_eq!(
+            sliced
+                .run
+                .queues
+                .iter()
+                .map(|e| e.request_id.as_str())
+                .collect::<Vec<_>>(),
+            ["selected-a", "selected-b"]
+        );
+        assert!(sliced.run.runtime_snapshots.is_empty());
+        assert!(sliced.run.inflight.is_empty());
+        assert!(!sliced.used_unix_fallback);
+        assert_eq!(sliced.run.metadata, expected_metadata);
+        assert_eq!(sliced.run.truncation, expected_truncation);
+        assert_eq!(sliced.run.schema_version, source.schema_version);
+    }
+
+    #[test]
+    fn window_policy_uses_inclusive_bounds_and_marks_only_retained_unix_fallbacks() {
+        let mut source = fixture(include_str!("../tests/fixtures/queue_saturation.json"));
+        source.runtime_snapshots =
+            fixture(include_str!("../tests/fixtures/blocking_pressure.json")).runtime_snapshots;
+        let selected = source
+            .requests
+            .iter()
+            .map(|r| r.request_id.clone())
+            .collect::<Vec<_>>();
+        for (sample, (unix, run)) in
+            source
+                .runtime_snapshots
+                .iter_mut()
+                .zip([(9, None), (100, Some(10)), (200, Some(20))])
+        {
+            sample.at_unix_ms = unix;
+            sample.at_run_us = run;
+        }
+        for (sample, (unix, run)) in
+            source
+                .inflight
+                .iter_mut()
+                .zip([(150, None), (300, None), (400, Some(30))])
+        {
+            sample.at_unix_ms = unix;
+            sample.at_run_us = run;
+        }
+
+        let sliced = slice_run(
+            &source,
+            &selected,
+            GlobalEvidencePolicy::Window(SampleWindow {
+                unix_start: 100,
+                unix_finish: 200,
+                run_relative: Some((10, 20)),
+            }),
+        );
+
+        assert_eq!(
+            sliced
+                .run
+                .runtime_snapshots
+                .iter()
+                .map(|s| s.at_run_us)
+                .collect::<Vec<_>>(),
+            [Some(10), Some(20)]
+        );
+        assert_eq!(sliced.run.inflight.len(), 1);
+        assert_eq!(sliced.run.inflight[0].at_unix_ms, 150);
+        assert!(sliced.used_unix_fallback);
+    }
+}

--- a/tailtriage-analyzer/src/slicing.rs
+++ b/tailtriage-analyzer/src/slicing.rs
@@ -2,7 +2,10 @@ use std::collections::HashSet;
 
 use tailtriage_core::Run;
 
-use super::{analyze_run_internal, AnalyzeOptions, EvidenceQuality, Report, Suspect};
+use super::{
+    analyze_run_internal, AnalyzeOptions, EvidenceQuality, Report, RouteBreakdown, Suspect,
+    TemporalSegment,
+};
 
 #[derive(Clone, Copy)]
 pub(super) enum GlobalEvidencePolicy {
@@ -48,6 +51,47 @@ impl From<Report> for ScopedReportProjection {
             primary_suspect: report.primary_suspect,
             secondary_suspects: report.secondary_suspects,
             warnings: report.warnings,
+        }
+    }
+}
+
+impl ScopedReportProjection {
+    pub(super) fn into_route_breakdown(self, route: String) -> RouteBreakdown {
+        RouteBreakdown {
+            route,
+            request_count: self.request_count,
+            p50_latency_us: self.p50_latency_us,
+            p95_latency_us: self.p95_latency_us,
+            p99_latency_us: self.p99_latency_us,
+            p95_queue_share_permille: self.p95_queue_share_permille,
+            p95_service_share_permille: self.p95_service_share_permille,
+            evidence_quality: self.evidence_quality,
+            primary_suspect: self.primary_suspect,
+            secondary_suspects: self.secondary_suspects,
+            warnings: self.warnings,
+        }
+    }
+
+    pub(super) fn into_temporal_segment(
+        self,
+        name: String,
+        started_at_unix_ms: Option<u64>,
+        finished_at_unix_ms: Option<u64>,
+    ) -> TemporalSegment {
+        TemporalSegment {
+            name,
+            request_count: self.request_count,
+            started_at_unix_ms,
+            finished_at_unix_ms,
+            p50_latency_us: self.p50_latency_us,
+            p95_latency_us: self.p95_latency_us,
+            p99_latency_us: self.p99_latency_us,
+            p95_queue_share_permille: self.p95_queue_share_permille,
+            p95_service_share_permille: self.p95_service_share_permille,
+            evidence_quality: self.evidence_quality,
+            primary_suspect: self.primary_suspect,
+            secondary_suspects: self.secondary_suspects,
+            warnings: self.warnings,
         }
     }
 }
@@ -126,7 +170,8 @@ fn retain_sample(at_unix_ms: u64, at_run_us: Option<u64>, window: SampleWindow) 
 
 #[cfg(test)]
 mod tests {
-    use super::{slice_run, GlobalEvidencePolicy, SampleWindow};
+    use super::{slice_run, GlobalEvidencePolicy, SampleWindow, ScopedReportProjection};
+    use crate::{analyze_run_internal, AnalyzeOptions};
     use tailtriage_core::Run;
 
     fn fixture(contents: &str) -> Run {
@@ -207,33 +252,160 @@ mod tests {
     }
 
     #[test]
-    fn window_policy_uses_inclusive_bounds_and_marks_only_retained_unix_fallbacks() {
+    fn scoped_projection_matches_internal_report_fields_exactly() {
+        let source = fixture(include_str!("../tests/fixtures/queue_saturation.json"));
+        let mut report = analyze_run_internal(&source, &AnalyzeOptions::default());
+        report.request_count = 37;
+        report.p50_latency_us = Some(101);
+        report.p95_latency_us = Some(202);
+        report.p99_latency_us = Some(303);
+        report.p95_queue_share_permille = Some(404);
+        report.p95_service_share_permille = Some(505);
+        report.evidence_quality.request_count = 41;
+        report.evidence_quality.queue_event_count = 42;
+        report.evidence_quality.stage_event_count = 43;
+        report.evidence_quality.runtime_snapshot_count = 44;
+        report.evidence_quality.inflight_snapshot_count = 45;
+        report.evidence_quality.limitations = vec!["quality-a".into(), "quality-b".into()];
+        report.primary_suspect.score = 71;
+        report.primary_suspect.evidence = vec!["primary-a".into(), "primary-b".into()];
+        let mut secondary_a = report.primary_suspect.clone();
+        secondary_a.score = 31;
+        secondary_a.evidence = vec!["secondary-a".into()];
+        let mut secondary_b = report.primary_suspect.clone();
+        secondary_b.score = 32;
+        secondary_b.evidence = vec!["secondary-b".into()];
+        report.secondary_suspects = vec![secondary_a, secondary_b];
+        report.warnings = vec!["warning-a".into(), "warning-b".into()];
+
+        let route = ScopedReportProjection::from(report.clone())
+            .into_route_breakdown("route-identity".into());
+        assert_eq!(route.route, "route-identity");
+        assert_eq!(route.request_count, report.request_count);
+        assert_eq!(route.p50_latency_us, report.p50_latency_us);
+        assert_eq!(route.p95_latency_us, report.p95_latency_us);
+        assert_eq!(route.p99_latency_us, report.p99_latency_us);
+        assert_eq!(
+            route.p95_queue_share_permille,
+            report.p95_queue_share_permille
+        );
+        assert_eq!(
+            route.p95_service_share_permille,
+            report.p95_service_share_permille
+        );
+        assert_eq!(route.evidence_quality, report.evidence_quality);
+        assert_eq!(route.primary_suspect, report.primary_suspect);
+        assert_eq!(route.secondary_suspects, report.secondary_suspects);
+        assert_eq!(route.warnings, report.warnings);
+
+        let temporal = ScopedReportProjection::from(report.clone()).into_temporal_segment(
+            "temporal-identity".into(),
+            Some(601),
+            Some(602),
+        );
+        assert_eq!(temporal.name, "temporal-identity");
+        assert_eq!(temporal.started_at_unix_ms, Some(601));
+        assert_eq!(temporal.finished_at_unix_ms, Some(602));
+        assert_eq!(temporal.request_count, report.request_count);
+        assert_eq!(temporal.p50_latency_us, report.p50_latency_us);
+        assert_eq!(temporal.p95_latency_us, report.p95_latency_us);
+        assert_eq!(temporal.p99_latency_us, report.p99_latency_us);
+        assert_eq!(
+            temporal.p95_queue_share_permille,
+            report.p95_queue_share_permille
+        );
+        assert_eq!(
+            temporal.p95_service_share_permille,
+            report.p95_service_share_permille
+        );
+        assert_eq!(temporal.evidence_quality, report.evidence_quality);
+        assert_eq!(temporal.primary_suspect, report.primary_suspect);
+        assert_eq!(temporal.secondary_suspects, report.secondary_suspects);
+        assert_eq!(temporal.warnings, report.warnings);
+
+        let route_json = serde_json::to_value(route).unwrap();
+        let temporal_json = serde_json::to_value(temporal).unwrap();
+        assert!(route_json.get("route_breakdowns").is_none());
+        assert!(route_json.get("temporal_segments").is_none());
+        assert!(temporal_json.get("route_breakdowns").is_none());
+        assert!(temporal_json.get("temporal_segments").is_none());
+    }
+
+    #[test]
+    fn temporal_slice_filters_global_samples_with_existing_clock_rules() {
         let mut source = fixture(include_str!("../tests/fixtures/queue_saturation.json"));
-        source.runtime_snapshots =
-            fixture(include_str!("../tests/fixtures/blocking_pressure.json")).runtime_snapshots;
+        let blocking = fixture(include_str!("../tests/fixtures/blocking_pressure.json"));
+        let runtime_template = blocking.runtime_snapshots[0].clone();
+        let inflight_template = source.inflight[0].clone();
         let selected = source
             .requests
             .iter()
             .map(|r| r.request_id.clone())
             .collect::<Vec<_>>();
-        for (sample, (unix, run)) in
-            source
-                .runtime_snapshots
-                .iter_mut()
-                .zip([(9, None), (100, Some(10)), (200, Some(20))])
-        {
+
+        source.runtime_snapshots = [(9, None), (90, Some(9)), (999, None)]
+            .into_iter()
+            .map(|(unix, run)| {
+                let mut sample = runtime_template.clone();
+                sample.at_unix_ms = unix;
+                sample.at_run_us = run;
+                sample
+            })
+            .collect();
+        source.inflight = [(8, None), (80, Some(8))]
+            .into_iter()
+            .map(|(unix, run)| {
+                let mut sample = inflight_template.clone();
+                sample.at_unix_ms = unix;
+                sample.at_run_us = run;
+                sample
+            })
+            .collect();
+        let negative = slice_run(
+            &source,
+            &selected,
+            GlobalEvidencePolicy::Window(SampleWindow {
+                unix_start: 100,
+                unix_finish: 200,
+                run_relative: Some((10, 20)),
+            }),
+        );
+        assert!(negative.run.runtime_snapshots.is_empty());
+        assert!(negative.run.inflight.is_empty());
+        assert!(!negative.used_unix_fallback);
+
+        source.runtime_snapshots = [
+            (999, Some(9)),
+            (999, Some(10)),
+            (150, None),
+            (0, Some(15)),
+            (0, Some(20)),
+            (150, Some(21)),
+        ]
+        .into_iter()
+        .map(|(unix, run)| {
+            let mut sample = runtime_template.clone();
             sample.at_unix_ms = unix;
             sample.at_run_us = run;
-        }
-        for (sample, (unix, run)) in
-            source
-                .inflight
-                .iter_mut()
-                .zip([(150, None), (300, None), (400, Some(30))])
-        {
+            sample
+        })
+        .collect();
+        source.inflight = [
+            (999, Some(9)),
+            (999, Some(10)),
+            (151, None),
+            (0, Some(15)),
+            (0, Some(20)),
+            (150, Some(21)),
+        ]
+        .into_iter()
+        .map(|(unix, run)| {
+            let mut sample = inflight_template.clone();
             sample.at_unix_ms = unix;
             sample.at_run_us = run;
-        }
+            sample
+        })
+        .collect();
 
         let sliced = slice_run(
             &source,
@@ -250,12 +422,19 @@ mod tests {
                 .run
                 .runtime_snapshots
                 .iter()
-                .map(|s| s.at_run_us)
+                .map(|s| (s.at_unix_ms, s.at_run_us))
                 .collect::<Vec<_>>(),
-            [Some(10), Some(20)]
+            [(999, Some(10)), (150, None), (0, Some(15)), (0, Some(20))]
         );
-        assert_eq!(sliced.run.inflight.len(), 1);
-        assert_eq!(sliced.run.inflight[0].at_unix_ms, 150);
+        assert_eq!(
+            sliced
+                .run
+                .inflight
+                .iter()
+                .map(|s| (s.at_unix_ms, s.at_run_us))
+                .collect::<Vec<_>>(),
+            [(999, Some(10)), (151, None), (0, Some(15)), (0, Some(20))]
+        );
         assert!(sliced.used_unix_fallback);
     }
 }

--- a/tailtriage-analyzer/src/temporal.rs
+++ b/tailtriage-analyzer/src/temporal.rs
@@ -1,10 +1,7 @@
 use tailtriage_core::{RequestEvent, Run};
 
-use super::{
-    analyze_run_internal, AnalyzeOptions, DiagnosisKind, Report, SignalCoverageStatus,
-    TemporalSegment,
-};
-use crate::route;
+use super::{AnalyzeOptions, DiagnosisKind, SignalCoverageStatus, TemporalSegment};
+use crate::slicing::{analyze_slice, GlobalEvidencePolicy, SampleWindow, ScopedReportProjection};
 
 const TEMPORAL_RUNTIME_ATTRIBUTION_WARNING: &str = "Runtime and in-flight evidence is sparse in this segment after timestamp filtering; executor/blocking attribution is limited.";
 pub(super) const TEMPORAL_SUSPECT_SHIFT_WARNING: &str = "Temporal segments show different primary suspects; inspect temporal_segments before acting on the global suspect.";
@@ -12,13 +9,6 @@ pub(super) const TEMPORAL_P95_SHIFT_WARNING: &str =
     "Temporal segments show a large p95 latency shift between early and late requests.";
 pub(super) const TEMPORAL_OVERLAP_ATTRIBUTION_WARNING: &str = "Segment windows overlap under concurrent requests; timestamp-filtered runtime/in-flight attribution is approximate.";
 pub(super) const TEMPORAL_WALL_CLOCK_FALLBACK_WARNING: &str = "Temporal segment used wall-clock timestamp fallback; attribution is approximate for artifacts without complete run-relative timing.";
-
-#[derive(Clone, Copy)]
-struct SegmentWindow {
-    unix_start: u64,
-    unix_finish: u64,
-    run_relative: Option<(u64, u64)>,
-}
 
 fn all_requests_have_run_relative_start(requests: &[RequestEvent]) -> bool {
     requests
@@ -75,60 +65,9 @@ fn segment_unix_window(requests: &[RequestEvent]) -> Option<(u64, u64)> {
     Some((start, finish))
 }
 
-fn retain_segment_sample(
-    at_unix_ms: u64,
-    at_run_us: Option<u64>,
-    window: SegmentWindow,
-) -> (bool, bool) {
-    if let (Some((start, finish)), Some(at)) = (window.run_relative, at_run_us) {
-        return (at >= start && at <= finish, false);
-    }
-
-    let retained = at_unix_ms >= window.unix_start && at_unix_ms <= window.unix_finish;
-    let used_unix_fallback = retained && window.run_relative.is_some() && at_run_us.is_none();
-    (retained, used_unix_fallback)
-}
-
-fn filter_segment_runtime_and_inflight(run: &mut Run, source: &Run, window: SegmentWindow) -> bool {
-    let mut used_unix_fallback = false;
-    run.runtime_snapshots = source
-        .runtime_snapshots
-        .iter()
-        .filter(|snapshot| {
-            let (retained, used_fallback) =
-                retain_segment_sample(snapshot.at_unix_ms, snapshot.at_run_us, window);
-            used_unix_fallback |= used_fallback;
-            retained
-        })
-        .cloned()
-        .collect();
-    run.inflight = source
-        .inflight
-        .iter()
-        .filter(|snapshot| {
-            let (retained, used_fallback) =
-                retain_segment_sample(snapshot.at_unix_ms, snapshot.at_run_us, window);
-            used_unix_fallback |= used_fallback;
-            retained
-        })
-        .cloned()
-        .collect();
-    used_unix_fallback
-}
-
-fn filtered_run_for_temporal_segment(
-    run: &Run,
-    request_ids: &[String],
-    window: SegmentWindow,
-) -> (Run, bool) {
-    let mut filtered = route::filtered_run_for_route(run, request_ids);
-    let used_unix_fallback = filter_segment_runtime_and_inflight(&mut filtered, run, window);
-    (filtered, used_unix_fallback)
-}
-
 fn temporal_segment_from_report(
     name: &str,
-    analyzed: Report,
+    analyzed: ScopedReportProjection,
     start: Option<u64>,
     finish: Option<u64>,
 ) -> TemporalSegment {
@@ -169,20 +108,20 @@ pub(super) fn temporal_segments(
     let build = |name: &str, seg: &[RequestEvent]| {
         let ids: Vec<String> = seg.iter().map(|r| r.request_id.clone()).collect();
         let Some((unix_start, unix_finish)) = segment_unix_window(seg) else {
-            let analyzed = analyze_run_internal(&route::filtered_run_for_route(run, &ids), options);
-            return temporal_segment_from_report(name, analyzed, None, None);
+            let analyzed = analyze_slice(run, &ids, GlobalEvidencePolicy::Exclude, options);
+            return temporal_segment_from_report(name, analyzed.report, None, None);
         };
         let start = Some(unix_start);
         let finish = Some(unix_finish);
         let run_relative_window = segment_run_relative_window(seg);
-        let window = SegmentWindow {
+        let window = SampleWindow {
             unix_start,
             unix_finish,
             run_relative: run_relative_window,
         };
-        let (filtered, used_snapshot_unix_fallback) =
-            filtered_run_for_temporal_segment(run, &ids, window);
-        let mut analyzed = analyze_run_internal(&filtered, options);
+        let analyzed = analyze_slice(run, &ids, GlobalEvidencePolicy::Window(window), options);
+        let used_snapshot_unix_fallback = analyzed.used_unix_fallback;
+        let mut analyzed = analyzed.report;
         if run_relative_window.is_none() || used_snapshot_unix_fallback {
             analyzed
                 .warnings

--- a/tailtriage-analyzer/src/temporal.rs
+++ b/tailtriage-analyzer/src/temporal.rs
@@ -1,7 +1,7 @@
 use tailtriage_core::{RequestEvent, Run};
 
 use super::{AnalyzeOptions, DiagnosisKind, SignalCoverageStatus, TemporalSegment};
-use crate::slicing::{analyze_slice, GlobalEvidencePolicy, SampleWindow, ScopedReportProjection};
+use crate::slicing::{analyze_slice, GlobalEvidencePolicy, SampleWindow};
 
 const TEMPORAL_RUNTIME_ATTRIBUTION_WARNING: &str = "Runtime and in-flight evidence is sparse in this segment after timestamp filtering; executor/blocking attribution is limited.";
 pub(super) const TEMPORAL_SUSPECT_SHIFT_WARNING: &str = "Temporal segments show different primary suspects; inspect temporal_segments before acting on the global suspect.";
@@ -65,29 +65,6 @@ fn segment_unix_window(requests: &[RequestEvent]) -> Option<(u64, u64)> {
     Some((start, finish))
 }
 
-fn temporal_segment_from_report(
-    name: &str,
-    analyzed: ScopedReportProjection,
-    start: Option<u64>,
-    finish: Option<u64>,
-) -> TemporalSegment {
-    TemporalSegment {
-        name: name.to_string(),
-        request_count: analyzed.request_count,
-        started_at_unix_ms: start,
-        finished_at_unix_ms: finish,
-        p50_latency_us: analyzed.p50_latency_us,
-        p95_latency_us: analyzed.p95_latency_us,
-        p99_latency_us: analyzed.p99_latency_us,
-        p95_queue_share_permille: analyzed.p95_queue_share_permille,
-        p95_service_share_permille: analyzed.p95_service_share_permille,
-        evidence_quality: analyzed.evidence_quality,
-        primary_suspect: analyzed.primary_suspect,
-        secondary_suspects: analyzed.secondary_suspects,
-        warnings: analyzed.warnings,
-    }
-}
-
 pub(super) fn temporal_segments(
     run: &Run,
     global_warnings: &mut Vec<String>,
@@ -109,7 +86,9 @@ pub(super) fn temporal_segments(
         let ids: Vec<String> = seg.iter().map(|r| r.request_id.clone()).collect();
         let Some((unix_start, unix_finish)) = segment_unix_window(seg) else {
             let analyzed = analyze_slice(run, &ids, GlobalEvidencePolicy::Exclude, options);
-            return temporal_segment_from_report(name, analyzed.report, None, None);
+            return analyzed
+                .report
+                .into_temporal_segment(name.to_string(), None, None);
         };
         let start = Some(unix_start);
         let finish = Some(unix_finish);
@@ -140,7 +119,7 @@ pub(super) fn temporal_segments(
                 .warnings
                 .push(TEMPORAL_RUNTIME_ATTRIBUTION_WARNING.to_string());
         }
-        temporal_segment_from_report(name, analyzed, start, finish)
+        analyzed.into_temporal_segment(name.to_string(), start, finish)
     };
     let mut early_seg = build("early", early);
     let mut late_seg = build("late", late);

--- a/tailtriage-analyzer/tests/analyzer_fixtures.rs
+++ b/tailtriage-analyzer/tests/analyzer_fixtures.rs
@@ -1,12 +1,113 @@
 use std::path::Path;
 
-use tailtriage_analyzer::{analyze_run, render_text, AnalyzeOptions, DiagnosisKind};
+use tailtriage_analyzer::{
+    analyze_run, render_json_pretty, render_text, AnalyzeOptions, DiagnosisKind,
+};
 use tailtriage_core::Run;
 
 fn load_fixture(name: &str) -> Run {
     let path = Path::new("tests/fixtures").join(name);
     let content = std::fs::read_to_string(path).expect("fixture should exist");
     serde_json::from_str(&content).expect("fixture should deserialize")
+}
+
+#[test]
+fn fixture_reports_match_canonical_pretty_json_golden_files() {
+    for fixture in [
+        "queue_saturation.json",
+        "blocking_pressure.json",
+        "executor_pressure.json",
+        "downstream_stage.json",
+        "insufficient_evidence.json",
+        "mixed_queue_vs_blocking.json",
+        "mixed_blocking_vs_downstream.json",
+        "scoped_route.json",
+        "scoped_temporal.json",
+    ] {
+        let run = load_fixture(fixture);
+        let report = analyze_run(&run, AnalyzeOptions::default());
+        let actual = render_json_pretty(&report).expect("report should render");
+        let stem = fixture.strip_suffix(".json").expect("fixture suffix");
+        let expected_path = Path::new("tests/expected").join(format!("{stem}.report.json"));
+        let expected = std::fs::read_to_string(&expected_path).expect("golden report should exist");
+        assert_eq!(actual, expected, "fixture={fixture}");
+    }
+}
+
+#[test]
+fn scoped_route_fixture_preserves_breakdown_contract() {
+    let report = analyze_run(
+        &load_fixture("scoped_route.json"),
+        AnalyzeOptions::default(),
+    );
+    assert_eq!(
+        report
+            .route_breakdowns
+            .iter()
+            .map(|breakdown| breakdown.route.as_str())
+            .collect::<Vec<_>>(),
+        ["/queue", "/downstream"]
+    );
+    assert_eq!(
+        report
+            .route_breakdowns
+            .iter()
+            .map(|breakdown| breakdown.request_count)
+            .collect::<Vec<_>>(),
+        [3, 3]
+    );
+    assert_eq!(
+        report
+            .route_breakdowns
+            .iter()
+            .map(|breakdown| breakdown.primary_suspect.kind.as_str())
+            .collect::<Vec<_>>(),
+        ["application_queue_saturation", "downstream_stage_dominates"]
+    );
+    assert!(report.route_breakdowns.iter().all(|breakdown| breakdown
+        .warnings
+        .iter()
+        .any(|warning| warning
+            == "Runtime and in-flight signals are global and are not attributed to this route.")));
+}
+
+#[test]
+fn scoped_temporal_fixture_preserves_windowed_evidence_contract() {
+    let report = analyze_run(
+        &load_fixture("scoped_temporal.json"),
+        AnalyzeOptions::default(),
+    );
+    assert_eq!(
+        report
+            .temporal_segments
+            .iter()
+            .map(|segment| segment.name.as_str())
+            .collect::<Vec<_>>(),
+        ["early", "late"]
+    );
+    assert_eq!(
+        report
+            .temporal_segments
+            .iter()
+            .map(|segment| segment.request_count)
+            .collect::<Vec<_>>(),
+        [10, 10]
+    );
+    assert_eq!(
+        report
+            .temporal_segments
+            .iter()
+            .map(|segment| segment.p95_latency_us)
+            .collect::<Vec<_>>(),
+        [Some(1_000), Some(6_000)]
+    );
+    for segment in &report.temporal_segments {
+        assert_eq!(segment.evidence_quality.runtime_snapshot_count, 1);
+        assert_eq!(segment.evidence_quality.inflight_snapshot_count, 1);
+        assert!(segment.warnings.iter().all(
+            |warning| !warning.contains("Temporal segment used wall-clock timestamp fallback")
+        ));
+    }
 }
 
 #[test]

--- a/tailtriage-analyzer/tests/expected/blocking_pressure.report.json
+++ b/tailtriage-analyzer/tests/expected/blocking_pressure.report.json
@@ -1,0 +1,55 @@
+{
+  "request_count": 3,
+  "p50_latency_us": 200,
+  "p95_latency_us": 210,
+  "p99_latency_us": 210,
+  "p95_queue_share_permille": 0,
+  "p95_service_share_permille": 1000,
+  "inflight_trend": null,
+  "warnings": [
+    "Run validation precise_interval_validation_unavailable: 3 request event(s) lack optional run-relative precision; legacy duration evidence was retained unchanged. sample: index 0, index 1, index 2.",
+    "Low completed-request count; diagnosis ranking may be unstable for this run window.",
+    "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited."
+  ],
+  "evidence_quality": {
+    "request_count": 3,
+    "queue_event_count": 0,
+    "stage_event_count": 0,
+    "runtime_snapshot_count": 3,
+    "inflight_snapshot_count": 0,
+    "requests": "partial",
+    "queues": "missing",
+    "stages": "missing",
+    "runtime_snapshots": "partial",
+    "inflight_snapshots": "missing",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "weak",
+    "limitations": [
+      "Low completed-request count can make suspect ranking unstable.",
+      "Queue and stage instrumentation are both unavailable, limiting application vs downstream interpretation.",
+      "Runtime snapshots have missing queue-depth fields, limiting executor vs blocking differentiation.",
+      "Validation limitation: Run validation precise_interval_validation_unavailable: 3 request event(s) lack optional run-relative precision; legacy duration evidence was retained unchanged. sample: index 0, index 1, index 2."
+    ]
+  },
+  "primary_suspect": {
+    "kind": "blocking_pool_pressure",
+    "score": 50,
+    "confidence": "low",
+    "evidence": [
+      "Blocking queue depth p95 is 4, peak is 4, with 3/3 nonzero samples."
+    ],
+    "next_checks": [
+      "Audit blocking sections and move avoidable synchronous work out of hot paths.",
+      "Inspect spawn_blocking callsites for long-running CPU or I/O work."
+    ],
+    "confidence_notes": []
+  },
+  "secondary_suspects": [],
+  "route_breakdowns": [],
+  "temporal_segments": []
+}

--- a/tailtriage-analyzer/tests/expected/downstream_stage.report.json
+++ b/tailtriage-analyzer/tests/expected/downstream_stage.report.json
@@ -1,0 +1,60 @@
+{
+  "request_count": 3,
+  "p50_latency_us": 310,
+  "p95_latency_us": 320,
+  "p99_latency_us": 320,
+  "p95_queue_share_permille": 0,
+  "p95_service_share_permille": 1000,
+  "inflight_trend": null,
+  "warnings": [
+    "Run validation precise_interval_validation_unavailable: 3 request event(s) lack optional run-relative precision; legacy duration evidence was retained unchanged. sample: index 0, index 1, index 2.",
+    "Run validation precise_interval_validation_unavailable: 6 stage event(s) lack optional run-relative precision; legacy duration evidence was retained unchanged. sample: index 0, index 1, index 2, index 3, index 4.",
+    "Low completed-request count; diagnosis ranking may be unstable for this run window."
+  ],
+  "evidence_quality": {
+    "request_count": 3,
+    "queue_event_count": 0,
+    "stage_event_count": 6,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 0,
+    "requests": "partial",
+    "queues": "missing",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "missing",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "weak",
+    "limitations": [
+      "Low completed-request count can make suspect ranking unstable.",
+      "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation.",
+      "Validation limitation: Run validation precise_interval_validation_unavailable: 3 request event(s) lack optional run-relative precision; legacy duration evidence was retained unchanged. sample: index 0, index 1, index 2.",
+      "Validation limitation: Run validation precise_interval_validation_unavailable: 6 stage event(s) lack optional run-relative precision; legacy duration evidence was retained unchanged. sample: index 0, index 1, index 2, index 3, index 4."
+    ]
+  },
+  "primary_suspect": {
+    "kind": "downstream_stage_dominates",
+    "score": 95,
+    "confidence": "medium",
+    "evidence": [
+      "Stage 'db' has p95 latency 200 us across 3 samples.",
+      "Stage 'db' cumulative latency is 570 us (612 permille of request latency).",
+      "Stage 'db' contributes 625 permille of tail request latency."
+    ],
+    "next_checks": [
+      "Inspect downstream dependency behind stage 'db'.",
+      "Collect downstream service timings and retry behavior during tail windows.",
+      "Review downstream SLO/error budget and align retry budget/backoff with it."
+    ],
+    "confidence_notes": [
+      "Low completed-request count caps confidence."
+    ]
+  },
+  "secondary_suspects": [],
+  "route_breakdowns": [],
+  "temporal_segments": []
+}

--- a/tailtriage-analyzer/tests/expected/executor_pressure.report.json
+++ b/tailtriage-analyzer/tests/expected/executor_pressure.report.json
@@ -1,0 +1,56 @@
+{
+  "request_count": 3,
+  "p50_latency_us": 110,
+  "p95_latency_us": 120,
+  "p99_latency_us": 120,
+  "p95_queue_share_permille": 0,
+  "p95_service_share_permille": 1000,
+  "inflight_trend": null,
+  "warnings": [
+    "Run validation precise_interval_validation_unavailable: 3 request event(s) lack optional run-relative precision; legacy duration evidence was retained unchanged. sample: index 0, index 1, index 2.",
+    "Low completed-request count; diagnosis ranking may be unstable for this run window.",
+    "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited."
+  ],
+  "evidence_quality": {
+    "request_count": 3,
+    "queue_event_count": 0,
+    "stage_event_count": 0,
+    "runtime_snapshot_count": 3,
+    "inflight_snapshot_count": 0,
+    "requests": "partial",
+    "queues": "missing",
+    "stages": "missing",
+    "runtime_snapshots": "partial",
+    "inflight_snapshots": "missing",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "weak",
+    "limitations": [
+      "Low completed-request count can make suspect ranking unstable.",
+      "Queue and stage instrumentation are both unavailable, limiting application vs downstream interpretation.",
+      "Runtime snapshots have missing queue-depth fields, limiting executor vs blocking differentiation.",
+      "Validation limitation: Run validation precise_interval_validation_unavailable: 3 request event(s) lack optional run-relative precision; legacy duration evidence was retained unchanged. sample: index 0, index 1, index 2."
+    ]
+  },
+  "primary_suspect": {
+    "kind": "executor_pressure_suspected",
+    "score": 36,
+    "confidence": "low",
+    "evidence": [
+      "Runtime global queue depth p95 is 8, suggesting scheduler contention.",
+      "Runtime alive_tasks p95 is 22."
+    ],
+    "next_checks": [
+      "Check for long polls without yielding and uneven task fan-out.",
+      "Compare with per-stage timings to isolate overloaded async stages."
+    ],
+    "confidence_notes": []
+  },
+  "secondary_suspects": [],
+  "route_breakdowns": [],
+  "temporal_segments": []
+}

--- a/tailtriage-analyzer/tests/expected/insufficient_evidence.report.json
+++ b/tailtriage-analyzer/tests/expected/insufficient_evidence.report.json
@@ -1,0 +1,55 @@
+{
+  "request_count": 3,
+  "p50_latency_us": 120,
+  "p95_latency_us": 130,
+  "p99_latency_us": 130,
+  "p95_queue_share_permille": 0,
+  "p95_service_share_permille": 1000,
+  "inflight_trend": null,
+  "warnings": [
+    "Run validation precise_interval_validation_unavailable: 3 request event(s) lack optional run-relative precision; legacy duration evidence was retained unchanged. sample: index 0, index 1, index 2.",
+    "Low completed-request count; diagnosis ranking may be unstable for this run window.",
+    "No runtime snapshots captured; executor and blocking-pressure interpretation is limited."
+  ],
+  "evidence_quality": {
+    "request_count": 3,
+    "queue_event_count": 0,
+    "stage_event_count": 0,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 0,
+    "requests": "partial",
+    "queues": "missing",
+    "stages": "missing",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "missing",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "weak",
+    "limitations": [
+      "Low completed-request count can make suspect ranking unstable.",
+      "Queue and stage instrumentation are both unavailable, limiting application vs downstream interpretation.",
+      "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation.",
+      "Validation limitation: Run validation precise_interval_validation_unavailable: 3 request event(s) lack optional run-relative precision; legacy duration evidence was retained unchanged. sample: index 0, index 1, index 2."
+    ]
+  },
+  "primary_suspect": {
+    "kind": "insufficient_evidence",
+    "score": 50,
+    "confidence": "low",
+    "evidence": [
+      "Not enough queue, stage, or runtime signals to rank a stronger suspect."
+    ],
+    "next_checks": [
+      "Wrap critical awaits with queue(...).await_on(...), and use stage(...).await_on(...) for Result-returning work or stage(...).await_value(...) for infallible work.",
+      "Enable RuntimeSampler during the run to capture runtime pressure signals."
+    ],
+    "confidence_notes": []
+  },
+  "secondary_suspects": [],
+  "route_breakdowns": [],
+  "temporal_segments": []
+}

--- a/tailtriage-analyzer/tests/expected/mixed_blocking_vs_downstream.report.json
+++ b/tailtriage-analyzer/tests/expected/mixed_blocking_vs_downstream.report.json
@@ -1,0 +1,73 @@
+{
+  "request_count": 3,
+  "p50_latency_us": 1050,
+  "p95_latency_us": 1100,
+  "p99_latency_us": 1100,
+  "p95_queue_share_permille": 0,
+  "p95_service_share_permille": 1000,
+  "inflight_trend": null,
+  "warnings": [
+    "Run validation precise_interval_validation_unavailable: 3 request event(s) lack optional run-relative precision; legacy duration evidence was retained unchanged. sample: index 0, index 1, index 2.",
+    "Run validation precise_interval_validation_unavailable: 3 stage event(s) lack optional run-relative precision; legacy duration evidence was retained unchanged. sample: index 0, index 1, index 2.",
+    "Low completed-request count; diagnosis ranking may be unstable for this run window.",
+    "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited."
+  ],
+  "evidence_quality": {
+    "request_count": 3,
+    "queue_event_count": 0,
+    "stage_event_count": 3,
+    "runtime_snapshot_count": 3,
+    "inflight_snapshot_count": 0,
+    "requests": "partial",
+    "queues": "missing",
+    "stages": "present",
+    "runtime_snapshots": "partial",
+    "inflight_snapshots": "missing",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "weak",
+    "limitations": [
+      "Low completed-request count can make suspect ranking unstable.",
+      "Runtime snapshots have missing queue-depth fields, limiting executor vs blocking differentiation.",
+      "Validation limitation: Run validation precise_interval_validation_unavailable: 3 request event(s) lack optional run-relative precision; legacy duration evidence was retained unchanged. sample: index 0, index 1, index 2.",
+      "Validation limitation: Run validation precise_interval_validation_unavailable: 3 stage event(s) lack optional run-relative precision; legacy duration evidence was retained unchanged. sample: index 0, index 1, index 2."
+    ]
+  },
+  "primary_suspect": {
+    "kind": "downstream_stage_dominates",
+    "score": 72,
+    "confidence": "medium",
+    "evidence": [
+      "Stage 'db' has p95 latency 450 us across 3 samples.",
+      "Stage 'db' cumulative latency is 1270 us (403 permille of request latency).",
+      "Stage 'db' contributes 409 permille of tail request latency."
+    ],
+    "next_checks": [
+      "Inspect downstream dependency behind stage 'db'.",
+      "Collect downstream service timings and retry behavior during tail windows.",
+      "Review downstream SLO/error budget and align retry budget/backoff with it."
+    ],
+    "confidence_notes": []
+  },
+  "secondary_suspects": [
+    {
+      "kind": "blocking_pool_pressure",
+      "score": 51,
+      "confidence": "low",
+      "evidence": [
+        "Blocking queue depth p95 is 5, peak is 5, with 3/3 nonzero samples."
+      ],
+      "next_checks": [
+        "Audit blocking sections and move avoidable synchronous work out of hot paths.",
+        "Inspect spawn_blocking callsites for long-running CPU or I/O work."
+      ],
+      "confidence_notes": []
+    }
+  ],
+  "route_breakdowns": [],
+  "temporal_segments": []
+}

--- a/tailtriage-analyzer/tests/expected/mixed_queue_vs_blocking.report.json
+++ b/tailtriage-analyzer/tests/expected/mixed_queue_vs_blocking.report.json
@@ -1,0 +1,71 @@
+{
+  "request_count": 3,
+  "p50_latency_us": 1000,
+  "p95_latency_us": 1000,
+  "p99_latency_us": 1000,
+  "p95_queue_share_permille": 360,
+  "p95_service_share_permille": 660,
+  "inflight_trend": null,
+  "warnings": [
+    "Run validation precise_interval_validation_unavailable: 3 request event(s) lack optional run-relative precision; legacy duration evidence was retained unchanged. sample: index 0, index 1, index 2.",
+    "Run validation precise_interval_validation_unavailable: 3 queue event(s) lack optional run-relative precision; legacy duration evidence was retained unchanged. sample: index 0, index 1, index 2.",
+    "Low completed-request count; diagnosis ranking may be unstable for this run window.",
+    "Runtime snapshots are missing blocking_queue_depth or local_queue_depth; separating executor vs blocking pressure is limited."
+  ],
+  "evidence_quality": {
+    "request_count": 3,
+    "queue_event_count": 3,
+    "stage_event_count": 0,
+    "runtime_snapshot_count": 3,
+    "inflight_snapshot_count": 0,
+    "requests": "partial",
+    "queues": "present",
+    "stages": "missing",
+    "runtime_snapshots": "partial",
+    "inflight_snapshots": "missing",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "weak",
+    "limitations": [
+      "Low completed-request count can make suspect ranking unstable.",
+      "Runtime snapshots have missing queue-depth fields, limiting executor vs blocking differentiation.",
+      "Validation limitation: Run validation precise_interval_validation_unavailable: 3 request event(s) lack optional run-relative precision; legacy duration evidence was retained unchanged. sample: index 0, index 1, index 2.",
+      "Validation limitation: Run validation precise_interval_validation_unavailable: 3 queue event(s) lack optional run-relative precision; legacy duration evidence was retained unchanged. sample: index 0, index 1, index 2."
+    ]
+  },
+  "primary_suspect": {
+    "kind": "application_queue_saturation",
+    "score": 49,
+    "confidence": "low",
+    "evidence": [
+      "Queue wait at p95 consumes 36.0% of request time.",
+      "Observed queue depth sample up to 4."
+    ],
+    "next_checks": [
+      "Inspect queue admission limits and producer burst patterns.",
+      "Compare queue wait distribution before and after increasing worker parallelism."
+    ],
+    "confidence_notes": []
+  },
+  "secondary_suspects": [
+    {
+      "kind": "blocking_pool_pressure",
+      "score": 48,
+      "confidence": "low",
+      "evidence": [
+        "Blocking queue depth p95 is 3, peak is 3, with 3/3 nonzero samples."
+      ],
+      "next_checks": [
+        "Audit blocking sections and move avoidable synchronous work out of hot paths.",
+        "Inspect spawn_blocking callsites for long-running CPU or I/O work."
+      ],
+      "confidence_notes": []
+    }
+  ],
+  "route_breakdowns": [],
+  "temporal_segments": []
+}

--- a/tailtriage-analyzer/tests/expected/queue_saturation.report.json
+++ b/tailtriage-analyzer/tests/expected/queue_saturation.report.json
@@ -1,0 +1,65 @@
+{
+  "request_count": 3,
+  "p50_latency_us": 120,
+  "p95_latency_us": 150,
+  "p99_latency_us": 150,
+  "p95_queue_share_permille": 666,
+  "p95_service_share_permille": 500,
+  "inflight_trend": {
+    "gauge": "worker_inflight",
+    "sample_count": 3,
+    "peak_count": 6,
+    "p95_count": 6,
+    "growth_delta": 5,
+    "growth_per_sec_milli": null
+  },
+  "warnings": [
+    "Run validation precise_interval_validation_unavailable: 3 request event(s) lack optional run-relative precision; legacy duration evidence was retained unchanged. sample: index 0, index 1, index 2.",
+    "Run validation precise_interval_validation_unavailable: 3 queue event(s) lack optional run-relative precision; legacy duration evidence was retained unchanged. sample: index 0, index 1, index 2.",
+    "Low completed-request count; diagnosis ranking may be unstable for this run window.",
+    "No runtime snapshots captured; executor and blocking-pressure interpretation is limited."
+  ],
+  "evidence_quality": {
+    "request_count": 3,
+    "queue_event_count": 3,
+    "stage_event_count": 0,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 3,
+    "requests": "partial",
+    "queues": "present",
+    "stages": "missing",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "weak",
+    "limitations": [
+      "Low completed-request count can make suspect ranking unstable.",
+      "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation.",
+      "Validation limitation: Run validation precise_interval_validation_unavailable: 3 request event(s) lack optional run-relative precision; legacy duration evidence was retained unchanged. sample: index 0, index 1, index 2.",
+      "Validation limitation: Run validation precise_interval_validation_unavailable: 3 queue event(s) lack optional run-relative precision; legacy duration evidence was retained unchanged. sample: index 0, index 1, index 2."
+    ]
+  },
+  "primary_suspect": {
+    "kind": "application_queue_saturation",
+    "score": 78,
+    "confidence": "medium",
+    "evidence": [
+      "Queue wait at p95 consumes 66.6% of request time.",
+      "Observed queue depth sample up to 6.",
+      "In-flight gauge 'worker_inflight' latest active episode grew by 5 across 3 samples (p95=6, peak=6); ordering used Unix-ms fallback and no precise growth rate was derived."
+    ],
+    "next_checks": [
+      "Inspect queue admission limits and producer burst patterns.",
+      "Compare queue wait distribution before and after increasing worker parallelism."
+    ],
+    "confidence_notes": []
+  },
+  "secondary_suspects": [],
+  "route_breakdowns": [],
+  "temporal_segments": []
+}

--- a/tailtriage-analyzer/tests/expected/scoped_route.report.json
+++ b/tailtriage-analyzer/tests/expected/scoped_route.report.json
@@ -1,0 +1,195 @@
+{
+  "request_count": 6,
+  "p50_latency_us": 10000,
+  "p95_latency_us": 10000,
+  "p99_latency_us": 10000,
+  "p95_queue_share_permille": 900,
+  "p95_service_share_permille": 1000,
+  "inflight_trend": {
+    "gauge": "worker_inflight",
+    "sample_count": 3,
+    "peak_count": 6,
+    "p95_count": 6,
+    "growth_delta": 5,
+    "growth_per_sec_milli": null
+  },
+  "warnings": [
+    "Run validation precise_interval_validation_unavailable: 6 request event(s) lack optional run-relative precision; legacy duration evidence was retained unchanged. sample: index 0, index 1, index 2, index 3, index 4.",
+    "Run validation precise_interval_validation_unavailable: 3 stage event(s) lack optional run-relative precision; legacy duration evidence was retained unchanged. sample: index 0, index 1, index 2.",
+    "Run validation precise_interval_validation_unavailable: 3 queue event(s) lack optional run-relative precision; legacy duration evidence was retained unchanged. sample: index 0, index 1, index 2.",
+    "Low completed-request count; diagnosis ranking may be unstable for this run window.",
+    "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect."
+  ],
+  "evidence_quality": {
+    "request_count": 6,
+    "queue_event_count": 3,
+    "stage_event_count": 3,
+    "runtime_snapshot_count": 0,
+    "inflight_snapshot_count": 3,
+    "requests": "partial",
+    "queues": "present",
+    "stages": "present",
+    "runtime_snapshots": "missing",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "weak",
+    "limitations": [
+      "Low completed-request count can make suspect ranking unstable.",
+      "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation.",
+      "Validation limitation: Run validation precise_interval_validation_unavailable: 6 request event(s) lack optional run-relative precision; legacy duration evidence was retained unchanged. sample: index 0, index 1, index 2, index 3, index 4.",
+      "Validation limitation: Run validation precise_interval_validation_unavailable: 3 stage event(s) lack optional run-relative precision; legacy duration evidence was retained unchanged. sample: index 0, index 1, index 2.",
+      "Validation limitation: Run validation precise_interval_validation_unavailable: 3 queue event(s) lack optional run-relative precision; legacy duration evidence was retained unchanged. sample: index 0, index 1, index 2."
+    ]
+  },
+  "primary_suspect": {
+    "kind": "application_queue_saturation",
+    "score": 95,
+    "confidence": "medium",
+    "evidence": [
+      "Queue wait at p95 consumes 90.0% of request time.",
+      "Observed queue depth sample up to 9.",
+      "In-flight gauge 'worker_inflight' latest active episode grew by 5 across 3 samples (p95=6, peak=6); ordering used Unix-ms fallback and no precise growth rate was derived."
+    ],
+    "next_checks": [
+      "Inspect queue admission limits and producer burst patterns.",
+      "Compare queue wait distribution before and after increasing worker parallelism."
+    ],
+    "confidence_notes": [
+      "Low completed-request count caps confidence."
+    ]
+  },
+  "secondary_suspects": [
+    {
+      "kind": "downstream_stage_dominates",
+      "score": 28,
+      "confidence": "low",
+      "evidence": [
+        "Stage 'db' has p95 latency 1900 us across 3 samples.",
+        "Stage 'db' cumulative latency is 5700 us (158 permille of request latency).",
+        "Stage 'db' contributes 0 permille of tail request latency."
+      ],
+      "next_checks": [
+        "Inspect downstream dependency behind stage 'db'.",
+        "Collect downstream service timings and retry behavior during tail windows.",
+        "Review downstream SLO/error budget and align retry budget/backoff with it."
+      ],
+      "confidence_notes": []
+    }
+  ],
+  "route_breakdowns": [
+    {
+      "route": "/queue",
+      "request_count": 3,
+      "p50_latency_us": 10000,
+      "p95_latency_us": 10000,
+      "p99_latency_us": 10000,
+      "p95_queue_share_permille": 900,
+      "p95_service_share_permille": 100,
+      "evidence_quality": {
+        "request_count": 3,
+        "queue_event_count": 3,
+        "stage_event_count": 0,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 0,
+        "requests": "partial",
+        "queues": "present",
+        "stages": "missing",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "missing",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "weak",
+        "limitations": [
+          "Low completed-request count can make suspect ranking unstable.",
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "application_queue_saturation",
+        "score": 92,
+        "confidence": "medium",
+        "evidence": [
+          "Queue wait at p95 consumes 90.0% of request time.",
+          "Observed queue depth sample up to 9."
+        ],
+        "next_checks": [
+          "Inspect queue admission limits and producer burst patterns.",
+          "Compare queue wait distribution before and after increasing worker parallelism."
+        ],
+        "confidence_notes": [
+          "Low completed-request count caps confidence."
+        ]
+      },
+      "secondary_suspects": [],
+      "warnings": [
+        "Low completed-request count; diagnosis ranking may be unstable for this run window.",
+        "Runtime and in-flight signals are global and are not attributed to this route."
+      ]
+    },
+    {
+      "route": "/downstream",
+      "request_count": 3,
+      "p50_latency_us": 2000,
+      "p95_latency_us": 2000,
+      "p99_latency_us": 2000,
+      "p95_queue_share_permille": 0,
+      "p95_service_share_permille": 1000,
+      "evidence_quality": {
+        "request_count": 3,
+        "queue_event_count": 0,
+        "stage_event_count": 3,
+        "runtime_snapshot_count": 0,
+        "inflight_snapshot_count": 0,
+        "requests": "partial",
+        "queues": "missing",
+        "stages": "present",
+        "runtime_snapshots": "missing",
+        "inflight_snapshots": "missing",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "weak",
+        "limitations": [
+          "Low completed-request count can make suspect ranking unstable.",
+          "Runtime snapshots are missing, limiting executor and blocking-pressure interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "downstream_stage_dominates",
+        "score": 95,
+        "confidence": "medium",
+        "evidence": [
+          "Stage 'db' has p95 latency 1900 us across 3 samples.",
+          "Stage 'db' cumulative latency is 5700 us (950 permille of request latency).",
+          "Stage 'db' contributes 950 permille of tail request latency."
+        ],
+        "next_checks": [
+          "Inspect downstream dependency behind stage 'db'.",
+          "Collect downstream service timings and retry behavior during tail windows.",
+          "Review downstream SLO/error budget and align retry budget/backoff with it."
+        ],
+        "confidence_notes": [
+          "Low completed-request count caps confidence."
+        ]
+      },
+      "secondary_suspects": [],
+      "warnings": [
+        "Low completed-request count; diagnosis ranking may be unstable for this run window.",
+        "Runtime and in-flight signals are global and are not attributed to this route."
+      ]
+    }
+  ],
+  "temporal_segments": []
+}

--- a/tailtriage-analyzer/tests/expected/scoped_temporal.report.json
+++ b/tailtriage-analyzer/tests/expected/scoped_temporal.report.json
@@ -1,0 +1,169 @@
+{
+  "request_count": 20,
+  "p50_latency_us": 6000,
+  "p95_latency_us": 6000,
+  "p99_latency_us": 6000,
+  "p95_queue_share_permille": 0,
+  "p95_service_share_permille": 1000,
+  "inflight_trend": {
+    "gauge": "requests",
+    "sample_count": 2,
+    "peak_count": 8,
+    "p95_count": 8,
+    "growth_delta": 6,
+    "growth_per_sec_milli": 600000
+  },
+  "warnings": [
+    "Temporal segments show a large p95 latency shift between early and late requests."
+  ],
+  "evidence_quality": {
+    "request_count": 20,
+    "queue_event_count": 0,
+    "stage_event_count": 0,
+    "runtime_snapshot_count": 2,
+    "inflight_snapshot_count": 2,
+    "requests": "present",
+    "queues": "missing",
+    "stages": "missing",
+    "runtime_snapshots": "present",
+    "inflight_snapshots": "present",
+    "truncated": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0,
+    "quality": "partial",
+    "limitations": [
+      "Queue and stage instrumentation are both unavailable, limiting application vs downstream interpretation."
+    ]
+  },
+  "primary_suspect": {
+    "kind": "executor_pressure_suspected",
+    "score": 48,
+    "confidence": "low",
+    "evidence": [
+      "Runtime global queue depth p95 is 20, suggesting scheduler contention.",
+      "Runtime local queue depth p95 is 20.",
+      "Runtime alive_tasks p95 is 100.",
+      "In-flight gauge 'requests' latest active episode grew by 6 across 2 samples (p95=8, peak=8, run-relative rate=600000 milli-counts/sec)."
+    ],
+    "next_checks": [
+      "Check for long polls without yielding and uneven task fan-out.",
+      "Compare with per-stage timings to isolate overloaded async stages."
+    ],
+    "confidence_notes": []
+  },
+  "secondary_suspects": [],
+  "route_breakdowns": [],
+  "temporal_segments": [
+    {
+      "name": "early",
+      "request_count": 10,
+      "started_at_unix_ms": 100,
+      "finished_at_unix_ms": 110,
+      "p50_latency_us": 1000,
+      "p95_latency_us": 1000,
+      "p99_latency_us": 1000,
+      "p95_queue_share_permille": 0,
+      "p95_service_share_permille": 1000,
+      "evidence_quality": {
+        "request_count": 10,
+        "queue_event_count": 0,
+        "stage_event_count": 0,
+        "runtime_snapshot_count": 1,
+        "inflight_snapshot_count": 1,
+        "requests": "partial",
+        "queues": "missing",
+        "stages": "missing",
+        "runtime_snapshots": "present",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "weak",
+        "limitations": [
+          "Low completed-request count can make suspect ranking unstable.",
+          "Queue and stage instrumentation are both unavailable, limiting application vs downstream interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "executor_pressure_suspected",
+        "score": 44,
+        "confidence": "low",
+        "evidence": [
+          "Runtime global queue depth p95 is 20, suggesting scheduler contention.",
+          "Runtime local queue depth p95 is 20.",
+          "Runtime alive_tasks p95 is 100."
+        ],
+        "next_checks": [
+          "Check for long polls without yielding and uneven task fan-out.",
+          "Compare with per-stage timings to isolate overloaded async stages."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [],
+      "warnings": [
+        "Low completed-request count; diagnosis ranking may be unstable for this run window.",
+        "Segment windows overlap under concurrent requests; timestamp-filtered runtime/in-flight attribution is approximate."
+      ]
+    },
+    {
+      "name": "late",
+      "request_count": 10,
+      "started_at_unix_ms": 110,
+      "finished_at_unix_ms": 120,
+      "p50_latency_us": 6000,
+      "p95_latency_us": 6000,
+      "p99_latency_us": 6000,
+      "p95_queue_share_permille": 0,
+      "p95_service_share_permille": 1000,
+      "evidence_quality": {
+        "request_count": 10,
+        "queue_event_count": 0,
+        "stage_event_count": 0,
+        "runtime_snapshot_count": 1,
+        "inflight_snapshot_count": 1,
+        "requests": "partial",
+        "queues": "missing",
+        "stages": "missing",
+        "runtime_snapshots": "present",
+        "inflight_snapshots": "present",
+        "truncated": false,
+        "dropped_requests": 0,
+        "dropped_stages": 0,
+        "dropped_queues": 0,
+        "dropped_inflight_snapshots": 0,
+        "dropped_runtime_snapshots": 0,
+        "quality": "weak",
+        "limitations": [
+          "Low completed-request count can make suspect ranking unstable.",
+          "Queue and stage instrumentation are both unavailable, limiting application vs downstream interpretation."
+        ]
+      },
+      "primary_suspect": {
+        "kind": "executor_pressure_suspected",
+        "score": 36,
+        "confidence": "low",
+        "evidence": [
+          "Runtime global queue depth p95 is 1, suggesting scheduler contention.",
+          "Runtime local queue depth p95 is 1.",
+          "Runtime alive_tasks p95 is 100."
+        ],
+        "next_checks": [
+          "Check for long polls without yielding and uneven task fan-out.",
+          "Compare with per-stage timings to isolate overloaded async stages."
+        ],
+        "confidence_notes": []
+      },
+      "secondary_suspects": [],
+      "warnings": [
+        "Low completed-request count; diagnosis ranking may be unstable for this run window.",
+        "Segment windows overlap under concurrent requests; timestamp-filtered runtime/in-flight attribution is approximate."
+      ]
+    }
+  ]
+}

--- a/tailtriage-analyzer/tests/fixtures/scoped_route.json
+++ b/tailtriage-analyzer/tests/fixtures/scoped_route.json
@@ -1,0 +1,139 @@
+{
+  "schema_version": 2,
+  "metadata": {
+    "run_id": "scoped-route-golden",
+    "service_name": "svc",
+    "service_version": null,
+    "started_at_unix_ms": 1,
+    "mode": "light",
+    "host": null,
+    "pid": 7,
+    "finalized_at_unix_ms": 2
+  },
+  "requests": [
+    {
+      "request_id": "q-0",
+      "route": "/queue",
+      "kind": null,
+      "started_at_unix_ms": 1,
+      "finished_at_unix_ms": 2,
+      "latency_us": 10000,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "q-1",
+      "route": "/queue",
+      "kind": null,
+      "started_at_unix_ms": 1,
+      "finished_at_unix_ms": 2,
+      "latency_us": 10000,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "q-2",
+      "route": "/queue",
+      "kind": null,
+      "started_at_unix_ms": 1,
+      "finished_at_unix_ms": 2,
+      "latency_us": 10000,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "d-0",
+      "route": "/downstream",
+      "kind": null,
+      "started_at_unix_ms": 1,
+      "finished_at_unix_ms": 2,
+      "latency_us": 2000,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "d-1",
+      "route": "/downstream",
+      "kind": null,
+      "started_at_unix_ms": 1,
+      "finished_at_unix_ms": 2,
+      "latency_us": 2000,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "d-2",
+      "route": "/downstream",
+      "kind": null,
+      "started_at_unix_ms": 1,
+      "finished_at_unix_ms": 2,
+      "latency_us": 2000,
+      "outcome": "ok"
+    }
+  ],
+  "stages": [
+    {
+      "request_id": "d-0",
+      "stage": "db",
+      "started_at_unix_ms": 1,
+      "finished_at_unix_ms": 2,
+      "latency_us": 1900,
+      "success": true
+    },
+    {
+      "request_id": "d-1",
+      "stage": "db",
+      "started_at_unix_ms": 1,
+      "finished_at_unix_ms": 2,
+      "latency_us": 1900,
+      "success": true
+    },
+    {
+      "request_id": "d-2",
+      "stage": "db",
+      "started_at_unix_ms": 1,
+      "finished_at_unix_ms": 2,
+      "latency_us": 1900,
+      "success": true
+    }
+  ],
+  "queues": [
+    {
+      "request_id": "q-0",
+      "queue": "worker",
+      "waited_from_unix_ms": 1,
+      "waited_until_unix_ms": 2,
+      "wait_us": 9000,
+      "depth_at_start": 9
+    },
+    {
+      "request_id": "q-1",
+      "queue": "worker",
+      "waited_from_unix_ms": 1,
+      "waited_until_unix_ms": 2,
+      "wait_us": 9000,
+      "depth_at_start": 9
+    },
+    {
+      "request_id": "q-2",
+      "queue": "worker",
+      "waited_from_unix_ms": 1,
+      "waited_until_unix_ms": 2,
+      "wait_us": 9000,
+      "depth_at_start": 9
+    }
+  ],
+  "inflight": [
+    {
+      "gauge": "worker_inflight",
+      "at_unix_ms": 1,
+      "count": 1
+    },
+    {
+      "gauge": "worker_inflight",
+      "at_unix_ms": 2,
+      "count": 3
+    },
+    {
+      "gauge": "worker_inflight",
+      "at_unix_ms": 3,
+      "count": 6
+    }
+  ],
+  "runtime_snapshots": []
+}

--- a/tailtriage-analyzer/tests/fixtures/scoped_temporal.json
+++ b/tailtriage-analyzer/tests/fixtures/scoped_temporal.json
@@ -1,0 +1,271 @@
+{
+  "schema_version": 2,
+  "metadata": {
+    "run_id": "scoped-temporal-golden",
+    "service_name": "svc",
+    "service_version": null,
+    "started_at_unix_ms": 1,
+    "mode": "light",
+    "host": null,
+    "pid": 7,
+    "finalized_at_unix_ms": 2
+  },
+  "requests": [
+    {
+      "request_id": "t-00",
+      "route": "/temporal",
+      "kind": null,
+      "started_at_unix_ms": 100,
+      "finished_at_unix_ms": 101,
+      "latency_us": 1000,
+      "outcome": "ok",
+      "started_at_run_us": 1000,
+      "finished_at_run_us": 2000
+    },
+    {
+      "request_id": "t-01",
+      "route": "/temporal",
+      "kind": null,
+      "started_at_unix_ms": 101,
+      "finished_at_unix_ms": 102,
+      "latency_us": 1000,
+      "outcome": "ok",
+      "started_at_run_us": 2000,
+      "finished_at_run_us": 3000
+    },
+    {
+      "request_id": "t-02",
+      "route": "/temporal",
+      "kind": null,
+      "started_at_unix_ms": 102,
+      "finished_at_unix_ms": 103,
+      "latency_us": 1000,
+      "outcome": "ok",
+      "started_at_run_us": 3000,
+      "finished_at_run_us": 4000
+    },
+    {
+      "request_id": "t-03",
+      "route": "/temporal",
+      "kind": null,
+      "started_at_unix_ms": 103,
+      "finished_at_unix_ms": 104,
+      "latency_us": 1000,
+      "outcome": "ok",
+      "started_at_run_us": 4000,
+      "finished_at_run_us": 5000
+    },
+    {
+      "request_id": "t-04",
+      "route": "/temporal",
+      "kind": null,
+      "started_at_unix_ms": 104,
+      "finished_at_unix_ms": 105,
+      "latency_us": 1000,
+      "outcome": "ok",
+      "started_at_run_us": 5000,
+      "finished_at_run_us": 6000
+    },
+    {
+      "request_id": "t-05",
+      "route": "/temporal",
+      "kind": null,
+      "started_at_unix_ms": 105,
+      "finished_at_unix_ms": 106,
+      "latency_us": 1000,
+      "outcome": "ok",
+      "started_at_run_us": 6000,
+      "finished_at_run_us": 7000
+    },
+    {
+      "request_id": "t-06",
+      "route": "/temporal",
+      "kind": null,
+      "started_at_unix_ms": 106,
+      "finished_at_unix_ms": 107,
+      "latency_us": 1000,
+      "outcome": "ok",
+      "started_at_run_us": 7000,
+      "finished_at_run_us": 8000
+    },
+    {
+      "request_id": "t-07",
+      "route": "/temporal",
+      "kind": null,
+      "started_at_unix_ms": 107,
+      "finished_at_unix_ms": 108,
+      "latency_us": 1000,
+      "outcome": "ok",
+      "started_at_run_us": 8000,
+      "finished_at_run_us": 9000
+    },
+    {
+      "request_id": "t-08",
+      "route": "/temporal",
+      "kind": null,
+      "started_at_unix_ms": 108,
+      "finished_at_unix_ms": 109,
+      "latency_us": 1000,
+      "outcome": "ok",
+      "started_at_run_us": 9000,
+      "finished_at_run_us": 10000
+    },
+    {
+      "request_id": "t-09",
+      "route": "/temporal",
+      "kind": null,
+      "started_at_unix_ms": 109,
+      "finished_at_unix_ms": 110,
+      "latency_us": 1000,
+      "outcome": "ok",
+      "started_at_run_us": 10000,
+      "finished_at_run_us": 11000
+    },
+    {
+      "request_id": "t-10",
+      "route": "/temporal",
+      "kind": null,
+      "started_at_unix_ms": 110,
+      "finished_at_unix_ms": 111,
+      "latency_us": 6000,
+      "outcome": "ok",
+      "started_at_run_us": 11000,
+      "finished_at_run_us": 17000
+    },
+    {
+      "request_id": "t-11",
+      "route": "/temporal",
+      "kind": null,
+      "started_at_unix_ms": 111,
+      "finished_at_unix_ms": 112,
+      "latency_us": 6000,
+      "outcome": "ok",
+      "started_at_run_us": 12000,
+      "finished_at_run_us": 18000
+    },
+    {
+      "request_id": "t-12",
+      "route": "/temporal",
+      "kind": null,
+      "started_at_unix_ms": 112,
+      "finished_at_unix_ms": 113,
+      "latency_us": 6000,
+      "outcome": "ok",
+      "started_at_run_us": 13000,
+      "finished_at_run_us": 19000
+    },
+    {
+      "request_id": "t-13",
+      "route": "/temporal",
+      "kind": null,
+      "started_at_unix_ms": 113,
+      "finished_at_unix_ms": 114,
+      "latency_us": 6000,
+      "outcome": "ok",
+      "started_at_run_us": 14000,
+      "finished_at_run_us": 20000
+    },
+    {
+      "request_id": "t-14",
+      "route": "/temporal",
+      "kind": null,
+      "started_at_unix_ms": 114,
+      "finished_at_unix_ms": 115,
+      "latency_us": 6000,
+      "outcome": "ok",
+      "started_at_run_us": 15000,
+      "finished_at_run_us": 21000
+    },
+    {
+      "request_id": "t-15",
+      "route": "/temporal",
+      "kind": null,
+      "started_at_unix_ms": 115,
+      "finished_at_unix_ms": 116,
+      "latency_us": 6000,
+      "outcome": "ok",
+      "started_at_run_us": 16000,
+      "finished_at_run_us": 22000
+    },
+    {
+      "request_id": "t-16",
+      "route": "/temporal",
+      "kind": null,
+      "started_at_unix_ms": 116,
+      "finished_at_unix_ms": 117,
+      "latency_us": 6000,
+      "outcome": "ok",
+      "started_at_run_us": 17000,
+      "finished_at_run_us": 23000
+    },
+    {
+      "request_id": "t-17",
+      "route": "/temporal",
+      "kind": null,
+      "started_at_unix_ms": 117,
+      "finished_at_unix_ms": 118,
+      "latency_us": 6000,
+      "outcome": "ok",
+      "started_at_run_us": 18000,
+      "finished_at_run_us": 24000
+    },
+    {
+      "request_id": "t-18",
+      "route": "/temporal",
+      "kind": null,
+      "started_at_unix_ms": 118,
+      "finished_at_unix_ms": 119,
+      "latency_us": 6000,
+      "outcome": "ok",
+      "started_at_run_us": 19000,
+      "finished_at_run_us": 25000
+    },
+    {
+      "request_id": "t-19",
+      "route": "/temporal",
+      "kind": null,
+      "started_at_unix_ms": 119,
+      "finished_at_unix_ms": 120,
+      "latency_us": 6000,
+      "outcome": "ok",
+      "started_at_run_us": 20000,
+      "finished_at_run_us": 26000
+    }
+  ],
+  "stages": [],
+  "queues": [],
+  "inflight": [
+    {
+      "at_unix_ms": 105,
+      "at_run_us": 5000,
+      "gauge": "requests",
+      "count": 2
+    },
+    {
+      "at_unix_ms": 115,
+      "at_run_us": 15000,
+      "gauge": "requests",
+      "count": 8
+    }
+  ],
+  "runtime_snapshots": [
+    {
+      "at_unix_ms": 105,
+      "at_run_us": 5000,
+      "alive_tasks": 100,
+      "global_queue_depth": 20,
+      "local_queue_depth": 20,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 115,
+      "at_run_us": 15000,
+      "alive_tasks": 100,
+      "global_queue_depth": 1,
+      "local_queue_depth": 1,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": null
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation

- Consolidate duplicated request-scoped filtering and scoped-report projection used by both route and temporal analysis into one small internal slicing layer. 
- Make the global-runtime / in-flight evidence policy explicit for scoped analysis so route and temporal semantics remain mechanical and auditable.
- Preserve all existing public report shapes, serialized field names, ordering, and analyzer semantics while removing duplicated code.

### Description

- Add a private slicing module `tailtriage-analyzer/src/slicing.rs` that implements a shared slicer and scoped analysis helper, including `analyze_slice`, `ScopedReportProjection`, and `SlicedRun`.
- Introduce an explicit global-evidence policy type `GlobalEvidencePolicy` with `Exclude` and `Window(SampleWindow)` variants and a `SampleWindow` shape that preserves the run-relative optional window.
- Move generic sample retention and inclusive mixed-clock fallback rules into the slicer (per-sample Unix fallback marker preserved) and have the slicer return whether a Unix fallback was used for retained samples.
- Route analysis now calls the shared slicer with `GlobalEvidencePolicy::Exclude` instead of `filtered_run_for_route`, preserving all route emission, divergence, sorting, truncation, and warning behavior.
- Temporal analysis now calls the shared slicer with `GlobalEvidencePolicy::Window(...)` and retains temporal segmentation policy in `temporal.rs` (split/sorting/eligibility/materiality/warnings unchanged); `temporal.rs` uses the shared `ScopedReportProjection` to construct `TemporalSegment` values.
- Add focused unit tests and canonical pretty-JSON goldens: new test `shared_slicer_preserves_request_scoped_source_order`, temporal/route scoped fixtures `scoped_route.json` and `scoped_temporal.json`, and golden reports under `tailtriage-analyzer/tests/expected/` to ensure exact byte-stable pretty JSON for existing fixtures plus the scoped cases.

### Testing

- Ran formatter and linter: `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (passed).
- Ran full analyzer test suite: `cargo test --workspace --all-targets --all-features --locked` and all tests passed, including the new slicer unit tests and the fixture golden-comparison test `fixture_reports_match_canonical_pretty_json_golden_files` (passed).
- Validated documentation/contracts: `python3 scripts/validate_docs_contracts.py` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6778058a448330a5a712d32d5e203c)