### PR TITLE
Harden JSONL temp creation and escape control chars in human output

### DIFF
--- a/tailtriage-analyzer/src/render.rs
+++ b/tailtriage-analyzer/src/render.rs
@@ -1,6 +1,6 @@
 use super::{Confidence, EvidenceQualityLevel, Report, TemporalSegment};
 
-use tailtriage_core::__internal::escape_human_text;
+use tailtriage_core::__internal::escape_control_chars;
 
 fn fmt_opt_u64(value: Option<u64>) -> String {
     match value {
@@ -67,25 +67,25 @@ pub fn render_text(report: &Report) -> String {
             .evidence_quality
             .limitations
             .first()
-            .map_or_else(String::new, |l| format!(" ({})", escape_human_text(l)))
+            .map_or_else(String::new, |l| format!(" ({})", escape_control_chars(l)))
     ));
 
     if !report.warnings.is_empty() {
         lines.push("Warnings:".to_string());
         for warning in &report.warnings {
-            lines.push(format!("- {}", escape_human_text(warning)));
+            lines.push(format!("- {}", escape_control_chars(warning)));
         }
     }
     if !report.primary_suspect.evidence.is_empty() {
         lines.push("Evidence:".to_string());
         for evidence in &report.primary_suspect.evidence {
-            lines.push(format!("- {}", escape_human_text(evidence)));
+            lines.push(format!("- {}", escape_control_chars(evidence)));
         }
     }
     if !report.primary_suspect.next_checks.is_empty() {
         lines.push("Next checks:".to_string());
         for next_check in &report.primary_suspect.next_checks {
-            lines.push(format!("- {}", escape_human_text(next_check)));
+            lines.push(format!("- {}", escape_control_chars(next_check)));
         }
     }
     if !report.secondary_suspects.is_empty() {
@@ -104,7 +104,7 @@ pub fn render_text(report: &Report) -> String {
         for route in &report.route_breakdowns {
             lines.push(format!(
                 "- {}: requests {}, p95 {}us, suspect {} ({} confidence)",
-                escape_human_text(&route.route),
+                escape_control_chars(&route.route),
                 route.request_count,
                 fmt_opt_u64(route.p95_latency_us),
                 route.primary_suspect.kind.as_str(),
@@ -118,8 +118,8 @@ pub fn render_text(report: &Report) -> String {
         for item in &config.non_default_options {
             lines.push(format!(
                 "- {}={}",
-                escape_human_text(&item.path),
-                escape_human_text(&item.value)
+                escape_control_chars(&item.path),
+                escape_control_chars(&item.value)
             ));
         }
     }
@@ -139,7 +139,7 @@ fn render_inflight_trend(trend: &crate::InflightTrend) -> String {
     );
     format!(
         "Inflight latest activity episode: gauge '{}', samples {}, peak {}, p95 {}, {}, {}",
-        escape_human_text(&trend.gauge),
+        escape_control_chars(&trend.gauge),
         trend.sample_count,
         trend.peak_count,
         trend.p95_count,
@@ -156,7 +156,7 @@ fn append_temporal_segment_text(lines: &mut Vec<String>, segments: &[TemporalSeg
     for seg in segments {
         lines.push(format!(
             "- {}: requests {}, p95 {}us, suspect {} ({} confidence)",
-            escape_human_text(&seg.name),
+            escape_control_chars(&seg.name),
             seg.request_count,
             fmt_opt_u64(seg.p95_latency_us),
             seg.primary_suspect.kind.as_str(),

--- a/tailtriage-analyzer/src/render.rs
+++ b/tailtriage-analyzer/src/render.rs
@@ -1,16 +1,6 @@
 use super::{Confidence, EvidenceQualityLevel, Report, TemporalSegment};
 
-fn escape_human_text(input: &str) -> String {
-    let mut output = String::with_capacity(input.len());
-    for ch in input.chars() {
-        if ch.is_control() {
-            output.extend(ch.escape_default());
-        } else {
-            output.push(ch);
-        }
-    }
-    output
-}
+use tailtriage_core::__internal::escape_human_text;
 
 fn fmt_opt_u64(value: Option<u64>) -> String {
     match value {
@@ -172,23 +162,5 @@ fn append_temporal_segment_text(lines: &mut Vec<String>, segments: &[TemporalSeg
             seg.primary_suspect.kind.as_str(),
             fmt_confidence(seg.primary_suspect.confidence)
         ));
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::escape_human_text;
-
-    #[test]
-    fn human_text_escaping_is_visible_idempotent_and_unicode_preserving() {
-        let input = "plain\\slash café 東京\n\r\t\u{1b}\u{7}\u{8}\u{7f}\u{85}";
-        let escaped = escape_human_text(input);
-        assert_eq!(
-            escaped,
-            "plain\\slash café 東京\\n\\r\\t\\u{1b}\\u{7}\\u{8}\\u{7f}\\u{85}"
-        );
-        assert!(!escaped.chars().any(char::is_control));
-        assert_eq!(escape_human_text(&escaped), escaped);
-        assert_eq!(escape_human_text("café 東京"), "café 東京");
     }
 }

--- a/tailtriage-analyzer/src/render.rs
+++ b/tailtriage-analyzer/src/render.rs
@@ -1,5 +1,17 @@
 use super::{Confidence, EvidenceQualityLevel, Report, TemporalSegment};
 
+fn escape_human_text(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    for ch in input.chars() {
+        if ch.is_control() {
+            output.extend(ch.escape_default());
+        } else {
+            output.push(ch);
+        }
+    }
+    output
+}
+
 fn fmt_opt_u64(value: Option<u64>) -> String {
     match value {
         Some(value) => value.to_string(),
@@ -65,25 +77,25 @@ pub fn render_text(report: &Report) -> String {
             .evidence_quality
             .limitations
             .first()
-            .map_or_else(String::new, |l| format!(" ({l})"))
+            .map_or_else(String::new, |l| format!(" ({})", escape_human_text(l)))
     ));
 
     if !report.warnings.is_empty() {
         lines.push("Warnings:".to_string());
         for warning in &report.warnings {
-            lines.push(format!("- {warning}"));
+            lines.push(format!("- {}", escape_human_text(warning)));
         }
     }
     if !report.primary_suspect.evidence.is_empty() {
         lines.push("Evidence:".to_string());
         for evidence in &report.primary_suspect.evidence {
-            lines.push(format!("- {evidence}"));
+            lines.push(format!("- {}", escape_human_text(evidence)));
         }
     }
     if !report.primary_suspect.next_checks.is_empty() {
         lines.push("Next checks:".to_string());
         for next_check in &report.primary_suspect.next_checks {
-            lines.push(format!("- {next_check}"));
+            lines.push(format!("- {}", escape_human_text(next_check)));
         }
     }
     if !report.secondary_suspects.is_empty() {
@@ -102,7 +114,7 @@ pub fn render_text(report: &Report) -> String {
         for route in &report.route_breakdowns {
             lines.push(format!(
                 "- {}: requests {}, p95 {}us, suspect {} ({} confidence)",
-                route.route,
+                escape_human_text(&route.route),
                 route.request_count,
                 fmt_opt_u64(route.p95_latency_us),
                 route.primary_suspect.kind.as_str(),
@@ -114,7 +126,11 @@ pub fn render_text(report: &Report) -> String {
         lines.push("Analyzer config:".to_string());
         lines.push(format!("- schema_version: {}", config.schema_version));
         for item in &config.non_default_options {
-            lines.push(format!("- {}={}", item.path, item.value));
+            lines.push(format!(
+                "- {}={}",
+                escape_human_text(&item.path),
+                escape_human_text(&item.value)
+            ));
         }
     }
     append_temporal_segment_text(&mut lines, &report.temporal_segments);
@@ -133,7 +149,12 @@ fn render_inflight_trend(trend: &crate::InflightTrend) -> String {
     );
     format!(
         "Inflight latest activity episode: gauge '{}', samples {}, peak {}, p95 {}, {}, {}",
-        trend.gauge, trend.sample_count, trend.peak_count, trend.p95_count, direction, rate,
+        escape_human_text(&trend.gauge),
+        trend.sample_count,
+        trend.peak_count,
+        trend.p95_count,
+        direction,
+        rate,
     )
 }
 
@@ -145,11 +166,29 @@ fn append_temporal_segment_text(lines: &mut Vec<String>, segments: &[TemporalSeg
     for seg in segments {
         lines.push(format!(
             "- {}: requests {}, p95 {}us, suspect {} ({} confidence)",
-            seg.name,
+            escape_human_text(&seg.name),
             seg.request_count,
             fmt_opt_u64(seg.p95_latency_us),
             seg.primary_suspect.kind.as_str(),
             fmt_confidence(seg.primary_suspect.confidence)
         ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::escape_human_text;
+
+    #[test]
+    fn human_text_escaping_is_visible_idempotent_and_unicode_preserving() {
+        let input = "plain\\slash café 東京\n\r\t\u{1b}\u{7}\u{8}\u{7f}\u{85}";
+        let escaped = escape_human_text(input);
+        assert_eq!(
+            escaped,
+            "plain\\slash café 東京\\n\\r\\t\\u{1b}\\u{7}\\u{8}\\u{7f}\\u{85}"
+        );
+        assert!(!escaped.chars().any(char::is_control));
+        assert_eq!(escape_human_text(&escaped), escaped);
+        assert_eq!(escape_human_text("café 東京"), "café 東京");
     }
 }

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -2762,6 +2762,30 @@ fn render_text_marks_one_sample_inflight_trend_unknown() {
 }
 
 #[test]
+fn render_text_escapes_artifact_controls_without_changing_report_json() {
+    let mut report = analyze_run(
+        &queue_bonus_run(vec![inflight("hostile\n\u{1b}[31m", 1, Some(1), 7)]),
+        AnalyzeOptions::default(),
+    )
+    .expect("analyzer options should be valid");
+    report.warnings.push("first\nforged\u{7}".to_owned());
+
+    let text = render_text(&report);
+    assert!(text.contains("gauge 'hostile\\n\\u{1b}[31m'"));
+    assert!(text.contains("- first\\nforged\\u{7}"));
+    assert!(!text.lines().any(|line| line == "forged"));
+
+    let json = render_json(&report).expect("report should serialize");
+    let decoded: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert!(decoded["warnings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|warning| warning.as_str() == Some("first\nforged\u{7}")));
+    assert_eq!(decoded["inflight_trend"]["gauge"], "hostile\n\u{1b}[31m");
+}
+
+#[test]
 fn render_text_formats_inflight_trend_fields() {
     let report = Report {
         request_count: 2,

--- a/tailtriage-cli/src/artifact.rs
+++ b/tailtriage-cli/src/artifact.rs
@@ -1,12 +1,12 @@
 use std::path::{Path, PathBuf};
 
 use tailtriage_core::{
-    __internal::escape_human_text, decode_run_json_path, normalize_run_permissive, Run,
+    __internal::escape_control_chars, decode_run_json_path, normalize_run_permissive, Run,
     RunJsonDecodeError, RunValidationReport,
 };
 
 fn display_path(path: &Path) -> String {
-    escape_human_text(&path.display().to_string())
+    escape_control_chars(&path.display().to_string())
 }
 
 /// A decoded run artifact plus non-fatal loader warnings.
@@ -74,7 +74,7 @@ impl std::fmt::Display for ArtifactLoadError {
                 write!(f, "failed to read run artifact '{}': {source}", display_path(path))
             }
             Self::Parse { path, message } => {
-                write!(f, "failed to parse run artifact '{}': {}", display_path(path), escape_human_text(message))
+                write!(f, "failed to parse run artifact '{}': {}", display_path(path), escape_control_chars(message))
             }
             Self::UnsupportedSchemaVersion {
                 path,
@@ -89,7 +89,7 @@ impl std::fmt::Display for ArtifactLoadError {
                 f,
                 "invalid run artifact '{}': {message}",
                 display_path(path),
-                message = escape_human_text(message)
+                message = escape_control_chars(message)
             ),
         }
     }

--- a/tailtriage-cli/src/artifact.rs
+++ b/tailtriage-cli/src/artifact.rs
@@ -4,6 +4,22 @@ use tailtriage_core::{
     decode_run_json_path, normalize_run_permissive, Run, RunJsonDecodeError, RunValidationReport,
 };
 
+fn escape_human_text(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    for ch in input.chars() {
+        if ch.is_control() {
+            output.extend(ch.escape_default());
+        } else {
+            output.push(ch);
+        }
+    }
+    output
+}
+
+fn display_path(path: &Path) -> String {
+    escape_human_text(&path.display().to_string())
+}
+
 /// A decoded run artifact plus non-fatal loader warnings.
 #[derive(Debug)]
 pub(crate) struct LoadedArtifact {
@@ -66,10 +82,10 @@ impl std::fmt::Display for ArtifactLoadError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Read { path, source } => {
-                write!(f, "failed to read run artifact '{}': {source}", path.display())
+                write!(f, "failed to read run artifact '{}': {source}", display_path(path))
             }
             Self::Parse { path, message } => {
-                write!(f, "failed to parse run artifact '{}': {message}", path.display())
+                write!(f, "failed to parse run artifact '{}': {}", display_path(path), escape_human_text(message))
             }
             Self::UnsupportedSchemaVersion {
                 path,
@@ -78,12 +94,13 @@ impl std::fmt::Display for ArtifactLoadError {
             } => write!(
                 f,
                 "unsupported run artifact schema_version={found}; this tailtriage version supports schema_version={supported}. Regenerate the artifact with a current tailtriage version. ('{}')",
-                path.display()
+                display_path(path)
             ),
             Self::Validation { path, message } => write!(
                 f,
                 "invalid run artifact '{}': {message}",
-                path.display()
+                display_path(path),
+                message = escape_human_text(message)
             ),
         }
     }
@@ -192,7 +209,19 @@ fn validate_required_sections(run: &Run, path: &Path) -> Result<(), ArtifactLoad
 
 #[cfg(test)]
 mod tests {
-    use super::load_run_artifact;
+    use super::{escape_human_text, load_run_artifact};
+
+    #[test]
+    fn human_text_escaping_is_visible_idempotent_and_unicode_preserving() {
+        let input = "plain\\slash café 東京\n\r\t\u{1b}\u{7}\u{8}\u{7f}\u{85}";
+        let escaped = escape_human_text(input);
+        assert_eq!(
+            escaped,
+            "plain\\slash café 東京\\n\\r\\t\\u{1b}\\u{7}\\u{8}\\u{7f}\\u{85}"
+        );
+        assert!(!escaped.chars().any(char::is_control));
+        assert_eq!(escape_human_text(&escaped), escaped);
+    }
 
     #[test]
     fn rejects_malformed_json() {

--- a/tailtriage-cli/src/artifact.rs
+++ b/tailtriage-cli/src/artifact.rs
@@ -1,20 +1,9 @@
 use std::path::{Path, PathBuf};
 
 use tailtriage_core::{
-    decode_run_json_path, normalize_run_permissive, Run, RunJsonDecodeError, RunValidationReport,
+    __internal::escape_human_text, decode_run_json_path, normalize_run_permissive, Run,
+    RunJsonDecodeError, RunValidationReport,
 };
-
-fn escape_human_text(input: &str) -> String {
-    let mut output = String::with_capacity(input.len());
-    for ch in input.chars() {
-        if ch.is_control() {
-            output.extend(ch.escape_default());
-        } else {
-            output.push(ch);
-        }
-    }
-    output
-}
 
 fn display_path(path: &Path) -> String {
     escape_human_text(&path.display().to_string())
@@ -209,19 +198,7 @@ fn validate_required_sections(run: &Run, path: &Path) -> Result<(), ArtifactLoad
 
 #[cfg(test)]
 mod tests {
-    use super::{escape_human_text, load_run_artifact};
-
-    #[test]
-    fn human_text_escaping_is_visible_idempotent_and_unicode_preserving() {
-        let input = "plain\\slash café 東京\n\r\t\u{1b}\u{7}\u{8}\u{7f}\u{85}";
-        let escaped = escape_human_text(input);
-        assert_eq!(
-            escaped,
-            "plain\\slash café 東京\\n\\r\\t\\u{1b}\\u{7}\\u{8}\\u{7f}\\u{85}"
-        );
-        assert!(!escaped.chars().any(char::is_control));
-        assert_eq!(escape_human_text(&escaped), escaped);
-    }
+    use super::load_run_artifact;
 
     #[test]
     fn rejects_malformed_json() {

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -9,20 +9,9 @@ use artifact::{decode_run_artifact, ArtifactLoadError};
 use clap::{Parser, ValueEnum};
 use tailtriage_analyzer::{analyze_run, render_json_pretty, render_text};
 
-fn escape_human_text(input: &str) -> String {
-    let mut output = String::with_capacity(input.len());
-    for ch in input.chars() {
-        if ch.is_control() {
-            output.extend(ch.escape_default());
-        } else {
-            output.push(ch);
-        }
-    }
-    output
-}
 use tailtriage_core::{
-    validate_run_strict, CaptureLimitsOverride, CaptureMode, LocalJsonSink, RunSink,
-    RunValidationSeverity,
+    __internal::escape_human_text, validate_run_strict, CaptureLimitsOverride, CaptureMode,
+    LocalJsonSink, RunSink, RunValidationSeverity,
 };
 use tailtriage_tracing::{ensure_persistable_run_has_requests, import_jsonl_path, ImportOptions};
 

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -10,7 +10,7 @@ use clap::{Parser, ValueEnum};
 use tailtriage_analyzer::{analyze_run, render_json_pretty, render_text};
 
 use tailtriage_core::{
-    __internal::escape_human_text, validate_run_strict, CaptureLimitsOverride, CaptureMode,
+    __internal::escape_control_chars, validate_run_strict, CaptureLimitsOverride, CaptureMode,
     LocalJsonSink, RunSink, RunValidationSeverity,
 };
 use tailtriage_tracing::{ensure_persistable_run_has_requests, import_jsonl_path, ImportOptions};
@@ -178,7 +178,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 .into());
             }
             for warning in &loaded.warnings {
-                eprintln!("warning: {}", escape_human_text(warning));
+                eprintln!("warning: {}", escape_control_chars(warning));
             }
             let options = build_analyze_options(analyzer_config.as_deref(), &analyzer_set)?;
             let report = analyze_run(&loaded.original_run, options)?;
@@ -234,7 +234,7 @@ fn validate_cli_strict_artifact(run: &tailtriage_core::Run) -> Result<(), std::i
                 format!(
                     "{} at {location}: {}",
                     issue.code.as_str(),
-                    escape_human_text(&issue.message)
+                    escape_control_chars(&issue.message)
                 )
             })
             .collect::<Vec<_>>();
@@ -271,7 +271,7 @@ fn emit_permissive_validation_warnings(report: &tailtriage_core::RunValidationRe
         eprintln!(
             "warning: permissive Run normalization {} at {location}: {}",
             issue.code.as_str(),
-            escape_human_text(&issue.message)
+            escape_control_chars(&issue.message)
         );
     }
 }
@@ -350,7 +350,7 @@ fn import_tracing_spans_jsonl(
         }
     })?;
     for warning in imported.warnings() {
-        eprintln!("warning: {}", escape_human_text(warning.message()));
+        eprintln!("warning: {}", escape_control_chars(warning.message()));
     }
     if let Err(err) = ensure_persistable_run_has_requests(imported.run()) {
         let message = format!("{err}\n{}", wrapper_only_rejection_guidance());

--- a/tailtriage-cli/src/main.rs
+++ b/tailtriage-cli/src/main.rs
@@ -8,6 +8,18 @@ use analyze_config::{analyzer_options_help_text, build_analyze_options};
 use artifact::{decode_run_artifact, ArtifactLoadError};
 use clap::{Parser, ValueEnum};
 use tailtriage_analyzer::{analyze_run, render_json_pretty, render_text};
+
+fn escape_human_text(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    for ch in input.chars() {
+        if ch.is_control() {
+            output.extend(ch.escape_default());
+        } else {
+            output.push(ch);
+        }
+    }
+    output
+}
 use tailtriage_core::{
     validate_run_strict, CaptureLimitsOverride, CaptureMode, LocalJsonSink, RunSink,
     RunValidationSeverity,
@@ -177,7 +189,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 .into());
             }
             for warning in &loaded.warnings {
-                eprintln!("warning: {warning}");
+                eprintln!("warning: {}", escape_human_text(warning));
             }
             let options = build_analyze_options(analyzer_config.as_deref(), &analyzer_set)?;
             let report = analyze_run(&loaded.original_run, options)?;
@@ -230,7 +242,11 @@ fn validate_cli_strict_artifact(run: &tailtriage_core::Run) -> Result<(), std::i
                     location.push('.');
                     location.push_str(field);
                 }
-                format!("{} at {location}: {}", issue.code.as_str(), issue.message)
+                format!(
+                    "{} at {location}: {}",
+                    issue.code.as_str(),
+                    escape_human_text(&issue.message)
+                )
             })
             .collect::<Vec<_>>();
         if error_count > detail_limit {
@@ -266,7 +282,7 @@ fn emit_permissive_validation_warnings(report: &tailtriage_core::RunValidationRe
         eprintln!(
             "warning: permissive Run normalization {} at {location}: {}",
             issue.code.as_str(),
-            issue.message
+            escape_human_text(&issue.message)
         );
     }
 }
@@ -345,7 +361,7 @@ fn import_tracing_spans_jsonl(
         }
     })?;
     for warning in imported.warnings() {
-        eprintln!("warning: {}", warning.message());
+        eprintln!("warning: {}", escape_human_text(warning.message()));
     }
     if let Err(err) = ensure_persistable_run_has_requests(imported.run()) {
         let message = format!("{err}\n{}", wrapper_only_rejection_guidance());

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -35,6 +35,36 @@ fn cli_json_output_is_valid_report_json() {
 }
 
 #[test]
+fn artifact_warning_controls_are_visible_on_stderr_but_preserved_in_json() {
+    let dir = tempfile::tempdir().expect("tempdir should build");
+    let artifact_path = dir.path().join("run.json");
+    let hostile = "warning first\\nforged\\u001b[31m";
+    let artifact = valid_cli_artifact_with_requests().replace(
+        "\"lifecycle_warnings\":[]",
+        &format!("\"lifecycle_warnings\":[\"{hostile}\"]"),
+    );
+    std::fs::write(&artifact_path, artifact).expect("fixture should write");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
+        .arg("analyze")
+        .arg(&artifact_path)
+        .arg("--format")
+        .arg("json")
+        .output()
+        .expect("cli should run");
+    assert!(output.status.success(), "cli failed: {output:?}");
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("warning first\\\\nforged\\\\u{1b}[31m"));
+    assert_eq!(stderr.lines().count(), 1);
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(report["warnings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|warning| warning.as_str() == Some("warning first\nforged\u{1b}[31m")));
+}
+
+#[test]
 fn cli_loader_rejects_empty_requests_but_analyzer_accepts_zero_request_run() {
     let dir = tempfile::tempdir().expect("tempdir should build");
     let artifact_path = dir.path().join("empty-requests.json");

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -54,14 +54,14 @@ fn artifact_warning_controls_are_visible_on_stderr_but_preserved_in_json() {
         .expect("cli should run");
     assert!(output.status.success(), "cli failed: {output:?}");
     let stderr = String::from_utf8(output.stderr).unwrap();
-    assert!(stderr.contains("warning first\\\\nforged\\\\u{1b}[31m"));
+    assert!(stderr.contains("warning first\\nforged\\u{1b}[31m"));
     assert_eq!(stderr.lines().count(), 1);
-    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert!(report["warnings"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .any(|warning| warning.as_str() == Some("warning first\nforged\u{1b}[31m")));
+    let stored: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&artifact_path).unwrap()).unwrap();
+    assert_eq!(
+        stored["metadata"]["lifecycle_warnings"][0].as_str(),
+        Some("warning first\nforged\u{1b}[31m")
+    );
 }
 
 #[test]

--- a/tailtriage-core/src/lib.rs
+++ b/tailtriage-core/src/lib.rs
@@ -69,6 +69,23 @@ pub use validation::{
 pub mod __internal {
     use crate::{EffectiveTokioSamplerConfig, RuntimeSamplerRegistrationError, Tailtriage};
 
+    /// Escapes control characters for human-readable output in workspace sibling integrations.
+    ///
+    /// This is not a general serialization or Unicode security mechanism. It is a doc-hidden,
+    /// unsupported integration hook for rendering dynamic fields at human-output boundaries.
+    #[must_use]
+    pub fn escape_human_text(input: &str) -> String {
+        let mut output = String::with_capacity(input.len());
+        for ch in input.chars() {
+            if ch.is_control() {
+                output.extend(ch.escape_default());
+            } else {
+                output.push(ch);
+            }
+        }
+        output
+    }
+
     /// Registers Tokio sampler startup metadata after real sampler preconditions pass.
     ///
     /// This is an intentionally narrow cross-crate boundary for
@@ -84,6 +101,24 @@ pub mod __internal {
         config: EffectiveTokioSamplerConfig,
     ) -> Result<(), RuntimeSamplerRegistrationError> {
         tailtriage.register_tokio_runtime_sampler(config)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::escape_human_text;
+
+        #[test]
+        fn human_text_escaping_preserves_the_internal_integration_contract() {
+            let input = "plain\\slash café 東京\n\r\t\u{1b}\u{7}\u{8}\u{7f}\u{85}";
+            let escaped = escape_human_text(input);
+
+            assert_eq!(
+                escaped,
+                "plain\\slash café 東京\\n\\r\\t\\u{1b}\\u{7}\\u{8}\\u{7f}\\u{85}"
+            );
+            assert!(!escaped.chars().any(char::is_control));
+            assert_eq!(escape_human_text(&escaped), escaped);
+        }
     }
 }
 

--- a/tailtriage-core/src/lib.rs
+++ b/tailtriage-core/src/lib.rs
@@ -74,7 +74,7 @@ pub mod __internal {
     /// This is not a general serialization or Unicode security mechanism. It is a doc-hidden,
     /// unsupported integration hook for rendering dynamic fields at human-output boundaries.
     #[must_use]
-    pub fn escape_human_text(input: &str) -> String {
+    pub fn escape_control_chars(input: &str) -> String {
         let mut output = String::with_capacity(input.len());
         for ch in input.chars() {
             if ch.is_control() {
@@ -105,19 +105,19 @@ pub mod __internal {
 
     #[cfg(test)]
     mod tests {
-        use super::escape_human_text;
+        use super::escape_control_chars;
 
         #[test]
         fn human_text_escaping_preserves_the_internal_integration_contract() {
             let input = "plain\\slash café 東京\n\r\t\u{1b}\u{7}\u{8}\u{7f}\u{85}";
-            let escaped = escape_human_text(input);
+            let escaped = escape_control_chars(input);
 
             assert_eq!(
                 escaped,
                 "plain\\slash café 東京\\n\\r\\t\\u{1b}\\u{7}\\u{8}\\u{7f}\\u{85}"
             );
             assert!(!escaped.chars().any(char::is_control));
-            assert_eq!(escape_human_text(&escaped), escaped);
+            assert_eq!(escape_control_chars(&escaped), escaped);
         }
     }
 }

--- a/tailtriage-tracing/src/error.rs
+++ b/tailtriage-tracing/src/error.rs
@@ -1,16 +1,6 @@
 use core::fmt;
 
-fn escape_human_text(input: &str) -> String {
-    let mut output = String::with_capacity(input.len());
-    for ch in input.chars() {
-        if ch.is_control() {
-            output.extend(ch.escape_default());
-        } else {
-            output.push(ch);
-        }
-    }
-    output
-}
+use tailtriage_core::__internal::escape_human_text;
 
 /// Import failures for tracing-shaped span ingestion.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -164,18 +154,19 @@ impl std::error::Error for ImportError {}
 
 #[cfg(test)]
 mod tests {
-    use super::{escape_human_text, ImportError};
+    use super::ImportError;
 
     #[test]
-    fn human_text_escaping_is_visible_idempotent_and_unicode_preserving() {
-        let input = "plain\\slash café 東京\n\r\t\u{1b}\u{7}\u{8}\u{7f}\u{85}";
-        let escaped = escape_human_text(input);
+    fn import_error_display_escapes_dynamic_fields_and_preserves_layout() {
+        let error = ImportError::ZeroRequestArtifactWithWarnings {
+            guidance: "retry\nnow".to_owned(),
+            warnings: vec!["hostile\u{1b}warning".to_owned()],
+        };
+
         assert_eq!(
-            escaped,
-            "plain\\slash café 東京\\n\\r\\t\\u{1b}\\u{7}\\u{8}\\u{7f}\\u{85}"
+            error.to_string(),
+            "retry\\nnow\nwarnings observed during tracing intake:\n- hostile\\u{1b}warning\n"
         );
-        assert!(!escaped.chars().any(char::is_control));
-        assert_eq!(escape_human_text(&escaped), escaped);
     }
 
     #[test]

--- a/tailtriage-tracing/src/error.rs
+++ b/tailtriage-tracing/src/error.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use tailtriage_core::__internal::escape_human_text;
+use tailtriage_core::__internal::escape_control_chars;
 
 /// Import failures for tracing-shaped span ingestion.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -86,14 +86,14 @@ impl fmt::Display for ImportError {
             } => write!(
                 f,
                 "io error while {operation} ({}): {}",
-                escape_human_text(context),
-                escape_human_text(reason)
+                escape_control_chars(context),
+                escape_control_chars(reason)
             ),
             Self::MalformedJsonLine { line, reason } => {
                 write!(
                     f,
                     "malformed JSONL at line {line}: {}",
-                    escape_human_text(reason)
+                    escape_control_chars(reason)
                 )
             }
             Self::JsonlRecordTooLarge { line, limit } => write!(
@@ -104,33 +104,43 @@ impl fmt::Display for ImportError {
                 write!(
                     f,
                     "expected tailtriage wrapper JSONL record: {}",
-                    escape_human_text(reason)
+                    escape_control_chars(reason)
                 )
             }
             Self::MissingField(field) => write!(f, "missing required field: {field}"),
             Self::InvalidField { field, reason } => {
-                write!(f, "invalid field `{field}`: {}", escape_human_text(reason))
+                write!(
+                    f,
+                    "invalid field `{field}`: {}",
+                    escape_control_chars(reason)
+                )
             }
             Self::InvalidConfiguration { option, reason } => {
                 write!(
                     f,
                     "invalid configuration `{option}`: {}",
-                    escape_human_text(reason)
+                    escape_control_chars(reason)
                 )
             }
             Self::StrictViolation(message) => {
-                write!(f, "strict import violation: {}", escape_human_text(message))
+                write!(
+                    f,
+                    "strict import violation: {}",
+                    escape_control_chars(message)
+                )
             }
             Self::EmptyServiceName => write!(f, "service name must not be empty"),
             Self::InvalidRunEvent(message) => {
-                write!(f, "invalid run event: {}", escape_human_text(message))
+                write!(f, "invalid run event: {}", escape_control_chars(message))
             }
-            Self::ZeroRequestArtifact { guidance } => write!(f, "{}", escape_human_text(guidance)),
+            Self::ZeroRequestArtifact { guidance } => {
+                write!(f, "{}", escape_control_chars(guidance))
+            }
             Self::ZeroRequestArtifactWithWarnings { guidance, warnings } => {
-                writeln!(f, "{}", escape_human_text(guidance))?;
+                writeln!(f, "{}", escape_control_chars(guidance))?;
                 writeln!(f, "warnings observed during tracing intake:")?;
                 for warning in warnings.iter().take(8) {
-                    writeln!(f, "- {}", escape_human_text(warning))?;
+                    writeln!(f, "- {}", escape_control_chars(warning))?;
                 }
                 let omitted = warnings.len().saturating_sub(8);
                 if omitted > 0 {
@@ -142,8 +152,8 @@ impl fmt::Display for ImportError {
                 write!(
                     f,
                     "failed to write run JSON at {}: {}",
-                    escape_human_text(path),
-                    escape_human_text(reason)
+                    escape_control_chars(path),
+                    escape_control_chars(reason)
                 )
             }
         }

--- a/tailtriage-tracing/src/error.rs
+++ b/tailtriage-tracing/src/error.rs
@@ -1,5 +1,17 @@
 use core::fmt;
 
+fn escape_human_text(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    for ch in input.chars() {
+        if ch.is_control() {
+            output.extend(ch.escape_default());
+        } else {
+            output.push(ch);
+        }
+    }
+    output
+}
+
 /// Import failures for tracing-shaped span ingestion.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ImportError {
@@ -81,33 +93,54 @@ impl fmt::Display for ImportError {
                 operation,
                 context,
                 reason,
-            } => write!(f, "io error while {operation} ({context}): {reason}"),
+            } => write!(
+                f,
+                "io error while {operation} ({}): {}",
+                escape_human_text(context),
+                escape_human_text(reason)
+            ),
             Self::MalformedJsonLine { line, reason } => {
-                write!(f, "malformed JSONL at line {line}: {reason}")
+                write!(
+                    f,
+                    "malformed JSONL at line {line}: {}",
+                    escape_human_text(reason)
+                )
             }
             Self::JsonlRecordTooLarge { line, limit } => write!(
                 f,
                 "JSONL record at line {line} exceeds the raw-byte limit of {limit} bytes"
             ),
             Self::ExpectedTailtriageWrapper { reason } => {
-                write!(f, "expected tailtriage wrapper JSONL record: {reason}")
+                write!(
+                    f,
+                    "expected tailtriage wrapper JSONL record: {}",
+                    escape_human_text(reason)
+                )
             }
             Self::MissingField(field) => write!(f, "missing required field: {field}"),
             Self::InvalidField { field, reason } => {
-                write!(f, "invalid field `{field}`: {reason}")
+                write!(f, "invalid field `{field}`: {}", escape_human_text(reason))
             }
             Self::InvalidConfiguration { option, reason } => {
-                write!(f, "invalid configuration `{option}`: {reason}")
+                write!(
+                    f,
+                    "invalid configuration `{option}`: {}",
+                    escape_human_text(reason)
+                )
             }
-            Self::StrictViolation(message) => write!(f, "strict import violation: {message}"),
+            Self::StrictViolation(message) => {
+                write!(f, "strict import violation: {}", escape_human_text(message))
+            }
             Self::EmptyServiceName => write!(f, "service name must not be empty"),
-            Self::InvalidRunEvent(message) => write!(f, "invalid run event: {message}"),
-            Self::ZeroRequestArtifact { guidance } => write!(f, "{guidance}"),
+            Self::InvalidRunEvent(message) => {
+                write!(f, "invalid run event: {}", escape_human_text(message))
+            }
+            Self::ZeroRequestArtifact { guidance } => write!(f, "{}", escape_human_text(guidance)),
             Self::ZeroRequestArtifactWithWarnings { guidance, warnings } => {
-                writeln!(f, "{guidance}")?;
+                writeln!(f, "{}", escape_human_text(guidance))?;
                 writeln!(f, "warnings observed during tracing intake:")?;
                 for warning in warnings.iter().take(8) {
-                    writeln!(f, "- {warning}")?;
+                    writeln!(f, "- {}", escape_human_text(warning))?;
                 }
                 let omitted = warnings.len().saturating_sub(8);
                 if omitted > 0 {
@@ -116,7 +149,12 @@ impl fmt::Display for ImportError {
                 Ok(())
             }
             Self::RunJsonWrite { path, reason } => {
-                write!(f, "failed to write run JSON at {path}: {reason}")
+                write!(
+                    f,
+                    "failed to write run JSON at {}: {}",
+                    escape_human_text(path),
+                    escape_human_text(reason)
+                )
             }
         }
     }
@@ -126,7 +164,19 @@ impl std::error::Error for ImportError {}
 
 #[cfg(test)]
 mod tests {
-    use super::ImportError;
+    use super::{escape_human_text, ImportError};
+
+    #[test]
+    fn human_text_escaping_is_visible_idempotent_and_unicode_preserving() {
+        let input = "plain\\slash café 東京\n\r\t\u{1b}\u{7}\u{8}\u{7f}\u{85}";
+        let escaped = escape_human_text(input);
+        assert_eq!(
+            escaped,
+            "plain\\slash café 東京\\n\\r\\t\\u{1b}\\u{7}\\u{8}\\u{7f}\\u{85}"
+        );
+        assert!(!escaped.chars().any(char::is_control));
+        assert_eq!(escape_human_text(&escaped), escaped);
+    }
 
     #[test]
     fn jsonl_resource_errors_have_deterministic_context() {

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -554,14 +554,14 @@ fn write_completed_span_jsonl_with_candidates(
             reason: "all 8 exclusive temporary-file candidates already exist".to_string(),
         });
     };
-    write_completed_span_jsonl_to_owned_temp(retained_sources, path, record_limit, temp_path, file)
+    write_completed_span_jsonl_to_owned_temp(retained_sources, path, record_limit, &temp_path, file)
 }
 
 fn write_completed_span_jsonl_to_owned_temp<W: Write>(
     retained_sources: &[SpanRecord],
     path: &Path,
     record_limit: usize,
-    temp_path: PathBuf,
+    temp_path: &Path,
     mut file: W,
 ) -> Result<(), ImportError> {
     let write_result = (|| -> Result<(), ImportError> {
@@ -610,12 +610,12 @@ fn write_completed_span_jsonl_to_owned_temp<W: Write>(
     drop(file);
 
     if let Err(err) = write_result {
-        let _ = std::fs::remove_file(&temp_path);
+        let _ = std::fs::remove_file(temp_path);
         return Err(err);
     }
 
-    std::fs::rename(&temp_path, path).map_err(|err| {
-        let _ = std::fs::remove_file(&temp_path);
+    std::fs::rename(temp_path, path).map_err(|err| {
+        let _ = std::fs::remove_file(temp_path);
         ImportError::Io {
             operation: "rename completed span jsonl temp file",
             context: format!("{} -> {}", temp_path.display(), path.display()),
@@ -1547,6 +1547,18 @@ mod tests {
     use super::*;
     use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
     use tracing_subscriber::prelude::*;
+
+    struct FailingWriter(std::fs::File);
+
+    impl Write for FailingWriter {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::Error::other("injected write failure"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            self.0.flush()
+        }
+    }
 
     fn with_recorder<T>(f: impl FnOnce(&LiveRecorder) -> T) -> T {
         let recorder = LiveRecorder::builder("svc").run_id("rid").build().unwrap();
@@ -4246,22 +4258,13 @@ mod tests {
             .write(true)
             .open(&owned)
             .unwrap();
-        struct FailingWriter(std::fs::File);
-        impl Write for FailingWriter {
-            fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
-                Err(io::Error::other("injected write failure"))
-            }
-            fn flush(&mut self) -> io::Result<()> {
-                self.0.flush()
-            }
-        }
         let source = SpanRecord::new("request", 1, 2);
 
         assert!(write_completed_span_jsonl_to_owned_temp(
             &[source],
             &path,
             usize::MAX,
-            owned.clone(),
+            &owned,
             FailingWriter(file),
         )
         .is_err());

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -513,18 +513,57 @@ fn write_completed_span_jsonl_with_limit(
     record_limit: usize,
 ) -> Result<(), ImportError> {
     create_output_parent_dir(path, "create completed span jsonl parent directory")?;
-    let temp_path = completed_span_jsonl_temp_path(path);
-    let mut file = std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .open(&temp_path)
-        .map_err(|err| ImportError::Io {
-            operation: "open completed span jsonl path",
-            context: temp_path.display().to_string(),
-            reason: err.to_string(),
-        })?;
+    write_completed_span_jsonl_with_candidates(retained_sources, path, record_limit, |attempt| {
+        completed_span_jsonl_temp_path(path, attempt)
+    })
+}
 
+fn write_completed_span_jsonl_with_candidates(
+    retained_sources: &[SpanRecord],
+    path: &Path,
+    record_limit: usize,
+    mut candidate: impl FnMut(usize) -> PathBuf,
+) -> Result<(), ImportError> {
+    const MAX_TEMP_ATTEMPTS: usize = 8;
+    let mut owned = None;
+    for attempt in 0..MAX_TEMP_ATTEMPTS {
+        let temp_path = candidate(attempt);
+        match std::fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&temp_path)
+        {
+            Ok(file) => {
+                owned = Some((temp_path, file));
+                break;
+            }
+            Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {}
+            Err(err) => {
+                return Err(ImportError::Io {
+                    operation: "create completed span jsonl temp file",
+                    context: temp_path.display().to_string(),
+                    reason: err.to_string(),
+                });
+            }
+        }
+    }
+    let Some((temp_path, file)) = owned else {
+        return Err(ImportError::Io {
+            operation: "create completed span jsonl temp file",
+            context: path.display().to_string(),
+            reason: "all 8 exclusive temporary-file candidates already exist".to_string(),
+        });
+    };
+    write_completed_span_jsonl_to_owned_temp(retained_sources, path, record_limit, temp_path, file)
+}
+
+fn write_completed_span_jsonl_to_owned_temp<W: Write>(
+    retained_sources: &[SpanRecord],
+    path: &Path,
+    record_limit: usize,
+    temp_path: PathBuf,
+    mut file: W,
+) -> Result<(), ImportError> {
     let write_result = (|| -> Result<(), ImportError> {
         for (index, span) in retained_sources.iter().enumerate() {
             let wrapped = CompletedSpanJsonlRecord {
@@ -601,7 +640,7 @@ fn create_output_parent_dir(path: &Path, operation: &'static str) -> Result<(), 
     })
 }
 
-fn completed_span_jsonl_temp_path(path: &Path) -> PathBuf {
+fn completed_span_jsonl_temp_path(path: &Path, attempt: usize) -> PathBuf {
     let file_name = path.file_name().map_or_else(
         || "completed-spans.jsonl".to_string(),
         |name| name.to_string_lossy().into_owned(),
@@ -610,8 +649,8 @@ fn completed_span_jsonl_temp_path(path: &Path) -> PathBuf {
         .duration_since(UNIX_EPOCH)
         .map_or(0, |duration| duration.as_nanos());
     let temp_name = format!(
-        ".{file_name}.tailtriage-tmp-{}-{nanos_since_unix_epoch}",
-        std::process::id(),
+        ".{file_name}.tailtriage-tmp-{}-{nanos_since_unix_epoch}-{attempt}",
+        std::process::id()
     );
     path.with_file_name(temp_name)
 }
@@ -4143,6 +4182,94 @@ mod tests {
         assert_no_completed_span_jsonl_temps(&path);
     }
 
+    #[test]
+    fn completed_jsonl_writer_retries_exclusive_collisions_without_modifying_them() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("final.jsonl");
+        let first = dir.path().join("first.tmp");
+        let second = dir.path().join("second.tmp");
+        let sentinel = b"do not modify";
+        std::fs::write(&first, sentinel).unwrap();
+        let source = SpanRecord::new("request", 1, 2);
+
+        write_completed_span_jsonl_with_candidates(&[source], &path, usize::MAX, |attempt| {
+            if attempt == 0 {
+                first.clone()
+            } else {
+                second.clone()
+            }
+        })
+        .unwrap();
+
+        assert_eq!(std::fs::read(&first).unwrap(), sentinel);
+        assert!(path.exists());
+        assert!(!second.exists());
+    }
+
+    #[test]
+    fn completed_jsonl_writer_exhausts_eight_collisions_without_modification() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("final.jsonl");
+        let candidates = (0..8)
+            .map(|attempt| dir.path().join(format!("collision-{attempt}.tmp")))
+            .collect::<Vec<_>>();
+        for candidate in &candidates {
+            std::fs::write(candidate, b"sentinel").unwrap();
+        }
+
+        let err = write_completed_span_jsonl_with_candidates(&[], &path, usize::MAX, |attempt| {
+            candidates[attempt].clone()
+        })
+        .unwrap_err();
+        assert_eq!(
+            err,
+            ImportError::Io {
+                operation: "create completed span jsonl temp file",
+                context: path.display().to_string(),
+                reason: "all 8 exclusive temporary-file candidates already exist".to_string(),
+            }
+        );
+        for candidate in &candidates {
+            assert_eq!(std::fs::read(candidate).unwrap(), b"sentinel");
+        }
+    }
+
+    #[test]
+    fn completed_jsonl_writer_failure_removes_only_owned_candidate() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("final.jsonl");
+        let collision = dir.path().join("collision.tmp");
+        let owned = dir.path().join("owned.tmp");
+        std::fs::write(&collision, b"sentinel").unwrap();
+        let file = std::fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&owned)
+            .unwrap();
+        struct FailingWriter(std::fs::File);
+        impl Write for FailingWriter {
+            fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+                Err(io::Error::other("injected write failure"))
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                self.0.flush()
+            }
+        }
+        let source = SpanRecord::new("request", 1, 2);
+
+        assert!(write_completed_span_jsonl_to_owned_temp(
+            &[source],
+            &path,
+            usize::MAX,
+            owned.clone(),
+            FailingWriter(file),
+        )
+        .is_err());
+        assert_eq!(std::fs::read(&collision).unwrap(), b"sentinel");
+        assert!(!owned.exists());
+        assert!(!path.exists());
+    }
+
     fn assert_no_completed_span_jsonl_temps(path: &Path) {
         let file_name = path.file_name().unwrap().to_string_lossy();
         let temp_prefix = format!(".{file_name}.tailtriage-tmp-");
@@ -5045,7 +5172,7 @@ mod tests {
             other => panic!("unexpected error: {other}"),
         }
         assert!(!spans_path.exists());
-        assert!(completed_span_jsonl_temp_path(&spans_path)
+        assert!(completed_span_jsonl_temp_path(&spans_path, 0)
             .file_name()
             .unwrap()
             .to_string_lossy()


### PR DESCRIPTION
### Motivation

- Prevent completed-span JSONL temporary-file races and truncation by making temporary creation atomic and bounded.
- Ensure artifact-controlled strings cannot emit raw control characters to human-readable terminal output while preserving structured JSON, stored artifact data, printable Unicode, and literal backslashes.

### Description

- Replace non-exclusive completed-span JSONL temp creation with `OpenOptions::create_new(true)` and bounded collision handling in `tailtriage-tracing/src/recorder.rs`.
  - Try at most 8 candidate paths.
  - Retry only `ErrorKind::AlreadyExists`.
  - Return other I/O errors immediately.
  - Never truncate, overwrite, delete, or otherwise modify a pre-existing collision candidate.
  - Only clean up a temporary path successfully created by the current invocation.
  - Preserve same-directory temp placement, per-record JSONL resource enforcement, serialization, flushing, rename behavior, and final output semantics.

- Add one canonical human-output escaping helper at the repository's existing sibling-crate internal integration boundary:
  - `tailtriage_core::__internal::escape_control_chars`
  - std-only; no new dependency.
  - Escape only characters for which `char::is_control()` is true, using `char::escape_default()`.
  - Preserve printable ASCII, printable non-ASCII Unicode, and literal backslashes.
  - Keep the transform idempotent.
  - Keep this doc-hidden and explicitly unsupported as normal end-user API rather than exposing it as a top-level `tailtriage-core` API.

- Apply the shared helper only at human-readable output boundaries:
  - analyzer text rendering;
  - CLI lifecycle/import/validation warnings and artifact-load diagnostics;
  - tracing `ImportError` dynamic fields.
  - Structured JSON and parsed/stored artifact strings remain unchanged.
  - Trusted application-owned diagnostic layout remains real layout; complete formatted errors are not blanket-escaped.

- Centralize the generic escaping contract tests in `tailtriage-core` while retaining focused sink-level regressions in analyzer, CLI, and tracing.

- Fix Clippy findings from the initial implementation:
  - change the owned-temp writer helper from `PathBuf` by value to `&Path`;
  - move the test `FailingWriter` item to module scope rather than declaring items after statements.

### Security properties

#### SEC-REQ-03 — tracing temporary output

The completed-span JSONL writer now guarantees that:

- temporary creation is exclusive;
- collisions do not modify pre-existing files;
- collision retries are bounded to 8 attempts;
- cleanup applies only to a temp entry successfully created by the current invocation;
- normal JSONL write/flush/rename behavior is preserved.

#### SEC-REQ-06 — human-readable output

Artifact-controlled human text now guarantees that:

- raw control characters do not reach the covered terminal/text sinks;
- printable Unicode remains readable;
- literal backslashes remain unchanged;
- already escaped visible output is stable under a second escaping pass;
- structured JSON remains lossless and unchanged by this rendering policy;
- application-owned multi-line diagnostic layout is preserved.

This intentionally does not introduce ANSI parsing or broader Unicode bidi/confusable/spoofing policy.

### Tests

Focused coverage includes:

- completed-span JSONL collision preservation;
- successful retry after an exclusive-create collision;
- deterministic exhaustion after 8 collisions;
- owned-temp-only cleanup after an injected write failure;
- normal successful final rename;
- canonical escaping behavior for LF, CR, tab, ESC, BEL, backspace, DEL, and a C1 control;
- no surviving control characters;
- idempotence;
- preservation of printable Unicode and literal backslashes;
- analyzer regression proving hostile artifact text cannot forge an extra report line while structured JSON retains the original value;
- CLI regression proving hostile lifecycle-warning text cannot forge an extra stderr line while the stored artifact retains the original value;
- tracing `ImportError` regression proving dynamic fields are escaped while trusted application-owned line layout remains intact.

### Files / areas changed

- `tailtriage-core/src/lib.rs`
  - canonical doc-hidden `__internal::escape_control_chars` helper and contract tests.

- `tailtriage-tracing/src/recorder.rs`
  - exclusive temp creation, bounded collision retry, owned-temp cleanup discipline, deterministic tests, and Clippy fixes.

- `tailtriage-tracing/src/error.rs`
  - shared human-text escaping for dynamic `ImportError` fields and focused display regression coverage.

- `tailtriage-analyzer/src/render.rs`
  - shared escaping at human-readable report sinks.

- `tailtriage-analyzer/src/tests.rs`
  - analyzer text/JSON boundary regression.

- `tailtriage-cli/src/main.rs`
  - shared escaping for terminal warnings and validation messages.

- `tailtriage-cli/src/artifact.rs`
  - shared escaping for artifact-path and dynamic load/validation diagnostics.

- `tailtriage-cli/tests/cli_boundary.rs`
  - CLI stderr/stored-artifact boundary regression.

### Scope / deferred concerns

- No artifact schema changes.
- No Run parsing or storage changes.
- No structured JSON behavior changes.
- No new dependency or crate.
- No aggregate tracing-stream byte ceiling.
- No arbitrary whole-Run byte ceiling.
- No workflow-trust remediation; that remains a later security task.
- No general Unicode bidi/confusable policy.
- No release/version/publishing work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a857f1c9c388330b4940d8e8f280d72)