### PR TITLE
Clarify diagnostic validation responsibilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Diagnostic validation responsibilities are now documented as typed analyzer-rule tests, deterministic artifact-pipeline regression, and local/manual live-workload validation.
+
 - Committed analyzer fixtures now have a deterministic inventory, byte, formatting, and structural integrity lock checked before diagnostic execution.
 
 - Diagnostic validation now separates analyzer-executed accuracy observations from pre-generated Report-contract checks.

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -8,13 +8,15 @@ Pre-generated and synthetic Reports validate Report fields, warnings, evidence, 
 
 ## Validation responsibilities
 
-| Layer | What it proves | Mechanism | Execution |
+| Layer | Purpose | Mechanism | Execution |
 | --- | --- | --- | --- |
 | Analyzer rule correctness | Explicit evidence selects the intended diagnosis | Typed Rust tests | Normal CI |
-| Artifact pipeline regression | Representative committed artifacts pass through real intake and analyzer paths | Existing corpus and integrity lock | Normal CI |
-| Live workload behavior | Real demos produce useful signals on a particular machine | Existing demo and matrix runners | Local/manual |
+| Artifact pipeline regression | Representative committed artifacts pass through real intake and analyzer paths | Diagnostic corpus and integrity lock | Normal CI |
+| Live workload behavior | Real demos produce expected signals and preserve integration behavior | Bounded demo smoke/parity checks plus repeated-run and mitigation matrices | CI smoke/parity; local/manual repeated runs |
 
-Prompt 18A owns corpus accounting. Prompt 18B owns integrity protection for committed analyzer artifacts. Prompt 18C does not expand the corpus: diagnosis-family completeness belongs in typed analyzer tests, while committed artifacts protect representative decoding, import, CLI, warning, and end-to-end regression boundaries. Live demo outputs remain local/manual under `target/` and are not committed.
+The diagnostic manifest and benchmark own corpus classification and accounting. The analyzer fixture lock and integrity checker protect committed analyzer artifacts. Typed analyzer tests own diagnosis-rule coverage.
+
+Real workloads are validated in two ways: bounded demo smoke and parity checks may run in CI, while repeated-run and mitigation matrices remain local/manual and machine-scoped. Generated Runs, Reports, summaries, and matrix outputs remain under `target/` and are not committed.
 
 ## Summary
 `tailtriage` is a triage tool, not root-cause proof. It produces evidence-ranked suspects and next checks, where suspects are leads and not causal certainty.

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -4,7 +4,17 @@
 
 The schema-version-2 deterministic corpus separates analyzer-executed cases, unique accuracy-eligible observations, and report-contract cases. Raw Runs are analyzed at benchmark execution; stable tracing JSONL is imported and then analyzed. Analyzer cases have typed success/failure contracts and may be execution-only. Multiple artifact encodings of one logical workload execute independently but count once for accuracy and must agree on ordered diagnosis visibility and confidence bucket.
 
-Pre-generated and synthetic Reports validate Report fields, warnings, evidence, next checks, confidence, routes, and temporal output without executing the analyzer. They never contribute to analyzer accuracy. Fixture ground truth is controlled fixture intent, not production truth or root-cause proof. Typed fixture generation is deferred to Prompt 18B; corpus expansion and exact demo replacements are deferred to Prompt 18C, and no demo is removed here.
+Pre-generated and synthetic Reports validate Report fields, warnings, evidence, next checks, confidence, routes, and temporal output without executing the analyzer. They never contribute to analyzer accuracy. Fixture ground truth is controlled fixture intent, not production truth or root-cause proof.
+
+## Validation responsibilities
+
+| Layer | What it proves | Mechanism | Execution |
+| --- | --- | --- | --- |
+| Analyzer rule correctness | Explicit evidence selects the intended diagnosis | Typed Rust tests | Normal CI |
+| Artifact pipeline regression | Representative committed artifacts pass through real intake and analyzer paths | Existing corpus and integrity lock | Normal CI |
+| Live workload behavior | Real demos produce useful signals on a particular machine | Existing demo and matrix runners | Local/manual |
+
+Prompt 18A owns corpus accounting. Prompt 18B owns integrity protection for committed analyzer artifacts. Prompt 18C does not expand the corpus: diagnosis-family completeness belongs in typed analyzer tests, while committed artifacts protect representative decoding, import, CLI, warning, and end-to-end regression boundaries. Live demo outputs remain local/manual under `target/` and are not committed.
 
 ## Summary
 `tailtriage` is a triage tool, not root-cause proof. It produces evidence-ranked suspects and next checks, where suspects are leads and not causal certainty.

--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -12,11 +12,17 @@ Deterministic fixture validation is mandatory in normal CI; durable scorecards r
 
 ## Validation responsibilities
 
-Typed analyzer tests construct explicit evidence and prove that scoring rules select the intended diagnosis. Diagnosis-family scoring coverage belongs in these deterministic, machine-independent tests.
+| Layer | Purpose | Mechanism | Execution |
+| --- | --- | --- | --- |
+| Analyzer rule correctness | Explicit evidence selects the intended diagnosis | Typed Rust tests | Normal CI |
+| Artifact pipeline regression | Representative committed artifacts pass through real intake and analyzer paths | Diagnostic corpus and integrity lock | Normal CI |
+| Live workload behavior | Real demos produce expected signals and preserve integration behavior | Bounded demo smoke/parity checks plus repeated-run and mitigation matrices | CI smoke/parity; local/manual repeated runs |
+
+The diagnostic manifest and benchmark own corpus classification and accounting. The analyzer fixture lock and integrity checker protect committed analyzer artifacts. Typed analyzer tests own diagnosis-rule coverage.
 
 The committed diagnostic corpus proves that representative Run and tracing artifacts pass through the real decoding, import, CLI, and analyzer paths. Its `analyzer_accuracy` field measures agreement against controlled committed observation labels. It does not estimate universal or production accuracy, and the corpus does not need one analyzer fixture for every diagnosis family.
 
-Live demo, repeated-run, and mitigation matrices evaluate whether real workloads produce useful signals on a particular machine. These scheduler-, timing-, workload-, and machine-sensitive checks remain local/manual, with generated Runs and summaries under `target/` rather than committed as corpus artifacts.
+Real workloads are validated in two ways: bounded demo smoke and parity checks may run in CI, while repeated-run and mitigation matrices remain local/manual and machine-scoped. Generated Runs, Reports, summaries, and matrix outputs remain under `target/` and are not committed.
 
 ## Confidence calibration
 The scorecard includes confidence-bucket accuracy summaries (low/medium/high buckets) as calibration hints, not probability guarantees.

--- a/docs/diagnostic-validation.md
+++ b/docs/diagnostic-validation.md
@@ -10,8 +10,13 @@ Top-1 means the observation primary equals ground truth. Top-2 means ground trut
 ## Deterministic vs repeated-run validation
 Deterministic fixture validation is mandatory in normal CI; durable scorecards remain manual/tag snapshot outputs. Report-contract checks cover Report fields, warnings, evidence, next checks, confidence, routes, and temporal output but are not analyzer accuracy. Repeated-run validation is a separate manual/local, machine/workload-scoped track.
 
-## Deferred corpus work
-Deterministic typed fixture generation is deferred to Prompt 18B. An expanded analyzer-executed corpus and exact demo replacements are deferred to Prompt 18C; no demo is removed here.
+## Validation responsibilities
+
+Typed analyzer tests construct explicit evidence and prove that scoring rules select the intended diagnosis. Diagnosis-family scoring coverage belongs in these deterministic, machine-independent tests.
+
+The committed diagnostic corpus proves that representative Run and tracing artifacts pass through the real decoding, import, CLI, and analyzer paths. Its `analyzer_accuracy` field measures agreement against controlled committed observation labels. It does not estimate universal or production accuracy, and the corpus does not need one analyzer fixture for every diagnosis family.
+
+Live demo, repeated-run, and mitigation matrices evaluate whether real workloads produce useful signals on a particular machine. These scheduler-, timing-, workload-, and machine-sensitive checks remain local/manual, with generated Runs and summaries under `target/` rather than committed as corpus artifacts.
 
 ## Confidence calibration
 The scorecard includes confidence-bucket accuracy summaries (low/medium/high buckets) as calibration hints, not probability guarantees.

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -1391,6 +1391,44 @@ fn runtime_snapshot(
 }
 
 #[test]
+fn clear_blocking_pressure_selects_blocking_pool() {
+    let mut run = test_run();
+    run.requests = (0..20).map(sample_request).collect();
+    run.runtime_snapshots = vec![runtime_snapshot(Some(0), Some(0), Some(24)); 40];
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert_eq!(
+        report.primary_suspect.kind,
+        DiagnosisKind::BlockingPoolPressure
+    );
+    assert!(report
+        .primary_suspect
+        .evidence
+        .iter()
+        .any(|evidence| evidence.contains("Blocking queue depth")));
+}
+
+#[test]
+fn clear_scheduler_pressure_selects_executor_pressure() {
+    let mut run = test_run();
+    run.requests = (0..20).map(sample_request).collect();
+    run.runtime_snapshots = vec![runtime_snapshot(Some(140), Some(12), Some(0)); 40];
+
+    let report = analyze_run(&run, AnalyzeOptions::default());
+
+    assert_eq!(
+        report.primary_suspect.kind,
+        DiagnosisKind::ExecutorPressureSuspected
+    );
+    assert!(report
+        .primary_suspect
+        .evidence
+        .iter()
+        .any(|evidence| evidence.contains("Runtime global queue depth")));
+}
+
+#[test]
 fn downstream_stage_tie_break_is_deterministic() {
     let mut run = test_run();
     run.stages = vec![

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -22,7 +22,9 @@ The integrity checker deliberately stops at inventory, bytes, formatting, and co
 
 Add a committed analyzer fixture only when it protects an artifact-format, importer, CLI, warning, or end-to-end regression boundary. Do not add fixtures solely to achieve one fixture per diagnosis family.
 
-Diagnosis-family scoring coverage belongs in typed analyzer tests. Live demo Runs and summaries belong under `target/` and remain local/manual. The Prompt 18B integrity lock remains required for the existing committed analyzer fixtures.
+The diagnostic manifest and benchmark own corpus classification and accounting. The analyzer fixture lock and integrity checker protect committed analyzer artifacts. Typed analyzer tests own diagnosis-rule coverage.
+
+Bounded demo smoke and parity checks may run in CI. Repeated-run and mitigation matrices remain local/manual and machine-scoped. Generated Runs, Reports, summaries, and matrix outputs remain under `target/` and are not committed.
 
 Run `python3 scripts/check_diagnostic_fixture_integrity.py` to check the committed lock. For an intentional analyzer-fixture change, run `python3 scripts/check_diagnostic_fixture_integrity.py --refresh`, review the byte and shape changes, and commit the updated lock with the manually edited fixture. Refresh modifies only the lock.
 

--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -18,6 +18,12 @@ Case diagnosis contracts use `expected_primary_kinds`, `required_visible_suspect
 
 The integrity checker deliberately stops at inventory, bytes, formatting, and compact shape. The benchmark remains the typed and semantic validation boundary: raw Run fixtures are decoded and strictly validated through the CLI, while stable tracing JSONL fixtures pass through the public tracing importer before analysis. Matching lock hashes does not prove diagnosis correctness, and fixture labels remain controlled intent rather than production truth.
 
+## Fixture ownership rule
+
+Add a committed analyzer fixture only when it protects an artifact-format, importer, CLI, warning, or end-to-end regression boundary. Do not add fixtures solely to achieve one fixture per diagnosis family.
+
+Diagnosis-family scoring coverage belongs in typed analyzer tests. Live demo Runs and summaries belong under `target/` and remain local/manual. The Prompt 18B integrity lock remains required for the existing committed analyzer fixtures.
+
 Run `python3 scripts/check_diagnostic_fixture_integrity.py` to check the committed lock. For an intentional analyzer-fixture change, run `python3 scripts/check_diagnostic_fixture_integrity.py --refresh`, review the byte and shape changes, and commit the updated lock with the manually edited fixture. Refresh modifies only the lock.
 
 ## Running the benchmark


### PR DESCRIPTION
### Motivation

* Make the repository’s diagnostic validation model explicit and easier to understand by separating three responsibilities:

  * typed analyzer-rule correctness;
  * deterministic artifact-pipeline regression;
  * live workload validation through bounded CI smoke/parity checks and local/manual repeated-run analysis.
* Keep diagnosis-family scoring coverage in deterministic, machine-independent typed analyzer tests rather than adding one committed fixture per diagnosis family.
* Preserve the existing diagnostic corpus, manifest accounting, and fixture integrity protections without adding new Run or Report artifacts.

### Changes

* Document the three validation layers and their ownership boundaries in `VALIDATION.md` and `docs/diagnostic-validation.md`.
* Clarify that:

  * typed Rust tests prove evidence-to-diagnosis behavior;
  * the committed corpus protects decoding, import, CLI, warning, and end-to-end analyzer regression boundaries;
  * bounded demo smoke and parity checks may run in CI;
  * repeated-run and mitigation matrices remain local/manual and machine-scoped;
  * generated Runs, Reports, summaries, and matrix outputs remain under `target/` and are not committed.
* Clarify that `analyzer_accuracy` measures agreement against controlled committed observation labels and is not an estimate of universal or production accuracy.
* Add a maintainer rule to `validation/diagnostics/README.md` stating that committed analyzer fixtures should protect artifact or pipeline boundaries, not exist solely to provide one fixture per diagnosis family.
* Add two focused typed analyzer tests:

  * `clear_blocking_pressure_selects_blocking_pool`
  * `clear_scheduler_pressure_selects_executor_pressure`
* Each test constructs a coherent typed `Run`, invokes the analyzer directly, asserts the expected primary `DiagnosisKind`, and verifies diagnosis-specific evidence.
* Add a concise changelog entry describing the clarified validation responsibilities.

### Validation

* `cargo fmt --check`
* `cargo test -p tailtriage-analyzer --all-features --locked`
* `cargo clippy -p tailtriage-analyzer --all-targets --all-features --locked -- -D warnings`
* `python3 scripts/check_diagnostic_fixture_integrity.py`
* `python3 scripts/validate_docs_contracts.py`
* `python3 -m unittest scripts.tests.test_validate_docs_contracts`
* `python3 -m unittest scripts.tests.test_diagnostic_benchmark`
* `git diff --check`

The existing diagnostic benchmark accounting remains unchanged:

* 49 manifest cases
* 11 analyzer-executed cases
* 10 Run artifacts
* 1 tracing JSONL artifact
* 11 accuracy observations
* top-1 correct: 10/11
* top-2 recall: 1.0
* high-confidence wrong: 0
* 38 Report-contract cases

No fixtures, manifest entries, lock data, scripts, workflows, metrics, dependencies, crates, or production analyzer behavior were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a138711788330a689ccfb8b04740a)