### PR TITLE
test: add direct F05 and Z02 proof owners

### DIFF
--- a/scripts/tests/test_demo_scripts.py
+++ b/scripts/tests/test_demo_scripts.py
@@ -23,6 +23,36 @@ from demo_tool import has_suspect_kind, parse_args, suspect_score  # noqa: E402
 
 
 class DemoWrapperTests(unittest.TestCase):
+    # TT-TEST: F05 primary
+    def test_committed_demo_report_pairs_satisfy_all_nine_canonical_policies(self) -> None:
+        fixture_pairs: dict[str, dict[str, Path]] = {}
+
+        for fixture_rel, generated_rel in check_demo_fixture_drift._scenario_specs():
+            if generated_rel.name not in {"before-analysis.json", "after-analysis.json"}:
+                continue
+            scenario = generated_rel.parent.name
+            variant = generated_rel.name.removesuffix("-analysis.json")
+            fixture_pairs.setdefault(scenario, {})[variant] = REPO_ROOT / fixture_rel
+
+        self.assertEqual(set(fixture_pairs), set(demo_tool.LIVE_SCENARIO_POLICIES))
+
+        for scenario in demo_tool.SCENARIOS:
+            with self.subTest(scenario=scenario):
+                pair = fixture_pairs[scenario]
+                self.assertEqual(set(pair), {"before", "after"})
+                before = _demo_runner.load_report_json(pair["before"])
+                after = _demo_runner.load_report_json(pair["after"])
+                result = demo_tool.evaluate_live_scenario(
+                    scenario,
+                    before,
+                    after,
+                    profile="dev",
+                )
+                self.assertTrue(
+                    result["policy_passed"],
+                    msg=f"{scenario}: {result['failed_expectations']}",
+                )
+
     # TT-TEST: support
     def test_canonical_live_policy_owns_exactly_nine_scenarios(self) -> None:
         expected = {

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -15,6 +15,10 @@ import validate_docs_contracts
 
 class ValidateDocsContractsTests(unittest.TestCase):
 
+    # TT-TEST: Z02 primary
+    def test_actual_repository_manual_release_boundary_is_non_mutating(self) -> None:
+        validate_docs_contracts.validate_manual_release_boundary()
+
     # TT-TEST: support
     def test_run_end_policy_variants_include_expected_kinds(self) -> None:
         kinds = validate_docs_contracts.extract_run_end_policy_kinds_from_source()


### PR DESCRIPTION
### Motivation

- Provide honest adjacent primary proof owners for two invariant families left after marker migration by adding direct tests that assert the committed artifacts satisfy the canonical policies and repository release boundaries. 
- Keep the change minimal and surgical by adding only two tests and not touching production or helper code. 
- Preserve existing test classifications and rely on the existing fixture and policy registries rather than hardcoding scenario tables.

### Description

- Added one primary F05 test `test_committed_demo_report_pairs_satisfy_all_nine_canonical_policies` in `scripts/tests/test_demo_scripts.py` that derives committed before/after fixture pairs from `check_demo_fixture_drift._scenario_specs()`, verifies the set matches `demo_tool.LIVE_SCENARIO_POLICIES`, loads each pair via `_demo_runner.load_report_json(...)`, and evaluates them via `demo_tool.evaluate_live_scenario(...)` with `profile="dev"` (marker: `# TT-TEST: F05 primary`).
- Added one primary Z02 test `test_actual_repository_manual_release_boundary_is_non_mutating` in `scripts/tests/test_validate_docs_contracts.py` that invokes the default actual-repository scan `validate_docs_contracts.validate_manual_release_boundary()` with no synthetic paths (marker: `# TT-TEST: Z02 primary`).
- No production code, helper code, fixtures, docs, or invariant registries were changed, and existing `TT-TEST` classifications were preserved.

### Testing

- Ran the two focused unit tests individually with `python3 -m unittest` and both passed: `scripts.tests.test_demo_scripts.DemoWrapperTests.test_committed_demo_report_pairs_satisfy_all_nine_canonical_policies` and `scripts.tests.test_validate_docs_contracts.ValidateDocsContractsTests.test_actual_repository_manual_release_boundary_is_non_mutating`.
- Ran repository checks and full Python test discovery with `python3 scripts/check_demo_fixture_drift.py --profile dev`, `python3 scripts/check_workflow_security.py`, `python3 scripts/validate_docs_contracts.py`, and `python3 -m unittest discover -s scripts/tests -v`; the full Python discovery executed `217` tests and they all passed; `check_workflow_security.py` and `validate_docs_contracts.py` passed as well.
- Noted the read-only fixture drift check reported two pre-existing stale demo analysis fixtures and no refresh was performed: `demos/blocking_service/fixtures/after-analysis.json` and `demos/db_pool_saturation_service/fixtures/after-analysis.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8d4821197c83309c4e35a551ac2159)