### PR TITLE
Prune prose-only docs validation and keep structural/source-backed checks

### DIFF
--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -1,301 +1,23 @@
 #!/usr/bin/env python3
-"""Tests for public-docs contract validation helpers."""
+"""Tests for structural docs and source-policy validation helpers."""
 
 from __future__ import annotations
-
 import subprocess
 import sys
 import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
-SCRIPTS_DIR = REPO_ROOT / "scripts"
+SCRIPTS_DIR = REPO_ROOT / 'scripts'
 sys.path.insert(0, str(SCRIPTS_DIR))
-
-import validate_docs_contracts  # noqa: E402
-
+import validate_docs_contracts
 
 class ValidateDocsContractsTests(unittest.TestCase):
 
-    def test_analyzer_rationale_contract_accepts_structure_and_index_link(self) -> None:
-        rationale = """# Analyzer rationale
-
-Classification uses recorded intent, present-purpose inference, and unknown provenance.
-[Mechanics](diagnostics.md#candidate-eligibility-and-scoring).
-
-### AN-TEST-001 — Rule
-
-**Rule or default:** rule
-**Classification:** hard contract
-**Problem addressed:** problem
-**Why this shape:** reason
-**Tradeoff:** cost
-**Proof owner:** test
-**Revision criteria:** evidence
-**Provenance:** recorded
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            root = Path(tmp_dir)
-            rationale_path = root / "analyzer-rationale.md"
-            index_path = root / "README.md"
-            rationale_path.write_text(rationale, encoding="utf-8")
-            index_path.write_text("[Rationale](analyzer-rationale.md)\n", encoding="utf-8")
-            validate_docs_contracts.validate_analyzer_rationale_contract(
-                rationale_path=rationale_path, docs_index_path=index_path
-            )
-
-    def test_analyzer_rationale_contract_rejects_missing_revision_criteria(self) -> None:
-        rationale = """Classification: recorded intent; present-purpose inference; unknown provenance.
-[Mechanics](diagnostics.md).
-### AN-TEST-001 — Rule
-**Rule or default:** rule
-**Classification:** hard contract
-**Problem addressed:** problem
-**Why this shape:** reason
-**Tradeoff:** cost
-**Proof owner:** test
-**Provenance:** recorded
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            root = Path(tmp_dir)
-            rationale_path = root / "analyzer-rationale.md"
-            index_path = root / "README.md"
-            rationale_path.write_text(rationale, encoding="utf-8")
-            index_path.write_text("[Rationale](analyzer-rationale.md)\n", encoding="utf-8")
-            with self.assertRaisesRegex(ValueError, "Revision criteria"):
-                validate_docs_contracts.validate_analyzer_rationale_contract(
-                    rationale_path=rationale_path, docs_index_path=index_path
-                )
-
-    def test_run_schema_v2_public_contract_rejects_stale_current_run_v1_wording(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / "README.md"
-            path.write_text("Current supported Run schema version: `1`.\n", encoding="utf-8")
-            with (
-                mock.patch.object(validate_docs_contracts, "REPO_ROOT", Path(tmp_dir)),
-                self.assertRaisesRegex(ValueError, r"stale current Run schema claim"),
-            ):
-                validate_docs_contracts.validate_run_schema_v2_public_contract(
-                    doc_paths=(path,), required_current_paths=()
-                )
-
-    def test_run_schema_v2_public_contract_rejects_stale_current_run_v1_colon_wording(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / "README.md"
-            path.write_text("Current supported Run schema version: 1.\n", encoding="utf-8")
-            with (
-                mock.patch.object(validate_docs_contracts, "REPO_ROOT", Path(tmp_dir)),
-                self.assertRaisesRegex(ValueError, r"stale current Run schema claim"),
-            ):
-                validate_docs_contracts.validate_run_schema_v2_public_contract(
-                    doc_paths=(path,), required_current_paths=()
-                )
-
-    def test_run_schema_v2_public_contract_rejects_stale_current_run_json_v1_wording(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / "README.md"
-            path.write_text("Current Run JSON schema version is 1.\n", encoding="utf-8")
-            with (
-                mock.patch.object(validate_docs_contracts, "REPO_ROOT", Path(tmp_dir)),
-                self.assertRaisesRegex(ValueError, r"stale current Run schema claim"),
-            ):
-                validate_docs_contracts.validate_run_schema_v2_public_contract(
-                    doc_paths=(path,), required_current_paths=()
-                )
-
-    def test_run_schema_v2_public_contract_accepts_unrelated_v1_domains(self) -> None:
-        body = """Run JSON schema version 2 uses `metadata.finalized_at_unix_ms` as the sole run-level finalization timestamp. Active snapshots use null finalization. Persisted CLI artifacts require numeric finalization. Schema-v1 Run JSON is rejected. Event-level completion timestamps remain unchanged. The tracing wrapper is `tailtriage.tracing-span.v1`; analyzer TOML uses `schema_version = 1`; validation output schema version 1 remains independent; event-level `finished_at_unix_ms` and `SpanRecord.finished_at_unix_ms` remain unchanged."""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / "README.md"
-            path.write_text(body, encoding="utf-8")
-            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", Path(tmp_dir)):
-                validate_docs_contracts.validate_run_schema_v2_public_contract(
-                    doc_paths=(path,)
-                )
-
-    def test_run_schema_v2_public_contract_rejects_removed_run_metadata_field(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / "SPEC.md"
-            path.write_text(
-                "Current Run metadata includes metadata.finished_at_unix_ms.\n",
-                encoding="utf-8",
-            )
-            with (
-                mock.patch.object(validate_docs_contracts, "REPO_ROOT", Path(tmp_dir)),
-                self.assertRaisesRegex(ValueError, r"removed current Run metadata field"),
-            ):
-                validate_docs_contracts.validate_run_schema_v2_public_contract(
-                    doc_paths=(path,), required_current_paths=()
-                )
-
-    def test_run_schema_v2_public_contract_rejects_missing_canonical_wording(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / "SPEC.md"
-            path.write_text("Run JSON schema version 2.\n", encoding="utf-8")
-            with (
-                mock.patch.object(validate_docs_contracts, "REPO_ROOT", Path(tmp_dir)),
-                self.assertRaisesRegex(ValueError, r"missing Run schema v2 wording"),
-            ):
-                validate_docs_contracts.validate_run_schema_v2_public_contract(
-                    doc_paths=(path,), required_current_paths=(path,)
-                )
-
-    def test_run_schema_v2_public_contract_accepts_validation_output_v1_json(self) -> None:
-        body = """Unrelated validation output:
-```json
-{"schema_version": 1, "generated_at": "2026-01-01T00:00:00Z", "cases": []}
-```
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / "VALIDATION.md"
-            path.write_text(body, encoding="utf-8")
-            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", Path(tmp_dir)):
-                validate_docs_contracts.validate_run_schema_v2_public_contract(
-                    doc_paths=(path,), required_current_paths=()
-                )
-
-    def test_run_schema_v2_public_contract_accepts_noncanonical_without_boilerplate(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / "notes.md"
-            path.write_text(
-                "This page discusses capture artifacts without schema boilerplate.\n",
-                encoding="utf-8",
-            )
-            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", Path(tmp_dir)):
-                validate_docs_contracts.validate_run_schema_v2_public_contract(
-                    doc_paths=(path,), required_current_paths=()
-                )
-
-    def test_run_schema_v2_public_contract_accepts_historical_schema_v1_prose(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / "CHANGELOG.md"
-            path.write_text(
-                "Historical note: schema-v1 Run JSON was supported before schema v2.\n",
-                encoding="utf-8",
-            )
-            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", Path(tmp_dir)):
-                validate_docs_contracts.validate_run_schema_v2_public_contract(
-                    doc_paths=(path,), required_current_paths=()
-                )
-
-    def test_run_schema_v2_public_contract_rejects_removed_rust_model_field(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / "SPEC.md"
-            path.write_text(
-                "Current Run metadata uses RunMetadata::finished_at_unix_ms.\n",
-                encoding="utf-8",
-            )
-            with (
-                mock.patch.object(validate_docs_contracts, "REPO_ROOT", Path(tmp_dir)),
-                self.assertRaisesRegex(ValueError, r"removed current Run metadata field"),
-            ):
-                validate_docs_contracts.validate_run_schema_v2_public_contract(
-                    doc_paths=(path,), required_current_paths=()
-                )
-
-    def test_run_schema_v2_public_contract_accepts_event_level_finish_fields(self) -> None:
-        body = """RequestEvent.finished_at_unix_ms
-StageEvent.finished_at_unix_ms
-SpanRecord.finished_at_unix_ms
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / "notes.md"
-            path.write_text(body, encoding="utf-8")
-            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", Path(tmp_dir)):
-                validate_docs_contracts.validate_run_schema_v2_public_contract(
-                    doc_paths=(path,), required_current_paths=()
-                )
-
-    def test_governance_strictness_contract_accepts_distinct_policies(self) -> None:
-        spec_text = """# Spec
-
-Schema contract:
-
-- default CLI Run artifact analysis strictly validates the original candidate and stops report generation on error-level core findings
-- `tailtriage analyze --allow-ambiguous-artifact` emits every issue and analyzes normalized evidence
-- analyzer library defaults remain permissive
-- tracing import `--strict` separately controls malformed or incomplete `tt.*` span handling during conversion; it does not replace strict Run artifact validation
-- tracing completed-span JSONL import supports the stable wrapper format as the only accepted tracing jsonl file format; pre-stable/internal jsonl must be regenerated
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            spec_path = Path(tmp_dir) / "SPEC.md"
-            spec_path.write_text(spec_text, encoding="utf-8")
-
-            with mock.patch.object(validate_docs_contracts, "SPEC_PATH", spec_path):
-                validate_docs_contracts.validate_governance_strictness_contract()
-
-    def test_governance_strictness_contract_rejects_cli_import_conflation(self) -> None:
-        spec_text = """# Spec
-
-- default CLI Run artifact analysis strictly validates the original candidate and stops report generation on error-level core findings
-- `tailtriage analyze --allow-ambiguous-artifact` emits every issue and analyzes normalized evidence
-- analyzer library defaults remain permissive
-- tracing import `--strict` separately controls malformed or incomplete `tt.*` span handling during conversion; it does not replace strict Run artifact validation
-- tracing completed-span JSONL import supports the stable wrapper format as the only accepted tracing jsonl file format; pre-stable/internal jsonl must be regenerated
-- strict artifact validation is currently opt-in through strict analyzer validation APIs or CLI/import strict flags
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            spec_path = Path(tmp_dir) / "SPEC.md"
-            spec_path.write_text(spec_text, encoding="utf-8")
-
-            with mock.patch.object(validate_docs_contracts, "SPEC_PATH", spec_path):
-                with self.assertRaisesRegex(ValueError, r"conflates strict Run artifact validation"):
-                    validate_docs_contracts.validate_governance_strictness_contract()
-
-    def test_analyzer_strictness_ownership_rejects_analyzer_strict_alternatives(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / "README.md"
-            path.write_text(
-                "Analyzer library entry points remain permissive by default and expose strict alternatives.\n",
-                encoding="utf-8",
-            )
-            with (
-                mock.patch.object(validate_docs_contracts, "REPO_ROOT", Path(tmp_dir)),
-                self.assertRaisesRegex(ValueError, "analyzer-owned strict validation alternatives"),
-            ):
-                validate_docs_contracts.validate_analyzer_strictness_ownership_contract(path=path)
-
-    def test_governance_pending_state_contract_accepts_unsealed_shutdown_wording(self) -> None:
-        design_text = """# Notes
-
-Not all live bookkeeping is bounded by capture limits today. Pending/unfinished request state can grow with admitted requests and remains until the corresponding request completion token finishes or the collector is dropped.
-
-`shutdown()` currently inspects pending requests and records unfinished-request metadata, but it does not clear pending bookkeeping or seal the collector against later admissions or completion activity.
-
-Pending-state tracking preserves lifecycle warnings but remains separate from the retained request, queue, stage, in-flight, and runtime vectors that capture limits bound.
-
-Pending-state limits and unsealed shutdown behavior remain known current limitations rather than desired permanent contracts.
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            design_path = Path(tmp_dir) / "DESIGN_NOTES.md"
-            design_path.write_text(design_text, encoding="utf-8")
-
-            with mock.patch.object(validate_docs_contracts, "DESIGN_NOTES_PATH", design_path):
-                validate_docs_contracts.validate_governance_pending_state_contract()
-
-    def test_governance_pending_state_contract_rejects_shutdown_as_boundary(self) -> None:
-        design_text = """# Notes
-
-Not all live bookkeeping is bounded by capture limits today. Pending/unfinished request state can grow with admitted requests until those requests complete or the run shuts down.
-Pending/unfinished request state can grow with admitted requests and remains until the corresponding request completion token finishes or the collector is dropped.
-`shutdown()` currently inspects pending requests and records unfinished-request metadata, but it does not clear pending bookkeeping or seal the collector against later admissions or completion activity.
-Pending-state tracking preserves lifecycle warnings but remains separate from the retained request, queue, stage, in-flight, and runtime vectors that capture limits bound.
-Pending-state limits and unsealed shutdown behavior remain known current limitations rather than desired permanent contracts.
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            design_path = Path(tmp_dir) / "DESIGN_NOTES.md"
-            design_path.write_text(design_text, encoding="utf-8")
-
-            with mock.patch.object(validate_docs_contracts, "DESIGN_NOTES_PATH", design_path):
-                with self.assertRaisesRegex(ValueError, r"shutdown clears pending request state"):
-                    validate_docs_contracts.validate_governance_pending_state_contract()
-
     def test_run_end_policy_variants_include_expected_kinds(self) -> None:
         kinds = validate_docs_contracts.extract_run_end_policy_kinds_from_source()
-        self.assertEqual(kinds, {"continue_after_limits_hit", "auto_seal_on_limits_hit"})
-
+        self.assertEqual(kinds, {'continue_after_limits_hit', 'auto_seal_on_limits_hit'})
 
     def test_crate_rustdocs_include_readmes_contract(self) -> None:
         validate_docs_contracts.validate_crate_rustdocs_include_readmes()
@@ -303,67 +25,39 @@ Pending-state limits and unsealed shutdown behavior remain known current limitat
     def test_crate_rustdocs_include_readmes_contract_fails_when_missing_include(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             repo_root = Path(tmp_dir)
-            rels = (
-                "tailtriage/src/lib.rs",
-                "tailtriage-core/src/lib.rs",
-                "tailtriage-controller/src/lib.rs",
-                "tailtriage-tokio/src/lib.rs",
-                "tailtriage-axum/src/lib.rs",
-                "tailtriage-analyzer/src/lib.rs",
-                "tailtriage-cli/src/lib.rs",
-                "tailtriage-tracing/src/lib.rs",
-            )
+            rels = ('tailtriage/src/lib.rs', 'tailtriage-core/src/lib.rs', 'tailtriage-controller/src/lib.rs', 'tailtriage-tokio/src/lib.rs', 'tailtriage-axum/src/lib.rs', 'tailtriage-analyzer/src/lib.rs', 'tailtriage-cli/src/lib.rs', 'tailtriage-tracing/src/lib.rs')
             paths = []
             for rel in rels:
                 path = repo_root / rel
                 path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_text('#![doc = include_str!("../README.md")]\n', encoding="utf-8")
+                path.write_text('#![doc = include_str!("../README.md")]\n', encoding='utf-8')
                 paths.append(path)
-
-            (repo_root / rels[0]).write_text('// missing include\n', encoding="utf-8")
-
-            with (
-                mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root),
-                mock.patch.object(
-                    validate_docs_contracts,
-                    "RUSTDOC_INCLUDE_CRATE_LIBS",
-                    tuple(paths),
-                ),
-            ):
-                with self.assertRaisesRegex(ValueError, r"README directive"):
+            (repo_root / rels[0]).write_text('// missing include\n', encoding='utf-8')
+            with mock.patch.object(validate_docs_contracts, 'REPO_ROOT', repo_root), mock.patch.object(validate_docs_contracts, 'RUSTDOC_INCLUDE_CRATE_LIBS', tuple(paths)):
+                with self.assertRaisesRegex(ValueError, 'README directive'):
                     validate_docs_contracts.validate_crate_rustdocs_include_readmes()
 
     def test_residual_public_api_cleanup_contract_accepts_private_cli_internals(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)
-            sources = {
-                "tailtriage-controller/src/lib.rs": "pub fn begin_request() {}\n",
-                "tailtriage-tokio/src/lib.rs": "pub fn builder() {}\n",
-                "tailtriage-axum/src/lib.rs": "pub fn middleware() {}\n",
-                "tailtriage-cli/src/lib.rs": "#![doc = include_str!(\"../README.md\")]\n",
-            }
+            sources = {'tailtriage-controller/src/lib.rs': 'pub fn begin_request() {}\n', 'tailtriage-tokio/src/lib.rs': 'pub fn builder() {}\n', 'tailtriage-axum/src/lib.rs': 'pub fn middleware() {}\n', 'tailtriage-cli/src/lib.rs': '#![doc = include_str!("../README.md")]\n'}
             for rel, body in sources.items():
                 path = root / rel
                 path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_text(body, encoding="utf-8")
-            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", root):
+                path.write_text(body, encoding='utf-8')
+            with mock.patch.object(validate_docs_contracts, 'REPO_ROOT', root):
                 validate_docs_contracts.validate_residual_public_api_cleanup()
 
     def test_residual_public_api_cleanup_contract_rejects_cli_helper_export(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)
-            sources = {
-                "tailtriage-controller/src/lib.rs": "",
-                "tailtriage-tokio/src/lib.rs": "",
-                "tailtriage-axum/src/lib.rs": "",
-                "tailtriage-cli/src/lib.rs": "pub fn build_analyze_options() {}\n",
-            }
+            sources = {'tailtriage-controller/src/lib.rs': '', 'tailtriage-tokio/src/lib.rs': '', 'tailtriage-axum/src/lib.rs': '', 'tailtriage-cli/src/lib.rs': 'pub fn build_analyze_options() {}\n'}
             for rel, body in sources.items():
                 path = root / rel
                 path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_text(body, encoding="utf-8")
-            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", root):
-                with self.assertRaisesRegex(ValueError, "removed residual public API"):
+                path.write_text(body, encoding='utf-8')
+            with mock.patch.object(validate_docs_contracts, 'REPO_ROOT', root):
+                with self.assertRaisesRegex(ValueError, 'removed residual public API'):
                     validate_docs_contracts.validate_residual_public_api_cleanup()
 
     def test_markdown_examples_validate_against_contract(self) -> None:
@@ -375,75 +69,58 @@ Pending-state limits and unsealed shutdown behavior remain known current limitat
     def test_analyzer_ownership_navigation_rejects_missing_link(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             repo_root = Path(tmp_dir)
-            path = repo_root / "README.md"
-            path.write_text("# Documentation\n", encoding="utf-8")
-            with self.assertRaisesRegex(ValueError, r"missing analyzer ownership links"):
-                validate_docs_contracts.validate_analyzer_ownership_navigation(
-                    required_links={path: ("analyzer-guide.md",)}, repo_root=repo_root
-                )
+            path = repo_root / 'README.md'
+            path.write_text('# Documentation\n', encoding='utf-8')
+            with self.assertRaisesRegex(ValueError, 'missing analyzer ownership links'):
+                validate_docs_contracts.validate_analyzer_ownership_navigation(required_links={path: ('analyzer-guide.md',)}, repo_root=repo_root)
 
     def test_analyzer_ownership_navigation_accepts_exact_relative_link(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             repo_root = Path(tmp_dir)
-            source = repo_root / "docs" / "guide.md"
-            target = repo_root / "docs" / "diagnostics.md"
+            source = repo_root / 'docs' / 'guide.md'
+            target = repo_root / 'docs' / 'diagnostics.md'
             source.parent.mkdir()
-            source.write_text("[Diagnostics](diagnostics.md)\n", encoding="utf-8")
-            target.write_text("# Diagnostics\n", encoding="utf-8")
-
-            validate_docs_contracts.validate_analyzer_ownership_navigation(
-                required_links={source: ("diagnostics.md",)}, repo_root=repo_root
-            )
+            source.write_text('[Diagnostics](diagnostics.md)\n', encoding='utf-8')
+            target.write_text('# Diagnostics\n', encoding='utf-8')
+            validate_docs_contracts.validate_analyzer_ownership_navigation(required_links={source: ('diagnostics.md',)}, repo_root=repo_root)
 
     def test_analyzer_ownership_navigation_accepts_fragment(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             repo_root = Path(tmp_dir)
-            source = repo_root / "guide.md"
-            target = repo_root / "diagnostics.md"
-            source.write_text("[Confidence](diagnostics.md#confidence)\n", encoding="utf-8")
-            target.write_text("# Diagnostics\n", encoding="utf-8")
-
-            validate_docs_contracts.validate_analyzer_ownership_navigation(
-                required_links={source: ("diagnostics.md",)}, repo_root=repo_root
-            )
+            source = repo_root / 'guide.md'
+            target = repo_root / 'diagnostics.md'
+            source.write_text('[Confidence](diagnostics.md#confidence)\n', encoding='utf-8')
+            target.write_text('# Diagnostics\n', encoding='utf-8')
+            validate_docs_contracts.validate_analyzer_ownership_navigation(required_links={source: ('diagnostics.md',)}, repo_root=repo_root)
 
     def test_analyzer_ownership_navigation_rejects_prefix_lookalike(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             repo_root = Path(tmp_dir)
-            source = repo_root / "guide.md"
-            lookalike = repo_root / "diagnostics.md-old"
-            source.write_text("[Wrong](diagnostics.md-old)\n", encoding="utf-8")
-            lookalike.write_text("not the destination\n", encoding="utf-8")
-
-            with self.assertRaisesRegex(ValueError, r"missing analyzer ownership links"):
-                validate_docs_contracts.validate_analyzer_ownership_navigation(
-                    required_links={source: ("diagnostics.md",)}, repo_root=repo_root
-                )
+            source = repo_root / 'guide.md'
+            lookalike = repo_root / 'diagnostics.md-old'
+            source.write_text('[Wrong](diagnostics.md-old)\n', encoding='utf-8')
+            lookalike.write_text('not the destination\n', encoding='utf-8')
+            with self.assertRaisesRegex(ValueError, 'missing analyzer ownership links'):
+                validate_docs_contracts.validate_analyzer_ownership_navigation(required_links={source: ('diagnostics.md',)}, repo_root=repo_root)
 
     def test_analyzer_ownership_navigation_rejects_missing_local_target(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             repo_root = Path(tmp_dir)
-            source = repo_root / "guide.md"
-            source.write_text("[Missing](diagnostics.md)\n", encoding="utf-8")
-
-            with self.assertRaisesRegex(ValueError, r"not an existing file"):
-                validate_docs_contracts.validate_analyzer_ownership_navigation(
-                    required_links={source: ("diagnostics.md",)}, repo_root=repo_root
-                )
+            source = repo_root / 'guide.md'
+            source.write_text('[Missing](diagnostics.md)\n', encoding='utf-8')
+            with self.assertRaisesRegex(ValueError, 'not an existing file'):
+                validate_docs_contracts.validate_analyzer_ownership_navigation(required_links={source: ('diagnostics.md',)}, repo_root=repo_root)
 
     def test_analyzer_ownership_navigation_rejects_repository_escape(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             workspace = Path(tmp_dir)
-            repo_root = workspace / "repo"
+            repo_root = workspace / 'repo'
             repo_root.mkdir()
-            source = repo_root / "guide.md"
-            (workspace / "outside.md").write_text("# Outside\n", encoding="utf-8")
-            source.write_text("[Outside](../outside.md)\n", encoding="utf-8")
-
-            with self.assertRaisesRegex(ValueError, r"escapes repository root"):
-                validate_docs_contracts.validate_analyzer_ownership_navigation(
-                    required_links={source: ("../outside.md",)}, repo_root=repo_root
-                )
+            source = repo_root / 'guide.md'
+            (workspace / 'outside.md').write_text('# Outside\n', encoding='utf-8')
+            source.write_text('[Outside](../outside.md)\n', encoding='utf-8')
+            with self.assertRaisesRegex(ValueError, 'escapes repository root'):
+                validate_docs_contracts.validate_analyzer_ownership_navigation(required_links={source: ('../outside.md',)}, repo_root=repo_root)
 
     def test_docs_index_contract(self) -> None:
         validate_docs_contracts.validate_docs_index_contract()
@@ -451,1573 +128,152 @@ Pending-state limits and unsealed shutdown behavior remain known current limitat
     def test_root_readme_docs_link(self) -> None:
         validate_docs_contracts.validate_root_readme_docs_link()
 
-    def test_user_guide_contract(self) -> None:
-        validate_docs_contracts.validate_user_guide_contract()
-
-    def test_tracing_completed_jsonl_public_contract(self) -> None:
-        validate_docs_contracts.validate_tracing_completed_jsonl_public_contract()
-
-    def test_live_tracing_session_public_contract(self) -> None:
-        validate_docs_contracts.validate_live_tracing_session_public_contract()
-
-    def test_operations_guide_contract(self) -> None:
-        validate_docs_contracts.validate_operations_guide_contract()
-
-    def test_operations_guide_contract_fails_when_required_concepts_missing(self) -> None:
-        incomplete = """# Production operations guide
-
-Minimal text that references VALIDATION.md, diagnostics.md, runtime-cost.md, and collector-limits.md,
-but intentionally omits required operational concepts.
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            operations_path = Path(tmp_dir) / "operations.md"
-            operations_path.write_text(incomplete, encoding="utf-8")
-            with mock.patch.object(validate_docs_contracts, "OPERATIONS_PATH", operations_path):
-                with self.assertRaisesRegex(ValueError, r"missing required concept/token"):
-                    validate_docs_contracts.validate_operations_guide_contract()
-
-    def test_operations_guide_contract_passes_with_complete_content(self) -> None:
-        complete = """# Production operations guide
-
-This is a production operations guide with a recommended rollout path.
-Use light first, escalate to investigation when needed.
-Runtime sampling may help.
-Artifact sizing and truncation behavior depend on capture limits.
-If results are insufficient_evidence, inspect evidence_quality and controller choices.
-These suspects are not proof of root cause and not universal production guarantees.
-
-See VALIDATION.md, diagnostics.md, runtime-cost.md, and collector-limits.md.
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            operations_path = Path(tmp_dir) / "operations.md"
-            operations_path.write_text(complete, encoding="utf-8")
-            with mock.patch.object(validate_docs_contracts, "OPERATIONS_PATH", operations_path):
-                validate_docs_contracts.validate_operations_guide_contract()
-
-    def test_user_guide_uses_controller_scoped_toml_shape(self) -> None:
-        text = validate_docs_contracts.USER_GUIDE_PATH.read_text(encoding="utf-8")
-        self.assertIn("[controller]", text)
-        self.assertIn("[controller.activation]", text)
-        self.assertIn("[controller.activation.sink]", text)
-        self.assertNotIn("\n[activation]\n", text)
-        self.assertNotIn("\n[activation.sink]\n", text)
-
-    def test_diagnostics_contract_truthfulness(self) -> None:
-        validate_docs_contracts.validate_diagnostics_contract_truthfulness()
-
     def test_analyzer_config_example_contract(self) -> None:
         validate_docs_contracts.validate_analyzer_config_example_contract()
 
     def test_analyzer_config_example_contract_rejects_missing_schema_version(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / "analyzer-config.toml"
-            path.write_text("[analyzer]\n[analyzer.queueing]\n", encoding="utf-8")
-            with self.assertRaisesRegex(ValueError, r"schema_version = 1"):
+            path = Path(tmp_dir) / 'analyzer-config.toml'
+            path.write_text('[analyzer]\n[analyzer.queueing]\n', encoding='utf-8')
+            with self.assertRaisesRegex(ValueError, 'schema_version = 1'):
                 validate_docs_contracts.validate_analyzer_config_example_contract(config_path=path)
 
     def test_analyzer_config_example_contract_rejects_missing_analyzer_table(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / "analyzer-config.toml"
-            path.write_text("schema_version = 1\n", encoding="utf-8")
-            with self.assertRaisesRegex(ValueError, r"\[analyzer\]"):
+            path = Path(tmp_dir) / 'analyzer-config.toml'
+            path.write_text('schema_version = 1\n', encoding='utf-8')
+            with self.assertRaisesRegex(ValueError, '\\[analyzer\\]'):
                 validate_docs_contracts.validate_analyzer_config_example_contract(config_path=path)
 
     def test_analyzer_config_example_contract_rejects_missing_group(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / "analyzer-config.toml"
-            body = "[analyzer]\nschema_version = 1\n" + "\n".join(
-                f"[analyzer.{g}]" for g in validate_docs_contracts.ANALYZER_GROUPS if g != "temporal"
-            )
-            path.write_text(body, encoding="utf-8")
-            with self.assertRaisesRegex(ValueError, r"temporal"):
+            path = Path(tmp_dir) / 'analyzer-config.toml'
+            body = '[analyzer]\nschema_version = 1\n' + '\n'.join((f'[analyzer.{g}]' for g in validate_docs_contracts.ANALYZER_GROUPS if g != 'temporal'))
+            path.write_text(body, encoding='utf-8')
+            with self.assertRaisesRegex(ValueError, 'temporal'):
                 validate_docs_contracts.validate_analyzer_config_example_contract(config_path=path)
 
     def test_analyzer_config_example_contract_rejects_root_level_group(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / "analyzer-config.toml"
-            body = "[analyzer]\nschema_version = 1\n" + "\n".join(
-                f"[analyzer.{g}]" for g in validate_docs_contracts.ANALYZER_GROUPS
-            ) + "\n[queueing]\ntrigger_permille = 100\n"
-            path.write_text(body, encoding="utf-8")
-            with self.assertRaisesRegex(ValueError, r"root-level analyzer groups"):
+            path = Path(tmp_dir) / 'analyzer-config.toml'
+            body = '[analyzer]\nschema_version = 1\n' + '\n'.join((f'[analyzer.{g}]' for g in validate_docs_contracts.ANALYZER_GROUPS)) + '\n[queueing]\ntrigger_permille = 100\n'
+            path.write_text(body, encoding='utf-8')
+            with self.assertRaisesRegex(ValueError, 'root-level analyzer groups'):
                 validate_docs_contracts.validate_analyzer_config_example_contract(config_path=path)
-
-    def test_extract_analyzer_paths_for_validation(self) -> None:
-        text = """
-Use `queueing.trigger_permille`, queueing.trigger_permille=400,
---analyzer-set queueing.trigger_permille=400, and `confidence.high_score_threshold`.
-Ignore file names like docs/operations.md, foo.bar, and include queuing.trigger_permille too.
-"""
-        paths = validate_docs_contracts._extract_analyzer_paths_for_validation(text)
-        self.assertIn("queueing.trigger_permille", paths)
-        self.assertIn("confidence.high_score_threshold", paths)
-        self.assertIn("queuing.trigger_permille", paths)
-        self.assertNotIn("foo.bar", paths)
-        self.assertNotIn("docs/operations.md", paths)
-
-    def test_analyzer_tuning_docs_contracts_on_committed_docs(self) -> None:
-        validate_docs_contracts.validate_analyzer_tuning_tokens_contract()
-        validate_docs_contracts.validate_no_root_level_analyzer_toml_in_docs()
-        validate_docs_contracts.validate_analyzer_override_paths_contract()
-
-    def test_worker_normalized_executor_option_is_a_valid_documented_path(self) -> None:
-        self.assertIn(
-            "executor.min_runnable_queue_per_worker_p95_milli_for_signal",
-            validate_docs_contracts.ANALYZER_V1_VALID_PATHS,
-        )
 
     def test_analyzer_no_root_level_docs_rejects_root_level_table_header(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             repo_root = Path(tmp_dir)
-            docs_dir = repo_root / "docs"
+            docs_dir = repo_root / 'docs'
             docs_dir.mkdir(parents=True, exist_ok=True)
-            path = docs_dir / "diagnostics.md"
-            path.write_text("[queueing]\ntrigger_permille = 400\n", encoding="utf-8")
-            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root):
-                with self.assertRaisesRegex(ValueError, r"invalid root-level TOML header"):
+            path = docs_dir / 'diagnostics.md'
+            path.write_text('[queueing]\ntrigger_permille = 400\n', encoding='utf-8')
+            with mock.patch.object(validate_docs_contracts, 'REPO_ROOT', repo_root):
+                with self.assertRaisesRegex(ValueError, 'invalid root-level TOML header'):
                     validate_docs_contracts.validate_no_root_level_analyzer_toml_in_docs(doc_paths=(path,))
 
     def test_analyzer_no_root_level_docs_allows_namespaced_table_header(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / "docs.md"
-            path.write_text("[analyzer.queueing]\ntrigger_permille = 400\n", encoding="utf-8")
+            path = Path(tmp_dir) / 'docs.md'
+            path.write_text('[analyzer.queueing]\ntrigger_permille = 400\n', encoding='utf-8')
             validate_docs_contracts.validate_no_root_level_analyzer_toml_in_docs(doc_paths=(path,))
 
-    def test_analyzer_override_paths_contract_rejects_invalid_paths(self) -> None:
-        invalid_candidates = (
-            "confidence.high_threshold",
-            "route.max_routes",
-            "temporal.windows",
-            "queuing.trigger_permille",
-        )
-        for candidate in invalid_candidates:
-            with self.subTest(candidate=candidate):
-                with tempfile.TemporaryDirectory() as tmp_dir:
-                    repo_root = Path(tmp_dir)
-                    doc = repo_root / "docs.md"
-                    doc.write_text(f"`{candidate}`\n", encoding="utf-8")
-                    with mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root):
-                        with self.assertRaisesRegex(ValueError, candidate):
-                            validate_docs_contracts.validate_analyzer_override_paths_contract(
-                                doc_paths=(doc,)
-                            )
-
-    def test_validation_ci_contract_checks_committed_workflow_and_docs(self) -> None:
-        validate_docs_contracts.validate_diagnostic_benchmark_ci_contract()
-        validate_docs_contracts.validate_validation_docs_ci_contract()
-
-    def test_validation_ci_contract_fails_without_diagnostic_benchmark_command(self) -> None:
-        workflow_text = """name: CI
-
-jobs:
-  verify:
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Validate diagnostic benchmark helper unit tests
-        run: python3 -m unittest scripts.tests.test_diagnostic_benchmark
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            workflow_path = Path(tmp_dir) / "ci.yml"
-            workflow_path.write_text(workflow_text, encoding="utf-8")
-
-            with self.assertRaisesRegex(ValueError, r"diagnostic_benchmark.py"):
-                validate_docs_contracts.validate_diagnostic_benchmark_ci_contract(
-                    workflow_path=workflow_path
-                )
-
-    def test_validation_ci_contract_fails_without_required_benchmark_args(self) -> None:
-        workflow_text = """name: CI
-
-jobs:
-  verify:
-    steps:
-      - name: Validate deterministic diagnostics benchmark corpus
-        run: >
-          python3 scripts/diagnostic_benchmark.py
-          --manifest validation/diagnostics/manifest.json
-          --min-top1 0.75
-          --max-high-confidence-wrong 0
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            workflow_path = Path(tmp_dir) / "ci.yml"
-            workflow_path.write_text(workflow_text, encoding="utf-8")
-
-            with self.assertRaisesRegex(ValueError, r"--min-top2 0.90"):
-                validate_docs_contracts.validate_diagnostic_benchmark_ci_contract(
-                    workflow_path=workflow_path
-                )
-
-    def test_validation_ci_contract_fails_when_benchmark_step_can_continue_on_error(self) -> None:
-        workflow_text = """name: CI
-
-jobs:
-  verify:
-    steps:
-      - name: Validate deterministic diagnostics benchmark corpus
-        continue-on-error: true
-        run: |
-          python3 scripts/diagnostic_benchmark.py \
-            --manifest validation/diagnostics/manifest.json \
-            --min-top1 0.75 \
-            --min-top2 0.90 \
-            --max-high-confidence-wrong 0
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            workflow_path = Path(tmp_dir) / "ci.yml"
-            workflow_path.write_text(workflow_text, encoding="utf-8")
-
-            with self.assertRaisesRegex(ValueError, r"continue-on-error"):
-                validate_docs_contracts.validate_diagnostic_benchmark_ci_contract(
-                    workflow_path=workflow_path
-                )
-
-    def test_validation_docs_contract_fails_on_stale_normal_pr_ci_wording(self) -> None:
-        doc_text = """# Validation
-
-Deterministic corpus: no in normal PR CI.
-Normal CI owns the deterministic benchmark gate and does not publish GitHub artifacts.
-Use scripts/generate_diagnostic_scorecard.py locally for local/manual scorecards.
-Use scripts/validate_all.py --profile publish for local/manual release-readiness.
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            doc_path = Path(tmp_dir) / "VALIDATION.md"
-            doc_path.write_text(doc_text, encoding="utf-8")
-
-            with self.assertRaisesRegex(ValueError, r"no in normal pr ci"):
-                validate_docs_contracts.validate_validation_docs_ci_contract(
-                    doc_paths=(doc_path,)
-                )
-
-    def test_validation_docs_contract_requires_local_scorecard_source(self) -> None:
-        doc_text = """# Validation
-
-Normal CI owns the deterministic benchmark gate and does not publish GitHub artifacts.
-Use scripts/validate_all.py --profile publish for local/manual release-readiness.
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            doc_path = Path(tmp_dir) / "VALIDATION.md"
-            doc_path.write_text(doc_text, encoding="utf-8")
-
-            with self.assertRaisesRegex(ValueError, r"generate_diagnostic_scorecard"):
-                validate_docs_contracts.validate_validation_docs_ci_contract(
-                    doc_paths=(doc_path,)
-                )
-
-
-    def test_cli_not_presented_as_library_analyzer_api_contract(self) -> None:
-        validate_docs_contracts.validate_cli_not_presented_as_library_analyzer_api()
-
-    def test_analyzer_cli_docs_split_contract(self) -> None:
-        validate_docs_contracts.validate_analyzer_cli_docs_split_contract()
-
-    def test_capture_readmes_analyzer_cli_wording_contract(self) -> None:
-        validate_docs_contracts.validate_capture_readmes_analyzer_cli_wording_contract()
-
-    def test_capture_readme_wording_rejects_cli_only_stale_phrase(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            repo_root = Path(tmp_dir)
-            paths = []
-            for rel in (
-                "tailtriage/README.md",
-                "tailtriage-core/README.md",
-                "tailtriage-controller/README.md",
-                "tailtriage-tokio/README.md",
-                "tailtriage-axum/README.md",
-            ):
-                path = repo_root / rel
-                path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_text(
-                    "Use tailtriage-analyzer in-process and tailtriage-cli for saved artifacts.",
-                    encoding="utf-8",
-                )
-                paths.append(path)
-
-            paths[0].write_text(
-                "Analysis is still done by `tailtriage-cli` for this crate.\n"
-                "Also references tailtriage-analyzer and tailtriage-cli.",
-                encoding="utf-8",
-            )
-
-            with (
-                mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root),
-                mock.patch.object(
-                    validate_docs_contracts,
-                    "CAPTURE_INTEGRATION_README_PATHS",
-                    tuple(paths),
-                ),
-            ):
-                with self.assertRaisesRegex(ValueError, r"stale CLI-only analyzer wording"):
-                    validate_docs_contracts.validate_capture_readmes_analyzer_cli_wording_contract()
-
-    def test_capture_readme_requires_analyzer_and_cli_mentions(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            repo_root = Path(tmp_dir)
-            paths = []
-            for rel in (
-                "tailtriage/README.md",
-                "tailtriage-core/README.md",
-                "tailtriage-controller/README.md",
-                "tailtriage-tokio/README.md",
-                "tailtriage-axum/README.md",
-            ):
-                path = repo_root / rel
-                path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_text(
-                    "Use tailtriage-analyzer in-process and tailtriage-cli for saved artifacts.",
-                    encoding="utf-8",
-                )
-                paths.append(path)
-            paths[1].write_text("Use tailtriage-cli for saved artifacts only.", encoding="utf-8")
-
-            with (
-                mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root),
-                mock.patch.object(
-                    validate_docs_contracts,
-                    "CAPTURE_INTEGRATION_README_PATHS",
-                    tuple(paths),
-                ),
-            ):
-                with self.assertRaisesRegex(ValueError, r"must mention tailtriage-analyzer"):
-                    validate_docs_contracts.validate_capture_readmes_analyzer_cli_wording_contract()
-
-    def test_cli_readme_positive_when_cli_invokes_analyzer(self) -> None:
-        analyzer_text = """
-tailtriage-analyzer is in-process analysis for completed Run values and returns a typed Report.
-Use analyze_run(run, AnalyzeOptions::default()) for the standard entry point.
-Use render_text(&report), render_json(&report), and render_json_pretty(&report) for Report rendering.
-First let report = analyze_run(run, AnalyzeOptions::default())?; then use render_json(&report) or render_json_pretty(&report).
-This crate is not streaming / not live streaming, and tailtriage-cli owns artifact loading.
-## How to interpret a report
-primary_suspect secondary_suspects evidence[] next_checks[] score confidence evidence_quality route_breakdowns temporal_segments Report JSON Run artifact JSON
-"""
-        cli_text = """
-tailtriage-cli loads saved run artifacts from disk, performs schema validation,
-enforces a non-empty requests loader rule, and uses tailtriage-analyzer.
-It provides command-line text/json output and emits Report JSON as output.
-Rust in-process users should use tailtriage-analyzer directly.
-Run artifact JSON is CLI input; Report JSON is CLI/analyzer output.
-CLI does not consume Report JSON as input.
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            repo_root = Path(tmp_dir)
-            analyzer_readme = repo_root / "tailtriage-analyzer" / "README.md"
-            cli_readme = repo_root / "tailtriage-cli" / "README.md"
-            analyzer_readme.parent.mkdir(parents=True, exist_ok=True)
-            cli_readme.parent.mkdir(parents=True, exist_ok=True)
-            analyzer_readme.write_text(analyzer_text, encoding="utf-8")
-            cli_readme.write_text(cli_text, encoding="utf-8")
-
-            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root):
-                validate_docs_contracts.validate_analyzer_cli_docs_split_contract()
-
-    def test_analyzer_readme_validation_fails_when_json_renderer_tokens_missing(self) -> None:
-        analyzer_text = """
-tailtriage-analyzer is in-process analysis for completed Run values with typed Report output.
-Use analyze_run(run, AnalyzeOptions::default())? and render_text(&report).
-This crate is not streaming and references tailtriage-cli for artifact loading.
-"""
-        cli_text = """
-tailtriage-cli loads saved run artifacts from disk, performs schema validation,
-enforces non-empty requests loader rules, uses tailtriage-analyzer, and provides command-line text/json output.
-Rust in-process users should use tailtriage-analyzer.
-Run artifact JSON is input; Report JSON is output; CLI does not consume Report JSON as input.
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            repo_root = Path(tmp_dir)
-            analyzer_readme = repo_root / "tailtriage-analyzer" / "README.md"
-            cli_readme = repo_root / "tailtriage-cli" / "README.md"
-            analyzer_readme.parent.mkdir(parents=True, exist_ok=True)
-            cli_readme.parent.mkdir(parents=True, exist_ok=True)
-            analyzer_readme.write_text(analyzer_text, encoding="utf-8")
-            cli_readme.write_text(cli_text, encoding="utf-8")
-
-            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root):
-                with self.assertRaisesRegex(ValueError, r"render_json"):
-                    validate_docs_contracts.validate_analyzer_cli_docs_split_contract()
-
-    def test_cli_readme_validation_fails_without_report_vs_run_artifact_distinction(self) -> None:
-        analyzer_text = """
-tailtriage-analyzer is in-process analysis for completed Run values and returns a typed Report.
-Use analyze_run(run, AnalyzeOptions::default()) and render_text(&report).
-First let report = analyze_run(run, AnalyzeOptions::default())?; then use render_json(&report) and render_json_pretty(&report).
-This crate is not streaming / not live streaming and references tailtriage-cli.
-## How to interpret a report
-primary_suspect secondary_suspects evidence[] next_checks[] score confidence evidence_quality route_breakdowns temporal_segments Report JSON Run artifact JSON
-"""
-        cli_text = """
-tailtriage-cli loads saved run artifacts from disk, performs schema validation,
-enforces non-empty requests loader rules, uses tailtriage-analyzer, and provides command-line text/json output.
-Rust in-process users should use tailtriage-analyzer.
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            repo_root = Path(tmp_dir)
-            analyzer_readme = repo_root / "tailtriage-analyzer" / "README.md"
-            cli_readme = repo_root / "tailtriage-cli" / "README.md"
-            analyzer_readme.parent.mkdir(parents=True, exist_ok=True)
-            cli_readme.parent.mkdir(parents=True, exist_ok=True)
-            analyzer_readme.write_text(analyzer_text, encoding="utf-8")
-            cli_readme.write_text(cli_text, encoding="utf-8")
-
-            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root):
-                with self.assertRaisesRegex(ValueError, r"report vs run artifact json distinction"):
-                    validate_docs_contracts.validate_analyzer_cli_docs_split_contract()
-
-
-    def test_published_analyzer_readmes_reject_repo_relative_docs_links(self) -> None:
-        analyzer_text = """
-tailtriage-analyzer is in-process analysis for completed Run values and returns a typed Report.
-Use analyze_run(run, AnalyzeOptions::default()) for the standard entry point.
-Use render_text(&report), render_json(&report), and render_json_pretty(&report) for Report rendering.
-First let report = analyze_run(run, AnalyzeOptions::default())?; then use render_json(&report) and render_json_pretty(&report).
-This crate is not streaming and references tailtriage-cli.
-## How to interpret a report
-primary_suspect secondary_suspects evidence[] next_checks[] score confidence evidence_quality route_breakdowns temporal_segments Report JSON Run artifact JSON
-"""
-        cli_text = """
-tailtriage-cli loads saved run artifacts from disk, performs schema validation,
-enforces non-empty requests loader rules, uses tailtriage-analyzer, and provides command-line text/json output.
-Rust in-process users should use tailtriage-analyzer.
-Run artifact JSON is input; Report JSON is output; CLI does not consume Report JSON as input.
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            repo_root = Path(tmp_dir)
-            analyzer_readme = repo_root / "tailtriage-analyzer" / "README.md"
-            cli_readme = repo_root / "tailtriage-cli" / "README.md"
-            analyzer_readme.parent.mkdir(parents=True, exist_ok=True)
-            cli_readme.parent.mkdir(parents=True, exist_ok=True)
-            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root):
-                for readme in (analyzer_readme, cli_readme):
-                    with self.subTest(readme=readme.parent.name):
-                        analyzer_readme.write_text(analyzer_text, encoding="utf-8")
-                        cli_readme.write_text(cli_text, encoding="utf-8")
-                        readme.write_text(
-                            readme.read_text(encoding="utf-8") + "\nSee ../docs/analyzer-guide.md\n",
-                            encoding="utf-8",
-                        )
-                        with self.assertRaisesRegex(ValueError, r"must not use.*\.\./docs/"):
-                            validate_docs_contracts.validate_analyzer_cli_docs_split_contract()
-
-    def test_repository_navigation_links_to_analyzer_guide_resolve(self) -> None:
-        for path in (validate_docs_contracts.README_PATH, validate_docs_contracts.DOCS_INDEX_PATH):
-            with self.subTest(path=path):
-                links = validate_docs_contracts.markdown_links(path.read_text(encoding="utf-8"))
-                guide_links = [link for link in links if link.endswith("analyzer-guide.md")]
-                self.assertEqual(len(guide_links), 1)
-                self.assertTrue((path.parent / guide_links[0]).resolve().is_file())
-
-    def test_analyzer_readme_contract_fails_when_interpret_heading_missing(self) -> None:
-        analyzer_text = """
-tailtriage-analyzer is in-process analysis for completed Run values and returns a typed Report.
-Use analyze_run(run, AnalyzeOptions::default()) for the standard entry point.
-Use render_text(&report), render_json(&report), and render_json_pretty(&report) for Report rendering.
-First let report = analyze_run(run, AnalyzeOptions::default())?; then use render_json(&report) and render_json_pretty(&report).
-This crate is not streaming and references tailtriage-cli.
-primary_suspect secondary_suspects evidence[] next_checks[] score confidence evidence_quality route_breakdowns temporal_segments Report JSON Run artifact JSON
-"""
-        cli_text = """
-tailtriage-cli loads saved run artifacts from disk, performs schema validation,
-enforces non-empty requests loader rules, uses tailtriage-analyzer, and provides command-line text/json output.
-Rust in-process users should use tailtriage-analyzer.
-Run artifact JSON is input; Report JSON is output; CLI does not consume Report JSON as input.
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            repo_root = Path(tmp_dir)
-            analyzer_readme = repo_root / "tailtriage-analyzer" / "README.md"
-            cli_readme = repo_root / "tailtriage-cli" / "README.md"
-            analyzer_readme.parent.mkdir(parents=True, exist_ok=True)
-            cli_readme.parent.mkdir(parents=True, exist_ok=True)
-            analyzer_readme.write_text(analyzer_text, encoding="utf-8")
-            cli_readme.write_text(cli_text, encoding="utf-8")
-
-            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root):
-                with self.assertRaisesRegex(ValueError, r"How to interpret a report"):
-                    validate_docs_contracts.validate_analyzer_cli_docs_split_contract()
-
-    def test_architecture_contract(self) -> None:
-        validate_docs_contracts.validate_architecture_contract()
-
-    def test_docs_no_history_framing(self) -> None:
-        validate_docs_contracts.validate_docs_no_history_framing()
-
-    def test_user_facing_wording_has_no_facade_term(self) -> None:
-        validate_docs_contracts.validate_no_user_facing_facade_wording()
-
-    def test_user_facing_wording_validation_fails_when_facade_present(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            temp_path = Path(tmp_dir) / "README.md"
-            temp_path.write_text("start with the facade crate", encoding="utf-8")
-
-            with mock.patch.object(
-                validate_docs_contracts,
-                "USER_FACING_TERMINOLOGY_PATHS",
-                (temp_path,),
-            ):
-                with self.assertRaisesRegex(ValueError, r"stale facade wording"):
-                    validate_docs_contracts.validate_no_user_facing_facade_wording()
-
-
-    def test_cli_library_analyzer_api_contract_fails_on_banned_token(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            temp_path = Path(tmp_dir) / "README.md"
-            temp_path.write_text("use tailtriage_cli::analyze::{analyze_run, render_text};", encoding="utf-8")
-
-            with mock.patch.object(validate_docs_contracts, "README_PATH", temp_path):
-                with self.assertRaisesRegex(ValueError, r"tailtriage_cli::analyze"):
-                    validate_docs_contracts.validate_cli_not_presented_as_library_analyzer_api()
-
-    def test_analyzer_readme_migration_note_allows_old_token_only_in_migration_block(self) -> None:
-        readme_text = """# tailtriage-analyzer
-
-## Migration note
-
-```rust
-use tailtriage_cli::analyze::{analyze_run, render_text};
-```
-"""
-        stripped = validate_docs_contracts._strip_allowed_analyzer_migration_note(readme_text)
-        self.assertNotIn("tailtriage_cli::analyze", stripped)
-
-    def test_analyzer_readme_contract_fails_on_old_token_outside_migration_note(self) -> None:
-        analyzer_text = """# tailtriage-analyzer
-
-Use `tailtriage_cli::analyze` in this section.
-
-## Migration note
-
-```rust
-use tailtriage_cli::analyze::{analyze_run, render_text};
-```
-"""
-        clean_text = "# tailtriage docs"
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            repo_root = Path(tmp_dir)
-            root_readme = repo_root / "README.md"
-            docs_index = repo_root / "docs" / "README.md"
-            user_guide = repo_root / "docs" / "user-guide.md"
-            diagnostics = repo_root / "docs" / "diagnostics.md"
-            architecture = repo_root / "docs" / "architecture.md"
-            cli_readme = repo_root / "tailtriage-cli" / "README.md"
-            tracing_readme = repo_root / "tailtriage-tracing" / "README.md"
-            analyzer_readme = repo_root / "tailtriage-analyzer" / "README.md"
-            for path in (docs_index, user_guide, diagnostics, architecture, cli_readme, tracing_readme, analyzer_readme):
-                path.parent.mkdir(parents=True, exist_ok=True)
-            root_readme.write_text(clean_text, encoding="utf-8")
-            docs_index.write_text(clean_text, encoding="utf-8")
-            user_guide.write_text(clean_text, encoding="utf-8")
-            diagnostics.write_text(clean_text, encoding="utf-8")
-            architecture.write_text(clean_text, encoding="utf-8")
-            cli_readme.write_text(clean_text, encoding="utf-8")
-            tracing_readme.write_text(clean_text, encoding="utf-8")
-            analyzer_readme.write_text(analyzer_text, encoding="utf-8")
-
-            with (
-                mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root),
-                mock.patch.object(validate_docs_contracts, "README_PATH", root_readme),
-                mock.patch.object(validate_docs_contracts, "DOCS_INDEX_PATH", docs_index),
-                mock.patch.object(validate_docs_contracts, "USER_GUIDE_PATH", user_guide),
-                mock.patch.object(validate_docs_contracts, "DIAGNOSTICS_PATH", diagnostics),
-                mock.patch.object(validate_docs_contracts, "ARCHITECTURE_PATH", architecture),
-            ):
-                with self.assertRaisesRegex(ValueError, r"tailtriage_cli::analyze"):
-                    validate_docs_contracts.validate_cli_not_presented_as_library_analyzer_api()
-
     def test_controller_readme_does_not_use_misleading_dependency_example_flow(self) -> None:
-        readme_text = validate_docs_contracts.CONTROLLER_README_PATH.read_text(encoding="utf-8")
+        readme_text = validate_docs_contracts.CONTROLLER_README_PATH.read_text(encoding='utf-8')
         self.assertFalse(validate_docs_contracts.is_misleading_controller_example_flow(readme_text))
-
-    def test_sampler_forge_method_detector_flags_public_methods(self) -> None:
-        source = """
-impl Tailtriage {
-    pub fn register_tokio_runtime_sampler(&self) {}
-    pub fn runtime_sampler_stats(&self) {}
-    pub(crate) fn register_tokio_runtime_sampler_internal(&self) {}
-}
-"""
-        self.assertEqual(
-            validate_docs_contracts.find_public_sampler_forge_methods(source),
-            ["register_tokio_runtime_sampler", "runtime_sampler_stats"],
-        )
 
     def test_sampler_integration_boundary_contract_validates(self) -> None:
         validate_docs_contracts.validate_sampler_integration_boundary()
 
-    def test_controller_readme_toml_validation_allows_equivalent_headings(self) -> None:
-        readme_text = """# tailtriage-controller
-
-## Config file (TOML)
-
-With TOML config loaded, service_name and initially_enabled fall back to builder values when omitted.
-Activation template settings come from TOML when config is loaded.
-Omitted optional activation subfields use TOML contract defaults.
-
-```toml
-[controller]
-service_name = "checkout-service"
-
-[controller.activation]
-mode = "light"
-
-[controller.activation.sink]
-type = "local_json"
-output_path = "tailtriage-run.json"
-```
-
-```toml
-[controller]
-service_name = "checkout-service"
-initially_enabled = false
-
-[controller.activation]
-mode = "investigation"
-strict_lifecycle = true
-
-[controller.activation.capture_limits_override]
-max_requests = 100
-max_stages = 200
-max_queues = 200
-max_inflight_snapshots = 200
-max_runtime_snapshots = 100
-
-[controller.activation.sink]
-type = "local_json"
-output_path = "tailtriage-run.json"
-
-[controller.activation.runtime_sampler]
-enabled_for_armed_runs = true
-mode_override = "investigation"
-interval_ms = 250
-max_runtime_snapshots = 50
-
-[controller.activation.run_end_policy]
-kind = "auto_seal_on_limits_hit"
-```
-
-## TOML field reference
-
-service_name initially_enabled mode strict_lifecycle capture_limits_override max_requests max_stages max_queues max_inflight_snapshots max_runtime_snapshots enabled_for_armed_runs mode_override interval_ms run_end_policy continue_after_limits_hit auto_seal_on_limits_hit
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            readme_path = Path(tmp_dir) / "README.md"
-            readme_path.write_text(readme_text, encoding="utf-8")
-
-            with mock.patch.object(validate_docs_contracts, "CONTROLLER_README_PATH", readme_path):
-                validate_docs_contracts.validate_controller_readme_toml()
-
-    def test_controller_readme_toml_validation_fails_without_field_reference_section(self) -> None:
-        readme_text = """# tailtriage-controller
-
-## Config file (TOML)
-
-With TOML config loaded, service_name and initially_enabled fall back to builder values when omitted.
-Activation template settings come from TOML when config is loaded.
-Omitted optional activation subfields use TOML contract defaults.
-
-```toml
-[controller]
-service_name = "checkout-service"
-
-[controller.activation]
-mode = "light"
-
-[controller.activation.sink]
-type = "local_json"
-output_path = "tailtriage-run.json"
-```
-
-```toml
-[controller]
-service_name = "checkout-service"
-initially_enabled = false
-
-[controller.activation]
-mode = "light"
-
-[controller.activation.capture_limits_override]
-max_requests = 100
-
-[controller.activation.sink]
-type = "local_json"
-output_path = "tailtriage-run.json"
-
-[controller.activation.runtime_sampler]
-enabled_for_armed_runs = true
-mode_override = "light"
-interval_ms = 250
-max_runtime_snapshots = 50
-
-[controller.activation.run_end_policy]
-kind = "continue_after_limits_hit"
-```
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            readme_path = Path(tmp_dir) / "README.md"
-            readme_path.write_text(readme_text, encoding="utf-8")
-
-            with mock.patch.object(validate_docs_contracts, "CONTROLLER_README_PATH", readme_path):
-                with self.assertRaisesRegex(
-                    ValueError, r"TOML field reference"
-                ):
-                    validate_docs_contracts.validate_controller_readme_toml()
-
-    def test_controller_readme_toml_validation_fails_when_important_tokens_missing(self) -> None:
-        readme_text = """# tailtriage-controller
-
-## Config file (TOML)
-
-With TOML config loaded, service_name and initially_enabled fall back to builder values when omitted.
-Activation template settings come from TOML when config is loaded.
-Omitted optional activation subfields use TOML contract defaults.
-
-```toml
-[controller]
-service_name = "checkout-service"
-
-[controller.activation]
-mode = "light"
-
-[controller.activation.sink]
-type = "local_json"
-output_path = "tailtriage-run.json"
-```
-
-```toml
-[controller]
-service_name = "checkout-service"
-initially_enabled = false
-
-[controller.activation]
-mode = "investigation"
-
-[controller.activation.capture_limits_override]
-max_requests = 100
-max_stages = 200
-max_queues = 200
-max_inflight_snapshots = 200
-max_runtime_snapshots = 100
-
-[controller.activation.sink]
-type = "local_json"
-output_path = "tailtriage-run.json"
-
-[controller.activation.runtime_sampler]
-enabled_for_armed_runs = true
-mode_override = "investigation"
-interval_ms = 250
-max_runtime_snapshots = 50
-
-[controller.activation.run_end_policy]
-kind = "auto_seal_on_limits_hit"
-```
-
-## TOML field reference
-
-service_name initially_enabled mode strict_lifecycle capture_limits_override
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            readme_path = Path(tmp_dir) / "README.md"
-            readme_path.write_text(readme_text, encoding="utf-8")
-
-            with mock.patch.object(validate_docs_contracts, "CONTROLLER_README_PATH", readme_path):
-                with self.assertRaisesRegex(
-                    ValueError, r"missing token"
-                ):
-                    validate_docs_contracts.validate_controller_readme_toml()
-
-    def test_controller_readme_toml_validation_fails_when_expanded_example_missing_sections(self) -> None:
-        readme_text = """# tailtriage-controller
-
-## Config file (TOML)
-
-With TOML config loaded, service_name and initially_enabled fall back to builder values when omitted.
-Activation template settings come from TOML when config is loaded.
-Omitted optional activation subfields use TOML contract defaults.
-
-```toml
-[controller]
-service_name = "checkout-service"
-
-[controller.activation]
-mode = "light"
-
-[controller.activation.sink]
-type = "local_json"
-output_path = "tailtriage-run.json"
-```
-
-```toml
-[controller]
-service_name = "checkout-service"
-initially_enabled = false
-
-[controller.activation]
-mode = "investigation"
-
-[controller.activation.sink]
-type = "local_json"
-output_path = "tailtriage-run.json"
-```
-
-## TOML field reference
-
-service_name initially_enabled mode strict_lifecycle capture_limits_override max_requests max_stages max_queues max_inflight_snapshots max_runtime_snapshots enabled_for_armed_runs mode_override interval_ms run_end_policy continue_after_limits_hit auto_seal_on_limits_hit
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            readme_path = Path(tmp_dir) / "README.md"
-            readme_path.write_text(readme_text, encoding="utf-8")
-
-            with mock.patch.object(validate_docs_contracts, "CONTROLLER_README_PATH", readme_path):
-                with self.assertRaisesRegex(
-                    ValueError, r"capture_limits_override"
-                ):
-                    validate_docs_contracts.validate_controller_readme_toml()
-
-    def test_controller_readme_toml_validation_accepts_semantic_precedence_wording(self) -> None:
-        readme_text = """# tailtriage-controller
-
-## Config behavior
-
-If omitted in TOML, `service_name` uses the builder value.
-If omitted in TOML, `initially_enabled` uses the builder value.
-Activation template settings are TOML-owned.
-Any omitted optional activation fields use contract defaults.
-
-```toml
-[controller]
-service_name = "checkout-service"
-
-[controller.activation]
-mode = "light"
-
-[controller.activation.sink]
-type = "local_json"
-output_path = "tailtriage-run.json"
-```
-
-```toml
-[controller]
-service_name = "checkout-service"
-initially_enabled = false
-
-[controller.activation]
-mode = "investigation"
-
-[controller.activation.capture_limits_override]
-max_requests = 100
-max_stages = 200
-max_queues = 200
-max_inflight_snapshots = 200
-max_runtime_snapshots = 100
-
-[controller.activation.sink]
-type = "local_json"
-output_path = "tailtriage-run.json"
-
-[controller.activation.runtime_sampler]
-enabled_for_armed_runs = true
-mode_override = "investigation"
-interval_ms = 250
-max_runtime_snapshots = 50
-
-[controller.activation.run_end_policy]
-kind = "auto_seal_on_limits_hit"
-```
-
-## TOML field reference
-
-service_name initially_enabled mode strict_lifecycle capture_limits_override max_requests max_stages max_queues max_inflight_snapshots max_runtime_snapshots enabled_for_armed_runs mode_override interval_ms run_end_policy continue_after_limits_hit auto_seal_on_limits_hit
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            readme_path = Path(tmp_dir) / "README.md"
-            readme_path.write_text(readme_text, encoding="utf-8")
-
-            with mock.patch.object(validate_docs_contracts, "CONTROLLER_README_PATH", readme_path):
-                validate_docs_contracts.validate_controller_readme_toml()
-
-    def test_controller_readme_toml_validation_fails_without_precedence_semantics(self) -> None:
-        readme_text = """# tailtriage-controller
-
-## Config behavior
-
-TOML controls config for this crate.
-
-```toml
-[controller]
-service_name = "checkout-service"
-
-[controller.activation]
-mode = "light"
-
-[controller.activation.sink]
-type = "local_json"
-output_path = "tailtriage-run.json"
-```
-
-```toml
-[controller]
-service_name = "checkout-service"
-initially_enabled = false
-
-[controller.activation]
-mode = "investigation"
-
-[controller.activation.capture_limits_override]
-max_requests = 100
-max_stages = 200
-max_queues = 200
-max_inflight_snapshots = 200
-max_runtime_snapshots = 100
-
-[controller.activation.sink]
-type = "local_json"
-output_path = "tailtriage-run.json"
-
-[controller.activation.runtime_sampler]
-enabled_for_armed_runs = true
-mode_override = "investigation"
-interval_ms = 250
-max_runtime_snapshots = 50
-
-[controller.activation.run_end_policy]
-kind = "auto_seal_on_limits_hit"
-```
-
-## TOML field reference
-
-service_name initially_enabled mode strict_lifecycle capture_limits_override max_requests max_stages max_queues max_inflight_snapshots max_runtime_snapshots enabled_for_armed_runs mode_override interval_ms run_end_policy continue_after_limits_hit auto_seal_on_limits_hit
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            readme_path = Path(tmp_dir) / "README.md"
-            readme_path.write_text(readme_text, encoding="utf-8")
-
-            with mock.patch.object(validate_docs_contracts, "CONTROLLER_README_PATH", readme_path):
-                with self.assertRaisesRegex(ValueError, r"precedence guidance missing semantic rule"):
-                    validate_docs_contracts.validate_controller_readme_toml()
-
-    def test_validate_docs_index_contract_checks_paths_not_link_labels(self) -> None:
-        docs_index = """# Documentation index
-
-- [Guide](user-guide.md)
-- [Diag](diagnostics.md)
-- [Controller crate](../tailtriage-controller/README.md)
-- [Sampler crate](../tailtriage-tokio/README.md)
-"""
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            repo_root = Path(tmp_dir)
-
-            # Files that should be required by repo_markdown_files().
-            for rel in (
-                "docs/README.md",
-                "docs/user-guide.md",
-                "docs/diagnostics.md",
-                "tailtriage-controller/README.md",
-                "tailtriage-tokio/README.md",
-            ):
-                path = repo_root / rel
-                path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_text(f"# {rel}\n", encoding="utf-8")
-
-            docs_index_path = repo_root / "docs" / "README.md"
-            docs_index_path.write_text(docs_index, encoding="utf-8")
-
-            with (
-                mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root),
-                mock.patch.object(validate_docs_contracts, "DOCS_INDEX_PATH", docs_index_path),
-                mock.patch.object(
-                    validate_docs_contracts,
-                    "DOCS_INDEX_EXCLUDED_MARKDOWN",
-                    {"docs/README.md"},
-                ),
-            ):
-                validate_docs_contracts.validate_docs_index_contract()
-
-    def test_docs_index_contract_accepts_normalized_fragments_and_schemes(self) -> None:
-        docs_index = """# Documentation index
-
-- [Guide](./user-guide.md#install)
-- [Diag](subdir/../diagnostics.md)
-- [Root](../README.md)
-- [Self](#documentation-index)
-- [External](https://example.com/page.md)
-- [Mail](mailto:docs@example.com)
-"""
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            repo_root = Path(tmp_dir)
-            for rel in (
-                "README.md",
-                "docs/README.md",
-                "docs/user-guide.md",
-                "docs/diagnostics.md",
-            ):
-                path = repo_root / rel
-                path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_text(f"# {rel}\n", encoding="utf-8")
-
-            docs_index_path = repo_root / "docs" / "README.md"
-            docs_index_path.write_text(docs_index, encoding="utf-8")
-
-            with (
-                mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root),
-                mock.patch.object(validate_docs_contracts, "DOCS_INDEX_PATH", docs_index_path),
-                mock.patch.object(
-                    validate_docs_contracts,
-                    "DOCS_INDEX_EXCLUDED_MARKDOWN",
-                    {"docs/README.md"},
-                ),
-            ):
-                validate_docs_contracts.validate_docs_index_contract()
-
-    def test_docs_index_contract_rejects_required_markdown_omitted_from_index(self) -> None:
-        docs_index = """# Documentation index
-
-- [Root](../README.md)
-"""
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            repo_root = Path(tmp_dir)
-            for rel in ("README.md", "docs/README.md", "docs/user-guide.md"):
-                path = repo_root / rel
-                path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_text(f"# {rel}\n", encoding="utf-8")
-
-            docs_index_path = repo_root / "docs" / "README.md"
-            docs_index_path.write_text(docs_index, encoding="utf-8")
-
-            with (
-                mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root),
-                mock.patch.object(validate_docs_contracts, "DOCS_INDEX_PATH", docs_index_path),
-                mock.patch.object(
-                    validate_docs_contracts,
-                    "DOCS_INDEX_EXCLUDED_MARKDOWN",
-                    {"docs/README.md"},
-                ),
-                self.assertRaisesRegex(ValueError, r"docs index missing required Markdown links"),
-            ):
-                validate_docs_contracts.validate_docs_index_contract()
-
-    def test_docs_index_contract_excludes_developer_docs_by_directory(self) -> None:
-        docs_index = """# Documentation index
-
-- [Root](../README.md)
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            repo_root = Path(tmp_dir)
-            for rel in ("README.md", "docs/README.md", "docs/dev/README.md", "docs/dev/notes.md"):
-                path = repo_root / rel
-                path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_text(f"# {rel}\n", encoding="utf-8")
-
-            docs_index_path = repo_root / "docs" / "README.md"
-            docs_index_path.write_text(docs_index, encoding="utf-8")
-            with (
-                mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root),
-                mock.patch.object(validate_docs_contracts, "DOCS_INDEX_PATH", docs_index_path),
-                mock.patch.object(validate_docs_contracts, "DEV_DOCS_DIR", repo_root / "docs" / "dev"),
-                mock.patch.object(
-                    validate_docs_contracts,
-                    "DOCS_INDEX_EXCLUDED_MARKDOWN",
-                    {"docs/README.md"},
-                ),
-            ):
-                validate_docs_contracts.validate_docs_index_contract()
-
-    def test_docs_index_contract_rejects_dead_local_markdown_target(self) -> None:
-        docs_index = """# Documentation index
-
-- [Root](../README.md)
-- [Missing](missing.md)
-"""
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            repo_root = Path(tmp_dir)
-            for rel in ("README.md", "docs/README.md"):
-                path = repo_root / rel
-                path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_text(f"# {rel}\n", encoding="utf-8")
-
-            docs_index_path = repo_root / "docs" / "README.md"
-            docs_index_path.write_text(docs_index, encoding="utf-8")
-
-            with (
-                mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root),
-                mock.patch.object(validate_docs_contracts, "DOCS_INDEX_PATH", docs_index_path),
-                mock.patch.object(
-                    validate_docs_contracts,
-                    "DOCS_INDEX_EXCLUDED_MARKDOWN",
-                    {"docs/README.md"},
-                ),
-                self.assertRaisesRegex(ValueError, r"dead local Markdown links"),
-            ):
-                validate_docs_contracts.validate_docs_index_contract()
-
     def test_docs_index_contract_checks_deliberate_developer_doc_link(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             repo_root = Path(tmp_dir)
-            docs_dir = repo_root / "docs"
+            docs_dir = repo_root / 'docs'
             docs_dir.mkdir(parents=True)
-            (repo_root / "README.md").write_text("# Root\n", encoding="utf-8")
-            docs_index_path = docs_dir / "README.md"
-            docs_index_path.write_text(
-                "[Root](../README.md)\n[Validation](dev/VALIDATION.md)\n",
-                encoding="utf-8",
-            )
-
-            with (
-                mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root),
-                mock.patch.object(validate_docs_contracts, "DOCS_INDEX_PATH", docs_index_path),
-                mock.patch.object(validate_docs_contracts, "DEV_DOCS_DIR", docs_dir / "dev"),
-                mock.patch.object(
-                    validate_docs_contracts,
-                    "DOCS_INDEX_EXCLUDED_MARKDOWN",
-                    {"docs/README.md"},
-                ),
-                self.assertRaisesRegex(ValueError, r"dead local Markdown links"),
-            ):
+            (repo_root / 'README.md').write_text('# Root\n', encoding='utf-8')
+            docs_index_path = docs_dir / 'README.md'
+            docs_index_path.write_text('[Root](../README.md)\n[Validation](dev/VALIDATION.md)\n', encoding='utf-8')
+            with mock.patch.object(validate_docs_contracts, 'REPO_ROOT', repo_root), mock.patch.object(validate_docs_contracts, 'DOCS_INDEX_PATH', docs_index_path), mock.patch.object(validate_docs_contracts, 'DEV_DOCS_DIR', docs_dir / 'dev'), mock.patch.object(validate_docs_contracts, 'DOCS_INDEX_EXCLUDED_MARKDOWN', {'docs/README.md'}), self.assertRaisesRegex(ValueError, 'dead local Markdown links'):
                 validate_docs_contracts.validate_docs_index_contract()
-
-    def test_moved_developer_contract_paths_are_canonical(self) -> None:
-        self.assertEqual(
-            validate_docs_contracts.DESIGN_NOTES_PATH,
-            REPO_ROOT / "docs" / "dev" / "DESIGN_NOTES.md",
-        )
-        self.assertIn(
-            REPO_ROOT / "docs" / "dev" / "VALIDATION.md",
-            validate_docs_contracts.VALIDATION_DOC_PATHS,
-        )
-        self.assertIn(
-            REPO_ROOT / "docs" / "dev" / "VALIDATION.md",
-            validate_docs_contracts.RUN_SCHEMA_CURRENT_CLAIM_PATHS,
-        )
 
     def test_docs_index_contract_rejects_repository_escape(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             workspace = Path(tmp_dir)
-            repo_root = workspace / "repo"
-            docs_dir = repo_root / "docs"
+            repo_root = workspace / 'repo'
+            docs_dir = repo_root / 'docs'
             docs_dir.mkdir(parents=True)
-            (workspace / "outside.md").write_text("# Outside\n", encoding="utf-8")
-            (repo_root / "README.md").write_text("# Root\n", encoding="utf-8")
-            docs_index_path = docs_dir / "README.md"
-            docs_index_path.write_text("[Outside](../../outside.md)\n", encoding="utf-8")
-
-            with (
-                mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root),
-                mock.patch.object(validate_docs_contracts, "DOCS_INDEX_PATH", docs_index_path),
-                self.assertRaisesRegex(ValueError, r"escapes repository root"),
-            ):
+            (workspace / 'outside.md').write_text('# Outside\n', encoding='utf-8')
+            (repo_root / 'README.md').write_text('# Root\n', encoding='utf-8')
+            docs_index_path = docs_dir / 'README.md'
+            docs_index_path.write_text('[Outside](../../outside.md)\n', encoding='utf-8')
+            with mock.patch.object(validate_docs_contracts, 'REPO_ROOT', repo_root), mock.patch.object(validate_docs_contracts, 'DOCS_INDEX_PATH', docs_index_path), self.assertRaisesRegex(ValueError, 'escapes repository root'):
                 validate_docs_contracts.validate_docs_index_contract()
 
-
-    def test_tracing_readme_migration_section_contract_rejects_duplicate_sentence(self) -> None:
-        readme_text = """# README
-
-For both `TracingSession` and `TracingSession`, use the builder.
-
-## Live tracing session migration
-
-Use `TracingSession` as the sole current live entry point for capture-to-Run workflows.
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            repo_root = Path(tmp_dir)
-            readme_path = repo_root / "tailtriage-tracing" / "README.md"
-            readme_path.parent.mkdir(parents=True)
-            readme_path.write_text(readme_text, encoding="utf-8")
-
-            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root):
-                with self.assertRaisesRegex(ValueError, r"duplicated TracingSession"):
-                    validate_docs_contracts.validate_tracing_readme_migration_section_contract()
-
-    def test_tracing_readme_migration_section_contract_requires_one_heading(self) -> None:
-        readme_text = """# README
-
-## Live tracing session migration
-
-Use `TracingSession` as the sole current live entry point.
-
-## Live tracing session migration
-
-Duplicate.
-"""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            repo_root = Path(tmp_dir)
-            readme_path = repo_root / "tailtriage-tracing" / "README.md"
-            readme_path.parent.mkdir(parents=True)
-            readme_path.write_text(readme_text, encoding="utf-8")
-
-            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root):
-                with self.assertRaisesRegex(ValueError, r"exactly one"):
-                    validate_docs_contracts.validate_tracing_readme_migration_section_contract()
-
-
-    def test_manual_release_boundary_accepts_non_mutating_automation(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            root = Path(tmp_dir)
-            workflow = root / ".github" / "workflows" / "ci.yml"
-            script = root / "scripts" / "check_release.py"
-            workflow.parent.mkdir(parents=True)
-            script.parent.mkdir()
-            workflow.write_text(
-                """# permissions: write-all
-permissions: read-all
-jobs:
-  inert:
-    steps:
-      - run: echo "permissions: write-all"
-      - run: printf '%s\\n' 'contents: write'
-  validate:
-    permissions:
-      contents: read
-    steps:
-      - run: git status --short
-      - run: git diff --check
-      - run: git rev-parse HEAD
-      - run: cargo test
-      - run: echo cargo publish --locked -p crate
-      - run: printf '%s\\n' 'Manual cargo publish --locked -p crate'
-      - uses: actions/upload-artifact@v4
-""",
-                encoding="utf-8",
-            )
-            script.write_text(
-                'print("Manual publication: cargo publish --locked -p crate")\n'
-                'command(["git", "status", "--porcelain"])\n',
-                encoding="utf-8",
-            )
-            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", root):
-                validate_docs_contracts.validate_manual_release_boundary(
-                    workflow_paths=(workflow,), release_script_paths=(script,)
-                )
-
     def test_manual_release_boundary_rejects_executable_release_script_mutation(self) -> None:
-        prohibited_cases = {
-            "cargo publish": ('command(["cargo", "publish", "--locked"])\n', "cargo publish"),
-            "cargo login": ('command(["cargo", "login"])\n', "cargo registry login"),
-            "git commit": ('command(["git", "commit", "-m", "automated"])\n', "git commit"),
-            "git tag": ('command(["git", "tag", "v0.4.0"])\n', "git tag creation"),
-            "git push": ('command(["git", "push", "origin", "main"])\n', "git push"),
-            "GitHub Release": ('command(["gh", "release", "create", "v0.4.0"])\n', "GitHub Release publication"),
-        }
+        prohibited_cases = {'cargo publish': ('command(["cargo", "publish", "--locked"])\n', 'cargo publish'), 'cargo login': ('command(["cargo", "login"])\n', 'cargo registry login'), 'git commit': ('command(["git", "commit", "-m", "automated"])\n', 'git commit'), 'git tag': ('command(["git", "tag", "v0.4.0"])\n', 'git tag creation'), 'git push': ('command(["git", "push", "origin", "main"])\n', 'git push'), 'GitHub Release': ('command(["gh", "release", "create", "v0.4.0"])\n', 'GitHub Release publication')}
         for label, (source, expected) in prohibited_cases.items():
             with self.subTest(label=label), tempfile.TemporaryDirectory() as tmp_dir:
                 root = Path(tmp_dir)
-                script = root / "scripts" / "check_release.py"
+                script = root / 'scripts' / 'check_release.py'
                 script.parent.mkdir()
-                script.write_text(source, encoding="utf-8")
-                with (
-                    mock.patch.object(validate_docs_contracts, "REPO_ROOT", root),
-                    self.assertRaisesRegex(ValueError, f"executes prohibited {expected}"),
-                ):
-                    validate_docs_contracts.validate_manual_release_boundary(
-                        workflow_paths=(), release_script_paths=(script,)
-                    )
+                script.write_text(source, encoding='utf-8')
+                with mock.patch.object(validate_docs_contracts, 'REPO_ROOT', root), self.assertRaisesRegex(ValueError, f'executes prohibited {expected}'):
+                    validate_docs_contracts.validate_manual_release_boundary(workflow_paths=(), release_script_paths=(script,))
 
     def test_manual_release_boundary_rejects_workflow_mutation_commands(self) -> None:
-        prohibited_cases = {
-            "cargo publish": ("cargo publish --locked", "cargo publish"),
-            "cargo toolchain publish": ("cargo +stable publish --locked", "cargo publish"),
-            "wrapped env cargo publish": ("env FOO=bar cargo publish --locked", "cargo publish"),
-            "wrapped command cargo publish": ("command cargo publish --locked", "cargo publish"),
-            "cargo login": ("cargo login", "cargo registry login"),
-            "git commit": ("git commit -m automated", "git commit"),
-            "git tag": ("git tag v0.4.0", "git tag creation"),
-            "git push": ("git push origin main", "git push"),
-            "git config tag": ("git -c user.name=bot tag v0.4.0", "git tag creation"),
-            "wrapped git push": ("env FOO=bar git push origin main", "git push"),
-            "GitHub Release": ("gh release create v0.4.0", "GitHub Release publication"),
-        }
+        prohibited_cases = {'cargo publish': ('cargo publish --locked', 'cargo publish'), 'cargo toolchain publish': ('cargo +stable publish --locked', 'cargo publish'), 'wrapped env cargo publish': ('env FOO=bar cargo publish --locked', 'cargo publish'), 'wrapped command cargo publish': ('command cargo publish --locked', 'cargo publish'), 'cargo login': ('cargo login', 'cargo registry login'), 'git commit': ('git commit -m automated', 'git commit'), 'git tag': ('git tag v0.4.0', 'git tag creation'), 'git push': ('git push origin main', 'git push'), 'git config tag': ('git -c user.name=bot tag v0.4.0', 'git tag creation'), 'wrapped git push': ('env FOO=bar git push origin main', 'git push'), 'GitHub Release': ('gh release create v0.4.0', 'GitHub Release publication')}
         for label, (command, expected) in prohibited_cases.items():
             with self.subTest(label=label), tempfile.TemporaryDirectory() as tmp_dir:
                 root = Path(tmp_dir)
-                workflow = root / ".github" / "workflows" / "release.yml"
+                workflow = root / '.github' / 'workflows' / 'release.yml'
                 workflow.parent.mkdir(parents=True)
-                workflow.write_text(f"steps:\n  - run: {command}\n", encoding="utf-8")
-                with (
-                    mock.patch.object(validate_docs_contracts, "REPO_ROOT", root),
-                    self.assertRaisesRegex(ValueError, f"executes prohibited {expected}"),
-                ):
-                    validate_docs_contracts.validate_manual_release_boundary(
-                        workflow_paths=(workflow,), release_script_paths=()
-                    )
+                workflow.write_text(f'steps:\n  - run: {command}\n', encoding='utf-8')
+                with mock.patch.object(validate_docs_contracts, 'REPO_ROOT', root), self.assertRaisesRegex(ValueError, f'executes prohibited {expected}'):
+                    validate_docs_contracts.validate_manual_release_boundary(workflow_paths=(workflow,), release_script_paths=())
 
     def test_manual_release_boundary_rejects_release_actions_and_credentials(self) -> None:
-        prohibited_cases = {
-            "release action": (
-                "steps:\n  - uses: softprops/action-gh-release@v2\n",
-                "invokes GitHub Release automation",
-            ),
-            "registry credentials": (
-                "env:\n  CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}\n",
-                "configures registry publication credentials",
-            ),
-            "registry-specific credentials": (
-                "env:\n  CARGO_REGISTRY_PRIVATE_TOKEN: ${{ secrets.PRIVATE_TOKEN }}\n",
-                "configures registry publication credentials",
-            ),
-        }
+        prohibited_cases = {'release action': ('steps:\n  - uses: softprops/action-gh-release@v2\n', 'invokes GitHub Release automation'), 'registry credentials': ('env:\n  CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}\n', 'configures registry publication credentials'), 'registry-specific credentials': ('env:\n  CARGO_REGISTRY_PRIVATE_TOKEN: ${{ secrets.PRIVATE_TOKEN }}\n', 'configures registry publication credentials')}
         for label, (source, expected) in prohibited_cases.items():
             with self.subTest(label=label), tempfile.TemporaryDirectory() as tmp_dir:
                 root = Path(tmp_dir)
-                workflow = root / ".github" / "workflows" / "release.yml"
+                workflow = root / '.github' / 'workflows' / 'release.yml'
                 workflow.parent.mkdir(parents=True)
-                workflow.write_text(source, encoding="utf-8")
-                with (
-                    mock.patch.object(validate_docs_contracts, "REPO_ROOT", root),
-                    self.assertRaisesRegex(ValueError, expected),
-                ):
-                    validate_docs_contracts.validate_manual_release_boundary(
-                        workflow_paths=(workflow,), release_script_paths=()
-                    )
+                workflow.write_text(source, encoding='utf-8')
+                with mock.patch.object(validate_docs_contracts, 'REPO_ROOT', root), self.assertRaisesRegex(ValueError, expected):
+                    validate_docs_contracts.validate_manual_release_boundary(workflow_paths=(workflow,), release_script_paths=())
 
     def test_manual_release_boundary_rejects_contents_write_permissions(self) -> None:
-        prohibited_cases = {
-            "workflow": "permissions:\n  contents: write\njobs: {}\n",
-            "job": "jobs:\n  release:\n    permissions:\n      contents: write\n    steps: []\n",
-            "workflow write-all": "permissions: write-all\njobs: {}\n",
-            "job write-all": "jobs:\n  validate:\n    permissions: write-all\n    steps: []\n",
-        }
+        prohibited_cases = {'workflow': 'permissions:\n  contents: write\njobs: {}\n', 'job': 'jobs:\n  release:\n    permissions:\n      contents: write\n    steps: []\n', 'workflow write-all': 'permissions: write-all\njobs: {}\n', 'job write-all': 'jobs:\n  validate:\n    permissions: write-all\n    steps: []\n'}
         for label, source in prohibited_cases.items():
             with self.subTest(label=label), tempfile.TemporaryDirectory() as tmp_dir:
                 root = Path(tmp_dir)
-                workflow = root / ".github" / "workflows" / "release.yml"
+                workflow = root / '.github' / 'workflows' / 'release.yml'
                 workflow.parent.mkdir(parents=True)
-                workflow.write_text(source, encoding="utf-8")
-                with (
-                    mock.patch.object(validate_docs_contracts, "REPO_ROOT", root),
-                    self.assertRaisesRegex(
-                        ValueError,
-                        "prohibited (?:contents: write|permissions: write-all) permission",
-                    ),
-                ):
-                    validate_docs_contracts.validate_manual_release_boundary(
-                        workflow_paths=(workflow,), release_script_paths=()
-                    )
+                workflow.write_text(source, encoding='utf-8')
+                with mock.patch.object(validate_docs_contracts, 'REPO_ROOT', root), self.assertRaisesRegex(ValueError, 'prohibited (?:contents: write|permissions: write-all) permission'):
+                    validate_docs_contracts.validate_manual_release_boundary(workflow_paths=(workflow,), release_script_paths=())
 
-
-class CheckpointDocumentationContractTests(unittest.TestCase):
-
-    @staticmethod
-    def canonical_checkpoint_body() -> str:
-        return """Run JSON schema version 2 uses `metadata.finalized_at_unix_ms` as the sole run-level finalization timestamp; this is `RunMetadata::finalized_at_unix_ms` in Rust. Active snapshots have `None`, finalized Runs have `Some(timestamp)`, and Event-level completion timestamps remain unchanged.
-Dropping an admitted request-completion token while capture is open records one request outcome `cancelled`; that Drop does not itself fabricate child evidence; an independently polled-and-dropped queue/stage helper records one bounded partial child event; a queue/stage helper that was polled and then dropped while capture remains open records one bounded partial child event; tracing spans remain completed-only; late Drop after finalization is inert.
-Overlap-safe queue and same-name stage attribution use request-scoped bounded attribution and do not double-count overlap.
-Completed queue/stage distributions exclude partial observations.
-Partial durations are an observed lower bound.
-Materially partial-reliant queue/stage candidates cannot exceed medium confidence.
-Tracing intake remains completed-only.
-The deterministic order is final confidence descending, then raw score descending, then stable suspect-kind rank, with InsufficientEvidence last.
-Raw-score proximity controls ambiguity membership, and ambiguity-cluster members are capped uniformly.
-"""
-
-    def assert_only_checkpoint_concept_missing(self, message: str, expected: str) -> None:
-        self.assertIn(expected, message)
-        for concept in (
-            "schema v2 finalization",
-            "request cancellation versus partial child Drop",
-            "overlap-safe attribution",
-            "partial lower-bound interpretation",
-            "completed-only tracing",
-            "confidence-first ordering",
-            "ambiguity cluster cap",
-        ):
-            missing = f"missing checkpoint contract tokens for {concept}"
-            if missing not in expected:
-                self.assertNotIn(missing, message)
-
-    def test_checkpoint_contract_accepts_current_canonical_wording(self) -> None:
+    def test_manual_release_boundary_ignores_inert_command_text(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / "canonical.md"
-            path.write_text(self.canonical_checkpoint_body(), encoding="utf-8")
-            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", Path(tmp_dir)):
-                validate_docs_contracts.validate_checkpoint_documentation_contract(
-                    markdown_paths=(path,), canonical_paths=(path,)
-                )
+            root = Path(tmp_dir)
+            workflow = root / 'ci.yml'
+            script = root / 'check_release.py'
+            workflow.write_text("permissions: read-all\nsteps:\n  - run: echo cargo publish --locked\n  - run: printf '%s' 'git push origin main'\n", encoding='utf-8')
+            script.write_text('print("cargo publish and gh release create are manual")\n', encoding='utf-8')
+            with mock.patch.object(validate_docs_contracts, 'REPO_ROOT', root):
+                validate_docs_contracts.validate_manual_release_boundary(workflow_paths=(workflow,), release_script_paths=(script,))
 
-    def test_checkpoint_contract_rejects_obsolete_analyzer_phrase_with_file(self) -> None:
+    def test_diagnostic_benchmark_ci_uses_executable_step(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / "README.md"
-            path.write_text("Analyzer interpretation is unchanged in this release.\n", encoding="utf-8")
-            with (
-                mock.patch.object(validate_docs_contracts, "REPO_ROOT", Path(tmp_dir)),
-                self.assertRaisesRegex(ValueError, r"README\.md contains obsolete checkpoint phrase"),
-            ):
-                validate_docs_contracts.validate_checkpoint_documentation_contract(
-                    markdown_paths=(path,), canonical_paths=()
-                )
+            workflow = Path(tmp_dir) / 'ci.yml'
+            workflow.write_text('jobs:\n  test:\n    steps:\n      - name: benchmark\n        run: python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0\n', encoding='utf-8')
+            validate_docs_contracts.validate_diagnostic_benchmark_ci_contract(workflow_path=workflow)
 
-    def test_checkpoint_contract_rejects_misleading_cancellation_case_insensitively(self) -> None:
+    def test_published_readme_rejects_repository_only_link(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / "docs" / "operations.md"
-            path.parent.mkdir()
-            path.write_text("cAnCeLlAtIoN does not add partial queue or stage evidence.\n", encoding="utf-8")
-            with (
-                mock.patch.object(validate_docs_contracts, "REPO_ROOT", Path(tmp_dir)),
-                self.assertRaisesRegex(ValueError, r"docs/operations\.md contains misleading cancellation wording"),
-            ):
-                validate_docs_contracts.validate_checkpoint_documentation_contract(
-                    markdown_paths=(path,), canonical_paths=()
-                )
-
-    def test_checkpoint_contract_rejects_missing_schema_token(self) -> None:
-        body = self.canonical_checkpoint_body().replace(
-            "Run JSON schema version 2 uses `metadata.finalized_at_unix_ms` as the sole run-level finalization timestamp; this is `RunMetadata::finalized_at_unix_ms` in Rust. Active snapshots have `None`, finalized Runs have `Some(timestamp)`, and Event-level completion timestamps remain unchanged.\n",
-            "",
-        )
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / "SPEC.md"
-            path.write_text(body, encoding="utf-8")
-            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", Path(tmp_dir)):
-                with self.assertRaises(ValueError) as ctx:
-                    validate_docs_contracts.validate_checkpoint_documentation_contract(
-                        markdown_paths=(path,), canonical_paths=(path,)
-                    )
-            self.assert_only_checkpoint_concept_missing(
-                str(ctx.exception),
-                "SPEC.md missing checkpoint contract tokens for schema v2 finalization",
-            )
-
-    def test_checkpoint_contract_rejects_missing_request_cancellation_distinction(self) -> None:
-        body = self.canonical_checkpoint_body().replace(
-            "Dropping an admitted request-completion token while capture is open records one request outcome `cancelled`; that Drop does not itself fabricate child evidence; an independently polled-and-dropped queue/stage helper records one bounded partial child event; a queue/stage helper that was polled and then dropped while capture remains open records one bounded partial child event; tracing spans remain completed-only; late Drop after finalization is inert.\n",
-            "",
-        )
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / "SPEC.md"
-            path.write_text(body, encoding="utf-8")
-            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", Path(tmp_dir)):
-                with self.assertRaises(ValueError) as ctx:
-                    validate_docs_contracts.validate_checkpoint_documentation_contract(
-                        markdown_paths=(path,), canonical_paths=(path,)
-                    )
-            self.assert_only_checkpoint_concept_missing(
-                str(ctx.exception),
-                "SPEC.md missing checkpoint contract tokens for request cancellation versus partial child Drop",
-            )
-
-    def test_checkpoint_contract_rejects_missing_overlap_safe_attribution(self) -> None:
-        body = self.canonical_checkpoint_body().replace(
-            "Overlap-safe queue and same-name stage attribution use request-scoped bounded attribution and do not double-count overlap.\n",
-            "",
-        )
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / "docs" / "operations.md"
-            path.parent.mkdir()
-            path.write_text(body, encoding="utf-8")
-            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", Path(tmp_dir)):
-                with self.assertRaises(ValueError) as ctx:
-                    validate_docs_contracts.validate_checkpoint_documentation_contract(
-                        markdown_paths=(path,), canonical_paths=(path,)
-                    )
-            self.assert_only_checkpoint_concept_missing(
-                str(ctx.exception),
-                "docs/operations.md missing checkpoint contract tokens for overlap-safe attribution",
-            )
-
-    def test_checkpoint_contract_rejects_missing_partial_lower_bound_token(self) -> None:
-        body = self.canonical_checkpoint_body().replace(
-            "Completed queue/stage distributions exclude partial observations.\nPartial durations are an observed lower bound.\nMaterially partial-reliant queue/stage candidates cannot exceed medium confidence.\n",
-            "",
-        )
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / "docs" / "operations.md"
-            path.parent.mkdir()
-            path.write_text(body, encoding="utf-8")
-            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", Path(tmp_dir)):
-                with self.assertRaises(ValueError) as ctx:
-                    validate_docs_contracts.validate_checkpoint_documentation_contract(
-                        markdown_paths=(path,), canonical_paths=(path,)
-                    )
-            self.assert_only_checkpoint_concept_missing(
-                str(ctx.exception),
-                "docs/operations.md missing checkpoint contract tokens for partial lower-bound interpretation",
-            )
-
-    def test_checkpoint_contract_rejects_missing_completed_only_tracing(self) -> None:
-        body = self.canonical_checkpoint_body().replace(
-            "Tracing intake remains completed-only.\n",
-            "",
-        )
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / "SPEC.md"
-            path.write_text(body, encoding="utf-8")
-            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", Path(tmp_dir)):
-                with self.assertRaises(ValueError) as ctx:
-                    validate_docs_contracts.validate_checkpoint_documentation_contract(
-                        markdown_paths=(path,), canonical_paths=(path,)
-                    )
-            self.assert_only_checkpoint_concept_missing(
-                str(ctx.exception),
-                "SPEC.md missing checkpoint contract tokens for completed-only tracing",
-            )
-
-    def test_checkpoint_contract_rejects_missing_confidence_first_ordering_token(self) -> None:
-        body = self.canonical_checkpoint_body().replace(
-            "The deterministic order is final confidence descending, then raw score descending, then stable suspect-kind rank, with InsufficientEvidence last.\n",
-            "",
-        )
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / "SPEC.md"
-            path.write_text(body, encoding="utf-8")
-            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", Path(tmp_dir)):
-                with self.assertRaises(ValueError) as ctx:
-                    validate_docs_contracts.validate_checkpoint_documentation_contract(
-                        markdown_paths=(path,), canonical_paths=(path,)
-                    )
-            self.assert_only_checkpoint_concept_missing(
-                str(ctx.exception),
-                "SPEC.md missing checkpoint contract tokens for confidence-first ordering",
-            )
-
-    def test_checkpoint_contract_rejects_missing_ambiguity_cluster_cap(self) -> None:
-        body = self.canonical_checkpoint_body().replace(
-            "Raw-score proximity controls ambiguity membership, and ambiguity-cluster members are capped uniformly.\n",
-            "",
-        )
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / "docs" / "operations.md"
-            path.parent.mkdir()
-            path.write_text(body, encoding="utf-8")
-            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", Path(tmp_dir)):
-                with self.assertRaises(ValueError) as ctx:
-                    validate_docs_contracts.validate_checkpoint_documentation_contract(
-                        markdown_paths=(path,), canonical_paths=(path,)
-                    )
-            self.assert_only_checkpoint_concept_missing(
-                str(ctx.exception),
-                "docs/operations.md missing checkpoint contract tokens for ambiguity cluster cap",
-            )
-
-    def test_checkpoint_contract_scans_tracked_markdown_repository_wide(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            repo_root = Path(tmp_dir)
-            subprocess.run(["git", "init"], cwd=repo_root, check=True, capture_output=True, text=True)
-            tracked = repo_root / "nested" / "tracked-contract.md"
-            untracked = repo_root / "untracked-contract.md"
-            tracked.parent.mkdir()
-            stale = "Analyzer interpretation is unchanged in this release.\n"
-            tracked.write_text(stale, encoding="utf-8")
-            untracked.write_text(stale, encoding="utf-8")
-            subprocess.run(
-                ["git", "add", "nested/tracked-contract.md"],
-                cwd=repo_root,
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-            with mock.patch.object(validate_docs_contracts, "REPO_ROOT", repo_root):
-                with self.assertRaises(ValueError) as ctx:
-                    validate_docs_contracts.validate_checkpoint_documentation_contract(
-                        canonical_paths=(),
-                    )
-            message = str(ctx.exception)
-            self.assertIn(
-                "nested/tracked-contract.md contains obsolete checkpoint phrase",
-                message,
-            )
-            self.assertNotIn("untracked-contract.md", message)
-
-
-
-if __name__ == "__main__":
+            readme = Path(tmp_dir) / 'README.md'
+            readme.write_text('See [guide](../docs/user-guide.md).\n', encoding='utf-8')
+            with self.assertRaisesRegex(ValueError, 'must not use.*\\.\\./docs/'):
+                validate_docs_contracts.validate_published_crate_readmes_are_self_contained((readme,))
+if __name__ == '__main__':
     unittest.main()

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -131,56 +131,18 @@ class ValidateDocsContractsTests(unittest.TestCase):
     def test_analyzer_config_example_contract(self) -> None:
         validate_docs_contracts.validate_analyzer_config_example_contract()
 
-    def test_analyzer_config_example_contract_rejects_missing_schema_version(self) -> None:
+    def test_analyzer_config_example_contract_rejects_malformed_toml(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             path = Path(tmp_dir) / 'analyzer-config.toml'
-            path.write_text('[analyzer]\n[analyzer.queueing]\n', encoding='utf-8')
-            with self.assertRaisesRegex(ValueError, 'schema_version = 1'):
+            path.write_text('[analyzer\n', encoding='utf-8')
+            with self.assertRaisesRegex(ValueError, 'invalid TOML'):
                 validate_docs_contracts.validate_analyzer_config_example_contract(config_path=path)
 
-    def test_analyzer_config_example_contract_rejects_missing_analyzer_table(self) -> None:
+    def test_analyzer_config_example_contract_does_not_require_schema_groups(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             path = Path(tmp_dir) / 'analyzer-config.toml'
-            path.write_text('schema_version = 1\n', encoding='utf-8')
-            with self.assertRaisesRegex(ValueError, '\\[analyzer\\]'):
-                validate_docs_contracts.validate_analyzer_config_example_contract(config_path=path)
-
-    def test_analyzer_config_example_contract_rejects_missing_group(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / 'analyzer-config.toml'
-            body = '[analyzer]\nschema_version = 1\n' + '\n'.join((f'[analyzer.{g}]' for g in validate_docs_contracts.ANALYZER_GROUPS if g != 'temporal'))
-            path.write_text(body, encoding='utf-8')
-            with self.assertRaisesRegex(ValueError, 'temporal'):
-                validate_docs_contracts.validate_analyzer_config_example_contract(config_path=path)
-
-    def test_analyzer_config_example_contract_rejects_root_level_group(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / 'analyzer-config.toml'
-            body = '[analyzer]\nschema_version = 1\n' + '\n'.join((f'[analyzer.{g}]' for g in validate_docs_contracts.ANALYZER_GROUPS)) + '\n[queueing]\ntrigger_permille = 100\n'
-            path.write_text(body, encoding='utf-8')
-            with self.assertRaisesRegex(ValueError, 'root-level analyzer groups'):
-                validate_docs_contracts.validate_analyzer_config_example_contract(config_path=path)
-
-    def test_analyzer_no_root_level_docs_rejects_root_level_table_header(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            repo_root = Path(tmp_dir)
-            docs_dir = repo_root / 'docs'
-            docs_dir.mkdir(parents=True, exist_ok=True)
-            path = docs_dir / 'diagnostics.md'
-            path.write_text('[queueing]\ntrigger_permille = 400\n', encoding='utf-8')
-            with mock.patch.object(validate_docs_contracts, 'REPO_ROOT', repo_root):
-                with self.assertRaisesRegex(ValueError, 'invalid root-level TOML header'):
-                    validate_docs_contracts.validate_no_root_level_analyzer_toml_in_docs(doc_paths=(path,))
-
-    def test_analyzer_no_root_level_docs_allows_namespaced_table_header(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            path = Path(tmp_dir) / 'docs.md'
-            path.write_text('[analyzer.queueing]\ntrigger_permille = 400\n', encoding='utf-8')
-            validate_docs_contracts.validate_no_root_level_analyzer_toml_in_docs(doc_paths=(path,))
-
-    def test_controller_readme_does_not_use_misleading_dependency_example_flow(self) -> None:
-        readme_text = validate_docs_contracts.CONTROLLER_README_PATH.read_text(encoding='utf-8')
-        self.assertFalse(validate_docs_contracts.is_misleading_controller_example_flow(readme_text))
+            path.write_text('syntactically_valid = true\n', encoding='utf-8')
+            validate_docs_contracts.validate_analyzer_config_example_contract(config_path=path)
 
     def test_sampler_integration_boundary_contract_validates(self) -> None:
         validate_docs_contracts.validate_sampler_integration_boundary()

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python3
-"""Validate public documentation contract expectations."""
+"""Validate structural documentation and repository source-policy contracts."""
 
 from __future__ import annotations
 
 import argparse
 import ast
-import json
 import re
 import shlex
-import subprocess
 import tomllib
 from pathlib import Path
 from typing import Any
@@ -16,209 +14,26 @@ from urllib.parse import urlsplit
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 README_PATH = REPO_ROOT / "README.md"
-SPEC_PATH = REPO_ROOT / "SPEC.md"
 DEV_DOCS_DIR = REPO_ROOT / "docs" / "dev"
-DESIGN_NOTES_PATH = DEV_DOCS_DIR / "DESIGN_NOTES.md"
-IMPLEMENTATION_PLAN_PATH = DEV_DOCS_DIR / "IMPLEMENTATION_PLAN.md"
-VALIDATION_PATH = DEV_DOCS_DIR / "VALIDATION.md"
-DEV_README_PATH = DEV_DOCS_DIR / "README.md"
 DOCS_INDEX_PATH = REPO_ROOT / "docs" / "README.md"
 USER_GUIDE_PATH = REPO_ROOT / "docs" / "user-guide.md"
 DIAGNOSTICS_PATH = REPO_ROOT / "docs" / "diagnostics.md"
-ANALYZER_RATIONALE_PATH = REPO_ROOT / "docs" / "analyzer-rationale.md"
 OPERATIONS_PATH = REPO_ROOT / "docs" / "operations.md"
+ARCHITECTURE_PATH = REPO_ROOT / "docs" / "architecture.md"
 ANALYZER_CONFIG_EXAMPLE_PATH = REPO_ROOT / "examples" / "analyzer-config.toml"
-ANALYZER_DOC_PATHS = (
-    DIAGNOSTICS_PATH,
-    OPERATIONS_PATH,
-    USER_GUIDE_PATH,
-    REPO_ROOT / "tailtriage-analyzer" / "README.md",
-    REPO_ROOT / "tailtriage-cli" / "README.md",
-    REPO_ROOT / "tailtriage-tracing" / "README.md",
-)
-DIAGNOSTIC_VALIDATION_PATH = REPO_ROOT / "docs" / "diagnostic-validation.md"
+ANALYZER_DOC_PATHS = (DIAGNOSTICS_PATH, OPERATIONS_PATH, USER_GUIDE_PATH, REPO_ROOT / "tailtriage-analyzer" / "README.md", REPO_ROOT / "tailtriage-cli" / "README.md", REPO_ROOT / "tailtriage-tracing" / "README.md")
 CI_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
-ARCHITECTURE_PATH = REPO_ROOT / "docs" / "architecture.md"
 CONTROLLER_README_PATH = REPO_ROOT / "tailtriage-controller" / "README.md"
-ANALYSIS_FIXTURE_PATH = REPO_ROOT / "demos" / "queue_service" / "fixtures" / "before-analysis.json"
 CONTROLLER_SOURCE_PATH = REPO_ROOT / "tailtriage-controller" / "src" / "lib.rs"
 CORE_COLLECTOR_SOURCE_PATH = REPO_ROOT / "tailtriage-core" / "src" / "collector.rs"
 CORE_LIB_SOURCE_PATH = REPO_ROOT / "tailtriage-core" / "src" / "lib.rs"
 PUBLIC_DOCS_GLOB = (REPO_ROOT / "docs").glob("*.md")
-USER_FACING_TERMINOLOGY_PATHS = (
-    README_PATH,
-    DOCS_INDEX_PATH,
-    USER_GUIDE_PATH,
-    DIAGNOSTICS_PATH,
-    OPERATIONS_PATH,
-    ARCHITECTURE_PATH,
-    REPO_ROOT / "docs" / "runtime-cost.md",
-    REPO_ROOT / "docs" / "collector-limits.md",
-    REPO_ROOT / "docs" / "getting-started-demo.md",
-    REPO_ROOT / "tailtriage" / "README.md",
-    REPO_ROOT / "tailtriage-core" / "README.md",
-    REPO_ROOT / "tailtriage-controller" / "README.md",
-    REPO_ROOT / "tailtriage-tokio" / "README.md",
-    REPO_ROOT / "tailtriage-axum" / "README.md",
-    REPO_ROOT / "tailtriage-analyzer" / "README.md",
-    REPO_ROOT / "tailtriage-cli" / "README.md",
-    REPO_ROOT / "tailtriage-tracing" / "README.md",
-    REPO_ROOT / "tailtriage" / "src" / "lib.rs",
-    REPO_ROOT / "tailtriage" / "Cargo.toml",
-)
-
-RUN_SCHEMA_CURRENT_CLAIM_PATHS = (
-    README_PATH,
-    SPEC_PATH,
-    VALIDATION_PATH,
-    IMPLEMENTATION_PLAN_PATH,
-    DESIGN_NOTES_PATH,
-    DOCS_INDEX_PATH,
-    USER_GUIDE_PATH,
-    DIAGNOSTICS_PATH,
-    OPERATIONS_PATH,
-    ARCHITECTURE_PATH,
-    REPO_ROOT / "tailtriage-core" / "README.md",
-    REPO_ROOT / "tailtriage-cli" / "README.md",
-    REPO_ROOT / "tailtriage-analyzer" / "README.md",
-    REPO_ROOT / "tailtriage-tracing" / "README.md",
-    REPO_ROOT / "tailtriage-controller" / "README.md",
-)
-
-STALE_CONTROLLER_POLICY_NAMES = (
-    'kind = "manual"',
-    'kind = "max_requests"',
-    'kind = "max_duration_ms"',
-    'kind = "first_limit_hit"',
-)
-
-DOCS_INDEX_EXCLUDED_MARKDOWN = {
-    # GitHub workflow templates, surfaced by GitHub UI rather than docs index.
-    ".github/ISSUE_TEMPLATE/bug_report.md",
-    ".github/ISSUE_TEMPLATE/feature_request.md",
-    ".github/pull_request_template.md",
-
-    # Agent working rules are not product docs.
-    "AGENTS.md",
-
-    # The docs index should not be required to link to itself.
-    "docs/README.md",
-
-    # Validation-domain internals. User-facing guidance is under docs/.
-    "validation/collector-limits/README.md",
-    "validation/collector-limits/latest/scorecard.md",
-    "validation/diagnostics/README.md",
-    "validation/diagnostics/latest/scorecard.md",
-    "validation/runtime-cost/README.md",
-    "validation/runtime-cost/latest/scorecard.md",
-}
-
-DOCS_DISALLOWED_HISTORY_PATTERNS = (
-    r"issue\s*#\d+",
-    r"PR\s*#\d+",
-)
-
-CAPTURE_INTEGRATION_README_PATHS = (
-    REPO_ROOT / "tailtriage" / "README.md",
-    REPO_ROOT / "tailtriage-core" / "README.md",
-    REPO_ROOT / "tailtriage-controller" / "README.md",
-    REPO_ROOT / "tailtriage-tokio" / "README.md",
-    REPO_ROOT / "tailtriage-axum" / "README.md",
-)
-
-DIAGNOSTICS_FIELD_REFERENCE_LABELS = (
-    "field reference",
-    "field-reference",
-)
-
-VALIDATION_DOC_PATHS = (
-    VALIDATION_PATH,
-    DIAGNOSTIC_VALIDATION_PATH,
-    REPO_ROOT / "validation" / "diagnostics" / "README.md",
-    REPO_ROOT / "validation" / "diagnostics" / "latest" / "scorecard.md",
-)
-
-DIAGNOSTIC_BENCHMARK_CI_ARGS = (
-    "--manifest validation/diagnostics/manifest.json",
-    "--min-top1 0.75",
-    "--min-top2 0.90",
-    "--max-high-confidence-wrong 0",
-)
-
-STALE_VALIDATION_DOC_PHRASES = (
-    "no in normal pr ci",
-)
-
-
-
-OBSOLETE_CHECKPOINT_PHRASES = (
-    "analyzer interpretation is unchanged in this release",
-    "Cancellation does not add partial queue or stage evidence",
-)
-
-MISLEADING_CANCELLATION_PATTERNS = (
-    r"cancellation\s+does\s+not\s+add\s+partial\s+queue\s+or\s+stage\s+evidence",
-)
-
-CANONICAL_CHECKPOINT_CONTRACT_PATHS = (
-    SPEC_PATH,
-    OPERATIONS_PATH,
-)
-
-RUSTDOC_INCLUDE_CRATE_LIBS = (
-    REPO_ROOT / "tailtriage" / "src" / "lib.rs",
-    REPO_ROOT / "tailtriage-core" / "src" / "lib.rs",
-    REPO_ROOT / "tailtriage-controller" / "src" / "lib.rs",
-    REPO_ROOT / "tailtriage-tokio" / "src" / "lib.rs",
-    REPO_ROOT / "tailtriage-axum" / "src" / "lib.rs",
-    REPO_ROOT / "tailtriage-analyzer" / "src" / "lib.rs",
-    REPO_ROOT / "tailtriage-cli" / "src" / "lib.rs",
-    REPO_ROOT / "tailtriage-tracing" / "src" / "lib.rs",
-)
-
-ANALYZER_GROUPS = (
-    "queueing",
-    "blocking",
-    "executor",
-    "downstream",
-    "confidence",
-    "evidence",
-    "route",
-    "temporal",
-)
-ANALYZER_V1_VALID_PATHS = {
-    "queueing.trigger_permille",
-    "blocking.min_nonzero_samples_for_signal",
-    "blocking.strong_p95_threshold",
-    "blocking.strong_peak_threshold",
-    "blocking.strong_nonzero_share_permille",
-    "blocking.strong_min_samples",
-    "executor.min_global_queue_p95_for_signal",
-    "executor.min_runnable_queue_per_worker_p95_milli_for_signal",
-    "downstream.blocking_correlated_stage_patterns",
-    "downstream.min_stage_samples",
-    "downstream.blocking_correlation_score_margin",
-    "confidence.medium_score_threshold",
-    "confidence.high_score_threshold",
-    "confidence.ambiguity_min_score",
-    "confidence.ambiguity_score_gap",
-    "evidence.low_completed_request_threshold",
-    "route.min_request_count",
-    "route.breakdown_limit",
-    "route.emit_on_divergent_suspects",
-    "route.slowest_to_fastest_p95_ratio_numerator",
-    "route.slowest_to_fastest_p95_ratio_denominator",
-    "route.slowest_to_global_p95_ratio_numerator",
-    "route.slowest_to_global_p95_ratio_denominator",
-    "temporal.min_request_count",
-    "temporal.min_segment_request_count",
-    "temporal.share_shift_permille",
-    "temporal.p95_shift_ratio_numerator",
-    "temporal.p95_shift_ratio_denominator",
-    "temporal.emit_on_suspect_shift",
-    "temporal.suppress_runtime_sparse_suspect_shift_without_supporting_movement",
-}
+STALE_CONTROLLER_POLICY_NAMES = ('kind = "manual"', 'kind = "max_requests"', 'kind = "max_duration_ms"', 'kind = "first_limit_hit"')
+DOCS_INDEX_EXCLUDED_MARKDOWN = {".github/ISSUE_TEMPLATE/bug_report.md", ".github/ISSUE_TEMPLATE/feature_request.md", ".github/pull_request_template.md", "AGENTS.md", "docs/README.md", "validation/collector-limits/README.md", "validation/collector-limits/latest/scorecard.md", "validation/diagnostics/README.md", "validation/diagnostics/latest/scorecard.md", "validation/runtime-cost/README.md", "validation/runtime-cost/latest/scorecard.md"}
+RUSTDOC_INCLUDE_CRATE_LIBS = tuple(REPO_ROOT / crate / "src" / "lib.rs" for crate in ("tailtriage", "tailtriage-core", "tailtriage-controller", "tailtriage-tokio", "tailtriage-axum", "tailtriage-analyzer", "tailtriage-cli", "tailtriage-tracing"))
+ANALYZER_GROUPS = ("queueing", "blocking", "executor", "downstream", "confidence", "evidence", "route", "temporal")
+DIAGNOSTIC_BENCHMARK_CI_ARGS = ("--manifest validation/diagnostics/manifest.json", "--min-top1 0.75", "--min-top2 0.90", "--max-high-confidence-wrong 0")
 
 
 def parse_args() -> argparse.Namespace:
@@ -285,98 +100,6 @@ def has_markdown_heading(markdown: str, heading_pattern: str) -> bool:
         is not None
     )
 
-
-def _kind_of(value: Any) -> str:
-    if value is None:
-        return "null"
-    if isinstance(value, bool):
-        return "bool"
-    if isinstance(value, int):
-        return "int"
-    if isinstance(value, float):
-        return "float"
-    if isinstance(value, str):
-        return "string"
-    if isinstance(value, list):
-        return "array"
-    if isinstance(value, dict):
-        return "object"
-    raise TypeError(f"unsupported JSON value type: {type(value)}")
-
-
-def assert_same_object_shape(*, name: str, actual: dict[str, Any], expected: dict[str, Any]) -> None:
-    actual_keys = set(actual.keys())
-    expected_keys = set(expected.keys())
-    if actual_keys != expected_keys:
-        raise ValueError(
-            f"{name} key drift: expected {sorted(expected_keys)}, got {sorted(actual_keys)}"
-        )
-
-    for key, expected_value in expected.items():
-        actual_kind = _kind_of(actual[key])
-        expected_kind = _kind_of(expected_value)
-        if actual_kind != expected_kind:
-            raise ValueError(f"{name}.{key} type drift: expected {expected_kind}, got {actual_kind}")
-
-
-
-def validate_governance_strictness_contract() -> None:
-    text = SPEC_PATH.read_text(encoding="utf-8")
-    lower_text = text.lower()
-
-    required_tokens = (
-        "default cli run artifact analysis strictly validates",
-        "tailtriage analyze --allow-ambiguous-artifact",
-        "analyzer library defaults remain permissive",
-        "tracing import `--strict` separately controls",
-        "does not replace strict run artifact validation",
-        "stable wrapper format",
-        "only accepted tracing jsonl file format",
-        "pre-stable/internal jsonl must be regenerated",
-    )
-    for token in required_tokens:
-        if token not in lower_text:
-            raise ValueError(f"SPEC.md strictness contract missing token: {token}")
-
-    conflations = (
-        r"strict artifact validation[^\n]*(?:cli/import strict flags|tracing import `--strict`)",
-        r"tracing import `--strict`[^\n]*(?<!not )replace(?:s)? strict run artifact validation",
-    )
-    for pattern in conflations:
-        if re.search(pattern, lower_text):
-            raise ValueError("SPEC.md conflates strict Run artifact validation with tracing import --strict")
-
-
-def validate_analyzer_strictness_ownership_contract(*, path: Path = DEV_README_PATH) -> None:
-    text = path.read_text(encoding="utf-8")
-    if re.search(r"analyzer (?:library )?entry points?[^\n]*expose strict alternatives", text, re.IGNORECASE):
-        raise ValueError(
-            f"{path.relative_to(REPO_ROOT)} claims analyzer-owned strict validation alternatives"
-        )
-
-
-def validate_governance_pending_state_contract() -> None:
-    text = DESIGN_NOTES_PATH.read_text(encoding="utf-8")
-    lower_text = text.lower()
-
-    required_tokens = (
-        "pending/unfinished request state can grow with admitted requests",
-        "completion token finishes or the collector is dropped",
-        "shutdown()` currently inspects pending requests",
-        "does not clear pending bookkeeping",
-        "seal the collector against later admissions",
-        "separate from the retained request, queue, stage, in-flight, and runtime vectors",
-        "known current limitations rather than desired permanent contracts",
-    )
-    for token in required_tokens:
-        if token not in lower_text:
-            raise ValueError(f"DESIGN_NOTES.md pending-state contract missing token: {token}")
-
-    if re.search(r"pending/unfinished request state[^\n]*until[^\n]*run shuts down", lower_text):
-        raise ValueError("DESIGN_NOTES.md must not claim shutdown clears pending request state")
-
-    if re.search(r"(?m)^\s*all live (?:bookkeeping|state) (?:is|are) (?:capture-limited|bounded by capture limits)", lower_text):
-        raise ValueError("DESIGN_NOTES.md must not claim all live bookkeeping is capture-limited")
 
 def validate_analyzer_ownership_navigation(
     *,
@@ -454,108 +177,15 @@ def extract_run_end_policy_kinds_from_source() -> set[str]:
 
 
 def validate_controller_readme_toml() -> None:
+    """Parse controller README examples and compare enum values with Rust source."""
     readme_text = CONTROLLER_README_PATH.read_text(encoding="utf-8")
-    if not has_markdown_heading(readme_text, r"TOML\s+field\s+reference"):
-        raise ValueError("controller README must include a TOML field reference section")
-    _validate_controller_precedence_semantics(readme_text)
+    snippets = extract_all_fenced_blocks(readme_text, fence="toml")
+    if len(snippets) < 2:
+        raise ValueError("controller README must include minimal and expanded TOML examples")
 
-    required_reference_tokens = (
-        "service_name",
-        "initially_enabled",
-        "mode",
-        "strict_lifecycle",
-        "capture_limits_override",
-        "max_requests",
-        "max_stages",
-        "max_queues",
-        "max_inflight_snapshots",
-        "max_runtime_snapshots",
-        "enabled_for_armed_runs",
-        "mode_override",
-        "interval_ms",
-        "run_end_policy",
-        "continue_after_limits_hit",
-        "auto_seal_on_limits_hit",
-    )
-    for token in required_reference_tokens:
-        if token not in readme_text:
-            raise ValueError(f"controller README TOML field reference missing token: {token}")
-
-    if "## Minimal TOML example" in readme_text and "## Expanded TOML example" in readme_text:
-        minimal_snippet = extract_fenced_block(
-            readme_text,
-            fence="toml",
-            anchor="## Minimal TOML example",
-        )
-        expanded_snippet = extract_fenced_block(
-            readme_text,
-            fence="toml",
-            anchor="## Expanded TOML example",
-        )
-    else:
-        snippets = extract_all_fenced_blocks(readme_text, fence="toml")
-        if len(snippets) < 2:
-            raise ValueError("controller README must include minimal and expanded TOML examples")
-        minimal_snippet, expanded_snippet = snippets[0], snippets[1]
-    minimal = tomllib.loads(minimal_snippet)
-    expanded = tomllib.loads(expanded_snippet)
-
+    minimal, expanded = (tomllib.loads(snippet) for snippet in snippets[:2])
     _validate_controller_toml_shape(parsed=minimal, example_name="minimal")
     _validate_controller_toml_shape(parsed=expanded, example_name="expanded")
-
-    expanded_controller = expanded["controller"]
-    if "initially_enabled" not in expanded_controller:
-        raise ValueError("expanded controller TOML example must include controller.initially_enabled")
-    if expanded_controller["initially_enabled"] is not False:
-        raise ValueError("expanded controller TOML example must set controller.initially_enabled = false")
-
-    expanded_activation = expanded_controller["activation"]
-    for required_table in ("capture_limits_override", "runtime_sampler", "run_end_policy"):
-        if required_table not in expanded_activation or not isinstance(
-            expanded_activation[required_table], dict
-        ):
-            raise ValueError(
-                f"expanded controller TOML example must include [controller.activation.{required_table}]"
-            )
-
-    runtime_sampler = expanded_activation["runtime_sampler"]
-    for key in (
-        "enabled_for_armed_runs",
-        "mode_override",
-        "interval_ms",
-        "max_runtime_snapshots",
-    ):
-        if key not in runtime_sampler:
-            raise ValueError(f"expanded controller TOML example must include runtime_sampler.{key}")
-
-    run_end_policy = expanded_activation["run_end_policy"]
-    if "kind" not in run_end_policy:
-        raise ValueError("expanded controller TOML example must include run_end_policy.kind")
-
-
-def _validate_controller_precedence_semantics(readme_text: str) -> None:
-    semantic_checks = (
-        (
-            "service_name fallback",
-            r"service_name[\s\S]{0,200}(?:fall[s]?\s+back|uses?)[\s\S]{0,120}builder",
-        ),
-        (
-            "initially_enabled fallback",
-            r"initially_enabled[\s\S]{0,200}(?:fall[s]?\s+back|uses?)[\s\S]{0,120}builder",
-        ),
-        (
-            "activation settings owned by TOML",
-            r"(?:activation[\s\S]{0,200}(?:comes?\s+from|owned\s+by)[\s\S]{0,80}toml|toml[\s\S]{0,80}owned[\s\S]{0,120}activation)",
-        ),
-        (
-            "activation optional-subfield defaults",
-            r"omitted[\s\S]{0,120}activation[\s\S]{0,120}default",
-        ),
-    )
-    lower_text = readme_text.lower()
-    for check_name, pattern in semantic_checks:
-        if re.search(pattern, lower_text, flags=re.IGNORECASE) is None:
-            raise ValueError(f"controller README precedence guidance missing semantic rule: {check_name}")
 
 
 def _validate_controller_toml_shape(*, parsed: dict[str, Any], example_name: str) -> None:
@@ -696,159 +326,13 @@ def validate_docs_index_contract() -> None:
         raise ValueError(f"docs index missing required Markdown links: {missing}")
 
 
-def validate_analyzer_rationale_contract(
-    *,
-    rationale_path: Path = ANALYZER_RATIONALE_PATH,
-    docs_index_path: Path = DOCS_INDEX_PATH,
-) -> None:
-    """Protect rationale ownership and structure without freezing catalog prose."""
-    rationale = rationale_path.read_text(encoding="utf-8")
-    index_links = markdown_links(docs_index_path.read_text(encoding="utf-8"))
-
-    if "analyzer-rationale.md" not in index_links:
-        raise ValueError("docs/README.md must link to analyzer-rationale.md")
-
-    required_concepts = (
-        "classification",
-        "recorded intent",
-        "present-purpose inference",
-        "unknown provenance",
-    )
-    missing = [concept for concept in required_concepts if concept.lower() not in rationale.lower()]
-    if missing:
-        raise ValueError(f"analyzer rationale missing required structural concepts: {missing}")
-
-    entry_fields = (
-        "**Rule or default:**",
-        "**Classification:**",
-        "**Problem addressed:**",
-        "**Why this shape:**",
-        "**Tradeoff:**",
-        "**Proof owner:**",
-        "**Revision criteria:**",
-        "**Provenance:**",
-    )
-    entries = re.findall(r"^###\s+AN-[^\n]+\n(.*?)(?=^###\s+AN-|^##\s+|\Z)", rationale, re.MULTILINE | re.DOTALL)
-    if not entries:
-        raise ValueError("analyzer rationale must contain stable AN-* catalog entries")
-    for index, entry in enumerate(entries, start=1):
-        missing = [field for field in entry_fields if field.lower() not in entry.lower()]
-        if missing:
-            raise ValueError(f"analyzer rationale entry {index} missing required fields: {missing}")
-
-    if not any(link.startswith("diagnostics.md") for link in markdown_links(rationale)):
-        raise ValueError("analyzer rationale must link mechanics to docs/diagnostics.md")
-
-
 def validate_root_readme_docs_link() -> None:
     text = README_PATH.read_text(encoding="utf-8")
     links = {normalize_doc_link(link) for link in markdown_links(text)}
 
     if "docs/README.md" not in links:
         raise ValueError("root README must link to docs/README.md")
-    
 
-def validate_user_guide_contract() -> None:
-    text = USER_GUIDE_PATH.read_text(encoding="utf-8")
-    lower_text = text.lower()
-    required_concepts = (
-        "default adoption path",
-        "request lifecycle contract",
-        "direct capture vs controller",
-        "controller toml config",
-        "tailtriagecontroller::builder(",
-        "[controller]",
-        "[controller.activation]",
-        "[controller.activation.sink]",
-        "runtime sampler",
-        "future generations only",
-        "insufficient_evidence",
-    )
-    for concept in required_concepts:
-        if concept not in lower_text:
-            raise ValueError(f"user guide missing required concept/token: {concept}")
-
-    toml_snippet = extract_fenced_block(
-        text,
-        fence="toml",
-        anchor="Minimal TOML shape:",
-    )
-    parsed = tomllib.loads(toml_snippet)
-    controller = parsed.get("controller")
-    if not isinstance(controller, dict):
-        raise ValueError("user guide TOML example must include a [controller] table")
-
-    service_name = controller.get("service_name")
-    if not isinstance(service_name, str) or not service_name.strip():
-        raise ValueError("user guide TOML example must include non-empty controller.service_name")
-
-    activation = controller.get("activation")
-    if not isinstance(activation, dict):
-        raise ValueError("user guide TOML example must include a [controller.activation] table")
-
-    mode = activation.get("mode")
-    if not isinstance(mode, str) or not mode.strip():
-        raise ValueError("user guide TOML example must include non-empty controller.activation.mode")
-
-    sink = activation.get("sink")
-    if not isinstance(sink, dict):
-        raise ValueError("user guide TOML example must include a [controller.activation.sink] table")
-
-    sink_type = sink.get("type")
-    output_path = sink.get("output_path")
-    if sink_type != "local_json":
-        raise ValueError(
-            "user guide TOML example must set controller.activation.sink.type = \"local_json\""
-        )
-    if not isinstance(output_path, str) or not output_path.strip():
-        raise ValueError(
-            "user guide TOML example must include non-empty controller.activation.sink.output_path"
-        )
-
-
-def validate_operations_guide_contract() -> None:
-    if not OPERATIONS_PATH.exists():
-        raise ValueError("operations guide is missing: docs/operations.md")
-
-    text = OPERATIONS_PATH.read_text(encoding="utf-8")
-    lower_text = text.lower()
-    required_concepts = (
-        "production operations guide",
-        "recommended rollout path",
-        "light",
-        "investigation",
-        "runtime sampling",
-        "artifact",
-        "truncation",
-        "capture limits",
-        "insufficient_evidence",
-        "evidence_quality",
-        "not universal production guarantees",
-        "not proof of root cause",
-        "controller",
-    )
-    for concept in required_concepts:
-        if concept not in lower_text:
-            raise ValueError(f"operations guide missing required concept/token: {concept}")
-
-    required_refs = ("validation.md", "diagnostics.md", "runtime-cost.md", "collector-limits.md")
-    for ref in required_refs:
-        if ref not in lower_text:
-            raise ValueError(f"operations guide missing required reference: {ref}")
-
-
-def validate_diagnostics_contract_truthfulness() -> None:
-    readme_text = README_PATH.read_text(encoding="utf-8")
-    docs_index_text = DOCS_INDEX_PATH.read_text(encoding="utf-8")
-    diagnostics_text = DIAGNOSTICS_PATH.read_text(encoding="utf-8")
-
-    combined_labels_text = f"{readme_text}\n{docs_index_text}".lower()
-    references_field_ref = any(label in combined_labels_text for label in DIAGNOSTICS_FIELD_REFERENCE_LABELS)
-    if references_field_ref and "## Field reference" not in diagnostics_text:
-        raise ValueError(
-            "README/docs index describe diagnostics as field reference, "
-            "but docs/diagnostics.md lacks a matching field reference section"
-        )
 
 def validate_analyzer_config_example_contract(*, config_path: Path = ANALYZER_CONFIG_EXAMPLE_PATH) -> None:
     if not config_path.exists():
@@ -880,60 +364,12 @@ def validate_analyzer_config_example_contract(*, config_path: Path = ANALYZER_CO
         )
 
 
-def _extract_analyzer_paths_for_validation(text: str) -> set[str]:
-    prefixes = "|".join((*ANALYZER_GROUPS, "queuing"))
-    pattern = re.compile(
-        rf"(?:`([^`]+)`|\b(--analyzer-set\s+)?(({prefixes})\.[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*)(?:=[^\s`]+)?)"
-    )
-    paths: set[str] = set()
-    for quoted, _, bare_with_optional_value, _ in pattern.findall(text):
-        candidate = quoted or bare_with_optional_value
-        candidate = candidate.split("=", 1)[0].strip()
-        candidate = re.sub(r"^--analyzer-set\s+", "", candidate)
-        if re.fullmatch(rf"(?:{prefixes})\.[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*", candidate):
-            paths.add(candidate)
-    return paths
-
-
 def validate_no_root_level_analyzer_toml_in_docs(*, doc_paths: tuple[Path, ...] = ANALYZER_DOC_PATHS) -> None:
     for path in doc_paths:
         text = path.read_text(encoding="utf-8")
         for group in ANALYZER_GROUPS:
             if re.search(rf"(?m)^\s*\[{group}\]\s*$", text):
                 raise ValueError(f"{path.relative_to(REPO_ROOT)} contains invalid root-level TOML header: [{group}]")
-
-
-def validate_analyzer_tuning_tokens_contract() -> None:
-    diagnostics_text = DIAGNOSTICS_PATH.read_text(encoding="utf-8")
-    diagnostics_lower = diagnostics_text.lower()
-    diagnostics_required = ("analyzer tuning", "analyzeoptions", "--help-analyzer-options")
-    for token in diagnostics_required:
-        if token not in diagnostics_lower:
-            raise ValueError(f"docs/diagnostics.md missing required analyzer token: {token}")
-    if "not proof" not in diagnostics_lower:
-        raise ValueError("docs/diagnostics.md must include bounded wording that suspects are not proof")
-
-    cli_lower = (REPO_ROOT / "tailtriage-cli" / "README.md").read_text(encoding="utf-8").lower()
-    for token in ("--analyzer-config", "--analyzer-set", "--help-analyzer-options", "report json"):
-        if token not in cli_lower:
-            raise ValueError(f"tailtriage-cli/README.md missing required analyzer token: {token}")
-
-    analyzer_lower = (REPO_ROOT / "tailtriage-analyzer" / "README.md").read_text(encoding="utf-8").lower()
-    for token in ("analyzeoptions", "analyze_run", "with_queueing", "analyzer_config"):
-        if token not in analyzer_lower:
-            raise ValueError(f"tailtriage-analyzer/README.md missing required analyzer token: {token}")
-
-def validate_analyzer_override_paths_contract(*, doc_paths: tuple[Path, ...] = ANALYZER_DOC_PATHS) -> None:
-    for path in doc_paths:
-        text = path.read_text(encoding="utf-8")
-        candidates = _extract_analyzer_paths_for_validation(text)
-        invalid = sorted(candidate for candidate in candidates if candidate not in ANALYZER_V1_VALID_PATHS)
-        if invalid:
-            raise ValueError(
-                f"{path.relative_to(REPO_ROOT)} contains invalid analyzer override path(s): "
-                + ", ".join(invalid)
-            )
-
 
 
 def _strip_allowed_analyzer_migration_note(text: str) -> str:
@@ -1002,105 +438,6 @@ def validate_published_crate_readmes_are_self_contained(paths: tuple[Path, ...])
         )
 
 
-def validate_analyzer_cli_docs_split_contract() -> None:
-    analyzer_readme = REPO_ROOT / "tailtriage-analyzer" / "README.md"
-    cli_readme = REPO_ROOT / "tailtriage-cli" / "README.md"
-    validate_published_crate_readmes_are_self_contained((analyzer_readme, cli_readme))
-
-    analyzer_text = analyzer_readme.read_text(encoding="utf-8")
-    analyzer_lower = analyzer_text.lower()
-    analyzer_required = (
-        "in-process",
-        "completed",
-        "run",
-        "typed",
-        "report",
-        "render_json",
-        "render_json_pretty",
-        "analyze_run",
-        "render_text",
-        "analyzeoptions::default()",
-        "tailtriage-cli",
-    )
-    for token in analyzer_required:
-        if token not in analyzer_lower:
-            raise ValueError(f"tailtriage-analyzer README missing required concept/token: {token}")
-
-    if "let report = analyze_run" not in analyzer_lower or "analyzeoptions::default())?" not in analyzer_lower:
-        raise ValueError("tailtriage-analyzer README must teach checked analyze_run and separate Report rendering")
-
-    if "not streaming" not in analyzer_lower and "not live streaming" not in analyzer_lower:
-        raise ValueError("tailtriage-analyzer README must state it is not streaming/live-streaming")
-
-    if "## How to interpret a report" not in analyzer_text:
-        raise ValueError("tailtriage-analyzer README must include heading: ## How to interpret a report")
-
-    analyzer_interpretation_tokens = (
-        "primary_suspect",
-        "evidence[]",
-        "next_checks[]",
-        "confidence",
-        "evidence_quality",
-        "Report JSON",
-        "Run artifact JSON",
-    )
-    for token in analyzer_interpretation_tokens:
-        if token not in analyzer_text:
-            raise ValueError(
-                "tailtriage-analyzer README interpretation guidance missing required token: "
-                f"{token}"
-            )
-
-    cli_text = cli_readme.read_text(encoding="utf-8")
-    cli_lower = cli_text.lower()
-    cli_required_patterns = (
-        ("saved/run artifact loading", r"(saved|captured|on-disk|persisted|run).{0,120}artifact"),
-        ("schema validation", r"(schema.{0,80}validat|validat.{0,80}schema)"),
-        ("non-empty requests loader rule", r"non[-\s]?empty.{0,80}requests"),
-        ("tailtriage-analyzer use", r"tailtriage-analyzer"),
-        ("command-line text/json output", r"(command[-\s]?line|cli).{0,160}(text|json|human-readable)"),
-        ("in-process pointer for Rust users", r"(rust|in-process).{0,120}tailtriage-analyzer"),
-        ("report vs run artifact json distinction", r"(report json).{0,140}(run artifact json|artifact json)|(run artifact json).{0,140}(report json)"),
-        ("cli does not consume report json as input", r"(does\s+not|never|is\s+not).{0,120}(consume|accept|load|read).{0,80}report json.{0,80}(input|artifact)"),
-    )
-    for label, pattern in cli_required_patterns:
-        if re.search(pattern, cli_lower, flags=re.IGNORECASE | re.DOTALL) is None:
-            raise ValueError(f"tailtriage-cli README missing required concept: {label}")
-
-
-def validate_capture_readmes_analyzer_cli_wording_contract() -> None:
-    stale_patterns = (
-        r"analysis\s+is\s+still\s+done\s+by\s+`?tailtriage-cli`?",
-        r"analysis\s+happens\s+in\s+`?tailtriage-cli`?",
-        r"artifact\s+produced\s+here.{0,80}analy[sz]ed\s+by\s+`?tailtriage-cli`?",
-        r"this\s+crate\s+writes\s+artifacts?.{0,80}`?tailtriage-cli`?\s+analy[sz]es",
-        r"analysis\s+or\s+report\s+generation.{0,120}`?tailtriage-cli`?",
-    )
-
-    failures: list[str] = []
-    for path in CAPTURE_INTEGRATION_README_PATHS:
-        text = path.read_text(encoding="utf-8")
-        lower = text.lower()
-        if "tailtriage-analyzer" not in lower:
-            failures.append(
-                f"{path.relative_to(REPO_ROOT)} must mention tailtriage-analyzer for in-process analysis"
-            )
-        if "tailtriage-cli" not in lower:
-            failures.append(
-                f"{path.relative_to(REPO_ROOT)} must mention tailtriage-cli for command-line artifact analysis"
-            )
-
-        for pattern in stale_patterns:
-            if re.search(pattern, lower, flags=re.IGNORECASE | re.DOTALL):
-                failures.append(
-                    f"{path.relative_to(REPO_ROOT)} contains stale CLI-only analyzer wording: {pattern}"
-                )
-
-    if failures:
-        raise ValueError(
-            "capture/integration README analyzer wording contract violation:\n" + "\n".join(failures)
-        )
-
 def _active_yaml_lines(text: str) -> str:
     return "\n".join(line for line in text.splitlines() if not line.lstrip().startswith("#"))
 
@@ -1155,93 +492,6 @@ def validate_diagnostic_benchmark_ci_contract(
         )
 
 
-def validate_validation_docs_ci_contract(
-    *, doc_paths: tuple[Path, ...] = VALIDATION_DOC_PATHS
-) -> None:
-    failures: list[str] = []
-    combined_text_parts: list[str] = []
-    for path in doc_paths:
-        text = path.read_text(encoding="utf-8")
-        combined_text_parts.append(text)
-        lower_text = text.lower()
-        for phrase in STALE_VALIDATION_DOC_PHRASES:
-            if phrase in lower_text:
-                try:
-                    display_path = str(path.relative_to(REPO_ROOT))
-                except ValueError:
-                    display_path = str(path)
-                failures.append(f"{display_path} contains stale validation-CI wording: {phrase}")
-
-    if failures:
-        raise ValueError("validation docs contain stale CI wording:\n" + "\n".join(failures))
-
-    combined_text = "\n".join(combined_text_parts)
-    ownership_contracts = (
-        (
-            r"normal\s+(?:mandatory\s+)?CI.{0,200}deterministic.{0,120}(?:gate|benchmark|corpus)",
-            "normal CI owns the deterministic diagnostics gate",
-        ),
-        (
-            r"scripts/generate_diagnostic_scorecard\.py.{0,180}(?:local/manual|locally|local evidence)",
-            "local/manual deterministic scorecards use scripts/generate_diagnostic_scorecard.py",
-        ),
-        (
-            r"scripts/validate_all\.py.{0,60}--profile\s+publish",
-            "local/manual release readiness uses scripts/validate_all.py --profile publish",
-        ),
-        (
-            r"normal\s+CI.{0,180}(?:does\s+not|doesn't).{0,120}(?:publish|upload).{0,100}(?:GitHub\s+artifacts?|scorecards?)",
-            "normal CI does not automatically publish scorecards or GitHub artifacts",
-        ),
-    )
-    for pattern, description in ownership_contracts:
-        if re.search(pattern, combined_text, flags=re.IGNORECASE | re.DOTALL) is None:
-            raise ValueError(f"validation docs must state that {description}")
-
-
-def validate_architecture_contract() -> None:
-    text = ARCHITECTURE_PATH.read_text(encoding="utf-8")
-    required_tokens = (
-        "`tailtriage`",
-        "`tailtriage-controller`",
-        "default entry point",
-        "file-based",
-    )
-    for token in required_tokens:
-        if token not in text:
-            raise ValueError(f"architecture doc missing required product-contract token: {token}")
-
-
-def validate_docs_no_history_framing() -> None:
-    failures: list[str] = []
-    for path in sorted(PUBLIC_DOCS_GLOB):
-        text = path.read_text(encoding="utf-8")
-        for pattern in DOCS_DISALLOWED_HISTORY_PATTERNS:
-            if re.search(pattern, text, flags=re.IGNORECASE):
-                failures.append(f"{path.relative_to(REPO_ROOT)} matches disallowed pattern: {pattern}")
-
-    if failures:
-        raise ValueError("docs include stale history/process framing:\n" + "\n".join(failures))
-
-
-def validate_no_user_facing_facade_wording() -> None:
-    failures: list[str] = []
-    for path in USER_FACING_TERMINOLOGY_PATHS:
-        text = path.read_text(encoding="utf-8")
-        if re.search(r"\bfacade\b", text, flags=re.IGNORECASE):
-            try:
-                display_path = str(path.relative_to(REPO_ROOT))
-            except ValueError:
-                display_path = str(path)
-            failures.append(f"{display_path} contains disallowed term: facade")
-
-    if failures:
-        raise ValueError(
-            "user-facing files contain stale facade wording:\n" + "\n".join(failures)
-        )
-
-
-
 def validate_crate_rustdocs_include_readmes() -> None:
     required = '#![doc = include_str!("../README.md")]'
     failures: list[str] = []
@@ -1281,6 +531,7 @@ def validate_residual_public_api_cleanup() -> None:
                 raise ValueError(
                     f"{path.relative_to(REPO_ROOT)} exposes removed residual public API: {symbol}"
                 )
+
 
 def is_misleading_controller_example_flow(readme_text: str) -> bool:
     for block in re.findall(r"```bash\n(.*?)\n```", readme_text, flags=re.DOTALL):
@@ -1325,322 +576,6 @@ def validate_sampler_integration_boundary() -> None:
         raise ValueError(
             "tailtriage-core hidden __internal register_tokio_runtime_sampler hook is missing"
         )
-
-
-
-def normalized_words(text: str) -> str:
-    return re.sub(r"\s+", " ", text.lower()).strip()
-
-
-def require_doc_concepts(path: Path, concepts: tuple[tuple[str, tuple[str, ...]], ...]) -> None:
-    text = normalized_words(path.read_text(encoding="utf-8"))
-    missing = [label for label, tokens in concepts if not all(token in text for token in tokens)]
-    if missing:
-        raise ValueError(
-            f"{path.relative_to(REPO_ROOT)} missing public docs contract concept(s): "
-            + ", ".join(missing)
-        )
-
-
-def validate_tracing_completed_jsonl_public_contract() -> None:
-    require_doc_concepts(
-        USER_GUIDE_PATH,
-        (
-            ("retained original source output", ("completed-span jsonl output contains retained original tracing source records",)),
-            ("representable-evidence-only replay parity", ("replay parity is limited to representable normalized request/stage/queue evidence",)),
-            ("complete run artifact", ("run json remains the complete persisted artifact",)),
-            ("run-only omissions", ("runtime snapshots", "in-flight snapshots", "semantic/raw truncation counters", "omitted-source diagnostics")),
-        ),
-    )
-    require_doc_concepts(
-        ARCHITECTURE_PATH,
-        (
-            ("tracing parser and retention role", ("tracing-specific parsing and retention",)),
-            ("core normalization role", ("core normalization",)),
-            ("private provenance role", ("private source provenance",)),
-            ("retained-source jsonl role", ("retained-source jsonl",)),
-            ("complete run artifact", ("run json remains the complete persisted artifact",)),
-        ),
-    )
-    require_doc_concepts(
-        SPEC_PATH,
-        (
-            ("prompt 05 public api boundary", ("prompt 05 owns public tracing api simplification",)),
-            ("prompt 06 compatibility boundary", ("prompt 06 owns compatibility-mode removal",)),
-        ),
-    )
-
-
-
-def validate_tracing_jsonl_no_compat_guidance_contract() -> None:
-    public_paths = (
-        README_PATH,
-        SPEC_PATH,
-        USER_GUIDE_PATH,
-        DOCS_INDEX_PATH,
-        ARCHITECTURE_PATH,
-        REPO_ROOT / "tailtriage-cli" / "README.md",
-        REPO_ROOT / "tailtriage-tracing" / "README.md",
-    )
-    disallowed_patterns = (
-        (r"jsonl" + r"parse" + r"mode", "JSONL parse mode API"),
-        (r"wrapper" + r"\s*" + r"-?" + r"\s*" + r"only" + r"\s+" + r"mode", "tracing JSONL wrapper-only mode wording"),
-        (r"--" + r"\s*" + r"input-format", "CLI input format option"),
-        (r"compatible\s+(?:mode|parser|tracing\s+import)", "compatible tracing import guidance"),
-        (r'(?<!"format":"tailtriage\.tracing-span\.v1",)"span"\s*:\s*\{', "unversioned tracing JSONL example"),
-    )
-    for path in public_paths:
-        text = path.read_text(encoding="utf-8")
-        compact = re.sub(r"\s+", " ", text.lower())
-        for pattern, label in disallowed_patterns:
-            if re.search(pattern, compact):
-                raise ValueError(f"{path.relative_to(REPO_ROOT)} contains unsupported tracing JSONL guidance: {label}")
-
-
-def strip_live_tracing_migration_sections(text: str) -> str:
-    pattern = re.compile(
-        r"^## Live tracing session migration\s*$.*?(?=^##\s+|\Z)",
-        flags=re.IGNORECASE | re.MULTILINE | re.DOTALL,
-    )
-    return pattern.sub("", text)
-
-
-def validate_tracing_readme_migration_section_contract() -> None:
-    path = REPO_ROOT / "tailtriage-tracing" / "README.md"
-    text = path.read_text(encoding="utf-8")
-    normalized = normalized_words(text)
-    duplicate = "for both `tracingsession` and `tracingsession`"
-    if duplicate in normalized:
-        raise ValueError(
-            "tailtriage-tracing/README.md contains duplicated TracingSession migration wording"
-        )
-    heading_count = len(
-        re.findall(
-            r"^## Live tracing session migration\s*$",
-            text,
-            flags=re.IGNORECASE | re.MULTILINE,
-        )
-    )
-    if heading_count != 1:
-        raise ValueError(
-            "tailtriage-tracing/README.md must contain exactly one "
-            "'## Live tracing session migration' heading"
-        )
-
-
-def validate_live_tracing_session_public_contract() -> None:
-    validate_tracing_readme_migration_section_contract()
-    required = (
-        USER_GUIDE_PATH,
-        REPO_ROOT / "tailtriage-tracing" / "README.md",
-    )
-    for path in required:
-        require_doc_concepts(
-            path,
-            (
-                ("sole current live entry point", ("tracingsession", "current live", "entry point")),
-                ("async shutdown", ("shutdown().await",)),
-                ("opt-in background sampling", ("background runtime sampling is opt-in", "sampler_interval",)),
-                ("opt-in manual runtime", ("manual runtime collection is opt-in", "manual_runtime_snapshots",)),
-                ("fallible manual recording", ("record_runtime_snapshot", "configuration error")),
-                ("retained original source jsonl", ("completed-span jsonl", "retained original tracing source")),
-                ("complete run artifact", ("run json", "complete persisted artifact")),
-                ("independent transactions", ("each output file is an independent transaction",)),
-            ),
-        )
-
-    obsolete = (
-        "TracingRecorder",
-        "TracingRecorderBuilder",
-        "TracingIntakeSession",
-        "TracingIntakeSessionBuilder",
-        "TracingTokioSession",
-        "TracingTokioSessionBuilder",
-        "TracingTokioSessionStartError",
-        "TracingTokioSessionShutdownError",
-        "disable_background_sampler",
-        "block_on_ready",
-    )
-    public_paths = (
-        README_PATH,
-        USER_GUIDE_PATH,
-        OPERATIONS_PATH,
-        ARCHITECTURE_PATH,
-        REPO_ROOT / "tailtriage" / "README.md",
-        REPO_ROOT / "tailtriage-tracing" / "README.md",
-        REPO_ROOT / "tailtriage" / "src" / "lib.rs",
-        REPO_ROOT / "tailtriage-tracing" / "src" / "lib.rs",
-    )
-    for path in public_paths:
-        current = strip_live_tracing_migration_sections(path.read_text(encoding="utf-8"))
-        found = [symbol for symbol in obsolete if symbol in current]
-        if found:
-            raise ValueError(
-                f"{path.relative_to(REPO_ROOT)} contains obsolete current live tracing guidance outside migration section: {found}"
-            )
-
-def tracked_markdown_paths() -> list[Path]:
-    result = subprocess.run(
-        ["git", "ls-files", "*.md"],
-        cwd=REPO_ROOT,
-        check=True,
-        text=True,
-        capture_output=True,
-    )
-    return [REPO_ROOT / line for line in result.stdout.splitlines() if line]
-
-
-def validate_checkpoint_documentation_contract(
-    *,
-    markdown_paths: tuple[Path, ...] | None = None,
-    canonical_paths: tuple[Path, ...] = CANONICAL_CHECKPOINT_CONTRACT_PATHS,
-) -> None:
-    if markdown_paths is None:
-        markdown_paths = tuple(tracked_markdown_paths())
-
-    errors: list[str] = []
-    for path in markdown_paths:
-        text = path.read_text(encoding="utf-8")
-        lower_text = text.lower()
-        for phrase in OBSOLETE_CHECKPOINT_PHRASES:
-            if phrase.lower() in lower_text:
-                errors.append(
-                    f"{path.relative_to(REPO_ROOT)} contains obsolete checkpoint phrase: {phrase}"
-                )
-        for pattern in MISLEADING_CANCELLATION_PATTERNS:
-            if re.search(pattern, text, flags=re.IGNORECASE):
-                errors.append(
-                    f"{path.relative_to(REPO_ROOT)} contains misleading cancellation wording: {pattern}"
-                )
-
-    required_concepts = (
-        (
-            "schema v2 finalization",
-            (
-                "Run JSON schema version 2",
-                "RunMetadata::finalized_at_unix_ms",
-                "sole run-level finalization timestamp",
-                "Active snapshots",
-                "None",
-                "finalized Runs",
-                "Some(timestamp)",
-            ),
-        ),
-        (
-            "request cancellation versus partial child Drop",
-            (
-                "dropping an admitted request-completion token while capture is open records one request outcome `cancelled`",
-                "does not itself fabricate child evidence",
-                "queue/stage helper that was polled and then dropped while capture remains open records one bounded partial child event",
-                "tracing spans remain completed-only",
-                "late Drop after finalization is inert",
-            ),
-        ),
-        (
-            "overlap-safe attribution",
-            (
-                "request-scoped bounded attribution",
-                "same-name stage",
-                "overlap",
-                "do not double-count",
-            ),
-        ),
-        (
-            "partial lower-bound interpretation",
-            (
-                "completed queue/stage distributions exclude partial observations",
-                "observed lower bound",
-                "materially partial-reliant queue/stage candidates cannot exceed medium confidence",
-            ),
-        ),
-        (
-            "completed-only tracing",
-            (
-                "tracing intake remains completed-only",
-            ),
-        ),
-        (
-            "confidence-first ordering",
-            (
-                "final confidence descending",
-                "raw score descending",
-                "stable suspect-kind rank",
-                "InsufficientEvidence last",
-            ),
-        ),
-        (
-            "ambiguity cluster cap",
-            (
-                "raw-score proximity",
-                "ambiguity",
-                "capped uniformly",
-            ),
-        ),
-    )
-    for path in canonical_paths:
-        text = path.read_text(encoding="utf-8")
-        lower_text = text.lower()
-        for concept, tokens in required_concepts:
-            missing = [token for token in tokens if token.lower() not in lower_text]
-            if missing:
-                errors.append(
-                    f"{path.relative_to(REPO_ROOT)} missing checkpoint contract tokens for {concept}: {missing}"
-                )
-
-    if errors:
-        raise ValueError("checkpoint documentation contract failed:\n" + "\n".join(errors))
-
-
-def validate_run_schema_v2_public_contract(
-    *,
-    doc_paths: tuple[Path, ...] = RUN_SCHEMA_CURRENT_CLAIM_PATHS,
-    required_current_paths: tuple[Path, ...] | None = None,
-) -> None:
-    if required_current_paths is None:
-        required_current_paths = (
-            SPEC_PATH,
-            DIAGNOSTICS_PATH,
-            REPO_ROOT / "tailtriage-cli" / "README.md",
-        )
-        if doc_paths != RUN_SCHEMA_CURRENT_CLAIM_PATHS:
-            required_current_paths = doc_paths
-    stale_run_patterns = (
-        r"current\s+supported\s+run\s+schema\s+version\s*(?:is\s*)?[:=]?\s*`?1`?",
-        r"current\s+run\s+json\s+schema\s+version\s*(?:is\s*)?[:=]?\s*`?1`?",
-    )
-    for path in doc_paths:
-        text = path.read_text(encoding="utf-8")
-        for pattern in stale_run_patterns:
-            if re.search(pattern, text, flags=re.IGNORECASE):
-                raise ValueError(
-                    f"{path.relative_to(REPO_ROOT)} contains stale current Run schema claim: {pattern}"
-                )
-        if re.search(
-            r"(?:metadata\.finished_at_unix_ms|RunMetadata::finished_at_unix_ms)",
-            text,
-            flags=re.IGNORECASE,
-        ):
-            raise ValueError(
-                f"{path.relative_to(REPO_ROOT)} contains removed current Run metadata field"
-            )
-
-    required = (
-        "Run JSON schema version 2",
-        "metadata.finalized_at_unix_ms",
-        "sole run-level finalization timestamp",
-        "Schema-v1 Run JSON",
-        "Event-level completion timestamps",
-    )
-    for path in required_current_paths:
-        text = path.read_text(encoding="utf-8")
-        missing = [token for token in required if token not in text]
-        if missing:
-            raise ValueError(f"{path.relative_to(REPO_ROOT)} missing Run schema v2 wording: {missing}")
-        lower = text.lower()
-        if "numeric finalization" not in lower and "numeric `metadata.finalized_at_unix_ms`" not in lower:
-            raise ValueError(f"{path.relative_to(REPO_ROOT)} must require numeric finalization for persisted Run artifacts")
-        if "null" not in lower:
-            raise ValueError(f"{path.relative_to(REPO_ROOT)} must permit null finalization for active snapshots")
 
 
 def _prohibited_release_command(command: str) -> str | None:
@@ -1799,41 +734,23 @@ def validate_manual_release_boundary(
     if errors:
         raise ValueError("manual release boundary failed:\n" + "\n".join(errors))
 
+
 def main() -> int:
     _ = parse_args()
-    validate_governance_strictness_contract()
-    validate_analyzer_strictness_ownership_contract()
-    validate_governance_pending_state_contract()
     validate_analyzer_ownership_navigation()
     validate_crate_rustdocs_include_readmes()
     validate_residual_public_api_cleanup()
     validate_controller_readme_toml()
     validate_no_stale_controller_policy_names()
     validate_docs_index_contract()
-    validate_analyzer_rationale_contract()
     validate_root_readme_docs_link()
-    validate_user_guide_contract()
-    validate_operations_guide_contract()
-    validate_diagnostics_contract_truthfulness()
     validate_analyzer_config_example_contract()
     validate_no_root_level_analyzer_toml_in_docs()
-    validate_analyzer_tuning_tokens_contract()
-    validate_analyzer_override_paths_contract()
     validate_cli_not_presented_as_library_analyzer_api()
-    validate_analyzer_cli_docs_split_contract()
-    validate_capture_readmes_analyzer_cli_wording_contract()
+    validate_published_crate_readmes_are_self_contained((REPO_ROOT / "tailtriage-analyzer" / "README.md", REPO_ROOT / "tailtriage-cli" / "README.md"))
     validate_diagnostic_benchmark_ci_contract()
-    validate_validation_docs_ci_contract()
-    validate_architecture_contract()
-    validate_docs_no_history_framing()
-    validate_no_user_facing_facade_wording()
     validate_controller_example_usage_contract()
     validate_sampler_integration_boundary()
-    validate_tracing_completed_jsonl_public_contract()
-    validate_tracing_jsonl_no_compat_guidance_contract()
-    validate_live_tracing_session_public_contract()
-    validate_run_schema_v2_public_contract()
-    validate_checkpoint_documentation_contract()
     validate_manual_release_boundary()
     print("docs contracts validated successfully")
     return 0

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -21,18 +21,14 @@ DIAGNOSTICS_PATH = REPO_ROOT / "docs" / "diagnostics.md"
 OPERATIONS_PATH = REPO_ROOT / "docs" / "operations.md"
 ARCHITECTURE_PATH = REPO_ROOT / "docs" / "architecture.md"
 ANALYZER_CONFIG_EXAMPLE_PATH = REPO_ROOT / "examples" / "analyzer-config.toml"
-ANALYZER_DOC_PATHS = (DIAGNOSTICS_PATH, OPERATIONS_PATH, USER_GUIDE_PATH, REPO_ROOT / "tailtriage-analyzer" / "README.md", REPO_ROOT / "tailtriage-cli" / "README.md", REPO_ROOT / "tailtriage-tracing" / "README.md")
 CI_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
 CONTROLLER_README_PATH = REPO_ROOT / "tailtriage-controller" / "README.md"
 CONTROLLER_SOURCE_PATH = REPO_ROOT / "tailtriage-controller" / "src" / "lib.rs"
 CORE_COLLECTOR_SOURCE_PATH = REPO_ROOT / "tailtriage-core" / "src" / "collector.rs"
 CORE_LIB_SOURCE_PATH = REPO_ROOT / "tailtriage-core" / "src" / "lib.rs"
-PUBLIC_DOCS_GLOB = (REPO_ROOT / "docs").glob("*.md")
-STALE_CONTROLLER_POLICY_NAMES = ('kind = "manual"', 'kind = "max_requests"', 'kind = "max_duration_ms"', 'kind = "first_limit_hit"')
 DOCS_INDEX_EXCLUDED_MARKDOWN = {".github/ISSUE_TEMPLATE/bug_report.md", ".github/ISSUE_TEMPLATE/feature_request.md", ".github/pull_request_template.md", "AGENTS.md", "docs/README.md", "validation/collector-limits/README.md", "validation/collector-limits/latest/scorecard.md", "validation/diagnostics/README.md", "validation/diagnostics/latest/scorecard.md", "validation/runtime-cost/README.md", "validation/runtime-cost/latest/scorecard.md"}
 RUSTDOC_INCLUDE_CRATE_LIBS = tuple(REPO_ROOT / crate / "src" / "lib.rs" for crate in ("tailtriage", "tailtriage-core", "tailtriage-controller", "tailtriage-tokio", "tailtriage-axum", "tailtriage-analyzer", "tailtriage-cli", "tailtriage-tracing"))
-ANALYZER_GROUPS = ("queueing", "blocking", "executor", "downstream", "confidence", "evidence", "route", "temporal")
 DIAGNOSTIC_BENCHMARK_CI_ARGS = ("--manifest validation/diagnostics/manifest.json", "--min-top1 0.75", "--min-top2 0.90", "--max-high-confidence-wrong 0")
 
 
@@ -251,20 +247,6 @@ def _validate_controller_toml_shape(*, parsed: dict[str, Any], example_name: str
         )
 
 
-def validate_no_stale_controller_policy_names() -> None:
-    paths = [README_PATH, CONTROLLER_README_PATH, *sorted(PUBLIC_DOCS_GLOB)]
-    hits: list[str] = []
-    for path in paths:
-        text = path.read_text(encoding="utf-8")
-        for token in STALE_CONTROLLER_POLICY_NAMES:
-            if token in text:
-                hits.append(f"{path.relative_to(REPO_ROOT)} contains stale token: {token}")
-
-    if hits:
-        joined = "\n".join(hits)
-        raise ValueError(f"stale controller run_end_policy docs found:\n{joined}")
-
-
 def normalize_doc_link(link: str) -> str:
     return link.split("#", 1)[0]
 
@@ -339,37 +321,9 @@ def validate_analyzer_config_example_contract(*, config_path: Path = ANALYZER_CO
         raise ValueError(f"missing analyzer config example: {config_path}")
     text = config_path.read_text(encoding="utf-8")
     try:
-        parsed = tomllib.loads(text)
+        tomllib.loads(text)
     except tomllib.TOMLDecodeError as exc:
         raise ValueError(f"invalid TOML in {config_path}: {exc}") from exc
-
-    analyzer = parsed.get("analyzer")
-    if not isinstance(analyzer, dict):
-        raise ValueError(f"{config_path} must define an [analyzer] table")
-    if analyzer.get("schema_version") != 1:
-        raise ValueError(f"{config_path} must set analyzer.schema_version = 1")
-
-    missing_groups = [group for group in ANALYZER_GROUPS if not isinstance(analyzer.get(group), dict)]
-    if missing_groups:
-        raise ValueError(
-            f"{config_path} missing required [analyzer.*] groups: "
-            f"{', '.join(missing_groups)}"
-        )
-
-    invalid_root = sorted(group for group in ANALYZER_GROUPS if isinstance(parsed.get(group), dict))
-    if invalid_root:
-        raise ValueError(
-            f"{config_path} must not define root-level analyzer groups: "
-            f"{', '.join(invalid_root)}"
-        )
-
-
-def validate_no_root_level_analyzer_toml_in_docs(*, doc_paths: tuple[Path, ...] = ANALYZER_DOC_PATHS) -> None:
-    for path in doc_paths:
-        text = path.read_text(encoding="utf-8")
-        for group in ANALYZER_GROUPS:
-            if re.search(rf"(?m)^\s*\[{group}\]\s*$", text):
-                raise ValueError(f"{path.relative_to(REPO_ROOT)} contains invalid root-level TOML header: [{group}]")
 
 
 def _strip_allowed_analyzer_migration_note(text: str) -> str:
@@ -531,22 +485,6 @@ def validate_residual_public_api_cleanup() -> None:
                 raise ValueError(
                     f"{path.relative_to(REPO_ROOT)} exposes removed residual public API: {symbol}"
                 )
-
-
-def is_misleading_controller_example_flow(readme_text: str) -> bool:
-    for block in re.findall(r"```bash\n(.*?)\n```", readme_text, flags=re.DOTALL):
-        if "cargo add tailtriage-controller" in block and "cargo run --example controller_minimal" in block:
-            return True
-    return False
-
-
-def validate_controller_example_usage_contract() -> None:
-    readme_text = CONTROLLER_README_PATH.read_text(encoding="utf-8")
-    if is_misleading_controller_example_flow(readme_text):
-        raise ValueError(
-            "controller README contains a misleading dependency-example flow: "
-            "`cargo add tailtriage-controller` + `cargo run --example controller_minimal`."
-        )
 
 
 def find_public_sampler_forge_methods(source: str) -> list[str]:
@@ -741,15 +679,12 @@ def main() -> int:
     validate_crate_rustdocs_include_readmes()
     validate_residual_public_api_cleanup()
     validate_controller_readme_toml()
-    validate_no_stale_controller_policy_names()
     validate_docs_index_contract()
     validate_root_readme_docs_link()
     validate_analyzer_config_example_contract()
-    validate_no_root_level_analyzer_toml_in_docs()
     validate_cli_not_presented_as_library_analyzer_api()
     validate_published_crate_readmes_are_self_contained((REPO_ROOT / "tailtriage-analyzer" / "README.md", REPO_ROOT / "tailtriage-cli" / "README.md"))
     validate_diagnostic_benchmark_ci_contract()
-    validate_controller_example_usage_contract()
     validate_sampler_integration_boundary()
     validate_manual_release_boundary()
     print("docs contracts validated successfully")


### PR DESCRIPTION
### Motivation
- Reduce the docs-validator surface to checks that independently derive objective facts rather than enforcing exact handwritten prose. 
- Remove families of prose-token synchronization that are low-value or oracle-less while preserving structural, parseable, and source-backed validations. 
- Preserve narrow, high-consequence workflow/security and repository release non-mutation checks (Z02-style) and avoid expanding validator scope.

### Description
- Remove many prose-oriented validation families from `scripts/validate_docs_contracts.py` and keep focused structural/source-backed checks such as Markdown navigation/link resolution, dead-link detection, TOML parsing for examples, crate rustdoc README includes, removed-public-API detection, CI-step argument checks, and the manual-release boundary classifier. 
- Simplify controller README validation to parse the fenced TOML examples and validate shape and documented `run_end_policy.kind` values against the actual Rust enum derived from `tailtriage-controller/src/lib.rs`. 
- Drop broad prose synchronization including governance, analyzer-rationale tokens, user/operations guide wording policing, tracing migration wording checks, Run-schema prose synchronization, and the duplicated `ANALYZER_V1_VALID_PATHS` path-synchronization checks; tests exercising those prose-only invariants were removed or rewritten. 
- Update `scripts/tests/test_validate_docs_contracts.py` to retain tests that exercise parsing, path resolution, repository-escape rejection, TOML structure, removed-API detection, CI/workflow step inspection, and manual-release boundary false-positive protection, and add small exercised helpers for inert-command text protection.

### Testing
- Ran `python3 -m unittest scripts.tests.test_validate_docs_contracts` and `python3 -m unittest scripts.tests.test_check_workflow_security` and both suites passed (`33` tests and `11` tests respectively passed). 
- Executed `python3 scripts/check_workflow_security.py` and `python3 scripts/validate_docs_contracts.py` and both completed successfully, and repository completion checks `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, and `cargo test --workspace --all-targets --all-features --locked` also passed. 
- Work carried in a single commit `af38a564059fe85cfccfa07edd8aee6d7a8971fb` touching `scripts/validate_docs_contracts.py` and `scripts/tests/test_validate_docs_contracts.py`, and the worktree is clean after the commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8b6dcc0010833095a929222fb7f289)