### PR TITLE
test(scripts): add audited `TT-TEST` markers to surviving Python tests

### DIFF
--- a/scripts/tests/test_check_diagnostic_fixture_integrity.py
+++ b/scripts/tests/test_check_diagnostic_fixture_integrity.py
@@ -95,33 +95,39 @@ class FixtureIntegrityTest(unittest.TestCase):
         self.assertNotIn("TypeError", result.stderr)
         return result
 
+    # TT-TEST: F04 primary
     def test_valid_inventory_passes(self):
         result = self.command()
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("match the integrity lock", result.stdout)
 
+    # TT-TEST: support
     def test_valid_lock_format_passes(self):
         self.assertEqual(self.lock()["format"], "tailtriage.analyzer-fixture-lock.v1")
         self.assertEqual(self.command().returncode, 0)
 
+    # TT-TEST: support
     def test_missing_lock_format_is_rejected(self):
         lock = self.lock()
         del lock["format"]
         self.write_lock(lock)
         self.assert_failure("missing lock field: format")
 
+    # TT-TEST: support
     def test_non_string_lock_format_is_rejected(self):
         lock = self.lock()
         lock["format"] = 1
         self.write_lock(lock)
         self.assert_failure("lock format must be a string")
 
+    # TT-TEST: support
     def test_unsupported_lock_format_is_rejected(self):
         lock = self.lock()
         lock["format"] = "tailtriage.analyzer-fixture-lock.v2"
         self.write_lock(lock)
         self.assert_failure("unsupported lock format")
 
+    # TT-TEST: support
     def test_legacy_schema_version_fields_are_rejected(self):
         lock = self.lock()
         lock.update(schema_version=1, manifest_schema_version=2)
@@ -129,6 +135,7 @@ class FixtureIntegrityTest(unittest.TestCase):
         result = self.assert_failure("unknown lock field: schema_version")
         self.assertIn("unknown lock field: manifest_schema_version", result.stderr)
 
+    # TT-TEST: support
     def test_refresh_writes_only_new_format_marker(self):
         lock = self.lock()
         lock.update(schema_version=1, manifest_schema_version=2)
@@ -136,11 +143,13 @@ class FixtureIntegrityTest(unittest.TestCase):
         self.assertEqual(self.command("--refresh").returncode, 0)
         self.assertEqual(set(self.lock()), {"format", "fixtures"})
 
+    # TT-TEST: F04 primary
     def test_refresh_is_byte_deterministic(self):
         before = (self.diagnostics / "analyzer-fixtures.lock.json").read_bytes()
         self.assertEqual(self.command("--refresh").returncode, 0)
         self.assertEqual(before, (self.diagnostics / "analyzer-fixtures.lock.json").read_bytes())
 
+    # TT-TEST: F04 secondary
     def test_refresh_writes_only_lock_file(self):
         before = {p.relative_to(self.root): p.read_bytes() for p in self.root.rglob("*") if p.is_file()}
         self.command("--refresh")
@@ -148,6 +157,7 @@ class FixtureIntegrityTest(unittest.TestCase):
         self.assertEqual(before, after)
         self.assertEqual(before[Path("validation/diagnostics/corpus/run.json")], self.run_path.read_bytes())
 
+    # TT-TEST: F04 secondary
     def test_check_mode_is_read_only(self):
         before = {p.relative_to(self.root): (p.stat().st_mtime_ns, p.read_bytes())
                   for p in self.root.rglob("*") if p.is_file()}
@@ -161,6 +171,7 @@ class FixtureIntegrityTest(unittest.TestCase):
         mutation(lock["fixtures"][0])
         self.write_lock(lock)
 
+    # TT-TEST: support
     def test_non_object_lock_entry_is_rejected(self):
         for value in (None, "fixture", 42, []):
             with self.subTest(value=value):
@@ -170,22 +181,27 @@ class FixtureIntegrityTest(unittest.TestCase):
                 self.assert_failure("lock fixture 2 must be an object")
                 self.command("--refresh")
 
+    # TT-TEST: support
     def test_missing_lock_entry_field_is_rejected(self):
         self.mutate_entry(lambda entry: entry.pop("artifact"))
         self.assert_failure("lock fixture 0 missing field: artifact")
 
+    # TT-TEST: support
     def test_unknown_lock_entry_field_is_rejected(self):
         self.mutate_entry(lambda entry: entry.update(extra=True))
         self.assert_failure("lock fixture 0 unknown field: extra")
 
+    # TT-TEST: support
     def test_empty_lock_case_id_is_rejected(self):
         self.mutate_entry(lambda entry: entry.update(case_id=""))
         self.assert_failure("case_id must be a non-empty string")
 
+    # TT-TEST: support
     def test_invalid_lock_artifact_type_is_rejected(self):
         self.mutate_entry(lambda entry: entry.update(artifact_type="report"))
         self.assert_failure("artifact_type must be run_artifact or tracing_span_jsonl")
 
+    # TT-TEST: support
     def test_unhashable_lock_artifact_type_is_rejected(self):
         for value in ([], {}):
             with self.subTest(value=value):
@@ -195,38 +211,47 @@ class FixtureIntegrityTest(unittest.TestCase):
                 )
                 self.command("--refresh")
 
+    # TT-TEST: support
     def test_empty_lock_artifact_path_is_rejected(self):
         self.mutate_entry(lambda entry: entry.update(artifact=""))
         self.assert_failure("artifact must be a non-empty string")
 
+    # TT-TEST: support
     def test_invalid_sha256_type_is_rejected(self):
         self.mutate_entry(lambda entry: entry.update(sha256=42))
         self.assert_failure("sha256 must be a string")
 
+    # TT-TEST: support
     def test_invalid_sha256_length_is_rejected(self):
         self.mutate_entry(lambda entry: entry.update(sha256="a" * 63))
         self.assert_failure("sha256 must be exactly 64 lowercase hexadecimal characters")
 
+    # TT-TEST: support
     def test_uppercase_sha256_is_rejected(self):
         self.mutate_entry(lambda entry: entry.update(sha256="A" * 64))
         self.assert_failure("sha256 must be exactly 64 lowercase hexadecimal characters")
 
+    # TT-TEST: support
     def test_non_hex_sha256_is_rejected(self):
         self.mutate_entry(lambda entry: entry.update(sha256="g" * 64))
         self.assert_failure("sha256 must be exactly 64 lowercase hexadecimal characters")
 
+    # TT-TEST: support
     def test_negative_byte_length_is_rejected(self):
         self.mutate_entry(lambda entry: entry.update(byte_length=-1))
         self.assert_failure("byte_length must be a non-negative integer")
 
+    # TT-TEST: support
     def test_boolean_byte_length_is_rejected(self):
         self.mutate_entry(lambda entry: entry.update(byte_length=True))
         self.assert_failure("byte_length must be a non-negative integer")
 
+    # TT-TEST: support
     def test_non_object_shape_is_rejected(self):
         self.mutate_entry(lambda entry: entry.update(shape=[]))
         self.assert_failure("shape must be an object")
 
+    # TT-TEST: support
     def test_multiple_malformed_entries_are_stably_sorted(self):
         lock = self.lock()
         lock["fixtures"] = [None, {"case_id": ""}]
@@ -236,26 +261,31 @@ class FixtureIntegrityTest(unittest.TestCase):
         self.assertIn("lock fixture 0 must be an object", lines)
         self.assertIn("lock fixture 1 missing field: artifact", lines)
 
+    # TT-TEST: F04 primary
     def test_changed_bytes_are_detected(self):
         self.run_path.write_bytes(self.run_bytes(outcome="error"))
         self.assert_failure("sha256 mismatch for run")
 
+    # TT-TEST: F04 primary
     def test_byte_length_drift_is_detected(self):
         lock = self.lock()
         lock["fixtures"][0]["byte_length"] += 1
         self.write_lock(lock)
         self.assert_failure("byte length mismatch")
 
+    # TT-TEST: F04 primary
     def test_missing_artifact_is_detected(self):
         self.run_path.unlink()
         self.assert_failure("artifact is not a regular file")
 
+    # TT-TEST: F04 primary
     def test_missing_lock_entry_is_detected(self):
         lock = self.lock()
         lock["fixtures"] = [entry for entry in lock["fixtures"] if entry["case_id"] != "run"]
         self.write_lock(lock)
         self.assert_failure("missing lock entry: run")
 
+    # TT-TEST: F04 primary
     def test_unexpected_lock_entry_is_detected(self):
         lock = self.lock()
         old = dict(lock["fixtures"][0])
@@ -264,30 +294,35 @@ class FixtureIntegrityTest(unittest.TestCase):
         self.write_lock(lock)
         self.assert_failure("unexpected lock entry: old")
 
+    # TT-TEST: F04 secondary
     def test_artifact_type_mismatch_is_detected(self):
         lock = self.lock()
         lock["fixtures"][0]["artifact_type"] = "tracing_span_jsonl"
         self.write_lock(lock)
         self.assert_failure("artifact type mismatch")
 
+    # TT-TEST: F04 secondary
     def test_artifact_path_mismatch_is_detected(self):
         lock = self.lock()
         lock["fixtures"][0]["artifact"] = "corpus/other.json"
         self.write_lock(lock)
         self.assert_failure("artifact path mismatch")
 
+    # TT-TEST: F04 secondary
     def test_duplicate_manifest_case_id_is_rejected(self):
         cases = self.cases()
         cases[1]["id"] = "run"
         self.write_manifest(cases)
         self.assert_failure("duplicate manifest case ID: run")
 
+    # TT-TEST: F04 secondary
     def test_duplicate_manifest_artifact_path_is_rejected(self):
         cases = self.cases()
         cases[1]["artifact"] = "corpus/run.json"
         self.write_manifest(cases)
         self.assert_failure("duplicate manifest artifact path: corpus/run.json")
 
+    # TT-TEST: support
     def test_unhashable_manifest_fields_are_rejected(self):
         fields = {
             "id": "non-empty case ID required",
@@ -304,6 +339,7 @@ class FixtureIntegrityTest(unittest.TestCase):
                         self.write_manifest(cases)
                         self.assert_validation_failure(phrase, *args)
 
+    # TT-TEST: support
     def test_combined_unhashable_manifest_values_report_all_errors(self):
         cases = self.cases()
         cases[0].update(id=[], artifact_type={}, artifact=[], observation_id={})
@@ -339,26 +375,31 @@ class FixtureIntegrityTest(unittest.TestCase):
              "accuracy_eligible": accuracy_eligible, "observation_id": second_observation},
         ]
 
+    # TT-TEST: F04 primary
     def test_distinct_accuracy_observations_cannot_share_bytes(self):
         self.write_manifest(self.duplicate_run_cases())
         self.assert_failure("identical analyzer artifact bytes are assigned to distinct accuracy observations")
 
+    # TT-TEST: F04 primary
     def test_equivalent_cases_with_same_observation_id_may_share_bytes(self):
         self.write_manifest(self.duplicate_run_cases(second_observation="one"))
         self.assertEqual(self.command("--refresh").returncode, 0)
         self.assertEqual(self.command().returncode, 0)
 
+    # TT-TEST: F04 secondary
     def test_non_accuracy_cases_may_share_bytes(self):
         self.write_manifest(self.duplicate_run_cases(accuracy_eligible=False))
         self.assertEqual(self.command("--refresh").returncode, 0)
         self.assertEqual(self.command().returncode, 0)
 
+    # TT-TEST: F04 primary
     def test_accuracy_case_requires_observation_id(self):
         cases = self.cases()
         cases[0].pop("observation_id")
         self.write_manifest(cases)
         self.assert_failure("non-empty observation_id required for accuracy-eligible analyzer run")
 
+    # TT-TEST: F04 secondary
     def test_duplicate_diagnostic_is_deterministic(self):
         cases = self.duplicate_run_cases()
         cases.reverse()
@@ -369,21 +410,25 @@ class FixtureIntegrityTest(unittest.TestCase):
                     f"observations: {digest}: a/one, b/two")
         self.assertIn(expected, result.stderr.splitlines())
 
+    # TT-TEST: F04 primary
     def test_report_contract_is_excluded(self):
         self.assertEqual({entry["case_id"] for entry in self.lock()["fixtures"]}, {"run", "trace"})
 
+    # TT-TEST: support
     def test_absolute_artifact_path_is_rejected(self):
         cases = self.cases()
         cases[0]["artifact"] = str(self.run_path)
         self.write_manifest(cases)
         self.assert_failure("absolute artifact path rejected")
 
+    # TT-TEST: support
     def test_parent_path_escape_is_rejected(self):
         cases = self.cases()
         cases[0]["artifact"] = "../outside.json"
         self.write_manifest(cases)
         self.assert_failure("artifact path escapes diagnostics root")
 
+    # TT-TEST: support
     def test_symlink_escape_is_rejected(self):
         outside = self.root / "outside.json"
         outside.write_bytes(self.run_bytes())
@@ -393,6 +438,7 @@ class FixtureIntegrityTest(unittest.TestCase):
         self.write_manifest(cases)
         self.assert_failure("artifact path escapes diagnostics root")
 
+    # TT-TEST: support
     def test_invalid_artifact_path_is_rejected_without_crashing(self):
         cases = self.cases()
         cases[0]["artifact"] = "corpus/\0invalid.json"
@@ -408,35 +454,43 @@ class FixtureIntegrityTest(unittest.TestCase):
             (self.diagnostics / "analyzer-fixtures.lock.json").read_bytes(),
         )
 
+    # TT-TEST: support
     def test_invalid_utf8_is_rejected(self):
         self.run_path.write_bytes(b"\xff\n")
         self.assert_failure("invalid UTF-8")
 
+    # TT-TEST: support
     def test_crlf_is_rejected(self):
         self.run_path.write_bytes(self.run_bytes().replace(b"\n", b"\r\n"))
         self.assert_failure("CR byte found")
 
+    # TT-TEST: support
     def test_missing_final_lf_is_rejected(self):
         self.run_path.write_bytes(self.run_bytes().rstrip(b"\n"))
         self.assert_failure("missing final LF")
 
+    # TT-TEST: support
     def test_blank_jsonl_line_is_rejected(self):
         self.trace_path.write_bytes(self.trace_bytes() + b"\n")
         self.assert_failure("blank line after final content")
 
+    # TT-TEST: support
     def test_malformed_run_json_is_rejected(self):
         self.run_path.write_bytes(b"{no}\n")
         self.assert_failure("malformed Run JSON")
 
+    # TT-TEST: support
     def test_malformed_tracing_jsonl_is_rejected(self):
         self.trace_path.write_bytes(b"{no}\n")
         self.assert_failure("malformed tracing JSONL")
 
+    # TT-TEST: support
     def test_wrong_tracing_format_marker_is_rejected(self):
         record = {"format": "wrong", "span": {"fields": {}}}
         self.trace_path.write_text(json.dumps(record) + "\n")
         self.assert_failure("wrong tracing format marker")
 
+    # TT-TEST: support
     def test_non_string_tracing_kind_is_rejected_without_crashing(self):
         for kind in ([], {}, 42, True):
             for args in ((), ("--refresh",)):
@@ -457,6 +511,7 @@ class FixtureIntegrityTest(unittest.TestCase):
                         (self.diagnostics / "analyzer-fixtures.lock.json").read_bytes(),
                     )
 
+    # TT-TEST: support
     def test_missing_and_unknown_tracing_kinds_are_other(self):
         records = [
             {"format": "tailtriage.tracing-span.v1", "span": {"fields": {}}},
@@ -475,6 +530,7 @@ class FixtureIntegrityTest(unittest.TestCase):
         self.assertEqual(entry["shape"]["other_span_count"], 2)
         self.assertEqual(self.command().returncode, 0)
 
+    # TT-TEST: F04 primary
     def test_run_shape_drift_is_detected(self):
         lock = self.lock()
         entry = next(item for item in lock["fixtures"] if item["case_id"] == "run")
@@ -482,6 +538,7 @@ class FixtureIntegrityTest(unittest.TestCase):
         self.write_lock(lock)
         self.assert_failure("shape mismatch for run at request_count")
 
+    # TT-TEST: F04 primary
     def test_tracing_shape_drift_is_detected(self):
         lock = self.lock()
         entry = next(item for item in lock["fixtures"] if item["case_id"] == "trace")
@@ -489,6 +546,7 @@ class FixtureIntegrityTest(unittest.TestCase):
         self.write_lock(lock)
         self.assert_failure("shape mismatch for trace at request_span_count")
 
+    # TT-TEST: support
     def test_all_failures_are_reported_in_stable_order(self):
         lock = self.lock()
         for entry in lock["fixtures"]:

--- a/scripts/tests/test_check_release.py
+++ b/scripts/tests/test_check_release.py
@@ -33,6 +33,7 @@ def metadata(version: str = "1.2.3") -> dict:
 
 
 class CheckReleaseTests(unittest.TestCase):
+    # TT-TEST: support
     def test_example_package_content_uses_actual_cargo_listings(self) -> None:
         calls = []
 
@@ -48,6 +49,7 @@ class CheckReleaseTests(unittest.TestCase):
         self.assertEqual(3, len(calls))
         self.assertTrue(all(call[-1] == "--list" for call in calls))
 
+    # TT-TEST: support
     def test_example_package_content_rejects_missing_examples(self) -> None:
         with patch.object(check_release, "command", return_value=result(stdout="Cargo.toml\nsrc/lib.rs\n")):
             errors = check_release.packaged_example_errors({"tailtriage-controller"})
@@ -56,6 +58,7 @@ class CheckReleaseTests(unittest.TestCase):
             errors,
         )
 
+    # TT-TEST: Z01 primary
     def test_classification_and_deterministic_dependency_order(self) -> None:
         packages = metadata()["packages"]
         publishable = [package for package in packages if check_release.is_publishable(package)]
@@ -64,6 +67,7 @@ class CheckReleaseTests(unittest.TestCase):
         self.assertEqual([], errors)
         self.assertEqual(["demo"], [package["name"] for package in packages if not check_release.is_publishable(package)])
 
+    # TT-TEST: Z01 secondary
     def test_readiness_failure_suppresses_package_and_publish_commands(self) -> None:
         calls: list[list[str]] = []
 
@@ -85,6 +89,7 @@ class CheckReleaseTests(unittest.TestCase):
         self.assertIn("worktree is not clean:\n M some/file\n?? another/file", output.getvalue())
         self.assertNotIn("cargo publish", output.getvalue())
 
+    # TT-TEST: Z01 primary
     def test_success_packages_once_and_prints_publication_order(self) -> None:
         calls: list[list[str]] = []
 
@@ -113,6 +118,7 @@ class CheckReleaseTests(unittest.TestCase):
         self.assertIn("cargo publish --locked -p private", printed)
         self.assertLess(printed.index("cargo publish --locked -p api"), printed.index("cargo publish --locked -p cli"))
 
+    # TT-TEST: Z01 primary
     def test_successful_preflight_executes_checks_and_package_but_never_publish(self) -> None:
         calls: list[list[str]] = []
 
@@ -151,6 +157,7 @@ class CheckReleaseTests(unittest.TestCase):
         )
         self.assertIn("cargo publish --locked -p core", output.getvalue())
 
+    # TT-TEST: Z01 secondary
     def test_packaging_failure_suppresses_publication_commands(self) -> None:
         def run(argv: list[str]):
             if argv[:2] == ["git", "status"]:

--- a/scripts/tests/test_check_workflow_security.py
+++ b/scripts/tests/test_check_workflow_security.py
@@ -11,20 +11,25 @@ SHA = "0123456789abcdef0123456789abcdef01234567"
 
 
 class WorkflowSecurityTests(unittest.TestCase):
+    # TT-TEST: S05 primary
     def test_full_sha_is_accepted(self) -> None:
         self.assertEqual(check_workflow_security.workflow_policy_errors(f"uses: owner/action@{SHA}"), [])
 
+    # TT-TEST: support
     def test_trailing_comment_is_accepted(self) -> None:
         self.assertEqual(
             check_workflow_security.workflow_policy_errors(f"- uses: owner/action@{SHA} # v1"), []
         )
 
+    # TT-TEST: S05 secondary
     def test_local_action_is_accepted(self) -> None:
         self.assertEqual(check_workflow_security.workflow_policy_errors("uses: ./actions/check"), [])
 
+    # TT-TEST: S05 primary
     def test_mutable_version_tag_is_rejected(self) -> None:
         self.assertTrue(check_workflow_security.workflow_policy_errors("uses: actions/checkout@v4"))
 
+    # TT-TEST: S05 secondary
     def test_mutable_branch_or_channel_is_rejected(self) -> None:
         for ref in ("main", "stable", "latest"):
             with self.subTest(ref=ref):
@@ -32,6 +37,7 @@ class WorkflowSecurityTests(unittest.TestCase):
                     check_workflow_security.workflow_policy_errors(f"uses: owner/action@{ref}")
                 )
 
+    # TT-TEST: S05 secondary
     def test_short_or_malformed_sha_is_rejected(self) -> None:
         for ref in (SHA[:-1], "g" * 40):
             with self.subTest(ref=ref):
@@ -39,10 +45,12 @@ class WorkflowSecurityTests(unittest.TestCase):
                     check_workflow_security.workflow_policy_errors(f"uses: owner/action@{ref}")
                 )
 
+    # TT-TEST: S05 primary
     def test_exact_cargo_deny_policy_is_accepted(self) -> None:
         text = "tool: cargo-deny@0.20.2\nfallback: none\n"
         self.assertEqual(check_workflow_security.cargo_deny_policy_errors(text), [])
 
+    # TT-TEST: S05 primary
     def test_moving_or_unversioned_cargo_deny_is_rejected(self) -> None:
         for tool in ("cargo-deny", "cargo-deny@latest", "cargo-deny@0.20"):
             with self.subTest(tool=tool):
@@ -52,6 +60,7 @@ class WorkflowSecurityTests(unittest.TestCase):
                     )
                 )
 
+    # TT-TEST: S05 primary
     def test_cargo_deny_fallback_other_than_none_is_rejected(self) -> None:
         self.assertTrue(
             check_workflow_security.cargo_deny_policy_errors(
@@ -59,9 +68,11 @@ class WorkflowSecurityTests(unittest.TestCase):
             )
         )
 
+    # TT-TEST: S05 primary
     def test_actual_repository_workflows_pass(self) -> None:
         self.assertEqual(check_workflow_security.check_repository(), [])
 
+    # TT-TEST: support
     def test_repository_scan_checks_yaml_and_yml(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             workflows = Path(tmp_dir)

--- a/scripts/tests/test_demo_scripts.py
+++ b/scripts/tests/test_demo_scripts.py
@@ -23,6 +23,7 @@ from demo_tool import has_suspect_kind, parse_args, suspect_score  # noqa: E402
 
 
 class DemoWrapperTests(unittest.TestCase):
+    # TT-TEST: support
     def test_canonical_live_policy_owns_exactly_nine_scenarios(self) -> None:
         expected = {
             "queue", "blocking", "executor", "downstream", "mixed",
@@ -31,10 +32,12 @@ class DemoWrapperTests(unittest.TestCase):
         self.assertEqual(expected, set(demo_tool.LIVE_SCENARIO_POLICIES))
         self.assertEqual(expected, set(demo_tool.SCENARIOS))
 
+    # TT-TEST: D02 secondary
     def test_unknown_live_policy_fails_clearly(self) -> None:
         with self.assertRaisesRegex(ValueError, "unsupported live-demo scenario: typo"):
             demo_tool.validate_scenario(REPO_ROOT, "typo")
 
+    # TT-TEST: D02 primary
     @patch("demo_tool._load_and_evaluate")
     @patch("demo_tool._run_scenario")
     def test_mitigation_reporting_preserves_pass_and_failure(self, run_mock, evaluate_mock) -> None:
@@ -65,6 +68,7 @@ class DemoWrapperTests(unittest.TestCase):
             "secondary_suspects": secondary or [], "p95_latency_us": p95,
             "p95_queue_share_permille": queue, "p95_service_share_permille": service}
 
+    # TT-TEST: D02 primary
     def test_queue_strong_movement_and_ratio_policy(self):
         before=self._report("application_queue_saturation", p95=1000, queue=700)
         after=self._report("application_queue_saturation", score=70, p95=940, queue=600)
@@ -73,6 +77,7 @@ class DemoWrapperTests(unittest.TestCase):
         after["p95_queue_share_permille"]=700
         self.assertIn("queue_share_decreases", demo_tool.evaluate_live_scenario("queue", before, after)["failed_expectations"])
 
+    # TT-TEST: D02 primary
     def test_target_score_and_high_confidence_wrong_fail_structurally(self):
         for scenario, target in (("queue", "application_queue_saturation"), ("blocking", "blocking_pool_pressure"), ("downstream", "downstream_stage_dominates")):
             evidence=["Blocking queue depth p95 is 10"] if scenario == "blocking" else []
@@ -84,6 +89,7 @@ class DemoWrapperTests(unittest.TestCase):
             self.assertIn("high_confidence_wrong_after", result["failed_expectations"])
             self.assertIn("targeted_score_nonworsening", result["expected_checks"])
 
+    # TT-TEST: D02 primary
     def test_required_queue_and_blocking_evidence_movement(self):
         db_before=self._report("application_queue_saturation", queue=600)
         db_after=self._report("application_queue_saturation", p95=500, queue=600)
@@ -92,6 +98,7 @@ class DemoWrapperTests(unittest.TestCase):
         after=self._report("blocking_pool_pressure", score=20, p95=500, evidence=["Blocking queue depth p95 is 10"])
         self.assertIn("blocking_depth_decreases", demo_tool.evaluate_live_scenario("blocking", before, after)["failed_expectations"])
 
+    # TT-TEST: D02 primary
     def test_executor_and_extended_semantics_remain(self):
         executor=self._report("executor_pressure_suspected", evidence=["Blocking queue depth p95 is 4"])
         result=demo_tool.evaluate_live_scenario("executor", executor, self._report("executor_pressure_suspected", p95=500))
@@ -99,6 +106,7 @@ class DemoWrapperTests(unittest.TestCase):
         retry=self._report("downstream_stage_dominates", service=950)
         self.assertTrue(demo_tool.evaluate_live_scenario("retry-storm", retry, self._report("downstream_stage_dominates", score=70, p95=500, service=800))["policy_passed"])
 
+    # TT-TEST: D02 primary
     def test_shared_lock_compares_actual_primary_scores(self):
         before = self._report(
             "application_queue_saturation",
@@ -115,6 +123,7 @@ class DemoWrapperTests(unittest.TestCase):
         lower_replacement = self._report("executor_pressure_suspected", score=70, p95=500)
         self.assertTrue(demo_tool.evaluate_live_scenario("shared-lock", before, lower_replacement)["policy_passed"])
 
+    # TT-TEST: D02 primary
     def test_retry_storm_compares_actual_primary_scores(self):
         before = self._report("downstream_stage_dominates", score=80, service=950)
         unchanged = self._report("downstream_stage_dominates", score=70, p95=500)
@@ -127,6 +136,7 @@ class DemoWrapperTests(unittest.TestCase):
         lower_replacement = self._report("executor_pressure_suspected", score=80, p95=500)
         self.assertTrue(demo_tool.evaluate_live_scenario("retry-storm", before, lower_replacement)["policy_passed"])
 
+    # TT-TEST: D02 primary
     def test_cold_start_primary_score_nonincrease_passes(self):
         before = self._report(
             "application_queue_saturation", score=80, p95=20_000, queue=700,
@@ -135,6 +145,7 @@ class DemoWrapperTests(unittest.TestCase):
         after = self._report("executor_pressure_suspected", score=80, p95=19_500, queue=700)
         self.assertTrue(demo_tool.evaluate_live_scenario("cold-start", before, after)["policy_passed"])
 
+    # TT-TEST: D02 primary
     def test_cold_start_score_increase_requires_material_latency_improvement(self):
         before = self._report(
             "application_queue_saturation", score=80, p95=20_000, queue=700,
@@ -144,6 +155,7 @@ class DemoWrapperTests(unittest.TestCase):
         result = demo_tool.evaluate_live_scenario("cold-start", before, after)
         self.assertIn("primary_score_increase_explainable", result["failed_expectations"])
 
+    # TT-TEST: D02 primary
     def test_cold_start_changed_primary_requires_material_queue_improvement(self):
         before = self._report(
             "application_queue_saturation", score=80, p95=20_000, queue=700,
@@ -156,6 +168,7 @@ class DemoWrapperTests(unittest.TestCase):
         explained = self._report("executor_pressure_suspected", score=90, p95=18_000, queue=600)
         self.assertTrue(demo_tool.evaluate_live_scenario("cold-start", before, explained)["policy_passed"])
 
+    # TT-TEST: D02 primary
     def test_cold_start_score_increase_retains_queue_worsening_tolerance(self):
         before = self._report(
             "application_queue_saturation", score=80, p95=20_000, queue=700,
@@ -168,6 +181,7 @@ class DemoWrapperTests(unittest.TestCase):
         result = demo_tool.evaluate_live_scenario("cold-start", before, worsened)
         self.assertIn("primary_score_increase_explainable", result["failed_expectations"])
 
+    # TT-TEST: D02 primary
     def test_cold_start_target_disappearance_does_not_bypass_score_rule(self):
         before = self._report(
             "application_queue_saturation", score=80, p95=20_000, queue=700,
@@ -178,6 +192,7 @@ class DemoWrapperTests(unittest.TestCase):
         self.assertNotIn("application_queue_saturation", [after["primary_suspect"]["kind"]])
         self.assertIn("primary_score_increase_explainable", result["failed_expectations"])
 
+    # TT-TEST: support
     def test_shared_scenario_metadata_owns_all_demo_paths(self) -> None:
         self.assertEqual(set(demo_tool.SCENARIOS), set(_demo_runner.SCENARIOS))
         self.assertIs(demo_tool.SCENARIO_PATHS, _demo_runner.SCENARIOS)
@@ -194,6 +209,7 @@ class DemoWrapperTests(unittest.TestCase):
                 demo_dir / "artifacts",
             )
 
+    # TT-TEST: support
     def test_fixture_refresh_owns_only_canonical_contracts(self) -> None:
         owned = [path.as_posix() for path, _ in check_demo_fixture_drift._scenario_specs()]
         self.assertEqual(len(owned), 19)
@@ -204,6 +220,7 @@ class DemoWrapperTests(unittest.TestCase):
             ["demos/downstream_service/fixtures/before-after-comparison.json"],
         )
 
+    # TT-TEST: support
     def test_demo_tool_help_runs(self) -> None:
         completed = subprocess.run(
             [sys.executable, str(SCRIPTS_DIR / "demo_tool.py"), "--help"],
@@ -219,39 +236,46 @@ class DemoWrapperTests(unittest.TestCase):
         )
         self.assertIn("usage:", completed.stdout)
 
+    # TT-TEST: support
     def test_parse_args_accepts_mixed_scenario(self) -> None:
         args = parse_args(["run", "mixed", "baseline"])
         self.assertEqual(args.command, "run")
         self.assertEqual(args.scenario, "mixed")
         self.assertEqual(args.mode, "baseline")
 
+    # TT-TEST: support
     def test_parse_args_accepts_cold_start_scenario(self) -> None:
         args = parse_args(["validate", "cold-start"])
         self.assertEqual(args.command, "validate")
         self.assertEqual(args.scenario, "cold-start")
 
 
+    # TT-TEST: support
     def test_parse_args_accepts_db_pool_scenario(self) -> None:
         args = parse_args(["run", "db-pool", "mitigated"])
         self.assertEqual(args.command, "run")
         self.assertEqual(args.scenario, "db-pool")
         self.assertEqual(args.mode, "mitigated")
 
+    # TT-TEST: support
     def test_parse_args_accepts_downstream_mode(self) -> None:
         args = parse_args(["run", "downstream", "after"])
         self.assertEqual(args.command, "run")
         self.assertEqual(args.scenario, "downstream")
         self.assertEqual(args.mode, "after")
 
+    # TT-TEST: support
     def test_parse_args_accepts_retry_storm_scenario(self) -> None:
         args = parse_args(["validate", "retry-storm"])
         self.assertEqual(args.command, "validate")
         self.assertEqual(args.scenario, "retry-storm")
 
+    # TT-TEST: support
     def test_parse_args_accepts_release_shortcut(self) -> None:
         args = parse_args(["validate", "queue", "--release"])
         self.assertEqual(args.profile, "release")
 
+    # TT-TEST: support
     def test_has_suspect_kind_handles_missing_primary(self) -> None:
         report = {
             "secondary_suspects": [{"kind": "downstream_stage_dominates"}],
@@ -260,6 +284,7 @@ class DemoWrapperTests(unittest.TestCase):
         self.assertTrue(has_suspect_kind(report, {"downstream_stage_dominates"}))
         self.assertFalse(has_suspect_kind(report, {"application_queue_saturation"}))
 
+    # TT-TEST: support
     def test_has_suspect_kind_checks_primary_and_secondary(self) -> None:
         report = {
             "primary_suspect": {"kind": "application_queue_saturation"},
@@ -270,6 +295,7 @@ class DemoWrapperTests(unittest.TestCase):
         self.assertTrue(has_suspect_kind(report, {"downstream_stage_dominates"}))
         self.assertFalse(has_suspect_kind(report, {"blocking_pool_pressure"}))
 
+    # TT-TEST: support
     def test_suspect_score_reads_secondary_kind_score(self) -> None:
         report = {
             "primary_suspect": {"kind": "application_queue_saturation", "score": 90},
@@ -278,6 +304,7 @@ class DemoWrapperTests(unittest.TestCase):
         self.assertEqual(suspect_score(report, "executor_pressure_suspected"), 70)
         self.assertIsNone(suspect_score(report, "blocking_pool_pressure"))
 
+    # TT-TEST: support
     def test_contains_blocking_depth_evidence_checks_secondary_suspects(self) -> None:
         report = {
             "primary_suspect": {"kind": "application_queue_saturation", "evidence": []},
@@ -290,6 +317,7 @@ class DemoWrapperTests(unittest.TestCase):
         }
         self.assertTrue("blocking queue depth" in demo_tool._evidence_text(report))
 
+    # TT-TEST: support
     @patch("demo_tool.load_report_json")
     @patch("demo_tool.run_scenario_executor")
     def test_validate_executor_requires_executor_primary(
@@ -315,42 +343,50 @@ class DemoWrapperTests(unittest.TestCase):
         ):
             demo_tool.validate_executor(Path("/tmp/tailscope"), profile="release")
 
+    # TT-TEST: support
     def test_parse_args_accepts_diagnosis_matrix(self) -> None:
         args = parse_args(["diagnosis-matrix", "--scenario", "queue", "--scenario", "executor"])
         self.assertEqual(args.command, "diagnosis-matrix")
         self.assertEqual(args.scenario, ["queue", "executor"])
 
+    # TT-TEST: support
     def test_parse_args_accepts_validate_tracing_parity(self) -> None:
         args = parse_args(["validate-tracing-parity", "queue", "--profile", "dev"])
         self.assertEqual(args.command, "validate-tracing-parity")
         self.assertEqual(args.scenario, "queue")
         self.assertEqual(args.profile, "dev")
 
+    # TT-TEST: support
     def test_parse_args_accepts_validate_tracing_parity_retry_storm(self) -> None:
         args = parse_args(["validate-tracing-parity", "retry-storm"])
         self.assertEqual(args.command, "validate-tracing-parity")
         self.assertEqual(args.scenario, "retry-storm")
 
+    # TT-TEST: support
     def test_parse_args_accepts_validate_tracing_parity_blocking(self) -> None:
         args = parse_args(["validate-tracing-parity", "blocking", "--profile", "dev"])
         self.assertEqual(args.command, "validate-tracing-parity")
         self.assertEqual(args.scenario, "blocking")
 
+    # TT-TEST: support
     def test_parse_args_accepts_validate_tracing_parity_executor(self) -> None:
         args = parse_args(["validate-tracing-parity", "executor", "--profile", "dev"])
         self.assertEqual(args.command, "validate-tracing-parity")
         self.assertEqual(args.scenario, "executor")
 
+    # TT-TEST: support
     def test_parse_args_accepts_validate_tracing_parity_all(self) -> None:
         args = parse_args(["validate-tracing-parity", "all", "--profile", "dev"])
         self.assertEqual(args.command, "validate-tracing-parity")
         self.assertEqual(args.scenario, "all")
 
+    # TT-TEST: support
     def test_parse_args_accepts_validate_tracing_retention_parity(self) -> None:
         args = parse_args(["validate-tracing-retention-parity", "--profile", "release"])
         self.assertEqual(args.command, "validate-tracing-retention-parity")
         self.assertEqual(args.profile, "release")
 
+    # TT-TEST: support
     @patch("demo_tool._require_equal")
     @patch("demo_tool._load_run")
     @patch("demo_tool.run_and_analyze")
@@ -380,6 +416,7 @@ class DemoWrapperTests(unittest.TestCase):
             self.assertEqual(extra_args[extra_args.index("--max-queues") + 1], "3")
         self.assertTrue(require_equal_mock.called)
 
+    # TT-TEST: support
     @patch("demo_tool.load_report_json")
     @patch("demo_tool.run_and_analyze")
     @patch("demo_tool._tracing_parity_config")
@@ -427,6 +464,7 @@ class DemoWrapperTests(unittest.TestCase):
             ):
                 demo_tool.validate_tracing_parity(Path("/tmp/repo"), "queue", profile="release")
 
+    # TT-TEST: support
     @patch("demo_tool.load_report_json")
     @patch("demo_tool._load_run")
     @patch("demo_tool.run_and_analyze")
@@ -484,6 +522,7 @@ class DemoWrapperTests(unittest.TestCase):
         self.assertIn("after-investigation-native-run.json", artifact_basenames)
         self.assertIn("after-investigation-tracing-run.json", artifact_basenames)
 
+    # TT-TEST: support
     @patch("demo_tool.load_report_json")
     @patch("demo_tool._load_run")
     @patch("demo_tool.run_and_analyze")
@@ -533,6 +572,7 @@ class DemoWrapperTests(unittest.TestCase):
             ):
                 demo_tool.validate_tracing_parity(Path("/tmp/repo"), "queue", profile="release")
 
+    # TT-TEST: support
     @patch("demo_tool.load_report_json")
     @patch("demo_tool._load_run")
     @patch("demo_tool.run_and_analyze")
@@ -580,6 +620,7 @@ class DemoWrapperTests(unittest.TestCase):
         with patch.object(Path, "exists", return_value=True):
             demo_tool.validate_tracing_parity(Path("/tmp/repo"), "blocking", profile="release")
 
+    # TT-TEST: support
     @patch("demo_tool.load_report_json")
     @patch("demo_tool._load_run")
     @patch("demo_tool.run_and_analyze")
@@ -630,6 +671,7 @@ class DemoWrapperTests(unittest.TestCase):
             ):
                 demo_tool.validate_tracing_parity(Path("/tmp/repo"), "blocking", profile="release")
 
+    # TT-TEST: support
     def test_parity_failure_message_contains_scenario_field_expected_actual(self) -> None:
         with self.assertRaisesRegex(
             SystemExit,
@@ -644,6 +686,7 @@ class DemoWrapperTests(unittest.TestCase):
                 actual="investigation",
             )
 
+    # TT-TEST: support
     @patch("demo_tool.load_report_json")
     @patch("demo_tool.run_scenario_downstream")
     def test_validate_downstream_uses_downstream_context(
@@ -668,6 +711,7 @@ class DemoWrapperTests(unittest.TestCase):
 
 
 class DemoMainRoutingTests(unittest.TestCase):
+    # TT-TEST: support
     @patch("demo_tool.repo_root", return_value=Path("/tmp/tailscope"))
     @patch("demo_tool.run_scenario_queue")
     def test_main_run_queue_baseline_dispatches_queue_scenario(
@@ -683,6 +727,7 @@ class DemoMainRoutingTests(unittest.TestCase):
             profile="dev",
         )
 
+    # TT-TEST: support
     @patch("demo_tool.repo_root", return_value=Path("/tmp/tailscope"))
     @patch("demo_tool.validate_scenario")
     def test_main_validate_mixed_dispatches_validate_mixed(
@@ -696,6 +741,7 @@ class DemoMainRoutingTests(unittest.TestCase):
             Path("/tmp/tailscope"), "mixed", profile="dev"
         )
 
+    # TT-TEST: support
     @patch("demo_tool.repo_root", return_value=Path("/tmp/tailscope"))
     @patch("demo_tool.run_scenario_downstream")
     def test_main_run_downstream_baseline_dispatches_downstream_scenario(

--- a/scripts/tests/test_diagnostic_benchmark.py
+++ b/scripts/tests/test_diagnostic_benchmark.py
@@ -79,6 +79,7 @@ class Tests(unittest.TestCase):
         with mock.patch.object(db, "_invoke", side_effect=outputs) as inv:
             return db.run(p, 0, 0, 99), inv
 
+    # TT-TEST: D01 primary
     def test_report_only_manifest_fails_with_zero_analyzer_executions(self):
         c = case("r", "analysis_report", False)
         with tempfile.TemporaryDirectory() as td:
@@ -90,6 +91,7 @@ class Tests(unittest.TestCase):
         self.assertIn("diagnostic corpus contains zero analyzer-executed cases", f)
         inv.assert_not_called()
 
+    # TT-TEST: D01 primary
     def test_analyzer_execution_without_accuracy_observations_fails_distinctly(self):
         c = case(eligible=False)
         with tempfile.TemporaryDirectory() as td:
@@ -102,6 +104,7 @@ class Tests(unittest.TestCase):
         self.assertNotIn("diagnostic corpus contains zero analyzer-executed cases", f)
         inv.assert_called_once()
 
+    # TT-TEST: D01 primary
     def test_report_contract_results_do_not_change_analyzer_accuracy(self):
         a = case()
         r = case("r", "analysis_report", False)
@@ -116,6 +119,7 @@ class Tests(unittest.TestCase):
                 vals.append(m["analyzer_accuracy"])
         self.assertEqual(vals[0], vals[1])
 
+    # TT-TEST: D01 primary
     def test_run_artifact_executes_cli_analyzer(self):
         c = case()
         with tempfile.TemporaryDirectory() as td:
@@ -130,6 +134,7 @@ class Tests(unittest.TestCase):
         self.assertEqual(m["analyzer_execution"]["run_artifact_count"], 1)
         self.assertEqual(m["report_contract"]["case_count"], 0)
 
+    # TT-TEST: D01 primary
     def test_tracing_jsonl_executes_import_then_analyzer(self):
         c = case("trace", "tracing_span_jsonl")
 
@@ -149,6 +154,7 @@ class Tests(unittest.TestCase):
         self.assertIn("analyze", inv.call_args_list[1].args[0])
         self.assertEqual(m["analyzer_execution"]["tracing_jsonl_count"], 1)
 
+    # TT-TEST: D01 primary
     def test_equivalent_encodings_share_one_accuracy_observation(self):
         a = case("a")
         b = case("b", observation_id="a")
@@ -162,6 +168,7 @@ class Tests(unittest.TestCase):
         self.assertEqual(m["analyzer_accuracy"]["encoding_count"], 2)
         self.assertEqual(m["analyzer_accuracy"]["observation_count"], 1)
 
+    # TT-TEST: D01 primary
     def test_equivalent_encoding_diagnosis_disagreement_fails_observation(self):
         a = case("a")
         b = case("b", observation_id="a")
@@ -180,6 +187,7 @@ class Tests(unittest.TestCase):
         self.assertEqual(x["member_case_ids"], ["a", "b"])
         self.assertEqual(m["analyzer_accuracy"]["observation_count"], 0)
 
+    # TT-TEST: D01 secondary
     def test_equivalent_encoding_confidence_disagreement_fails_observation(self):
         a = case("a")
         b = case("b", observation_id="a")
@@ -196,6 +204,7 @@ class Tests(unittest.TestCase):
             "confidence disagreement", m["failed_analyzer_cases"][-1]["error"]
         )
 
+    # TT-TEST: D01 secondary
     def test_observation_labels_must_match(self):
         changes = {
             "ground_truth": "blocking_pool_pressure",
@@ -214,6 +223,7 @@ class Tests(unittest.TestCase):
                 ):
                     db.validate_manifest(manifest(a, b))
 
+    # TT-TEST: support
     def test_accuracy_ground_truth_must_be_in_both_contract_lists(self):
         variants = [
             ({"expected_primary_kinds": ["blocking_pool_pressure"]}, False),
@@ -247,6 +257,7 @@ class Tests(unittest.TestCase):
                     with self.assertRaisesRegex(ValueError, "ground_truth must be in"):
                         db.validate_manifest(manifest(c))
 
+    # TT-TEST: D01 secondary
     def test_ground_truth_top1_cannot_be_high_confidence_wrong(self):
         c = case(
             expected_primary_kinds=[
@@ -259,6 +270,7 @@ class Tests(unittest.TestCase):
             (m, _), _ = self.runmock(p, [Result(out=json.dumps(report()))])
         self.assertEqual(m["analyzer_accuracy"]["high_confidence_wrong_count"], 0)
 
+    # TT-TEST: support
     def test_class_type_and_eligibility_matrix(self):
         bad = [
             case("x", "analysis_report", False, validation_class="analyzer_execution"),
@@ -291,11 +303,13 @@ class Tests(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     db.validate_manifest(manifest(c))
 
+    # TT-TEST: support
     def test_version_1_fields_are_rejected(self):
         for key in db.OLD:
             with self.assertRaisesRegex(ValueError, "version-1"):
                 db.validate_manifest(manifest(case(**{key: []})))
 
+    # TT-TEST: D01 secondary
     def test_expected_execution_failure_is_checked_not_skipped(self):
         base = case(
             eligible=False,
@@ -332,6 +346,7 @@ class Tests(unittest.TestCase):
             (m, _), _ = self.runmock(p, [Result(1, "", "bad")])
             self.assertFalse(m["analyzer_execution"]["cases"][0]["passed"])
 
+    # TT-TEST: support
     def test_expected_failure_diagnostics_are_stderr_only(self):
         base = case(
             eligible=False,
@@ -372,6 +387,7 @@ class Tests(unittest.TestCase):
                 if result.stdout == "needed" and not result.stderr:
                     self.assertIn("missing stderr diagnostic", row["error"])
 
+    # TT-TEST: support
     def test_optional_contract_fields_are_strictly_validated(self):
         valid = {
             "exact_primary_kind": "application_queue_saturation",
@@ -420,6 +436,7 @@ class Tests(unittest.TestCase):
                         )
                     )
 
+    # TT-TEST: support
     def test_extract_rejects_malformed_report_shapes(self):
         mutations = [
             lambda r: r.update(secondary_suspects=[42]),
@@ -474,6 +491,7 @@ class Tests(unittest.TestCase):
         r["primary_suspect"]["confidence_notes"] = ["note"]
         db.extract(r)
 
+    # TT-TEST: D01 primary
     def test_incomplete_equivalent_encoding_group_is_not_scored(self):
         bad_outputs = [
             Result(1, "", "boom"),
@@ -518,6 +536,7 @@ class Tests(unittest.TestCase):
             m["analyzer_accuracy"]["observations"][0]["observation_id"], "c"
         )
 
+    # TT-TEST: support
     def test_artifact_policy_is_typed(self):
         db.validate_manifest(manifest(case()))
         db.validate_manifest(manifest(case(artifact_policy="allow_ambiguous")))
@@ -534,6 +553,7 @@ class Tests(unittest.TestCase):
             with self.assertRaises(ValueError):
                 db.validate_manifest(manifest(c))
 
+    # TT-TEST: D01 primary
     def test_committed_manifest_invariants(self):
         p = Path(__file__).parents[2] / "validation/diagnostics/manifest.json"
         m = json.loads(p.read_text())

--- a/scripts/tests/test_generate_diagnostic_scorecard.py
+++ b/scripts/tests/test_generate_diagnostic_scorecard.py
@@ -5,18 +5,24 @@ from scripts.generate_diagnostic_scorecard import *
 def env():return {'generated_at_utc':'t','snapshot_label':'s','git':{'sha':'a','tag':None,'describe':'a'},'tailtriage':{'workspace_package_version':'1','packages':{}},'github_actions':{},'software':{},'hardware':{},'inputs':{'manifest_sha256':'m','referenced_artifacts_sha256':'a','thresholds':{}}}
 def metrics(zero=False):return {'schema_version':2,'manifest_case_count':2,'analyzer_execution':{'case_count':1,'success_count':1,'expected_failure_count':0,'unexpected_failure_count':0,'run_artifact_count':1,'tracing_jsonl_count':0},'analyzer_accuracy':{'observation_count':0 if zero else 1,'encoding_count':0 if zero else 1,'top1_accuracy':None if zero else 1.0,'top2_recall':None if zero else 1.0,'high_confidence_wrong_count':0,'per_ground_truth_counts':{},'confusion_matrix':{},'confidence_bucket_accuracy':{}},'report_contract':{'case_count':1,'passed_count':1,'failed_count':0,'analysis_report_count':1,'synthetic_report_count':0},'validated_paths':{},'failed_analyzer_cases':[],'failed_report_contract_cases':[]}
 class Tests(unittest.TestCase):
+ # TT-TEST: support
  def test_scorecard_json_is_separated(self):
   m=metrics();self.assertEqual(m['schema_version'],2);self.assertNotIn('total_cases',m);self.assertEqual({'analyzer_execution','analyzer_accuracy','report_contract'} <= m.keys(),True)
+ # TT-TEST: support
  def test_scorecard_markdown_is_separated(self):
   text=render_scorecard(metrics(),env())
   for h in ['## Analyzer execution','## Analyzer accuracy','## Report-contract validation','## Validated input paths','## Failed analyzer cases','## Failed report-contract cases','## Non-claims']:self.assertIn(h,text)
   self.assertIn('Unique accuracy observations: 1',text);self.assertIn('Executed artifact encodings: 1',text);self.assertIn('do not contribute to analyzer accuracy',text)
   self.assertIn('The native/tracing equivalence contract is not an accuracy denominator.',text)
+ # TT-TEST: support
  def test_unavailable_accuracy_renders_na(self):
   text=render_scorecard(metrics(True),env());self.assertIn('Top-1 accuracy: n/a',text);self.assertIn('Top-2 recall: n/a',text)
+ # TT-TEST: support
  def test_environment_schema_two(self):
   repo=Path(__file__).parents[2];e=collect_environment(repo,repo/'validation/diagnostics/manifest.json','x',{});self.assertEqual(e['schema_version'],2)
+ # TT-TEST: support
  def test_hashes(self):self.assertEqual(sha256_bytes(b'a'),sha256_bytes(b'a'))
+ # TT-TEST: support
  def test_generate_writes_separated_json(self):
   with tempfile.TemporaryDirectory() as td:
    root=Path(td);(root/'Cargo.toml').write_text('[workspace]\nmembers=[]\n[workspace.package]\nversion="1"\n');p=root/'validation';p.mkdir();(p/'manifest.json').write_text('{"cases":[]}')

--- a/scripts/tests/test_measure_collector_limits.py
+++ b/scripts/tests/test_measure_collector_limits.py
@@ -91,6 +91,7 @@ class CollectorLimitsSummaryTests(unittest.TestCase):
             "measurement_notes": ["collector synthetic note"],
         }
 
+    # TT-TEST: support
     def test_parse_modes_validation(self) -> None:
         parsed = measure_collector_limits.parse_modes(" baseline , core_light ")
         self.assertEqual(parsed, ("baseline", "core_light"))
@@ -100,6 +101,7 @@ class CollectorLimitsSummaryTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             measure_collector_limits.parse_modes("baseline,unknown_mode")
 
+    # TT-TEST: support
     def test_pct_delta(self) -> None:
         self.assertEqual(measure_collector_limits.pct_delta(100.0, 125.0), 25.0)
         self.assertEqual(measure_collector_limits.pct_delta(10.0, 8.0), -20.0)
@@ -107,6 +109,7 @@ class CollectorLimitsSummaryTests(unittest.TestCase):
         self.assertIsNone(measure_collector_limits.pct_delta(10.0, None))
         self.assertIsNone(measure_collector_limits.pct_delta(0.0, 1.0))
 
+    # TT-TEST: support
     def test_summarize_values_handles_empty_and_nonempty(self) -> None:
         self.assertEqual(
             measure_collector_limits.summarize_values([]),
@@ -128,6 +131,7 @@ class CollectorLimitsSummaryTests(unittest.TestCase):
         self.assertEqual(summary["max"], 3.0)
         self.assertEqual(summary["stdev"], 1.0)
 
+    # TT-TEST: support
     def test_group_rows_groups_by_case_and_mode(self) -> None:
         rows = [
             {"case_id": "baseline_shape", "mode": "baseline", "run_id": 1},
@@ -139,6 +143,7 @@ class CollectorLimitsSummaryTests(unittest.TestCase):
         self.assertEqual(set(grouped), {"baseline_shape::baseline", "high_concurrency::baseline"})
         self.assertEqual([row["run_id"] for row in grouped["baseline_shape::baseline"]], [1, 2])
 
+    # TT-TEST: support
     def test_signal_for_mode_handles_derived_and_missing_metrics(self) -> None:
         summary_by_case_mode = {
             "low_concurrency::core_light": {
@@ -195,6 +200,8 @@ class CollectorLimitsSummaryTests(unittest.TestCase):
             },
         )
 
+    # TT-TEST: O02 primary
+    # TT-TEST: K01 secondary
     def test_summarize_synthetic_rows_exposes_structure_mode_filtering_sampler_and_onset(self) -> None:
         mode = "core_light_tokio_sampler"
         rows = [

--- a/scripts/tests/test_measure_runtime_cost.py
+++ b/scripts/tests/test_measure_runtime_cost.py
@@ -64,6 +64,7 @@ class RuntimeCostSummaryTests(unittest.TestCase):
             }
         return row
 
+    # TT-TEST: O01 primary
     def test_mode_matrix_preserves_unsaturated_saturated_and_sampler_scenarios(self) -> None:
         self.assertEqual(
             measure_runtime_cost.UNSATURATED_CORE_MODES,
@@ -94,10 +95,12 @@ class RuntimeCostSummaryTests(unittest.TestCase):
             ),
         )
 
+    # TT-TEST: support
     def test_safe_ratio_handles_zero_denominator(self) -> None:
         self.assertIsNone(measure_runtime_cost.safe_ratio(10.0, 0.0))
         self.assertEqual(measure_runtime_cost.safe_ratio(10.0, 2.0), 5.0)
 
+    # TT-TEST: O01 primary
     def test_summary_includes_required_overhead_headings_and_drop_path(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             raw_path = Path(tmp) / "runtime-cost-raw.jsonl"
@@ -159,6 +162,7 @@ class RuntimeCostSummaryTests(unittest.TestCase):
             self.assertEqual(drop_summary["limit_reached_rounds"], 4)
             self.assertGreater(drop_summary["dropped_requests"]["mean"], 0)
 
+    # TT-TEST: O01 secondary
     def test_sanity_fails_on_parity_latency_ratio(self) -> None:
         summary = {"absolute_metrics": {m: {"throughput_rps": {"median": 10.0}, "latency_p95_ms": {"median": 2.0},
                                             "run_requests": {"median": 1}, "run_stages": {"median": 1}, "run_queues": {"median": 1},
@@ -179,6 +183,7 @@ class RuntimeCostSummaryTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             measure_runtime_cost._validate_sanity(summary)
 
+    # TT-TEST: O01 secondary
     def test_sanity_fails_on_parity_throughput_ratio(self) -> None:
         summary = {"absolute_metrics": {m: {"throughput_rps": {"median": 10.0}, "latency_p95_ms": {"median": 2.0},
                                             "run_requests": {"median": 1}, "run_stages": {"median": 1}, "run_queues": {"median": 1},
@@ -199,6 +204,7 @@ class RuntimeCostSummaryTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             measure_runtime_cost._validate_sanity(summary)
 
+    # TT-TEST: O01 secondary
     def test_sanity_passes_for_reasonable_tracing_ratios(self) -> None:
         summary = {"absolute_metrics": {m: {"throughput_rps": {"median": 10.0}, "latency_p95_ms": {"median": 2.0},
                                             "run_requests": {"median": 1}, "run_stages": {"median": 1}, "run_queues": {"median": 1},
@@ -218,6 +224,7 @@ class RuntimeCostSummaryTests(unittest.TestCase):
         summary["absolute_metrics"]["tracing_light_drop_path"]["drop_path_signal_present_rounds"] = 1
         measure_runtime_cost._validate_sanity(summary)
 
+    # TT-TEST: support
     def test_parity_warning_for_latency_above_soft_band(self) -> None:
         warnings = measure_runtime_cost.evaluate_tracing_parity({
             "tracing_light_vs_core_light_latency_p95": 1.03,
@@ -229,6 +236,7 @@ class RuntimeCostSummaryTests(unittest.TestCase):
         })
         self.assertTrue(any("tracing_light p95 is 1.03x native" in w for w in warnings))
 
+    # TT-TEST: support
     def test_parity_no_warning_for_latency_at_or_below_soft_band(self) -> None:
         warnings = measure_runtime_cost.evaluate_tracing_parity({
             "tracing_light_vs_core_light_latency_p95": 1.02,
@@ -240,6 +248,7 @@ class RuntimeCostSummaryTests(unittest.TestCase):
         })
         self.assertEqual(warnings, [])
 
+    # TT-TEST: support
     def test_parity_warning_for_throughput_below_soft_band(self) -> None:
         warnings = measure_runtime_cost.evaluate_tracing_parity({
             "tracing_light_vs_core_light_latency_p95": 1.0,
@@ -251,6 +260,7 @@ class RuntimeCostSummaryTests(unittest.TestCase):
         })
         self.assertTrue(any("tracing_light throughput is 0.97x native" in w for w in warnings))
 
+    # TT-TEST: support
     def test_parity_no_warning_for_throughput_at_or_above_soft_band(self) -> None:
         warnings = measure_runtime_cost.evaluate_tracing_parity({
             "tracing_light_vs_core_light_latency_p95": 1.0,

--- a/scripts/tests/test_run_diagnostic_matrix.py
+++ b/scripts/tests/test_run_diagnostic_matrix.py
@@ -31,16 +31,19 @@ class RunDiagnosticMatrixTests(unittest.TestCase):
         base.update(updates)
         return base
 
+    # TT-TEST: D02 secondary
     def test_extract_run_record(self):
         rec = rdm.build_record(report=self.sample_report(), metadata=self.metadata(), run_index=1, profile="dev", artifact_path=Path("a.json"), analysis_path=Path("b.json"))
         self.assertTrue(rec["top1_ok"])
         self.assertTrue(rec["top2_ok"])
         self.assertFalse(rec["high_confidence_wrong"])
 
+    # TT-TEST: D02 secondary
     def test_high_confidence_wrong(self):
         rec = rdm.build_record(report=self.sample_report(primary_kind="blocking_pool_pressure"), metadata=self.metadata(), run_index=1, profile="dev", artifact_path=Path("a"), analysis_path=Path("b"))
         self.assertTrue(rec["high_confidence_wrong"])
 
+    # TT-TEST: D01 primary
     def test_primary_stability_and_confidence_bucket(self):
         records = [
             rdm.build_record(report=self.sample_report(), metadata=self.metadata(), run_index=1, profile="dev", artifact_path=Path("a"), analysis_path=Path("b")),
@@ -52,11 +55,13 @@ class RunDiagnosticMatrixTests(unittest.TestCase):
         self.assertAlmostEqual(per["primary_stability"], 2 / 3)
         self.assertIn("high", per["confidence_bucket_accuracy"])
 
+    # TT-TEST: support
     def test_latency_stats_odd_even_and_missing(self):
         self.assertEqual(rdm.latency_stats([1, 2, 3])["median"], 2)
         self.assertEqual(rdm.latency_stats([1, 2, 3, 4])["median"], 2)
         self.assertIsNone(rdm.latency_stats([]))
 
+    # TT-TEST: D01 primary
     def test_threshold_failures(self):
         rec = rdm.build_record(report=self.sample_report(primary_kind="blocking_pool_pressure"), metadata=self.metadata(), run_index=1, profile="dev", artifact_path=Path("a"), analysis_path=Path("b"))
         summary = rdm.summarize([rec], runs=1, profile="dev")
@@ -64,12 +69,14 @@ class RunDiagnosticMatrixTests(unittest.TestCase):
         self.assertTrue(any("top1_accuracy" in f for f in failures))
         self.assertTrue(any("high_confidence_wrong_count" in f for f in failures))
 
+    # TT-TEST: D02 secondary
     def test_mixed_without_top1_requirement(self):
         rec = rdm.build_record(report=self.sample_report(primary_kind="executor_pressure_suspected", second=[{"kind": "application_queue_saturation"}]), metadata=self.metadata(name="mixed", top1_required=False, acceptable_primary=["application_queue_saturation", "executor_pressure_suspected"]), run_index=1, profile="dev", artifact_path=Path("a"), analysis_path=Path("b"))
         summary = rdm.summarize([rec], runs=1, profile="dev")
         failures = rdm.evaluate_thresholds(summary, {"mixed": self.metadata(name="mixed", top1_required=False, acceptable_primary=["application_queue_saturation", "executor_pressure_suspected"])}, min_top1=0.95, min_top2=1.0, max_high_confidence_wrong=0)
         self.assertFalse(any("top1_accuracy" in f for f in failures))
 
+    # TT-TEST: support
     def test_jsonl_write(self):
         records = [{"a": 1}, {"b": 2}]
         with tempfile.TemporaryDirectory() as td:
@@ -79,6 +86,7 @@ class RunDiagnosticMatrixTests(unittest.TestCase):
             self.assertEqual(len(lines), 2)
             self.assertEqual(json.loads(lines[0])["a"], 1)
 
+    # TT-TEST: support
     def test_missing_optional_p99_in_summary(self):
         report = self.sample_report()
         report.pop("p99_latency_us")

--- a/scripts/tests/test_validate_all.py
+++ b/scripts/tests/test_validate_all.py
@@ -11,6 +11,7 @@ class ValidateAllTests(unittest.TestCase):
     def args(self, profile="smoke"):
         return SimpleNamespace(profile=profile, out=f"target/validation/{profile}", runs=1, profile_mode="dev", skip_cargo=False, no_fail_thresholds=False, python="python3")
 
+    # TT-TEST: support
     def test_smoke_plan(self):
         plan = va.build_plan(self.args("smoke"))
         names = " ".join(c.name for c in plan)
@@ -21,6 +22,7 @@ class ValidateAllTests(unittest.TestCase):
         self.assertIn("runtime-cost smoke", names)
         self.assertIn("collector-limits smoke", names)
 
+    # TT-TEST: support
     def test_ci_plan_has_tests(self):
         plan = va.build_plan(self.args("ci"))
         joined = "\n".join(" ".join(c.argv) for c in plan)
@@ -32,6 +34,7 @@ class ValidateAllTests(unittest.TestCase):
         self.assertIn("scripts.tests.test_measure_collector_limits", joined)
         self.assertIn("scripts.tests.test_validate_docs_contracts", joined)
 
+    # TT-TEST: D01 secondary
     def test_ci_plan_deterministic_benchmark_uses_ci_thresholds(self):
         plan = va.build_plan(self.args("ci"))
         benchmark = next(
@@ -56,6 +59,7 @@ class ValidateAllTests(unittest.TestCase):
             "0",
         )
 
+    # TT-TEST: support
     def test_full_includes_live_tracks(self):
         a = self.args("full"); a.runs = 7
         plan = va.build_plan(a)
@@ -82,6 +86,7 @@ class ValidateAllTests(unittest.TestCase):
         self.assertEqual(diagnostic_matrix.argv[diagnostic_matrix.argv.index("--runs") + 1], "7")
         self.assertEqual(runtime_cost.argv[runtime_cost.argv.index("--rounds") + 1], "7")
 
+    # TT-TEST: support
     def test_no_fail_thresholds_propagates_to_mitigation_report(self):
         for profile, command_name in (("smoke", "mitigation smoke"), ("full", "mitigation full")):
             args = self.args(profile)
@@ -90,12 +95,14 @@ class ValidateAllTests(unittest.TestCase):
             self.assertIn("mitigation-report", command.argv)
             self.assertIn("--no-fail-thresholds", command.argv)
 
+    # TT-TEST: support
     def test_default_repetition_depths(self):
         self.assertEqual(va.default_runs("smoke"), 1)
         self.assertEqual(va.default_runs("ci"), 1)
         self.assertEqual(va.default_runs("full"), 5)
         self.assertEqual(va.default_runs("publish"), 5)
 
+    # TT-TEST: support
     def test_full_and_publish_have_same_substantive_depth(self):
         for profile in ("full", "publish"):
             a = self.args(profile)
@@ -109,6 +116,7 @@ class ValidateAllTests(unittest.TestCase):
             self.assertEqual(collector.argv[collector.argv.index("--profile") + 1], "default")
             self.assertEqual(collector.argv[collector.argv.index("--repeats") + 1], "1")
 
+    # TT-TEST: support
     def test_publish_has_separate_operational_tracks(self):
         plan = va.build_plan(self.args("publish"))
         names = [c.name for c in plan]
@@ -116,6 +124,7 @@ class ValidateAllTests(unittest.TestCase):
         self.assertIn("collector-limits full", names)
         self.assertNotIn("operational full", names)
 
+    # TT-TEST: support
     def test_operational_commands_use_direct_owner_artifact_dirs(self):
         for profile in ("smoke", "full", "publish"):
             a = self.args(profile)
@@ -133,11 +142,13 @@ class ValidateAllTests(unittest.TestCase):
                 self.assertIn("--artifact-dir", joined)
                 self.assertIn(str(expected_root), joined)
 
+    # TT-TEST: support
     def test_publish_default_dir(self):
         p = va.derive_publish_dir()
         self.assertIn("validation/artifacts", str(p))
         self.assertNotEqual(p, va.default_out_dir("full"))
 
+    # TT-TEST: P03 secondary
     def test_cargo_baseline_matches_ci_flags(self):
         a = self.args("smoke")
         cargo = {c.name: c.argv for c in va.build_plan(a) if c.track == "cargo"}
@@ -168,18 +179,21 @@ class ValidateAllTests(unittest.TestCase):
             ],
         )
 
+    # TT-TEST: support
     def test_skip_cargo(self):
         a = self.args("ci")
         self.assertTrue(any(c.track == "cargo" for c in va.build_plan(a)))
         a.skip_cargo = True
         self.assertFalse(any(c.track == "cargo" for c in va.build_plan(a)))
 
+    # TT-TEST: support
     def test_profile_mode_propagates(self):
         a = self.args("smoke"); a.profile_mode = "release"
         plan = va.build_plan(a)
         joined = "\n".join(" ".join(c.argv) for c in plan)
         self.assertIn("--profile release", joined)
 
+    # TT-TEST: support
     def test_summary_and_logs(self):
         spec_ok = va.CommandSpec("ok", "runtime_cost", ["echo", "ok"])
         spec_bad = va.CommandSpec("bad", "collector_limits", ["false"])
@@ -202,6 +216,7 @@ class ValidateAllTests(unittest.TestCase):
             self.assertNotIn("warnings/downgrades", sc.read_text())
             self.assertIn("retained/truncation/drop evidence", sc.read_text())
 
+    # TT-TEST: support
     def test_environment_best_effort(self):
         env = va.collect_environment("dev")
         self.assertIn("schema_version", env)

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -15,13 +15,16 @@ import validate_docs_contracts
 
 class ValidateDocsContractsTests(unittest.TestCase):
 
+    # TT-TEST: support
     def test_run_end_policy_variants_include_expected_kinds(self) -> None:
         kinds = validate_docs_contracts.extract_run_end_policy_kinds_from_source()
         self.assertEqual(kinds, {'continue_after_limits_hit', 'auto_seal_on_limits_hit'})
 
+    # TT-TEST: M01 primary
     def test_crate_rustdocs_include_readmes_contract(self) -> None:
         validate_docs_contracts.validate_crate_rustdocs_include_readmes()
 
+    # TT-TEST: M01 secondary
     def test_crate_rustdocs_include_readmes_contract_fails_when_missing_include(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             repo_root = Path(tmp_dir)
@@ -37,6 +40,7 @@ class ValidateDocsContractsTests(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, 'README directive'):
                     validate_docs_contracts.validate_crate_rustdocs_include_readmes()
 
+    # TT-TEST: M02 primary
     def test_residual_public_api_cleanup_contract_accepts_private_cli_internals(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)
@@ -48,6 +52,7 @@ class ValidateDocsContractsTests(unittest.TestCase):
             with mock.patch.object(validate_docs_contracts, 'REPO_ROOT', root):
                 validate_docs_contracts.validate_residual_public_api_cleanup()
 
+    # TT-TEST: M02 primary
     def test_residual_public_api_cleanup_contract_rejects_cli_helper_export(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)
@@ -60,12 +65,15 @@ class ValidateDocsContractsTests(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, 'removed residual public API'):
                     validate_docs_contracts.validate_residual_public_api_cleanup()
 
+    # TT-TEST: M01 primary
     def test_markdown_examples_validate_against_contract(self) -> None:
         validate_docs_contracts.validate_controller_readme_toml()
 
+    # TT-TEST: M01 primary
     def test_analyzer_ownership_navigation(self) -> None:
         validate_docs_contracts.validate_analyzer_ownership_navigation()
 
+    # TT-TEST: M01 secondary
     def test_analyzer_ownership_navigation_rejects_missing_link(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             repo_root = Path(tmp_dir)
@@ -74,6 +82,7 @@ class ValidateDocsContractsTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, 'missing analyzer ownership links'):
                 validate_docs_contracts.validate_analyzer_ownership_navigation(required_links={path: ('analyzer-guide.md',)}, repo_root=repo_root)
 
+    # TT-TEST: M01 secondary
     def test_analyzer_ownership_navigation_accepts_exact_relative_link(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             repo_root = Path(tmp_dir)
@@ -84,6 +93,7 @@ class ValidateDocsContractsTests(unittest.TestCase):
             target.write_text('# Diagnostics\n', encoding='utf-8')
             validate_docs_contracts.validate_analyzer_ownership_navigation(required_links={source: ('diagnostics.md',)}, repo_root=repo_root)
 
+    # TT-TEST: M01 secondary
     def test_analyzer_ownership_navigation_accepts_fragment(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             repo_root = Path(tmp_dir)
@@ -93,6 +103,7 @@ class ValidateDocsContractsTests(unittest.TestCase):
             target.write_text('# Diagnostics\n', encoding='utf-8')
             validate_docs_contracts.validate_analyzer_ownership_navigation(required_links={source: ('diagnostics.md',)}, repo_root=repo_root)
 
+    # TT-TEST: M01 secondary
     def test_analyzer_ownership_navigation_rejects_prefix_lookalike(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             repo_root = Path(tmp_dir)
@@ -103,6 +114,7 @@ class ValidateDocsContractsTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, 'missing analyzer ownership links'):
                 validate_docs_contracts.validate_analyzer_ownership_navigation(required_links={source: ('diagnostics.md',)}, repo_root=repo_root)
 
+    # TT-TEST: M01 secondary
     def test_analyzer_ownership_navigation_rejects_missing_local_target(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             repo_root = Path(tmp_dir)
@@ -111,6 +123,7 @@ class ValidateDocsContractsTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, 'not an existing file'):
                 validate_docs_contracts.validate_analyzer_ownership_navigation(required_links={source: ('diagnostics.md',)}, repo_root=repo_root)
 
+    # TT-TEST: M01 secondary
     def test_analyzer_ownership_navigation_rejects_repository_escape(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             workspace = Path(tmp_dir)
@@ -122,15 +135,19 @@ class ValidateDocsContractsTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, 'escapes repository root'):
                 validate_docs_contracts.validate_analyzer_ownership_navigation(required_links={source: ('../outside.md',)}, repo_root=repo_root)
 
+    # TT-TEST: M01 primary
     def test_docs_index_contract(self) -> None:
         validate_docs_contracts.validate_docs_index_contract()
 
+    # TT-TEST: M01 primary
     def test_root_readme_docs_link(self) -> None:
         validate_docs_contracts.validate_root_readme_docs_link()
 
+    # TT-TEST: M01 primary
     def test_analyzer_config_example_contract(self) -> None:
         validate_docs_contracts.validate_analyzer_config_example_contract()
 
+    # TT-TEST: M01 secondary
     def test_analyzer_config_example_contract_rejects_malformed_toml(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             path = Path(tmp_dir) / 'analyzer-config.toml'
@@ -138,15 +155,18 @@ class ValidateDocsContractsTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, 'invalid TOML'):
                 validate_docs_contracts.validate_analyzer_config_example_contract(config_path=path)
 
+    # TT-TEST: support
     def test_analyzer_config_example_contract_does_not_require_schema_groups(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             path = Path(tmp_dir) / 'analyzer-config.toml'
             path.write_text('syntactically_valid = true\n', encoding='utf-8')
             validate_docs_contracts.validate_analyzer_config_example_contract(config_path=path)
 
+    # TT-TEST: M02 secondary
     def test_sampler_integration_boundary_contract_validates(self) -> None:
         validate_docs_contracts.validate_sampler_integration_boundary()
 
+    # TT-TEST: M01 secondary
     def test_docs_index_contract_checks_deliberate_developer_doc_link(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             repo_root = Path(tmp_dir)
@@ -158,6 +178,7 @@ class ValidateDocsContractsTests(unittest.TestCase):
             with mock.patch.object(validate_docs_contracts, 'REPO_ROOT', repo_root), mock.patch.object(validate_docs_contracts, 'DOCS_INDEX_PATH', docs_index_path), mock.patch.object(validate_docs_contracts, 'DEV_DOCS_DIR', docs_dir / 'dev'), mock.patch.object(validate_docs_contracts, 'DOCS_INDEX_EXCLUDED_MARKDOWN', {'docs/README.md'}), self.assertRaisesRegex(ValueError, 'dead local Markdown links'):
                 validate_docs_contracts.validate_docs_index_contract()
 
+    # TT-TEST: M01 secondary
     def test_docs_index_contract_rejects_repository_escape(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             workspace = Path(tmp_dir)
@@ -171,6 +192,7 @@ class ValidateDocsContractsTests(unittest.TestCase):
             with mock.patch.object(validate_docs_contracts, 'REPO_ROOT', repo_root), mock.patch.object(validate_docs_contracts, 'DOCS_INDEX_PATH', docs_index_path), self.assertRaisesRegex(ValueError, 'escapes repository root'):
                 validate_docs_contracts.validate_docs_index_contract()
 
+    # TT-TEST: support
     def test_manual_release_boundary_rejects_executable_release_script_mutation(self) -> None:
         prohibited_cases = {'cargo publish': ('command(["cargo", "publish", "--locked"])\n', 'cargo publish'), 'cargo login': ('command(["cargo", "login"])\n', 'cargo registry login'), 'git commit': ('command(["git", "commit", "-m", "automated"])\n', 'git commit'), 'git tag': ('command(["git", "tag", "v0.4.0"])\n', 'git tag creation'), 'git push': ('command(["git", "push", "origin", "main"])\n', 'git push'), 'GitHub Release': ('command(["gh", "release", "create", "v0.4.0"])\n', 'GitHub Release publication')}
         for label, (source, expected) in prohibited_cases.items():
@@ -182,6 +204,7 @@ class ValidateDocsContractsTests(unittest.TestCase):
                 with mock.patch.object(validate_docs_contracts, 'REPO_ROOT', root), self.assertRaisesRegex(ValueError, f'executes prohibited {expected}'):
                     validate_docs_contracts.validate_manual_release_boundary(workflow_paths=(), release_script_paths=(script,))
 
+    # TT-TEST: support
     def test_manual_release_boundary_rejects_workflow_mutation_commands(self) -> None:
         prohibited_cases = {'cargo publish': ('cargo publish --locked', 'cargo publish'), 'cargo toolchain publish': ('cargo +stable publish --locked', 'cargo publish'), 'wrapped env cargo publish': ('env FOO=bar cargo publish --locked', 'cargo publish'), 'wrapped command cargo publish': ('command cargo publish --locked', 'cargo publish'), 'cargo login': ('cargo login', 'cargo registry login'), 'git commit': ('git commit -m automated', 'git commit'), 'git tag': ('git tag v0.4.0', 'git tag creation'), 'git push': ('git push origin main', 'git push'), 'git config tag': ('git -c user.name=bot tag v0.4.0', 'git tag creation'), 'wrapped git push': ('env FOO=bar git push origin main', 'git push'), 'GitHub Release': ('gh release create v0.4.0', 'GitHub Release publication')}
         for label, (command, expected) in prohibited_cases.items():
@@ -193,6 +216,7 @@ class ValidateDocsContractsTests(unittest.TestCase):
                 with mock.patch.object(validate_docs_contracts, 'REPO_ROOT', root), self.assertRaisesRegex(ValueError, f'executes prohibited {expected}'):
                     validate_docs_contracts.validate_manual_release_boundary(workflow_paths=(workflow,), release_script_paths=())
 
+    # TT-TEST: support
     def test_manual_release_boundary_rejects_release_actions_and_credentials(self) -> None:
         prohibited_cases = {'release action': ('steps:\n  - uses: softprops/action-gh-release@v2\n', 'invokes GitHub Release automation'), 'registry credentials': ('env:\n  CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}\n', 'configures registry publication credentials'), 'registry-specific credentials': ('env:\n  CARGO_REGISTRY_PRIVATE_TOKEN: ${{ secrets.PRIVATE_TOKEN }}\n', 'configures registry publication credentials')}
         for label, (source, expected) in prohibited_cases.items():
@@ -204,6 +228,7 @@ class ValidateDocsContractsTests(unittest.TestCase):
                 with mock.patch.object(validate_docs_contracts, 'REPO_ROOT', root), self.assertRaisesRegex(ValueError, expected):
                     validate_docs_contracts.validate_manual_release_boundary(workflow_paths=(workflow,), release_script_paths=())
 
+    # TT-TEST: support
     def test_manual_release_boundary_rejects_contents_write_permissions(self) -> None:
         prohibited_cases = {'workflow': 'permissions:\n  contents: write\njobs: {}\n', 'job': 'jobs:\n  release:\n    permissions:\n      contents: write\n    steps: []\n', 'workflow write-all': 'permissions: write-all\njobs: {}\n', 'job write-all': 'jobs:\n  validate:\n    permissions: write-all\n    steps: []\n'}
         for label, source in prohibited_cases.items():
@@ -215,6 +240,7 @@ class ValidateDocsContractsTests(unittest.TestCase):
                 with mock.patch.object(validate_docs_contracts, 'REPO_ROOT', root), self.assertRaisesRegex(ValueError, 'prohibited (?:contents: write|permissions: write-all) permission'):
                     validate_docs_contracts.validate_manual_release_boundary(workflow_paths=(workflow,), release_script_paths=())
 
+    # TT-TEST: support
     def test_manual_release_boundary_ignores_inert_command_text(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)
@@ -225,12 +251,14 @@ class ValidateDocsContractsTests(unittest.TestCase):
             with mock.patch.object(validate_docs_contracts, 'REPO_ROOT', root):
                 validate_docs_contracts.validate_manual_release_boundary(workflow_paths=(workflow,), release_script_paths=(script,))
 
+    # TT-TEST: support
     def test_diagnostic_benchmark_ci_uses_executable_step(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             workflow = Path(tmp_dir) / 'ci.yml'
             workflow.write_text('jobs:\n  test:\n    steps:\n      - name: benchmark\n        run: python3 scripts/diagnostic_benchmark.py --manifest validation/diagnostics/manifest.json --min-top1 0.75 --min-top2 0.90 --max-high-confidence-wrong 0\n', encoding='utf-8')
             validate_docs_contracts.validate_diagnostic_benchmark_ci_contract(workflow_path=workflow)
 
+    # TT-TEST: M01 secondary
     def test_published_readme_rejects_repository_only_link(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             readme = Path(tmp_dir) / 'README.md'


### PR DESCRIPTION
### Motivation

- Record the audited test classification metadata for the surviving Python unit tests so downstream tooling and reviewers can rely on explicit `TT-TEST` annotations.

### Description

- Add exactly 216 `# TT-TEST: ...` comment lines (no deletions) immediately above the decorated block or `def` for 215 existing tests across 11 files under `scripts/tests/` as a mechanical, marker-only migration.
- Files updated: `test_check_diagnostic_fixture_integrity.py`, `test_check_release.py`, `test_check_workflow_security.py`, `test_demo_scripts.py`, `test_diagnostic_benchmark.py`, `test_generate_diagnostic_scorecard.py`, `test_measure_collector_limits.py`, `test_measure_runtime_cost.py`, `test_run_diagnostic_matrix.py`, `test_validate_all.py`, and `test_validate_docs_contracts.py`.
- The only test with two adjacent markers is `test_summarize_synthetic_rows_exposes_structure_mode_filtering_sampler_and_onset` and it now has `O02 primary` followed by `K01 secondary` in separate comment lines as required.
- This change is strictly non-functional: no production code, test bodies, helpers, assertions, formatting, or existing comments were modified; removing the added `TT-TEST` lines restores the pre-change files byte-for-byte.

### Testing

- Ran the full Python test suite with `python3 -m unittest discover -s scripts/tests -v` and all `215` tests passed (OK).
- Ran repository checks required by the contributor guide: `python3 scripts/validate_docs_contracts.py` (passed), `cargo fmt --check` (passed), `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (passed), and `cargo test --workspace --all-targets --all-features --locked` (passed).
- Performed `git diff --check` and repository diff inspection to confirm the final diff contains only the 216 added `# TT-TEST:` comment lines across the 11 files and no deletions or other edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8cc090bb7c833093de1788e53c9e1b)