### PR TITLE
Separate analyzer accuracy from Report-contract validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Diagnostic validation now separates analyzer-executed accuracy observations from pre-generated Report-contract checks.
+
 - Native/core Run fixtures and stable tracing JSONL now have a deterministic equivalence contract for shared completed evidence and analyzer results, with explicit Run-only limitations.
 
 - Route and temporal analysis now share internal request-scoped Run slicing and scoped-report projection while preserving their distinct runtime/in-flight attribution policies and existing serialized Report output.

--- a/SPEC.md
+++ b/SPEC.md
@@ -283,7 +283,7 @@ The validation surface includes:
 
 ### 8.1 Deterministic diagnostic corpus
 
-The deterministic corpus validates analyzer/report behavior against labeled fixtures. The current corpus mixes analyzer-executed artifacts (`run_artifact` and `tracing_span_jsonl`, which flow through Run JSON analysis) with report-only fixtures that validate report contract handling without re-running the analyzer.
+The schema-version-2 deterministic corpus mechanically separates analyzer-executed cases from report-contract cases. Diagnosis accuracy uses only unique accuracy-eligible observations; equivalent artifact encodings execute independently but count once. Report-contract fixtures validate Report output contracts without executing the analyzer or entering accuracy. The current corpus mixes analyzer-executed artifacts (`run_artifact` and `tracing_span_jsonl`, which flow through Run JSON analysis) with report-only fixtures that validate report contract handling without re-running the analyzer.
 
 It may check:
 

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -1,5 +1,11 @@
 # Validation
 
+## Diagnostic corpus accounting
+
+The schema-version-2 deterministic corpus separates analyzer-executed cases, unique accuracy-eligible observations, and report-contract cases. Raw Runs are analyzed at benchmark execution; stable tracing JSONL is imported and then analyzed. Analyzer cases have typed success/failure contracts and may be execution-only. Multiple artifact encodings of one logical workload execute independently but count once for accuracy and must agree on ordered diagnosis visibility and confidence bucket.
+
+Pre-generated and synthetic Reports validate Report fields, warnings, evidence, next checks, confidence, routes, and temporal output without executing the analyzer. They never contribute to analyzer accuracy. Fixture ground truth is controlled fixture intent, not production truth or root-cause proof. Typed fixture generation is deferred to Prompt 18B; corpus expansion and exact demo replacements are deferred to Prompt 18C, and no demo is removed here.
+
 ## Summary
 `tailtriage` is a triage tool, not root-cause proof. It produces evidence-ranked suspects and next checks, where suspects are leads and not causal certainty.
 

--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -3,23 +3,15 @@
 `tailtriage` validation checks diagnosis quality for triage. It does not provide root-cause proof.
 
 ## Methodology
-The benchmark evaluates a deterministic corpus of analyzer reports and selected raw run artifacts against workload-grounded labels. Raw run artifacts are analyzed via Run -> analyze_run() in the CLI path. It checks suspect ranking behavior, evidence/warning expectations, and bounded failure semantics.
+The schema-version-2 benchmark separates three concepts. An analyzer-executed case either analyzes a raw Run or imports stable tracing JSONL and then analyzes it; its success or failure execution contract is always checked. An accuracy-eligible observation is a unique logical workload and is the only diagnosis-accuracy denominator, even when multiple artifact encodings execute independently. A report-contract case inspects a pre-generated or synthetic Report and never executes the analyzer or affects accuracy.
+
+Top-1 means the observation primary equals ground truth. Top-2 means ground truth is primary or first secondary. High-confidence-wrong means a high-confidence primary falls outside `expected_primary_kinds`. Ground truth is controlled fixture intent, not production truth or root-cause proof. Equivalent encodings must agree on ordered diagnosis visibility and confidence bucket.
 
 ## Deterministic vs repeated-run validation
-Deterministic fixture validation is exercised directly in normal CI against `validation/diagnostics/manifest.json` and referenced fixtures, and is also exercised by the scorecard generator. Durable scorecards are generated only by the versioned/manual snapshot workflow (`validation-snapshot.yml`) on `workflow_dispatch` and `v*` tags. Normal CI does not publish durable diagnostic scorecards.
+Deterministic fixture validation is mandatory in normal CI; durable scorecards remain manual/tag snapshot outputs. Report-contract checks cover Report fields, warnings, evidence, next checks, confidence, routes, and temporal output but are not analyzer accuracy. Repeated-run validation is a separate manual/local, machine/workload-scoped track.
 
-## Top-1 vs required top-2
-- **Top-1**: primary suspect matches `ground_truth`.
-- **Required top-2**: every kind in `required_top2` appears in primary or first secondary suspect.
-
-## Ground-truth interpretation
-`ground_truth` means the expected diagnostic family for the controlled fixture intent. It does not mean production root-cause proof.
-
-## `acceptable_primary`
-`acceptable_primary` defines which primary kinds are acceptable for ambiguous/mixed interpretation and high-confidence-wrong classification. It does not replace `required_top2`.
-
-## High-confidence-wrong count
-`high_confidence_wrong_count` increments when primary confidence is `high` and primary kind is outside `acceptable_primary`.
+## Deferred corpus work
+Deterministic typed fixture generation is deferred to Prompt 18B. An expanded analyzer-executed corpus and exact demo replacements are deferred to Prompt 18C; no demo is removed here.
 
 ## Confidence calibration
 The scorecard includes confidence-bucket accuracy summaries (low/medium/high buckets) as calibration hints, not probability guarantees.

--- a/scripts/diagnostic_benchmark.py
+++ b/scripts/diagnostic_benchmark.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+"""Run the diagnostic corpus with separate execution, accuracy, and Report contracts."""
 import argparse
 import json
 import subprocess
@@ -6,575 +7,195 @@ import tempfile
 from collections import Counter, defaultdict
 from pathlib import Path
 
-ALLOWED_GROUND_TRUTH = {
-    "application_queue_saturation",
-    "blocking_pool_pressure",
-    "executor_pressure_suspected",
-    "downstream_stage_dominates",
-    "insufficient_evidence",
-}
-CONF_HIGH = {"high"}
-CONFIDENCE_ORDER = {"low": 0, "medium": 1, "high": 2}
-CONFIDENCE_BUCKETS = ("low", "medium", "high")
-ALLOWED_EVIDENCE_QUALITY = {"strong", "partial", "weak"}
-ALLOWED_SIGNAL_FAMILIES = {"requests", "queues", "stages", "runtime_snapshots", "inflight_snapshots"}
-ALLOWED_SIGNAL_STATUSES = {"present", "missing", "partial", "truncated"}
-ALLOWED_ARTIFACT_TYPES = {"analysis_report", "synthetic_analysis_report", "run_artifact", "tracing_span_jsonl"}
-
+KINDS={"application_queue_saturation","blocking_pool_pressure","executor_pressure_suspected","downstream_stage_dominates","insufficient_evidence"}
+TYPES={"run_artifact","tracing_span_jsonl","analysis_report","synthetic_analysis_report"}
+TYPE_CLASS={"run_artifact":"analyzer_execution","tracing_span_jsonl":"analyzer_execution","analysis_report":"report_contract","synthetic_analysis_report":"report_contract"}
+COMMON=("id","artifact","artifact_type","validation_class","accuracy_eligible","tags","notes","expected_primary_kinds","required_visible_suspects","must_include_evidence","must_include_next_checks","expected_warnings","allowed_warnings")
+OLD={"required_top2","acceptable_primary","top1_required"}
+CONF_ORDER={"low":0,"medium":1,"high":2}
 
 def load_json(path):
-    with path.open("r", encoding="utf-8") as f:
-        return json.load(f)
+    with Path(path).open(encoding="utf-8") as f:return json.load(f)
 
-
-def _run_cli_json(command, *, case_id, artifact_path, context):
-    result = subprocess.run(command, capture_output=True, text=True)
-    if result.returncode != 0:
-        raise ValueError(
-            f"{context} failed for case {case_id} ({artifact_path})\n"
-            f"exit_code: {result.returncode}\n"
-            f"command: {' '.join(command)}\n"
-            f"stdout: {result.stdout.strip() or '<empty>'}\n"
-            f"stderr: {result.stderr.strip() or '<empty>'}"
-        )
-    output = result.stdout.strip()
-    if not output:
-        raise ValueError(f"{context} produced empty output for case {case_id} ({artifact_path})")
-    try:
-        return json.loads(output)
-    except json.JSONDecodeError as err:
-        raise ValueError(
-            f"{context} emitted invalid JSON for case {case_id} ({artifact_path}): {err}\n"
-            f"stdout: {output}\n"
-            f"stderr: {result.stderr.strip() or '<empty>'}"
-        ) from err
-
-
-def _analyze_run_artifact(case, artifact_path):
-    command = [
-        "cargo",
-        "run",
-        "--quiet",
-        "-p",
-        "tailtriage-cli",
-        "--",
-        "analyze",
-        str(artifact_path),
-        "--format",
-        "json",
-    ]
-    return _run_cli_json(
-        command,
-        case_id=case["id"],
-        artifact_path=artifact_path,
-        context="run_artifact analyze",
-    )
-
-
-def _import_tracing_span_jsonl_then_analyze(case, artifact_path):
-    with tempfile.TemporaryDirectory(prefix=f"tailtriage-{case['id']}-") as td:
-        tmp_run = Path(td) / "imported-run.json"
-        import_command = [
-            "cargo",
-            "run",
-            "--quiet",
-            "-p",
-            "tailtriage-cli",
-            "--",
-            "import",
-            "tracing-spans-jsonl",
-            str(artifact_path),
-            "--service",
-            "validation-tracing",
-            "--output",
-            str(tmp_run),
-        ]
-        import_result = subprocess.run(import_command, capture_output=True, text=True)
-        if import_result.returncode != 0:
-            raise ValueError(
-                f"tracing_span_jsonl import failed for case {case['id']} ({artifact_path})\n"
-                f"exit_code: {import_result.returncode}\n"
-                f"command: {' '.join(import_command)}\n"
-                f"stdout: {import_result.stdout.strip() or '<empty>'}\n"
-                f"stderr: {import_result.stderr.strip() or '<empty>'}"
-            )
-        if not tmp_run.exists():
-            raise ValueError(
-                f"tracing_span_jsonl import did not create run artifact for case {case['id']} ({artifact_path})\n"
-                f"exit_code: {import_result.returncode}\n"
-                f"command: {' '.join(import_command)}\n"
-                f"stdout: {import_result.stdout.strip() or '<empty>'}\n"
-                f"stderr: {import_result.stderr.strip() or '<empty>'}"
-            )
-        return _analyze_run_artifact(case, tmp_run)
-
-
-def load_case_report(case, root):
-    artifact_path = (root / case["artifact"]).resolve()
-    artifact_type = case["artifact_type"]
-    if artifact_type in {"analysis_report", "synthetic_analysis_report"}:
-        report = load_json(artifact_path)
-        if artifact_type == "analysis_report" and "score" not in report.get("primary_suspect", {}):
-            raise ValueError(f"analysis_report requires report.primary_suspect.score for case {case['id']} ({artifact_path})")
-        return report
-    if artifact_type == "run_artifact":
-        return _analyze_run_artifact(case, artifact_path)
-    if artifact_type == "tracing_span_jsonl":
-        return _import_tracing_span_jsonl_then_analyze(case, artifact_path)
-    raise ValueError(f"unsupported artifact_type {artifact_type} for case {case['id']}")
-
+def _strings(value,name,cid,nonempty=False):
+    if not isinstance(value,list) or any(not isinstance(x,str) or not x for x in value) or (nonempty and not value):
+        raise ValueError(f"{name} must be a {'non-empty ' if nonempty else ''}list of non-empty strings for {cid}")
 
 def validate_manifest(manifest):
-    if not isinstance(manifest, dict) or "cases" not in manifest or not isinstance(manifest["cases"], list):
-        raise ValueError("manifest must be an object containing a cases list")
-    if manifest.get("schema_version") != 1:
-        raise ValueError("manifest schema_version must be 1")
-    seen = set()
-    for case in manifest["cases"]:
-        for field in ["id", "artifact", "artifact_type", "ground_truth", "required_top2", "acceptable_primary", "tags", "must_include_evidence", "must_include_next_checks", "expected_warnings", "allowed_warnings", "top1_required", "notes"]:
-            if field not in case:
-                raise ValueError(f"case missing required field: {field}")
-        cid = case["id"]
-        if not isinstance(cid, str) or not cid.strip():
-            raise ValueError("case id must be a non-empty string")
-        if cid in seen:
-            raise ValueError(f"duplicate case id: {cid}")
+    if not isinstance(manifest,dict) or not isinstance(manifest.get("cases"),list):raise ValueError("manifest must be an object containing a cases list")
+    if manifest.get("schema_version") != 2:raise ValueError("manifest schema_version must be 2")
+    seen=set(); labels={}
+    for c in manifest["cases"]:
+        cid=c.get("id","<unknown>")
+        for key in COMMON:
+            if key not in c:raise ValueError(f"case missing required field: {key}")
+        stale=OLD & c.keys()
+        if stale:raise ValueError(f"version-1 field is not allowed for {cid}: {sorted(stale)[0]}")
+        if not isinstance(cid,str) or not cid.strip():raise ValueError("case id must be a non-empty string")
+        if cid in seen:raise ValueError(f"duplicate case id: {cid}")
         seen.add(cid)
-        if not isinstance(case["artifact"], str) or not case["artifact"].strip():
-            raise ValueError(f"artifact must be a non-empty string for {cid}")
-        if case["artifact_type"] not in ALLOWED_ARTIFACT_TYPES:
-            allowed = ", ".join(sorted(ALLOWED_ARTIFACT_TYPES))
-            raise ValueError(f"artifact_type must be one of {allowed} for {cid}")
-        gt = case["ground_truth"]
-        if gt not in ALLOWED_GROUND_TRUTH:
-            raise ValueError(f"unknown ground_truth for {cid}: {gt}")
-        if not isinstance(case["required_top2"], list) or not case["required_top2"]:
-            raise ValueError(f"required_top2 must be a non-empty list for {cid}")
-        if any(kind not in ALLOWED_GROUND_TRUTH for kind in case["required_top2"]):
-            raise ValueError(f"required_top2 contains unknown diagnosis kind for {cid}")
-        if gt not in case["required_top2"]:
-            raise ValueError(f"required_top2 must include ground_truth for {cid}")
-        if not isinstance(case["acceptable_primary"], list) or not case["acceptable_primary"]:
-            raise ValueError(f"acceptable_primary must be a non-empty list for {cid}")
-        if any(kind not in ALLOWED_GROUND_TRUTH for kind in case["acceptable_primary"]):
-            raise ValueError(f"acceptable_primary contains unknown diagnosis kind for {cid}")
-        if gt not in case["acceptable_primary"]:
-            raise ValueError(f"acceptable_primary must include ground_truth for {cid}")
-        if not isinstance(case["tags"], list) or any((not isinstance(t, str) or not t.strip()) for t in case["tags"]):
-            raise ValueError(f"tags must be a list of non-empty strings for {cid}")
-        validate_string_list(case["must_include_evidence"], "must_include_evidence", cid)
-        validate_string_list(case["must_include_next_checks"], "must_include_next_checks", cid)
-        validate_string_list(case["expected_warnings"], "expected_warnings", cid)
-        validate_string_list(case["allowed_warnings"], "allowed_warnings", cid)
-        if "*" in case["expected_warnings"] or "*" in case["allowed_warnings"]:
-            raise ValueError(f"wildcard '*' is not allowed in warnings lists for {cid}")
-        if "expected_evidence_quality" in case:
-            quality = case["expected_evidence_quality"]
-            if not isinstance(quality, str):
-                raise ValueError(f"expected_evidence_quality must be a string for {cid}")
-            if quality not in ALLOWED_EVIDENCE_QUALITY:
-                raise ValueError(f"expected_evidence_quality must be one of strong/partial/weak for {cid}")
-        if "expected_signal_statuses" in case:
-            statuses = case["expected_signal_statuses"]
-            if not isinstance(statuses, dict):
-                raise ValueError(f"expected_signal_statuses must be an object for {cid}")
-            for family, status in statuses.items():
-                if not isinstance(family, str):
-                    raise ValueError(f"expected_signal_statuses keys must be strings for {cid}")
-                if family not in ALLOWED_SIGNAL_FAMILIES:
-                    raise ValueError(f"unknown signal family in expected_signal_statuses for {cid}: {family}")
-                if not isinstance(status, str):
-                    raise ValueError(f"expected_signal_statuses values must be strings for {cid}")
-                if status not in ALLOWED_SIGNAL_STATUSES:
-                    raise ValueError(f"unknown signal status in expected_signal_statuses for {cid}: {status}")
-        for field in ["must_include_confidence_notes", "must_include_route_warning", "must_include_temporal_warning", "expected_top_level_warnings"]:
-            if field in case:
-                validate_string_list(case[field], field, cid)
-                if "*" in case[field]:
-                    raise ValueError(f"wildcard '*' is not allowed in warnings lists for {cid}")
-        if "expected_route_breakdowns" in case:
-            expected_route_breakdowns = case["expected_route_breakdowns"]
-            if not isinstance(expected_route_breakdowns, str):
-                raise ValueError(f"expected_route_breakdowns must be a string for {cid}")
-            if expected_route_breakdowns not in {"empty", "non_empty"}:
-                raise ValueError(f"expected_route_breakdowns must be one of empty/non_empty for {cid}")
-        if "expected_temporal_segments" in case:
-            expected_temporal_segments = case["expected_temporal_segments"]
-            if not isinstance(expected_temporal_segments, str):
-                raise ValueError(f"expected_temporal_segments must be a string for {cid}")
-            if expected_temporal_segments not in {"empty", "non_empty"}:
-                raise ValueError(f"expected_temporal_segments must be one of empty/non_empty for {cid}")
-        if not isinstance(case["top1_required"], bool):
-            raise ValueError(f"top1_required must be a bool for {cid}")
-        if not isinstance(case["notes"], str) or not case["notes"].strip():
-            raise ValueError(f"notes must be a non-empty string for {cid}")
-        if "max_primary_confidence" in case:
-            ceiling = case["max_primary_confidence"]
-            if not isinstance(ceiling, str):
-                raise ValueError(f"max_primary_confidence must be a string for {cid}")
-            if ceiling not in CONFIDENCE_ORDER:
-                raise ValueError(f"max_primary_confidence must be one of low/medium/high for {cid}")
+        typ=c["artifact_type"]; cls=c["validation_class"]
+        if typ not in TYPES:raise ValueError(f"unknown artifact_type for {cid}: {typ}")
+        if cls != TYPE_CLASS[typ]:raise ValueError(f"artifact_type {typ} requires validation_class {TYPE_CLASS[typ]} for {cid}")
+        if not isinstance(c["accuracy_eligible"],bool):raise ValueError(f"accuracy_eligible must be a bool for {cid}")
+        for key in ("expected_primary_kinds","required_visible_suspects"):
+            _strings(c[key],key,cid,True)
+            if any(x not in KINDS for x in c[key]):raise ValueError(f"{key} contains unknown diagnosis kind for {cid}")
+        for key in ("tags","must_include_evidence","must_include_next_checks","expected_warnings","allowed_warnings"):_strings(c[key],key,cid)
+        if "*" in c["expected_warnings"]+c["allowed_warnings"]:raise ValueError(f"wildcard '*' is not allowed in warnings lists for {cid}")
+        if not isinstance(c["artifact"],str) or not c["artifact"] or not isinstance(c["notes"],str) or not c["notes"]:raise ValueError(f"artifact and notes must be non-empty strings for {cid}")
+        if cls=="report_contract":
+            if c["accuracy_eligible"]:raise ValueError(f"report_contract must be accuracy ineligible for {cid}")
+            for key in ("ground_truth","observation_id","execution_expectation","artifact_policy"):
+                if key in c:raise ValueError(f"{key} is not allowed on report_contract for {cid}")
+        else:
+            expectation=c.get("execution_expectation","success")
+            if expectation not in {"success","failure"}:raise ValueError(f"unknown execution_expectation for {cid}")
+            policy=c.get("artifact_policy","strict")
+            if policy not in {"strict","allow_ambiguous"}:raise ValueError(f"unknown artifact_policy for {cid}")
+            if "artifact_policy" in c and typ!="run_artifact":raise ValueError(f"artifact_policy is allowed only on run_artifact for {cid}")
+            if "command" in c or "args" in c:raise ValueError(f"arbitrary command arguments are not allowed for {cid}")
+            if expectation=="failure":
+                if c["accuracy_eligible"]:raise ValueError(f"failure case must be accuracy ineligible for {cid}")
+                for key in ("failure_stage","expected_error_substrings","forbidden_error_substrings","stdout_expectation"):
+                    if key not in c:raise ValueError(f"failure case missing {key} for {cid}")
+                if c["failure_stage"] not in ({"analyze"} if typ=="run_artifact" else {"import","analyze"}):raise ValueError(f"invalid failure_stage for {cid}")
+                _strings(c["expected_error_substrings"],"expected_error_substrings",cid);_strings(c["forbidden_error_substrings"],"forbidden_error_substrings",cid)
+                if c["stdout_expectation"] not in {"empty","non_empty","ignore"}:raise ValueError(f"invalid stdout_expectation for {cid}")
+            if c["accuracy_eligible"]:
+                for key in ("observation_id","ground_truth"):
+                    if not isinstance(c.get(key),str) or not c[key].strip():raise ValueError(f"accuracy eligible case requires non-empty {key} for {cid}")
+                if c["ground_truth"] not in KINDS:raise ValueError(f"unknown ground_truth for {cid}")
+                if "exact_primary_kind" in c and c["exact_primary_kind"]!=c["ground_truth"]:raise ValueError(f"exact_primary_kind must equal ground_truth for {cid}")
+                label=(c["ground_truth"],tuple(c["expected_primary_kinds"]),tuple(c["required_visible_suspects"]),c.get("exact_primary_kind"))
+                oid=c["observation_id"]
+                if oid in labels and labels[oid]!=label:raise ValueError(f"observation labels disagree for {oid}")
+                labels[oid]=label
+            else:
+                for key in ("ground_truth","observation_id"):
+                    if key in c:raise ValueError(f"{key} is allowed only on accuracy eligible cases for {cid}")
 
+def _command(stage,case,input_path,output_path=None):
+    base=["cargo","run","--quiet","-p","tailtriage-cli","--"]
+    if stage=="import":return base+["import","tracing-spans-jsonl",str(input_path),"--service","validation-tracing","--output",str(output_path)]
+    cmd=base+["analyze",str(input_path),"--format","json"]
+    if case.get("artifact_policy","strict")=="allow_ambiguous":cmd.append("--allow-ambiguous-artifact")
+    return cmd
 
+def _invoke(command):return subprocess.run(command,capture_output=True,text=True)
 
-def validate_string_list(value, field_name, cid):
-    if not isinstance(value, list):
-        raise ValueError(f"{field_name} must be a list of strings for {cid}")
-    for item in value:
-        if not isinstance(item, str):
-            raise ValueError(f"{field_name} must be a list of strings for {cid}")
-
-
-def collect_confidence_notes(suspects):
-    notes = []
-    for suspect in suspects:
-        entries = suspect.get("confidence_notes", [])
-        if isinstance(entries, list):
-            notes.extend([n for n in entries if isinstance(n, str)])
-    return notes
-
-
-def collect_nested_warnings(items):
-    warnings = []
-    for item in items:
-        entries = item.get("warnings", [])
-        if isinstance(entries, list):
-            warnings.extend([w for w in entries if isinstance(w, str)])
-    return warnings
-
-def confidence_bucket(conf):
-    if conf == "high":
-        return "high"
-    if conf == "medium":
-        return "medium"
-    if conf == "low":
-        return "low"
-    raise ValueError("report.primary_suspect.confidence must be one of low/medium/high")
-
-
-def format_confidence_bucket_summary(metrics, bucket):
-    bucket_stats = metrics.get("confidence_bucket_accuracy", {}).get(bucket)
-    if not bucket_stats:
-        return f"confidence_bucket_accuracy.{bucket}=n/a total=0 correct=0"
-    total = bucket_stats.get("total", 0)
-    correct = bucket_stats.get("correct", 0)
-    if total == 0:
-        return f"confidence_bucket_accuracy.{bucket}=n/a total=0 correct=0"
-    accuracy = bucket_stats.get("accuracy", 0.0)
-    return f"confidence_bucket_accuracy.{bucket}={accuracy:.3f} total={total} correct={correct}"
-
+def _execute(case,path):
+    stages=[]
+    with tempfile.TemporaryDirectory(prefix=f"tailtriage-{case['id']}-") as td:
+        analyze_path=path
+        if case["artifact_type"]=="tracing_span_jsonl":
+            analyze_path=Path(td)/"imported-run.json"; r=_invoke(_command("import",case,path,analyze_path));stages.append(("import",r))
+            if r.returncode!=0:return None,stages
+            if not analyze_path.exists():
+                r.returncode=1;r.stderr += "\nimport did not create run artifact";return None,stages
+        r=_invoke(_command("analyze",case,analyze_path));stages.append(("analyze",r))
+        if r.returncode:return None,stages
+        try:return json.loads(r.stdout),stages
+        except json.JSONDecodeError:return None,stages
 
 def extract(report):
-    if not isinstance(report, dict):
-        raise ValueError("report must be a JSON object")
-    if "primary_suspect" not in report or not isinstance(report["primary_suspect"], dict):
-        raise ValueError("report.primary_suspect must be an object")
-    if "secondary_suspects" not in report or not isinstance(report["secondary_suspects"], list):
-        raise ValueError("report.secondary_suspects must be a list")
-    if "warnings" not in report or not isinstance(report["warnings"], list):
-        raise ValueError("report.warnings must be a list")
+    if not isinstance(report,dict) or not isinstance(report.get("primary_suspect"),dict) or not isinstance(report.get("secondary_suspects"),list) or not isinstance(report.get("warnings"),list):raise ValueError("invalid Report shape")
+    p=report["primary_suspect"]; kind=p.get("kind");conf=p.get("confidence")
+    if kind not in KINDS or conf not in CONF_ORDER:raise ValueError("invalid primary suspect")
+    suspects=[p]+[x for x in report["secondary_suspects"] if isinstance(x,dict)]
+    def flatten(field):return [v for s in suspects for v in s.get(field,[]) if isinstance(v,str)]
+    return {"top1":kind,"top2":[s.get("kind") for s in suspects[:2] if s.get("kind")],"primary_confidence":conf,"evidence":flatten("evidence"),"next_checks":flatten("next_checks"),"confidence_notes":flatten("confidence_notes"),"warnings":report["warnings"],"evidence_quality":report.get("evidence_quality",{}),"route_breakdowns":report.get("route_breakdowns",[]),"temporal_segments":report.get("temporal_segments",[])}
 
-    primary = report["primary_suspect"]
-    kind = primary.get("kind")
-    if kind not in ALLOWED_GROUND_TRUTH:
-        raise ValueError("report.primary_suspect.kind must be an allowed diagnosis kind")
-    conf = primary.get("confidence")
-    if not isinstance(conf, str):
-        raise ValueError("report.primary_suspect.confidence must be a string bucket")
-    confidence_bucket(conf)
-    if "score" in primary and not isinstance(primary["score"], (int, float)):
-        raise ValueError("report.primary_suspect.score must be numeric when present")
-    if not isinstance(primary.get("evidence"), list) or not all(isinstance(e, str) for e in primary["evidence"]):
-        raise ValueError("report.primary_suspect.evidence must be a list of strings")
-    if "next_checks" in primary and (not isinstance(primary["next_checks"], list) or not all(isinstance(n, str) for n in primary["next_checks"])):
-        raise ValueError("report.primary_suspect.next_checks must be a list of strings when present")
+def _contains(required,actual):return all(any(r.lower() in a.lower() for a in actual) for r in required)
+def _assert_case(case,ext):
+    visible=ext["top2"]; unexpected=[w for w in ext["warnings"] if not any(x.lower() in w.lower() for x in case["expected_warnings"]+case["allowed_warnings"])]
+    missing=[x for x in case["expected_warnings"] if not any(x.lower() in w.lower() for w in ext["warnings"])]
+    checks={"primary_ok":ext["top1"] in case["expected_primary_kinds"],"visible_suspects_ok":all(x in visible for x in case["required_visible_suspects"]),"exact_primary_ok":case.get("exact_primary_kind",ext["top1"])==ext["top1"],"evidence_ok":_contains(case["must_include_evidence"],ext["evidence"]),"next_check_ok":_contains(case["must_include_next_checks"],ext["next_checks"]),"warnings_ok":not unexpected and not missing}
+    if "max_primary_confidence" in case:checks["confidence_ceiling_ok"]=CONF_ORDER[ext["primary_confidence"]]<=CONF_ORDER[case["max_primary_confidence"]]
+    if "expected_evidence_quality" in case:checks["evidence_quality_ok"]=ext["evidence_quality"].get("quality")==case["expected_evidence_quality"]
+    if "expected_signal_statuses" in case:checks["signal_status_ok"]=all(ext["evidence_quality"].get(k)==v for k,v in case["expected_signal_statuses"].items())
+    if "must_include_confidence_notes" in case:checks["confidence_notes_ok"]=_contains(case["must_include_confidence_notes"],ext["confidence_notes"])
+    if "expected_top_level_warnings" in case:checks["top_level_warnings_ok"]=_contains(case["expected_top_level_warnings"],ext["warnings"])
+    for prefix,field,shape_key,warning_key in (("route","route_breakdowns","expected_route_breakdowns","must_include_route_warning"),("temporal","temporal_segments","expected_temporal_segments","must_include_temporal_warning")):
+        items=ext[field] if isinstance(ext[field],list) else []
+        if shape_key in case:checks[prefix+"_shape_ok"]=(bool(items)==(case[shape_key]=="non_empty"))
+        if warning_key in case:
+            nested=[w for x in items if isinstance(x,dict) for w in x.get("warnings",[]) if isinstance(w,str)]
+            checks[prefix+"_warnings_ok"]=_contains(case[warning_key],nested)
+    checks["unexpected_warnings"]=unexpected;checks["missing_expected_warnings"]=missing
+    return {"id":case["id"],"primary_kind":ext["top1"],"first_secondary_kind":ext["top2"][1] if len(ext["top2"])>1 else None,"primary_confidence":ext["primary_confidence"],**checks}, all(v for k,v in checks.items() if k.endswith("_ok"))
 
-    secondary = report["secondary_suspects"]
-    if not all(isinstance(s, dict) for s in secondary):
-        raise ValueError("report.secondary_suspects must be a list of objects")
-    for s in secondary:
-        if "kind" in s and s["kind"] not in ALLOWED_GROUND_TRUTH:
-            raise ValueError("report.secondary_suspects.kind must be an allowed diagnosis kind when present")
-        if "confidence" in s:
-            if not isinstance(s["confidence"], str) or s["confidence"] not in {"low", "medium", "high"}:
-                raise ValueError("report.secondary_suspects.confidence must be one of low/medium/high when present")
-        if "score" in s and not isinstance(s["score"], (int, float)):
-            raise ValueError("report.secondary_suspects.score must be numeric when present")
-        if "evidence" in s and (not isinstance(s["evidence"], list) or not all(isinstance(e, str) for e in s["evidence"])):
-            raise ValueError("report.secondary_suspects.evidence must be a list of strings when present")
-        if "next_checks" in s and (not isinstance(s["next_checks"], list) or not all(isinstance(n, str) for n in s["next_checks"])):
-            raise ValueError("report.secondary_suspects.next_checks must be a list of strings when present")
-    if not all(isinstance(w, str) for w in report["warnings"]):
-        raise ValueError("report.warnings must be a list of strings")
+def _failure_contract(case,stages):
+    if not stages:return False,"command was not invoked"
+    stage,res=stages[-1]; text=res.stdout+"\n"+res.stderr
+    if res.returncode==0:return False,"expected execution failure succeeded"
+    errors=[]
+    if stage!=case["failure_stage"]:errors.append(f"failed at {stage}, expected {case['failure_stage']}")
+    errors += [f"missing diagnostic: {x}" for x in case["expected_error_substrings"] if x not in text]
+    errors += [f"forbidden diagnostic: {x}" for x in case["forbidden_error_substrings"] if x in text]
+    want=case["stdout_expectation"]
+    if want=="empty" and res.stdout:errors.append("stdout was not empty")
+    if want=="non_empty" and not res.stdout:errors.append("stdout was empty")
+    return not errors,"; ".join(errors)
 
-    all_suspects = [primary] + secondary
-    route_breakdowns = report.get("route_breakdowns", [])
-    temporal_segments = report.get("temporal_segments", [])
-    evidence_quality = report.get("evidence_quality", {})
-    return {
-        "top1": kind,
-        "top2": [s.get("kind") for s in all_suspects[:2] if s.get("kind")],
-        "primary_confidence": conf,
-        "evidence": [e for s in all_suspects for e in s.get("evidence", [])],
-        "warnings": report["warnings"],
-        "next_checks": [n for s in all_suspects for n in s.get("next_checks", [])],
-        "confidence_notes": collect_confidence_notes(all_suspects),
-        "route_breakdowns": route_breakdowns if isinstance(route_breakdowns, list) else [],
-        "temporal_segments": temporal_segments if isinstance(temporal_segments, list) else [],
-        "route_warnings": collect_nested_warnings(route_breakdowns if isinstance(route_breakdowns, list) else []),
-        "temporal_warnings": collect_nested_warnings(temporal_segments if isinstance(temporal_segments, list) else []),
-        "evidence_quality": evidence_quality if isinstance(evidence_quality, dict) else {},
-    }
-
-
-def run(manifest_path, min_top1, min_top2, max_high_confidence_wrong):
-    manifest_path = Path(manifest_path).resolve()
-    root = manifest_path.parent
-    manifest = load_json(manifest_path)
-    validate_manifest(manifest)
-
-    results = []
-    failed_cases = []
-    confusion = defaultdict(Counter)
-    per_gt = Counter()
-    evidence_pass = 0
-    unexpected_warning_count = 0
-    missing_expected_warning_count = 0
-    high_conf_wrong = 0
-    conf_buckets = defaultdict(lambda: {"total": 0, "correct": 0})
-    next_check_required_cases = 0
-    next_check_passed_cases = 0
-    next_check_presence_cases = 0
-    confidence_ceiling_cases = 0
-    confidence_ceiling_passed_cases = 0
-    evidence_quality_check_cases = 0
-    evidence_quality_check_passed_cases = 0
-    signal_status_check_cases = 0
-    signal_status_check_passed_cases = 0
-    confidence_note_check_cases = 0
-    confidence_note_check_passed_cases = 0
-    route_breakdown_check_cases = 0
-    route_breakdown_check_passed_cases = 0
-    temporal_segment_check_cases = 0
-    temporal_segment_check_passed_cases = 0
-    validated_paths = Counter()
-
-    for case in manifest["cases"]:
-        validated_paths[case["artifact_type"]] += 1
-        report = load_case_report(case, root)
-        ext = extract(report)
-
-        gt = case["ground_truth"]
-        per_gt[gt] += 1
-        confusion[gt][ext["top1"]] += 1
-        top1_ok = ext["top1"] == gt
-        top2_ok = all(kind in ext["top2"] for kind in case["required_top2"])
-
-        bucket = confidence_bucket(ext["primary_confidence"])
-        conf_buckets[bucket]["total"] += 1
-        if top1_ok:
-            conf_buckets[bucket]["correct"] += 1
-        if ext["primary_confidence"] in CONF_HIGH and ext["top1"] not in case["acceptable_primary"]:
-            high_conf_wrong += 1
-
-        ev_ok = all(any(req.lower() in ev.lower() for ev in ext["evidence"]) for req in case["must_include_evidence"])
-        evidence_pass += 1 if ev_ok else 0
-
-        required_next = case["must_include_next_checks"]
-        next_check_ok = True
-        if required_next:
-            next_check_required_cases += 1
-            next_check_ok = all(any(req.lower() in nc.lower() for nc in ext["next_checks"]) for req in required_next)
-            if next_check_ok:
-                next_check_passed_cases += 1
-        if ext["next_checks"]:
-            next_check_presence_cases += 1
-        max_primary_confidence = case.get("max_primary_confidence")
-        confidence_ceiling_ok = True
-        if max_primary_confidence is not None:
-            confidence_ceiling_cases += 1
-            confidence_ceiling_ok = CONFIDENCE_ORDER[ext["primary_confidence"]] <= CONFIDENCE_ORDER[max_primary_confidence]
-            if confidence_ceiling_ok:
-                confidence_ceiling_passed_cases += 1
-
-        unexpected = [w for w in ext["warnings"] if not any(exp.lower() in w.lower() for exp in (case["expected_warnings"] + case["allowed_warnings"]))]
-        missing_expected = [exp for exp in case["expected_warnings"] if not any(exp.lower() in w.lower() for w in ext["warnings"])]
-        expected_top_level = case.get("expected_top_level_warnings", [])
-        missing_top_level = [exp for exp in expected_top_level if not any(exp.lower() in w.lower() for w in ext["warnings"])]
-
-        evidence_quality_ok = True
-        if "expected_evidence_quality" in case:
-            evidence_quality_check_cases += 1
-            evidence_quality_ok = ext["evidence_quality"].get("quality") == case["expected_evidence_quality"]
-            if evidence_quality_ok:
-                evidence_quality_check_passed_cases += 1
-
-        signal_status_ok = True
-        signal_status_mismatches = []
-        if "expected_signal_statuses" in case:
-            signal_status_check_cases += 1
-            for family, expected_status in case["expected_signal_statuses"].items():
-                actual_status = ext["evidence_quality"].get(family)
-                if actual_status != expected_status:
-                    signal_status_mismatches.append({"family": family, "expected": expected_status, "actual": actual_status})
-            signal_status_ok = len(signal_status_mismatches) == 0
-            if signal_status_ok:
-                signal_status_check_passed_cases += 1
-
-        confidence_note_ok = True
-        required_notes = case.get("must_include_confidence_notes", [])
-        missing_confidence_notes = []
-        if required_notes:
-            confidence_note_check_cases += 1
-            missing_confidence_notes = [req for req in required_notes if not any(req.lower() in n.lower() for n in ext["confidence_notes"])]
-            confidence_note_ok = len(missing_confidence_notes) == 0
-            if confidence_note_ok:
-                confidence_note_check_passed_cases += 1
-
-        route_breakdown_ok = True
-        has_route_checks = ("expected_route_breakdowns" in case) or bool(case.get("must_include_route_warning", []))
-        if "expected_route_breakdowns" in case:
-            route_breakdown_ok = (len(ext["route_breakdowns"]) == 0) if case["expected_route_breakdowns"] == "empty" else (len(ext["route_breakdowns"]) > 0)
-        required_route_warnings = case.get("must_include_route_warning", [])
-        missing_route_warnings = [req for req in required_route_warnings if not any(req.lower() in w.lower() for w in ext["route_warnings"])]
-        route_warning_ok = len(missing_route_warnings) == 0
-        if has_route_checks:
-            route_breakdown_check_cases += 1
-            if route_breakdown_ok and route_warning_ok:
-                route_breakdown_check_passed_cases += 1
-
-        temporal_segment_ok = True
-        has_temporal_checks = ("expected_temporal_segments" in case) or bool(case.get("must_include_temporal_warning", []))
-        if "expected_temporal_segments" in case:
-            temporal_segment_ok = (len(ext["temporal_segments"]) == 0) if case["expected_temporal_segments"] == "empty" else (len(ext["temporal_segments"]) > 0)
-        required_temporal_warnings = case.get("must_include_temporal_warning", [])
-        missing_temporal_warnings = [req for req in required_temporal_warnings if not any(req.lower() in w.lower() for w in ext["temporal_warnings"])]
-        temporal_warning_ok = len(missing_temporal_warnings) == 0
-        if has_temporal_checks:
-            temporal_segment_check_cases += 1
-            if temporal_segment_ok and temporal_warning_ok:
-                temporal_segment_check_passed_cases += 1
-        unexpected_warning_count += len(unexpected)
-        missing_expected_warning_count += len(missing_expected)
-
-        case_failed = (not top2_ok) or (case["top1_required"] and not top1_ok) or (not ev_ok) or (not next_check_ok) or (not confidence_ceiling_ok) or bool(unexpected) or bool(missing_expected) or bool(missing_top_level) or (not evidence_quality_ok) or (not signal_status_ok) or (not confidence_note_ok) or (not route_breakdown_ok) or (not route_warning_ok) or (not temporal_segment_ok) or (not temporal_warning_ok)
-        row = {"id": case["id"], "top1_ok": top1_ok, "top2_ok": top2_ok, "evidence_ok": ev_ok, "next_check_ok": next_check_ok, "confidence_ceiling_ok": confidence_ceiling_ok, "max_primary_confidence": max_primary_confidence, "primary_confidence": ext["primary_confidence"], "unexpected_warnings": unexpected, "missing_expected_warnings": missing_expected, "missing_expected_top_level_warnings": missing_top_level, "evidence_quality_ok": evidence_quality_ok, "expected_evidence_quality": case.get("expected_evidence_quality"), "actual_evidence_quality": ext["evidence_quality"].get("quality"), "signal_status_ok": signal_status_ok, "signal_status_mismatches": signal_status_mismatches, "confidence_note_ok": confidence_note_ok, "missing_confidence_notes": missing_confidence_notes, "route_breakdown_ok": route_breakdown_ok, "route_warning_ok": route_warning_ok, "missing_route_warnings": missing_route_warnings, "temporal_segment_ok": temporal_segment_ok, "temporal_warning_ok": temporal_warning_ok, "missing_temporal_warnings": missing_temporal_warnings}
-        results.append(row)
-        if case_failed:
-            failed_cases.append({**row, "top1_required": case["top1_required"]})
-
-    total = len(results)
-    top1 = sum(1 for r in results if r["top1_ok"]) / total if total else 0.0
-    top2 = sum(1 for r in results if r["top2_ok"]) / total if total else 0.0
-
-    metrics = {
-        "total_cases": total,
-        "top1_accuracy": top1,
-        "top2_recall": top2,
-        "high_confidence_wrong_count": high_conf_wrong,
-        "per_ground_truth_counts": dict(per_gt),
-        "confusion_matrix": {k: dict(v) for k, v in confusion.items()},
-        "confidence_bucket_accuracy": {k: {"accuracy": (v["correct"] / v["total"] if v["total"] else 0.0), **v} for k, v in conf_buckets.items()},
-        "required_evidence_pass_rate": (evidence_pass / total) if total else 0.0,
-        "next_check_required_cases": next_check_required_cases,
-        "next_check_passed_cases": next_check_passed_cases,
-        "next_check_presence_rate": (next_check_presence_cases / total) if total else 0.0,
-        "next_check_pass_rate": (next_check_passed_cases / next_check_required_cases) if next_check_required_cases else None,
-        "confidence_ceiling_cases": confidence_ceiling_cases,
-        "confidence_ceiling_passed_cases": confidence_ceiling_passed_cases,
-        "confidence_ceiling_pass_rate": (confidence_ceiling_passed_cases / confidence_ceiling_cases) if confidence_ceiling_cases else None,
-        "unexpected_warning_count": unexpected_warning_count,
-        "missing_expected_warning_count": missing_expected_warning_count,
-        "evidence_quality_check_cases": evidence_quality_check_cases,
-        "evidence_quality_check_passed_cases": evidence_quality_check_passed_cases,
-        "signal_status_check_cases": signal_status_check_cases,
-        "signal_status_check_passed_cases": signal_status_check_passed_cases,
-        "confidence_note_check_cases": confidence_note_check_cases,
-        "confidence_note_check_passed_cases": confidence_note_check_passed_cases,
-        "route_breakdown_check_cases": route_breakdown_check_cases,
-        "route_breakdown_check_passed_cases": route_breakdown_check_passed_cases,
-        "temporal_segment_check_cases": temporal_segment_check_cases,
-        "temporal_segment_check_passed_cases": temporal_segment_check_passed_cases,
-        "failed_cases": failed_cases,
-        "validated_paths": dict(validated_paths),
-    }
-
-    failures = []
-    if failed_cases:
-        failures.append("one or more per-case checks failed (top2/top1_required/evidence/warnings/next_checks)")
-    if top1 < min_top1:
-        failures.append(f"top1_accuracy {top1:.3f} below threshold {min_top1:.3f}")
-    if top2 < min_top2:
-        failures.append(f"top2_recall {top2:.3f} below threshold {min_top2:.3f}")
-    if high_conf_wrong > max_high_confidence_wrong:
-        failures.append(f"high_confidence_wrong_count {high_conf_wrong} exceeds max {max_high_confidence_wrong}")
-    return metrics, failures
-
+def run(manifest_path,min_top1=.75,min_top2=.90,max_high_confidence_wrong=0):
+    path=Path(manifest_path).resolve();manifest=load_json(path);validate_manifest(manifest)
+    analyzer=[];contracts=[];failed_a=[];failed_r=[];members=defaultdict(list);paths=Counter();expected_failures=unexpected_failures=successes=run_executions=tracing_executions=0
+    for c in manifest["cases"]:
+        paths[c["artifact_type"]]+=1; artifact=(path.parent/c["artifact"]).resolve()
+        if c["validation_class"]=="report_contract":
+            try: row,ok=_assert_case(c,extract(load_json(artifact)))
+            except Exception as e:row={"id":c["id"],"error":str(e)};ok=False
+            contracts.append(row)
+            if not ok:failed_r.append(row)
+            continue
+        report,stages=_execute(c,artifact)
+        if any(stage=="analyze" for stage,_ in stages):
+            if c["artifact_type"]=="run_artifact":run_executions+=1
+            else:tracing_executions+=1
+        if c.get("execution_expectation","success")=="failure":
+            ok,error=_failure_contract(c,stages);row={"id":c["id"],"expected_failure":True,"passed":ok,"error":error};analyzer.append(row)
+            if ok:expected_failures+=1
+            else:unexpected_failures+=1;failed_a.append(row)
+            continue
+        if report is None:
+            unexpected_failures+=1;row={"id":c["id"],"error":"analyzer execution failed unexpectedly"};analyzer.append(row);failed_a.append(row);continue
+        successes+=1
+        try:ext=extract(report);row,ok=_assert_case(c,ext)
+        except Exception as e:row={"id":c["id"],"error":str(e)};ok=False;ext=None
+        analyzer.append(row)
+        if not ok:failed_a.append(row)
+        if c["accuracy_eligible"] and ext is not None:members[c["observation_id"]].append((c,ext))
+    observations=[]
+    for oid,group in members.items():
+        ids=[c["id"] for c,_ in group]; signatures={(e["top1"],tuple(e["top2"]),e["primary_confidence"]) for _,e in group}
+        if len(signatures)!=1:
+            failed_a.append({"observation_id":oid,"member_case_ids":ids,"error":"equivalent encoding diagnosis or confidence disagreement"});continue
+        c,e=group[0];observations.append({"observation_id":oid,"member_case_ids":ids,"ground_truth":c["ground_truth"],"expected_primary_kinds":c["expected_primary_kinds"],"top1":e["top1"],"top2":e["top2"],"confidence":e["primary_confidence"]})
+    per=Counter();confusion=defaultdict(Counter);buckets=defaultdict(lambda:{"total":0,"correct":0});hcw=0
+    for o in observations:
+        gt=o["ground_truth"];correct=o["top1"]==gt;per[gt]+=1;confusion[gt][o["top1"]]+=1;b=buckets[o["confidence"]];b["total"]+=1;b["correct"]+=correct
+        if o["confidence"]=="high" and o["top1"] not in o["expected_primary_kinds"]:hcw+=1
+    n=len(observations);top1=sum(o["top1"]==o["ground_truth"] for o in observations)/n if n else None;top2=sum(o["ground_truth"] in o["top2"] for o in observations)/n if n else None
+    accuracy={"observation_count":n,"encoding_count":sum(len(x) for x in members.values()),"top1_accuracy":top1,"top2_recall":top2,"high_confidence_wrong_count":hcw,"per_ground_truth_counts":dict(per),"confusion_matrix":{k:dict(v) for k,v in confusion.items()},"confidence_bucket_accuracy":{k:{**v,"accuracy":v["correct"]/v["total"]} for k,v in buckets.items()},"observations":observations}
+    metrics={"schema_version":2,"manifest_case_count":len(manifest["cases"]),"analyzer_execution":{"case_count":len(analyzer),"success_count":successes,"expected_failure_count":expected_failures,"unexpected_failure_count":unexpected_failures,"run_artifact_count":run_executions,"tracing_jsonl_count":tracing_executions,"cases":analyzer},"analyzer_accuracy":accuracy,"report_contract":{"case_count":len(contracts),"passed_count":len(contracts)-len(failed_r),"failed_count":len(failed_r),"analysis_report_count":paths["analysis_report"],"synthetic_report_count":paths["synthetic_analysis_report"],"cases":contracts},"validated_paths":dict(paths),"failed_analyzer_cases":failed_a,"failed_report_contract_cases":failed_r}
+    failures=[]
+    if failed_a:failures.append("one or more analyzer-execution cases failed")
+    if failed_r:failures.append("one or more report-contract cases failed")
+    if not analyzer:failures.append("diagnostic corpus contains zero analyzer-executed cases")
+    if not observations:failures.append("diagnostic corpus contains zero accuracy-eligible analyzer observations")
+    else:
+        if top1<min_top1:failures.append(f"top1_accuracy {top1:.3f} below threshold {min_top1:.3f}")
+        if top2<min_top2:failures.append(f"top2_recall {top2:.3f} below threshold {min_top2:.3f}")
+        if hcw>max_high_confidence_wrong:failures.append(f"high_confidence_wrong_count {hcw} exceeds max {max_high_confidence_wrong}")
+    return metrics,failures
 
 def main():
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--manifest", required=True)
-    ap.add_argument("--output")
-    ap.add_argument("--min-top1", type=float, default=0.75)
-    ap.add_argument("--min-top2", type=float, default=0.90)
-    ap.add_argument("--max-high-confidence-wrong", type=int, default=0)
-    args = ap.parse_args()
-    try:
-        metrics, failures = run(args.manifest, args.min_top1, args.min_top2, args.max_high_confidence_wrong)
-    except Exception as exc:
-        print(f"ERROR: {exc}")
-        raise SystemExit(1)
-    if args.output:
-        out = Path(args.output)
-        out.parent.mkdir(parents=True, exist_ok=True)
-        out.write_text(json.dumps(metrics, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-
-    next_check_pass_rate = metrics["next_check_pass_rate"]
-    next_check_pass_rate_text = "n/a" if next_check_pass_rate is None else f"{next_check_pass_rate:.3f}"
-    print(f"total_cases={metrics['total_cases']}")
-    print(f"top1_accuracy={metrics['top1_accuracy']:.3f}")
-    print(f"top2_recall={metrics['top2_recall']:.3f}")
-    print(f"high_confidence_wrong_count={metrics['high_confidence_wrong_count']}")
-    print(f"required_evidence_pass_rate={metrics['required_evidence_pass_rate']:.3f}")
-    confidence_ceiling_pass_rate = metrics["confidence_ceiling_pass_rate"]
-    confidence_ceiling_pass_rate_text = "n/a" if confidence_ceiling_pass_rate is None else f"{confidence_ceiling_pass_rate:.3f}"
-    print(f"confidence_ceiling_cases={metrics['confidence_ceiling_cases']}")
-    print(f"confidence_ceiling_passed_cases={metrics['confidence_ceiling_passed_cases']}")
-    print(f"confidence_ceiling_pass_rate={confidence_ceiling_pass_rate_text}")
-    print(f"unexpected_warning_count={metrics['unexpected_warning_count']}")
-    print(f"missing_expected_warning_count={metrics['missing_expected_warning_count']}")
-    print(f"next_check_required_cases={metrics['next_check_required_cases']}")
-    print(f"next_check_pass_rate={next_check_pass_rate_text}")
-    print(f"next_check_presence_rate={metrics['next_check_presence_rate']:.3f}")
-    print(
-        "evidence_quality_checks="
-        f"{metrics['evidence_quality_check_passed_cases']}/{metrics['evidence_quality_check_cases']}"
-    )
-    print(
-        "signal_status_checks="
-        f"{metrics['signal_status_check_passed_cases']}/{metrics['signal_status_check_cases']}"
-    )
-    print(
-        "confidence_note_checks="
-        f"{metrics['confidence_note_check_passed_cases']}/{metrics['confidence_note_check_cases']}"
-    )
-    print(
-        "route_breakdown_checks="
-        f"{metrics['route_breakdown_check_passed_cases']}/{metrics['route_breakdown_check_cases']}"
-    )
-    print(
-        "temporal_segment_checks="
-        f"{metrics['temporal_segment_check_passed_cases']}/{metrics['temporal_segment_check_cases']}"
-    )
-    for bucket in CONFIDENCE_BUCKETS:
-        print(format_confidence_bucket_summary(metrics, bucket))
-    print(f"failed_case_count={len(metrics['failed_cases'])}")
-
-    if failures:
-        for f in failures:
-            print(f"FAIL: {f}")
-        raise SystemExit(1)
-
-
-if __name__ == "__main__":
-    main()
+    p=argparse.ArgumentParser();p.add_argument("--manifest",required=True);p.add_argument("--output");p.add_argument("--min-top1",type=float,default=.75);p.add_argument("--min-top2",type=float,default=.90);p.add_argument("--max-high-confidence-wrong",type=int,default=0);a=p.parse_args()
+    try:m,f=run(a.manifest,a.min_top1,a.min_top2,a.max_high_confidence_wrong)
+    except Exception as e:print(f"ERROR: {e}");raise SystemExit(1)
+    if a.output:Path(a.output).write_text(json.dumps(m,indent=2,sort_keys=True)+"\n")
+    acc=m["analyzer_accuracy"];print(f"manifest_case_count={m['manifest_case_count']}");print(f"analyzer_execution_case_count={m['analyzer_execution']['case_count']}");print(f"accuracy_observation_count={acc['observation_count']}");print("top1_accuracy="+("n/a" if acc["top1_accuracy"] is None else f"{acc['top1_accuracy']:.3f}"));print("top2_recall="+("n/a" if acc["top2_recall"] is None else f"{acc['top2_recall']:.3f}"));print(f"high_confidence_wrong_count={acc['high_confidence_wrong_count']}")
+    for x in f:print("FAIL:",x)
+    if f:raise SystemExit(1)
+if __name__=="__main__":main()

--- a/scripts/diagnostic_benchmark.py
+++ b/scripts/diagnostic_benchmark.py
@@ -13,6 +13,10 @@ TYPE_CLASS={"run_artifact":"analyzer_execution","tracing_span_jsonl":"analyzer_e
 COMMON=("id","artifact","artifact_type","validation_class","accuracy_eligible","tags","notes","expected_primary_kinds","required_visible_suspects","must_include_evidence","must_include_next_checks","expected_warnings","allowed_warnings")
 OLD={"required_top2","acceptable_primary","top1_required"}
 CONF_ORDER={"low":0,"medium":1,"high":2}
+EVIDENCE_QUALITIES={"strong","partial","weak"}
+SIGNAL_FAMILIES={"requests","queues","stages","runtime_snapshots","inflight_snapshots"}
+SIGNAL_STATUSES={"present","missing","partial","truncated"}
+FAILURE_FIELDS=("failure_stage","expected_error_substrings","forbidden_error_substrings","stdout_expectation")
 
 def load_json(path):
     with Path(path).open(encoding="utf-8") as f:return json.load(f)
@@ -43,10 +47,25 @@ def validate_manifest(manifest):
             if any(x not in KINDS for x in c[key]):raise ValueError(f"{key} contains unknown diagnosis kind for {cid}")
         for key in ("tags","must_include_evidence","must_include_next_checks","expected_warnings","allowed_warnings"):_strings(c[key],key,cid)
         if "*" in c["expected_warnings"]+c["allowed_warnings"]:raise ValueError(f"wildcard '*' is not allowed in warnings lists for {cid}")
+        if "exact_primary_kind" in c:
+            if not isinstance(c["exact_primary_kind"],str) or c["exact_primary_kind"] not in KINDS:raise ValueError(f"exact_primary_kind must be an allowed diagnosis kind for {cid}")
+        if "max_primary_confidence" in c and (not isinstance(c["max_primary_confidence"],str) or c["max_primary_confidence"] not in CONF_ORDER):raise ValueError(f"max_primary_confidence must be one of low/medium/high for {cid}")
+        if "expected_evidence_quality" in c and (not isinstance(c["expected_evidence_quality"],str) or c["expected_evidence_quality"] not in EVIDENCE_QUALITIES):raise ValueError(f"expected_evidence_quality must be one of strong/partial/weak for {cid}")
+        if "expected_signal_statuses" in c:
+            statuses=c["expected_signal_statuses"]
+            if not isinstance(statuses,dict):raise ValueError(f"expected_signal_statuses must be an object for {cid}")
+            if any(not isinstance(k,str) or k not in SIGNAL_FAMILIES for k in statuses):raise ValueError(f"expected_signal_statuses contains unknown signal family for {cid}")
+            if any(not isinstance(v,str) or v not in SIGNAL_STATUSES for v in statuses.values()):raise ValueError(f"expected_signal_statuses contains unknown signal status for {cid}")
+        for key in ("must_include_confidence_notes","must_include_route_warning","must_include_temporal_warning","expected_top_level_warnings"):
+            if key in c:
+                _strings(c[key],key,cid)
+                if key!="must_include_confidence_notes" and "*" in c[key]:raise ValueError(f"wildcard '*' is not allowed in {key} for {cid}")
+        for key in ("expected_route_breakdowns","expected_temporal_segments"):
+            if key in c and (not isinstance(c[key],str) or c[key] not in {"empty","non_empty"}):raise ValueError(f"{key} must be one of empty/non_empty for {cid}")
         if not isinstance(c["artifact"],str) or not c["artifact"] or not isinstance(c["notes"],str) or not c["notes"]:raise ValueError(f"artifact and notes must be non-empty strings for {cid}")
         if cls=="report_contract":
             if c["accuracy_eligible"]:raise ValueError(f"report_contract must be accuracy ineligible for {cid}")
-            for key in ("ground_truth","observation_id","execution_expectation","artifact_policy"):
+            for key in ("ground_truth","observation_id","execution_expectation","artifact_policy","command","args",*FAILURE_FIELDS):
                 if key in c:raise ValueError(f"{key} is not allowed on report_contract for {cid}")
         else:
             expectation=c.get("execution_expectation","success")
@@ -62,10 +81,15 @@ def validate_manifest(manifest):
                 if c["failure_stage"] not in ({"analyze"} if typ=="run_artifact" else {"import","analyze"}):raise ValueError(f"invalid failure_stage for {cid}")
                 _strings(c["expected_error_substrings"],"expected_error_substrings",cid);_strings(c["forbidden_error_substrings"],"forbidden_error_substrings",cid)
                 if c["stdout_expectation"] not in {"empty","non_empty","ignore"}:raise ValueError(f"invalid stdout_expectation for {cid}")
+            else:
+                for key in FAILURE_FIELDS:
+                    if key in c:raise ValueError(f"{key} is allowed only on failure cases for {cid}")
             if c["accuracy_eligible"]:
                 for key in ("observation_id","ground_truth"):
                     if not isinstance(c.get(key),str) or not c[key].strip():raise ValueError(f"accuracy eligible case requires non-empty {key} for {cid}")
                 if c["ground_truth"] not in KINDS:raise ValueError(f"unknown ground_truth for {cid}")
+                if c["ground_truth"] not in c["expected_primary_kinds"]:raise ValueError(f"ground_truth must be in expected_primary_kinds for {cid}")
+                if c["ground_truth"] not in c["required_visible_suspects"]:raise ValueError(f"ground_truth must be in required_visible_suspects for {cid}")
                 if "exact_primary_kind" in c and c["exact_primary_kind"]!=c["ground_truth"]:raise ValueError(f"exact_primary_kind must equal ground_truth for {cid}")
                 label=(c["ground_truth"],tuple(c["expected_primary_kinds"]),tuple(c["required_visible_suspects"]),c.get("exact_primary_kind"))
                 oid=c["observation_id"]
@@ -99,11 +123,32 @@ def _execute(case,path):
         except json.JSONDecodeError:return None,stages
 
 def extract(report):
-    if not isinstance(report,dict) or not isinstance(report.get("primary_suspect"),dict) or not isinstance(report.get("secondary_suspects"),list) or not isinstance(report.get("warnings"),list):raise ValueError("invalid Report shape")
-    p=report["primary_suspect"]; kind=p.get("kind");conf=p.get("confidence")
-    if kind not in KINDS or conf not in CONF_ORDER:raise ValueError("invalid primary suspect")
-    suspects=[p]+[x for x in report["secondary_suspects"] if isinstance(x,dict)]
-    def flatten(field):return [v for s in suspects for v in s.get(field,[]) if isinstance(v,str)]
+    if not isinstance(report,dict):raise ValueError("report must be a JSON object")
+    if not isinstance(report.get("primary_suspect"),dict):raise ValueError("report.primary_suspect must be an object")
+    if not isinstance(report.get("secondary_suspects"),list):raise ValueError("report.secondary_suspects must be a list")
+    if not isinstance(report.get("warnings"),list) or any(not isinstance(x,str) for x in report["warnings"]):raise ValueError("report.warnings must be a list of strings")
+    def suspect(value,name,primary=False):
+        if not isinstance(value,dict):raise ValueError(f"{name} must be an object")
+        if primary and value.get("kind") not in KINDS:raise ValueError(f"{name}.kind must be an allowed diagnosis kind")
+        if not primary and "kind" in value and value["kind"] not in KINDS:raise ValueError(f"{name}.kind must be an allowed diagnosis kind when present")
+        if primary and value.get("confidence") not in CONF_ORDER:raise ValueError(f"{name}.confidence must be one of low/medium/high")
+        if "confidence" in value and value["confidence"] not in CONF_ORDER:raise ValueError(f"{name}.confidence must be one of low/medium/high when present")
+        if "score" in value and (isinstance(value["score"],bool) or not isinstance(value["score"],(int,float))):raise ValueError(f"{name}.score must be numeric when present")
+        if primary and (not isinstance(value.get("evidence"),list) or any(not isinstance(x,str) for x in value["evidence"])):raise ValueError(f"{name}.evidence must be a list of strings")
+        for field in ("evidence","next_checks","confidence_notes"):
+            if field in value and (not isinstance(value[field],list) or any(not isinstance(x,str) for x in value[field])):raise ValueError(f"{name}.{field} must be a list of strings when present")
+    p=report["primary_suspect"];suspect(p,"report.primary_suspect",True)
+    for s in report["secondary_suspects"]:suspect(s,"report.secondary_suspects entry")
+    for field in ("route_breakdowns","temporal_segments"):
+        if field in report:
+            items=report[field]
+            if not isinstance(items,list):raise ValueError(f"report.{field} must be a list when present")
+            for item in items:
+                if not isinstance(item,dict):raise ValueError(f"report.{field} entries must be objects")
+                if "warnings" in item and (not isinstance(item["warnings"],list) or any(not isinstance(x,str) for x in item["warnings"])):raise ValueError(f"report.{field} entry warnings must be a list of strings")
+    if "evidence_quality" in report and not isinstance(report["evidence_quality"],dict):raise ValueError("report.evidence_quality must be an object when present")
+    kind=p["kind"];conf=p["confidence"];suspects=[p]+report["secondary_suspects"]
+    def flatten(field):return [v for s in suspects for v in s.get(field,[])]
     return {"top1":kind,"top2":[s.get("kind") for s in suspects[:2] if s.get("kind")],"primary_confidence":conf,"evidence":flatten("evidence"),"next_checks":flatten("next_checks"),"confidence_notes":flatten("confidence_notes"),"warnings":report["warnings"],"evidence_quality":report.get("evidence_quality",{}),"route_breakdowns":report.get("route_breakdowns",[]),"temporal_segments":report.get("temporal_segments",[])}
 
 def _contains(required,actual):return all(any(r.lower() in a.lower() for a in actual) for r in required)
@@ -127,12 +172,12 @@ def _assert_case(case,ext):
 
 def _failure_contract(case,stages):
     if not stages:return False,"command was not invoked"
-    stage,res=stages[-1]; text=res.stdout+"\n"+res.stderr
+    stage,res=stages[-1]
     if res.returncode==0:return False,"expected execution failure succeeded"
     errors=[]
     if stage!=case["failure_stage"]:errors.append(f"failed at {stage}, expected {case['failure_stage']}")
-    errors += [f"missing diagnostic: {x}" for x in case["expected_error_substrings"] if x not in text]
-    errors += [f"forbidden diagnostic: {x}" for x in case["forbidden_error_substrings"] if x in text]
+    errors += [f"missing stderr diagnostic: {x}" for x in case["expected_error_substrings"] if x not in res.stderr]
+    errors += [f"forbidden stderr diagnostic: {x}" for x in case["forbidden_error_substrings"] if x in res.stderr]
     want=case["stdout_expectation"]
     if want=="empty" and res.stdout:errors.append("stdout was not empty")
     if want=="non_empty" and not res.stdout:errors.append("stdout was empty")
@@ -141,6 +186,9 @@ def _failure_contract(case,stages):
 def run(manifest_path,min_top1=.75,min_top2=.90,max_high_confidence_wrong=0):
     path=Path(manifest_path).resolve();manifest=load_json(path);validate_manifest(manifest)
     analyzer=[];contracts=[];failed_a=[];failed_r=[];members=defaultdict(list);paths=Counter();expected_failures=unexpected_failures=successes=run_executions=tracing_executions=0
+    expected_members=defaultdict(list)
+    for c in manifest["cases"]:
+        if c["accuracy_eligible"]:expected_members[c["observation_id"]].append(c["id"])
     for c in manifest["cases"]:
         paths[c["artifact_type"]]+=1; artifact=(path.parent/c["artifact"]).resolve()
         if c["validation_class"]=="report_contract":
@@ -167,11 +215,14 @@ def run(manifest_path,min_top1=.75,min_top2=.90,max_high_confidence_wrong=0):
         if not ok:failed_a.append(row)
         if c["accuracy_eligible"] and ext is not None:members[c["observation_id"]].append((c,ext))
     observations=[]
-    for oid,group in members.items():
-        ids=[c["id"] for c,_ in group]; signatures={(e["top1"],tuple(e["top2"]),e["primary_confidence"]) for _,e in group}
+    for oid,expected_ids in expected_members.items():
+        group=members[oid];usable_ids=[c["id"] for c,_ in group];unusable_ids=[x for x in expected_ids if x not in usable_ids]
+        if usable_ids!=expected_ids:
+            failed_a.append({"observation_id":oid,"expected_member_ids":expected_ids,"usable_member_ids":usable_ids,"unusable_member_ids":unusable_ids,"error":"accuracy observation is incomplete because one or more declared encodings produced no usable Report"});continue
+        signatures={(e["top1"],tuple(e["top2"]),e["primary_confidence"]) for _,e in group}
         if len(signatures)!=1:
-            failed_a.append({"observation_id":oid,"member_case_ids":ids,"error":"equivalent encoding diagnosis or confidence disagreement"});continue
-        c,e=group[0];observations.append({"observation_id":oid,"member_case_ids":ids,"ground_truth":c["ground_truth"],"expected_primary_kinds":c["expected_primary_kinds"],"top1":e["top1"],"top2":e["top2"],"confidence":e["primary_confidence"]})
+            failed_a.append({"observation_id":oid,"member_case_ids":expected_ids,"error":"equivalent encoding diagnosis or confidence disagreement"});continue
+        c,e=group[0];observations.append({"observation_id":oid,"member_case_ids":expected_ids,"ground_truth":c["ground_truth"],"expected_primary_kinds":c["expected_primary_kinds"],"top1":e["top1"],"top2":e["top2"],"confidence":e["primary_confidence"]})
     per=Counter();confusion=defaultdict(Counter);buckets=defaultdict(lambda:{"total":0,"correct":0});hcw=0
     for o in observations:
         gt=o["ground_truth"];correct=o["top1"]==gt;per[gt]+=1;confusion[gt][o["top1"]]+=1;b=buckets[o["confidence"]];b["total"]+=1;b["correct"]+=correct

--- a/scripts/generate_diagnostic_scorecard.py
+++ b/scripts/generate_diagnostic_scorecard.py
@@ -116,7 +116,7 @@ def _linux_mem_kib():
 def collect_environment(repo_root: Path, manifest_path: Path, snapshot_label, thresholds):
     manifest_sha, artifacts_sha = manifest_and_artifact_hashes(manifest_path)
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "generated_at_utc": dt.datetime.now(dt.timezone.utc).isoformat(),
         "snapshot_label": snapshot_label,
         "git": {
@@ -169,28 +169,25 @@ def collect_environment(repo_root: Path, manifest_path: Path, snapshot_label, th
 def render_failed_cases(failed_cases):
     if not failed_cases:
         return "None\n"
-    lines = ["| id | top1_ok | top2_ok | evidence_ok | next_check_ok | confidence_ceiling_ok |", "|---|---:|---:|---:|---:|---:|"]
+    lines = ["| id | diagnostic |", "|---|---|"]
     for case in failed_cases:
-        lines.append(f"| {case['id']} | {case['top1_ok']} | {case['top2_ok']} | {case['evidence_ok']} | {case['next_check_ok']} | {case['confidence_ceiling_ok']} |")
+        lines.append(f"| {case.get('id', case.get('observation_id'))} | {case.get('error', 'case contract failed')} |")
     return "\n".join(lines) + "\n"
 
 
 def render_scorecard(metrics, env):
-    metric_keys = ["total_cases", "top1_accuracy", "top2_recall", "high_confidence_wrong_count", "required_evidence_pass_rate", "next_check_required_cases", "next_check_passed_cases", "next_check_pass_rate", "next_check_presence_rate", "confidence_ceiling_cases", "confidence_ceiling_passed_cases", "confidence_ceiling_pass_rate", "unexpected_warning_count", "missing_expected_warning_count"]
+    execution=metrics["analyzer_execution"];accuracy=metrics["analyzer_accuracy"];contracts=metrics["report_contract"]
+    fmt=lambda v: "n/a" if v is None else v
     parts = ["# Diagnostic validation scorecard\n", "## Snapshot\n", f"- Generated at (UTC): {env['generated_at_utc']}", f"- Snapshot label: {env.get('snapshot_label')}", f"- Git SHA: {env['git'].get('sha')}", f"- Git tag: {env['git'].get('tag')}", f"- Git describe: {env['git'].get('describe')}\n", "## Environment\n", f"- tailtriage workspace package version: {env['tailtriage'].get('workspace_package_version')}"]
     for k, v in env["tailtriage"]["packages"].items():
         parts.append(f"- {k}: {v}")
-    parts.extend([f"- GitHub run: {env['github_actions'].get('run_id')} ({env['github_actions'].get('ref')})", f"- Runner: {env['github_actions'].get('runner_os')} {env['github_actions'].get('runner_arch')} / {env['github_actions'].get('image_version')}", f"- Python: {env['software'].get('python')}", f"- rustc: {env['software'].get('rustc')}", f"- cargo: {env['software'].get('cargo')}", f"- CPU model: {env['hardware'].get('cpu_model')}", f"- Logical cores: {env['hardware'].get('logical_cores')}", f"- Memory KiB: {env['hardware'].get('memory_total_kib')}\n", "## Inputs\n", f"- Manifest SHA256: {env['inputs']['manifest_sha256']}", f"- Referenced artifacts SHA256: {env['inputs']['referenced_artifacts_sha256']}", f"- Thresholds: {json.dumps(env['inputs']['thresholds'], sort_keys=True)}\n", "## Metrics\n", "| metric | value |", "|---|---:|"])
-    for k in metric_keys:
-        parts.append(f"| {k} | {metrics.get(k)} |")
-    parts.append(f"| failed_case_count | {len(metrics.get('failed_cases', []))} |\n")
-    parts.append("## Per-ground-truth case counts\n")
-    for k, v in sorted(metrics.get("per_ground_truth_counts", {}).items()):
+    parts.extend([f"- GitHub run: {env['github_actions'].get('run_id')} ({env['github_actions'].get('ref')})", f"- Runner: {env['github_actions'].get('runner_os')} {env['github_actions'].get('runner_arch')} / {env['github_actions'].get('image_version')}", f"- Python: {env['software'].get('python')}", f"- rustc: {env['software'].get('rustc')}", f"- cargo: {env['software'].get('cargo')}", f"- CPU model: {env['hardware'].get('cpu_model')}", f"- Logical cores: {env['hardware'].get('logical_cores')}", f"- Memory KiB: {env['hardware'].get('memory_total_kib')}\n", "## Inputs\n", f"- Manifest cases: {metrics['manifest_case_count']}", f"- Manifest SHA256: {env['inputs']['manifest_sha256']}", f"- Referenced artifacts SHA256: {env['inputs']['referenced_artifacts_sha256']}", f"- Thresholds: {json.dumps(env['inputs']['thresholds'], sort_keys=True)}\n", "## Analyzer execution\n", f"- Cases: {execution['case_count']}",f"- Successful analyzer executions: {execution['success_count']}",f"- Expected failures: {execution['expected_failure_count']}",f"- Unexpected failures: {execution['unexpected_failure_count']}\n","## Analyzer accuracy\n",f"- Unique accuracy observations: {accuracy['observation_count']}",f"- Executed artifact encodings: {accuracy['encoding_count']}",f"- Top-1 accuracy: {fmt(accuracy['top1_accuracy'])}",f"- Top-2 recall: {fmt(accuracy['top2_recall'])}",f"- High-confidence wrong: {accuracy['high_confidence_wrong_count']}\n","### Per-ground-truth observation counts\n"])
+    for k, v in sorted(accuracy.get("per_ground_truth_counts", {}).items()):
         parts.append(f"- {k}: {v}")
-    parts.append("\n## Confidence bucket accuracy\n")
-    for k, v in sorted(metrics.get("confidence_bucket_accuracy", {}).items()):
+    parts.append("\n### Confidence bucket accuracy\n")
+    for k, v in sorted(accuracy.get("confidence_bucket_accuracy", {}).items()):
         parts.append(f"- {k}: accuracy={v.get('accuracy')} total={v.get('total')} correct={v.get('correct')}")
-    parts.append("\n## Validated paths\n")
+    parts.extend(["\n## Report-contract validation\n",f"- Cases: {contracts['case_count']}",f"- Passed: {contracts['passed_count']}",f"- Failed: {contracts['failed_count']}","- Report-contract cases do not contribute to analyzer accuracy.\n","## Validated input paths\n"])
     validated_path_labels = {
         "analysis_report": "analysis_report fixtures",
         "synthetic_analysis_report": "synthetic_analysis_report fixtures",
@@ -199,10 +196,12 @@ def render_scorecard(metrics, env):
     }
     for k, label in validated_path_labels.items():
         parts.append(f"- {label}: {metrics.get('validated_paths', {}).get(k, 0)}")
-    parts.append("\n## Failed cases\n")
-    parts.append(render_failed_cases(metrics.get("failed_cases", [])))
+    parts.append("\n## Failed analyzer cases\n")
+    parts.append(render_failed_cases(metrics.get("failed_analyzer_cases", [])))
+    parts.append("## Failed report-contract cases\n")
+    parts.append(render_failed_cases(metrics.get("failed_report_contract_cases", [])))
     parts.append("## Non-claims\n")
-    parts.extend(["- This is not root-cause proof.", "- This is not universal production accuracy.", "- This is not universal production overhead.", "- This is not real-service validation.", "- `ground_truth` labels are controlled fixture intent, not production truth."])
+    parts.extend(["- This is not root-cause proof.", "- This is not universal production accuracy.", "- This is not universal production overhead.", "- This is not real-service validation.", "- Fixture labels are controlled intent, not production truth.","- Report-contract pass rates are not analyzer accuracy.","- Equivalent artifact encodings are not independent observations.","- Prompt 17 equivalence is not an accuracy denominator."])
     return "\n".join(parts) + "\n"
 
 

--- a/scripts/tests/test_diagnostic_benchmark.py
+++ b/scripts/tests/test_diagnostic_benchmark.py
@@ -70,7 +70,26 @@ class Tests(unittest.TestCase):
   for key,value in changes.items():
    with self.subTest(key=key):
     a=case('a');b=case('b',observation_id='a');b[key]=value
-    with self.assertRaisesRegex(ValueError,'observation labels disagree|exact_primary_kind'):db.validate_manifest(manifest(a,b))
+    with self.assertRaisesRegex(ValueError,'observation labels disagree|exact_primary_kind|ground_truth must be in'):db.validate_manifest(manifest(a,b))
+ def test_accuracy_ground_truth_must_be_in_both_contract_lists(self):
+  variants=[
+   ({'expected_primary_kinds':['blocking_pool_pressure']},False),
+   ({'required_visible_suspects':['blocking_pool_pressure']},False),
+   ({},True),
+   ({'expected_primary_kinds':['blocking_pool_pressure','application_queue_saturation']},True),
+   ({'required_visible_suspects':['blocking_pool_pressure','application_queue_saturation']},True),
+  ]
+  for changes,valid in variants:
+   with self.subTest(changes=changes):
+    c=case(**changes)
+    if valid:db.validate_manifest(manifest(c))
+    else:
+     with self.assertRaisesRegex(ValueError,'ground_truth must be in'):db.validate_manifest(manifest(c))
+ def test_ground_truth_top1_cannot_be_high_confidence_wrong(self):
+  c=case(expected_primary_kinds=['blocking_pool_pressure','application_queue_saturation'])
+  with tempfile.TemporaryDirectory() as td:
+   p=self.write(td,[c]);(m,_),_=self.runmock(p,[Result(out=json.dumps(report()))])
+  self.assertEqual(m['analyzer_accuracy']['high_confidence_wrong_count'],0)
  def test_class_type_and_eligibility_matrix(self):
   bad=[case('x','analysis_report',False,validation_class='analyzer_execution'),case('x','synthetic_analysis_report',False,validation_class='analyzer_execution'),case(validation_class='report_contract'),case('x','tracing_span_jsonl',True,validation_class='report_contract'),case('x','analysis_report',False,accuracy_eligible=True),case('x','analysis_report',False,ground_truth='insufficient_evidence'),case('x','analysis_report',False,observation_id='x'),case(observation_id=None),case(ground_truth=None),case(eligible=False,ground_truth='insufficient_evidence'),case(eligible=False,execution_expectation='failure',failure_stage='analyze',expected_error_substrings=[],forbidden_error_substrings=[],stdout_expectation='empty',accuracy_eligible=True)]
   for c in bad:
@@ -88,6 +107,49 @@ class Tests(unittest.TestCase):
   trace=case('t','tracing_span_jsonl',False,execution_expectation='failure',failure_stage='analyze',expected_error_substrings=[],forbidden_error_substrings=[],stdout_expectation='ignore')
   with tempfile.TemporaryDirectory() as td:
    p=self.write(td,[trace]);(m,_),_=self.runmock(p,[Result(1,'','bad')]);self.assertFalse(m['analyzer_execution']['cases'][0]['passed'])
+ def test_expected_failure_diagnostics_are_stderr_only(self):
+  base=case(eligible=False,execution_expectation='failure',failure_stage='analyze',expected_error_substrings=['needed'],forbidden_error_substrings=['secret'],stdout_expectation='ignore')
+  scenarios=[(Result(1,'','needed'),True),(Result(1,'needed',''),False),(Result(1,'needed',''),False),(Result(1,'','needed secret'),False),(Result(1,'output','needed'),False),(Result(1,'','needed'),False),(Result(1,'anything','needed'),True)]
+  policies=['ignore','non_empty','ignore','ignore','empty','non_empty','ignore']
+  for result,passed,policy in zip((x[0] for x in scenarios),(x[1] for x in scenarios),policies):
+   with self.subTest(result=result.__dict__,policy=policy):
+    c=dict(base,stdout_expectation=policy)
+    with tempfile.TemporaryDirectory() as td:
+     p=self.write(td,[c]);(m,_),_=self.runmock(p,[result]);row=m['analyzer_execution']['cases'][0]
+    self.assertEqual(row['passed'],passed)
+    if result.stdout=='needed' and not result.stderr:self.assertIn('missing stderr diagnostic',row['error'])
+ def test_optional_contract_fields_are_strictly_validated(self):
+  valid={'exact_primary_kind':'application_queue_saturation','max_primary_confidence':'high','expected_evidence_quality':'strong','expected_signal_statuses':{'queues':'present'},'must_include_confidence_notes':[],'must_include_route_warning':[],'must_include_temporal_warning':[],'expected_top_level_warnings':[],'expected_route_breakdowns':'empty','expected_temporal_segments':'non_empty'}
+  db.validate_manifest(manifest(case(**valid)))
+  invalid=[('exact_primary_kind',42),('exact_primary_kind','unknown'),('max_primary_confidence',42),('max_primary_confidence','very_high'),('expected_evidence_quality',42),('expected_evidence_quality','complete'),('expected_signal_statuses',[]),('expected_signal_statuses',{'unknown':'present'}),('expected_signal_statuses',{'queues':'available'}),('must_include_confidence_notes','not-a-list'),('must_include_route_warning','not-a-list'),('must_include_temporal_warning',[42]),('expected_top_level_warnings',['*']),('must_include_route_warning',['*']),('must_include_temporal_warning',['*']),('expected_route_breakdowns','sometimes'),('expected_route_breakdowns',True),('expected_temporal_segments','sometimes'),('expected_temporal_segments',True)]
+  for field,value in invalid:
+   with self.subTest(field=field,value=value):
+    with self.assertRaises(ValueError):db.validate_manifest(manifest(case(**{field:value})))
+  for field in db.FAILURE_FIELDS:
+   with self.subTest(success_field=field):
+    with self.assertRaisesRegex(ValueError,'only on failure'):db.validate_manifest(manifest(case(**{field:[] if 'substrings' in field else 'analyze'})))
+ def test_extract_rejects_malformed_report_shapes(self):
+  mutations=[
+   lambda r:r.update(secondary_suspects=[42]),lambda r:r.update(secondary_suspects=[{'kind':'unknown'}]),lambda r:r.update(secondary_suspects=[{'kind':'blocking_pool_pressure','confidence':'certain'}]),lambda r:r['primary_suspect'].update(score='one'),lambda r:r['primary_suspect'].update(score=True),lambda r:r.update(secondary_suspects=[{'kind':'blocking_pool_pressure','score':'one'}]),lambda r:r.update(secondary_suspects=[{'kind':'blocking_pool_pressure','score':False}]),lambda r:r['primary_suspect'].update(evidence=['ok',42]),lambda r:r.update(secondary_suspects=[{'kind':'blocking_pool_pressure','evidence':[42]}]),lambda r:r['primary_suspect'].update(next_checks=[42]),lambda r:r.update(secondary_suspects=[{'kind':'blocking_pool_pressure','next_checks':[42]}]),lambda r:r['primary_suspect'].update(confidence_notes=[42]),lambda r:r.update(warnings=[42]),lambda r:r.update(evidence_quality=[]),lambda r:r.update(route_breakdowns={}),lambda r:r.update(route_breakdowns=[42]),lambda r:r.update(temporal_segments={}),lambda r:r.update(temporal_segments=[42]),lambda r:r.update(route_breakdowns=[{'warnings':[42]}]),lambda r:r.update(temporal_segments=[{'warnings':[42]}]),
+  ]
+  for mutate in mutations:
+   with self.subTest(mutate=mutate):
+    r=report();mutate(r)
+    with self.assertRaises(ValueError):db.extract(r)
+  r=report(secondary='blocking_pool_pressure');r.update(evidence_quality={'quality':'strong'},route_breakdowns=[{'warnings':['route']}],temporal_segments=[{'warnings':['time']}]);r['primary_suspect']['confidence_notes']=['note'];db.extract(r)
+ def test_incomplete_equivalent_encoding_group_is_not_scored(self):
+  bad_outputs=[Result(1,'','boom'),Result(out='not json'),Result(out=json.dumps({'primary_suspect':{}}))]
+  for bad in bad_outputs:
+   with self.subTest(bad=bad.__dict__):
+    a=case('a');b=case('b',observation_id='a')
+    with tempfile.TemporaryDirectory() as td:
+     p=self.write(td,[a,b]);(m,_),_=self.runmock(p,[Result(out=json.dumps(report())),bad])
+    acc=m['analyzer_accuracy'];self.assertEqual(acc['encoding_count'],1);self.assertEqual(acc['observation_count'],0);self.assertEqual(acc['per_ground_truth_counts'],{});self.assertEqual(acc['confusion_matrix'],{});self.assertEqual(acc['confidence_bucket_accuracy'],{});self.assertEqual(acc['observations'],[])
+    row=m['failed_analyzer_cases'][-1];self.assertEqual(row['expected_member_ids'],['a','b']);self.assertEqual(row['usable_member_ids'],['a']);self.assertEqual(row['unusable_member_ids'],['b']);self.assertIn('incomplete',row['error'])
+  a=case('a');b=case('b',observation_id='a');c=case('c')
+  with tempfile.TemporaryDirectory() as td:
+   p=self.write(td,[a,b,c]);(m,_),_=self.runmock(p,[Result(out=json.dumps(report())),Result(1,'','boom'),Result(out=json.dumps(report()))])
+  self.assertEqual(m['analyzer_accuracy']['encoding_count'],2);self.assertEqual(m['analyzer_accuracy']['observation_count'],1);self.assertEqual(m['analyzer_accuracy']['observations'][0]['observation_id'],'c')
  def test_artifact_policy_is_typed(self):
   db.validate_manifest(manifest(case()));db.validate_manifest(manifest(case(artifact_policy='allow_ambiguous')))
   self.assertIn('--allow-ambiguous-artifact',db._command('analyze',case(artifact_policy='allow_ambiguous'),Path('x')))

--- a/scripts/tests/test_diagnostic_benchmark.py
+++ b/scripts/tests/test_diagnostic_benchmark.py
@@ -1,591 +1,99 @@
-import copy
-import contextlib
-import io
-import json
-import os
-import tempfile
-import unittest
+import json,tempfile,unittest
 from pathlib import Path
 from unittest import mock
-
 from scripts import diagnostic_benchmark as db
 
-ALLOWED = sorted(db.ALLOWED_GROUND_TRUTH)
-
-BASE_CASE = {
-    "id": "case-1",
-    "artifact": "case-1.json",
-    "artifact_type": "analysis_report",
-    "ground_truth": "application_queue_saturation",
-    "required_top2": ["application_queue_saturation"],
-    "acceptable_primary": ["application_queue_saturation"],
-    "tags": ["queue"],
-    "must_include_evidence": [],
-    "must_include_next_checks": [],
-    "expected_warnings": [],
-    "allowed_warnings": [],
-    "top1_required": False,
-    "notes": "deterministic queue case",
-}
-
-
-def valid_report(*, primary_kind="application_queue_saturation", confidence="high", score=1.0, evidence=None, next_checks=None, secondary=None, warnings=None, confidence_notes=None, evidence_quality=None, route_breakdowns=None, temporal_segments=None):
-    primary = {
-        "kind": primary_kind,
-        "confidence": confidence,
-        "score": score,
-        "evidence": evidence if evidence is not None else ["Queue wait dominates"],
-    }
-    if next_checks is not None:
-        primary["next_checks"] = next_checks
-    if confidence_notes is not None:
-        primary["confidence_notes"] = confidence_notes
-    return {
-        "primary_suspect": primary,
-        "secondary_suspects": secondary or [],
-        "warnings": warnings or [],
-        "evidence_quality": evidence_quality or {},
-        "route_breakdowns": route_breakdowns or [],
-        "temporal_segments": temporal_segments or [],
-    }
-
-
-class DiagnosticBenchmarkTests(unittest.TestCase):
-    def make_case(self, **updates):
-        case = copy.deepcopy(BASE_CASE)
-        case.update(updates)
-        return case
-
-    def make_manifest(self, *cases, schema_version=1):
-        return {"schema_version": schema_version, "cases": list(cases)}
-
-    def write_json(self, root, relative_path, payload):
-        path = Path(root) / relative_path
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(payload), encoding="utf-8")
-        return path
-
-    def run_single_case(self, case, report, *, min_top1=0.0, min_top2=0.0, max_high_confidence_wrong=99):
-        with tempfile.TemporaryDirectory() as td:
-            self.write_json(td, case["artifact"], report)
-            manifest_path = self.write_json(td, "manifest.json", self.make_manifest(case))
-            return db.run(str(manifest_path), min_top1, min_top2, max_high_confidence_wrong)
-
-    # Manifest validation tests
-    def test_manifest_schema_version_required(self):
-        with self.assertRaisesRegex(ValueError, "schema_version"):
-            db.validate_manifest(self.make_manifest(self.make_case(), schema_version=0))
-
-    def test_committed_manifest_has_required_schema_version(self):
-        manifest_path = Path(__file__).resolve().parents[2] / "validation" / "diagnostics" / "manifest.json"
-        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-        self.assertEqual(manifest.get("schema_version"), 1)
-        db.validate_manifest(manifest)
-
-    def test_manifest_duplicate_ids_fail(self):
-        c1 = self.make_case(id="dup", artifact="a.json")
-        c2 = self.make_case(id="dup", artifact="b.json")
-        with self.assertRaisesRegex(ValueError, "duplicate case id"):
-            db.validate_manifest(self.make_manifest(c1, c2))
-
-    def test_manifest_non_empty_id_and_artifact_required(self):
-        with self.assertRaisesRegex(ValueError, "id"):
-            db.validate_manifest(self.make_manifest(self.make_case(id="")))
-        with self.assertRaisesRegex(ValueError, "artifact"):
-            db.validate_manifest(self.make_manifest(self.make_case(artifact="")))
-
-    def test_manifest_artifact_type_must_be_allowed(self):
-        bad = self.make_case(artifact_type="anything_else")
-        with self.assertRaisesRegex(ValueError, "artifact_type"):
-            db.validate_manifest(self.make_manifest(bad))
-        db.validate_manifest(self.make_manifest(self.make_case(artifact_type="run_artifact")))
-        db.validate_manifest(self.make_manifest(self.make_case(artifact_type="tracing_span_jsonl")))
-
-    def test_manifest_ground_truth_and_required_top2_rules(self):
-        with self.assertRaisesRegex(ValueError, "unknown ground_truth"):
-            db.validate_manifest(self.make_manifest(self.make_case(ground_truth="not_a_kind")))
-        with self.assertRaisesRegex(ValueError, "required_top2 must be a non-empty list"):
-            db.validate_manifest(self.make_manifest(self.make_case(required_top2=[])))
-        with self.assertRaisesRegex(ValueError, "required_top2 contains unknown diagnosis kind"):
-            db.validate_manifest(self.make_manifest(self.make_case(required_top2=["unknown"])))
-        with self.assertRaisesRegex(ValueError, "required_top2 must include ground_truth"):
-            db.validate_manifest(self.make_manifest(self.make_case(required_top2=["blocking_pool_pressure"])))
-
-    def test_manifest_acceptable_primary_rules(self):
-        with self.assertRaisesRegex(ValueError, "acceptable_primary must be a non-empty list"):
-            db.validate_manifest(self.make_manifest(self.make_case(acceptable_primary=[])))
-        with self.assertRaisesRegex(ValueError, "acceptable_primary contains unknown diagnosis kind"):
-            db.validate_manifest(self.make_manifest(self.make_case(acceptable_primary=["bad_kind"])))
-        with self.assertRaisesRegex(ValueError, "acceptable_primary must include ground_truth"):
-            db.validate_manifest(self.make_manifest(self.make_case(acceptable_primary=["blocking_pool_pressure"])))
-
-    def test_manifest_list_and_scalar_field_shapes(self):
-        with self.assertRaisesRegex(ValueError, "tags"):
-            db.validate_manifest(self.make_manifest(self.make_case(tags=[""])))
-        with self.assertRaisesRegex(ValueError, "must_include_evidence"):
-            db.validate_manifest(self.make_manifest(self.make_case(must_include_evidence=[1])))
-        with self.assertRaisesRegex(ValueError, "must_include_next_checks"):
-            db.validate_manifest(self.make_manifest(self.make_case(must_include_next_checks=[1])))
-        with self.assertRaisesRegex(ValueError, "expected_warnings"):
-            db.validate_manifest(self.make_manifest(self.make_case(expected_warnings=[1])))
-        with self.assertRaisesRegex(ValueError, "allowed_warnings"):
-            db.validate_manifest(self.make_manifest(self.make_case(allowed_warnings=[1])))
-
-    def test_manifest_wildcard_warnings_and_remaining_fields(self):
-        with self.assertRaisesRegex(ValueError, "wildcard"):
-            db.validate_manifest(self.make_manifest(self.make_case(expected_warnings=["*"])))
-        with self.assertRaisesRegex(ValueError, "wildcard"):
-            db.validate_manifest(self.make_manifest(self.make_case(allowed_warnings=["*"])))
-        with self.assertRaisesRegex(ValueError, "top1_required"):
-            db.validate_manifest(self.make_manifest(self.make_case(top1_required="yes")))
-        with self.assertRaisesRegex(ValueError, "notes"):
-            db.validate_manifest(self.make_manifest(self.make_case(notes="")))
-    def test_manifest_max_primary_confidence_rules(self):
-        db.validate_manifest(self.make_manifest(self.make_case()))
-        for allowed in ["low", "medium", "high"]:
-            db.validate_manifest(self.make_manifest(self.make_case(max_primary_confidence=allowed)))
-        with self.assertRaisesRegex(ValueError, "max_primary_confidence must be one of"):
-            db.validate_manifest(self.make_manifest(self.make_case(max_primary_confidence="very_high")))
-        with self.assertRaisesRegex(ValueError, "max_primary_confidence must be one of"):
-            db.validate_manifest(self.make_manifest(self.make_case(max_primary_confidence="extreme")))
-        with self.assertRaisesRegex(ValueError, "max_primary_confidence must be a string"):
-            db.validate_manifest(self.make_manifest(self.make_case(max_primary_confidence=1)))
-
-
-    def test_run_artifact_loads_report_via_cli_json(self):
-        case = self.make_case(artifact_type="run_artifact", artifact="run.json")
-        fake_report = valid_report()
-        with tempfile.TemporaryDirectory() as td:
-            artifact_path = self.write_json(td, case["artifact"], {"schema_version": 1})
-            with mock.patch("scripts.diagnostic_benchmark.subprocess.run") as mocked_run:
-                mocked_run.return_value = mock.Mock(returncode=0, stdout=json.dumps(fake_report), stderr="")
-                loaded = db.load_case_report(case, Path(td))
-        self.assertEqual(loaded["primary_suspect"]["kind"], fake_report["primary_suspect"]["kind"])
-        mocked_run.assert_called_once()
-        cmd = mocked_run.call_args.args[0]
-        self.assertEqual(cmd[0], "cargo")
-        self.assertIn("tailtriage-cli", cmd)
-        self.assertIn("analyze", cmd)
-        self.assertIn(str(artifact_path.resolve()), cmd)
-        self.assertEqual(cmd[-2:], ["--format", "json"])
-
-    def test_tracing_span_jsonl_imports_then_analyzes_via_cli(self):
-        case = self.make_case(artifact_type="tracing_span_jsonl", artifact="spans.jsonl", id="trace-case")
-        fake_report = valid_report()
-        with tempfile.TemporaryDirectory() as td:
-            artifact_path = Path(td) / case["artifact"]
-            artifact_path.write_text("{}\n", encoding="utf-8")
-            calls = []
-
-            def fake_run(command, capture_output, text):
-                calls.append(command)
-                if "import" in command:
-                    output_path = Path(command[command.index("--output") + 1])
-                    output_path.write_text('{"schema_version":1}', encoding="utf-8")
-                    return mock.Mock(returncode=0, stdout="", stderr="")
-                return mock.Mock(returncode=0, stdout=json.dumps(fake_report), stderr="")
-
-            with mock.patch("scripts.diagnostic_benchmark.subprocess.run", side_effect=fake_run):
-                loaded = db.load_case_report(case, Path(td))
-
-        self.assertEqual(loaded["primary_suspect"]["kind"], fake_report["primary_suspect"]["kind"])
-        self.assertEqual(len(calls), 2)
-        self.assertIn("import", calls[0])
-        self.assertIn("tracing-spans-jsonl", calls[0])
-        self.assertIn(str(artifact_path.resolve()), calls[0])
-        self.assertIn("analyze", calls[1])
-        self.assertEqual(calls[1][-2:], ["--format", "json"])
-
-    def test_tracing_span_jsonl_import_failure_includes_command_output_and_path(self):
-        case = self.make_case(artifact_type="tracing_span_jsonl", artifact="spans.jsonl", id="trace-fail")
-        with tempfile.TemporaryDirectory() as td:
-            artifact_path = Path(td) / case["artifact"]
-            artifact_path.write_text("{}\n", encoding="utf-8")
-            with mock.patch("scripts.diagnostic_benchmark.subprocess.run") as mocked_run:
-                mocked_run.return_value = mock.Mock(returncode=1, stdout="out detail", stderr="err detail")
-                with self.assertRaisesRegex(ValueError, "trace-fail") as ctx:
-                    db.load_case_report(case, Path(td))
-        message = str(ctx.exception)
-        self.assertIn(str(artifact_path.resolve()), message)
-        self.assertIn("tracing-spans-jsonl", message)
-        self.assertIn("out detail", message)
-        self.assertIn("err detail", message)
-
-    def test_run_artifact_cli_failure_includes_case_and_path(self):
-        case = self.make_case(artifact_type="run_artifact", artifact="run.json", id="raw-case")
-        with tempfile.TemporaryDirectory() as td:
-            artifact_path = self.write_json(td, case["artifact"], {"schema_version": 1})
-            with mock.patch("scripts.diagnostic_benchmark.subprocess.run") as mocked_run:
-                mocked_run.return_value = mock.Mock(returncode=1, stdout="", stderr="boom")
-                with self.assertRaisesRegex(ValueError, "raw-case"):
-                    db.load_case_report(case, Path(td))
-                with self.assertRaisesRegex(ValueError, str(artifact_path.resolve())):
-                    db.load_case_report(case, Path(td))
-
-    # Report validation tests
-    def test_report_missing_primary_fails(self):
-        with self.assertRaisesRegex(ValueError, "primary_suspect"):
-            db.extract({"secondary_suspects": [], "warnings": []})
-
-    def test_report_primary_field_validation(self):
-        with self.assertRaisesRegex(ValueError, "primary_suspect.kind"):
-            db.extract({"primary_suspect": {"kind": "bad", "confidence": "high", "evidence": []}, "secondary_suspects": [], "warnings": []})
-        with self.assertRaisesRegex(ValueError, "confidence"):
-            db.extract({"primary_suspect": {"kind": ALLOWED[0], "confidence": "bad", "evidence": []}, "secondary_suspects": [], "warnings": []})
-        with self.assertRaisesRegex(ValueError, "confidence"):
-            db.extract({"primary_suspect": {"kind": ALLOWED[0], "confidence": "very_high", "evidence": []}, "secondary_suspects": [], "warnings": []})
-        with self.assertRaisesRegex(ValueError, "score"):
-            db.extract({"primary_suspect": {"kind": ALLOWED[0], "confidence": "high", "score": "x", "evidence": []}, "secondary_suspects": [], "warnings": []})
-        with self.assertRaisesRegex(ValueError, "evidence"):
-            db.extract({"primary_suspect": {"kind": ALLOWED[0], "confidence": "high", "evidence": "x"}, "secondary_suspects": [], "warnings": []})
-        with self.assertRaisesRegex(ValueError, "next_checks"):
-            db.extract({"primary_suspect": {"kind": ALLOWED[0], "confidence": "high", "evidence": [], "next_checks": "x"}, "secondary_suspects": [], "warnings": []})
-
-    def test_report_secondary_and_warnings_validation(self):
-        primary = {"kind": ALLOWED[0], "confidence": "high", "evidence": []}
-        with self.assertRaisesRegex(ValueError, "secondary_suspects.kind"):
-            db.extract({"primary_suspect": primary, "secondary_suspects": [{"kind": "bad"}], "warnings": []})
-        with self.assertRaisesRegex(ValueError, "secondary_suspects.confidence"):
-            db.extract({"primary_suspect": primary, "secondary_suspects": [{"confidence": "bad"}], "warnings": []})
-        with self.assertRaisesRegex(ValueError, "secondary_suspects.confidence"):
-            db.extract({"primary_suspect": primary, "secondary_suspects": [{"confidence": "very_high"}], "warnings": []})
-        with self.assertRaisesRegex(ValueError, "secondary_suspects.score"):
-            db.extract({"primary_suspect": primary, "secondary_suspects": [{"score": "bad"}], "warnings": []})
-        with self.assertRaisesRegex(ValueError, "secondary_suspects.evidence"):
-            db.extract({"primary_suspect": primary, "secondary_suspects": [{"evidence": "bad"}], "warnings": []})
-        with self.assertRaisesRegex(ValueError, "secondary_suspects.next_checks"):
-            db.extract({"primary_suspect": primary, "secondary_suspects": [{"next_checks": "bad"}], "warnings": []})
-        with self.assertRaisesRegex(ValueError, "warnings"):
-            db.extract({"primary_suspect": primary, "secondary_suspects": [], "warnings": [1]})
-
-    def test_analysis_report_requires_primary_score_but_synthetic_may_omit(self):
-        case = self.make_case(artifact_type="analysis_report")
-        no_score_report = valid_report(score=None)
-        del no_score_report["primary_suspect"]["score"]
-        with self.assertRaisesRegex(ValueError, "analysis_report requires"):
-            self.run_single_case(case, no_score_report)
-
-        synthetic = self.make_case(artifact_type="synthetic_analysis_report")
-        metrics, failures = self.run_single_case(synthetic, no_score_report)
-        self.assertEqual(metrics["total_cases"], 1)
-        self.assertFalse(failures)
-
-    # Metric semantics tests
-    def test_top1_required_wrong_primary_fails(self):
-        case = self.make_case(top1_required=True)
-        metrics, failures = self.run_single_case(case, valid_report(primary_kind="blocking_pool_pressure"))
-        self.assertTrue(failures)
-        self.assertEqual(len(metrics["failed_cases"]), 1)
-        self.assertFalse(metrics["failed_cases"][0]["top1_ok"])
-
-    def test_required_top2_missing_fails_even_if_primary_acceptable(self):
-        case = self.make_case(
-            required_top2=["application_queue_saturation"],
-            acceptable_primary=["application_queue_saturation", "blocking_pool_pressure"],
-        )
-        metrics, failures = self.run_single_case(case, valid_report(primary_kind="blocking_pool_pressure"))
-        self.assertTrue(failures)
-        self.assertFalse(metrics["failed_cases"][0]["top2_ok"])
-
-    def test_acceptable_alternate_primary_with_ground_truth_secondary(self):
-        case = self.make_case(acceptable_primary=["application_queue_saturation", "blocking_pool_pressure"])
-        secondary = [{"kind": "application_queue_saturation", "evidence": ["backup"]}]
-        metrics, failures = self.run_single_case(case, valid_report(primary_kind="blocking_pool_pressure", secondary=secondary))
-        self.assertFalse(failures)
-        self.assertEqual(metrics["high_confidence_wrong_count"], 0)
-
-    def test_high_confidence_unacceptable_primary_counts_even_with_gt_secondary(self):
-        case = self.make_case(acceptable_primary=["application_queue_saturation"])
-        secondary = [{"kind": "application_queue_saturation", "evidence": ["backup"]}]
-        metrics, failures = self.run_single_case(case, valid_report(primary_kind="blocking_pool_pressure", secondary=secondary), max_high_confidence_wrong=0)
-        self.assertEqual(metrics["high_confidence_wrong_count"], 1)
-        self.assertTrue(failures)
-
-    def test_warning_and_evidence_semantics(self):
-        case = self.make_case(must_include_evidence=["secondary evidence"], expected_warnings=["expected warn"], allowed_warnings=["optional warn"])
-        secondary = [{"kind": "blocking_pool_pressure", "evidence": ["secondary evidence"]}]
-        good_report = valid_report(secondary=secondary, warnings=["expected warn", "optional warn"])
-        metrics, failures = self.run_single_case(case, good_report)
-        self.assertFalse(failures)
-        self.assertEqual(metrics["unexpected_warning_count"], 0)
-
-        missing_expected = valid_report(secondary=secondary, warnings=[])
-        metrics, failures = self.run_single_case(case, missing_expected)
-        self.assertEqual(metrics["missing_expected_warning_count"], 1)
-        self.assertTrue(failures)
-
-        unexpected_warning = valid_report(secondary=secondary, warnings=["expected warn", "not allowed"])
-        metrics, failures = self.run_single_case(case, unexpected_warning)
-        self.assertEqual(metrics["unexpected_warning_count"], 1)
-        self.assertTrue(failures)
-
-    def test_next_check_metrics_and_required_substrings(self):
-        case_no_requirements = self.make_case()
-        report_with_next_checks = valid_report(next_checks=["inspect queue depth"], secondary=[{"kind": "blocking_pool_pressure", "next_checks": ["check blocking pool"]}])
-        metrics, failures = self.run_single_case(case_no_requirements, report_with_next_checks)
-        self.assertFalse(failures)
-        self.assertIsNone(metrics["next_check_pass_rate"])
-        self.assertEqual(metrics["next_check_presence_rate"], 1.0)
-
-        required_case = self.make_case(must_include_next_checks=["queue depth"])
-        metrics, failures = self.run_single_case(required_case, report_with_next_checks)
-        self.assertFalse(failures)
-        self.assertEqual(metrics["next_check_required_cases"], 1)
-        self.assertEqual(metrics["next_check_passed_cases"], 1)
-
-        missing_report = valid_report(next_checks=["check runtime metrics"])
-        metrics, failures = self.run_single_case(required_case, missing_report)
-        self.assertTrue(failures)
-        self.assertEqual(metrics["next_check_passed_cases"], 0)
-        self.assertFalse(metrics["failed_cases"][0]["next_check_ok"])
-
-    def test_failed_cases_include_useful_fields(self):
-        case = self.make_case(top1_required=True, expected_warnings=["must appear"])
-        metrics, _ = self.run_single_case(case, valid_report(primary_kind="blocking_pool_pressure", warnings=[]))
-        self.assertEqual(len(metrics["failed_cases"]), 1)
-        row = metrics["failed_cases"][0]
-        for field in ["id", "top1_ok", "top2_ok", "evidence_ok", "next_check_ok", "confidence_ceiling_ok", "max_primary_confidence", "primary_confidence", "unexpected_warnings", "missing_expected_warnings", "top1_required"]:
-            self.assertIn(field, row)
-    def test_confidence_ceiling_semantics_and_metrics(self):
-        base_case = self.make_case(max_primary_confidence="medium")
-        metrics, failures = self.run_single_case(base_case, valid_report(confidence="medium"))
-        self.assertFalse(failures)
-        self.assertEqual(metrics["confidence_ceiling_cases"], 1)
-        self.assertEqual(metrics["confidence_ceiling_passed_cases"], 1)
-        self.assertEqual(metrics["confidence_ceiling_pass_rate"], 1.0)
-
-        metrics, failures = self.run_single_case(base_case, valid_report(confidence="low"))
-        self.assertFalse(failures)
-        self.assertEqual(metrics["confidence_ceiling_passed_cases"], 1)
-
-        metrics, failures = self.run_single_case(base_case, valid_report(confidence="high"))
-        self.assertTrue(failures)
-        self.assertEqual(metrics["confidence_ceiling_passed_cases"], 0)
-        row = metrics["failed_cases"][0]
-        self.assertFalse(row["confidence_ceiling_ok"])
-        self.assertEqual(row["max_primary_confidence"], "medium")
-        self.assertEqual(row["primary_confidence"], "high")
-
-
-    def test_optional_manifest_field_validation(self):
-        with self.assertRaisesRegex(ValueError, "expected_evidence_quality must be a string"):
-            db.validate_manifest(self.make_manifest(self.make_case(expected_evidence_quality=1)))
-        with self.assertRaisesRegex(ValueError, "expected_evidence_quality"):
-            db.validate_manifest(self.make_manifest(self.make_case(expected_evidence_quality="bad")))
-        with self.assertRaisesRegex(ValueError, "unknown signal family"):
-            db.validate_manifest(self.make_manifest(self.make_case(expected_signal_statuses={"bad":"present"})))
-        with self.assertRaisesRegex(ValueError, "expected_signal_statuses values must be strings"):
-            db.validate_manifest(self.make_manifest(self.make_case(expected_signal_statuses={"queues": 1})))
-        with self.assertRaisesRegex(ValueError, "unknown signal status"):
-            db.validate_manifest(self.make_manifest(self.make_case(expected_signal_statuses={"queues":"bad"})))
-        with self.assertRaisesRegex(ValueError, "expected_route_breakdowns must be a string"):
-            db.validate_manifest(self.make_manifest(self.make_case(expected_route_breakdowns=1)))
-        with self.assertRaisesRegex(ValueError, "expected_temporal_segments must be a string"):
-            db.validate_manifest(self.make_manifest(self.make_case(expected_temporal_segments=1)))
-        with self.assertRaisesRegex(ValueError, "must_include_confidence_notes"):
-            db.validate_manifest(self.make_manifest(self.make_case(must_include_confidence_notes="x")))
-
-    def test_optional_checks_pass_and_fail(self):
-        case = self.make_case(expected_evidence_quality="strong", expected_signal_statuses={"queues":"present"}, must_include_confidence_notes=["queue"], expected_route_breakdowns="non_empty", expected_temporal_segments="non_empty", must_include_route_warning=["route caveat"], must_include_temporal_warning=["overlap"], expected_top_level_warnings=["top warning"], allowed_warnings=["top warning"])
-        report = valid_report(confidence_notes=["Queue confidence note"], warnings=["top warning"], evidence_quality={"quality":"strong","queues":"present"}, route_breakdowns=[{"warnings":["route caveat"]}], temporal_segments=[{"warnings":["overlap"]}])
-        metrics, failures = self.run_single_case(case, report)
-        self.assertFalse(failures)
-        self.assertEqual(metrics["evidence_quality_check_passed_cases"], 1)
-
-        bad = valid_report(confidence_notes=["other"], warnings=[], evidence_quality={"quality":"weak","queues":"missing"}, route_breakdowns=[], temporal_segments=[])
-        metrics, failures = self.run_single_case(case, bad)
-        self.assertTrue(failures)
-        row = metrics["failed_cases"][0]
-        self.assertFalse(row["evidence_quality_ok"])
-        self.assertFalse(row["signal_status_ok"])
-        self.assertFalse(row["confidence_note_ok"])
-        self.assertFalse(row["route_breakdown_ok"])
-        self.assertFalse(row["temporal_segment_ok"])
-        self.assertFalse(row["route_warning_ok"])
-        self.assertFalse(row["temporal_warning_ok"])
-        self.assertEqual(row["missing_expected_top_level_warnings"], ["top warning"])
-
-    def test_existing_cases_without_optional_fields_still_pass(self):
-        case = self.make_case()
-        metrics, failures = self.run_single_case(case, valid_report())
-        self.assertFalse(failures)
-        self.assertEqual(metrics["evidence_quality_check_cases"], 0)
-
-    def test_route_temporal_warning_only_checks_count_cases(self):
-        route_case = self.make_case(must_include_route_warning=["route caveat"])
-        route_report = valid_report(route_breakdowns=[{"warnings": ["route caveat noted"]}])
-        metrics, failures = self.run_single_case(route_case, route_report)
-        self.assertFalse(failures)
-        self.assertEqual(metrics["route_breakdown_check_cases"], 1)
-        self.assertEqual(metrics["route_breakdown_check_passed_cases"], 1)
-
-        temporal_case = self.make_case(must_include_temporal_warning=["segment overlap"])
-        temporal_report = valid_report(temporal_segments=[{"warnings": ["segment overlap warning"]}])
-        metrics, failures = self.run_single_case(temporal_case, temporal_report)
-        self.assertFalse(failures)
-        self.assertEqual(metrics["temporal_segment_check_cases"], 1)
-        self.assertEqual(metrics["temporal_segment_check_passed_cases"], 1)
-
-    def test_route_temporal_shape_and_warning_do_not_double_count(self):
-        route_case = self.make_case(expected_route_breakdowns="non_empty", must_include_route_warning=["route caveat"])
-        route_report = valid_report(route_breakdowns=[{"warnings": ["route caveat"]}])
-        metrics, failures = self.run_single_case(route_case, route_report)
-        self.assertFalse(failures)
-        self.assertEqual(metrics["route_breakdown_check_cases"], 1)
-
-        temporal_case = self.make_case(expected_temporal_segments="non_empty", must_include_temporal_warning=["overlap"])
-        temporal_report = valid_report(temporal_segments=[{"warnings": ["overlap"]}])
-        metrics, failures = self.run_single_case(temporal_case, temporal_report)
-        self.assertFalse(failures)
-        self.assertEqual(metrics["temporal_segment_check_cases"], 1)
-
-    def test_failed_rows_include_optional_mismatch_details(self):
-        case = self.make_case(
-            expected_evidence_quality="strong",
-            expected_signal_statuses={"queues": "present"},
-            must_include_confidence_notes=["queue confidence"],
-            must_include_route_warning=["route caveat"],
-            must_include_temporal_warning=["segment overlap"],
-        )
-        report = valid_report(
-            confidence_notes=["other note"],
-            evidence_quality={"quality": "weak", "queues": "missing"},
-            route_breakdowns=[{"warnings": ["different route warning"]}],
-            temporal_segments=[{"warnings": ["different segment warning"]}],
-        )
-        metrics, failures = self.run_single_case(case, report)
-        self.assertTrue(failures)
-        row = metrics["failed_cases"][0]
-        self.assertEqual(row["expected_evidence_quality"], "strong")
-        self.assertEqual(row["actual_evidence_quality"], "weak")
-        self.assertEqual(row["signal_status_mismatches"], [{"family": "queues", "expected": "present", "actual": "missing"}])
-        self.assertEqual(row["missing_confidence_notes"], ["queue confidence"])
-        self.assertEqual(row["missing_route_warnings"], ["route caveat"])
-        self.assertEqual(row["missing_temporal_warnings"], ["segment overlap"])
-
-    def test_malformed_optional_fields_do_not_satisfy_non_empty_checks(self):
-        case = self.make_case(expected_route_breakdowns="non_empty", expected_temporal_segments="non_empty")
-        report = valid_report(route_breakdowns=[], temporal_segments=[])
-        report["route_breakdowns"] = "not-a-list"
-        report["temporal_segments"] = "not-a-list"
-        metrics, failures = self.run_single_case(case, report)
-        self.assertTrue(failures)
-        row = metrics["failed_cases"][0]
-        self.assertFalse(row["route_breakdown_ok"])
-        self.assertFalse(row["temporal_segment_ok"])
-    # Threshold and output/path tests
-    def test_threshold_failures(self):
-        case = self.make_case()
-        report = valid_report(primary_kind="blocking_pool_pressure")
-        _, failures = self.run_single_case(case, report, min_top1=1.0)
-        self.assertTrue(any("top1_accuracy" in f for f in failures))
-        _, failures = self.run_single_case(case, report, min_top2=1.0)
-        self.assertTrue(any("top2_recall" in f for f in failures))
-        _, failures = self.run_single_case(case, report, max_high_confidence_wrong=0)
-        self.assertTrue(any("high_confidence_wrong_count" in f for f in failures))
-
-    def test_metrics_shape_and_absolute_manifest_path(self):
-        with tempfile.TemporaryDirectory() as td:
-            case = self.make_case()
-            self.write_json(td, case["artifact"], valid_report())
-            manifest = self.write_json(td, "manifest.json", self.make_manifest(case))
-            cwd = os.getcwd()
-            os.chdir("/")
-            try:
-                metrics, failures = db.run(str(manifest.resolve()), 0.0, 0.0, 99)
-            finally:
-                os.chdir(cwd)
-
-            self.assertFalse(failures)
-            expected_keys = {
-                "total_cases", "top1_accuracy", "top2_recall", "high_confidence_wrong_count",
-                "per_ground_truth_counts", "confusion_matrix", "confidence_bucket_accuracy",
-                "required_evidence_pass_rate", "next_check_required_cases", "next_check_passed_cases",
-                "next_check_presence_rate", "next_check_pass_rate", "confidence_ceiling_cases",
-                "confidence_ceiling_passed_cases", "confidence_ceiling_pass_rate", "unexpected_warning_count",
-                "missing_expected_warning_count", "evidence_quality_check_cases", "evidence_quality_check_passed_cases",
-                "signal_status_check_cases", "signal_status_check_passed_cases", "confidence_note_check_cases",
-                "confidence_note_check_passed_cases", "route_breakdown_check_cases", "route_breakdown_check_passed_cases",
-                "temporal_segment_check_cases", "temporal_segment_check_passed_cases", "failed_cases",
-                "validated_paths",
-            }
-            self.assertEqual(set(metrics.keys()), expected_keys)
-
-    def test_main_prints_optional_check_counters(self):
-        case = self.make_case(
-            expected_evidence_quality="strong",
-            expected_signal_statuses={"queues": "present"},
-            must_include_confidence_notes=["queue"],
-            expected_route_breakdowns="non_empty",
-            expected_temporal_segments="non_empty",
-        )
-        report = valid_report(
-            confidence_notes=["queue note"],
-            evidence_quality={"quality": "strong", "queues": "present"},
-            route_breakdowns=[{"warnings": []}],
-            temporal_segments=[{"warnings": []}],
-        )
-        with tempfile.TemporaryDirectory() as td:
-            self.write_json(td, case["artifact"], report)
-            manifest_path = self.write_json(td, "manifest.json", self.make_manifest(case))
-            buf = io.StringIO()
-            with contextlib.redirect_stdout(buf):
-                with mock.patch(
-                    "sys.argv",
-                    [
-                        "diagnostic_benchmark.py",
-                        "--manifest",
-                        str(manifest_path),
-                        "--min-top1",
-                        "0.0",
-                        "--min-top2",
-                        "0.0",
-                        "--max-high-confidence-wrong",
-                        "99",
-                    ],
-                ):
-                    db.main()
-            output = buf.getvalue()
-        self.assertIn("evidence_quality_checks=1/1", output)
-        self.assertIn("signal_status_checks=1/1", output)
-        self.assertIn("confidence_note_checks=1/1", output)
-        self.assertIn("route_breakdown_checks=1/1", output)
-        self.assertIn("temporal_segment_checks=1/1", output)
-        self.assertIn("confidence_bucket_accuracy.low=n/a total=0 correct=0", output)
-        self.assertIn("confidence_bucket_accuracy.medium=n/a total=0 correct=0", output)
-        self.assertIn("confidence_bucket_accuracy.high=1.000 total=1 correct=1", output)
-
-    def test_main_prints_confidence_bucket_accuracy_for_missing_and_present_buckets(self):
-        low_case = self.make_case(id="low-case", artifact="low-case.json")
-        medium_case = self.make_case(id="medium-case", artifact="medium-case.json")
-        low_report = valid_report(confidence="low")
-        medium_report = valid_report(confidence="medium")
-        with tempfile.TemporaryDirectory() as td:
-            self.write_json(td, low_case["artifact"], low_report)
-            self.write_json(td, medium_case["artifact"], medium_report)
-            manifest_path = self.write_json(td, "manifest.json", self.make_manifest(low_case, medium_case))
-            buf = io.StringIO()
-            with contextlib.redirect_stdout(buf):
-                with mock.patch(
-                    "sys.argv",
-                    [
-                        "diagnostic_benchmark.py",
-                        "--manifest",
-                        str(manifest_path),
-                        "--min-top1",
-                        "0.0",
-                        "--min-top2",
-                        "0.0",
-                        "--max-high-confidence-wrong",
-                        "99",
-                    ],
-                ):
-                    db.main()
-            output = buf.getvalue()
-        self.assertIn("confidence_bucket_accuracy.low=1.000 total=1 correct=1", output)
-        self.assertIn("confidence_bucket_accuracy.medium=1.000 total=1 correct=1", output)
-        self.assertIn("confidence_bucket_accuracy.high=n/a total=0 correct=0", output)
-
-
-if __name__ == "__main__":
-    unittest.main()
+def report(kind='application_queue_saturation',conf='high',secondary=None):
+ return {'primary_suspect':{'kind':kind,'confidence':conf,'score':1,'evidence':['queue evidence'],'next_checks':['check queue']},'secondary_suspects':([] if secondary is None else [{'kind':secondary,'confidence':'medium','evidence':[],'next_checks':[]}]),'warnings':[]}
+def case(cid='run',typ='run_artifact',eligible=True,**kw):
+ c={'id':cid,'artifact':cid+'.json','artifact_type':typ,'validation_class':db.TYPE_CLASS[typ],'accuracy_eligible':eligible,'tags':[],'notes':'test case','expected_primary_kinds':['application_queue_saturation'],'required_visible_suspects':['application_queue_saturation'],'must_include_evidence':['queue'],'must_include_next_checks':['check'],'expected_warnings':[],'allowed_warnings':[]}
+ if eligible:c.update(observation_id=cid,ground_truth='application_queue_saturation',exact_primary_kind='application_queue_saturation')
+ c.update(kw);return c
+def manifest(*cases):return {'schema_version':2,'cases':list(cases)}
+class Result:
+ def __init__(self,code=0,out='',err=''):self.returncode=code;self.stdout=out;self.stderr=err
+class Tests(unittest.TestCase):
+ def write(self,root,cases,reports=None):
+  root=Path(root)
+  for c,r in zip(cases,reports or [report()]*len(cases)):(root/c['artifact']).write_text(json.dumps(r))
+  p=root/'manifest.json';p.write_text(json.dumps(manifest(*cases)));return p
+ def runmock(self,p,outputs):
+  with mock.patch.object(db,'_invoke',side_effect=outputs) as inv:return db.run(p,0,0,99),inv
+ def test_report_only_manifest_fails_with_zero_analyzer_executions(self):
+  c=case('r','analysis_report',False)
+  with tempfile.TemporaryDirectory() as td:
+   p=self.write(td,[c]);(m,f),inv=self.runmock(p,[])
+  self.assertEqual(m['report_contract']['passed_count'],1);self.assertEqual(m['analyzer_execution']['case_count'],0);self.assertIsNone(m['analyzer_accuracy']['top1_accuracy']);self.assertIn('diagnostic corpus contains zero analyzer-executed cases',f);inv.assert_not_called()
+ def test_analyzer_execution_without_accuracy_observations_fails_distinctly(self):
+  c=case(eligible=False)
+  with tempfile.TemporaryDirectory() as td:
+   p=self.write(td,[c]);(m,f),inv=self.runmock(p,[Result(out=json.dumps(report()))])
+  self.assertEqual(m['analyzer_execution']['case_count'],1);self.assertIn('diagnostic corpus contains zero accuracy-eligible analyzer observations',f);self.assertNotIn('diagnostic corpus contains zero analyzer-executed cases',f);inv.assert_called_once()
+ def test_report_contract_results_do_not_change_analyzer_accuracy(self):
+  a=case();r=case('r','analysis_report',False)
+  vals=[]
+  for rr in [report(),report('blocking_pool_pressure','low','downstream_stage_dominates')]:
+   with tempfile.TemporaryDirectory() as td:
+    p=self.write(td,[a,r],[report(),rr]);(m,_),_=self.runmock(p,[Result(out=json.dumps(report()))]);vals.append(m['analyzer_accuracy'])
+  self.assertEqual(vals[0],vals[1])
+ def test_run_artifact_executes_cli_analyzer(self):
+  c=case()
+  with tempfile.TemporaryDirectory() as td:
+   p=self.write(td,[c]);(m,_),inv=self.runmock(p,[Result(out=json.dumps(report()))])
+  cmd=inv.call_args.args[0];self.assertEqual(cmd[:7],['cargo','run','--quiet','-p','tailtriage-cli','--','analyze']);self.assertNotIn('--allow-ambiguous-artifact',cmd);self.assertEqual(m['analyzer_execution']['run_artifact_count'],1);self.assertEqual(m['report_contract']['case_count'],0)
+ def test_tracing_jsonl_executes_import_then_analyzer(self):
+  c=case('trace','tracing_span_jsonl');
+  def invoke(cmd):
+   if 'import' in cmd:Path(cmd[-1]).write_text('{}');return Result()
+   return Result(out=json.dumps(report()))
+  with tempfile.TemporaryDirectory() as td:
+   p=self.write(td,[c]);
+   with mock.patch.object(db,'_invoke',side_effect=invoke) as inv:m,f=db.run(p,0,0,99)
+  self.assertFalse(f);self.assertIn('import',inv.call_args_list[0].args[0]);self.assertIn('tracing-spans-jsonl',inv.call_args_list[0].args[0]);self.assertIn('analyze',inv.call_args_list[1].args[0]);self.assertEqual(m['analyzer_execution']['tracing_jsonl_count'],1)
+ def test_equivalent_encodings_share_one_accuracy_observation(self):
+  a=case('a');b=case('b',observation_id='a')
+  with tempfile.TemporaryDirectory() as td:
+   p=self.write(td,[a,b]);(m,f),_=self.runmock(p,[Result(out=json.dumps(report())),Result(out=json.dumps(report()))])
+  self.assertFalse(f);self.assertEqual(m['analyzer_execution']['case_count'],2);self.assertEqual(m['analyzer_accuracy']['encoding_count'],2);self.assertEqual(m['analyzer_accuracy']['observation_count'],1)
+ def test_equivalent_encoding_diagnosis_disagreement_fails_observation(self):
+  a=case('a');b=case('b',observation_id='a')
+  with tempfile.TemporaryDirectory() as td:
+   p=self.write(td,[a,b]);(m,f),_=self.runmock(p,[Result(out=json.dumps(report())),Result(out=json.dumps(report(secondary='blocking_pool_pressure')))])
+  self.assertTrue(f);x=m['failed_analyzer_cases'][-1];self.assertEqual(x['observation_id'],'a');self.assertEqual(x['member_case_ids'],['a','b']);self.assertEqual(m['analyzer_accuracy']['observation_count'],0)
+ def test_equivalent_encoding_confidence_disagreement_fails_observation(self):
+  a=case('a');b=case('b',observation_id='a')
+  with tempfile.TemporaryDirectory() as td:
+   p=self.write(td,[a,b]);(m,_),_=self.runmock(p,[Result(out=json.dumps(report(conf='high'))),Result(out=json.dumps(report(conf='medium')))])
+  self.assertIn('confidence disagreement',m['failed_analyzer_cases'][-1]['error'])
+ def test_observation_labels_must_match(self):
+  changes={'ground_truth':'blocking_pool_pressure','expected_primary_kinds':['blocking_pool_pressure'],'required_visible_suspects':['blocking_pool_pressure'],'exact_primary_kind':'blocking_pool_pressure'}
+  for key,value in changes.items():
+   with self.subTest(key=key):
+    a=case('a');b=case('b',observation_id='a');b[key]=value
+    with self.assertRaisesRegex(ValueError,'observation labels disagree|exact_primary_kind'):db.validate_manifest(manifest(a,b))
+ def test_class_type_and_eligibility_matrix(self):
+  bad=[case('x','analysis_report',False,validation_class='analyzer_execution'),case('x','synthetic_analysis_report',False,validation_class='analyzer_execution'),case(validation_class='report_contract'),case('x','tracing_span_jsonl',True,validation_class='report_contract'),case('x','analysis_report',False,accuracy_eligible=True),case('x','analysis_report',False,ground_truth='insufficient_evidence'),case('x','analysis_report',False,observation_id='x'),case(observation_id=None),case(ground_truth=None),case(eligible=False,ground_truth='insufficient_evidence'),case(eligible=False,execution_expectation='failure',failure_stage='analyze',expected_error_substrings=[],forbidden_error_substrings=[],stdout_expectation='empty',accuracy_eligible=True)]
+  for c in bad:
+   with self.subTest(c=c):
+    with self.assertRaises(ValueError):db.validate_manifest(manifest(c))
+ def test_version_1_fields_are_rejected(self):
+  for key in db.OLD:
+   with self.assertRaisesRegex(ValueError,'version-1'):db.validate_manifest(manifest(case(**{key:[]})))
+ def test_expected_execution_failure_is_checked_not_skipped(self):
+  base=case(eligible=False,execution_expectation='failure',failure_stage='analyze',expected_error_substrings=['needed'],forbidden_error_substrings=['secret'],stdout_expectation='empty')
+  scenarios=[(Result(1,'','needed'),True),(Result(0,json.dumps(report()),''),False),(Result(1,'','missing'),False),(Result(1,'','needed secret'),False),(Result(1,'output','needed'),False)]
+  for result,passed in scenarios:
+   with tempfile.TemporaryDirectory() as td:
+    p=self.write(td,[base]);(m,_),_=self.runmock(p,[result]);self.assertEqual(m['analyzer_execution']['cases'][0]['passed'],passed)
+  trace=case('t','tracing_span_jsonl',False,execution_expectation='failure',failure_stage='analyze',expected_error_substrings=[],forbidden_error_substrings=[],stdout_expectation='ignore')
+  with tempfile.TemporaryDirectory() as td:
+   p=self.write(td,[trace]);(m,_),_=self.runmock(p,[Result(1,'','bad')]);self.assertFalse(m['analyzer_execution']['cases'][0]['passed'])
+ def test_artifact_policy_is_typed(self):
+  db.validate_manifest(manifest(case()));db.validate_manifest(manifest(case(artifact_policy='allow_ambiguous')))
+  self.assertIn('--allow-ambiguous-artifact',db._command('analyze',case(artifact_policy='allow_ambiguous'),Path('x')))
+  for c in [case('t','tracing_span_jsonl',True,artifact_policy='strict'),case('r','analysis_report',False,artifact_policy='strict'),case(artifact_policy='other'),case(command=['evil'])]:
+   with self.assertRaises(ValueError):db.validate_manifest(manifest(c))
+ def test_committed_manifest_invariants(self):
+  p=Path(__file__).parents[2]/'validation/diagnostics/manifest.json';m=json.loads(p.read_text());db.validate_manifest(m)
+  self.assertEqual(m['schema_version'],2);self.assertTrue(any(c['validation_class']=='analyzer_execution' for c in m['cases']));self.assertTrue(any(c['validation_class']=='report_contract' for c in m['cases']));self.assertTrue(any(c['accuracy_eligible'] for c in m['cases']))
+if __name__=='__main__':unittest.main()

--- a/scripts/tests/test_generate_diagnostic_scorecard.py
+++ b/scripts/tests/test_generate_diagnostic_scorecard.py
@@ -1,100 +1,25 @@
-import json
-import tempfile
-import unittest
+import json,tempfile,unittest
 from pathlib import Path
-
-from scripts.generate_diagnostic_scorecard import collect_environment, generate_scorecard, get_tailtriage_versions, manifest_and_artifact_hashes, render_failed_cases, render_scorecard, sha256_bytes
-
-
-class GenerateScorecardTests(unittest.TestCase):
-    def test_sha256_stable(self):
-        self.assertEqual(sha256_bytes(b"abc"), sha256_bytes(b"abc"))
-
-    def test_versions_workspace_and_explicit(self):
-        with tempfile.TemporaryDirectory() as td:
-            root = Path(td)
-            (root / "Cargo.toml").write_text('[workspace]\nmembers=["a","b"]\n[workspace.package]\nversion="1.2.3"\n', encoding="utf-8")
-            (root / "a").mkdir()
-            (root / "a/Cargo.toml").write_text('[package]\nname="tailtriage"\nversion={ workspace = true }\n', encoding="utf-8")
-            (root / "b").mkdir()
-            (root / "b/Cargo.toml").write_text('[package]\nname="tailtriage-core"\nversion="9.9.9"\n', encoding="utf-8")
-            versions = get_tailtriage_versions(root)
-            self.assertEqual(versions["workspace_package_version"], "1.2.3")
-            self.assertEqual(versions["packages"]["tailtriage"], "1.2.3")
-            self.assertEqual(versions["packages"]["tailtriage-core"], "9.9.9")
-
-    def test_artifact_hash_changes(self):
-        with tempfile.TemporaryDirectory() as td:
-            root = Path(td)
-            (root / "a.json").write_text('{"x":1}', encoding="utf-8")
-            (root / "manifest.json").write_text(json.dumps({"cases": [{"artifact": "a.json"}]}), encoding="utf-8")
-            h1 = manifest_and_artifact_hashes(root / "manifest.json")[1]
-            (root / "a.json").write_text('{"x":2}', encoding="utf-8")
-            h2 = manifest_and_artifact_hashes(root / "manifest.json")[1]
-            self.assertNotEqual(h1, h2)
-
-    def test_render_contains_non_claims_and_metrics(self):
-        env = {"generated_at_utc": "t", "snapshot_label": "s", "git": {"sha": "a", "tag": "v1", "describe": "d"}, "tailtriage": {"workspace_package_version": "1", "packages": {"tailtriage": "1"}}, "github_actions": {"run_id": None, "ref": None, "runner_os": None, "runner_arch": None, "image_version": None}, "software": {"python": "3", "rustc": "r", "cargo": "c"}, "hardware": {"cpu_model": "cpu", "logical_cores": 1, "memory_total_kib": 2}, "inputs": {"manifest_sha256": "m", "referenced_artifacts_sha256": "a", "thresholds": {"min_top1": 0.75}}}
-        metrics = {"failed_cases": [], "per_ground_truth_counts": {}, "confidence_bucket_accuracy": {}}
-        for k in ["total_cases", "top1_accuracy", "top2_recall", "high_confidence_wrong_count", "required_evidence_pass_rate", "next_check_required_cases", "next_check_passed_cases", "next_check_pass_rate", "next_check_presence_rate", "confidence_ceiling_cases", "confidence_ceiling_passed_cases", "confidence_ceiling_pass_rate", "unexpected_warning_count", "missing_expected_warning_count"]:
-            metrics[k] = 0
-        text = render_scorecard(metrics, env)
-        self.assertIn("failed_case_count", text)
-        self.assertIn("not root-cause proof", text)
-        self.assertIn("## Confidence bucket accuracy", text)
-
-
-    def test_render_includes_validated_path_counts(self):
-        env = {"generated_at_utc": "t", "snapshot_label": "s", "git": {"sha": "a", "tag": "v1", "describe": "d"}, "tailtriage": {"workspace_package_version": "1", "packages": {"tailtriage": "1"}}, "github_actions": {"run_id": None, "ref": None, "runner_os": None, "runner_arch": None, "image_version": None}, "software": {"python": "3", "rustc": "r", "cargo": "c"}, "hardware": {"cpu_model": "cpu", "logical_cores": 1, "memory_total_kib": 2}, "inputs": {"manifest_sha256": "m", "referenced_artifacts_sha256": "a", "thresholds": {"min_top1": 0.75}}}
-        metrics = {"failed_cases": [], "per_ground_truth_counts": {}, "confidence_bucket_accuracy": {}, "validated_paths": {"analysis_report": 1, "run_artifact": 2, "tracing_span_jsonl": 1}}
-        for k in ["total_cases", "top1_accuracy", "top2_recall", "high_confidence_wrong_count", "required_evidence_pass_rate", "next_check_required_cases", "next_check_passed_cases", "next_check_pass_rate", "next_check_presence_rate", "confidence_ceiling_cases", "confidence_ceiling_passed_cases", "confidence_ceiling_pass_rate", "unexpected_warning_count", "missing_expected_warning_count"]:
-            metrics[k] = 0
-        text = render_scorecard(metrics, env)
-        self.assertIn("## Validated paths", text)
-        self.assertIn("analysis_report fixtures: 1", text)
-        self.assertIn("tailtriage-cli analyze run_artifact: 2", text)
-        self.assertIn("tailtriage-cli import tracing-spans-jsonl -> analyze: 1", text)
-
-    def test_render_includes_confidence_bucket_accuracy_rows(self):
-        env = {"generated_at_utc": "t", "snapshot_label": "s", "git": {"sha": "a", "tag": "v1", "describe": "d"}, "tailtriage": {"workspace_package_version": "1", "packages": {"tailtriage": "1"}}, "github_actions": {"run_id": None, "ref": None, "runner_os": None, "runner_arch": None, "image_version": None}, "software": {"python": "3", "rustc": "r", "cargo": "c"}, "hardware": {"cpu_model": "cpu", "logical_cores": 1, "memory_total_kib": 2}, "inputs": {"manifest_sha256": "m", "referenced_artifacts_sha256": "a", "thresholds": {"min_top1": 0.75}}}
-        metrics = {"failed_cases": [], "per_ground_truth_counts": {}, "confidence_bucket_accuracy": {"low": {"accuracy": 0.5, "total": 2, "correct": 1}}}
-        for k in ["total_cases", "top1_accuracy", "top2_recall", "high_confidence_wrong_count", "required_evidence_pass_rate", "next_check_required_cases", "next_check_passed_cases", "next_check_pass_rate", "next_check_presence_rate", "confidence_ceiling_cases", "confidence_ceiling_passed_cases", "confidence_ceiling_pass_rate", "unexpected_warning_count", "missing_expected_warning_count"]:
-            metrics[k] = 0
-        text = render_scorecard(metrics, env)
-        self.assertIn("- low: accuracy=0.5 total=2 correct=1", text)
-
-    def test_failed_case_rendering(self):
-        self.assertEqual(render_failed_cases([]).strip(), "None")
-        table = render_failed_cases([{"id": "a", "top1_ok": False, "top2_ok": True, "evidence_ok": True, "next_check_ok": True, "confidence_ceiling_ok": True}])
-        self.assertIn("| a |", table)
-
-    def test_environment_keys(self):
-        repo = Path(__file__).resolve().parents[2]
-        env = collect_environment(repo, repo / "validation/diagnostics/manifest.json", "x", {"min_top1": 0.75, "min_top2": 0.9, "max_high_confidence_wrong": 0})
-        for key in ["schema_version", "generated_at_utc", "git", "tailtriage", "github_actions", "software", "hardware", "inputs"]:
-            self.assertIn(key, env)
-
-    def test_generate_scorecard_end_to_end_tiny_fixture(self):
-        with tempfile.TemporaryDirectory() as td:
-            root = Path(td)
-            (root / "Cargo.toml").write_text('[workspace]\nmembers=["tailtriage"]\n[workspace.package]\nversion="1.2.3"\n', encoding="utf-8")
-            (root / "tailtriage").mkdir()
-            (root / "tailtriage/Cargo.toml").write_text('[package]\nname="tailtriage"\nversion={ workspace = true }\n', encoding="utf-8")
-            manifest_dir = root / "validation/diagnostics"
-            manifest_dir.mkdir(parents=True)
-            (manifest_dir / "tiny.json").write_text(json.dumps({"primary_suspect": {"kind": "insufficient_evidence", "confidence": "low", "score": 0, "evidence": ["not enough requests"], "next_checks": ["rerun with enough requests"]}, "secondary_suspects": [], "warnings": ["not enough requests"]}), encoding="utf-8")
-            (manifest_dir / "manifest.json").write_text(json.dumps({"schema_version": 1, "cases": [{"id": "tiny_insufficient", "artifact": "tiny.json", "artifact_type": "analysis_report", "ground_truth": "insufficient_evidence", "required_top2": ["insufficient_evidence"], "acceptable_primary": ["insufficient_evidence"], "tags": ["tiny"], "must_include_evidence": ["not enough requests"], "must_include_next_checks": ["rerun"], "expected_warnings": ["not enough requests"], "allowed_warnings": [], "top1_required": True, "notes": "tiny generator smoke fixture"}]}, indent=2), encoding="utf-8")
-            failures = generate_scorecard(root, "validation/diagnostics/manifest.json", "target/validation/diagnostics", 1.0, 1.0, 0, "tiny")
-            self.assertEqual(failures, [])
-            out_dir = root / "target/validation/diagnostics"
-            self.assertTrue((out_dir / "benchmark-summary.json").exists())
-            self.assertTrue((out_dir / "environment.json").exists())
-            self.assertTrue((out_dir / "scorecard.md").exists())
-            summary = json.loads((out_dir / "benchmark-summary.json").read_text(encoding="utf-8"))
-            environment = json.loads((out_dir / "environment.json").read_text(encoding="utf-8"))
-            self.assertEqual(summary["total_cases"], 1)
-            self.assertEqual(environment["tailtriage"]["workspace_package_version"], "1.2.3")
-
-
-if __name__ == "__main__":
-    unittest.main()
+from unittest import mock
+from scripts.generate_diagnostic_scorecard import *
+def env():return {'generated_at_utc':'t','snapshot_label':'s','git':{'sha':'a','tag':None,'describe':'a'},'tailtriage':{'workspace_package_version':'1','packages':{}},'github_actions':{},'software':{},'hardware':{},'inputs':{'manifest_sha256':'m','referenced_artifacts_sha256':'a','thresholds':{}}}
+def metrics(zero=False):return {'schema_version':2,'manifest_case_count':2,'analyzer_execution':{'case_count':1,'success_count':1,'expected_failure_count':0,'unexpected_failure_count':0,'run_artifact_count':1,'tracing_jsonl_count':0},'analyzer_accuracy':{'observation_count':0 if zero else 1,'encoding_count':0 if zero else 1,'top1_accuracy':None if zero else 1.0,'top2_recall':None if zero else 1.0,'high_confidence_wrong_count':0,'per_ground_truth_counts':{},'confusion_matrix':{},'confidence_bucket_accuracy':{}},'report_contract':{'case_count':1,'passed_count':1,'failed_count':0,'analysis_report_count':1,'synthetic_report_count':0},'validated_paths':{},'failed_analyzer_cases':[],'failed_report_contract_cases':[]}
+class Tests(unittest.TestCase):
+ def test_scorecard_json_is_separated(self):
+  m=metrics();self.assertEqual(m['schema_version'],2);self.assertNotIn('total_cases',m);self.assertEqual({'analyzer_execution','analyzer_accuracy','report_contract'} <= m.keys(),True)
+ def test_scorecard_markdown_is_separated(self):
+  text=render_scorecard(metrics(),env())
+  for h in ['## Analyzer execution','## Analyzer accuracy','## Report-contract validation','## Validated input paths','## Failed analyzer cases','## Failed report-contract cases','## Non-claims']:self.assertIn(h,text)
+  self.assertIn('Unique accuracy observations: 1',text);self.assertIn('Executed artifact encodings: 1',text);self.assertIn('do not contribute to analyzer accuracy',text)
+ def test_unavailable_accuracy_renders_na(self):
+  text=render_scorecard(metrics(True),env());self.assertIn('Top-1 accuracy: n/a',text);self.assertIn('Top-2 recall: n/a',text)
+ def test_environment_schema_two(self):
+  repo=Path(__file__).parents[2];e=collect_environment(repo,repo/'validation/diagnostics/manifest.json','x',{});self.assertEqual(e['schema_version'],2)
+ def test_hashes(self):self.assertEqual(sha256_bytes(b'a'),sha256_bytes(b'a'))
+ def test_generate_writes_separated_json(self):
+  with tempfile.TemporaryDirectory() as td:
+   root=Path(td);(root/'Cargo.toml').write_text('[workspace]\nmembers=[]\n[workspace.package]\nversion="1"\n');p=root/'validation';p.mkdir();(p/'manifest.json').write_text('{"cases":[]}')
+   with mock.patch('scripts.generate_diagnostic_scorecard.run_diagnostic_benchmark',return_value=(metrics(),[])):
+    generate_scorecard(root,'validation/manifest.json','out',.75,.9,0,'x')
+   got=json.loads((root/'out/benchmark-summary.json').read_text());self.assertEqual(got['schema_version'],2);self.assertIn('analyzer_accuracy',got)
+if __name__=='__main__':unittest.main()

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -6,40 +6,17 @@ Demos teach; validation measures.
 
 Normal CI runs the deterministic corpus benchmark against `validation/diagnostics/manifest.json` as a required gate for schema/corpus drift. Durable/versioned scorecards remain manual/tag snapshot artifacts from `.github/workflows/validation-snapshot.yml`.
 
-## Case schema fields
+## Validation classes and schema
 
-- `schema_version`: manifest schema version (currently `1`).
-- `artifact`: path to the analyzer-report fixture, relative to `manifest.json`.
-- `artifact_type`:
-  - `analysis_report`: real demo-emitted analyzer report fixture.
-  - `synthetic_analysis_report`: hand-written report-shaped synthetic fixture used for coverage gaps.
-  - `run_artifact`: raw captured run fixture analyzed through `tailtriage analyze` (Run -> analyze_run()) for analyzer-path validation.
-  - `tracing_span_jsonl`: completed tailtriage tracing-span JSONL imported through `tailtriage import tracing-spans-jsonl`, then analyzed through `tailtriage analyze` for import + analyzer-path validation.
-- `ground_truth`: expected diagnostic family for the controlled fixture intent. It does not mean production root-cause proof.
-- `required_top2`: diagnosis kinds that must appear in primary or first secondary suspect. Usually `[ground_truth]`. Must include `ground_truth`.
-- `acceptable_primary`: diagnosis kinds acceptable as primary for mixed/ambiguous interpretation. Must include `ground_truth`. This does **not** satisfy `required_top2` by itself.
-- `top1_required`: when `true`, primary kind must equal `ground_truth`.
-- `max_primary_confidence`: optional confidence ceiling for primary suspect (`low|medium|high`).
-- `must_include_evidence`: evidence substrings that must appear in primary or secondary evidence.
-- `must_include_next_checks`: next-check substrings that must appear when required by a case. Selected adversarial cases use this to validate relevant follow-up guidance.
-- `expected_warnings`: warning substrings that must appear.
-- `allowed_warnings`: warning substrings that may appear in addition to expected warnings (tolerated extras only).
-- `notes`: workload-intent note explaining why labels are set.
-- `tags`: non-empty string tags for grouping/filtering.
+Manifest schema version 2 requires every case to declare an artifact type, `validation_class`, and `accuracy_eligible`. Raw `run_artifact` cases and stable `tracing_span_jsonl` cases are `analyzer_execution`; the latter import first and both analyze at benchmark execution. Their execution expectation defaults to `success`; typed failure contracts declare `failure_stage`, required and forbidden diagnostics, and stdout expectations. Run artifacts default to strict policy and may explicitly select the existing `allow_ambiguous` CLI policy.
 
-## Corpus discipline
+An accuracy-eligible analyzer case declares `observation_id` and `ground_truth`. Encodings of the same logical workload share an observation ID, must have consistent labels and diagnosis/confidence output, and count once. These unique accuracy-eligible observations are the only diagnosis-accuracy denominator. Ground truth is controlled fixture intent, not production truth or root-cause proof.
 
-- Label by fixture/workload intent, not by analyzer output.
-- `required_top2` and `acceptable_primary` are different:
-  - `required_top2` = required visibility of true causes.
-  - `acceptable_primary` = tolerated primary classification for ambiguity handling/high-confidence-wrong interpretation.
-- Do not use wildcard warning allowlists (`"*"` is invalid).
-- Keep synthetic fixtures small, hand-readable, and explicitly scoped to gaps.
-- Use `max_primary_confidence` for humility checks in sparse-sample, missing-instrumentation, truncation, noise-only, or close mixed-signal cases.
-- Confidence ceilings validate conservative triage behavior, not truth probabilities.
-- Synthetic fixtures are report-shaped adversarial coverage artifacts, not substitutes for analyzer-generated captures.
-- Raw `run_artifact` fixtures validate analyzer-path behavior on committed captured-shape evidence and remain deterministic fixture checks, not production-accuracy claims or real-service validation.
-- `tracing_span_jsonl` fixtures validate the completed tailtriage tracing JSONL import path and then the same Run JSON analyzer path; they do not claim support for ordinary tracing log JSON or prove production root cause.
+Pre-generated `analysis_report` and report-shaped `synthetic_analysis_report` cases are `report_contract`, are always accuracy ineligible, and contain neither ground truth nor observation IDs. They inspect Report suspects, evidence, next checks, confidence, warnings, route breakdowns, and temporal segments without executing an importer or analyzer. Report-contract cases do not contribute to top-1, top-2, confusion, confidence-bucket, per-ground-truth, or high-confidence-wrong metrics. Exact warning allowlisting remains mandatory.
+
+Case diagnosis contracts use `expected_primary_kinds`, `required_visible_suspects` (primary or first secondary), and optional `exact_primary_kind`. Analyzer success cases may be execution-only; expected execution failures must be accuracy ineligible.
+
+Deterministic typed fixture generation is deferred to Prompt 18B. Corpus expansion and exact demo-replacement cases are deferred to Prompt 18C. No demo is removed here.
 
 ## Running the benchmark
 

--- a/validation/diagnostics/latest/scorecard.md
+++ b/validation/diagnostics/latest/scorecard.md
@@ -17,7 +17,7 @@
 | mitigation validation | Manual/local mitigation matrix available | baseline/mitigated controlled demos compare latency and evidence movement; generated outputs are not committed by default. |
 | real service validation | Planned | add curated real-service anonymized artifacts. |
 
-Deterministic synthetic adversarial cases, selected deterministic raw run-artifact adversarial cases, and completed tailtriage tracing JSONL import fixtures validate benchmark/report contract behavior and humility checks; they are not real-service validation and do not provide root-cause proof.
+Schema-version-2 accounting separates 11 analyzer-executed, accuracy-eligible observations from 38 report-contract cases. Report-contract pass rates do not contribute to analyzer accuracy; equivalent artifact encodings are one logical observation, not independent samples. Fixture labels are controlled intent, not production truth. These checks are not real-service validation and do not provide root-cause proof.
 
 Normal CI runs the deterministic benchmark against the committed diagnostics manifest and fixtures as a required validation gate. Normal CI still does not publish durable scorecards.
 

--- a/validation/diagnostics/manifest.json
+++ b/validation/diagnostics/manifest.json
@@ -1,33 +1,34 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "description": "Diagnostic validation corpus for tailtriage analyzer reports.",
   "cases": [
     {
       "id": "queue_before",
       "artifact": "../../demos/queue_service/fixtures/before-analysis.json",
       "artifact_type": "analysis_report",
-      "ground_truth": "application_queue_saturation",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "queue",
         "demo",
         "before"
       ],
+      "notes": "Queue scenario before mitigation is queue-dominant.",
+      "expected_primary_kinds": [
+        "application_queue_saturation"
+      ],
+      "required_visible_suspects": [
+        "application_queue_saturation"
+      ],
+      "exact_primary_kind": "application_queue_saturation",
       "must_include_evidence": [
         "Queue wait"
       ],
-      "notes": "Queue scenario before mitigation is queue-dominant.",
+      "must_include_next_checks": [],
       "expected_warnings": [
         "Temporal segments show a large p95 latency shift between early and late requests."
       ],
-      "top1_required": true,
       "allowed_warnings": [],
-      "required_top2": [
-        "application_queue_saturation"
-      ],
-      "acceptable_primary": [
-        "application_queue_saturation"
-      ],
-      "must_include_next_checks": [],
       "expected_evidence_quality": "strong",
       "expected_signal_statuses": {
         "queues": "present",
@@ -40,56 +41,57 @@
       "id": "queue_after",
       "artifact": "../../demos/queue_service/fixtures/after-analysis.json",
       "artifact_type": "analysis_report",
-      "ground_truth": "downstream_stage_dominates",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "queue",
         "demo",
         "after"
       ],
-      "must_include_evidence": [
-        "Stage"
-      ],
       "notes": "After mitigation, queue contribution drops and work stage dominates.",
-      "expected_warnings": [],
-      "top1_required": false,
-      "allowed_warnings": [],
-      "required_top2": [
-        "downstream_stage_dominates"
-      ],
-      "acceptable_primary": [
+      "expected_primary_kinds": [
         "downstream_stage_dominates",
         "application_queue_saturation"
       ],
-      "must_include_next_checks": []
+      "required_visible_suspects": [
+        "downstream_stage_dominates"
+      ],
+      "must_include_evidence": [
+        "Stage"
+      ],
+      "must_include_next_checks": [],
+      "expected_warnings": [],
+      "allowed_warnings": []
     },
     {
       "id": "blocking_before",
       "artifact": "../../demos/blocking_service/fixtures/before-analysis.json",
       "artifact_type": "analysis_report",
-      "ground_truth": "blocking_pool_pressure",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "blocking",
         "demo",
         "before"
       ],
+      "notes": "Blocking pool backlog is intentional pre-fix condition.",
+      "expected_primary_kinds": [
+        "blocking_pool_pressure"
+      ],
+      "required_visible_suspects": [
+        "blocking_pool_pressure"
+      ],
+      "exact_primary_kind": "blocking_pool_pressure",
       "must_include_evidence": [
         "Blocking queue depth"
       ],
-      "notes": "Blocking pool backlog is intentional pre-fix condition.",
+      "must_include_next_checks": [],
       "expected_warnings": [
         "missing blocking_queue_depth or local_queue_depth",
         "Top suspects are close in score",
         "Temporal segments show a large p95 latency shift between early and late requests."
       ],
-      "top1_required": true,
       "allowed_warnings": [],
-      "required_top2": [
-        "blocking_pool_pressure"
-      ],
-      "acceptable_primary": [
-        "blocking_pool_pressure"
-      ],
-      "must_include_next_checks": [],
       "expected_evidence_quality": "partial",
       "expected_signal_statuses": {
         "runtime_snapshots": "partial"
@@ -102,162 +104,165 @@
       "id": "blocking_after",
       "artifact": "../../demos/blocking_service/fixtures/after-analysis.json",
       "artifact_type": "analysis_report",
-      "ground_truth": "downstream_stage_dominates",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "blocking",
         "demo",
         "after"
       ],
+      "notes": "After blocking mitigation, downstream work can dominate residual tail.",
+      "expected_primary_kinds": [
+        "downstream_stage_dominates",
+        "blocking_pool_pressure"
+      ],
+      "required_visible_suspects": [
+        "downstream_stage_dominates"
+      ],
       "must_include_evidence": [
         "Stage"
       ],
-      "notes": "After blocking mitigation, downstream work can dominate residual tail.",
+      "must_include_next_checks": [],
       "expected_warnings": [
         "missing blocking_queue_depth or local_queue_depth",
         "Temporal segments show a large p95 latency shift between early and late requests."
       ],
-      "top1_required": false,
       "allowed_warnings": [
         "Top suspects are close in score"
-      ],
-      "required_top2": [
-        "downstream_stage_dominates"
-      ],
-      "acceptable_primary": [
-        "downstream_stage_dominates",
-        "blocking_pool_pressure"
-      ],
-      "must_include_next_checks": []
+      ]
     },
     {
       "id": "executor_before",
       "artifact": "../../demos/executor_pressure_service/fixtures/before-analysis.json",
       "artifact_type": "analysis_report",
-      "ground_truth": "executor_pressure_suspected",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "executor",
         "demo",
         "before"
       ],
+      "notes": "Executor-pressure demo before mitigation should prioritize executor suspect.",
+      "expected_primary_kinds": [
+        "executor_pressure_suspected"
+      ],
+      "required_visible_suspects": [
+        "executor_pressure_suspected"
+      ],
+      "exact_primary_kind": "executor_pressure_suspected",
       "must_include_evidence": [
         "Global queue depth"
       ],
-      "notes": "Executor-pressure demo before mitigation should prioritize executor suspect.",
+      "must_include_next_checks": [],
       "expected_warnings": [],
-      "top1_required": true,
-      "allowed_warnings": [],
-      "required_top2": [
-        "executor_pressure_suspected"
-      ],
-      "acceptable_primary": [
-        "executor_pressure_suspected"
-      ],
-      "must_include_next_checks": []
+      "allowed_warnings": []
     },
     {
       "id": "executor_after",
       "artifact": "../../demos/executor_pressure_service/fixtures/after-analysis.json",
       "artifact_type": "analysis_report",
-      "ground_truth": "executor_pressure_suspected",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "executor",
         "demo",
         "after"
       ],
-      "must_include_evidence": [
-        "Runtime global queue depth"
-      ],
       "notes": "Post-mitigation executor pressure reduces, but executor remains the expected true cause in this fixture; downstream may appear as an acceptable alternate primary.",
-      "expected_warnings": [],
-      "top1_required": false,
-      "allowed_warnings": [],
-      "required_top2": [
-        "executor_pressure_suspected"
-      ],
-      "acceptable_primary": [
+      "expected_primary_kinds": [
         "executor_pressure_suspected",
         "downstream_stage_dominates"
       ],
-      "must_include_next_checks": []
+      "required_visible_suspects": [
+        "executor_pressure_suspected"
+      ],
+      "must_include_evidence": [
+        "Runtime global queue depth"
+      ],
+      "must_include_next_checks": [],
+      "expected_warnings": [],
+      "allowed_warnings": []
     },
     {
       "id": "downstream_before",
       "artifact": "../../demos/downstream_service/fixtures/before-analysis.json",
       "artifact_type": "analysis_report",
-      "ground_truth": "downstream_stage_dominates",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "downstream",
         "demo",
         "before"
       ],
-      "must_include_evidence": [
-        "Stage"
-      ],
       "notes": "Downstream slowdown scenario should identify downstream stage dominance.",
-      "expected_warnings": [],
-      "top1_required": true,
-      "allowed_warnings": [],
-      "required_top2": [
-        "downstream_stage_dominates"
-      ],
-      "acceptable_primary": [
+      "expected_primary_kinds": [
         "downstream_stage_dominates",
         "application_queue_saturation"
       ],
-      "must_include_next_checks": []
+      "required_visible_suspects": [
+        "downstream_stage_dominates"
+      ],
+      "exact_primary_kind": "downstream_stage_dominates",
+      "must_include_evidence": [
+        "Stage"
+      ],
+      "must_include_next_checks": [],
+      "expected_warnings": [],
+      "allowed_warnings": []
     },
     {
       "id": "downstream_after",
       "artifact": "../../demos/downstream_service/fixtures/after-analysis.json",
       "artifact_type": "analysis_report",
-      "ground_truth": "downstream_stage_dominates",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "downstream",
         "demo",
         "after"
       ],
+      "notes": "After improvements downstream may still be top but with reduced severity.",
+      "expected_primary_kinds": [
+        "downstream_stage_dominates"
+      ],
+      "required_visible_suspects": [
+        "downstream_stage_dominates"
+      ],
+      "exact_primary_kind": "downstream_stage_dominates",
       "must_include_evidence": [
         "Stage"
       ],
-      "notes": "After improvements downstream may still be top but with reduced severity.",
+      "must_include_next_checks": [],
       "expected_warnings": [],
-      "top1_required": true,
-      "allowed_warnings": [],
-      "required_top2": [
-        "downstream_stage_dominates"
-      ],
-      "acceptable_primary": [
-        "downstream_stage_dominates"
-      ],
-      "must_include_next_checks": []
+      "allowed_warnings": []
     },
     {
       "id": "mixed_baseline",
       "artifact": "../../demos/mixed_contention_service/fixtures/baseline-analysis.json",
       "artifact_type": "analysis_report",
-      "ground_truth": "application_queue_saturation",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "mixed",
         "demo",
         "baseline"
       ],
-      "must_include_evidence": [
-        "Queue wait"
-      ],
       "notes": "Mixed baseline intentionally keeps queue and executor signals close.",
-      "expected_warnings": [
-        "Temporal segments show a large p95 latency shift between early and late requests."
-      ],
-      "top1_required": false,
-      "allowed_warnings": [],
-      "required_top2": [
-        "application_queue_saturation"
-      ],
-      "acceptable_primary": [
+      "expected_primary_kinds": [
         "application_queue_saturation",
         "executor_pressure_suspected"
       ],
+      "required_visible_suspects": [
+        "application_queue_saturation"
+      ],
+      "must_include_evidence": [
+        "Queue wait"
+      ],
       "must_include_next_checks": [],
+      "expected_warnings": [
+        "Temporal segments show a large p95 latency shift between early and late requests."
+      ],
+      "allowed_warnings": [],
       "expected_temporal_segments": "non_empty",
       "expected_top_level_warnings": [
         "large p95 latency shift"
@@ -270,491 +275,506 @@
       "id": "mixed_mitigated",
       "artifact": "../../demos/mixed_contention_service/fixtures/mitigated-analysis.json",
       "artifact_type": "analysis_report",
-      "ground_truth": "downstream_stage_dominates",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "mixed",
         "demo",
         "mitigated"
       ],
-      "must_include_evidence": [
-        "Stage"
-      ],
       "notes": "Mitigated mixed case reduces contention so downstream work often leads.",
-      "expected_warnings": [],
-      "top1_required": false,
-      "allowed_warnings": [],
-      "required_top2": [
-        "downstream_stage_dominates"
-      ],
-      "acceptable_primary": [
+      "expected_primary_kinds": [
         "downstream_stage_dominates",
         "application_queue_saturation"
       ],
-      "must_include_next_checks": []
+      "required_visible_suspects": [
+        "downstream_stage_dominates"
+      ],
+      "must_include_evidence": [
+        "Stage"
+      ],
+      "must_include_next_checks": [],
+      "expected_warnings": [],
+      "allowed_warnings": []
     },
     {
       "id": "cold_start_before",
       "artifact": "../../demos/cold_start_burst_service/fixtures/before-analysis.json",
       "artifact_type": "analysis_report",
-      "ground_truth": "application_queue_saturation",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "cold-start",
         "demo",
         "before"
       ],
-      "must_include_evidence": [
-        "Queue wait"
-      ],
       "notes": "Cold-start burst before mitigation shows admission queue pressure.",
-      "expected_warnings": [],
-      "top1_required": false,
-      "allowed_warnings": [],
-      "required_top2": [
-        "application_queue_saturation"
-      ],
-      "acceptable_primary": [
+      "expected_primary_kinds": [
         "application_queue_saturation",
         "executor_pressure_suspected"
       ],
-      "must_include_next_checks": []
+      "required_visible_suspects": [
+        "application_queue_saturation"
+      ],
+      "must_include_evidence": [
+        "Queue wait"
+      ],
+      "must_include_next_checks": [],
+      "expected_warnings": [],
+      "allowed_warnings": []
     },
     {
       "id": "cold_start_after",
       "artifact": "../../demos/cold_start_burst_service/fixtures/after-analysis.json",
       "artifact_type": "analysis_report",
-      "ground_truth": "downstream_stage_dominates",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "cold-start",
         "demo",
         "after"
       ],
-      "must_include_evidence": [
-        "Stage"
-      ],
       "notes": "After warmup mitigation queue pressure drops and stage work dominates.",
-      "expected_warnings": [],
-      "top1_required": false,
-      "allowed_warnings": [],
-      "required_top2": [
-        "downstream_stage_dominates"
-      ],
-      "acceptable_primary": [
+      "expected_primary_kinds": [
         "downstream_stage_dominates",
         "application_queue_saturation"
       ],
-      "must_include_next_checks": []
+      "required_visible_suspects": [
+        "downstream_stage_dominates"
+      ],
+      "must_include_evidence": [
+        "Stage"
+      ],
+      "must_include_next_checks": [],
+      "expected_warnings": [],
+      "allowed_warnings": []
     },
     {
       "id": "db_pool_before",
       "artifact": "../../demos/db_pool_saturation_service/fixtures/before-analysis.json",
       "artifact_type": "analysis_report",
-      "ground_truth": "application_queue_saturation",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "db-pool",
         "demo",
         "before"
       ],
-      "must_include_evidence": [
-        "Queue wait"
-      ],
       "notes": "Before pool tuning queueing from limited DB pool appears strongly.",
-      "expected_warnings": [
-        "Temporal segments show a large p95 latency shift between early and late requests."
-      ],
-      "top1_required": false,
-      "allowed_warnings": [],
-      "required_top2": [
-        "application_queue_saturation"
-      ],
-      "acceptable_primary": [
+      "expected_primary_kinds": [
         "application_queue_saturation",
         "downstream_stage_dominates"
       ],
-      "must_include_next_checks": []
+      "required_visible_suspects": [
+        "application_queue_saturation"
+      ],
+      "must_include_evidence": [
+        "Queue wait"
+      ],
+      "must_include_next_checks": [],
+      "expected_warnings": [
+        "Temporal segments show a large p95 latency shift between early and late requests."
+      ],
+      "allowed_warnings": []
     },
     {
       "id": "db_pool_after",
       "artifact": "../../demos/db_pool_saturation_service/fixtures/after-analysis.json",
       "artifact_type": "analysis_report",
-      "ground_truth": "downstream_stage_dominates",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "db-pool",
         "demo",
         "after"
       ],
-      "must_include_evidence": [
-        "Stage"
-      ],
       "notes": "After queue improvement, dependency stage often dominates residual tails.",
-      "expected_warnings": [],
-      "top1_required": false,
-      "allowed_warnings": [],
-      "required_top2": [
-        "downstream_stage_dominates"
-      ],
-      "acceptable_primary": [
+      "expected_primary_kinds": [
         "downstream_stage_dominates",
         "application_queue_saturation"
       ],
-      "must_include_next_checks": []
+      "required_visible_suspects": [
+        "downstream_stage_dominates"
+      ],
+      "must_include_evidence": [
+        "Stage"
+      ],
+      "must_include_next_checks": [],
+      "expected_warnings": [],
+      "allowed_warnings": []
     },
     {
       "id": "shared_lock_before",
       "artifact": "../../demos/shared_state_lock_service/fixtures/before-analysis.json",
       "artifact_type": "analysis_report",
-      "ground_truth": "downstream_stage_dominates",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "shared-lock",
         "demo",
         "before"
       ],
-      "must_include_evidence": [
-        "Stage"
-      ],
       "notes": "Shared lock contention manifests through stage latency dominance.",
-      "expected_warnings": [
-        "Temporal segments show a large p95 latency shift between early and late requests."
-      ],
-      "top1_required": false,
-      "allowed_warnings": [],
-      "required_top2": [
-        "downstream_stage_dominates"
-      ],
-      "acceptable_primary": [
+      "expected_primary_kinds": [
         "downstream_stage_dominates",
         "application_queue_saturation"
       ],
-      "must_include_next_checks": []
+      "required_visible_suspects": [
+        "downstream_stage_dominates"
+      ],
+      "must_include_evidence": [
+        "Stage"
+      ],
+      "must_include_next_checks": [],
+      "expected_warnings": [
+        "Temporal segments show a large p95 latency shift between early and late requests."
+      ],
+      "allowed_warnings": []
     },
     {
       "id": "shared_lock_after",
       "artifact": "../../demos/shared_state_lock_service/fixtures/after-analysis.json",
       "artifact_type": "analysis_report",
-      "ground_truth": "downstream_stage_dominates",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "shared-lock",
         "demo",
         "after"
       ],
-      "must_include_evidence": [
-        "Stage"
-      ],
       "notes": "After mitigation remaining time is still mostly stage work.",
-      "expected_warnings": [
-        "Temporal segments show a large p95 latency shift between early and late requests."
-      ],
-      "top1_required": false,
-      "allowed_warnings": [],
-      "required_top2": [
-        "downstream_stage_dominates"
-      ],
-      "acceptable_primary": [
+      "expected_primary_kinds": [
         "downstream_stage_dominates",
         "application_queue_saturation"
       ],
-      "must_include_next_checks": []
+      "required_visible_suspects": [
+        "downstream_stage_dominates"
+      ],
+      "must_include_evidence": [
+        "Stage"
+      ],
+      "must_include_next_checks": [],
+      "expected_warnings": [
+        "Temporal segments show a large p95 latency shift between early and late requests."
+      ],
+      "allowed_warnings": []
     },
     {
       "id": "retry_before",
       "artifact": "../../demos/retry_storm_service/fixtures/before-analysis.json",
       "artifact_type": "analysis_report",
-      "ground_truth": "downstream_stage_dominates",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "retry",
         "demo",
         "before"
       ],
-      "must_include_evidence": [
-        "downstream"
-      ],
       "notes": "Retry storm amplifies downstream latency contribution.",
-      "expected_warnings": [],
-      "top1_required": false,
-      "allowed_warnings": [],
-      "required_top2": [
-        "downstream_stage_dominates"
-      ],
-      "acceptable_primary": [
+      "expected_primary_kinds": [
         "downstream_stage_dominates",
         "application_queue_saturation"
       ],
-      "must_include_next_checks": []
+      "required_visible_suspects": [
+        "downstream_stage_dominates"
+      ],
+      "must_include_evidence": [
+        "downstream"
+      ],
+      "must_include_next_checks": [],
+      "expected_warnings": [],
+      "allowed_warnings": []
     },
     {
       "id": "retry_after",
       "artifact": "../../demos/retry_storm_service/fixtures/after-analysis.json",
       "artifact_type": "analysis_report",
-      "ground_truth": "downstream_stage_dominates",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "retry",
         "demo",
         "after"
       ],
+      "notes": "After retry tuning downstream remains dominant but improved.",
+      "expected_primary_kinds": [
+        "downstream_stage_dominates"
+      ],
+      "required_visible_suspects": [
+        "downstream_stage_dominates"
+      ],
+      "exact_primary_kind": "downstream_stage_dominates",
       "must_include_evidence": [
         "Stage"
       ],
-      "notes": "After retry tuning downstream remains dominant but improved.",
+      "must_include_next_checks": [],
       "expected_warnings": [],
-      "top1_required": true,
-      "allowed_warnings": [],
-      "required_top2": [
-        "downstream_stage_dominates"
-      ],
-      "acceptable_primary": [
-        "downstream_stage_dominates"
-      ],
-      "must_include_next_checks": []
+      "allowed_warnings": []
     },
     {
       "id": "queue_sample",
       "artifact": "../../demos/queue_service/fixtures/sample-analysis.json",
       "artifact_type": "analysis_report",
-      "ground_truth": "application_queue_saturation",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "queue",
         "demo",
         "sample"
       ],
+      "notes": "Queue sample is canonical queue saturation evidence.",
+      "expected_primary_kinds": [
+        "application_queue_saturation"
+      ],
+      "required_visible_suspects": [
+        "application_queue_saturation"
+      ],
+      "exact_primary_kind": "application_queue_saturation",
       "must_include_evidence": [
         "Queue wait"
       ],
-      "notes": "Queue sample is canonical queue saturation evidence.",
+      "must_include_next_checks": [],
       "expected_warnings": [
         "Temporal segments show a large p95 latency shift between early and late requests."
       ],
-      "top1_required": true,
-      "allowed_warnings": [],
-      "required_top2": [
-        "application_queue_saturation"
-      ],
-      "acceptable_primary": [
-        "application_queue_saturation"
-      ],
-      "must_include_next_checks": []
+      "allowed_warnings": []
     },
     {
       "id": "blocking_sample",
       "artifact": "../../demos/blocking_service/fixtures/sample-analysis.json",
       "artifact_type": "analysis_report",
-      "ground_truth": "blocking_pool_pressure",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "blocking",
         "demo",
         "sample"
       ],
+      "notes": "Blocking sample is canonical blocking saturation evidence.",
+      "expected_primary_kinds": [
+        "blocking_pool_pressure"
+      ],
+      "required_visible_suspects": [
+        "blocking_pool_pressure"
+      ],
+      "exact_primary_kind": "blocking_pool_pressure",
       "must_include_evidence": [
         "Blocking queue depth"
       ],
-      "notes": "Blocking sample is canonical blocking saturation evidence.",
+      "must_include_next_checks": [],
       "expected_warnings": [
         "missing blocking_queue_depth or local_queue_depth",
         "Top suspects are close in score",
         "Temporal segments show a large p95 latency shift between early and late requests."
       ],
-      "top1_required": true,
-      "allowed_warnings": [],
-      "required_top2": [
-        "blocking_pool_pressure"
-      ],
-      "acceptable_primary": [
-        "blocking_pool_pressure"
-      ],
-      "must_include_next_checks": []
+      "allowed_warnings": []
     },
     {
       "id": "executor_sample",
       "artifact": "../../demos/executor_pressure_service/fixtures/sample-analysis.json",
       "artifact_type": "analysis_report",
-      "ground_truth": "executor_pressure_suspected",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "executor",
         "demo",
         "sample"
       ],
+      "notes": "Executor sample has clear runtime queue pressure cues.",
+      "expected_primary_kinds": [
+        "executor_pressure_suspected"
+      ],
+      "required_visible_suspects": [
+        "executor_pressure_suspected"
+      ],
+      "exact_primary_kind": "executor_pressure_suspected",
       "must_include_evidence": [
         "Global queue depth"
       ],
-      "notes": "Executor sample has clear runtime queue pressure cues.",
+      "must_include_next_checks": [],
       "expected_warnings": [],
-      "top1_required": true,
-      "allowed_warnings": [],
-      "required_top2": [
-        "executor_pressure_suspected"
-      ],
-      "acceptable_primary": [
-        "executor_pressure_suspected"
-      ],
-      "must_include_next_checks": []
+      "allowed_warnings": []
     },
     {
       "id": "downstream_sample",
       "artifact": "../../demos/downstream_service/fixtures/sample-analysis.json",
       "artifact_type": "analysis_report",
-      "ground_truth": "downstream_stage_dominates",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "downstream",
         "demo",
         "sample"
       ],
+      "notes": "Downstream sample has clear stage dominance cues.",
+      "expected_primary_kinds": [
+        "downstream_stage_dominates"
+      ],
+      "required_visible_suspects": [
+        "downstream_stage_dominates"
+      ],
+      "exact_primary_kind": "downstream_stage_dominates",
       "must_include_evidence": [
         "Stage"
       ],
-      "notes": "Downstream sample has clear stage dominance cues.",
+      "must_include_next_checks": [],
       "expected_warnings": [],
-      "top1_required": true,
-      "allowed_warnings": [],
-      "required_top2": [
-        "downstream_stage_dominates"
-      ],
-      "acceptable_primary": [
-        "downstream_stage_dominates"
-      ],
-      "must_include_next_checks": []
+      "allowed_warnings": []
     },
     {
       "id": "synthetic_insufficient",
       "artifact": "corpus/insufficient-evidence.json",
       "artifact_type": "synthetic_analysis_report",
-      "ground_truth": "insufficient_evidence",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "synthetic",
         "insufficient"
       ],
+      "notes": "Intentional low-signal report validates insufficient-evidence behavior.",
+      "expected_primary_kinds": [
+        "insufficient_evidence"
+      ],
+      "required_visible_suspects": [
+        "insufficient_evidence"
+      ],
       "must_include_evidence": [
         "Not enough"
       ],
-      "notes": "Intentional low-signal report validates insufficient-evidence behavior.",
+      "must_include_next_checks": [],
       "expected_warnings": [
         "Missing queue",
         "Missing stage"
       ],
-      "top1_required": false,
-      "allowed_warnings": [],
-      "required_top2": [
-        "insufficient_evidence"
-      ],
-      "acceptable_primary": [
-        "insufficient_evidence"
-      ],
-      "must_include_next_checks": []
+      "allowed_warnings": []
     },
     {
       "id": "synthetic_missing_runtime",
       "artifact": "corpus/missing-runtime-warning.json",
       "artifact_type": "synthetic_analysis_report",
-      "ground_truth": "executor_pressure_suspected",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "synthetic",
         "warning"
       ],
-      "must_include_evidence": [
-        "Global queue depth"
-      ],
       "notes": "Runtime warning should be accepted when expected.",
-      "expected_warnings": [
-        "Runtime signals are missing"
-      ],
-      "top1_required": false,
-      "allowed_warnings": [],
-      "required_top2": [
-        "executor_pressure_suspected"
-      ],
-      "acceptable_primary": [
+      "expected_primary_kinds": [
         "executor_pressure_suspected",
         "application_queue_saturation"
       ],
-      "must_include_next_checks": []
+      "required_visible_suspects": [
+        "executor_pressure_suspected"
+      ],
+      "must_include_evidence": [
+        "Global queue depth"
+      ],
+      "must_include_next_checks": [],
+      "expected_warnings": [
+        "Runtime signals are missing"
+      ],
+      "allowed_warnings": []
     },
     {
       "id": "synthetic_missing_stage",
       "artifact": "corpus/missing-stage-warning.json",
       "artifact_type": "synthetic_analysis_report",
-      "ground_truth": "application_queue_saturation",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "synthetic",
         "warning"
       ],
+      "notes": "Stage warning allowed for partial instrumentation cases.",
+      "expected_primary_kinds": [
+        "application_queue_saturation"
+      ],
+      "required_visible_suspects": [
+        "application_queue_saturation"
+      ],
+      "exact_primary_kind": "application_queue_saturation",
       "must_include_evidence": [
         "Queue wait"
       ],
-      "notes": "Stage warning allowed for partial instrumentation cases.",
+      "must_include_next_checks": [],
       "expected_warnings": [
         "Stage instrumentation is missing"
       ],
-      "top1_required": true,
-      "allowed_warnings": [],
-      "required_top2": [
-        "application_queue_saturation"
-      ],
-      "acceptable_primary": [
-        "application_queue_saturation"
-      ],
-      "must_include_next_checks": []
+      "allowed_warnings": []
     },
     {
       "id": "synthetic_truncation",
       "artifact": "corpus/truncation-warning.json",
       "artifact_type": "synthetic_analysis_report",
-      "ground_truth": "application_queue_saturation",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "synthetic",
         "truncation"
       ],
-      "must_include_evidence": [
-        "Queue wait"
-      ],
       "notes": "Truncation warning validates partial-data handling without changing ranking.",
-      "expected_warnings": [
-        "Truncation"
-      ],
-      "top1_required": false,
-      "allowed_warnings": [],
-      "required_top2": [
-        "application_queue_saturation"
-      ],
-      "acceptable_primary": [
+      "expected_primary_kinds": [
         "application_queue_saturation",
         "executor_pressure_suspected"
       ],
-      "must_include_next_checks": []
+      "required_visible_suspects": [
+        "application_queue_saturation"
+      ],
+      "must_include_evidence": [
+        "Queue wait"
+      ],
+      "must_include_next_checks": [],
+      "expected_warnings": [
+        "Truncation"
+      ],
+      "allowed_warnings": []
     },
     {
       "id": "synthetic_ambiguous",
       "artifact": "corpus/weak-mixed-ambiguity.json",
       "artifact_type": "synthetic_analysis_report",
-      "ground_truth": "application_queue_saturation",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "synthetic",
         "mixed"
       ],
-      "must_include_evidence": [
-        "Queue wait"
-      ],
       "notes": "Close scores case validates ambiguity-warning handling.",
-      "expected_warnings": [
-        "Ambiguous diagnosis"
-      ],
-      "top1_required": false,
-      "allowed_warnings": [],
-      "required_top2": [
-        "application_queue_saturation"
-      ],
-      "acceptable_primary": [
+      "expected_primary_kinds": [
         "application_queue_saturation",
         "downstream_stage_dominates"
       ],
-      "must_include_next_checks": []
+      "required_visible_suspects": [
+        "application_queue_saturation"
+      ],
+      "must_include_evidence": [
+        "Queue wait"
+      ],
+      "must_include_next_checks": [],
+      "expected_warnings": [
+        "Ambiguous diagnosis"
+      ],
+      "allowed_warnings": []
     },
     {
       "id": "adversarial_low_request_count",
       "artifact": "corpus/low-request-count.json",
       "artifact_type": "synthetic_analysis_report",
-      "ground_truth": "insufficient_evidence",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "synthetic",
         "adversarial",
         "sparse-sample"
       ],
+      "notes": "Synthetic adversarial case for sparse sample humility: too few requests should force insufficient-evidence with low confidence.",
+      "expected_primary_kinds": [
+        "insufficient_evidence"
+      ],
+      "required_visible_suspects": [
+        "insufficient_evidence"
+      ],
+      "exact_primary_kind": "insufficient_evidence",
       "must_include_evidence": [
         "unstable",
         "requests"
@@ -767,15 +787,7 @@
         "Low request count"
       ],
       "allowed_warnings": [],
-      "top1_required": true,
-      "required_top2": [
-        "insufficient_evidence"
-      ],
-      "acceptable_primary": [
-        "insufficient_evidence"
-      ],
       "max_primary_confidence": "low",
-      "notes": "Synthetic adversarial case for sparse sample humility: too few requests should force insufficient-evidence with low confidence.",
       "expected_evidence_quality": "weak",
       "must_include_confidence_notes": [
         "Low request count"
@@ -785,11 +797,21 @@
       "id": "adversarial_no_queue_events",
       "artifact": "corpus/no-queue-events.json",
       "artifact_type": "synthetic_analysis_report",
-      "ground_truth": "downstream_stage_dominates",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "synthetic",
         "adversarial",
         "missing-queue"
+      ],
+      "notes": "Synthetic adversarial missing-queue case: downstream can lead, but queue saturation must remain visible in top-2 and confidence must stay conservative.",
+      "expected_primary_kinds": [
+        "downstream_stage_dominates",
+        "application_queue_saturation"
+      ],
+      "required_visible_suspects": [
+        "downstream_stage_dominates",
+        "application_queue_saturation"
       ],
       "must_include_evidence": [
         "Stage",
@@ -802,27 +824,27 @@
         "Queue instrumentation missing"
       ],
       "allowed_warnings": [],
-      "top1_required": false,
-      "required_top2": [
-        "downstream_stage_dominates",
-        "application_queue_saturation"
-      ],
-      "acceptable_primary": [
-        "downstream_stage_dominates",
-        "application_queue_saturation"
-      ],
-      "max_primary_confidence": "medium",
-      "notes": "Synthetic adversarial missing-queue case: downstream can lead, but queue saturation must remain visible in top-2 and confidence must stay conservative."
+      "max_primary_confidence": "medium"
     },
     {
       "id": "adversarial_no_stage_events",
       "artifact": "corpus/no-stage-events.json",
       "artifact_type": "synthetic_analysis_report",
-      "ground_truth": "application_queue_saturation",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "synthetic",
         "adversarial",
         "missing-stage"
+      ],
+      "notes": "Synthetic adversarial missing-stage case: queue may lead, but downstream dominance cannot be excluded without stage events.",
+      "expected_primary_kinds": [
+        "application_queue_saturation",
+        "downstream_stage_dominates"
+      ],
+      "required_visible_suspects": [
+        "application_queue_saturation",
+        "downstream_stage_dominates"
       ],
       "must_include_evidence": [
         "Queue wait",
@@ -835,27 +857,27 @@
         "Stage instrumentation missing"
       ],
       "allowed_warnings": [],
-      "top1_required": false,
-      "required_top2": [
-        "application_queue_saturation",
-        "downstream_stage_dominates"
-      ],
-      "acceptable_primary": [
-        "application_queue_saturation",
-        "downstream_stage_dominates"
-      ],
-      "max_primary_confidence": "medium",
-      "notes": "Synthetic adversarial missing-stage case: queue may lead, but downstream dominance cannot be excluded without stage events."
+      "max_primary_confidence": "medium"
     },
     {
       "id": "adversarial_no_runtime_snapshots",
       "artifact": "corpus/no-runtime-snapshots.json",
       "artifact_type": "synthetic_analysis_report",
-      "ground_truth": "executor_pressure_suspected",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "synthetic",
         "adversarial",
         "missing-runtime"
+      ],
+      "notes": "Synthetic adversarial runtime-missing case: executor and blocking suspects should both remain visible with capped confidence.",
+      "expected_primary_kinds": [
+        "executor_pressure_suspected",
+        "blocking_pool_pressure"
+      ],
+      "required_visible_suspects": [
+        "executor_pressure_suspected",
+        "blocking_pool_pressure"
       ],
       "must_include_evidence": [
         "runtime snapshots are absent"
@@ -867,27 +889,27 @@
         "Runtime snapshots missing"
       ],
       "allowed_warnings": [],
-      "top1_required": false,
-      "required_top2": [
-        "executor_pressure_suspected",
-        "blocking_pool_pressure"
-      ],
-      "acceptable_primary": [
-        "executor_pressure_suspected",
-        "blocking_pool_pressure"
-      ],
-      "max_primary_confidence": "medium",
-      "notes": "Synthetic adversarial runtime-missing case: executor and blocking suspects should both remain visible with capped confidence."
+      "max_primary_confidence": "medium"
     },
     {
       "id": "adversarial_missing_optional_runtime_fields",
       "artifact": "corpus/missing-optional-runtime-fields.json",
       "artifact_type": "synthetic_analysis_report",
-      "ground_truth": "blocking_pool_pressure",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "synthetic",
         "adversarial",
         "runtime-fields"
+      ],
+      "notes": "Synthetic adversarial partial-runtime-fields case: optional Tokio fields missing should limit confidence while retaining plausible runtime suspects.",
+      "expected_primary_kinds": [
+        "blocking_pool_pressure",
+        "executor_pressure_suspected"
+      ],
+      "required_visible_suspects": [
+        "blocking_pool_pressure",
+        "executor_pressure_suspected"
       ],
       "must_include_evidence": [
         "optional runtime fields",
@@ -901,28 +923,27 @@
         "Optional runtime fields missing"
       ],
       "allowed_warnings": [],
-      "top1_required": false,
-      "required_top2": [
-        "blocking_pool_pressure",
-        "executor_pressure_suspected"
-      ],
-      "acceptable_primary": [
-        "blocking_pool_pressure",
-        "executor_pressure_suspected"
-      ],
-      "max_primary_confidence": "medium",
-      "notes": "Synthetic adversarial partial-runtime-fields case: optional Tokio fields missing should limit confidence while retaining plausible runtime suspects."
+      "max_primary_confidence": "medium"
     },
     {
       "id": "adversarial_truncated_artifact",
       "artifact": "corpus/truncated-artifact-adversarial.json",
       "artifact_type": "synthetic_analysis_report",
-      "ground_truth": "downstream_stage_dominates",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "synthetic",
         "adversarial",
         "truncation",
         "partial-data"
+      ],
+      "notes": "Synthetic adversarial truncation case: plausible dominant stage signal is retained but confidence is capped and truncation follow-up is required.",
+      "expected_primary_kinds": [
+        "downstream_stage_dominates",
+        "blocking_pool_pressure"
+      ],
+      "required_visible_suspects": [
+        "downstream_stage_dominates"
       ],
       "must_include_evidence": [
         "Truncation warning",
@@ -936,22 +957,14 @@
         "Artifact appears truncated"
       ],
       "allowed_warnings": [],
-      "top1_required": false,
-      "required_top2": [
-        "downstream_stage_dominates"
-      ],
-      "acceptable_primary": [
-        "downstream_stage_dominates",
-        "blocking_pool_pressure"
-      ],
-      "max_primary_confidence": "medium",
-      "notes": "Synthetic adversarial truncation case: plausible dominant stage signal is retained but confidence is capped and truncation follow-up is required."
+      "max_primary_confidence": "medium"
     },
     {
       "id": "adversarial_weak_blocking_strong_downstream",
       "artifact": "corpus/weak-blocking-strong-downstream.json",
       "artifact_type": "synthetic_analysis_report",
-      "ground_truth": "downstream_stage_dominates",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "synthetic",
         "adversarial",
@@ -959,6 +972,15 @@
         "downstream",
         "blocking"
       ],
+      "notes": "Synthetic adversarial mixed-signal case: strong downstream evidence should outrank weak blocking hints while keeping blocking visible in top-2.",
+      "expected_primary_kinds": [
+        "downstream_stage_dominates"
+      ],
+      "required_visible_suspects": [
+        "downstream_stage_dominates",
+        "blocking_pool_pressure"
+      ],
+      "exact_primary_kind": "downstream_stage_dominates",
       "must_include_evidence": [
         "tail time",
         "weak"
@@ -967,22 +989,14 @@
         "downstream dependency"
       ],
       "expected_warnings": [],
-      "allowed_warnings": [],
-      "top1_required": true,
-      "required_top2": [
-        "downstream_stage_dominates",
-        "blocking_pool_pressure"
-      ],
-      "acceptable_primary": [
-        "downstream_stage_dominates"
-      ],
-      "notes": "Synthetic adversarial mixed-signal case: strong downstream evidence should outrank weak blocking hints while keeping blocking visible in top-2."
+      "allowed_warnings": []
     },
     {
       "id": "adversarial_blocking_correlated_stage",
       "artifact": "corpus/blocking-correlated-stage.json",
       "artifact_type": "synthetic_analysis_report",
-      "ground_truth": "blocking_pool_pressure",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "synthetic",
         "adversarial",
@@ -990,6 +1004,15 @@
         "blocking",
         "stage-correlation"
       ],
+      "notes": "Synthetic adversarial correlation case: stage latency is visible but blocking pressure should win when blocking correlation evidence is strong.",
+      "expected_primary_kinds": [
+        "blocking_pool_pressure"
+      ],
+      "required_visible_suspects": [
+        "blocking_pool_pressure",
+        "downstream_stage_dominates"
+      ],
+      "exact_primary_kind": "blocking_pool_pressure",
       "must_include_evidence": [
         "Blocking queue depth",
         "correlated"
@@ -999,28 +1022,28 @@
         "blocking callsites"
       ],
       "expected_warnings": [],
-      "allowed_warnings": [],
-      "top1_required": true,
-      "required_top2": [
-        "blocking_pool_pressure",
-        "downstream_stage_dominates"
-      ],
-      "acceptable_primary": [
-        "blocking_pool_pressure"
-      ],
-      "notes": "Synthetic adversarial correlation case: stage latency is visible but blocking pressure should win when blocking correlation evidence is strong."
+      "allowed_warnings": []
     },
     {
       "id": "adversarial_noise_only_workload",
       "artifact": "corpus/noise-only-workload.json",
       "artifact_type": "synthetic_analysis_report",
-      "ground_truth": "insufficient_evidence",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "synthetic",
         "adversarial",
         "noise",
         "mixed-low-signal"
       ],
+      "notes": "Synthetic adversarial noise-only case: mixed low-signal evidence should remain insufficient-evidence with low confidence.",
+      "expected_primary_kinds": [
+        "insufficient_evidence"
+      ],
+      "required_visible_suspects": [
+        "insufficient_evidence"
+      ],
+      "exact_primary_kind": "insufficient_evidence",
       "must_include_evidence": [
         "No bottleneck family",
         "weak and mixed"
@@ -1032,27 +1055,28 @@
         "No dominant signal"
       ],
       "allowed_warnings": [],
-      "top1_required": true,
-      "required_top2": [
-        "insufficient_evidence"
-      ],
-      "acceptable_primary": [
-        "insufficient_evidence"
-      ],
-      "max_primary_confidence": "low",
-      "notes": "Synthetic adversarial noise-only case: mixed low-signal evidence should remain insufficient-evidence with low confidence."
+      "max_primary_confidence": "low"
     },
     {
       "id": "adversarial_high_latency_missing_instrumentation",
       "artifact": "corpus/high-latency-missing-instrumentation.json",
       "artifact_type": "synthetic_analysis_report",
-      "ground_truth": "insufficient_evidence",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "synthetic",
         "adversarial",
         "high-latency",
         "missing-instrumentation"
       ],
+      "notes": "Synthetic adversarial high-latency-without-explanatory-signals case: latency alone should not force a specific high-confidence suspect.",
+      "expected_primary_kinds": [
+        "insufficient_evidence"
+      ],
+      "required_visible_suspects": [
+        "insufficient_evidence"
+      ],
+      "exact_primary_kind": "insufficient_evidence",
       "must_include_evidence": [
         "High p99 latency",
         "instrumentation is missing"
@@ -1064,39 +1088,32 @@
         "High latency observed"
       ],
       "allowed_warnings": [],
-      "top1_required": true,
-      "required_top2": [
-        "insufficient_evidence"
-      ],
-      "acceptable_primary": [
-        "insufficient_evidence"
-      ],
-      "max_primary_confidence": "low",
-      "notes": "Synthetic adversarial high-latency-without-explanatory-signals case: latency alone should not force a specific high-confidence suspect."
+      "max_primary_confidence": "low"
     },
     {
       "id": "synthetic_route_divergence",
       "artifact": "corpus/route-divergence.json",
       "artifact_type": "synthetic_analysis_report",
-      "ground_truth": "downstream_stage_dominates",
+      "validation_class": "report_contract",
+      "accuracy_eligible": false,
       "tags": [
         "synthetic",
         "route"
       ],
+      "notes": "Synthetic route divergence case for route breakdown validation.",
+      "expected_primary_kinds": [
+        "downstream_stage_dominates"
+      ],
+      "required_visible_suspects": [
+        "downstream_stage_dominates"
+      ],
+      "exact_primary_kind": "downstream_stage_dominates",
       "must_include_evidence": [
         "Route /slow"
       ],
-      "notes": "Synthetic route divergence case for route breakdown validation.",
-      "expected_warnings": [],
-      "top1_required": true,
-      "allowed_warnings": [],
-      "required_top2": [
-        "downstream_stage_dominates"
-      ],
-      "acceptable_primary": [
-        "downstream_stage_dominates"
-      ],
       "must_include_next_checks": [],
+      "expected_warnings": [],
+      "allowed_warnings": [],
       "expected_route_breakdowns": "non_empty",
       "must_include_route_warning": [
         "not route-attributed"
@@ -1110,26 +1127,29 @@
       "id": "tracing_queue_dominant",
       "artifact": "corpus/tracing-queue-dominant.jsonl",
       "artifact_type": "tracing_span_jsonl",
+      "validation_class": "analyzer_execution",
+      "accuracy_eligible": true,
+      "observation_id": "tracing_queue_dominant",
       "ground_truth": "application_queue_saturation",
-      "required_top2": [
-        "application_queue_saturation"
-      ],
-      "acceptable_primary": [
-        "application_queue_saturation"
-      ],
       "tags": [
         "tracing",
         "import",
         "queue"
       ],
+      "notes": "Completed tailtriage tracing span JSONL fixture validates CLI import to Run JSON, CLI analyze, and queue-dominant diagnosis behavior.",
+      "expected_primary_kinds": [
+        "application_queue_saturation"
+      ],
+      "required_visible_suspects": [
+        "application_queue_saturation"
+      ],
+      "exact_primary_kind": "application_queue_saturation",
       "must_include_evidence": [
         "Queue wait"
       ],
       "must_include_next_checks": [],
       "expected_warnings": [],
       "allowed_warnings": [],
-      "top1_required": true,
-      "notes": "Completed tailtriage tracing span JSONL fixture validates CLI import to Run JSON, CLI analyze, and queue-dominant diagnosis behavior.",
       "expected_evidence_quality": "strong",
       "expected_signal_statuses": {
         "queues": "present",
@@ -1141,18 +1161,23 @@
       "id": "raw_low_request_insufficient",
       "artifact": "corpus/run-artifacts/low-request-insufficient.json",
       "artifact_type": "run_artifact",
+      "validation_class": "analyzer_execution",
+      "accuracy_eligible": true,
+      "observation_id": "raw_low_request_insufficient",
       "ground_truth": "insufficient_evidence",
-      "required_top2": [
-        "insufficient_evidence"
-      ],
-      "acceptable_primary": [
-        "insufficient_evidence"
-      ],
       "tags": [
         "adversarial",
         "raw-run",
         "low-request"
       ],
+      "notes": "Raw run fixture with low request count validates analyze_run insufficient-evidence fallback.",
+      "expected_primary_kinds": [
+        "insufficient_evidence"
+      ],
+      "required_visible_suspects": [
+        "insufficient_evidence"
+      ],
+      "exact_primary_kind": "insufficient_evidence",
       "must_include_evidence": [],
       "must_include_next_checks": [],
       "expected_warnings": [
@@ -1165,26 +1190,28 @@
         "No stage events captured",
         "No runtime snapshots captured"
       ],
-      "top1_required": true,
-      "notes": "Raw run fixture with low request count validates analyze_run insufficient-evidence fallback.",
       "max_primary_confidence": "low"
     },
     {
       "id": "raw_no_queue_events",
       "artifact": "corpus/run-artifacts/no-queue-events.json",
       "artifact_type": "run_artifact",
+      "validation_class": "analyzer_execution",
+      "accuracy_eligible": true,
+      "observation_id": "raw_no_queue_events",
       "ground_truth": "downstream_stage_dominates",
-      "required_top2": [
-        "downstream_stage_dominates"
-      ],
-      "acceptable_primary": [
-        "downstream_stage_dominates",
-        "insufficient_evidence"
-      ],
       "tags": [
         "adversarial",
         "raw-run",
         "missing-queue"
+      ],
+      "notes": "Raw run fixture without queue events checks missing-queue warning and conservative interpretation.",
+      "expected_primary_kinds": [
+        "downstream_stage_dominates",
+        "insufficient_evidence"
+      ],
+      "required_visible_suspects": [
+        "downstream_stage_dominates"
       ],
       "must_include_evidence": [
         "Stage"
@@ -1197,26 +1224,28 @@
         "No queue events captured",
         "No runtime snapshots captured"
       ],
-      "top1_required": false,
-      "notes": "Raw run fixture without queue events checks missing-queue warning and conservative interpretation.",
       "max_primary_confidence": "medium"
     },
     {
       "id": "raw_no_stage_events",
       "artifact": "corpus/run-artifacts/no-stage-events.json",
       "artifact_type": "run_artifact",
+      "validation_class": "analyzer_execution",
+      "accuracy_eligible": true,
+      "observation_id": "raw_no_stage_events",
       "ground_truth": "application_queue_saturation",
-      "required_top2": [
-        "application_queue_saturation"
-      ],
-      "acceptable_primary": [
-        "application_queue_saturation",
-        "insufficient_evidence"
-      ],
       "tags": [
         "adversarial",
         "raw-run",
         "missing-stage"
+      ],
+      "notes": "Raw run fixture without stage events checks missing-stage warning and confidence cap.",
+      "expected_primary_kinds": [
+        "application_queue_saturation",
+        "insufficient_evidence"
+      ],
+      "required_visible_suspects": [
+        "application_queue_saturation"
       ],
       "must_include_evidence": [
         "Queue wait"
@@ -1229,26 +1258,29 @@
         "No stage events captured",
         "No runtime snapshots captured"
       ],
-      "top1_required": false,
-      "notes": "Raw run fixture without stage events checks missing-stage warning and confidence cap.",
       "max_primary_confidence": "medium"
     },
     {
       "id": "raw_no_runtime_snapshots",
       "artifact": "corpus/run-artifacts/no-runtime-snapshots.json",
       "artifact_type": "run_artifact",
+      "validation_class": "analyzer_execution",
+      "accuracy_eligible": true,
+      "observation_id": "raw_no_runtime_snapshots",
       "ground_truth": "application_queue_saturation",
-      "required_top2": [
-        "application_queue_saturation"
-      ],
-      "acceptable_primary": [
-        "application_queue_saturation"
-      ],
       "tags": [
         "adversarial",
         "raw-run",
         "missing-runtime"
       ],
+      "notes": "Raw run fixture checks runtime-missing warning from analyzer run path.",
+      "expected_primary_kinds": [
+        "application_queue_saturation"
+      ],
+      "required_visible_suspects": [
+        "application_queue_saturation"
+      ],
+      "exact_primary_kind": "application_queue_saturation",
       "must_include_evidence": [
         "Queue wait"
       ],
@@ -1259,26 +1291,29 @@
       "allowed_warnings": [
         "Low completed-request count"
       ],
-      "top1_required": true,
-      "notes": "Raw run fixture checks runtime-missing warning from analyzer run path.",
       "max_primary_confidence": "medium"
     },
     {
       "id": "raw_truncated_partial_evidence",
       "artifact": "corpus/run-artifacts/truncated-queues.json",
       "artifact_type": "run_artifact",
+      "validation_class": "analyzer_execution",
+      "accuracy_eligible": true,
+      "observation_id": "raw_truncated_partial_evidence",
       "ground_truth": "application_queue_saturation",
-      "required_top2": [
-        "application_queue_saturation"
-      ],
-      "acceptable_primary": [
-        "application_queue_saturation"
-      ],
       "tags": [
         "adversarial",
         "raw-run",
         "truncation"
       ],
+      "notes": "Raw run fixture with truncation validates warning propagation and conservative confidence.",
+      "expected_primary_kinds": [
+        "application_queue_saturation"
+      ],
+      "required_visible_suspects": [
+        "application_queue_saturation"
+      ],
+      "exact_primary_kind": "application_queue_saturation",
       "must_include_evidence": [
         "Queue wait"
       ],
@@ -1291,193 +1326,201 @@
         "Low completed-request count",
         "No runtime snapshots captured"
       ],
-      "top1_required": true,
-      "notes": "Raw run fixture with truncation validates warning propagation and conservative confidence.",
       "max_primary_confidence": "medium"
     },
     {
       "id": "partial-evidence-completed-only",
       "artifact": "corpus/partial-evidence-completed-only.json",
       "artifact_type": "run_artifact",
+      "validation_class": "analyzer_execution",
+      "accuracy_eligible": true,
+      "observation_id": "partial-evidence-completed-only",
       "ground_truth": "application_queue_saturation",
       "tags": [
         "partial-evidence"
       ],
-      "must_include_evidence": [
-        "Queue wait at p95 consumes"
-      ],
-      "must_include_confidence_notes": [],
-      "expected_top_level_warnings": [],
-      "top1_required": false,
-      "allowed_warnings": [
-        "Top suspects are close in score"
-      ],
-      "required_top2": [
-        "application_queue_saturation"
-      ],
-      "acceptable_primary": [
+      "notes": "Partial evidence fixture; suspects are triage leads, not production truth.",
+      "expected_primary_kinds": [
         "application_queue_saturation",
         "downstream_stage_dominates"
       ],
+      "required_visible_suspects": [
+        "application_queue_saturation"
+      ],
+      "must_include_evidence": [
+        "Queue wait at p95 consumes"
+      ],
+      "must_include_next_checks": [],
+      "expected_warnings": [],
+      "allowed_warnings": [
+        "Top suspects are close in score"
+      ],
+      "must_include_confidence_notes": [],
+      "expected_top_level_warnings": [],
       "expected_evidence_quality": "strong",
       "expected_signal_statuses": {
         "queues": "present",
         "stages": "present"
-      },
-      "must_include_next_checks": [],
-      "notes": "Partial evidence fixture; suspects are triage leads, not production truth.",
-      "expected_warnings": []
+      }
     },
     {
       "id": "partial-evidence-mixed",
       "artifact": "corpus/partial-evidence-mixed.json",
       "artifact_type": "run_artifact",
+      "validation_class": "analyzer_execution",
+      "accuracy_eligible": true,
+      "observation_id": "partial-evidence-mixed",
       "ground_truth": "downstream_stage_dominates",
       "tags": [
         "partial-evidence"
       ],
+      "notes": "Partial evidence fixture; suspects are triage leads, not production truth.",
+      "expected_primary_kinds": [
+        "downstream_stage_dominates",
+        "application_queue_saturation"
+      ],
+      "required_visible_suspects": [
+        "downstream_stage_dominates"
+      ],
       "must_include_evidence": [
         "observed lower-bound p95 latency"
+      ],
+      "must_include_next_checks": [],
+      "expected_warnings": [
+        "Partial queue/stage observations are lower bounds"
+      ],
+      "allowed_warnings": [
+        "Top suspects are close in score"
       ],
       "must_include_confidence_notes": [
         "Partial stage evidence materially contributes to this suspect; confidence cannot exceed medium because partial durations are lower bounds."
       ],
       "expected_top_level_warnings": [
         "Partial queue/stage observations are lower bounds"
-      ],
-      "top1_required": false,
-      "allowed_warnings": [
-        "Top suspects are close in score"
-      ],
-      "required_top2": [
-        "downstream_stage_dominates"
-      ],
-      "acceptable_primary": [
-        "downstream_stage_dominates",
-        "application_queue_saturation"
       ],
       "expected_evidence_quality": "partial",
       "expected_signal_statuses": {
         "stages": "partial",
         "queues": "partial"
       },
-      "max_primary_confidence": "medium",
-      "must_include_next_checks": [],
-      "notes": "Partial evidence fixture; suspects are triage leads, not production truth.",
-      "expected_warnings": [
-        "Partial queue/stage observations are lower bounds"
-      ]
+      "max_primary_confidence": "medium"
     },
     {
       "id": "partial-evidence-queue-only",
       "artifact": "corpus/partial-evidence-queue-only.json",
       "artifact_type": "run_artifact",
+      "validation_class": "analyzer_execution",
+      "accuracy_eligible": true,
+      "observation_id": "partial-evidence-queue-only",
       "ground_truth": "application_queue_saturation",
       "tags": [
         "partial-evidence"
       ],
+      "notes": "Partial evidence fixture; suspects are triage leads, not production truth.",
+      "expected_primary_kinds": [
+        "application_queue_saturation",
+        "downstream_stage_dominates"
+      ],
+      "required_visible_suspects": [
+        "application_queue_saturation"
+      ],
       "must_include_evidence": [
         "Observed queue-wait lower bound at p95 is"
       ],
+      "must_include_next_checks": [],
+      "expected_warnings": [
+        "Partial queue/stage observations are lower bounds"
+      ],
+      "allowed_warnings": [],
       "must_include_confidence_notes": [
         "Partial queue evidence materially contributes to this suspect; confidence cannot exceed medium because partial durations are lower bounds."
       ],
       "expected_top_level_warnings": [
         "Partial queue/stage observations are lower bounds"
       ],
-      "top1_required": false,
-      "allowed_warnings": [],
-      "required_top2": [
-        "application_queue_saturation"
-      ],
-      "acceptable_primary": [
-        "application_queue_saturation",
-        "downstream_stage_dominates"
-      ],
       "expected_evidence_quality": "partial",
       "expected_signal_statuses": {
         "queues": "partial"
       },
-      "max_primary_confidence": "medium",
-      "must_include_next_checks": [],
-      "notes": "Partial evidence fixture; suspects are triage leads, not production truth.",
-      "expected_warnings": [
-        "Partial queue/stage observations are lower bounds"
-      ]
+      "max_primary_confidence": "medium"
     },
     {
       "id": "partial-evidence-stage-only",
       "artifact": "corpus/partial-evidence-stage-only.json",
       "artifact_type": "run_artifact",
+      "validation_class": "analyzer_execution",
+      "accuracy_eligible": true,
+      "observation_id": "partial-evidence-stage-only",
       "ground_truth": "downstream_stage_dominates",
       "tags": [
         "partial-evidence"
       ],
+      "notes": "Partial evidence fixture; suspects are triage leads, not production truth.",
+      "expected_primary_kinds": [
+        "downstream_stage_dominates",
+        "application_queue_saturation"
+      ],
+      "required_visible_suspects": [
+        "downstream_stage_dominates"
+      ],
       "must_include_evidence": [
         "observed lower-bound p95 latency"
       ],
+      "must_include_next_checks": [],
+      "expected_warnings": [
+        "Partial queue/stage observations are lower bounds"
+      ],
+      "allowed_warnings": [],
       "must_include_confidence_notes": [
         "Partial stage evidence materially contributes to this suspect; confidence cannot exceed medium because partial durations are lower bounds."
       ],
       "expected_top_level_warnings": [
         "Partial queue/stage observations are lower bounds"
       ],
-      "top1_required": false,
-      "allowed_warnings": [],
-      "required_top2": [
-        "downstream_stage_dominates"
-      ],
-      "acceptable_primary": [
-        "downstream_stage_dominates",
-        "application_queue_saturation"
-      ],
       "expected_evidence_quality": "partial",
       "expected_signal_statuses": {
         "stages": "partial"
       },
-      "max_primary_confidence": "medium",
-      "must_include_next_checks": [],
-      "notes": "Partial evidence fixture; suspects are triage leads, not production truth.",
-      "expected_warnings": [
-        "Partial queue/stage observations are lower bounds"
-      ]
+      "max_primary_confidence": "medium"
     },
     {
       "id": "cancelled-request-with-partial-child",
       "artifact": "corpus/cancelled-request-with-partial-child.json",
       "artifact_type": "run_artifact",
+      "validation_class": "analyzer_execution",
+      "accuracy_eligible": true,
+      "observation_id": "cancelled-request-with-partial-child",
       "ground_truth": "downstream_stage_dominates",
       "tags": [
         "partial-evidence"
       ],
+      "notes": "Partial evidence fixture; suspects are triage leads, not production truth.",
+      "expected_primary_kinds": [
+        "downstream_stage_dominates",
+        "application_queue_saturation"
+      ],
+      "required_visible_suspects": [
+        "downstream_stage_dominates"
+      ],
       "must_include_evidence": [
         "observed lower-bound p95 latency"
       ],
+      "must_include_next_checks": [],
+      "expected_warnings": [
+        "Partial queue/stage observations are lower bounds"
+      ],
+      "allowed_warnings": [],
       "must_include_confidence_notes": [
         "Partial stage evidence materially contributes to this suspect; confidence cannot exceed medium because partial durations are lower bounds."
       ],
       "expected_top_level_warnings": [
         "Partial queue/stage observations are lower bounds"
       ],
-      "top1_required": false,
-      "allowed_warnings": [],
-      "required_top2": [
-        "downstream_stage_dominates"
-      ],
-      "acceptable_primary": [
-        "downstream_stage_dominates",
-        "application_queue_saturation"
-      ],
       "expected_evidence_quality": "partial",
       "expected_signal_statuses": {
         "stages": "partial"
       },
-      "max_primary_confidence": "medium",
-      "must_include_next_checks": [],
-      "notes": "Partial evidence fixture; suspects are triage leads, not production truth.",
-      "expected_warnings": [
-        "Partial queue/stage observations are lower bounds"
-      ]
+      "max_primary_confidence": "medium"
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- Make validation semantics truthful by separating analyzer-executed accuracy observations from pre-generated Report-contract checks so report-only fixtures cannot influence analyzer accuracy metrics.
- Introduce a manifest schema that explicitly records validation class, accuracy eligibility, observation identity, and execution expectations to prevent ambiguity and accidental denominator inflation.
- Provide a stable foundation for later work (typed fixture generator and corpus expansion) without changing analyzer scoring, Rust production code, fixtures, demos, or dependencies.

### Description
- Migrate the diagnostics manifest to schema version `2` and require new per-case fields including `validation_class`, `accuracy_eligible`, `observation_id` (for eligible analyzer cases), `expected_primary_kinds`, and `required_visible_suspects`, while rejecting old version-1 fields (`required_top2`, `acceptable_primary`, `top1_required`).
- Refactor `scripts/diagnostic_benchmark.py` to produce three explicit result domains: analyzer-execution case results, analyzer-accuracy (unique observation) results, and report-contract case results; accuracy is computed only over successfully executed, accuracy-eligible, mutually-consistent unique observations and equivalent encodings are grouped and counted once.
- Add typed analyzer execution contracts (`execution_expectation`, `failure_stage`, `expected_error_substrings`, `forbidden_error_substrings`, `stdout_expectation`) and a typed `artifact_policy` (`strict` default, `allow_ambiguous` for `run_artifact` only) with validation rules; expected failures are validated rather than skipped.
- Update `scripts/generate_diagnostic_scorecard.py` to emit schema version `2` JSON and a Markdown scorecard with explicit sections for Analyzer execution, Analyzer accuracy, Report-contract validation, validated input paths, failed-analyzer cases, failed-report-contract cases, and strengthened non-claims; render unavailable accuracy as `n/a`.
- Migrate `validation/diagnostics/manifest.json` cases to the new schema and update related documentation to describe the new accounting and to explicitly defer Prompt 18B/18C work.
- Tests: add/adjust unit tests in `scripts/tests/test_diagnostic_benchmark.py` and `scripts/tests/test_generate_diagnostic_scorecard.py` to cover class/type matrix validation, zero-denominator behaviors, expected execution failures, artifact-policy typing, equivalent-encoding grouping and disagreement, and that report-contract cases do not affect analyzer accuracy.

### Testing
- Ran unit test suites: `python3 -m unittest scripts.tests.test_diagnostic_benchmark`, `python3 -m unittest scripts.tests.test_generate_diagnostic_scorecard`, and `python3 -m unittest scripts.tests.test_validate_docs_contracts`; combined run: 105 tests, all OK.
- Executed the migrated deterministic benchmark: `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 .75 --min-top2 .90 --max-high-confidence-wrong 0`, which produced 49 manifest cases, 11 analyzer-execution cases, 11 unique accuracy observations, top-1 = 0.909, top-2 = 1.000, high-confidence-wrong = 0.
- Generated a scorecard: `python3 scripts/generate_diagnostic_scorecard.py --manifest validation/diagnostics/manifest.json --out-dir target/validation/prompt18a-scorecard --min-top1 .75 --min-top2 .90 --max-high-confidence-wrong 0 --snapshot-label prompt18a-local`, and validated the produced `benchmark-summary.json` and `scorecard.md` contain the required separated sections and schema version `2`.
- Ran repository-wide checks: `python3 -m py_compile` for updated scripts, `python3 scripts/validate_docs_contracts.py` (docs validator), `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, and `cargo test -p tailtriage-tracing --test equivalence_contract --all-features --locked`; all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68ef0214fc8330af97de4bfbe93d8d)