### PR TITLE
Add manual release procedure and release preflight checker

### DIFF
--- a/.github/workflows/validation-snapshot.yml
+++ b/.github/workflows/validation-snapshot.yml
@@ -7,9 +7,6 @@ on:
         description: "Snapshot label, for example v0.3.0, pre-release, or validation-check"
         required: true
         type: string
-  push:
-    tags:
-      - "v*"
 
 permissions:
   contents: read
@@ -32,12 +29,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Set snapshot label
-        run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
-            echo "SNAPSHOT_LABEL=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"
-          else
-            echo "SNAPSHOT_LABEL=${{ inputs.snapshot_label }}" >> "$GITHUB_ENV"
-          fi
+        run: echo "SNAPSHOT_LABEL=${{ inputs.snapshot_label }}" >> "$GITHUB_ENV"
 
       - name: Sanitize snapshot label for artifact name
         run: |
@@ -68,7 +60,3 @@ jobs:
           name: diagnostic-validation-${{ env.SAFE_SNAPSHOT_LABEL }}-${{ env.SHORT_SHA }}
           path: target/validation/diagnostics
           retention-days: 90
-
-      - name: TODO release attach
-        run: |
-          echo "TODO: optionally attach snapshot artifact to GitHub Releases in a follow-up task."

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,47 @@
+# Manual release procedure
+
+This is the authoritative procedure for a manual `tailtriage` release. Release tooling is check-only. Crate publication is performed manually by a maintainer.
+
+1. Finalize the intended package version and dated changelog in a separate release-finalization change.
+2. Merge that change and select one exact, clean release commit.
+3. Record the commit's exact SHA.
+4. Run the normal repository completion gate:
+
+   ```bash
+   cargo fmt --check
+   cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+   cargo test --workspace --all-targets --all-features --locked
+   python3 scripts/validate_docs_contracts.py
+   ```
+
+5. Run the release validation profile:
+
+   ```bash
+   python3 scripts/validate_all.py \
+     --profile publish \
+     --profile-mode release
+   ```
+
+6. Run the release preflight checker (`0.4.0` is an example, not permanent policy):
+
+   ```bash
+   VERSION=0.4.0
+   python3 scripts/check_release.py --version "$VERSION"
+   ```
+
+7. Review the detected packages, publication order, Cargo packaging result, and generated manual commands.
+8. Manually publish one package at a time in the generated order.
+9. Verify each exact crate version publicly before continuing.
+10. Create and push an annotated tag only after every intended package is published. Tag signing is optional unless policy changes later.
+11. Create a draft GitHub Release manually.
+12. Review and publish the GitHub Release manually.
+
+Repository tooling does not publish crates. Generated publication commands are inert instructions only, and no crates.io credential belongs in repository tooling or GitHub Actions. Tags must not be pushed for an incomplete release. GitHub Release creation and publication remain manual.
+
+## If publication is interrupted
+
+- Verify which exact versions are already public; never republish an existing version.
+- Resume from the first unpublished package whose dependencies are public, preserving the generated order.
+- Do not tag an incomplete release.
+- Treat published packages as immutable.
+- Use a corrected patch version when an already published set cannot be completed coherently.

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -33,7 +33,7 @@ This repository includes an initial deterministic validation corpus for controll
 |---|---|---:|---:|
 | `scripts/diagnostic_benchmark.py` | Deterministic diagnostics corpus gate for committed manifest/fixtures | Yes | No |
 | `scripts/validate_docs_contracts.py` | Public-doc and validation-doc truth contract | Yes | No |
-| `.github/workflows/validation-snapshot.yml` | Versioned/manual diagnostic scorecard snapshot | Manual/tag | Yes |
+| `.github/workflows/validation-snapshot.yml` | Manual diagnostic scorecard snapshot | Manual | Yes |
 | `scripts/run_diagnostic_matrix.py` | Repeated controlled demo runs | No, local/manual | No |
 | `scripts/run_mitigation_matrix.py` | Baseline vs mitigated evidence-movement checks | No, local/manual | No |
 | `scripts/run_operational_validation.py` | Runtime-cost and collector-limit operational validation | Manual/local; some narrower smoke checks exist elsewhere | No |
@@ -124,8 +124,8 @@ Validation does not claim:
 Demos teach scenarios; validation measures bounded diagnostic behavior.
 
 
-## Versioned/manual diagnostic snapshots
-Durable diagnostic validation scorecards are generated only by `.github/workflows/validation-snapshot.yml` on `workflow_dispatch` and `v*` tags. Normal CI does not publish durable diagnostic scorecards and does not auto-overwrite `validation/diagnostics/latest/scorecard.md`.
+## Manual diagnostic snapshots
+Durable diagnostic validation scorecards are generated only by `.github/workflows/validation-snapshot.yml` through manual `workflow_dispatch`. Normal CI does not publish durable diagnostic scorecards and does not auto-overwrite `validation/diagnostics/latest/scorecard.md`.
 
 Snapshot artifacts include deterministic benchmark metrics, thresholds, git/ref metadata, `tailtriage` workspace/package version metadata, GitHub Actions metadata when available, software/hardware metadata, and manifest/referenced-artifact hashes.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,7 @@ This is the canonical map for the `tailtriage` documentation set. Choose the row
 ## Examples, demos, and repository reference
 
 - [Repository overview](../README.md)
+- [Manual release procedure](../RELEASING.md)
 - [Getting-started demo](getting-started-demo.md)
 - [Demo index](../demos/README.md)
 - [Implementation plan](../IMPLEMENTATION_PLAN.md)

--- a/scripts/check_release.py
+++ b/scripts/check_release.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Check whether a commit is ready for a manual crates.io release."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def command(argv: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(argv, capture_output=True, text=True)
+
+
+def is_publishable(package: dict[str, Any]) -> bool:
+    allowed = package.get("publish")
+    return allowed is None or "crates-io" in allowed
+
+
+def version_tuple(version: str) -> tuple[int, int, int] | None:
+    match = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)(?:[-+].*)?", version)
+    return tuple(map(int, match.groups())) if match else None  # type: ignore[return-value]
+
+
+def requirement_allows(requirement: str, version: str) -> bool:
+    """Cover the Cargo requirement forms used for workspace path dependencies."""
+    wanted = version_tuple(version)
+    if wanted is None:
+        return False
+    for alternative in requirement.split("||"):
+        clauses = [part.strip() for part in alternative.split(",")]
+        permitted = True
+        for clause in clauses:
+            match = re.fullmatch(r"(\^|~|=|>=|<=|>|<)?\s*(\d+)(?:\.(\d+|\*))?(?:\.(\d+|\*))?", clause)
+            if not match:
+                permitted = False
+                break
+            operator, major, minor, patch = match.groups()
+            parts = (int(major), int(minor or 0) if minor != "*" else 0, int(patch or 0) if patch != "*" else 0)
+            if minor == "*" or patch == "*" or (operator is None and (minor is None or patch is None)):
+                specified = 1 if minor in {None, "*"} else 2
+                permitted &= wanted[:specified] == parts[:specified]
+            elif operator in {None, "^"}:
+                upper = (parts[0] + 1, 0, 0) if parts[0] else ((0, parts[1] + 1, 0) if parts[1] else (0, 0, parts[2] + 1))
+                permitted &= parts <= wanted < upper
+            elif operator == "~":
+                permitted &= parts <= wanted < (parts[0], parts[1] + 1, 0)
+            else:
+                permitted &= {"=": wanted == parts, ">=": wanted >= parts, "<=": wanted <= parts, ">": wanted > parts, "<": wanted < parts}[operator]
+        if permitted:
+            return True
+    return False
+
+
+def publication_order(packages: list[dict[str, Any]], version: str) -> tuple[list[str], list[str]]:
+    names = {package["name"] for package in packages}
+    dependencies: dict[str, set[str]] = {name: set() for name in names}
+    errors: list[str] = []
+    for package in packages:
+        for dependency in package.get("dependencies", []):
+            dependency_name = dependency["name"]  # Cargo's package name, not a local rename.
+            if dependency_name not in names or dependency.get("kind") == "dev":
+                continue
+            dependencies[package["name"]].add(dependency_name)
+            if not requirement_allows(dependency["req"], version):
+                errors.append(
+                    f"{package['name']} requires internal package {dependency_name} as "
+                    f"{dependency['req']!r}, which does not allow {version}"
+                )
+
+    order: list[str] = []
+    remaining = {name: set(required) for name, required in dependencies.items()}
+    while remaining:
+        ready = sorted(name for name, required in remaining.items() if not required)
+        if not ready:
+            errors.append("publishable package dependency cycle detected: " + ", ".join(sorted(remaining)))
+            break
+        for name in ready:
+            order.append(name)
+            del remaining[name]
+        for required in remaining.values():
+            required.difference_update(ready)
+    return order, errors
+
+
+def changelog_errors(version: str, text: str) -> list[str]:
+    heading = re.search(rf"^##\s+\[?{re.escape(version)}\]?\s+-\s+(.+)$", text, re.MULTILINE)
+    if not heading:
+        return [f"CHANGELOG.md has no section for {version}"]
+    date = heading.group(1).strip()
+    errors = []
+    if date.lower() == "unreleased":
+        errors.append(f"CHANGELOG.md section for {version} is still Unreleased")
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", date):
+        errors.append(f"CHANGELOG.md heading for {version} needs a concrete YYYY-MM-DD date")
+    body_start = heading.end()
+    next_heading = re.search(r"^##\s+", text[body_start:], re.MULTILINE)
+    body = text[body_start : body_start + next_heading.start() if next_heading else None]
+    if not body.strip():
+        errors.append(f"CHANGELOG.md section for {version} is empty")
+    return errors
+
+
+def check(version: str, changelog: Path = Path("CHANGELOG.md")) -> int:
+    errors: list[str] = []
+    status = command(["git", "status", "--porcelain"])
+    if status.returncode != 0:
+        errors.append("could not inspect worktree cleanliness")
+    elif status.stdout.strip():
+        errors.append("worktree is not clean")
+
+    head_result = command(["git", "rev-parse", "HEAD"])
+    head = head_result.stdout.strip()
+    if head_result.returncode != 0 or not head:
+        errors.append("could not determine HEAD")
+    else:
+        print(f"HEAD: {head}")
+
+    metadata_result = command(["cargo", "metadata", "--format-version", "1", "--locked"])
+    metadata: dict[str, Any] = {}
+    if metadata_result.returncode != 0:
+        errors.append("cargo metadata failed")
+    else:
+        try:
+            metadata = json.loads(metadata_result.stdout)
+        except json.JSONDecodeError:
+            errors.append("cargo metadata returned invalid JSON")
+
+    workspace_ids = set(metadata.get("workspace_members", []))
+    workspace = [package for package in metadata.get("packages", []) if package["id"] in workspace_ids]
+    publishable = [package for package in workspace if is_publishable(package)]
+    non_publishable = sorted(package["name"] for package in workspace if not is_publishable(package))
+    if metadata and not publishable:
+        errors.append("workspace has no crates.io-publishable packages")
+    for package in publishable:
+        if package["version"] != version:
+            errors.append(f"{package['name']} has version {package['version']}, expected {version}")
+    order, graph_errors = publication_order(publishable, version)
+    errors.extend(graph_errors)
+    try:
+        errors.extend(changelog_errors(version, changelog.read_text(encoding="utf-8")))
+    except OSError as exc:
+        errors.append(f"could not read CHANGELOG.md: {exc}")
+
+    if errors:
+        print("Release preflight failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    package_command = ["cargo", "package", "--locked"]
+    for name in order:
+        package_command.extend(["-p", name])
+    packaged = command(package_command)
+    if packaged.returncode != 0:
+        print(f"Release preflight failed: cargo package exited with {packaged.returncode}", file=sys.stderr)
+        return 1
+
+    print(f"Requested version: {version}")
+    print("Publishable packages: " + ", ".join(sorted(package["name"] for package in publishable)))
+    print("Non-publishable workspace packages: " + (", ".join(non_publishable) or "none"))
+    print("Publication order: " + " -> ".join(order))
+    print("Cargo packaging: succeeded")
+    print("Manual publication instructions (do not run automatically):")
+    for name in order:
+        print(f"cargo publish --locked -p {name}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True)
+    return check(parser.parse_args().version)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_release.py
+++ b/scripts/check_release.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Check whether a commit is ready for a manual crates.io release."""
+"""Check whether a commit is ready for a manual release."""
 
 from __future__ import annotations
 
@@ -27,7 +27,7 @@ def failed_command(argv: list[str], result: subprocess.CompletedProcess[str]) ->
 
 def is_publishable(package: dict[str, Any]) -> bool:
     allowed = package.get("publish")
-    return allowed is None or "crates-io" in allowed
+    return allowed is None or bool(allowed)
 
 
 def version_tuple(version: str) -> tuple[int, int, int] | None:
@@ -121,7 +121,7 @@ def check(version: str, changelog: Path = Path("CHANGELOG.md")) -> int:
     if status.returncode != 0:
         errors.append("could not inspect worktree cleanliness:\n" + failed_command(status_command, status))
     elif status.stdout.strip():
-        errors.append("worktree is not clean")
+        errors.append("worktree is not clean:\n" + status.stdout.rstrip())
 
     head_command = ["git", "rev-parse", "HEAD"]
     head_result = command(head_command)
@@ -149,7 +149,7 @@ def check(version: str, changelog: Path = Path("CHANGELOG.md")) -> int:
     publishable = [package for package in workspace if is_publishable(package)]
     non_publishable = sorted(package["name"] for package in workspace if not is_publishable(package))
     if metadata and not publishable:
-        errors.append("workspace has no crates.io-publishable packages")
+        errors.append("workspace has no publishable packages")
     for package in publishable:
         if package["version"] != version:
             errors.append(f"{package['name']} has version {package['version']}, expected {version}")

--- a/scripts/check_release.py
+++ b/scripts/check_release.py
@@ -16,6 +16,15 @@ def command(argv: list[str]) -> subprocess.CompletedProcess[str]:
     return subprocess.run(argv, capture_output=True, text=True)
 
 
+def failed_command(argv: list[str], result: subprocess.CompletedProcess[str]) -> str:
+    details = [f"command {argv!r} exited with {result.returncode}"]
+    if result.stdout:
+        details.append(f"stdout:\n{result.stdout.rstrip()}")
+    if result.stderr:
+        details.append(f"stderr:\n{result.stderr.rstrip()}")
+    return "\n".join(details)
+
+
 def is_publishable(package: dict[str, Any]) -> bool:
     allowed = package.get("publish")
     return allowed is None or "crates-io" in allowed
@@ -107,28 +116,33 @@ def changelog_errors(version: str, text: str) -> list[str]:
 
 def check(version: str, changelog: Path = Path("CHANGELOG.md")) -> int:
     errors: list[str] = []
-    status = command(["git", "status", "--porcelain"])
+    status_command = ["git", "status", "--porcelain"]
+    status = command(status_command)
     if status.returncode != 0:
-        errors.append("could not inspect worktree cleanliness")
+        errors.append("could not inspect worktree cleanliness:\n" + failed_command(status_command, status))
     elif status.stdout.strip():
         errors.append("worktree is not clean")
 
-    head_result = command(["git", "rev-parse", "HEAD"])
+    head_command = ["git", "rev-parse", "HEAD"]
+    head_result = command(head_command)
     head = head_result.stdout.strip()
-    if head_result.returncode != 0 or not head:
+    if head_result.returncode != 0:
+        errors.append("could not determine HEAD:\n" + failed_command(head_command, head_result))
+    elif not head:
         errors.append("could not determine HEAD")
     else:
         print(f"HEAD: {head}")
 
-    metadata_result = command(["cargo", "metadata", "--format-version", "1", "--locked"])
+    metadata_command = ["cargo", "metadata", "--format-version", "1", "--locked"]
+    metadata_result = command(metadata_command)
     metadata: dict[str, Any] = {}
     if metadata_result.returncode != 0:
-        errors.append("cargo metadata failed")
+        errors.append("cargo metadata failed:\n" + failed_command(metadata_command, metadata_result))
     else:
         try:
             metadata = json.loads(metadata_result.stdout)
-        except json.JSONDecodeError:
-            errors.append("cargo metadata returned invalid JSON")
+        except json.JSONDecodeError as exc:
+            errors.append(f"cargo metadata returned invalid JSON: {exc}")
 
     workspace_ids = set(metadata.get("workspace_members", []))
     workspace = [package for package in metadata.get("packages", []) if package["id"] in workspace_ids]
@@ -157,7 +171,7 @@ def check(version: str, changelog: Path = Path("CHANGELOG.md")) -> int:
         package_command.extend(["-p", name])
     packaged = command(package_command)
     if packaged.returncode != 0:
-        print(f"Release preflight failed: cargo package exited with {packaged.returncode}", file=sys.stderr)
+        print("Release preflight failed: " + failed_command(package_command, packaged), file=sys.stderr)
         return 1
 
     print(f"Requested version: {version}")

--- a/scripts/tests/test_check_release.py
+++ b/scripts/tests/test_check_release.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts import check_release
+
+
+def result(returncode: int = 0, stdout: str = ""):
+    return check_release.subprocess.CompletedProcess([], returncode, stdout, "")
+
+
+def metadata(version: str = "1.2.3") -> dict:
+    packages = [
+        {"id": "core", "name": "core", "version": version, "publish": None, "dependencies": []},
+        {
+            "id": "api",
+            "name": "api",
+            "version": version,
+            "publish": ["crates-io"],
+            "dependencies": [{"name": "core", "rename": "foundation", "req": "^1.2.3", "kind": "build"}],
+        },
+        {"id": "cli", "name": "cli", "version": version, "publish": None, "dependencies": [{"name": "core", "req": "^1.2.3", "kind": None}]},
+        {"id": "demo", "name": "demo", "version": version, "publish": [], "dependencies": []},
+        {"id": "private", "name": "private", "version": version, "publish": ["internal"], "dependencies": []},
+    ]
+    return {"workspace_members": [package["id"] for package in packages], "packages": packages}
+
+
+class CheckReleaseTests(unittest.TestCase):
+    def test_classification_and_deterministic_dependency_order(self) -> None:
+        packages = metadata()["packages"]
+        publishable = [package for package in packages if check_release.is_publishable(package)]
+        order, errors = check_release.publication_order(publishable, "1.2.3")
+        self.assertEqual(["core", "api", "cli"], order)
+        self.assertEqual([], errors)
+        self.assertEqual(["demo", "private"], [package["name"] for package in packages if not check_release.is_publishable(package)])
+
+    def test_readiness_failure_suppresses_package_and_publish_commands(self) -> None:
+        calls: list[list[str]] = []
+
+        def run(argv: list[str]):
+            calls.append(argv)
+            if argv[:2] == ["git", "status"]:
+                return result(stdout="dirty\n")
+            if argv[:2] == ["git", "rev-parse"]:
+                return result(stdout="abc\n")
+            return result(stdout=json.dumps(metadata()))
+
+        with tempfile.TemporaryDirectory() as directory:
+            changelog = Path(directory) / "CHANGELOG.md"
+            changelog.write_text("## [1.2.3] - Unreleased\n\nNotes.\n", encoding="utf-8")
+            output = io.StringIO()
+            with patch.object(check_release, "command", side_effect=run), redirect_stdout(output), redirect_stderr(output):
+                self.assertEqual(1, check_release.check("1.2.3", changelog))
+        self.assertFalse(any(call[:2] == ["cargo", "package"] for call in calls))
+        self.assertNotIn("cargo publish", output.getvalue())
+
+    def test_success_packages_once_and_prints_publication_order(self) -> None:
+        calls: list[list[str]] = []
+
+        def run(argv: list[str]):
+            calls.append(argv)
+            if argv[:2] == ["git", "status"]:
+                return result()
+            if argv[:2] == ["git", "rev-parse"]:
+                return result(stdout="abc\n")
+            if argv[:2] == ["cargo", "metadata"]:
+                return result(stdout=json.dumps(metadata()))
+            return result()
+
+        with tempfile.TemporaryDirectory() as directory:
+            changelog = Path(directory) / "CHANGELOG.md"
+            changelog.write_text("## [1.2.3] - 2026-08-07\n\nNotes.\n", encoding="utf-8")
+            output = io.StringIO()
+            with patch.object(check_release, "command", side_effect=run), redirect_stdout(output):
+                self.assertEqual(0, check_release.check("1.2.3", changelog))
+        packages = [call for call in calls if call[:2] == ["cargo", "package"]]
+        self.assertEqual([["cargo", "package", "--locked", "-p", "core", "-p", "api", "-p", "cli"]], packages)
+        printed = output.getvalue()
+        self.assertLess(printed.index("cargo publish --locked -p core"), printed.index("cargo publish --locked -p api"))
+        self.assertLess(printed.index("cargo publish --locked -p api"), printed.index("cargo publish --locked -p cli"))
+
+    def test_packaging_failure_suppresses_publication_commands(self) -> None:
+        def run(argv: list[str]):
+            if argv[:2] == ["git", "status"]:
+                return result()
+            if argv[:2] == ["git", "rev-parse"]:
+                return result(stdout="abc\n")
+            if argv[:2] == ["cargo", "metadata"]:
+                return result(stdout=json.dumps(metadata()))
+            return result(returncode=2)
+
+        with tempfile.TemporaryDirectory() as directory:
+            changelog = Path(directory) / "CHANGELOG.md"
+            changelog.write_text("## [1.2.3] - 2026-08-07\n\nNotes.\n", encoding="utf-8")
+            output = io.StringIO()
+            with patch.object(check_release, "command", side_effect=run), redirect_stdout(output), redirect_stderr(output):
+                self.assertEqual(1, check_release.check("1.2.3", changelog))
+        self.assertIn("cargo package exited with 2", output.getvalue())
+        self.assertNotIn("cargo publish", output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_check_release.py
+++ b/scripts/tests/test_check_release.py
@@ -37,9 +37,9 @@ class CheckReleaseTests(unittest.TestCase):
         packages = metadata()["packages"]
         publishable = [package for package in packages if check_release.is_publishable(package)]
         order, errors = check_release.publication_order(publishable, "1.2.3")
-        self.assertEqual(["core", "api", "cli"], order)
+        self.assertEqual(["core", "private", "api", "cli"], order)
         self.assertEqual([], errors)
-        self.assertEqual(["demo", "private"], [package["name"] for package in packages if not check_release.is_publishable(package)])
+        self.assertEqual(["demo"], [package["name"] for package in packages if not check_release.is_publishable(package)])
 
     def test_readiness_failure_suppresses_package_and_publish_commands(self) -> None:
         calls: list[list[str]] = []
@@ -47,7 +47,7 @@ class CheckReleaseTests(unittest.TestCase):
         def run(argv: list[str]):
             calls.append(argv)
             if argv[:2] == ["git", "status"]:
-                return result(stdout="dirty\n")
+                return result(stdout=" M some/file\n?? another/file\n")
             if argv[:2] == ["git", "rev-parse"]:
                 return result(stdout="abc\n")
             return result(stdout=json.dumps(metadata()))
@@ -59,6 +59,7 @@ class CheckReleaseTests(unittest.TestCase):
             with patch.object(check_release, "command", side_effect=run), redirect_stdout(output), redirect_stderr(output):
                 self.assertEqual(1, check_release.check("1.2.3", changelog))
         self.assertFalse(any(call[:2] == ["cargo", "package"] for call in calls))
+        self.assertIn("worktree is not clean:\n M some/file\n?? another/file", output.getvalue())
         self.assertNotIn("cargo publish", output.getvalue())
 
     def test_success_packages_once_and_prints_publication_order(self) -> None:
@@ -81,9 +82,12 @@ class CheckReleaseTests(unittest.TestCase):
             with patch.object(check_release, "command", side_effect=run), redirect_stdout(output):
                 self.assertEqual(0, check_release.check("1.2.3", changelog))
         packages = [call for call in calls if call[:2] == ["cargo", "package"]]
-        self.assertEqual([["cargo", "package", "--locked", "-p", "core", "-p", "api", "-p", "cli"]], packages)
+        self.assertEqual(
+            [["cargo", "package", "--locked", "-p", "core", "-p", "private", "-p", "api", "-p", "cli"]], packages
+        )
         printed = output.getvalue()
         self.assertLess(printed.index("cargo publish --locked -p core"), printed.index("cargo publish --locked -p api"))
+        self.assertIn("cargo publish --locked -p private", printed)
         self.assertLess(printed.index("cargo publish --locked -p api"), printed.index("cargo publish --locked -p cli"))
 
     def test_packaging_failure_suppresses_publication_commands(self) -> None:
@@ -103,7 +107,10 @@ class CheckReleaseTests(unittest.TestCase):
             with patch.object(check_release, "command", side_effect=run), redirect_stdout(output), redirect_stderr(output):
                 self.assertEqual(1, check_release.check("1.2.3", changelog))
         printed = output.getvalue()
-        self.assertIn("command ['cargo', 'package', '--locked', '-p', 'core', '-p', 'api', '-p', 'cli'] exited with 2", printed)
+        self.assertIn(
+            "command ['cargo', 'package', '--locked', '-p', 'core', '-p', 'private', '-p', 'api', '-p', 'cli'] exited with 2",
+            printed,
+        )
         self.assertIn("stdout:\npackage stdout", printed)
         self.assertIn("stderr:\npackage stderr", printed)
         self.assertNotIn("cargo publish", printed)

--- a/scripts/tests/test_check_release.py
+++ b/scripts/tests/test_check_release.py
@@ -11,8 +11,8 @@ from unittest.mock import patch
 from scripts import check_release
 
 
-def result(returncode: int = 0, stdout: str = ""):
-    return check_release.subprocess.CompletedProcess([], returncode, stdout, "")
+def result(returncode: int = 0, stdout: str = "", stderr: str = ""):
+    return check_release.subprocess.CompletedProcess([], returncode, stdout, stderr)
 
 
 def metadata(version: str = "1.2.3") -> dict:
@@ -94,7 +94,7 @@ class CheckReleaseTests(unittest.TestCase):
                 return result(stdout="abc\n")
             if argv[:2] == ["cargo", "metadata"]:
                 return result(stdout=json.dumps(metadata()))
-            return result(returncode=2)
+            return result(returncode=2, stdout="package stdout\n", stderr="package stderr\n")
 
         with tempfile.TemporaryDirectory() as directory:
             changelog = Path(directory) / "CHANGELOG.md"
@@ -102,8 +102,11 @@ class CheckReleaseTests(unittest.TestCase):
             output = io.StringIO()
             with patch.object(check_release, "command", side_effect=run), redirect_stdout(output), redirect_stderr(output):
                 self.assertEqual(1, check_release.check("1.2.3", changelog))
-        self.assertIn("cargo package exited with 2", output.getvalue())
-        self.assertNotIn("cargo publish", output.getvalue())
+        printed = output.getvalue()
+        self.assertIn("command ['cargo', 'package', '--locked', '-p', 'core', '-p', 'api', '-p', 'cli'] exited with 2", printed)
+        self.assertIn("stdout:\npackage stdout", printed)
+        self.assertIn("stderr:\npackage stderr", printed)
+        self.assertNotIn("cargo publish", printed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation

* Establish one authoritative manual release procedure for `tailtriage`.
* Keep repository release tooling check-only: package publication, tagging, and GitHub Release publication remain manual maintainer actions.
* Add a compact credential-free preflight checker that validates release readiness, package ordering, and Cargo packaging without publishing anything.
* Remove obsolete release-adjacent behavior from the diagnostic snapshot workflow so validation snapshots are explicitly manual and independent from releases.

### Description

* Add `RELEASING.md` as the authoritative manual release procedure, covering:
  * repository validation;
  * release preflight checks;
  * dependency-aware publication order;
  * manual package publication;
  * post-publication verification;
  * tagging and GitHub Release steps;
  * interrupted-publication handling.
* Link the release procedure from `docs/README.md`.
* Add `scripts/check_release.py`, a single-mode CLI (`--version <version>`) that:

  * requires a clean worktree and reports the exact `HEAD`;
  * runs `cargo metadata --format-version 1 --locked`;
  * derives publishable workspace packages from Cargo metadata without hard-coding a registry;
  * verifies package versions and internal dependency requirements;
  * checks for a dated, non-empty changelog section;
  * computes a deterministic dependency-correct publication order, including build dependencies and excluding dev dependencies;
  * rejects dependency cycles;
  * runs one multi-package `cargo package --locked -p ...` verification only after readiness checks pass;
  * reports detailed subprocess failures including argv, exit code, stdout, and stderr;
  * prints inert `cargo publish --locked -p <package>` instructions only after packaging succeeds.
* Add four focused unit tests in `scripts/tests/test_check_release.py` covering:

  * publishability classification and dependency ordering;
  * readiness-failure suppression of packaging/publication instructions;
  * successful one-shot packaging and publication-order output;
  * packaging failure diagnostics and suppression of publication instructions.
* Simplify `.github/workflows/validation-snapshot.yml` to manual `workflow_dispatch` only:

  * remove the `v*` tag trigger;
  * remove tag-specific snapshot-label handling;
  * remove the obsolete GitHub Release attachment placeholder;
  * retain diagnostic snapshot generation and artifact upload.
* Update `VALIDATION.md` so durable diagnostic snapshots are documented as manual-only.

### Release boundaries

* No repository or GitHub Actions path executes `cargo publish`.
* No registry credentials or tokens are added to repository tooling.
* Registry selection is not hard-coded by the preflight checker.
* Tags and GitHub Releases remain manual.
* Diagnostic snapshots are not coupled to release tags or publication.

### Testing

* `python3 -m unittest scripts.tests.test_check_release`
* `python3 -m unittest scripts.tests.test_validate_docs_contracts`
* `python3 scripts/validate_docs_contracts.py`
* `python3 scripts/check_release.py --version 0.4.0`

  * expected to fail against the current repository state because release finalization has not occurred;
  * confirms readiness failures suppress `cargo package` and publication instructions.
* `cargo fmt --check`
* `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
* `cargo test --workspace --all-targets --all-features --locked`
* `git diff --check`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7591e388988330ac74aaa576c3ff21)