### PR TITLE
test: add audited TT-TEST markers to CLI, facade, and demos

### DIFF
--- a/demos/collector_stress/src/main.rs
+++ b/demos/collector_stress/src/main.rs
@@ -837,6 +837,7 @@ const fn capture_mode_label(mode: CaptureMode) -> &'static str {
 mod tests {
     use super::{parse_cli_from, Mode, WorkLabel};
 
+    // TT-TEST: support
     #[test]
     fn parse_cli_supports_required_knobs() {
         let cli = parse_cli_from([
@@ -878,6 +879,7 @@ mod tests {
         assert_eq!(cli.output_dir.to_string_lossy(), "tmp/out");
     }
 
+    // TT-TEST: support
     #[test]
     fn parse_cli_rejects_zero_requests() {
         let err = parse_cli_from(["--mode", "baseline", "--requests", "0"])
@@ -885,6 +887,7 @@ mod tests {
         assert!(err.to_string().contains("--requests must be > 0"));
     }
 
+    // TT-TEST: support
     #[test]
     fn parse_cli_accepts_legacy_aliases() {
         let cli = parse_cli_from([

--- a/demos/demo_support/src/lib.rs
+++ b/demos/demo_support/src/lib.rs
@@ -631,6 +631,7 @@ mod tests {
     use tailtriage_core::{Outcome, RequestEvent, Run, RunBuilder, RunBuilderOptions};
     use tailtriage_tracing::ImportedRun;
 
+    // TT-TEST: support
     #[test]
     fn demo_args_default_instrumentation_is_native() {
         let args = parse_demo_args_from(&["out.json".to_string()], "ignored").expect("parse args");
@@ -638,6 +639,7 @@ mod tests {
         assert_eq!(args.instrumentation, InstrumentationMode::Native);
     }
 
+    // TT-TEST: support
     #[test]
     fn demo_args_explicit_native_instrumentation() {
         let args = parse_demo_args_from(
@@ -652,6 +654,7 @@ mod tests {
         assert_eq!(args.instrumentation, InstrumentationMode::Native);
     }
 
+    // TT-TEST: support
     #[test]
     fn demo_args_explicit_tracing_instrumentation() {
         let args = parse_demo_args_from(
@@ -666,6 +669,7 @@ mod tests {
         assert_eq!(args.instrumentation, InstrumentationMode::Tracing);
     }
 
+    // TT-TEST: support
     #[test]
     fn demo_args_unsupported_instrumentation_errors() {
         let err = parse_demo_args_from(
@@ -680,6 +684,7 @@ mod tests {
         assert!(err.to_string().contains("unsupported instrumentation"));
     }
 
+    // TT-TEST: support
     #[test]
     fn demo_args_old_positional_mode_aliases_still_work() {
         let before_args =
@@ -693,12 +698,14 @@ mod tests {
         assert_eq!(after_args.mode, DemoMode::Mitigated);
     }
 
+    // TT-TEST: support
     #[test]
     fn outcome_other_preserves_custom_label() {
         let outcome = Outcome::Other("custom".to_string());
         assert_eq!(outcome.as_str(), "custom");
     }
 
+    // TT-TEST: support
     #[test]
     fn tracing_shutdown_writer_rejects_zero_requests_without_writing() {
         let output = unique_temp_output_path("empty-run");
@@ -709,6 +716,7 @@ mod tests {
         assert!(!output.exists());
     }
 
+    // TT-TEST: support
     #[test]
     fn tracing_shutdown_writer_persists_non_empty_run_json() {
         let output = unique_temp_output_path("non-empty-run");

--- a/demos/runtime_cost/src/main.rs
+++ b/demos/runtime_cost/src/main.rs
@@ -555,6 +555,7 @@ fn micros_to_millis_f64(m: u64) -> anyhow::Result<f64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // TT-TEST: support
     #[tokio::test(flavor = "current_thread")]
     async fn native_finalize_reads_finalized_run_from_memory_sink() {
         let output_dir = std::env::temp_dir().join(format!(
@@ -584,6 +585,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[tokio::test(flavor = "current_thread")]
     async fn baked_in_no_request_context_finalizes_and_skips_analyzer_render() {
         let output_dir = std::env::temp_dir().join(format!(
@@ -623,6 +625,7 @@ mod tests {
         );
     }
 
+    // TT-TEST: support
     #[test]
     fn mode_parse_accepts_tracing_modes() {
         assert_eq!(Mode::parse("tracing_light"), Some(Mode::TracingLight));
@@ -635,10 +638,12 @@ mod tests {
             Some(Mode::TracingLightDropPath)
         );
     }
+    // TT-TEST: support
     #[test]
     fn mode_parse_rejects_unknown() {
         assert_eq!(Mode::parse("wat"), None);
     }
+    // TT-TEST: support
     #[test]
     fn mode_classification_works() {
         let m = Mode::TracingLightTokioSampler;

--- a/tailtriage-cli/src/analyze_config.rs
+++ b/tailtriage-cli/src/analyze_config.rs
@@ -110,6 +110,7 @@ mod tests {
         )
     }
 
+    // TT-TEST: L04 primary
     #[test]
     fn positive_config_composition_cases() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -140,6 +141,7 @@ mod tests {
         }
     }
 
+    // TT-TEST: L04 secondary
     #[test]
     fn misspelled_path_reports_suggestion() {
         let err = build_analyze_options(None, &["queuing.trigger_permille=400".to_string()])
@@ -148,6 +150,7 @@ mod tests {
         assert!(msg.contains("queueing.trigger_permille"));
     }
 
+    // TT-TEST: L04 primary
     #[test]
     fn invalid_type_reports_expected_type() {
         let err = build_analyze_options(None, &["queueing.trigger_permille=abc".to_string()])
@@ -157,6 +160,7 @@ mod tests {
         assert!(matches!(err, CliAnalyzeConfigError::Analyzer(_)));
     }
 
+    // TT-TEST: L04 secondary
     #[test]
     fn missing_config_returns_read_config_error_with_path() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -174,6 +178,7 @@ mod tests {
         ));
     }
 
+    // TT-TEST: L04 primary
     #[test]
     fn invalid_toml_returns_analyzer_error() {
         let dir = tempfile::tempdir().expect("tempdir");

--- a/tailtriage-cli/src/artifact.rs
+++ b/tailtriage-cli/src/artifact.rs
@@ -200,6 +200,8 @@ fn validate_required_sections(run: &Run, path: &Path) -> Result<(), ArtifactLoad
 mod tests {
     use super::load_run_artifact;
 
+    // TT-TEST: L02 primary
+    // TT-TEST: S02 secondary
     #[test]
     fn rejects_malformed_json() {
         let dir = tempfile::tempdir().expect("tempdir should build");
@@ -213,6 +215,7 @@ mod tests {
         assert!(message.contains("malformed JSON"));
     }
 
+    // TT-TEST: L02 primary
     #[test]
     fn rejects_missing_required_fields() {
         let dir = tempfile::tempdir().expect("tempdir should build");
@@ -227,6 +230,7 @@ mod tests {
         assert!(message.contains("missing required fields"));
     }
 
+    // TT-TEST: L02 primary
     #[test]
     fn rejects_empty_requests_section() {
         let dir = tempfile::tempdir().expect("tempdir should build");
@@ -239,6 +243,7 @@ mod tests {
         assert!(message.contains("requests section is empty"));
     }
 
+    // TT-TEST: L02 primary
     #[test]
     fn rejects_missing_schema_version() {
         let dir = tempfile::tempdir().expect("tempdir should build");
@@ -252,6 +257,7 @@ mod tests {
         assert!(message.contains("schema_version"));
     }
 
+    // TT-TEST: L02 primary
     #[test]
     fn rejects_non_integer_schema_versions() {
         let dir = tempfile::tempdir().expect("tempdir should build");
@@ -269,6 +275,7 @@ mod tests {
         assert!(message.contains("invalid type"));
     }
 
+    // TT-TEST: L02 primary
     #[test]
     fn rejects_unsupported_schema_versions() {
         let dir = tempfile::tempdir().expect("tempdir should build");
@@ -283,6 +290,7 @@ mod tests {
         assert!(message.contains("schema_version=99"));
     }
 
+    // TT-TEST: support
     #[test]
     fn flags_truncation_like_parse_errors() {
         let dir = tempfile::tempdir().expect("tempdir should build");
@@ -295,6 +303,7 @@ mod tests {
         assert!(message.contains("may be truncated"));
     }
 
+    // TT-TEST: support
     #[test]
     fn surfaces_unfinished_request_warnings() {
         let dir = tempfile::tempdir().expect("tempdir should build");
@@ -312,6 +321,8 @@ mod tests {
             .any(|warning| warning.contains("unfinished request")));
     }
 
+    // TT-TEST: L02 primary
+    // TT-TEST: S02 secondary
     #[test]
     fn cli_loads_finalized_schema_v2_artifact() {
         let dir = tempfile::tempdir().expect("tempdir should build");
@@ -322,6 +333,7 @@ mod tests {
         assert_eq!(loaded.original_run.metadata.finalized_at_unix_ms, Some(2));
     }
 
+    // TT-TEST: S02 secondary
     #[test]
     fn structurally_incompatible_old_schema_fails_as_shape_error() {
         let dir = tempfile::tempdir().expect("tempdir should build");
@@ -332,6 +344,7 @@ mod tests {
         assert!(message.contains("JSON shape does not match"));
     }
 
+    // TT-TEST: L02 primary
     #[test]
     fn cli_rejects_unfinalized_schema_v2_artifact() {
         let dir = tempfile::tempdir().expect("tempdir should build");

--- a/tailtriage-cli/tests/cli_boundary.rs
+++ b/tailtriage-cli/tests/cli_boundary.rs
@@ -7,6 +7,7 @@ use std::process::Command;
 use tailtriage_analyzer::{analyze_run, AnalyzeOptions};
 use tailtriage_core::{CaptureMode, Run};
 
+// TT-TEST: L05 secondary
 #[test]
 fn cli_json_output_is_valid_report_json() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -34,6 +35,7 @@ fn cli_json_output_is_valid_report_json() {
     assert!(report.get("primary_suspect").is_some());
 }
 
+// TT-TEST: S04 primary
 #[test]
 fn artifact_warning_controls_are_visible_on_stderr_but_preserved_in_json() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -64,6 +66,7 @@ fn artifact_warning_controls_are_visible_on_stderr_but_preserved_in_json() {
     );
 }
 
+// TT-TEST: V03 primary
 #[test]
 fn cli_loader_rejects_empty_requests_but_analyzer_accepts_zero_request_run() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -84,6 +87,7 @@ fn cli_loader_rejects_empty_requests_but_analyzer_accepts_zero_request_run() {
     assert_eq!(report.request_count, 0);
 }
 
+// TT-TEST: support
 #[test]
 fn help_analyzer_options_works_without_run_json() {
     let exe = env!("CARGO_BIN_EXE_tailtriage");
@@ -98,6 +102,7 @@ fn help_analyzer_options_works_without_run_json() {
     assert!(stdout.contains("queueing.trigger_permille"));
 }
 
+// TT-TEST: L04 secondary
 #[test]
 fn cli_analyzer_config_applies_toml_and_reports_non_default_config() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -126,6 +131,7 @@ fn cli_analyzer_config_applies_toml_and_reports_non_default_config() {
     assert_eq!(non_defaults[0]["value"], "410");
 }
 
+// TT-TEST: L04 secondary
 #[test]
 fn cli_analyzer_set_applies_override_and_reports_non_default_config() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -148,6 +154,7 @@ fn cli_analyzer_set_applies_override_and_reports_non_default_config() {
     assert_eq!(non_defaults[0]["value"], "420");
 }
 
+// TT-TEST: L04 secondary
 #[test]
 fn cli_analyzer_set_beats_toml_and_repeated_overrides_are_last_wins() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -180,6 +187,8 @@ fn cli_analyzer_set_beats_toml_and_repeated_overrides_are_last_wins() {
     assert_eq!(non_defaults[0]["value"], "440");
 }
 
+// TT-TEST: V03 primary
+// TT-TEST: L03 primary
 #[test]
 fn analyze_rejects_duplicate_completed_request_ids_by_default() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -205,6 +214,7 @@ fn analyze_rejects_duplicate_completed_request_ids_by_default() {
     assert!(stderr.contains("request[1]"));
 }
 
+// TT-TEST: L03 secondary
 #[test]
 fn analyze_allow_ambiguous_artifact_warns_then_rejects_empty_normalized_run() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -237,6 +247,7 @@ fn analyze_allow_ambiguous_artifact_warns_then_rejects_empty_normalized_run() {
     assert!(!stderr.contains("unsupported run artifact"));
 }
 
+// TT-TEST: L03 secondary
 #[test]
 fn analyze_rejects_orphan_stage_by_default() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -259,6 +270,7 @@ fn analyze_rejects_orphan_stage_by_default() {
     assert!(stderr.contains("stage[0]"));
 }
 
+// TT-TEST: L03 primary
 #[test]
 fn analyze_default_accepts_warning_only_precision_findings() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -288,6 +300,7 @@ fn analyze_default_accepts_warning_only_precision_findings() {
         .any(|limitation| limitation.contains("precise_interval_validation_unavailable")));
 }
 
+// TT-TEST: support
 #[test]
 fn analyze_default_required_field_location_includes_index_and_field() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -308,6 +321,7 @@ fn analyze_default_required_field_location_includes_index_and_field() {
     assert!(stderr.contains("request[0].route"));
 }
 
+// TT-TEST: support
 #[test]
 fn analyze_default_duplicate_plus_orphan_displays_unique_error_codes_only() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -337,6 +351,7 @@ fn analyze_default_duplicate_plus_orphan_displays_unique_error_codes_only() {
     assert!(!stderr.contains("precise_interval_validation_unavailable"));
 }
 
+// TT-TEST: support
 #[test]
 fn analyze_malformed_json_fails_before_core_validation() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -356,6 +371,7 @@ fn analyze_malformed_json_fails_before_core_validation() {
     assert!(!stderr.contains("strict artifact validation failed"));
 }
 
+// TT-TEST: support
 #[test]
 fn analyze_default_discloses_truncated_error_details() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -387,6 +403,8 @@ fn analyze_default_discloses_truncated_error_details() {
     assert!(stderr.contains("2 additional error finding(s) omitted"));
 }
 
+// TT-TEST: V03 primary
+// TT-TEST: L03 primary
 #[test]
 fn analyze_allow_ambiguous_artifact_excludes_orphan_and_warns() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -419,6 +437,7 @@ fn analyze_allow_ambiguous_artifact_excludes_orphan_and_warns() {
     assert!(original.metadata.lifecycle_warnings.is_empty());
 }
 
+// TT-TEST: support
 #[test]
 fn analyze_allow_ambiguous_artifact_retains_duration_and_clears_partial_precision() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -450,6 +469,7 @@ fn analyze_allow_ambiguous_artifact_retains_duration_and_clears_partial_precisio
         .any(|limitation| limitation.contains("duration evidence was retained")));
 }
 
+// TT-TEST: support
 #[test]
 fn analyze_permissive_artifact_excludes_precise_child_outside_parent_but_retains_request() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -484,6 +504,7 @@ fn analyze_permissive_artifact_excludes_precise_child_outside_parent_but_retains
     assert!(!report.to_string().contains(r#""db""#));
 }
 
+// TT-TEST: support
 #[test]
 fn analyze_rejects_inverted_interval_by_default() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -510,6 +531,7 @@ fn analyze_rejects_inverted_interval_by_default() {
     }
 }
 
+// TT-TEST: support
 #[test]
 fn allow_ambiguous_artifact_is_noop_for_valid_artifact() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -538,6 +560,7 @@ fn allow_ambiguous_artifact_is_noop_for_valid_artifact() {
     assert!(strict.stderr.is_empty() && permissive.stderr.is_empty());
 }
 
+// TT-TEST: L01 primary
 #[test]
 fn analyze_help_documents_strict_default_and_permissive_escape_hatch() {
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
@@ -552,6 +575,7 @@ fn analyze_help_documents_strict_default_and_permissive_escape_hatch() {
     assert!(!help.contains("malformed/incomplete tailtriage spans"));
 }
 
+// TT-TEST: L01 primary
 #[test]
 fn analyze_rejects_removed_strict_artifact_flag() {
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
@@ -565,6 +589,7 @@ fn analyze_rejects_removed_strict_artifact_flag() {
     );
 }
 
+// TT-TEST: L01 primary
 #[test]
 fn tracing_import_help_keeps_distinct_strict_input_flag() {
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
@@ -578,6 +603,7 @@ fn tracing_import_help_keeps_distinct_strict_input_flag() {
     assert!(!help.contains("--allow-ambiguous-artifact"));
 }
 
+// TT-TEST: support
 #[test]
 fn cli_misspelled_analyzer_set_reports_suggestion() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -597,6 +623,7 @@ fn cli_misspelled_analyzer_set_reports_suggestion() {
     assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
 }
 
+// TT-TEST: support
 #[test]
 fn cli_invalid_analyzer_set_type_reports_expected_type() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -617,6 +644,7 @@ fn cli_invalid_analyzer_set_type_reports_expected_type() {
     assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
 }
 
+// TT-TEST: support
 #[test]
 fn cli_missing_analyzer_config_file_reports_path() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -642,6 +670,7 @@ fn cli_missing_analyzer_config_file_reports_path() {
     assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
 }
 
+// TT-TEST: support
 #[test]
 fn missing_run_json_without_help_flag_fails_clearly() {
     let exe = env!("CARGO_BIN_EXE_tailtriage");
@@ -655,6 +684,7 @@ fn missing_run_json_without_help_flag_fails_clearly() {
     assert!(stderr.contains("RUN_JSON") || stderr.contains("missing required"));
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_creates_missing_output_parent_directories() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -684,6 +714,7 @@ fn import_tracing_spans_jsonl_creates_missing_output_parent_directories() {
     assert_no_precise_interval_lifecycle_warning(&loaded.run);
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_fails_when_output_parent_path_is_not_directory() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -714,6 +745,7 @@ fn import_tracing_spans_jsonl_fails_when_output_parent_path_is_not_directory() {
     assert!(!run_path.exists(), "run artifact should not be written");
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_writes_run_json_analyzable_by_existing_apis() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -744,6 +776,7 @@ fn import_tracing_spans_jsonl_writes_run_json_analyzable_by_existing_apis() {
     assert_no_precise_interval_lifecycle_warning(&loaded.run);
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_writes_run_json_when_output_path_contains_spaces() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -770,6 +803,7 @@ fn import_tracing_spans_jsonl_writes_run_json_when_output_path_contains_spaces()
     assert_eq!(loaded.run.requests.len(), 1);
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_mode_investigation_sets_run_metadata_mode() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -793,6 +827,7 @@ fn import_tracing_spans_jsonl_mode_investigation_sets_run_metadata_mode() {
     assert_eq!(loaded.run.metadata.mode, CaptureMode::Investigation);
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_capture_limit_overrides_apply() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -822,6 +857,7 @@ fn import_tracing_spans_jsonl_capture_limit_overrides_apply() {
     assert_eq!(loaded.run.queues.len(), 1);
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_rejects_zero_max_requests() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -852,6 +888,7 @@ fn import_tracing_spans_jsonl_rejects_zero_max_requests() {
     assert!(!run_path.exists());
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_allows_zero_stage_and_queue_limits() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -886,6 +923,7 @@ fn import_tracing_spans_jsonl_allows_zero_stage_and_queue_limits() {
     assert_no_precise_interval_lifecycle_warning(&loaded.run);
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_rejects_inert_runtime_snapshot_flags() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -909,6 +947,7 @@ fn import_tracing_spans_jsonl_rejects_inert_runtime_snapshot_flags() {
     assert!(stderr.contains("unexpected argument '--max-runtime-snapshots'"));
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_rejects_inert_inflight_snapshot_flags() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -932,6 +971,7 @@ fn import_tracing_spans_jsonl_rejects_inert_inflight_snapshot_flags() {
     assert!(stderr.contains("unexpected argument '--max-inflight-snapshots'"));
 }
 
+// TT-TEST: L01 primary
 #[test]
 fn tailtriage_help_mentions_import_and_analyze_artifacts() {
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
@@ -943,6 +983,8 @@ fn tailtriage_help_mentions_import_and_analyze_artifacts() {
     assert!(stdout.contains("Import and analyze tailtriage run artifacts"));
 }
 
+// TT-TEST: R01 secondary
+// TT-TEST: F02 secondary
 #[test]
 fn import_tracing_spans_jsonl_input_format_tailtriage_wrapper_only_accepts_fixture() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -974,6 +1016,7 @@ fn import_tracing_spans_jsonl_input_format_tailtriage_wrapper_only_accepts_fixtu
     assert_eq!(report.request_count, 1);
 }
 
+// TT-TEST: R01 secondary
 #[test]
 fn import_tracing_spans_jsonl_input_format_tailtriage_wrapper_only_rejects_unwrapped() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -998,6 +1041,7 @@ fn import_tracing_spans_jsonl_input_format_tailtriage_wrapper_only_rejects_unwra
     assert!(!run_path.exists());
 }
 
+// TT-TEST: R01 secondary
 #[test]
 fn import_tracing_spans_jsonl_default_wrapper_mode_rejects_wrong_wrapper_format_with_guidance() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -1019,6 +1063,7 @@ fn import_tracing_spans_jsonl_default_wrapper_mode_rejects_wrong_wrapper_format_
     assert!(stderr.contains("tailtriage.tracing-span.v1"));
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_default_wrapper_mode_semantic_missing_route_no_wrapper_guidance() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -1042,6 +1087,7 @@ fn import_tracing_spans_jsonl_default_wrapper_mode_semantic_missing_route_no_wra
     assert!(!stderr.contains("tracing_subscriber::fmt().json()"));
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_default_wrapper_mode_semantic_invalid_kind_type_no_wrapper_guidance()
 {
@@ -1066,6 +1112,7 @@ fn import_tracing_spans_jsonl_default_wrapper_mode_semantic_invalid_kind_type_no
     assert!(!stderr.contains("tracing_subscriber::fmt().json()"));
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_default_wrapper_mode_missing_input_does_not_append_wrapper_guidance()
 {
@@ -1089,6 +1136,7 @@ fn import_tracing_spans_jsonl_default_wrapper_mode_missing_input_does_not_append
     assert!(!stderr.contains("tracing_subscriber::fmt().json()"));
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_default_wrapper_mode_malformed_json_does_not_append_wrapper_guidance()
 {
@@ -1113,6 +1161,7 @@ fn import_tracing_spans_jsonl_default_wrapper_mode_malformed_json_does_not_appen
     assert!(!stderr.contains("tracing_subscriber::fmt().json()"));
 }
 
+// TT-TEST: R01 secondary
 #[test]
 fn import_tracing_spans_jsonl_default_rejects_fmt_json_with_guidance() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -1148,6 +1197,7 @@ fn import_tracing_spans_jsonl_default_rejects_fmt_json_with_guidance() {
     assert!(!run_path.exists());
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_compatible_rejects_ordinary_fmt_json_without_completed_span_timing() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -1177,6 +1227,7 @@ fn import_tracing_spans_jsonl_compatible_rejects_ordinary_fmt_json_without_compl
     assert!(!run_path.exists(), "run json should not be written");
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_rejects_fmt_metadata_with_completed_span_timing() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -1203,6 +1254,7 @@ fn import_tracing_spans_jsonl_rejects_fmt_metadata_with_completed_span_timing() 
     assert!(!run_path.exists(), "run json should not be written");
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_help_shows_only_live_input_format_values() {
     let output = Command::new(env!("CARGO_BIN_EXE_tailtriage"))
@@ -1218,6 +1270,7 @@ fn import_tracing_spans_jsonl_help_shows_only_live_input_format_values() {
     assert!(!stdout.contains("tracing-subscriber-fmt-json"));
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_input_format_compatible_is_clap_unknown_argument() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -1250,6 +1303,7 @@ fn import_tracing_spans_jsonl_input_format_compatible_is_clap_unknown_argument()
     assert!(!run_path.exists());
 }
 
+// TT-TEST: R02 secondary
 #[test]
 fn import_tracing_spans_jsonl_strict_fails_on_incomplete_tailtriage_span() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -1279,6 +1333,7 @@ fn import_tracing_spans_jsonl_strict_fails_on_incomplete_tailtriage_span() {
     );
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_strict_with_max_requests_rejects_retained_orphan_children() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -1324,6 +1379,7 @@ fn import_tracing_spans_jsonl_strict_with_max_requests_rejects_retained_orphan_c
     );
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_permissive_with_max_requests_excludes_retained_orphan_children() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -1381,6 +1437,7 @@ fn import_tracing_spans_jsonl_permissive_with_max_requests_excludes_retained_orp
         .any(|warning| warning.contains("orphan_request_scoped_event")));
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_strict_with_max_requests_fails_on_invalid_overflow_stage() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -1421,6 +1478,7 @@ fn import_tracing_spans_jsonl_strict_with_max_requests_fails_on_invalid_overflow
     );
 }
 
+// TT-TEST: R02 secondary
 #[test]
 fn import_tracing_spans_jsonl_non_strict_writes_output_and_emits_warning_to_stderr() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -1454,6 +1512,7 @@ fn import_tracing_spans_jsonl_non_strict_writes_output_and_emits_warning_to_stde
     assert_eq!(loaded.run.requests.len(), 1);
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_writes_metadata_flags_into_run_json() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -1488,6 +1547,7 @@ fn import_tracing_spans_jsonl_writes_metadata_flags_into_run_json() {
     assert_no_precise_interval_lifecycle_warning(&loaded.run);
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_accepts_paths_with_spaces() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -1513,6 +1573,7 @@ fn import_tracing_spans_jsonl_accepts_paths_with_spaces() {
     artifact::load_run_artifact(&run_path).expect("imported run should load in cli loader");
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_rejects_whitespace_service_name() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -1535,6 +1596,7 @@ fn import_tracing_spans_jsonl_rejects_whitespace_service_name() {
     assert!(!run_path.exists(), "run output should not be written");
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_fails_when_only_unrelated_lines_are_present() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -1558,6 +1620,7 @@ fn import_tracing_spans_jsonl_fails_when_only_unrelated_lines_are_present() {
     assert!(!run_path.exists(), "run output should not be written");
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_fails_when_non_strict_skips_all_malformed_tt_spans() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -1581,6 +1644,7 @@ fn import_tracing_spans_jsonl_fails_when_non_strict_skips_all_malformed_tt_spans
     assert!(!run_path.exists(), "run output should not be written");
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_fails_when_only_tt_spans_are_missing_kind() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -1606,6 +1670,7 @@ fn import_tracing_spans_jsonl_fails_when_only_tt_spans_are_missing_kind() {
     assert!(!run_path.exists(), "run output should not be written");
 }
 
+// TT-TEST: R02 secondary
 #[test]
 fn import_tracing_spans_jsonl_warns_for_tt_fields_missing_kind_and_still_writes_run() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -1643,6 +1708,7 @@ fn import_tracing_spans_jsonl_warns_for_tt_fields_missing_kind_and_still_writes_
     assert_eq!(warning_matches, 1);
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_persists_unknown_kind_warning_in_run_artifact() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -1680,6 +1746,7 @@ fn import_tracing_spans_jsonl_persists_unknown_kind_warning_in_run_artifact() {
     assert_eq!(warning_matches, 1);
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_persists_optional_default_assumption_warnings_in_run_artifact() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -1726,6 +1793,7 @@ fn import_tracing_spans_jsonl_persists_optional_default_assumption_warnings_in_r
     assert_eq!(report.request_count, 1);
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_whitespace_outcome_non_strict_warns_and_fails_zero_request() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -1751,6 +1819,7 @@ fn import_tracing_spans_jsonl_whitespace_outcome_non_strict_warns_and_fails_zero
     assert!(stderr.contains("zero request events"));
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_whitespace_outcome_strict_fails_with_message() {
     let dir = tempfile::tempdir().expect("tempdir should build");
@@ -1775,6 +1844,7 @@ fn import_tracing_spans_jsonl_whitespace_outcome_strict_fails_with_message() {
     assert!(stderr.contains("expected non-empty, non-whitespace string"));
 }
 
+// TT-TEST: support
 #[test]
 fn import_tracing_spans_jsonl_valid_outcomes_import_successfully() {
     let dir = tempfile::tempdir().expect("tempdir should build");

--- a/tailtriage-cli/tests/demo_smoke_fixtures.rs
+++ b/tailtriage-cli/tests/demo_smoke_fixtures.rs
@@ -42,6 +42,7 @@ fn assert_primary_evidence_contains_any(report: &Value, cues: &[&str], fixture: 
     );
 }
 
+// TT-TEST: F05 secondary
 #[test]
 fn queue_demo_fixture_reports_application_queue_saturation() {
     let fixture = "demos/queue_service/fixtures/before-analysis.json";
@@ -51,6 +52,7 @@ fn queue_demo_fixture_reports_application_queue_saturation() {
     assert_primary_score_floor(&report, 70, fixture);
 }
 
+// TT-TEST: F05 secondary
 #[test]
 fn blocking_demo_fixture_reports_blocking_pool_pressure() {
     let fixture = "demos/blocking_service/fixtures/before-analysis.json";
@@ -60,6 +62,7 @@ fn blocking_demo_fixture_reports_blocking_pool_pressure() {
     assert_primary_score_floor(&report, 70, fixture);
 }
 
+// TT-TEST: F05 secondary
 #[test]
 fn downstream_demo_fixture_reports_downstream_stage_dominance() {
     let fixture = "demos/downstream_service/fixtures/before-analysis.json";
@@ -69,6 +72,7 @@ fn downstream_demo_fixture_reports_downstream_stage_dominance() {
     assert_primary_score_floor(&report, 60, fixture);
 }
 
+// TT-TEST: F05 secondary
 #[test]
 fn executor_demo_fixture_reports_executor_pressure() {
     let fixture = "demos/executor_pressure_service/fixtures/before-analysis.json";
@@ -78,6 +82,7 @@ fn executor_demo_fixture_reports_executor_pressure() {
     assert_primary_score_floor(&report, 60, fixture);
 }
 
+// TT-TEST: F05 secondary
 #[test]
 fn mixed_contention_baseline_fixture_has_queue_primary_with_secondary_contention_cues() {
     let fixture = "demos/mixed_contention_service/fixtures/baseline-analysis.json";
@@ -99,6 +104,7 @@ fn mixed_contention_baseline_fixture_has_queue_primary_with_secondary_contention
     assert_primary_score_floor(&report, 70, fixture);
 }
 
+// TT-TEST: F05 secondary
 #[test]
 fn cold_start_burst_before_fixture_has_cold_start_queue_evidence() {
     let fixture = "demos/cold_start_burst_service/fixtures/before-analysis.json";
@@ -125,6 +131,7 @@ fn cold_start_burst_before_fixture_has_cold_start_queue_evidence() {
     assert_primary_score_floor(&report, 70, fixture);
 }
 
+// TT-TEST: F05 secondary
 #[test]
 fn db_pool_saturation_before_fixture_preserves_queue_signal_floor() {
     let fixture = "demos/db_pool_saturation_service/fixtures/before-analysis.json";
@@ -139,6 +146,7 @@ fn db_pool_saturation_before_fixture_preserves_queue_signal_floor() {
     assert_primary_score_floor(&report, 65, fixture);
 }
 
+// TT-TEST: F05 secondary
 #[test]
 fn retry_storm_before_fixture_preserves_downstream_retry_cues() {
     let fixture = "demos/retry_storm_service/fixtures/before-analysis.json";

--- a/tailtriage-cli/tests/json_parity.rs
+++ b/tailtriage-cli/tests/json_parity.rs
@@ -12,6 +12,7 @@ use std::task::{Context, Poll, Waker};
 
 use tailtriage_core::{normalize_run_permissive, RequestOptions, Run, Tailtriage};
 
+// TT-TEST: L05 primary
 #[test]
 fn cli_json_matches_analyzer_renderer_output() {
     let tempdir = tempfile::tempdir().expect("tempdir should build");
@@ -59,6 +60,7 @@ fn cli_json_matches_analyzer_renderer_output() {
     assert_eq!(stdout, format!("{expected_json}\n"));
 }
 
+// TT-TEST: L03 secondary
 #[test]
 fn allow_ambiguous_artifact_reports_preserve_core_warning_equivalence_for_boundary_artifacts() {
     for candidate in [
@@ -157,6 +159,7 @@ fn allow_ambiguous_artifact_reports_preserve_core_warning_equivalence_for_bounda
     }
 }
 
+// TT-TEST: L03 secondary
 #[test]
 fn allow_ambiguous_artifact_emits_every_core_issue_in_order() {
     let mut original: Run =
@@ -268,6 +271,7 @@ fn precise_child_outside_parent() -> &'static str {
     r#"{"schema_version":2,"metadata":{"run_id":"r1","service_name":"svc","service_version":null,"started_at_unix_ms":1,"finalized_at_unix_ms":2,"mode":"light","host":null,"pid":null,"lifecycle_warnings":[],"unfinished_requests":{"count":0,"sample":[]}},"requests":[{"request_id":"req1","route":"/","kind":null,"started_at_unix_ms":1,"started_at_run_us":10,"finished_at_unix_ms":2,"finished_at_run_us":20,"latency_us":10,"outcome":"ok"}],"stages":[{"request_id":"req1","stage":"db","started_at_unix_ms":1,"started_at_run_us":0,"finished_at_unix_ms":2,"finished_at_run_us":5,"latency_us":5,"success":true}],"queues":[],"inflight":[],"runtime_snapshots":[]}"#
 }
 
+// TT-TEST: V02 secondary
 #[test]
 #[allow(clippy::too_many_lines)]
 fn canonical_run_integrity_equivalence_matrix_across_entries() {
@@ -428,6 +432,7 @@ fn canonical_run_integrity_equivalence_matrix_across_entries() {
     }
 }
 
+// TT-TEST: support
 #[test]
 fn canonical_tracing_conversion_matches_core_for_supported_cases() {
     for case in tracing_candidates() {
@@ -502,6 +507,7 @@ fn canonical_tracing_conversion_matches_core_for_supported_cases() {
     }
 }
 
+// TT-TEST: support
 #[test]
 fn native_run_is_strict_valid_and_normalization_idempotent() {
     let tailtriage = Tailtriage::builder("native-svc")
@@ -556,6 +562,7 @@ fn native_run_is_strict_valid_and_normalization_idempotent() {
     assert_eq!(analyzer.request_count, normalized_projection.requests.len());
 }
 
+// TT-TEST: support
 #[test]
 fn native_derived_missing_precision_keeps_duration_evidence_without_lifecycle_mutation() {
     let tailtriage = Tailtriage::builder("native-svc")
@@ -604,6 +611,7 @@ fn native_derived_missing_precision_keeps_duration_evidence_without_lifecycle_mu
     );
 }
 
+// TT-TEST: support
 #[test]
 fn cli_missing_precision_warnings_and_artifact_are_deduplicated() {
     let tempdir = tempfile::tempdir().expect("tempdir");

--- a/tailtriage/src/lib.rs
+++ b/tailtriage/src/lib.rs
@@ -38,11 +38,13 @@ pub use tailtriage_tracing as tracing;
 
 #[cfg(test)]
 mod tests {
+    // TT-TEST: P01 primary
     #[test]
     fn core_reexport_exposes_tailtriage() {
         let _builder = crate::Tailtriage::builder("default-smoke");
     }
 
+    // TT-TEST: P01 primary
     #[cfg(feature = "tokio")]
     #[test]
     fn tokio_namespace_reexport_compiles() {
@@ -53,6 +55,7 @@ mod tests {
         ));
     }
 
+    // TT-TEST: P01 primary
     #[cfg(feature = "tokio")]
     #[test]
     fn tokio_helper_trait_reexport_path_compiles() {
@@ -62,18 +65,21 @@ mod tests {
         assert_trait::<crate::RequestHandle<'_>>();
     }
 
+    // TT-TEST: P01 primary
     #[cfg(feature = "controller")]
     #[test]
     fn controller_namespace_reexport_compiles() {
         let _builder = crate::controller::TailtriageController::builder("default-controller");
     }
 
+    // TT-TEST: P02 primary
     #[cfg(feature = "axum")]
     #[test]
     fn axum_namespace_reexport_compiles() {
         std::hint::black_box(crate::axum::middleware);
     }
 
+    // TT-TEST: P02 primary
     #[cfg(feature = "tracing")]
     #[test]
     fn tracing_namespace_reexport_compiles() {

--- a/tailtriage/tests/tracing_facade.rs
+++ b/tailtriage/tests/tracing_facade.rs
@@ -1,3 +1,4 @@
+// TT-TEST: R03 secondary
 #[cfg(feature = "tracing-live")]
 #[test]
 fn tracing_live_facade_exposes_builder_layer_snapshot_and_async_shutdown() {
@@ -14,6 +15,7 @@ fn tracing_live_facade_exposes_builder_layer_snapshot_and_async_shutdown() {
     assert_eq!(final_run.run().metadata.service_name, "svc");
 }
 
+// TT-TEST: R04 secondary
 #[cfg(feature = "tracing-tokio")]
 #[tokio::test(flavor = "current_thread")]
 async fn tracing_tokio_facade_exposes_runtime_methods_and_async_shutdown() {
@@ -62,6 +64,7 @@ async fn tracing_tokio_facade_exposes_runtime_methods_and_async_shutdown() {
         .any(|snapshot| snapshot.at_unix_ms == 88 && snapshot.alive_tasks == Some(12)));
 }
 
+// TT-TEST: P02 secondary
 #[cfg(feature = "tracing")]
 #[test]
 fn tracing_facade_exposes_stable_jsonl_reader_and_path_imports() {


### PR DESCRIPTION
### Motivation

- Add machine-readable `TT-TEST` audit markers to existing tests so they can be tracked and validated without changing any test behavior or source lines.
- Keep the change mechanical, minimal, and strictly additive (comment-only) to preserve test semantics and repository contracts.

### Description

- Inserted `// TT-TEST: ...` marker comments immediately above the attribute block for 124 existing Rust tests across 10 files, adding exactly 129 marker lines and zero deletions.
- Updated these files only: `demos/collector_stress/src/main.rs`, `demos/demo_support/src/lib.rs`, `demos/runtime_cost/src/main.rs`, `tailtriage-cli/src/analyze_config.rs`, `tailtriage-cli/src/artifact.rs`, `tailtriage-cli/tests/cli_boundary.rs`, `tailtriage-cli/tests/demo_smoke_fixtures.rs`, `tailtriage-cli/tests/json_parity.rs`, `tailtriage/src/lib.rs`, and `tailtriage/tests/tracing_facade.rs`.
- Preserved all existing code, test bodies, docs, manifests, validators, and formatting; five tests received two adjacent marker comments as specified.

### Testing

- Ran the focused package tests with `cargo test -p tailtriage-cli --all-targets --all-features --locked`, `cargo test -p tailtriage --all-targets --all-features --locked`, `cargo test -p demo-support --all-targets --all-features --locked`, `cargo test -p runtime_cost --all-targets --all-features --locked`, and `cargo test -p collector_stress --all-targets --all-features --locked`, all of which completed successfully.
- Ran repository checks `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, and `python3 scripts/validate_docs_contracts.py`, all of which passed and produced no unexpected diffs or warnings.
- Verified structural constraints: `124` tests marked, `129` `TT-TEST` comment lines added, `10` files changed, exactly `5` tests with two markers, zero `TT-INVARIANT` occurrences, and no existing line or behavior modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8cb737178c8330ac3afcc35bc27293)