### PR TITLE
test(tracing): add audited TT-TEST markers to tailtriage-tracing

### DIFF
--- a/tailtriage-tracing/src/convention.rs
+++ b/tailtriage-tracing/src/convention.rs
@@ -21,6 +21,7 @@ pub const TT_SUCCESS: &str = "tt.success";
 mod tests {
     use super::*;
 
+    // TT-TEST: support
     #[test]
     fn constants_match_expected_keys() {
         assert_eq!(TT_KIND, "tt.kind");

--- a/tailtriage-tracing/src/error.rs
+++ b/tailtriage-tracing/src/error.rs
@@ -166,6 +166,7 @@ impl std::error::Error for ImportError {}
 mod tests {
     use super::ImportError;
 
+    // TT-TEST: S04 primary
     #[test]
     fn import_error_display_escapes_dynamic_fields_and_preserves_layout() {
         let error = ImportError::ZeroRequestArtifactWithWarnings {
@@ -179,6 +180,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn jsonl_resource_errors_have_deterministic_context() {
         assert_eq!(

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -317,6 +317,8 @@ mod tests {
         }
     }
 
+    // TT-TEST: R01 primary
+    // TT-TEST: F02 primary
     #[test]
     fn stable_wrapper_fixture_imports() {
         let fixture = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -325,6 +327,7 @@ mod tests {
         assert!(!imported.run().requests.is_empty());
     }
 
+    // TT-TEST: R01 primary
     #[test]
     fn rejects_raw_top_level_span_record() {
         assert_wrapper_rejected(
@@ -334,6 +337,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: R01 primary
     #[test]
     fn rejects_unversioned_span_envelope() {
         assert_wrapper_rejected(
@@ -343,6 +347,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn rejects_start_unix_ms_and_end_unix_ms_aliases() {
         assert_wrapper_rejected(
@@ -352,6 +357,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn rejects_top_level_tt_fields() {
         assert_wrapper_rejected(
@@ -361,6 +367,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn rejects_outer_fields_compatibility_input() {
         assert_wrapper_rejected(
@@ -370,6 +377,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn rejects_mixed_compatibility_field_locations() {
         assert_wrapper_rejected(
@@ -379,6 +387,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn stable_wrapper_rejects_wrapper_level_fields() {
         assert_wrapper_rejected(
@@ -388,6 +397,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn stable_wrapper_rejects_wrapper_level_tt_key() {
         assert_wrapper_rejected(
@@ -397,6 +407,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn stable_wrapper_rejects_mixed_compatibility_placement_deterministically() {
         assert_wrapper_rejected(
@@ -406,6 +417,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn stable_wrapper_rejects_alias_only_timestamps_in_strict_and_non_strict() {
         let input = r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"request","start_unix_ms":1,"end_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/"}}}"#;
@@ -417,6 +429,7 @@ mod tests {
         assert!(err.to_string().contains("start_unix_ms"));
     }
 
+    // TT-TEST: support
     #[test]
     fn stable_wrapper_rejects_canonical_timestamps_plus_aliases() {
         assert_wrapper_rejected(
@@ -426,6 +439,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn stable_wrapper_accepts_unrelated_wrapper_extension_key() {
         let input = r#"{"format":"tailtriage.tracing-span.v1","producer":"example","span":{"name":"request","started_at_unix_ms":1,"finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/"}}}"#;
@@ -434,6 +448,7 @@ mod tests {
         assert_eq!(imported.retained_sources()[0].name(), "request");
     }
 
+    // TT-TEST: R01 primary
     #[test]
     fn rejects_ordinary_tracing_formatter_json() {
         assert_wrapper_rejected(
@@ -443,16 +458,19 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn rejects_missing_format() {
         assert_wrapper_rejected(r#"{"message":"x"}"#, 1, "missing field 'format'");
     }
 
+    // TT-TEST: support
     #[test]
     fn rejects_non_string_format() {
         assert_wrapper_rejected(r#"{"format":1,"span":{}}"#, 1, "invalid field 'format'");
     }
 
+    // TT-TEST: support
     #[test]
     fn rejects_unsupported_format_marker() {
         assert_wrapper_rejected(
@@ -462,6 +480,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn rejects_missing_span() {
         assert_wrapper_rejected(
@@ -471,6 +490,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn rejects_non_object_span() {
         assert_wrapper_rejected(
@@ -480,6 +500,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn rejects_malformed_json_with_line_number() {
         let err =
@@ -490,11 +511,13 @@ mod tests {
         }
     }
 
+    // TT-TEST: support
     #[test]
     fn rejects_non_object_json_value() {
         assert_wrapper_rejected("[]", 1, "JSONL record must be an object");
     }
 
+    // TT-TEST: R01 primary
     #[test]
     fn structural_errors_are_fatal_even_non_strict() {
         let input = format!(
@@ -513,6 +536,7 @@ mod tests {
         }
     }
 
+    // TT-TEST: S01 primary
     #[test]
     fn valid_only_multiline_preserves_source_order() {
         let input = format!(
@@ -527,6 +551,7 @@ mod tests {
         assert_eq!(retained[1].name(), "req-b");
     }
 
+    // TT-TEST: support
     #[test]
     fn stable_wrapper_duration_us_is_authoritative_when_wall_timestamps_disagree() {
         let input = r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"request","started_at_unix_ms":1700000000000,"started_at_run_us":0,"finished_at_unix_ms":1700000000001,"finished_at_run_us":1000,"duration_us":50000,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}"#;
@@ -543,6 +568,7 @@ mod tests {
         assert!(err.to_string().contains("duration_mismatch"));
     }
 
+    // TT-TEST: R02 secondary
     #[test]
     fn invalid_contained_span_warns_non_strict_and_errors_strict() {
         let input = r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"req","started_at_unix_ms":"bad","finished_at_unix_ms":2,"fields":{"tt.kind":"request","tt.request_id":"r1","tt.route":"/a"}}}"#;
@@ -557,6 +583,7 @@ mod tests {
         assert!(err.to_string().contains("line 1"));
     }
 
+    // TT-TEST: R06 primary
     #[test]
     fn stable_writer_output_reimports_with_explicit_evidence() {
         let span = SpanRecord::new("http.request", 1000, 1100)
@@ -593,6 +620,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: S01 primary
     #[test]
     fn raw_record_boundary_and_unterminated_eof_are_deterministic() {
         let valid = stable_request("request", "r1");
@@ -630,6 +658,7 @@ mod tests {
         }
     }
 
+    // TT-TEST: S01 primary
     #[test]
     fn unterminated_oversized_record_is_rejected_after_bounded_consumption() {
         let read = Rc::new(Cell::new(0));
@@ -651,6 +680,7 @@ mod tests {
         assert!(read.get() <= crate::MAX_JSONL_RECORD_BYTES + 16 * 1024);
     }
 
+    // TT-TEST: S01 primary
     #[test]
     fn oversized_record_is_fatal_at_the_correct_logical_line() {
         let input = format!(
@@ -669,6 +699,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: S01 primary
     #[test]
     fn many_small_records_have_no_aggregate_byte_ceiling() {
         let input = " \n".repeat(100);
@@ -679,6 +710,7 @@ mod tests {
         assert_eq!(crate::MAX_JSONL_RECORD_BYTES, 8 * 1024 * 1024);
     }
 
+    // TT-TEST: S01 primary
     #[test]
     fn malformed_contained_span_warning_sample_is_bounded() {
         let malformed = r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"bad","started_at_unix_ms":"bad","finished_at_unix_ms":2,"fields":{"tt.kind":"request"}}}"#;

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -906,6 +906,7 @@ mod persistable_tests {
     use crate::ImportError;
     use tailtriage_core::{MemorySink, RequestEvent, Tailtriage};
 
+    // TT-TEST: support
     #[test]
     fn ensure_persistable_run_has_requests_accepts_non_empty_runs() {
         let collector = Tailtriage::builder("svc")
@@ -927,6 +928,7 @@ mod persistable_tests {
         assert!(ensure_persistable_run_has_requests(&run).is_ok());
     }
 
+    // TT-TEST: support
     #[test]
     fn ensure_persistable_run_has_requests_rejects_empty_runs() {
         let run = Tailtriage::builder("svc")
@@ -1045,6 +1047,7 @@ fn parse_depth_at_start(
 mod tests {
     use super::*;
 
+    // TT-TEST: S01 primary
     #[test]
     fn streaming_conversion_directly_bounds_temporary_candidate_and_source_state() {
         let mut spans = Vec::new();
@@ -1133,6 +1136,7 @@ mod tests {
     }
     use tailtriage_core::CaptureMode;
 
+    // TT-TEST: support
     #[test]
     fn span_kind_parser_accepts_supported_values_only() {
         assert_eq!(SpanKind::parse("request"), Some(SpanKind::Request));
@@ -1261,6 +1265,7 @@ mod tests {
             .collect()
     }
 
+    // TT-TEST: R05 primary
     #[test]
     fn provenance_maps_valid_request_stage_queue_source_indices() {
         let spans = vec![
@@ -1286,6 +1291,7 @@ mod tests {
         assert_eq!(result.retained_sources, spans);
     }
 
+    // TT-TEST: support
     #[test]
     fn imported_run_privately_carries_exact_retained_original_sources() {
         let request = req("a", 100, 120)
@@ -1312,6 +1318,7 @@ mod tests {
         let (_run, _warnings) = imported.into_parts();
     }
 
+    // TT-TEST: support
     #[test]
     fn imported_run_new_has_no_private_retained_sources() {
         let imported = ImportedRun::new(empty_candidate_run(), Vec::new());
@@ -1319,6 +1326,7 @@ mod tests {
         assert!(imported.retained_sources().is_empty());
     }
 
+    // TT-TEST: R05 primary
     #[test]
     #[allow(clippy::too_many_lines)]
     fn provenance_excludes_children_of_core_excluded_parents_without_truncation() {
@@ -1490,6 +1498,7 @@ mod tests {
         assert!(!candidate.truncation.limits_hit);
     }
 
+    // TT-TEST: R05 primary
     #[test]
     fn provenance_retained_output_indices_are_exact_and_contiguous_per_section() {
         let spans = vec![
@@ -1574,6 +1583,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: R05 secondary
     #[test]
     fn provenance_retained_sources_follow_original_source_order_not_canonical_sections() {
         let spans = vec![
@@ -1620,6 +1630,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn provenance_core_exclusions_do_not_increment_tracing_truncation_counters() {
         let spans = vec![
@@ -1655,6 +1666,7 @@ mod tests {
         assert!(!result.imported.run().truncation.limits_hit);
     }
 
+    // TT-TEST: R05 secondary
     #[test]
     fn provenance_never_revives_source_parsing_drops() {
         let spans = vec![
@@ -1696,6 +1708,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn provenance_retains_original_source_when_optional_precision_is_missing_or_repaired() {
         let missing = vec![
@@ -1737,6 +1750,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn provenance_excludes_core_duplicate_ambiguous_orphan_parent_and_containment_cases() {
         let spans = vec![
@@ -1778,6 +1792,7 @@ mod tests {
         assert_eq!(result.imported.run().truncation.dropped_queues, 0);
     }
 
+    // TT-TEST: R05 secondary
     #[test]
     fn provenance_semantic_limits_preserve_mappings_and_never_revive_dropped_sources() {
         let spans = vec![
@@ -1827,6 +1842,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn provenance_ordering_issue_codes_repeatability_and_public_equivalence_are_deterministic() {
         let spans = vec![
@@ -1881,6 +1897,7 @@ mod tests {
                 .collect::<Vec<_>>()
         );
     }
+    // TT-TEST: support
     #[test]
     fn request_only_conversion_creates_one_request_event() {
         let spans = vec![SpanRecord::new("req", 100, 110)
@@ -1891,6 +1908,7 @@ mod tests {
         assert_eq!(imported.run().requests.len(), 1);
     }
 
+    // TT-TEST: support
     #[test]
     fn request_and_stage_convert() {
         let spans = vec![
@@ -1913,6 +1931,7 @@ mod tests {
         assert_eq!(run.stages.len(), 1);
     }
 
+    // TT-TEST: support
     #[test]
     fn request_and_queue_convert() {
         let spans = vec![
@@ -1934,6 +1953,7 @@ mod tests {
         assert_eq!(run.queues.len(), 1);
     }
 
+    // TT-TEST: support
     #[test]
     fn span_record_run_relative_fields_convert_to_core_events() {
         let spans = vec![
@@ -1972,6 +1992,7 @@ mod tests {
         assert_eq!(run.queues[0].waited_until_run_us, Some(3_010));
     }
 
+    // TT-TEST: support
     #[test]
     fn missing_duration_uses_run_relative_delta_before_unix_bounds() {
         let spans = vec![SpanRecord::new("req", 10, 11)
@@ -1986,6 +2007,7 @@ mod tests {
         assert_eq!(imported.run().requests[0].latency_us, 50_000);
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_duration_matching_run_relative_allows_wall_clock_mismatch() {
         let spans = vec![SpanRecord::new("req", 10, 11)
@@ -2002,6 +2024,7 @@ mod tests {
         assert_eq!(imported.run().requests[0].latency_us, 50_000);
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_duration_mismatching_run_relative_fails_even_if_unix_matches() {
         let spans = vec![SpanRecord::new("req", 10, 60)
@@ -2019,6 +2042,7 @@ mod tests {
         assert!(message.contains("duration_mismatch"));
     }
 
+    // TT-TEST: support
     #[test]
     fn non_strict_duration_mismatching_run_relative_warns_and_retains_duration() {
         let spans = vec![SpanRecord::new("req", 10, 60)
@@ -2044,6 +2068,7 @@ mod tests {
             .any(|w| w.contains("duration_mismatch")));
     }
 
+    // TT-TEST: support
     #[test]
     fn non_strict_inverted_request_run_relative_offsets_are_dropped_with_warning() {
         let spans = vec![SpanRecord::new("req", 100, 120)
@@ -2069,6 +2094,7 @@ mod tests {
             .any(|w| w.message().contains("optional run-relative offsets")));
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_inverted_request_run_relative_offsets_fail() {
         let spans = vec![SpanRecord::new("req", 100, 120)
@@ -2085,6 +2111,7 @@ mod tests {
         assert!(err.to_string().contains("inverted_interval"));
     }
 
+    // TT-TEST: support
     #[test]
     fn non_strict_incomplete_request_run_relative_offsets_are_dropped_with_warning() {
         let spans = vec![SpanRecord::new("req", 100, 120)
@@ -2108,6 +2135,7 @@ mod tests {
             .any(|w| w.message().contains("optional run-relative offsets")));
     }
 
+    // TT-TEST: support
     #[test]
     fn non_strict_inverted_queue_run_relative_offsets_are_dropped_with_warning() {
         let spans = vec![
@@ -2135,6 +2163,7 @@ mod tests {
             .any(|w| w.message().contains("inverted_interval")));
     }
 
+    // TT-TEST: support
     #[test]
     fn non_strict_inverted_stage_run_relative_without_duration_uses_coarse_delta() {
         let spans = vec![
@@ -2166,6 +2195,7 @@ mod tests {
             .any(|w| w.message().contains("optional run-relative offsets")));
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_inverted_queue_run_relative_offsets_fail() {
         let spans = vec![
@@ -2188,6 +2218,7 @@ mod tests {
         assert!(err.to_string().contains("inverted_interval"));
     }
 
+    // TT-TEST: support
     #[test]
     fn non_strict_incomplete_queue_run_relative_offsets_are_dropped_with_warning() {
         let spans = vec![
@@ -2217,6 +2248,7 @@ mod tests {
             .any(|w| w.message().contains("optional run-relative offsets")));
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_incomplete_queue_run_relative_offsets_fail() {
         let spans = vec![
@@ -2238,6 +2270,7 @@ mod tests {
         assert!(err.to_string().contains("partial_run_relative_interval"));
     }
 
+    // TT-TEST: support
     #[test]
     fn non_strict_orphan_stage_is_skipped_and_warning_is_durable() {
         let spans = vec![
@@ -2266,6 +2299,7 @@ mod tests {
             .any(|w| w.contains(warning)));
     }
 
+    // TT-TEST: support
     #[test]
     fn orphan_stage_does_not_affect_retained_bounds_or_default_stage_success_warning() {
         let spans = vec![
@@ -2299,6 +2333,7 @@ mod tests {
             .any(|w| w.contains("missing optional 'tt.success'; assumed true")));
     }
 
+    // TT-TEST: R02 secondary
     #[test]
     fn strict_orphan_stage_fails() {
         let spans = vec![
@@ -2320,6 +2355,7 @@ mod tests {
         }
     }
 
+    // TT-TEST: support
     #[test]
     fn non_strict_orphan_queue_is_skipped_and_warning_is_durable() {
         let spans = vec![
@@ -2348,6 +2384,7 @@ mod tests {
             .any(|w| w.contains(warning)));
     }
 
+    // TT-TEST: R02 secondary
     #[test]
     fn strict_orphan_queue_fails() {
         let spans = vec![
@@ -2369,6 +2406,7 @@ mod tests {
         }
     }
 
+    // TT-TEST: support
     #[test]
     fn wall_clock_stage_before_request_start_is_retained_without_precise_containment_warning() {
         let spans = vec![
@@ -2398,6 +2436,7 @@ mod tests {
             .any(|w| w.contains("precise_interval_validation_unavailable")));
     }
 
+    // TT-TEST: support
     #[test]
     fn wall_clock_stage_after_request_finish_is_retained_without_precise_containment_warning() {
         let spans = vec![
@@ -2427,6 +2466,7 @@ mod tests {
             .any(|w| w.contains("precise_interval_validation_unavailable")));
     }
 
+    // TT-TEST: support
     #[test]
     fn wall_clock_queue_before_request_start_is_retained_without_precise_containment_warning() {
         let spans = vec![
@@ -2456,6 +2496,7 @@ mod tests {
             .any(|w| w.contains("precise_interval_validation_unavailable")));
     }
 
+    // TT-TEST: support
     #[test]
     fn wall_clock_queue_after_request_finish_is_retained_without_precise_containment_warning() {
         let spans = vec![
@@ -2485,6 +2526,7 @@ mod tests {
             .any(|w| w.contains("precise_interval_validation_unavailable")));
     }
 
+    // TT-TEST: R02 primary
     #[test]
     fn precise_stage_outside_request_is_excluded_permissively_and_rejected_strictly() {
         let spans = vec![
@@ -2512,6 +2554,7 @@ mod tests {
         assert!(err.to_string().contains("child_interval_outside_request"));
     }
 
+    // TT-TEST: R02 secondary
     #[test]
     fn precise_queue_outside_request_is_excluded_permissively_and_rejected_strictly() {
         let spans = vec![
@@ -2539,6 +2582,7 @@ mod tests {
         assert!(err.to_string().contains("child_interval_outside_request"));
     }
 
+    // TT-TEST: support
     #[test]
     fn wall_clock_stage_starting_before_request_is_retained_without_containment() {
         let spans = vec![
@@ -2555,6 +2599,7 @@ mod tests {
         assert_eq!(imported.run().stages.len(), 1);
     }
 
+    // TT-TEST: support
     #[test]
     fn wall_clock_queue_ending_after_request_is_retained_without_containment() {
         let spans = vec![
@@ -2571,6 +2616,7 @@ mod tests {
         assert_eq!(imported.run().queues.len(), 1);
     }
 
+    // TT-TEST: support
     #[test]
     fn boundary_equal_stage_and_queue_are_accepted() {
         let spans = vec![
@@ -2595,6 +2641,7 @@ mod tests {
         assert_eq!(run.queues.len(), 1);
     }
 
+    // TT-TEST: support
     #[test]
     fn zero_duration_request_with_boundary_equal_stage_and_queue_is_accepted() {
         let spans = vec![
@@ -2621,6 +2668,7 @@ mod tests {
         assert_eq!(run.queues.len(), 1);
     }
 
+    // TT-TEST: support
     #[test]
     fn non_strict_duplicate_request_id_excludes_all_duplicate_requests_and_children() {
         let spans = vec![
@@ -2670,6 +2718,7 @@ mod tests {
             .any(|w| w.contains("ambiguous_parent_request_id")));
     }
 
+    // TT-TEST: support
     #[test]
     fn non_strict_retained_duplicate_missing_outcome_warns_before_core_exclusion() {
         let spans = vec![
@@ -2700,6 +2749,7 @@ mod tests {
             .any(|w| w.contains("missing optional 'tt.outcome'; assumed 'ok'")));
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_duplicate_request_id_fails() {
         let spans = vec![
@@ -2716,6 +2766,7 @@ mod tests {
         assert!(matches!(err, ImportError::StrictViolation(_)));
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_error_lists_unique_core_issue_codes_once_in_order() {
         let spans = vec![
@@ -2747,6 +2798,7 @@ mod tests {
         assert_eq!(message.matches("ambiguous_parent_request_id").count(), 1);
     }
 
+    // TT-TEST: support
     #[test]
     fn overflow_duplicate_request_ids_beyond_max_requests_do_not_warn() {
         let spans = vec![
@@ -2779,6 +2831,7 @@ mod tests {
             .any(|w| w.message().contains("duplicate_completed_request_id")));
     }
 
+    // TT-TEST: support
     #[test]
     fn invalid_extreme_timestamps_do_not_affect_metadata_bounds_or_default_run_id() {
         let spans = vec![
@@ -2810,6 +2863,7 @@ mod tests {
         assert!(run.metadata.run_id.contains("tracing-import-100-120"));
     }
 
+    // TT-TEST: support
     #[test]
     fn orphan_queue_does_not_affect_retained_bounds_or_default_run_id() {
         let spans = vec![
@@ -2833,6 +2887,7 @@ mod tests {
         assert!(run.metadata.run_id.contains("tracing-import-100-120"));
     }
 
+    // TT-TEST: support
     #[test]
     fn overflow_request_does_not_affect_metadata_bounds_or_run_id() {
         let max_requests = 2;
@@ -2873,6 +2928,7 @@ mod tests {
             .contains("missing optional 'tt.outcome'; assumed 'ok'")));
     }
 
+    // TT-TEST: support
     #[test]
     fn overflow_stage_does_not_affect_metadata_bounds_or_success_warning() {
         let max_stages = 2;
@@ -2916,6 +2972,7 @@ mod tests {
             .contains("missing optional 'tt.success'; assumed true")));
     }
 
+    // TT-TEST: support
     #[test]
     fn overflow_queue_does_not_affect_metadata_bounds() {
         let max_queues = 2;
@@ -2955,6 +3012,7 @@ mod tests {
         assert_eq!(run.metadata.finalized_at_unix_ms.expect("finalized"), 120);
     }
 
+    // TT-TEST: support
     #[test]
     fn run_from_span_records_respects_import_mode_and_resolved_limits() {
         let spans = vec![
@@ -3015,6 +3073,7 @@ mod tests {
         assert_eq!(run.truncation.dropped_queues, 1);
     }
 
+    // TT-TEST: support
     #[test]
     fn retained_request_missing_outcome_still_warns() {
         let spans = vec![SpanRecord::new("req", 100, 120)
@@ -3027,6 +3086,7 @@ mod tests {
             .contains("missing optional 'tt.outcome'; assumed 'ok'")));
     }
 
+    // TT-TEST: support
     #[test]
     fn retained_stage_missing_success_still_warns() {
         let spans = vec![
@@ -3046,6 +3106,7 @@ mod tests {
             .contains("missing optional 'tt.success'; assumed true")));
     }
 
+    // TT-TEST: support
     #[test]
     fn matched_request_stage_queue_are_retained() {
         let spans = vec![
@@ -3071,6 +3132,7 @@ mod tests {
         assert_eq!(run.queues.len(), 1);
     }
 
+    // TT-TEST: support
     #[test]
     fn missing_optional_fields_default() {
         let spans = vec![
@@ -3096,6 +3158,7 @@ mod tests {
         assert_eq!(run.queues[0].depth_at_start, None);
     }
 
+    // TT-TEST: R02 primary
     #[test]
     fn missing_required_field_warns_and_skips_non_strict() {
         let spans = vec![SpanRecord::new("req", 1, 2)
@@ -3106,6 +3169,7 @@ mod tests {
         assert!(!imported.warnings().is_empty());
     }
 
+    // TT-TEST: R02 primary
     #[test]
     fn missing_required_field_errors_in_strict() {
         let spans = vec![SpanRecord::new("req", 1, 2)
@@ -3115,6 +3179,7 @@ mod tests {
         assert!(matches!(err, ImportError::StrictViolation(_)));
     }
 
+    // TT-TEST: R02 primary
     #[test]
     fn unknown_kind_warns_non_strict() {
         let spans = vec![SpanRecord::new("x", 1, 2).field(TT_KIND, "wat")];
@@ -3128,6 +3193,7 @@ mod tests {
             .any(|warning| warning.contains("unknown tt.kind 'wat'")));
     }
 
+    // TT-TEST: R02 primary
     #[test]
     fn unknown_kind_errors_in_strict() {
         let spans = vec![SpanRecord::new("x", 1, 2).field(TT_KIND, "wat")];
@@ -3135,6 +3201,7 @@ mod tests {
         assert!(matches!(err, ImportError::StrictViolation(_)));
     }
 
+    // TT-TEST: support
     #[test]
     fn span_without_kind_ignored_silently() {
         let spans = vec![SpanRecord::new("x", 1, 2).field("a", "b")];
@@ -3142,6 +3209,7 @@ mod tests {
         assert!(imported.warnings().is_empty());
     }
 
+    // TT-TEST: support
     #[test]
     fn tailtriage_tagged_span_missing_kind_warns_or_errors() {
         let spans = vec![SpanRecord::new("http.request", 1, 2)
@@ -3157,6 +3225,7 @@ mod tests {
         assert!(matches!(err, ImportError::StrictViolation(_)));
     }
 
+    // TT-TEST: support
     #[test]
     fn missing_optional_defaults_emit_aggregate_warnings() {
         let spans = vec![
@@ -3217,6 +3286,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn inverted_timestamps_warn_or_error() {
         let spans = vec![SpanRecord::new("req", 5, 4)
@@ -3229,6 +3299,7 @@ mod tests {
         assert!(matches!(err, ImportError::StrictViolation(_)));
     }
 
+    // TT-TEST: support
     #[test]
     fn run_from_span_records_validates_service_name_before_strict_span_parsing() {
         let spans = vec![SpanRecord::new("bad", 10, 20).field(TT_KIND, 123_u64)];
@@ -3236,6 +3307,7 @@ mod tests {
         assert!(matches!(err, ImportError::EmptyServiceName));
     }
 
+    // TT-TEST: support
     #[test]
     fn run_from_span_records_empty_input_uses_equal_start_finish_finalized() {
         let imported = run_from_span_records(Vec::new(), ImportOptions::new("svc")).unwrap();
@@ -3252,6 +3324,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn normalized_empty_import_uses_fallback_bounds_after_core_exclusions() {
         let before = tailtriage_core::unix_time_ms();
@@ -3291,6 +3364,7 @@ mod tests {
         assert!(imported.retained_sources().is_empty());
     }
 
+    // TT-TEST: R02 secondary
     #[test]
     fn tracing_import_remains_completed_only_under_partial_aware_analysis() {
         let imported = run_from_span_records(
@@ -3343,6 +3417,7 @@ mod tests {
                     && !note.contains("Partial stage evidence"))));
     }
 
+    // TT-TEST: support
     #[test]
     fn tracing_import_uses_min_start_and_max_finish_as_run_bounds() {
         let spans = vec![SpanRecord::new("req", 10, 20)
@@ -3358,6 +3433,7 @@ mod tests {
         assert_eq!(run.metadata.finalized_at_unix_ms, Some(20));
     }
 
+    // TT-TEST: support
     #[test]
     fn run_from_span_records_preserves_computed_import_run_id() {
         let spans = vec![SpanRecord::new("req", 10, 20)
@@ -3371,6 +3447,7 @@ mod tests {
         assert_eq!(run.metadata.run_id, "tracing-import-10-20");
     }
 
+    // TT-TEST: support
     #[test]
     fn run_from_span_records_preserves_explicit_import_run_id() {
         let spans = vec![SpanRecord::new("req", 10, 20)
@@ -3384,6 +3461,7 @@ mod tests {
         assert_eq!(run.metadata.run_id, "explicit-run");
     }
 
+    // TT-TEST: support
     #[test]
     fn runtime_snapshots_and_inflight_are_empty() {
         let imported = run_from_span_records(Vec::new(), ImportOptions::new("svc")).unwrap();
@@ -3391,6 +3469,7 @@ mod tests {
         assert!(imported.run().inflight.is_empty());
     }
 
+    // TT-TEST: support
     #[test]
     fn ordinary_span_without_kind_does_not_affect_metadata_bounds() {
         let spans = vec![
@@ -3408,6 +3487,7 @@ mod tests {
         assert_eq!(run.metadata.finalized_at_unix_ms.expect("finalized"), 20);
     }
 
+    // TT-TEST: support
     #[test]
     fn unknown_kind_does_not_affect_metadata_bounds_and_is_durable_lifecycle_warning() {
         let spans = vec![
@@ -3435,6 +3515,7 @@ mod tests {
             .any(|w| w.contains("unknown tt.kind")));
     }
 
+    // TT-TEST: support
     #[test]
     fn non_string_kind_warns_non_strict_and_errors_strict() {
         let bad = SpanRecord::new("bad", 1, 2).field(TT_KIND, true);
@@ -3443,6 +3524,7 @@ mod tests {
         assert!(run_from_span_records(vec![bad], ImportOptions::new("svc").strict(true)).is_err());
     }
 
+    // TT-TEST: support
     #[test]
     fn non_string_required_and_optional_fields_warn_non_strict_and_error_strict() {
         let bad_route = SpanRecord::new("req", 1, 2)
@@ -3472,6 +3554,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn whitespace_only_request_id_non_strict_skips_request_and_warns() {
         let spans = vec![SpanRecord::new("req", 1, 2)
@@ -3487,6 +3570,7 @@ mod tests {
         }));
     }
 
+    // TT-TEST: support
     #[test]
     fn whitespace_only_route_non_strict_skips_request_and_warns() {
         let spans = vec![SpanRecord::new("req", 1, 2)
@@ -3502,6 +3586,7 @@ mod tests {
         }));
     }
 
+    // TT-TEST: support
     #[test]
     fn whitespace_only_stage_non_strict_skips_stage_and_warns() {
         let spans = vec![
@@ -3523,6 +3608,7 @@ mod tests {
         }));
     }
 
+    // TT-TEST: support
     #[test]
     fn whitespace_only_queue_non_strict_skips_queue_and_warns() {
         let spans = vec![
@@ -3544,6 +3630,7 @@ mod tests {
         }));
     }
 
+    // TT-TEST: support
     #[test]
     fn whitespace_only_required_field_strict_returns_strict_violation() {
         let spans = vec![SpanRecord::new("req", 1, 2)
@@ -3557,6 +3644,7 @@ mod tests {
             .contains("invalid field 'tt.request_id' in span 'req'"));
     }
 
+    // TT-TEST: support
     #[test]
     fn builtin_request_outcomes_are_retained_exactly() {
         let spans = RECOMMENDED_OUTCOME_LABELS
@@ -3580,6 +3668,7 @@ mod tests {
         assert_eq!(retained, RECOMMENDED_OUTCOME_LABELS);
     }
 
+    // TT-TEST: support
     #[test]
     fn missing_outcome_defaults_ok_and_warns() {
         let spans = vec![SpanRecord::new("req", 1, 2)
@@ -3594,6 +3683,7 @@ mod tests {
             .contains("missing optional 'tt.outcome'; assumed 'ok'")));
     }
 
+    // TT-TEST: support
     #[test]
     fn custom_outcome_is_accepted_and_preserved_exactly() {
         let spans = vec![SpanRecord::new("http.request", 1, 2)
@@ -3606,6 +3696,7 @@ mod tests {
         assert_eq!(imported.run().requests[0].outcome, "cache_miss_fallback");
     }
 
+    // TT-TEST: support
     #[test]
     fn whitespace_only_outcome_non_strict_skips_request_and_warns() {
         let spans = vec![SpanRecord::new("http.request", 1, 2)
@@ -3620,6 +3711,7 @@ mod tests {
             .contains("invalid field 'tt.outcome' in span 'http.request': expected non-empty, non-whitespace string")));
     }
 
+    // TT-TEST: support
     #[test]
     fn whitespace_only_outcome_strict_fails() {
         let spans = vec![SpanRecord::new("http.request", 1, 2)
@@ -3634,6 +3726,7 @@ mod tests {
             .contains("invalid field 'tt.outcome' in span 'http.request': expected non-empty, non-whitespace string"));
     }
 
+    // TT-TEST: support
     #[test]
     fn non_string_outcome_non_strict_skips_request_and_warns() {
         let spans = vec![SpanRecord::new("http.request", 1, 2)
@@ -3648,6 +3741,7 @@ mod tests {
             .contains("invalid field 'tt.outcome' in span 'http.request': expected string")));
     }
 
+    // TT-TEST: support
     #[test]
     fn non_string_outcome_strict_fails() {
         let spans = vec![SpanRecord::new("http.request", 1, 2)
@@ -3662,6 +3756,7 @@ mod tests {
             .contains("invalid field 'tt.outcome' in span 'http.request': expected string"));
     }
 
+    // TT-TEST: support
     #[test]
     fn native_other_outcome_round_trips_through_tracing_style_outcome_field() {
         let native = tailtriage_core::Outcome::Other("custom".to_owned());
@@ -3675,6 +3770,7 @@ mod tests {
         assert_eq!(imported.run().requests[0].outcome, native.as_str());
     }
 
+    // TT-TEST: support
     #[test]
     fn invalid_whitespace_outcome_skips_child_spans_via_existing_correlation_logic() {
         let spans = vec![
@@ -3703,6 +3799,7 @@ mod tests {
             .any(|w| w.message().contains("orphan_request_scoped_event")));
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_mode_duplicate_request_id_overflow_keeps_retained_children() {
         let spans = vec![
@@ -3753,6 +3850,7 @@ mod tests {
         assert_eq!(imported.run().truncation.dropped_queues, 0);
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_mode_duplicate_request_id_overflow_only_children_retains_coarse_timing() {
         let spans = vec![
@@ -3789,6 +3887,7 @@ mod tests {
         assert_eq!(imported.run().queues.len(), 1);
     }
 
+    // TT-TEST: support
     #[test]
     fn non_strict_duplicate_request_id_overflow_only_children_retains_coarse_timing() {
         let spans = vec![
@@ -3849,6 +3948,7 @@ mod tests {
             .iter()
             .all(|msg| !msg.contains("valid but not retained due to max_requests")));
     }
+    // TT-TEST: support
     #[test]
     fn strict_mode_max_requests_overflow_children_are_retention_fallout() {
         let spans = vec![
@@ -3893,6 +3993,7 @@ mod tests {
         assert!(imported.to_string().contains("orphan_request_scoped_event"));
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_mode_max_requests_overflow_invalid_stage_still_fails() {
         let spans = vec![
@@ -3927,6 +4028,7 @@ mod tests {
         assert!(!msg.contains("valid but not retained due to max_requests"));
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_mode_max_requests_overflow_invalid_queue_still_fails() {
         let spans = vec![
@@ -3961,6 +4063,7 @@ mod tests {
         assert!(!msg.contains("valid but not retained due to max_requests"));
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_mode_max_requests_overflow_non_lexical_request_ids_follow_input_order() {
         let spans = vec![
@@ -4005,6 +4108,7 @@ mod tests {
         assert!(imported.to_string().contains("orphan_request_scoped_event"));
     }
 
+    // TT-TEST: support
     #[test]
     fn invalid_success_warns_and_skips_stage_non_strict() {
         let spans = vec![
@@ -4033,6 +4137,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn invalid_success_errors_strict() {
         let spans = vec![
@@ -4050,6 +4155,7 @@ mod tests {
         assert!(run_from_span_records(spans, ImportOptions::new("svc").strict(true)).is_err());
     }
 
+    // TT-TEST: support
     #[test]
     fn invalid_depth_warns_and_skips_queue_non_strict() {
         let spans = vec![
@@ -4078,6 +4184,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn invalid_depth_errors_strict() {
         let spans = vec![
@@ -4095,6 +4202,7 @@ mod tests {
         assert!(run_from_span_records(spans, ImportOptions::new("svc").strict(true)).is_err());
     }
 
+    // TT-TEST: support
     #[test]
     fn valid_optional_fields_are_applied() {
         let spans = vec![
@@ -4121,6 +4229,7 @@ mod tests {
         assert_eq!(run.queues[0].depth_at_start, Some(9));
     }
 
+    // TT-TEST: support
     #[test]
     fn mismatched_request_duration_warns_and_retains_duration_us_in_non_strict_mode() {
         let spans = vec![SpanRecord::new("req", 100, 101)
@@ -4148,6 +4257,7 @@ mod tests {
             .any(|w| w.contains("duration evidence was retained")));
     }
 
+    // TT-TEST: support
     #[test]
     fn absent_request_duration_us_derives_from_timestamps() {
         let spans = vec![SpanRecord::new("req", 100, 101)
@@ -4168,6 +4278,7 @@ mod tests {
             .any(|w| w.contains("precise_interval_validation_unavailable")));
     }
 
+    // TT-TEST: support
     #[test]
     fn mismatched_stage_duration_warns_and_retains_duration_us_in_non_strict_mode() {
         let spans = vec![
@@ -4191,6 +4302,7 @@ mod tests {
             .any(|w| w.message().contains("duration evidence was retained")));
     }
 
+    // TT-TEST: support
     #[test]
     fn mismatched_queue_duration_warns_and_retains_duration_us_in_non_strict_mode() {
         let spans = vec![
@@ -4214,6 +4326,7 @@ mod tests {
             .any(|w| w.message().contains("duration evidence was retained")));
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_mode_rejects_mismatched_request_duration() {
         let spans = vec![SpanRecord::new("req", 100, 101)
@@ -4230,6 +4343,7 @@ mod tests {
         assert!(message.contains("duration_mismatch"));
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_mode_rejects_contradictory_stage_duration() {
         let spans = vec![
@@ -4251,6 +4365,7 @@ mod tests {
         ));
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_mode_rejects_contradictory_queue_duration() {
         let spans = vec![
@@ -4272,6 +4387,7 @@ mod tests {
         ));
     }
 
+    // TT-TEST: support
     #[test]
     fn duration_us_within_2000_microseconds_is_accepted() {
         let spans = vec![SpanRecord::new("req", 100, 101)
@@ -4287,6 +4403,7 @@ mod tests {
             .any(|w| w.message().contains("duration_mismatch")));
     }
 
+    // TT-TEST: support
     #[test]
     fn empty_service_name_is_rejected() {
         let err = run_from_span_records(Vec::new(), ImportOptions::new(" ")).unwrap_err();

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -1749,6 +1749,7 @@ mod tests {
             .collect()
     }
 
+    // TT-TEST: support
     #[test]
     fn open_span_from_start_sample_uses_supplied_start_times() {
         let started_at_unix_ms = 123_456_789;
@@ -1773,6 +1774,7 @@ mod tests {
         assert_eq!(open.started_instant, started_instant);
     }
 
+    // TT-TEST: support
     #[test]
     fn live_recorder_request_conversion_populates_run_relative_fields() {
         with_recorder(|recorder| {
@@ -1796,6 +1798,7 @@ mod tests {
         });
     }
 
+    // TT-TEST: support
     #[test]
     fn live_recorder_stage_conversion_populates_run_relative_fields() {
         with_recorder(|recorder| {
@@ -1823,6 +1826,7 @@ mod tests {
         });
     }
 
+    // TT-TEST: support
     #[test]
     fn live_recorder_queue_conversion_populates_run_relative_fields() {
         with_recorder(|recorder| {
@@ -1852,6 +1856,7 @@ mod tests {
         });
     }
 
+    // TT-TEST: R03 primary
     #[test]
     fn request_span_collected() {
         with_recorder(|recorder| {
@@ -1867,6 +1872,7 @@ mod tests {
         });
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_snapshot_run_succeeds_for_completed_request_span() {
         let recorder = LiveRecorder::builder("svc").strict(true).build().unwrap();
@@ -1885,6 +1891,7 @@ mod tests {
         assert_eq!(snapshot.run().requests.len(), 1);
     }
 
+    // TT-TEST: support
     #[tokio::test(flavor = "current_thread")]
     async fn live_completed_request_records_close_wall_clock_and_monotonic_latency() {
         use tracing::Instrument as _;
@@ -1910,6 +1917,7 @@ mod tests {
         assert!(request.latency_us > 0);
     }
 
+    // TT-TEST: support
     #[test]
     fn duration_uses_captured_close_instant_not_current_time() {
         let started_instant = std::time::Instant::now();
@@ -1922,6 +1930,7 @@ mod tests {
         assert!(duration_us < 10_000);
     }
 
+    // TT-TEST: support
     #[test]
     fn live_finished_wall_clock_is_not_synthesized_from_duration() {
         let recorder = LiveRecorder::builder("svc").run_id("rid").build().unwrap();
@@ -1955,6 +1964,7 @@ mod tests {
         });
     }
 
+    // TT-TEST: R03 secondary
     #[test]
     fn stage_span_collected() {
         with_recorder(|recorder| {
@@ -1982,6 +1992,7 @@ mod tests {
         });
     }
 
+    // TT-TEST: R03 secondary
     #[test]
     fn queue_span_collected() {
         with_recorder(|recorder| {
@@ -2005,6 +2016,7 @@ mod tests {
         });
     }
 
+    // TT-TEST: support
     #[test]
     fn on_record_updates_field() {
         with_recorder(|recorder| {
@@ -2022,6 +2034,7 @@ mod tests {
         });
     }
 
+    // TT-TEST: support
     #[test]
     fn unrelated_span_ignored() {
         with_recorder(|recorder| {
@@ -2034,6 +2047,7 @@ mod tests {
         });
     }
 
+    // TT-TEST: R03 primary
     #[test]
     fn snapshot_run_is_non_consuming_and_shutdown_consumes_owned_handle() {
         with_recorder(|recorder| {
@@ -2066,6 +2080,7 @@ mod tests {
         assert_eq!(run.run().requests[0].request_id, "r2");
     }
 
+    // TT-TEST: support
     #[test]
     fn builder_metadata_applies_to_imported_run() {
         let recorder = LiveRecorder::builder("checkout-service")
@@ -2091,6 +2106,7 @@ mod tests {
         assert_eq!(run.run().metadata.run_id, "run-42");
     }
 
+    // TT-TEST: R03 primary
     #[test]
     fn strict_mode_errors_on_malformed_request() {
         let recorder = LiveRecorder::builder("svc").strict(true).build().unwrap();
@@ -2103,6 +2119,7 @@ mod tests {
         assert!(recorder.snapshot_run().is_err());
     }
 
+    // TT-TEST: support
     #[test]
     fn tt_kind_recorded_later_is_captured() {
         with_recorder(|recorder| {
@@ -2121,6 +2138,7 @@ mod tests {
         });
     }
 
+    // TT-TEST: support
     #[test]
     fn non_tailtriage_fields_do_not_make_span_candidate() {
         with_recorder(|recorder| {
@@ -2140,6 +2158,7 @@ mod tests {
         });
     }
 
+    // TT-TEST: support
     #[test]
     fn debug_or_invalid_tt_kind_does_not_become_valid_kind() {
         with_recorder(|recorder| {
@@ -2166,6 +2185,7 @@ mod tests {
         });
     }
 
+    // TT-TEST: support
     #[test]
     fn display_formatted_tt_kind_request_is_imported() {
         with_recorder(|recorder| {
@@ -2197,6 +2217,7 @@ mod tests {
         });
     }
 
+    // TT-TEST: support
     #[test]
     fn debug_formatted_string_tt_kind_is_rejected_with_invalid_kind_warning() {
         with_recorder(|recorder| {
@@ -2224,6 +2245,7 @@ mod tests {
         });
     }
 
+    // TT-TEST: support
     #[test]
     fn shutdown_output_is_analyzable_and_has_no_runtime_snapshots() {
         with_recorder(|recorder| {
@@ -2262,6 +2284,7 @@ mod tests {
         });
     }
 
+    // TT-TEST: S01 secondary
     #[test]
     fn completed_candidate_cap_emits_warning_and_sets_limits_hit_non_strict() {
         let recorder = LiveRecorder::builder("svc")
@@ -2304,6 +2327,7 @@ mod tests {
         assert_eq!(imported.run().requests[0].request_id, "r1");
     }
 
+    // TT-TEST: support
     #[test]
     fn completed_candidate_cap_preserves_request_over_children_non_strict() {
         let recorder = LiveRecorder::builder("svc")
@@ -2351,6 +2375,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn raw_cap_does_not_evict_retained_request_child_for_later_unretained_request() {
         let recorder = LiveRecorder::builder("svc")
@@ -2408,6 +2433,7 @@ mod tests {
         assert!(!warning_text.contains("dropped 1 completed request candidate span"));
     }
 
+    // TT-TEST: support
     #[test]
     fn raw_cap_still_preserves_request_root_when_within_semantic_request_limit() {
         let recorder = LiveRecorder::builder("svc")
@@ -2465,6 +2491,7 @@ mod tests {
         assert!(!warning_text.contains("dropped 1 completed request candidate span"));
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_mode_errors_when_completed_candidate_cap_drops_spans() {
         let recorder = LiveRecorder::builder("svc")
@@ -2498,6 +2525,7 @@ mod tests {
         }
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_mode_errors_when_completed_candidate_cap_evicts_child_for_request() {
         let recorder = LiveRecorder::builder("svc")
@@ -2538,6 +2566,7 @@ mod tests {
         }
     }
 
+    // TT-TEST: support
     #[test]
     fn completed_candidate_conversion_order_is_request_stage_queue() {
         let mut state = RecorderState::default();
@@ -2552,6 +2581,7 @@ mod tests {
         assert_eq!(ordered[2].name(), "queue");
     }
 
+    // TT-TEST: S01 secondary
     #[test]
     fn raw_completed_candidate_cap_is_separate_from_semantic_capture_limits() {
         let recorder = LiveRecorder::builder("svc")
@@ -2586,6 +2616,7 @@ mod tests {
             .any(|w| w.message().contains("max_completed_candidate_spans")));
     }
 
+    // TT-TEST: support
     #[test]
     fn raw_completed_candidate_cap_drops_incoming_request_when_full_of_requests() {
         let recorder = LiveRecorder::builder("svc")
@@ -2644,6 +2675,7 @@ mod tests {
         }));
     }
 
+    // TT-TEST: support
     #[test]
     fn request_arriving_at_full_child_containing_cap_evicts_child_regardless_of_identity() {
         let recorder = LiveRecorder::builder("svc")
@@ -2700,6 +2732,7 @@ mod tests {
         }));
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_mode_errors_when_raw_cap_evicts_child_before_core_excludes_ambiguous_requests() {
         let recorder = LiveRecorder::builder("svc")
@@ -2751,6 +2784,7 @@ mod tests {
         }
     }
 
+    // TT-TEST: support
     #[test]
     fn full_request_only_raw_cap_drops_incoming_request_regardless_of_identity() {
         let recorder = LiveRecorder::builder("svc")
@@ -2801,6 +2835,7 @@ mod tests {
         }));
     }
 
+    // TT-TEST: R05 secondary
     #[test]
     fn retained_sources_follow_live_recorder_section_order_with_exact_identity() {
         let recorder = LiveRecorder::builder("svc").build().unwrap();
@@ -2873,6 +2908,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: R05 secondary
     #[test]
     fn snapshots_are_non_consuming_and_shutdown_retained_sources_are_deterministic() {
         let build = || {
@@ -2913,6 +2949,7 @@ mod tests {
         assert_eq!(first.retained_sources(), shutdown.retained_sources());
     }
 
+    // TT-TEST: support
     #[cfg(feature = "tokio")]
     #[tokio::test(flavor = "current_thread")]
     async fn shutdown_snapshots_recorder_after_sampler_hook() {
@@ -2956,6 +2993,7 @@ mod tests {
         }));
     }
 
+    // TT-TEST: support
     #[test]
     fn semantic_request_limit_applies_after_raw_recorder_retention() {
         let recorder = LiveRecorder::builder("svc")
@@ -3002,6 +3040,7 @@ mod tests {
             .any(|w| w.message().contains("max_completed_candidate_spans")));
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_mode_errors_when_max_open_spans_drops_candidate_spans() {
         let recorder = LiveRecorder::builder("svc")
@@ -3039,6 +3078,7 @@ mod tests {
         }
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_mode_combines_recorder_drop_and_conversion_strict_violations() {
         let recorder = LiveRecorder::builder("svc")
@@ -3076,6 +3116,7 @@ mod tests {
         }
     }
 
+    // TT-TEST: support
     #[test]
     fn incomplete_request_does_not_consume_completed_candidate_cap_in_non_strict_mode() {
         let recorder = LiveRecorder::builder("svc")
@@ -3109,6 +3150,7 @@ mod tests {
             .any(|w| w.message().contains("max_completed_candidate_spans")));
     }
 
+    // TT-TEST: support
     #[test]
     fn incomplete_stage_does_not_consume_completed_candidate_cap_in_non_strict_mode() {
         let recorder = LiveRecorder::builder("svc")
@@ -3154,6 +3196,7 @@ mod tests {
             .any(|w| w.message().contains("max_completed_candidate_spans")));
     }
 
+    // TT-TEST: support
     #[test]
     fn incomplete_queue_does_not_consume_completed_candidate_cap_in_non_strict_mode() {
         let recorder = LiveRecorder::builder("svc")
@@ -3199,6 +3242,7 @@ mod tests {
             .any(|w| w.message().contains("max_completed_candidate_spans")));
     }
 
+    // TT-TEST: support
     #[test]
     fn invalid_numeric_required_fields_do_not_consume_completed_candidate_cap() {
         let recorder = LiveRecorder::builder("svc")
@@ -3233,6 +3277,7 @@ mod tests {
             .any(|w| w.message().contains("max_completed_candidate_spans")));
     }
 
+    // TT-TEST: support
     #[test]
     fn whitespace_only_required_field_reports_incomplete_candidate_not_invalid_run_event() {
         let recorder = LiveRecorder::builder("svc")
@@ -3267,6 +3312,7 @@ mod tests {
             .any(|w| w.message().contains("InvalidRunEvent")));
     }
 
+    // TT-TEST: support
     #[test]
     fn invalid_numeric_stage_does_not_consume_completed_candidate_cap() {
         let recorder = LiveRecorder::builder("svc")
@@ -3309,6 +3355,7 @@ mod tests {
             .any(|w| w.message().contains("max_completed_candidate_spans")));
     }
 
+    // TT-TEST: support
     #[test]
     fn invalid_numeric_queue_does_not_consume_completed_candidate_cap() {
         let recorder = LiveRecorder::builder("svc")
@@ -3351,6 +3398,7 @@ mod tests {
             .any(|w| w.message().contains("max_completed_candidate_spans")));
     }
 
+    // TT-TEST: support
     #[test]
     fn source_valid_orphan_stage_consumes_semantic_stage_retention_before_core_exclusion() {
         let recorder = LiveRecorder::builder("svc")
@@ -3388,6 +3436,7 @@ mod tests {
         assert_eq!(imported.run().truncation.dropped_stages, 1);
     }
 
+    // TT-TEST: support
     #[test]
     fn source_valid_orphan_queue_consumes_semantic_queue_retention_before_core_exclusion() {
         let recorder = LiveRecorder::builder("svc")
@@ -3425,6 +3474,7 @@ mod tests {
         assert_eq!(imported.run().truncation.dropped_queues, 1);
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_mode_fails_for_malformed_request_span() {
         let recorder = LiveRecorder::builder("svc").strict(true).build().unwrap();
@@ -3440,6 +3490,7 @@ mod tests {
         assert!(matches!(err, ImportError::StrictViolation(_)));
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_mode_fails_for_invalid_numeric_request_route() {
         let recorder = LiveRecorder::builder("svc").strict(true).build().unwrap();
@@ -3461,6 +3512,7 @@ mod tests {
         }
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_mode_fails_for_malformed_stage_span() {
         let recorder = LiveRecorder::builder("svc").strict(true).build().unwrap();
@@ -3483,6 +3535,7 @@ mod tests {
         assert!(matches!(err, ImportError::StrictViolation(_)));
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_mode_fails_for_invalid_numeric_stage_field() {
         let recorder = LiveRecorder::builder("svc").strict(true).build().unwrap();
@@ -3511,6 +3564,7 @@ mod tests {
         }
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_mode_fails_for_malformed_queue_span() {
         let recorder = LiveRecorder::builder("svc").strict(true).build().unwrap();
@@ -3533,6 +3587,7 @@ mod tests {
         assert!(matches!(err, ImportError::StrictViolation(_)));
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_mode_fails_for_invalid_numeric_queue_field() {
         let recorder = LiveRecorder::builder("svc").strict(true).build().unwrap();
@@ -3561,6 +3616,7 @@ mod tests {
         }
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_mode_fails_for_orphan_stage_span() {
         let recorder = LiveRecorder::builder("svc").strict(true).build().unwrap();
@@ -3577,6 +3633,7 @@ mod tests {
         assert!(matches!(err, ImportError::StrictViolation(_)));
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_mode_fails_for_orphan_queue_span() {
         let recorder = LiveRecorder::builder("svc").strict(true).build().unwrap();
@@ -3593,6 +3650,7 @@ mod tests {
         assert!(matches!(err, ImportError::StrictViolation(_)));
     }
 
+    // TT-TEST: support
     #[test]
     fn open_span_saturation_emits_warning_and_sets_limits_hit() {
         let recorder = LiveRecorder::builder("svc")
@@ -3631,6 +3689,7 @@ mod tests {
         assert!(imported.run().truncation.limits_hit);
     }
 
+    // TT-TEST: support
     #[test]
     fn non_strict_mode_reports_drop_warnings_and_truncation() {
         let recorder = LiveRecorder::builder("svc")
@@ -3694,6 +3753,7 @@ mod tests {
         assert!(imported.run().truncation.limits_hit);
     }
 
+    // TT-TEST: support
     #[test]
     fn unrelated_spans_do_not_consume_open_limit() {
         let recorder = LiveRecorder::builder("svc")
@@ -3718,18 +3778,21 @@ mod tests {
         assert!(imported.warnings().is_empty());
     }
 
+    // TT-TEST: support
     #[test]
     fn live_recorder_builder_rejects_blank_service_name() {
         let err = LiveRecorder::builder("   ").build().unwrap_err();
         assert!(matches!(err, ImportError::EmptyServiceName));
     }
 
+    // TT-TEST: support
     #[test]
     fn tracing_intake_session_builder_rejects_blank_service_name() {
         let err = TracingSession::builder("   ").build().unwrap_err();
         assert!(matches!(err, ImportError::EmptyServiceName));
     }
 
+    // TT-TEST: support
     #[test]
     fn closed_candidate_missing_tt_kind_warns_non_strict() {
         with_recorder(|recorder| {
@@ -3761,6 +3824,7 @@ mod tests {
         });
     }
 
+    // TT-TEST: support
     #[test]
     fn closed_candidate_unknown_tt_kind_warns_non_strict() {
         with_recorder(|recorder| {
@@ -3786,6 +3850,7 @@ mod tests {
         });
     }
 
+    // TT-TEST: support
     #[test]
     fn closed_candidate_malformed_tt_kind_warns_non_strict() {
         with_recorder(|recorder| {
@@ -3811,6 +3876,7 @@ mod tests {
         });
     }
 
+    // TT-TEST: support
     #[test]
     fn invalid_kind_warning_aggregates_missing_unknown_and_malformed_counts() {
         with_recorder(|recorder| {
@@ -3845,6 +3911,7 @@ mod tests {
         });
     }
 
+    // TT-TEST: support
     #[test]
     fn closed_candidate_missing_tt_kind_errors_strict() {
         let recorder = LiveRecorder::builder("svc").strict(true).build().unwrap();
@@ -3870,6 +3937,7 @@ mod tests {
         }
     }
 
+    // TT-TEST: support
     #[test]
     fn closed_candidate_missing_tt_kind_shutdown_errors_strict() {
         let recorder = LiveRecorder::builder("svc").strict(true).build().unwrap();
@@ -3895,6 +3963,7 @@ mod tests {
         }
     }
 
+    // TT-TEST: support
     #[test]
     fn strict_mode_reports_open_and_closed_missing_kind_causes_together() {
         let recorder = LiveRecorder::builder("svc").strict(true).build().unwrap();
@@ -3927,6 +3996,7 @@ mod tests {
         });
     }
 
+    // TT-TEST: support
     #[test]
     fn unrelated_closed_span_still_ignored_without_warning() {
         with_recorder(|recorder| {
@@ -3939,6 +4009,7 @@ mod tests {
             assert!(imported.warnings().is_empty());
         });
     }
+    // TT-TEST: support
     #[test]
     fn strict_mode_rejects_open_candidate_spans_without_fabricating_completions() {
         let recorder = LiveRecorder::builder("svc").strict(true).build().unwrap();
@@ -3962,6 +4033,7 @@ mod tests {
         }
     }
 
+    // TT-TEST: support
     #[test]
     fn open_candidate_span_warns_on_snapshot_and_shutdown_non_strict() {
         with_recorder(|recorder| {
@@ -3990,6 +4062,7 @@ mod tests {
         });
     }
 
+    // TT-TEST: R03 primary
     #[test]
     fn open_candidate_span_errors_in_strict_mode() {
         let recorder = LiveRecorder::builder("svc").strict(true).build().unwrap();
@@ -4002,6 +4075,7 @@ mod tests {
         });
     }
 
+    // TT-TEST: support
     #[test]
     fn unrelated_open_span_does_not_warn() {
         with_recorder(|recorder| {
@@ -4011,6 +4085,7 @@ mod tests {
         });
     }
 
+    // TT-TEST: support
     #[test]
     fn open_candidate_with_empty_tt_kind_still_warns() {
         with_recorder(|recorder| {
@@ -4027,6 +4102,7 @@ mod tests {
         });
     }
 
+    // TT-TEST: R06 secondary
     #[test]
     fn direct_completed_span_jsonl_writer_preserves_exact_retained_sources() {
         let dir = tempfile::tempdir().unwrap();
@@ -4088,6 +4164,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: S01 primary
     #[test]
     fn completed_jsonl_writer_enforces_per_record_bytes_without_total_ceiling() {
         let dir = tempfile::tempdir().unwrap();
@@ -4142,6 +4219,8 @@ mod tests {
         );
     }
 
+    // TT-TEST: S01 secondary
+    // TT-TEST: S03 secondary
     #[test]
     fn completed_jsonl_writer_reports_line_and_cleans_temp_on_oversize() {
         let dir = tempfile::tempdir().unwrap();
@@ -4167,6 +4246,7 @@ mod tests {
         assert_no_completed_span_jsonl_temps(&path);
     }
 
+    // TT-TEST: S03 secondary
     #[test]
     fn completed_jsonl_writer_preserves_existing_target_on_oversize() {
         let dir = tempfile::tempdir().unwrap();
@@ -4194,6 +4274,7 @@ mod tests {
         assert_no_completed_span_jsonl_temps(&path);
     }
 
+    // TT-TEST: S03 primary
     #[test]
     fn completed_jsonl_writer_retries_exclusive_collisions_without_modifying_them() {
         let dir = tempfile::tempdir().unwrap();
@@ -4218,6 +4299,7 @@ mod tests {
         assert!(!second.exists());
     }
 
+    // TT-TEST: S03 primary
     #[test]
     fn completed_jsonl_writer_exhausts_eight_collisions_without_modification() {
         let dir = tempfile::tempdir().unwrap();
@@ -4246,6 +4328,7 @@ mod tests {
         }
     }
 
+    // TT-TEST: S03 primary
     #[test]
     fn completed_jsonl_writer_failure_removes_only_owned_candidate() {
         let dir = tempfile::tempdir().unwrap();
@@ -4287,6 +4370,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: R06 primary
     #[test]
     fn production_completed_span_jsonl_writer_output_reimports_expected_fields() {
         let dir = tempfile::tempdir().unwrap();
@@ -4336,6 +4420,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn direct_completed_span_jsonl_writer_excludes_core_excluded_sources() {
         let dir = tempfile::tempdir().unwrap();
@@ -4434,6 +4519,7 @@ mod tests {
             .field("tt.queue", name)
     }
 
+    // TT-TEST: R06 secondary
     #[test]
     #[allow(clippy::too_many_lines)]
     fn canonical_completed_span_jsonl_replay_matches_representable_evidence_projection() {
@@ -4684,6 +4770,7 @@ mod tests {
         }
     }
 
+    // TT-TEST: support
     #[test]
     #[allow(clippy::too_many_lines)]
     fn repaired_optional_precision_writer_emits_original_source_values() {
@@ -4799,6 +4886,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn semantic_unavailable_records_are_not_written_to_completed_jsonl() {
         let semantic_dir = tempfile::tempdir().unwrap();
@@ -4873,6 +4961,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn raw_unavailable_records_are_not_written_to_completed_jsonl() {
         let raw_dir = tempfile::tempdir().unwrap();
@@ -4968,6 +5057,7 @@ mod tests {
         futures_executor::block_on(session.shutdown()).unwrap()
     }
 
+    // TT-TEST: R06 secondary
     #[test]
     fn live_session_completed_jsonl_is_section_grouped_and_byte_deterministic() {
         let first_dir = tempfile::tempdir().unwrap();
@@ -5033,6 +5123,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: R06 secondary
     #[test]
     fn stable_wrapper_import_reemits_precise_and_repairable_sources_byte_identically() {
         assert_stable_wrapper_reemits_byte_identically(
@@ -5072,6 +5163,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: R06 secondary
     #[cfg(feature = "tokio")]
     #[tokio::test(flavor = "current_thread")]
     async fn tokio_session_retained_sources_replay_request_stage_queue_but_not_runtime_snapshots() {
@@ -5148,6 +5240,7 @@ mod tests {
         // evidence only; runtime snapshots remain Run-only metadata.
     }
 
+    // TT-TEST: support
     #[test]
     fn completed_jsonl_missing_retained_sources_error_is_deterministic_without_output() {
         let dir = tempfile::tempdir().unwrap();
@@ -5182,6 +5275,7 @@ mod tests {
             .contains("tailtriage-tmp"));
     }
 
+    // TT-TEST: support
     #[test]
     fn intake_session_wrapper_jsonl_and_truncate_behavior() {
         let dir = tempfile::tempdir().unwrap();
@@ -5213,6 +5307,7 @@ mod tests {
         assert_eq!(lines.len(), 1);
     }
 
+    // TT-TEST: support
     #[test]
     fn intake_session_emits_wrapper_shape_and_round_trips_wrapper_only() {
         let dir = tempfile::tempdir().unwrap();
@@ -5255,6 +5350,7 @@ mod tests {
         assert_eq!(imported.run().requests[0].route, "/a");
     }
 
+    // TT-TEST: R06 primary
     #[test]
     fn session_shutdown_writes_retained_original_sources_directly() {
         let dir = tempfile::tempdir().unwrap();
@@ -5311,6 +5407,7 @@ mod tests {
         assert_eq!(&run_json, imported.run());
     }
 
+    // TT-TEST: support
     #[test]
     fn completed_jsonl_matches_retained_run_counts() {
         let dir = tempfile::tempdir().unwrap();
@@ -5369,6 +5466,7 @@ mod tests {
         }
     }
 
+    // TT-TEST: R06 primary
     #[test]
     fn intake_session_write_failure_returns_io_on_shutdown() {
         let dir = tempfile::tempdir().unwrap();
@@ -5396,6 +5494,7 @@ mod tests {
             .contains("create completed span jsonl parent directory"));
     }
 
+    // TT-TEST: support
     #[test]
     fn intake_session_non_strict_write_failure_returns_io_on_shutdown() {
         let dir = tempfile::tempdir().unwrap();
@@ -5423,6 +5522,7 @@ mod tests {
             .contains("create completed span jsonl parent directory"));
     }
 
+    // TT-TEST: support
     #[test]
     fn intake_session_run_json_path_writes_valid_run_json() {
         let dir = tempfile::tempdir().unwrap();
@@ -5447,6 +5547,7 @@ mod tests {
         assert_eq!(run.requests.len(), 1);
     }
 
+    // TT-TEST: support
     #[test]
     fn session_shutdown_succeeds_when_request_span_handle_is_dropped_before_shutdown() {
         let dir = tempfile::tempdir().unwrap();
@@ -5470,6 +5571,7 @@ mod tests {
         assert!(run_path.exists());
     }
 
+    // TT-TEST: R03 secondary
     #[test]
     fn session_shutdown_rejects_open_request_span_for_persisted_output() {
         let dir = tempfile::tempdir().unwrap();
@@ -5509,6 +5611,7 @@ mod tests {
         drop(span);
     }
 
+    // TT-TEST: support
     #[test]
     fn intake_session_run_json_path_creates_nested_parent_directories() {
         let dir = tempfile::tempdir().unwrap();
@@ -5530,6 +5633,7 @@ mod tests {
         assert!(run_path.exists());
     }
 
+    // TT-TEST: support
     #[test]
     fn intake_session_run_json_path_rejects_zero_requests_without_creating_file() {
         let dir = tempfile::tempdir().unwrap();
@@ -5543,6 +5647,7 @@ mod tests {
         assert!(!run_path.exists());
     }
 
+    // TT-TEST: support
     #[test]
     fn intake_session_zero_request_persisted_error_includes_intake_warnings() {
         let dir = tempfile::tempdir().unwrap();
@@ -5573,6 +5678,7 @@ mod tests {
         assert!(!run_path.exists());
     }
 
+    // TT-TEST: support
     #[test]
     fn shutdown_with_completed_span_jsonl_only_and_zero_requests_writes_no_artifact() {
         let dir = tempfile::tempdir().unwrap();
@@ -5586,6 +5692,7 @@ mod tests {
         assert!(!spans_path.exists());
     }
 
+    // TT-TEST: support
     #[test]
     fn shutdown_with_no_persisted_paths_and_zero_requests_still_returns_imported_run() {
         let session = TracingSession::builder("svc").build().unwrap();
@@ -5593,6 +5700,7 @@ mod tests {
         assert_eq!(imported.run().requests.len(), 0);
     }
 
+    // TT-TEST: support
     #[test]
     fn intake_session_run_json_path_rejects_zero_requests_without_overwriting_existing_file() {
         let dir = tempfile::tempdir().unwrap();
@@ -5607,6 +5715,7 @@ mod tests {
         assert_eq!(std::fs::read_to_string(&run_path).unwrap(), "keep-me");
     }
 
+    // TT-TEST: support
     #[test]
     fn shutdown_with_both_outputs_and_zero_requests_writes_no_final_or_temp_artifacts() {
         let dir = tempfile::tempdir().unwrap();
@@ -5624,6 +5733,7 @@ mod tests {
         assert_no_temp_artifacts(dir.path());
     }
 
+    // TT-TEST: support
     #[test]
     fn completed_jsonl_failure_prevents_run_json_transaction() {
         let dir = tempfile::tempdir().unwrap();
@@ -5668,6 +5778,7 @@ mod tests {
         assert_no_temp_artifacts(dir.path());
     }
 
+    // TT-TEST: support
     #[test]
     fn completed_jsonl_remains_finalized_when_run_json_write_fails() {
         let dir = tempfile::tempdir().unwrap();
@@ -5720,6 +5831,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn intake_session_persisted_success_keeps_warnings_and_writes_outputs() {
         let dir = tempfile::tempdir().unwrap();
@@ -5756,6 +5868,7 @@ mod tests {
         assert!(run_path.exists());
     }
 
+    // TT-TEST: support
     #[test]
     fn completed_span_jsonl_success_writes_final_wrapper_file() {
         let dir = tempfile::tempdir().unwrap();
@@ -5784,6 +5897,7 @@ mod tests {
         assert!(value["span"].is_object());
     }
 
+    // TT-TEST: support
     #[test]
     fn completed_span_jsonl_path_creates_nested_parent_directories() {
         let dir = tempfile::tempdir().unwrap();
@@ -5805,12 +5919,14 @@ mod tests {
         assert!(spans_path.exists());
     }
 
+    // TT-TEST: support
     #[test]
     fn create_output_parent_dir_skips_filename_only_path() {
         create_output_parent_dir(Path::new("run.json"), "create run json parent directory")
             .unwrap();
     }
 
+    // TT-TEST: support
     #[test]
     fn unrelated_spans_are_ignored_by_completed_span_jsonl_writer() {
         let dir = tempfile::tempdir().unwrap();
@@ -5838,6 +5954,7 @@ mod tests {
         assert!(!line.contains("unrelated"));
     }
 
+    // TT-TEST: support
     #[test]
     fn completed_jsonl_excludes_malformed_and_orphan_stage_queue_spans() {
         let dir = tempfile::tempdir().unwrap();
@@ -5883,6 +6000,7 @@ mod tests {
         assert_eq!(imported.run().queues.len(), 0);
     }
 
+    // TT-TEST: support
     #[test]
     fn intake_session_captures_request_stage_queue() {
         let session = TracingSession::builder("svc").build().unwrap();

--- a/tailtriage-tracing/src/tokio.rs
+++ b/tailtriage-tracing/src/tokio.rs
@@ -126,6 +126,7 @@ mod tests {
         }
     }
 
+    // TT-TEST: support
     #[test]
     fn merge_runtime_data_preserves_active_input_lifecycle() {
         let imported = ImportedRun::new(base_run(100, None), Vec::new());
@@ -151,6 +152,7 @@ mod tests {
         assert_eq!(run.runtime_snapshots[0].worker_count, Some(3));
     }
 
+    // TT-TEST: support
     #[test]
     fn merge_runtime_data_preserves_finalized_input_lifecycle() {
         let imported = ImportedRun::new(base_run(100, Some(500)), Vec::new());

--- a/tailtriage-tracing/src/types.rs
+++ b/tailtriage-tracing/src/types.rs
@@ -409,6 +409,7 @@ mod tests {
     use super::*;
     use crate::{TT_DEPTH_AT_START, TT_KIND, TT_SUCCESS};
 
+    // TT-TEST: support
     #[test]
     fn span_record_builder_stores_fields() {
         let record = SpanRecord::new("request", 10, 20)
@@ -431,6 +432,7 @@ mod tests {
         assert_eq!(record.fields().len(), 4);
     }
 
+    // TT-TEST: support
     #[test]
     fn field_value_from_conversions_work() {
         assert_eq!(
@@ -447,6 +449,7 @@ mod tests {
         assert_eq!(FieldValue::from(3.5_f64), FieldValue::F64(3.5));
     }
 
+    // TT-TEST: support
     #[test]
     fn import_options_builder_sets_values() {
         let options = ImportOptions::new("checkout-service")
@@ -460,12 +463,14 @@ mod tests {
         assert!(options.strict_mode());
     }
 
+    // TT-TEST: support
     #[test]
     fn import_warning_display_matches_message() {
         let warning = ImportWarning::new("dropped unknown field");
         assert_eq!(warning.to_string(), "dropped unknown field");
     }
 
+    // TT-TEST: support
     #[test]
     fn imported_run_accessors_and_into_parts_work() {
         let metadata = tailtriage_core::RunMetadata {
@@ -495,6 +500,7 @@ mod tests {
         assert_eq!(parts_warnings, warnings);
     }
 
+    // TT-TEST: support
     #[test]
     fn import_options_default_resolution_uses_light_core_defaults() {
         let options = ImportOptions::new("svc");
@@ -505,6 +511,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn import_options_mode_investigation_updates_defaults() {
         let options = ImportOptions::new("svc").mode(tailtriage_core::CaptureMode::Investigation);
@@ -514,6 +521,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn import_options_full_capture_limits_override_wins() {
         let full = tailtriage_core::CaptureLimits {
@@ -536,6 +544,7 @@ mod tests {
         assert_eq!(options.resolved_capture_limits(), full);
     }
 
+    // TT-TEST: support
     #[test]
     fn import_options_additive_capture_limits_override_applies_to_mode_defaults() {
         let additive = tailtriage_core::CaptureLimitsOverride {

--- a/tailtriage-tracing/tests/equivalence.rs
+++ b/tailtriage-tracing/tests/equivalence.rs
@@ -3,6 +3,7 @@ mod live_harness;
 
 use live_harness::assert_deterministic_span_import_full_parity;
 
+// TT-TEST: F03 secondary
 #[test]
 fn deterministic_span_import_remains_a_compact_live_harness_smoke_test() {
     assert_deterministic_span_import_full_parity();

--- a/tailtriage-tracing/tests/equivalence_contract.rs
+++ b/tailtriage-tracing/tests/equivalence_contract.rs
@@ -56,14 +56,17 @@ fn assert_case_matches_independent_oracles(name: &str, limits: Option<CaptureLim
     assert_eq!(report(&native), expected_report);
     assert_eq!(report(&tracing), expected_report);
 }
+// TT-TEST: F03 primary
 #[test]
 fn precise_native_and_tracing_runs_match_independent_representable_projection() {
     assert_both("precise_route_divergent")
 }
+// TT-TEST: F03 primary
 #[test]
 fn precise_native_and_tracing_reports_match_independent_expected_projection() {
     assert_reports("precise_route_divergent")
 }
+// TT-TEST: F03 primary
 #[test]
 fn route_breakdowns_match_for_equivalent_native_and_tracing_evidence() {
     assert_case_matches_independent_oracles("precise_route_divergent", None);
@@ -100,6 +103,7 @@ fn route_breakdowns_match_for_equivalent_native_and_tracing_evidence() {
         assert_eq!(r.warnings.last().unwrap(), "Different routes show different primary suspects; inspect route_breakdowns before acting on the global suspect.");
     }
 }
+// TT-TEST: F03 primary
 #[test]
 fn temporal_segments_match_for_equivalent_native_and_tracing_evidence() {
     assert_case_matches_independent_oracles("precise_temporal_movement", None);
@@ -146,6 +150,7 @@ fn temporal_segments_match_for_equivalent_native_and_tracing_evidence() {
             .any(|w| w == "Temporal segments show different primary suspects; inspect temporal_segments before acting on the global suspect."));
     }
 }
+// TT-TEST: F03 secondary
 #[test]
 fn duration_only_native_and_tracing_cases_share_core_warning_and_report_semantics() {
     assert_case_matches_independent_oracles("duration_only_legacy", None);
@@ -199,6 +204,7 @@ fn duration_only_native_and_tracing_cases_share_core_warning_and_report_semantic
         assert_eq!(actual, expected);
     }
 }
+// TT-TEST: F03 secondary
 #[test]
 #[allow(clippy::too_many_lines)]
 fn semantic_limits_retain_the_same_evidence_and_drop_counts() {
@@ -317,6 +323,7 @@ fn semantic_limits_retain_the_same_evidence_and_drop_counts() {
         assert!(run.inflight.is_empty() && run.runtime_snapshots.is_empty());
     }
 }
+// TT-TEST: support
 #[test]
 fn completed_span_jsonl_import_never_fabricates_runtime_or_inflight_evidence() {
     let t = import_case("precise_route_divergent", None);
@@ -324,6 +331,7 @@ fn completed_span_jsonl_import_never_fabricates_runtime_or_inflight_evidence() {
     assert!(t.inflight.is_empty());
     assert_eq!(t.metadata.effective_tokio_sampler_config, None);
 }
+// TT-TEST: F03 secondary
 #[test]
 fn completed_span_equivalence_rejects_native_partial_stage_and_queue_evidence() {
     let mut r = native_case("precise_route_divergent");
@@ -339,6 +347,7 @@ fn completed_span_equivalence_rejects_native_partial_stage_and_queue_evidence() 
         Err(UnsupportedParityEvidence::PartialQueue)
     );
 }
+// TT-TEST: F03 secondary
 #[test]
 fn completed_span_equivalence_rejects_run_only_runtime_and_inflight_evidence() {
     let mut r = native_case("precise_route_divergent");
@@ -365,6 +374,7 @@ fn completed_span_equivalence_rejects_run_only_runtime_and_inflight_evidence() {
         Err(UnsupportedParityEvidence::RuntimeSnapshots)
     );
 }
+// TT-TEST: support
 #[test]
 fn run_only_metadata_differences_do_not_change_representable_projection() {
     let a = native_case("precise_route_divergent");
@@ -377,6 +387,7 @@ fn run_only_metadata_differences_do_not_change_representable_projection() {
     assert_eq!(project_run(&a), project_run(&b));
 }
 
+// TT-TEST: support
 #[test]
 #[allow(clippy::too_many_lines)]
 fn equivalence_projections_detect_every_contract_field_mutation() {
@@ -888,6 +899,7 @@ fn equivalence_projections_detect_every_contract_field_mutation() {
     assert_eq!(unix_actual, unix_expected);
 }
 
+// TT-TEST: support
 #[test]
 fn native_and_tracing_projection_json_matches_checked_in_bytes() {
     for (name, limits) in [

--- a/tailtriage-tracing/tests/live_api_defaults.rs
+++ b/tailtriage-tracing/tests/live_api_defaults.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "live")]
 
+// TT-TEST: support
 #[test]
 fn crate_root_exports_live_recorder_default_limits_consistently() {
     let defaults = tailtriage_tracing::RecorderLimits::default();

--- a/tailtriage-tracing/tests/live_api_surface.rs
+++ b/tailtriage-tracing/tests/live_api_surface.rs
@@ -2,6 +2,7 @@
 
 use tailtriage_tracing::{RecorderLimits, TailtriageLayer, TracingSession, TracingSessionBuilder};
 
+// TT-TEST: R03 primary
 #[test]
 fn public_live_api_imports_only_session_layer_and_limits() {
     fn accepts_builder(_: TracingSessionBuilder) {}
@@ -16,6 +17,7 @@ fn public_live_api_imports_only_session_layer_and_limits() {
     assert_eq!(imported.run().metadata.service_name, "svc");
 }
 
+// TT-TEST: R04 secondary
 #[cfg(feature = "tokio")]
 #[tokio::test(flavor = "current_thread")]
 async fn direct_crate_tokio_methods_compile_and_work() {

--- a/tailtriage-tracing/tests/support/live_harness.rs
+++ b/tailtriage-tracing/tests/support/live_harness.rs
@@ -697,6 +697,7 @@ fn find_primary_suspect_line(rendered: &str) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
+// TT-TEST: support
 #[test]
 fn parity_report_detects_queue_name_mismatch() {
     let native = deterministic_native_run();
@@ -715,6 +716,7 @@ fn parity_report_detects_queue_name_mismatch() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn normalization_replaces_unstable_id_and_timestamp_lines() {
     let run_id_a = normalize_rendered_report("Run ID: abc123");
@@ -730,6 +732,7 @@ fn normalization_replaces_unstable_id_and_timestamp_lines() {
     assert_eq!(generated_a, generated_b);
 }
 
+// TT-TEST: support
 #[test]
 fn normalization_replaces_unstable_timestamp_field_lines() {
     let cases = [
@@ -753,6 +756,7 @@ fn normalization_replaces_unstable_timestamp_field_lines() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn normalization_preserves_semantic_content() {
     let a = "## Summary
@@ -791,6 +795,7 @@ Next checks:
     );
 }
 
+// TT-TEST: support
 #[test]
 fn parity_report_detects_request_outcome_mismatch() {
     let native = deterministic_native_run();
@@ -814,6 +819,7 @@ fn parity_report_detects_request_outcome_mismatch() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn live_session_preserves_event_shape_and_outputs_analyzable_run() {
     let (run, warnings) = live_tracing_run();

--- a/tailtriage-tracing/tests/tokio_session.rs
+++ b/tailtriage-tracing/tests/tokio_session.rs
@@ -23,6 +23,7 @@ async fn wait_for_runtime_snapshot(session: &TracingSession) {
     }
 }
 
+// TT-TEST: support
 #[tokio::test(flavor = "current_thread")]
 async fn tracing_session_snapshot_is_unfinalized() {
     let session = TracingSession::builder("svc")
@@ -35,6 +36,7 @@ async fn tracing_session_snapshot_is_unfinalized() {
     session.shutdown().await.expect("shutdown session");
 }
 
+// TT-TEST: R04 secondary
 #[tokio::test(flavor = "current_thread")]
 async fn tracing_session_shutdown_output_is_finalized() {
     let session = TracingSession::builder("svc")
@@ -107,6 +109,7 @@ async fn tracing_session_shutdown_output_is_finalized() {
     assert!(serialized["metadata"].get("finished_at_unix_ms").is_none());
 }
 
+// TT-TEST: T03 secondary
 #[test]
 fn start_outside_runtime_fails_clearly() {
     let err = TracingSession::builder("svc")
@@ -122,6 +125,7 @@ fn start_outside_runtime_fails_clearly() {
     ));
 }
 
+// TT-TEST: support
 #[tokio::test(flavor = "current_thread")]
 async fn tracing_tokio_session_start_rejects_blank_service_name() {
     let err = TracingSession::builder("   ")
@@ -131,6 +135,7 @@ async fn tracing_tokio_session_start_rejects_blank_service_name() {
     assert!(matches!(err, ImportError::EmptyServiceName));
 }
 
+// TT-TEST: T03 secondary
 #[tokio::test(flavor = "current_thread")]
 async fn zero_sampler_interval_fails_clearly() {
     let err = TracingSession::builder("svc")
@@ -144,6 +149,7 @@ async fn zero_sampler_interval_fails_clearly() {
     ));
 }
 
+// TT-TEST: support
 #[tokio::test(flavor = "current_thread")]
 async fn zero_sampler_interval_fails_even_with_manual_runtime_snapshots() {
     let err = TracingSession::builder("svc")
@@ -158,6 +164,7 @@ async fn zero_sampler_interval_fails_even_with_manual_runtime_snapshots() {
     ));
 }
 
+// TT-TEST: R04 primary
 #[tokio::test(flavor = "current_thread")]
 async fn a1_bare_tokio_feature_session_rejects_manual_runtime_recording() {
     let session = TracingSession::builder("svc")
@@ -185,6 +192,7 @@ async fn a1_bare_tokio_feature_session_rejects_manual_runtime_recording() {
     assert!(imported.run().metadata.lifecycle_warnings.is_empty());
 }
 
+// TT-TEST: R04 primary
 #[tokio::test(flavor = "current_thread")]
 async fn a2_manual_runtime_snapshots_retains_snapshot_without_sampler() {
     let session = TracingSession::builder("svc")
@@ -247,6 +255,7 @@ async fn a2_manual_runtime_snapshots_retains_snapshot_without_sampler() {
         }));
 }
 
+// TT-TEST: R04 primary
 #[tokio::test(flavor = "current_thread")]
 async fn a3_sampler_interval_starts_background_and_retains_manual_snapshot() {
     let session = TracingSession::builder("svc")
@@ -286,6 +295,7 @@ async fn a3_sampler_interval_starts_background_and_retains_manual_snapshot() {
         .any(|warning| { warning.contains("background runtime sampling disabled") }));
 }
 
+// TT-TEST: support
 #[tokio::test(flavor = "current_thread")]
 async fn a5_ordinary_live_session_captures_request_stage_queue_without_runtime_config() {
     let session = TracingSession::builder("svc")
@@ -327,6 +337,7 @@ async fn a5_ordinary_live_session_captures_request_stage_queue_without_runtime_c
     assert!(imported.run().metadata.lifecycle_warnings.is_empty());
 }
 
+// TT-TEST: R04 primary
 #[tokio::test(flavor = "current_thread")]
 async fn active_sampler_shutdown_stops_before_outputs_and_keeps_runtime_run_only() {
     let dir = tempfile::tempdir().expect("tempdir");

--- a/tailtriage-tracing/tests/tracing_examples.rs
+++ b/tailtriage-tracing/tests/tracing_examples.rs
@@ -127,6 +127,7 @@ fn assert_single_request_timing_semantics(run: &Run) {
     assert_eq!(report.p95_queue_share_permille, Some(600));
 }
 
+// TT-TEST: F03 secondary
 #[cfg(feature = "live")]
 #[test]
 fn native_core_and_live_tracing_capture_preserve_timing_semantics() {
@@ -137,6 +138,7 @@ fn native_core_and_live_tracing_capture_preserve_timing_semantics() {
     assert_single_request_timing_semantics(&tracing);
 }
 
+// TT-TEST: F02 secondary
 #[test]
 fn jsonl_fixture_imports_completed_span_shape() {
     let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -168,6 +170,7 @@ fn jsonl_fixture_imports_completed_span_shape() {
         .contains("precise_interval_validation_unavailable")));
 }
 
+// TT-TEST: F02 secondary
 #[test]
 fn jsonl_fixture_reader_and_path_import_parity_on_counts() {
     let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -192,6 +195,7 @@ fn jsonl_fixture_reader_and_path_import_parity_on_counts() {
     assert_eq!(run_path.stages.len(), run_reader.stages.len());
 }
 
+// TT-TEST: support
 #[test]
 fn imported_fixture_run_is_analyzable_and_has_no_runtime_snapshots() {
     let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -213,6 +217,7 @@ fn imported_fixture_run_is_analyzable_and_has_no_runtime_snapshots() {
     assert_eq!(report.request_count, 1);
 }
 
+// TT-TEST: support
 #[test]
 fn stable_wrapper_duration_us_is_authoritative_when_wall_timestamps_disagree() {
     let input = r#"{"format":"tailtriage.tracing-span.v1","span":{"name":"request","started_at_unix_ms":1700000000000,"started_at_run_us":0,"finished_at_unix_ms":1700000000001,"finished_at_run_us":1000,"duration_us":50000,"fields":{"tt.kind":"request","tt.request_id":"req-1","tt.route":"/checkout","tt.outcome":"ok"}}}"#;


### PR DESCRIPTION
### Motivation

- Apply an audited, mechanical `TT-TEST` classification migration to the `tailtriage-tracing` crate so every existing test is explicitly tagged for downstream tracking and validation. 
- Keep this change minimal and non-functional: only add marker comments above existing test attributes without altering test bodies, logic, formatting, or other repository surfaces.

### Description

- Added `// TT-TEST: ...` comment lines immediately above the attribute block for 317 existing executable Rust tests spread across 14 files in `tailtriage-tracing`.
- Introduced exactly 319 new `TT-TEST` comment lines in total, with the two dual-marker tests being `stable_wrapper_fixture_imports` and `completed_jsonl_writer_reports_line_and_cleans_temp_on_oversize` as specified.
- Changes are purely additive comment lines; no existing lines were modified or deleted and no production code, docs, manifests, validators, or formatting were changed.
- Files affected: tailtriage-tracing/src/{convention,error,jsonl,lib,recorder,tokio,types}.rs and tailtriage-tracing/tests/{equivalence,equivalence_contract,live_api_defaults,live_api_surface,support/live_harness,tokio_session,tracing_examples}.rs.

### Testing

- Ran package and workspace validation and tests: `cargo test -p tailtriage-tracing --all-targets --all-features --locked`, `cargo test --workspace --all-targets --all-features --locked`, `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, and `python3 scripts/validate_docs_contracts.py`, and all completed successfully.
- Performed an exact diff audit and `git diff --check` validation to confirm the patch contains exactly 319 added `// TT-TEST: ...` lines and zero deletions, and confirmed the two specified tests contain two adjacent markers each.
- Structural checks confirmed: 317 listed tests exist and were tagged, 319 marker-comment lines were added, only the 14 scoped files were changed, and no `TT-INVARIANT` comments or other unintended edits were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8ca24ba11c83309001ebbbd09b9955)