### PR TITLE
test: add audited TT-TEST markers to core/controller/tokio/axum

### DIFF
--- a/tailtriage-axum/src/lib.rs
+++ b/tailtriage-axum/src/lib.rs
@@ -159,6 +159,7 @@ mod tests {
     use axum::http::StatusCode;
     use tailtriage_core::Outcome;
 
+    // TT-TEST: X02 primary
     #[test]
     fn default_status_mapping_matches_http_contract() {
         assert_eq!(default_status_to_outcome(StatusCode::OK), Outcome::Ok);

--- a/tailtriage-axum/tests/axum_adapter.rs
+++ b/tailtriage-axum/tests/axum_adapter.rs
@@ -43,6 +43,7 @@ async fn timeout_handler(TailtriageRequest(_): TailtriageRequest) -> StatusCode 
     StatusCode::REQUEST_TIMEOUT
 }
 
+// TT-TEST: X01 primary
 #[tokio::test(flavor = "current_thread")]
 async fn middleware_injects_request_handle_and_finishes_from_response_status() {
     let nanos = SystemTime::now()
@@ -113,6 +114,7 @@ async fn middleware_injects_request_handle_and_finishes_from_response_status() {
     assert_eq!(failure.outcome, "error");
 }
 
+// TT-TEST: X02 primary
 #[tokio::test(flavor = "current_thread")]
 async fn middleware_records_default_http_outcomes_in_snapshot() {
     let tailtriage = Arc::new(
@@ -172,6 +174,7 @@ async fn middleware_records_default_http_outcomes_in_snapshot() {
     assert_eq!(outcome_for("/fail"), "error");
 }
 
+// TT-TEST: X02 primary
 #[tokio::test(flavor = "current_thread")]
 async fn configurable_middleware_classifier_changes_recorded_outcome() {
     let tailtriage = Arc::new(

--- a/tailtriage-controller/src/lib.rs
+++ b/tailtriage-controller/src/lib.rs
@@ -2251,6 +2251,7 @@ mod tests {
         fs::write(path, content).expect("complete config write should succeed");
     }
 
+    // TT-TEST: G01 secondary
     #[test]
     fn enable_capture_disable_finalizes_generation() {
         let output = test_output("enable-capture-disable");
@@ -2283,6 +2284,7 @@ mod tests {
         fs::remove_file(expected).expect("cleanup should succeed");
     }
 
+    // TT-TEST: G02 secondary
     #[test]
     #[allow(clippy::too_many_lines)]
     fn admission_and_disable_linearize_without_generation_migration() {
@@ -2453,6 +2455,7 @@ mod tests {
         fs::remove_file(generation_two.artifact_path).expect("cleanup generation 2 artifact");
     }
 
+    // TT-TEST: support
     #[test]
     fn active_generation_started_at_matches_underlying_run_metadata() {
         let output = test_output("generation-started-at-run-metadata");
@@ -2475,6 +2478,7 @@ mod tests {
         fs::remove_file(active.artifact_path).expect("cleanup should succeed");
     }
 
+    // TT-TEST: G05 primary
     #[test]
     fn initially_enabled_build_starts_first_active_generation() {
         let output = test_output("initially-enabled");
@@ -2500,6 +2504,7 @@ mod tests {
         fs::remove_file(active.artifact_path).expect("cleanup should succeed");
     }
 
+    // TT-TEST: support
     #[test]
     fn disabled_status_reports_next_generation() {
         let controller = TailtriageController::builder("checkout-service")
@@ -2512,6 +2517,7 @@ mod tests {
         ));
     }
 
+    // TT-TEST: G01 primary
     #[test]
     fn enable_disable_reenable_creates_distinct_generation_and_artifact() {
         let output = test_output("reenable");
@@ -2539,6 +2545,7 @@ mod tests {
         fs::remove_file(second.artifact_path).expect("cleanup second artifact should succeed");
     }
 
+    // TT-TEST: G02 secondary
     #[test]
     fn request_started_before_disable_can_finish_after_disable() {
         let output = test_output("finish-after-disable");
@@ -2571,6 +2578,7 @@ mod tests {
         fs::remove_file(active.artifact_path).expect("cleanup should succeed");
     }
 
+    // TT-TEST: G01 secondary
     #[test]
     fn no_new_admissions_after_disable() {
         let output = test_output("no-admissions");
@@ -2590,6 +2598,7 @@ mod tests {
         fs::remove_file(active.artifact_path).expect("cleanup should succeed");
     }
 
+    // TT-TEST: support
     #[test]
     fn default_policy_preserves_cheap_drop_after_saturation() {
         let output = test_output("default-policy-cheap-drop");
@@ -2647,6 +2656,7 @@ mod tests {
         fs::remove_file(active.artifact_path).expect("cleanup should succeed");
     }
 
+    // TT-TEST: support
     #[test]
     fn auto_seal_policy_ends_generation_after_limits_hit() {
         let output = test_output("auto-seal-policy");
@@ -2687,6 +2697,7 @@ mod tests {
         fs::remove_file(active.artifact_path).expect("cleanup should succeed");
     }
 
+    // TT-TEST: support
     #[test]
     fn admitted_request_alone_controls_auto_seal_drain() {
         let output = test_output("auto-seal-admitted-drain");
@@ -2736,6 +2747,7 @@ mod tests {
         fs::remove_file(active.artifact_path).expect("cleanup should succeed");
     }
 
+    // TT-TEST: support
     #[test]
     fn request_limit_synchronous_callback_returns_without_gate_reentry() {
         let output = test_output("synchronous-request-limit-callback");
@@ -2783,6 +2795,7 @@ mod tests {
         fs::remove_file(active.artifact_path).expect("cleanup should succeed");
     }
 
+    // TT-TEST: support
     #[test]
     fn zero_request_capacity_refuses_without_controller_inflight() {
         let output = test_output("zero-request-capacity");
@@ -2817,6 +2830,7 @@ mod tests {
         fs::remove_file(active.artifact_path).expect("cleanup should succeed");
     }
 
+    // TT-TEST: support
     #[test]
     fn runtime_snapshot_saturation_triggers_auto_seal() {
         let output = test_output("auto-seal-runtime-snapshot");
@@ -2869,6 +2883,7 @@ mod tests {
         fs::remove_file(active.artifact_path).expect("cleanup should succeed");
     }
 
+    // TT-TEST: support
     #[tokio::test(flavor = "current_thread")]
     async fn queue_saturation_triggers_auto_seal_and_waits_for_inflight_drain() {
         let output = test_output("auto-seal-queue-saturation");
@@ -2920,6 +2935,7 @@ mod tests {
         fs::remove_file(active.artifact_path).expect("cleanup should succeed");
     }
 
+    // TT-TEST: G01 secondary
     #[test]
     fn auto_seal_then_next_enable_creates_fresh_generation() {
         let output = test_output("auto-seal-next-generation");
@@ -2953,6 +2969,7 @@ mod tests {
         fs::remove_file(second.artifact_path).expect("cleanup second should succeed");
     }
 
+    // TT-TEST: G01 primary
     #[test]
     fn one_active_generation_at_a_time() {
         let controller = TailtriageController::builder("checkout-service")
@@ -2978,6 +2995,7 @@ mod tests {
         fs::remove_file(first.artifact_path).expect("cleanup should succeed");
     }
 
+    // TT-TEST: G02 primary
     #[test]
     fn request_completion_remains_bound_to_original_generation_after_reenable() {
         let output = test_output("generation-binding");
@@ -3025,6 +3043,7 @@ mod tests {
         fs::remove_file(gen_b.artifact_path).expect("cleanup generation B should succeed");
     }
 
+    // TT-TEST: support
     #[test]
     fn disabled_begin_request_is_inert_and_never_joins_later_generation() {
         let output = test_output("disabled-admission");
@@ -3056,6 +3075,7 @@ mod tests {
         fs::remove_file(active.artifact_path).expect("cleanup should succeed");
     }
 
+    // TT-TEST: support
     #[test]
     fn disabled_handle_and_completion_operations_are_noop() {
         let output = test_output("disabled-noop");
@@ -3099,6 +3119,7 @@ mod tests {
         fs::remove_file(active.artifact_path).expect("cleanup should succeed");
     }
 
+    // TT-TEST: support
     #[test]
     fn inert_disabled_request_id_contract_preserves_explicit_and_generates_fallback() {
         let output = test_output("inert-disabled-request-id");
@@ -3123,6 +3144,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn inert_closing_request_id_contract_preserves_explicit_and_generates_fallback() {
         let output = test_output("inert-closing-request-id");
@@ -3155,6 +3177,7 @@ mod tests {
         fs::remove_file(active.artifact_path).expect("cleanup should succeed");
     }
 
+    // TT-TEST: G01 secondary
     #[test]
     fn rapid_enable_disable_boundaries_keep_generation_isolation() {
         let output = test_output("rapid-boundaries");
@@ -3200,6 +3223,8 @@ mod tests {
         }
     }
 
+    // TT-TEST: C04 secondary
+    // TT-TEST: G03 primary
     #[test]
     fn completion_drain_finalizes_once_without_duplicate_side_effects() {
         let output = test_output("single-finalize");
@@ -3233,6 +3258,7 @@ mod tests {
         fs::remove_file(active.artifact_path).expect("cleanup should succeed");
     }
 
+    // TT-TEST: C03 secondary
     #[test]
     fn dropped_controller_completion_drains_closing_generation_as_cancelled() {
         let output = test_output("drop-drain-cancelled");
@@ -3267,6 +3293,7 @@ mod tests {
         fs::remove_file(active.artifact_path).expect("cleanup should succeed");
     }
 
+    // TT-TEST: C08 secondary
     #[test]
     fn controller_output_is_finalized_schema_v2() {
         let output = test_output("shutdown-active");
@@ -3318,6 +3345,7 @@ mod tests {
         fs::remove_file(active.artifact_path).expect("cleanup should succeed");
     }
 
+    // TT-TEST: G03 primary
     #[test]
     fn drain_finalization_sink_failure_is_observable_and_terminal() {
         let output = std::env::temp_dir().join(format!(
@@ -3376,6 +3404,8 @@ mod tests {
         );
     }
 
+    // TT-TEST: C07 secondary
+    // TT-TEST: G03 primary
     #[test]
     fn drain_finalization_strict_lifecycle_failure_is_observable_and_retriable() {
         let output = test_output("strict-drain-failure");
@@ -3430,6 +3460,7 @@ mod tests {
         fs::remove_file(active.artifact_path).expect("cleanup should succeed");
     }
 
+    // TT-TEST: support
     #[test]
     fn disable_error_prefix_collision_formats_original_and_typed_replay_identically() {
         const EXPECTED_DISABLE: &str = "failed to finalize generation: I/O error while writing run output: failed to finalize generation: sentinel";
@@ -3445,6 +3476,7 @@ mod tests {
         assert_eq!(replay.to_string(), EXPECTED_DISABLE);
     }
 
+    // TT-TEST: support
     #[test]
     #[allow(clippy::too_many_lines)]
     fn blocked_generation_waiter_replays_exact_failure_after_rollover() {
@@ -3582,6 +3614,7 @@ mod tests {
         fs::remove_file(gen2.artifact_path).expect("cleanup gen2 artifact should succeed");
     }
 
+    // TT-TEST: support
     #[test]
     fn generation_bound_terminal_failure_replays_after_rollover() {
         let output_dir = std::env::temp_dir().join(format!(
@@ -3648,6 +3681,7 @@ mod tests {
         fs::remove_dir_all(output_dir).expect("cleanup output dir should succeed");
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_lifecycle_failure_leaves_generation_result_pending_until_retry() {
         let output = test_output("strict-generation-result-pending");
@@ -3698,6 +3732,7 @@ mod tests {
         fs::remove_file(active.artifact_path).expect("cleanup should succeed");
     }
 
+    // TT-TEST: support
     #[test]
     fn drain_finalization_sink_failure_is_not_retried_after_environment_fix() {
         let output_dir = std::env::temp_dir().join(format!(
@@ -3747,6 +3782,7 @@ mod tests {
         fs::remove_dir_all(output_dir).expect("cleanup output dir should succeed");
     }
 
+    // TT-TEST: G05 primary
     #[test]
     fn toml_parsing_success_and_failure() {
         let output = test_output("toml-parse");
@@ -3783,6 +3819,7 @@ mod tests {
         fs::remove_file(config).expect("config cleanup should succeed");
     }
 
+    // TT-TEST: G04 secondary
     #[test]
     fn builder_direct_reload_and_config_reload_share_template_resolution() {
         let output = test_output("complete-template-resolution");
@@ -3863,6 +3900,7 @@ mod tests {
         fs::remove_file(config).expect("config cleanup should succeed");
     }
 
+    // TT-TEST: support
     #[test]
     fn toml_parses_windows_style_escaped_output_path() {
         let config_toml = r#"[controller]
@@ -3887,6 +3925,7 @@ output_path = "C:\\Users\\someone\\AppData\\Local\\Temp\\tailtriage.json"
         );
     }
 
+    // TT-TEST: G04 primary
     #[test]
     fn reload_updates_next_activation_template_only() {
         let output_before = test_output("reload-template-before");
@@ -3917,6 +3956,7 @@ output_path = "C:\\Users\\someone\\AppData\\Local\\Temp\\tailtriage.json"
         fs::remove_file(config).expect("config cleanup should succeed");
     }
 
+    // TT-TEST: G04 primary
     #[test]
     fn invalid_direct_reload_is_transactional_and_side_effect_free() {
         let output = test_output("try-reload-template-validate");
@@ -3953,6 +3993,7 @@ output_path = "C:\\Users\\someone\\AppData\\Local\\Temp\\tailtriage.json"
         assert!(!super::generated_artifact_path(&before.template.sink_template, 1).exists());
     }
 
+    // TT-TEST: G04 primary
     #[test]
     fn sampler_template_reload_is_side_effect_free_until_enable() {
         let output = test_output("sampler-reload-side-effect-free");
@@ -3986,6 +4027,7 @@ output_path = "C:\\Users\\someone\\AppData\\Local\\Temp\\tailtriage.json"
         ));
     }
 
+    // TT-TEST: G04 primary
     #[test]
     fn invalid_config_reload_is_transactional_and_side_effect_free() {
         let output = test_output("reload-config-validate");
@@ -4036,6 +4078,7 @@ kind = "continue_after_limits_hit"
         fs::remove_file(config).expect("config cleanup should succeed");
     }
 
+    // TT-TEST: support
     #[test]
     fn controller_recovers_after_poisoned_lifecycle_lock() {
         let output = test_output("poisoned-lock-recovery");
@@ -4064,6 +4107,7 @@ kind = "continue_after_limits_hit"
         ));
     }
 
+    // TT-TEST: G04 primary
     #[test]
     fn active_generation_keeps_original_config_after_reload() {
         let output_before = test_output("active-keeps-before");
@@ -4127,6 +4171,7 @@ kind = "continue_after_limits_hit"
         fs::remove_file(config).expect("config cleanup should succeed");
     }
 
+    // TT-TEST: G05 primary
     #[test]
     fn build_from_toml_initially_enabled_starts_generation_with_toml_activation_settings() {
         let output = test_output("toml-initially-enabled");
@@ -4197,6 +4242,7 @@ kind = "continue_after_limits_hit"
         fs::remove_file(config).expect("config cleanup should succeed");
     }
 
+    // TT-TEST: T03 secondary
     #[test]
     fn enable_with_sampler_without_tokio_runtime_returns_missing_runtime_error() {
         let output = test_output("missing-runtime");
@@ -4229,6 +4275,7 @@ kind = "continue_after_limits_hit"
         assert!(!expected_artifact.exists());
     }
 
+    // TT-TEST: G05 primary
     #[test]
     fn sparse_toml_uses_builder_fallbacks_and_activation_defaults() {
         let output = test_output("sparse-toml-defaults");
@@ -4279,6 +4326,7 @@ kind = "continue_after_limits_hit"
         fs::remove_file(config).expect("config cleanup should succeed");
     }
 
+    // TT-TEST: support
     #[test]
     fn build_with_missing_config_path_returns_config_load_error() {
         let config = test_config_path("missing-config-build");
@@ -4294,6 +4342,7 @@ kind = "continue_after_limits_hit"
         ));
     }
 
+    // TT-TEST: G05 primary
     #[test]
     fn config_service_name_overrides_builder_service_name_when_present() {
         let output = test_output("build-config-service-name-overrides");
@@ -4312,6 +4361,7 @@ kind = "continue_after_limits_hit"
         fs::remove_file(config).expect("config cleanup should succeed");
     }
 
+    // TT-TEST: G05 secondary
     #[test]
     fn blank_builder_service_name_uses_non_blank_toml_service_name() {
         let output = test_output("build-blank-builder-uses-toml");
@@ -4330,6 +4380,7 @@ kind = "continue_after_limits_hit"
         fs::remove_file(config).expect("config cleanup should succeed");
     }
 
+    // TT-TEST: support
     #[test]
     fn blank_builder_service_name_without_config_fails_build() {
         let err = TailtriageController::builder("   ")
@@ -4338,6 +4389,7 @@ kind = "continue_after_limits_hit"
         assert!(matches!(err, ControllerBuildError::EmptyServiceName));
     }
 
+    // TT-TEST: support
     #[test]
     fn blank_builder_and_blank_toml_service_name_fail_build() {
         let output = test_output("build-blank-builder-blank-toml");
@@ -4353,6 +4405,7 @@ kind = "continue_after_limits_hit"
         fs::remove_file(config).expect("config cleanup should succeed");
     }
 
+    // TT-TEST: support
     #[test]
     fn build_from_toml_with_blank_service_name_returns_empty_service_name_error() {
         let config = test_config_path("toml-empty-service-name");
@@ -4379,6 +4432,7 @@ output_path = "tailtriage-run.json"
         fs::remove_file(config).expect("config cleanup should succeed");
     }
 
+    // TT-TEST: G05 primary
     #[test]
     fn build_from_toml_with_invalid_mode_returns_parse_error() {
         let config = test_config_path("toml-invalid-mode");
@@ -4407,6 +4461,7 @@ output_path = "tailtriage-run.json"
         fs::remove_file(config).expect("config cleanup should succeed");
     }
 
+    // TT-TEST: support
     #[test]
     fn build_from_toml_with_invalid_run_end_policy_kind_returns_parse_error() {
         let config = test_config_path("toml-invalid-run-end-policy");
@@ -4438,6 +4493,7 @@ kind = "not-a-real-policy"
         fs::remove_file(config).expect("config cleanup should succeed");
     }
 
+    // TT-TEST: support
     #[test]
     fn build_from_toml_with_run_end_policy_table_missing_kind_returns_parse_error() {
         let config = test_config_path("toml-run-end-policy-missing-kind");
@@ -4468,6 +4524,7 @@ output_path = "tailtriage-run.json"
         fs::remove_file(config).expect("config cleanup should succeed");
     }
 
+    // TT-TEST: support
     #[test]
     fn build_from_toml_with_invalid_sink_type_returns_parse_error() {
         let config = test_config_path("toml-invalid-sink-type");
@@ -4496,6 +4553,7 @@ output_path = "tailtriage-run.json"
         fs::remove_file(config).expect("config cleanup should succeed");
     }
 
+    // TT-TEST: T03 secondary
     #[test]
     fn build_from_toml_initially_enabled_sampler_without_runtime_returns_initial_enable_error() {
         let config = test_config_path("toml-initially-enabled-missing-runtime");
@@ -4530,6 +4588,7 @@ max_runtime_snapshots = 10
         fs::remove_file(config).expect("config cleanup should succeed");
     }
 
+    // TT-TEST: support
     #[test]
     fn reload_config_after_config_file_deleted_returns_load_error() {
         let output = test_output("reload-deleted-config");
@@ -4548,6 +4607,7 @@ max_runtime_snapshots = 10
         ));
     }
 
+    // TT-TEST: T04 secondary
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn armed_generation_with_sampler_enabled_records_effective_metadata() {
         let output = test_output("sampler-enabled");
@@ -4590,6 +4650,7 @@ max_runtime_snapshots = 10
         fs::remove_file(active.artifact_path).expect("cleanup should succeed");
     }
 
+    // TT-TEST: T04 secondary
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn armed_generation_with_sampler_disabled_keeps_sampler_metadata_empty() {
         let output = test_output("sampler-disabled");
@@ -4618,6 +4679,7 @@ max_runtime_snapshots = 10
         fs::remove_file(active.artifact_path).expect("cleanup should succeed");
     }
 
+    // TT-TEST: G01 secondary
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn sampler_stops_on_disarm_and_reenable_uses_fresh_generation_sampler_lifecycle() {
         let output = test_output("sampler-reenable");

--- a/tailtriage-core/src/artifact.rs
+++ b/tailtriage-core/src/artifact.rs
@@ -103,11 +103,13 @@ mod tests {
         decode_run_json_reader(Cursor::new(bytes))
     }
 
+    // TT-TEST: S02 primary
     #[test]
     fn valid_supported_run_decodes() {
         assert!(decode(&valid()).is_ok());
     }
 
+    // TT-TEST: S02 primary
     #[test]
     fn malformed_and_truncated_json_are_rejected() {
         assert!(matches!(
@@ -120,6 +122,7 @@ mod tests {
         ));
     }
 
+    // TT-TEST: S02 primary
     #[test]
     fn typed_shape_errors_are_rejected() {
         assert!(matches!(
@@ -142,6 +145,7 @@ mod tests {
         ));
     }
 
+    // TT-TEST: S02 primary
     #[test]
     fn structurally_valid_unsupported_schema_has_dedicated_error() {
         let data = String::from_utf8(valid())
@@ -156,6 +160,7 @@ mod tests {
         ));
     }
 
+    // TT-TEST: S02 primary
     #[test]
     fn trailing_content_is_rejected() {
         let mut data = valid();
@@ -166,6 +171,7 @@ mod tests {
         ));
     }
 
+    // TT-TEST: S02 primary
     #[test]
     fn deep_json_fails_under_normal_recursion_protection() {
         let nesting_depth = 256;
@@ -185,6 +191,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn unknown_nested_fields_are_ignored() {
         let mut data = String::from_utf8(valid()).unwrap();
@@ -192,6 +199,7 @@ mod tests {
         assert!(decode(data.as_bytes()).is_ok());
     }
 
+    // TT-TEST: support
     #[test]
     fn escaped_terminal_control_is_inert_string_data() {
         let data = String::from_utf8(valid()).unwrap().replace(
@@ -212,6 +220,7 @@ mod tests {
         }
     }
 
+    // TT-TEST: S02 primary
     #[test]
     fn decoder_accepts_non_seekable_reader() {
         let reader = NonSeekReader {
@@ -220,6 +229,7 @@ mod tests {
         assert!(decode_run_json_reader(reader).is_ok());
     }
 
+    // TT-TEST: support
     #[test]
     fn path_with_spaces() {
         let dir = tempfile::tempdir().unwrap();

--- a/tailtriage-core/src/collector.rs
+++ b/tailtriage-core/src/collector.rs
@@ -1030,12 +1030,14 @@ mod tests {
     use super::normalize_host_name;
     use std::ffi::OsString;
 
+    // TT-TEST: support
     #[test]
     fn normalize_host_name_rejects_blank_values() {
         assert_eq!(normalize_host_name(OsString::from("")), None);
         assert_eq!(normalize_host_name(OsString::from("   ")), None);
     }
 
+    // TT-TEST: support
     #[test]
     fn normalize_host_name_trims_non_blank_values() {
         assert_eq!(

--- a/tailtriage-core/src/lib.rs
+++ b/tailtriage-core/src/lib.rs
@@ -107,6 +107,7 @@ pub mod __internal {
     mod tests {
         use super::escape_control_chars;
 
+        // TT-TEST: S04 primary
         #[test]
         fn human_text_escaping_preserves_the_internal_integration_contract() {
             let input = "plain\\slash café 東京\n\r\t\u{1b}\u{7}\u{8}\u{7f}\u{85}";

--- a/tailtriage-core/src/sink.rs
+++ b/tailtriage-core/src/sink.rs
@@ -260,6 +260,7 @@ mod tests {
         })
     }
 
+    // TT-TEST: support
     #[test]
     fn local_sink_write_creates_deserializable_artifact() {
         let output = unique_path("success");
@@ -276,12 +277,14 @@ mod tests {
         let _ = std::fs::remove_file(output);
     }
 
+    // TT-TEST: support
     #[test]
     fn discard_sink_write_succeeds() {
         let sink = DiscardSink;
         sink.write(&sample_run()).expect("discard should succeed");
     }
 
+    // TT-TEST: support
     #[test]
     fn memory_sink_replaces_previous_run() {
         let sink = MemorySink::new();
@@ -308,6 +311,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn memory_sink_recovers_from_poisoned_mutex_operations() {
         let sink = MemorySink::new();
@@ -328,6 +332,7 @@ mod tests {
         assert!(sink.last_run().is_some(), "write should store run");
     }
 
+    // TT-TEST: support
     #[test]
     fn local_sink_write_replaces_existing_destination_with_new_run() {
         let output = unique_path("replace-existing");
@@ -360,6 +365,7 @@ mod tests {
         let _ = std::fs::remove_file(output);
     }
 
+    // TT-TEST: support
     #[test]
     fn failed_finalization_keeps_existing_destination_unchanged() {
         let output = unique_path("finalization-failure");
@@ -377,6 +383,7 @@ mod tests {
         let _ = std::fs::remove_file(output);
     }
 
+    // TT-TEST: support
     #[test]
     fn local_sink_failed_finalization_cleans_up_temp_file_and_preserves_final_path() {
         let output = std::env::temp_dir().join(format!(

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -27,6 +27,7 @@ fn build_for_test(name: &str, filename: &str) -> Tailtriage {
         .expect("build should succeed")
 }
 
+// TT-TEST: support
 #[test]
 fn rejects_blank_service_name() {
     let err = Tailtriage::builder("   ")
@@ -35,6 +36,7 @@ fn rejects_blank_service_name() {
     assert_eq!(err, BuildError::EmptyServiceName);
 }
 
+// TT-TEST: C01 primary
 #[test]
 fn started_request_records_request_event() {
     let tailtriage = build_for_test("payments", "tailtriage-core-request.json");
@@ -57,6 +59,7 @@ fn started_request_records_request_event() {
     assert_eq!(snapshot.stages.len(), 1);
 }
 
+// TT-TEST: support
 #[test]
 fn generated_request_ids_are_unique() {
     let tailtriage = build_for_test("payments", "tailtriage-core-generated-id.json");
@@ -67,6 +70,7 @@ fn generated_request_ids_are_unique() {
     second.completion.finish_ok();
 }
 
+// TT-TEST: support
 #[test]
 fn generated_default_run_ids_are_unique() {
     let first = Tailtriage::builder("payments")
@@ -82,6 +86,7 @@ fn generated_default_run_ids_are_unique() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn active_snapshot_has_no_finalization_timestamp() {
     let tailtriage = Tailtriage::builder("payments")
@@ -97,6 +102,7 @@ fn active_snapshot_has_no_finalization_timestamp() {
     assert!(serialized["metadata"].get("finished_at_unix_ms").is_none());
 }
 
+// TT-TEST: C08 primary
 #[test]
 fn serialized_completed_run_uses_schema_v2_finalization_shape() {
     let run = crate::RunBuilder::new(
@@ -118,6 +124,7 @@ fn serialized_completed_run_uses_schema_v2_finalization_shape() {
     );
 }
 
+// TT-TEST: V04 primary
 #[test]
 fn runtime_snapshot_worker_count_serde_is_optional_and_schema_v2_compatible() {
     let json = r#"{"schema_version":2,"metadata":{"run_id":"r","service_name":"s","started_at_unix_ms":1,"finalized_at_unix_ms":2,"mode":"light"},"requests":[],"stages":[],"queues":[],"inflight":[],"runtime_snapshots":[{"at_unix_ms":1,"at_run_us":null,"alive_tasks":1,"global_queue_depth":0,"local_queue_depth":null,"blocking_queue_depth":null,"remote_schedule_count":null}]}"#;
@@ -137,6 +144,7 @@ fn runtime_snapshot_worker_count_serde_is_optional_and_schema_v2_compatible() {
     assert_eq!(round_trip.runtime_snapshots[0].worker_count, Some(4));
 }
 
+// TT-TEST: support
 #[test]
 fn serialized_run_has_no_metadata_finished_at_unix_ms() {
     let run = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc"))
@@ -146,6 +154,7 @@ fn serialized_run_has_no_metadata_finished_at_unix_ms() {
     assert!(serialized["metadata"].get("finished_at_unix_ms").is_none());
 }
 
+// TT-TEST: support
 #[test]
 fn explicit_run_id_is_preserved() {
     let run = Tailtriage::builder("payments")
@@ -156,6 +165,7 @@ fn explicit_run_id_is_preserved() {
     assert_eq!(run.snapshot().metadata.run_id, "user-supplied-run-id");
 }
 
+// TT-TEST: support
 #[test]
 fn duplicate_explicit_request_ids_are_tracked_and_finished_independently() {
     let tailtriage = build_for_test("payments", "tailtriage-core-duplicate-explicit-id.json");
@@ -180,6 +190,7 @@ fn duplicate_explicit_request_ids_are_tracked_and_finished_independently() {
         .all(|warning| !warning.contains("duplicate_completed_request_id")));
 }
 
+// TT-TEST: support
 #[test]
 fn generated_request_ids_remain_warning_free_after_completion() {
     let tailtriage = build_for_test("payments", "tailtriage-core-generated-id-no-warning.json");
@@ -202,6 +213,7 @@ fn generated_request_ids_remain_warning_free_after_completion() {
         .all(|warning| !warning.contains("duplicate completed request_id")));
 }
 
+// TT-TEST: support
 #[test]
 fn duplicate_explicit_request_id_warning_is_persisted_on_shutdown() {
     let sink = Arc::new(RecordingSink::default());
@@ -237,6 +249,7 @@ fn duplicate_explicit_request_id_warning_is_persisted_on_shutdown() {
     assert!(finalized >= written.metadata.started_at_unix_ms);
 }
 
+// TT-TEST: support
 #[test]
 fn active_snapshot_preserves_pending_request_child_evidence_without_lifecycle_normalization() {
     let tailtriage = build_for_test(
@@ -274,6 +287,7 @@ fn active_snapshot_preserves_pending_request_child_evidence_without_lifecycle_no
     assert_eq!(completed.queues[0].request_id, "req-active");
 }
 
+// TT-TEST: C06 primary
 #[test]
 fn shutdown_normalizes_unfinished_request_children_without_fabricating_completion() {
     let sink = Arc::new(RecordingSink::default());
@@ -321,6 +335,7 @@ fn shutdown_normalizes_unfinished_request_children_without_fabricating_completio
     }));
 }
 
+// TT-TEST: support
 #[test]
 fn queue_stage_and_inflight_are_recorded() {
     let tailtriage = build_for_test("payments", "tailtriage-core-timers.json");
@@ -345,6 +360,7 @@ fn queue_stage_and_inflight_are_recorded() {
     assert_eq!(snapshot.stages.len(), 1);
 }
 
+// TT-TEST: support
 #[test]
 fn request_stage_and_queue_timing_preserves_order_after_sleep() {
     let tailtriage = build_for_test("payments", "tailtriage-core-sleep-timing.json");
@@ -402,6 +418,7 @@ fn request_stage_and_queue_timing_preserves_order_after_sleep() {
     assert!(queue.wait_us > 0);
 }
 
+// TT-TEST: support
 #[test]
 fn unfinished_requests_still_trigger_strict_lifecycle_errors() {
     let sink = Arc::new(RecordingSink::default());
@@ -430,6 +447,7 @@ fn unfinished_requests_still_trigger_strict_lifecycle_errors() {
     );
 }
 
+// TT-TEST: C08 primary
 #[test]
 fn shutdown_sets_one_finalization_timestamp() {
     let output = std::env::temp_dir().join("tailtriage-core-shutdown.json");
@@ -474,6 +492,7 @@ fn shutdown_sets_one_finalization_timestamp() {
     assert!(typed_finalized >= run.metadata.started_at_unix_ms);
 }
 
+// TT-TEST: support
 #[test]
 fn shutdown_with_discard_sink_succeeds() {
     let tailtriage = Tailtriage::builder("payments")
@@ -484,6 +503,7 @@ fn shutdown_with_discard_sink_succeeds() {
     tailtriage.shutdown().expect("shutdown should succeed");
 }
 
+// TT-TEST: support
 #[test]
 fn memory_sink_stores_finalized_run_after_shutdown() {
     let sink = MemorySink::new();
@@ -499,6 +519,7 @@ fn memory_sink_stores_finalized_run_after_shutdown() {
     assert_eq!(run.requests.len(), 1);
 }
 
+// TT-TEST: support
 #[test]
 fn memory_sink_last_run_returns_clone_without_clearing() {
     let sink = MemorySink::new();
@@ -514,6 +535,7 @@ fn memory_sink_last_run_returns_clone_without_clearing() {
     assert_eq!(first, second);
 }
 
+// TT-TEST: support
 #[test]
 fn memory_sink_take_run_returns_and_clears() {
     let sink = MemorySink::new();
@@ -526,6 +548,7 @@ fn memory_sink_take_run_returns_and_clears() {
     assert!(sink.last_run().is_none(), "take should clear stored run");
 }
 
+// TT-TEST: support
 #[test]
 fn memory_sink_clear_removes_stored_run() {
     let sink = MemorySink::new();
@@ -538,6 +561,7 @@ fn memory_sink_clear_removes_stored_run() {
     assert!(sink.last_run().is_none());
 }
 
+// TT-TEST: support
 #[test]
 fn memory_sink_clone_handle_observes_builder_write() {
     let sink = MemorySink::new();
@@ -555,6 +579,7 @@ fn memory_sink_clone_handle_observes_builder_write() {
     );
 }
 
+// TT-TEST: K01 primary
 #[test]
 fn capture_limits_apply_to_all_sections() {
     let limits = CaptureLimits {
@@ -612,6 +637,7 @@ fn capture_limits_apply_to_all_sections() {
     assert_eq!(snapshot.runtime_snapshots.len(), 1);
 }
 
+// TT-TEST: support
 #[test]
 fn mode_defaults_differ_between_light_and_investigation() {
     assert_ne!(
@@ -620,6 +646,7 @@ fn mode_defaults_differ_between_light_and_investigation() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn capture_limits_remains_full_override() {
     let full_override = CaptureLimits {
@@ -645,6 +672,7 @@ fn capture_limits_remains_full_override() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn capture_limits_override_applies_selected_fields_on_mode_defaults() {
     let tailtriage = Tailtriage::builder("payments")
@@ -663,6 +691,7 @@ fn capture_limits_override_applies_selected_fields_on_mode_defaults() {
     assert_eq!(tailtriage.effective_core_config().capture_limits, expected);
 }
 
+// TT-TEST: support
 #[test]
 fn strict_lifecycle_is_unchanged_by_mode() {
     let light = Tailtriage::builder("payments")
@@ -680,6 +709,7 @@ fn strict_lifecycle_is_unchanged_by_mode() {
     assert!(investigation.effective_core_config().strict_lifecycle);
 }
 
+// TT-TEST: support
 #[test]
 fn selected_mode_and_effective_config_are_preserved_in_metadata() {
     let tailtriage = Tailtriage::builder("payments")
@@ -709,6 +739,7 @@ fn selected_mode_and_effective_config_are_preserved_in_metadata() {
     );
 }
 
+// TT-TEST: T03 secondary
 #[test]
 fn runtime_sampler_registration_is_single_start_and_metadata_cannot_be_overwritten() {
     let tailtriage = Tailtriage::builder("payments")
@@ -744,6 +775,7 @@ fn runtime_sampler_registration_is_single_start_and_metadata_cannot_be_overwritt
     );
 }
 
+// TT-TEST: K01 secondary
 #[test]
 fn limit_hit_flag_is_set_when_truncation_occurs() {
     let tailtriage = Tailtriage::builder("payments")
@@ -765,6 +797,7 @@ fn limit_hit_flag_is_set_when_truncation_occurs() {
     assert!(snapshot.truncation.dropped_requests > 0);
 }
 
+// TT-TEST: K01 primary
 #[test]
 fn saturation_preserves_exact_drop_counts_across_sections() {
     let tailtriage = Tailtriage::builder("payments")
@@ -826,6 +859,7 @@ fn saturation_preserves_exact_drop_counts_across_sections() {
     assert_eq!(snapshot.truncation.dropped_runtime_snapshots, 2);
 }
 
+// TT-TEST: K01 primary
 #[test]
 fn request_admission_bounds_retained_plus_pending_and_makes_refused_children_inert() {
     let tailtriage = Tailtriage::builder("request-admission-bound")
@@ -875,6 +909,7 @@ fn request_admission_bounds_retained_plus_pending_and_makes_refused_children_ine
     assert!(run.truncation.limits_hit);
 }
 
+// TT-TEST: K01 primary
 #[test]
 fn shutdown_counts_only_admitted_pending_requests_after_saturation() {
     let sink = MemorySink::new();
@@ -910,6 +945,7 @@ fn shutdown_counts_only_admitted_pending_requests_after_saturation() {
     drop(refused.completion);
 }
 
+// TT-TEST: K01 primary
 #[test]
 fn concurrent_request_admission_cannot_exceed_retained_plus_pending_limit() {
     const CALLERS: usize = 8;
@@ -951,6 +987,7 @@ fn concurrent_request_admission_cannot_exceed_retained_plus_pending_limit() {
     assert!(run.truncation.limits_hit);
 }
 
+// TT-TEST: K01 primary
 #[test]
 fn shutdown_artifact_includes_post_saturation_drops() {
     let sink = Arc::new(RecordingSink::default());
@@ -1014,6 +1051,7 @@ fn shutdown_artifact_includes_post_saturation_drops() {
     assert_eq!(artifact.truncation.dropped_runtime_snapshots, 2);
 }
 
+// TT-TEST: K01 secondary
 #[test]
 fn unsaturated_runs_keep_zero_truncation_counters() {
     let tailtriage = Tailtriage::builder("payments")
@@ -1055,6 +1093,7 @@ fn unsaturated_runs_keep_zero_truncation_counters() {
     assert_eq!(snapshot.truncation.dropped_runtime_snapshots, 0);
 }
 
+// TT-TEST: support
 #[test]
 fn mode_does_not_change_event_types_or_lifecycle_shape() {
     let light = Tailtriage::builder("payments")
@@ -1091,6 +1130,7 @@ fn mode_does_not_change_event_types_or_lifecycle_shape() {
     assert_eq!(investigation_snapshot.stages.len(), 1);
 }
 
+// TT-TEST: support
 #[test]
 fn schema_v2_artifact_without_effective_core_config_deserializes_as_unknown() {
     let legacy = serde_json::json!({
@@ -1171,6 +1211,7 @@ fn schema_v2_artifact_without_effective_core_config_deserializes_as_unknown() {
     assert_eq!(parsed.runtime_snapshots[0].at_run_us, None);
 }
 
+// TT-TEST: support
 #[test]
 fn run_deserialization_ignores_unknown_metadata_fields() {
     let with_extra = serde_json::json!({
@@ -1244,6 +1285,7 @@ fn run_deserialization_ignores_unknown_metadata_fields() {
     assert_eq!(parsed.metadata.finalized_at_unix_ms, Some(2));
 }
 
+// TT-TEST: C01 primary
 #[test]
 fn finish_records_outcome() {
     let tailtriage = build_for_test("payments", "tailtriage-core-finish.json");
@@ -1257,6 +1299,7 @@ fn finish_records_outcome() {
     assert_eq!(snapshot.requests[0].outcome, "ok");
 }
 
+// TT-TEST: C01 secondary
 #[test]
 fn finish_result_maps_result_to_request_outcome() {
     let tailtriage = build_for_test("payments", "tailtriage-core-finish-result.json");
@@ -1281,6 +1324,7 @@ fn finish_result_maps_result_to_request_outcome() {
     assert_eq!(snapshot.requests[1].outcome, "error");
 }
 
+// TT-TEST: C02 primary
 #[test]
 fn owned_started_request_maps_result_to_request_outcome() {
     let tailtriage = Arc::new(build_for_test(
@@ -1318,6 +1362,7 @@ async fn stage_in_helper_layer(
         .await
 }
 
+// TT-TEST: C02 primary
 #[test]
 fn request_handle_supports_fractured_code_usage() {
     let tailtriage = build_for_test("payments", "tailtriage-core-fractured.json");
@@ -1342,6 +1387,7 @@ fn request_handle_supports_fractured_code_usage() {
     assert_eq!(snapshot.queues.len(), 1);
 }
 
+// TT-TEST: support
 #[test]
 fn shutdown_warns_with_unfinished_requests() {
     let tailtriage = build_for_test("payments", "tailtriage-core-unfinished.json");
@@ -1357,6 +1403,7 @@ fn shutdown_warns_with_unfinished_requests() {
     assert!(!snapshot.metadata.lifecycle_warnings.is_empty());
 }
 
+// TT-TEST: support
 #[test]
 fn strict_lifecycle_fails_shutdown_with_unfinished_requests() {
     let tailtriage = Tailtriage::builder("payments")
@@ -1375,6 +1422,7 @@ fn strict_lifecycle_fails_shutdown_with_unfinished_requests() {
     ));
 }
 
+// TT-TEST: support
 #[test]
 fn custom_sink_receives_shutdown_run() {
     let sink = Arc::new(RecordingSink::default());
@@ -1398,6 +1446,7 @@ fn custom_sink_receives_shutdown_run() {
     assert_eq!(stored.requests.len(), 1);
 }
 
+// TT-TEST: C03 secondary
 #[test]
 fn dropping_unfinished_completion_records_cancelled_without_panic() {
     let tailtriage = build_for_test("payments", "tailtriage-core-drop-unfinished.json");
@@ -1413,6 +1462,7 @@ fn dropping_unfinished_completion_records_cancelled_without_panic() {
     assert_eq!(snapshot.requests[0].outcome, "cancelled");
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_creates_empty_run_with_explicit_metadata() {
     let limits = CaptureLimits {
@@ -1475,12 +1525,14 @@ fn run_builder_creates_empty_run_with_explicit_metadata() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_rejects_blank_service_name() {
     let err = crate::RunBuilder::new(crate::RunBuilderOptions::new("  ")).expect_err("should fail");
     assert_eq!(err, BuildError::EmptyServiceName);
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_default_run_ids_are_unique() {
     let first = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc"))
@@ -1492,6 +1544,7 @@ fn run_builder_default_run_ids_are_unique() {
     assert_ne!(first.metadata.run_id, second.metadata.run_id);
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_defaults_host_and_pid_to_none() {
     let run = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc"))
@@ -1501,6 +1554,7 @@ fn run_builder_defaults_host_and_pid_to_none() {
     assert!(run.metadata.pid.is_none());
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_defaults_start_and_finalization_from_one_timestamp() {
     let run = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc"))
@@ -1512,6 +1566,7 @@ fn run_builder_defaults_start_and_finalization_from_one_timestamp() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_preserves_explicit_start_and_finalization() {
     let run = crate::RunBuilder::new(
@@ -1525,6 +1580,7 @@ fn run_builder_preserves_explicit_start_and_finalization() {
     assert_eq!(run.metadata.finalized_at_unix_ms, Some(777));
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_preserves_explicit_start_with_default_finalization() {
     let run = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").started_at_unix_ms(100))
@@ -1533,6 +1589,7 @@ fn run_builder_preserves_explicit_start_with_default_finalization() {
     assert!(run.metadata.finalized_at_unix_ms.expect("finalized") >= 100);
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_preserves_explicit_finalization_with_default_start() {
     let run =
@@ -1542,6 +1599,7 @@ fn run_builder_preserves_explicit_finalization_with_default_start() {
     assert_eq!(run.metadata.finalized_at_unix_ms, Some(u64::MAX));
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_allows_equal_timestamp_bounds() {
     let run = crate::RunBuilder::new(
@@ -1556,6 +1614,7 @@ fn run_builder_allows_equal_timestamp_bounds() {
     assert_eq!(run.metadata.finalized_at_unix_ms, Some(100));
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_rejects_finalization_before_start() {
     let err = crate::RunBuilder::new(
@@ -1574,6 +1633,7 @@ fn run_builder_rejects_finalization_before_start() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_default_timestamps_produce_valid_finalized_run() {
     let run = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc"))
@@ -1586,6 +1646,7 @@ fn run_builder_default_timestamps_produce_valid_finalized_run() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_strict_lifecycle_in_effective_core_config() {
     let run = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").strict_lifecycle(true))
@@ -1599,6 +1660,7 @@ fn run_builder_strict_lifecycle_in_effective_core_config() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_set_run_end_reason_if_absent_only_sets_once() {
     let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
@@ -1611,6 +1673,7 @@ fn run_builder_set_run_end_reason_if_absent_only_sets_once() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_preserves_lifecycle_warnings() {
     let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
@@ -1623,6 +1686,7 @@ fn run_builder_preserves_lifecycle_warnings() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_preserves_unfinished_requests() {
     let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
@@ -1680,6 +1744,7 @@ fn test_queue_event(request_id: &str, queue: &str) -> crate::QueueEvent {
     }
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_applies_request_limit_and_updates_truncation() {
     let limits = CaptureLimits {
@@ -1710,6 +1775,7 @@ fn run_builder_applies_request_limit_and_updates_truncation() {
     assert!(run.truncation.is_truncated());
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_applies_stage_limit_and_updates_truncation() {
     let limits = CaptureLimits {
@@ -1743,6 +1809,7 @@ fn run_builder_applies_stage_limit_and_updates_truncation() {
     assert!(run.truncation.is_truncated());
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_applies_queue_limit_and_updates_truncation() {
     let limits = CaptureLimits {
@@ -1776,6 +1843,7 @@ fn run_builder_applies_queue_limit_and_updates_truncation() {
     assert!(run.truncation.is_truncated());
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_applies_inflight_snapshot_limit_and_updates_truncation() {
     let limits = CaptureLimits {
@@ -1816,6 +1884,7 @@ fn run_builder_applies_inflight_snapshot_limit_and_updates_truncation() {
     assert!(run.truncation.is_truncated());
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_applies_runtime_snapshot_limit_and_updates_truncation() {
     let limits = CaptureLimits {
@@ -1864,6 +1933,7 @@ fn run_builder_applies_runtime_snapshot_limit_and_updates_truncation() {
     assert!(run.truncation.is_truncated());
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_does_not_report_truncation_within_limits() {
     let limits = CaptureLimits {
@@ -1920,6 +1990,7 @@ fn run_builder_does_not_report_truncation_within_limits() {
     assert!(!run.truncation.is_truncated());
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_uses_mode_default_limits_when_limits_not_explicit() {
     let default_limits = CaptureMode::Light.core_defaults();
@@ -1938,6 +2009,7 @@ fn run_builder_uses_mode_default_limits_when_limits_not_explicit() {
     assert!(run.truncation.is_truncated());
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_valid_pushes_return_ok() {
     let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
@@ -1968,6 +2040,7 @@ fn run_builder_valid_pushes_return_ok() {
         .is_ok());
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_event_validation_rejects_invalid_shapes() {
     let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
@@ -2042,6 +2115,7 @@ fn run_builder_event_validation_rejects_invalid_shapes() {
         .is_err());
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_rejects_inverted_request_run_relative_offsets() {
     let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
@@ -2062,6 +2136,7 @@ fn run_builder_rejects_inverted_request_run_relative_offsets() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_rejects_inverted_stage_run_relative_offsets() {
     let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
@@ -2082,6 +2157,7 @@ fn run_builder_rejects_inverted_stage_run_relative_offsets() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_rejects_inverted_queue_run_relative_offsets() {
     let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
@@ -2102,6 +2178,7 @@ fn run_builder_rejects_inverted_queue_run_relative_offsets() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_accepts_incomplete_run_relative_offsets() {
     let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
@@ -2130,6 +2207,7 @@ fn run_builder_accepts_incomplete_run_relative_offsets() {
     assert_eq!(run.queues[0].waited_until_run_us, None);
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_accepts_authoritative_request_latency_when_timestamps_disagree() {
     let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
@@ -2145,6 +2223,7 @@ fn run_builder_accepts_authoritative_request_latency_when_timestamps_disagree() 
     assert_eq!(run.requests[0].latency_us, 50_000);
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_accepts_authoritative_stage_latency_when_timestamps_disagree() {
     let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
@@ -2163,6 +2242,7 @@ fn run_builder_accepts_authoritative_stage_latency_when_timestamps_disagree() {
     assert_eq!(run.stages[0].latency_us, 50_000);
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_accepts_authoritative_queue_wait_when_timestamps_disagree() {
     let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
@@ -2181,6 +2261,7 @@ fn run_builder_accepts_authoritative_queue_wait_when_timestamps_disagree() {
     assert_eq!(run.queues[0].wait_us, 50_000);
 }
 
+// TT-TEST: support
 #[test]
 fn run_builder_zero_duration_timestamps_with_zero_duration_are_accepted() {
     let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
@@ -2192,6 +2273,7 @@ fn run_builder_zero_duration_timestamps_with_zero_duration_are_accepted() {
     assert!(builder.push_request(request).is_ok());
 }
 
+// TT-TEST: support
 #[test]
 fn record_runtime_snapshot_stamps_run_relative_time_when_missing() {
     let tailtriage = build_for_test("runtime", "runtime-run-relative.json");
@@ -2231,6 +2313,7 @@ mod run_validation_contract {
         })
     }
 
+    // TT-TEST: V04 primary
     #[test]
     fn invalid_worker_count_is_rejected_strictly_and_cleared_permissively() {
         let mut run = base_run();
@@ -2282,6 +2365,7 @@ mod run_validation_contract {
         }
     }
 
+    // TT-TEST: support
     #[test]
     fn multiple_invalid_worker_counts_are_grouped_and_each_snapshot_is_retained() {
         let mut run = base_run();
@@ -2343,6 +2427,7 @@ mod run_validation_contract {
         }
     }
 
+    // TT-TEST: support
     #[test]
     fn positive_and_absent_worker_counts_are_valid() {
         for worker_count in [None, Some(1), Some(4)] {
@@ -2407,6 +2492,7 @@ mod run_validation_contract {
         }
     }
 
+    // TT-TEST: V01 primary
     #[test]
     fn issue_code_labels_are_stable() {
         assert_eq!(
@@ -2455,6 +2541,7 @@ mod run_validation_contract {
         );
     }
 
+    // TT-TEST: V02 primary
     #[test]
     fn timing_errors_clear_offsets_but_retain_duration_authority() {
         let mut run = base_run();
@@ -2478,6 +2565,7 @@ mod run_validation_contract {
             .any(|i| i.code == RunValidationIssueCode::DurationMismatch));
     }
 
+    // TT-TEST: V02 primary
     #[test]
     fn duplicates_are_all_excluded_with_children() {
         let mut run = base_run();
@@ -2509,6 +2597,7 @@ mod run_validation_contract {
             .any(|i| i.code == RunValidationIssueCode::AmbiguousParentRequestId));
     }
 
+    // TT-TEST: support
     #[test]
     fn mixed_invalid_and_valid_same_id_retains_valid_parent_and_child() {
         let mut run = base_run();
@@ -2538,6 +2627,7 @@ mod run_validation_contract {
         }));
     }
 
+    // TT-TEST: V02 primary
     #[test]
     fn parent_states_classify_unique_ambiguous_excluded_only_and_absent_children() {
         let mut run = base_run();
@@ -2568,6 +2658,7 @@ mod run_validation_contract {
         }
     }
 
+    // TT-TEST: V02 primary
     #[test]
     fn run_builder_excludes_child_only_stage_and_queue_with_durable_orphan_summary() {
         let mut builder = RunBuilder::new(RunBuilderOptions::new("svc")).expect("builder");
@@ -2590,6 +2681,7 @@ mod run_validation_contract {
         }));
     }
 
+    // TT-TEST: V01 primary
     #[test]
     fn validation_summaries_describe_actual_effects_exactly() {
         let mut run = base_run();
@@ -2626,6 +2718,7 @@ mod run_validation_contract {
         );
     }
 
+    // TT-TEST: V01 primary
     #[test]
     fn validation_summaries_use_stable_labels_and_lifecycle_filtering() {
         let mut run = base_run();
@@ -2650,6 +2743,7 @@ mod run_validation_contract {
             .any(|summary| summary.contains("orphan_request_scoped_event")));
     }
 
+    // TT-TEST: support
     #[test]
     #[allow(clippy::too_many_lines)]
     fn mixed_candidate_has_exact_issue_and_disposition_contract() {
@@ -2891,6 +2985,7 @@ mod run_validation_contract {
             .any(|issue| issue.severity == RunValidationSeverity::Error));
     }
 
+    // TT-TEST: support
     #[test]
     #[allow(clippy::too_many_lines)]
     fn zero_request_runs_are_generically_valid_but_other_sections_are_inspected() {
@@ -3039,6 +3134,7 @@ mod run_validation_contract {
         assert_eq!(indices, (0..retained_count).collect::<Vec<_>>());
     }
 
+    // TT-TEST: support
     #[test]
     fn orphan_outside_and_legacy_duration_only_child_policy_is_deterministic() {
         let mut run = base_run();
@@ -3100,6 +3196,7 @@ mod run_validation_contract {
     }
 }
 
+// TT-TEST: C03 primary
 #[test]
 fn borrowed_completion_drop_records_cancelled_request() {
     let sink = MemorySink::new();
@@ -3129,6 +3226,7 @@ fn borrowed_completion_drop_records_cancelled_request() {
     assert_eq!(run.metadata.unfinished_requests.count, 0);
 }
 
+// TT-TEST: C03 primary
 #[test]
 fn owned_completion_drop_records_cancelled_request() {
     let sink = MemorySink::new();
@@ -3155,6 +3253,7 @@ fn owned_completion_drop_records_cancelled_request() {
     assert_eq!(run.metadata.unfinished_requests.count, 0);
 }
 
+// TT-TEST: C04 primary
 #[test]
 fn explicit_finish_disarms_drop_without_duplicate_cancelled_event() {
     let tailtriage = build_for_test("payments", "tailtriage-core-explicit-disarms.json");
@@ -3167,6 +3266,7 @@ fn explicit_finish_disarms_drop_without_duplicate_cancelled_event() {
     assert_eq!(snapshot.requests[0].outcome, "error");
 }
 
+// TT-TEST: C03 primary
 #[test]
 fn completion_drop_during_unwind_is_non_panicking_and_cancelled() {
     let tailtriage = Tailtriage::builder("payments")
@@ -3201,6 +3301,7 @@ impl crate::RunSink for Arc<CountingFailSink> {
     }
 }
 
+// TT-TEST: C05 primary
 #[test]
 fn sink_failure_is_terminal_and_late_mutations_are_inert() {
     let sink = Arc::new(CountingFailSink::default());
@@ -3234,6 +3335,7 @@ fn sink_failure_is_terminal_and_late_mutations_are_inert() {
     assert_eq!(tailtriage.snapshot(), before);
 }
 
+// TT-TEST: C07 primary
 #[test]
 fn strict_shutdown_with_pending_is_side_effect_free_and_retryable_after_drop() {
     let sink = Arc::new(RecordingSink::default());
@@ -3282,6 +3384,7 @@ impl crate::RunSink for Arc<BlockingSink> {
     }
 }
 
+// TT-TEST: C05 secondary
 #[test]
 fn shutdown_wins_before_drop_keeps_request_unfinished_only() {
     let (entered_tx, entered_rx) = std::sync::mpsc::channel();
@@ -3333,6 +3436,7 @@ fn inflight_counts(run: &crate::Run) -> Vec<u64> {
     run.inflight.iter().map(|snapshot| snapshot.count).collect()
 }
 
+// TT-TEST: K01 primary
 #[test]
 fn inflight_drop_records_zero_then_removes_live_entry() {
     let tailtriage = Tailtriage::builder("inflight-zero")
@@ -3344,6 +3448,7 @@ fn inflight_drop_records_zero_then_removes_live_entry() {
     assert_eq!(tailtriage.live_inflight_gauge_count(), 0);
 }
 
+// TT-TEST: K01 primary
 #[test]
 fn inflight_label_reuse_records_one_zero_one_zero() {
     let tailtriage = Tailtriage::builder("inflight-reuse")
@@ -3356,6 +3461,7 @@ fn inflight_label_reuse_records_one_zero_one_zero() {
     assert_eq!(tailtriage.live_inflight_gauge_count(), 0);
 }
 
+// TT-TEST: K01 primary
 #[test]
 fn inflight_many_distinct_labels_leave_no_live_entries() {
     const LABELS: usize = 32;
@@ -3379,6 +3485,7 @@ fn inflight_many_distinct_labels_leave_no_live_entries() {
     assert_eq!(tailtriage.live_inflight_gauge_count(), 0);
 }
 
+// TT-TEST: K01 primary
 #[test]
 fn inflight_concurrent_same_label_records_exact_balanced_sequence() {
     const N: usize = 8;
@@ -3406,6 +3513,7 @@ fn inflight_concurrent_same_label_records_exact_balanced_sequence() {
     assert_eq!(tailtriage.live_inflight_gauge_count(), 0);
 }
 
+// TT-TEST: K01 primary
 #[test]
 fn inflight_zero_cleanup_survives_snapshot_retention_saturation() {
     let tailtriage = Tailtriage::builder("inflight-saturated")
@@ -3423,6 +3531,7 @@ fn inflight_zero_cleanup_survives_snapshot_retention_saturation() {
     assert_eq!(tailtriage.live_inflight_gauge_count(), 0);
 }
 
+// TT-TEST: K01 primary
 #[test]
 fn inflight_distinct_label_admission_is_bounded_and_refused_guard_is_inert() {
     let tailtriage = Tailtriage::builder("inflight-label-bound")
@@ -3459,6 +3568,7 @@ fn inflight_distinct_label_admission_is_bounded_and_refused_guard_is_inert() {
     assert!(run.truncation.limits_hit);
 }
 
+// TT-TEST: K01 primary
 #[test]
 fn concurrent_distinct_inflight_admission_cannot_exceed_limit() {
     const CALLERS: usize = 8;
@@ -3496,6 +3606,7 @@ fn concurrent_distinct_inflight_admission_cannot_exceed_limit() {
     assert!(run.truncation.limits_hit);
 }
 
+// TT-TEST: K01 secondary
 #[test]
 fn inflight_drop_before_shutdown_persists_zero() {
     let sink = MemorySink::new();
@@ -3509,6 +3620,7 @@ fn inflight_drop_before_shutdown_persists_zero() {
     assert_eq!(inflight_counts(&sink.last_run().unwrap()), vec![1, 0]);
 }
 
+// TT-TEST: C05 primary
 #[test]
 fn shutdown_before_inflight_drop_keeps_late_drop_inert() {
     let (entered_tx, entered_rx) = std::sync::mpsc::channel();
@@ -3543,6 +3655,7 @@ fn shutdown_before_inflight_drop_keeps_late_drop_inert() {
     assert_eq!(sink.calls.load(std::sync::atomic::Ordering::SeqCst), 1);
 }
 
+// TT-TEST: support
 #[test]
 fn inflight_drop_during_unwind_is_non_panicking() {
     let tailtriage = Tailtriage::builder("inflight-unwind")
@@ -3558,6 +3671,7 @@ fn inflight_drop_during_unwind_is_non_panicking() {
     assert_eq!(tailtriage.live_inflight_gauge_count(), 0);
 }
 
+// TT-TEST: support
 #[test]
 fn inflight_drop_contains_panicking_limits_listener() {
     let tailtriage = Tailtriage::builder("inflight-listener-panic")
@@ -3579,6 +3693,7 @@ fn inflight_drop_contains_panicking_limits_listener() {
     assert_eq!(tailtriage.live_inflight_gauge_count(), 0);
 }
 
+// TT-TEST: support
 #[test]
 fn inflight_snapshot_serialization_contract_and_schema_stay_unchanged() {
     assert_eq!(crate::SCHEMA_VERSION, 2);
@@ -3618,18 +3733,21 @@ mod prompt09_partial_events {
             .unwrap()
     }
 
+    // TT-TEST: support
     #[test]
     fn legacy_stage_event_missing_completed_deserializes_true() {
         let event: StageEvent = serde_json::from_str(r#"{"request_id":"r","stage":"db","started_at_unix_ms":1,"finished_at_unix_ms":2,"latency_us":3,"success":true}"#).unwrap();
         assert!(event.completed);
     }
 
+    // TT-TEST: support
     #[test]
     fn legacy_queue_event_missing_completed_deserializes_true() {
         let event: QueueEvent = serde_json::from_str(r#"{"request_id":"r","queue":"q","waited_from_unix_ms":1,"waited_until_unix_ms":2,"wait_us":3,"depth_at_start":7}"#).unwrap();
         assert!(event.completed);
     }
 
+    // TT-TEST: support
     #[test]
     fn completed_stage_and_queue_json_omit_completed_and_schema_stays_two() {
         assert_eq!(SCHEMA_VERSION, 2);
@@ -3645,6 +3763,7 @@ mod prompt09_partial_events {
         );
     }
 
+    // TT-TEST: K02 primary
     #[test]
     fn partial_stage_and_queue_json_serialize_completed_false_and_round_trip() {
         let stage = StageEvent::new("r", "db", 1, 2, 3, true).into_partial();
@@ -3683,6 +3802,7 @@ mod prompt09_partial_events {
         );
     }
 
+    // TT-TEST: K02 primary
     #[test]
     fn partial_stage_and_queue_validate_and_normalize_without_rewriting_completed() {
         let mut run = capture().snapshot();
@@ -3714,6 +3834,7 @@ mod prompt09_partial_events {
         assert_eq!(normalized.queues[0], run.queues[0]);
     }
 
+    // TT-TEST: support
     #[test]
     fn stage_await_on_immediate_ready_records_one_completed_event() {
         let tt = capture();
@@ -3730,6 +3851,7 @@ mod prompt09_partial_events {
         assert!(ev.success);
     }
 
+    // TT-TEST: support
     #[test]
     fn stage_await_value_immediate_ready_records_successful_completed_event() {
         let tt = capture();
@@ -3740,6 +3862,7 @@ mod prompt09_partial_events {
         assert!(ev.success);
     }
 
+    // TT-TEST: support
     #[test]
     fn queue_immediate_ready_records_one_completed_event() {
         let tt = capture();
@@ -3757,6 +3880,7 @@ mod prompt09_partial_events {
         assert!(ev.completed);
     }
 
+    // TT-TEST: K02 primary
     #[test]
     fn stage_pending_then_drop_records_one_partial_event() {
         let tt = capture();
@@ -3778,6 +3902,7 @@ mod prompt09_partial_events {
         assert!(ev.latency_us <= ev.finished_at_run_us.unwrap_or(u64::MAX));
     }
 
+    // TT-TEST: K02 primary
     #[test]
     fn queue_pending_then_drop_records_one_partial_event_with_depth() {
         let tt = capture();
@@ -3799,6 +3924,7 @@ mod prompt09_partial_events {
         assert!(!ev.completed);
     }
 
+    // TT-TEST: K02 primary
     #[test]
     fn stage_never_polled_drop_records_no_event() {
         let tt = capture();
@@ -3811,6 +3937,7 @@ mod prompt09_partial_events {
         assert!(tt.snapshot().stages.is_empty());
     }
 
+    // TT-TEST: K02 primary
     #[test]
     fn queue_never_polled_drop_records_no_event() {
         let tt = capture();
@@ -3823,6 +3950,7 @@ mod prompt09_partial_events {
         assert!(tt.snapshot().queues.is_empty());
     }
 
+    // TT-TEST: K02 secondary
     #[test]
     fn repeated_pending_polls_then_ready_records_completed_without_partial() {
         let tt = capture();
@@ -3842,6 +3970,7 @@ mod prompt09_partial_events {
         assert!(run.stages[0].completed);
     }
 
+    // TT-TEST: K02 secondary
     #[test]
     fn queue_repeated_pending_polls_then_ready_records_completed_without_partial() {
         let tt = capture();
@@ -3861,6 +3990,7 @@ mod prompt09_partial_events {
         assert!(run.queues[0].completed);
     }
 
+    // TT-TEST: support
     #[test]
     fn stage_panic_after_arming_does_not_double_panic_and_records_at_most_one_partial() {
         let tt = capture();
@@ -3882,6 +4012,7 @@ mod prompt09_partial_events {
         }
     }
 
+    // TT-TEST: support
     #[test]
     fn queue_panic_after_arming_does_not_double_panic_and_records_at_most_one_partial() {
         let tt = capture();
@@ -3937,6 +4068,7 @@ mod prompt09_partial_events {
         assert_eq!(events[0].depth_at_start, Some(expected_depth));
     }
 
+    // TT-TEST: support
     #[test]
     fn partial_stage_and_queue_are_preserved_through_owned_and_borrowed_handles() {
         let tt = Arc::new(capture());
@@ -4034,6 +4166,7 @@ mod prompt09_partial_events {
         assert_one_partial_queue(&run, "owned-queue-request", "owned-queue", 9);
     }
 
+    // TT-TEST: support
     #[test]
     fn pending_helper_drop_plus_completion_token_drop_records_partial_child_and_cancelled_request()
     {
@@ -4054,6 +4187,7 @@ mod prompt09_partial_events {
         assert_eq!(run.requests[0].outcome, Outcome::Cancelled.as_str());
     }
 
+    // TT-TEST: C05 primary
     #[test]
     fn armed_stage_and_queue_drop_after_finalization_leave_persisted_run_unchanged() {
         let sink = MemorySink::default();

--- a/tailtriage-core/src/time.rs
+++ b/tailtriage-core/src/time.rs
@@ -121,6 +121,7 @@ mod tests {
     use super::{duration_to_unix_ms, duration_to_us, system_time_to_unix_ms, RunClock};
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+    // TT-TEST: support
     #[test]
     fn duration_to_us_saturates_at_u64_max() {
         assert_eq!(duration_to_us(Duration::from_micros(123)), 123);
@@ -131,6 +132,7 @@ mod tests {
         assert_eq!(duration_to_us(overflow_duration), u64::MAX);
     }
 
+    // TT-TEST: support
     #[test]
     fn run_clock_intervals_include_run_relative_offsets() {
         let clock = RunClock::new();
@@ -152,6 +154,7 @@ mod tests {
         assert!(clock.run_started_at_unix_ms() <= finished.finished_at_unix_ms);
     }
 
+    // TT-TEST: support
     #[test]
     fn system_time_to_unix_ms_clamps_epoch_and_overflow() {
         let before_epoch = UNIX_EPOCH

--- a/tailtriage-tokio/src/lib.rs
+++ b/tailtriage-tokio/src/lib.rs
@@ -732,6 +732,7 @@ mod tests {
         assert!(condition(), "{failure_message}");
     }
 
+    // TT-TEST: support
     #[tokio::test(flavor = "current_thread")]
     async fn runtime_sampler_records_snapshots() {
         let nanos = SystemTime::now()
@@ -770,6 +771,7 @@ mod tests {
         assert!(first.global_queue_depth.is_some());
     }
 
+    // TT-TEST: T03 primary
     #[tokio::test(flavor = "current_thread")]
     async fn runtime_sampler_rejects_zero_interval() {
         let tailtriage = Arc::new(
@@ -786,6 +788,7 @@ mod tests {
         assert_eq!(err, SamplerStartError::ZeroInterval);
     }
 
+    // TT-TEST: T03 primary
     #[test]
     fn runtime_sampler_requires_active_runtime() {
         let tailtriage = Arc::new(
@@ -810,6 +813,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: T04 primary
     #[tokio::test(flavor = "current_thread")]
     async fn core_light_inherits_tokio_light_defaults() {
         let tailtriage = Arc::new(
@@ -842,6 +846,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: T04 primary
     #[tokio::test(flavor = "current_thread")]
     async fn core_investigation_inherits_tokio_investigation_defaults() {
         let tailtriage = Arc::new(
@@ -874,6 +879,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: T04 primary
     #[tokio::test(flavor = "current_thread")]
     async fn explicit_tokio_mode_override_beats_inherited_core_mode() {
         let tailtriage = Arc::new(
@@ -903,6 +909,7 @@ mod tests {
         assert_eq!(config.resolved_mode, CaptureMode::Investigation);
     }
 
+    // TT-TEST: T04 primary
     #[tokio::test(flavor = "current_thread")]
     async fn explicit_cadence_override_beats_mode_default() {
         let tailtriage = Arc::new(
@@ -926,6 +933,7 @@ mod tests {
         assert_eq!(config.resolved_sampler_cadence_ms, 17);
     }
 
+    // TT-TEST: T04 primary
     #[tokio::test(flavor = "current_thread")]
     async fn explicit_retention_override_beats_mode_default() {
         let tailtriage = Arc::new(
@@ -964,6 +972,7 @@ mod tests {
         assert_eq!(snapshot.runtime_snapshots.len(), 1);
     }
 
+    // TT-TEST: T04 primary
     #[tokio::test(flavor = "current_thread")]
     async fn sampler_stops_task_after_reaching_resolved_cap() {
         let tailtriage = Arc::new(
@@ -1002,6 +1011,7 @@ mod tests {
         sampler.shutdown().await;
     }
 
+    // TT-TEST: T05 secondary
     #[tokio::test(flavor = "current_thread")]
     async fn runtime_sampler_records_when_started() {
         let tailtriage = Arc::new(
@@ -1031,6 +1041,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: T04 primary
     #[tokio::test(flavor = "current_thread")]
     async fn tokio_retention_override_is_clamped_by_core_limit() {
         let tailtriage = Arc::new(
@@ -1069,6 +1080,7 @@ mod tests {
         assert_eq!(snapshot.truncation.dropped_runtime_snapshots, 0);
     }
 
+    // TT-TEST: support
     #[tokio::test(flavor = "current_thread")]
     async fn sampler_does_not_autostart_from_capture_mode() {
         let tailtriage = Tailtriage::builder("runtime-test")
@@ -1083,6 +1095,7 @@ mod tests {
         assert!(snapshot.metadata.effective_tokio_sampler_config.is_none());
     }
 
+    // TT-TEST: T05 primary
     #[tokio::test(flavor = "current_thread")]
     async fn unavailable_runtime_metrics_are_recorded_as_none() {
         let snapshot = super::capture_runtime_snapshot(&tokio::runtime::Handle::current());
@@ -1096,6 +1109,7 @@ mod tests {
         }
     }
 
+    // TT-TEST: T05 primary
     #[test]
     fn configured_multithread_worker_counts_are_captured() {
         for expected in [2_u32, 4] {
@@ -1109,6 +1123,7 @@ mod tests {
         }
     }
 
+    // TT-TEST: T03 primary
     #[tokio::test(flavor = "current_thread")]
     async fn runtime_sampler_rejects_duplicate_start_for_same_run() {
         let tailtriage = Arc::new(
@@ -1192,6 +1207,7 @@ mod helper_tests {
         req.rwlock_write("rw_write_lifetime", lock).await
     }
 
+    // TT-TEST: T01 primary
     #[tokio::test(flavor = "current_thread")]
     async fn queue_and_lock_helpers_record_queue_only() {
         let run = run();
@@ -1261,6 +1277,7 @@ mod helper_tests {
         assert!(snap.stages.is_empty());
     }
 
+    // TT-TEST: T02 primary
     #[tokio::test(flavor = "current_thread")]
     async fn stage_helpers_and_inflight_behave_and_preserve_results() {
         let run = run();
@@ -1334,6 +1351,7 @@ mod helper_tests {
         assert!(!stage("blocking_panic").success);
     }
 
+    // TT-TEST: T02 primary
     #[tokio::test(flavor = "current_thread")]
     async fn blocking_stage_is_lazy_until_polled_and_records_on_await() {
         let run = run();
@@ -1382,6 +1400,7 @@ mod helper_tests {
         started.completion.finish_ok();
     }
 
+    // TT-TEST: T02 primary
     #[tokio::test(flavor = "current_thread")]
     async fn timeout_stage_is_lazy_until_polled() {
         let run = run();
@@ -1410,6 +1429,7 @@ mod helper_tests {
         started.completion.finish_ok();
     }
 
+    // TT-TEST: support
     #[tokio::test(flavor = "current_thread")]
     async fn timeout_stage_accepts_non_send_futures() {
         let run = run();
@@ -1427,6 +1447,7 @@ mod helper_tests {
         started.completion.finish_ok();
     }
 
+    // TT-TEST: K02 secondary
     #[tokio::test(flavor = "current_thread")]
     async fn dropping_pending_queue_and_stage_helpers_records_partial_events() {
         let run = run();
@@ -1476,6 +1497,7 @@ mod helper_tests {
         started.completion.finish_ok();
     }
 
+    // TT-TEST: T02 secondary
     #[tokio::test(flavor = "current_thread")]
     async fn owned_request_handle_works_and_helpers_do_not_finish_request() {
         let run = Arc::new(run());
@@ -1497,6 +1519,7 @@ mod helper_tests {
         assert_eq!(run.snapshot().requests.len(), 1);
     }
 
+    // TT-TEST: support
     #[test]
     fn extension_impls_exist_for_borrowed_and_owned_handles() {
         fn assert_impl<T: crate::TokioRequestHandleExt>() {}
@@ -1504,6 +1527,7 @@ mod helper_tests {
         assert_impl::<tailtriage_core::OwnedRequestHandle>();
     }
 
+    // TT-TEST: T01 primary
     #[tokio::test(flavor = "current_thread")]
     async fn semaphore_helper_preserves_semaphore_lifetime() {
         let run = run();
@@ -1520,6 +1544,7 @@ mod helper_tests {
         assert_eq!(run.snapshot().requests.len(), 1);
     }
 
+    // TT-TEST: T01 primary
     #[tokio::test(flavor = "current_thread")]
     async fn lock_helpers_preserve_lock_lifetimes() {
         let run = run();
@@ -1582,6 +1607,7 @@ mod prompt09_tokio_partial_tests {
             .unwrap()
     }
 
+    // TT-TEST: T01 primary
     #[tokio::test(flavor = "current_thread")]
     async fn borrowed_semaphore_pending_then_drop_records_partial_queue() {
         let tt = capture();
@@ -1599,6 +1625,7 @@ mod prompt09_tokio_partial_tests {
         assert!(!ev.completed);
     }
 
+    // TT-TEST: K02 secondary
     #[tokio::test(flavor = "current_thread")]
     async fn owned_semaphore_pending_then_drop_records_partial_queue() {
         let tt = capture();
@@ -1618,6 +1645,7 @@ mod prompt09_tokio_partial_tests {
         assert!(!ev.completed);
     }
 
+    // TT-TEST: K02 secondary
     #[tokio::test(flavor = "current_thread")]
     async fn mpsc_send_pending_then_drop_records_partial_queue() {
         let tt = capture();
@@ -1634,6 +1662,7 @@ mod prompt09_tokio_partial_tests {
         assert!(!ev.completed);
     }
 
+    // TT-TEST: K02 secondary
     #[tokio::test(flavor = "current_thread")]
     async fn mutex_and_rwlock_pending_then_drop_record_partial_queues() {
         let tt = capture();
@@ -1673,6 +1702,7 @@ mod prompt09_tokio_partial_tests {
         );
     }
 
+    // TT-TEST: T02 primary
     #[tokio::test(flavor = "current_thread")]
     async fn join_timeout_and_blocking_pending_then_drop_record_partial_stages() {
         let tt = capture();
@@ -1724,6 +1754,7 @@ mod prompt09_tokio_partial_tests {
         );
     }
 
+    // TT-TEST: K02 secondary
     #[tokio::test(flavor = "current_thread")]
     async fn owned_handle_stage_helper_pending_then_drop_records_partial_stage() {
         let tt = Arc::new(capture());


### PR DESCRIPTION
### Motivation

- Add explicit, audited `TT-TEST` classification markers to a focused set of tests so the invariant proof matrix and test ownership are machine-readable and discoverable. 
- Migrate legacy `TT-INVARIANT` linkage comments out of the ten listed files and ensure the classification model is applied without changing behavior.

### Description

- Inserted `// TT-TEST: …` comment lines immediately above the `#[test]`/`#[tokio::test]` attributes in exactly ten files, providing the exact classification for each listed test (252 tests total, two tests carry two classifications resulting in 254 `TT-TEST` lines). 
- Removed any superseded `TT-INVARIANT` linkage comments from those ten files only and left all test bodies, assertions, production code, docs, validators, CI, and workflows unchanged. 
- Changes are comment-only and limited to the following files: `tailtriage-core/src/artifact.rs`, `tailtriage-core/src/collector.rs`, `tailtriage-core/src/lib.rs`, `tailtriage-core/src/sink.rs`, `tailtriage-core/src/tests.rs`, `tailtriage-core/src/time.rs`, `tailtriage-controller/src/lib.rs`, `tailtriage-tokio/src/lib.rs`, `tailtriage-axum/src/lib.rs`, and `tailtriage-axum/tests/axum_adapter.rs`. 

### Testing

- Ran `cargo fmt --check` and it passed. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and it passed with no warnings. 
- Ran `cargo test --workspace --all-targets --all-features --locked` and the entire test suite completed successfully. 
- Ran `python3 scripts/validate_docs_contracts.py` and it validated successfully, and `git diff --check` produced no check failures, confirming the changes are comment-only and follow repository validators.
- Structural validation confirmed `252 tests` were classified with `254` `TT-TEST` comment lines and no `TT-INVARIANT` comments remain in the ten migrated files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8c9b70d8ec8330b2aad2f896566668)