### PR TITLE
Lock and validate committed analyzer fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,6 +243,14 @@ jobs:
         if: matrix.extended && matrix.profile == 'release'
         run: python3 -m unittest scripts.tests.test_measure_collector_limits
 
+      - name: Validate diagnostic fixture integrity helper tests
+        if: matrix.extended && matrix.profile == 'dev'
+        run: python3 -m unittest scripts.tests.test_check_diagnostic_fixture_integrity
+
+      - name: Check diagnostic analyzer fixture integrity
+        if: matrix.extended && matrix.profile == 'dev'
+        run: python3 scripts/check_diagnostic_fixture_integrity.py
+
       - name: Validate diagnostic benchmark helper unit tests
         if: matrix.extended && matrix.profile == 'dev'
         run: python3 -m unittest scripts.tests.test_diagnostic_benchmark

--- a/.github/workflows/validation-snapshot.yml
+++ b/.github/workflows/validation-snapshot.yml
@@ -49,6 +49,9 @@ jobs:
           fi
           echo "SAFE_SNAPSHOT_LABEL=$SAFE_SNAPSHOT_LABEL" >> "$GITHUB_ENV"
 
+      - name: Check diagnostic analyzer fixture integrity
+        run: python3 scripts/check_diagnostic_fixture_integrity.py
+
       - name: Generate scorecard snapshot
         run: |
           python3 scripts/generate_diagnostic_scorecard.py \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Committed analyzer fixtures now have a deterministic inventory, byte, formatting, and structural integrity lock checked before diagnostic execution.
+
 - Diagnostic validation now separates analyzer-executed accuracy observations from pre-generated Report-contract checks.
 
 - Native/core Run fixtures and stable tracing JSONL now have a deterministic equivalence contract for shared completed evidence and analyzer results, with explicit Run-only limitations.

--- a/scripts/check_diagnostic_fixture_integrity.py
+++ b/scripts/check_diagnostic_fixture_integrity.py
@@ -57,21 +57,27 @@ def manifest_inventory(root, failures):
             failures.append(f"non-empty artifact path required for {label}")
             readable = False
         else:
-            candidate = Path(artifact)
-            if candidate.is_absolute():
-                failures.append(f"absolute artifact path rejected for {label}: {artifact}")
-                readable = False
-            else:
-                resolved = (root / candidate).resolve()
-                try:
-                    resolved.relative_to(root_resolved)
-                except ValueError:
-                    failures.append(f"artifact path escapes diagnostics root for {label}: {artifact}")
+            try:
+                candidate = Path(artifact)
+                if candidate.is_absolute():
+                    failures.append(f"absolute artifact path rejected for {label}: {artifact}")
                     readable = False
                 else:
-                    if not resolved.is_file():
-                        failures.append(f"artifact is not a regular file for {label}: {artifact}")
+                    resolved = (root / candidate).resolve()
+            except (OSError, RuntimeError, ValueError):
+                failures.append(f"invalid artifact path for {label}: {artifact}")
+                readable = False
+            else:
+                if not candidate.is_absolute():
+                    try:
+                        resolved.relative_to(root_resolved)
+                    except ValueError:
+                        failures.append(f"artifact path escapes diagnostics root for {label}: {artifact}")
                         readable = False
+                    else:
+                        if not resolved.is_file():
+                            failures.append(f"artifact is not a regular file for {label}: {artifact}")
+                            readable = False
         if accuracy_eligible and (not isinstance(observation_id, str) or not observation_id):
             failures.append(f"non-empty observation_id required for accuracy-eligible analyzer {label}")
         inventory.append({"case_id": case_id, "artifact_type": artifact_type,
@@ -187,6 +193,8 @@ def tracing_shape(text):
         span = require_object(record.get("span"), f"span on line {number}")
         fields = require_object(span.get("fields"), f"span.fields on line {number}")
         kind = fields.get("tt.kind")
+        if kind is not None and not isinstance(kind, str):
+            raise ValueError(f"span tt.kind must be a string on line {number}")
         category = kind if kind in {"request", "stage", "queue"} else "other"
         counts[category] += 1
         if category == "request":

--- a/scripts/check_diagnostic_fixture_integrity.py
+++ b/scripts/check_diagnostic_fixture_integrity.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Check exact bytes and compact shapes of analyzer-executed fixtures."""
+
+import argparse
+from collections import Counter
+import hashlib
+import json
+from pathlib import Path
+import sys
+
+
+DIAGNOSTICS_ROOT = Path(__file__).resolve().parents[1] / "validation" / "diagnostics"
+LOCK_NAME = "analyzer-fixtures.lock.json"
+ARTIFACT_TYPES = {"run_artifact", "tracing_span_jsonl"}
+
+
+def read_json(path, description, failures):
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        failures.append(f"invalid {description}: {error}")
+        return None
+
+
+def manifest_inventory(root, failures):
+    manifest = read_json(root / "manifest.json", "manifest", failures)
+    if not isinstance(manifest, dict):
+        return []
+    if manifest.get("schema_version") != 2:
+        failures.append("manifest schema_version must be 2")
+    cases = manifest.get("cases")
+    if not isinstance(cases, list):
+        failures.append("manifest cases must be a list")
+        return []
+
+    inventory = []
+    root_resolved = root.resolve()
+    for number, case in enumerate(cases):
+        if not isinstance(case, dict) or case.get("validation_class") != "analyzer_execution":
+            continue
+        case_id = case.get("id")
+        artifact_type = case.get("artifact_type")
+        artifact = case.get("artifact")
+        label = case_id if isinstance(case_id, str) and case_id else f"case {number}"
+        readable = True
+        if not isinstance(case_id, str) or not case_id:
+            failures.append(f"non-empty case ID required for analyzer {label}")
+            readable = False
+        if artifact_type not in ARTIFACT_TYPES:
+            failures.append(f"invalid artifact type for {label}")
+            readable = False
+        if not isinstance(artifact, str) or not artifact:
+            failures.append(f"non-empty artifact path required for {label}")
+            readable = False
+        else:
+            candidate = Path(artifact)
+            if candidate.is_absolute():
+                failures.append(f"absolute artifact path rejected for {label}: {artifact}")
+                readable = False
+            else:
+                resolved = (root / candidate).resolve()
+                try:
+                    resolved.relative_to(root_resolved)
+                except ValueError:
+                    failures.append(f"artifact path escapes diagnostics root for {label}: {artifact}")
+                    readable = False
+                else:
+                    if not resolved.is_file():
+                        failures.append(f"artifact is not a regular file for {label}: {artifact}")
+                        readable = False
+        inventory.append({"case_id": case_id, "artifact_type": artifact_type,
+                          "artifact": artifact, "readable": readable})
+
+    ids = Counter(item["case_id"] for item in inventory)
+    paths = Counter(item["artifact"] for item in inventory)
+    for value, count in ids.items():
+        if count > 1:
+            failures.append(f"duplicate manifest case ID: {value}")
+    for value, count in paths.items():
+        if count > 1:
+            failures.append(f"duplicate manifest artifact path: {value}")
+    if not inventory:
+        failures.append("manifest has no analyzer-execution cases")
+    return inventory
+
+
+def artifact_text(root, item, failures):
+    artifact = item["artifact"]
+    path = root / artifact
+    try:
+        data = path.read_bytes()
+    except OSError as error:
+        failures.append(f"cannot read {artifact}: {error}")
+        return None, None
+    if not data:
+        failures.append(f"empty artifact: {artifact}")
+    if b"\r" in data:
+        failures.append(f"CR byte found in {artifact}")
+    if not data.endswith(b"\n"):
+        failures.append(f"missing final LF in {artifact}")
+    elif data.endswith(b"\n\n"):
+        failures.append(f"blank line after final content in {artifact}")
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        failures.append(f"invalid UTF-8 in {artifact}")
+        text = None
+    return data, text
+
+
+def require_object(value, label):
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be an object")
+    return value
+
+
+def run_shape(text):
+    try:
+        run = json.loads(text)
+    except json.JSONDecodeError as error:
+        raise ValueError(f"malformed Run JSON: {error}") from error
+    require_object(run, "Run")
+    names = ("requests", "stages", "queues", "inflight", "runtime_snapshots")
+    for name in names:
+        if not isinstance(run.get(name), list):
+            raise ValueError(f"Run {name} must be a list")
+    requests, stages, queues = run["requests"], run["stages"], run["queues"]
+    outcomes = Counter()
+    request_ids = []
+    for request in requests:
+        require_object(request, "request")
+        outcome = request.get("outcome")
+        if not isinstance(outcome, str):
+            raise ValueError("request outcome must be a string")
+        request_id = request.get("request_id")
+        if not isinstance(request_id, str):
+            raise ValueError("request ID must be a string")
+        outcomes[outcome] += 1
+        request_ids.append(request_id)
+    for event in stages:
+        require_object(event, "stage")
+    for event in queues:
+        require_object(event, "queue")
+    truncation = run.get("truncation")
+    if "truncation" in run and not isinstance(truncation, dict):
+        raise ValueError("Run truncation must be an object when present")
+    return {
+        "request_count": len(requests), "stage_count": len(stages),
+        "queue_count": len(queues), "inflight_snapshot_count": len(run["inflight"]),
+        "runtime_snapshot_count": len(run["runtime_snapshots"]),
+        "partial_stage_count": sum(event.get("completed") is False for event in stages),
+        "partial_queue_count": sum(event.get("completed") is False for event in queues),
+        "outcomes": dict(sorted(outcomes.items())),
+        "requests_with_run_interval": sum("started_at_run_us" in event and "finished_at_run_us" in event for event in requests),
+        "stages_with_run_interval": sum("started_at_run_us" in event and "finished_at_run_us" in event for event in stages),
+        "queues_with_run_interval": sum("waited_from_run_us" in event and "waited_until_run_us" in event for event in queues),
+        "first_request_id": request_ids[0] if request_ids else None,
+        "last_request_id": request_ids[-1] if request_ids else None,
+        "truncation": truncation,
+    }
+
+
+def tracing_shape(text):
+    physical_lines = text[:-1].split("\n") if text.endswith("\n") else text.split("\n")
+    if any(not line for line in physical_lines):
+        raise ValueError("blank JSONL line")
+    counts = Counter()
+    request_ids = []
+    for number, line in enumerate(physical_lines, 1):
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise ValueError(f"malformed tracing JSONL line {number}: {error}") from error
+        require_object(record, f"tracing line {number}")
+        if record.get("format") != "tailtriage.tracing-span.v1":
+            raise ValueError(f"wrong tracing format marker on line {number}")
+        span = require_object(record.get("span"), f"span on line {number}")
+        fields = require_object(span.get("fields"), f"span.fields on line {number}")
+        kind = fields.get("tt.kind")
+        category = kind if kind in {"request", "stage", "queue"} else "other"
+        counts[category] += 1
+        if category == "request":
+            request_id = fields.get("tt.request_id")
+            if not isinstance(request_id, str):
+                raise ValueError(f"request span ID must be a string on line {number}")
+            request_ids.append(request_id)
+    return {
+        "line_count": len(physical_lines), "request_span_count": counts["request"],
+        "stage_span_count": counts["stage"], "queue_span_count": counts["queue"],
+        "other_span_count": counts["other"],
+        "first_request_id": request_ids[0] if request_ids else None,
+        "last_request_id": request_ids[-1] if request_ids else None,
+    }
+
+
+def calculate_entries(root, inventory, failures):
+    entries = []
+    for item in inventory:
+        if not item["readable"]:
+            continue
+        data, text = artifact_text(root, item, failures)
+        if data is None or text is None:
+            continue
+        try:
+            shape = run_shape(text) if item["artifact_type"] == "run_artifact" else tracing_shape(text)
+        except ValueError as error:
+            failures.append(f"invalid {item['artifact']} for {item['case_id']}: {error}")
+            continue
+        entries.append({key: item[key] for key in ("case_id", "artifact_type", "artifact")}
+                       | {"sha256": hashlib.sha256(data).hexdigest(),
+                          "byte_length": len(data), "shape": shape})
+    return sorted(entries, key=lambda entry: entry["case_id"])
+
+
+def compare_lock(lock, entries, failures):
+    if not isinstance(lock, dict):
+        return
+    if lock.get("schema_version") != 1:
+        failures.append("lock schema_version must be 1")
+    if lock.get("manifest_schema_version") != 2:
+        failures.append("lock manifest_schema_version must be 2")
+    fixtures = lock.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append("lock fixtures must be a list")
+        return
+    case_ids = [entry.get("case_id") for entry in fixtures if isinstance(entry, dict)]
+    for case_id, count in Counter(case_ids).items():
+        if count > 1:
+            failures.append(f"duplicate lock case ID: {case_id}")
+    if case_ids != sorted(case_ids):
+        failures.append("lock fixtures must be ordered by case ID")
+    locked = {entry.get("case_id"): entry for entry in fixtures if isinstance(entry, dict)}
+    current = {entry["case_id"]: entry for entry in entries}
+    for case_id in current.keys() - locked.keys():
+        failures.append(f"missing lock entry: {case_id}")
+    for case_id in locked.keys() - current.keys():
+        failures.append(f"unexpected lock entry: {case_id}")
+    for case_id in current.keys() & locked.keys():
+        expected, actual = locked[case_id], current[case_id]
+        for field in ("artifact_type", "artifact", "sha256", "byte_length"):
+            if expected.get(field) != actual[field]:
+                label = {"artifact": "artifact path"}.get(field, field.replace("_", " "))
+                failures.append(f"{label} mismatch for {case_id}")
+        expected_shape = expected.get("shape")
+        if not isinstance(expected_shape, dict):
+            failures.append(f"shape mismatch for {case_id}")
+        else:
+            for field in sorted(set(expected_shape) | set(actual["shape"])):
+                if expected_shape.get(field) != actual["shape"].get(field):
+                    failures.append(f"shape mismatch for {case_id} at {field}")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--refresh", action="store_true")
+    args = parser.parse_args(argv)
+    root = DIAGNOSTICS_ROOT
+    failures = []
+    inventory = manifest_inventory(root, failures)
+    entries = calculate_entries(root, inventory, failures)
+    lock_path = root / LOCK_NAME
+    if args.refresh:
+        if failures:
+            for failure in sorted(set(failures)):
+                print(failure, file=sys.stderr)
+            return 1
+        payload = {"schema_version": 1, "manifest_schema_version": 2, "fixtures": entries}
+        lock_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        print("diagnostic analyzer fixture lock refreshed")
+        return 0
+    lock = read_json(lock_path, "fixture lock", failures)
+    compare_lock(lock, entries, failures)
+    if failures:
+        for failure in sorted(set(failures)):
+            print(failure, file=sys.stderr)
+        return 1
+    print("diagnostic analyzer fixtures match the integrity lock")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_diagnostic_fixture_integrity.py
+++ b/scripts/check_diagnostic_fixture_integrity.py
@@ -11,7 +11,9 @@ import sys
 
 DIAGNOSTICS_ROOT = Path(__file__).resolve().parents[1] / "validation" / "diagnostics"
 LOCK_NAME = "analyzer-fixtures.lock.json"
+LOCK_FORMAT = "tailtriage.analyzer-fixture-lock.v1"
 ARTIFACT_TYPES = {"run_artifact", "tracing_span_jsonl"}
+LOCK_ENTRY_FIELDS = {"case_id", "artifact_type", "artifact", "sha256", "byte_length", "shape"}
 
 
 def read_json(path, description, failures):
@@ -41,6 +43,8 @@ def manifest_inventory(root, failures):
         case_id = case.get("id")
         artifact_type = case.get("artifact_type")
         artifact = case.get("artifact")
+        accuracy_eligible = case.get("accuracy_eligible") is True
+        observation_id = case.get("observation_id")
         label = case_id if isinstance(case_id, str) and case_id else f"case {number}"
         readable = True
         if not isinstance(case_id, str) or not case_id:
@@ -68,8 +72,12 @@ def manifest_inventory(root, failures):
                     if not resolved.is_file():
                         failures.append(f"artifact is not a regular file for {label}: {artifact}")
                         readable = False
+        if accuracy_eligible and (not isinstance(observation_id, str) or not observation_id):
+            failures.append(f"non-empty observation_id required for accuracy-eligible analyzer {label}")
         inventory.append({"case_id": case_id, "artifact_type": artifact_type,
-                          "artifact": artifact, "readable": readable})
+                          "artifact": artifact, "readable": readable,
+                          "accuracy_eligible": accuracy_eligible,
+                          "observation_id": observation_id})
 
     ids = Counter(item["case_id"] for item in inventory)
     paths = Counter(item["artifact"] for item in inventory)
@@ -209,27 +217,78 @@ def calculate_entries(root, inventory, failures):
         entries.append({key: item[key] for key in ("case_id", "artifact_type", "artifact")}
                        | {"sha256": hashlib.sha256(data).hexdigest(),
                           "byte_length": len(data), "shape": shape})
+    accuracy_by_hash = {}
+    for item, entry in ((item, entry) for item in inventory for entry in entries
+                        if item["case_id"] == entry["case_id"] and item["accuracy_eligible"]):
+        accuracy_by_hash.setdefault(entry["sha256"], []).append(
+            (item["case_id"], item["observation_id"]))
+    for digest, members in accuracy_by_hash.items():
+        if len({observation_id for _, observation_id in members}) > 1:
+            rendered = ", ".join(f"{case_id}/{observation_id}"
+                                 for case_id, observation_id in sorted(members))
+            failures.append("identical analyzer artifact bytes are assigned to distinct "
+                            f"accuracy observations: {digest}: {rendered}")
     return sorted(entries, key=lambda entry: entry["case_id"])
 
 
 def compare_lock(lock, entries, failures):
     if not isinstance(lock, dict):
+        failures.append("fixture lock must be an object")
         return
-    if lock.get("schema_version") != 1:
-        failures.append("lock schema_version must be 1")
-    if lock.get("manifest_schema_version") != 2:
-        failures.append("lock manifest_schema_version must be 2")
+    missing = {"format", "fixtures"} - set(lock)
+    unknown = set(lock) - {"format", "fixtures"}
+    for field in sorted(missing):
+        failures.append(f"missing lock field: {field}")
+    for field in sorted(unknown):
+        failures.append(f"unknown lock field: {field}")
+    if "format" in lock:
+        if not isinstance(lock["format"], str):
+            failures.append("lock format must be a string")
+        elif lock["format"] != LOCK_FORMAT:
+            failures.append(f"unsupported lock format: {lock['format']}")
     fixtures = lock.get("fixtures")
     if not isinstance(fixtures, list):
         failures.append("lock fixtures must be a list")
         return
-    case_ids = [entry.get("case_id") for entry in fixtures if isinstance(entry, dict)]
+    valid_entries = []
+    for number, entry in enumerate(fixtures):
+        label = f"lock fixture {number}"
+        if not isinstance(entry, dict):
+            failures.append(f"{label} must be an object")
+            continue
+        for field in sorted(LOCK_ENTRY_FIELDS - set(entry)):
+            failures.append(f"{label} missing field: {field}")
+        for field in sorted(set(entry) - LOCK_ENTRY_FIELDS):
+            failures.append(f"{label} unknown field: {field}")
+        case_id = entry.get("case_id")
+        artifact_type = entry.get("artifact_type")
+        artifact = entry.get("artifact")
+        sha256 = entry.get("sha256")
+        byte_length = entry.get("byte_length")
+        shape = entry.get("shape")
+        if not isinstance(case_id, str) or not case_id:
+            failures.append(f"{label} case_id must be a non-empty string")
+        if artifact_type not in ARTIFACT_TYPES:
+            failures.append(f"{label} artifact_type must be run_artifact or tracing_span_jsonl")
+        if not isinstance(artifact, str) or not artifact:
+            failures.append(f"{label} artifact must be a non-empty string")
+        if not isinstance(sha256, str):
+            failures.append(f"{label} sha256 must be a string")
+        elif len(sha256) != 64 or any(char not in "0123456789abcdef" for char in sha256):
+            failures.append(f"{label} sha256 must be exactly 64 lowercase hexadecimal characters")
+        if isinstance(byte_length, bool) or not isinstance(byte_length, int) or byte_length < 0:
+            failures.append(f"{label} byte_length must be a non-negative integer")
+        if not isinstance(shape, dict):
+            failures.append(f"{label} shape must be an object")
+        if set(entry) == LOCK_ENTRY_FIELDS and isinstance(case_id, str) and case_id:
+            valid_entries.append(entry)
+    case_ids = [entry["case_id"] for entry in valid_entries]
     for case_id, count in Counter(case_ids).items():
         if count > 1:
             failures.append(f"duplicate lock case ID: {case_id}")
     if case_ids != sorted(case_ids):
         failures.append("lock fixtures must be ordered by case ID")
-    locked = {entry.get("case_id"): entry for entry in fixtures if isinstance(entry, dict)}
+    locked = {entry["case_id"]: entry for entry in valid_entries}
     current = {entry["case_id"]: entry for entry in entries}
     for case_id in current.keys() - locked.keys():
         failures.append(f"missing lock entry: {case_id}")
@@ -264,7 +323,7 @@ def main(argv=None):
             for failure in sorted(set(failures)):
                 print(failure, file=sys.stderr)
             return 1
-        payload = {"schema_version": 1, "manifest_schema_version": 2, "fixtures": entries}
+        payload = {"format": LOCK_FORMAT, "fixtures": entries}
         lock_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
         print("diagnostic analyzer fixture lock refreshed")
         return 0

--- a/scripts/check_diagnostic_fixture_integrity.py
+++ b/scripts/check_diagnostic_fixture_integrity.py
@@ -50,7 +50,7 @@ def manifest_inventory(root, failures):
         if not isinstance(case_id, str) or not case_id:
             failures.append(f"non-empty case ID required for analyzer {label}")
             readable = False
-        if artifact_type not in ARTIFACT_TYPES:
+        if not isinstance(artifact_type, str) or artifact_type not in ARTIFACT_TYPES:
             failures.append(f"invalid artifact type for {label}")
             readable = False
         if not isinstance(artifact, str) or not artifact:
@@ -79,8 +79,10 @@ def manifest_inventory(root, failures):
                           "accuracy_eligible": accuracy_eligible,
                           "observation_id": observation_id})
 
-    ids = Counter(item["case_id"] for item in inventory)
-    paths = Counter(item["artifact"] for item in inventory)
+    ids = Counter(item["case_id"] for item in inventory
+                  if isinstance(item["case_id"], str) and item["case_id"])
+    paths = Counter(item["artifact"] for item in inventory
+                    if isinstance(item["artifact"], str) and item["artifact"])
     for value, count in ids.items():
         if count > 1:
             failures.append(f"duplicate manifest case ID: {value}")
@@ -219,7 +221,9 @@ def calculate_entries(root, inventory, failures):
                           "byte_length": len(data), "shape": shape})
     accuracy_by_hash = {}
     for item, entry in ((item, entry) for item in inventory for entry in entries
-                        if item["case_id"] == entry["case_id"] and item["accuracy_eligible"]):
+                        if item["case_id"] == entry["case_id"] and item["accuracy_eligible"]
+                        and isinstance(item["observation_id"], str)
+                        and item["observation_id"]):
         accuracy_by_hash.setdefault(entry["sha256"], []).append(
             (item["case_id"], item["observation_id"]))
     for digest, members in accuracy_by_hash.items():
@@ -268,7 +272,7 @@ def compare_lock(lock, entries, failures):
         shape = entry.get("shape")
         if not isinstance(case_id, str) or not case_id:
             failures.append(f"{label} case_id must be a non-empty string")
-        if artifact_type not in ARTIFACT_TYPES:
+        if not isinstance(artifact_type, str) or artifact_type not in ARTIFACT_TYPES:
             failures.append(f"{label} artifact_type must be run_artifact or tracing_span_jsonl")
         if not isinstance(artifact, str) or not artifact:
             failures.append(f"{label} artifact must be a non-empty string")

--- a/scripts/tests/test_check_diagnostic_fixture_integrity.py
+++ b/scripts/tests/test_check_diagnostic_fixture_integrity.py
@@ -1,0 +1,247 @@
+import hashlib
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+SOURCE = Path(__file__).parents[1] / "check_diagnostic_fixture_integrity.py"
+
+
+class FixtureIntegrityTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        (self.root / "scripts").mkdir()
+        shutil.copy2(SOURCE, self.root / "scripts" / SOURCE.name)
+        self.diagnostics = self.root / "validation" / "diagnostics"
+        (self.diagnostics / "corpus").mkdir(parents=True)
+        self.run_path = self.diagnostics / "corpus" / "run.json"
+        self.trace_path = self.diagnostics / "corpus" / "trace.jsonl"
+        self.run_path.write_bytes(self.run_bytes())
+        self.trace_path.write_bytes(self.trace_bytes())
+        self.write_manifest()
+        result = self.command("--refresh")
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    @staticmethod
+    def run_bytes(request_id="r1", outcome="ok"):
+        value = {
+            "requests": [{"request_id": request_id, "outcome": outcome,
+                          "started_at_run_us": 1, "finished_at_run_us": 2}],
+            "stages": [{"completed": False, "started_at_run_us": 1,
+                        "finished_at_run_us": 2}],
+            "queues": [{"waited_from_run_us": 1, "waited_until_run_us": 2}],
+            "inflight": [], "runtime_snapshots": [],
+        }
+        return (json.dumps(value, separators=(",", ":")) + "\n").encode()
+
+    @staticmethod
+    def trace_bytes(request_id="r1", extra=False):
+        records = [{
+            "format": "tailtriage.tracing-span.v1",
+            "span": {"fields": {"tt.kind": "request", "tt.request_id": request_id}},
+        }]
+        if extra:
+            records.append({"format": "tailtriage.tracing-span.v1",
+                            "span": {"fields": {"tt.kind": "queue"}}})
+        return ("\n".join(json.dumps(record) for record in records) + "\n").encode()
+
+    def cases(self):
+        return [
+            {"id": "run", "validation_class": "analyzer_execution",
+             "artifact_type": "run_artifact", "artifact": "corpus/run.json"},
+            {"id": "trace", "validation_class": "analyzer_execution",
+             "artifact_type": "tracing_span_jsonl", "artifact": "corpus/trace.jsonl"},
+            {"id": "report", "validation_class": "report_contract",
+             "artifact_type": "synthetic_analysis_report", "artifact": "ignored.json"},
+        ]
+
+    def write_manifest(self, cases=None):
+        value = {"schema_version": 2, "cases": self.cases() if cases is None else cases}
+        (self.diagnostics / "manifest.json").write_text(json.dumps(value) + "\n")
+
+    def command(self, *args):
+        return subprocess.run(
+            [sys.executable, "scripts/check_diagnostic_fixture_integrity.py", *args],
+            cwd=self.root, text=True, capture_output=True, check=False,
+        )
+
+    def lock(self):
+        return json.loads((self.diagnostics / "analyzer-fixtures.lock.json").read_text())
+
+    def write_lock(self, value):
+        (self.diagnostics / "analyzer-fixtures.lock.json").write_text(
+            json.dumps(value, indent=2) + "\n"
+        )
+
+    def assert_failure(self, phrase, *args):
+        result = self.command(*args)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(phrase, result.stderr)
+        return result
+
+    def test_valid_inventory_passes(self):
+        result = self.command()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("match the integrity lock", result.stdout)
+
+    def test_refresh_is_byte_deterministic(self):
+        before = (self.diagnostics / "analyzer-fixtures.lock.json").read_bytes()
+        self.assertEqual(self.command("--refresh").returncode, 0)
+        self.assertEqual(before, (self.diagnostics / "analyzer-fixtures.lock.json").read_bytes())
+
+    def test_refresh_writes_only_lock_file(self):
+        before = {p.relative_to(self.root): p.read_bytes() for p in self.root.rglob("*") if p.is_file()}
+        self.command("--refresh")
+        after = {p.relative_to(self.root): p.read_bytes() for p in self.root.rglob("*") if p.is_file()}
+        self.assertEqual(before, after)
+        self.assertEqual(before[Path("validation/diagnostics/corpus/run.json")], self.run_path.read_bytes())
+
+    def test_check_mode_is_read_only(self):
+        before = {p.relative_to(self.root): (p.stat().st_mtime_ns, p.read_bytes())
+                  for p in self.root.rglob("*") if p.is_file()}
+        self.command()
+        after = {p.relative_to(self.root): (p.stat().st_mtime_ns, p.read_bytes())
+                 for p in self.root.rglob("*") if p.is_file()}
+        self.assertEqual(before, after)
+
+    def test_changed_bytes_are_detected(self):
+        self.run_path.write_bytes(self.run_bytes(outcome="error"))
+        self.assert_failure("sha256 mismatch for run")
+
+    def test_byte_length_drift_is_detected(self):
+        lock = self.lock()
+        lock["fixtures"][0]["byte_length"] += 1
+        self.write_lock(lock)
+        self.assert_failure("byte length mismatch")
+
+    def test_missing_artifact_is_detected(self):
+        self.run_path.unlink()
+        self.assert_failure("artifact is not a regular file")
+
+    def test_missing_lock_entry_is_detected(self):
+        lock = self.lock()
+        lock["fixtures"] = [entry for entry in lock["fixtures"] if entry["case_id"] != "run"]
+        self.write_lock(lock)
+        self.assert_failure("missing lock entry: run")
+
+    def test_unexpected_lock_entry_is_detected(self):
+        lock = self.lock()
+        lock["fixtures"].append({"case_id": "old"})
+        self.write_lock(lock)
+        self.assert_failure("unexpected lock entry: old")
+
+    def test_artifact_type_mismatch_is_detected(self):
+        lock = self.lock()
+        lock["fixtures"][0]["artifact_type"] = "tracing_span_jsonl"
+        self.write_lock(lock)
+        self.assert_failure("artifact type mismatch")
+
+    def test_artifact_path_mismatch_is_detected(self):
+        lock = self.lock()
+        lock["fixtures"][0]["artifact"] = "corpus/other.json"
+        self.write_lock(lock)
+        self.assert_failure("artifact path mismatch")
+
+    def test_duplicate_manifest_case_id_is_rejected(self):
+        cases = self.cases()
+        cases[1]["id"] = "run"
+        self.write_manifest(cases)
+        self.assert_failure("duplicate manifest case ID: run")
+
+    def test_duplicate_manifest_artifact_path_is_rejected(self):
+        cases = self.cases()
+        cases[1]["artifact"] = "corpus/run.json"
+        self.write_manifest(cases)
+        self.assert_failure("duplicate manifest artifact path: corpus/run.json")
+
+    def test_report_contract_is_excluded(self):
+        self.assertEqual({entry["case_id"] for entry in self.lock()["fixtures"]}, {"run", "trace"})
+
+    def test_absolute_artifact_path_is_rejected(self):
+        cases = self.cases()
+        cases[0]["artifact"] = str(self.run_path)
+        self.write_manifest(cases)
+        self.assert_failure("absolute artifact path rejected")
+
+    def test_parent_path_escape_is_rejected(self):
+        cases = self.cases()
+        cases[0]["artifact"] = "../outside.json"
+        self.write_manifest(cases)
+        self.assert_failure("artifact path escapes diagnostics root")
+
+    def test_symlink_escape_is_rejected(self):
+        outside = self.root / "outside.json"
+        outside.write_bytes(self.run_bytes())
+        (self.diagnostics / "corpus" / "escape.json").symlink_to(outside)
+        cases = self.cases()
+        cases[0]["artifact"] = "corpus/escape.json"
+        self.write_manifest(cases)
+        self.assert_failure("artifact path escapes diagnostics root")
+
+    def test_invalid_utf8_is_rejected(self):
+        self.run_path.write_bytes(b"\xff\n")
+        self.assert_failure("invalid UTF-8")
+
+    def test_crlf_is_rejected(self):
+        self.run_path.write_bytes(self.run_bytes().replace(b"\n", b"\r\n"))
+        self.assert_failure("CR byte found")
+
+    def test_missing_final_lf_is_rejected(self):
+        self.run_path.write_bytes(self.run_bytes().rstrip(b"\n"))
+        self.assert_failure("missing final LF")
+
+    def test_blank_jsonl_line_is_rejected(self):
+        self.trace_path.write_bytes(self.trace_bytes() + b"\n")
+        self.assert_failure("blank line after final content")
+
+    def test_malformed_run_json_is_rejected(self):
+        self.run_path.write_bytes(b"{no}\n")
+        self.assert_failure("malformed Run JSON")
+
+    def test_malformed_tracing_jsonl_is_rejected(self):
+        self.trace_path.write_bytes(b"{no}\n")
+        self.assert_failure("malformed tracing JSONL")
+
+    def test_wrong_tracing_format_marker_is_rejected(self):
+        record = {"format": "wrong", "span": {"fields": {}}}
+        self.trace_path.write_text(json.dumps(record) + "\n")
+        self.assert_failure("wrong tracing format marker")
+
+    def test_run_shape_drift_is_detected(self):
+        lock = self.lock()
+        entry = next(item for item in lock["fixtures"] if item["case_id"] == "run")
+        entry["shape"]["request_count"] = 9
+        self.write_lock(lock)
+        self.assert_failure("shape mismatch for run at request_count")
+
+    def test_tracing_shape_drift_is_detected(self):
+        lock = self.lock()
+        entry = next(item for item in lock["fixtures"] if item["case_id"] == "trace")
+        entry["shape"]["request_span_count"] = 9
+        self.write_lock(lock)
+        self.assert_failure("shape mismatch for trace at request_span_count")
+
+    def test_all_failures_are_reported_in_stable_order(self):
+        lock = self.lock()
+        for entry in lock["fixtures"]:
+            entry["sha256"] = "0" * 64
+            entry["byte_length"] = 0
+        self.write_lock(lock)
+        result = self.command()
+        lines = result.stderr.splitlines()
+        self.assertEqual(lines, sorted(lines))
+        self.assertEqual(4, len(lines))
+        self.assertTrue(any("sha256 mismatch for run" in line for line in lines))
+        self.assertTrue(any("sha256 mismatch for trace" in line for line in lines))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_check_diagnostic_fixture_integrity.py
+++ b/scripts/tests/test_check_diagnostic_fixture_integrity.py
@@ -89,6 +89,12 @@ class FixtureIntegrityTest(unittest.TestCase):
         self.assertIn(phrase, result.stderr)
         return result
 
+    def assert_validation_failure(self, phrase, *args):
+        result = self.assert_failure(phrase, *args)
+        self.assertNotIn("Traceback", result.stderr)
+        self.assertNotIn("TypeError", result.stderr)
+        return result
+
     def test_valid_inventory_passes(self):
         result = self.command()
         self.assertEqual(result.returncode, 0, result.stderr)
@@ -179,6 +185,15 @@ class FixtureIntegrityTest(unittest.TestCase):
     def test_invalid_lock_artifact_type_is_rejected(self):
         self.mutate_entry(lambda entry: entry.update(artifact_type="report"))
         self.assert_failure("artifact_type must be run_artifact or tracing_span_jsonl")
+
+    def test_unhashable_lock_artifact_type_is_rejected(self):
+        for value in ([], {}):
+            with self.subTest(value=value):
+                self.mutate_entry(lambda entry, value=value: entry.update(artifact_type=value))
+                self.assert_validation_failure(
+                    "artifact_type must be run_artifact or tracing_span_jsonl"
+                )
+                self.command("--refresh")
 
     def test_empty_lock_artifact_path_is_rejected(self):
         self.mutate_entry(lambda entry: entry.update(artifact=""))
@@ -272,6 +287,44 @@ class FixtureIntegrityTest(unittest.TestCase):
         cases[1]["artifact"] = "corpus/run.json"
         self.write_manifest(cases)
         self.assert_failure("duplicate manifest artifact path: corpus/run.json")
+
+    def test_unhashable_manifest_fields_are_rejected(self):
+        fields = {
+            "id": "non-empty case ID required",
+            "artifact_type": "invalid artifact type",
+            "artifact": "non-empty artifact path required",
+            "observation_id": "non-empty observation_id required",
+        }
+        for field, phrase in fields.items():
+            for value in ([], {}):
+                for args in ((), ("--refresh",)):
+                    with self.subTest(field=field, value=value, args=args):
+                        cases = self.cases()
+                        cases[0][field] = value
+                        self.write_manifest(cases)
+                        self.assert_validation_failure(phrase, *args)
+
+    def test_combined_unhashable_manifest_values_report_all_errors(self):
+        cases = self.cases()
+        cases[0].update(id=[], artifact_type={}, artifact=[], observation_id={})
+        self.write_manifest(cases)
+        expected = {
+            "invalid artifact type for case 0",
+            "non-empty artifact path required for case 0",
+            "non-empty case ID required for analyzer case 0",
+            "non-empty observation_id required for accuracy-eligible analyzer case 0",
+        }
+        lock_before = (self.diagnostics / "analyzer-fixtures.lock.json").read_bytes()
+        for args in ((), ("--refresh",)):
+            with self.subTest(args=args):
+                result = self.assert_validation_failure("invalid artifact type", *args)
+                lines = result.stderr.splitlines()
+                self.assertEqual(lines, sorted(lines))
+                self.assertTrue(expected.issubset(lines))
+        self.assertEqual(
+            lock_before,
+            (self.diagnostics / "analyzer-fixtures.lock.json").read_bytes(),
+        )
 
     def duplicate_run_cases(self, first_observation="one", second_observation="two",
                             accuracy_eligible=True):

--- a/scripts/tests/test_check_diagnostic_fixture_integrity.py
+++ b/scripts/tests/test_check_diagnostic_fixture_integrity.py
@@ -393,6 +393,21 @@ class FixtureIntegrityTest(unittest.TestCase):
         self.write_manifest(cases)
         self.assert_failure("artifact path escapes diagnostics root")
 
+    def test_invalid_artifact_path_is_rejected_without_crashing(self):
+        cases = self.cases()
+        cases[0]["artifact"] = "corpus/\0invalid.json"
+        self.write_manifest(cases)
+        lock_before = (self.diagnostics / "analyzer-fixtures.lock.json").read_bytes()
+        for args in ((), ("--refresh",)):
+            with self.subTest(args=args):
+                result = self.assert_validation_failure("invalid artifact path for run", *args)
+                for exception in ("ValueError", "OSError", "RuntimeError"):
+                    self.assertNotIn(exception, result.stderr)
+        self.assertEqual(
+            lock_before,
+            (self.diagnostics / "analyzer-fixtures.lock.json").read_bytes(),
+        )
+
     def test_invalid_utf8_is_rejected(self):
         self.run_path.write_bytes(b"\xff\n")
         self.assert_failure("invalid UTF-8")
@@ -421,6 +436,44 @@ class FixtureIntegrityTest(unittest.TestCase):
         record = {"format": "wrong", "span": {"fields": {}}}
         self.trace_path.write_text(json.dumps(record) + "\n")
         self.assert_failure("wrong tracing format marker")
+
+    def test_non_string_tracing_kind_is_rejected_without_crashing(self):
+        for kind in ([], {}, 42, True):
+            for args in ((), ("--refresh",)):
+                with self.subTest(kind=kind, args=args):
+                    record = {
+                        "format": "tailtriage.tracing-span.v1",
+                        "span": {"fields": {"tt.kind": kind}},
+                    }
+                    self.trace_path.write_text(json.dumps(record) + "\n")
+                    lock_before = (
+                        self.diagnostics / "analyzer-fixtures.lock.json"
+                    ).read_bytes()
+                    result = self.assert_validation_failure(
+                        "span tt.kind must be a string on line 1", *args
+                    )
+                    self.assertEqual(
+                        lock_before,
+                        (self.diagnostics / "analyzer-fixtures.lock.json").read_bytes(),
+                    )
+
+    def test_missing_and_unknown_tracing_kinds_are_other(self):
+        records = [
+            {"format": "tailtriage.tracing-span.v1", "span": {"fields": {}}},
+            {
+                "format": "tailtriage.tracing-span.v1",
+                "span": {"fields": {"tt.kind": "custom"}},
+            },
+        ]
+        self.trace_path.write_text(
+            "\n".join(json.dumps(record) for record in records) + "\n"
+        )
+        self.assertEqual(self.command("--refresh").returncode, 0)
+        entry = next(
+            item for item in self.lock()["fixtures"] if item["case_id"] == "trace"
+        )
+        self.assertEqual(entry["shape"]["other_span_count"], 2)
+        self.assertEqual(self.command().returncode, 0)
 
     def test_run_shape_drift_is_detected(self):
         lock = self.lock()

--- a/scripts/tests/test_check_diagnostic_fixture_integrity.py
+++ b/scripts/tests/test_check_diagnostic_fixture_integrity.py
@@ -56,9 +56,11 @@ class FixtureIntegrityTest(unittest.TestCase):
     def cases(self):
         return [
             {"id": "run", "validation_class": "analyzer_execution",
-             "artifact_type": "run_artifact", "artifact": "corpus/run.json"},
+             "artifact_type": "run_artifact", "artifact": "corpus/run.json",
+             "accuracy_eligible": True, "observation_id": "run"},
             {"id": "trace", "validation_class": "analyzer_execution",
-             "artifact_type": "tracing_span_jsonl", "artifact": "corpus/trace.jsonl"},
+             "artifact_type": "tracing_span_jsonl", "artifact": "corpus/trace.jsonl",
+             "accuracy_eligible": True, "observation_id": "trace"},
             {"id": "report", "validation_class": "report_contract",
              "artifact_type": "synthetic_analysis_report", "artifact": "ignored.json"},
         ]
@@ -92,6 +94,42 @@ class FixtureIntegrityTest(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("match the integrity lock", result.stdout)
 
+    def test_valid_lock_format_passes(self):
+        self.assertEqual(self.lock()["format"], "tailtriage.analyzer-fixture-lock.v1")
+        self.assertEqual(self.command().returncode, 0)
+
+    def test_missing_lock_format_is_rejected(self):
+        lock = self.lock()
+        del lock["format"]
+        self.write_lock(lock)
+        self.assert_failure("missing lock field: format")
+
+    def test_non_string_lock_format_is_rejected(self):
+        lock = self.lock()
+        lock["format"] = 1
+        self.write_lock(lock)
+        self.assert_failure("lock format must be a string")
+
+    def test_unsupported_lock_format_is_rejected(self):
+        lock = self.lock()
+        lock["format"] = "tailtriage.analyzer-fixture-lock.v2"
+        self.write_lock(lock)
+        self.assert_failure("unsupported lock format")
+
+    def test_legacy_schema_version_fields_are_rejected(self):
+        lock = self.lock()
+        lock.update(schema_version=1, manifest_schema_version=2)
+        self.write_lock(lock)
+        result = self.assert_failure("unknown lock field: schema_version")
+        self.assertIn("unknown lock field: manifest_schema_version", result.stderr)
+
+    def test_refresh_writes_only_new_format_marker(self):
+        lock = self.lock()
+        lock.update(schema_version=1, manifest_schema_version=2)
+        self.write_lock(lock)
+        self.assertEqual(self.command("--refresh").returncode, 0)
+        self.assertEqual(set(self.lock()), {"format", "fixtures"})
+
     def test_refresh_is_byte_deterministic(self):
         before = (self.diagnostics / "analyzer-fixtures.lock.json").read_bytes()
         self.assertEqual(self.command("--refresh").returncode, 0)
@@ -111,6 +149,77 @@ class FixtureIntegrityTest(unittest.TestCase):
         after = {p.relative_to(self.root): (p.stat().st_mtime_ns, p.read_bytes())
                  for p in self.root.rglob("*") if p.is_file()}
         self.assertEqual(before, after)
+
+    def mutate_entry(self, mutation):
+        lock = self.lock()
+        mutation(lock["fixtures"][0])
+        self.write_lock(lock)
+
+    def test_non_object_lock_entry_is_rejected(self):
+        for value in (None, "fixture", 42, []):
+            with self.subTest(value=value):
+                lock = self.lock()
+                lock["fixtures"].append(value)
+                self.write_lock(lock)
+                self.assert_failure("lock fixture 2 must be an object")
+                self.command("--refresh")
+
+    def test_missing_lock_entry_field_is_rejected(self):
+        self.mutate_entry(lambda entry: entry.pop("artifact"))
+        self.assert_failure("lock fixture 0 missing field: artifact")
+
+    def test_unknown_lock_entry_field_is_rejected(self):
+        self.mutate_entry(lambda entry: entry.update(extra=True))
+        self.assert_failure("lock fixture 0 unknown field: extra")
+
+    def test_empty_lock_case_id_is_rejected(self):
+        self.mutate_entry(lambda entry: entry.update(case_id=""))
+        self.assert_failure("case_id must be a non-empty string")
+
+    def test_invalid_lock_artifact_type_is_rejected(self):
+        self.mutate_entry(lambda entry: entry.update(artifact_type="report"))
+        self.assert_failure("artifact_type must be run_artifact or tracing_span_jsonl")
+
+    def test_empty_lock_artifact_path_is_rejected(self):
+        self.mutate_entry(lambda entry: entry.update(artifact=""))
+        self.assert_failure("artifact must be a non-empty string")
+
+    def test_invalid_sha256_type_is_rejected(self):
+        self.mutate_entry(lambda entry: entry.update(sha256=42))
+        self.assert_failure("sha256 must be a string")
+
+    def test_invalid_sha256_length_is_rejected(self):
+        self.mutate_entry(lambda entry: entry.update(sha256="a" * 63))
+        self.assert_failure("sha256 must be exactly 64 lowercase hexadecimal characters")
+
+    def test_uppercase_sha256_is_rejected(self):
+        self.mutate_entry(lambda entry: entry.update(sha256="A" * 64))
+        self.assert_failure("sha256 must be exactly 64 lowercase hexadecimal characters")
+
+    def test_non_hex_sha256_is_rejected(self):
+        self.mutate_entry(lambda entry: entry.update(sha256="g" * 64))
+        self.assert_failure("sha256 must be exactly 64 lowercase hexadecimal characters")
+
+    def test_negative_byte_length_is_rejected(self):
+        self.mutate_entry(lambda entry: entry.update(byte_length=-1))
+        self.assert_failure("byte_length must be a non-negative integer")
+
+    def test_boolean_byte_length_is_rejected(self):
+        self.mutate_entry(lambda entry: entry.update(byte_length=True))
+        self.assert_failure("byte_length must be a non-negative integer")
+
+    def test_non_object_shape_is_rejected(self):
+        self.mutate_entry(lambda entry: entry.update(shape=[]))
+        self.assert_failure("shape must be an object")
+
+    def test_multiple_malformed_entries_are_stably_sorted(self):
+        lock = self.lock()
+        lock["fixtures"] = [None, {"case_id": ""}]
+        self.write_lock(lock)
+        lines = self.command().stderr.splitlines()
+        self.assertEqual(lines, sorted(lines))
+        self.assertIn("lock fixture 0 must be an object", lines)
+        self.assertIn("lock fixture 1 missing field: artifact", lines)
 
     def test_changed_bytes_are_detected(self):
         self.run_path.write_bytes(self.run_bytes(outcome="error"))
@@ -134,7 +243,9 @@ class FixtureIntegrityTest(unittest.TestCase):
 
     def test_unexpected_lock_entry_is_detected(self):
         lock = self.lock()
-        lock["fixtures"].append({"case_id": "old"})
+        old = dict(lock["fixtures"][0])
+        old["case_id"] = "old"
+        lock["fixtures"].append(old)
         self.write_lock(lock)
         self.assert_failure("unexpected lock entry: old")
 
@@ -161,6 +272,49 @@ class FixtureIntegrityTest(unittest.TestCase):
         cases[1]["artifact"] = "corpus/run.json"
         self.write_manifest(cases)
         self.assert_failure("duplicate manifest artifact path: corpus/run.json")
+
+    def duplicate_run_cases(self, first_observation="one", second_observation="two",
+                            accuracy_eligible=True):
+        duplicate = self.diagnostics / "corpus" / "run-copy.json"
+        duplicate.write_bytes(self.run_path.read_bytes())
+        return [
+            {"id": "a", "validation_class": "analyzer_execution",
+             "artifact_type": "run_artifact", "artifact": "corpus/run.json",
+             "accuracy_eligible": accuracy_eligible, "observation_id": first_observation},
+            {"id": "b", "validation_class": "analyzer_execution",
+             "artifact_type": "run_artifact", "artifact": "corpus/run-copy.json",
+             "accuracy_eligible": accuracy_eligible, "observation_id": second_observation},
+        ]
+
+    def test_distinct_accuracy_observations_cannot_share_bytes(self):
+        self.write_manifest(self.duplicate_run_cases())
+        self.assert_failure("identical analyzer artifact bytes are assigned to distinct accuracy observations")
+
+    def test_equivalent_cases_with_same_observation_id_may_share_bytes(self):
+        self.write_manifest(self.duplicate_run_cases(second_observation="one"))
+        self.assertEqual(self.command("--refresh").returncode, 0)
+        self.assertEqual(self.command().returncode, 0)
+
+    def test_non_accuracy_cases_may_share_bytes(self):
+        self.write_manifest(self.duplicate_run_cases(accuracy_eligible=False))
+        self.assertEqual(self.command("--refresh").returncode, 0)
+        self.assertEqual(self.command().returncode, 0)
+
+    def test_accuracy_case_requires_observation_id(self):
+        cases = self.cases()
+        cases[0].pop("observation_id")
+        self.write_manifest(cases)
+        self.assert_failure("non-empty observation_id required for accuracy-eligible analyzer run")
+
+    def test_duplicate_diagnostic_is_deterministic(self):
+        cases = self.duplicate_run_cases()
+        cases.reverse()
+        self.write_manifest(cases)
+        result = self.command()
+        digest = hashlib.sha256(self.run_path.read_bytes()).hexdigest()
+        expected = ("identical analyzer artifact bytes are assigned to distinct accuracy "
+                    f"observations: {digest}: a/one, b/two")
+        self.assertIn(expected, result.stderr.splitlines())
 
     def test_report_contract_is_excluded(self):
         self.assertEqual({entry["case_id"] for entry in self.lock()["fixtures"]}, {"run", "trace"})

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -4,7 +4,7 @@ This directory defines the deterministic diagnostic-validation corpus used by `s
 
 Demos teach; validation measures.
 
-The analyzer artifacts are manually authored and committed. `analyzer-fixtures.lock.json` records their manifest-owned inventory, exact bytes, text formatting, and compact structural shape. It is an integrity lock, not a fixture generator. Normal CI checks it before running the deterministic corpus benchmark against `validation/diagnostics/manifest.json`; durable/versioned scorecards remain manual/tag snapshot artifacts from `.github/workflows/validation-snapshot.yml`.
+The analyzer artifacts are manually authored and committed. `analyzer-fixtures.lock.json` uses the self-identifying `tailtriage.analyzer-fixture-lock.v1` format to record their manifest-owned inventory, exact bytes, text formatting, and compact structural shape. It is an integrity lock, not a fixture generator. The checker also rejects byte-identical analyzer inputs assigned to distinct accuracy observations; multiple encodings for the same observation may share bytes. Normal CI checks the lock before running the deterministic corpus benchmark against `validation/diagnostics/manifest.json`; durable/versioned scorecards remain manual/tag snapshot artifacts from `.github/workflows/validation-snapshot.yml`.
 
 ## Validation classes and schema
 

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -4,7 +4,7 @@ This directory defines the deterministic diagnostic-validation corpus used by `s
 
 Demos teach; validation measures.
 
-Normal CI runs the deterministic corpus benchmark against `validation/diagnostics/manifest.json` as a required gate for schema/corpus drift. Durable/versioned scorecards remain manual/tag snapshot artifacts from `.github/workflows/validation-snapshot.yml`.
+The analyzer artifacts are manually authored and committed. `analyzer-fixtures.lock.json` records their manifest-owned inventory, exact bytes, text formatting, and compact structural shape. It is an integrity lock, not a fixture generator. Normal CI checks it before running the deterministic corpus benchmark against `validation/diagnostics/manifest.json`; durable/versioned scorecards remain manual/tag snapshot artifacts from `.github/workflows/validation-snapshot.yml`.
 
 ## Validation classes and schema
 
@@ -16,7 +16,9 @@ Pre-generated `analysis_report` and report-shaped `synthetic_analysis_report` ca
 
 Case diagnosis contracts use `expected_primary_kinds`, `required_visible_suspects` (primary or first secondary), and optional `exact_primary_kind`. Analyzer success cases may be execution-only; expected execution failures must be accuracy ineligible.
 
-Deterministic typed fixture generation is deferred to Prompt 18B. Corpus expansion and exact demo-replacement cases are deferred to Prompt 18C. No demo is removed here.
+The integrity checker deliberately stops at inventory, bytes, formatting, and compact shape. The benchmark remains the typed and semantic validation boundary: raw Run fixtures are decoded and strictly validated through the CLI, while stable tracing JSONL fixtures pass through the public tracing importer before analysis. Matching lock hashes does not prove diagnosis correctness, and fixture labels remain controlled intent rather than production truth.
+
+Run `python3 scripts/check_diagnostic_fixture_integrity.py` to check the committed lock. For an intentional analyzer-fixture change, run `python3 scripts/check_diagnostic_fixture_integrity.py --refresh`, review the byte and shape changes, and commit the updated lock with the manually edited fixture. Refresh modifies only the lock.
 
 ## Running the benchmark
 

--- a/validation/diagnostics/analyzer-fixtures.lock.json
+++ b/validation/diagnostics/analyzer-fixtures.lock.json
@@ -1,6 +1,5 @@
 {
-  "schema_version": 1,
-  "manifest_schema_version": 2,
+  "format": "tailtriage.analyzer-fixture-lock.v1",
   "fixtures": [
     {
       "case_id": "cancelled-request-with-partial-child",
@@ -217,11 +216,11 @@
       "case_id": "raw_no_runtime_snapshots",
       "artifact_type": "run_artifact",
       "artifact": "corpus/run-artifacts/no-runtime-snapshots.json",
-      "sha256": "d1894fdb62cb21ff835404c30b631de6b9bd2ac17a20ea6c918d562da5e11581",
-      "byte_length": 2126,
+      "sha256": "2b45c75b3639f7fb6b1e93faadf7d692676372e5d88e3cfaf3d6ee406d25b87a",
+      "byte_length": 2868,
       "shape": {
         "request_count": 3,
-        "stage_count": 0,
+        "stage_count": 3,
         "queue_count": 3,
         "inflight_snapshot_count": 3,
         "runtime_snapshot_count": 0,
@@ -231,7 +230,7 @@
           "ok": 3
         },
         "requests_with_run_interval": 3,
-        "stages_with_run_interval": 0,
+        "stages_with_run_interval": 3,
         "queues_with_run_interval": 3,
         "first_request_id": "r1",
         "last_request_id": "r3",

--- a/validation/diagnostics/analyzer-fixtures.lock.json
+++ b/validation/diagnostics/analyzer-fixtures.lock.json
@@ -1,0 +1,315 @@
+{
+  "schema_version": 1,
+  "manifest_schema_version": 2,
+  "fixtures": [
+    {
+      "case_id": "cancelled-request-with-partial-child",
+      "artifact_type": "run_artifact",
+      "artifact": "corpus/cancelled-request-with-partial-child.json",
+      "sha256": "f5015440a70fcbc974c228ef0d80f2deeb4627f0bd6521ced35a2116e78a595f",
+      "byte_length": 8459,
+      "shape": {
+        "request_count": 20,
+        "stage_count": 20,
+        "queue_count": 0,
+        "inflight_snapshot_count": 0,
+        "runtime_snapshot_count": 0,
+        "partial_stage_count": 20,
+        "partial_queue_count": 0,
+        "outcomes": {
+          "cancelled": 1,
+          "ok": 19
+        },
+        "requests_with_run_interval": 20,
+        "stages_with_run_interval": 20,
+        "queues_with_run_interval": 0,
+        "first_request_id": "r0",
+        "last_request_id": "r19",
+        "truncation": {
+          "limits_hit": false,
+          "dropped_requests": 0,
+          "dropped_stages": 0,
+          "dropped_queues": 0,
+          "dropped_inflight_snapshots": 0,
+          "dropped_runtime_snapshots": 0
+        }
+      }
+    },
+    {
+      "case_id": "partial-evidence-completed-only",
+      "artifact_type": "run_artifact",
+      "artifact": "corpus/partial-evidence-completed-only.json",
+      "sha256": "c07f0c6c0c5b155807239c6ff5e7172d1ecec1a154836827f924f036af87af81",
+      "byte_length": 11702,
+      "shape": {
+        "request_count": 20,
+        "stage_count": 20,
+        "queue_count": 20,
+        "inflight_snapshot_count": 0,
+        "runtime_snapshot_count": 0,
+        "partial_stage_count": 0,
+        "partial_queue_count": 0,
+        "outcomes": {
+          "ok": 20
+        },
+        "requests_with_run_interval": 20,
+        "stages_with_run_interval": 20,
+        "queues_with_run_interval": 20,
+        "first_request_id": "r0",
+        "last_request_id": "r19",
+        "truncation": {
+          "limits_hit": false,
+          "dropped_requests": 0,
+          "dropped_stages": 0,
+          "dropped_queues": 0,
+          "dropped_inflight_snapshots": 0,
+          "dropped_runtime_snapshots": 0
+        }
+      }
+    },
+    {
+      "case_id": "partial-evidence-mixed",
+      "artifact_type": "run_artifact",
+      "artifact": "corpus/partial-evidence-mixed.json",
+      "sha256": "b5b80b8dac3a7a8c217a5e31abd26f8b88126a4d29c55ba1f86d014c54558312",
+      "byte_length": 12137,
+      "shape": {
+        "request_count": 20,
+        "stage_count": 20,
+        "queue_count": 20,
+        "inflight_snapshot_count": 0,
+        "runtime_snapshot_count": 0,
+        "partial_stage_count": 12,
+        "partial_queue_count": 12,
+        "outcomes": {
+          "ok": 20
+        },
+        "requests_with_run_interval": 20,
+        "stages_with_run_interval": 20,
+        "queues_with_run_interval": 20,
+        "first_request_id": "r0",
+        "last_request_id": "r19",
+        "truncation": {
+          "limits_hit": false,
+          "dropped_requests": 0,
+          "dropped_stages": 0,
+          "dropped_queues": 0,
+          "dropped_inflight_snapshots": 0,
+          "dropped_runtime_snapshots": 0
+        }
+      }
+    },
+    {
+      "case_id": "partial-evidence-queue-only",
+      "artifact_type": "run_artifact",
+      "artifact": "corpus/partial-evidence-queue-only.json",
+      "sha256": "a8cb48254ac33b86e664198630044e732b89fcdc6ce8441f204d534f8fd7ff66",
+      "byte_length": 8623,
+      "shape": {
+        "request_count": 20,
+        "stage_count": 0,
+        "queue_count": 20,
+        "inflight_snapshot_count": 0,
+        "runtime_snapshot_count": 0,
+        "partial_stage_count": 0,
+        "partial_queue_count": 20,
+        "outcomes": {
+          "ok": 20
+        },
+        "requests_with_run_interval": 20,
+        "stages_with_run_interval": 0,
+        "queues_with_run_interval": 20,
+        "first_request_id": "r0",
+        "last_request_id": "r19",
+        "truncation": {
+          "limits_hit": false,
+          "dropped_requests": 0,
+          "dropped_stages": 0,
+          "dropped_queues": 0,
+          "dropped_inflight_snapshots": 0,
+          "dropped_runtime_snapshots": 0
+        }
+      }
+    },
+    {
+      "case_id": "partial-evidence-stage-only",
+      "artifact_type": "run_artifact",
+      "artifact": "corpus/partial-evidence-stage-only.json",
+      "sha256": "945c8a3df30a598175980debdb8d2777017b4d3e2b54ecda555f7e5acbe88722",
+      "byte_length": 8443,
+      "shape": {
+        "request_count": 20,
+        "stage_count": 20,
+        "queue_count": 0,
+        "inflight_snapshot_count": 0,
+        "runtime_snapshot_count": 0,
+        "partial_stage_count": 20,
+        "partial_queue_count": 0,
+        "outcomes": {
+          "ok": 20
+        },
+        "requests_with_run_interval": 20,
+        "stages_with_run_interval": 20,
+        "queues_with_run_interval": 0,
+        "first_request_id": "r0",
+        "last_request_id": "r19",
+        "truncation": {
+          "limits_hit": false,
+          "dropped_requests": 0,
+          "dropped_stages": 0,
+          "dropped_queues": 0,
+          "dropped_inflight_snapshots": 0,
+          "dropped_runtime_snapshots": 0
+        }
+      }
+    },
+    {
+      "case_id": "raw_low_request_insufficient",
+      "artifact_type": "run_artifact",
+      "artifact": "corpus/run-artifacts/low-request-insufficient.json",
+      "sha256": "40ddae72148812d0f78e3b27d81084dde39af52ad40e3ba022802728da65f607",
+      "byte_length": 916,
+      "shape": {
+        "request_count": 3,
+        "stage_count": 0,
+        "queue_count": 0,
+        "inflight_snapshot_count": 0,
+        "runtime_snapshot_count": 0,
+        "partial_stage_count": 0,
+        "partial_queue_count": 0,
+        "outcomes": {
+          "ok": 3
+        },
+        "requests_with_run_interval": 0,
+        "stages_with_run_interval": 0,
+        "queues_with_run_interval": 0,
+        "first_request_id": "r1",
+        "last_request_id": "r3",
+        "truncation": null
+      }
+    },
+    {
+      "case_id": "raw_no_queue_events",
+      "artifact_type": "run_artifact",
+      "artifact": "corpus/run-artifacts/no-queue-events.json",
+      "sha256": "0be768f6b5cf5779aea98bf51ed853bf2245924e871a75aae565fed58e7ffb87",
+      "byte_length": 2563,
+      "shape": {
+        "request_count": 3,
+        "stage_count": 6,
+        "queue_count": 0,
+        "inflight_snapshot_count": 0,
+        "runtime_snapshot_count": 0,
+        "partial_stage_count": 0,
+        "partial_queue_count": 0,
+        "outcomes": {
+          "ok": 3
+        },
+        "requests_with_run_interval": 3,
+        "stages_with_run_interval": 6,
+        "queues_with_run_interval": 0,
+        "first_request_id": "r1",
+        "last_request_id": "r3",
+        "truncation": null
+      }
+    },
+    {
+      "case_id": "raw_no_runtime_snapshots",
+      "artifact_type": "run_artifact",
+      "artifact": "corpus/run-artifacts/no-runtime-snapshots.json",
+      "sha256": "d1894fdb62cb21ff835404c30b631de6b9bd2ac17a20ea6c918d562da5e11581",
+      "byte_length": 2126,
+      "shape": {
+        "request_count": 3,
+        "stage_count": 0,
+        "queue_count": 3,
+        "inflight_snapshot_count": 3,
+        "runtime_snapshot_count": 0,
+        "partial_stage_count": 0,
+        "partial_queue_count": 0,
+        "outcomes": {
+          "ok": 3
+        },
+        "requests_with_run_interval": 3,
+        "stages_with_run_interval": 0,
+        "queues_with_run_interval": 3,
+        "first_request_id": "r1",
+        "last_request_id": "r3",
+        "truncation": null
+      }
+    },
+    {
+      "case_id": "raw_no_stage_events",
+      "artifact_type": "run_artifact",
+      "artifact": "corpus/run-artifacts/no-stage-events.json",
+      "sha256": "d1894fdb62cb21ff835404c30b631de6b9bd2ac17a20ea6c918d562da5e11581",
+      "byte_length": 2126,
+      "shape": {
+        "request_count": 3,
+        "stage_count": 0,
+        "queue_count": 3,
+        "inflight_snapshot_count": 3,
+        "runtime_snapshot_count": 0,
+        "partial_stage_count": 0,
+        "partial_queue_count": 0,
+        "outcomes": {
+          "ok": 3
+        },
+        "requests_with_run_interval": 3,
+        "stages_with_run_interval": 0,
+        "queues_with_run_interval": 3,
+        "first_request_id": "r1",
+        "last_request_id": "r3",
+        "truncation": null
+      }
+    },
+    {
+      "case_id": "raw_truncated_partial_evidence",
+      "artifact_type": "run_artifact",
+      "artifact": "corpus/run-artifacts/truncated-queues.json",
+      "sha256": "6fa941745b311ffa2a02cc7514c6e71b9cd7d8e23628cd2d50fd8e9e1105b21d",
+      "byte_length": 2335,
+      "shape": {
+        "request_count": 3,
+        "stage_count": 0,
+        "queue_count": 3,
+        "inflight_snapshot_count": 3,
+        "runtime_snapshot_count": 0,
+        "partial_stage_count": 0,
+        "partial_queue_count": 0,
+        "outcomes": {
+          "ok": 3
+        },
+        "requests_with_run_interval": 3,
+        "stages_with_run_interval": 0,
+        "queues_with_run_interval": 3,
+        "first_request_id": "r1",
+        "last_request_id": "r3",
+        "truncation": {
+          "dropped_requests": 0,
+          "dropped_stages": 0,
+          "dropped_queues": 2,
+          "dropped_inflight_snapshots": 0,
+          "dropped_runtime_snapshots": 0,
+          "limits_hit": true
+        }
+      }
+    },
+    {
+      "case_id": "tracing_queue_dominant",
+      "artifact_type": "tracing_span_jsonl",
+      "artifact": "corpus/tracing-queue-dominant.jsonl",
+      "sha256": "fb02eef1cd8fe3735a87d3925dd8343e143445ee655939fbc5ee64cdde718136",
+      "byte_length": 23267,
+      "shape": {
+        "line_count": 72,
+        "request_span_count": 24,
+        "stage_span_count": 24,
+        "queue_span_count": 24,
+        "other_span_count": 0,
+        "first_request_id": "trace-req-00",
+        "last_request_id": "trace-req-23"
+      }
+    }
+  ]
+}

--- a/validation/diagnostics/corpus/run-artifacts/no-runtime-snapshots.json
+++ b/validation/diagnostics/corpus/run-artifacts/no-runtime-snapshots.json
@@ -45,7 +45,38 @@
       "finished_at_run_us": 2000150
     }
   ],
-  "stages": [],
+  "stages": [
+    {
+      "request_id": "r1",
+      "stage": "downstream",
+      "started_at_unix_ms": 1,
+      "finished_at_unix_ms": 2,
+      "latency_us": 40,
+      "success": true,
+      "started_at_run_us": 50,
+      "finished_at_run_us": 90
+    },
+    {
+      "request_id": "r2",
+      "stage": "downstream",
+      "started_at_unix_ms": 1,
+      "finished_at_unix_ms": 2,
+      "latency_us": 35,
+      "success": true,
+      "started_at_run_us": 1000075,
+      "finished_at_run_us": 1000110
+    },
+    {
+      "request_id": "r3",
+      "stage": "downstream",
+      "started_at_unix_ms": 1,
+      "finished_at_unix_ms": 2,
+      "latency_us": 40,
+      "success": true,
+      "started_at_run_us": 2000100,
+      "finished_at_run_us": 2000140
+    }
+  ],
   "queues": [
     {
       "request_id": "r1",


### PR DESCRIPTION
### Motivation

The analyzer-executed diagnostic fixtures are manually authored and committed. They need a lightweight way to make inventory, byte, formatting, and structural changes explicit without adding a fixture generator or duplicating the production Run schema outside Rust.

The existing benchmark remains the typed and semantic validation boundary:

* raw Run artifacts are decoded and strictly validated through the CLI;
* stable tracing JSONL is imported through the public tracing importer;
* analyzer expectations and accuracy accounting remain owned by the diagnostic manifest.

### Changes

* Add `validation/diagnostics/analyzer-fixtures.lock.json` using the self-identifying format:

  ```text
  tailtriage.analyzer-fixture-lock.v1
  ```

  The lock contains the exact analyzer-execution inventory—10 Run artifacts and one stable tracing JSONL artifact—with:

  * case ID;
  * artifact type and path;
  * SHA-256;
  * byte length;
  * compact structural shape.

* Add `scripts/check_diagnostic_fixture_integrity.py`, a standard-library Python checker with:

  * read-only check mode;
  * deterministic `--refresh` mode;
  * manifest and lock inventory agreement;
  * UTF-8, LF-only, and final-newline checks;
  * absolute-path, parent-escape, symlink-escape, and invalid-path protection;
  * Run and tracing envelope shape summaries;
  * stable, aggregated diagnostics for malformed input and drift;
  * rejection of byte-identical analyzer inputs assigned to distinct accuracy observations.

* Keep shared bytes permitted when multiple cases represent the same logical observation, and exclude accuracy-ineligible cases from that rule.

* Correct `no-runtime-snapshots.json` so it contains completed stage evidence while retaining queue and in-flight evidence and an empty runtime-snapshot list. This makes it distinct from the separate `no-stage-events.json` observation.

* Add unit coverage for:

  * lock format and inventory;
  * deterministic refresh and read-only checking;
  * byte and structural drift;
  * malformed manifest, lock, Run, and tracing values;
  * path traversal and path-resolution failures;
  * duplicate accuracy-input handling;
  * controlled failures without Python tracebacks.

* Run the integrity unit tests and committed lock check before the diagnostic benchmark in normal CI.

* Check fixture integrity before scorecard generation in the validation-snapshot workflow.

* Update the diagnostic-validation documentation and changelog.

### Scope

This change does not add:

* a Rust crate or workspace member;
* a fixture generator;
* a dependency;
* generated fixture copies;
* production Rust changes;
* analyzer, CLI, import, schema, benchmark, or scorecard behavior changes;
* demo changes.

The fixtures remain manually authored and committed.

### Validation

The following validation passes on the PR branch:

```bash
python3 -m unittest scripts.tests.test_check_diagnostic_fixture_integrity
python3 scripts/check_diagnostic_fixture_integrity.py
python3 -m unittest scripts.tests.test_diagnostic_benchmark
python3 -m unittest scripts.tests.test_generate_diagnostic_scorecard
python3 scripts/validate_docs_contracts.py
python3 -m unittest scripts.tests.test_validate_docs_contracts
cargo test -p tailtriage-tracing --test equivalence_contract --all-features --locked
```

The committed diagnostic benchmark preserves:

```text
manifest cases: 49
analyzer-execution cases: 11
run artifacts: 10
tracing JSONL artifacts: 1
accuracy observations: 11
accuracy encodings: 11
top-1 accuracy: 10 / 11
top-2 recall: 1.0
high-confidence wrong: 0
report-contract cases: 38
```

Normal CI also validates the repository-wide Rust workspace and runs the new integrity check before the committed diagnostic benchmark.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69c333c59c8330ba0bf8a5156fd01a)