### PR TITLE
Fix Axum extractor Clippy compatibility

### DIFF
--- a/tailtriage-axum/src/lib.rs
+++ b/tailtriage-axum/src/lib.rs
@@ -103,12 +103,17 @@ where
 {
     type Rejection = TailtriageExtractorError;
 
-    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
-        parts
-            .extensions
-            .get::<TailtriageRequest>()
-            .cloned()
-            .ok_or(TailtriageExtractorError)
+    fn from_request_parts(
+        parts: &mut Parts,
+        _state: &S,
+    ) -> impl Future<Output = Result<Self, Self::Rejection>> {
+        std::future::ready(
+            parts
+                .extensions
+                .get::<TailtriageRequest>()
+                .cloned()
+                .ok_or(TailtriageExtractorError),
+        )
     }
 }
 


### PR DESCRIPTION
### Motivation
- Resolve the `clippy::unused_async_trait_impl` lint in the `TailtriageRequest` Axum extractor so the workspace is compatible with Rust/Clippy 1.98 without changing runtime behavior.

### Description
- Replace the await-free `async fn from_request_parts` with the future-returning form accepted by the Axum `FromRequestParts` trait using `std::future::ready` in `tailtriage-axum/src/lib.rs`, preserving the same extension lookup, cloning behavior, and `TailtriageExtractorError` rejection.

### Testing
- Recorded `rustc --version` (`rustc 1.95.0`) and `cargo clippy --version` (`clippy 0.1.95`), then ran `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, `python3 scripts/validate_docs_contracts.py`, and `git diff --check`, all of which completed successfully locally; note that the installed Clippy is older than 1.98.0 so the local run does not reproduce the exact 1.98 lint environment but the change addresses the known 1.98 diagnostic directly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8b1bcf046483309442e017715af2b8)