### PR TITLE
Remove two redundant tests from generate_diagnostic_scorecard test file

### DIFF
--- a/scripts/tests/test_generate_diagnostic_scorecard.py
+++ b/scripts/tests/test_generate_diagnostic_scorecard.py
@@ -6,9 +6,6 @@ def env():return {'generated_at_utc':'t','snapshot_label':'s','git':{'sha':'a','
 def metrics(zero=False):return {'schema_version':2,'manifest_case_count':2,'analyzer_execution':{'case_count':1,'success_count':1,'expected_failure_count':0,'unexpected_failure_count':0,'run_artifact_count':1,'tracing_jsonl_count':0},'analyzer_accuracy':{'observation_count':0 if zero else 1,'encoding_count':0 if zero else 1,'top1_accuracy':None if zero else 1.0,'top2_recall':None if zero else 1.0,'high_confidence_wrong_count':0,'per_ground_truth_counts':{},'confusion_matrix':{},'confidence_bucket_accuracy':{}},'report_contract':{'case_count':1,'passed_count':1,'failed_count':0,'analysis_report_count':1,'synthetic_report_count':0},'validated_paths':{},'failed_analyzer_cases':[],'failed_report_contract_cases':[]}
 class Tests(unittest.TestCase):
  # TT-TEST: support
- def test_scorecard_json_is_separated(self):
-  m=metrics();self.assertEqual(m['schema_version'],2);self.assertNotIn('total_cases',m);self.assertEqual({'analyzer_execution','analyzer_accuracy','report_contract'} <= m.keys(),True)
- # TT-TEST: support
  def test_scorecard_markdown_is_separated(self):
   text=render_scorecard(metrics(),env())
   for h in ['## Analyzer execution','## Analyzer accuracy','## Report-contract validation','## Validated input paths','## Failed analyzer cases','## Failed report-contract cases','## Non-claims']:self.assertIn(h,text)
@@ -20,8 +17,6 @@ class Tests(unittest.TestCase):
  # TT-TEST: support
  def test_environment_schema_two(self):
   repo=Path(__file__).parents[2];e=collect_environment(repo,repo/'validation/diagnostics/manifest.json','x',{});self.assertEqual(e['schema_version'],2)
- # TT-TEST: support
- def test_hashes(self):self.assertEqual(sha256_bytes(b'a'),sha256_bytes(b'a'))
  # TT-TEST: support
  def test_generate_writes_separated_json(self):
   with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
### Motivation
- Simplify the diagnostic scorecard test suite by removing redundant or flaky checks that are no longer applicable to the refactored scorecard code.

### Description
- Remove the `test_scorecard_json_is_separated` unit test from `scripts/tests/test_generate_diagnostic_scorecard.py` which asserted JSON layout details.
- Remove the `test_hashes` unit test from `scripts/tests/test_generate_diagnostic_scorecard.py` which compared `sha256_bytes` outputs.
- Preserve the remaining tests that validate markdown rendering, unavailable accuracy formatting, environment schema collection, and generation of separated JSON output.

### Testing
- Ran the module tests via `python -m unittest scripts.tests.test_generate_diagnostic_scorecard` and the remaining tests in the file passed successfully.
- The `generate_scorecard`-related test that writes `out/benchmark-summary.json` still confirms `schema_version` and `analyzer_accuracy` presence and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8d6f664ebc83309f271ecea7ebd8e5)