### PR TITLE
controller: private admission ledger for bounded request slots; restore sync limits-hit in core; add regression tests

### DIFF
--- a/tailtriage-controller/src/lib.rs
+++ b/tailtriage-controller/src/lib.rs
@@ -217,7 +217,7 @@ struct ActiveGenerationRuntime {
     state: ActiveGenerationState,
     artifact_path: PathBuf,
     run: Arc<Tailtriage>,
-    admission_gate: Mutex<()>,
+    admission_gate: Mutex<AdmissionState>,
     finalization_gate: Mutex<()>,
     finalization_result: Mutex<GenerationFinalizationResult>,
     accepting_new: AtomicBool,
@@ -230,6 +230,12 @@ struct ActiveGenerationRuntime {
     finalization_test_hooks: Mutex<FinalizationTestHooks>,
     #[cfg(test)]
     admission_test_hooks: Mutex<AdmissionTestHooks>,
+}
+
+#[derive(Debug, Default)]
+struct AdmissionState {
+    // Monotonic count of controller requests admitted into this generation.
+    admitted_request_slots: usize,
 }
 
 #[cfg(test)]
@@ -525,7 +531,7 @@ impl TailtriageController {
             },
             artifact_path,
             run: Arc::clone(&run),
-            admission_gate: Mutex::new(()),
+            admission_gate: Mutex::new(AdmissionState::default()),
             finalization_gate: Mutex::new(()),
             finalization_result: Mutex::default(),
             accepting_new: AtomicBool::new(true),
@@ -671,7 +677,7 @@ impl TailtriageController {
                 }
             }
 
-            let _admission = active
+            let mut admission = active
                 .admission_gate
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -686,28 +692,59 @@ impl TailtriageController {
                         RunEndReason::AutoSealOnLimitsHit,
                     );
                 } else {
-                    // Admission is linearized with every controller closure path by the
-                    // generation admission gate. The core pair is created before the
-                    // controller in-flight counter is committed, and neither is exposed to
-                    // the caller until both steps complete.
-                    let started = active
+                    let max_requests = active
                         .run
-                        .begin_request_with_owned(route.clone(), options.clone());
-                    active.inflight_captured.fetch_add(1, Ordering::AcqRel);
+                        .effective_core_config()
+                        .capture_limits
+                        .max_requests;
+                    if admission.admitted_request_slots >= max_requests {
+                        // Pending requests become retained requests on completion, so a
+                        // request slot is never released. Controller admissions are
+                        // serialized here; core independently enforces the same hard bound.
+                        if active.state.activation_config.run_end_policy
+                            == RunEndPolicy::AutoSealOnLimitsHit
+                        {
+                            Self::close_generation_admissions_locked(
+                                &active,
+                                RunEndReason::AutoSealOnLimitsHit,
+                            );
+                        }
 
-                    return ControllerStartedRequest {
-                        handle: ControllerRequestHandle::Active(started.handle),
-                        completion: ControllerRequestCompletion {
-                            kind: ControllerCompletionKind::Active(ActiveControllerCompletion {
-                                completion: Some(started.completion),
-                                admission_generation_id: active.state.generation_id,
-                                admitted_generation: Arc::downgrade(&active),
-                                inner: Arc::downgrade(&self.inner),
-                                run_end_policy: active.state.activation_config.run_end_policy,
-                                inflight_recorded: true,
-                            }),
-                        },
-                    };
+                        // Core remains authoritative for refusal, truncation accounting,
+                        // and the synchronous first-transition notification.
+                        let _ = active
+                            .run
+                            .begin_request_with_owned(route.clone(), options.clone());
+                    } else {
+                        // Admission is linearized with every controller closure path by the
+                        // generation admission gate. The core pair is created before the
+                        // controller in-flight counter is committed, and neither is exposed to
+                        // the caller until both steps complete.
+                        let started = active
+                            .run
+                            .begin_request_with_owned(route.clone(), options.clone());
+                        admission.admitted_request_slots += 1;
+                        active.inflight_captured.fetch_add(1, Ordering::AcqRel);
+
+                        return ControllerStartedRequest {
+                            handle: ControllerRequestHandle::Active(started.handle),
+                            completion: ControllerRequestCompletion {
+                                kind: ControllerCompletionKind::Active(
+                                    ActiveControllerCompletion {
+                                        completion: Some(started.completion),
+                                        admission_generation_id: active.state.generation_id,
+                                        admitted_generation: Arc::downgrade(&active),
+                                        inner: Arc::downgrade(&self.inner),
+                                        run_end_policy: active
+                                            .state
+                                            .activation_config
+                                            .run_end_policy,
+                                        inflight_recorded: true,
+                                    },
+                                ),
+                            },
+                        };
+                    }
                 }
             }
         }
@@ -1004,8 +1041,13 @@ impl TailtriageController {
         let Some(active) = active.upgrade() else {
             return;
         };
-        let inflight =
-            Self::close_generation_admissions(&active, RunEndReason::AutoSealOnLimitsHit);
+        let inflight = if active.closing.load(Ordering::Acquire) {
+            // Request-capacity auto-seal may already have linearized closure while
+            // holding the admission gate. Avoid recursively acquiring that mutex.
+            active.inflight_captured.load(Ordering::Acquire)
+        } else {
+            Self::close_generation_admissions(&active, RunEndReason::AutoSealOnLimitsHit)
+        };
 
         if inflight > 0 {
             return;
@@ -1980,7 +2022,7 @@ mod tests {
             },
             artifact_path,
             run,
-            admission_gate: Mutex::new(()),
+            admission_gate: Mutex::new(super::AdmissionState::default()),
             finalization_gate: Mutex::new(()),
             finalization_result: Mutex::default(),
             accepting_new: std::sync::atomic::AtomicBool::new(true),
@@ -2586,6 +2628,47 @@ mod tests {
     }
 
     #[test]
+    fn refused_requests_do_not_delay_manual_disable_or_accumulate_inflight() {
+        let output = test_output("refused-manual-disable");
+        let controller = TailtriageController::builder("checkout-service")
+            .output(&output)
+            .capture_limits_override(CaptureLimitsOverride {
+                max_requests: Some(1),
+                ..CaptureLimitsOverride::default()
+            })
+            .build()
+            .expect("build should succeed");
+
+        let active = controller.enable().expect("enable should succeed");
+        controller.begin_request("/admitted").completion.finish_ok();
+        let refused_one = controller.begin_request("/refused-one");
+        let refused_two = controller.begin_request("/refused-two");
+
+        let GenerationState::Active(status) = controller.status().generation else {
+            panic!("continue-after-limits-hit should remain active");
+        };
+        assert_eq!(status.inflight_captured_requests, 0);
+        let snapshot = active_runtime(&controller).run.snapshot();
+        assert!(snapshot.truncation.limits_hit);
+        assert_eq!(snapshot.truncation.dropped_requests, 2);
+
+        assert!(matches!(
+            controller.disable(),
+            Ok(DisableOutcome::Finalized { generation_id }) if generation_id == active.generation_id
+        ));
+        refused_one.completion.finish_ok();
+        drop(refused_two.completion);
+        assert!(matches!(
+            controller.status().generation,
+            GenerationState::Disabled { next_generation: 2 }
+        ));
+
+        let run = read_run(&active.artifact_path);
+        assert_eq!(run.truncation.dropped_requests, 2);
+        fs::remove_file(active.artifact_path).expect("cleanup should succeed");
+    }
+
+    #[test]
     fn auto_seal_policy_ends_generation_after_limits_hit() {
         let output = test_output("auto-seal-policy");
         let controller = TailtriageController::builder("checkout-service")
@@ -2616,6 +2699,118 @@ mod tests {
             Some(tailtriage_core::RunEndReason::AutoSealOnLimitsHit)
         );
 
+        fs::remove_file(active.artifact_path).expect("cleanup should succeed");
+    }
+
+    #[test]
+    fn refused_request_held_alive_cannot_delay_auto_seal_finalization() {
+        let output = test_output("auto-seal-refused-held");
+        let controller = TailtriageController::builder("checkout-service")
+            .output(&output)
+            .run_end_policy(RunEndPolicy::AutoSealOnLimitsHit)
+            .capture_limits_override(CaptureLimitsOverride {
+                max_requests: Some(1),
+                ..CaptureLimitsOverride::default()
+            })
+            .build()
+            .expect("build should succeed");
+
+        let active = controller.enable().expect("enable should succeed");
+        controller.begin_request("/admitted").completion.finish_ok();
+        let refused = controller.begin_request("/refused");
+
+        assert!(matches!(
+            controller.status().generation,
+            GenerationState::Disabled { next_generation: 2 }
+        ));
+        let run = read_run(&active.artifact_path);
+        assert!(run.truncation.limits_hit);
+        assert_eq!(run.truncation.dropped_requests, 1);
+        assert_eq!(
+            run.metadata.run_end_reason,
+            Some(tailtriage_core::RunEndReason::AutoSealOnLimitsHit)
+        );
+
+        refused.completion.finish_ok();
+        assert!(matches!(
+            controller.status().generation,
+            GenerationState::Disabled { next_generation: 2 }
+        ));
+        fs::remove_file(active.artifact_path).expect("cleanup should succeed");
+    }
+
+    #[test]
+    fn admitted_request_alone_controls_auto_seal_drain() {
+        let output = test_output("auto-seal-admitted-drain");
+        let controller = TailtriageController::builder("checkout-service")
+            .output(&output)
+            .run_end_policy(RunEndPolicy::AutoSealOnLimitsHit)
+            .capture_limits_override(CaptureLimitsOverride {
+                max_requests: Some(1),
+                ..CaptureLimitsOverride::default()
+            })
+            .build()
+            .expect("build should succeed");
+
+        let active = controller.enable().expect("enable should succeed");
+        let admitted = controller.begin_request("/admitted");
+        let refused = controller.begin_request("/refused");
+
+        let GenerationState::Active(status) = controller.status().generation else {
+            panic!("generation should remain closing while the admitted request is pending");
+        };
+        assert!(status.closing);
+        assert!(!status.accepting_new_admissions);
+        assert_eq!(status.inflight_captured_requests, 1);
+
+        admitted.completion.finish_ok();
+        assert!(matches!(
+            controller.status().generation,
+            GenerationState::Disabled { next_generation: 2 }
+        ));
+        refused.completion.finish_ok();
+        assert!(matches!(
+            controller.status().generation,
+            GenerationState::Disabled { next_generation: 2 }
+        ));
+
+        let run = read_run(&active.artifact_path);
+        assert_eq!(run.truncation.dropped_requests, 1);
+        fs::remove_file(active.artifact_path).expect("cleanup should succeed");
+    }
+
+    #[test]
+    fn synchronous_request_limit_notification_does_not_deadlock() {
+        let output = test_output("auto-seal-synchronous-notification");
+        let controller = TailtriageController::builder("checkout-service")
+            .output(&output)
+            .run_end_policy(RunEndPolicy::AutoSealOnLimitsHit)
+            .capture_limits_override(CaptureLimitsOverride {
+                max_requests: Some(0),
+                ..CaptureLimitsOverride::default()
+            })
+            .build()
+            .expect("zero request capacity should be supported");
+        let active = controller.enable().expect("enable should succeed");
+        let (sent, received) = std::sync::mpsc::channel();
+        let worker_controller = controller.clone();
+
+        let worker = std::thread::spawn(move || {
+            let refused = worker_controller.begin_request("/known-full");
+            sent.send(refused).expect("receiver should remain alive");
+        });
+        let refused = received
+            .recv_timeout(Duration::from_secs(2))
+            .expect("synchronous notification should return without lock re-entry");
+        worker.join().expect("admission worker should not panic");
+
+        assert!(matches!(
+            controller.status().generation,
+            GenerationState::Disabled { next_generation: 2 }
+        ));
+        let run = read_run(&active.artifact_path);
+        assert_eq!(run.truncation.dropped_requests, 1);
+        refused.completion.finish_ok();
         fs::remove_file(active.artifact_path).expect("cleanup should succeed");
     }
 

--- a/tailtriage-core/src/collector.rs
+++ b/tailtriage-core/src/collector.rs
@@ -680,22 +680,6 @@ impl Tailtriage {
         }
     }
 
-    fn notify_limits_hit_listener_async(&self) {
-        let listener = self
-            .limits_hit_listener
-            .lock()
-            .expect("limits-hit listener lock poisoned")
-            .clone();
-        if let Some(listener) = listener {
-            // Request admission may be called while an integration holds its
-            // own admission lock. Dispatching this one-shot transition avoids
-            // calling back into that integration while its lock is held.
-            let _ = std::thread::Builder::new()
-                .name("tailtriage-limits-hit".into())
-                .spawn(move || listener());
-        }
-    }
-
     fn start_request(
         &self,
         route: String,
@@ -731,7 +715,7 @@ impl Tailtriage {
         };
         drop(state);
         if notify_limits_hit {
-            self.notify_limits_hit_listener_async();
+            self.notify_limits_hit_listener();
         }
 
         (request_id, route, kind, pending_key, interval_start)


### PR DESCRIPTION
### Motivation

- Fix a controller accounting bug where refused core requests were incorrectly counted as admitted and could delay generation finalization.
- Avoid adding any cross-crate admission-status API by letting the controller know it has exhausted capacity before calling core, using the run's resolved effective core config.
- Prevent synchronous re-entrant deadlock on limits-hit callbacks while preserving core as the authoritative enforcement and truncation/accounting boundary.

### Description

- Replace the generation admission mutex `Mutex<()>` with a `Mutex<AdmissionState>` that owns a monotonic `admitted_request_slots` counter that increments once per controller-admitted request and never decrements. (controller changes in `tailtriage-controller/src/lib.rs`).
- During admission, read `active.run.effective_core_config().capture_limits.max_requests` and, while holding the admission gate, either: (a) if capacity available, call `begin_request_with_owned`, increment the private ledger slot and `inflight_captured`, and return the active handle; or (b) if known-full, pre-linearize AutoSeal when configured, call core so it records the refusal (dropped_requests/limits_hit) and notify the listener synchronously, but do not increment the ledger or `inflight_captured` and return an inert controller request. (controller logic changes and AutoSeal pre-linearization).
- Restore synchronous limits-hit notification in core by removing the request-admission specific `notify_limits_hit_listener_async()` and calling the existing `notify_limits_hit_listener()` path after core-side state changes, so first-transition semantics remain synchronous where safe (core change in `tailtriage-core/src/collector.rs`).
- Make the synchronous listener closing-aware so it can finalize immediately when the generation was already linearized to closing and there are zero genuinely admitted in-flight requests, avoiding re-acquisition of the admission gate. (controller listener change).
- Add focused regression tests in `tailtriage-controller/src/lib.rs` covering: refused requests do not count as controller inflight or delay manual disable; refused requests held alive cannot delay AutoSeal finalization; a genuinely admitted request still controls drain; and a deterministic deadlock-regression test for the zero-capacity known-full path. Also added/updated small core helpers/tests where needed. No public API or schema fields were added. The change was committed as `fix(controller): track bounded request admissions`.

### Testing

- Ran `git status --short` and `git rev-parse HEAD` to confirm a clean worktree and expected starting HEAD; both were as required. 
- Ran `cargo fmt --check` and it passed. 
- Ran `cargo test -p tailtriage-core --all-targets --all-features --locked` and all core tests passed (146 passed, 0 failed). 
- Ran `cargo test -p tailtriage-controller --all-targets --all-features --locked` and all controller tests passed (61 passed, 0 failed), including the new regression tests. 
- Ran `cargo clippy` for both `tailtriage-core` and `tailtriage-controller` with `-D warnings` and no warnings were reported. 
- Ran full workspace `cargo test` and `cargo clippy --workspace` and both completed successfully. 
- Ran `python3 scripts/validate_docs_contracts.py` and docs contract validation succeeded. 
- Performed `git diff --stat` which shows the follow-up change footprint: controller and core edits plus added controller tests (summary in repo: 2 files changed for the controller/core follow-up, overall PR includes core tests file additions); worktree is clean after the commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a834b9316cc833099a6facf24b14315)