### PR TITLE
Harden Run JSON artifact intake with streaming decode in core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,7 +850,6 @@ name = "tailtriage-cli"
 version = "0.3.0"
 dependencies = [
  "clap",
- "serde",
  "serde_json",
  "tailtriage-analyzer",
  "tailtriage-core",
@@ -878,6 +877,7 @@ dependencies = [
  "hostname",
  "serde",
  "serde_json",
+ "tempfile",
  "uuid",
 ]
 

--- a/tailtriage-cli/Cargo.toml
+++ b/tailtriage-cli/Cargo.toml
@@ -23,8 +23,6 @@ doc = false
 
 [dependencies]
 clap = { version = "4.5.40", features = ["derive"] }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.145"
 tailtriage-core.workspace = true
 tailtriage-analyzer.workspace = true
 tailtriage-tracing = { workspace = true, features = ["jsonl"] }
@@ -36,4 +34,5 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dev-dependencies]
+serde_json = "1.0.145"
 tempfile = "3.23.0"

--- a/tailtriage-cli/src/artifact.rs
+++ b/tailtriage-cli/src/artifact.rs
@@ -1,7 +1,8 @@
 use std::path::{Path, PathBuf};
 
-use tailtriage_core::__internal::{decode_run_json_path, RunJsonDecodeError};
-use tailtriage_core::{normalize_run_permissive, Run, RunValidationReport};
+use tailtriage_core::{
+    decode_run_json_path, normalize_run_permissive, Run, RunJsonDecodeError, RunValidationReport,
+};
 
 /// A decoded run artifact plus non-fatal loader warnings.
 #[derive(Debug)]
@@ -36,13 +37,6 @@ pub(crate) enum ArtifactLoadError {
         /// Underlying I/O failure.
         source: std::io::Error,
     },
-    /// The artifact exceeded the fixed raw intake ceiling.
-    ArtifactTooLarge {
-        /// Path of the oversized artifact.
-        path: PathBuf,
-        /// Maximum accepted raw byte count.
-        limit: u64,
-    },
     /// JSON parsing or schema-shape decoding failed.
     Parse {
         /// Path that failed to parse.
@@ -59,16 +53,6 @@ pub(crate) enum ArtifactLoadError {
         /// Supported schema version expected by this binary.
         supported: u64,
     },
-    /// Required top-level `schema_version` key was missing.
-    MissingSchemaVersion {
-        /// Artifact path missing `schema_version`.
-        path: PathBuf,
-    },
-    /// Top-level `schema_version` existed but was not an integer.
-    InvalidSchemaVersionType {
-        /// Artifact path with invalid `schema_version` type.
-        path: PathBuf,
-    },
     /// Additional validation rejected the artifact contents.
     Validation {
         /// Artifact path that failed validation.
@@ -84,11 +68,6 @@ impl std::fmt::Display for ArtifactLoadError {
             Self::Read { path, source } => {
                 write!(f, "failed to read run artifact '{}': {source}", path.display())
             }
-            Self::ArtifactTooLarge { path, limit } => write!(
-                f,
-                "run artifact '{}' exceeds the {limit}-byte intake limit; capture a smaller artifact before analysis",
-                path.display()
-            ),
             Self::Parse { path, message } => {
                 write!(f, "failed to parse run artifact '{}': {message}", path.display())
             }
@@ -99,16 +78,6 @@ impl std::fmt::Display for ArtifactLoadError {
             } => write!(
                 f,
                 "unsupported run artifact schema_version={found}; this tailtriage version supports schema_version={supported}. Regenerate the artifact with a current tailtriage version. ('{}')",
-                path.display()
-            ),
-            Self::MissingSchemaVersion { path } => write!(
-                f,
-                "invalid run artifact in '{}': missing required top-level schema_version.",
-                path.display()
-            ),
-            Self::InvalidSchemaVersionType { path } => write!(
-                f,
-                "invalid run artifact in '{}': schema_version must be an integer.",
                 path.display()
             ),
             Self::Validation { path, message } => write!(
@@ -133,7 +102,7 @@ impl std::error::Error for ArtifactLoadError {
 /// Loads and decodes a tailtriage run artifact from disk, then applies
 /// permissive core normalization for command-level checks.
 ///
-/// Core owns bounded canonical Run JSON decoding. The CLI owns path diagnostics,
+/// Core owns canonical streaming Run JSON decoding. The CLI owns path diagnostics,
 /// finalization policy, warnings, normalization, and the analyze command's
 /// requirement that at least one request remains after normalization.
 ///
@@ -191,9 +160,6 @@ fn map_decode_error(path: &Path, error: RunJsonDecodeError) -> ArtifactLoadError
     let path = path.to_path_buf();
     match error {
         RunJsonDecodeError::Io(source) => ArtifactLoadError::Read { path, source },
-        RunJsonDecodeError::TooLarge { limit } => ArtifactLoadError::ArtifactTooLarge { path, limit },
-        RunJsonDecodeError::MissingSchemaVersion => ArtifactLoadError::MissingSchemaVersion { path },
-        RunJsonDecodeError::InvalidSchemaVersionType => ArtifactLoadError::InvalidSchemaVersionType { path },
         RunJsonDecodeError::UnsupportedSchemaVersion { found, supported } => ArtifactLoadError::UnsupportedSchemaVersion { path, found, supported },
         RunJsonDecodeError::Malformed(error) => {
             let message = if error.is_eof() {
@@ -208,6 +174,7 @@ fn map_decode_error(path: &Path, error: RunJsonDecodeError) -> ArtifactLoadError
             ArtifactLoadError::Parse { path, message }
         }
         RunJsonDecodeError::Shape(error) => ArtifactLoadError::Parse { path, message: format!("JSON shape does not match the tailtriage run schema ({error}). Check for missing required fields such as metadata.run_id and requests[].") },
+        _ => ArtifactLoadError::Parse { path, message: error.to_string() },
     }
 }
 
@@ -225,22 +192,7 @@ fn validate_required_sections(run: &Run, path: &Path) -> Result<(), ArtifactLoad
 
 #[cfg(test)]
 mod tests {
-    use super::{load_run_artifact, map_decode_error, ArtifactLoadError};
-    use std::path::Path;
-    use tailtriage_core::__internal::RunJsonDecodeError;
-
-    #[test]
-    fn maps_core_size_limit_without_reparsing() {
-        let error = map_decode_error(
-            Path::new("large run.json"),
-            RunJsonDecodeError::TooLarge { limit: 17 },
-        );
-        assert!(matches!(
-            error,
-            ArtifactLoadError::ArtifactTooLarge { limit: 17, .. }
-        ));
-        assert!(error.to_string().contains("17-byte intake limit"));
-    }
+    use super::load_run_artifact;
 
     #[test]
     fn rejects_malformed_json() {
@@ -290,7 +242,8 @@ mod tests {
         let error = load_run_artifact(&path).expect_err("expected missing version failure");
         let message = error.to_string();
 
-        assert!(message.contains("missing required top-level schema_version"));
+        assert!(message.contains("JSON shape does not match"));
+        assert!(message.contains("schema_version"));
     }
 
     #[test]
@@ -306,7 +259,8 @@ mod tests {
         let error = load_run_artifact(&path).expect_err("expected schema type failure");
         let message = error.to_string();
 
-        assert!(message.contains("schema_version must be an integer"));
+        assert!(message.contains("JSON shape does not match"));
+        assert!(message.contains("invalid type"));
     }
 
     #[test]
@@ -363,14 +317,13 @@ mod tests {
     }
 
     #[test]
-    fn cli_rejects_schema_v1_before_shape_decode() {
+    fn structurally_incompatible_old_schema_fails_as_shape_error() {
         let dir = tempfile::tempdir().expect("tempdir should build");
         let path = dir.path().join("v1.json");
         std::fs::write(&path, r#"{"schema_version":1,"metadata":{"finished_at_unix_ms":2},"requests":"not decoded as v2"}"#).expect("fixture should write");
-        let error = load_run_artifact(&path).expect_err("v1 should fail at envelope");
+        let error = load_run_artifact(&path).expect_err("incompatible shape should fail");
         let message = error.to_string();
-        assert!(message.contains("unsupported run artifact schema_version=1"));
-        assert!(message.contains("supports schema_version=2"));
+        assert!(message.contains("JSON shape does not match"));
     }
 
     #[test]

--- a/tailtriage-cli/src/artifact.rs
+++ b/tailtriage-cli/src/artifact.rs
@@ -1,9 +1,7 @@
 use std::path::{Path, PathBuf};
 
-use serde_json::Value;
-use tailtriage_core::{normalize_run_permissive, Run, RunValidationReport, SCHEMA_VERSION};
-
-const SUPPORTED_SCHEMA_VERSION: u64 = SCHEMA_VERSION;
+use tailtriage_core::__internal::{decode_run_json_path, RunJsonDecodeError};
+use tailtriage_core::{normalize_run_permissive, Run, RunValidationReport};
 
 /// A decoded run artifact plus non-fatal loader warnings.
 #[derive(Debug)]
@@ -37,6 +35,13 @@ pub(crate) enum ArtifactLoadError {
         path: PathBuf,
         /// Underlying I/O failure.
         source: std::io::Error,
+    },
+    /// The artifact exceeded the fixed raw intake ceiling.
+    ArtifactTooLarge {
+        /// Path of the oversized artifact.
+        path: PathBuf,
+        /// Maximum accepted raw byte count.
+        limit: u64,
     },
     /// JSON parsing or schema-shape decoding failed.
     Parse {
@@ -79,6 +84,11 @@ impl std::fmt::Display for ArtifactLoadError {
             Self::Read { path, source } => {
                 write!(f, "failed to read run artifact '{}': {source}", path.display())
             }
+            Self::ArtifactTooLarge { path, limit } => write!(
+                f,
+                "run artifact '{}' exceeds the {limit}-byte intake limit; capture a smaller artifact before analysis",
+                path.display()
+            ),
             Self::Parse { path, message } => {
                 write!(f, "failed to parse run artifact '{}': {message}", path.display())
             }
@@ -123,8 +133,9 @@ impl std::error::Error for ArtifactLoadError {
 /// Loads and decodes a tailtriage run artifact from disk, then applies
 /// permissive core normalization for command-level checks.
 ///
-/// The CLI owns file/JSON/schema-envelope decoding and the analyze command
-/// requirement that at least one request remains after core normalization.
+/// Core owns bounded canonical Run JSON decoding. The CLI owns path diagnostics,
+/// finalization policy, warnings, normalization, and the analyze command's
+/// requirement that at least one request remains after normalization.
 ///
 /// Loader warnings are non-fatal findings and are returned in
 /// [`LoadedArtifact::warnings`].
@@ -147,24 +158,7 @@ pub(crate) fn load_run_artifact(path: &Path) -> Result<LoadedArtifact, ArtifactL
 /// Returns [`ArtifactLoadError`] when the file cannot be read, the JSON is malformed,
 /// the schema envelope is unsupported, or the decoded shape is incompatible.
 pub(crate) fn decode_run_artifact(path: &Path) -> Result<LoadedArtifact, ArtifactLoadError> {
-    let input = std::fs::read_to_string(path).map_err(|source| ArtifactLoadError::Read {
-        path: path.to_path_buf(),
-        source,
-    })?;
-
-    let raw: Value = serde_json::from_str(&input).map_err(|err| ArtifactLoadError::Parse {
-        path: path.to_path_buf(),
-        message: parse_error_message(&err),
-    })?;
-
-    validate_schema_version(&raw, path)?;
-
-    let original_run: Run = serde_json::from_value(raw).map_err(|err| ArtifactLoadError::Parse {
-        path: path.to_path_buf(),
-        message: format!(
-            "JSON shape does not match the tailtriage run schema ({err}). Check for missing required fields such as metadata.run_id and requests[]."
-        ),
-    })?;
+    let original_run = decode_run_json_path(path).map_err(|error| map_decode_error(path, error))?;
 
     if original_run.metadata.finalized_at_unix_ms.is_none() {
         return Err(ArtifactLoadError::Validation {
@@ -193,28 +187,28 @@ pub(crate) fn decode_run_artifact(path: &Path) -> Result<LoadedArtifact, Artifac
     })
 }
 
-fn validate_schema_version(raw: &Value, path: &Path) -> Result<(), ArtifactLoadError> {
-    let Some(version) = raw.get("schema_version") else {
-        return Err(ArtifactLoadError::MissingSchemaVersion {
-            path: path.to_path_buf(),
-        });
-    };
-
-    let Some(found) = version.as_u64() else {
-        return Err(ArtifactLoadError::InvalidSchemaVersionType {
-            path: path.to_path_buf(),
-        });
-    };
-
-    if found != SUPPORTED_SCHEMA_VERSION {
-        return Err(ArtifactLoadError::UnsupportedSchemaVersion {
-            path: path.to_path_buf(),
-            found,
-            supported: SUPPORTED_SCHEMA_VERSION,
-        });
+fn map_decode_error(path: &Path, error: RunJsonDecodeError) -> ArtifactLoadError {
+    let path = path.to_path_buf();
+    match error {
+        RunJsonDecodeError::Io(source) => ArtifactLoadError::Read { path, source },
+        RunJsonDecodeError::TooLarge { limit } => ArtifactLoadError::ArtifactTooLarge { path, limit },
+        RunJsonDecodeError::MissingSchemaVersion => ArtifactLoadError::MissingSchemaVersion { path },
+        RunJsonDecodeError::InvalidSchemaVersionType => ArtifactLoadError::InvalidSchemaVersionType { path },
+        RunJsonDecodeError::UnsupportedSchemaVersion { found, supported } => ArtifactLoadError::UnsupportedSchemaVersion { path, found, supported },
+        RunJsonDecodeError::Malformed(error) => {
+            let message = if error.is_eof() {
+                format!("JSON ended unexpectedly ({error}). The artifact may be truncated; re-run capture and ensure the file was fully written.")
+            } else if error.is_syntax() {
+                format!("malformed JSON ({error}).")
+            } else if error.is_data() {
+                format!("JSON data is incompatible with the expected run schema ({error}).")
+            } else {
+                format!("I/O error while parsing JSON ({error}).")
+            };
+            ArtifactLoadError::Parse { path, message }
+        }
+        RunJsonDecodeError::Shape(error) => ArtifactLoadError::Parse { path, message: format!("JSON shape does not match the tailtriage run schema ({error}). Check for missing required fields such as metadata.run_id and requests[].") },
     }
-
-    Ok(())
 }
 
 #[cfg(test)]
@@ -229,26 +223,24 @@ fn validate_required_sections(run: &Run, path: &Path) -> Result<(), ArtifactLoad
     Ok(())
 }
 
-fn parse_error_message(error: &serde_json::Error) -> String {
-    match error.classify() {
-        serde_json::error::Category::Eof => {
-            format!("JSON ended unexpectedly ({error}). The artifact may be truncated; re-run capture and ensure the file was fully written.")
-        }
-        serde_json::error::Category::Syntax => {
-            format!("malformed JSON ({error}).")
-        }
-        serde_json::error::Category::Data => {
-            format!("JSON data is incompatible with the expected run schema ({error}).")
-        }
-        serde_json::error::Category::Io => {
-            format!("I/O error while parsing JSON ({error}).")
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::load_run_artifact;
+    use super::{load_run_artifact, map_decode_error, ArtifactLoadError};
+    use std::path::Path;
+    use tailtriage_core::__internal::RunJsonDecodeError;
+
+    #[test]
+    fn maps_core_size_limit_without_reparsing() {
+        let error = map_decode_error(
+            Path::new("large run.json"),
+            RunJsonDecodeError::TooLarge { limit: 17 },
+        );
+        assert!(matches!(
+            error,
+            ArtifactLoadError::ArtifactTooLarge { limit: 17, .. }
+        ));
+        assert!(error.to_string().contains("17-byte intake limit"));
+    }
 
     #[test]
     fn rejects_malformed_json() {

--- a/tailtriage-core/Cargo.toml
+++ b/tailtriage-core/Cargo.toml
@@ -30,3 +30,4 @@ workspace = true
 
 [dev-dependencies]
 futures-executor = "0.3"
+tempfile = "3.23.0"

--- a/tailtriage-core/src/artifact.rs
+++ b/tailtriage-core/src/artifact.rs
@@ -1,0 +1,358 @@
+use std::fmt;
+use std::fs::File;
+use std::io::{self, BufReader, Read, Seek, SeekFrom};
+use std::path::Path;
+
+use serde::de::{self, DeserializeSeed, IgnoredAny, MapAccess, SeqAccess, Visitor};
+use serde::Deserialize;
+
+use crate::{Run, SCHEMA_VERSION};
+
+// Investigation defaults can retain 2.4 million events. At roughly 400 bytes
+// per pretty-printed event that is about 960 MB; 2 GiB leaves more than 2x
+// headroom for representative identifiers and JSON formatting while remaining
+// an absolute, artifact-independent intake boundary for the 0.4 line.
+/// Fixed raw Run JSON intake ceiling used by sibling artifact consumers.
+pub const MAX_RUN_JSON_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+
+#[derive(Debug)]
+/// Internal failure categories for canonical Run JSON decoding.
+pub enum RunJsonDecodeError {
+    /// The artifact could not be opened, read, or rewound.
+    Io(io::Error),
+    /// The raw artifact required more than the fixed byte allowance.
+    TooLarge {
+        /// Maximum raw bytes accepted.
+        limit: u64,
+    },
+    /// The JSON envelope was syntactically malformed or truncated.
+    Malformed(serde_json::Error),
+    /// The top-level schema version field was absent.
+    MissingSchemaVersion,
+    /// The schema version was not a non-negative integer.
+    InvalidSchemaVersionType,
+    /// The schema version is not supported by this core version.
+    UnsupportedSchemaVersion {
+        /// Version found in the artifact.
+        found: u64,
+        /// Version supported by this decoder.
+        supported: u64,
+    },
+    /// The supported envelope did not decode into a Run.
+    Shape(serde_json::Error),
+}
+
+impl fmt::Display for RunJsonDecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(error) => write!(f, "I/O error while reading Run JSON: {error}"),
+            Self::TooLarge { limit } => write!(f, "Run JSON exceeds the {limit}-byte intake limit"),
+            Self::Malformed(error) => write!(f, "invalid Run JSON: {error}"),
+            Self::MissingSchemaVersion => write!(f, "missing required top-level schema_version"),
+            Self::InvalidSchemaVersionType => write!(f, "schema_version must be an integer"),
+            Self::UnsupportedSchemaVersion { found, supported } => write!(
+                f,
+                "unsupported schema_version={found}; supported schema_version={supported}"
+            ),
+            Self::Shape(error) => write!(f, "JSON shape does not match the Run schema: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for RunJsonDecodeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(error) => Some(error),
+            Self::Malformed(error) | Self::Shape(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+/// Decodes one canonical Run JSON file through the fixed bounded intake path.
+///
+/// # Errors
+///
+/// Returns a categorized decode error for I/O, resource-bound, JSON envelope,
+/// schema-version, or typed Run-shape failures.
+pub fn decode_run_json_path(path: &Path) -> Result<Run, RunJsonDecodeError> {
+    decode_run_json_file_with_limit(
+        File::open(path).map_err(RunJsonDecodeError::Io)?,
+        MAX_RUN_JSON_BYTES,
+    )
+}
+
+fn decode_run_json_file_with_limit(mut file: File, limit: u64) -> Result<Run, RunJsonDecodeError> {
+    probe_schema(&mut file, limit)?;
+    file.seek(SeekFrom::Start(0))
+        .map_err(RunJsonDecodeError::Io)?;
+    decode_typed(&mut file, limit)
+}
+
+fn probe_schema<R: Read>(reader: R, limit: u64) -> Result<(), RunJsonDecodeError> {
+    let mut bounded = BoundedReader::new(reader, limit);
+    let result = {
+        let mut deserializer = serde_json::Deserializer::from_reader(BufReader::new(&mut bounded));
+        SchemaProbe.deserialize(&mut deserializer)
+    };
+    let version = map_json_result(result, &bounded, true)?;
+    match version {
+        None => Err(RunJsonDecodeError::MissingSchemaVersion),
+        Some(None) => Err(RunJsonDecodeError::InvalidSchemaVersionType),
+        Some(Some(found)) if found != SCHEMA_VERSION => {
+            Err(RunJsonDecodeError::UnsupportedSchemaVersion {
+                found,
+                supported: SCHEMA_VERSION,
+            })
+        }
+        Some(Some(_)) => Ok(()),
+    }
+}
+
+fn decode_typed<R: Read>(reader: R, limit: u64) -> Result<Run, RunJsonDecodeError> {
+    let mut bounded = BoundedReader::new(reader, limit);
+    let result = {
+        let mut deserializer = serde_json::Deserializer::from_reader(BufReader::new(&mut bounded));
+        match Run::deserialize(&mut deserializer) {
+            Ok(run) => deserializer.end().map(|()| run),
+            Err(error) => Err(error),
+        }
+    };
+    let run = map_json_result(result, &bounded, false)?;
+    if run.schema_version != SCHEMA_VERSION {
+        return Err(RunJsonDecodeError::UnsupportedSchemaVersion {
+            found: run.schema_version,
+            supported: SCHEMA_VERSION,
+        });
+    }
+    Ok(run)
+}
+
+fn map_json_result<T>(
+    result: Result<T, serde_json::Error>,
+    reader: &BoundedReader<impl Read>,
+    probe: bool,
+) -> Result<T, RunJsonDecodeError> {
+    result.map_err(|error| {
+        if reader.exceeded {
+            RunJsonDecodeError::TooLarge {
+                limit: reader.limit,
+            }
+        } else if error.classify() == serde_json::error::Category::Io {
+            RunJsonDecodeError::Io(io::Error::other(error))
+        } else if probe {
+            RunJsonDecodeError::Malformed(error)
+        } else {
+            RunJsonDecodeError::Shape(error)
+        }
+    })
+}
+
+struct BoundedReader<R> {
+    inner: R,
+    limit: u64,
+    consumed: u64,
+    exceeded: bool,
+}
+impl<R> BoundedReader<R> {
+    fn new(inner: R, limit: u64) -> Self {
+        Self {
+            inner,
+            limit,
+            consumed: 0,
+            exceeded: false,
+        }
+    }
+}
+impl<R: Read> Read for BoundedReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        let remaining = self.limit.saturating_sub(self.consumed);
+        if remaining == 0 {
+            let mut byte = [0];
+            if self.inner.read(&mut byte)? == 0 {
+                return Ok(0);
+            }
+            self.exceeded = true;
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Run JSON intake limit exceeded",
+            ));
+        }
+        let allowed = usize::try_from(remaining)
+            .unwrap_or(usize::MAX)
+            .min(buf.len());
+        let read = self.inner.read(&mut buf[..allowed])?;
+        self.consumed = self.consumed.saturating_add(read as u64);
+        Ok(read)
+    }
+}
+
+struct SchemaProbe;
+impl<'de> DeserializeSeed<'de> for SchemaProbe {
+    type Value = Option<Option<u64>>;
+    fn deserialize<D: de::Deserializer<'de>>(
+        self,
+        deserializer: D,
+    ) -> Result<Self::Value, D::Error> {
+        deserializer.deserialize_map(SchemaVisitor)
+    }
+}
+struct SchemaVisitor;
+impl<'de> Visitor<'de> for SchemaVisitor {
+    type Value = Option<Option<u64>>;
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("a Run JSON object")
+    }
+    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+        let mut version = None;
+        while let Some(key) = map.next_key::<String>()? {
+            if key == "schema_version" {
+                version = Some(map.next_value_seed(IntegerProbe)?);
+            } else {
+                map.next_value::<IgnoredAny>()?;
+            }
+        }
+        Ok(version)
+    }
+}
+struct IntegerProbe;
+impl<'de> DeserializeSeed<'de> for IntegerProbe {
+    type Value = Option<u64>;
+    fn deserialize<D: de::Deserializer<'de>>(self, d: D) -> Result<Self::Value, D::Error> {
+        d.deserialize_any(IntegerVisitor)
+    }
+}
+struct IntegerVisitor;
+impl<'de> Visitor<'de> for IntegerVisitor {
+    type Value = Option<u64>;
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("any JSON value")
+    }
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+        Ok(Some(value))
+    }
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
+        Ok(u64::try_from(value).ok())
+    }
+    fn visit_bool<E>(self, _: bool) -> Result<Self::Value, E> {
+        Ok(None)
+    }
+    fn visit_f64<E>(self, _: f64) -> Result<Self::Value, E> {
+        Ok(None)
+    }
+    fn visit_str<E>(self, _: &str) -> Result<Self::Value, E> {
+        Ok(None)
+    }
+    fn visit_string<E>(self, _: String) -> Result<Self::Value, E> {
+        Ok(None)
+    }
+    fn visit_none<E>(self) -> Result<Self::Value, E> {
+        Ok(None)
+    }
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        Ok(None)
+    }
+    fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+        while seq.next_element::<IgnoredAny>()?.is_some() {}
+        Ok(None)
+    }
+    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+        while map.next_entry::<IgnoredAny, IgnoredAny>()?.is_some() {}
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+    fn valid() -> Vec<u8> {
+        br#"{"schema_version":2,"metadata":{"run_id":"r","service_name":"s","service_version":null,"started_at_unix_ms":1,"finalized_at_unix_ms":2,"mode":"light","host":null,"pid":null},"requests":[],"stages":[],"queues":[],"inflight":[],"runtime_snapshots":[]}"#.to_vec()
+    }
+    fn decode(bytes: &[u8], limit: u64) -> Result<Run, RunJsonDecodeError> {
+        probe_schema(Cursor::new(bytes), limit)?;
+        decode_typed(Cursor::new(bytes), limit)
+    }
+    #[test]
+    fn exact_limit_and_one_over() {
+        let v = valid();
+        assert!(decode(&v, v.len() as u64).is_ok());
+        assert!(matches!(
+            decode(&v, v.len() as u64 - 1),
+            Err(RunJsonDecodeError::TooLarge { .. })
+        ));
+    }
+    #[test]
+    fn schema_errors() {
+        assert!(matches!(
+            decode(br"{}", 2),
+            Err(RunJsonDecodeError::MissingSchemaVersion)
+        ));
+        assert!(matches!(
+            decode(br#"{"schema_version":"2"}"#, 22),
+            Err(RunJsonDecodeError::InvalidSchemaVersionType)
+        ));
+        assert!(matches!(
+            decode(br#"{"schema_version":99}"#, 21),
+            Err(RunJsonDecodeError::UnsupportedSchemaVersion { found: 99, .. })
+        ));
+    }
+    #[test]
+    fn malformed_and_trailing_are_not_size_errors() {
+        assert!(matches!(
+            decode(br#"{"schema_version":2"#, 19),
+            Err(RunJsonDecodeError::Malformed(_))
+        ));
+        let mut v = valid();
+        v.extend(b" x");
+        assert!(matches!(
+            decode(&v, v.len() as u64),
+            Err(RunJsonDecodeError::Shape(_))
+        ));
+    }
+    #[test]
+    fn nested_unknown_and_control_string_are_inert() {
+        let mut v = valid();
+        let needle = b"\"requests\":[]";
+        let pos = v.windows(needle.len()).position(|w| w == needle).unwrap();
+        v.splice(
+            pos..pos,
+            b"\"unknown\":[[[{\"x\":\"\\u001b[31m\"}]]],"
+                .iter()
+                .copied(),
+        );
+        assert!(decode(&v, v.len() as u64).is_ok());
+    }
+    #[test]
+    fn deep_json_fails_safely() {
+        let data = format!(
+            "{{\"schema_version\":2,\"unknown\":{} }}",
+            "[".repeat(256) + &"]".repeat(256)
+        );
+        assert!(matches!(
+            decode(data.as_bytes(), data.len() as u64),
+            Err(RunJsonDecodeError::Malformed(_) | RunJsonDecodeError::Shape(_))
+        ));
+    }
+    #[test]
+    fn large_string_hits_reader_bound() {
+        let data = format!(
+            "{{\"schema_version\":2,\"unknown\":\"{}\"}}",
+            "x".repeat(100)
+        );
+        assert!(matches!(
+            decode(data.as_bytes(), 32),
+            Err(RunJsonDecodeError::TooLarge { limit: 32 })
+        ));
+    }
+    #[test]
+    fn path_with_spaces() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("run artifact.json");
+        std::fs::write(&path, valid()).unwrap();
+        assert!(decode_run_json_path(&path).is_ok());
+    }
+}

--- a/tailtriage-core/src/artifact.rs
+++ b/tailtriage-core/src/artifact.rs
@@ -1,60 +1,41 @@
 use std::fmt;
 use std::fs::File;
-use std::io::{self, BufReader, Read, Seek, SeekFrom};
+use std::io::{self, BufReader, Read};
 use std::path::Path;
 
-use serde::de::{self, DeserializeSeed, IgnoredAny, MapAccess, SeqAccess, Visitor};
 use serde::Deserialize;
 
 use crate::{Run, SCHEMA_VERSION};
 
-// Investigation defaults can retain 2.4 million events. At roughly 400 bytes
-// per pretty-printed event that is about 960 MB; 2 GiB leaves more than 2x
-// headroom for representative identifiers and JSON formatting while remaining
-// an absolute, artifact-independent intake boundary for the 0.4 line.
-/// Fixed raw Run JSON intake ceiling used by sibling artifact consumers.
-pub const MAX_RUN_JSON_BYTES: u64 = 2 * 1024 * 1024 * 1024;
-
+/// Failures produced while decoding canonical Run JSON.
 #[derive(Debug)]
-/// Internal failure categories for canonical Run JSON decoding.
+#[non_exhaustive]
 pub enum RunJsonDecodeError {
-    /// The artifact could not be opened, read, or rewound.
+    /// The artifact could not be opened or read.
     Io(io::Error),
-    /// The raw artifact required more than the fixed byte allowance.
-    TooLarge {
-        /// Maximum raw bytes accepted.
-        limit: u64,
-    },
-    /// The JSON envelope was syntactically malformed or truncated.
+    /// The JSON document was syntactically malformed or truncated.
     Malformed(serde_json::Error),
-    /// The top-level schema version field was absent.
-    MissingSchemaVersion,
-    /// The schema version was not a non-negative integer.
-    InvalidSchemaVersionType,
-    /// The schema version is not supported by this core version.
+    /// The JSON data was incompatible with the canonical [`Run`] shape.
+    Shape(serde_json::Error),
+    /// The decoded Run uses a schema version unsupported by this core version.
     UnsupportedSchemaVersion {
         /// Version found in the artifact.
         found: u64,
         /// Version supported by this decoder.
         supported: u64,
     },
-    /// The supported envelope did not decode into a Run.
-    Shape(serde_json::Error),
 }
 
 impl fmt::Display for RunJsonDecodeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Io(error) => write!(f, "I/O error while reading Run JSON: {error}"),
-            Self::TooLarge { limit } => write!(f, "Run JSON exceeds the {limit}-byte intake limit"),
             Self::Malformed(error) => write!(f, "invalid Run JSON: {error}"),
-            Self::MissingSchemaVersion => write!(f, "missing required top-level schema_version"),
-            Self::InvalidSchemaVersionType => write!(f, "schema_version must be an integer"),
+            Self::Shape(error) => write!(f, "JSON shape does not match the Run schema: {error}"),
             Self::UnsupportedSchemaVersion { found, supported } => write!(
                 f,
                 "unsupported schema_version={found}; supported schema_version={supported}"
             ),
-            Self::Shape(error) => write!(f, "JSON shape does not match the Run schema: {error}"),
         }
     }
 }
@@ -64,61 +45,31 @@ impl std::error::Error for RunJsonDecodeError {
         match self {
             Self::Io(error) => Some(error),
             Self::Malformed(error) | Self::Shape(error) => Some(error),
-            _ => None,
+            Self::UnsupportedSchemaVersion { .. } => None,
         }
     }
 }
 
-/// Decodes one canonical Run JSON file through the fixed bounded intake path.
+/// Decodes one canonical Run JSON file with a streaming typed parse.
+///
+/// The document is decoded directly into [`Run`] without first retaining the
+/// complete input as a string or generic JSON value. Trailing non-whitespace is
+/// rejected.
 ///
 /// # Errors
 ///
-/// Returns a categorized decode error for I/O, resource-bound, JSON envelope,
-/// schema-version, or typed Run-shape failures.
+/// Returns a categorized error for I/O, malformed JSON, incompatible Run data,
+/// or a successfully decoded Run whose schema version is unsupported.
 pub fn decode_run_json_path(path: &Path) -> Result<Run, RunJsonDecodeError> {
-    decode_run_json_file_with_limit(
-        File::open(path).map_err(RunJsonDecodeError::Io)?,
-        MAX_RUN_JSON_BYTES,
-    )
+    let file = File::open(path).map_err(RunJsonDecodeError::Io)?;
+    decode_run_json_reader(file)
 }
 
-fn decode_run_json_file_with_limit(mut file: File, limit: u64) -> Result<Run, RunJsonDecodeError> {
-    probe_schema(&mut file, limit)?;
-    file.seek(SeekFrom::Start(0))
-        .map_err(RunJsonDecodeError::Io)?;
-    decode_typed(&mut file, limit)
-}
+fn decode_run_json_reader<R: Read>(reader: R) -> Result<Run, RunJsonDecodeError> {
+    let mut deserializer = serde_json::Deserializer::from_reader(BufReader::new(reader));
+    let run = Run::deserialize(&mut deserializer).map_err(map_json_error)?;
+    deserializer.end().map_err(map_json_error)?;
 
-fn probe_schema<R: Read>(reader: R, limit: u64) -> Result<(), RunJsonDecodeError> {
-    let mut bounded = BoundedReader::new(reader, limit);
-    let result = {
-        let mut deserializer = serde_json::Deserializer::from_reader(BufReader::new(&mut bounded));
-        SchemaProbe.deserialize(&mut deserializer)
-    };
-    let version = map_json_result(result, &bounded, true)?;
-    match version {
-        None => Err(RunJsonDecodeError::MissingSchemaVersion),
-        Some(None) => Err(RunJsonDecodeError::InvalidSchemaVersionType),
-        Some(Some(found)) if found != SCHEMA_VERSION => {
-            Err(RunJsonDecodeError::UnsupportedSchemaVersion {
-                found,
-                supported: SCHEMA_VERSION,
-            })
-        }
-        Some(Some(_)) => Ok(()),
-    }
-}
-
-fn decode_typed<R: Read>(reader: R, limit: u64) -> Result<Run, RunJsonDecodeError> {
-    let mut bounded = BoundedReader::new(reader, limit);
-    let result = {
-        let mut deserializer = serde_json::Deserializer::from_reader(BufReader::new(&mut bounded));
-        match Run::deserialize(&mut deserializer) {
-            Ok(run) => deserializer.end().map(|()| run),
-            Err(error) => Err(error),
-        }
-    };
-    let run = map_json_result(result, &bounded, false)?;
     if run.schema_version != SCHEMA_VERSION {
         return Err(RunJsonDecodeError::UnsupportedSchemaVersion {
             found: run.schema_version,
@@ -128,140 +79,13 @@ fn decode_typed<R: Read>(reader: R, limit: u64) -> Result<Run, RunJsonDecodeErro
     Ok(run)
 }
 
-fn map_json_result<T>(
-    result: Result<T, serde_json::Error>,
-    reader: &BoundedReader<impl Read>,
-    probe: bool,
-) -> Result<T, RunJsonDecodeError> {
-    result.map_err(|error| {
-        if reader.exceeded {
-            RunJsonDecodeError::TooLarge {
-                limit: reader.limit,
-            }
-        } else if error.classify() == serde_json::error::Category::Io {
-            RunJsonDecodeError::Io(io::Error::other(error))
-        } else if probe {
+fn map_json_error(error: serde_json::Error) -> RunJsonDecodeError {
+    match error.classify() {
+        serde_json::error::Category::Io => RunJsonDecodeError::Io(io::Error::other(error)),
+        serde_json::error::Category::Syntax | serde_json::error::Category::Eof => {
             RunJsonDecodeError::Malformed(error)
-        } else {
-            RunJsonDecodeError::Shape(error)
         }
-    })
-}
-
-struct BoundedReader<R> {
-    inner: R,
-    limit: u64,
-    consumed: u64,
-    exceeded: bool,
-}
-impl<R> BoundedReader<R> {
-    fn new(inner: R, limit: u64) -> Self {
-        Self {
-            inner,
-            limit,
-            consumed: 0,
-            exceeded: false,
-        }
-    }
-}
-impl<R: Read> Read for BoundedReader<R> {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        if buf.is_empty() {
-            return Ok(0);
-        }
-        let remaining = self.limit.saturating_sub(self.consumed);
-        if remaining == 0 {
-            let mut byte = [0];
-            if self.inner.read(&mut byte)? == 0 {
-                return Ok(0);
-            }
-            self.exceeded = true;
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Run JSON intake limit exceeded",
-            ));
-        }
-        let allowed = usize::try_from(remaining)
-            .unwrap_or(usize::MAX)
-            .min(buf.len());
-        let read = self.inner.read(&mut buf[..allowed])?;
-        self.consumed = self.consumed.saturating_add(read as u64);
-        Ok(read)
-    }
-}
-
-struct SchemaProbe;
-impl<'de> DeserializeSeed<'de> for SchemaProbe {
-    type Value = Option<Option<u64>>;
-    fn deserialize<D: de::Deserializer<'de>>(
-        self,
-        deserializer: D,
-    ) -> Result<Self::Value, D::Error> {
-        deserializer.deserialize_map(SchemaVisitor)
-    }
-}
-struct SchemaVisitor;
-impl<'de> Visitor<'de> for SchemaVisitor {
-    type Value = Option<Option<u64>>;
-    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("a Run JSON object")
-    }
-    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
-        let mut version = None;
-        while let Some(key) = map.next_key::<String>()? {
-            if key == "schema_version" {
-                version = Some(map.next_value_seed(IntegerProbe)?);
-            } else {
-                map.next_value::<IgnoredAny>()?;
-            }
-        }
-        Ok(version)
-    }
-}
-struct IntegerProbe;
-impl<'de> DeserializeSeed<'de> for IntegerProbe {
-    type Value = Option<u64>;
-    fn deserialize<D: de::Deserializer<'de>>(self, d: D) -> Result<Self::Value, D::Error> {
-        d.deserialize_any(IntegerVisitor)
-    }
-}
-struct IntegerVisitor;
-impl<'de> Visitor<'de> for IntegerVisitor {
-    type Value = Option<u64>;
-    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("any JSON value")
-    }
-    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
-        Ok(Some(value))
-    }
-    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
-        Ok(u64::try_from(value).ok())
-    }
-    fn visit_bool<E>(self, _: bool) -> Result<Self::Value, E> {
-        Ok(None)
-    }
-    fn visit_f64<E>(self, _: f64) -> Result<Self::Value, E> {
-        Ok(None)
-    }
-    fn visit_str<E>(self, _: &str) -> Result<Self::Value, E> {
-        Ok(None)
-    }
-    fn visit_string<E>(self, _: String) -> Result<Self::Value, E> {
-        Ok(None)
-    }
-    fn visit_none<E>(self) -> Result<Self::Value, E> {
-        Ok(None)
-    }
-    fn visit_unit<E>(self) -> Result<Self::Value, E> {
-        Ok(None)
-    }
-    fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
-        while seq.next_element::<IgnoredAny>()?.is_some() {}
-        Ok(None)
-    }
-    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
-        while map.next_entry::<IgnoredAny, IgnoredAny>()?.is_some() {}
-        Ok(None)
+        serde_json::error::Category::Data => RunJsonDecodeError::Shape(error),
     }
 }
 
@@ -269,85 +93,127 @@ impl<'de> Visitor<'de> for IntegerVisitor {
 mod tests {
     use super::*;
     use std::io::Cursor;
+
     fn valid() -> Vec<u8> {
         br#"{"schema_version":2,"metadata":{"run_id":"r","service_name":"s","service_version":null,"started_at_unix_ms":1,"finalized_at_unix_ms":2,"mode":"light","host":null,"pid":null},"requests":[],"stages":[],"queues":[],"inflight":[],"runtime_snapshots":[]}"#.to_vec()
     }
-    fn decode(bytes: &[u8], limit: u64) -> Result<Run, RunJsonDecodeError> {
-        probe_schema(Cursor::new(bytes), limit)?;
-        decode_typed(Cursor::new(bytes), limit)
+
+    fn decode(bytes: &[u8]) -> Result<Run, RunJsonDecodeError> {
+        decode_run_json_reader(Cursor::new(bytes))
     }
+
     #[test]
-    fn exact_limit_and_one_over() {
-        let v = valid();
-        assert!(decode(&v, v.len() as u64).is_ok());
-        assert!(matches!(
-            decode(&v, v.len() as u64 - 1),
-            Err(RunJsonDecodeError::TooLarge { .. })
-        ));
+    fn valid_supported_run_decodes() {
+        assert!(decode(&valid()).is_ok());
     }
+
     #[test]
-    fn schema_errors() {
+    fn malformed_and_truncated_json_are_rejected() {
         assert!(matches!(
-            decode(br"{}", 2),
-            Err(RunJsonDecodeError::MissingSchemaVersion)
-        ));
-        assert!(matches!(
-            decode(br#"{"schema_version":"2"}"#, 22),
-            Err(RunJsonDecodeError::InvalidSchemaVersionType)
-        ));
-        assert!(matches!(
-            decode(br#"{"schema_version":99}"#, 21),
-            Err(RunJsonDecodeError::UnsupportedSchemaVersion { found: 99, .. })
-        ));
-    }
-    #[test]
-    fn malformed_and_trailing_are_not_size_errors() {
-        assert!(matches!(
-            decode(br#"{"schema_version":2"#, 19),
+            decode(br#"{"schema_version":2, nope}"#),
             Err(RunJsonDecodeError::Malformed(_))
         ));
-        let mut v = valid();
-        v.extend(b" x");
         assert!(matches!(
-            decode(&v, v.len() as u64),
+            decode(br#"{"schema_version":2"#),
+            Err(RunJsonDecodeError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn typed_shape_errors_are_rejected() {
+        assert!(matches!(
+            decode(br#"{"schema_version":2}"#),
+            Err(RunJsonDecodeError::Shape(_))
+        ));
+        let wrong_version_type = String::from_utf8(valid())
+            .unwrap()
+            .replace("\"schema_version\":2", "\"schema_version\":\"2\"");
+        assert!(matches!(
+            decode(wrong_version_type.as_bytes()),
+            Err(RunJsonDecodeError::Shape(_))
+        ));
+        let missing_version = String::from_utf8(valid())
+            .unwrap()
+            .replace("\"schema_version\":2,", "");
+        assert!(matches!(
+            decode(missing_version.as_bytes()),
             Err(RunJsonDecodeError::Shape(_))
         ));
     }
+
     #[test]
-    fn nested_unknown_and_control_string_are_inert() {
-        let mut v = valid();
-        let needle = b"\"requests\":[]";
-        let pos = v.windows(needle.len()).position(|w| w == needle).unwrap();
-        v.splice(
-            pos..pos,
-            b"\"unknown\":[[[{\"x\":\"\\u001b[31m\"}]]],"
-                .iter()
-                .copied(),
-        );
-        assert!(decode(&v, v.len() as u64).is_ok());
-    }
-    #[test]
-    fn deep_json_fails_safely() {
-        let data = format!(
-            "{{\"schema_version\":2,\"unknown\":{} }}",
-            "[".repeat(256) + &"]".repeat(256)
-        );
+    fn structurally_valid_unsupported_schema_has_dedicated_error() {
+        let data = String::from_utf8(valid())
+            .unwrap()
+            .replace("\"schema_version\":2", "\"schema_version\":99");
         assert!(matches!(
-            decode(data.as_bytes(), data.len() as u64),
+            decode(data.as_bytes()),
+            Err(RunJsonDecodeError::UnsupportedSchemaVersion {
+                found: 99,
+                supported: SCHEMA_VERSION
+            })
+        ));
+    }
+
+    #[test]
+    fn trailing_content_is_rejected() {
+        let mut data = valid();
+        data.extend_from_slice(b" true");
+        assert!(matches!(
+            decode(&data),
+            Err(RunJsonDecodeError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn deep_json_fails_under_normal_recursion_protection() {
+        // Leave the pathological nesting truncated as well. The decoder keeps
+        // serde_json's normal parser protections and reports the hostile input
+        // rather than attempting any recovery or recursion-limit override.
+        let nested = "[".repeat(256) + &"]".repeat(255);
+        let mut data = String::from_utf8(valid()).unwrap();
+        data.insert_str(data.len() - 1, &format!(",\"unknown\":{nested}"));
+        assert!(matches!(
+            decode(data.as_bytes()),
             Err(RunJsonDecodeError::Malformed(_) | RunJsonDecodeError::Shape(_))
         ));
     }
+
     #[test]
-    fn large_string_hits_reader_bound() {
-        let data = format!(
-            "{{\"schema_version\":2,\"unknown\":\"{}\"}}",
-            "x".repeat(100)
-        );
-        assert!(matches!(
-            decode(data.as_bytes(), 32),
-            Err(RunJsonDecodeError::TooLarge { limit: 32 })
-        ));
+    fn unknown_nested_fields_are_ignored() {
+        let mut data = String::from_utf8(valid()).unwrap();
+        data.insert_str(data.len() - 1, ",\"unknown\":{\"nested\":[1,2,3]}");
+        assert!(decode(data.as_bytes()).is_ok());
     }
+
+    #[test]
+    fn escaped_terminal_control_is_inert_string_data() {
+        let data = String::from_utf8(valid()).unwrap().replace(
+            "\"service_name\":\"s\"",
+            "\"service_name\":\"\\u001b[31mservice\"",
+        );
+        let run = decode(data.as_bytes()).unwrap();
+        assert_eq!(run.metadata.service_name, "\u{1b}[31mservice");
+    }
+
+    struct NonSeekReader {
+        bytes: Cursor<Vec<u8>>,
+    }
+
+    impl Read for NonSeekReader {
+        fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+            self.bytes.read(buffer)
+        }
+    }
+
+    #[test]
+    fn decoder_accepts_non_seekable_reader() {
+        let reader = NonSeekReader {
+            bytes: Cursor::new(valid()),
+        };
+        assert!(decode_run_json_reader(reader).is_ok());
+    }
+
     #[test]
     fn path_with_spaces() {
         let dir = tempfile::tempdir().unwrap();

--- a/tailtriage-core/src/artifact.rs
+++ b/tailtriage-core/src/artifact.rs
@@ -54,7 +54,8 @@ impl std::error::Error for RunJsonDecodeError {
 ///
 /// The document is decoded directly into [`Run`] without first retaining the
 /// complete input as a string or generic JSON value. Trailing non-whitespace is
-/// rejected.
+/// rejected. This removes avoidable raw-input amplification; it does not impose
+/// a universal allocation bound on arbitrarily large, otherwise valid Runs.
 ///
 /// # Errors
 ///
@@ -167,16 +168,21 @@ mod tests {
 
     #[test]
     fn deep_json_fails_under_normal_recursion_protection() {
-        // Leave the pathological nesting truncated as well. The decoder keeps
-        // serde_json's normal parser protections and reports the hostile input
-        // rather than attempting any recovery or recursion-limit override.
-        let nested = "[".repeat(256) + &"]".repeat(255);
+        let nesting_depth = 256;
+        let nested = "[".repeat(nesting_depth) + &"]".repeat(nesting_depth);
         let mut data = String::from_utf8(valid()).unwrap();
         data.insert_str(data.len() - 1, &format!(",\"unknown\":{nested}"));
-        assert!(matches!(
-            decode(data.as_bytes()),
-            Err(RunJsonDecodeError::Malformed(_) | RunJsonDecodeError::Shape(_))
-        ));
+
+        // Deserialize the complete balanced document into a recursively visited
+        // representation so this test exercises serde_json's depth guard even
+        // though Run's derived visitor efficiently skips unknown field values.
+        let mut deserializer = serde_json::Deserializer::from_slice(data.as_bytes());
+        let json_error = serde_json::Value::deserialize(&mut deserializer)
+            .expect_err("deep nesting must be rejected");
+        assert!(
+            json_error.to_string().contains("recursion limit exceeded"),
+            "expected recursion-limit exhaustion, got {json_error}"
+        );
     }
 
     #[test]

--- a/tailtriage-core/src/lib.rs
+++ b/tailtriage-core/src/lib.rs
@@ -27,6 +27,7 @@
 // # }
 // ```
 
+mod artifact;
 mod collector;
 mod config;
 mod events;
@@ -65,6 +66,8 @@ pub use validation::{
 /// Internal integration hooks for sibling crates in this workspace.
 #[doc(hidden)]
 pub mod __internal {
+    pub use crate::artifact::{decode_run_json_path, RunJsonDecodeError, MAX_RUN_JSON_BYTES};
+
     use crate::{EffectiveTokioSamplerConfig, RuntimeSamplerRegistrationError, Tailtriage};
 
     /// Registers Tokio sampler startup metadata after real sampler preconditions pass.

--- a/tailtriage-core/src/lib.rs
+++ b/tailtriage-core/src/lib.rs
@@ -38,6 +38,7 @@ mod time;
 mod timers;
 mod validation;
 
+pub use artifact::{decode_run_json_path, RunJsonDecodeError};
 pub use collector::{
     OwnedRequestCompletion, OwnedRequestHandle, OwnedStartedRequest, RequestCompletion,
     RequestHandle, RuntimeSamplerRegistrationError, StartedRequest, Tailtriage,
@@ -66,8 +67,6 @@ pub use validation::{
 /// Internal integration hooks for sibling crates in this workspace.
 #[doc(hidden)]
 pub mod __internal {
-    pub use crate::artifact::{decode_run_json_path, RunJsonDecodeError, MAX_RUN_JSON_BYTES};
-
     use crate::{EffectiveTokioSamplerConfig, RuntimeSamplerRegistrationError, Tailtriage};
 
     /// Registers Tokio sampler startup metadata after real sampler preconditions pass.


### PR DESCRIPTION
### Motivation

- Harden canonical Run JSON intake by removing the CLI's previous `read_to_string -> serde_json::Value -> Run` amplification path.
- Centralize canonical Run JSON decoding with the crate that owns `Run`, `SCHEMA_VERSION`, validation, and Run JSON serialization semantics.
- Keep artifact-controlled content inert during decoding while avoiding unnecessary duplicate parsing and memory representations.
- Address the Run JSON portion of 28B1 / SEC-REQ-02 under the revised maintainer-approved resource model.

### Description

- Added canonical Run JSON decoding to `tailtriage-core`.
- Added the narrow supported core API:
  - `decode_run_json_path`
  - `RunJsonDecodeError`
- `RunJsonDecodeError` is `#[non_exhaustive]` so the public error surface can evolve without requiring exhaustive downstream matches.
- The existing Tokio-only `tailtriage_core::__internal` integration hook is unchanged; Run decoding is not exposed through that doc-hidden namespace.
- Reworked `tailtriage-cli` artifact loading to delegate canonical JSON decoding to core while retaining CLI-specific policy and diagnostics.

The production decode path is now:

```text
File
  -> BufReader
  -> serde_json::Deserializer
  -> Run::deserialize
  -> Deserializer::end()
  -> schema-version compatibility check
```

This removes:

* whole-file `String` retention;
* whole-document `serde_json::Value` retention;
* duplicate full-document parsing;
* schema pre-probing and rewind/seek;
* CLI-owned canonical Run JSON parsing.

Trailing non-whitespace after the Run document is rejected.

The private core reader helper only requires `Read`; a regression test uses a non-seekable reader so the canonical decoder cannot silently regress to a probe/rewind/two-pass design.

### Ownership

`tailtriage-core` now owns:

* canonical `Run` JSON deserialization;
* JSON syntax/typed-shape classification;
* supported `schema_version` checking;
* canonical decode error categories.

`tailtriage-cli` continues to own:

* artifact path context in user-facing errors;
* finalized-artifact policy;
* strict versus `--allow-ambiguous-artifact` behavior;
* permissive normalization used by CLI policy;
* lifecycle and unfinished-request warnings;
* minimum-request analysis policy;
* analyzer invocation and output presentation.

Tracing JSONL remains owned by `tailtriage-tracing`.

### Schema-version behavior

A structurally valid Run with an unsupported `schema_version` receives a dedicated unsupported-version error after typed decoding.

Missing or wrong-type `schema_version` values now naturally fail as typed Run-shape/data errors. This intentionally avoids a separate full-document schema probe and a second parse merely to preserve more specialized error precedence.

### Resource/security model

This change intentionally does **not** impose an arbitrary fixed whole-Run byte ceiling.

The earlier fixed whole-document limit design was rejected because:

* Run size depends on public capture limits;
* Run contains developer-controlled strings;
* the producer has no equivalent total-output size contract;
* a raw JSON byte ceiling is not itself a reliable bound on the memory required for the resulting semantic `Run`.

Instead, 28B1C removes the avoidable raw parsing amplification and performs one direct typed streaming parse.

This means the change closes the concrete:

```text
raw String
+ generic JSON Value
+ typed Run
```

amplification path, but it does **not** claim a universal memory bound for arbitrarily large, otherwise valid hostile Run JSON.

The decoder retains serde_json's normal recursion protection and does not disable parser depth limits.

### Malicious content

Artifact-controlled strings remain inert data during decoding.

Focused tests cover:

* deeply nested/pathological JSON under serde_json recursion protection;
* unknown nested fields;
* trailing content;
* malformed and truncated JSON;
* typed shape errors;
* unsupported schema versions;
* escaped terminal-control content remaining ordinary String data;
* non-seekable one-pass decoding;
* paths containing spaces.

This packet does not sanitize or reinterpret artifact strings.

Remaining security work is intentionally separated:

* **28B1D:** terminal/control-character escaping at human-readable output boundaries and tracing temp-file hardening.
* **28B1E:** workflow interpolation/trust-boundary hardening, Action pinning, and operational CI artifact/file/time controls where appropriate.
* **Later follow-up:** broader hostile-input allocation/string budgets and optional artifact authenticity/provenance mechanisms if justified.

Final SEC-REQ-02 disposition should be evaluated in 28B1F against this revised resource/threat model rather than claiming that the superseded whole-file-byte-ceiling design was implemented.

### Dependency cleanup

* Removed direct production `serde` and `serde_json` dependencies from `tailtriage-cli`.
* Kept `serde_json` as a CLI dev-dependency because CLI tests use it directly.
* Kept `tempfile` as a CLI dev-dependency for CLI artifact tests.
* Added `tempfile` as a core dev-dependency for core artifact path tests.
* Core already depended on `serde` and `serde_json`, so canonical decoding adds no new production JSON dependency to core.

### Files changed

* `tailtriage-core/src/artifact.rs`
* `tailtriage-core/src/lib.rs`
* `tailtriage-core/Cargo.toml`
* `tailtriage-cli/src/artifact.rs`
* `tailtriage-cli/Cargo.toml`
* `Cargo.lock`

### Validation

Validated with:

```text
cargo fmt --check
cargo test -p tailtriage-core --all-targets --locked
cargo clippy -p tailtriage-core --all-targets --locked -- -D warnings
cargo test -p tailtriage-cli --all-targets --locked
cargo clippy -p tailtriage-cli --all-targets --locked -- -D warnings
RUSTDOCFLAGS="-D warnings" cargo doc -p tailtriage-core --no-deps --locked
git diff --check
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a84b3626ab48330bd1a7b1d49a9f5db)