### PR TITLE
Bound tracing JSONL raw-input resources

### DIFF
--- a/tailtriage-tracing/src/error.rs
+++ b/tailtriage-tracing/src/error.rs
@@ -19,16 +19,11 @@ pub enum ImportError {
         /// Underlying JSON parser error text.
         reason: String,
     },
-    /// One logical JSONL record exceeded the fixed raw-byte intake ceiling.
+    /// One logical JSONL record exceeded the shared fixed raw-byte ceiling.
     JsonlRecordTooLarge {
         /// 1-based logical line number.
         line: usize,
         /// Maximum permitted raw bytes, excluding the newline delimiter.
-        limit: usize,
-    },
-    /// A JSONL import exceeded the fixed total raw-byte intake ceiling.
-    JsonlInputTooLarge {
-        /// Maximum permitted raw bytes, including delimiters and whitespace.
         limit: usize,
     },
     /// JSONL input did not match the stable tailtriage wrapper shape required by the stable tracing JSONL wrapper contract.
@@ -94,10 +89,6 @@ impl fmt::Display for ImportError {
                 f,
                 "JSONL record at line {line} exceeds the raw-byte limit of {limit} bytes"
             ),
-            Self::JsonlInputTooLarge { limit } => write!(
-                f,
-                "JSONL input exceeds the total raw-byte limit of {limit} bytes"
-            ),
             Self::ExpectedTailtriageWrapper { reason } => {
                 write!(f, "expected tailtriage wrapper JSONL record: {reason}")
             }
@@ -142,10 +133,6 @@ mod tests {
         assert_eq!(
             ImportError::JsonlRecordTooLarge { line: 7, limit: 9 }.to_string(),
             "JSONL record at line 7 exceeds the raw-byte limit of 9 bytes"
-        );
-        assert_eq!(
-            ImportError::JsonlInputTooLarge { limit: 11 }.to_string(),
-            "JSONL input exceeds the total raw-byte limit of 11 bytes"
         );
     }
 }

--- a/tailtriage-tracing/src/error.rs
+++ b/tailtriage-tracing/src/error.rs
@@ -19,6 +19,18 @@ pub enum ImportError {
         /// Underlying JSON parser error text.
         reason: String,
     },
+    /// One logical JSONL record exceeded the fixed raw-byte intake ceiling.
+    JsonlRecordTooLarge {
+        /// 1-based logical line number.
+        line: usize,
+        /// Maximum permitted raw bytes, excluding the newline delimiter.
+        limit: usize,
+    },
+    /// A JSONL import exceeded the fixed total raw-byte intake ceiling.
+    JsonlInputTooLarge {
+        /// Maximum permitted raw bytes, including delimiters and whitespace.
+        limit: usize,
+    },
     /// JSONL input did not match the stable tailtriage wrapper shape required by the stable tracing JSONL wrapper contract.
     ExpectedTailtriageWrapper {
         /// Human-readable reason the wrapper shape was rejected.
@@ -78,6 +90,14 @@ impl fmt::Display for ImportError {
             Self::MalformedJsonLine { line, reason } => {
                 write!(f, "malformed JSONL at line {line}: {reason}")
             }
+            Self::JsonlRecordTooLarge { line, limit } => write!(
+                f,
+                "JSONL record at line {line} exceeds the raw-byte limit of {limit} bytes"
+            ),
+            Self::JsonlInputTooLarge { limit } => write!(
+                f,
+                "JSONL input exceeds the total raw-byte limit of {limit} bytes"
+            ),
             Self::ExpectedTailtriageWrapper { reason } => {
                 write!(f, "expected tailtriage wrapper JSONL record: {reason}")
             }
@@ -112,3 +132,20 @@ impl fmt::Display for ImportError {
 }
 
 impl std::error::Error for ImportError {}
+
+#[cfg(test)]
+mod tests {
+    use super::ImportError;
+
+    #[test]
+    fn jsonl_resource_errors_have_deterministic_context() {
+        assert_eq!(
+            ImportError::JsonlRecordTooLarge { line: 7, limit: 9 }.to_string(),
+            "JSONL record at line 7 exceeds the raw-byte limit of 9 bytes"
+        );
+        assert_eq!(
+            ImportError::JsonlInputTooLarge { limit: 11 }.to_string(),
+            "JSONL input exceeds the total raw-byte limit of 11 bytes"
+        );
+    }
+}

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -3,9 +3,12 @@ use std::path::Path;
 
 use serde_json::Value;
 
-use crate::{run_from_span_records, ImportError, ImportOptions, ImportedRun, SpanRecord};
+use crate::{run_from_span_record_results, ImportError, ImportOptions, ImportedRun, SpanRecord};
 
 const FORMAT_MARKER: &str = "tailtriage.tracing-span.v1";
+// Private intake ceilings bound attacker-controlled buffering independently of capture limits.
+const MAX_JSONL_RECORD_BYTES: usize = 1024 * 1024;
+const MAX_JSONL_INPUT_BYTES: usize = 64 * 1024 * 1024;
 
 /// Imports newline-delimited stable completed-span JSONL records from a reader into a converted run.
 ///
@@ -16,6 +19,8 @@ const FORMAT_MARKER: &str = "tailtriage.tracing-span.v1";
 /// # Errors
 ///
 /// Returns [`ImportError::Io`] for reader I/O failures,
+/// [`ImportError::JsonlRecordTooLarge`] or [`ImportError::JsonlInputTooLarge`]
+/// when a fixed raw-byte intake ceiling is exceeded,
 /// [`ImportError::MalformedJsonLine`] for malformed non-empty JSONL lines,
 /// [`ImportError::ExpectedTailtriageWrapper`] for structural JSONL shape errors,
 /// and existing field/conversion errors for malformed tailtriage span records
@@ -24,35 +29,44 @@ pub fn import_jsonl_reader<R: Read>(
     reader: R,
     options: ImportOptions,
 ) -> Result<ImportedRun, ImportError> {
-    let mut spans = Vec::new();
+    import_jsonl_reader_with_limits(
+        reader,
+        options,
+        MAX_JSONL_RECORD_BYTES,
+        MAX_JSONL_INPUT_BYTES,
+    )
+}
+
+fn import_jsonl_reader_with_limits<R: Read>(
+    reader: R,
+    options: ImportOptions,
+    record_limit: usize,
+    total_limit: usize,
+) -> Result<ImportedRun, ImportError> {
     let mut parse_warnings = Vec::new();
-    let reader = BufReader::new(reader);
     let strict = options.strict_mode();
-
-    for (line_no, line_result) in reader.lines().enumerate() {
-        let line_no = line_no + 1;
-        let line = line_result.map_err(|err| ImportError::Io {
-            operation: "read jsonl line",
-            context: format!("line {line_no}"),
-            reason: err.to_string(),
-        })?;
-
-        if line.trim().is_empty() {
-            continue;
+    let records = BoundedJsonlRecords::new(reader, record_limit, total_limit);
+    let spans = records.filter_map(|record| match record {
+        Err(error) => Some(Err(error)),
+        Ok((_line_no, line)) if line.iter().all(u8::is_ascii_whitespace) => None,
+        Ok((line_no, line)) => {
+            let value: Value = match serde_json::from_slice(&line) {
+                Ok(value) => value,
+                Err(err) => {
+                    return Some(Err(ImportError::MalformedJsonLine {
+                        line: line_no,
+                        reason: err.to_string(),
+                    }));
+                }
+            };
+            match parse_record(line_no, &value, strict, &mut parse_warnings) {
+                Ok(Some(span)) => Some(Ok(span)),
+                Ok(None) => None,
+                Err(error) => Some(Err(error)),
+            }
         }
-
-        let value: Value =
-            serde_json::from_str(&line).map_err(|err| ImportError::MalformedJsonLine {
-                line: line_no,
-                reason: err.to_string(),
-            })?;
-
-        if let Some(span) = parse_record(line_no, &value, strict, &mut parse_warnings)? {
-            spans.push(span);
-        }
-    }
-
-    let imported = run_from_span_records(spans, options)?;
+    });
+    let imported = run_from_span_record_results(spans, options)?;
     let (mut run, mut conversion_warnings, retained_sources) = imported.into_internal_parts();
     attach_parse_warnings_to_lifecycle(&mut run, &parse_warnings);
     parse_warnings.append(&mut conversion_warnings);
@@ -61,6 +75,97 @@ pub fn import_jsonl_reader<R: Read>(
         parse_warnings,
         retained_sources,
     ))
+}
+
+struct BoundedJsonlRecords<R> {
+    reader: BufReader<R>,
+    record: Vec<u8>,
+    line: usize,
+    total: usize,
+    record_limit: usize,
+    total_limit: usize,
+    done: bool,
+}
+
+impl<R: Read> BoundedJsonlRecords<R> {
+    fn new(reader: R, record_limit: usize, total_limit: usize) -> Self {
+        Self {
+            reader: BufReader::new(reader),
+            record: Vec::new(),
+            line: 1,
+            total: 0,
+            record_limit,
+            total_limit,
+            done: false,
+        }
+    }
+
+    fn account(&mut self, bytes: usize) -> Result<(), ImportError> {
+        self.total = self
+            .total
+            .checked_add(bytes)
+            .ok_or(ImportError::JsonlInputTooLarge {
+                limit: self.total_limit,
+            })?;
+        if self.total > self.total_limit {
+            return Err(ImportError::JsonlInputTooLarge {
+                limit: self.total_limit,
+            });
+        }
+        Ok(())
+    }
+}
+
+impl<R: Read> Iterator for BoundedJsonlRecords<R> {
+    type Item = Result<(usize, Vec<u8>), ImportError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+        loop {
+            let (take, newline, eof) = match self.reader.fill_buf() {
+                Ok([]) => (0, false, true),
+                Ok(buf) => match buf.iter().position(|byte| *byte == b'\n') {
+                    Some(index) => (index, true, false),
+                    None => (buf.len(), false, false),
+                },
+                Err(err) => {
+                    self.done = true;
+                    return Some(Err(ImportError::Io {
+                        operation: "read jsonl record",
+                        context: format!("line {}", self.line),
+                        reason: err.to_string(),
+                    }));
+                }
+            };
+            if eof {
+                self.done = true;
+                return (!self.record.is_empty())
+                    .then(|| Ok((self.line, std::mem::take(&mut self.record))));
+            }
+            let consumed = take + usize::from(newline);
+            if let Err(error) = self.account(consumed) {
+                self.done = true;
+                return Some(Err(error));
+            }
+            if self.record.len().saturating_add(take) > self.record_limit {
+                self.done = true;
+                return Some(Err(ImportError::JsonlRecordTooLarge {
+                    line: self.line,
+                    limit: self.record_limit,
+                }));
+            }
+            let buf = self.reader.fill_buf().expect("buffer was just read");
+            self.record.extend_from_slice(&buf[..take]);
+            self.reader.consume(consumed);
+            if newline {
+                let line = self.line;
+                self.line += 1;
+                return Some(Ok((line, std::mem::take(&mut self.record))));
+            }
+        }
+    }
 }
 
 fn attach_parse_warnings_to_lifecycle(
@@ -85,6 +190,8 @@ fn attach_parse_warnings_to_lifecycle(
 /// # Errors
 ///
 /// Returns [`ImportError::Io`] when path open or line reads fail,
+/// [`ImportError::JsonlRecordTooLarge`] or [`ImportError::JsonlInputTooLarge`]
+/// when a fixed raw-byte intake ceiling is exceeded,
 /// [`ImportError::MalformedJsonLine`] for malformed non-empty JSONL lines,
 /// [`ImportError::ExpectedTailtriageWrapper`] for structural JSONL shape errors,
 /// and existing field/conversion errors for malformed tailtriage-tagged records
@@ -151,7 +258,7 @@ fn parse_record(
             if strict {
                 Err(ImportError::StrictViolation(message))
             } else {
-                warnings.push(crate::ImportWarning::new(message));
+                crate::push_import_warning(warnings, crate::ImportWarning::new(message));
                 Ok(None)
             }
         }
@@ -224,6 +331,7 @@ mod tests {
     use super::*;
     use crate::{FieldValue, ImportOptions};
     use std::io::Cursor;
+    use std::{cell::Cell, rc::Rc};
 
     fn stable_request(name: &str, request_id: &str) -> String {
         format!(
@@ -517,5 +625,128 @@ mod tests {
             source.fields().get("custom"),
             Some(&FieldValue::String("kept".to_owned()))
         );
+    }
+
+    #[test]
+    fn raw_record_boundary_and_unterminated_eof_are_deterministic() {
+        let valid = stable_request("request", "r1");
+        let mut at_limit = valid.into_bytes();
+        at_limit.resize(MAX_JSONL_RECORD_BYTES, b' ');
+        let imported = import_jsonl_reader(Cursor::new(at_limit), ImportOptions::new("svc"))
+            .expect("a valid record exactly at the ceiling must import at EOF");
+        assert_eq!(imported.run().requests.len(), 1);
+
+        for strict in [false, true] {
+            let over = vec![b' '; MAX_JSONL_RECORD_BYTES + 1];
+            assert_eq!(
+                import_jsonl_reader(Cursor::new(over), ImportOptions::new("svc").strict(strict))
+                    .unwrap_err(),
+                ImportError::JsonlRecordTooLarge {
+                    line: 1,
+                    limit: MAX_JSONL_RECORD_BYTES,
+                }
+            );
+        }
+    }
+
+    struct RepeatingReader {
+        remaining: usize,
+        read: Rc<Cell<usize>>,
+    }
+
+    impl Read for RepeatingReader {
+        fn read(&mut self, output: &mut [u8]) -> std::io::Result<usize> {
+            let count = output.len().min(self.remaining);
+            output[..count].fill(b'x');
+            self.remaining -= count;
+            self.read.set(self.read.get() + count);
+            Ok(count)
+        }
+    }
+
+    #[test]
+    fn unterminated_oversized_record_is_rejected_after_bounded_consumption() {
+        let read = Rc::new(Cell::new(0));
+        let source_len = MAX_JSONL_RECORD_BYTES * 8;
+        let err = import_jsonl_reader(
+            RepeatingReader {
+                remaining: source_len,
+                read: Rc::clone(&read),
+            },
+            ImportOptions::new("svc"),
+        )
+        .unwrap_err();
+        assert!(matches!(err, ImportError::JsonlRecordTooLarge { .. }));
+        assert!(
+            read.get() < source_len / 2,
+            "reader consumed {} bytes",
+            read.get()
+        );
+        assert!(read.get() <= MAX_JSONL_RECORD_BYTES + 16 * 1024);
+    }
+
+    #[test]
+    fn oversized_record_is_fatal_at_the_correct_logical_line() {
+        let input = format!(
+            "\n{}\n{}\n{}",
+            stable_request("first", "r1"),
+            "x".repeat(MAX_JSONL_RECORD_BYTES + 1),
+            stable_request("never", "r2")
+        );
+        let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap_err();
+        assert_eq!(
+            err,
+            ImportError::JsonlRecordTooLarge {
+                line: 3,
+                limit: MAX_JSONL_RECORD_BYTES,
+            }
+        );
+    }
+
+    #[test]
+    fn total_budget_counts_all_raw_bytes_and_is_overflow_safe() {
+        let exact = BoundedJsonlRecords::new(Cursor::new(b" \n \n"), 8, 4)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(exact.len(), 2);
+
+        for strict in [false, true] {
+            assert_eq!(
+                import_jsonl_reader_with_limits(
+                    Cursor::new(b" \n \n "),
+                    ImportOptions::new("svc").strict(strict),
+                    8,
+                    4,
+                )
+                .unwrap_err(),
+                ImportError::JsonlInputTooLarge { limit: 4 }
+            );
+        }
+
+        let mut records = BoundedJsonlRecords::new(Cursor::new([]), 1, usize::MAX);
+        records.total = usize::MAX;
+        assert_eq!(
+            records.account(1).unwrap_err(),
+            ImportError::JsonlInputTooLarge { limit: usize::MAX }
+        );
+    }
+
+    #[test]
+    fn many_small_records_cannot_bypass_total_budget() {
+        let input = " \n".repeat(6);
+        let records = BoundedJsonlRecords::new(Cursor::new(input), 1, 10);
+        assert_eq!(
+            records.collect::<Result<Vec<_>, _>>().unwrap_err(),
+            ImportError::JsonlInputTooLarge { limit: 10 }
+        );
+    }
+
+    #[test]
+    fn malformed_contained_span_warning_sample_is_bounded() {
+        let malformed = r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"bad","started_at_unix_ms":"bad","finished_at_unix_ms":2,"fields":{"tt.kind":"request"}}}"#;
+        let input = format!("{malformed}\n").repeat(crate::MAX_IMPORT_WARNINGS + 50);
+        let imported = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap();
+        assert_eq!(imported.warnings().len(), crate::MAX_IMPORT_WARNINGS);
+        assert!(imported.warnings()[0].message().contains("line 1"));
     }
 }

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -6,9 +6,6 @@ use serde_json::Value;
 use crate::{run_from_span_record_results, ImportError, ImportOptions, ImportedRun, SpanRecord};
 
 const FORMAT_MARKER: &str = "tailtriage.tracing-span.v1";
-// Private intake ceilings bound attacker-controlled buffering independently of capture limits.
-const MAX_JSONL_RECORD_BYTES: usize = 1024 * 1024;
-const MAX_JSONL_INPUT_BYTES: usize = 64 * 1024 * 1024;
 
 /// Imports newline-delimited stable completed-span JSONL records from a reader into a converted run.
 ///
@@ -19,33 +16,26 @@ const MAX_JSONL_INPUT_BYTES: usize = 64 * 1024 * 1024;
 /// # Errors
 ///
 /// Returns [`ImportError::Io`] for reader I/O failures,
-/// [`ImportError::JsonlRecordTooLarge`] or [`ImportError::JsonlInputTooLarge`]
-/// when a fixed raw-byte intake ceiling is exceeded,
+/// [`ImportError::JsonlRecordTooLarge`] when the fixed per-record raw-byte ceiling is exceeded,
 /// [`ImportError::MalformedJsonLine`] for malformed non-empty JSONL lines,
 /// [`ImportError::ExpectedTailtriageWrapper`] for structural JSONL shape errors,
 /// and existing field/conversion errors for malformed tailtriage span records
-/// or strict conversion violations surfaced by [`run_from_span_records`].
+/// or strict conversion violations surfaced by [`crate::run_from_span_records`].
 pub fn import_jsonl_reader<R: Read>(
     reader: R,
     options: ImportOptions,
 ) -> Result<ImportedRun, ImportError> {
-    import_jsonl_reader_with_limits(
-        reader,
-        options,
-        MAX_JSONL_RECORD_BYTES,
-        MAX_JSONL_INPUT_BYTES,
-    )
+    import_jsonl_reader_with_limit(reader, options, crate::MAX_JSONL_RECORD_BYTES)
 }
 
-fn import_jsonl_reader_with_limits<R: Read>(
+fn import_jsonl_reader_with_limit<R: Read>(
     reader: R,
     options: ImportOptions,
     record_limit: usize,
-    total_limit: usize,
 ) -> Result<ImportedRun, ImportError> {
     let mut parse_warnings = Vec::new();
     let strict = options.strict_mode();
-    let records = BoundedJsonlRecords::new(reader, record_limit, total_limit);
+    let records = BoundedJsonlRecords::new(reader, record_limit);
     let spans = records.filter_map(|record| match record {
         Err(error) => Some(Err(error)),
         Ok((_line_no, line)) if line.iter().all(u8::is_ascii_whitespace) => None,
@@ -81,38 +71,19 @@ struct BoundedJsonlRecords<R> {
     reader: BufReader<R>,
     record: Vec<u8>,
     line: usize,
-    total: usize,
     record_limit: usize,
-    total_limit: usize,
     done: bool,
 }
 
 impl<R: Read> BoundedJsonlRecords<R> {
-    fn new(reader: R, record_limit: usize, total_limit: usize) -> Self {
+    fn new(reader: R, record_limit: usize) -> Self {
         Self {
             reader: BufReader::new(reader),
             record: Vec::new(),
             line: 1,
-            total: 0,
             record_limit,
-            total_limit,
             done: false,
         }
-    }
-
-    fn account(&mut self, bytes: usize) -> Result<(), ImportError> {
-        self.total = self
-            .total
-            .checked_add(bytes)
-            .ok_or(ImportError::JsonlInputTooLarge {
-                limit: self.total_limit,
-            })?;
-        if self.total > self.total_limit {
-            return Err(ImportError::JsonlInputTooLarge {
-                limit: self.total_limit,
-            });
-        }
-        Ok(())
     }
 }
 
@@ -145,10 +116,6 @@ impl<R: Read> Iterator for BoundedJsonlRecords<R> {
                     .then(|| Ok((self.line, std::mem::take(&mut self.record))));
             }
             let consumed = take + usize::from(newline);
-            if let Err(error) = self.account(consumed) {
-                self.done = true;
-                return Some(Err(error));
-            }
             if self.record.len().saturating_add(take) > self.record_limit {
                 self.done = true;
                 return Some(Err(ImportError::JsonlRecordTooLarge {
@@ -190,8 +157,7 @@ fn attach_parse_warnings_to_lifecycle(
 /// # Errors
 ///
 /// Returns [`ImportError::Io`] when path open or line reads fail,
-/// [`ImportError::JsonlRecordTooLarge`] or [`ImportError::JsonlInputTooLarge`]
-/// when a fixed raw-byte intake ceiling is exceeded,
+/// [`ImportError::JsonlRecordTooLarge`] when the fixed per-record raw-byte ceiling is exceeded,
 /// [`ImportError::MalformedJsonLine`] for malformed non-empty JSONL lines,
 /// [`ImportError::ExpectedTailtriageWrapper`] for structural JSONL shape errors,
 /// and existing field/conversion errors for malformed tailtriage-tagged records
@@ -631,19 +597,19 @@ mod tests {
     fn raw_record_boundary_and_unterminated_eof_are_deterministic() {
         let valid = stable_request("request", "r1");
         let mut at_limit = valid.into_bytes();
-        at_limit.resize(MAX_JSONL_RECORD_BYTES, b' ');
+        at_limit.resize(crate::MAX_JSONL_RECORD_BYTES, b' ');
         let imported = import_jsonl_reader(Cursor::new(at_limit), ImportOptions::new("svc"))
             .expect("a valid record exactly at the ceiling must import at EOF");
         assert_eq!(imported.run().requests.len(), 1);
 
         for strict in [false, true] {
-            let over = vec![b' '; MAX_JSONL_RECORD_BYTES + 1];
+            let over = vec![b' '; crate::MAX_JSONL_RECORD_BYTES + 1];
             assert_eq!(
                 import_jsonl_reader(Cursor::new(over), ImportOptions::new("svc").strict(strict))
                     .unwrap_err(),
                 ImportError::JsonlRecordTooLarge {
                     line: 1,
-                    limit: MAX_JSONL_RECORD_BYTES,
+                    limit: crate::MAX_JSONL_RECORD_BYTES,
                 }
             );
         }
@@ -667,7 +633,7 @@ mod tests {
     #[test]
     fn unterminated_oversized_record_is_rejected_after_bounded_consumption() {
         let read = Rc::new(Cell::new(0));
-        let source_len = MAX_JSONL_RECORD_BYTES * 8;
+        let source_len = crate::MAX_JSONL_RECORD_BYTES * 8;
         let err = import_jsonl_reader(
             RepeatingReader {
                 remaining: source_len,
@@ -682,7 +648,7 @@ mod tests {
             "reader consumed {} bytes",
             read.get()
         );
-        assert!(read.get() <= MAX_JSONL_RECORD_BYTES + 16 * 1024);
+        assert!(read.get() <= crate::MAX_JSONL_RECORD_BYTES + 16 * 1024);
     }
 
     #[test]
@@ -690,7 +656,7 @@ mod tests {
         let input = format!(
             "\n{}\n{}\n{}",
             stable_request("first", "r1"),
-            "x".repeat(MAX_JSONL_RECORD_BYTES + 1),
+            "x".repeat(crate::MAX_JSONL_RECORD_BYTES + 1),
             stable_request("never", "r2")
         );
         let err = import_jsonl_reader(Cursor::new(input), ImportOptions::new("svc")).unwrap_err();
@@ -698,47 +664,19 @@ mod tests {
             err,
             ImportError::JsonlRecordTooLarge {
                 line: 3,
-                limit: MAX_JSONL_RECORD_BYTES,
+                limit: crate::MAX_JSONL_RECORD_BYTES,
             }
         );
     }
 
     #[test]
-    fn total_budget_counts_all_raw_bytes_and_is_overflow_safe() {
-        let exact = BoundedJsonlRecords::new(Cursor::new(b" \n \n"), 8, 4)
+    fn many_small_records_have_no_aggregate_byte_ceiling() {
+        let input = " \n".repeat(100);
+        let records = BoundedJsonlRecords::new(Cursor::new(input), 1)
             .collect::<Result<Vec<_>, _>>()
             .unwrap();
-        assert_eq!(exact.len(), 2);
-
-        for strict in [false, true] {
-            assert_eq!(
-                import_jsonl_reader_with_limits(
-                    Cursor::new(b" \n \n "),
-                    ImportOptions::new("svc").strict(strict),
-                    8,
-                    4,
-                )
-                .unwrap_err(),
-                ImportError::JsonlInputTooLarge { limit: 4 }
-            );
-        }
-
-        let mut records = BoundedJsonlRecords::new(Cursor::new([]), 1, usize::MAX);
-        records.total = usize::MAX;
-        assert_eq!(
-            records.account(1).unwrap_err(),
-            ImportError::JsonlInputTooLarge { limit: usize::MAX }
-        );
-    }
-
-    #[test]
-    fn many_small_records_cannot_bypass_total_budget() {
-        let input = " \n".repeat(6);
-        let records = BoundedJsonlRecords::new(Cursor::new(input), 1, 10);
-        assert_eq!(
-            records.collect::<Result<Vec<_>, _>>().unwrap_err(),
-            ImportError::JsonlInputTooLarge { limit: 10 }
-        );
+        assert_eq!(records.len(), 100);
+        assert_eq!(crate::MAX_JSONL_RECORD_BYTES, 8 * 1024 * 1024);
     }
 
     #[test]

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -64,6 +64,9 @@ pub use types::{FieldValue, ImportOptions, ImportWarning, ImportedRun, SpanKind,
 // Retain a deterministic diagnostic sample without allowing one allocation per input record.
 const MAX_IMPORT_WARNINGS: usize = 256;
 
+// Serialized JSON object bytes count toward this limit; the JSONL newline does not.
+pub(crate) const MAX_JSONL_RECORD_BYTES: usize = 8 * 1024 * 1024;
+
 fn push_import_warning(warnings: &mut Vec<ImportWarning>, warning: ImportWarning) {
     if warnings.len() < MAX_IMPORT_WARNINGS {
         warnings.push(warning);
@@ -173,6 +176,8 @@ where
     let mut parsed_requests = Vec::new();
     let mut parsed_stages = Vec::new();
     let mut parsed_queues = Vec::new();
+    #[cfg(test)]
+    let mut collection_peaks = CollectionPeaks::default();
 
     let mut dropped_requests = 0_u64;
     let mut dropped_stages = 0_u64;
@@ -272,6 +277,13 @@ where
                         },
                         outcome_defaulted,
                     });
+                    #[cfg(test)]
+                    collection_peaks.observe(
+                        parsed_requests.len(),
+                        parsed_stages.len(),
+                        parsed_queues.len(),
+                        source_spans.len(),
+                    );
                 }
             }
             SpanKind::Stage => {
@@ -314,6 +326,13 @@ where
                         },
                         success_defaulted: matches!(success_field, OptionalField::Missing),
                     });
+                    #[cfg(test)]
+                    collection_peaks.observe(
+                        parsed_requests.len(),
+                        parsed_stages.len(),
+                        parsed_queues.len(),
+                        source_spans.len(),
+                    );
                 }
             }
             SpanKind::Queue => {
@@ -355,6 +374,13 @@ where
                             completed: true,
                         },
                     });
+                    #[cfg(test)]
+                    collection_peaks.observe(
+                        parsed_requests.len(),
+                        parsed_stages.len(),
+                        parsed_queues.len(),
+                        source_spans.len(),
+                    );
                 }
             }
         }
@@ -467,6 +493,8 @@ where
         candidate_provenance: provenance,
         source_outcomes,
         retained_sources,
+        #[cfg(test)]
+        collection_peaks,
     })
 }
 
@@ -478,6 +506,27 @@ struct ProvenanceImportedRun {
     source_outcomes: SourceOutcomes,
     #[allow(dead_code)]
     retained_sources: Vec<SpanRecord>,
+    #[cfg(test)]
+    collection_peaks: CollectionPeaks,
+}
+
+#[cfg(test)]
+#[derive(Debug, Default, PartialEq, Eq)]
+struct CollectionPeaks {
+    requests: usize,
+    stages: usize,
+    queues: usize,
+    source_spans: usize,
+}
+
+#[cfg(test)]
+impl CollectionPeaks {
+    fn observe(&mut self, requests: usize, stages: usize, queues: usize, source_spans: usize) {
+        self.requests = self.requests.max(requests);
+        self.stages = self.stages.max(stages);
+        self.queues = self.queues.max(queues);
+        self.source_spans = self.source_spans.max(source_spans);
+    }
 }
 
 impl ProvenanceImportedRun {
@@ -995,6 +1044,93 @@ fn parse_depth_at_start(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn streaming_conversion_directly_bounds_temporary_candidate_and_source_state() {
+        let mut spans = Vec::new();
+        for index in 0..4 {
+            spans.push(
+                SpanRecord::new(format!("request-{index}"), 1, 2)
+                    .field(TT_KIND, "request")
+                    .field(TT_REQUEST_ID, format!("r{index}"))
+                    .field(TT_ROUTE, "/bounded"),
+            );
+        }
+        for index in 0..4 {
+            spans.push(
+                SpanRecord::new(format!("stage-{index}"), 1, 2)
+                    .field(TT_KIND, "stage")
+                    .field(TT_REQUEST_ID, "r0")
+                    .field(TT_STAGE, format!("s{index}")),
+            );
+        }
+        for index in 0..4 {
+            spans.push(
+                SpanRecord::new(format!("queue-{index}"), 1, 2)
+                    .field(TT_KIND, "queue")
+                    .field(TT_REQUEST_ID, "r0")
+                    .field(TT_QUEUE, format!("q{index}")),
+            );
+        }
+        let converted = convert_span_records_with_provenance(
+            spans,
+            ImportOptions::new("svc").capture_limits(tailtriage_core::CaptureLimits {
+                max_requests: 1,
+                max_stages: 2,
+                max_queues: 3,
+                ..tailtriage_core::CaptureLimits::default()
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(
+            converted.collection_peaks,
+            CollectionPeaks {
+                requests: 1,
+                stages: 2,
+                queues: 3,
+                source_spans: 6,
+            }
+        );
+        let run = converted.imported.run();
+        assert_eq!(
+            (run.requests.len(), run.stages.len(), run.queues.len()),
+            (1, 2, 3)
+        );
+        assert_eq!(
+            (
+                run.truncation.dropped_requests,
+                run.truncation.dropped_stages,
+                run.truncation.dropped_queues,
+            ),
+            (3, 2, 1)
+        );
+        assert!(run.truncation.limits_hit);
+        assert_eq!(run.requests[0].request_id, "r0");
+        assert_eq!(
+            run.stages
+                .iter()
+                .map(|x| x.stage.as_str())
+                .collect::<Vec<_>>(),
+            ["s0", "s1"]
+        );
+        assert_eq!(
+            run.queues
+                .iter()
+                .map(|x| x.queue.as_str())
+                .collect::<Vec<_>>(),
+            ["q0", "q1", "q2"]
+        );
+        assert_eq!(converted.imported.retained_sources().len(), 6);
+        assert!(converted
+            .imported
+            .retained_sources()
+            .iter()
+            .all(|span| !matches!(
+                span.name(),
+                "request-1" | "request-2" | "request-3" | "stage-2" | "stage-3" | "queue-3"
+            )));
+    }
     use tailtriage_core::CaptureMode;
 
     #[test]

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -61,6 +61,15 @@ pub use recorder::{
 };
 pub use types::{FieldValue, ImportOptions, ImportWarning, ImportedRun, SpanKind, SpanRecord};
 
+// Retain a deterministic diagnostic sample without allowing one allocation per input record.
+const MAX_IMPORT_WARNINGS: usize = 256;
+
+fn push_import_warning(warnings: &mut Vec<ImportWarning>, warning: ImportWarning) {
+    if warnings.len() < MAX_IMPORT_WARNINGS {
+        warnings.push(warning);
+    }
+}
+
 /// Ensures a run is suitable for persisted Run JSON artifacts intended for CLI analysis.
 ///
 /// # Errors
@@ -120,10 +129,25 @@ pub fn run_from_span_records<I>(
 where
     I: IntoIterator<Item = SpanRecord>,
 {
-    Ok(convert_span_records_with_provenance(spans, options)?.into_imported())
+    Ok(
+        convert_span_record_results_with_provenance(spans.into_iter().map(Ok), options)?
+            .into_imported(),
+    )
+}
+
+#[cfg(feature = "jsonl")]
+fn run_from_span_record_results<I>(
+    spans: I,
+    options: ImportOptions,
+) -> Result<ImportedRun, ImportError>
+where
+    I: IntoIterator<Item = Result<SpanRecord, ImportError>>,
+{
+    Ok(convert_span_record_results_with_provenance(spans, options)?.into_imported())
 }
 
 #[allow(clippy::too_many_lines, clippy::needless_pass_by_value)]
+#[cfg(test)]
 fn convert_span_records_with_provenance<I>(
     spans: I,
     options: ImportOptions,
@@ -131,19 +155,31 @@ fn convert_span_records_with_provenance<I>(
 where
     I: IntoIterator<Item = SpanRecord>,
 {
+    convert_span_record_results_with_provenance(spans.into_iter().map(Ok), options)
+}
+
+#[allow(clippy::too_many_lines, clippy::needless_pass_by_value)]
+fn convert_span_record_results_with_provenance<I>(
+    spans: I,
+    options: ImportOptions,
+) -> Result<ProvenanceImportedRun, ImportError>
+where
+    I: IntoIterator<Item = Result<SpanRecord, ImportError>>,
+{
     validate_service_name(options.service_name())?;
-    let source_spans = spans
-        .into_iter()
-        .enumerate()
-        .map(|(source_index, span)| SourceSpan { source_index, span })
-        .collect::<Vec<_>>();
+    let capture_limits = options.resolved_capture_limits();
     let mut warnings = Vec::new();
+    let mut source_spans = Vec::new();
     let mut parsed_requests = Vec::new();
     let mut parsed_stages = Vec::new();
     let mut parsed_queues = Vec::new();
 
-    for source in &source_spans {
-        let span = &source.span;
+    let mut dropped_requests = 0_u64;
+    let mut dropped_stages = 0_u64;
+    let mut dropped_queues = 0_u64;
+    for (source_index, span) in spans.into_iter().enumerate() {
+        let span = span?;
+        let span = &span;
         let kind = match get_string_field_state(span, TT_KIND) {
             StringFieldState::Missing => {
                 if span_has_tailtriage_field(span) {
@@ -209,8 +245,16 @@ where
                     };
                     let (started_at_run_us, finished_at_run_us) =
                         sanitized_run_relative_offsets(span);
+                    if parsed_requests.len() >= capture_limits.max_requests {
+                        dropped_requests = dropped_requests.saturating_add(1);
+                        continue;
+                    }
+                    source_spans.push(SourceSpan {
+                        source_index,
+                        span: span.clone(),
+                    });
                     parsed_requests.push(ParsedRequestEvent {
-                        source_index: source.source_index,
+                        source_index,
                         event: RequestEvent {
                             request_id,
                             route,
@@ -243,8 +287,16 @@ where
                     };
                     let (started_at_run_us, finished_at_run_us) =
                         sanitized_run_relative_offsets(span);
+                    if parsed_stages.len() >= capture_limits.max_stages {
+                        dropped_stages = dropped_stages.saturating_add(1);
+                        continue;
+                    }
+                    source_spans.push(SourceSpan {
+                        source_index,
+                        span: span.clone(),
+                    });
                     parsed_stages.push(ParsedStageEvent {
-                        source_index: source.source_index,
+                        source_index,
                         event: StageEvent {
                             request_id,
                             stage,
@@ -277,8 +329,16 @@ where
                         };
                     let (waited_from_run_us, waited_until_run_us) =
                         sanitized_run_relative_offsets(span);
+                    if parsed_queues.len() >= capture_limits.max_queues {
+                        dropped_queues = dropped_queues.saturating_add(1);
+                        continue;
+                    }
+                    source_spans.push(SourceSpan {
+                        source_index,
+                        span: span.clone(),
+                    });
                     parsed_queues.push(ParsedQueueEvent {
-                        source_index: source.source_index,
+                        source_index,
                         event: QueueEvent {
                             request_id,
                             queue,
@@ -300,7 +360,6 @@ where
         }
     }
     let mode = options.mode_value();
-    let capture_limits = options.resolved_capture_limits();
 
     let request_outcome_default_count = parsed_requests
         .iter()
@@ -308,7 +367,7 @@ where
         .filter(|request| request.outcome_defaulted)
         .count();
     if request_outcome_default_count > 0 {
-        warnings.push(ImportWarning::new(format!("{request_outcome_default_count} request span(s) missing optional '{TT_OUTCOME}'; assumed 'ok'")));
+        push_import_warning(&mut warnings, ImportWarning::new(format!("{request_outcome_default_count} request span(s) missing optional '{TT_OUTCOME}'; assumed 'ok'")));
     }
     let stage_success_default_count = parsed_stages
         .iter()
@@ -316,21 +375,13 @@ where
         .filter(|stage| stage.success_defaulted)
         .count();
     if stage_success_default_count > 0 {
-        warnings.push(ImportWarning::new(format!("{stage_success_default_count} stage span(s) missing optional '{TT_SUCCESS}'; assumed true")));
+        push_import_warning(&mut warnings, ImportWarning::new(format!("{stage_success_default_count} stage span(s) missing optional '{TT_SUCCESS}'; assumed true")));
     }
 
     let mut truncation = TruncationSummary::default();
-    apply_retention_limit(
-        &mut parsed_requests,
-        capture_limits.max_requests,
-        |dropped| truncation.dropped_requests = dropped,
-    );
-    apply_retention_limit(&mut parsed_stages, capture_limits.max_stages, |dropped| {
-        truncation.dropped_stages = dropped;
-    });
-    apply_retention_limit(&mut parsed_queues, capture_limits.max_queues, |dropped| {
-        truncation.dropped_queues = dropped;
-    });
+    truncation.dropped_requests = dropped_requests;
+    truncation.dropped_stages = dropped_stages;
+    truncation.dropped_queues = dropped_queues;
     truncation.limits_hit = truncation.dropped_requests > 0
         || truncation.dropped_stages > 0
         || truncation.dropped_queues > 0;
@@ -400,7 +451,7 @@ where
             .iter()
             .any(|existing| existing.message() == warning)
         {
-            warnings.push(ImportWarning::new(warning));
+            push_import_warning(&mut warnings, ImportWarning::new(warning));
         }
     }
     attach_durable_conversion_warnings(&mut run, &warnings);
@@ -417,12 +468,6 @@ where
         source_outcomes,
         retained_sources,
     })
-}
-
-#[derive(Debug, Clone)]
-struct SourceSpan {
-    source_index: usize,
-    span: SpanRecord,
 }
 
 #[derive(Debug)]
@@ -444,6 +489,12 @@ impl ProvenanceImportedRun {
         );
         self.imported
     }
+}
+
+#[derive(Debug, Clone)]
+struct SourceSpan {
+    source_index: usize,
+    span: SpanRecord,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -591,14 +642,6 @@ fn source_outcome_sort_key(outcome: &SourceOutcome) -> (usize, u8, usize) {
         _ => 3,
     };
     (outcome.source_index, section, outcome.input_index)
-}
-
-fn apply_retention_limit<T>(items: &mut Vec<T>, max: usize, set_dropped: impl FnOnce(u64)) {
-    let dropped = items.len().saturating_sub(max) as u64;
-    if items.len() > max {
-        items.truncate(max);
-    }
-    set_dropped(dropped);
 }
 
 fn strict_core_error(err: &tailtriage_core::RunValidationError) -> ImportError {
@@ -855,7 +898,7 @@ fn strict_or_warn(
     if strict {
         return Err(ImportError::StrictViolation(message));
     }
-    warnings.push(ImportWarning::new(message));
+    push_import_warning(warnings, ImportWarning::new(message));
     Ok(())
 }
 

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -4113,7 +4113,48 @@ mod tests {
             }
         );
         assert!(!path.exists());
-        assert!(!completed_span_jsonl_temp_path(&path).exists());
+        assert_no_completed_span_jsonl_temps(&path);
+    }
+
+    #[test]
+    fn completed_jsonl_writer_preserves_existing_target_on_oversize() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("existing.jsonl");
+        let sentinel = b"existing completed-span output\n";
+        std::fs::write(&path, sentinel).unwrap();
+
+        let small = SpanRecord::new("small", 1, 2);
+        let large = SpanRecord::new("large", 1, 2).field("padding", "x".repeat(256));
+        let small_len = serde_json::to_vec(&serde_json::json!({
+            "format": "tailtriage.tracing-span.v1",
+            "span": &small,
+        }))
+        .unwrap()
+        .len();
+
+        assert_eq!(
+            write_completed_span_jsonl_with_limit(&[small, large], &path, small_len).unwrap_err(),
+            ImportError::JsonlRecordTooLarge {
+                line: 2,
+                limit: small_len,
+            }
+        );
+        assert_eq!(std::fs::read(&path).unwrap(), sentinel);
+        assert_no_completed_span_jsonl_temps(&path);
+    }
+
+    fn assert_no_completed_span_jsonl_temps(path: &Path) {
+        let file_name = path.file_name().unwrap().to_string_lossy();
+        let temp_prefix = format!(".{file_name}.tailtriage-tmp-");
+        let leftovers = std::fs::read_dir(path.parent().unwrap())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .filter(|name| name.to_string_lossy().starts_with(&temp_prefix))
+            .collect::<Vec<_>>();
+        assert!(
+            leftovers.is_empty(),
+            "completed-span JSONL temp artifacts remain: {leftovers:?}"
+        );
     }
 
     #[test]

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::fmt;
 use std::fmt::Write as _;
-use std::io::Write;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 #[cfg(feature = "tokio")]
@@ -475,6 +475,43 @@ fn write_completed_span_jsonl_from_retained_sources(
     retained_sources: &[SpanRecord],
     path: &Path,
 ) -> Result<(), ImportError> {
+    write_completed_span_jsonl_with_limit(retained_sources, path, crate::MAX_JSONL_RECORD_BYTES)
+}
+
+struct RecordLimitedWriter<'a, W> {
+    inner: &'a mut W,
+    written: usize,
+    limit: usize,
+    exceeded: bool,
+}
+
+#[derive(serde::Serialize)]
+struct CompletedSpanJsonlRecord<'a> {
+    format: &'static str,
+    span: &'a SpanRecord,
+}
+
+impl<W: Write> Write for RecordLimitedWriter<'_, W> {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        if bytes.len() > self.limit.saturating_sub(self.written) {
+            self.exceeded = true;
+            return Err(io::Error::other("JSONL record byte limit exceeded"));
+        }
+        let count = self.inner.write(bytes)?;
+        self.written += count;
+        Ok(count)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+fn write_completed_span_jsonl_with_limit(
+    retained_sources: &[SpanRecord],
+    path: &Path,
+    record_limit: usize,
+) -> Result<(), ImportError> {
     create_output_parent_dir(path, "create completed span jsonl parent directory")?;
     let temp_path = completed_span_jsonl_temp_path(path);
     let mut file = std::fs::OpenOptions::new()
@@ -489,16 +526,32 @@ fn write_completed_span_jsonl_from_retained_sources(
         })?;
 
     let write_result = (|| -> Result<(), ImportError> {
-        for span in retained_sources {
-            let wrapped =
-                serde_json::json!({ "format": "tailtriage.tracing-span.v1", "span": span });
+        for (index, span) in retained_sources.iter().enumerate() {
+            let wrapped = CompletedSpanJsonlRecord {
+                format: "tailtriage.tracing-span.v1",
+                span,
+            };
+            let mut limited = RecordLimitedWriter {
+                inner: &mut file,
+                written: 0,
+                limit: record_limit,
+                exceeded: false,
+            };
+            if let Err(err) = serde_json::to_writer(&mut limited, &wrapped) {
+                if limited.exceeded {
+                    return Err(ImportError::JsonlRecordTooLarge {
+                        line: index + 1,
+                        limit: record_limit,
+                    });
+                }
+                return Err(ImportError::Io {
+                    operation: "write completed span jsonl record",
+                    context: temp_path.display().to_string(),
+                    reason: err.to_string(),
+                });
+            }
 
-            serde_json::to_writer(&mut file, &wrapped).map_err(|err| ImportError::Io {
-                operation: "write completed span jsonl record",
-                context: temp_path.display().to_string(),
-                reason: err.to_string(),
-            })?;
-
+            // The delimiter is written outside the limited adapter and does not count.
             file.write_all(b"\n").map_err(|err| ImportError::Io {
                 operation: "write completed span jsonl newline",
                 context: temp_path.display().to_string(),
@@ -3982,6 +4035,85 @@ mod tests {
             std::fs::read(&first_path).unwrap(),
             std::fs::read(&second_path).unwrap()
         );
+    }
+
+    #[test]
+    fn completed_jsonl_writer_enforces_per_record_bytes_without_total_ceiling() {
+        let dir = tempfile::tempdir().unwrap();
+        let exact_path = dir.path().join("exact.jsonl");
+        let source = SpanRecord::new("request", 1, 2)
+            .field(TT_KIND, "request")
+            .field("tt.request_id", "r1")
+            .field("tt.route", "/")
+            .field("padding", "x".repeat(256));
+        let wrapped = serde_json::json!({
+            "format": "tailtriage.tracing-span.v1",
+            "span": &source,
+        });
+        let serialized_len = serde_json::to_vec(&wrapped).unwrap().len();
+
+        write_completed_span_jsonl_with_limit(
+            std::slice::from_ref(&source),
+            &exact_path,
+            serialized_len,
+        )
+        .unwrap();
+        assert_eq!(
+            usize::try_from(std::fs::metadata(&exact_path).unwrap().len()).unwrap(),
+            serialized_len + 1
+        );
+
+        let one_over_path = dir.path().join("one-over.jsonl");
+        assert_eq!(
+            write_completed_span_jsonl_with_limit(
+                std::slice::from_ref(&source),
+                &one_over_path,
+                serialized_len - 1,
+            )
+            .unwrap_err(),
+            ImportError::JsonlRecordTooLarge {
+                line: 1,
+                limit: serialized_len - 1,
+            }
+        );
+        assert!(!one_over_path.exists());
+
+        let aggregate_path = dir.path().join("aggregate.jsonl");
+        write_completed_span_jsonl_with_limit(
+            &[source.clone(), source.clone()],
+            &aggregate_path,
+            serialized_len,
+        )
+        .unwrap();
+        assert_eq!(
+            usize::try_from(std::fs::metadata(&aggregate_path).unwrap().len()).unwrap(),
+            2 * (serialized_len + 1)
+        );
+    }
+
+    #[test]
+    fn completed_jsonl_writer_reports_line_and_cleans_temp_on_oversize() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("oversize.jsonl");
+        let small = SpanRecord::new("small", 1, 2);
+        let large = SpanRecord::new("large", 1, 2).field("padding", "x".repeat(256));
+        let small_len = serde_json::to_vec(&serde_json::json!({
+            "format": "tailtriage.tracing-span.v1",
+            "span": &small,
+        }))
+        .unwrap()
+        .len();
+        let err =
+            write_completed_span_jsonl_with_limit(&[small, large], &path, small_len).unwrap_err();
+        assert_eq!(
+            err,
+            ImportError::JsonlRecordTooLarge {
+                line: 2,
+                limit: small_len,
+            }
+        );
+        assert!(!path.exists());
+        assert!(!completed_span_jsonl_temp_path(&path).exists());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Harden tracing JSONL ingestion against unbounded per-record buffering and unbounded pre-retention semantic/provenance state.
- Replace `BufRead::lines()` with an incremental bounded logical-record reader.
- Keep the tracing JSONL producer and importer consistent so Tailtriage does not emit individual records that its own importer rejects.
- Preserve the existing JSONL format, strict/non-strict semantic behavior, capture-limit semantics, and tracing equivalence contracts.

### Resource model

This change uses a **per-record** resource boundary rather than an arbitrary whole-stream ceiling.

- One logical tracing JSONL record is limited to **8 MiB** of serialized JSON object bytes.
- The trailing JSONL newline is **not** counted toward the record limit.
- The same private 8 MiB limit is enforced by both the JSONL reader and completed-span JSONL writer.
- There is **no aggregate whole-stream byte limit**.
- Semantic request/stage/queue candidate storage is bounded by the resolved capture limits.
- Retained provenance is bounded by admitted semantic candidates.
- Retained import warnings are capped at 256.

This allows arbitrarily long streams to be processed incrementally while bounding the memory-sensitive units that previously grew before retention was applied.

### Description

#### Bounded incremental JSONL reader

- Replaced `BufRead::lines()` with a private incremental logical-record reader based on `BufReader::fill_buf()` / `consume()`.
- Bytes are checked against the per-record ceiling before being appended to the retained record buffer.
- Oversized unterminated records fail after bounded source consumption rather than requiring the complete logical line to be materialized.
- EOF without a final newline remains supported.
- Blank/whitespace-only records continue to be ignored.
- Non-empty records are parsed directly from the bounded byte buffer with `serde_json::from_slice`.
- `import_jsonl_path(...)` continues to inherit the same behavior by delegating to the reader import path.

The dedicated resource error is:

```text
JsonlRecordTooLarge { line, limit }
```

with deterministic 1-based logical line reporting.

Resource-limit failures are fatal regardless of strict mode.

#### Symmetric completed-span JSONL writer

* The completed-span JSONL writer enforces the same shared private 8 MiB serialized-record limit.
* Serialization is streamed through a limited writer rather than first creating an arbitrarily large serialized `Vec`.
* The newline delimiter is written outside the record-size accounting.
* An oversized record prevents the final output from being committed.
* Failure cleanup removes the actual temporary output artifact.
* If the final target already exists, an oversized attempted replacement leaves the existing target unchanged.

There is intentionally no whole-output-file ceiling.

#### Live-bounded semantic conversion

* Parsed span records now stream into conversion instead of first collecting all source spans.
* Request, stage, and queue candidate collections stop retaining additional candidates once their resolved capture capacities are reached.
* Overflow candidates increment saturating drop counters rather than remaining in temporary collections.
* Those counters feed the existing truncation summary and `limits_hit` behavior.
* Source provenance is retained only for admitted semantic candidates.

A direct regression proof exercises tiny limits and verifies peak temporary state remains bounded:

```text
requests     <= max_requests
stages       <= max_stages
queues       <= max_queues
source_spans <= max_requests + max_stages + max_queues
```

The regression also verifies exact drop counts, first-N retention, category continuation, and absence of provenance for dropped candidates.

#### Bounded warning retention

Import warning retention is capped at:

```text
MAX_IMPORT_WARNINGS = 256
```

so malformed-but-contained input cannot cause one retained diagnostic allocation per input record.

### Security scope

This packet addresses the tracing JSONL portion of the raw-input resource finding by bounding:

* logical-record buffering;
* semantic candidate collections;
* provenance collections;
* retained warning samples.

It intentionally does **not** impose a whole-stream byte ceiling. Once record buffering and retained semantic state are bounded, total stream length primarily represents proportional I/O/CPU work rather than proportional retained parser memory.

This packet also does not sanitize artifact-controlled strings. Terminal/control-character safety at presentation boundaries remains assigned to 28B1D.

The CLI Run JSON side of SEC-REQ-02 remains separate 28B1C work.

### Tests

Focused tracing tests cover:

* production record limit is exactly 8 MiB;
* record exactly at the boundary is accepted;
* one byte over the boundary is rejected;
* newline delimiter is excluded from the limit;
* strict/non-strict resource-error parity;
* correct 1-based logical line reporting;
* EOF without a final newline;
* oversized unterminated input is rejected after bounded consumption;
* many small records are not rejected by an aggregate stream ceiling;
* completed-span writer boundary behavior;
* completed-span writer rejects one-byte-over records;
* correct writer record/line reporting;
* multiple valid records may collectively exceed one record limit;
* writer output remains readable by the importer;
* oversized writer output does not commit a missing final target;
* oversized writer output preserves an existing final target byte-for-byte;
* actual temporary artifacts are removed after write failure;
* temporary semantic/provenance collection peaks remain within capture limits;
* overflow drop counts and first-N retention remain correct;
* warning sampling remains bounded.

### Files changed

* `tailtriage-tracing/src/error.rs`
* `tailtriage-tracing/src/jsonl.rs`
* `tailtriage-tracing/src/lib.rs`
* `tailtriage-tracing/src/recorder.rs`

### Validation

Validated with:

```text
cargo fmt --check
cargo test -p tailtriage-tracing --all-targets --all-features --locked
cargo clippy -p tailtriage-tracing --all-targets --all-features --locked -- -D warnings
RUSTDOCFLAGS="-D warnings" cargo doc -p tailtriage-tracing --all-features --no-deps --locked
git diff --check
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a83ebc563e08330b476fa528dcdf23b)