### PR TITLE
Add bounded blocking and executor analyzer observations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- The analyzer-executed diagnostic corpus now includes bounded committed blocking-pool and executor-pressure Runs derived from controlled baseline demos.
+
 - Committed analyzer fixtures now have a deterministic inventory, byte, formatting, and structural integrity lock checked before diagnostic execution.
 
 - Diagnostic validation now separates analyzer-executed accuracy observations from pre-generated Report-contract checks.

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -4,7 +4,7 @@
 
 The schema-version-2 deterministic corpus separates analyzer-executed cases, unique accuracy-eligible observations, and report-contract cases. Raw Runs are analyzed at benchmark execution; stable tracing JSONL is imported and then analyzed. Analyzer cases have typed success/failure contracts and may be execution-only. Multiple artifact encodings of one logical workload execute independently but count once for accuracy and must agree on ordered diagnosis visibility and confidence bucket.
 
-Pre-generated and synthetic Reports validate Report fields, warnings, evidence, next checks, confidence, routes, and temporal output without executing the analyzer. They never contribute to analyzer accuracy. Fixture ground truth is controlled fixture intent, not production truth or root-cause proof. Typed fixture generation is deferred to Prompt 18B; corpus expansion and exact demo replacements are deferred to Prompt 18C, and no demo is removed here.
+Pre-generated and synthetic Reports validate Report fields, warnings, evidence, next checks, confidence, routes, and temporal output without executing the analyzer. They never contribute to analyzer accuracy. Fixture ground truth is controlled fixture intent, not production truth or root-cause proof. Committed analyzer fixtures are integrity locked. Bounded demo-derived Runs provide deterministic analyzer coverage for blocking-pool and executor pressure, while complete and repeated demo execution remains a separate machine-scoped validation track. These bounded fixtures are controlled validation evidence, not universal production truth.
 
 ## Summary
 `tailtriage` is a triage tool, not root-cause proof. It produces evidence-ranked suspects and next checks, where suspects are leads and not causal certainty.

--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -10,8 +10,16 @@ Top-1 means the observation primary equals ground truth. Top-2 means ground trut
 ## Deterministic vs repeated-run validation
 Deterministic fixture validation is mandatory in normal CI; durable scorecards remain manual/tag snapshot outputs. Report-contract checks cover Report fields, warnings, evidence, next checks, confidence, routes, and temporal output but are not analyzer accuracy. Repeated-run validation is a separate manual/local, machine/workload-scoped track.
 
-## Deferred corpus work
-Deterministic typed fixture generation is deferred to Prompt 18B. An expanded analyzer-executed corpus and exact demo replacements are deferred to Prompt 18C; no demo is removed here.
+## Analyzer-executed ground-truth coverage
+Analyzer-executed ground-truth coverage includes:
+
+- `application_queue_saturation`
+- `downstream_stage_dominates`
+- `blocking_pool_pressure`
+- `executor_pressure_suspected`
+- `insufficient_evidence`
+
+The blocking-pool and executor-pressure Runs are bounded, demo-derived deterministic corpus snapshots. They preserve controlled evidence for stable analyzer checks; they do not claim that every complete demo execution is byte-identical or that the fixture labels are universal production truth.
 
 ## Confidence calibration
 The scorecard includes confidence-bucket accuracy summaries (low/medium/high buckets) as calibration hints, not probability guarantees.

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -20,6 +20,16 @@ The integrity checker deliberately stops at inventory, bytes, formatting, and co
 
 Run `python3 scripts/check_diagnostic_fixture_integrity.py` to check the committed lock. For an intentional analyzer-fixture change, run `python3 scripts/check_diagnostic_fixture_integrity.py --refresh`, review the byte and shape changes, and commit the updated lock with the manually edited fixture. Refresh modifies only the lock.
 
+For a bounded demo-derived Run fixture, maintainers:
+
+1. capture the relevant controlled Run under `target/`;
+2. derive a bounded representative fixture;
+3. validate the existing diagnosis contract;
+4. copy only the bounded fixture into the corpus;
+5. refresh and review the integrity lock.
+
+Nothing under `target/` is committed.
+
 ## Running the benchmark
 
 ```bash

--- a/validation/diagnostics/analyzer-fixtures.lock.json
+++ b/validation/diagnostics/analyzer-fixtures.lock.json
@@ -2,6 +2,38 @@
   "format": "tailtriage.analyzer-fixture-lock.v1",
   "fixtures": [
     {
+      "case_id": "blocking_sample",
+      "artifact_type": "run_artifact",
+      "artifact": "corpus/demo-runs/blocking-sample.json",
+      "sha256": "4a14f6b8898c98387e59b1d0309f5a2502379c8e66ca278053bd31caeea6161b",
+      "byte_length": 72598,
+      "shape": {
+        "request_count": 64,
+        "stage_count": 64,
+        "queue_count": 64,
+        "inflight_snapshot_count": 33,
+        "runtime_snapshot_count": 41,
+        "partial_stage_count": 0,
+        "partial_queue_count": 0,
+        "outcomes": {
+          "ok": 64
+        },
+        "requests_with_run_interval": 64,
+        "stages_with_run_interval": 64,
+        "queues_with_run_interval": 64,
+        "first_request_id": "request-0",
+        "last_request_id": "request-249",
+        "truncation": {
+          "limits_hit": false,
+          "dropped_requests": 0,
+          "dropped_stages": 0,
+          "dropped_queues": 0,
+          "dropped_inflight_snapshots": 0,
+          "dropped_runtime_snapshots": 0
+        }
+      }
+    },
+    {
       "case_id": "cancelled-request-with-partial-child",
       "artifact_type": "run_artifact",
       "artifact": "corpus/cancelled-request-with-partial-child.json",
@@ -24,6 +56,38 @@
         "queues_with_run_interval": 0,
         "first_request_id": "r0",
         "last_request_id": "r19",
+        "truncation": {
+          "limits_hit": false,
+          "dropped_requests": 0,
+          "dropped_stages": 0,
+          "dropped_queues": 0,
+          "dropped_inflight_snapshots": 0,
+          "dropped_runtime_snapshots": 0
+        }
+      }
+    },
+    {
+      "case_id": "executor_sample",
+      "artifact_type": "run_artifact",
+      "artifact": "corpus/demo-runs/executor-sample.json",
+      "sha256": "1320d1533c0c6800440ca7defc2a9d2eb5e094d00fb0008631d950763ed33085",
+      "byte_length": 35922,
+      "shape": {
+        "request_count": 64,
+        "stage_count": 0,
+        "queue_count": 0,
+        "inflight_snapshot_count": 33,
+        "runtime_snapshot_count": 42,
+        "partial_stage_count": 0,
+        "partial_queue_count": 0,
+        "outcomes": {
+          "ok": 64
+        },
+        "requests_with_run_interval": 64,
+        "stages_with_run_interval": 0,
+        "queues_with_run_interval": 0,
+        "first_request_id": "request-132",
+        "last_request_id": "request-97",
         "truncation": {
           "limits_hit": false,
           "dropped_requests": 0,

--- a/validation/diagnostics/corpus/demo-runs/blocking-sample.json
+++ b/validation/diagnostics/corpus/demo-runs/blocking-sample.json
@@ -1,0 +1,2600 @@
+{
+  "schema_version": 2,
+  "metadata": {
+    "run_id": "run-46f4ff5b-e379-4975-8db7-5a16863b7444",
+    "service_name": "blocking_service_demo",
+    "service_version": null,
+    "started_at_unix_ms": 1785328554068,
+    "finalized_at_unix_ms": 1785328557843,
+    "mode": "light",
+    "effective_core_config": {
+      "mode": "light",
+      "capture_limits": {
+        "max_requests": 100000,
+        "max_stages": 200000,
+        "max_queues": 200000,
+        "max_inflight_snapshots": 200000,
+        "max_runtime_snapshots": 100000
+      },
+      "strict_lifecycle": false
+    },
+    "effective_tokio_sampler_config": null,
+    "host": null,
+    "pid": null,
+    "lifecycle_warnings": [],
+    "unfinished_requests": {
+      "count": 0,
+      "sample": []
+    },
+    "run_end_reason": null
+  },
+  "requests": [
+    {
+      "request_id": "request-0",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554069,
+      "started_at_run_us": 442,
+      "finished_at_unix_ms": 1785328554100,
+      "finished_at_run_us": 32289,
+      "latency_us": 31846,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-7",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554071,
+      "started_at_run_us": 2941,
+      "finished_at_unix_ms": 1785328554161,
+      "finished_at_run_us": 92484,
+      "latency_us": 89543,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-8",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554071,
+      "started_at_run_us": 2948,
+      "finished_at_unix_ms": 1785328554221,
+      "finished_at_run_us": 152926,
+      "latency_us": 149977,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-12",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554073,
+      "started_at_run_us": 4410,
+      "finished_at_unix_ms": 1785328554281,
+      "finished_at_run_us": 213091,
+      "latency_us": 208680,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-11",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554073,
+      "started_at_run_us": 4403,
+      "finished_at_unix_ms": 1785328554341,
+      "finished_at_run_us": 273382,
+      "latency_us": 268979,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-20",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554075,
+      "started_at_run_us": 6870,
+      "finished_at_unix_ms": 1785328554402,
+      "finished_at_run_us": 333572,
+      "latency_us": 326701,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-19",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554075,
+      "started_at_run_us": 6855,
+      "finished_at_unix_ms": 1785328554462,
+      "finished_at_run_us": 393778,
+      "latency_us": 386922,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-32",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554076,
+      "started_at_run_us": 8235,
+      "finished_at_unix_ms": 1785328554522,
+      "finished_at_run_us": 454026,
+      "latency_us": 445791,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-31",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554076,
+      "started_at_run_us": 8168,
+      "finished_at_unix_ms": 1785328554582,
+      "finished_at_run_us": 514277,
+      "latency_us": 506108,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-35",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554079,
+      "started_at_run_us": 10640,
+      "finished_at_unix_ms": 1785328554643,
+      "finished_at_run_us": 574436,
+      "latency_us": 563796,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-37",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554079,
+      "started_at_run_us": 10660,
+      "finished_at_unix_ms": 1785328554703,
+      "finished_at_run_us": 634810,
+      "latency_us": 624150,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-45",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554081,
+      "started_at_run_us": 13089,
+      "finished_at_unix_ms": 1785328554735,
+      "finished_at_run_us": 666524,
+      "latency_us": 653435,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-44",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554081,
+      "started_at_run_us": 13081,
+      "finished_at_unix_ms": 1785328554795,
+      "finished_at_run_us": 726800,
+      "latency_us": 713718,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-53",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554084,
+      "started_at_run_us": 15464,
+      "finished_at_unix_ms": 1785328554855,
+      "finished_at_run_us": 787097,
+      "latency_us": 771633,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-52",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554084,
+      "started_at_run_us": 15455,
+      "finished_at_unix_ms": 1785328554916,
+      "finished_at_run_us": 847422,
+      "latency_us": 831967,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-58",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554086,
+      "started_at_run_us": 18005,
+      "finished_at_unix_ms": 1785328554976,
+      "finished_at_run_us": 907691,
+      "latency_us": 889686,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-60",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554086,
+      "started_at_run_us": 18014,
+      "finished_at_unix_ms": 1785328555036,
+      "finished_at_run_us": 967901,
+      "latency_us": 949886,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-66",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554089,
+      "started_at_run_us": 20413,
+      "finished_at_unix_ms": 1785328555097,
+      "finished_at_run_us": 1028401,
+      "latency_us": 1007987,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-72",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554089,
+      "started_at_run_us": 20437,
+      "finished_at_unix_ms": 1785328555157,
+      "finished_at_run_us": 1088442,
+      "latency_us": 1068005,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-75",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554091,
+      "started_at_run_us": 22871,
+      "finished_at_unix_ms": 1785328555217,
+      "finished_at_run_us": 1148676,
+      "latency_us": 1125805,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-77",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554091,
+      "started_at_run_us": 22902,
+      "finished_at_unix_ms": 1785328555277,
+      "finished_at_run_us": 1209100,
+      "latency_us": 1186197,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-81",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554092,
+      "started_at_run_us": 24092,
+      "finished_at_unix_ms": 1785328555338,
+      "finished_at_run_us": 1269404,
+      "latency_us": 1245312,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-86",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554092,
+      "started_at_run_us": 24153,
+      "finished_at_unix_ms": 1785328555398,
+      "finished_at_run_us": 1329847,
+      "latency_us": 1305694,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-90",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554098,
+      "started_at_run_us": 29475,
+      "finished_at_unix_ms": 1785328555458,
+      "finished_at_run_us": 1390087,
+      "latency_us": 1360611,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-92",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554098,
+      "started_at_run_us": 29501,
+      "finished_at_unix_ms": 1785328555518,
+      "finished_at_run_us": 1450361,
+      "latency_us": 1420860,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-100",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554100,
+      "started_at_run_us": 31925,
+      "finished_at_unix_ms": 1785328555579,
+      "finished_at_run_us": 1510664,
+      "latency_us": 1478738,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-98",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554100,
+      "started_at_run_us": 31904,
+      "finished_at_unix_ms": 1785328555639,
+      "finished_at_run_us": 1570932,
+      "latency_us": 1539028,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-105",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554102,
+      "started_at_run_us": 33567,
+      "finished_at_unix_ms": 1785328555699,
+      "finished_at_run_us": 1631200,
+      "latency_us": 1597632,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-108",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554102,
+      "started_at_run_us": 33594,
+      "finished_at_unix_ms": 1785328555760,
+      "finished_at_run_us": 1691555,
+      "latency_us": 1657960,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-115",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554104,
+      "started_at_run_us": 36024,
+      "finished_at_unix_ms": 1785328555820,
+      "finished_at_run_us": 1751926,
+      "latency_us": 1715901,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-114",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554104,
+      "started_at_run_us": 36179,
+      "finished_at_unix_ms": 1785328555880,
+      "finished_at_run_us": 1812181,
+      "latency_us": 1776001,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-122",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554107,
+      "started_at_run_us": 38611,
+      "finished_at_unix_ms": 1785328555941,
+      "finished_at_run_us": 1872431,
+      "latency_us": 1833819,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-127",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554107,
+      "started_at_run_us": 38627,
+      "finished_at_unix_ms": 1785328556000,
+      "finished_at_run_us": 1932245,
+      "latency_us": 1893618,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-129",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554109,
+      "started_at_run_us": 41076,
+      "finished_at_unix_ms": 1785328556061,
+      "finished_at_run_us": 1992489,
+      "latency_us": 1951413,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-134",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554109,
+      "started_at_run_us": 41116,
+      "finished_at_unix_ms": 1785328556121,
+      "finished_at_run_us": 2052876,
+      "latency_us": 2011759,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-137",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554112,
+      "started_at_run_us": 43518,
+      "finished_at_unix_ms": 1785328556181,
+      "finished_at_run_us": 2113313,
+      "latency_us": 2069794,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-139",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554112,
+      "started_at_run_us": 43549,
+      "finished_at_unix_ms": 1785328556242,
+      "finished_at_run_us": 2173554,
+      "latency_us": 2130005,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-145",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554114,
+      "started_at_run_us": 46016,
+      "finished_at_unix_ms": 1785328556302,
+      "finished_at_run_us": 2234084,
+      "latency_us": 2188067,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-152",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554114,
+      "started_at_run_us": 46067,
+      "finished_at_unix_ms": 1785328556363,
+      "finished_at_run_us": 2294407,
+      "latency_us": 2248339,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-153",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554117,
+      "started_at_run_us": 48437,
+      "finished_at_unix_ms": 1785328556423,
+      "finished_at_run_us": 2354595,
+      "latency_us": 2306157,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-158",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554117,
+      "started_at_run_us": 48501,
+      "finished_at_unix_ms": 1785328556483,
+      "finished_at_run_us": 2414919,
+      "latency_us": 2366417,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-162",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554119,
+      "started_at_run_us": 50894,
+      "finished_at_unix_ms": 1785328556544,
+      "finished_at_run_us": 2476223,
+      "latency_us": 2425328,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-167",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554119,
+      "started_at_run_us": 50909,
+      "finished_at_unix_ms": 1785328556604,
+      "finished_at_run_us": 2536225,
+      "latency_us": 2485316,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-169",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554120,
+      "started_at_run_us": 52087,
+      "finished_at_unix_ms": 1785328556665,
+      "finished_at_run_us": 2596612,
+      "latency_us": 2544525,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-173",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554120,
+      "started_at_run_us": 52178,
+      "finished_at_unix_ms": 1785328556725,
+      "finished_at_run_us": 2656889,
+      "latency_us": 2604711,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-177",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554123,
+      "started_at_run_us": 54598,
+      "finished_at_unix_ms": 1785328556786,
+      "finished_at_run_us": 2717616,
+      "latency_us": 2663017,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-180",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554123,
+      "started_at_run_us": 54627,
+      "finished_at_unix_ms": 1785328556846,
+      "finished_at_run_us": 2778012,
+      "latency_us": 2723384,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-185",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554125,
+      "started_at_run_us": 57032,
+      "finished_at_unix_ms": 1785328556907,
+      "finished_at_run_us": 2838616,
+      "latency_us": 2781583,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-189",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554125,
+      "started_at_run_us": 57068,
+      "finished_at_unix_ms": 1785328556967,
+      "finished_at_run_us": 2899216,
+      "latency_us": 2842147,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-198",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554128,
+      "started_at_run_us": 59481,
+      "finished_at_unix_ms": 1785328557027,
+      "finished_at_run_us": 2959292,
+      "latency_us": 2899811,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-194",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554128,
+      "started_at_run_us": 59458,
+      "finished_at_unix_ms": 1785328557088,
+      "finished_at_run_us": 3019635,
+      "latency_us": 2960177,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-201",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554130,
+      "started_at_run_us": 61889,
+      "finished_at_unix_ms": 1785328557148,
+      "finished_at_run_us": 3080021,
+      "latency_us": 3018131,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-204",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554130,
+      "started_at_run_us": 61929,
+      "finished_at_unix_ms": 1785328557208,
+      "finished_at_run_us": 3140382,
+      "latency_us": 3078452,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-214",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554132,
+      "started_at_run_us": 63746,
+      "finished_at_unix_ms": 1785328557239,
+      "finished_at_run_us": 3170669,
+      "latency_us": 3106922,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-216",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554132,
+      "started_at_run_us": 63742,
+      "finished_at_unix_ms": 1785328557299,
+      "finished_at_run_us": 3230975,
+      "latency_us": 3167232,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-212",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554132,
+      "started_at_run_us": 63733,
+      "finished_at_unix_ms": 1785328557359,
+      "finished_at_run_us": 3291338,
+      "latency_us": 3227605,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-223",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554134,
+      "started_at_run_us": 66153,
+      "finished_at_unix_ms": 1785328557420,
+      "finished_at_run_us": 3351735,
+      "latency_us": 3285581,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-229",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554137,
+      "started_at_run_us": 68578,
+      "finished_at_unix_ms": 1785328557480,
+      "finished_at_run_us": 3412113,
+      "latency_us": 3343534,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-232",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554137,
+      "started_at_run_us": 68967,
+      "finished_at_unix_ms": 1785328557541,
+      "finished_at_run_us": 3472575,
+      "latency_us": 3403607,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-239",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554138,
+      "started_at_run_us": 70323,
+      "finished_at_unix_ms": 1785328557601,
+      "finished_at_run_us": 3533228,
+      "latency_us": 3462905,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-237",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554138,
+      "started_at_run_us": 70298,
+      "finished_at_unix_ms": 1785328557662,
+      "finished_at_run_us": 3594164,
+      "latency_us": 3523866,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-246",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554141,
+      "started_at_run_us": 72743,
+      "finished_at_unix_ms": 1785328557723,
+      "finished_at_run_us": 3654575,
+      "latency_us": 3581831,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-245",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554141,
+      "started_at_run_us": 72737,
+      "finished_at_unix_ms": 1785328557783,
+      "finished_at_run_us": 3714877,
+      "latency_us": 3642140,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-249",
+      "route": "/blocking-demo",
+      "kind": null,
+      "started_at_unix_ms": 1785328554143,
+      "started_at_run_us": 75122,
+      "finished_at_unix_ms": 1785328557843,
+      "finished_at_run_us": 3775242,
+      "latency_us": 3700120,
+      "outcome": "ok"
+    }
+  ],
+  "stages": [
+    {
+      "request_id": "request-0",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554070,
+      "started_at_run_us": 1964,
+      "finished_at_unix_ms": 1785328554100,
+      "finished_at_run_us": 32280,
+      "latency_us": 30315,
+      "success": true
+    },
+    {
+      "request_id": "request-7",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554071,
+      "started_at_run_us": 3184,
+      "finished_at_unix_ms": 1785328554161,
+      "finished_at_run_us": 92471,
+      "latency_us": 89286,
+      "success": true
+    },
+    {
+      "request_id": "request-8",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554072,
+      "started_at_run_us": 4351,
+      "finished_at_unix_ms": 1785328554221,
+      "finished_at_run_us": 152913,
+      "latency_us": 148562,
+      "success": true
+    },
+    {
+      "request_id": "request-12",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554074,
+      "started_at_run_us": 5616,
+      "finished_at_unix_ms": 1785328554281,
+      "finished_at_run_us": 213080,
+      "latency_us": 207463,
+      "success": true
+    },
+    {
+      "request_id": "request-11",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554074,
+      "started_at_run_us": 5655,
+      "finished_at_unix_ms": 1785328554341,
+      "finished_at_run_us": 273366,
+      "latency_us": 267710,
+      "success": true
+    },
+    {
+      "request_id": "request-20",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554076,
+      "started_at_run_us": 8026,
+      "finished_at_unix_ms": 1785328554402,
+      "finished_at_run_us": 333560,
+      "latency_us": 325534,
+      "success": true
+    },
+    {
+      "request_id": "request-19",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554076,
+      "started_at_run_us": 8059,
+      "finished_at_unix_ms": 1785328554462,
+      "finished_at_run_us": 393764,
+      "latency_us": 385704,
+      "success": true
+    },
+    {
+      "request_id": "request-32",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554077,
+      "started_at_run_us": 9390,
+      "finished_at_unix_ms": 1785328554522,
+      "finished_at_run_us": 454006,
+      "latency_us": 444615,
+      "success": true
+    },
+    {
+      "request_id": "request-31",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554078,
+      "started_at_run_us": 9438,
+      "finished_at_unix_ms": 1785328554582,
+      "finished_at_run_us": 514200,
+      "latency_us": 504761,
+      "success": true
+    },
+    {
+      "request_id": "request-35",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554080,
+      "started_at_run_us": 11848,
+      "finished_at_unix_ms": 1785328554643,
+      "finished_at_run_us": 574424,
+      "latency_us": 562576,
+      "success": true
+    },
+    {
+      "request_id": "request-37",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554080,
+      "started_at_run_us": 11870,
+      "finished_at_unix_ms": 1785328554703,
+      "finished_at_run_us": 634794,
+      "latency_us": 622923,
+      "success": true
+    },
+    {
+      "request_id": "request-45",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554082,
+      "started_at_run_us": 14242,
+      "finished_at_unix_ms": 1785328554735,
+      "finished_at_run_us": 666510,
+      "latency_us": 652267,
+      "success": true
+    },
+    {
+      "request_id": "request-44",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554082,
+      "started_at_run_us": 14254,
+      "finished_at_unix_ms": 1785328554795,
+      "finished_at_run_us": 726789,
+      "latency_us": 712534,
+      "success": true
+    },
+    {
+      "request_id": "request-53",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554085,
+      "started_at_run_us": 16745,
+      "finished_at_unix_ms": 1785328554855,
+      "finished_at_run_us": 787086,
+      "latency_us": 770340,
+      "success": true
+    },
+    {
+      "request_id": "request-52",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554085,
+      "started_at_run_us": 16793,
+      "finished_at_unix_ms": 1785328554916,
+      "finished_at_run_us": 847410,
+      "latency_us": 830617,
+      "success": true
+    },
+    {
+      "request_id": "request-58",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554087,
+      "started_at_run_us": 19185,
+      "finished_at_unix_ms": 1785328554976,
+      "finished_at_run_us": 907676,
+      "latency_us": 888491,
+      "success": true
+    },
+    {
+      "request_id": "request-60",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554087,
+      "started_at_run_us": 19200,
+      "finished_at_unix_ms": 1785328555036,
+      "finished_at_run_us": 967895,
+      "latency_us": 948695,
+      "success": true
+    },
+    {
+      "request_id": "request-66",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554090,
+      "started_at_run_us": 21640,
+      "finished_at_unix_ms": 1785328555096,
+      "finished_at_run_us": 1028384,
+      "latency_us": 1006744,
+      "success": true
+    },
+    {
+      "request_id": "request-72",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554090,
+      "started_at_run_us": 21661,
+      "finished_at_unix_ms": 1785328555157,
+      "finished_at_run_us": 1088437,
+      "latency_us": 1066776,
+      "success": true
+    },
+    {
+      "request_id": "request-75",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554092,
+      "started_at_run_us": 24100,
+      "finished_at_unix_ms": 1785328555217,
+      "finished_at_run_us": 1148671,
+      "latency_us": 1124570,
+      "success": true
+    },
+    {
+      "request_id": "request-77",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554092,
+      "started_at_run_us": 24151,
+      "finished_at_unix_ms": 1785328555277,
+      "finished_at_run_us": 1209085,
+      "latency_us": 1184934,
+      "success": true
+    },
+    {
+      "request_id": "request-81",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554093,
+      "started_at_run_us": 25304,
+      "finished_at_unix_ms": 1785328555337,
+      "finished_at_run_us": 1269355,
+      "latency_us": 1244050,
+      "success": true
+    },
+    {
+      "request_id": "request-86",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554093,
+      "started_at_run_us": 25338,
+      "finished_at_unix_ms": 1785328555398,
+      "finished_at_run_us": 1329832,
+      "latency_us": 1304494,
+      "success": true
+    },
+    {
+      "request_id": "request-90",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554099,
+      "started_at_run_us": 30654,
+      "finished_at_unix_ms": 1785328555458,
+      "finished_at_run_us": 1390079,
+      "latency_us": 1359424,
+      "success": true
+    },
+    {
+      "request_id": "request-92",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554099,
+      "started_at_run_us": 30682,
+      "finished_at_unix_ms": 1785328555518,
+      "finished_at_run_us": 1450346,
+      "latency_us": 1419663,
+      "success": true
+    },
+    {
+      "request_id": "request-100",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554100,
+      "started_at_run_us": 32334,
+      "finished_at_unix_ms": 1785328555579,
+      "finished_at_run_us": 1510649,
+      "latency_us": 1478314,
+      "success": true
+    },
+    {
+      "request_id": "request-98",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554100,
+      "started_at_run_us": 32346,
+      "finished_at_unix_ms": 1785328555639,
+      "finished_at_run_us": 1570917,
+      "latency_us": 1538571,
+      "success": true
+    },
+    {
+      "request_id": "request-105",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554103,
+      "started_at_run_us": 34778,
+      "finished_at_unix_ms": 1785328555699,
+      "finished_at_run_us": 1631185,
+      "latency_us": 1596407,
+      "success": true
+    },
+    {
+      "request_id": "request-108",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554103,
+      "started_at_run_us": 34790,
+      "finished_at_unix_ms": 1785328555760,
+      "finished_at_run_us": 1691550,
+      "latency_us": 1656760,
+      "success": true
+    },
+    {
+      "request_id": "request-115",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554105,
+      "started_at_run_us": 37382,
+      "finished_at_unix_ms": 1785328555820,
+      "finished_at_run_us": 1751912,
+      "latency_us": 1714529,
+      "success": true
+    },
+    {
+      "request_id": "request-114",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554105,
+      "started_at_run_us": 37394,
+      "finished_at_unix_ms": 1785328555880,
+      "finished_at_run_us": 1812176,
+      "latency_us": 1774782,
+      "success": true
+    },
+    {
+      "request_id": "request-122",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554108,
+      "started_at_run_us": 39877,
+      "finished_at_unix_ms": 1785328555941,
+      "finished_at_run_us": 1872426,
+      "latency_us": 1832548,
+      "success": true
+    },
+    {
+      "request_id": "request-127",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554108,
+      "started_at_run_us": 39890,
+      "finished_at_unix_ms": 1785328556000,
+      "finished_at_run_us": 1932224,
+      "latency_us": 1892333,
+      "success": true
+    },
+    {
+      "request_id": "request-129",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554110,
+      "started_at_run_us": 42267,
+      "finished_at_unix_ms": 1785328556061,
+      "finished_at_run_us": 1992473,
+      "latency_us": 1950206,
+      "success": true
+    },
+    {
+      "request_id": "request-134",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554110,
+      "started_at_run_us": 42311,
+      "finished_at_unix_ms": 1785328556121,
+      "finished_at_run_us": 2052856,
+      "latency_us": 2010545,
+      "success": true
+    },
+    {
+      "request_id": "request-137",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554113,
+      "started_at_run_us": 44754,
+      "finished_at_unix_ms": 1785328556181,
+      "finished_at_run_us": 2113298,
+      "latency_us": 2068544,
+      "success": true
+    },
+    {
+      "request_id": "request-139",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554113,
+      "started_at_run_us": 44795,
+      "finished_at_unix_ms": 1785328556242,
+      "finished_at_run_us": 2173535,
+      "latency_us": 2128739,
+      "success": true
+    },
+    {
+      "request_id": "request-145",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554115,
+      "started_at_run_us": 47213,
+      "finished_at_unix_ms": 1785328556302,
+      "finished_at_run_us": 2234052,
+      "latency_us": 2186838,
+      "success": true
+    },
+    {
+      "request_id": "request-152",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554115,
+      "started_at_run_us": 47229,
+      "finished_at_unix_ms": 1785328556362,
+      "finished_at_run_us": 2294374,
+      "latency_us": 2247144,
+      "success": true
+    },
+    {
+      "request_id": "request-153",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554118,
+      "started_at_run_us": 49655,
+      "finished_at_unix_ms": 1785328556423,
+      "finished_at_run_us": 2354578,
+      "latency_us": 2304923,
+      "success": true
+    },
+    {
+      "request_id": "request-158",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554118,
+      "started_at_run_us": 49673,
+      "finished_at_unix_ms": 1785328556483,
+      "finished_at_run_us": 2414900,
+      "latency_us": 2365227,
+      "success": true
+    },
+    {
+      "request_id": "request-162",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554120,
+      "started_at_run_us": 52082,
+      "finished_at_unix_ms": 1785328556544,
+      "finished_at_run_us": 2476201,
+      "latency_us": 2424119,
+      "success": true
+    },
+    {
+      "request_id": "request-167",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554120,
+      "started_at_run_us": 52165,
+      "finished_at_unix_ms": 1785328556604,
+      "finished_at_run_us": 2536208,
+      "latency_us": 2484043,
+      "success": true
+    },
+    {
+      "request_id": "request-169",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554121,
+      "started_at_run_us": 53342,
+      "finished_at_unix_ms": 1785328556665,
+      "finished_at_run_us": 2596591,
+      "latency_us": 2543249,
+      "success": true
+    },
+    {
+      "request_id": "request-173",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554121,
+      "started_at_run_us": 53375,
+      "finished_at_unix_ms": 1785328556725,
+      "finished_at_run_us": 2656874,
+      "latency_us": 2603498,
+      "success": true
+    },
+    {
+      "request_id": "request-177",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554124,
+      "started_at_run_us": 55794,
+      "finished_at_unix_ms": 1785328556786,
+      "finished_at_run_us": 2717598,
+      "latency_us": 2661804,
+      "success": true
+    },
+    {
+      "request_id": "request-180",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554124,
+      "started_at_run_us": 55812,
+      "finished_at_unix_ms": 1785328556846,
+      "finished_at_run_us": 2777996,
+      "latency_us": 2722183,
+      "success": true
+    },
+    {
+      "request_id": "request-185",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554126,
+      "started_at_run_us": 58236,
+      "finished_at_unix_ms": 1785328556907,
+      "finished_at_run_us": 2838596,
+      "latency_us": 2780360,
+      "success": true
+    },
+    {
+      "request_id": "request-189",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554126,
+      "started_at_run_us": 58252,
+      "finished_at_unix_ms": 1785328556967,
+      "finished_at_run_us": 2899188,
+      "latency_us": 2840935,
+      "success": true
+    },
+    {
+      "request_id": "request-198",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554129,
+      "started_at_run_us": 60664,
+      "finished_at_unix_ms": 1785328557027,
+      "finished_at_run_us": 2959274,
+      "latency_us": 2898610,
+      "success": true
+    },
+    {
+      "request_id": "request-194",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554129,
+      "started_at_run_us": 60705,
+      "finished_at_unix_ms": 1785328557088,
+      "finished_at_run_us": 3019617,
+      "latency_us": 2958912,
+      "success": true
+    },
+    {
+      "request_id": "request-201",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554131,
+      "started_at_run_us": 62435,
+      "finished_at_unix_ms": 1785328557148,
+      "finished_at_run_us": 3080003,
+      "latency_us": 3017567,
+      "success": true
+    },
+    {
+      "request_id": "request-204",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554131,
+      "started_at_run_us": 62468,
+      "finished_at_unix_ms": 1785328557208,
+      "finished_at_run_us": 3140317,
+      "latency_us": 3077849,
+      "success": true
+    },
+    {
+      "request_id": "request-214",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554133,
+      "started_at_run_us": 64895,
+      "finished_at_unix_ms": 1785328557239,
+      "finished_at_run_us": 3170665,
+      "latency_us": 3105770,
+      "success": true
+    },
+    {
+      "request_id": "request-216",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554133,
+      "started_at_run_us": 64915,
+      "finished_at_unix_ms": 1785328557299,
+      "finished_at_run_us": 3230959,
+      "latency_us": 3166043,
+      "success": true
+    },
+    {
+      "request_id": "request-212",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554133,
+      "started_at_run_us": 64924,
+      "finished_at_unix_ms": 1785328557359,
+      "finished_at_run_us": 3291335,
+      "latency_us": 3226411,
+      "success": true
+    },
+    {
+      "request_id": "request-223",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554135,
+      "started_at_run_us": 67333,
+      "finished_at_unix_ms": 1785328557420,
+      "finished_at_run_us": 3351720,
+      "latency_us": 3284387,
+      "success": true
+    },
+    {
+      "request_id": "request-229",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554137,
+      "started_at_run_us": 69036,
+      "finished_at_unix_ms": 1785328557480,
+      "finished_at_run_us": 3412098,
+      "latency_us": 3343061,
+      "success": true
+    },
+    {
+      "request_id": "request-232",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554138,
+      "started_at_run_us": 70194,
+      "finished_at_unix_ms": 1785328557541,
+      "finished_at_run_us": 3472561,
+      "latency_us": 3402366,
+      "success": true
+    },
+    {
+      "request_id": "request-239",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554140,
+      "started_at_run_us": 71450,
+      "finished_at_unix_ms": 1785328557601,
+      "finished_at_run_us": 3533177,
+      "latency_us": 3461726,
+      "success": true
+    },
+    {
+      "request_id": "request-237",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554140,
+      "started_at_run_us": 71478,
+      "finished_at_unix_ms": 1785328557662,
+      "finished_at_run_us": 3594161,
+      "latency_us": 3522683,
+      "success": true
+    },
+    {
+      "request_id": "request-246",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554142,
+      "started_at_run_us": 73892,
+      "finished_at_unix_ms": 1785328557723,
+      "finished_at_run_us": 3654559,
+      "latency_us": 3580666,
+      "success": true
+    },
+    {
+      "request_id": "request-245",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554142,
+      "started_at_run_us": 73913,
+      "finished_at_unix_ms": 1785328557783,
+      "finished_at_run_us": 3714864,
+      "latency_us": 3640950,
+      "success": true
+    },
+    {
+      "request_id": "request-249",
+      "stage": "spawn_blocking_path",
+      "started_at_unix_ms": 1785328554144,
+      "started_at_run_us": 76269,
+      "finished_at_unix_ms": 1785328557843,
+      "finished_at_run_us": 3775235,
+      "latency_us": 3698966,
+      "success": true
+    }
+  ],
+  "queues": [
+    {
+      "request_id": "request-0",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554069,
+      "waited_from_run_us": 528,
+      "waited_until_unix_ms": 1785328554070,
+      "waited_until_run_us": 1682,
+      "wait_us": 1153,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-7",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554071,
+      "waited_from_run_us": 2944,
+      "waited_until_unix_ms": 1785328554071,
+      "waited_until_run_us": 3152,
+      "wait_us": 207,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-8",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554071,
+      "waited_from_run_us": 2989,
+      "waited_until_unix_ms": 1785328554072,
+      "waited_until_run_us": 4348,
+      "wait_us": 1358,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-12",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554073,
+      "waited_from_run_us": 4413,
+      "waited_until_unix_ms": 1785328554074,
+      "waited_until_run_us": 5610,
+      "wait_us": 1196,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-11",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554073,
+      "waited_from_run_us": 4406,
+      "waited_until_unix_ms": 1785328554074,
+      "waited_until_run_us": 5630,
+      "wait_us": 1224,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-20",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554075,
+      "waited_from_run_us": 6874,
+      "waited_until_unix_ms": 1785328554076,
+      "waited_until_run_us": 8024,
+      "wait_us": 1149,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-19",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554075,
+      "waited_from_run_us": 6863,
+      "waited_until_unix_ms": 1785328554076,
+      "waited_until_run_us": 8035,
+      "wait_us": 1172,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-32",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554076,
+      "waited_from_run_us": 8238,
+      "waited_until_unix_ms": 1785328554077,
+      "waited_until_run_us": 9384,
+      "wait_us": 1146,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-31",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554076,
+      "waited_from_run_us": 8229,
+      "waited_until_unix_ms": 1785328554078,
+      "waited_until_run_us": 9398,
+      "wait_us": 1169,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-35",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554079,
+      "waited_from_run_us": 10647,
+      "waited_until_unix_ms": 1785328554080,
+      "waited_until_run_us": 11810,
+      "wait_us": 1162,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-37",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554079,
+      "waited_from_run_us": 10664,
+      "waited_until_unix_ms": 1785328554080,
+      "waited_until_run_us": 11867,
+      "wait_us": 1203,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-45",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554081,
+      "waited_from_run_us": 13092,
+      "waited_until_unix_ms": 1785328554082,
+      "waited_until_run_us": 14211,
+      "wait_us": 1118,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-44",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554081,
+      "waited_from_run_us": 13085,
+      "waited_until_unix_ms": 1785328554082,
+      "waited_until_run_us": 14252,
+      "wait_us": 1167,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-52",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554084,
+      "waited_from_run_us": 15458,
+      "waited_until_unix_ms": 1785328554085,
+      "waited_until_run_us": 16736,
+      "wait_us": 1278,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-53",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554084,
+      "waited_from_run_us": 15471,
+      "waited_until_unix_ms": 1785328554085,
+      "waited_until_run_us": 16743,
+      "wait_us": 1272,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-58",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554086,
+      "waited_from_run_us": 18008,
+      "waited_until_unix_ms": 1785328554087,
+      "waited_until_run_us": 19183,
+      "wait_us": 1174,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-60",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554086,
+      "waited_from_run_us": 18017,
+      "waited_until_unix_ms": 1785328554087,
+      "waited_until_run_us": 19198,
+      "wait_us": 1180,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-66",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554089,
+      "waited_from_run_us": 20416,
+      "waited_until_unix_ms": 1785328554090,
+      "waited_until_run_us": 21638,
+      "wait_us": 1221,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-72",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554089,
+      "waited_from_run_us": 20441,
+      "waited_until_unix_ms": 1785328554090,
+      "waited_until_run_us": 21659,
+      "wait_us": 1218,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-75",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554091,
+      "waited_from_run_us": 22874,
+      "waited_until_unix_ms": 1785328554092,
+      "waited_until_run_us": 24072,
+      "wait_us": 1197,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-77",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554091,
+      "waited_from_run_us": 22906,
+      "waited_until_unix_ms": 1785328554092,
+      "waited_until_run_us": 24149,
+      "wait_us": 1243,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-81",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554092,
+      "waited_from_run_us": 24122,
+      "waited_until_unix_ms": 1785328554093,
+      "waited_until_run_us": 25302,
+      "wait_us": 1180,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-86",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554092,
+      "waited_from_run_us": 24156,
+      "waited_until_unix_ms": 1785328554093,
+      "waited_until_run_us": 25336,
+      "wait_us": 1180,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-90",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554098,
+      "waited_from_run_us": 29485,
+      "waited_until_unix_ms": 1785328554099,
+      "waited_until_run_us": 30653,
+      "wait_us": 1167,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-92",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554098,
+      "waited_from_run_us": 29504,
+      "waited_until_unix_ms": 1785328554099,
+      "waited_until_run_us": 30680,
+      "wait_us": 1175,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-100",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554100,
+      "waited_from_run_us": 31929,
+      "waited_until_unix_ms": 1785328554100,
+      "waited_until_run_us": 32332,
+      "wait_us": 403,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-98",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554100,
+      "waited_from_run_us": 31907,
+      "waited_until_unix_ms": 1785328554100,
+      "waited_until_run_us": 32344,
+      "wait_us": 437,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-105",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554102,
+      "waited_from_run_us": 33575,
+      "waited_until_unix_ms": 1785328554103,
+      "waited_until_run_us": 34752,
+      "wait_us": 1177,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-108",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554102,
+      "waited_from_run_us": 33598,
+      "waited_until_unix_ms": 1785328554103,
+      "waited_until_run_us": 34788,
+      "wait_us": 1189,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-115",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554104,
+      "waited_from_run_us": 36192,
+      "waited_until_unix_ms": 1785328554105,
+      "waited_until_run_us": 37375,
+      "wait_us": 1183,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-114",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554104,
+      "waited_from_run_us": 36183,
+      "waited_until_unix_ms": 1785328554105,
+      "waited_until_run_us": 37392,
+      "wait_us": 1208,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-122",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554107,
+      "waited_from_run_us": 38614,
+      "waited_until_unix_ms": 1785328554108,
+      "waited_until_run_us": 39875,
+      "wait_us": 1261,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-127",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554107,
+      "waited_from_run_us": 38631,
+      "waited_until_unix_ms": 1785328554108,
+      "waited_until_run_us": 39883,
+      "wait_us": 1251,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-129",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554109,
+      "waited_from_run_us": 41086,
+      "waited_until_unix_ms": 1785328554110,
+      "waited_until_run_us": 42265,
+      "wait_us": 1179,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-134",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554109,
+      "waited_from_run_us": 41121,
+      "waited_until_unix_ms": 1785328554110,
+      "waited_until_run_us": 42309,
+      "wait_us": 1187,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-137",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554112,
+      "waited_from_run_us": 43526,
+      "waited_until_unix_ms": 1785328554113,
+      "waited_until_run_us": 44752,
+      "wait_us": 1225,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-139",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554112,
+      "waited_from_run_us": 43553,
+      "waited_until_unix_ms": 1785328554113,
+      "waited_until_run_us": 44793,
+      "wait_us": 1239,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-145",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554114,
+      "waited_from_run_us": 46024,
+      "waited_until_unix_ms": 1785328554115,
+      "waited_until_run_us": 47211,
+      "wait_us": 1187,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-152",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554114,
+      "waited_from_run_us": 46072,
+      "waited_until_unix_ms": 1785328554115,
+      "waited_until_run_us": 47228,
+      "wait_us": 1156,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-153",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554117,
+      "waited_from_run_us": 48468,
+      "waited_until_unix_ms": 1785328554118,
+      "waited_until_run_us": 49653,
+      "wait_us": 1184,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-158",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554117,
+      "waited_from_run_us": 48504,
+      "waited_until_unix_ms": 1785328554118,
+      "waited_until_run_us": 49671,
+      "wait_us": 1166,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-162",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554119,
+      "waited_from_run_us": 50898,
+      "waited_until_unix_ms": 1785328554120,
+      "waited_until_run_us": 52080,
+      "wait_us": 1182,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-167",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554119,
+      "waited_from_run_us": 50913,
+      "waited_until_unix_ms": 1785328554120,
+      "waited_until_run_us": 52162,
+      "wait_us": 1248,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-169",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554120,
+      "waited_from_run_us": 52093,
+      "waited_until_unix_ms": 1785328554121,
+      "waited_until_run_us": 53340,
+      "wait_us": 1247,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-173",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554120,
+      "waited_from_run_us": 52183,
+      "waited_until_unix_ms": 1785328554121,
+      "waited_until_run_us": 53353,
+      "wait_us": 1170,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-177",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554123,
+      "waited_from_run_us": 54609,
+      "waited_until_unix_ms": 1785328554124,
+      "waited_until_run_us": 55791,
+      "wait_us": 1182,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-180",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554123,
+      "waited_from_run_us": 54636,
+      "waited_until_unix_ms": 1785328554124,
+      "waited_until_run_us": 55805,
+      "wait_us": 1168,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-185",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554125,
+      "waited_from_run_us": 57040,
+      "waited_until_unix_ms": 1785328554126,
+      "waited_until_run_us": 58233,
+      "wait_us": 1192,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-189",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554125,
+      "waited_from_run_us": 57071,
+      "waited_until_unix_ms": 1785328554126,
+      "waited_until_run_us": 58246,
+      "wait_us": 1174,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-198",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554128,
+      "waited_from_run_us": 59487,
+      "waited_until_unix_ms": 1785328554129,
+      "waited_until_run_us": 60661,
+      "wait_us": 1174,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-194",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554128,
+      "waited_from_run_us": 59461,
+      "waited_until_unix_ms": 1785328554129,
+      "waited_until_run_us": 60703,
+      "wait_us": 1241,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-201",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554130,
+      "waited_from_run_us": 61898,
+      "waited_until_unix_ms": 1785328554131,
+      "waited_until_run_us": 62433,
+      "wait_us": 535,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-204",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554130,
+      "waited_from_run_us": 61933,
+      "waited_until_unix_ms": 1785328554131,
+      "waited_until_run_us": 62442,
+      "wait_us": 508,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-214",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554132,
+      "waited_from_run_us": 63749,
+      "waited_until_unix_ms": 1785328554133,
+      "waited_until_run_us": 64886,
+      "wait_us": 1136,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-216",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554132,
+      "waited_from_run_us": 63746,
+      "waited_until_unix_ms": 1785328554133,
+      "waited_until_run_us": 64913,
+      "wait_us": 1167,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-212",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554132,
+      "waited_from_run_us": 63736,
+      "waited_until_unix_ms": 1785328554133,
+      "waited_until_run_us": 64922,
+      "wait_us": 1186,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-223",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554134,
+      "waited_from_run_us": 66156,
+      "waited_until_unix_ms": 1785328554135,
+      "waited_until_run_us": 67327,
+      "wait_us": 1170,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-229",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554137,
+      "waited_from_run_us": 68957,
+      "waited_until_unix_ms": 1785328554137,
+      "waited_until_run_us": 69031,
+      "wait_us": 73,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-232",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554137,
+      "waited_from_run_us": 68971,
+      "waited_until_unix_ms": 1785328554138,
+      "waited_until_run_us": 70192,
+      "wait_us": 1220,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-239",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554138,
+      "waited_from_run_us": 70326,
+      "waited_until_unix_ms": 1785328554140,
+      "waited_until_run_us": 71442,
+      "wait_us": 1116,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-237",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554138,
+      "waited_from_run_us": 70303,
+      "waited_until_unix_ms": 1785328554140,
+      "waited_until_run_us": 71472,
+      "wait_us": 1168,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-246",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554141,
+      "waited_from_run_us": 72747,
+      "waited_until_unix_ms": 1785328554142,
+      "waited_until_run_us": 73883,
+      "wait_us": 1136,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-245",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554141,
+      "waited_from_run_us": 72740,
+      "waited_until_unix_ms": 1785328554142,
+      "waited_until_run_us": 73911,
+      "wait_us": 1171,
+      "depth_at_start": 0
+    },
+    {
+      "request_id": "request-249",
+      "queue": "dispatch_overhead",
+      "waited_from_unix_ms": 1785328554143,
+      "waited_from_run_us": 75130,
+      "waited_until_unix_ms": 1785328554144,
+      "waited_until_run_us": 76261,
+      "wait_us": 1131,
+      "depth_at_start": 0
+    }
+  ],
+  "inflight": [
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328554069,
+      "at_run_us": 475,
+      "count": 1
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328554073,
+      "at_run_us": 4471,
+      "count": 17
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328554076,
+      "at_run_us": 8257,
+      "count": 33
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328554081,
+      "at_run_us": 13090,
+      "count": 49
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328554086,
+      "at_run_us": 18039,
+      "count": 65
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328554091,
+      "at_run_us": 22911,
+      "count": 81
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328554100,
+      "at_run_us": 31893,
+      "count": 98
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328554102,
+      "at_run_us": 33601,
+      "count": 110
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328554107,
+      "at_run_us": 38716,
+      "count": 126
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328554112,
+      "at_run_us": 43611,
+      "count": 142
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328554117,
+      "at_run_us": 48503,
+      "count": 158
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328554120,
+      "at_run_us": 52191,
+      "count": 174
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328554125,
+      "at_run_us": 57089,
+      "count": 190
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328554130,
+      "at_run_us": 61932,
+      "count": 206
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328554134,
+      "at_run_us": 66154,
+      "count": 218
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328554138,
+      "at_run_us": 70300,
+      "count": 234
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328554143,
+      "at_run_us": 75126,
+      "count": 246
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328554221,
+      "at_run_us": 152920,
+      "count": 241
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328554462,
+      "at_run_us": 393770,
+      "count": 225
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328554703,
+      "at_run_us": 634801,
+      "count": 209
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328554944,
+      "at_run_us": 876040,
+      "count": 193
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328555186,
+      "at_run_us": 1117684,
+      "count": 177
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328555427,
+      "at_run_us": 1359155,
+      "count": 161
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328555668,
+      "at_run_us": 1600369,
+      "count": 145
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328555910,
+      "at_run_us": 1841733,
+      "count": 129
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328556151,
+      "at_run_us": 2082959,
+      "count": 113
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328556393,
+      "at_run_us": 2324727,
+      "count": 97
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328556635,
+      "at_run_us": 2567071,
+      "count": 80
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328556877,
+      "at_run_us": 2808453,
+      "count": 64
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328557118,
+      "at_run_us": 3049937,
+      "count": 48
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328557359,
+      "at_run_us": 3291336,
+      "count": 32
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328557601,
+      "at_run_us": 3533221,
+      "count": 16
+    },
+    {
+      "gauge": "blocking_service_inflight",
+      "at_unix_ms": 1785328557843,
+      "at_run_us": 3775237,
+      "count": 0
+    }
+  ],
+  "runtime_snapshots": [
+    {
+      "at_unix_ms": 1785328554070,
+      "at_run_us": 1648,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554095,
+      "at_run_us": 26462,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 89,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554120,
+      "at_run_us": 52070,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 160,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554144,
+      "at_run_us": 76276,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 246,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554160,
+      "at_run_us": 91684,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 246,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554170,
+      "at_run_us": 102017,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 244,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554199,
+      "at_run_us": 131194,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 242,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554224,
+      "at_run_us": 156250,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 240,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554250,
+      "at_run_us": 181933,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 240,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554275,
+      "at_run_us": 206982,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 238,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554300,
+      "at_run_us": 231818,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 236,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554325,
+      "at_run_us": 256932,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 234,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554350,
+      "at_run_us": 281943,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 232,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554375,
+      "at_run_us": 306864,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 230,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554400,
+      "at_run_us": 331712,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 230,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554425,
+      "at_run_us": 356819,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 228,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554455,
+      "at_run_us": 386660,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 226,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554480,
+      "at_run_us": 411683,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 224,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554505,
+      "at_run_us": 436808,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 222,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554529,
+      "at_run_us": 461300,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 220,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554555,
+      "at_run_us": 486733,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 218,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554579,
+      "at_run_us": 511337,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 218,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554604,
+      "at_run_us": 536350,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 216,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554630,
+      "at_run_us": 561587,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 214,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554655,
+      "at_run_us": 586407,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 212,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554680,
+      "at_run_us": 611413,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 210,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554710,
+      "at_run_us": 641722,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 208,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554735,
+      "at_run_us": 666535,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 206,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554759,
+      "at_run_us": 691272,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 206,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554784,
+      "at_run_us": 716367,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 204,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554809,
+      "at_run_us": 741296,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 202,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554834,
+      "at_run_us": 766193,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 200,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554859,
+      "at_run_us": 791242,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 198,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554885,
+      "at_run_us": 816887,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 197,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554910,
+      "at_run_us": 841960,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 196,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554935,
+      "at_run_us": 866962,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 194,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554964,
+      "at_run_us": 895998,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 192,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328554990,
+      "at_run_us": 922062,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 190,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328555015,
+      "at_run_us": 947039,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 188,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328555040,
+      "at_run_us": 972025,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 186,
+      "remote_schedule_count": null
+    },
+    {
+      "at_unix_ms": 1785328555065,
+      "at_run_us": 996583,
+      "alive_tasks": null,
+      "global_queue_depth": 0,
+      "local_queue_depth": null,
+      "blocking_queue_depth": 186,
+      "remote_schedule_count": null
+    }
+  ],
+  "truncation": {
+    "limits_hit": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0
+  }
+}

--- a/validation/diagnostics/corpus/demo-runs/executor-sample.json
+++ b/validation/diagnostics/corpus/demo-runs/executor-sample.json
@@ -1,0 +1,1327 @@
+{
+  "schema_version": 2,
+  "metadata": {
+    "run_id": "run-06ce2b1c-bd9f-4105-a6d7-af0fdc06ee4b",
+    "service_name": "executor_pressure_demo",
+    "service_version": null,
+    "started_at_unix_ms": 1785328560649,
+    "finalized_at_unix_ms": 1785328597836,
+    "mode": "light",
+    "effective_core_config": {
+      "mode": "light",
+      "capture_limits": {
+        "max_requests": 100000,
+        "max_stages": 200000,
+        "max_queues": 200000,
+        "max_inflight_snapshots": 200000,
+        "max_runtime_snapshots": 100000
+      },
+      "strict_lifecycle": false
+    },
+    "effective_tokio_sampler_config": null,
+    "host": null,
+    "pid": null,
+    "lifecycle_warnings": [],
+    "unfinished_requests": {
+      "count": 0,
+      "sample": []
+    },
+    "run_end_reason": null
+  },
+  "requests": [
+    {
+      "request_id": "request-132",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563435,
+      "started_at_run_us": 2786345,
+      "finished_at_unix_ms": 1785328595646,
+      "finished_at_run_us": 34996731,
+      "latency_us": 32210386,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-34",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563443,
+      "started_at_run_us": 2794554,
+      "finished_at_unix_ms": 1785328596772,
+      "finished_at_run_us": 36123271,
+      "latency_us": 33328717,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-99",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563441,
+      "started_at_run_us": 2792056,
+      "finished_at_unix_ms": 1785328597074,
+      "finished_at_run_us": 36424843,
+      "latency_us": 33632787,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-205",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563447,
+      "started_at_run_us": 2797719,
+      "finished_at_unix_ms": 1785328597220,
+      "finished_at_run_us": 36571010,
+      "latency_us": 33773291,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-64",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563446,
+      "started_at_run_us": 2797045,
+      "finished_at_unix_ms": 1785328597270,
+      "finished_at_run_us": 36620987,
+      "latency_us": 33823942,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-126",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563440,
+      "started_at_run_us": 2790662,
+      "finished_at_unix_ms": 1785328597338,
+      "finished_at_run_us": 36689062,
+      "latency_us": 33898399,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-6",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563435,
+      "started_at_run_us": 2785684,
+      "finished_at_unix_ms": 1785328597373,
+      "finished_at_run_us": 36724627,
+      "latency_us": 33938943,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-102",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563441,
+      "started_at_run_us": 2792337,
+      "finished_at_unix_ms": 1785328597446,
+      "finished_at_run_us": 36797106,
+      "latency_us": 34004768,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-220",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563437,
+      "started_at_run_us": 2788577,
+      "finished_at_unix_ms": 1785328597496,
+      "finished_at_run_us": 36847169,
+      "latency_us": 34058592,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-30",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563435,
+      "started_at_run_us": 2786102,
+      "finished_at_unix_ms": 1785328597561,
+      "finished_at_run_us": 36912372,
+      "latency_us": 34126270,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-75",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563440,
+      "started_at_run_us": 2791557,
+      "finished_at_unix_ms": 1785328597565,
+      "finished_at_run_us": 36915904,
+      "latency_us": 34124347,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-5",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563445,
+      "started_at_run_us": 2795802,
+      "finished_at_unix_ms": 1785328597565,
+      "finished_at_run_us": 36915935,
+      "latency_us": 34120133,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-169",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563443,
+      "started_at_run_us": 2793726,
+      "finished_at_unix_ms": 1785328597566,
+      "finished_at_run_us": 36917458,
+      "latency_us": 34123731,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-123",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563436,
+      "started_at_run_us": 2787228,
+      "finished_at_unix_ms": 1785328597568,
+      "finished_at_run_us": 36919235,
+      "latency_us": 34132006,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-94",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563448,
+      "started_at_run_us": 2799424,
+      "finished_at_unix_ms": 1785328597602,
+      "finished_at_run_us": 36952720,
+      "latency_us": 34153296,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-96",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563436,
+      "started_at_run_us": 2786934,
+      "finished_at_unix_ms": 1785328597603,
+      "finished_at_run_us": 36954530,
+      "latency_us": 34167596,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-111",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563441,
+      "started_at_run_us": 2792485,
+      "finished_at_unix_ms": 1785328597615,
+      "finished_at_run_us": 36966371,
+      "latency_us": 34173885,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-194",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563441,
+      "started_at_run_us": 2792230,
+      "finished_at_unix_ms": 1785328597618,
+      "finished_at_run_us": 36969126,
+      "latency_us": 34176896,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-210",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563449,
+      "started_at_run_us": 2800627,
+      "finished_at_unix_ms": 1785328597628,
+      "finished_at_run_us": 36979323,
+      "latency_us": 34178695,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-131",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563442,
+      "started_at_run_us": 2792875,
+      "finished_at_unix_ms": 1785328597637,
+      "finished_at_run_us": 36988251,
+      "latency_us": 34195376,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-157",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563455,
+      "started_at_run_us": 2806376,
+      "finished_at_unix_ms": 1785328597670,
+      "finished_at_run_us": 37020888,
+      "latency_us": 34214512,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-23",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563445,
+      "started_at_run_us": 2796241,
+      "finished_at_unix_ms": 1785328597673,
+      "finished_at_run_us": 37023985,
+      "latency_us": 34227744,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-235",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563444,
+      "started_at_run_us": 2795397,
+      "finished_at_unix_ms": 1785328597697,
+      "finished_at_run_us": 37047894,
+      "latency_us": 34252496,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-101",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563441,
+      "started_at_run_us": 2792210,
+      "finished_at_unix_ms": 1785328597698,
+      "finished_at_run_us": 37048885,
+      "latency_us": 34256674,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-35",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563435,
+      "started_at_run_us": 2786264,
+      "finished_at_unix_ms": 1785328597706,
+      "finished_at_run_us": 37057137,
+      "latency_us": 34270873,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-191",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563437,
+      "started_at_run_us": 2788120,
+      "finished_at_unix_ms": 1785328597712,
+      "finished_at_run_us": 37062806,
+      "latency_us": 34274686,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-179",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563457,
+      "started_at_run_us": 2808543,
+      "finished_at_unix_ms": 1785328597729,
+      "finished_at_run_us": 37080548,
+      "latency_us": 34272005,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-219",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563437,
+      "started_at_run_us": 2788257,
+      "finished_at_unix_ms": 1785328597729,
+      "finished_at_run_us": 37080611,
+      "latency_us": 34292354,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-161",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563437,
+      "started_at_run_us": 2787976,
+      "finished_at_unix_ms": 1785328597739,
+      "finished_at_run_us": 37089653,
+      "latency_us": 34301677,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-135",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563442,
+      "started_at_run_us": 2792994,
+      "finished_at_unix_ms": 1785328597742,
+      "finished_at_run_us": 37093209,
+      "latency_us": 34300215,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-43",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563444,
+      "started_at_run_us": 2794826,
+      "finished_at_unix_ms": 1785328597743,
+      "finished_at_run_us": 37094158,
+      "latency_us": 34299332,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-233",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563438,
+      "started_at_run_us": 2788868,
+      "finished_at_unix_ms": 1785328597759,
+      "finished_at_run_us": 37110470,
+      "latency_us": 34321601,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-100",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563455,
+      "started_at_run_us": 2805848,
+      "finished_at_unix_ms": 1785328597759,
+      "finished_at_run_us": 37110496,
+      "latency_us": 34304647,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-199",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563453,
+      "started_at_run_us": 2803864,
+      "finished_at_unix_ms": 1785328597759,
+      "finished_at_run_us": 37110526,
+      "latency_us": 34306662,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-110",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563454,
+      "started_at_run_us": 2805171,
+      "finished_at_unix_ms": 1785328597766,
+      "finished_at_run_us": 37116879,
+      "latency_us": 34311707,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-73",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563439,
+      "started_at_run_us": 2790081,
+      "finished_at_unix_ms": 1785328597779,
+      "finished_at_run_us": 37130522,
+      "latency_us": 34340441,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-28",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563438,
+      "started_at_run_us": 2789211,
+      "finished_at_unix_ms": 1785328597780,
+      "finished_at_run_us": 37131525,
+      "latency_us": 34342313,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-201",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563437,
+      "started_at_run_us": 2787974,
+      "finished_at_unix_ms": 1785328597780,
+      "finished_at_run_us": 37131550,
+      "latency_us": 34343575,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-85",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563446,
+      "started_at_run_us": 2797447,
+      "finished_at_unix_ms": 1785328597780,
+      "finished_at_run_us": 37131638,
+      "latency_us": 34334190,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-11",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563445,
+      "started_at_run_us": 2795676,
+      "finished_at_unix_ms": 1785328597781,
+      "finished_at_run_us": 37131674,
+      "latency_us": 34335997,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-193",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563437,
+      "started_at_run_us": 2787852,
+      "finished_at_unix_ms": 1785328597781,
+      "finished_at_run_us": 37131756,
+      "latency_us": 34343904,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-213",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563443,
+      "started_at_run_us": 2793801,
+      "finished_at_unix_ms": 1785328597794,
+      "finished_at_run_us": 37145370,
+      "latency_us": 34351568,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-209",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563443,
+      "started_at_run_us": 2794248,
+      "finished_at_unix_ms": 1785328597794,
+      "finished_at_run_us": 37145394,
+      "latency_us": 34351146,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-223",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563444,
+      "started_at_run_us": 2794878,
+      "finished_at_unix_ms": 1785328597794,
+      "finished_at_run_us": 37145425,
+      "latency_us": 34350546,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-88",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563439,
+      "started_at_run_us": 2790202,
+      "finished_at_unix_ms": 1785328597794,
+      "finished_at_run_us": 37145455,
+      "latency_us": 34355252,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-163",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563456,
+      "started_at_run_us": 2806904,
+      "finished_at_unix_ms": 1785328597794,
+      "finished_at_run_us": 37145486,
+      "latency_us": 34338582,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-216",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563443,
+      "started_at_run_us": 2794497,
+      "finished_at_unix_ms": 1785328597794,
+      "finished_at_run_us": 37145564,
+      "latency_us": 34351067,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-178",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563446,
+      "started_at_run_us": 2797203,
+      "finished_at_unix_ms": 1785328597794,
+      "finished_at_run_us": 37145583,
+      "latency_us": 34348380,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-63",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563440,
+      "started_at_run_us": 2791310,
+      "finished_at_unix_ms": 1785328597814,
+      "finished_at_run_us": 37165110,
+      "latency_us": 34373799,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-217",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563443,
+      "started_at_run_us": 2794622,
+      "finished_at_unix_ms": 1785328597814,
+      "finished_at_run_us": 37165213,
+      "latency_us": 34370590,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-150",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563451,
+      "started_at_run_us": 2802247,
+      "finished_at_unix_ms": 1785328597814,
+      "finished_at_run_us": 37165251,
+      "latency_us": 34363003,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-130",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563456,
+      "started_at_run_us": 2806903,
+      "finished_at_unix_ms": 1785328597814,
+      "finished_at_run_us": 37165324,
+      "latency_us": 34358420,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-124",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563455,
+      "started_at_run_us": 2805706,
+      "finished_at_unix_ms": 1785328597814,
+      "finished_at_run_us": 37165357,
+      "latency_us": 34359651,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-45",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563446,
+      "started_at_run_us": 2796670,
+      "finished_at_unix_ms": 1785328597814,
+      "finished_at_run_us": 37165533,
+      "latency_us": 34368862,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-62",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563444,
+      "started_at_run_us": 2795431,
+      "finished_at_unix_ms": 1785328597823,
+      "finished_at_run_us": 37174210,
+      "latency_us": 34378778,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-10",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563443,
+      "started_at_run_us": 2794306,
+      "finished_at_unix_ms": 1785328597823,
+      "finished_at_run_us": 37174479,
+      "latency_us": 34380173,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-9",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563445,
+      "started_at_run_us": 2795929,
+      "finished_at_unix_ms": 1785328597823,
+      "finished_at_run_us": 37174500,
+      "latency_us": 34378570,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-31",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563445,
+      "started_at_run_us": 2796540,
+      "finished_at_unix_ms": 1785328597823,
+      "finished_at_run_us": 37174525,
+      "latency_us": 34377984,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-175",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563452,
+      "started_at_run_us": 2802963,
+      "finished_at_unix_ms": 1785328597830,
+      "finished_at_run_us": 37180743,
+      "latency_us": 34377779,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-227",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563438,
+      "started_at_run_us": 2788718,
+      "finished_at_unix_ms": 1785328597830,
+      "finished_at_run_us": 37180771,
+      "latency_us": 34392052,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-3",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563438,
+      "started_at_run_us": 2788839,
+      "finished_at_unix_ms": 1785328597831,
+      "finished_at_run_us": 37181769,
+      "latency_us": 34392930,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-36",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563453,
+      "started_at_run_us": 2804597,
+      "finished_at_unix_ms": 1785328597831,
+      "finished_at_run_us": 37181808,
+      "latency_us": 34377210,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-172",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563446,
+      "started_at_run_us": 2796953,
+      "finished_at_unix_ms": 1785328597835,
+      "finished_at_run_us": 37185898,
+      "latency_us": 34388945,
+      "outcome": "ok"
+    },
+    {
+      "request_id": "request-97",
+      "route": "/executor-pressure",
+      "kind": null,
+      "started_at_unix_ms": 1785328563449,
+      "started_at_run_us": 2799778,
+      "finished_at_unix_ms": 1785328597836,
+      "finished_at_run_us": 37186914,
+      "latency_us": 34387135,
+      "outcome": "ok"
+    }
+  ],
+  "stages": [],
+  "queues": [],
+  "inflight": [
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328563435,
+      "at_run_us": 2785746,
+      "count": 1
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328563436,
+      "at_run_us": 2786935,
+      "count": 16
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328563437,
+      "at_run_us": 2788478,
+      "count": 32
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328563438,
+      "at_run_us": 2789451,
+      "count": 47
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328563440,
+      "at_run_us": 2791049,
+      "count": 63
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328563441,
+      "at_run_us": 2792059,
+      "count": 78
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328563443,
+      "at_run_us": 2793729,
+      "count": 94
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328563444,
+      "at_run_us": 2794688,
+      "count": 109
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328563445,
+      "at_run_us": 2795820,
+      "count": 125
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328563446,
+      "at_run_us": 2796920,
+      "count": 140
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328563447,
+      "at_run_us": 2797952,
+      "count": 156
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328563448,
+      "at_run_us": 2799426,
+      "count": 171
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328563451,
+      "at_run_us": 2801965,
+      "count": 186
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328563452,
+      "at_run_us": 2803422,
+      "count": 202
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328563454,
+      "at_run_us": 2805148,
+      "count": 217
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328563456,
+      "at_run_us": 2806730,
+      "count": 233
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328563458,
+      "at_run_us": 2809073,
+      "count": 240
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328597074,
+      "at_run_us": 36424774,
+      "count": 232
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328597373,
+      "at_run_us": 36724615,
+      "count": 216
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328597565,
+      "at_run_us": 36915902,
+      "count": 201
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328597602,
+      "at_run_us": 36953224,
+      "count": 185
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328597634,
+      "at_run_us": 36985348,
+      "count": 170
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328597697,
+      "at_run_us": 37047905,
+      "count": 155
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328597729,
+      "at_run_us": 37080560,
+      "count": 139
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328597743,
+      "at_run_us": 37094164,
+      "count": 124
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328597779,
+      "at_run_us": 37130503,
+      "count": 108
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328597781,
+      "at_run_us": 37131655,
+      "count": 93
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328597794,
+      "at_run_us": 37145414,
+      "count": 77
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328597794,
+      "at_run_us": 37145576,
+      "count": 62
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328597814,
+      "at_run_us": 37165322,
+      "count": 46
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328597823,
+      "at_run_us": 37174470,
+      "count": 31
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328597830,
+      "at_run_us": 37180769,
+      "count": 15
+    },
+    {
+      "gauge": "executor_pressure_inflight",
+      "at_unix_ms": 1785328597836,
+      "at_run_us": 37186906,
+      "count": 0
+    }
+  ],
+  "runtime_snapshots": [
+    {
+      "at_unix_ms": 1785328563434,
+      "at_run_us": 2784760,
+      "alive_tasks": 0,
+      "global_queue_depth": 0,
+      "local_queue_depth": 0,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 0
+    },
+    {
+      "at_unix_ms": 1785328567899,
+      "at_run_us": 7250348,
+      "alive_tasks": 1920,
+      "global_queue_depth": 1920,
+      "local_queue_depth": 42224,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 42224
+    },
+    {
+      "at_unix_ms": 1785328585076,
+      "at_run_us": 24426880,
+      "alive_tasks": 1920,
+      "global_queue_depth": 1920,
+      "local_queue_depth": 37928,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 37928
+    },
+    {
+      "at_unix_ms": 1785328595264,
+      "at_run_us": 34615242,
+      "alive_tasks": 1920,
+      "global_queue_depth": 1920,
+      "local_queue_depth": 15688,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 15688
+    },
+    {
+      "at_unix_ms": 1785328595652,
+      "at_run_us": 35002954,
+      "alive_tasks": 1912,
+      "global_queue_depth": 1912,
+      "local_queue_depth": 13472,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 13472
+    },
+    {
+      "at_unix_ms": 1785328597777,
+      "at_run_us": 37127988,
+      "alive_tasks": 880,
+      "global_queue_depth": 880,
+      "local_queue_depth": 512,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 512
+    },
+    {
+      "at_unix_ms": 1785328597778,
+      "at_run_us": 37129407,
+      "alive_tasks": 880,
+      "global_queue_depth": 880,
+      "local_queue_depth": 512,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 512
+    },
+    {
+      "at_unix_ms": 1785328597779,
+      "at_run_us": 37130531,
+      "alive_tasks": 840,
+      "global_queue_depth": 840,
+      "local_queue_depth": 496,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 496
+    },
+    {
+      "at_unix_ms": 1785328597781,
+      "at_run_us": 37131711,
+      "alive_tasks": 720,
+      "global_queue_depth": 720,
+      "local_queue_depth": 488,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 488
+    },
+    {
+      "at_unix_ms": 1785328597795,
+      "at_run_us": 37146495,
+      "alive_tasks": 488,
+      "global_queue_depth": 488,
+      "local_queue_depth": 296,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 296
+    },
+    {
+      "at_unix_ms": 1785328597796,
+      "at_run_us": 37147583,
+      "alive_tasks": 488,
+      "global_queue_depth": 488,
+      "local_queue_depth": 280,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 280
+    },
+    {
+      "at_unix_ms": 1785328597798,
+      "at_run_us": 37148744,
+      "alive_tasks": 488,
+      "global_queue_depth": 488,
+      "local_queue_depth": 272,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 272
+    },
+    {
+      "at_unix_ms": 1785328597799,
+      "at_run_us": 37149845,
+      "alive_tasks": 488,
+      "global_queue_depth": 488,
+      "local_queue_depth": 264,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 264
+    },
+    {
+      "at_unix_ms": 1785328597800,
+      "at_run_us": 37151000,
+      "alive_tasks": 480,
+      "global_queue_depth": 480,
+      "local_queue_depth": 256,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 256
+    },
+    {
+      "at_unix_ms": 1785328597801,
+      "at_run_us": 37152112,
+      "alive_tasks": 480,
+      "global_queue_depth": 480,
+      "local_queue_depth": 256,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 256
+    },
+    {
+      "at_unix_ms": 1785328597802,
+      "at_run_us": 37153254,
+      "alive_tasks": 480,
+      "global_queue_depth": 480,
+      "local_queue_depth": 256,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 256
+    },
+    {
+      "at_unix_ms": 1785328597803,
+      "at_run_us": 37154583,
+      "alive_tasks": 480,
+      "global_queue_depth": 480,
+      "local_queue_depth": 248,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 248
+    },
+    {
+      "at_unix_ms": 1785328597805,
+      "at_run_us": 37155695,
+      "alive_tasks": 480,
+      "global_queue_depth": 480,
+      "local_queue_depth": 248,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 248
+    },
+    {
+      "at_unix_ms": 1785328597806,
+      "at_run_us": 37156850,
+      "alive_tasks": 480,
+      "global_queue_depth": 480,
+      "local_queue_depth": 240,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 240
+    },
+    {
+      "at_unix_ms": 1785328597810,
+      "at_run_us": 37160783,
+      "alive_tasks": 464,
+      "global_queue_depth": 464,
+      "local_queue_depth": 184,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 184
+    },
+    {
+      "at_unix_ms": 1785328597811,
+      "at_run_us": 37161908,
+      "alive_tasks": 464,
+      "global_queue_depth": 464,
+      "local_queue_depth": 184,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 184
+    },
+    {
+      "at_unix_ms": 1785328597812,
+      "at_run_us": 37162999,
+      "alive_tasks": 464,
+      "global_queue_depth": 464,
+      "local_queue_depth": 168,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 168
+    },
+    {
+      "at_unix_ms": 1785328597813,
+      "at_run_us": 37164110,
+      "alive_tasks": 464,
+      "global_queue_depth": 464,
+      "local_queue_depth": 160,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 160
+    },
+    {
+      "at_unix_ms": 1785328597815,
+      "at_run_us": 37165823,
+      "alive_tasks": 280,
+      "global_queue_depth": 280,
+      "local_queue_depth": 152,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 152
+    },
+    {
+      "at_unix_ms": 1785328597816,
+      "at_run_us": 37166921,
+      "alive_tasks": 280,
+      "global_queue_depth": 280,
+      "local_queue_depth": 144,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 144
+    },
+    {
+      "at_unix_ms": 1785328597817,
+      "at_run_us": 37168029,
+      "alive_tasks": 280,
+      "global_queue_depth": 280,
+      "local_queue_depth": 136,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 136
+    },
+    {
+      "at_unix_ms": 1785328597818,
+      "at_run_us": 37169209,
+      "alive_tasks": 280,
+      "global_queue_depth": 280,
+      "local_queue_depth": 128,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 128
+    },
+    {
+      "at_unix_ms": 1785328597819,
+      "at_run_us": 37170308,
+      "alive_tasks": 280,
+      "global_queue_depth": 280,
+      "local_queue_depth": 120,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 120
+    },
+    {
+      "at_unix_ms": 1785328597820,
+      "at_run_us": 37171412,
+      "alive_tasks": 280,
+      "global_queue_depth": 280,
+      "local_queue_depth": 104,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 104
+    },
+    {
+      "at_unix_ms": 1785328597821,
+      "at_run_us": 37172554,
+      "alive_tasks": 280,
+      "global_queue_depth": 280,
+      "local_queue_depth": 104,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 104
+    },
+    {
+      "at_unix_ms": 1785328597823,
+      "at_run_us": 37173993,
+      "alive_tasks": 280,
+      "global_queue_depth": 280,
+      "local_queue_depth": 96,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 96
+    },
+    {
+      "at_unix_ms": 1785328597824,
+      "at_run_us": 37175229,
+      "alive_tasks": 184,
+      "global_queue_depth": 184,
+      "local_queue_depth": 88,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 88
+    },
+    {
+      "at_unix_ms": 1785328597825,
+      "at_run_us": 37176392,
+      "alive_tasks": 184,
+      "global_queue_depth": 184,
+      "local_queue_depth": 80,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 80
+    },
+    {
+      "at_unix_ms": 1785328597826,
+      "at_run_us": 37177537,
+      "alive_tasks": 184,
+      "global_queue_depth": 184,
+      "local_queue_depth": 72,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 72
+    },
+    {
+      "at_unix_ms": 1785328597827,
+      "at_run_us": 37178649,
+      "alive_tasks": 184,
+      "global_queue_depth": 184,
+      "local_queue_depth": 64,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 64
+    },
+    {
+      "at_unix_ms": 1785328597829,
+      "at_run_us": 37179733,
+      "alive_tasks": 184,
+      "global_queue_depth": 184,
+      "local_queue_depth": 48,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 48
+    },
+    {
+      "at_unix_ms": 1785328597830,
+      "at_run_us": 37180916,
+      "alive_tasks": 120,
+      "global_queue_depth": 120,
+      "local_queue_depth": 40,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 40
+    },
+    {
+      "at_unix_ms": 1785328597831,
+      "at_run_us": 37182126,
+      "alive_tasks": 40,
+      "global_queue_depth": 40,
+      "local_queue_depth": 32,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 32
+    },
+    {
+      "at_unix_ms": 1785328597832,
+      "at_run_us": 37183229,
+      "alive_tasks": 40,
+      "global_queue_depth": 40,
+      "local_queue_depth": 24,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 24
+    },
+    {
+      "at_unix_ms": 1785328597834,
+      "at_run_us": 37184727,
+      "alive_tasks": 40,
+      "global_queue_depth": 40,
+      "local_queue_depth": 16,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 16
+    },
+    {
+      "at_unix_ms": 1785328597835,
+      "at_run_us": 37185840,
+      "alive_tasks": 40,
+      "global_queue_depth": 40,
+      "local_queue_depth": 0,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 0
+    },
+    {
+      "at_unix_ms": 1785328597836,
+      "at_run_us": 37187490,
+      "alive_tasks": 0,
+      "global_queue_depth": 0,
+      "local_queue_depth": 0,
+      "blocking_queue_depth": 0,
+      "remote_schedule_count": 0
+    }
+  ],
+  "truncation": {
+    "limits_hit": false,
+    "dropped_requests": 0,
+    "dropped_stages": 0,
+    "dropped_queues": 0,
+    "dropped_inflight_snapshots": 0,
+    "dropped_runtime_snapshots": 0
+  }
+}

--- a/validation/diagnostics/manifest.json
+++ b/validation/diagnostics/manifest.json
@@ -541,16 +541,18 @@
     },
     {
       "id": "blocking_sample",
-      "artifact": "../../demos/blocking_service/fixtures/sample-analysis.json",
-      "artifact_type": "analysis_report",
-      "validation_class": "report_contract",
-      "accuracy_eligible": false,
+      "artifact": "corpus/demo-runs/blocking-sample.json",
+      "artifact_type": "run_artifact",
+      "validation_class": "analyzer_execution",
+      "accuracy_eligible": true,
       "tags": [
         "blocking",
         "demo",
-        "sample"
+        "sample",
+        "raw-run",
+        "bounded-demo-snapshot"
       ],
-      "notes": "Blocking sample is canonical blocking saturation evidence.",
+      "notes": "Bounded committed fixture derived from a controlled blocking baseline capture.",
       "expected_primary_kinds": [
         "blocking_pool_pressure"
       ],
@@ -567,20 +569,24 @@
         "Top suspects are close in score",
         "Temporal segments show a large p95 latency shift between early and late requests."
       ],
-      "allowed_warnings": []
+      "allowed_warnings": [],
+      "observation_id": "blocking_sample",
+      "ground_truth": "blocking_pool_pressure"
     },
     {
       "id": "executor_sample",
-      "artifact": "../../demos/executor_pressure_service/fixtures/sample-analysis.json",
-      "artifact_type": "analysis_report",
-      "validation_class": "report_contract",
-      "accuracy_eligible": false,
+      "artifact": "corpus/demo-runs/executor-sample.json",
+      "artifact_type": "run_artifact",
+      "validation_class": "analyzer_execution",
+      "accuracy_eligible": true,
       "tags": [
         "executor",
         "demo",
-        "sample"
+        "sample",
+        "raw-run",
+        "bounded-demo-snapshot"
       ],
-      "notes": "Executor sample has clear runtime queue pressure cues.",
+      "notes": "Bounded committed fixture derived from a controlled executor baseline capture.",
       "expected_primary_kinds": [
         "executor_pressure_suspected"
       ],
@@ -593,7 +599,9 @@
       ],
       "must_include_next_checks": [],
       "expected_warnings": [],
-      "allowed_warnings": []
+      "allowed_warnings": [],
+      "observation_id": "executor_sample",
+      "ground_truth": "executor_pressure_suspected"
     },
     {
       "id": "downstream_sample",


### PR DESCRIPTION
### Motivation

- Provide analyzer-executed, accuracy-eligible coverage for the two controlled bottleneck families currently only covered by Report-contract fixtures: `blocking_pool_pressure` and `executor_pressure_suspected`.
- Preserve deterministic, low-volume committed fixtures (not full captures) so the deterministic corpus benchmark can validate analyzer accuracy without committing large demo captures.

### Description

- Add two bounded Run fixtures at `validation/diagnostics/corpus/demo-runs/blocking-sample.json` and `validation/diagnostics/corpus/demo-runs/executor-sample.json`, sized 72,598 bytes and 35,922 bytes respectively and combined 108,520 bytes, with host and pid cleared and truncation metadata preserved as non-truncated.
- Convert the `blocking_sample` and `executor_sample` manifest cases to `analyzer_execution` `run_artifact` entries, set `accuracy_eligible: true`, add `observation_id` and `ground_truth` (`blocking_pool_pressure` and `executor_pressure_suspected`), and append the `raw-run` and `bounded-demo-snapshot` tags while preserving existing contract fields.
- Refresh the analyzer fixture integrity lock (`validation/diagnostics/analyzer-fixtures.lock.json`) to include the two new fixtures and their byte/shape/hash inventory, and document the bounded-demo workflow in `validation/diagnostics/README.md`.
- Update validation docs to remove the deferred-corpus language and declare the five analyzer-executed ground-truth families, and add a concise `CHANGELOG.md` entry describing the committed bounded fixtures.

### Testing

- Verified fixture integrity with `python3 scripts/check_diagnostic_fixture_integrity.py` and refreshed the lock with `python3 scripts/check_diagnostic_fixture_integrity.py --refresh`, which produced a deterministic lock containing 13 fixtures and succeeded.
- Validated each bounded Run with the CLI analyzer via `cargo run -p tailtriage-cli -- analyze <fixture> --format json`, confirming the blocking fixture produced primary `blocking_pool_pressure` and the executor fixture produced primary `executor_pressure_suspected` while preserving required evidence and warnings.
- Ran the deterministic benchmark with `python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --output <summary>` and observed the expected final accounting: `manifest_case_count == 49`, `analyzer_execution == 13`, `run_artifact_count == 12`, `accuracy observations == 13`, `top-1 == 12/13`, `top-2 recall == 1.0`, and `high_confidence_wrong == 0`.
- Executed the repository validation and unit test suite including `python3 -m unittest` for the scripts tests, `python3 scripts/validate_docs_contracts.py`, `cargo test -p tailtriage-tracing --test equivalence_contract --all-features --locked`, and `cargo fmt --check`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69f33dd778833084930ec08920a880)