### PR TITLE
test(analyzer): add audited TT-TEST markers to tailtriage-analyzer

### DIFF
--- a/tailtriage-analyzer/src/attribution.rs
+++ b/tailtriage-analyzer/src/attribution.rs
@@ -86,6 +86,7 @@ mod tests {
         attributed.duration_us
     }
 
+    // TT-TEST: support
     #[test]
     fn empty_intervals_are_precise_zero() {
         let attributed = attributed_elapsed_duration(&[], 100);
@@ -93,6 +94,7 @@ mod tests {
         assert_eq!(attributed.duration_us, 0);
     }
 
+    // TT-TEST: support
     #[test]
     fn nonempty_imprecise_input_with_zero_cap_is_approximate_zero() {
         let attributed = attributed_elapsed_duration(
@@ -107,6 +109,7 @@ mod tests {
         assert_eq!(attributed.mode, AttributionMode::Approximate);
     }
 
+    // TT-TEST: support
     #[test]
     fn approximate_fallback_sums_all_authoritative_durations_before_cap() {
         let attributed = attributed_elapsed_duration(
@@ -127,41 +130,49 @@ mod tests {
         assert_eq!(attributed.mode, AttributionMode::Approximate);
     }
 
+    // TT-TEST: support
     #[test]
     fn one_interval() {
         assert_eq!(precise_duration(&[(10, 40)], 100), 30);
     }
 
+    // TT-TEST: support
     #[test]
     fn disjoint_intervals_sum_covered_time() {
         assert_eq!(precise_duration(&[(0, 20), (40, 70)], 100), 50);
     }
 
+    // TT-TEST: support
     #[test]
     fn touching_intervals_are_merged() {
         assert_eq!(precise_duration(&[(0, 20), (20, 50)], 100), 50);
     }
 
+    // TT-TEST: support
     #[test]
     fn nested_intervals_do_not_inflate_time() {
         assert_eq!(precise_duration(&[(0, 80), (20, 40)], 100), 80);
     }
 
+    // TT-TEST: support
     #[test]
     fn partially_overlapping_intervals_are_union_attributed() {
         assert_eq!(precise_duration(&[(0, 60), (40, 90)], 100), 90);
     }
 
+    // TT-TEST: support
     #[test]
     fn exact_duplicate_intervals_count_once() {
         assert_eq!(precise_duration(&[(0, 60), (0, 60)], 100), 60);
     }
 
+    // TT-TEST: support
     #[test]
     fn unsorted_input_is_sorted_before_union() {
         assert_eq!(precise_duration(&[(50, 90), (0, 20), (15, 30)], 100), 70);
     }
 
+    // TT-TEST: support
     #[test]
     fn zero_length_intervals_do_not_add_time() {
         assert_eq!(precise_duration(&[(0, 0), (10, 10), (20, 30)], 100), 10);

--- a/tailtriage-analyzer/src/options/overrides.rs
+++ b/tailtriage-analyzer/src/options/overrides.rs
@@ -288,6 +288,7 @@ mod tests {
         format!("[analyzer]\nschema_version = 1\n[analyzer.{group}]\n{field} = {value}\n")
     }
 
+    // TT-TEST: Q01 secondary
     #[test]
     fn registry_paths_are_unique_and_exact() {
         let paths = AnalyzeOptions::valid_override_paths();
@@ -297,6 +298,7 @@ mod tests {
         assert_eq!(paths, EXPECTED_PATHS);
     }
 
+    // TT-TEST: Q01 secondary
     #[test]
     fn descriptor_paths_and_valid_override_paths_are_identical() {
         let descriptor_paths: Vec<_> = analyze_option_descriptors()
@@ -306,6 +308,7 @@ mod tests {
         assert_eq!(descriptor_paths, AnalyzeOptions::valid_override_paths());
     }
 
+    // TT-TEST: Q01 secondary
     #[test]
     fn every_registered_path_accepts_equivalent_cli_and_toml_value() {
         assert_eq!(CASES.len(), 29);
@@ -319,6 +322,7 @@ mod tests {
         }
     }
 
+    // TT-TEST: support
     #[test]
     fn every_registered_path_produces_one_expected_summary_entry() {
         for case in CASES {
@@ -333,6 +337,7 @@ mod tests {
         }
     }
 
+    // TT-TEST: support
     #[test]
     fn multiple_non_default_summaries_are_deterministically_sorted() {
         let mut options = AnalyzeOptions::default();
@@ -358,6 +363,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn toml_unknown_groups_and_fields_remain_errors() {
         assert!(AnalyzeOptions::from_toml_str(
@@ -370,6 +376,7 @@ mod tests {
         .is_err());
     }
 
+    // TT-TEST: support
     #[test]
     fn misspelled_path_has_suggestion() {
         match AnalyzeOptions::default().apply_override("queuing.trigger_permille=1") {
@@ -380,6 +387,7 @@ mod tests {
         }
     }
 
+    // TT-TEST: support
     #[test]
     fn toml_string_list_preserves_commas_inside_items() {
         let options = AnalyzeOptions::from_toml_str(
@@ -392,6 +400,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: A13 secondary
     #[test]
     fn descriptor_defaults_and_value_types_remain_public_contract() {
         let actual: Vec<_> = analyze_option_descriptors()
@@ -446,6 +455,7 @@ mod tests {
         assert_eq!(actual, expected);
     }
 
+    // TT-TEST: support
     #[test]
     fn missing_equals_is_invalid_override_syntax() {
         let err = AnalyzeOptions::default()
@@ -459,6 +469,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn multiple_equals_is_invalid_override_syntax() {
         let err = AnalyzeOptions::default()
@@ -472,6 +483,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn unknown_path_returns_unknown_override_path() {
         let err = AnalyzeOptions::default()
@@ -486,6 +498,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn negative_unsigned_override_is_invalid_override_value() {
         let err = AnalyzeOptions::default()
@@ -501,6 +514,7 @@ mod tests {
         ));
     }
 
+    // TT-TEST: support
     #[test]
     fn u8_overflow_is_invalid_override_value() {
         let err = AnalyzeOptions::default()
@@ -516,6 +530,7 @@ mod tests {
         ));
     }
 
+    // TT-TEST: support
     #[test]
     fn invalid_bool_text_is_invalid_override_value() {
         let err = AnalyzeOptions::default()
@@ -531,6 +546,7 @@ mod tests {
         ));
     }
 
+    // TT-TEST: support
     #[test]
     fn comma_separated_cli_lists_trim_entries() {
         let mut options = AnalyzeOptions::default();
@@ -543,6 +559,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn empty_cli_list_entries_are_rejected() {
         let err = AnalyzeOptions::default()
@@ -558,6 +575,7 @@ mod tests {
         ));
     }
 
+    // TT-TEST: support
     #[test]
     fn repeated_valid_overrides_use_last_value() {
         let mut options = AnalyzeOptions::default();
@@ -570,6 +588,7 @@ mod tests {
         assert_eq!(options.queueing.trigger_permille, 450);
     }
 
+    // TT-TEST: support
     #[test]
     fn semantically_invalid_single_override_leaves_original_options_unchanged() {
         let mut options = AnalyzeOptions::default();
@@ -587,6 +606,7 @@ mod tests {
         assert_eq!(options, before);
     }
 
+    // TT-TEST: support
     #[test]
     fn invalid_path_leaves_original_options_unchanged() {
         let mut options = AnalyzeOptions::default();
@@ -601,6 +621,7 @@ mod tests {
         assert_eq!(options, before);
     }
 
+    // TT-TEST: support
     #[test]
     fn batch_processing_stops_without_applying_later_entries() {
         let mut options = AnalyzeOptions::default();
@@ -622,6 +643,7 @@ mod tests {
         assert_eq!(options, before);
     }
 
+    // TT-TEST: support
     #[test]
     fn apply_overrides_is_transactional_when_later_override_fails() {
         let mut opts = AnalyzeOptions::default();

--- a/tailtriage-analyzer/src/options/registry.rs
+++ b/tailtriage-analyzer/src/options/registry.rs
@@ -258,6 +258,7 @@ fn edit_distance(a: &str, b: &str) -> usize {
 mod tests {
     use super::*;
 
+    // TT-TEST: support
     #[test]
     fn every_entry_reapplies_its_own_typed_value_without_change() {
         for entry in OPTION_ENTRIES {

--- a/tailtriage-analyzer/src/ratio.rs
+++ b/tailtriage-analyzer/src/ratio.rs
@@ -13,6 +13,7 @@ pub(super) fn meets_ratio(higher: u64, lower: u64, numerator: u64, denominator: 
 mod tests {
     use super::meets_ratio;
 
+    // TT-TEST: support
     #[test]
     fn ratio_boundary_is_inclusive_and_distinguishes_adjacent_values() {
         assert!(!meets_ratio(2, 2, 3, 2));
@@ -20,11 +21,13 @@ mod tests {
         assert!(meets_ratio(4, 2, 3, 2));
     }
 
+    // TT-TEST: support
     #[test]
     fn zero_baseline_never_meets_ratio() {
         assert!(!meets_ratio(u64::MAX, 0, 3, 2));
     }
 
+    // TT-TEST: support
     #[test]
     fn large_qualifying_and_non_qualifying_values_are_exact() {
         assert!(meets_ratio(u64::MAX, u64::MAX / 2, 3, 2));
@@ -32,6 +35,7 @@ mod tests {
         assert!(!meets_ratio(u64::MAX - 1, u64::MAX, 3, 2));
     }
 
+    // TT-TEST: support
     #[test]
     fn arithmetic_is_exact_near_u64_max() {
         assert!(meets_ratio(u64::MAX, u64::MAX - 1, 1, 1));

--- a/tailtriage-analyzer/src/route.rs
+++ b/tailtriage-analyzer/src/route.rs
@@ -146,6 +146,7 @@ mod tests {
     use super::has_material_route_p95_ratio;
     use crate::AnalyzeOptions;
 
+    // TT-TEST: support
     #[test]
     fn slowest_to_fastest_ratio_uses_its_boundary_and_baseline() {
         let mut options = AnalyzeOptions::default();
@@ -160,6 +161,7 @@ mod tests {
         assert!(has_material_route_p95_ratio(31, 20, Some(1), &options));
     }
 
+    // TT-TEST: support
     #[test]
     fn slowest_to_global_ratio_uses_its_boundary_and_baseline() {
         let mut options = AnalyzeOptions::default();

--- a/tailtriage-analyzer/src/scoring.rs
+++ b/tailtriage-analyzer/src/scoring.rs
@@ -698,6 +698,7 @@ mod worker_normalized_tests {
         run
     }
 
+    // TT-TEST: support
     #[test]
     fn classifies_all_worker_evidence_statuses() {
         assert_eq!(
@@ -725,6 +726,7 @@ mod worker_normalized_tests {
         );
     }
 
+    // TT-TEST: A02 primary
     #[test]
     fn normalized_contribution_boundaries_are_exact() {
         for (p95, expected) in [
@@ -743,6 +745,7 @@ mod worker_normalized_tests {
         }
     }
 
+    // TT-TEST: support
     #[test]
     fn normalization_floors_scales_and_clamps_with_u128_intermediates() {
         assert_eq!(queue_per_worker_milli(1, None, 3), 333);
@@ -754,6 +757,7 @@ mod worker_normalized_tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn percentile_combines_each_snapshots_global_and_local_depth_first() {
         let combined = [
@@ -763,6 +767,7 @@ mod worker_normalized_tests {
         assert_eq!(percentile(&combined, 95, 100), Some(5000));
     }
 
+    // TT-TEST: support
     #[test]
     fn normalized_pressure_is_monotonic_and_scale_invariant() {
         for workers in 1..=12 {
@@ -806,6 +811,7 @@ mod worker_normalized_tests {
         }
     }
 
+    // TT-TEST: support
     #[test]
     fn normalized_contribution_is_monotonic() {
         let mut previous = 0;

--- a/tailtriage-analyzer/src/slicing.rs
+++ b/tailtriage-analyzer/src/slicing.rs
@@ -203,6 +203,7 @@ mod tests {
         slice_run(source, source, request_ids, global_evidence)
     }
 
+    // TT-TEST: A08 primary
     #[test]
     fn shared_slicer_preserves_request_scoped_source_order() {
         let downstream = fixture(include_str!("../tests/fixtures/downstream_stage.json"));
@@ -276,6 +277,7 @@ mod tests {
         assert_eq!(sliced.run.schema_version, source.schema_version);
     }
 
+    // TT-TEST: support
     #[test]
     fn scoped_projection_matches_internal_report_fields_exactly() {
         let source = fixture(include_str!("../tests/fixtures/queue_saturation.json"));
@@ -360,6 +362,7 @@ mod tests {
         assert!(temporal_json.get("temporal_segments").is_none());
     }
 
+    // TT-TEST: A09 secondary
     #[test]
     fn temporal_slice_filters_global_samples_with_existing_clock_rules() {
         let mut source = fixture(include_str!("../tests/fixtures/queue_saturation.json"));

--- a/tailtriage-analyzer/src/stage_attribution.rs
+++ b/tailtriage-analyzer/src/stage_attribution.rs
@@ -226,6 +226,7 @@ mod tests {
         }
     }
 
+    // TT-TEST: A02 primary
     #[test]
     fn overlapping_same_name_stages_use_per_request_union() {
         let mut run = run_with_requests(&["a", "b", "c"], 100);
@@ -244,6 +245,7 @@ mod tests {
         assert_eq!(summary.tail_share_permille, 433);
     }
 
+    // TT-TEST: support
     #[test]
     fn disjoint_repeated_same_name_stages_remain_additive_per_request() {
         let mut run = run_with_requests(&["a", "b", "c"], 100);
@@ -261,6 +263,7 @@ mod tests {
         assert_eq!(summary.tail_share_permille, 266);
     }
 
+    // TT-TEST: A03 secondary
     #[test]
     fn approximate_fallback_uses_all_events_in_one_request_stage_group() {
         let mut run = run_with_requests(&["a", "b", "c"], 100);
@@ -278,6 +281,7 @@ mod tests {
         assert_eq!(summary.tail_share_permille, 400);
     }
 
+    // TT-TEST: support
     #[test]
     fn interleaved_stage_request_groups_are_independent_and_deterministic() {
         let mut run = run_with_requests(&["a", "b", "c"], 100);
@@ -310,6 +314,7 @@ mod tests {
         assert_eq!(db.cumulative_share_permille, 266);
     }
 
+    // TT-TEST: support
     #[test]
     fn different_stage_names_remain_independent_when_nested() {
         let mut run = run_with_requests(&["a", "b", "c"], 100);
@@ -326,6 +331,7 @@ mod tests {
         assert_eq!(summaries[1].cumulative_attributed_latency_us, 240);
     }
 
+    // TT-TEST: support
     #[test]
     fn coarse_unix_timestamps_do_not_drive_stage_attribution() {
         let mut run = run_with_requests(&["a", "b", "c"], 100);

--- a/tailtriage-analyzer/src/temporal.rs
+++ b/tailtriage-analyzer/src/temporal.rs
@@ -293,6 +293,7 @@ mod tests {
         options
     }
 
+    // TT-TEST: A09 primary
     #[test]
     fn p95_shift_is_inclusive_and_distinguishes_adjacent_values() {
         let options = options_with_ratio(3, 2);
@@ -301,6 +302,7 @@ mod tests {
         assert!(has_material_p95_shift(Some(20), Some(31), &options));
     }
 
+    // TT-TEST: support
     #[test]
     fn p95_shift_orders_values_symmetrically() {
         let options = options_with_ratio(3, 2);
@@ -310,6 +312,7 @@ mod tests {
         assert!(!has_material_p95_shift(Some(20), Some(29), &options));
     }
 
+    // TT-TEST: support
     #[test]
     fn p95_shift_rejects_zero_and_missing_baselines() {
         let options = options_with_ratio(3, 2);
@@ -318,6 +321,7 @@ mod tests {
         assert!(!has_material_p95_shift(Some(30), None, &options));
     }
 
+    // TT-TEST: A09 primary
     #[test]
     fn p95_shift_uses_exact_arithmetic_near_u64_max() {
         let options = options_with_ratio(3, 2);

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -175,6 +175,7 @@ fn finalized_literal_order(
     suspects.into_iter().map(|s| s.suspect.kind).collect()
 }
 
+// TT-TEST: A05 primary
 #[test]
 fn final_confidence_ranking_selects_primary_before_raw_score() {
     let expected = vec![
@@ -211,6 +212,7 @@ fn final_confidence_ranking_selects_primary_before_raw_score() {
     assert_eq!(finalized_literal_order(reversed), expected);
 }
 
+// TT-TEST: A05 primary
 #[test]
 fn final_confidence_ties_break_by_raw_score_then_kind() {
     let candidates = vec![
@@ -368,6 +370,7 @@ fn scoped_evidence(
     )
 }
 
+// TT-TEST: A06 primary
 #[test]
 fn ambiguity_cluster_membership_uses_raw_scores_only() {
     let options = AnalyzeOptions::default().with_confidence(|o| {
@@ -412,6 +415,7 @@ fn ambiguity_cluster_membership_uses_raw_scores_only() {
     }
 }
 
+// TT-TEST: A05 primary
 #[test]
 fn evidence_cap_can_promote_lower_raw_score_candidate() {
     let report = analyze_run(&cap_flip_run(), AnalyzeOptions::default())
@@ -479,6 +483,7 @@ fn evidence_cap_can_promote_lower_raw_score_candidate() {
     );
 }
 
+// TT-TEST: A05 primary
 #[test]
 fn cap_induced_primary_flip_has_exact_json() {
     let report = analyze_run(&cap_flip_run(), AnalyzeOptions::default())
@@ -487,6 +492,7 @@ fn cap_induced_primary_flip_has_exact_json() {
     assert_eq!(render_json(&report).unwrap(), expected_json);
 }
 
+// TT-TEST: A05 primary
 #[test]
 fn cap_induced_primary_flip_has_exact_text() {
     let report = analyze_run(&cap_flip_run(), AnalyzeOptions::default())
@@ -495,6 +501,7 @@ fn cap_induced_primary_flip_has_exact_text() {
     assert_eq!(render_text(&report), expected_text);
 }
 
+// TT-TEST: A06 primary
 #[test]
 fn raw_score_ambiguity_caps_all_cluster_members_uniformly() {
     let mut run = cap_flip_run();
@@ -584,6 +591,7 @@ fn raw_score_ambiguity_caps_all_cluster_members_uniformly() {
     }
 }
 
+// TT-TEST: A06 primary
 #[test]
 fn equal_final_confidence_without_raw_score_proximity_is_not_ambiguous() {
     let mut run = cap_flip_run();
@@ -634,6 +642,7 @@ fn equal_final_confidence_without_raw_score_proximity_is_not_ambiguous() {
             .any(|n| n.contains("capped by ambiguity"))));
 }
 
+// TT-TEST: support
 #[test]
 fn candidate_order_is_stable_under_irrelevant_input_reordering() {
     let run = cap_flip_run();
@@ -683,6 +692,7 @@ fn scoped_flip_report() -> Report {
     analyze_run(&run, options).expect("analyzer options should be valid")
 }
 
+// TT-TEST: support
 #[test]
 fn global_route_and_temporal_share_final_confidence_ordering() {
     let report = scoped_flip_report();
@@ -771,6 +781,7 @@ fn global_route_and_temporal_share_final_confidence_ordering() {
     assert!(late.warnings.is_empty());
 }
 
+// TT-TEST: A02 secondary
 #[test]
 fn downstream_overlap_uses_request_scoped_stage_attribution_for_score() {
     let mut run = test_run();
@@ -805,6 +816,7 @@ fn downstream_overlap_uses_request_scoped_stage_attribution_for_score() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn downstream_eligibility_uses_distinct_request_samples_not_raw_events() {
     let mut run = test_run();
@@ -832,6 +844,7 @@ fn downstream_eligibility_uses_distinct_request_samples_not_raw_events() {
         .all(|s| s.kind != DiagnosisKind::DownstreamStageDominates));
 }
 
+// TT-TEST: support
 #[test]
 fn downstream_approximate_stage_group_warns_only_with_canonical_precision_warning() {
     let mut run = test_run();
@@ -871,6 +884,7 @@ fn downstream_approximate_stage_group_warns_only_with_canonical_precision_warnin
     assert!(!report.warnings.iter().any(|w| w.contains("attribution")));
 }
 
+// TT-TEST: support
 #[test]
 fn downstream_stage_attribution_respects_normalization_boundary() {
     let mut run = test_run();
@@ -913,6 +927,7 @@ fn downstream_stage_attribution_respects_normalization_boundary() {
     assert!(!report.warnings.iter().any(|w| w.contains("attribution")));
 }
 
+// TT-TEST: support
 #[test]
 fn downstream_stage_input_order_invariance_extends_to_canonical_json() {
     let mut first = test_run();
@@ -953,6 +968,7 @@ fn downstream_stage_input_order_invariance_extends_to_canonical_json() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn downstream_non_overlap_single_event_per_request_behavior_remains_stable() {
     let mut run = test_run();
@@ -984,6 +1000,7 @@ fn downstream_non_overlap_single_event_per_request_behavior_remains_stable() {
     );
 }
 
+// TT-TEST: A02 secondary
 #[test]
 fn overlapping_precise_queues_are_union_attributed() {
     let mut run = test_run();
@@ -1000,6 +1017,7 @@ fn overlapping_precise_queues_are_union_attributed() {
     assert_eq!(report.p95_service_share_permille, Some(100));
 }
 
+// TT-TEST: support
 #[test]
 fn missing_run_relative_queue_endpoint_falls_back_to_capped_duration_sum() {
     let mut run = test_run();
@@ -1030,6 +1048,7 @@ fn missing_run_relative_queue_endpoint_falls_back_to_capped_duration_sum() {
         .any(|warning| warning.contains("precise_interval_validation_unavailable")));
 }
 
+// TT-TEST: support
 #[test]
 fn out_of_parent_precise_queue_is_excluded_before_attribution_not_clipped() {
     let mut run = test_run();
@@ -1051,6 +1070,7 @@ fn out_of_parent_precise_queue_is_excluded_before_attribution_not_clipped() {
             && warning.contains("queue")));
 }
 
+// TT-TEST: support
 #[test]
 fn non_overlapping_queue_attribution_remains_stable() {
     let mut run = test_run();
@@ -1067,6 +1087,7 @@ fn non_overlapping_queue_attribution_remains_stable() {
     assert_eq!(report.p95_service_share_permille, Some(500));
 }
 
+// TT-TEST: support
 #[test]
 fn repeated_analysis_is_deterministic_for_overlap_safe_queue_attribution() {
     let mut run = test_run();
@@ -1088,6 +1109,7 @@ fn repeated_analysis_is_deterministic_for_overlap_safe_queue_attribution() {
     }
 }
 
+// TT-TEST: support
 #[test]
 fn interleaved_queue_events_group_by_request_and_preserve_request_order() {
     let mut run = test_run();
@@ -1110,6 +1132,7 @@ fn interleaved_queue_events_group_by_request_and_preserve_request_order() {
     assert_eq!(report.p95_service_share_permille, Some(600));
 }
 
+// TT-TEST: support
 #[test]
 fn duplicate_completed_request_ids_emit_warning_without_panic() {
     let mut run = test_run();
@@ -1137,6 +1160,7 @@ fn duplicate_completed_request_ids_emit_warning_without_panic() {
             && warning.contains("request_id")));
 }
 
+// TT-TEST: support
 #[test]
 fn unique_completed_request_ids_do_not_emit_duplicate_warning() {
     let report = analyze_run(&test_run(), AnalyzeOptions::default())
@@ -1148,6 +1172,7 @@ fn unique_completed_request_ids_do_not_emit_duplicate_warning() {
         .any(|warning| warning.contains("duplicate_completed_request_id")));
 }
 
+// TT-TEST: support
 #[test]
 fn permissive_analysis_warns_but_accepts_orphan_request_scoped_events() {
     let mut run = test_run();
@@ -1186,6 +1211,7 @@ fn permissive_analysis_warns_but_accepts_orphan_request_scoped_events() {
     }));
 }
 
+// TT-TEST: support
 #[test]
 fn matching_unique_request_scoped_events_do_not_add_request_id_limitations() {
     let mut run = test_run();
@@ -1223,6 +1249,7 @@ fn matching_unique_request_scoped_events_do_not_add_request_id_limitations() {
             == "Stage or queue evidence with no matching completed request_id cannot be reliably attributed."));
 }
 
+// TT-TEST: A02 secondary
 #[test]
 fn latency_percentiles_use_duration_fields_not_timestamp_subtraction() {
     let mut run = test_run();
@@ -1356,6 +1383,7 @@ fn suspect_position(report: &Report, kind: &DiagnosisKind) -> usize {
         .unwrap_or_else(|| panic!("missing expected suspect {kind:?}"))
 }
 
+// TT-TEST: support
 #[test]
 fn normalized_executor_remains_secondary_to_strong_blocking_pressure() {
     let report = analyze_run(
@@ -1380,6 +1408,7 @@ fn normalized_executor_remains_secondary_to_strong_blocking_pressure() {
         .any(|e| { e.contains("2000 milli-tasks per worker") && e.contains("worker_count=4") }));
 }
 
+// TT-TEST: support
 #[test]
 fn normalized_executor_remains_secondary_to_strong_downstream_stage() {
     let report = analyze_run(
@@ -1405,6 +1434,7 @@ fn normalized_executor_remains_secondary_to_strong_downstream_stage() {
         .any(|e| e.contains("Stage 'database' has p95 latency 970 us across 45 samples")));
 }
 
+// TT-TEST: support
 #[test]
 fn application_queue_controls_preserve_normalized_executor_visibility_and_order() {
     let cases = [
@@ -1439,6 +1469,7 @@ fn application_queue_controls_preserve_normalized_executor_visibility_and_order(
     }
 }
 
+// TT-TEST: support
 #[test]
 fn clear_normalized_executor_remains_primary_against_weak_competing_signals() {
     let report = analyze_run(
@@ -1462,6 +1493,7 @@ fn clear_normalized_executor_remains_primary_against_weak_competing_signals() {
         .all(|suspect| suspect.score < report.primary_suspect.score));
 }
 
+// TT-TEST: support
 #[test]
 fn normalized_lower_bound_cap_keeps_higher_score_executor_below_high_confidence_stage() {
     let mut run = competing_executor_run(140, 60, 0, None, Some(500));
@@ -1540,6 +1572,7 @@ fn temporal_worker_report(run: &Run) -> Report {
     .expect("analyzer options should be valid")
 }
 
+// TT-TEST: support
 #[test]
 fn temporal_worker_evidence_is_classified_within_each_original_window() {
     let report = temporal_worker_report(&worker_test_run());
@@ -1562,6 +1595,7 @@ fn temporal_worker_evidence_is_classified_within_each_original_window() {
     }
 }
 
+// TT-TEST: support
 #[test]
 fn excluded_requests_do_not_change_canonical_temporal_segments() {
     let baseline = worker_test_run();
@@ -1595,6 +1629,7 @@ fn excluded_requests_do_not_change_canonical_temporal_segments() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn cleared_optional_request_timing_defines_temporal_order_and_windows() {
     let mut invalid = worker_test_run();
@@ -1628,6 +1663,7 @@ fn cleared_optional_request_timing_defines_temporal_order_and_windows() {
         .any(|warning| warning == TEMPORAL_WALL_CLOCK_FALLBACK_WARNING));
 }
 
+// TT-TEST: support
 #[test]
 fn temporal_partial_invalid_and_missing_local_limit_only_the_affected_window() {
     for (name, mutate, expected) in [
@@ -1677,6 +1713,7 @@ fn temporal_partial_invalid_and_missing_local_limit_only_the_affected_window() {
     }
 }
 
+// TT-TEST: A03 primary
 #[test]
 fn ambiguous_worker_fallbacks_match_historical_score_and_explain_the_cap() {
     let mut historical = worker_test_run();
@@ -1719,6 +1756,7 @@ fn ambiguous_worker_fallbacks_match_historical_score_and_explain_the_cap() {
     }
 }
 
+// TT-TEST: A03 primary
 #[test]
 fn missing_local_depth_remains_normalized_lower_bound() {
     let mut run = worker_test_run();
@@ -1743,6 +1781,7 @@ fn missing_local_depth_remains_normalized_lower_bound() {
     assert_ne!(suspect.confidence, Confidence::High);
 }
 
+// TT-TEST: support
 #[test]
 fn normalized_local_queue_signal_does_not_attribute_contention_to_zero_global_depth() {
     let mut run = worker_test_run();
@@ -1763,6 +1802,7 @@ fn normalized_local_queue_signal_does_not_attribute_contention_to_zero_global_de
     }));
 }
 
+// TT-TEST: A03 secondary
 #[test]
 fn worker_count_enables_normalized_executor_scoring() {
     let mut historical = test_run();
@@ -1805,6 +1845,7 @@ fn executor_arithmetic_run(samples: usize, global: u64, local: u64, alive: u64) 
     run
 }
 
+// TT-TEST: A03 primary
 #[test]
 fn historical_executor_arithmetic_boundaries_are_exact() {
     let no_signal = executor_arithmetic_run(20, 0, 60, 400);
@@ -1854,6 +1895,7 @@ fn historical_executor_arithmetic_boundaries_are_exact() {
     }
 }
 
+// TT-TEST: support
 #[test]
 fn historical_clean_extreme_requires_thirty_samples_and_absence_has_no_worker_cap() {
     for (samples, expected_score) in [(29, 94), (30, 96)] {
@@ -1884,6 +1926,7 @@ fn historical_clean_extreme_requires_thirty_samples_and_absence_has_no_worker_ca
     }
 }
 
+// TT-TEST: support
 #[test]
 fn normalized_executor_score_ignores_alive_tasks_and_queue_redistribution() {
     let mut baseline = executor_arithmetic_run(20, 32, 32, 1);
@@ -1920,6 +1963,7 @@ fn normalized_executor_score_ignores_alive_tasks_and_queue_redistribution() {
     assert_eq!(baseline_score, redistributed_score);
 }
 
+// TT-TEST: A04 primary
 #[test]
 fn worker_confidence_limits_compose_with_existing_caps_without_duplicate_notes() {
     let mut ambiguous = executor_arithmetic_run(20, 140, 60, 400);
@@ -1968,6 +2012,7 @@ fn worker_confidence_limits_compose_with_existing_caps_without_duplicate_notes()
     }
 }
 
+// TT-TEST: A02 primary
 #[test]
 fn clear_blocking_pressure_selects_blocking_pool() {
     let mut run = test_run();
@@ -1988,6 +2033,7 @@ fn clear_blocking_pressure_selects_blocking_pool() {
         .any(|evidence| evidence.contains("Blocking queue depth")));
 }
 
+// TT-TEST: A02 primary
 #[test]
 fn clear_scheduler_pressure_selects_executor_pressure() {
     let mut run = test_run();
@@ -2008,6 +2054,7 @@ fn clear_scheduler_pressure_selects_executor_pressure() {
         .any(|evidence| evidence.contains("Runtime global queue depth")));
 }
 
+// TT-TEST: A02 primary
 #[test]
 fn downstream_stage_tie_break_is_deterministic() {
     let mut run = test_run();
@@ -2093,11 +2140,13 @@ fn downstream_stage_tie_break_is_deterministic() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn inflight_trend_is_none_for_empty_series() {
     assert!(super::dominant_inflight_trend(&[]).is_none());
 }
 
+// TT-TEST: support
 #[test]
 fn inflight_trend_handles_constant_series() {
     let trend = super::dominant_inflight_trend(&[
@@ -2121,6 +2170,7 @@ fn inflight_trend_handles_constant_series() {
     assert_eq!(trend.growth_delta, 0);
 }
 
+// TT-TEST: support
 #[test]
 fn inflight_trend_handles_monotonic_increase() {
     let trend = super::dominant_inflight_trend(&[
@@ -2165,6 +2215,7 @@ fn inflight(
     }
 }
 
+// TT-TEST: support
 #[test]
 fn latest_active_inflight_episode_outranks_closed_historical_spike() {
     let trend = super::dominant_inflight_trend(&[
@@ -2189,6 +2240,7 @@ fn latest_active_inflight_episode_outranks_closed_historical_spike() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn reused_inflight_label_uses_only_latest_episode() {
     let counts = [1, 9, 0, 2, 3, 5];
@@ -2210,6 +2262,7 @@ fn reused_inflight_label_uses_only_latest_episode() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn leading_and_consecutive_zero_snapshots_do_not_create_episodes() {
     let samples = [0, 0, 2, 4, 0, 0, 3, 0]
@@ -2224,6 +2277,7 @@ fn leading_and_consecutive_zero_snapshots_do_not_create_episodes() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn all_zero_inflight_label_has_no_candidate() {
     assert!(super::dominant_inflight_trend(&[
@@ -2233,6 +2287,7 @@ fn all_zero_inflight_label_has_no_candidate() {
     .is_none());
 }
 
+// TT-TEST: support
 #[test]
 fn run_relative_time_orders_inflight_samples_before_wall_clock() {
     let trend = super::dominant_inflight_trend(&[
@@ -2247,6 +2302,7 @@ fn run_relative_time_orders_inflight_samples_before_wall_clock() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn inflight_wall_clock_fallback_is_deterministic_without_rate() {
     let trend = super::dominant_inflight_trend(&[
@@ -2257,6 +2313,7 @@ fn inflight_wall_clock_fallback_is_deterministic_without_rate() {
     assert_eq!((trend.growth_delta, trend.growth_per_sec_milli), (3, None));
 }
 
+// TT-TEST: support
 #[test]
 fn distinct_timestamp_reordering_preserves_inflight_selection() {
     let a = vec![
@@ -2271,6 +2328,7 @@ fn distinct_timestamp_reordering_preserves_inflight_selection() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn equal_timestamp_inflight_order_uses_original_input_index() {
     let forward = super::dominant_inflight_trend(&[
@@ -2287,6 +2345,7 @@ fn equal_timestamp_inflight_order_uses_original_input_index() {
     assert_eq!(forward.growth_per_sec_milli, None);
 }
 
+// TT-TEST: support
 #[test]
 fn one_sample_inflight_episode_is_unknown_and_adds_no_bonus() {
     let trend = super::dominant_inflight_trend(&[inflight("single", 1, Some(1), 7)]).unwrap();
@@ -2310,6 +2369,7 @@ fn assert_dominant_inflight(
     assert_eq!(super::dominant_inflight_trend(samples), Some(expected));
 }
 
+// TT-TEST: support
 #[test]
 fn inflight_candidate_order_prefers_active_over_closed() {
     assert_dominant_inflight(
@@ -2331,6 +2391,7 @@ fn inflight_candidate_order_prefers_active_over_closed() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn inflight_candidate_order_prefers_positive_over_unknown() {
     let samples = [
@@ -2351,6 +2412,7 @@ fn inflight_candidate_order_prefers_positive_over_unknown() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn inflight_candidate_order_prefers_positive_over_non_growing() {
     for (label, counts) in [("flat", [20, 20]), ("declining", [20, 10])] {
@@ -2374,6 +2436,7 @@ fn inflight_candidate_order_prefers_positive_over_non_growing() {
     }
 }
 
+// TT-TEST: support
 #[test]
 fn inflight_candidate_order_prefers_larger_positive_delta() {
     let samples = [
@@ -2395,6 +2458,7 @@ fn inflight_candidate_order_prefers_larger_positive_delta() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn inflight_candidate_order_prefers_available_positive_rate() {
     assert_dominant_inflight(
@@ -2415,6 +2479,7 @@ fn inflight_candidate_order_prefers_available_positive_rate() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn inflight_candidate_order_prefers_larger_positive_rate() {
     let samples = [
@@ -2436,6 +2501,7 @@ fn inflight_candidate_order_prefers_larger_positive_rate() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn inflight_candidate_order_prefers_larger_p95() {
     let mut samples = (1..=21)
@@ -2458,6 +2524,7 @@ fn inflight_candidate_order_prefers_larger_p95() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn inflight_candidate_order_prefers_larger_peak() {
     let mut samples = vec![inflight("larger-peak", 1, Some(1), 10)];
@@ -2476,6 +2543,7 @@ fn inflight_candidate_order_prefers_larger_peak() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn inflight_candidate_order_uses_lexical_label_last() {
     assert_dominant_inflight(
@@ -2496,6 +2564,7 @@ fn inflight_candidate_order_uses_lexical_label_last() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn truncated_inflight_history_does_not_infer_missing_zero() {
     let mut run = test_run();
@@ -2511,6 +2580,7 @@ fn truncated_inflight_history_does_not_infer_missing_zero() {
     assert_eq!((trend.sample_count, trend.growth_delta), (2, 1));
 }
 
+// TT-TEST: support
 #[test]
 fn inflight_trend_json_shape_and_values_remain_unchanged() {
     let value = serde_json::to_value(InflightTrend {
@@ -2589,6 +2659,7 @@ fn suspect_evidence<'a>(report: &'a Report, kind: &DiagnosisKind) -> &'a [String
         .evidence
 }
 
+// TT-TEST: support
 #[test]
 fn closed_historical_inflight_spike_adds_no_bonus_when_active_flat_episode_wins() {
     let baseline = analyze_run(&queue_bonus_run(vec![]), AnalyzeOptions::default())
@@ -2626,6 +2697,7 @@ fn closed_historical_inflight_spike_adds_no_bonus_when_active_flat_episode_wins(
     );
 }
 
+// TT-TEST: support
 #[test]
 fn inflight_growth_evidence_states_unix_fallback_without_rate() {
     let baseline = analyze_run(&queue_bonus_run(vec![]), AnalyzeOptions::default())
@@ -2654,6 +2726,7 @@ fn inflight_growth_evidence_states_unix_fallback_without_rate() {
     assert!(!evidence.contains("rate="));
 }
 
+// TT-TEST: support
 #[test]
 fn inflight_growth_evidence_states_unavailable_run_relative_rate() {
     let baseline = analyze_run(&queue_bonus_run(vec![]), AnalyzeOptions::default())
@@ -2681,6 +2754,7 @@ fn inflight_growth_evidence_states_unavailable_run_relative_rate() {
     assert!(!evidence.contains("Unix-ms fallback"));
 }
 
+// TT-TEST: A02 primary
 #[test]
 fn queue_inflight_growth_bonus_remains_exactly_five() {
     let baseline = analyze_run(&queue_bonus_run(vec![]), AnalyzeOptions::default())
@@ -2700,6 +2774,7 @@ fn queue_inflight_growth_bonus_remains_exactly_five() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn executor_inflight_growth_bonus_remains_exactly_four() {
     let mut baseline = option_run_twenty_requests();
@@ -2726,6 +2801,7 @@ fn executor_inflight_growth_bonus_remains_exactly_four() {
         .any(|e| e.contains("latest active episode") && e.contains("run-relative rate=2000")));
 }
 
+// TT-TEST: support
 #[test]
 fn declining_inflight_episode_adds_no_growth_bonus() {
     let baseline = analyze_run(&queue_bonus_run(vec![]), AnalyzeOptions::default())
@@ -2749,6 +2825,7 @@ fn declining_inflight_episode_adds_no_growth_bonus() {
     }
 }
 
+// TT-TEST: support
 #[test]
 fn render_text_marks_one_sample_inflight_trend_unknown() {
     let report = analyze_run(
@@ -2761,6 +2838,7 @@ fn render_text_marks_one_sample_inflight_trend_unknown() {
     assert!(!text.contains("net growth +0"));
 }
 
+// TT-TEST: S04 primary
 #[test]
 fn render_text_escapes_artifact_controls_without_changing_report_json() {
     let mut report = analyze_run(
@@ -2785,6 +2863,7 @@ fn render_text_escapes_artifact_controls_without_changing_report_json() {
     assert_eq!(decoded["inflight_trend"]["gauge"], "hostile\n\u{1b}[31m");
 }
 
+// TT-TEST: support
 #[test]
 fn render_text_formats_inflight_trend_fields() {
     let report = Report {
@@ -2847,6 +2926,7 @@ fn render_text_formats_inflight_trend_fields() {
     assert!(text.contains("Request time at p95: queue 10.0%, non-queue service 90.0%"));
 }
 
+// TT-TEST: support
 #[test]
 fn render_text_marks_missing_inflight_trend() {
     let report = Report {
@@ -2898,6 +2978,7 @@ fn render_text_marks_missing_inflight_trend() {
     assert!(text.contains("- Capture truncated requests."));
 }
 
+// TT-TEST: A07 primary
 #[test]
 fn analyze_run_emits_truncation_warnings() {
     let mut run = test_run();
@@ -2921,6 +3002,7 @@ fn analyze_run_emits_truncation_warnings() {
         .any(|warning| warning.contains("dropped 1 entries")));
 }
 
+// TT-TEST: support
 #[test]
 fn low_request_count_warning_appears() {
     let report = analyze_run(&test_run(), AnalyzeOptions::default())
@@ -2931,6 +3013,7 @@ fn low_request_count_warning_appears() {
         .any(|w| w.contains("Low completed-request count")));
 }
 
+// TT-TEST: support
 #[test]
 fn no_runtime_warning_not_emitted_for_clean_queue_primary() {
     let mut run = test_run();
@@ -2981,6 +3064,7 @@ fn no_runtime_warning_not_emitted_for_clean_queue_primary() {
         .any(|w| w.contains("No runtime snapshots captured")));
 }
 
+// TT-TEST: support
 #[test]
 fn runtime_missing_warning_uses_configured_high_confidence_threshold() {
     let mut run = test_run();
@@ -3033,6 +3117,7 @@ fn runtime_missing_warning_uses_configured_high_confidence_threshold() {
     assert!(strict_report.analyzer_config.is_some());
 }
 
+// TT-TEST: support
 #[test]
 fn runtime_warning_emitted_when_insufficient_evidence() {
     let report = analyze_run(&test_run(), AnalyzeOptions::default())
@@ -3043,6 +3128,7 @@ fn runtime_warning_emitted_when_insufficient_evidence() {
         .any(|w| w.contains("No runtime snapshots captured")));
 }
 
+// TT-TEST: support
 #[test]
 fn downstream_beats_weak_blocking() {
     let mut run = test_run();
@@ -3090,6 +3176,7 @@ fn downstream_beats_weak_blocking() {
     );
 }
 
+// TT-TEST: A01 primary
 #[test]
 fn score_100_is_reserved_for_overwhelming_queue_evidence() {
     let mut run = test_run();
@@ -3130,6 +3217,7 @@ fn score_100_is_reserved_for_overwhelming_queue_evidence() {
     assert!(report.primary_suspect.score >= 95);
 }
 
+// TT-TEST: support
 #[test]
 fn ambiguity_warning_requires_close_calibrated_scores() {
     let suspects = vec![
@@ -3149,6 +3237,7 @@ fn ambiguity_warning_requires_close_calibrated_scores() {
     assert!(super::ambiguity_warning(&suspects, &AnalyzeOptions::default()).is_some());
 }
 
+// TT-TEST: support
 #[test]
 fn blocking_like_stage_does_not_outrank_strong_blocking_runtime_signal() {
     let mut run = test_run();
@@ -3193,6 +3282,7 @@ fn blocking_like_stage_does_not_outrank_strong_blocking_runtime_signal() {
         .any(|s| s.kind == DiagnosisKind::DownstreamStageDominates));
 }
 
+// TT-TEST: support
 #[test]
 fn retry_or_db_stage_is_not_treated_as_blocking_correlated_stage() {
     assert!(!super::scoring::stage_correlates_with_blocking_pool(
@@ -3209,6 +3299,7 @@ fn retry_or_db_stage_is_not_treated_as_blocking_correlated_stage() {
     ));
 }
 
+// TT-TEST: support
 #[test]
 fn downstream_blocking_correlation_margin_changes_downstream_cap_behavior() {
     let mut run = test_run();
@@ -3259,6 +3350,7 @@ fn downstream_blocking_correlation_margin_changes_downstream_cap_behavior() {
     assert!(large_margin_score < no_margin_score);
 }
 
+// TT-TEST: support
 #[test]
 fn non_default_overrides_are_sorted_and_include_downstream_margin_override() {
     let options = AnalyzeOptions::default()
@@ -3278,6 +3370,7 @@ fn non_default_overrides_are_sorted_and_include_downstream_margin_override() {
         .any(|o| { o.path == "downstream.blocking_correlation_score_margin" && o.value == "7" }));
 }
 
+// TT-TEST: support
 #[test]
 fn truncation_warnings_remain_additive() {
     let mut run = test_run();
@@ -3300,6 +3393,7 @@ fn truncation_warnings_remain_additive() {
         .any(|w| w.contains("dropped 1 entries after reaching max_runtime_snapshots")));
 }
 
+// TT-TEST: support
 #[test]
 fn evidence_quality_weak_for_low_requests() {
     let report = analyze_run(&test_run(), AnalyzeOptions::default())
@@ -3311,6 +3405,7 @@ fn evidence_quality_weak_for_low_requests() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn evidence_quality_requests_missing_when_zero_requests_even_if_dropped() {
     let mut run = test_run();
@@ -3324,6 +3419,7 @@ fn evidence_quality_requests_missing_when_zero_requests_even_if_dropped() {
     );
 }
 
+// TT-TEST: A07 primary
 #[test]
 fn evidence_quality_partial_for_runtime_partial_fields() {
     let mut run = test_run();
@@ -3368,6 +3464,7 @@ fn evidence_quality_partial_for_runtime_partial_fields() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn evidence_quality_strong_without_runtime_snapshots_when_queue_stage_present() {
     let mut run = test_run();
@@ -3422,6 +3519,7 @@ fn evidence_quality_strong_without_runtime_snapshots_when_queue_stage_present() 
     );
 }
 
+// TT-TEST: A07 primary
 #[test]
 fn evidence_quality_marks_queue_signal_truncated_and_not_strong() {
     let mut run = test_run();
@@ -3482,6 +3580,7 @@ fn evidence_quality_marks_queue_signal_truncated_and_not_strong() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn confidence_caps_do_not_change_score_ordering() {
     let mut run = test_run();
@@ -3536,6 +3635,7 @@ fn confidence_caps_do_not_change_score_ordering() {
     assert!(scores.windows(2).all(|w| w[0] >= w[1]));
 }
 
+// TT-TEST: A04 primary
 #[test]
 fn low_request_count_caps_primary_confidence_and_adds_note() {
     let mut run = test_run();
@@ -3577,6 +3677,7 @@ fn low_request_count_caps_primary_confidence_and_adds_note() {
         .any(|n| n == "Low completed-request count caps confidence."));
 }
 
+// TT-TEST: support
 #[test]
 fn clean_strong_queue_evidence_keeps_high_confidence_without_notes() {
     let mut run = test_run();
@@ -3632,6 +3733,7 @@ fn clean_strong_queue_evidence_keeps_high_confidence_without_notes() {
     assert!(report.primary_suspect.confidence_notes.is_empty());
 }
 
+// TT-TEST: support
 #[test]
 fn queue_truncation_uses_truncation_note_not_missing_queue_note() {
     let mut run = test_run();
@@ -3679,6 +3781,7 @@ fn queue_truncation_uses_truncation_note_not_missing_queue_note() {
         .any(|n| n == "Missing queue instrumentation limits queue-saturation confidence."));
 }
 
+// TT-TEST: support
 #[test]
 fn missing_queue_instrumentation_uses_missing_queue_note() {
     let mut run = test_run();
@@ -3703,6 +3806,7 @@ fn missing_queue_instrumentation_uses_missing_queue_note() {
         .any(|n| n == "Missing queue instrumentation limits queue-saturation confidence."));
 }
 
+// TT-TEST: support
 #[test]
 fn stage_truncation_uses_truncation_note_not_missing_stage_note() {
     let mut run = test_run();
@@ -3750,6 +3854,7 @@ fn stage_truncation_uses_truncation_note_not_missing_stage_note() {
         .any(|n| n == "Missing stage instrumentation limits downstream-stage confidence."));
 }
 
+// TT-TEST: support
 #[test]
 fn missing_stage_instrumentation_uses_missing_stage_note() {
     let mut run = test_run();
@@ -3774,6 +3879,7 @@ fn missing_stage_instrumentation_uses_missing_stage_note() {
         .any(|n| n == "Missing stage instrumentation limits downstream-stage confidence."));
 }
 
+// TT-TEST: A04 primary
 #[test]
 fn runtime_partial_fields_cap_executor_or_blocking_confidence() {
     let mut run = test_run();
@@ -3814,6 +3920,7 @@ fn runtime_partial_fields_cap_executor_or_blocking_confidence() {
         .any(|n| n == "Missing runtime snapshots limit executor/blocking confidence."));
 }
 
+// TT-TEST: support
 #[test]
 fn missing_runtime_snapshots_use_missing_runtime_note() {
     let mut run = test_run();
@@ -3838,6 +3945,7 @@ fn missing_runtime_snapshots_use_missing_runtime_note() {
         .any(|n| n == "Missing runtime snapshots limit executor/blocking confidence."));
 }
 
+// TT-TEST: A04 primary
 #[test]
 fn ambiguity_cap_adds_note_to_close_top_suspects() {
     let mut suspects = vec![
@@ -3869,6 +3977,7 @@ fn ambiguity_cap_adds_note_to_close_top_suspects() {
         .any(|n| n == "Top suspects are close in score; confidence is capped by ambiguity."));
 }
 
+// TT-TEST: A06 primary
 #[test]
 fn ambiguity_capping_preserves_order_and_scores() {
     let mut suspects = vec![
@@ -3903,6 +4012,7 @@ fn ambiguity_capping_preserves_order_and_scores() {
         .any(|n| n == "Top suspects are close in score; confidence is capped by ambiguity."));
 }
 
+// TT-TEST: support
 #[test]
 fn non_ambiguous_clean_evidence_keeps_high_confidence() {
     let mut run = test_run();
@@ -3955,6 +4065,7 @@ fn non_ambiguous_clean_evidence_keeps_high_confidence() {
     assert!(suspects[0].confidence_notes.is_empty());
 }
 
+// TT-TEST: A08 primary
 #[test]
 fn route_breakdowns_empty_for_single_route() {
     let report = analyze_run(&test_run(), AnalyzeOptions::default())
@@ -3966,6 +4077,7 @@ fn route_breakdowns_empty_for_single_route() {
         .all(|warning| warning != ROUTE_DIVERGENCE_WARNING));
 }
 
+// TT-TEST: support
 #[test]
 fn single_route_executor_signals_do_not_emit_route_breakdowns_or_divergence_warning() {
     let mut run = test_run();
@@ -3979,6 +4091,7 @@ fn single_route_executor_signals_do_not_emit_route_breakdowns_or_divergence_warn
         .all(|warning| warning != ROUTE_DIVERGENCE_WARNING));
 }
 
+// TT-TEST: A08 primary
 #[test]
 fn multi_route_divergence_emits_sorted_breakdowns_and_stable_warning() {
     let mut run = test_run();
@@ -4069,6 +4182,7 @@ fn multi_route_divergence_emits_sorted_breakdowns_and_stable_warning() {
     }
 }
 
+// TT-TEST: support
 #[test]
 fn route_divergence_warning_respects_emit_toggle_even_when_breakdowns_emit_from_p95_disparity() {
     let mut run = test_run();
@@ -4130,6 +4244,7 @@ fn route_divergence_warning_respects_emit_toggle_even_when_breakdowns_emit_from_
         .all(|warning| warning != ROUTE_DIVERGENCE_WARNING));
 }
 
+// TT-TEST: support
 #[test]
 fn multi_route_same_primary_keeps_route_breakdowns_empty() {
     let mut run = test_run();
@@ -4170,6 +4285,7 @@ fn multi_route_same_primary_keeps_route_breakdowns_empty() {
         .all(|warning| warning != ROUTE_DIVERGENCE_WARNING));
 }
 
+// TT-TEST: A08 primary
 #[test]
 fn route_breakdowns_do_not_change_global_primary_suspect() {
     let mut run = test_run();
@@ -4185,6 +4301,7 @@ fn route_breakdowns_do_not_change_global_primary_suspect() {
     assert_eq!(report.primary_suspect.score, global.primary_suspect.score);
 }
 
+// TT-TEST: A09 primary
 #[test]
 fn temporal_segments_present_and_empty_below_threshold() {
     let report = analyze_run(&test_run(), AnalyzeOptions::default())
@@ -4194,6 +4311,7 @@ fn temporal_segments_present_and_empty_below_threshold() {
     assert!(report.temporal_segments.is_empty());
 }
 
+// TT-TEST: support
 #[test]
 fn temporal_segment_window_uses_max_finish_timestamp() {
     let mut run = test_run();
@@ -4232,6 +4350,7 @@ fn temporal_segment_window_uses_max_finish_timestamp() {
     assert_eq!(early.finished_at_unix_ms, Some(1000));
 }
 
+// TT-TEST: support
 #[test]
 fn temporal_sort_prefers_run_relative_start_when_unix_starts_match() {
     let mut run = test_run();
@@ -4301,6 +4420,7 @@ fn temporal_sort_prefers_run_relative_start_when_unix_starts_match() {
     );
 }
 
+// TT-TEST: A09 primary
 #[test]
 fn temporal_runtime_and_inflight_filtering_uses_run_relative_times() {
     let mut run = test_run();
@@ -4383,6 +4503,7 @@ fn temporal_runtime_and_inflight_filtering_uses_run_relative_times() {
     }
 }
 
+// TT-TEST: support
 #[test]
 fn temporal_runtime_and_inflight_mixed_clock_snapshots_fall_back_per_sample() {
     let mut run = test_run();
@@ -4478,6 +4599,7 @@ fn temporal_runtime_and_inflight_mixed_clock_snapshots_fall_back_per_sample() {
     }
 }
 
+// TT-TEST: support
 #[test]
 fn temporal_segments_fallback_for_older_artifacts_warns() {
     let mut run = test_run();
@@ -4533,6 +4655,7 @@ fn temporal_segments_fallback_for_older_artifacts_warns() {
     }
 }
 
+// TT-TEST: support
 #[test]
 fn temporal_segments_with_complete_run_relative_fields_do_not_warn_about_fallback() {
     let mut run = test_run();
@@ -4557,6 +4680,7 @@ fn temporal_segments_with_complete_run_relative_fields_do_not_warn_about_fallbac
     }
 }
 
+// TT-TEST: support
 #[test]
 fn temporal_segments_sort_complete_run_relative_starts_by_run_time() {
     let mut run = test_run();
@@ -4584,6 +4708,7 @@ fn temporal_segments_sort_complete_run_relative_starts_by_run_time() {
     assert_eq!(report.temporal_segments[1].p95_latency_us, Some(6_000));
 }
 
+// TT-TEST: support
 #[test]
 fn temporal_segments_sort_partial_run_relative_starts_by_unix_time() {
     let mut run = test_run();
@@ -4619,6 +4744,7 @@ fn temporal_segments_sort_partial_run_relative_starts_by_unix_time() {
     assert_eq!(report.temporal_segments[1].p95_latency_us, Some(6_000));
 }
 
+// TT-TEST: support
 #[test]
 fn temporal_segments_not_emitted_when_no_meaningful_difference() {
     let mut run = test_run();
@@ -4632,6 +4758,7 @@ fn temporal_segments_not_emitted_when_no_meaningful_difference() {
         .any(|w| w == TEMPORAL_SUSPECT_SHIFT_WARNING));
 }
 
+// TT-TEST: support
 #[test]
 fn temporal_segments_emitted_when_primary_suspects_differ() {
     let mut run = test_run();
@@ -4679,6 +4806,7 @@ fn temporal_segments_emitted_when_primary_suspects_differ() {
         .any(|w| w == TEMPORAL_P95_SHIFT_WARNING));
 }
 
+// TT-TEST: support
 #[test]
 fn temporal_p95_shift_emits_segments_and_ignores_missing_or_zero_lower_p95() {
     let mut run = test_run();
@@ -4713,6 +4841,7 @@ fn temporal_p95_shift_emits_segments_and_ignores_missing_or_zero_lower_p95() {
     ));
 }
 
+// TT-TEST: A09 primary
 #[test]
 fn temporal_segments_do_not_change_global_primary_suspect_or_score() {
     let mut run = test_run();
@@ -4823,6 +4952,7 @@ fn run_with_temporal_shift_and_run_relative_offsets() -> Run {
     run
 }
 
+// TT-TEST: support
 #[test]
 fn temporal_segments_warn_only_when_run_relative_timing_is_incomplete() {
     let complete_report = analyze_run(
@@ -4854,6 +4984,7 @@ fn temporal_segments_warn_only_when_run_relative_timing_is_incomplete() {
     }
 }
 
+// TT-TEST: support
 #[test]
 fn sparse_timestamp_filtered_runtime_inflight_alone_do_not_emit_temporal_segments() {
     let mut run = test_run();
@@ -4879,6 +5010,7 @@ fn sparse_timestamp_filtered_runtime_inflight_alone_do_not_emit_temporal_segment
     assert!(report.temporal_segments.is_empty());
 }
 
+// TT-TEST: support
 #[test]
 fn queue_to_downstream_shift_emits_temporal_segments_when_runtime_samples_are_sparse() {
     let mut run = test_run();
@@ -4938,6 +5070,7 @@ fn queue_to_downstream_shift_emits_temporal_segments_when_runtime_samples_are_sp
     assert_eq!(report.primary_suspect.score, global.primary_suspect.score);
 }
 
+// TT-TEST: support
 #[test]
 fn temporal_segments_emit_both_global_warnings_when_p95_and_suspect_shift_apply() {
     let mut run = test_run();
@@ -4984,6 +5117,7 @@ fn temporal_segments_emit_both_global_warnings_when_p95_and_suspect_shift_apply(
         .any(|w| w == TEMPORAL_P95_SHIFT_WARNING));
 }
 
+// TT-TEST: support
 #[test]
 fn overlapping_temporal_windows_warn_runtime_inflight_attribution_is_approximate() {
     let mut run = test_run();
@@ -5008,6 +5142,7 @@ fn overlapping_temporal_windows_warn_runtime_inflight_attribution_is_approximate
     }
 }
 
+// TT-TEST: support
 #[test]
 fn non_overlapping_temporal_windows_do_not_add_overlap_warning() {
     let mut run = test_run();
@@ -5032,6 +5167,7 @@ fn non_overlapping_temporal_windows_do_not_add_overlap_warning() {
     }
 }
 
+// TT-TEST: support
 #[test]
 fn missing_late_finish_timestamp_does_not_add_overlap_warning() {
     let mut run = test_run();
@@ -5062,6 +5198,7 @@ fn missing_late_finish_timestamp_does_not_add_overlap_warning() {
     }
 }
 
+// TT-TEST: A12 secondary
 #[test]
 fn public_api_supports_report_text_and_json_contract_fields() {
     let run = test_run();
@@ -5078,6 +5215,7 @@ fn public_api_supports_report_text_and_json_contract_fields() {
     assert!(report_json.contains("\"temporal_segments\""));
 }
 
+// TT-TEST: A12 primary
 #[test]
 fn render_json_pretty_matches_serde_json_pretty() {
     let report = analyze_run(&test_run(), AnalyzeOptions::default())
@@ -5087,6 +5225,7 @@ fn render_json_pretty_matches_serde_json_pretty() {
     assert_eq!(actual, expected);
 }
 
+// TT-TEST: A12 primary
 #[test]
 fn render_json_matches_serde_json_compact() {
     let report = analyze_run(&test_run(), AnalyzeOptions::default())
@@ -5096,6 +5235,7 @@ fn render_json_matches_serde_json_compact() {
     assert_eq!(actual, expected);
 }
 
+// TT-TEST: A12 primary
 #[test]
 fn compact_and_pretty_report_json_are_value_equivalent() {
     let report = analyze_run(&test_run(), AnalyzeOptions::default())
@@ -5109,6 +5249,7 @@ fn compact_and_pretty_report_json_are_value_equivalent() {
     assert_eq!(compact_value, pretty_value);
 }
 
+// TT-TEST: A13 primary
 #[test]
 fn analyze_options_defaults_match_v1_surface() {
     let options = AnalyzeOptions::default();
@@ -5150,11 +5291,13 @@ fn analyze_options_defaults_match_v1_surface() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn analyze_options_default_validates() {
     assert!(AnalyzeOptions::default().validate().is_ok());
 }
 
+// TT-TEST: Q01 primary
 #[test]
 fn analyze_options_validate_rejects_invalid_classes() {
     assert!(AnalyzeOptions::default()
@@ -5234,6 +5377,7 @@ fn analyze_options_validate_rejects_invalid_classes() {
         .is_err());
 }
 
+// TT-TEST: Q01 primary
 #[test]
 fn validate_ratio_zero_denominators_report_exact_paths() {
     let err = AnalyzeOptions::default()
@@ -5273,6 +5417,7 @@ fn validate_ratio_zero_denominators_report_exact_paths() {
     ));
 }
 
+// TT-TEST: A11 primary
 #[test]
 fn analyze_run_rejects_invalid_options() {
     let run = test_run();
@@ -5286,6 +5431,7 @@ fn analyze_run_rejects_invalid_options() {
     ));
 }
 
+// TT-TEST: A11 primary
 #[test]
 fn analyze_run_still_works_with_default_options() {
     let run = test_run();
@@ -5294,6 +5440,7 @@ fn analyze_run_still_works_with_default_options() {
     assert_eq!(report.request_count, 3);
 }
 
+// TT-TEST: support
 #[test]
 fn queueing_trigger_descriptor_direction_text_is_correct() {
     let descriptor = crate::analyze_option_descriptors()
@@ -5310,6 +5457,8 @@ fn queueing_trigger_descriptor_direction_text_is_correct() {
         .contains("easier"));
 }
 
+// TT-TEST: A13 primary
+// TT-TEST: Q01 primary
 #[test]
 fn descriptors_have_unique_and_exact_v1_paths() {
     let descriptors = crate::analyze_option_descriptors();
@@ -5355,6 +5504,7 @@ fn descriptors_have_unique_and_exact_v1_paths() {
     assert_eq!(paths, expected);
 }
 
+// TT-TEST: A13 secondary
 #[test]
 #[allow(clippy::too_many_lines)]
 fn descriptor_defaults_match_analyze_options_defaults() {
@@ -5510,6 +5660,7 @@ fn assert_default_report_has_no_analyzer_config(report: &Report) {
     assert!(report.analyzer_config.is_none());
 }
 
+// TT-TEST: support
 #[test]
 fn default_options_compat_queue_saturation_case() {
     let mut run = test_run();
@@ -5537,6 +5688,7 @@ fn default_options_compat_queue_saturation_case() {
     assert_default_report_has_no_analyzer_config(&report);
 }
 
+// TT-TEST: support
 #[test]
 fn default_options_compat_blocking_pool_pressure_case() {
     let mut run = test_run();
@@ -5566,6 +5718,7 @@ fn default_options_compat_blocking_pool_pressure_case() {
     assert_default_report_has_no_analyzer_config(&report);
 }
 
+// TT-TEST: support
 #[test]
 fn default_options_compat_insufficient_and_weak_evidence_case() {
     let report = analyze_run(&test_run(), AnalyzeOptions::default())
@@ -5582,6 +5735,7 @@ fn default_options_compat_insufficient_and_weak_evidence_case() {
     assert_default_report_has_no_analyzer_config(&report);
 }
 
+// TT-TEST: support
 #[test]
 fn default_options_compat_downstream_stage_dominates_case() {
     let mut run = test_run();
@@ -5610,6 +5764,7 @@ fn default_options_compat_downstream_stage_dominates_case() {
     assert_default_report_has_no_analyzer_config(&report);
 }
 
+// TT-TEST: support
 #[test]
 fn default_options_compat_truncated_evidence_case() {
     let mut run = test_run();
@@ -5625,6 +5780,7 @@ fn default_options_compat_truncated_evidence_case() {
     assert_default_report_has_no_analyzer_config(&report);
 }
 
+// TT-TEST: support
 #[test]
 fn default_options_compat_ambiguous_top_suspects_case() {
     let suspects = vec![
@@ -5644,6 +5800,7 @@ fn default_options_compat_ambiguous_top_suspects_case() {
     assert!(super::ambiguity_warning(&suspects, &AnalyzeOptions::default()).is_some());
 }
 
+// TT-TEST: support
 #[test]
 fn default_options_compat_route_breakdowns_case() {
     let mut run = test_run();
@@ -5697,6 +5854,7 @@ fn default_options_compat_route_breakdowns_case() {
     assert_default_report_has_no_analyzer_config(&report);
 }
 
+// TT-TEST: support
 #[test]
 fn default_options_compat_temporal_segments_case() {
     let mut run = test_run();
@@ -5751,6 +5909,7 @@ fn default_options_compat_temporal_segments_case() {
     assert_default_report_has_no_analyzer_config(&report);
 }
 
+// TT-TEST: A13 primary
 #[test]
 fn analyzer_config_transparency_default_report_omits_config() {
     let run = test_run();
@@ -5772,6 +5931,7 @@ fn analyzer_config_transparency_default_report_omits_config() {
     );
 }
 
+// TT-TEST: A13 primary
 #[test]
 fn analyzer_config_transparency_non_default_report_includes_config() {
     let run = test_run();
@@ -5845,6 +6005,7 @@ fn option_run_twenty_requests() -> Run {
     run
 }
 
+// TT-TEST: support
 #[test]
 fn option_queueing_trigger_permille_changes_queue_suspect() {
     let mut run = option_run_twenty_requests();
@@ -5875,6 +6036,7 @@ fn option_queueing_trigger_permille_changes_queue_suspect() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn option_blocking_min_nonzero_samples_changes_signal_emission() {
     let mut run = option_run_twenty_requests();
@@ -5894,6 +6056,7 @@ fn option_blocking_min_nonzero_samples_changes_signal_emission() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn option_executor_min_global_queue_p95_changes_signal_emission() {
     let mut run = option_run_twenty_requests();
@@ -5912,6 +6075,7 @@ fn option_executor_min_global_queue_p95_changes_signal_emission() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn option_confidence_high_score_threshold_changes_scoring_suspect_bucket() {
     let mut run = option_run_twenty_requests();
@@ -5948,6 +6112,7 @@ fn option_confidence_high_score_threshold_changes_scoring_suspect_bucket() {
     assert_eq!(strict_report.primary_suspect.confidence, Confidence::Medium);
 }
 
+// TT-TEST: A13 primary
 #[test]
 fn analyzer_toml_full_parses() {
     let input = include_str!("../../examples/analyzer-config.toml");
@@ -5955,6 +6120,7 @@ fn analyzer_toml_full_parses() {
     assert_eq!(options.queueing.trigger_permille, 400);
 }
 
+// TT-TEST: support
 #[test]
 fn analyzer_toml_sparse_preserves_defaults() {
     let input = "[analyzer]\nschema_version=1\n[analyzer.queueing]\ntrigger_permille=450\n";
@@ -5963,6 +6129,7 @@ fn analyzer_toml_sparse_preserves_defaults() {
     assert_eq!(options.blocking, AnalyzeOptions::default().blocking);
 }
 
+// TT-TEST: support
 #[test]
 fn analyzer_toml_merge_sparse_preserves_unrelated_non_default_base_values() {
     let base = AnalyzeOptions::default().with_blocking(|o| o.strong_p95_threshold = 99);
@@ -5973,6 +6140,7 @@ fn analyzer_toml_merge_sparse_preserves_unrelated_non_default_base_values() {
     assert_eq!(merged.blocking.strong_p95_threshold, 99);
 }
 
+// TT-TEST: support
 #[test]
 fn analyzer_toml_missing_analyzer_fails() {
     assert!(matches!(
@@ -5980,6 +6148,7 @@ fn analyzer_toml_missing_analyzer_fails() {
         Err(AnalyzeConfigError::MissingAnalyzerTable)
     ));
 }
+// TT-TEST: support
 #[test]
 fn analyzer_toml_root_level_queueing_group_is_rejected() {
     assert!(matches!(
@@ -5988,6 +6157,7 @@ fn analyzer_toml_root_level_queueing_group_is_rejected() {
     ));
 }
 
+// TT-TEST: support
 #[test]
 fn analyzer_toml_missing_schema_fails() {
     assert!(matches!(
@@ -5995,6 +6165,7 @@ fn analyzer_toml_missing_schema_fails() {
         Err(AnalyzeConfigError::MissingSchemaVersion)
     ));
 }
+// TT-TEST: support
 #[test]
 fn analyzer_toml_unsupported_schema_fails() {
     assert!(matches!(
@@ -6005,11 +6176,13 @@ fn analyzer_toml_unsupported_schema_fails() {
         })
     ));
 }
+// TT-TEST: support
 #[test]
 fn analyzer_toml_unknown_top_level_sibling_ignored() {
     let input = "[controller]\nmode='light'\n[analyzer]\nschema_version=1\n";
     assert!(AnalyzeOptions::from_toml_str(input).is_ok());
 }
+// TT-TEST: support
 #[test]
 fn analyzer_toml_unknown_field_under_analyzer_fails() {
     assert!(matches!(
@@ -6017,6 +6190,7 @@ fn analyzer_toml_unknown_field_under_analyzer_fails() {
         Err(AnalyzeConfigError::InvalidToml { .. })
     ));
 }
+// TT-TEST: support
 #[test]
 fn analyzer_toml_unknown_subgroup_fails() {
     assert!(matches!(
@@ -6024,6 +6198,7 @@ fn analyzer_toml_unknown_subgroup_fails() {
         Err(AnalyzeConfigError::InvalidToml { .. })
     ));
 }
+// TT-TEST: support
 #[test]
 fn analyzer_toml_unknown_field_in_known_subgroup_fails() {
     assert!(matches!(
@@ -6033,6 +6208,7 @@ fn analyzer_toml_unknown_field_in_known_subgroup_fails() {
         Err(AnalyzeConfigError::InvalidToml { .. })
     ));
 }
+// TT-TEST: support
 #[test]
 fn analyzer_toml_invalid_type_fails() {
     assert!(matches!(
@@ -6042,6 +6218,7 @@ fn analyzer_toml_invalid_type_fails() {
         Err(AnalyzeConfigError::InvalidToml { .. })
     ));
 }
+// TT-TEST: support
 #[test]
 fn analyzer_toml_invalid_range_fails_validation() {
     let err = AnalyzeOptions::from_toml_str(
@@ -6056,12 +6233,14 @@ fn analyzer_toml_invalid_range_fails_validation() {
         }
     ));
 }
+// TT-TEST: support
 #[test]
 fn analyzer_toml_canonical_example_path_parses() {
     let _ = AnalyzeOptions::from_toml_str(include_str!("../../examples/analyzer-config.toml"))
         .expect("canonical repo-root example parse");
 }
 
+// TT-TEST: support
 #[test]
 fn analyzer_toml_example_file_has_v1_namespaced_groups_only() {
     let input = include_str!("../../examples/analyzer-config.toml");
@@ -6081,6 +6260,7 @@ fn analyzer_toml_example_file_has_v1_namespaced_groups_only() {
         assert!(!input.contains(&format!("[{group}]")));
     }
 }
+// TT-TEST: support
 #[test]
 fn analyzer_toml_downstream_patterns_list_parses() {
     let input = "[analyzer]\nschema_version=1\n[analyzer.downstream]\nblocking_correlated_stage_patterns=['db','cache']\n";
@@ -6090,6 +6270,7 @@ fn analyzer_toml_downstream_patterns_list_parses() {
         vec!["db", "cache"]
     );
 }
+// TT-TEST: support
 #[test]
 fn analyzer_toml_empty_pattern_fails_validation() {
     let err = AnalyzeOptions::from_toml_str("[analyzer]\nschema_version=1\n[analyzer.downstream]\nblocking_correlated_stage_patterns=['']\n").expect_err("must fail");
@@ -6102,6 +6283,7 @@ fn analyzer_toml_empty_pattern_fails_validation() {
     ));
 }
 
+// TT-TEST: A10 secondary
 #[test]
 fn prompt09_partial_events_are_now_visible_without_contaminating_completed_percentiles() {
     let completed = partial_policy_run(false, false);
@@ -6124,6 +6306,7 @@ fn prompt09_partial_events_are_now_visible_without_contaminating_completed_perce
         .any(|w| w == super::partial_evidence::PARTIAL_WARNING));
 }
 
+// TT-TEST: A10 primary
 #[test]
 fn partial_queue_events_do_not_enter_completed_queue_percentiles() {
     let completed = partial_policy_run(false, false);
@@ -6151,6 +6334,7 @@ fn partial_queue_events_do_not_enter_completed_queue_percentiles() {
     );
 }
 
+// TT-TEST: A10 primary
 #[test]
 fn partial_only_queue_evidence_can_rank_queue_suspect_but_caps_confidence() {
     let mut run = partial_policy_run(true, false);
@@ -6173,6 +6357,7 @@ fn partial_only_queue_evidence_can_rank_queue_suspect_but_caps_confidence() {
         .contains(&super::partial_evidence::PARTIAL_QUEUE_CONFIDENCE_NOTE.to_string()));
 }
 
+// TT-TEST: A10 primary
 #[test]
 fn partial_stage_events_do_not_enter_completed_stage_percentiles() {
     let completed = partial_policy_run(false, false);
@@ -6195,6 +6380,7 @@ fn partial_stage_events_do_not_enter_completed_stage_percentiles() {
     assert!(bsus.evidence[0].contains("observed lower-bound"));
 }
 
+// TT-TEST: A10 primary
 #[test]
 fn partial_only_stage_evidence_can_rank_downstream_suspect_but_caps_confidence() {
     let mut run = partial_policy_run(false, true);
@@ -6222,6 +6408,7 @@ fn partial_only_stage_evidence_can_rank_downstream_suspect_but_caps_confidence()
         .contains(&super::partial_evidence::PARTIAL_STAGE_CONFIDENCE_NOTE.to_string()));
 }
 
+// TT-TEST: support
 #[test]
 fn completed_only_report_json_text_scores_and_rankings_remain_exact() {
     let run = partial_policy_run(false, false);
@@ -6263,6 +6450,7 @@ fn completed_only_report_json_text_scores_and_rankings_remain_exact() {
     assert_eq!(report.p95_service_share_permille, Some(100));
 }
 
+// TT-TEST: support
 #[test]
 fn completed_only_warning_and_limitation_order_remains_stable() {
     let mut run = partial_policy_run(false, false);
@@ -6284,6 +6472,7 @@ fn completed_only_warning_and_limitation_order_remains_stable() {
         ]
     );
 }
+// TT-TEST: support
 #[test]
 fn mixed_queue_evidence_uses_higher_basis_and_labels_material_partial_reliance() {
     let mut run = partial_policy_run(false, false);
@@ -6358,6 +6547,7 @@ fn mixed_queue_evidence_uses_higher_basis_and_labels_material_partial_reliance()
     );
 }
 
+// TT-TEST: support
 #[test]
 fn fully_overlapped_partial_queue_does_not_cap_completed_candidate() {
     let mut run = partial_policy_run(false, false);
@@ -6420,6 +6610,7 @@ fn fully_overlapped_partial_queue_does_not_cap_completed_candidate() {
     assert_eq!(r.evidence_quality.limitations[0], "Partial evidence captured: queues 45 completed/1 partial; stages 45 completed/0 partial. Partial durations are observed lower bounds.");
 }
 
+// TT-TEST: support
 #[test]
 fn mixed_stage_evidence_uses_higher_basis_and_labels_material_partial_reliance() {
     let mut run = partial_policy_run(false, false);
@@ -6486,6 +6677,7 @@ fn mixed_stage_evidence_uses_higher_basis_and_labels_material_partial_reliance()
     );
 }
 
+// TT-TEST: support
 #[test]
 fn fully_overlapped_partial_stage_does_not_cap_completed_candidate() {
     let mut run = partial_policy_run(false, false);
@@ -6535,6 +6727,7 @@ fn fully_overlapped_partial_stage_does_not_cap_completed_candidate() {
     assert_eq!(r.evidence_quality.stage_event_count, 46);
     assert_eq!(r.evidence_quality.limitations[0], "Partial evidence captured: queues 45 completed/0 partial; stages 45 completed/1 partial. Partial durations are observed lower bounds.");
 }
+// TT-TEST: support
 #[test]
 fn partial_counts_and_signal_statuses_are_deterministic() {
     let run = partial_policy_run(true, true);
@@ -6546,6 +6739,7 @@ fn partial_counts_and_signal_statuses_are_deterministic() {
     assert_eq!(r.evidence_quality.quality, EvidenceQualityLevel::Partial);
     assert_eq!(r.evidence_quality.limitations[0],"Partial evidence captured: queues 0 completed/45 partial; stages 0 completed/45 partial. Partial durations are observed lower bounds.");
 }
+// TT-TEST: A07 primary
 #[test]
 fn partial_and_truncated_family_reports_truncated_status() {
     let mut run = partial_policy_run(true, true);
@@ -6602,6 +6796,7 @@ fn assert_no_duplicate_warnings(values: &[String]) {
     assert_eq!(values.len(), set.len(), "duplicate warnings: {values:?}");
 }
 
+// TT-TEST: support
 #[test]
 fn global_partial_warning_is_emitted_once_and_not_copied_to_nested_warnings() {
     let run = scoped_partial_acceptance_run();
@@ -6776,6 +6971,7 @@ fn assert_partial_scoped_projection(report: &Report, name: &str, route_warning: 
         .all(|w| w != super::partial_evidence::PARTIAL_WARNING));
 }
 
+// TT-TEST: A10 secondary
 #[test]
 fn route_breakdowns_apply_completed_distribution_and_partial_confidence_policy() {
     let run = scoped_partial_acceptance_run();
@@ -6867,6 +7063,7 @@ fn route_breakdowns_apply_completed_distribution_and_partial_confidence_policy()
     );
 }
 
+// TT-TEST: A10 secondary
 #[test]
 fn temporal_segments_apply_completed_distribution_and_partial_confidence_policy() {
     let run = scoped_partial_acceptance_run();
@@ -6934,6 +7131,7 @@ fn temporal_segments_apply_completed_distribution_and_partial_confidence_policy(
     );
 }
 
+// TT-TEST: support
 #[test]
 fn cancelled_requests_with_partial_children_are_qualified_without_fabricated_failure() {
     let mut run = partial_policy_run(false, true);
@@ -7009,6 +7207,7 @@ fn cancelled_requests_with_partial_children_are_qualified_without_fabricated_fai
     }
 }
 
+// TT-TEST: support
 #[test]
 fn validation_corpus_completed_defaults_and_partial_flags_deserialize() {
     let paths = [

--- a/tailtriage-analyzer/tests/analyzer_fixtures.rs
+++ b/tailtriage-analyzer/tests/analyzer_fixtures.rs
@@ -11,6 +11,7 @@ fn load_fixture(name: &str) -> Run {
     serde_json::from_str(&content).expect("fixture should deserialize")
 }
 
+// TT-TEST: F01 primary
 #[test]
 fn fixture_reports_match_canonical_pretty_json_golden_files() {
     for fixture in [
@@ -35,6 +36,7 @@ fn fixture_reports_match_canonical_pretty_json_golden_files() {
     }
 }
 
+// TT-TEST: A08 secondary
 #[test]
 fn scoped_route_fixture_preserves_breakdown_contract() {
     let report = analyze_run(
@@ -73,6 +75,7 @@ fn scoped_route_fixture_preserves_breakdown_contract() {
             == "Runtime and in-flight signals are global and are not attributed to this route.")));
 }
 
+// TT-TEST: A09 secondary
 #[test]
 fn scoped_temporal_fixture_preserves_windowed_evidence_contract() {
     let report = analyze_run(
@@ -113,6 +116,7 @@ fn scoped_temporal_fixture_preserves_windowed_evidence_contract() {
     }
 }
 
+// TT-TEST: F01 secondary
 #[test]
 fn fixture_categories_produce_expected_primary_suspect() {
     let cases = [
@@ -154,6 +158,7 @@ fn fixture_categories_produce_expected_primary_suspect() {
     }
 }
 
+// TT-TEST: support
 #[test]
 fn fixture_reports_render_to_text_and_json() {
     let run = load_fixture("queue_saturation.json");
@@ -174,6 +179,7 @@ fn fixture_reports_render_to_text_and_json() {
     assert!(json.contains("p95_service_share_permille"));
 }
 
+// TT-TEST: support
 #[test]
 fn fixture_reports_include_expected_request_time_shares() {
     let queue_run = load_fixture("queue_saturation.json");
@@ -189,6 +195,7 @@ fn fixture_reports_include_expected_request_time_shares() {
     assert_eq!(downstream_report.p95_service_share_permille, Some(1000));
 }
 
+// TT-TEST: support
 #[test]
 fn queue_fixture_includes_inflight_trend_evidence() {
     let run = load_fixture("queue_saturation.json");

--- a/tailtriage-analyzer/tests/boundary_thresholds.rs
+++ b/tailtriage-analyzer/tests/boundary_thresholds.rs
@@ -77,6 +77,7 @@ fn base_run() -> Run {
     }
 }
 
+// TT-TEST: A01 primary
 #[test]
 fn queue_share_threshold_uses_300_permille_boundary() {
     let mut below = base_run();
@@ -124,6 +125,7 @@ fn queue_share_threshold_uses_300_permille_boundary() {
     );
 }
 
+// TT-TEST: A01 primary
 #[test]
 fn blocking_and_executor_pressure_require_nonzero_p95_depth() {
     let mut zero = base_run();
@@ -202,6 +204,7 @@ fn blocking_and_executor_pressure_require_nonzero_p95_depth() {
     assert!(kinds.contains(&DiagnosisKind::ExecutorPressureSuspected));
 }
 
+// TT-TEST: A01 primary
 #[test]
 fn downstream_stage_requires_at_least_three_samples() {
     let mut two_samples = base_run();
@@ -284,6 +287,7 @@ fn downstream_stage_requires_at_least_three_samples() {
     );
 }
 
+// TT-TEST: A02 secondary
 #[test]
 fn mixed_signal_fixtures_preserve_stronger_evidence_ordering() {
     let queue_vs_blocking = analyze_run(

--- a/tailtriage-analyzer/tests/end_to_end_capture_analysis.rs
+++ b/tailtriage-analyzer/tests/end_to_end_capture_analysis.rs
@@ -11,6 +11,7 @@ fn unique_path(name: &str) -> PathBuf {
     std::env::temp_dir().join(format!("tailtriage-{name}-{nanos}.json"))
 }
 
+// TT-TEST: C01 secondary
 #[tokio::test(flavor = "current_thread")]
 async fn queue_and_stage_data_drives_ranked_suspects() {
     let artifact = unique_path("e2e-queue");
@@ -53,6 +54,7 @@ async fn queue_and_stage_data_drives_ranked_suspects() {
     );
 }
 
+// TT-TEST: A02 secondary
 #[tokio::test(flavor = "current_thread")]
 async fn downstream_heavy_stage_is_ranked() {
     let artifact = unique_path("e2e-downstream");
@@ -113,6 +115,7 @@ async fn downstream_heavy_stage_is_ranked() {
     );
 }
 
+// TT-TEST: A07 secondary
 #[tokio::test(flavor = "current_thread")]
 async fn low_evidence_run_yields_insufficient_signal() {
     let artifact = unique_path("e2e-insufficient");

--- a/tailtriage-analyzer/tests/public_api_contract.rs
+++ b/tailtriage-analyzer/tests/public_api_contract.rs
@@ -12,6 +12,8 @@ fn load_fixture(name: &str) -> Run {
     serde_json::from_str(&content).expect("fixture should deserialize")
 }
 
+// TT-TEST: A11 secondary
+// TT-TEST: A12 secondary
 #[test]
 fn public_api_supports_checked_analysis_and_canonical_renderers() {
     let run = load_fixture("queue_saturation.json");

--- a/tailtriage-analyzer/tests/report_schema_contract.rs
+++ b/tailtriage-analyzer/tests/report_schema_contract.rs
@@ -15,6 +15,7 @@ fn json_path_exists<'a>(value: &'a Value, path: &[&str]) -> Option<&'a Value> {
         .try_fold(value, |current, key| current.get(*key))
 }
 
+// TT-TEST: A13 primary
 #[test]
 fn documented_report_keys_exist_in_json_output() {
     let run = load_fixture("queue_saturation.json");


### PR DESCRIPTION
### Motivation

- Add machine-readable `TT-TEST` audit markers to the analyzer test suite so each test is explicitly classified for downstream auditing and tracking. 
- This is a purely mechanical migration to annotate existing tests without changing behavior or semantics. 
- Keep the test files and public API unchanged while improving traceability and test metadata.

### Description

- Inserted 275 new `// TT-TEST: ...` comment lines immediately above the existing test attribute blocks across 15 files in `tailtriage-analyzer/`, covering 273 executable Rust tests. 
- Exactly two tests were given two adjacent markers in the requested order (`descriptors_have_unique_and_exact_v1_paths` and `public_api_supports_checked_analysis_and_canonical_renderers`).
- No existing source, test bodies, assertions, comments (other than added markers), docs, manifests, CI, validators, or behavior were modified or removed.
- All marker lines are comment-only additions and there are zero deletions in the change set.

### Testing

- Ran `cargo test -p tailtriage-analyzer --all-targets --all-features --locked` and all analyzer tests passed. 
- Ran `cargo fmt --check` and formatting check passed. 
- Ran `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` and linting passed with no warnings. 
- Ran full workspace `cargo test --workspace --all-targets --all-features --locked` and `python3 scripts/validate_docs_contracts.py` and both succeeded; `git diff --check` reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8cb3110b34833095d7cc661ff303c7)