### PR TITLE
harden release tooling: correct crates.io publishability and add package-consumer proof

### DIFF
--- a/docs/dev/RELEASING.md
+++ b/docs/dev/RELEASING.md
@@ -22,19 +22,30 @@ This is the authoritative procedure for a manual `tailtriage` release. Release t
      --profile-mode release
    ```
 
-6. Run the release preflight checker (`0.4.0` is an example, not permanent policy):
+6. Prove that the Cargo-produced package material works in an outside-workspace consumer:
+
+   ```bash
+   python3 scripts/check_package_consumer.py
+   ```
+
+   This creates `.crate` archives for all eight product packages, extracts them into a temporary
+   standalone project outside the repository workspace, and patches internal packages only to
+   other extracted archive contents. It runs offline without publication credentials. This is a
+   package-consumption proof, not proof of publication or registry availability.
+
+7. Run the release preflight checker (`0.4.0` is an example, not permanent policy):
 
    ```bash
    VERSION=0.4.0
    python3 scripts/check_release.py --version "$VERSION"
    ```
 
-7. Review the detected packages, publication order, Cargo packaging result, and generated manual commands.
-8. Manually publish one package at a time in the generated order.
-9. Verify each exact crate version publicly before continuing.
-10. Create and push an annotated tag only after every intended package is published. Tag signing is optional unless policy changes later.
-11. Create a draft GitHub Release manually.
-12. Review and publish the GitHub Release manually.
+8. Review the detected packages, publication order, Cargo packaging result, and generated manual commands.
+9. Manually publish one package at a time in the generated order.
+10. Verify each exact crate version publicly before continuing.
+11. Create and push an annotated tag only after every intended package is published. Tag signing is optional unless policy changes later.
+12. Create a draft GitHub Release manually.
+13. Review and publish the GitHub Release manually.
 
 Repository tooling does not publish crates. Generated publication commands are inert instructions only, and no crates.io credential belongs in repository tooling or GitHub Actions. Tags must not be pushed for an incomplete release. GitHub Release creation and publication remain manual.
 

--- a/scripts/check_package_consumer.py
+++ b/scripts/check_package_consumer.py
@@ -29,9 +29,13 @@ def run(argv: list[str], *, cwd: Path = REPO_ROOT) -> None:
     subprocess.run(argv, cwd=cwd, check=True)
 
 
+def metadata_command() -> list[str]:
+    return ["cargo", "metadata", "--format-version", "1", "--locked", "--offline"]
+
+
 def cargo_metadata() -> dict[str, Any]:
     result = subprocess.run(
-        ["cargo", "metadata", "--format-version", "1", "--locked"],
+        metadata_command(),
         cwd=REPO_ROOT,
         check=True,
         capture_output=True,

--- a/scripts/check_package_consumer.py
+++ b/scripts/check_package_consumer.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Prove Cargo package material works in an offline outside-workspace consumer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import tarfile
+import tempfile
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PRODUCT_PACKAGES = (
+    "tailtriage",
+    "tailtriage-core",
+    "tailtriage-controller",
+    "tailtriage-tokio",
+    "tailtriage-axum",
+    "tailtriage-tracing",
+    "tailtriage-analyzer",
+    "tailtriage-cli",
+)
+PATCH_PACKAGES = PRODUCT_PACKAGES[1:6]
+
+
+def run(argv: list[str], *, cwd: Path = REPO_ROOT) -> None:
+    subprocess.run(argv, cwd=cwd, check=True)
+
+
+def cargo_metadata() -> dict[str, Any]:
+    result = subprocess.run(
+        ["cargo", "metadata", "--format-version", "1", "--locked"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def product_package_versions(metadata: dict[str, Any]) -> dict[str, str]:
+    workspace_ids = set(metadata.get("workspace_members", []))
+    versions: dict[str, str] = {}
+    duplicates: set[str] = set()
+    for package in metadata.get("packages", []):
+        name = package.get("name")
+        if package.get("id") not in workspace_ids or name not in PRODUCT_PACKAGES:
+            continue
+        if name in versions:
+            duplicates.add(name)
+        versions[name] = package["version"]
+    missing = [name for name in PRODUCT_PACKAGES if name not in versions]
+    if missing or duplicates:
+        details = []
+        if missing:
+            details.append("missing product packages: " + ", ".join(missing))
+        if duplicates:
+            details.append("duplicated product packages: " + ", ".join(sorted(duplicates)))
+        raise ValueError("; ".join(details))
+    return {name: versions[name] for name in PRODUCT_PACKAGES}
+
+
+def package_command(allow_dirty: bool = False) -> list[str]:
+    argv = ["cargo", "package", "--locked", "--offline", "--no-verify"]
+    if allow_dirty:
+        argv.append("--allow-dirty")
+    for name in PRODUCT_PACKAGES:
+        argv.extend(["-p", name])
+    return argv
+
+
+def consumer_manifest(extracted: dict[str, Path]) -> str:
+    def quoted_path(name: str) -> str:
+        return json.dumps(str(extracted[name].resolve()))
+
+    patches = "\n".join(f"{name} = {{ path = {quoted_path(name)} }}" for name in PATCH_PACKAGES)
+    return f'''[package]
+name = "tailtriage-package-consumer"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+tailtriage = {{ path = {quoted_path("tailtriage")}, default-features = false, features = ["full"] }}
+tailtriage-analyzer = {{ path = {quoted_path("tailtriage-analyzer")} }}
+
+[patch.crates-io]
+{patches}
+'''
+
+
+def consumer_source() -> str:
+    return '''use tailtriage::Tailtriage;
+use tailtriage_analyzer::AnalyzeOptions;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let capture = Tailtriage::builder("package-consumer").build()?;
+    let started = capture.begin_request("/package-consumer");
+    started.completion.finish_ok();
+
+    let _options = AnalyzeOptions::default();
+
+    capture.shutdown()?;
+    Ok(())
+}
+'''
+
+
+def extract_archive(archive: Path, root: Path, expected_directory: Path) -> None:
+    resolved_root = root.resolve()
+    with tarfile.open(archive, "r:gz") as package:
+        for member in package.getmembers():
+            destination = (root / member.name).resolve()
+            if destination != resolved_root and resolved_root not in destination.parents:
+                raise RuntimeError(f"archive member escapes extraction root: {member.name}")
+        package.extractall(root, filter="data")
+    if not expected_directory.is_dir():
+        raise RuntimeError(f"archive did not create expected directory: {expected_directory.name}")
+
+
+def check(allow_dirty: bool) -> None:
+    metadata = cargo_metadata()
+    versions = product_package_versions(metadata)
+    package_root = Path(metadata["target_directory"]) / "package"
+    archives = {
+        name: package_root / f"{name}-{versions[name]}.crate" for name in PRODUCT_PACKAGES
+    }
+    for archive in archives.values():
+        archive.unlink(missing_ok=True)
+    run(package_command(allow_dirty))
+    missing = [str(path) for path in archives.values() if not path.is_file()]
+    if missing:
+        raise RuntimeError("Cargo did not generate expected archives: " + ", ".join(missing))
+
+    with tempfile.TemporaryDirectory(prefix="tailtriage-package-consumer-") as temporary:
+        proof_root = Path(temporary).resolve()
+        repository = REPO_ROOT.resolve()
+        if proof_root == repository or repository in proof_root.parents:
+            raise RuntimeError("temporary proof root is inside the repository checkout")
+
+        extracted = {
+            name: proof_root / f"{name}-{versions[name]}" for name in PRODUCT_PACKAGES
+        }
+        for name in PRODUCT_PACKAGES:
+            extract_archive(archives[name], proof_root, extracted[name])
+
+        consumer = proof_root / "consumer"
+        (consumer / "src").mkdir(parents=True)
+        (consumer / "Cargo.toml").write_text(consumer_manifest(extracted), encoding="utf-8")
+        (consumer / "src" / "main.rs").write_text(consumer_source(), encoding="utf-8")
+        run(["cargo", "generate-lockfile", "--offline"], cwd=consumer)
+        run(["cargo", "run", "--locked", "--offline"], cwd=consumer)
+
+        print("Product packages: " + ", ".join(f"{name} {versions[name]}" for name in PRODUCT_PACKAGES))
+        print("Cargo archives: generated all eight fresh .crate files")
+        print("Consumer root: temporary and outside the repository workspace")
+        print("Consumer: lock generation and execution succeeded offline")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--allow-dirty", action="store_true")
+    args = parser.parse_args()
+    try:
+        check(args.allow_dirty)
+    except (OSError, ValueError, RuntimeError, subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+        print(f"package consumer proof failed: {exc}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_release.py
+++ b/scripts/check_release.py
@@ -33,7 +33,7 @@ def failed_command(argv: list[str], result: subprocess.CompletedProcess[str]) ->
 
 def is_publishable(package: dict[str, Any]) -> bool:
     allowed = package.get("publish")
-    return allowed is None or bool(allowed)
+    return allowed is None or (isinstance(allowed, list) and "crates-io" in allowed)
 
 
 def version_tuple(version: str) -> tuple[int, int, int] | None:

--- a/scripts/tests/test_check_package_consumer.py
+++ b/scripts/tests/test_check_package_consumer.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts import check_package_consumer
+
+
+class CheckPackageConsumerTests(unittest.TestCase):
+    # TT-TEST: support
+    def test_product_package_versions_requires_all_eight_packages(self) -> None:
+        packages = [
+            {"id": f"id-{name}", "name": name, "version": f"1.2.{index}"}
+            for index, name in enumerate(check_package_consumer.PRODUCT_PACKAGES)
+        ]
+        packages.append({"id": "other", "name": "unrelated", "version": "9.9.9"})
+        metadata = {
+            "workspace_members": [package["id"] for package in packages],
+            "packages": packages,
+        }
+        self.assertEqual(
+            {
+                name: f"1.2.{index}"
+                for index, name in enumerate(check_package_consumer.PRODUCT_PACKAGES)
+            },
+            check_package_consumer.product_package_versions(metadata),
+        )
+        metadata["packages"] = packages[:-2] + packages[-1:]
+        with self.assertRaisesRegex(ValueError, "missing product packages: tailtriage-cli"):
+            check_package_consumer.product_package_versions(metadata)
+
+    # TT-TEST: support
+    def test_package_command_is_locked_offline_no_verify_and_dirty_is_opt_in(self) -> None:
+        command = check_package_consumer.package_command()
+        self.assertEqual(["cargo", "package"], command[:2])
+        self.assertTrue({"--locked", "--offline", "--no-verify"}.issubset(command))
+        self.assertNotIn("--allow-dirty", command)
+        self.assertNotIn("publish", command)
+        selected = [command[index + 1] for index, value in enumerate(command) if value == "-p"]
+        self.assertEqual(list(check_package_consumer.PRODUCT_PACKAGES), selected)
+        dirty = check_package_consumer.package_command(True)
+        self.assertIn("--allow-dirty", dirty)
+        self.assertNotIn("publish", dirty)
+
+    # TT-TEST: support
+    def test_consumer_manifest_uses_only_extracted_package_material(self) -> None:
+        extracted_root = Path("/temporary/proof/extracted")
+        extracted = {name: extracted_root / name for name in check_package_consumer.PRODUCT_PACKAGES}
+        manifest = check_package_consumer.consumer_manifest(extracted)
+        self.assertIn(
+            f'tailtriage = {{ path = "{extracted["tailtriage"]}", default-features = false, features = ["full"] }}',
+            manifest,
+        )
+        self.assertIn(f'tailtriage-analyzer = {{ path = "{extracted["tailtriage-analyzer"]}" }}', manifest)
+        for name in check_package_consumer.PATCH_PACKAGES:
+            self.assertIn(f'{name} = {{ path = "{extracted[name]}" }}', manifest)
+        self.assertNotIn(str(check_package_consumer.REPO_ROOT), manifest)
+        self.assertNotIn("0.1.1", manifest)
+
+    # TT-TEST: support
+    def test_consumer_source_exercises_facade_and_analyzer_public_usage(self) -> None:
+        source = check_package_consumer.consumer_source()
+        for usage in (
+            "Tailtriage::builder",
+            "begin_request",
+            "finish_ok",
+            "AnalyzeOptions::default",
+            "shutdown",
+        ):
+            self.assertIn(usage, source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_check_package_consumer.py
+++ b/scripts/tests/test_check_package_consumer.py
@@ -31,6 +31,16 @@ class CheckPackageConsumerTests(unittest.TestCase):
 
     # TT-TEST: support
     def test_package_command_is_locked_offline_no_verify_and_dirty_is_opt_in(self) -> None:
+        metadata = check_package_consumer.metadata_command()
+        self.assertEqual(["cargo", "metadata"], metadata[:2])
+        format_version = metadata.index("--format-version")
+        self.assertEqual("1", metadata[format_version + 1])
+        self.assertIn("--locked", metadata)
+        self.assertIn("--offline", metadata)
+        self.assertNotIn("publish", metadata)
+        for network_or_login_argument in ("--registry", "login", "--token"):
+            self.assertNotIn(network_or_login_argument, metadata)
+
         command = check_package_consumer.package_command()
         self.assertEqual(["cargo", "package"], command[:2])
         self.assertTrue({"--locked", "--offline", "--no-verify"}.issubset(command))

--- a/scripts/tests/test_check_release.py
+++ b/scripts/tests/test_check_release.py
@@ -34,6 +34,20 @@ def metadata(version: str = "1.2.3") -> dict:
 
 class CheckReleaseTests(unittest.TestCase):
     # TT-TEST: support
+    def test_publishability_classification_respects_crates_io_registry_restrictions(self) -> None:
+        cases = [
+            (None, True),
+            (False, False),
+            ([], False),
+            (["crates-io"], True),
+            (["internal", "crates-io"], True),
+            (["internal"], False),
+        ]
+        for publish, expected in cases:
+            with self.subTest(publish=publish):
+                self.assertEqual(expected, check_release.is_publishable({"publish": publish}))
+
+    # TT-TEST: support
     def test_example_package_content_uses_actual_cargo_listings(self) -> None:
         calls = []
 
@@ -63,9 +77,12 @@ class CheckReleaseTests(unittest.TestCase):
         packages = metadata()["packages"]
         publishable = [package for package in packages if check_release.is_publishable(package)]
         order, errors = check_release.publication_order(publishable, "1.2.3")
-        self.assertEqual(["core", "private", "api", "cli"], order)
+        self.assertEqual(["core", "api", "cli"], order)
         self.assertEqual([], errors)
-        self.assertEqual(["demo"], [package["name"] for package in packages if not check_release.is_publishable(package)])
+        self.assertEqual(
+            ["demo", "private"],
+            [package["name"] for package in packages if not check_release.is_publishable(package)],
+        )
 
     # TT-TEST: Z01 secondary
     def test_readiness_failure_suppresses_package_and_publish_commands(self) -> None:
@@ -111,11 +128,11 @@ class CheckReleaseTests(unittest.TestCase):
                 self.assertEqual(0, check_release.check("1.2.3", changelog))
         packages = [call for call in calls if call[:2] == ["cargo", "package"]]
         self.assertEqual(
-            [["cargo", "package", "--locked", "-p", "core", "-p", "private", "-p", "api", "-p", "cli"]], packages
+            [["cargo", "package", "--locked", "-p", "core", "-p", "api", "-p", "cli"]], packages
         )
         printed = output.getvalue()
         self.assertLess(printed.index("cargo publish --locked -p core"), printed.index("cargo publish --locked -p api"))
-        self.assertIn("cargo publish --locked -p private", printed)
+        self.assertNotIn("cargo publish --locked -p private", printed)
         self.assertLess(printed.index("cargo publish --locked -p api"), printed.index("cargo publish --locked -p cli"))
 
     # TT-TEST: Z01 primary
@@ -142,7 +159,7 @@ class CheckReleaseTests(unittest.TestCase):
                 ["git", "status", "--porcelain"],
                 ["git", "rev-parse", "HEAD"],
                 ["cargo", "metadata", "--format-version", "1", "--locked"],
-                ["cargo", "package", "--locked", "-p", "core", "-p", "private", "-p", "api", "-p", "cli"],
+                ["cargo", "package", "--locked", "-p", "core", "-p", "api", "-p", "cli"],
             ],
             calls,
             "successful preflight must execute only readiness checks and packaging",
@@ -176,7 +193,7 @@ class CheckReleaseTests(unittest.TestCase):
                 self.assertEqual(1, check_release.check("1.2.3", changelog))
         printed = output.getvalue()
         self.assertIn(
-            "command ['cargo', 'package', '--locked', '-p', 'core', '-p', 'private', '-p', 'api', '-p', 'cli'] exited with 2",
+            "command ['cargo', 'package', '--locked', '-p', 'core', '-p', 'api', '-p', 'cli'] exited with 2",
             printed,
         )
         self.assertIn("stdout:\npackage stdout", printed)


### PR DESCRIPTION
### Motivation
- Fix incorrect crates.io publishability logic which currently treats any non-empty `publish` list as publishable to crates.io.  
- Add a credential-free, outside-workspace proof that the current checkout produces consumable Cargo `.crate` archives without using a historical registry release or workspace source.  
- Wire the new proof into the manual release procedure so maintainers can run the check before final preflight.

### Description
- Change `is_publishable` in `scripts/check_release.py` to implement crates.io semantics: `publish is None` => publishable, `publish is False` or `[]` => not publishable, and a restricted list is publishable only if it contains the exact string `"crates-io"`.  
- Update `scripts/tests/test_check_release.py` expectations to exclude an internal-only package (`publish: ["internal"]`) from the publishable set and add a focused support test `test_publishability_classification_respects_crates_io_registry_restrictions` covering the six canonical `publish` cases.  
- Add `scripts/check_package_consumer.py` (std-lib-only) which: reads locked `cargo metadata`, confirms the eight product packages are present exactly once, runs `cargo package --locked --offline --no-verify` for the eight packages (optional `--allow-dirty` opt-in), extracts only the produced `<name>-<version>.crate` archives into a `tempfile.TemporaryDirectory` outside the repository, builds a standalone temporary consumer with an explicit `Cargo.toml` that points dependencies/`[patch.crates-io]` only at the extracted package directories (no workspace source or historical registry versions), runs `cargo generate-lockfile --offline` and `cargo run --locked --offline`, and prints concise success evidence.  
- Add `scripts/tests/test_check_package_consumer.py` with four support tests that validate metadata extraction, the package command flags/ordering and dirty opt-in, the generated consumer manifest uses only extracted paths and feature knobs, and the representative consumer source exercises the facade/analyzer public usage.  
- Update `docs/dev/RELEASING.md` to instruct maintainers to run `python3 scripts/check_package_consumer.py` before the final preflight and clarify the consumer proof is a package-consumption proof (offline, credential-free) not a publication/registry availability proof.  

### Testing
- Ran `python3 -m unittest scripts.tests.test_check_release -v` and `python3 -m unittest scripts.tests.test_check_package_consumer -v`; both test suites passed (8 and 4 tests respectively).  
- Executed `python3 scripts/check_package_consumer.py --allow-dirty`; Cargo generated all eight `.crate` archives from the checkout, the temporary consumer lockfile was generated offline, and `cargo run --locked --offline` compiled and executed the representative consumer successfully.  
- Ran repository checks: `python3 scripts/check_workflow_security.py`, `python3 scripts/validate_docs_contracts.py`, and `python3 scripts/validate_invariant_proofs.py` — all passed locally.  
- Ran the full Python test discovery (`python3 -m unittest discover -s scripts/tests -v`) and Rust validation (`cargo test`, `cargo doc`, `cargo fmt --check`, `cargo clippy ... -D warnings`) as part of the full validation flow; these succeeded in the local environment.  
- `cargo deny --version` reported `deny` is not installed locally so `cargo deny check` was not run per instructions; no installation or network fetches were attempted.  

Files changed: `scripts/check_release.py`, `scripts/tests/test_check_release.py`, new `scripts/check_package_consumer.py`, new `scripts/tests/test_check_package_consumer.py`, and `docs/dev/RELEASING.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8dde4ff75c8330a275354c0712b71e)