### PR TITLE
security: bound live collector bookkeeping

### DIFF
--- a/tailtriage-controller/src/lib.rs
+++ b/tailtriage-controller/src/lib.rs
@@ -217,7 +217,7 @@ struct ActiveGenerationRuntime {
     state: ActiveGenerationState,
     artifact_path: PathBuf,
     run: Arc<Tailtriage>,
-    admission_gate: Mutex<()>,
+    admission_gate: Mutex<AdmissionState>,
     finalization_gate: Mutex<()>,
     finalization_result: Mutex<GenerationFinalizationResult>,
     accepting_new: AtomicBool,
@@ -230,6 +230,11 @@ struct ActiveGenerationRuntime {
     finalization_test_hooks: Mutex<FinalizationTestHooks>,
     #[cfg(test)]
     admission_test_hooks: Mutex<AdmissionTestHooks>,
+}
+
+#[derive(Debug, Default)]
+struct AdmissionState {
+    admitted_request_slots: usize,
 }
 
 #[cfg(test)]
@@ -525,7 +530,7 @@ impl TailtriageController {
             },
             artifact_path,
             run: Arc::clone(&run),
-            admission_gate: Mutex::new(()),
+            admission_gate: Mutex::new(AdmissionState::default()),
             finalization_gate: Mutex::new(()),
             finalization_result: Mutex::default(),
             accepting_new: AtomicBool::new(true),
@@ -671,7 +676,7 @@ impl TailtriageController {
                 }
             }
 
-            let _admission = active
+            let mut admission = active
                 .admission_gate
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -686,28 +691,62 @@ impl TailtriageController {
                         RunEndReason::AutoSealOnLimitsHit,
                     );
                 } else {
-                    // Admission is linearized with every controller closure path by the
-                    // generation admission gate. The core pair is created before the
-                    // controller in-flight counter is committed, and neither is exposed to
-                    // the caller until both steps complete.
-                    let started = active
+                    let max_requests = active
                         .run
-                        .begin_request_with_owned(route.clone(), options.clone());
-                    active.inflight_captured.fetch_add(1, Ordering::AcqRel);
+                        .effective_core_config()
+                        .capture_limits
+                        .max_requests;
+                    if admission.admitted_request_slots >= max_requests {
+                        if active.state.activation_config.run_end_policy
+                            == RunEndPolicy::AutoSealOnLimitsHit
+                        {
+                            Self::close_generation_admissions_locked(
+                                &active,
+                                RunEndReason::AutoSealOnLimitsHit,
+                            );
+                        }
 
-                    return ControllerStartedRequest {
-                        handle: ControllerRequestHandle::Active(started.handle),
-                        completion: ControllerRequestCompletion {
-                            kind: ControllerCompletionKind::Active(ActiveControllerCompletion {
-                                completion: Some(started.completion),
-                                admission_generation_id: active.state.generation_id,
-                                admitted_generation: Arc::downgrade(&active),
-                                inner: Arc::downgrade(&self.inner),
-                                run_end_policy: active.state.activation_config.run_end_policy,
-                                inflight_recorded: true,
-                            }),
-                        },
-                    };
+                        // Core remains authoritative for refusal accounting and the
+                        // synchronous first-transition notification. Auto-seal closure
+                        // is already linearized above, so its callback cannot re-enter
+                        // this gate.
+                        let _refused = active
+                            .run
+                            .begin_request_with_owned(route.clone(), options.clone());
+                    } else {
+                        // Admission is linearized with every controller closure path by the
+                        // generation admission gate. The core pair is created before the
+                        // controller in-flight counter is committed, and neither is exposed to
+                        // the caller until both steps complete.
+                        let started = active
+                            .run
+                            .begin_request_with_owned(route.clone(), options.clone());
+                        // Request capacity is monotonic for a run: pending requests become
+                        // retained requests without releasing a slot. Controller-owned
+                        // production admissions are serialized here, while core independently
+                        // enforces the same hard bound.
+                        admission.admitted_request_slots += 1;
+                        active.inflight_captured.fetch_add(1, Ordering::AcqRel);
+
+                        return ControllerStartedRequest {
+                            handle: ControllerRequestHandle::Active(started.handle),
+                            completion: ControllerRequestCompletion {
+                                kind: ControllerCompletionKind::Active(
+                                    ActiveControllerCompletion {
+                                        completion: Some(started.completion),
+                                        admission_generation_id: active.state.generation_id,
+                                        admitted_generation: Arc::downgrade(&active),
+                                        inner: Arc::downgrade(&self.inner),
+                                        run_end_policy: active
+                                            .state
+                                            .activation_config
+                                            .run_end_policy,
+                                        inflight_recorded: true,
+                                    },
+                                ),
+                            },
+                        };
+                    }
                 }
             }
         }
@@ -1004,8 +1043,14 @@ impl TailtriageController {
         let Some(active) = active.upgrade() else {
             return;
         };
-        let inflight =
-            Self::close_generation_admissions(&active, RunEndReason::AutoSealOnLimitsHit);
+        let inflight = if active.closing.load(Ordering::Acquire) {
+            // Request-capacity auto-seal is pre-linearized while admission_gate is
+            // held. Once closing is visible no later admission can change this count,
+            // so the synchronous core callback must not recursively acquire the gate.
+            active.inflight_captured.load(Ordering::Acquire)
+        } else {
+            Self::close_generation_admissions(&active, RunEndReason::AutoSealOnLimitsHit)
+        };
 
         if inflight > 0 {
             return;
@@ -1980,7 +2025,7 @@ mod tests {
             },
             artifact_path,
             run,
-            admission_gate: Mutex::new(()),
+            admission_gate: Mutex::new(super::AdmissionState::default()),
             finalization_gate: Mutex::new(()),
             finalization_result: Mutex::default(),
             accepting_new: std::sync::atomic::AtomicBool::new(true),
@@ -2559,8 +2604,11 @@ mod tests {
 
         let active = controller.enable().expect("enable should succeed");
         controller.begin_request("/checkout").completion.finish_ok();
-        controller.begin_request("/checkout").completion.finish_ok();
-        controller.begin_request("/checkout").completion.finish_ok();
+        let refused_one = controller.begin_request_with(
+            "/checkout",
+            RequestOptions::new().request_id("refused-one").kind("test"),
+        );
+        let refused_two = controller.begin_request("/checkout");
 
         let status = controller.status();
         let GenerationState::Active(active_status) = status.generation else {
@@ -2568,6 +2616,13 @@ mod tests {
         };
         assert!(active_status.accepting_new_admissions);
         assert!(!active_status.closing);
+        assert_eq!(active_status.inflight_captured_requests, 0);
+        assert!(matches!(
+            &refused_one.handle,
+            super::ControllerRequestHandle::Inert(_)
+        ));
+        assert_eq!(refused_one.handle.request_id(), "refused-one");
+        assert_eq!(refused_one.handle.kind(), Some("test"));
 
         assert!(matches!(
             controller.disable(),
@@ -2581,6 +2636,13 @@ mod tests {
             run.metadata.run_end_reason,
             Some(tailtriage_core::RunEndReason::ManualDisarm)
         );
+
+        refused_one.completion.finish_ok();
+        drop(refused_two.completion);
+        assert!(matches!(
+            controller.status().generation,
+            GenerationState::Disabled { next_generation: 2 }
+        ));
 
         fs::remove_file(active.artifact_path).expect("cleanup should succeed");
     }
@@ -2600,7 +2662,7 @@ mod tests {
 
         let active = controller.enable().expect("enable should succeed");
         controller.begin_request("/checkout").completion.finish_ok();
-        controller.begin_request("/checkout").completion.finish_ok();
+        let refused = controller.begin_request("/checkout");
 
         let status = controller.status();
         assert!(matches!(
@@ -2610,11 +2672,131 @@ mod tests {
 
         let run = read_run(&active.artifact_path);
         assert!(run.truncation.limits_hit);
-        assert!(run.truncation.dropped_requests > 0);
+        assert_eq!(run.truncation.dropped_requests, 1);
         assert_eq!(
             run.metadata.run_end_reason,
             Some(tailtriage_core::RunEndReason::AutoSealOnLimitsHit)
         );
+
+        refused.completion.finish_ok();
+        assert!(matches!(
+            controller.status().generation,
+            GenerationState::Disabled { next_generation: 2 }
+        ));
+
+        fs::remove_file(active.artifact_path).expect("cleanup should succeed");
+    }
+
+    #[test]
+    fn admitted_request_alone_controls_auto_seal_drain() {
+        let output = test_output("auto-seal-admitted-drain");
+        let controller = TailtriageController::builder("checkout-service")
+            .output(&output)
+            .run_end_policy(RunEndPolicy::AutoSealOnLimitsHit)
+            .capture_limits_override(CaptureLimitsOverride {
+                max_requests: Some(1),
+                ..CaptureLimitsOverride::default()
+            })
+            .build()
+            .expect("build should succeed");
+
+        let active = controller.enable().expect("enable should succeed");
+        let admitted = controller.begin_request("/admitted");
+        let refused = controller.begin_request("/refused");
+
+        let GenerationState::Active(status) = controller.status().generation else {
+            panic!("admitted request should keep the generation draining");
+        };
+        assert!(status.closing);
+        assert!(!status.accepting_new_admissions);
+        assert_eq!(status.inflight_captured_requests, 1);
+        assert!(matches!(
+            &refused.handle,
+            super::ControllerRequestHandle::Inert(_)
+        ));
+
+        refused.completion.finish_ok();
+        assert!(matches!(
+            controller.status().generation,
+            GenerationState::Active(ref status) if status.inflight_captured_requests == 1
+        ));
+
+        admitted.completion.finish_ok();
+        assert!(matches!(
+            controller.status().generation,
+            GenerationState::Disabled { next_generation: 2 }
+        ));
+        let run = read_run(&active.artifact_path);
+        assert_eq!(run.truncation.dropped_requests, 1);
+        assert_eq!(
+            run.metadata.run_end_reason,
+            Some(tailtriage_core::RunEndReason::AutoSealOnLimitsHit)
+        );
+
+        fs::remove_file(active.artifact_path).expect("cleanup should succeed");
+    }
+
+    #[test]
+    fn request_limit_synchronous_callback_returns_without_gate_reentry() {
+        let output = test_output("synchronous-request-limit-callback");
+        let controller = TailtriageController::builder("checkout-service")
+            .output(&output)
+            .run_end_policy(RunEndPolicy::AutoSealOnLimitsHit)
+            .capture_limits_override(CaptureLimitsOverride {
+                max_requests: Some(0),
+                ..CaptureLimitsOverride::default()
+            })
+            .build()
+            .expect("build should succeed");
+
+        let active = controller.enable().expect("enable should succeed");
+        let refused = controller.begin_request("/known-full");
+
+        assert!(matches!(
+            controller.status().generation,
+            GenerationState::Disabled { next_generation: 2 }
+        ));
+        let run = read_run(&active.artifact_path);
+        assert_eq!(run.truncation.dropped_requests, 1);
+        assert_eq!(
+            run.metadata.run_end_reason,
+            Some(tailtriage_core::RunEndReason::AutoSealOnLimitsHit)
+        );
+        drop(refused.completion);
+
+        fs::remove_file(active.artifact_path).expect("cleanup should succeed");
+    }
+
+    #[test]
+    fn zero_request_capacity_refuses_without_controller_inflight() {
+        let output = test_output("zero-request-capacity");
+        let controller = TailtriageController::builder("checkout-service")
+            .output(&output)
+            .capture_limits_override(CaptureLimitsOverride {
+                max_requests: Some(0),
+                ..CaptureLimitsOverride::default()
+            })
+            .build()
+            .expect("zero request capacity should be supported");
+
+        let active = controller.enable().expect("enable should succeed");
+        let refused = controller.begin_request("/refused");
+        let GenerationState::Active(status) = controller.status().generation else {
+            panic!("continue policy should remain active");
+        };
+        assert_eq!(status.inflight_captured_requests, 0);
+        assert!(matches!(
+            &refused.handle,
+            super::ControllerRequestHandle::Inert(_)
+        ));
+        assert!(matches!(
+            controller.disable(),
+            Ok(DisableOutcome::Finalized { generation_id }) if generation_id == active.generation_id
+        ));
+        let run = read_run(&active.artifact_path);
+        assert_eq!(run.truncation.dropped_requests, 1);
+        assert!(run.truncation.limits_hit);
+        drop(refused.completion);
 
         fs::remove_file(active.artifact_path).expect("cleanup should succeed");
     }

--- a/tailtriage-controller/src/lib.rs
+++ b/tailtriage-controller/src/lib.rs
@@ -2750,7 +2750,23 @@ mod tests {
             .expect("build should succeed");
 
         let active = controller.enable().expect("enable should succeed");
-        let refused = controller.begin_request("/known-full");
+        let (returned_tx, returned_rx) = mpsc::channel();
+        let worker_controller = controller.clone();
+        let worker = std::thread::spawn(move || {
+            let refused = worker_controller.begin_request("/known-full");
+            returned_tx
+                .send(refused)
+                .expect("test thread should receive the refused request");
+        });
+        let refused = returned_rx
+            .recv_timeout(Duration::from_secs(2))
+            .unwrap_or_else(|error| {
+                panic!(
+                    "synchronous request-limit notification failed to return and may have \
+                     re-entered the admission gate: {error}"
+                )
+            });
+        worker.join().expect("request admission worker should exit");
 
         assert!(matches!(
             controller.status().generation,

--- a/tailtriage-core/src/collector.rs
+++ b/tailtriage-core/src/collector.rs
@@ -387,6 +387,11 @@ impl Tailtriage {
         lock_state(&self.state.mutex).inflight_counts.len()
     }
 
+    #[cfg(test)]
+    pub(crate) fn pending_request_count(&self) -> usize {
+        lock_state(&self.state.mutex).pending_requests.len()
+    }
+
     /// Writes the current run artifact and finishes the run lifecycle.
     ///
     /// With default/non-strict lifecycle, unfinished requests are recorded in
@@ -496,6 +501,26 @@ impl Tailtriage {
             let sample = self.run_clock.sample();
             let mut state = lock_state(&self.state.mutex);
             if !matches!(state.phase, CollectorPhase::Open) {
+                return InflightGuard {
+                    tailtriage: self,
+                    gauge,
+                    enabled: false,
+                };
+            }
+            if !state.inflight_counts.contains_key(&gauge)
+                && state.inflight_counts.len() >= self.limits.max_inflight_snapshots
+            {
+                self.truncation_state.inflight.mark_saturated();
+                state.run.truncation.dropped_inflight_snapshots = state
+                    .run
+                    .truncation
+                    .dropped_inflight_snapshots
+                    .saturating_add(1);
+                let notify_limits_hit = self.truncation_state.mark_run_limits_hit(&mut state.run);
+                drop(state);
+                if notify_limits_hit {
+                    self.notify_limits_hit_listener();
+                }
                 return InflightGuard {
                     tailtriage: self,
                     gauge,
@@ -655,6 +680,22 @@ impl Tailtriage {
         }
     }
 
+    fn notify_limits_hit_listener_async(&self) {
+        let listener = self
+            .limits_hit_listener
+            .lock()
+            .expect("limits-hit listener lock poisoned")
+            .clone();
+        if let Some(listener) = listener {
+            // Request admission may be called while an integration holds its
+            // own admission lock. Dispatching this one-shot transition avoids
+            // calling back into that integration while its lock is held.
+            let _ = std::thread::Builder::new()
+                .name("tailtriage-limits-hit".into())
+                .spawn(move || listener());
+        }
+    }
+
     fn start_request(
         &self,
         route: String,
@@ -672,13 +713,26 @@ impl Tailtriage {
             kind: kind.clone(),
             interval_start,
         };
+        let mut notify_limits_hit = false;
         let mut state = lock_state(&self.state.mutex);
-        let pending_key = if matches!(state.phase, CollectorPhase::Open) {
+        let pending_key = if matches!(state.phase, CollectorPhase::Open)
+            && state.run.requests.len() + state.pending_requests.len() < self.limits.max_requests
+        {
             state.pending_requests.insert(pending_key, pending);
             Some(pending_key)
         } else {
+            if matches!(state.phase, CollectorPhase::Open) {
+                state.run.truncation.dropped_requests =
+                    state.run.truncation.dropped_requests.saturating_add(1);
+                self.truncation_state.requests.mark_saturated();
+                notify_limits_hit = self.truncation_state.mark_run_limits_hit(&mut state.run);
+            }
             None
         };
+        drop(state);
+        if notify_limits_hit {
+            self.notify_limits_hit_listener_async();
+        }
 
         (request_id, route, kind, pending_key, interval_start)
     }

--- a/tailtriage-core/src/collector.rs
+++ b/tailtriage-core/src/collector.rs
@@ -680,22 +680,6 @@ impl Tailtriage {
         }
     }
 
-    fn notify_limits_hit_listener_async(&self) {
-        let listener = self
-            .limits_hit_listener
-            .lock()
-            .expect("limits-hit listener lock poisoned")
-            .clone();
-        if let Some(listener) = listener {
-            // Request admission may be called while an integration holds its
-            // own admission lock. Dispatching this one-shot transition avoids
-            // calling back into that integration while its lock is held.
-            let _ = std::thread::Builder::new()
-                .name("tailtriage-limits-hit".into())
-                .spawn(move || listener());
-        }
-    }
-
     fn start_request(
         &self,
         route: String,
@@ -731,7 +715,7 @@ impl Tailtriage {
         };
         drop(state);
         if notify_limits_hit {
-            self.notify_limits_hit_listener_async();
+            self.notify_limits_hit_listener();
         }
 
         (request_id, route, kind, pending_key, interval_start)

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -827,6 +827,131 @@ fn saturation_preserves_exact_drop_counts_across_sections() {
 }
 
 #[test]
+fn request_admission_bounds_retained_plus_pending_and_makes_refused_children_inert() {
+    let tailtriage = Tailtriage::builder("request-admission-bound")
+        .sink(MemorySink::new())
+        .capture_limits_override(CaptureLimitsOverride {
+            max_requests: Some(2),
+            ..Default::default()
+        })
+        .build()
+        .unwrap();
+
+    let first =
+        tailtriage.begin_request_with("/first", RequestOptions::new().request_id("admitted-first"));
+    let second = tailtriage.begin_request_with(
+        "/second",
+        RequestOptions::new().request_id("admitted-second"),
+    );
+    assert_eq!(tailtriage.pending_request_count(), 2);
+
+    let refused =
+        tailtriage.begin_request_with("/refused", RequestOptions::new().request_id("refused"));
+    assert_eq!(tailtriage.pending_request_count(), 2);
+    futures_executor::block_on(refused.handle.stage("refused-stage").await_value(ready(())));
+    futures_executor::block_on(refused.handle.queue("refused-queue").await_on(ready(())));
+    drop(refused.handle.inflight("refused-inflight"));
+    refused.completion.finish_ok();
+
+    first.completion.finish_ok();
+    assert_eq!(tailtriage.snapshot().requests.len(), 1);
+    assert_eq!(tailtriage.pending_request_count(), 1);
+
+    // Completion moves an admitted request from pending to retained; it does
+    // not release request capacity while that retained event remains captured.
+    let still_refused = tailtriage.begin_request("/still-refused");
+    assert_eq!(tailtriage.pending_request_count(), 1);
+    still_refused.completion.finish_ok();
+
+    second.completion.finish_ok();
+    let run = tailtriage.snapshot();
+    assert_eq!(run.requests.len(), 2);
+    assert_eq!(tailtriage.pending_request_count(), 0);
+    assert!(run.stages.is_empty());
+    assert!(run.queues.is_empty());
+    assert!(run.inflight.is_empty());
+    assert_eq!(tailtriage.live_inflight_gauge_count(), 0);
+    assert_eq!(run.truncation.dropped_requests, 2);
+    assert!(run.truncation.limits_hit);
+}
+
+#[test]
+fn shutdown_counts_only_admitted_pending_requests_after_saturation() {
+    let sink = MemorySink::new();
+    let tailtriage = Tailtriage::builder("bounded-unfinished")
+        .sink(sink.clone())
+        .capture_limits_override(CaptureLimitsOverride {
+            max_requests: Some(1),
+            ..Default::default()
+        })
+        .build()
+        .unwrap();
+    let admitted = tailtriage.begin_request_with(
+        "/admitted",
+        RequestOptions::new().request_id("admitted-pending"),
+    );
+    let refused = tailtriage.begin_request_with(
+        "/refused",
+        RequestOptions::new().request_id("refused-pending"),
+    );
+
+    assert_eq!(tailtriage.pending_request_count(), 1);
+    tailtriage.shutdown().unwrap();
+    let run = sink.last_run().unwrap();
+    assert_eq!(run.metadata.unfinished_requests.count, 1);
+    assert_eq!(run.metadata.unfinished_requests.sample.len(), 1);
+    assert_eq!(
+        run.metadata.unfinished_requests.sample[0].request_id,
+        "admitted-pending"
+    );
+    assert_eq!(run.truncation.dropped_requests, 1);
+    assert!(run.truncation.limits_hit);
+    drop(admitted.completion);
+    drop(refused.completion);
+}
+
+#[test]
+fn concurrent_request_admission_cannot_exceed_retained_plus_pending_limit() {
+    const CALLERS: usize = 8;
+    let tailtriage = Tailtriage::builder("request-admission-concurrent-bound")
+        .sink(MemorySink::new())
+        .capture_limits_override(CaptureLimitsOverride {
+            max_requests: Some(1),
+            ..Default::default()
+        })
+        .build()
+        .unwrap();
+    let entered = std::sync::Barrier::new(CALLERS + 1);
+    let release = std::sync::Barrier::new(CALLERS + 1);
+
+    std::thread::scope(|scope| {
+        for caller in 0..CALLERS {
+            let tailtriage = &tailtriage;
+            let entered = &entered;
+            let release = &release;
+            scope.spawn(move || {
+                let started = tailtriage.begin_request(format!("/request-{caller}"));
+                entered.wait();
+                release.wait();
+                started.completion.finish_ok();
+            });
+        }
+        entered.wait();
+        assert_eq!(tailtriage.pending_request_count(), 1);
+        let run = tailtriage.snapshot();
+        assert!(run.requests.is_empty());
+        assert_eq!(run.truncation.dropped_requests, (CALLERS - 1) as u64);
+        release.wait();
+    });
+
+    let run = tailtriage.snapshot();
+    assert_eq!(run.requests.len(), 1);
+    assert_eq!(tailtriage.pending_request_count(), 0);
+    assert_eq!(run.truncation.dropped_requests, (CALLERS - 1) as u64);
+    assert!(run.truncation.limits_hit);
+}
+
+#[test]
 fn shutdown_artifact_includes_post_saturation_drops() {
     let sink = Arc::new(RecordingSink::default());
     let tailtriage = Tailtriage::builder("payments")
@@ -3296,6 +3421,79 @@ fn inflight_zero_cleanup_survives_snapshot_retention_saturation() {
     assert_eq!(inflight_counts(&run), vec![1]);
     assert_eq!(run.truncation.dropped_inflight_snapshots, 1);
     assert_eq!(tailtriage.live_inflight_gauge_count(), 0);
+}
+
+#[test]
+fn inflight_distinct_label_admission_is_bounded_and_refused_guard_is_inert() {
+    let tailtriage = Tailtriage::builder("inflight-label-bound")
+        .sink(MemorySink::new())
+        .capture_limits_override(CaptureLimitsOverride {
+            max_inflight_snapshots: Some(2),
+            ..Default::default()
+        })
+        .build()
+        .unwrap();
+
+    let first = tailtriage.inflight("first");
+    let second = tailtriage.inflight("second");
+    assert_eq!(tailtriage.live_inflight_gauge_count(), 2);
+
+    let refused = tailtriage.inflight("refused");
+    assert!(!refused.enabled);
+    assert_eq!(tailtriage.live_inflight_gauge_count(), 2);
+
+    let repeated = tailtriage.inflight("first");
+    assert!(repeated.enabled);
+    drop(refused);
+    assert_eq!(tailtriage.live_inflight_gauge_count(), 2);
+    drop(repeated);
+    assert_eq!(tailtriage.live_inflight_gauge_count(), 2);
+    drop(first);
+    assert_eq!(tailtriage.live_inflight_gauge_count(), 1);
+    drop(second);
+    assert_eq!(tailtriage.live_inflight_gauge_count(), 0);
+
+    let run = tailtriage.snapshot();
+    assert_eq!(inflight_counts(&run), vec![1, 1]);
+    assert_eq!(run.truncation.dropped_inflight_snapshots, 5);
+    assert!(run.truncation.limits_hit);
+}
+
+#[test]
+fn concurrent_distinct_inflight_admission_cannot_exceed_limit() {
+    const CALLERS: usize = 8;
+    let tailtriage = Tailtriage::builder("inflight-label-concurrent-bound")
+        .sink(MemorySink::new())
+        .capture_limits_override(CaptureLimitsOverride {
+            max_inflight_snapshots: Some(1),
+            ..Default::default()
+        })
+        .build()
+        .unwrap();
+    let entered = std::sync::Barrier::new(CALLERS + 1);
+    let release = std::sync::Barrier::new(CALLERS + 1);
+
+    std::thread::scope(|scope| {
+        for caller in 0..CALLERS {
+            let tailtriage = &tailtriage;
+            let entered = &entered;
+            let release = &release;
+            scope.spawn(move || {
+                let guard = tailtriage.inflight(format!("label-{caller}"));
+                entered.wait();
+                release.wait();
+                drop(guard);
+            });
+        }
+        entered.wait();
+        assert_eq!(tailtriage.live_inflight_gauge_count(), 1);
+        release.wait();
+    });
+    assert_eq!(tailtriage.live_inflight_gauge_count(), 0);
+    let run = tailtriage.snapshot();
+    assert_eq!(run.inflight.len(), 1);
+    assert_eq!(run.truncation.dropped_inflight_snapshots, CALLERS as u64);
+    assert!(run.truncation.limits_hit);
 }
 
 #[test]


### PR DESCRIPTION
### Motivation

- Prevent unbounded live-memory growth in collector bookkeeping for pending requests and distinct in-flight gauge labels so live state obeys the existing capture-limit model (`SEC-REQ-01`).
- Preserve existing public API, schema, and capture-limit configuration.
- Keep controller lifecycle accounting aligned with core request admission when request capacity is exhausted.
- Avoid synchronous limits-hit callback deadlock without introducing asynchronous notification threads.

### Description

- Bound request admission in `tailtriage-core` under the collector mutex by admitting a pending request only while:

  `retained requests + pending requests < max_requests`

  Refused requests remain inert and increment the existing dropped-request / `limits_hit` accounting.

- Bound distinct live in-flight gauge labels by refusing a previously unseen label when the live label map reaches the existing `max_inflight_snapshots` bound. Existing admitted labels can continue to increment, decrement, and unwind normally.

- Add a private, generation-local controller admission ledger that tracks the monotonic number of request slots consumed by controller-admitted requests. The controller reads the already-resolved request limit from:

  `run.effective_core_config().capture_limits.max_requests`

  No new public admission-status API or capture-limit knob is introduced.

- When controller request capacity is known to be exhausted:
  - the attempted request is still passed to core so core remains authoritative for refusal, `dropped_requests`, and `limits_hit`;
  - controller `inflight_captured` is not incremented;
  - the caller receives the existing inert controller request representation;
  - refused completion tokens do not participate in controller drain or finalization.

- For `RunEndPolicy::AutoSealOnLimitsHit`, request-capacity exhaustion is pre-linearized while the controller already holds its admission gate. The generation is marked closing before the transition-causing request is sent to core.

- Restore the normal synchronous core limits-hit notification path. The controller's limits-hit handler is closing-aware: when AutoSeal closure was already linearized by the request-admission path, the callback does not reacquire the admission gate and instead uses the genuine admitted in-flight count to determine whether finalization can proceed.

- Remove the request-specific asynchronous limits-hit notification helper and its thread-spawn path.

### Testing

Added and strengthened focused security and lifecycle regression coverage for:

- retained + pending request admission never exceeding `max_requests`;
- refused request handles and child instrumentation remaining inert;
- strict lifecycle counting only genuinely admitted unfinished requests;
- concurrent request admission respecting the request bound;
- distinct live in-flight label cardinality remaining bounded;
- existing in-flight labels unwinding correctly after saturation;
- concurrent distinct-label admission respecting the live-map bound;
- refused controller requests not increasing `inflight_captured`;
- repeated refused requests under `ContinueAfterLimitsHit` preserving exact drop accounting without delaying manual disable;
- refused requests held alive not delaying AutoSeal finalization;
- genuinely admitted requests continuing to control controller drain;
- zero request capacity behaving correctly;
- synchronous request-limit notification completing without admission-gate re-entry, using a bounded worker/channel regression so a deadlock produces a focused timeout failure instead of hanging the test process.

Validation included:

- `cargo fmt --check`
- `cargo test -p tailtriage-core --all-targets --all-features --locked`
- `cargo test -p tailtriage-controller --all-targets --all-features --locked`
- `cargo clippy -p tailtriage-core --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p tailtriage-controller --all-targets --all-features --locked -- -D warnings`
- workspace test/clippy validation
- docs-contract validation
- collector-limits operational smoke validation
- `git diff --check`

No public API, artifact schema, release configuration, or new capture-limit setting is introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8304000f4c83308b4d7092350086f0)